### PR TITLE
8352895: UserCookie.java runs wrong test class

### DIFF
--- a/test/jdk/sun/net/www/protocol/http/UserCookie.java
+++ b/test/jdk/sun/net/www/protocol/http/UserCookie.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,9 +24,9 @@
 /*
  * @test
  * @bug 6439651
- * @modules jdk.httpserver
- * @run main/othervm UserAuth
  * @summary Sending "Cookie" header with JRE 1.5.0_07 doesn't work anymore
+ * @modules jdk.httpserver
+ * @run main/othervm UserCookie
  */
 
 import java.net.*;


### PR DESCRIPTION
Can I please get a review of this trivial test-only change which fixes the test definition to run the correct test class? This addresses https://bugs.openjdk.org/browse/JDK-8352895.

The test code can be cleaned up a lot more. In fact, I have a local version with additional clean ups. But I decided not to do those change now since I don't have a Java 1.5.x version which verifies that the test changes will still reproduce the original issue for which this test was introduced.

The test passes with this proposed change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8352895](https://bugs.openjdk.org/browse/JDK-8352895): UserCookie.java runs wrong test class (**Bug** - P4)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24476/head:pull/24476` \
`$ git checkout pull/24476`

Update a local copy of the PR: \
`$ git checkout pull/24476` \
`$ git pull https://git.openjdk.org/jdk.git pull/24476/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24476`

View PR using the GUI difftool: \
`$ git pr show -t 24476`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24476.diff">https://git.openjdk.org/jdk/pull/24476.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24476#issuecomment-2782229049)
</details>
