### PR TITLE
8353649: Deprecate security permission classes for removal

### DIFF
--- a/src/java.base/share/classes/java/lang/Class.java
+++ b/src/java.base/share/classes/java/lang/Class.java
@@ -2704,6 +2704,7 @@ public final class Class<T> implements java.io.Serializable,
     private transient final ProtectionDomain protectionDomain;
 
     /** Holder for the protection domain returned when the internal domain is null */
+    @SuppressWarnings("removal")
     private static class Holder {
         private static final ProtectionDomain allPermDomain;
         static {

--- a/src/java.base/share/classes/java/security/AllPermission.java
+++ b/src/java.base/share/classes/java/security/AllPermission.java
@@ -32,7 +32,7 @@ import java.util.Enumeration;
 /**
  * The {@code AllPermission} is a permission that implies all other permissions.
  *
- * @apiNote
+ * @deprecated
  * This permission cannot be used for controlling access to resources
  * as the Security Manager is no longer supported.
  *
@@ -46,6 +46,7 @@ import java.util.Enumeration;
  * @serial exclude
  */
 
+@Deprecated(since="25", forRemoval=true)
 public final class AllPermission extends Permission {
 
     @java.io.Serial
@@ -91,6 +92,7 @@ public final class AllPermission extends Permission {
      * @return true if {@code obj} is an {@code AllPermission}, false otherwise.
      */
     @Override
+    @SuppressWarnings("removal")
     public boolean equals(Object obj) {
         return (obj instanceof AllPermission);
     }
@@ -177,6 +179,7 @@ final class AllPermissionCollection
      *                                object has been marked readonly
      */
 
+    @SuppressWarnings("removal")
     public void add(Permission permission) {
         if (! (permission instanceof AllPermission))
             throw new IllegalArgumentException("invalid permission: "+

--- a/src/java.base/share/classes/java/security/Permissions.java
+++ b/src/java.base/share/classes/java/security/Permissions.java
@@ -125,6 +125,7 @@ implements Serializable
      * @see PermissionCollection#isReadOnly()
      */
     @Override
+    @SuppressWarnings("removal")
     public void add(Permission permission) {
         if (isReadOnly())
             throw new SecurityException(
@@ -288,6 +289,7 @@ implements Serializable
      *  or {@code null} if there were no unresolved permissions of type p.
      *
      */
+    @SuppressWarnings("removal")
     private PermissionCollection getUnresolvedPermissions(Permission p)
     {
         UnresolvedPermissionCollection uc =
@@ -392,6 +394,7 @@ implements Serializable
      * permsMap field. Reads in allPermission.
      */
     @java.io.Serial
+    @SuppressWarnings("removal")
     private void readObject(ObjectInputStream in) throws IOException,
     ClassNotFoundException {
         // Don't call defaultReadObject()

--- a/src/java.base/share/classes/java/security/SecurityPermission.java
+++ b/src/java.base/share/classes/java/security/SecurityPermission.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,7 +32,7 @@ package java.security;
  * <p>
  * The target name is the name of a security configuration parameter.
  *
- * @apiNote
+ * @deprecated
  * This permission cannot be used for controlling access to resources
  * as the Security Manager is no longer supported.
  *
@@ -46,7 +46,8 @@ package java.security;
  * @author Roland Schemers
  * @since 1.2
  */
-
+ 
+@Deprecated(since="25", forRemoval=true)
 public final class SecurityPermission extends BasicPermission {
 
     @java.io.Serial

--- a/src/java.base/share/classes/java/security/UnresolvedPermission.java
+++ b/src/java.base/share/classes/java/security/UnresolvedPermission.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,8 +49,12 @@ import java.util.Objects;
  *
  * @author Roland Schemers
  * @since 1.2
+ *
+ * @deprecated This permission cannot be used for controlling access to
+ *       resources as the Security Manager is no longer supported.
  */
 
+@Deprecated(since="25", forRemoval=true)
 public final class UnresolvedPermission extends Permission
 implements java.io.Serializable
 {

--- a/src/java.base/share/classes/java/security/UnresolvedPermissionCollection.java
+++ b/src/java.base/share/classes/java/security/UnresolvedPermissionCollection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -58,6 +58,7 @@ implements java.io.Serializable
      * of the same type.
      * Not serialized; see serialization section at end of class.
      */
+    @SuppressWarnings("removal")
     private transient ConcurrentHashMap<String, List<UnresolvedPermission>> perms;
 
     /**
@@ -75,6 +76,7 @@ implements java.io.Serializable
      * @param permission the Permission object to add.
      */
     @Override
+    @SuppressWarnings("removal")
     public void add(Permission permission) {
         if (!(permission instanceof UnresolvedPermission unresolvedPermission))
             throw new IllegalArgumentException("invalid permission: "+
@@ -98,6 +100,7 @@ implements java.io.Serializable
      * get any unresolved permissions of the same type as p,
      * and return the List containing them.
      */
+    @SuppressWarnings("removal")
     List<UnresolvedPermission> getUnresolvedPermissions(Permission p) {
         return perms.get(p.getClass().getName());
     }
@@ -118,6 +121,7 @@ implements java.io.Serializable
      * @return an enumeration of all the UnresolvedPermission objects.
      */
     @Override
+    @SuppressWarnings("removal")
     public Enumeration<Permission> elements() {
         List<Permission> results =
             new ArrayList<>(); // where results are stored
@@ -156,6 +160,7 @@ implements java.io.Serializable
      * @throws IOException if an I/O error occurs
      */
     @java.io.Serial
+    @SuppressWarnings("removal")
     private void writeObject(ObjectOutputStream out) throws IOException {
         // Don't call out.defaultWriteObject()
 
@@ -189,6 +194,7 @@ implements java.io.Serializable
      * @throws ClassNotFoundException if a serialized class cannot be loaded
      */
     @java.io.Serial
+    @SuppressWarnings("removal")
     private void readObject(ObjectInputStream in) throws IOException,
     ClassNotFoundException {
         // Don't call defaultReadObject()

--- a/src/java.base/share/classes/javax/net/ssl/SSLPermission.java
+++ b/src/java.base/share/classes/javax/net/ssl/SSLPermission.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,7 +40,7 @@ import java.security.*;
  * signify a wildcard match. For example: "foo.*" and "*" signify a wildcard
  * match, while "*foo" and "a*b" do not.
  *
- * @apiNote
+ * @deprecated
  * This permission cannot be used for controlling access to resources
  * as the Security Manager is no longer supported.
  *
@@ -55,6 +55,7 @@ import java.security.*;
  * @author Roland Schemers
  */
 
+@Deprecated(since="25", forRemoval=true)
 public final class SSLPermission extends BasicPermission {
 
     @java.io.Serial

--- a/src/java.base/share/classes/javax/security/auth/AuthPermission.java
+++ b/src/java.base/share/classes/javax/security/auth/AuthPermission.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,12 +30,14 @@ package javax.security.auth;
  * contains a name (also referred to as a "target name") but no actions
  * list; you either have the named permission or you don't.
  *
- * @apiNote
+ * @deprecated
  * This permission cannot be used for controlling access to resources
  * as the Security Manager is no longer supported.
  *
  * @since 1.4
  */
+
+@Deprecated(since="25", forRemoval=true)
 public final class AuthPermission extends
 java.security.BasicPermission {
 

--- a/src/java.base/share/classes/javax/security/auth/PrivateCredentialPermission.java
+++ b/src/java.base/share/classes/javax/security/auth/PrivateCredentialPermission.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,12 +47,14 @@ import sun.security.util.ResourcesMgr;
  *      CredentialClass {PrincipalClass "PrincipalName"}*
  * </pre>
  *
- * @apiNote
+ * @deprecated
  * This permission cannot be used for controlling access to resources
  * as the Security Manager is no longer supported.
  *
  * @since 1.4
  */
+
+@Deprecated(since="25", forRemoval=true)
 public final class PrivateCredentialPermission extends Permission {
 
     @java.io.Serial

--- a/src/java.base/share/classes/sun/reflect/misc/MethodUtil.java
+++ b/src/java.base/share/classes/sun/reflect/misc/MethodUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -186,6 +186,7 @@ public final class MethodUtil extends SecureClassLoader {
         return defineClass(name, b, 0, b.length, cs);
     }
 
+    @SuppressWarnings("removal")
     protected PermissionCollection getPermissions(CodeSource codesource) {
         PermissionCollection perms = super.getPermissions(codesource);
         perms.add(new AllPermission());

--- a/src/java.base/share/classes/sun/security/util/SecurityConstants.java
+++ b/src/java.base/share/classes/sun/security/util/SecurityConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -59,6 +59,7 @@ public final class SecurityConstants {
     // Permission constants used in the various checkPermission() calls in JDK.
 
     // java.net.URLConnection, java.security.AllPermission
+    @SuppressWarnings("removal")
     public static final AllPermission ALL_PERMISSION = new AllPermission();
 
     public static final String PROVIDER_VER =

--- a/src/java.security.jgss/share/classes/javax/security/auth/kerberos/DelegationPermission.java
+++ b/src/java.security.jgss/share/classes/javax/security/auth/kerberos/DelegationPermission.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,13 +43,14 @@ import java.util.concurrent.ConcurrentHashMap;
  * latter service principal is specified to restrict the use of a
  * proxiable ticket.
  *
- * @apiNote
+ * @deprecated
  * This permission cannot be used for controlling access to resources
  * as the Security Manager is no longer supported.
  *
  * @since 1.4
  */
 
+@Deprecated(since="25", forRemoval=true)
 public final class DelegationPermission extends BasicPermission
     implements java.io.Serializable {
 
@@ -249,6 +250,7 @@ final class KrbDelegationPermissionCollection extends PermissionCollection
      * the collection, false if not.
      */
     @Override
+    @SuppressWarnings("removal")
     public boolean implies(Permission permission) {
         if (! (permission instanceof DelegationPermission))
             return false;
@@ -270,6 +272,7 @@ final class KrbDelegationPermissionCollection extends PermissionCollection
      *                                has been marked readonly
      */
     @Override
+    @SuppressWarnings("removal")
     public void add(Permission permission) {
         if (! (permission instanceof DelegationPermission))
             throw new IllegalArgumentException("invalid permission: "+

--- a/src/java.security.jgss/share/classes/javax/security/auth/kerberos/ServicePermission.java
+++ b/src/java.security.jgss/share/classes/javax/security/auth/kerberos/ServicePermission.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -54,13 +54,14 @@ import java.util.concurrent.ConcurrentHashMap;
  *                            principal.
  * </pre>
  *
- * @apiNote
+ * @deprecated
  * This permission cannot be used for controlling access to resources
  * as the Security Manager is no longer supported.
  *
  * @since 1.4
  */
 
+@Deprecated(since="25", forRemoval=true)
 public final class ServicePermission extends Permission
     implements java.io.Serializable {
 
@@ -433,6 +434,7 @@ final class KrbServicePermissionCollection extends PermissionCollection
      * the collection, false if not.
      */
     @Override
+    @SuppressWarnings("removal")
     public boolean implies(Permission permission) {
         if (! (permission instanceof ServicePermission np))
             return false;
@@ -480,6 +482,7 @@ final class KrbServicePermissionCollection extends PermissionCollection
      *                                has been marked readonly
      */
     @Override
+    @SuppressWarnings("removal")
     public void add(Permission permission) {
         if (! (permission instanceof ServicePermission sp))
             throw new IllegalArgumentException("invalid permission: "+

--- a/src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/utils/JavaUtils.java
+++ b/src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/utils/JavaUtils.java
@@ -39,6 +39,7 @@ public final class JavaUtils {
     private static final com.sun.org.slf4j.internal.Logger LOG =
         com.sun.org.slf4j.internal.LoggerFactory.getLogger(JavaUtils.class);
 
+    @SuppressWarnings("removal")
     private static final SecurityPermission REGISTER_PERMISSION =
         new SecurityPermission("com.sun.org.apache.xml.internal.security.register");
 

--- a/src/jdk.security.jgss/share/classes/com/sun/security/jgss/InquireSecContextPermission.java
+++ b/src/jdk.security.jgss/share/classes/com/sun/security/jgss/InquireSecContextPermission.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,12 +32,14 @@ import java.security.BasicPermission;
  *
  * <p>The target name is the {@link InquireType} allowed.
  *
- * @apiNote
+ * @deprecated
  * This permission cannot be used for controlling access to resources
  * as the Security Manager is no longer supported.
  *
  * @since 1.7
  */
+
+@Deprecated(since="25", forRemoval=true)
 public final class InquireSecContextPermission extends BasicPermission {
     private static final long serialVersionUID = -7131173349668647297L;
 


### PR DESCRIPTION
The following security related permission classes will be deprecated for removal: `java.security.AllPermission`, `java.security.UnresolvedPermission`, `javax.net.ssl.SSLPermission`, `javax.security.auth.AuthPermission`, `javax.security.auth.PrivateCredentialPermission`, `javax.security.auth.kerberos.DelegationPermission`, `javax.security.auth.kerberos.ServicePermission`, `com.sun.security.jgss.InquireSecContextPermission`. These classes were only useful in conjunction with the Security Manager, which is no longer supported.

Release Note: https://bugs.openjdk.org/browse/JDK-8353680