### PR TITLE
8353787: Increased number of SHA-384-Digest java.util.jar.Attributes$Name instances leading to higher memory footprint

### DIFF
--- a/src/java.base/share/classes/java/util/jar/Attributes.java
+++ b/src/java.base/share/classes/java/util/jar/Attributes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -727,6 +727,7 @@ public class Attributes implements Map<Object,Object>, Cloneable {
                 addName(names, new Name("Created-By"));
                 addName(names, new Name("SHA1-Digest"));
                 addName(names, new Name("SHA-256-Digest"));
+                addName(names, new Name("SHA-384-Digest"));
                 KNOWN_NAMES = Map.copyOf(names);
             } else {
                 // Even if KNOWN_NAMES was read from archive, we still need


### PR DESCRIPTION
Can I please get a review of this change which proposes to address the increase in memory footprint of an application that uses signed JAR files, signed with `SHA-384` digest algorithm? This addresses https://bugs.openjdk.org/browse/JDK-8353787.

As noted in that issue and the linked mailing list discussion, it has been noticed that when JARs signed with `SHA-384` digest algorithm (which is the default since Java 19) are loaded, the number of `java.util.Attributes$Name` instances held in memory increase, leading to an increase in the memory footprint of the application.

The `Attributes` class has an internal cache which is meant to store `Name` instances of some well-known manifest attributes. It already has the `Name` instances for `SHA1-Digest` and `SHA-256-Digest` manifest attributes cached, but is missing an entry for `SHA-384-Digest`. The commit in this PR adds `SHA-384-Digest` to that cache.

Given the nature of this change, no new jtreg test has been introduced and existing tests in tier1, tier2 and tier3 continue to pass with this change. I've manually verified that this change does reduce the memory footprint of an application which has signed JARs with `SHA-384` digest algorithm  (details in a comment of this PR).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8353787](https://bugs.openjdk.org/browse/JDK-8353787): Increased number of SHA-384-Digest java.util.jar.Attributes$Name instances leading to higher memory footprint (**Bug** - P3)


### Reviewers
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24475/head:pull/24475` \
`$ git checkout pull/24475`

Update a local copy of the PR: \
`$ git checkout pull/24475` \
`$ git pull https://git.openjdk.org/jdk.git pull/24475/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24475`

View PR using the GUI difftool: \
`$ git pr show -t 24475`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24475.diff">https://git.openjdk.org/jdk/pull/24475.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24475#issuecomment-2782175465)
</details>
