### PR TITLE
8300339: Run jtreg in the work dir

### DIFF
--- a/make/RunTests.gmk
+++ b/make/RunTests.gmk
@@ -995,24 +995,26 @@ define SetupRunJtregTestBody
 	$$(RM) -r $$($1_TEST_SUPPORT_DIR)
 	$$(RM) -r $$($1_TEST_RESULTS_DIR)
 
+  $1_JTREG_ARGUMENTS := \
+      $$($1_JTREG_LAUNCHER_OPTIONS) \
+      -Dprogram=jtreg -jar $$(JT_HOME)/lib/jtreg.jar \
+      $$($1_JTREG_BASIC_OPTIONS) \
+      -testjdk:$$(JDK_UNDER_TEST) \
+      -dir:$$(JTREG_TOPDIR) \
+      -reportDir:$$($1_TEST_RESULTS_DIR) \
+      -workDir:$$($1_TEST_SUPPORT_DIR) \
+      -report:$${JTREG_REPORT} \
+      $$$${JTREG_STATUS} \
+      $$(JTREG_OPTIONS) \
+      $$(JTREG_FAILURE_HANDLER_OPTIONS) \
+      $$(JTREG_COV_OPTIONS) \
+      $$($1_TEST_NAME) \
+      #
+
   $1_COMMAND_LINE := \
-      cd $$($1_TEST_SUPPORT_DIR) && $$(JTREG_JAVA) \
-          $$($1_JTREG_LAUNCHER_OPTIONS) \
-          -Dprogram=jtreg -jar $$(JT_HOME)/lib/jtreg.jar \
-          $$($1_JTREG_BASIC_OPTIONS) \
-          -testjdk:$$(JDK_UNDER_TEST) \
-          -dir:$$(JTREG_TOPDIR) \
-          -reportDir:$$($1_TEST_RESULTS_DIR) \
-          -workDir:$$($1_TEST_SUPPORT_DIR) \
-          -report:$${JTREG_REPORT} \
-          $$$${JTREG_STATUS} \
-          $$(JTREG_OPTIONS) \
-          $$(JTREG_FAILURE_HANDLER_OPTIONS) \
-          $$(JTREG_COV_OPTIONS) \
-          $$($1_TEST_NAME) \
+      cd $$($1_TEST_SUPPORT_DIR) && $$(JTREG_JAVA) $$($1_JTREG_ARGUMENTS) \
       && $$(ECHO) $$$$? > $$($1_EXITCODE) \
       || $$(ECHO) $$$$? > $$($1_EXITCODE)
-
 
   ifneq ($$(JTREG_RETRY_COUNT), 0)
     $1_COMMAND_LINE := \

--- a/make/RunTests.gmk
+++ b/make/RunTests.gmk
@@ -997,7 +997,7 @@ define SetupRunJtregTestBody
 
   $1_COMMAND_LINE := \
       cd $$($1_TEST_SUPPORT_DIR) && $$(JTREG_JAVA) \
-      $$($1_JTREG_LAUNCHER_OPTIONS) \
+          $$($1_JTREG_LAUNCHER_OPTIONS) \
           -Dprogram=jtreg -jar $$(JT_HOME)/lib/jtreg.jar \
           $$($1_JTREG_BASIC_OPTIONS) \
           -testjdk:$$(JDK_UNDER_TEST) \

--- a/make/RunTests.gmk
+++ b/make/RunTests.gmk
@@ -996,7 +996,8 @@ define SetupRunJtregTestBody
 	$$(RM) -r $$($1_TEST_RESULTS_DIR)
 
   $1_COMMAND_LINE := \
-      $$(JTREG_JAVA) $$($1_JTREG_LAUNCHER_OPTIONS) \
+      cd $$($1_TEST_SUPPORT_DIR) && $$(JTREG_JAVA) \
+      $$($1_JTREG_LAUNCHER_OPTIONS) \
           -Dprogram=jtreg -jar $$(JT_HOME)/lib/jtreg.jar \
           $$($1_JTREG_BASIC_OPTIONS) \
           -testjdk:$$(JDK_UNDER_TEST) \


### PR DESCRIPTION
We had a test setup failure in our distributed test system where the process running jtreg crashed. This caused the hs_err file to end up in the root of the source tree. Dropping crash files in the source tree is bad practice and makes it harder to find such files. We should change the current working directory to the work/output dir before launching jtreg to help avoid this situation in the future.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300339](https://bugs.openjdk.org/browse/JDK-8300339): Run jtreg in the work dir (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24452/head:pull/24452` \
`$ git checkout pull/24452`

Update a local copy of the PR: \
`$ git checkout pull/24452` \
`$ git pull https://git.openjdk.org/jdk.git pull/24452/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24452`

View PR using the GUI difftool: \
`$ git pr show -t 24452`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24452.diff">https://git.openjdk.org/jdk/pull/24452.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24452#issuecomment-2779158783)
</details>
