### PR TITLE
8353659: SubmissionPublisherTest::testCap1Submit times out

### DIFF
--- a/src/java.base/share/classes/java/util/concurrent/ForkJoinPool.java
+++ b/src/java.base/share/classes/java/util/concurrent/ForkJoinPool.java
@@ -1278,8 +1278,7 @@ public class ForkJoinPool extends AbstractExecutorService
          * @param internal if caller owns this queue
          * @throws RejectedExecutionException if array could not be resized
          */
-        final void push(ForkJoinTask<?> task, ForkJoinPool pool,
-                        boolean internal) {
+        final void push(ForkJoinTask<?> task, ForkJoinPool pool, boolean internal) {
             int s = top, b = base, m, cap, room; ForkJoinTask<?>[] a;
             if ((a = array) != null && (cap = a.length) > 0 && // else disabled
                 task != null) {
@@ -1383,8 +1382,7 @@ public class ForkJoinPool extends AbstractExecutorService
             if (a != null && (cap = a.length) > 0 &&
                 U.getReference(a, k = slotOffset((cap - 1) & s)) == task &&
                 (internal || tryLockPhase())) {
-                if (top == p &&
-                    U.compareAndSetReference(a, k, task, null)) {
+                if (top == p && U.compareAndSetReference(a, k, task, null)) {
                     taken = true;
                     updateTop(s);
                 }
@@ -2061,8 +2059,9 @@ public class ForkJoinPool extends AbstractExecutorService
             ((e & SHUTDOWN) != 0L && ac == 0 && quiescent() > 0) ||
             (qs = queues) == null || (n = qs.length) <= 0)
             return IDLE;                      // terminating
-        int k = Math.max(n << 2, SPIN_WAITS << 1);
-        for (int prechecks = k / n;;) {       // reactivation threshold
+
+        for (int prechecks = Math.min(ac, 2), // reactivation threshold
+             k = Math.max(n + (n << 1), SPIN_WAITS << 1);;) {
             WorkQueue q; int cap; ForkJoinTask<?>[] a; long c;
             if (w.phase == activePhase)
                 return activePhase;
@@ -2071,7 +2070,7 @@ public class ForkJoinPool extends AbstractExecutorService
             if ((q = qs[k & (n - 1)]) == null)
                 Thread.onSpinWait();
             else if ((a = q.array) != null && (cap = a.length) > 0 &&
-                     a[q.base & (cap - 1)] != null && --prechecks <= 0 &&
+                     a[q.base & (cap - 1)] != null && --prechecks < 0 &&
                      (int)(c = ctl) == activePhase &&
                      compareAndSetCtl(c, (sp & LMASK) | ((c + RC_UNIT) & UMASK)))
                 return w.phase = activePhase; // reactivate

--- a/test/jdk/java/util/concurrent/tck/ForkJoinPool20Test.java
+++ b/test/jdk/java/util/concurrent/tck/ForkJoinPool20Test.java
@@ -528,6 +528,7 @@ public class ForkJoinPool20Test extends JSR166TestCase {
         final CountDownLatch delayedDone = new CountDownLatch(1);
         final CountDownLatch immediateDone = new CountDownLatch(1);
         final ForkJoinPool p = new ForkJoinPool(2);
+        p.cancelDelayedTasksOnShutdown();
         try (PoolCleaner cleaner = cleaner(p)) {
             final Runnable delayed = () -> {
                 delayedDone.countDown();
@@ -568,8 +569,8 @@ public class ForkJoinPool20Test extends JSR166TestCase {
             public Boolean call() throws Exception {
                 Thread.sleep(LONGER_DELAY_MS); return Boolean.TRUE; }};
         ForkJoinTask<?> task = p.submitWithTimeout(c, 1, NANOSECONDS, null);
-        Thread.sleep(timeoutMillis());
-        assertTrue(task.isCancelled());
+        while(!task.isCancelled())
+            Thread.sleep(timeoutMillis());
     }
 
     static final class SubmitWithTimeoutException extends RuntimeException {}
@@ -586,7 +587,6 @@ public class ForkJoinPool20Test extends JSR166TestCase {
             c, 1, NANOSECONDS,
             (ForkJoinTask<Item> t) ->
             t.complete(two));
-        Thread.sleep(timeoutMillis());
         assertEquals(task.join(), two);
     }
 
@@ -602,7 +602,6 @@ public class ForkJoinPool20Test extends JSR166TestCase {
             c, 1, NANOSECONDS,
             (ForkJoinTask<Boolean> t) ->
             t.completeExceptionally(new SubmitWithTimeoutException()));
-        Thread.sleep(timeoutMillis());
         try {
             task.join();
             shouldThrow();


### PR DESCRIPTION
This PR reverts the deactivation changes of the updates to FJP introduced in JDK-8319447.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8353659](https://bugs.openjdk.org/browse/JDK-8353659): SubmissionPublisherTest::testCap1Submit times out (**Bug** - P4)


### Reviewers
 * [Doug Lea](https://openjdk.org/census#dl) (@DougLea - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24473/head:pull/24473` \
`$ git checkout pull/24473`

Update a local copy of the PR: \
`$ git checkout pull/24473` \
`$ git pull https://git.openjdk.org/jdk.git pull/24473/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24473`

View PR using the GUI difftool: \
`$ git pr show -t 24473`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24473.diff">https://git.openjdk.org/jdk/pull/24473.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24473#issuecomment-2781543198)
</details>
