### PR TITLE
8353757: Log class should have a proper clear() method

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/api/JavacTaskPool.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/api/JavacTaskPool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -267,7 +267,7 @@ public class JavacTaskPool {
 
             if (ht.get(Log.logKey) instanceof ReusableLog) {
                 //log already inited - not first round
-                ((ReusableLog)Log.instance(this)).clear();
+                Log.instance(this).clear();
                 Enter.instance(this).newRound();
                 ((ReusableJavaCompiler)ReusableJavaCompiler.instance(this)).clear();
                 Types.instance(this).newRound();
@@ -395,11 +395,9 @@ public class JavacTaskPool {
                 this.context = context;
             }
 
-            void clear() {
-                recorded.clear();
-                sourceMap.clear();
-                nerrors = 0;
-                nwarnings = 0;
+            @Override
+            public void clear() {
+                super.clear();
                 //Set a fake listener that will lazily lookup the context for the 'real' listener. Since
                 //this field is never updated when a new task is created, we cannot simply reset the field
                 //or keep old value. This is a hack to workaround the limitations in the current infrastructure.

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/api/JavacTrees.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/api/JavacTrees.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -361,14 +361,9 @@ public class JavacTrees extends DocTrees {
                         new Log.DeferredDiagnosticHandler(log);
                 try {
                     Env<AttrContext> env = getAttrContext(path.getTreePath());
-                    JavaFileObject prevSource = log.useSource(env.toplevel.sourcefile);
-                    try {
-                        Type t = attr.attribType(dcReference.qualifierExpression, env);
-                        if (t != null && !t.isErroneous()) {
-                            return t;
-                        }
-                    } finally {
-                        log.useSource(prevSource);
+                    Type t = attr.attribType(dcReference.qualifierExpression, env);
+                    if (t != null && !t.isErroneous()) {
+                        return t;
                     }
                 } catch (Abort e) { // may be thrown by Check.completionError in case of bad class file
                     return null;
@@ -395,7 +390,6 @@ public class JavacTrees extends DocTrees {
         }
         Log.DeferredDiagnosticHandler deferredDiagnosticHandler =
                 new Log.DeferredDiagnosticHandler(log);
-        JavaFileObject prevSource = log.useSource(env.toplevel.sourcefile);
         try {
             final TypeSymbol tsym;
             final Name memberName;
@@ -517,7 +511,6 @@ public class JavacTrees extends DocTrees {
         } catch (Abort e) { // may be thrown by Check.completionError in case of bad class file
             return null;
         } finally {
-            log.useSource(prevSource);
             log.popDiagnosticHandler(deferredDiagnosticHandler);
         }
     }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/api/JavacTrees.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/api/JavacTrees.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -361,9 +361,14 @@ public class JavacTrees extends DocTrees {
                         new Log.DeferredDiagnosticHandler(log);
                 try {
                     Env<AttrContext> env = getAttrContext(path.getTreePath());
-                    Type t = attr.attribType(dcReference.qualifierExpression, env);
-                    if (t != null && !t.isErroneous()) {
-                        return t;
+                    JavaFileObject prevSource = log.useSource(env.toplevel.sourcefile);
+                    try {
+                        Type t = attr.attribType(dcReference.qualifierExpression, env);
+                        if (t != null && !t.isErroneous()) {
+                            return t;
+                        }
+                    } finally {
+                        log.useSource(prevSource);
                     }
                 } catch (Abort e) { // may be thrown by Check.completionError in case of bad class file
                     return null;
@@ -390,6 +395,7 @@ public class JavacTrees extends DocTrees {
         }
         Log.DeferredDiagnosticHandler deferredDiagnosticHandler =
                 new Log.DeferredDiagnosticHandler(log);
+        JavaFileObject prevSource = log.useSource(env.toplevel.sourcefile);
         try {
             final TypeSymbol tsym;
             final Name memberName;
@@ -511,6 +517,7 @@ public class JavacTrees extends DocTrees {
         } catch (Abort e) { // may be thrown by Check.completionError in case of bad class file
             return null;
         } finally {
+            log.useSource(prevSource);
             log.popDiagnosticHandler(deferredDiagnosticHandler);
         }
     }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Log.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Log.java
@@ -699,6 +699,8 @@ public class Log extends AbstractLog {
         nwarnings = 0;
         nsuppressederrors = 0;
         nsuppressedwarns = 0;
+        while (diagnosticHandler.prev != null)
+            popDiagnosticHandler(diagnosticHandler);
     }
 
     /**

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Log.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Log.java
@@ -690,6 +690,18 @@ public class Log extends AbstractLog {
      }
 
     /**
+     * Reset the state of this instance.
+     */
+    public void clear() {
+        recorded.clear();
+        sourceMap.clear();
+        nerrors = 0;
+        nwarnings = 0;
+        nsuppressederrors = 0;
+        nsuppressedwarns = 0;
+    }
+
+    /**
      * Common diagnostic handling.
      * The diagnostic is counted, and depending on the options and how many diagnostics have been
      * reported so far, the diagnostic may be handed off to writeDiagnostic.


### PR DESCRIPTION
This is a simple refactoring to add a method `Log.clear()`, move `ReusableLog.clear()`'s clearing operations into it and invoke `super.clear()` instead, and add two more fields that should be included in the clear operation but were not because they were added to `Log` after `ReusableLog.clear()` was added and were missed.

A natural question: Are there any other fields in `Log` that should be cleared in `Log.clear()`? The two I've added (`nsuppressederrors` and `nsuppressedwarns`) are the only two that weren't there when `ReusableLog` as added, so presumably not, but it's possible.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8353757](https://bugs.openjdk.org/browse/JDK-8353757): Log class should have a proper clear() method (**Enhancement** - P5)


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24460/head:pull/24460` \
`$ git checkout pull/24460`

Update a local copy of the PR: \
`$ git checkout pull/24460` \
`$ git pull https://git.openjdk.org/jdk.git pull/24460/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24460`

View PR using the GUI difftool: \
`$ git pr show -t 24460`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24460.diff">https://git.openjdk.org/jdk/pull/24460.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24460#issuecomment-2779810534)
</details>
