### PR TITLE
8353829: RISC-V: Auto-enable several more extensions for debug builds

### DIFF
--- a/src/hotspot/os_cpu/linux_riscv/riscv_hwprobe.cpp
+++ b/src/hotspot/os_cpu/linux_riscv/riscv_hwprobe.cpp
@@ -224,6 +224,16 @@ void RiscvHwprobe::add_features_from_query_result() {
     VM_Version::ext_Zfa.enable_feature();
   }
 #endif
+#ifndef PRODUCT
+  if (is_set(RISCV_HWPROBE_KEY_IMA_EXT_0, RISCV_HWPROBE_EXT_ZTSO)) {
+    VM_Version::ext_Ztso.enable_feature();
+  }
+#endif
+#ifndef PRODUCT
+  if (is_set(RISCV_HWPROBE_KEY_IMA_EXT_0, RISCV_HWPROBE_EXT_ZACAS)) {
+    VM_Version::ext_Zacas.enable_feature();
+  }
+#endif
   if (is_set(RISCV_HWPROBE_KEY_IMA_EXT_0, RISCV_HWPROBE_EXT_ZICOND)) {
     VM_Version::ext_Zicond.enable_feature();
   }


### PR DESCRIPTION
Hi,
Please consider this followup change after https://bugs.openjdk.org/browse/JDK-8353344.
This adds detection and enablement of two more extensions: Ztso and Zacas.
Testing: hs:tier1-hs:tier3 tested with qemu-system equipmented with these extensions.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8353829](https://bugs.openjdk.org/browse/JDK-8353829): RISC-V: Auto-enable several more extensions for debug builds (**Enhancement** - P4)


### Reviewers
 * [Robbin Ehn](https://openjdk.org/census#rehn) (@robehn - **Reviewer**)
 * [Feilong Jiang](https://openjdk.org/census#fjiang) (@feilongjiang - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24478/head:pull/24478` \
`$ git checkout pull/24478`

Update a local copy of the PR: \
`$ git checkout pull/24478` \
`$ git pull https://git.openjdk.org/jdk.git pull/24478/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24478`

View PR using the GUI difftool: \
`$ git pr show -t 24478`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24478.diff">https://git.openjdk.org/jdk/pull/24478.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24478#issuecomment-2782344931)
</details>
