### PR TITLE
8353637: ZGC: Discontiguous memory reservation is broken on Windows

### DIFF
--- a/src/hotspot/os/posix/gc/z/zVirtualMemory_posix.cpp
+++ b/src/hotspot/os/posix/gc/z/zVirtualMemory_posix.cpp
@@ -32,7 +32,7 @@ void ZVirtualMemoryManager::pd_initialize_before_reserve() {
   // Does nothing
 }
 
-void ZVirtualMemoryManager::pd_initialize_after_reserve() {
+void ZVirtualMemoryManager::pd_register_callbacks(ZMemoryManager* manager) {
   // Does nothing
 }
 

--- a/src/hotspot/os/windows/gc/z/zVirtualMemory_windows.cpp
+++ b/src/hotspot/os/windows/gc/z/zVirtualMemory_windows.cpp
@@ -33,7 +33,7 @@
 class ZVirtualMemoryManagerImpl : public CHeapObj<mtGC> {
 public:
   virtual void initialize_before_reserve() {}
-  virtual void initialize_after_reserve(ZMemoryManager* manager) {}
+  virtual void register_callbacks(ZMemoryManager* manager) {}
   virtual bool reserve(zaddress_unsafe addr, size_t size) = 0;
   virtual void unreserve(zaddress_unsafe addr, size_t size) = 0;
 };
@@ -47,7 +47,7 @@ public:
 class ZVirtualMemoryManagerSmallPages : public ZVirtualMemoryManagerImpl {
 private:
   class PlaceholderCallbacks : public AllStatic {
-  public:
+  private:
     static void split_placeholder(zoffset start, size_t size) {
       ZMapper::split_placeholder(ZOffset::address_unsafe(start), size);
     }
@@ -79,99 +79,93 @@ private:
       }
     }
 
-    // Called when a memory area is returned to the memory manager but can't
-    // be merged with an already existing area. Make sure this area is covered
-    // by a single placeholder.
-    static void create_callback(const ZMemory* area) {
-      assert(is_aligned(area->size(), ZGranuleSize), "Must be granule aligned");
+    // Callback implementations
 
-      coalesce_into_one_placeholder(area->start(), area->size());
+    // Called when a memory area is returned to the memory manager.
+    //
+    // Makes sure this area is covered by a single placeholder.
+    static void insert_callback(const ZMemory& area) {
+      assert(is_aligned(area.size(), ZGranuleSize), "Must be granule aligned");
+
+      coalesce_into_one_placeholder(area.start(), area.size());
     }
 
-    // Called when a complete memory area in the memory manager is allocated.
-    // Create granule sized placeholders for the entire area.
-    static void destroy_callback(const ZMemory* area) {
-      assert(is_aligned(area->size(), ZGranuleSize), "Must be granule aligned");
+    // Called when a memory area is going to be handed out to be used.
+    //
+    // Splits the memory area into granule sized placeholders.
+    static void remove_callback(const ZMemory& area) {
+      assert(is_aligned(area.size(), ZGranuleSize), "Must be granule aligned");
 
-      split_into_granule_sized_placeholders(area->start(), area->size());
+      split_into_granule_sized_placeholders(area.start(), area.size());
     }
 
-    // Called when a memory area is allocated at the front of an exising memory area.
-    // Turn the first part of the memory area into granule sized placeholders.
-    static void shrink_from_front_callback(const ZMemory* area, size_t size) {
-      assert(area->size() > size, "Must be larger than what we try to split out");
-      assert(is_aligned(size, ZGranuleSize), "Must be granule aligned");
+    // Called when inserting a memory area and it can be merged at the start of
+    // an existing area.
+    //
+    // Coalesces the underlying placeholders into one.
+    static void grow_callback(const ZMemory& from, const ZMemory& to) {
+      assert(is_aligned(from.size(), ZGranuleSize), "Must be granule aligned");
+      assert(is_aligned(to.size(), ZGranuleSize), "Must be granule aligned");
+      assert(from != to, "Must have grown");
+      assert(to.contains(from), "Must be within");
+
+      coalesce_into_one_placeholder(to.start(), to.size());
+    }
+
+    // Called when a memory area is removed at the front of an existing memory
+    // area.
+    //
+    // Turns the first part of the memory area into granule-sized placeholders.
+    static void shrink_callback(const ZMemory& from, const ZMemory& to) {
+      assert(is_aligned(from.size(), ZGranuleSize), "Must be granule aligned");
+      assert(is_aligned(to.size(), ZGranuleSize), "Must be granule aligned");
+      assert(from != to, "Must have shrunk");
+      assert(from.contains(to), "Must be larger than what we try to split out");
+      assert(from.start() == to.start() || from.end() == to.end(),
+             "Only verified to work if we split a placeholder into two placeholders");
 
       // Split the area into two placeholders
-      split_placeholder(area->start(), size);
-
-      // Split the first part into granule sized placeholders
-      split_into_granule_sized_placeholders(area->start(), size);
+      split_placeholder(to.start(), to.size());
     }
 
-    // Called when a memory area is allocated at the end of an existing memory area.
-    // Turn the second part of the memory area into granule sized placeholders.
-    static void shrink_from_back_callback(const ZMemory* area, size_t size) {
-      assert(area->size() > size, "Must be larger than what we try to split out");
-      assert(is_aligned(size, ZGranuleSize), "Must be granule aligned");
-
-      // Split the area into two placeholders
-      const zoffset start = to_zoffset(area->end() - size);
-      split_placeholder(start, size);
-
-      // Split the second part into granule sized placeholders
-      split_into_granule_sized_placeholders(start, size);
-    }
-
-    // Called when freeing a memory area and it can be merged at the start of an
-    // existing area. Coalesce the underlying placeholders into one.
-    static void grow_from_front_callback(const ZMemory* area, size_t size) {
-      assert(is_aligned(area->size(), ZGranuleSize), "Must be granule aligned");
-
-      const zoffset start = area->start() - size;
-      coalesce_into_one_placeholder(start, area->size() + size);
-    }
-
-    // Called when freeing a memory area and it can be merged at the end of an
-    // existing area. Coalesce the underlying placeholders into one.
-    static void grow_from_back_callback(const ZMemory* area, size_t size) {
-      assert(is_aligned(area->size(), ZGranuleSize), "Must be granule aligned");
-
-      coalesce_into_one_placeholder(area->start(), area->size() + size);
-    }
-
-    static void register_with(ZMemoryManager* manager) {
+  public:
+    static ZMemoryManager::Callbacks callbacks() {
       // Each reserved virtual memory address area registered in _manager is
       // exactly covered by a single placeholder. Callbacks are installed so
       // that whenever a memory area changes, the corresponding placeholder
       // is adjusted.
       //
-      // The create and grow callbacks are called when virtual memory is
-      // returned to the memory manager. The new memory area is then covered
-      // by a new single placeholder.
+      // The insert callback is called when virtual memory is returned to the
+      // memory manager. The returned memory area is then covered by a new
+      // single placeholder.
       //
-      // The destroy and shrink callbacks are called when virtual memory is
-      // allocated from the memory manager. The memory area is then is split
-      // into granule-sized placeholders.
+      // The remove callback is called when virtual memory is removed and
+      // handed out to callers. The memory area is split into granule-sized
+      // placeholders.
+      //
+      // The grow callback is called when a virtual memory area grows. The
+      // resulting memory area is then covered by a single placeholder.
+      //
+      // The split callback is called when a virtual memory area is split into
+      // two parts. The two resulting memory areas are then covered by two
+      // separate placeholders.
       //
       // See comment in zMapper_windows.cpp explaining why placeholders are
       // split into ZGranuleSize sized placeholders.
 
       ZMemoryManager::Callbacks callbacks;
 
-      callbacks._create = &create_callback;
-      callbacks._destroy = &destroy_callback;
-      callbacks._shrink_from_front = &shrink_from_front_callback;
-      callbacks._shrink_from_back = &shrink_from_back_callback;
-      callbacks._grow_from_front = &grow_from_front_callback;
-      callbacks._grow_from_back = &grow_from_back_callback;
+      callbacks._insert = &insert_callback;
+      callbacks._remove = &remove_callback;
+      callbacks._grow = &grow_callback;
+      callbacks._shrink = &shrink_callback;
 
-      manager->register_callbacks(callbacks);
+      return callbacks;
     }
   };
 
-  virtual void initialize_after_reserve(ZMemoryManager* manager) {
-    PlaceholderCallbacks::register_with(manager);
+  virtual void register_callbacks(ZMemoryManager* manager) {
+    manager->register_callbacks(PlaceholderCallbacks::callbacks());
   }
 
   virtual bool reserve(zaddress_unsafe addr, size_t size) {
@@ -220,8 +214,8 @@ void ZVirtualMemoryManager::pd_initialize_before_reserve() {
   _impl->initialize_before_reserve();
 }
 
-void ZVirtualMemoryManager::pd_initialize_after_reserve() {
-  _impl->initialize_after_reserve(&_manager);
+void ZVirtualMemoryManager::pd_register_callbacks(ZMemoryManager* manager) {
+  _impl->register_callbacks(manager);
 }
 
 bool ZVirtualMemoryManager::pd_reserve(zaddress_unsafe addr, size_t size) {

--- a/src/hotspot/share/gc/z/zArguments.hpp
+++ b/src/hotspot/share/gc/z/zArguments.hpp
@@ -29,6 +29,8 @@
 class CollectedHeap;
 
 class ZArguments : public GCArguments {
+  friend class ZTest;
+
 private:
   static void select_max_gc_threads();
 

--- a/src/hotspot/share/gc/z/zInitialize.hpp
+++ b/src/hotspot/share/gc/z/zInitialize.hpp
@@ -37,6 +37,8 @@ public:
 };
 
 class ZInitialize : public AllStatic {
+  friend class ZTest;
+
 private:
   static constexpr size_t ErrorMessageLength = 256;
 

--- a/src/hotspot/share/gc/z/zMemory.cpp
+++ b/src/hotspot/share/gc/z/zMemory.cpp
@@ -25,56 +25,47 @@
 #include "gc/z/zLock.inline.hpp"
 #include "gc/z/zMemory.inline.hpp"
 
-ZMemory* ZMemoryManager::create(zoffset start, size_t size) {
-  ZMemory* const area = new ZMemory(start, size);
-  if (_callbacks._create != nullptr) {
-    _callbacks._create(area);
-  }
-  return area;
-}
-
-void ZMemoryManager::destroy(ZMemory* area) {
-  if (_callbacks._destroy != nullptr) {
-    _callbacks._destroy(area);
-  }
-  delete area;
-}
-
 void ZMemoryManager::shrink_from_front(ZMemory* area, size_t size) {
-  if (_callbacks._shrink_from_front != nullptr) {
-    _callbacks._shrink_from_front(area, size);
+  if (_callbacks._shrink != nullptr) {
+    const ZMemory* from = area;
+    const ZMemory to(area->start() + size, area->size() - size);
+    _callbacks._shrink(*from, to);
   }
   area->shrink_from_front(size);
 }
 
 void ZMemoryManager::shrink_from_back(ZMemory* area, size_t size) {
-  if (_callbacks._shrink_from_back != nullptr) {
-    _callbacks._shrink_from_back(area, size);
+  if (_callbacks._shrink != nullptr) {
+    const ZMemory* from = area;
+    const ZMemory to(area->start(), area->size() - size);
+    _callbacks._shrink(*from, to);
   }
   area->shrink_from_back(size);
 }
 
 void ZMemoryManager::grow_from_front(ZMemory* area, size_t size) {
-  if (_callbacks._grow_from_front != nullptr) {
-    _callbacks._grow_from_front(area, size);
+  if (_callbacks._grow != nullptr) {
+    const ZMemory* from = area;
+    const ZMemory to(area->start() - size, area->size() + size);
+    _callbacks._grow(*from, to);
   }
   area->grow_from_front(size);
 }
 
 void ZMemoryManager::grow_from_back(ZMemory* area, size_t size) {
-  if (_callbacks._grow_from_back != nullptr) {
-    _callbacks._grow_from_back(area, size);
+  if (_callbacks._grow != nullptr) {
+    const ZMemory* from = area;
+    const ZMemory to(area->start(), area->size() + size);
+    _callbacks._grow(*from, to);
   }
   area->grow_from_back(size);
 }
 
 ZMemoryManager::Callbacks::Callbacks()
-  : _create(nullptr),
-    _destroy(nullptr),
-    _shrink_from_front(nullptr),
-    _shrink_from_back(nullptr),
-    _grow_from_front(nullptr),
-    _grow_from_back(nullptr) {}
+  : _insert(nullptr),
+    _remove(nullptr),
+    _grow(nullptr),
+    _shrink(nullptr) {}
 
 ZMemoryManager::ZMemoryManager()
   : _freelist(),
@@ -118,18 +109,24 @@ zoffset ZMemoryManager::alloc_low_address(size_t size) {
   ZListIterator<ZMemory> iter(&_freelist);
   for (ZMemory* area; iter.next(&area);) {
     if (area->size() >= size) {
+      zoffset start;
+
       if (area->size() == size) {
         // Exact match, remove area
-        const zoffset start = area->start();
+        start = area->start();
         _freelist.remove(area);
-        destroy(area);
-        return start;
+        delete area;
       } else {
         // Larger than requested, shrink area
-        const zoffset start = area->start();
+        start = area->start();
         shrink_from_front(area, size);
-        return start;
       }
+
+      if (_callbacks._remove != nullptr) {
+        _callbacks._remove(ZMemory(start, size));
+      }
+
+      return start;
     }
   }
 
@@ -142,20 +139,24 @@ zoffset ZMemoryManager::alloc_low_address_at_most(size_t size, size_t* allocated
 
   ZMemory* const area = _freelist.first();
   if (area != nullptr) {
+    const zoffset start = area->start();
+
     if (area->size() <= size) {
       // Smaller than or equal to requested, remove area
-      const zoffset start = area->start();
-      *allocated = area->size();
       _freelist.remove(area);
-      destroy(area);
-      return start;
+      *allocated = area->size();
+      delete area;
     } else {
       // Larger than requested, shrink area
-      const zoffset start = area->start();
       shrink_from_front(area, size);
       *allocated = size;
-      return start;
     }
+
+    if (_callbacks._remove != nullptr) {
+      _callbacks._remove(ZMemory(start, *allocated));
+    }
+
+    return start;
   }
 
   // Out of memory
@@ -169,17 +170,24 @@ zoffset ZMemoryManager::alloc_high_address(size_t size) {
   ZListReverseIterator<ZMemory> iter(&_freelist);
   for (ZMemory* area; iter.next(&area);) {
     if (area->size() >= size) {
+      zoffset start;
+
       if (area->size() == size) {
         // Exact match, remove area
-        const zoffset start = area->start();
+        start = area->start();
         _freelist.remove(area);
-        destroy(area);
-        return start;
+        delete area;
       } else {
         // Larger than requested, shrink area
         shrink_from_back(area, size);
-        return to_zoffset(area->end());
+        start = to_zoffset(area->end());
       }
+
+      if (_callbacks._remove != nullptr) {
+        _callbacks._remove(ZMemory(start, size));
+      }
+
+      return start;
     }
   }
 
@@ -187,11 +195,9 @@ zoffset ZMemoryManager::alloc_high_address(size_t size) {
   return zoffset(UINTPTR_MAX);
 }
 
-void ZMemoryManager::free(zoffset start, size_t size) {
+void ZMemoryManager::move_into(zoffset start, size_t size) {
   assert(start != zoffset(UINTPTR_MAX), "Invalid address");
   const zoffset_end end = to_zoffset_end(start, size);
-
-  ZLocker<ZLock> locker(&_lock);
 
   ZListIterator<ZMemory> iter(&_freelist);
   for (ZMemory* area; iter.next(&area);) {
@@ -213,7 +219,7 @@ void ZMemoryManager::free(zoffset start, size_t size) {
       } else {
         // Insert new area before current area
         assert(end < area->start(), "Areas must not overlap");
-        ZMemory* const new_area = create(start, size);
+        ZMemory* const new_area = new ZMemory(start, size);
         _freelist.insert_before(area, new_area);
       }
 
@@ -229,7 +235,44 @@ void ZMemoryManager::free(zoffset start, size_t size) {
     grow_from_back(last, size);
   } else {
     // Insert new area last
-    ZMemory* const new_area = create(start, size);
+    ZMemory* const new_area = new ZMemory(start, size);
     _freelist.insert_last(new_area);
   }
+}
+
+void ZMemoryManager::free(zoffset start, size_t size) {
+  ZLocker<ZLock> locker(&_lock);
+
+  if (_callbacks._insert != nullptr) {
+    _callbacks._insert(ZMemory(start, size));
+  }
+
+  move_into(start, size);
+}
+
+void ZMemoryManager::register_range(zoffset start, size_t size) {
+  move_into(start, size);
+}
+
+bool ZMemoryManager::unregister_first(zoffset* start_out, size_t* size_out) {
+  // This intentionally does not call the "remove" callback.
+  // This call is typically used to unregister memory before unreserving a surplus.
+
+  ZLocker<ZLock> locker(&_lock);
+
+  if (_freelist.is_empty()) {
+    return false;
+  }
+
+  // Don't invoke the "remove" callback
+
+  ZMemory* const area = _freelist.remove_first();
+
+  // Return the range
+  *start_out = area->start();
+  *size_out  = area->size();
+
+  delete area;
+
+  return true;
 }

--- a/src/hotspot/share/gc/z/zMemory.hpp
+++ b/src/hotspot/share/gc/z/zMemory.hpp
@@ -44,6 +44,11 @@ public:
   zoffset_end end() const;
   size_t size() const;
 
+  bool operator==(const ZMemory& other) const;
+  bool operator!=(const ZMemory& other) const;
+
+  bool contains(const ZMemory& other) const;
+
   void shrink_from_front(size_t size);
   void shrink_from_back(size_t size);
   void grow_from_front(size_t size);
@@ -51,17 +56,19 @@ public:
 };
 
 class ZMemoryManager {
+  friend class ZVirtualMemoryManagerTest;
+
 public:
-  typedef void (*CreateDestroyCallback)(const ZMemory* area);
-  typedef void (*ResizeCallback)(const ZMemory* area, size_t size);
+  typedef void (*CallbackInsert)(const ZMemory& area);
+  typedef void (*CallbackRemove)(const ZMemory& area);
+  typedef void (*CallbackGrow)(const ZMemory& from, const ZMemory& to);
+  typedef void (*CallbackShrink)(const ZMemory& from, const ZMemory& to);
 
   struct Callbacks {
-    CreateDestroyCallback _create;
-    CreateDestroyCallback _destroy;
-    ResizeCallback        _shrink_from_front;
-    ResizeCallback        _shrink_from_back;
-    ResizeCallback        _grow_from_front;
-    ResizeCallback        _grow_from_back;
+    CallbackInsert _insert;
+    CallbackRemove _remove;
+    CallbackGrow   _grow;
+    CallbackShrink _shrink;
 
     Callbacks();
   };
@@ -71,12 +78,12 @@ private:
   ZList<ZMemory> _freelist;
   Callbacks      _callbacks;
 
-  ZMemory* create(zoffset start, size_t size);
-  void destroy(ZMemory* area);
   void shrink_from_front(ZMemory* area, size_t size);
   void shrink_from_back(ZMemory* area, size_t size);
   void grow_from_front(ZMemory* area, size_t size);
   void grow_from_back(ZMemory* area, size_t size);
+
+  void move_into(zoffset start, size_t size);
 
 public:
   ZMemoryManager();
@@ -92,6 +99,8 @@ public:
   zoffset alloc_high_address(size_t size);
 
   void free(zoffset start, size_t size);
+  void register_range(zoffset start, size_t size);
+  bool unregister_first(zoffset* start_out, size_t* size_out);
 };
 
 #endif // SHARE_GC_Z_ZMEMORY_HPP

--- a/src/hotspot/share/gc/z/zMemory.hpp
+++ b/src/hotspot/share/gc/z/zMemory.hpp
@@ -59,16 +59,14 @@ class ZMemoryManager {
   friend class ZVirtualMemoryManagerTest;
 
 public:
-  typedef void (*CallbackInsert)(const ZMemory& area);
-  typedef void (*CallbackRemove)(const ZMemory& area);
-  typedef void (*CallbackGrow)(const ZMemory& from, const ZMemory& to);
-  typedef void (*CallbackShrink)(const ZMemory& from, const ZMemory& to);
+  typedef void (*CallbackPrepare)(const ZMemory& area);
+  typedef void (*CallbackResize)(const ZMemory& from, const ZMemory& to);
 
   struct Callbacks {
-    CallbackInsert _insert;
-    CallbackRemove _remove;
-    CallbackGrow   _grow;
-    CallbackShrink _shrink;
+    CallbackPrepare _prepare_for_hand_out;
+    CallbackPrepare _prepare_for_hand_back;
+    CallbackResize  _grow;
+    CallbackResize  _shrink;
 
     Callbacks();
   };

--- a/src/hotspot/share/gc/z/zMemory.inline.hpp
+++ b/src/hotspot/share/gc/z/zMemory.inline.hpp
@@ -46,6 +46,18 @@ inline size_t ZMemory::size() const {
   return end() - start();
 }
 
+inline bool ZMemory::operator==(const ZMemory& other) const {
+  return _start == other._start && _end == other._end;
+}
+
+inline bool ZMemory::operator!=(const ZMemory& other) const {
+  return !operator==(other);
+}
+
+inline bool ZMemory::contains(const ZMemory& other) const {
+  return _start <= other._start && other.end() <= end();
+}
+
 inline void ZMemory::shrink_from_front(size_t size) {
   assert(this->size() > size, "Too small");
   _start += size;

--- a/src/hotspot/share/gc/z/zNMT.cpp
+++ b/src/hotspot/share/gc/z/zNMT.cpp
@@ -40,6 +40,26 @@ void ZNMT::reserve(zaddress_unsafe start, size_t size) {
   MemTracker::record_virtual_memory_reserve((address)untype(start), size, CALLER_PC, mtJavaHeap);
 }
 
+void ZNMT::unreserve(zaddress_unsafe start, size_t size) {
+  precond(is_aligned(untype(start), ZGranuleSize));
+  precond(is_aligned(size, ZGranuleSize));
+
+  if (MemTracker::enabled()) {
+    // We are the owner of the reserved memory, and any failure to unreserve
+    // are fatal, so so we don't need to hold a lock while unreserving memory.
+
+    MemTracker::NmtVirtualMemoryLocker nvml;
+
+    // The current NMT implementation does not support unreserving a memory
+    // region that was built up from smaller memory reservations. Workaround
+    // this problem by splitting the work up into granule-sized chunks, which
+    // is the smallest unit we ever reserve.
+    for (size_t i = 0; i < size; i += ZGranuleSize) {
+      MemTracker::record_virtual_memory_release((address)untype(start + i), ZGranuleSize);
+    }
+  }
+}
+
 void ZNMT::commit(zoffset offset, size_t size) {
   MemTracker::allocate_memory_in(ZNMT::_device, untype(offset), size, CALLER_PC, mtJavaHeap);
 }

--- a/src/hotspot/share/gc/z/zNMT.hpp
+++ b/src/hotspot/share/gc/z/zNMT.hpp
@@ -42,6 +42,8 @@ public:
   static void initialize();
 
   static void reserve(zaddress_unsafe start, size_t size);
+  static void unreserve(zaddress_unsafe start, size_t size);
+
   static void commit(zoffset offset, size_t size);
   static void uncommit(zoffset offset, size_t size);
 

--- a/src/hotspot/share/gc/z/zPhysicalMemory.cpp
+++ b/src/hotspot/share/gc/z/zPhysicalMemory.cpp
@@ -238,7 +238,7 @@ ZPhysicalMemory ZPhysicalMemory::split_committed() {
 ZPhysicalMemoryManager::ZPhysicalMemoryManager(size_t max_capacity)
   : _backing(max_capacity) {
   // Make the whole range free
-  _manager.free(zoffset(0), max_capacity);
+  _manager.register_range(zoffset(0), max_capacity);
 }
 
 bool ZPhysicalMemoryManager::is_initialized() const {

--- a/src/hotspot/share/gc/z/zVirtualMemory.hpp
+++ b/src/hotspot/share/gc/z/zVirtualMemory.hpp
@@ -48,6 +48,7 @@ public:
 
 class ZVirtualMemoryManager {
   friend class ZMapperTest;
+  friend class ZVirtualMemoryManagerTest;
 
 private:
   static size_t calculate_min_range(size_t size);
@@ -58,7 +59,7 @@ private:
 
   // Platform specific implementation
   void pd_initialize_before_reserve();
-  void pd_initialize_after_reserve();
+  void pd_register_callbacks(ZMemoryManager* manager);
   bool pd_reserve(zaddress_unsafe addr, size_t size);
   void pd_unreserve(zaddress_unsafe addr, size_t size);
 
@@ -67,6 +68,8 @@ private:
   size_t reserve_discontiguous(zoffset start, size_t size, size_t min_range);
   size_t reserve_discontiguous(size_t size);
   bool reserve(size_t max_capacity);
+
+  void unreserve(zoffset start, size_t size);
 
   DEBUG_ONLY(size_t force_reserve_discontiguous(size_t size);)
 
@@ -81,6 +84,8 @@ public:
 
   ZVirtualMemory alloc(size_t size, bool force_low_address);
   void free(const ZVirtualMemory& vmem);
+
+  void unreserve_all();
 };
 
 #endif // SHARE_GC_Z_ZVIRTUALMEMORY_HPP

--- a/test/hotspot/gtest/gc/z/test_zMapper_windows.cpp
+++ b/test/hotspot/gtest/gc/z/test_zMapper_windows.cpp
@@ -29,182 +29,71 @@
 #include "gc/z/zMapper_windows.hpp"
 #include "gc/z/zMemory.inline.hpp"
 #include "gc/z/zSyscall_windows.hpp"
-#include "gc/z/zVirtualMemory.hpp"
+#include "gc/z/zVirtualMemory.inline.hpp"
 #include "runtime/os.hpp"
-#include "unittest.hpp"
+#include "zunittest.hpp"
 
 using namespace testing;
 
-#define EXPECT_ALLOC_OK(offset) EXPECT_NE(offset, zoffset(UINTPTR_MAX))
-
-class ZMapperTest : public Test {
+class ZMapperTest : public ZTest {
 private:
-  static constexpr size_t ZMapperTestReservationSize = 32 * M;
+  static constexpr size_t ReservationSize = 32 * M;
 
-  static bool            _initialized;
-  static ZMemoryManager* _va;
-
-  static ZVirtualMemoryManager* _vmm;
-
-  static bool _has_unreserved;
+  ZVirtualMemoryManager* _vmm;
+  ZMemoryManager*        _va;
 
 public:
-  bool reserve_for_test() {
-    // Initialize platform specific parts before reserving address space
-    _vmm->pd_initialize_before_reserve();
-
-    // Reserve address space
-    if (!_vmm->pd_reserve(ZOffset::address_unsafe(zoffset(0)), ZMapperTestReservationSize)) {
-      return false;
-    }
-
-    // Make the address range free before setting up callbacks below
-    _va->free(zoffset(0), ZMapperTestReservationSize);
-
-    // Initialize platform specific parts after reserving address space
-    _vmm->pd_initialize_after_reserve();
-
-    return true;
-  }
-
   virtual void SetUp() {
     // Only run test on supported Windows versions
-    if (!ZSyscall::is_supported()) {
+    if (!is_os_supported()) {
       GTEST_SKIP() << "Requires Windows version 1803 or later";
-      return;
     }
-
-    ZSyscall::initialize();
-    ZGlobalsPointers::initialize();
 
     // Fake a ZVirtualMemoryManager
     _vmm = (ZVirtualMemoryManager*)os::malloc(sizeof(ZVirtualMemoryManager), mtTest);
+    _vmm = ::new (_vmm) ZVirtualMemoryManager(ReservationSize);
 
     // Construct its internal ZMemoryManager
     _va = new (&_vmm->_manager) ZMemoryManager();
 
     // Reserve address space for the test
-    if (!reserve_for_test()) {
+    if (_vmm->reserved() != ReservationSize) {
       GTEST_SKIP() << "Failed to reserve address space";
-      return;
     }
-
-    _initialized = true;
-    _has_unreserved = false;
   }
 
   virtual void TearDown() {
-    if (!ZSyscall::is_supported()) {
+    if (!is_os_supported()) {
       // Test skipped, nothing to cleanup
       return;
     }
 
-    if (_initialized && !_has_unreserved) {
-      _vmm->pd_unreserve(ZOffset::address_unsafe(zoffset(0)), 0);
-    }
+    // Best-effort cleanup
+    _vmm->unreserve_all();
+    _vmm->~ZVirtualMemoryManager();
     os::free(_vmm);
   }
 
-  static void test_unreserve() {
+  void test_unreserve() {
     zoffset bottom = _va->alloc_low_address(ZGranuleSize);
-    zoffset top    = _va->alloc_high_address(ZGranuleSize);
+    zoffset middle = _va->alloc_low_address(ZGranuleSize);
+    zoffset top    = _va->alloc_low_address(ZGranuleSize);
+
+    ASSERT_EQ(bottom, zoffset(0));
+    ASSERT_EQ(middle, bottom + 1 * ZGranuleSize);
+    ASSERT_EQ(top,    bottom + 2 * ZGranuleSize);
 
     // Unreserve the middle part
-    ZMapper::unreserve(ZOffset::address_unsafe(bottom + ZGranuleSize), ZGranuleSize);
+    ZMapper::unreserve(ZOffset::address_unsafe(middle), ZGranuleSize);
 
     // Make sure that we still can unreserve the memory before and after
     ZMapper::unreserve(ZOffset::address_unsafe(bottom), ZGranuleSize);
     ZMapper::unreserve(ZOffset::address_unsafe(top), ZGranuleSize);
-
-    _has_unreserved = true;
-  }
-
-  static void test_alloc_low_address() {
-    // Verify that we get placeholder for first granule
-    zoffset bottom = _va->alloc_low_address(ZGranuleSize);
-    EXPECT_ALLOC_OK(bottom);
-
-    _va->free(bottom, ZGranuleSize);
-
-    // Alloc something larger than a granule and free it
-    bottom = _va->alloc_low_address(ZGranuleSize * 3);
-    EXPECT_ALLOC_OK(bottom);
-
-    _va->free(bottom, ZGranuleSize * 3);
-
-    // Free with more memory allocated
-    bottom = _va->alloc_low_address(ZGranuleSize);
-    EXPECT_ALLOC_OK(bottom);
-
-    zoffset next = _va->alloc_low_address(ZGranuleSize);
-    EXPECT_ALLOC_OK(next);
-
-    _va->free(bottom, ZGranuleSize);
-    _va->free(next, ZGranuleSize);
-  }
-
-  static void test_alloc_high_address() {
-    // Verify that we get placeholder for last granule
-    zoffset high = _va->alloc_high_address(ZGranuleSize);
-    EXPECT_ALLOC_OK(high);
-
-    zoffset prev = _va->alloc_high_address(ZGranuleSize);
-    EXPECT_ALLOC_OK(prev);
-
-    _va->free(high, ZGranuleSize);
-    _va->free(prev, ZGranuleSize);
-
-    // Alloc something larger than a granule and return it
-    high = _va->alloc_high_address(ZGranuleSize * 2);
-    EXPECT_ALLOC_OK(high);
-
-    _va->free(high, ZGranuleSize * 2);
-  }
-
-  static void test_alloc_whole_area() {
-    // Alloc the whole reservation
-    zoffset bottom = _va->alloc_low_address(ZMapperTestReservationSize);
-    EXPECT_ALLOC_OK(bottom);
-
-    // Free two chunks and then allocate them again
-    _va->free(bottom, ZGranuleSize * 4);
-    _va->free(bottom + ZGranuleSize * 6, ZGranuleSize * 6);
-
-    zoffset offset = _va->alloc_low_address(ZGranuleSize * 4);
-    EXPECT_ALLOC_OK(offset);
-
-    offset = _va->alloc_low_address(ZGranuleSize * 6);
-    EXPECT_ALLOC_OK(offset);
-
-    // Now free it all, and verify it can be re-allocated
-    _va->free(bottom, ZMapperTestReservationSize);
-
-    bottom = _va->alloc_low_address(ZMapperTestReservationSize);
-    EXPECT_ALLOC_OK(bottom);
-
-    _va->free(bottom, ZMapperTestReservationSize);
   }
 };
 
-bool ZMapperTest::_initialized   = false;
-ZMemoryManager* ZMapperTest::_va = nullptr;
-ZVirtualMemoryManager* ZMapperTest::_vmm = nullptr;
-bool ZMapperTest::_has_unreserved;
-
 TEST_VM_F(ZMapperTest, test_unreserve) {
   test_unreserve();
-}
-
-TEST_VM_F(ZMapperTest, test_alloc_low_address) {
-  test_alloc_low_address();
-}
-
-TEST_VM_F(ZMapperTest, test_alloc_high_address) {
-  test_alloc_high_address();
-}
-
-TEST_VM_F(ZMapperTest, test_alloc_whole_area) {
-  test_alloc_whole_area();
 }
 
 #endif // _WINDOWS

--- a/test/hotspot/gtest/gc/z/test_zMemory.cpp
+++ b/test/hotspot/gtest/gc/z/test_zMemory.cpp
@@ -23,28 +23,10 @@
 
 #include "gc/z/zGlobals.hpp"
 #include "gc/z/zMemory.inline.hpp"
-#include "unittest.hpp"
-
-class ZAddressOffsetMaxSetter {
-private:
-  const size_t _old_max;
-  const size_t _old_mask;
-
-public:
-  ZAddressOffsetMaxSetter()
-    : _old_max(ZAddressOffsetMax),
-      _old_mask(ZAddressOffsetMask) {
-    ZAddressOffsetMax = size_t(16) * G * 1024;
-    ZAddressOffsetMask = ZAddressOffsetMax - 1;
-  }
-  ~ZAddressOffsetMaxSetter() {
-    ZAddressOffsetMax = _old_max;
-    ZAddressOffsetMask = _old_mask;
-  }
-};
+#include "zunittest.hpp"
 
 TEST(ZMemory, accessors) {
-  ZAddressOffsetMaxSetter setter;
+  ZAddressOffsetMaxSetter setter(size_t(16) * G * 1024);
 
   {
     ZMemory mem(zoffset(0), ZGranuleSize);
@@ -74,7 +56,7 @@ TEST(ZMemory, accessors) {
 }
 
 TEST(ZMemory, resize) {
-  ZAddressOffsetMaxSetter setter;
+  ZAddressOffsetMaxSetter setter(size_t(16) * G * 1024);
 
   ZMemory mem(zoffset(ZGranuleSize * 2), ZGranuleSize * 2) ;
 

--- a/test/hotspot/gtest/gc/z/test_zVirtualMemory.cpp
+++ b/test/hotspot/gtest/gc/z/test_zVirtualMemory.cpp
@@ -22,9 +22,11 @@
  */
 
 #include "gc/z/zVirtualMemory.inline.hpp"
-#include "unittest.hpp"
+#include "zunittest.hpp"
 
 TEST(ZVirtualMemory, split) {
+  ZAddressOffsetMaxSetter setter(size_t(16) * G * 1024);
+
   ZVirtualMemory vmem(zoffset(0), 10);
 
   ZVirtualMemory vmem0 = vmem.split(0);

--- a/test/hotspot/gtest/gc/z/test_zVirtualMemoryManager.cpp
+++ b/test/hotspot/gtest/gc/z/test_zVirtualMemoryManager.cpp
@@ -1,0 +1,269 @@
+/*
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include "gc/z/zAddress.inline.hpp"
+#include "gc/z/zArguments.hpp"
+#include "gc/z/zGlobals.hpp"
+#include "gc/z/zInitialize.hpp"
+#include "gc/z/zList.inline.hpp"
+#include "gc/z/zMemory.inline.hpp"
+#include "gc/z/zNUMA.inline.hpp"
+#include "gc/z/zValue.inline.hpp"
+#include "gc/z/zVirtualMemory.hpp"
+#include "runtime/os.hpp"
+#include "zunittest.hpp"
+
+using namespace testing;
+
+#define ASSERT_ALLOC_OK(offset) ASSERT_NE(offset, zoffset(UINTPTR_MAX))
+
+class ZCallbacksResetter {
+private:
+  ZMemoryManager::Callbacks* _callbacks;
+  ZMemoryManager::Callbacks  _saved;
+
+public:
+  ZCallbacksResetter(ZMemoryManager::Callbacks* callbacks)
+    : _callbacks(callbacks),
+      _saved(*callbacks) {
+    *_callbacks = {};
+  }
+  ~ZCallbacksResetter() {
+    *_callbacks = _saved;
+  }
+};
+
+class ZVirtualMemoryManagerTest : public ZTest {
+private:
+  static constexpr size_t ReservationSize = 32 * M;
+
+  ZMemoryManager*        _va;
+  ZVirtualMemoryManager* _vmm;
+
+public:
+  virtual void SetUp() {
+    // Only run test on supported Windows versions
+    if (!is_os_supported()) {
+      GTEST_SKIP() << "OS not supported";
+    }
+
+    void* vmr_mem = os::malloc(sizeof(ZVirtualMemoryManager), mtTest);
+    _vmm = ::new (vmr_mem) ZVirtualMemoryManager(ReservationSize);
+    _va = &_vmm->_manager;
+  }
+
+  virtual void TearDown() {
+    if (!is_os_supported()) {
+      // Test skipped, nothing to cleanup
+      return;
+    }
+
+    // Best-effort cleanup
+    _vmm->unreserve_all();
+    _vmm->~ZVirtualMemoryManager();
+    os::free(_vmm);
+  }
+
+  void test_reserve_discontiguous_and_coalesce() {
+    // Start by ensuring that we have 3 unreserved granules, and then let the
+    // fourth granule be pre-reserved and therefore blocking subsequent requests
+    // to reserve memory.
+    //
+    // +----+----+----+----+
+    //                -----  pre-reserved - to block contiguous reservation
+    // ---------------       unreserved   - to allow reservation of 3 granules
+    //
+    // If we then asks for 4 granules starting at the first granule above,
+    // then we won't be able to allocate 4 consecutive granules and the code
+    // reverts into the discontiguous mode. This mode uses interval halving
+    // to find the limits of memory areas that have already been reserved.
+    // This will lead to the first 2 granules being reserved, then the third
+    // granule will be reserved.
+    //
+    // The problem we had with this is that this would yield two separate
+    // placeholder reservations, even though they are adjacent. The callbacks
+    // are supposed to fix that by coalescing the placeholders, *but* the
+    // callbacks used to be only turned on *after* the reservation call. So,
+    // we end up with one 3 granule large memory area in the manager, which
+    // unexpectedly was covered by two placeholders (instead of the expected
+    // one placeholder).
+    //
+    // Later when the callbacks had been installed and we tried to fetch memory
+    // from the manager, the callbacks would try to split off the placeholder
+    // to separate the fetched memory from the memory left in the manager. This
+    // used to fail because the memory was already split into two placeholders.
+
+    if (_vmm->reserved() < 4 * ZGranuleSize || !_va->free_is_contiguous()) {
+      GTEST_SKIP() << "Fixture fail to reserve adequate memory, reserved "
+          << (_vmm->reserved() >> ZGranuleSizeShift) << " * ZGranuleSize";
+    }
+
+    // Start at the offset we reserved.
+    const zoffset base_offset = _vmm->lowest_available_address();
+
+    // Empty the reserved memory in preparation for the rest of the test.
+    _vmm->unreserve_all();
+
+    const zaddress_unsafe base = ZOffset::address_unsafe(base_offset);
+    const zaddress_unsafe blocked = base + 3 * ZGranuleSize;
+
+    // Reserve the memory that is acting as a blocking reservation.
+    {
+      char* const result = os::attempt_reserve_memory_at((char*)untype(blocked), ZGranuleSize, !ExecMem, mtTest);
+      if (uintptr_t(result) != untype(blocked)) {
+        GTEST_SKIP() << "Failed to reserve requested memory at " << untype(blocked);
+      }
+    }
+
+    {
+      // This ends up reserving 2 granules and then 1 granule adjacent to the
+      // first. In previous implementations this resulted in two separate
+      // placeholders (4MB and 2MB). This was a bug, because the manager is
+      // designed to have one placeholder per memory area. This in turn would
+      // lead to a subsequent failure when _vmm->alloc tried to split off the
+      // 4MB that is already covered by its own placeholder. You can't place
+      // a placeholder over an already existing placeholder.
+
+      // To reproduce this, the test needed to mimic the initializing memory
+      // reservation code which had the placeholders turned off. This was done
+      // with this helper:
+      //
+      // ZCallbacksResetter resetter(&_va->_callbacks);
+      //
+      // After the fix, we always have the callbacks turned on, so we don't
+      // need this to mimic the initializing memory reservation.
+
+      const size_t reserved = _vmm->reserve_discontiguous(base_offset, 4 * ZGranuleSize, ZGranuleSize);
+      ASSERT_LE(reserved, 3 * ZGranuleSize);
+      if (reserved < 3 * ZGranuleSize) {
+        GTEST_SKIP() << "Failed reserve_discontiguous"
+            ", expected 3 * ZGranuleSize, got " << (reserved >> ZGranuleSizeShift)
+            << " * ZGranuleSize";
+      }
+    }
+
+    {
+      // The test used to crash here because the 3 granule memory area was
+      // inadvertently covered by two place holders (2 granules + 1 granule).
+      const ZVirtualMemory vmem = _vmm->alloc(2 * ZGranuleSize, true);
+      ASSERT_EQ(vmem.start(), base_offset);
+      ASSERT_EQ(vmem.size(), 2 * ZGranuleSize);
+
+      // Cleanup - Must happen in granule-sizes because of how Windows hands
+      // out memory in granule-sized placeholder reservations.
+      _vmm->unreserve(base_offset, ZGranuleSize);
+      _vmm->unreserve(base_offset + ZGranuleSize, ZGranuleSize);
+    }
+
+    // Final cleanup
+    const ZVirtualMemory vmem = _vmm->alloc(ZGranuleSize, true);
+    ASSERT_EQ(vmem.start(), base_offset + 2 * ZGranuleSize);
+    ASSERT_EQ(vmem.size(), ZGranuleSize);
+    _vmm->unreserve(vmem.start(), vmem.size());
+
+    const bool released = os::release_memory((char*)untype(blocked), ZGranuleSize);
+    ASSERT_TRUE(released);
+  }
+
+  void test_alloc_low_address() {
+    // Verify that we get placeholder for first granule
+    zoffset bottom = _va->alloc_low_address(ZGranuleSize);
+    ASSERT_ALLOC_OK(bottom);
+
+    _va->free(bottom, ZGranuleSize);
+
+    // Alloc something larger than a granule and free it
+    bottom = _va->alloc_low_address(ZGranuleSize * 3);
+    ASSERT_ALLOC_OK(bottom);
+
+    _va->free(bottom, ZGranuleSize * 3);
+
+    // Free with more memory allocated
+    bottom = _va->alloc_low_address(ZGranuleSize);
+    ASSERT_ALLOC_OK(bottom);
+
+    zoffset next = _va->alloc_low_address(ZGranuleSize);
+    ASSERT_ALLOC_OK(next);
+
+    _va->free(bottom, ZGranuleSize);
+    _va->free(next, ZGranuleSize);
+  }
+
+  void test_alloc_high_address() {
+    // Verify that we get placeholder for last granule
+    zoffset high = _va->alloc_high_address(ZGranuleSize);
+    ASSERT_ALLOC_OK(high);
+
+    zoffset prev = _va->alloc_high_address(ZGranuleSize);
+    ASSERT_ALLOC_OK(prev);
+
+    _va->free(high, ZGranuleSize);
+    _va->free(prev, ZGranuleSize);
+
+    // Alloc something larger than a granule and return it
+    high = _va->alloc_high_address(ZGranuleSize * 2);
+    ASSERT_ALLOC_OK(high);
+
+    _va->free(high, ZGranuleSize * 2);
+  }
+
+  void test_alloc_whole_area() {
+    // Alloc the whole reservation
+    zoffset bottom = _va->alloc_low_address(ReservationSize);
+    ASSERT_ALLOC_OK(bottom);
+
+    // Free two chunks and then allocate them again
+    _va->free(bottom, ZGranuleSize * 4);
+    _va->free(bottom + ZGranuleSize * 6, ZGranuleSize * 6);
+
+    zoffset offset = _va->alloc_low_address(ZGranuleSize * 4);
+    ASSERT_ALLOC_OK(offset);
+
+    offset = _va->alloc_low_address(ZGranuleSize * 6);
+    ASSERT_ALLOC_OK(offset);
+
+    // Now free it all, and verify it can be re-allocated
+    _va->free(bottom, ReservationSize);
+
+    bottom = _va->alloc_low_address(ReservationSize);
+    ASSERT_ALLOC_OK(bottom);
+
+    _va->free(bottom, ReservationSize);
+  }
+};
+
+TEST_VM_F(ZVirtualMemoryManagerTest, test_reserve_discontiguous_and_coalesce) {
+  test_reserve_discontiguous_and_coalesce();
+}
+
+TEST_VM_F(ZVirtualMemoryManagerTest, test_alloc_low_address) {
+  test_alloc_low_address();
+}
+
+TEST_VM_F(ZVirtualMemoryManagerTest, test_alloc_high_address) {
+  test_alloc_high_address();
+}
+
+TEST_VM_F(ZVirtualMemoryManagerTest, test_alloc_whole_area) {
+  test_alloc_whole_area();
+}

--- a/test/hotspot/gtest/gc/z/test_zVirtualMemoryManager.cpp
+++ b/test/hotspot/gtest/gc/z/test_zVirtualMemoryManager.cpp
@@ -114,7 +114,7 @@ public:
     // used to fail because the memory was already split into two placeholders.
 
     if (_vmm->reserved() < 4 * ZGranuleSize || !_va->free_is_contiguous()) {
-      GTEST_SKIP() << "Fixture fail to reserve adequate memory, reserved "
+      GTEST_SKIP() << "Fixture failed to reserve adequate memory, reserved "
           << (_vmm->reserved() >> ZGranuleSizeShift) << " * ZGranuleSize";
     }
 
@@ -186,7 +186,7 @@ public:
   }
 
   void test_alloc_low_address() {
-    // Verify that we get placeholder for first granule
+    // Verify that we get a placeholder for the first granule
     zoffset bottom = _va->alloc_low_address(ZGranuleSize);
     ASSERT_ALLOC_OK(bottom);
 
@@ -210,7 +210,7 @@ public:
   }
 
   void test_alloc_high_address() {
-    // Verify that we get placeholder for last granule
+    // Verify that we get a placeholder for the last granule
     zoffset high = _va->alloc_high_address(ZGranuleSize);
     ASSERT_ALLOC_OK(high);
 

--- a/test/hotspot/gtest/gc/z/zunittest.hpp
+++ b/test/hotspot/gtest/gc/z/zunittest.hpp
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#ifndef ZUNITTEST_HPP
+#define ZUNITTEST_HPP
+
+#include "gc/z/zAddress.hpp"
+#include "gc/z/zArguments.hpp"
+#include "gc/z/zInitialize.hpp"
+#include "unittest.hpp"
+
+class ZAddressOffsetMaxSetter {
+  friend class ZTest;
+
+private:
+  size_t _old_max;
+  size_t _old_mask;
+
+public:
+  ZAddressOffsetMaxSetter(size_t zaddress_offset_max)
+    : _old_max(ZAddressOffsetMax),
+      _old_mask(ZAddressOffsetMask) {
+    ZAddressOffsetMax = zaddress_offset_max;
+    ZAddressOffsetMask = ZAddressOffsetMax - 1;
+  }
+  ~ZAddressOffsetMaxSetter() {
+    ZAddressOffsetMax = _old_max;
+    ZAddressOffsetMask = _old_mask;
+  }
+};
+
+class ZTest : public testing::Test {
+private:
+  ZAddressOffsetMaxSetter _zaddress_offset_max_setter;
+
+protected:
+  ZTest()
+    : _zaddress_offset_max_setter(ZAddressOffsetMax) {
+    if (!is_os_supported()) {
+      // If the OS does not support ZGC do not run initialization, as it may crash the VM.
+      return;
+    }
+
+    // Initialize ZGC subsystems for gtests, may only be called once per process.
+    static bool runs_once = [&]() {
+      ZInitialize::pd_initialize();
+      ZGlobalsPointers::initialize();
+
+      // ZGlobalsPointers::initialize() sets ZAddressOffsetMax, make sure the
+      // first test fixture invocation has a correct ZAddressOffsetMaxSetter.
+      _zaddress_offset_max_setter._old_max = ZAddressOffsetMax;
+      _zaddress_offset_max_setter._old_mask = ZAddressOffsetMask;
+      return true;
+    }();
+  }
+
+  bool is_os_supported() {
+    return ZArguments::is_os_supported();
+  }
+};
+
+#endif // ZUNITTEST_HPP


### PR DESCRIPTION
While working on [JDK-8350441](https://bugs.openjdk.org/browse/JDK-8350441) I realized that the current Windows implementation to use placeholders for reservations are broken if we ever fallback to using the part that performs discontiguous heap reservation.

To understand this bug you first need to understand how and why we use the placeholder mechanism. From zMapper_windows.cpp:

```
// Memory reservation, commit, views, and placeholders.
//
// To be able to up-front reserve address space for the heap views, and later
// multi-map the heap views to the same physical memory, without ever losing the
// reservation of the reserved address space, we use "placeholders".
//
// These placeholders block out the address space from being used by other parts
// of the process. To commit memory in this address space, the placeholder must
// be replaced by anonymous memory, or replaced by mapping a view against a
// paging file mapping. We use the later to support multi-mapping.
//
// We want to be able to dynamically commit and uncommit the physical memory of
// the heap (and also unmap ZPages), in granules of ZGranuleSize bytes. There is
// no way to grow and shrink the committed memory of a paging file mapping.
// Therefore, we create multiple granule-sized page file mappings. The memory is
// committed by creating a page file mapping, map a view against it, commit the
// memory, unmap the view. The memory will stay committed until all views are
// unmapped, and the paging file mapping handle is closed.
//
// When replacing a placeholder address space reservation with a mapped view
// against a paging file mapping, the virtual address space must exactly match
// an existing placeholder's address and size. Therefore we only deal with
// granule-sized placeholders at this layer. Higher layers that keep track of
// reserved available address space can (and will) coalesce placeholders, but
// they will be split before being used.
```
And the way we implement this is through the callbacks in zVirtualMemory_windows.cpp:

```
// Each reserved virtual memory address area registered in _manager is
// exactly covered by a single placeholder. Callbacks are installed so
// that whenever a memory area changes, the corresponding placeholder
// is adjusted.
//
// The create and grow callbacks are called when virtual memory is
// returned to the memory manager. The new memory area is then covered
// by a new single placeholder.
//
// The destroy and shrink callbacks are called when virtual memory is
// allocated from the memory manager. The memory area is then is split
// into granule-sized placeholders.
//
// See comment in zMapper_windows.cpp explaining why placeholders are
// split into ZGranuleSize sized placeholders.
```
So, we have the expectation that all memory areas in the memory manager should be covered by exactly one placeholder. We implement that by having the callbacks disabled while we initialize the reserved memory for the heap. This works as long as we get a contiguous memory reservation, and the code has various mechanisms to really try to get contiguous memory for the heap. However, if all those attempts fail, we have a fallback to reserve discontiguous memory. That mode uses interval halving to reserve exactly around the memory that is blocking use from getting a contiguous memory reservation. An example of this would be a request to reserve four "granules" (2MB), but the forth granule is already reserved:

```
+--A--+--B--+--C--+--D--+
                     ^ D is pre-reserved
```
After failing to reserve the four granules (A, B, C, D), the code will split the range into two halves (A, B) and (C, D), and try to reserve them individually. It will succeed to reserve (A, B) but not (C, D). So, the code registers (A, B) and proceeds to split (C, D) into two parts (C) and (D), and try to reserve them individually. It will succeed with (C) but fail with (D). So, the code registers (C). When (C) is registered, the code sees that (A, B) and (C) are adjacent and fuse them into one region (A, B, C). The problem is that we don't have any callbacks to also fuse the placeholders, so we are left with reservation placeholders over (A, B) and (C). Later one, when we want to use use (A, B) for the heap, the code works under the impression that we have on single placeholder over (A, B, C), so it tries to split that memory are into two placeholders (A, B) and (C). This fails with a fatal error, because Windows will refuse make this split since we already have split the placeholder.

The proposal to fix this is to first enable callbacks from the start, before the initializing memory reservation calls are made. And then to change the virtual memory manager to differentiate between the two kinds of insertion (and extraction) operations we have:

1) The first insert operation happens when we "registers" new virtual memory. This is what's done during initialization of ZGC.
2) The other insert operation happens when the system "hands back" memory to the virtual memory manager.

The reason why we need to separate these to is that in (1) the memory area has one placeholder that spans the provided memory area, but in (2) we the memory area has a placeholder for every 2MB granule (as described above).

So, the patch applies the 'insert' callback for the (2) areas to convert them into looking like (1), and then they both can use the same code to insert the memory into the virtual memory manager.

An opposite mechanism is used when "handing out" memory vs de-registering memory for being unreserved. Where the "handing out" operation will perform a 'remove' callback before actually handing out the memory, ensuring that the memory is covered by 2MB placeholders.

The shrink and grow operations are relieved of their previous duties to split and coalesce the 2MB placeholders and are now only tasked with splitting memory into two placeholders and combining two placeholders into one. This is handled by the 'grow' and 'shrink' callbacks.

To be able to provoke this bug we have written a small gtest, which I think has enough comments to explain what's going on and when things used to break down. The added tests uses enough high-level operations that I also had to add the support to unreserve memory, without it verification code starts to fail.

The added unreserve code also introduces calls to NMT to register the releasing of memory. This in turn is problematic because NMT doesn't support releasing a larger memory area than what we previously registered. So, we have a similar problem that we had with the placeholders that the code isn't prepared to have adjacent memory treated as a single memory area. This is going to be fixed by the on-going rewrites to NMT, but for now I've added a workaround to release memory in 2MB chunks, which is supported by the current NMT implementation.

I've moved some of the tests in test_zMapper_windows.cpp to the new test_zVirtualMemoryManager.cpp file so that we can run these tests on other platforms as well.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8353637](https://bugs.openjdk.org/browse/JDK-8353637): ZGC: Discontiguous memory reservation is broken on Windows (**Bug** - P2)


### Reviewers
 * [Joel Sikström](https://openjdk.org/census#jsikstro) (@jsikstro - Committer)
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - **Reviewer**)
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**)

### Contributors
 * Axel Boldt-Christmas `<aboldtch@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24443/head:pull/24443` \
`$ git checkout pull/24443`

Update a local copy of the PR: \
`$ git checkout pull/24443` \
`$ git pull https://git.openjdk.org/jdk.git pull/24443/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24443`

View PR using the GUI difftool: \
`$ git pr show -t 24443`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24443.diff">https://git.openjdk.org/jdk/pull/24443.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24443#issuecomment-2778235896)
</details>
