### PR TITLE
8352687: Opensource few JInternalFrame and JTextField tests

### DIFF
--- a/test/jdk/javax/swing/JInternalFrame/bug4190516.java
+++ b/test/jdk/javax/swing/JInternalFrame/bug4190516.java
@@ -57,7 +57,7 @@ public class bug4190516 {
         JDesktopPane jdp = new JDesktopPane();
         fr.getContentPane().add(jdp);
 
-        JInternalFrame  jif = new JInternalFrame("Title", true, true, true, true);
+        JInternalFrame jif = new JInternalFrame("Title", true, true, true, true);
         jdp.add(jif);
         jif.setSize(150, 150);
         jif.setVisible(true);

--- a/test/jdk/javax/swing/JInternalFrame/bug4190516.java
+++ b/test/jdk/javax/swing/JInternalFrame/bug4190516.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4190516
+ * @summary JInternalFrame should be maximized when Desktop resized
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual bug4190516
+ */
+
+import javax.swing.JDesktopPane;
+import javax.swing.JFrame;
+import javax.swing.JInternalFrame;
+import javax.swing.SwingUtilities;
+
+public class bug4190516 {
+
+    private static final String INSTRUCTIONS = """
+        Try to resize frame "bug4190516 Frame".
+        If the internal frame remains maximized
+        inside this frame then test passes, else test fails.""";
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                .title("bug4190516 Instructions")
+                .instructions(INSTRUCTIONS)
+                .columns(25)
+                .testUI(bug4190516::createTestUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static JFrame createTestUI() {
+        JFrame fr = new JFrame("bug4190516 Frame");
+        JDesktopPane jdp = new JDesktopPane();
+        fr.getContentPane().add(jdp);
+
+        JInternalFrame  jif = new JInternalFrame("Title", true, true, true, true);
+        jdp.add(jif);
+        jif.setSize(150, 150);
+        jif.setVisible(true);
+
+        fr.setSize(300, 200);
+        try {
+            jif.setMaximum(true);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        SwingUtilities.updateComponentTreeUI(fr);
+        return fr;
+    }
+}

--- a/test/jdk/javax/swing/JInternalFrame/bug4242045.java
+++ b/test/jdk/javax/swing/JInternalFrame/bug4242045.java
@@ -51,7 +51,7 @@ public class bug4242045 {
         Add and remove iconify/maximize/close buttons using the buttons
         "Iconifiable", "Maximizable", "Closable" under different LookAndFeels.
         If they appears and disappears correctly then test passes. If any
-        button not appear or disappear as expected or appear with incorrect
+        button does not appear or disappear as expected or appear with incorrect
         placement then test fails.""";
 
     public static void main(String[] args) throws Exception {

--- a/test/jdk/javax/swing/JInternalFrame/bug4242045.java
+++ b/test/jdk/javax/swing/JInternalFrame/bug4242045.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4242045
+ * @requires (os.family == "windows")
+ * @summary JInternalFrame titlepane icons should be restored after attribute change
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual bug4242045
+ */
+
+import java.awt.BorderLayout;
+import java.awt.event.ActionEvent;
+
+import javax.swing.JButton;
+import javax.swing.JDesktopPane;
+import javax.swing.JFrame;
+import javax.swing.JInternalFrame;
+import javax.swing.JPanel;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+import javax.swing.UnsupportedLookAndFeelException;
+
+public class bug4242045 {
+
+    private static JFrame frame;
+
+    private static final String INSTRUCTIONS = """
+        Add and remove iconify/maximize/close buttons using the buttons
+        "Iconifiable", "Maximizable", "Closable" under different LookAndFeels.
+        If they appears and disappears correctly then test passes. If any
+        button not appear or disappear as expected or appear with incorrect
+        placement then test fails.""";
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                .title("bug4242045 Instructions")
+                .instructions(INSTRUCTIONS)
+                .columns(35)
+                .testUI(bug4242045::createTestUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+     private static void setLF(ActionEvent e) {
+        try {
+            UIManager.setLookAndFeel(((JButton)e.getSource()).getActionCommand());
+            SwingUtilities.updateComponentTreeUI(frame);
+        } catch (ClassNotFoundException | InstantiationException
+                 | UnsupportedLookAndFeelException
+                 | IllegalAccessException ex) {
+             throw new RuntimeException(ex);
+        }
+    }
+
+    private static JFrame createTestUI() {
+
+        frame = new JFrame("bug4242045");
+        JDesktopPane jdp = new JDesktopPane();
+        JInternalFrame jif = new JInternalFrame("Test", true);
+        frame.add(jdp);
+
+        jdp.add(jif);
+        jif.setSize(150, 150);
+        jif.setVisible(true);
+
+        JPanel p = new JPanel();
+
+        JButton metal = new JButton("Metal");
+        metal.setActionCommand("javax.swing.plaf.metal.MetalLookAndFeel");
+        metal.addActionListener((ActionEvent e) -> setLF(e));
+        p.add(metal);
+
+        JButton windows = new JButton("Windows");
+        windows.setActionCommand("com.sun.java.swing.plaf.windows.WindowsLookAndFeel");
+        windows.addActionListener((ActionEvent e) -> setLF(e));
+        p.add(windows);
+
+        JButton motif = new JButton("Motif");
+        motif.setActionCommand("com.sun.java.swing.plaf.motif.MotifLookAndFeel");
+        motif.addActionListener((ActionEvent e) -> setLF(e));
+        p.add(motif);
+
+        JButton clo = new JButton("Closable");
+        clo.addActionListener(e -> jif.setClosable(!jif.isClosable()));
+        p.add(clo);
+
+        JButton ico = new JButton("Iconifiable");
+        ico.addActionListener(e -> jif.setIconifiable(!jif.isIconifiable()));
+        p.add(ico);
+
+        JButton max = new JButton("Maximizable");
+        max.addActionListener(e -> jif.setMaximizable(!jif.isMaximizable()));
+        p.add(max);
+
+        frame.add(p, BorderLayout.SOUTH);
+        frame.setSize(650, 250);
+        return frame;
+    }
+
+}

--- a/test/jdk/javax/swing/JTextField/bug4232716.java
+++ b/test/jdk/javax/swing/JTextField/bug4232716.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4232716
+ * @key headful
+ * @summary Tests if <input type="text" size="5"> creates a maximized JTextField
+ * @run main bug4232716
+ */
+
+import java.awt.Component;
+import java.awt.Container;
+import java.awt.Robot;
+import javax.swing.JEditorPane;
+import javax.swing.JFrame;
+import javax.swing.JTextField;
+import javax.swing.SwingUtilities;
+
+public class bug4232716 {
+
+    private static JFrame frame;
+    private static JEditorPane e;
+
+    public static void main(String[] args) throws Exception {
+        Robot robot = new Robot();
+        try {
+            SwingUtilities.invokeAndWait(() -> {
+                frame = new JFrame("bug4232716");
+                String html ="<html> <head> <title> Test </title> </head> " +
+                             "<body> <form> <input type=\"text\" size=\"5\"> " +
+                             "</form> </body> </html>";
+                e = new JEditorPane("text/html", html);
+                e.setEditable(false);
+                frame.getContentPane().add(e);
+                frame.setSize(400, 300);
+                frame.setLocationRelativeTo(null);
+                frame.setVisible(true);
+            });
+            robot.waitForIdle();
+            robot.delay(1000);
+
+            Container c = (Container)e.getComponent(0);
+            Component swingComponent = c.getComponent(0);
+            System.out.println(swingComponent);
+            if (swingComponent instanceof JTextField tf) {
+                System.out.println(tf.getWidth());
+                System.out.println(frame.getWidth());
+                if (swingComponent.getWidth() > (frame.getWidth() * 0.75)) {
+                    throw new RuntimeException("textfield width almost same as frame width");
+                }
+            }
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+    }
+}

--- a/test/jdk/javax/swing/JTextField/bug4232716.java
+++ b/test/jdk/javax/swing/JTextField/bug4232716.java
@@ -52,7 +52,7 @@ public class bug4232716 {
                              "</form> </body> </html>";
                 e = new JEditorPane("text/html", html);
                 e.setEditable(false);
-                frame.getContentPane().add(e);
+                frame.add(e);
                 frame.setSize(400, 300);
                 frame.setLocationRelativeTo(null);
                 frame.setVisible(true);

--- a/test/jdk/javax/swing/JTextField/bug5027332.java
+++ b/test/jdk/javax/swing/JTextField/bug5027332.java
@@ -24,8 +24,7 @@
 /*
  * @test
  * @bug 5027332
- * @requires (os.family == "linux")
- * @library /java/awt/regtesthelpers /test/lib
+ * @library /java/awt/regtesthelpers
  * @build PassFailJFrame
  * @summary Tests that textfield caret is placed slightly off textfield borders
  * @run main/manual bug5027332
@@ -43,23 +42,18 @@ import jtreg.SkippedException;
 public class bug5027332 {
 
     private static final String INSTRUCTIONS = """
-            This test is for GTK LookAndFeel.
-
             Click into the text field so that caret appears inside.
             The caret should be placed slightly off text field borders,
             so that it can be easily distinguished from the border.
             Test fails if the caret touches the border.""";
 
     public static void main(String[] args) throws Exception {
-        try {
-            UIManager.setLookAndFeel("com.sun.java.swing.plaf.gtk.GTKLookAndFeel");
-        } catch (Exception e) {
-            throw new SkippedException("Test applicable only for GTK L&F");
-        }
+        UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
 
         PassFailJFrame.builder()
                 .title("bug5027332 Instructions")
                 .instructions(INSTRUCTIONS)
+                .rows(6)
                 .columns(35)
                 .testUI(bug5027332::createTestUI)
                 .build()
@@ -67,7 +61,6 @@ public class bug5027332 {
     }
 
     private static JFrame createTestUI() {
-
         JFrame frame = new JFrame("bug5027332");
         JTextField t = new JTextField(10);
         JPanel p = new JPanel();

--- a/test/jdk/javax/swing/JTextField/bug5027332.java
+++ b/test/jdk/javax/swing/JTextField/bug5027332.java
@@ -37,8 +37,6 @@ import javax.swing.JPanel;
 import javax.swing.JTextField;
 import javax.swing.UIManager;
 
-import jtreg.SkippedException;
-
 public class bug5027332 {
 
     private static final String INSTRUCTIONS = """

--- a/test/jdk/javax/swing/JTextField/bug5027332.java
+++ b/test/jdk/javax/swing/JTextField/bug5027332.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2004, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 5027332
+ * @requires (os.family == "linux")
+ * @library /java/awt/regtesthelpers /test/lib
+ * @build PassFailJFrame
+ * @summary Tests that textfield caret is placed slightly off textfield borders
+ * @run main/manual bug5027332
+ */
+
+import java.awt.BorderLayout;
+
+import javax.swing.JFrame;
+import javax.swing.JPanel;
+import javax.swing.JTextField;
+import javax.swing.UIManager;
+
+import jtreg.SkippedException;
+
+public class bug5027332 {
+
+    private static final String INSTRUCTIONS = """
+            This test is for GTK LookAndFeel.
+
+            Click into the text field so that caret appears inside.
+            The caret should be placed slightly off text field borders,
+            so that it can be easily distinguished from the border.
+            Test fails if the caret touches the border.""";
+
+    public static void main(String[] args) throws Exception {
+        try {
+            UIManager.setLookAndFeel("com.sun.java.swing.plaf.gtk.GTKLookAndFeel");
+        } catch (Exception e) {
+            throw new SkippedException("Test applicable only for GTK L&F");
+        }
+
+        PassFailJFrame.builder()
+                .title("bug5027332 Instructions")
+                .instructions(INSTRUCTIONS)
+                .columns(35)
+                .testUI(bug5027332::createTestUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static JFrame createTestUI() {
+
+        JFrame frame = new JFrame("bug5027332");
+        JTextField t = new JTextField(10);
+        JPanel p = new JPanel();
+        p.add(t, BorderLayout.CENTER);
+        frame.setContentPane(p);
+        frame.pack();
+        return frame;
+    }
+}


### PR DESCRIPTION
Few JInternalFrame and JTextField tests are opensourced

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8352687](https://bugs.openjdk.org/browse/JDK-8352687): Opensource few JInternalFrame and JTextField tests (**Bug** - P4)


### Reviewers
 * [Harshitha Onkar](https://openjdk.org/census#honkar) (@honkar-jdk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24474/head:pull/24474` \
`$ git checkout pull/24474`

Update a local copy of the PR: \
`$ git checkout pull/24474` \
`$ git pull https://git.openjdk.org/jdk.git pull/24474/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24474`

View PR using the GUI difftool: \
`$ git pr show -t 24474`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24474.diff">https://git.openjdk.org/jdk/pull/24474.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24474#issuecomment-2782002635)
</details>
