### PR TITLE
8353475: Open source two Swing DefaultCaret tests

### DIFF
--- a/test/jdk/javax/swing/text/DefaultCaret/PaintTest.java
+++ b/test/jdk/javax/swing/text/DefaultCaret/PaintTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 4785160
+ * @bug 4193062
  * @summary Tests that when a TextField first gets focus, if modelToView fails
  *          (null is returned) that the caret will start to blink again.
  * @library /java/awt/regtesthelpers

--- a/test/jdk/javax/swing/text/DefaultCaret/PaintTest.java
+++ b/test/jdk/javax/swing/text/DefaultCaret/PaintTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4785160
+ * @summary Tests that when a TextField first gets focus, if modelToView fails
+ *          (null is returned) that the caret will start to blink again.
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual PaintTest
+*/
+
+import java.awt.FlowLayout;
+import javax.swing.JFrame;
+import javax.swing.JTextField;
+
+public class PaintTest {
+
+    static final String INSTRUCTIONS = """
+         If the test window displays with the text caret flashing (do wait at
+         least several second for it to start) the test PASSES, otherwise it FAILS.
+    """;
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+            .title("PaintTest Test Instructions")
+            .instructions(INSTRUCTIONS)
+            .columns(50)
+            .testUI(PaintTest::createUI)
+            .build()
+            .awaitAndCheck();
+    }
+
+    static JFrame createUI() {
+        JFrame frame = new JFrame("PaintTest");
+        JTextField tf = new JTextField(20);
+        frame.setLayout(new FlowLayout());
+        frame.add(tf);
+        frame.setSize(300, 300);
+        return frame;
+    }
+}

--- a/test/jdk/javax/swing/text/DefaultCaret/bug4785160.java
+++ b/test/jdk/javax/swing/text/DefaultCaret/bug4785160.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4785160
+ * @summary Test that the cursor is always visible when typing in JTextArea with JScrollBar
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual bug4785160
+*/
+
+import javax.swing.JFrame;
+import javax.swing.JScrollPane;
+import javax.swing.JTextArea;
+
+public class bug4785160 {
+
+    static final String INSTRUCTIONS = """
+         Ensure that the horizontal scrollbar is visible in the JTextArea.
+         If necessary, reduce the width of the window so that the scrollbar becomes visible.
+         Scroll all the way to the right so the end of the line is visible.
+         If necessary, move the text caret in the text area to the end of line.
+         The test PASSES if the caret is visible at the end of the line.
+         The test FAILS if the caret disappears when moved to the end of the line.
+    """;
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+            .title("bug4785160 Test Instructions")
+            .instructions(INSTRUCTIONS)
+            .columns(50)
+            .testUI(bug4785160::createUI)
+            .build()
+            .awaitAndCheck();
+    }
+
+    static JFrame createUI() {
+        JFrame frame = new JFrame("bug4785160");
+        JTextArea area = new JTextArea();
+        String s = "";
+        for (int i = 0; i < 80; i++) {
+             s += "m";
+        }
+        area.setText(s);
+        area.getCaret().setDot(area.getText().length() + 1);
+        frame.add(new JScrollPane(area));
+        frame.setSize(300, 300);
+        return frame;
+    }
+}


### PR DESCRIPTION
Open source two Swing caret related tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8353475](https://bugs.openjdk.org/browse/JDK-8353475): Open source two Swing DefaultCaret tests (**Bug** - P4)


### Reviewers
 * [Harshitha Onkar](https://openjdk.org/census#honkar) (@honkar-jdk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24455/head:pull/24455` \
`$ git checkout pull/24455`

Update a local copy of the PR: \
`$ git checkout pull/24455` \
`$ git pull https://git.openjdk.org/jdk.git pull/24455/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24455`

View PR using the GUI difftool: \
`$ git pr show -t 24455`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24455.diff">https://git.openjdk.org/jdk/pull/24455.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24455#issuecomment-2779521589)
</details>
