### PR TITLE
8311227: Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+root = true
+
+[*.{cpp,hpp,c,h,java,cc,hh,m,mm,S,md,properties,gmk,m4,ac}]
+trim_trailing_whitespace = true
+
+[Makefile]
+trim_trailing_whitespace = true

--- a/src/hotspot/.editorconfig
+++ b/src/hotspot/.editorconfig
@@ -1,0 +1,3 @@
+[*.{cpp,hpp,c,h}]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
Alternative to https://github.com/openjdk/jdk/pull/23693 for implementing JDK-8311227.

This `.editorconfig` file is a 1-to-1 conversion of the checks done by jcheck into .editorconfig format. I believe that is a better way to introduce an `.editorconfig` file into the existing JDK project.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8311227](https://bugs.openjdk.org/browse/JDK-8311227): Add .editorconfig (**Enhancement** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewers without OpenJDK IDs
 * @dbriemann (no known openjdk.org user name / role)

### Contributors
 * David Briemann `<david@briemann.com>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24448/head:pull/24448` \
`$ git checkout pull/24448`

Update a local copy of the PR: \
`$ git checkout pull/24448` \
`$ git pull https://git.openjdk.org/jdk.git pull/24448/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24448`

View PR using the GUI difftool: \
`$ git pr show -t 24448`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24448.diff">https://git.openjdk.org/jdk/pull/24448.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24448#issuecomment-2778822509)
</details>
