### PR TITLE
JDK-8353486 : Open source Swing Tests - Set 4

### DIFF
--- a/test/jdk/javax/swing/JFileChooser/bug4464774.java
+++ b/test/jdk/javax/swing/JFileChooser/bug4464774.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4464774
+ * @requires (os.family == "windows")
+ * @summary JFileChooser: selection of left-side folder buttons shown incorrectly
+            in Windows L&F
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual bug4464774
+ */
+
+import java.awt.BorderLayout;
+import java.awt.Dimension;
+import javax.swing.JButton;
+import javax.swing.JFileChooser;
+import javax.swing.JPanel;
+import javax.swing.UIManager;
+
+public class bug4464774 {
+    private static final String INSTRUCTIONS = """
+            Click on "Show JFileChooser" button below to display
+            a JFileChooser dialog.
+            Click any button from the buttons to the left
+            ("Documents", "Desktop", "My Computer" etc.) in FileChooser dialog.
+            When the button is toggled, it should be lowered and
+            should not have focus painted inside it (black dotted frame).
+
+            If the above is true, press PASS else FAIL.
+            """;
+
+    public static void main(String[] argv) throws Exception {
+        UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
+        PassFailJFrame.builder()
+                .title("JFileChooser Instructions")
+                .instructions(INSTRUCTIONS)
+                .rows(10)
+                .columns(65)
+                .splitUIBottom(bug4464774::createAndShowUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    public static JPanel createAndShowUI() {
+        JButton button = new JButton("Show JFileChooser");
+        button.addActionListener(e -> {
+            JFileChooser jfc = new JFileChooser();
+            jfc.showOpenDialog(null);
+        });
+        JPanel p = new JPanel();
+        p.setLayout(new BorderLayout());
+        p.setPreferredSize(new Dimension(200, 50));
+        p.add(button);
+        return p;
+    }
+}

--- a/test/jdk/javax/swing/JFileChooser/bug4464774.java
+++ b/test/jdk/javax/swing/JFileChooser/bug4464774.java
@@ -32,17 +32,12 @@
  * @run main/manual bug4464774
  */
 
-import java.awt.BorderLayout;
-import java.awt.Dimension;
-import javax.swing.JButton;
 import javax.swing.JFileChooser;
-import javax.swing.JPanel;
+import javax.swing.JFrame;
 import javax.swing.UIManager;
 
 public class bug4464774 {
     private static final String INSTRUCTIONS = """
-            Click on "Show JFileChooser" button below to display
-            a JFileChooser dialog.
             Click any button from the buttons to the left
             ("Documents", "Desktop", "My Computer" etc.) in FileChooser dialog.
             When the button is toggled, it should be lowered and
@@ -58,21 +53,16 @@ public class bug4464774 {
                 .instructions(INSTRUCTIONS)
                 .rows(10)
                 .columns(65)
-                .splitUIBottom(bug4464774::createAndShowUI)
+                .testUI(bug4464774::createAndShowUI)
                 .build()
                 .awaitAndCheck();
     }
 
-    public static JPanel createAndShowUI() {
-        JButton button = new JButton("Show JFileChooser");
-        button.addActionListener(e -> {
-            JFileChooser jfc = new JFileChooser();
-            jfc.showOpenDialog(null);
-        });
-        JPanel p = new JPanel();
-        p.setLayout(new BorderLayout());
-        p.setPreferredSize(new Dimension(200, 50));
-        p.add(button);
-        return p;
+    public static JFrame createAndShowUI() {
+        JFrame frame = new JFrame("JFileChooser bug4464774");
+        JFileChooser jfc = new JFileChooser();
+        frame.add(jfc);
+        frame.pack();
+        return frame;
     }
 }

--- a/test/jdk/javax/swing/JFileChooser/bug4464774.java
+++ b/test/jdk/javax/swing/JFileChooser/bug4464774.java
@@ -33,7 +33,6 @@
  */
 
 import javax.swing.JFileChooser;
-import javax.swing.JFrame;
 import javax.swing.UIManager;
 
 public class bug4464774 {
@@ -41,7 +40,7 @@ public class bug4464774 {
             Click any button from the buttons to the left
             ("Documents", "Desktop", "My Computer" etc.) in FileChooser dialog.
             When the button is toggled, it should be lowered and
-            should not have focus painted inside it (black dotted frame).
+            should NOT have focus painted inside it (black dotted frame).
 
             If the above is true, press PASS else FAIL.
             """;
@@ -49,22 +48,15 @@ public class bug4464774 {
     public static void main(String[] argv) throws Exception {
         UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
         PassFailJFrame.builder()
-                .title("JFileChooser Instructions")
                 .instructions(INSTRUCTIONS)
-                .rows(10)
                 .columns(65)
-                .testUI(bug4464774::createAndShowUI)
+                .rows(10)
+                .testUI(() -> {
+                    JFileChooser jfc = new JFileChooser();
+                    jfc.setControlButtonsAreShown(false);
+                    return jfc;
+                })
                 .build()
                 .awaitAndCheck();
-    }
-
-    public static JFrame createAndShowUI() {
-        JFileChooser jfc = new JFileChooser();
-        jfc.setControlButtonsAreShown(false);
-
-        JFrame frame = new JFrame("JFileChooser bug4464774");
-        frame.add(jfc);
-        frame.pack();
-        return frame;
     }
 }

--- a/test/jdk/javax/swing/JFileChooser/bug4464774.java
+++ b/test/jdk/javax/swing/JFileChooser/bug4464774.java
@@ -59,8 +59,10 @@ public class bug4464774 {
     }
 
     public static JFrame createAndShowUI() {
-        JFrame frame = new JFrame("JFileChooser bug4464774");
         JFileChooser jfc = new JFileChooser();
+        jfc.setControlButtonsAreShown(false);
+
+        JFrame frame = new JFrame("JFileChooser bug4464774");
         frame.add(jfc);
         frame.pack();
         return frame;

--- a/test/jdk/javax/swing/JFileChooser/bug4522756.java
+++ b/test/jdk/javax/swing/JFileChooser/bug4522756.java
@@ -44,7 +44,7 @@ public class bug4522756 {
             2. Press Desktop button. Check that you actually
                go up to the desktop.
 
-            If the above is true press PASS else FAIL.
+            If the above is true, press PASS else FAIL.
             """;
 
     public static void main(String[] args) throws Exception {

--- a/test/jdk/javax/swing/JFileChooser/bug4522756.java
+++ b/test/jdk/javax/swing/JFileChooser/bug4522756.java
@@ -25,8 +25,8 @@
  * @test
  * @bug 4522756
  * @requires (os.family == "windows")
- * @summary To verify that if for the first time JFileChooser is opened,
-            the icon for Desktop is not missing.
+ * @summary Verifies that the Desktop icon is not missing when
+            JFileChooser is opened for the first time.
  * @library /java/awt/regtesthelpers
  * @build PassFailJFrame
  * @run main/manual bug4522756

--- a/test/jdk/javax/swing/JFileChooser/bug4522756.java
+++ b/test/jdk/javax/swing/JFileChooser/bug4522756.java
@@ -61,8 +61,10 @@ public class bug4522756 {
     }
 
     public static JFrame createAndShowUI() {
-        JFrame frame = new JFrame("JFileChooser bug4522756");
         JFileChooser jfc = new JFileChooser();
+        jfc.setControlButtonsAreShown(false);
+
+        JFrame frame = new JFrame("JFileChooser bug4522756");
         frame.add(jfc);
         frame.pack();
         return frame;

--- a/test/jdk/javax/swing/JFileChooser/bug4522756.java
+++ b/test/jdk/javax/swing/JFileChooser/bug4522756.java
@@ -32,6 +32,7 @@
  */
 
 import java.awt.BorderLayout;
+import java.awt.Dimension;
 import javax.swing.JButton;
 import javax.swing.JFileChooser;
 import javax.swing.JPanel;
@@ -69,7 +70,7 @@ public class bug4522756 {
         });
         JPanel p = new JPanel();
         p.setLayout(new BorderLayout());
-        p.setSize(200, 200);
+        p.setPreferredSize(new Dimension(200, 50));
         p.add(button);
         return p;
     }

--- a/test/jdk/javax/swing/JFileChooser/bug4522756.java
+++ b/test/jdk/javax/swing/JFileChooser/bug4522756.java
@@ -33,7 +33,6 @@
  */
 
 import javax.swing.JFileChooser;
-import javax.swing.JFrame;
 import javax.swing.UIManager;
 
 public class bug4522756 {
@@ -51,22 +50,15 @@ public class bug4522756 {
     public static void main(String[] args) throws Exception {
         UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
         PassFailJFrame.builder()
-                .title("Instructions")
                 .instructions(INSTRUCTIONS)
-                .rows(12)
                 .columns(50)
-                .testUI(bug4522756::createAndShowUI)
+                .rows(12)
+                .testUI(() -> {
+                    JFileChooser jfc = new JFileChooser();
+                    jfc.setControlButtonsAreShown(false);
+                    return jfc;
+                })
                 .build()
                 .awaitAndCheck();
-    }
-
-    public static JFrame createAndShowUI() {
-        JFileChooser jfc = new JFileChooser();
-        jfc.setControlButtonsAreShown(false);
-
-        JFrame frame = new JFrame("JFileChooser bug4522756");
-        frame.add(jfc);
-        frame.pack();
-        return frame;
     }
 }

--- a/test/jdk/javax/swing/JFileChooser/bug4522756.java
+++ b/test/jdk/javax/swing/JFileChooser/bug4522756.java
@@ -21,26 +21,24 @@
  * questions.
  */
 
-/* @test
-   @bug 4522756
-   @requires (os.family == "windows")
-   @summary To verify that if for the first time JFileChooser is opened,
+/*
+ * @test
+ * @bug 4522756
+ * @requires (os.family == "windows")
+ * @summary To verify that if for the first time JFileChooser is opened,
             the icon for Desktop is not missing.
  * @library /java/awt/regtesthelpers
  * @build PassFailJFrame
  * @run main/manual bug4522756
  */
 
-import java.awt.BorderLayout;
-import java.awt.Dimension;
-import javax.swing.JButton;
 import javax.swing.JFileChooser;
-import javax.swing.JPanel;
+import javax.swing.JFrame;
 import javax.swing.UIManager;
 
 public class bug4522756 {
     private static final String INSTRUCTIONS = """
-            Click on "Show JFileChooser" button below and verify the following:
+            Verify the following:
 
             1. If Desktop icon image is present on the Desktop button
                on the left panel of JFileChooser.
@@ -57,21 +55,16 @@ public class bug4522756 {
                 .instructions(INSTRUCTIONS)
                 .rows(12)
                 .columns(50)
-                .splitUIBottom(bug4522756::createAndShowUI)
+                .testUI(bug4522756::createAndShowUI)
                 .build()
                 .awaitAndCheck();
     }
 
-    public static JPanel createAndShowUI() {
-        JButton button = new JButton("Show JFileChooser");
-        button.addActionListener(e -> {
-            JFileChooser jfc = new JFileChooser();
-            jfc.showOpenDialog(null);
-        });
-        JPanel p = new JPanel();
-        p.setLayout(new BorderLayout());
-        p.setPreferredSize(new Dimension(200, 50));
-        p.add(button);
-        return p;
+    public static JFrame createAndShowUI() {
+        JFrame frame = new JFrame("JFileChooser bug4522756");
+        JFileChooser jfc = new JFileChooser();
+        frame.add(jfc);
+        frame.pack();
+        return frame;
     }
 }

--- a/test/jdk/javax/swing/JFileChooser/bug4522756.java
+++ b/test/jdk/javax/swing/JFileChooser/bug4522756.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+   @bug 4522756
+   @requires (os.family == "windows")
+   @summary To verify that if for the first time JFileChooser is opened,
+            the icon for Desktop is not missing.
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual bug4522756
+ */
+
+import java.awt.BorderLayout;
+import javax.swing.JButton;
+import javax.swing.JFileChooser;
+import javax.swing.JPanel;
+import javax.swing.UIManager;
+
+public class bug4522756 {
+    private static final String INSTRUCTIONS = """
+            Click on "Show JFileChooser" button below and verify the following:
+
+            1. If Desktop icon image is present on the Desktop button
+               on the left panel of JFileChooser.
+            2. Press Desktop button. Check that you actually
+               go up to the desktop.
+
+            If the above is true press PASS else FAIL.
+            """;
+
+    public static void main(String[] args) throws Exception {
+        UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
+        PassFailJFrame.builder()
+                .title("Instructions")
+                .instructions(INSTRUCTIONS)
+                .rows(12)
+                .columns(50)
+                .splitUIBottom(bug4522756::createAndShowUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    public static JPanel createAndShowUI() {
+        JButton button = new JButton("Show JFileChooser");
+        button.addActionListener(e -> {
+            JFileChooser jfc = new JFileChooser();
+            jfc.showOpenDialog(null);
+        });
+        JPanel p = new JPanel();
+        p.setLayout(new BorderLayout());
+        p.setSize(200, 200);
+        p.add(button);
+        return p;
+    }
+}

--- a/test/jdk/javax/swing/JFileChooser/bug4759934.java
+++ b/test/jdk/javax/swing/JFileChooser/bug4759934.java
@@ -55,6 +55,7 @@ public class bug4759934 {
             Robot robot = new Robot();
             robot.setAutoWaitForIdle(true);
             robot.setAutoDelay(50);
+
             SwingUtilities.invokeAndWait(bug4759934::createTestUI);
             robot.waitForIdle();
             robot.delay(1000);
@@ -97,9 +98,9 @@ public class bug4759934 {
         fr = new JFrame("bug4759934 - JFrame");
 
         frameBtn = new JButton("Show Dialog");
+        frameBtn.addActionListener(e -> createDialog());
         fr.add(frameBtn);
 
-        frameBtn.addActionListener(e -> createDialog());
         fr.setSize(300, 200);
         fr.setLocationRelativeTo(null);
         fr.setVisible(true);

--- a/test/jdk/javax/swing/JFileChooser/bug4759934.java
+++ b/test/jdk/javax/swing/JFileChooser/bug4759934.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @key headful
+ * @bug 4759934
+ * @summary windows activation problem
+ * @library /javax/swing/regtesthelpers
+ * @build Util
+ * @run main bug4759934
+ */
+
+import java.awt.Component;
+import java.awt.Dialog;
+import java.awt.Dimension;
+import java.awt.FlowLayout;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.Robot;
+import java.awt.event.MouseEvent;
+import javax.swing.JButton;
+import javax.swing.JDialog;
+import javax.swing.JFileChooser;
+import javax.swing.JFrame;
+import javax.swing.SwingUtilities;
+
+public class bug4759934 {
+    private static JFrame fr;
+    private static Dialog dlg;
+    private static JFileChooser jfc;
+
+    private static JButton frameBtn;
+    private static JButton dialogBtn;
+    public static void main(String[] args) throws Exception {
+        try {
+            Robot robot = new Robot();
+            robot.setAutoWaitForIdle(true);
+            robot.setAutoDelay(50);
+            SwingUtilities.invokeAndWait(bug4759934::createTestUI);
+            robot.waitForIdle();
+            robot.delay(1000);
+
+            Point frameBtnLoc = Util.getCenterPoint(frameBtn);
+            robot.mouseMove(frameBtnLoc.x, frameBtnLoc.y);
+            robot.mousePress(MouseEvent.BUTTON1_DOWN_MASK);
+            robot.mouseRelease(MouseEvent.BUTTON1_DOWN_MASK);
+            robot.delay(500);
+
+            Point dlgBtnLoc = Util.getCenterPoint(dialogBtn);
+            robot.mouseMove(dlgBtnLoc.x , dlgBtnLoc.y);
+            robot.mousePress(MouseEvent.BUTTON1_DOWN_MASK);
+            robot.mouseRelease(MouseEvent.BUTTON1_DOWN_MASK);
+            robot.delay(1000);
+
+            Rectangle jfcBounds = Util.invokeOnEDT(() ->
+                                        getComponentBounds(jfc));
+            robot.mouseMove(jfcBounds.x + jfcBounds.width - 50,
+                            jfcBounds.y + jfcBounds.height - 25);
+            robot.mousePress(MouseEvent.BUTTON1_DOWN_MASK);
+            robot.mouseRelease(MouseEvent.BUTTON1_DOWN_MASK);
+            robot.delay(500);
+
+            SwingUtilities.invokeAndWait(() -> {
+                if (frameBtn.hasFocus() && !dialogBtn.hasFocus()) {
+                    throw new RuntimeException("Test failed! Focus was passed back" +
+                            " to Frame instead of Dialog");
+                }
+            });
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (dlg != null) {
+                    dlg.dispose();
+                }
+                if (fr != null) {
+                    fr.dispose();
+                }
+            });
+        }
+    }
+
+    private static void createTestUI() {
+        fr = new JFrame("bug4759934 - JFrame");
+        fr.setLayout(new FlowLayout());
+
+        frameBtn = new JButton("Show Dialog");
+        frameBtn.setActionCommand("Show Dialog");
+        fr.add(frameBtn);
+
+        frameBtn.addActionListener(e -> createDialog());
+        fr.setSize(300, 200);
+        fr.setLocationRelativeTo(null);
+        fr.setVisible(true);
+    }
+
+    private static void createDialog() {
+        dlg = new JDialog(fr, "bug4759934 - JDialog");
+        dlg.setLayout(new FlowLayout());
+
+        dialogBtn = new JButton("Show FileChooser");
+        dialogBtn.setActionCommand("Show FileChooser");
+        dlg.add(dialogBtn);
+
+        dialogBtn.addActionListener(e -> {
+            jfc = new JFileChooser();
+            jfc.showOpenDialog(dlg);
+        });
+
+        dlg.setSize(300, 200);
+        dlg.setLocation(fr.getX() + fr.getWidth() + 10, fr.getY());
+        dlg.setVisible(true);
+    }
+
+    private static Rectangle getComponentBounds(Component component) {
+        Point locationOnScreen = component.getLocationOnScreen();
+        Dimension size = component.getSize();
+        return new Rectangle(locationOnScreen, size);
+    }
+}

--- a/test/jdk/javax/swing/JFileChooser/bug4759934.java
+++ b/test/jdk/javax/swing/JFileChooser/bug4759934.java
@@ -31,13 +31,10 @@
  * @run main bug4759934
  */
 
-import java.awt.Component;
 import java.awt.Dialog;
-import java.awt.Dimension;
-import java.awt.FlowLayout;
 import java.awt.Point;
-import java.awt.Rectangle;
 import java.awt.Robot;
+import java.awt.event.KeyEvent;
 import java.awt.event.MouseEvent;
 import javax.swing.JButton;
 import javax.swing.JDialog;
@@ -52,6 +49,7 @@ public class bug4759934 {
 
     private static JButton frameBtn;
     private static JButton dialogBtn;
+
     public static void main(String[] args) throws Exception {
         try {
             Robot robot = new Robot();
@@ -71,14 +69,10 @@ public class bug4759934 {
             robot.mouseMove(dlgBtnLoc.x , dlgBtnLoc.y);
             robot.mousePress(MouseEvent.BUTTON1_DOWN_MASK);
             robot.mouseRelease(MouseEvent.BUTTON1_DOWN_MASK);
-            robot.delay(1000);
+            robot.delay(500);
 
-            Rectangle jfcBounds = Util.invokeOnEDT(() ->
-                                        getComponentBounds(jfc));
-            robot.mouseMove(jfcBounds.x + jfcBounds.width - 50,
-                            jfcBounds.y + jfcBounds.height - 25);
-            robot.mousePress(MouseEvent.BUTTON1_DOWN_MASK);
-            robot.mouseRelease(MouseEvent.BUTTON1_DOWN_MASK);
+            robot.keyPress(KeyEvent.VK_ESCAPE);
+            robot.keyRelease(KeyEvent.VK_ESCAPE);
             robot.delay(500);
 
             SwingUtilities.invokeAndWait(() -> {
@@ -101,10 +95,8 @@ public class bug4759934 {
 
     private static void createTestUI() {
         fr = new JFrame("bug4759934 - JFrame");
-        fr.setLayout(new FlowLayout());
 
         frameBtn = new JButton("Show Dialog");
-        frameBtn.setActionCommand("Show Dialog");
         fr.add(frameBtn);
 
         frameBtn.addActionListener(e -> createDialog());
@@ -115,10 +107,8 @@ public class bug4759934 {
 
     private static void createDialog() {
         dlg = new JDialog(fr, "bug4759934 - JDialog");
-        dlg.setLayout(new FlowLayout());
 
         dialogBtn = new JButton("Show FileChooser");
-        dialogBtn.setActionCommand("Show FileChooser");
         dlg.add(dialogBtn);
 
         dialogBtn.addActionListener(e -> {
@@ -129,11 +119,5 @@ public class bug4759934 {
         dlg.setSize(300, 200);
         dlg.setLocation(fr.getX() + fr.getWidth() + 10, fr.getY());
         dlg.setVisible(true);
-    }
-
-    private static Rectangle getComponentBounds(Component component) {
-        Point locationOnScreen = component.getLocationOnScreen();
-        Dimension size = component.getSize();
-        return new Rectangle(locationOnScreen, size);
     }
 }

--- a/test/jdk/javax/swing/JFileChooser/bug4943900.java
+++ b/test/jdk/javax/swing/JFileChooser/bug4943900.java
@@ -38,23 +38,26 @@ import javax.swing.filechooser.FileFilter;
 
 public class bug4943900 {
     private static final String INSTRUCTIONS = """
-        1. When the test runs a JFileChooser will be displayed.
+        <html>
+        <p> 1. When the test runs a JFileChooser will be displayed.</p>
 
-        2. Ensure that there is a Filter combo box with these two items:
+        <p> 2. Ensure that there is a Filter combo box with these two items:
          - Text Files (*.txt)  [must be selected when the dialog opens]
-         - All Files
+         - All Files </p>
 
-        3. Leave the "Text files" item selected and check that the
-        filter works: only *.txt files can appear in the file list
+        <p> 3. Leave the "Text files" item selected and check that the
+        filter works: only *.txt files can appear in the file list.
         You can navigate directories in the FileChooser and find one
         that contains some *.txt files to ensure they are shown in
         the file list. On macOS when the text filter is applied verify
-        that the non-text files are greyed out.
+        that the non-text files are greyed out.</p>
 
-        4. Try switching the filters and ensure that the file list
-        is updated properly.
+        <p>4. Try switching the filters and ensure that the file list
+        is updated properly.</p>
 
-        If the FileFilter works correctly, press Pass else press Fail.
+        <p>If the FileFilter works correctly, press <b>Pass</b> else
+        press <b>Fail</b></p>.
+        </html>
         """;
 
     public static void main(String[] args) throws Exception {
@@ -63,8 +66,9 @@ public class bug4943900 {
         PassFailJFrame.builder()
                 .title("bug4943900 Test Instructions")
                 .instructions(INSTRUCTIONS)
+                .rows(14)
+                .columns(60)
                 .testUI(bug4943900::createAndShowUI)
-                .columns(68)
                 .build()
                 .awaitAndCheck();
     }

--- a/test/jdk/javax/swing/JFileChooser/bug4943900.java
+++ b/test/jdk/javax/swing/JFileChooser/bug4943900.java
@@ -31,32 +31,33 @@
  */
 
 import java.io.File;
-import javax.swing.JComponent;
 import javax.swing.JFileChooser;
+import javax.swing.JFrame;
 import javax.swing.UIManager;
 import javax.swing.filechooser.FileFilter;
 
 public class bug4943900 {
     private static final String INSTRUCTIONS = """
         <html>
-        <p> 1. When the test runs a JFileChooser will be displayed.</p>
-
-        <p> 2. Ensure that there is a Filter combo box with these two items:
-         - Text Files (*.txt)  [must be selected when the dialog opens]
-         - All Files </p>
-
-        <p> 3. Leave the "Text files" item selected and check that the
-        filter works: only *.txt files can appear in the file list.
-        You can navigate directories in the FileChooser and find one
-        that contains some *.txt files to ensure they are shown in
+        <ol>
+        <li>When the test runs, a <code>JFileChooser</code> will be displayed.
+        <li>Ensure that there is a filter combo box with these two items:
+          <ul>
+          <li><b>Text Files (*.txt)</b>
+              &mdash; <em>[must be selected when the dialog opens]</em>
+          <li><b>All Files</b>
+          </ul>
+        <li>Leave the <b>Text files</b> item selected and check that the
+        filter works: only <code>*.txt</code> files can appear in the file list.
+        You can navigate directories in the file chooser and find one
+        that contains some <code>*.txt</code> files to ensure they are shown in
         the file list. On macOS when the text filter is applied verify
-        that the non-text files are greyed out.</p>
-
-        <p>4. Try switching the filters and ensure that the file list
-        is updated properly.</p>
-
-        <p>If the FileFilter works correctly, press <b>Pass</b> else
-        press <b>Fail</b></p>.
+        that the non-text files are greyed out.
+        <li>Try switching the filters and ensure that the file list
+        is updated properly.
+        <li>If the <code>FileFilter</code> works correctly,
+            press <b>Pass</b> else press <b>Fail</b>.
+        </ol>
         </html>
         """;
 
@@ -67,18 +68,22 @@ public class bug4943900 {
                 .title("bug4943900 Test Instructions")
                 .instructions(INSTRUCTIONS)
                 .rows(14)
-                .columns(60)
+                .columns(50)
                 .testUI(bug4943900::createAndShowUI)
                 .build()
                 .awaitAndCheck();
     }
 
-    public static JComponent createAndShowUI() {
+    public static JFrame createAndShowUI() {
         JFileChooser fc = new JFileChooser();
         fc.setControlButtonsAreShown(false);
         TextFileFilter filter = new TextFileFilter();
         fc.setFileFilter(filter);
-        return fc;
+
+        JFrame frame = new JFrame("bug4943900 - JFileChooser");
+        frame.add(fc);
+        frame.pack();
+        return frame;
     }
 
     private static final class TextFileFilter extends FileFilter {

--- a/test/jdk/javax/swing/JFileChooser/bug4943900.java
+++ b/test/jdk/javax/swing/JFileChooser/bug4943900.java
@@ -45,16 +45,16 @@ public class bug4943900 {
          - All Files
 
         3. Leave the "Text files" item selected and check that the
-        filter works: only *.txt files can appear in the files list
+        filter works: only *.txt files can appear in the file list
         You can navigate directories in the FileChooser and find one
         that contains some *.txt files to ensure they are shown in
         the file list. On macOS when the text filter is applied verify
-        that the non-text files are shown disabled (greyed out).
+        that the non-text files are greyed out.
 
         4. Try switching the filters and ensure that the file list
         is updated properly.
 
-        If the FileFilter works correctly, press PASS else press FAIL.
+        If the FileFilter works correctly, press Pass else press Fail.
         """;
 
     public static void main(String[] args) throws Exception {

--- a/test/jdk/javax/swing/JFileChooser/bug4943900.java
+++ b/test/jdk/javax/swing/JFileChooser/bug4943900.java
@@ -75,10 +75,12 @@ public class bug4943900 {
     }
 
     public static JFrame createAndShowUI() {
-        JFrame frame = new JFrame("JFileChooser bug4464774");
         JFileChooser fc = new JFileChooser();
+        fc.setControlButtonsAreShown(false);
         TextFileFilter filter = new TextFileFilter();
         fc.setFileFilter(filter);
+
+        JFrame frame = new JFrame("JFileChooser bug4464774");
         frame.add(fc);
         frame.pack();
         return frame;

--- a/test/jdk/javax/swing/JFileChooser/bug4943900.java
+++ b/test/jdk/javax/swing/JFileChooser/bug4943900.java
@@ -39,8 +39,7 @@ import jtreg.SkippedException;
 
 public class bug4943900 {
     private static final String INSTRUCTIONS = """
-        1. Click "Show FileChooser" button below, FileChooser dialog must
-           appear.
+        1. When the test runs a JFileChooser will be displayed.
 
         2. Ensure that there is a Filter combo box with these two items:
          - Text Files (*.txt)  [must be selected when the dialog opens]
@@ -69,7 +68,7 @@ public class bug4943900 {
                 .title("bug4943900 Test Instructions")
                 .instructions(INSTRUCTIONS)
                 .rows(20)
-                .columns(65)
+                .columns(68)
                 .testUI(bug4943900::createAndShowUI)
                 .build()
                 .awaitAndCheck();

--- a/test/jdk/javax/swing/JFileChooser/bug4943900.java
+++ b/test/jdk/javax/swing/JFileChooser/bug4943900.java
@@ -82,6 +82,7 @@ public class bug4943900 {
     }
 
     private static final class TextFileFilter extends FileFilter {
+        @Override
         public boolean accept(File f) {
             if (f != null) {
                 if (f.isDirectory()) {
@@ -93,11 +94,12 @@ public class bug4943900 {
             return false;
         }
 
+        @Override
         public String getDescription() {
             return "Text Files (*.txt)";
         }
 
-        public String getExtension(File f) {
+        private static String getExtension(File f) {
             if (f != null) {
                 String filename = f.getName();
                 int i = filename.lastIndexOf('.');

--- a/test/jdk/javax/swing/JFileChooser/bug4943900.java
+++ b/test/jdk/javax/swing/JFileChooser/bug4943900.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2004, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4943900
+ * @summary Tests that FileFilter combo box is shown in FileChooser
+ * @library /java/awt/regtesthelpers /test/lib
+ * @build PassFailJFrame jtreg.SkippedException
+ * @run main/manual bug4943900
+ */
+
+import java.awt.BorderLayout;
+import java.awt.Dimension;
+import java.io.File;
+import javax.swing.JButton;
+import javax.swing.JFileChooser;
+import javax.swing.JPanel;
+import javax.swing.UIManager;
+import javax.swing.filechooser.FileFilter;
+import jtreg.SkippedException;
+
+public class bug4943900 {
+    private static final String INSTRUCTIONS = """
+        1. Click "Show FileChooser" button below, FileChooser dialog must
+           appear.
+
+        2. Ensure that there is a Filter combo box with these two items:
+         - Text Files (*.txt)  [must be selected when the dialog opens]
+         - All Files
+
+        3. Leave the "Text files" item selected and check that the
+        filter works: only *.txt files can appear in the files list
+        You can navigate directories in the FileChooser and find one
+        that contains some *.txt files to ensure they are shown in
+        the file list.
+
+        4. Try switching the filters and ensure that the file list
+        is updated properly.
+
+        If the FileFilter works correctly, press PASS else press FAIL.
+        """;
+
+    public static void main(String[] args) throws Exception {
+        try {
+            UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
+        } catch (Exception e) {
+            throw new SkippedException("LaF not supported", e);
+        }
+
+        PassFailJFrame.builder()
+                .title("bug4943900 Test Instructions")
+                .instructions(INSTRUCTIONS)
+                .rows(20)
+                .columns(65)
+                .splitUIBottom(bug4943900::createAndShowUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    public static JPanel createAndShowUI() {
+        JButton button = new JButton("Show JFileChooser");
+
+        button.addActionListener(e -> {
+            JFileChooser fc = new JFileChooser();
+            TextFileFilter filter = new TextFileFilter();
+            fc.setFileFilter(filter);
+            fc.showOpenDialog(null);
+        });
+
+        JPanel p = new JPanel();
+        p.setLayout(new BorderLayout());
+        p.setPreferredSize(new Dimension(200, 50));
+        p.add(button);
+        return p;
+    }
+
+    private static final class TextFileFilter extends FileFilter {
+        public boolean accept(File f) {
+            if (f != null) {
+                if (f.isDirectory()) {
+                    return true;
+                }
+                String extension = getExtension(f);
+                return extension != null && extension.equals("txt");
+            }
+            return false;
+        }
+
+        public String getDescription() {
+            return "Text Files (*.txt)";
+        }
+
+        public String getExtension(File f) {
+            if (f != null) {
+                String filename = f.getName();
+                int i = filename.lastIndexOf('.');
+                if (i > 0 && i < filename.length() - 1) {
+                    return filename.substring(i + 1).toLowerCase();
+                }
+            }
+            return null;
+        }
+    }
+}

--- a/test/jdk/javax/swing/JFileChooser/bug4943900.java
+++ b/test/jdk/javax/swing/JFileChooser/bug4943900.java
@@ -25,8 +25,8 @@
  * @test
  * @bug 4943900
  * @summary Tests that FileFilter combo box is shown in FileChooser
- * @library /java/awt/regtesthelpers /test/lib
- * @build PassFailJFrame jtreg.SkippedException
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
  * @run main/manual bug4943900
  */
 
@@ -35,7 +35,6 @@ import javax.swing.JComponent;
 import javax.swing.JFileChooser;
 import javax.swing.UIManager;
 import javax.swing.filechooser.FileFilter;
-import jtreg.SkippedException;
 
 public class bug4943900 {
     private static final String INSTRUCTIONS = """
@@ -49,7 +48,8 @@ public class bug4943900 {
         filter works: only *.txt files can appear in the files list
         You can navigate directories in the FileChooser and find one
         that contains some *.txt files to ensure they are shown in
-        the file list.
+        the file list. On macOS when the text filter is applied verify
+        that the non-text files are shown disabled (greyed out).
 
         4. Try switching the filters and ensure that the file list
         is updated properly.
@@ -58,11 +58,7 @@ public class bug4943900 {
         """;
 
     public static void main(String[] args) throws Exception {
-        try {
-            UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
-        } catch (Exception e) {
-            throw new SkippedException("LaF not supported", e);
-        }
+        UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
 
         PassFailJFrame.builder()
                 .title("bug4943900 Test Instructions")

--- a/test/jdk/javax/swing/JFileChooser/bug4943900.java
+++ b/test/jdk/javax/swing/JFileChooser/bug4943900.java
@@ -30,12 +30,9 @@
  * @run main/manual bug4943900
  */
 
-import java.awt.BorderLayout;
-import java.awt.Dimension;
 import java.io.File;
-import javax.swing.JButton;
 import javax.swing.JFileChooser;
-import javax.swing.JPanel;
+import javax.swing.JFrame;
 import javax.swing.UIManager;
 import javax.swing.filechooser.FileFilter;
 import jtreg.SkippedException;
@@ -73,26 +70,19 @@ public class bug4943900 {
                 .instructions(INSTRUCTIONS)
                 .rows(20)
                 .columns(65)
-                .splitUIBottom(bug4943900::createAndShowUI)
+                .testUI(bug4943900::createAndShowUI)
                 .build()
                 .awaitAndCheck();
     }
 
-    public static JPanel createAndShowUI() {
-        JButton button = new JButton("Show JFileChooser");
-
-        button.addActionListener(e -> {
-            JFileChooser fc = new JFileChooser();
-            TextFileFilter filter = new TextFileFilter();
-            fc.setFileFilter(filter);
-            fc.showOpenDialog(null);
-        });
-
-        JPanel p = new JPanel();
-        p.setLayout(new BorderLayout());
-        p.setPreferredSize(new Dimension(200, 50));
-        p.add(button);
-        return p;
+    public static JFrame createAndShowUI() {
+        JFrame frame = new JFrame("JFileChooser bug4464774");
+        JFileChooser fc = new JFileChooser();
+        TextFileFilter filter = new TextFileFilter();
+        fc.setFileFilter(filter);
+        frame.add(fc);
+        frame.pack();
+        return frame;
     }
 
     private static final class TextFileFilter extends FileFilter {

--- a/test/jdk/javax/swing/JFileChooser/bug4943900.java
+++ b/test/jdk/javax/swing/JFileChooser/bug4943900.java
@@ -31,8 +31,8 @@
  */
 
 import java.io.File;
+import javax.swing.JComponent;
 import javax.swing.JFileChooser;
-import javax.swing.JFrame;
 import javax.swing.UIManager;
 import javax.swing.filechooser.FileFilter;
 import jtreg.SkippedException;
@@ -67,23 +67,18 @@ public class bug4943900 {
         PassFailJFrame.builder()
                 .title("bug4943900 Test Instructions")
                 .instructions(INSTRUCTIONS)
-                .rows(20)
-                .columns(68)
                 .testUI(bug4943900::createAndShowUI)
+                .columns(68)
                 .build()
                 .awaitAndCheck();
     }
 
-    public static JFrame createAndShowUI() {
+    public static JComponent createAndShowUI() {
         JFileChooser fc = new JFileChooser();
         fc.setControlButtonsAreShown(false);
         TextFileFilter filter = new TextFileFilter();
         fc.setFileFilter(filter);
-
-        JFrame frame = new JFrame("JFileChooser bug4464774");
-        frame.add(fc);
-        frame.pack();
-        return frame;
+        return fc;
     }
 
     private static final class TextFileFilter extends FileFilter {

--- a/test/jdk/javax/swing/JOptionPane/bug4194862.java
+++ b/test/jdk/javax/swing/JOptionPane/bug4194862.java
@@ -68,8 +68,9 @@ public class bug4194862 {
 
         JButton b = new JButton("Show JOption dialog");
         b.addActionListener(e -> {
-            int retVal = JOptionPane.showInternalConfirmDialog(jInternalFrame,
-                                                      "Am I centered?");
+            int retVal = JOptionPane.showInternalConfirmDialog(
+                                      jInternalFrame, "Am I centered?",
+                                      "bug4194862 JOptionPane", JOptionPane.YES_NO_OPTION);
             switch (retVal) {
                 case JOptionPane.YES_OPTION -> PassFailJFrame.forcePass();
                 case JOptionPane.NO_OPTION ->

--- a/test/jdk/javax/swing/JOptionPane/bug4194862.java
+++ b/test/jdk/javax/swing/JOptionPane/bug4194862.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+   @bug 4194862
+   @summary Tests that internal frame-based dialogs are centered relative
+            to their parents
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual bug4194862
+ */
+
+import javax.swing.JButton;
+import javax.swing.JDesktopPane;
+import javax.swing.JFrame;
+import javax.swing.JInternalFrame;
+import javax.swing.JOptionPane;
+
+public class bug4194862 {
+    private static final String INSTRUCTIONS = """
+            In the internal frame titled "Main",
+            click the "Show JOption dialog" button.
+            A dialog will appear. It should be centered w.r.t
+            to the JInternalFrame - "Main".
+
+            If the above is true then click on JOptionPane's "YES" button
+            to PASS else click JOptionPane's "NO" button to FAIL the test.
+            """;
+
+    public static void main(String[] args) throws Exception{
+        PassFailJFrame.builder()
+                .title("Instructions")
+                .instructions(INSTRUCTIONS)
+                .columns(40)
+                .testUI(bug4194862::createAndShowUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static JFrame createAndShowUI() {
+        JFrame frame = new JFrame("bug4194862 - JInternalFrame JOptionPane");
+        JDesktopPane desktop = new JDesktopPane();
+        frame.add(desktop);
+        JInternalFrame jInternalFrame = new JInternalFrame("Main", true);
+        desktop.add(jInternalFrame);
+        jInternalFrame.setBounds(5, 30, 390, 240);
+        jInternalFrame.setVisible(true);
+
+        JButton b = new JButton("Show JOption dialog");
+        b.addActionListener(e -> {
+            int retVal = JOptionPane.showInternalConfirmDialog(jInternalFrame,
+                                                      "Am I centered?");
+            switch (retVal) {
+                case JOptionPane.YES_OPTION -> PassFailJFrame.forcePass();
+                case JOptionPane.NO_OPTION ->
+                        PassFailJFrame.forceFail("User pressed the NO button");
+            }
+        });
+        jInternalFrame.add(b);
+
+        for (int i = 0; i < 4; i++) {
+            JInternalFrame f = new JInternalFrame("JIF: "+ i);
+            f.setBounds(i * 50, i * 33, 120, 120);
+            f.setVisible(true);
+            desktop.add(f);
+        }
+        frame.setSize(450, 400);
+        return frame;
+    }
+}

--- a/test/jdk/javax/swing/JOptionPane/bug4194862.java
+++ b/test/jdk/javax/swing/JOptionPane/bug4194862.java
@@ -21,9 +21,10 @@
  * questions.
  */
 
-/* @test
-   @bug 4194862
-   @summary Tests that internal frame-based dialogs are centered relative
+/*
+ * @test
+ * @bug 4194862
+ * @summary Tests that internal frame-based dialogs are centered relative
             to their parents
  * @library /java/awt/regtesthelpers
  * @build PassFailJFrame

--- a/test/jdk/javax/swing/JOptionPane/bug4194862.java
+++ b/test/jdk/javax/swing/JOptionPane/bug4194862.java
@@ -73,7 +73,8 @@ public class bug4194862 {
             switch (retVal) {
                 case JOptionPane.YES_OPTION -> PassFailJFrame.forcePass();
                 case JOptionPane.NO_OPTION ->
-                        PassFailJFrame.forceFail("User pressed the NO button");
+                        PassFailJFrame.forceFail("JOptionPane isn't centered"
+                                + " within JInternalFrame \"Main\"");
             }
         });
         jInternalFrame.add(b);

--- a/test/jdk/javax/swing/JOptionPane/bug4194862.java
+++ b/test/jdk/javax/swing/JOptionPane/bug4194862.java
@@ -40,9 +40,9 @@ import javax.swing.JOptionPane;
 public class bug4194862 {
     private static final String INSTRUCTIONS = """
             In the internal frame titled "Main",
-            click the "Show JOption dialog" button.
-            A dialog will appear. It should be centered w.r.t
-            to the JInternalFrame - "Main".
+            click the "Show JOptionPane Dialog" button.
+            A dialog will appear. It should be centered with
+            respect to the JInternalFrame - "Main".
 
             If the above is true then click on JOptionPane's "YES" button
             to PASS else click JOptionPane's "NO" button to FAIL the test.
@@ -54,6 +54,7 @@ public class bug4194862 {
                 .instructions(INSTRUCTIONS)
                 .columns(40)
                 .testUI(bug4194862::createAndShowUI)
+                .screenCapture()
                 .build()
                 .awaitAndCheck();
     }
@@ -67,7 +68,7 @@ public class bug4194862 {
         jInternalFrame.setBounds(5, 30, 390, 240);
         jInternalFrame.setVisible(true);
 
-        JButton b = new JButton("Show JOption dialog");
+        JButton b = new JButton("Show JOptionPane Dialog");
         b.addActionListener(e -> {
             int retVal = JOptionPane.showInternalConfirmDialog(
                                       jInternalFrame, "Am I centered?",


### PR DESCRIPTION
Open-sourced the following Swing tests:

1. javax/swing/JFileChooser/bug4464774.java
2. javax/swing/JFileChooser/bug4522756.java
3. javax/swing/JFileChooser/bug4759934.java
4. javax/swing/JFileChooser/bug4943900.java
5. javax/swing/JOptionPane/bug4194862.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8353486](https://bugs.openjdk.org/browse/JDK-8353486): Open source Swing Tests - Set 4 (**Bug** - P4)


### Reviewers
 * [Damon Nguyen](https://openjdk.org/census#dnguyen) (@DamonGuy - Committer) Review applies to [fa9529dd](https://git.openjdk.org/jdk/pull/24456/files/fa9529dd9a7da64b78ec1e3689a2a180ddc4f5fb)
 * [Tejesh R](https://openjdk.org/census#tr) (@TejeshR13 - **Reviewer**) Review applies to [fa9529dd](https://git.openjdk.org/jdk/pull/24456/files/fa9529dd9a7da64b78ec1e3689a2a180ddc4f5fb)
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24456/head:pull/24456` \
`$ git checkout pull/24456`

Update a local copy of the PR: \
`$ git checkout pull/24456` \
`$ git pull https://git.openjdk.org/jdk.git pull/24456/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24456`

View PR using the GUI difftool: \
`$ git pr show -t 24456`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24456.diff">https://git.openjdk.org/jdk/pull/24456.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24456#issuecomment-2779601815)
</details>
