### PR TITLE
JDK-8353201 : Open source Swing Tooltip tests - Set 2

### DIFF
--- a/test/jdk/javax/swing/ToolTipManager/bug4250178.java
+++ b/test/jdk/javax/swing/ToolTipManager/bug4250178.java
@@ -58,8 +58,8 @@ public class bug4250178 {
         JButton button = new JButton("Button");
         button.setToolTipText("ToolTip");
         ToolTipManager.sharedInstance().setLightWeightPopupEnabled(true);
-        fr.getContentPane().add(button);
-        fr.pack();
+        fr.add(button);
+        fr.setSize(250, 100);
         return fr;
     }
 }

--- a/test/jdk/javax/swing/ToolTipManager/bug4250178.java
+++ b/test/jdk/javax/swing/ToolTipManager/bug4250178.java
@@ -21,7 +21,8 @@
  * questions.
  */
 
-/* @test
+/*
+ * @test
  * @bug 4250178
  * @summary Tooltip in incorrect location on ToolBar
  * @library /java/awt/regtesthelpers

--- a/test/jdk/javax/swing/ToolTipManager/bug4250178.java
+++ b/test/jdk/javax/swing/ToolTipManager/bug4250178.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @bug 4250178
+ * @summary Tooltip in incorrect location on ToolBar
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual bug4250178
+ */
+
+import javax.swing.JButton;
+import javax.swing.JFrame;
+import javax.swing.ToolTipManager;
+
+public class bug4250178 {
+    private static final String INSTRUCTIONS = """
+        Click somewhere in the test UI frame to make it focused.
+        Move mouse to the bottom right corner of the button in this frame
+        and wait until tooltip appears.
+
+        If the tooltip fits into the frame OR partially covered by the mouse
+        cursor then test fails. Otherwise test passes.
+        """;
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                .title("Test Instructions")
+                .instructions(INSTRUCTIONS)
+                .columns(35)
+                .testUI(bug4250178::createAndShowUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static JFrame createAndShowUI() {
+        JFrame fr = new JFrame("bug4250178");
+        JButton button = new JButton("Button");
+        button.setToolTipText("ToolTip");
+        ToolTipManager.sharedInstance().setLightWeightPopupEnabled(true);
+        fr.getContentPane().add(button);
+        fr.pack();
+        return fr;
+    }
+}

--- a/test/jdk/javax/swing/ToolTipManager/bug4294808.java
+++ b/test/jdk/javax/swing/ToolTipManager/bug4294808.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4294808
+ * @summary Tooltip blinking.
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual bug4294808
+ */
+
+import java.awt.Dimension;
+import javax.swing.JButton;
+import javax.swing.JComponent;
+
+public class bug4294808 {
+    private static final String INSTRUCTIONS = """
+        Move mouse cursor to the button named "Tooltip Button"
+        at the bottom of the instruction window and wait until
+        tooltip has appeared.
+
+        If tooltip appears and eventually disappears without
+        rapid blinking then press PASS else FAIL.
+        """;
+
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                .title("bug4294808 Test Instructions")
+                .instructions(INSTRUCTIONS)
+                .columns(35)
+                .splitUIBottom(bug4294808::createAndShowUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static JComponent createAndShowUI() {
+        JButton bt = new JButton("Tooltip Button");
+        bt.setToolTipText("Long tooltip text here");
+        bt.setPreferredSize(new Dimension(200, 60));
+        return bt;
+    }
+}

--- a/test/jdk/javax/swing/ToolTipManager/bug6178004.java
+++ b/test/jdk/javax/swing/ToolTipManager/bug6178004.java
@@ -52,21 +52,20 @@ public class bug6178004 {
     private static final int SIZE = 300;
 
     private static final String INSTRUCTIONS = """
-            You can change Look And Feel using the menu "LaF"
-            for Windows, Metal or Motif LaF:
+            You can change Look And Feel using the menu "Change LaF".
 
             Make sure that Frame2 or instruction window is active.
             Move mouse over the button inside "Frame 1".
             If tooltip is NOT shown or Frame 1 jumped on top of
             the Frame2, press FAIL.
 
-            For LaFs other than Motif/GTK/Nimbus:
+            For Metal/Windows LaF:
             Tooltips are shown only if one of the frames (or the instruction
             window) is active. To test it click on any other application to
             make frames and instruction window inactive and then verify that
             tooltips are not shown any more.
 
-            For Motif/GTK/Nimbus LaF:
+            For Motif/GTK/Nimbus/Aqua LaF:
             Tooltips should be shown for all frames irrespective of whether
             the application is active or inactive.
 

--- a/test/jdk/javax/swing/ToolTipManager/bug6178004.java
+++ b/test/jdk/javax/swing/ToolTipManager/bug6178004.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2006, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4148057 6178004
+ * @summary REGRESSION: setToolTipText does not work if the
+ *          component is not focused
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual bug6178004
+ */
+
+import java.awt.Point;
+import java.awt.Window;
+import java.awt.event.MouseEvent;
+import java.util.List;
+import javax.swing.ButtonGroup;
+import javax.swing.JButton;
+import javax.swing.JCheckBoxMenuItem;
+import javax.swing.JFrame;
+import javax.swing.JMenu;
+import javax.swing.JMenuBar;
+import javax.swing.LookAndFeel;
+import javax.swing.SwingUtilities;
+import javax.swing.ToolTipManager;
+import javax.swing.UIManager;
+
+public class bug6178004 {
+    private static JFrame frame1;
+    private static JFrame frame2;
+    private static final int SIZE = 300;
+
+    private static final String INSTRUCTIONS = """
+            You can change Look And Feel using the menu "LaF"
+            for Windows, Metal or Motif LaF:
+
+            Make sure that Frame2 or instruction window is active.
+            Move mouse over the button inside "Frame 1".
+            If tooltip is NOT shown or Frame 1 jumped on top of
+            the Frame2, press FAIL.
+
+            For LaFs other than Motif/GTK/Nimbus:
+            Tooltips are shown only if one of the frames (or the instruction
+            window) is active. To test it click on any other application to
+            make frames and instruction window inactive and then verify that
+            tooltips are not shown any more.
+
+            For Motif/GTK/Nimbus LaF:
+            Tooltips should be shown for all frames irrespective of whether
+            the application is active or inactive.
+
+            Note: Tooltip for Frame1 is always shown at the top-left corner.
+            Tooltips could be shown partly covered by another frame.
+
+            If above is true press PASS else FAIL.
+            """;
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                .title("bug6178004 Test Instructions")
+                .instructions(INSTRUCTIONS)
+                .testTimeOut(10)
+                .columns(40)
+                .testUI(createAndShowUI())
+                .positionTestUI(bug6178004::positionTestWindows)
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static List<Window> createAndShowUI() {
+        ToolTipManager.sharedInstance().setInitialDelay(0);
+
+        frame1 = new JFrame("bug6178004 Frame1");
+        frame1.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+        JButton button = new JButton("Test") {
+            public Point getToolTipLocation(MouseEvent event) {
+                return new Point(10, 10);
+            }
+        };
+        button.setToolTipText("Tooltip-1");
+        frame1.add(button);
+        frame1.setSize(SIZE, SIZE);
+
+        frame2 = new JFrame("bug6178004 Frame2");
+        frame2.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+        JButton button2 = new JButton("Click me") ;
+        button2.setToolTipText("Tooltip-2");
+        frame2.add(button2);
+        frame2.setSize(SIZE, SIZE);
+
+        JMenuBar bar = new JMenuBar();
+        JMenu lafMenu = new JMenu("Change LaF");
+        ButtonGroup lafGroup = new ButtonGroup();
+
+        LookAndFeel currentLaf = UIManager.getLookAndFeel();
+        UIManager.LookAndFeelInfo[] lafs = UIManager.getInstalledLookAndFeels();
+        for (final UIManager.LookAndFeelInfo lafInfo : lafs) {
+            JCheckBoxMenuItem lafItem = new JCheckBoxMenuItem(lafInfo.getName());
+            lafItem.addActionListener(e -> setLaF(lafInfo.getClassName()));
+            if (lafInfo.getClassName().equals(currentLaf.getClass().getName())) {
+                lafItem.setSelected(true);
+            }
+
+            lafGroup.add(lafItem);
+            lafMenu.add(lafItem);
+        }
+
+        bar.add(lafMenu);
+        frame2.setJMenuBar(bar);
+        return List.of(frame1, frame2);
+    }
+
+    private static void setLaF(String laf) {
+        try {
+            UIManager.setLookAndFeel(laf);
+            SwingUtilities.updateComponentTreeUI(frame1);
+            SwingUtilities.updateComponentTreeUI(frame2);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    // custom window layout required for this test
+    private static void positionTestWindows(List<? extends Window> testWindows,
+                                            PassFailJFrame.InstructionUI instructionUI) {
+        int gap = 5;
+        int x = instructionUI.getLocation().x + instructionUI.getSize().width + gap;
+        // the two test frames need to overlap for this test
+        testWindows.get(0).setLocation(x, instructionUI.getLocation().y);
+        testWindows.get(1).setLocation((x + SIZE / 2), instructionUI.getLocation().y);
+    }
+}


### PR DESCRIPTION
Open sourced the following ToolTipManager tests-

- javax/swing/ToolTipManager/bug4250178.java
- javax/swing/ToolTipManager/bug4294808.java
- javax/swing/ToolTipManager/bug6178004.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8353201](https://bugs.openjdk.org/browse/JDK-8353201): Open source Swing Tooltip tests - Set 2 (**Bug** - P4)


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**) Review applies to [52a23bd7](https://git.openjdk.org/jdk/pull/24453/files/52a23bd76a4793d9a4ed8bfb5769f10699c906d1)
 * [Damon Nguyen](https://openjdk.org/census#dnguyen) (@DamonGuy - Committer)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24453/head:pull/24453` \
`$ git checkout pull/24453`

Update a local copy of the PR: \
`$ git checkout pull/24453` \
`$ git pull https://git.openjdk.org/jdk.git pull/24453/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24453`

View PR using the GUI difftool: \
`$ git pr show -t 24453`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24453.diff">https://git.openjdk.org/jdk/pull/24453.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24453#issuecomment-2779398729)
</details>
