### PR TITLE
8352681: C2 compilation hits asserts "must set the initial type just once"

### DIFF
--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -290,7 +290,7 @@ static Node *step_through_mergemem(PhaseGVN *phase, MergeMemNode *mmem,  const T
         toop->is_instptr()->instance_klass()->is_java_lang_Object() &&
         toop->offset() == Type::OffsetBot)) {
     // IGVN _delay_transform may be set to true and if that is the case and mmem
-    // is already a registered then the validation inside transform will
+    // is already a registered node then the validation inside transform will
     // complain.
     Node* m = mmem;
     PhaseIterGVN* igvn = phase->is_IterGVN();

--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -289,10 +289,17 @@ static Node *step_through_mergemem(PhaseGVN *phase, MergeMemNode *mmem,  const T
         toop->isa_instptr() &&
         toop->is_instptr()->instance_klass()->is_java_lang_Object() &&
         toop->offset() == Type::OffsetBot)) {
-    // compress paths and change unreachable cycles to TOP
-    // If not, we can update the input infinitely along a MergeMem cycle
-    // Equivalent code in PhiNode::Ideal
-    Node* m  = phase->transform(mmem);
+    // IGVN _delay_transform may be set to true and if that is the case and mmem
+    // is already a registered then the validation inside transform will
+    // complain.
+    Node* m = mmem;
+    PhaseIterGVN* igvn = phase->is_IterGVN();
+    if (igvn == nullptr || !igvn->delay_transform()) {
+      // compress paths and change unreachable cycles to TOP
+      // If not, we can update the input infinitely along a MergeMem cycle
+      // Equivalent code in PhiNode::Ideal
+      m = phase->transform(mmem);
+    }
     // If transformed to a MergeMem, get the desired slice
     // Otherwise the returned node represents memory for every slice
     mem = (m->is_MergeMem())? m->as_MergeMem()->memory_at(alias_idx) : m;

--- a/test/hotspot/jtreg/compiler/escapeAnalysis/TestReduceAllocationAndSetTypeTwice.java
+++ b/test/hotspot/jtreg/compiler/escapeAnalysis/TestReduceAllocationAndSetTypeTwice.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8352681
+ * @summary Check that RAM does not crash when split load through phi
+ *          tries to register an old node twice with IGVN.
+ * @run main/othervm -XX:CompileCommand=compileonly,*TestReduceAllocationAndSetTypeTwice*::*
+ *                   -Xcomp compiler.escapeAnalysis.TestReduceAllocationAndSetTypeTwice
+ * @run main compiler.escapeAnalysis.TestReduceAllocationAndSetTypeTwice
+ */
+
+package compiler.escapeAnalysis;
+
+public class TestReduceAllocationAndSetTypeTwice {
+    public static double dummy() {
+        return 3.1415;
+    }
+
+    public static double test(double param) {
+        Double double_1 = -26.335025324149626D;
+        Double double_2 = 87.9546734116494D;
+
+        for (int i = 0, j = 0; i < 256; i++) {
+            if (param != param) {
+                j--;
+            } else if (dummy() > 0) {
+                return (j < 1234 ? double_1 : double_2);
+            }
+        }
+
+        return 10.0;
+    }
+
+    public static void main(String[] args) {
+        for (int i = 0; i < 512; i++) {
+            test(-3.1415);
+        }
+    }
+}

--- a/test/hotspot/jtreg/compiler/escapeAnalysis/TestReduceAllocationAndSetTypeTwice.java
+++ b/test/hotspot/jtreg/compiler/escapeAnalysis/TestReduceAllocationAndSetTypeTwice.java
@@ -27,6 +27,7 @@
  * @summary Check that RAM does not crash when split load through phi
  *          tries to register an old node twice with IGVN.
  * @run main/othervm -XX:CompileCommand=compileonly,*TestReduceAllocationAndSetTypeTwice*::*
+ *                   -XX:CompileCommand=dontinline,*TestReduceAllocationAndSetTypeTwice*::*
  *                   -Xcomp compiler.escapeAnalysis.TestReduceAllocationAndSetTypeTwice
  * @run main compiler.escapeAnalysis.TestReduceAllocationAndSetTypeTwice
  */


### PR DESCRIPTION
The reason for the error reported is that when RAM tries to reduce a field load through a Phi it ends up calling `step_through_mergemem` with `_delay_transform` set to true and, since `step_through_mergemem` assumes that `_delay_transform` is `false`, it calls `igvn->transform` passing a MergeMem that has been added to the graph long ago.

I didn't opt to make `_delay_transform` false during the RAM transformations because that seemed to be a risky move, nevertheless I'll create an RFE and keep investigating that option.

Also, while working on a test case I found that C2 doesn't remove (at least not before EA steps) the `if (param != param) {...}` and I'm going to investigate that as a separate RFE.

I tested this with JTREG Tier 1-3 on Linux x86_64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8352681](https://bugs.openjdk.org/browse/JDK-8352681): C2 compilation hits asserts "must set the initial type just once" (**Bug** - P3)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Damon Fenacci](https://openjdk.org/census#dfenacci) (@dafedafe - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24471/head:pull/24471` \
`$ git checkout pull/24471`

Update a local copy of the PR: \
`$ git checkout pull/24471` \
`$ git pull https://git.openjdk.org/jdk.git pull/24471/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24471`

View PR using the GUI difftool: \
`$ git pr show -t 24471`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24471.diff">https://git.openjdk.org/jdk/pull/24471.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24471#issuecomment-2781209175)
</details>
