### PR TITLE
8353713: Improve Currency.getInstance exception handling

### DIFF
--- a/src/java.base/share/classes/java/util/Currency.java
+++ b/src/java.base/share/classes/java/util/Currency.java
@@ -314,8 +314,8 @@ public final class Currency implements Serializable {
             // or in the list of other currencies.
             boolean found = false;
             if (currencyCode.length() != 3) {
-                throw new IllegalArgumentException("The input currency code must " +
-                        "have a length of 3 characters");
+                throw new IllegalArgumentException(
+                        "The input currency code: \"%s\" must have a length of 3 characters".formatted(currencyCode));
             }
             char char1 = currencyCode.charAt(0);
             char char2 = currencyCode.charAt(1);
@@ -338,8 +338,8 @@ public final class Currency implements Serializable {
             if (!found) {
                 OtherCurrencyEntry ocEntry = OtherCurrencyEntry.findEntry(currencyCode);
                 if (ocEntry == null) {
-                    throw new IllegalArgumentException("The input currency code" +
-                            " is not a valid ISO 4217 code");
+                    throw new IllegalArgumentException(
+                            "The input currency code: \"%s\" is not a valid ISO 4217 code".formatted(currencyCode));
                 }
                 defaultFractionDigits = ocEntry.fraction;
                 numericCode = ocEntry.numericCode;
@@ -394,8 +394,8 @@ public final class Currency implements Serializable {
         String country = CalendarDataUtility.findRegionOverride(locale).getCountry();
 
         if (country == null || !country.matches("^[a-zA-Z]{2}$")) {
-            throw new IllegalArgumentException("The country of the input locale" +
-                    " is not a valid ISO 3166 country code");
+            throw new IllegalArgumentException(
+                    "The country of the input locale: \"%s\" is not a valid ISO 3166 country code".formatted(locale));
         }
 
         char char1 = country.charAt(0);
@@ -412,8 +412,8 @@ public final class Currency implements Serializable {
         } else {
             // special cases
             if (tableEntry == INVALID_COUNTRY_ENTRY) {
-                throw new IllegalArgumentException("The country of the input locale" +
-                        " is not a valid ISO 3166 country code");
+                throw new IllegalArgumentException(
+                        "The country of the input locale: \"%s\" is not a valid ISO 3166 country code".formatted(locale));
             }
             if (tableEntry == COUNTRY_WITHOUT_CURRENCY_ENTRY) {
                 return null;
@@ -698,8 +698,8 @@ public final class Currency implements Serializable {
      */
     private static int getMainTableEntry(char char1, char char2) {
         if (char1 < 'A' || char1 > 'Z' || char2 < 'A' || char2 > 'Z') {
-            throw new IllegalArgumentException("The country code is not a " +
-                    "valid ISO 3166 code");
+            throw new IllegalArgumentException(
+                    "The country code: \"%c%c\" is not a valid ISO 3166 code".formatted(char1, char2));
         }
         return mainTable[(char1 - 'A') * A_TO_Z + (char2 - 'A')];
     }
@@ -710,8 +710,8 @@ public final class Currency implements Serializable {
      */
     private static void setMainTableEntry(char char1, char char2, int entry) {
         if (char1 < 'A' || char1 > 'Z' || char2 < 'A' || char2 > 'Z') {
-            throw new IllegalArgumentException("The country code is not a " +
-                    "valid ISO 3166 code");
+            throw new IllegalArgumentException(
+                    "The country code: \"%c%c\" is not a valid ISO 3166 code".formatted(char1, char2));
         }
         mainTable[(char1 - 'A') * A_TO_Z + (char2 - 'A')] = entry;
     }

--- a/test/jdk/java/util/Currency/CurrencyTest.java
+++ b/test/jdk/java/util/Currency/CurrencyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,7 @@
  * @test
  * @bug 4290801 4692419 4693631 5101540 5104960 6296410 6336600 6371531
  *      6488442 7036905 8008577 8039317 8074350 8074351 8150324 8167143
- *      8264792 8334653
+ *      8264792 8334653 8353713
  * @summary Basic tests for Currency class.
  * @modules java.base/java.util:open
  *          jdk.localedata
@@ -84,12 +84,23 @@ public class CurrencyTest {
         public void invalidCurrencyTest(String currencyCode) {
             IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () ->
                     Currency.getInstance(currencyCode), "getInstance() did not throw IAE");
-            assertEquals("The input currency code is not a" +
-                    " valid ISO 4217 code", ex.getMessage());
+            assertEquals("The input currency code: \"%s\" is not a valid ISO 4217 code"
+                    .formatted(currencyCode), ex.getMessage());
         }
 
         private static Stream<String> non4217Currencies() {
             return Stream.of("AQD", "US$");
+        }
+
+        // Provide 3 length code, but first 2 chars should not be able to index
+        // the main table
+        @Test
+        void invalidCountryInCodeTest() {
+            var badCode = "..A";
+            IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () ->
+                    Currency.getInstance(badCode), "getInstance() did not throw IAE");
+            assertEquals("The country code: \"%s\" is not a valid ISO 3166 code"
+                    .formatted(badCode.substring(0,2)), ex.getMessage());
         }
 
         // Calling getInstance() with a currency code not 3 characters long should throw
@@ -99,8 +110,8 @@ public class CurrencyTest {
         public void invalidCurrencyLengthTest(String currencyCode) {
             IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () ->
                     Currency.getInstance(currencyCode), "getInstance() did not throw IAE");
-            assertEquals("The input currency code must have a length of 3" +
-                    " characters", ex.getMessage());
+            assertEquals("The input currency code: \"%s\" must have a length of 3 characters"
+                    .formatted(currencyCode), ex.getMessage());
         }
 
         private static Stream<String> invalidLengthCurrencies() {
@@ -163,8 +174,8 @@ public class CurrencyTest {
                                 "AC|CP|DG|EA|EU|FX|IC|SU|TA|UK")) { // exceptional reservation codes
                     IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
                             () -> Currency.getInstance(locale), "Did not throw IAE");
-                    assertEquals("The country of the input locale is not a" +
-                            " valid ISO 3166 country code", ex.getMessage());
+                    assertEquals("The country of the input locale: \"%s\" is not a valid ISO 3166 country code"
+                            .formatted(locale), ex.getMessage());
                 } else {
                     goodCountries++;
                     Currency currency = Currency.getInstance(locale);
@@ -180,13 +191,15 @@ public class CurrencyTest {
             }
         }
 
-        // Check an invalid country code
+        // Check an invalid country code supplied via the region override
         @Test
-        public void invalidCountryTest() {
+        public void invalidCountryRegionOverrideTest() {
+            // Override US with nonsensical country
+            var loc = Locale.forLanguageTag("en-US-u-rg-XXzzzz");
             IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
-                    ()-> Currency.getInstance(Locale.of("", "EU")), "Did not throw IAE");
-            assertEquals("The country of the input locale is not a valid" +
-                    " ISO 3166 country code", ex.getMessage());
+                    ()-> Currency.getInstance(loc), "Did not throw IAE");
+            assertEquals("The country of the input locale: \"%s\" is not a valid ISO 3166 country code"
+                    .formatted(loc), ex.getMessage());
         }
 
         // Ensure a selection of countries have the expected currency

--- a/test/jdk/java/util/Currency/CurrencyTest.java
+++ b/test/jdk/java/util/Currency/CurrencyTest.java
@@ -93,14 +93,13 @@ public class CurrencyTest {
         }
 
         // Provide 3 length code, but first 2 chars should not be able to index
-        // the main table
+        // the main table, thus resulting as incorrect country code
         @Test
         void invalidCountryInCodeTest() {
-            var badCode = "..A";
             IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () ->
-                    Currency.getInstance(badCode), "getInstance() did not throw IAE");
+                    Currency.getInstance("..A"), "getInstance() did not throw IAE");
             assertEquals("The country code: \"%s\" is not a valid ISO 3166 code"
-                    .formatted(badCode.substring(0,2)), ex.getMessage());
+                    .formatted(".."), ex.getMessage());
         }
 
         // Calling getInstance() with a currency code not 3 characters long should throw


### PR DESCRIPTION
Please review this PR which improves some Currency `IllegalArgumentException`s by including the input in the message. This could be a currency code, country code, or locale. This change also includes tests to check the messages for an invalid country via the region override as well as an invalid country code within a 3 length currency code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8353713](https://bugs.openjdk.org/browse/JDK-8353713): Improve Currency.getInstance exception handling (**Enhancement** - P4)


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24459/head:pull/24459` \
`$ git checkout pull/24459`

Update a local copy of the PR: \
`$ git checkout pull/24459` \
`$ git pull https://git.openjdk.org/jdk.git pull/24459/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24459`

View PR using the GUI difftool: \
`$ git pr show -t 24459`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24459.diff">https://git.openjdk.org/jdk/pull/24459.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24459#issuecomment-2779762079)
</details>
