### PR TITLE
8346552: C2: Add IR tests to check that Predicate cloning in Loop Unswitching works as expected

### DIFF
--- a/src/hotspot/share/opto/ifnode.cpp
+++ b/src/hotspot/share/opto/ifnode.cpp
@@ -2219,13 +2219,13 @@ void ParsePredicateNode::dump_spec(outputStream* st) const {
       st->print("Loop ");
       break;
     case Deoptimization::DeoptReason::Reason_profile_predicate:
-      st->print("Profiled Loop ");
+      st->print("Profiled_Loop ");
       break;
     case Deoptimization::DeoptReason::Reason_auto_vectorization_check:
       st->print("Auto_Vectorization_Check ");
       break;
     case Deoptimization::DeoptReason::Reason_loop_limit_check:
-      st->print("Loop Limit Check ");
+      st->print("Loop_Limit_Check ");
       break;
     default:
       fatal("unknown kind");

--- a/src/hotspot/share/opto/predicates.cpp
+++ b/src/hotspot/share/opto/predicates.cpp
@@ -1098,9 +1098,10 @@ CloneUnswitchedLoopPredicatesVisitor::CloneUnswitchedLoopPredicatesVisitor(
       _is_counted_loop(true_path_loop_head->is_CountedLoop()) {}
 
 // The PredicateIterator will always start at the loop entry and first visits the Loop Limit Check Predicate Block.
-// Does not clone Loop Limit Check parse predicates iff a counted loop is unswitched, because a loop limit check before
-// the unswitched loop selector covers both unswitched counted loops. Otherwise, we would need to hoist the loop limit
-// checks from both loops back up to the loop selector.
+// Does not clone a Loop Limit Check Parse Predicate if a counted loop is unswitched, because it most likely will not be
+// used anymore (it could only be used when both unswitched loop versions die and the Loop Limit Check Parse Predicate
+// ends up at a LoopNode without Loop Limit Check Parse Predicate directly following the unswitched loop that can then
+// be speculatively converted to a counted loop - this is rather rare).
 void CloneUnswitchedLoopPredicatesVisitor::visit(const ParsePredicate& parse_predicate) {
   Deoptimization::DeoptReason deopt_reason = parse_predicate.head()->deopt_reason();
   if (_is_counted_loop && deopt_reason == Deoptimization::Reason_loop_limit_check) {

--- a/src/hotspot/share/opto/predicates.hpp
+++ b/src/hotspot/share/opto/predicates.hpp
@@ -1176,7 +1176,7 @@ class CloneUnswitchedLoopPredicatesVisitor : public PredicateVisitor {
   ClonePredicateToTargetLoop _clone_predicate_to_false_path_loop;
 
   PhaseIdealLoop* const _phase;
-  bool const _is_counted_loop;
+  const bool _is_counted_loop;
 
  public:
   CloneUnswitchedLoopPredicatesVisitor(LoopNode* true_path_loop_head,

--- a/src/hotspot/share/opto/predicates.hpp
+++ b/src/hotspot/share/opto/predicates.hpp
@@ -1176,6 +1176,7 @@ class CloneUnswitchedLoopPredicatesVisitor : public PredicateVisitor {
   ClonePredicateToTargetLoop _clone_predicate_to_false_path_loop;
 
   PhaseIdealLoop* const _phase;
+  bool const _is_counted_loop;
 
  public:
   CloneUnswitchedLoopPredicatesVisitor(LoopNode* true_path_loop_head,

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
@@ -1470,6 +1470,11 @@ public class IRNode {
         optoOnly(OOPMAP_WITH, regex);
     }
 
+    public static final String OPAQUE_TEMPLATE_ASSERTION_PREDICATE = PREFIX + "OPAQUE_TEMPLATE_ASSERTION_PREDICATE" + POSTFIX;
+    static {
+        fromAfterLoopPredicationRcToBeforeCCP1(OPAQUE_TEMPLATE_ASSERTION_PREDICATE, "OpaqueTemplateAssertionPredicate");
+    }
+
     public static final String OR_I = PREFIX + "OR_I" + POSTFIX;
     static {
         beforeMatchingNameRegex(OR_I, "OrI");
@@ -2809,6 +2814,16 @@ public class IRNode {
         IR_NODE_MAPPINGS.put(irNodePlaceholder, new SinglePhaseRangeEntry(CompilePhase.PRINT_IDEAL, regex,
                                                                           CompilePhase.OPTIMIZE_FINISHED,
                                                                           CompilePhase.BEFORE_MATCHING));
+    }
+
+    /**
+     * Apply {@code regex} on all ideal graph phases starting from {@link CompilePhase#AFTER_LOOP_PREDICATION_RC}
+     * up to and including {@link CompilePhase#BEFORE_CCP1}
+     */
+    private static void fromAfterLoopPredicationRcToBeforeCCP1(String irNodePlaceholder, String regex) {
+        IR_NODE_MAPPINGS.put(irNodePlaceholder, new SinglePhaseRangeEntry(CompilePhase.AFTER_BEAUTIFY_LOOPS, regex,
+                                                                          CompilePhase.AFTER_LOOP_PREDICATION_RC,
+                                                                          CompilePhase.BEFORE_CCP1));
     }
 
     private static void trapNodes(String irNodePlaceholder, String trapReason) {

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
@@ -2823,7 +2823,7 @@ public class IRNode {
 
     /**
      * Apply {@code regex} on all ideal graph phases starting from {@link CompilePhase#BEFORE_LOOP_OPTS}
-     * up to and including {@link CompilePhase#AFTER_LOOP_OPTS}
+     * up to and including {@link CompilePhase#AFTER_LOOP_OPTS}.
      */
     private static void duringLoopOpts(String irNodePlaceholder, String regex) {
         IR_NODE_MAPPINGS.put(irNodePlaceholder, new SinglePhaseRangeEntry(CompilePhase.AFTER_LOOP_OPTS, regex,

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
@@ -1589,6 +1589,11 @@ public class IRNode {
         parsePredicateNodes(PROFILED_LOOP_PARSE_PREDICATE, "Profiled Loop");
     }
 
+    public static final String AUTO_VECTORIZATION_CHECK_PARSE_PREDICATE = PREFIX + "AUTO_VECTORIZATION_CHECK_PARSE_PREDICATE" + POSTFIX;
+    static {
+        parsePredicateNodes(AUTO_VECTORIZATION_CHECK_PARSE_PREDICATE, "Auto_Vectorization_Check");
+    }
+
     public static final String PREDICATE_TRAP = PREFIX + "PREDICATE_TRAP" + POSTFIX;
     static {
         trapNodes(PREDICATE_TRAP, "predicate");

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
@@ -1581,12 +1581,12 @@ public class IRNode {
 
     public static final String LOOP_LIMIT_CHECK_PARSE_PREDICATE = PREFIX + "LOOP_LIMIT_CHECK_PARSE_PREDICATE" + POSTFIX;
     static {
-        parsePredicateNodes(LOOP_LIMIT_CHECK_PARSE_PREDICATE, "Loop Limit Check");
+        parsePredicateNodes(LOOP_LIMIT_CHECK_PARSE_PREDICATE, "Loop_Limit_Check");
     }
 
     public static final String PROFILED_LOOP_PARSE_PREDICATE = PREFIX + "PROFILED_LOOP_PARSE_PREDICATE" + POSTFIX;
     static {
-        parsePredicateNodes(PROFILED_LOOP_PARSE_PREDICATE, "Profiled Loop");
+        parsePredicateNodes(PROFILED_LOOP_PARSE_PREDICATE, "Profiled_Loop");
     }
 
     public static final String AUTO_VECTORIZATION_CHECK_PARSE_PREDICATE = PREFIX + "AUTO_VECTORIZATION_CHECK_PARSE_PREDICATE" + POSTFIX;
@@ -2837,7 +2837,7 @@ public class IRNode {
     }
 
     private static void parsePredicateNodes(String irNodePlaceholder, String label) {
-        String regex = START + "ParsePredicate" + MID + "#" + label + "[ ]*!jvms:" + END;
+        String regex = START + "ParsePredicate" + MID + "#" + label + " " + END;
         IR_NODE_MAPPINGS.put(irNodePlaceholder, new SinglePhaseRangeEntry(CompilePhase.AFTER_PARSING, regex,
                                                                           CompilePhase.AFTER_PARSING,
                                                                           CompilePhase.PHASEIDEALLOOP_ITERATIONS));

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
@@ -1472,7 +1472,7 @@ public class IRNode {
 
     public static final String OPAQUE_TEMPLATE_ASSERTION_PREDICATE = PREFIX + "OPAQUE_TEMPLATE_ASSERTION_PREDICATE" + POSTFIX;
     static {
-        fromAfterLoopPredicationRcToBeforeCCP1(OPAQUE_TEMPLATE_ASSERTION_PREDICATE, "OpaqueTemplateAssertionPredicate");
+        duringLoopOpts(OPAQUE_TEMPLATE_ASSERTION_PREDICATE, "OpaqueTemplateAssertionPredicate");
     }
 
     public static final String OR_I = PREFIX + "OR_I" + POSTFIX;
@@ -2822,13 +2822,13 @@ public class IRNode {
     }
 
     /**
-     * Apply {@code regex} on all ideal graph phases starting from {@link CompilePhase#AFTER_LOOP_PREDICATION_RC}
-     * up to and including {@link CompilePhase#BEFORE_CCP1}
+     * Apply {@code regex} on all ideal graph phases starting from {@link CompilePhase#BEFORE_LOOP_OPTS}
+     * up to and including {@link CompilePhase#AFTER_LOOP_OPTS}
      */
-    private static void fromAfterLoopPredicationRcToBeforeCCP1(String irNodePlaceholder, String regex) {
-        IR_NODE_MAPPINGS.put(irNodePlaceholder, new SinglePhaseRangeEntry(CompilePhase.AFTER_BEAUTIFY_LOOPS, regex,
-                                                                          CompilePhase.AFTER_LOOP_PREDICATION_RC,
-                                                                          CompilePhase.BEFORE_CCP1));
+    private static void duringLoopOpts(String irNodePlaceholder, String regex) {
+        IR_NODE_MAPPINGS.put(irNodePlaceholder, new SinglePhaseRangeEntry(CompilePhase.AFTER_LOOP_OPTS, regex,
+                                                                          CompilePhase.BEFORE_LOOP_OPTS,
+                                                                          CompilePhase.AFTER_LOOP_OPTS));
     }
 
     private static void trapNodes(String irNodePlaceholder, String trapReason) {
@@ -2840,7 +2840,7 @@ public class IRNode {
         String regex = START + "ParsePredicate" + MID + "#" + label + " " + END;
         IR_NODE_MAPPINGS.put(irNodePlaceholder, new SinglePhaseRangeEntry(CompilePhase.AFTER_PARSING, regex,
                                                                           CompilePhase.AFTER_PARSING,
-                                                                          CompilePhase.PHASEIDEALLOOP_ITERATIONS));
+                                                                          CompilePhase.AFTER_LOOP_OPTS));
     }
 
     private static void loadOfNodes(String irNodePlaceholder, String irNodeRegex) {

--- a/test/hotspot/jtreg/compiler/loopopts/TestUnswitchPredicateCloning.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestUnswitchPredicateCloning.java
@@ -21,22 +21,26 @@
  * questions.
  */
 
- package compiler.loopopts;
+package compiler.loopopts;
 
- import compiler.lib.ir_framework.*;
- import jdk.test.lib.Asserts;
+import compiler.lib.ir_framework.*;
+import java.util.Random;
+import jdk.test.lib.Utils;
+import jdk.test.lib.Asserts;
 
- /*
-  * @test
-  * @bug 8346552
-  * @summary Test that all parse predicates are cloned after loop unswitching.
-  * @library /test/lib /
-  * @run driver compiler.loopopts.TestUnswitchPredicateCloning
-  */
+/*
+ * @test
+ * @bug 8346552
+ * @summary Test that all parse predicates are cloned after loop unswitching.
+ * @key randomness
+ * @library /test/lib /
+ * @run driver compiler.loopopts.TestUnswitchPredicateCloning
+ */
 
 public class TestUnswitchPredicateCloning {
     static final int SIZE = 100;
-    static final int IDX = 42;
+
+    private static final Random random = Utils.getRandomInstance();
 
     public static void main(String[] strArr) {
         TestFramework.run();
@@ -45,15 +49,15 @@ public class TestUnswitchPredicateCloning {
     @Run(test = {"testUnswitchingBeforePredication", "testPredicationBeforeUnswitching", "testUnswitchingUncounted"})
     @Warmup(0)
     private static void runNoWarmup() {
-        int res = testUnswitchingBeforePredication(IDX);
-        Asserts.assertEQ(res, SIZE * IDX);
-        final boolean cond = false;
-        res = testPredicationBeforeUnswitching(IDX, cond);
-        Asserts.assertEQ(res, (SIZE * (SIZE - 1)) / 2 + (cond ? SIZE * IDX : 0));
+        final int idx = random.nextInt(SIZE);
+        final boolean cond = random.nextBoolean();
+        int res = testUnswitchingBeforePredication(idx);
+        Asserts.assertEQ(SIZE * idx, res);
+        res = testPredicationBeforeUnswitching(idx, cond);
+        Asserts.assertEQ((SIZE * (SIZE - 1)) / 2 + (cond ? SIZE * idx : 0), res);
         res = testUnswitchingUncounted(cond);
-        Asserts.assertEQ(res, (SIZE * (SIZE - 1)) / 2 + (cond ? SIZE : 0));
+        Asserts.assertEQ((SIZE * (SIZE - 1)) / 2 + (cond ? SIZE : 0), res);
     }
-
 
     @DontInline
     private static int[] getArr() {

--- a/test/hotspot/jtreg/compiler/loopopts/TestUnswitchPredicateCloning.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestUnswitchPredicateCloning.java
@@ -65,7 +65,6 @@ public class TestUnswitchPredicateCloning {
         for (int i = 0; i < SIZE; i++) {
             arr[i] = i;
         }
-
         return arr;
     }
 
@@ -78,16 +77,15 @@ public class TestUnswitchPredicateCloning {
                    IRNode.LOOP_LIMIT_CHECK_PARSE_PREDICATE, "3",
                    IRNode.AUTO_VECTORIZATION_CHECK_PARSE_PREDICATE, "3" },
         phase = CompilePhase.BEFORE_LOOP_UNSWITCHING)
-    // Since we know that predication happens after unswitching, we can test the
-    // predicate cloning before predication, such that the useless, killed predicates
+    // Since we know that Loop Predication happens after Loop Unswitching, we can test the
     // have already been removed in the beautify loop phase.
     @IR(counts = { IRNode.LOOP_PARSE_PREDICATE, "4",
                    IRNode.PROFILED_LOOP_PARSE_PREDICATE, "4",
                    IRNode.LOOP_LIMIT_CHECK_PARSE_PREDICATE, "3",
                    IRNode.AUTO_VECTORIZATION_CHECK_PARSE_PREDICATE, "4" },
-        phase = CompilePhase.BEFORE_LOOP_PREDICATION_IC)
-    // Check that opaque template assertion predicated are added in loop predication
-    // even if loop predication only happens after loop unswitching.
+        phase = CompilePhase.BEFORE_LOOP_PREDICATION_RC)
+    // Check that Opaque Template Assertion Predicates are added in Loop Predication
+    // even if Loop Predication only happens after Loop Unswitching.
     @IR(failOn = { IRNode.OPAQUE_TEMPLATE_ASSERTION_PREDICATE },
         phase = CompilePhase.AFTER_LOOP_UNSWITCHING)
     @IR(counts = { IRNode.OPAQUE_TEMPLATE_ASSERTION_PREDICATE, "2" },
@@ -119,8 +117,8 @@ public class TestUnswitchPredicateCloning {
     }
 
     @Test
-    // Check that Loop Unswitching doubled the number of parse and tempalte
-    // assertion predicates. Again, the Loop Limit Check Parse Predicate
+    // Check that Loop Unswitching doubled the number of Parse and Template
+    // Assertion Predicates. Again, the Loop Limit Check Parse Predicate
     // remains at the Loop Selector since this is a counted loop.
     @IR(failOn = { IRNode.OPAQUE_TEMPLATE_ASSERTION_PREDICATE },
         phase = CompilePhase.BEFORE_LOOP_PREDICATION_RC)
@@ -130,7 +128,7 @@ public class TestUnswitchPredicateCloning {
                    IRNode.LOOP_LIMIT_CHECK_PARSE_PREDICATE, "1",
                    IRNode.AUTO_VECTORIZATION_CHECK_PARSE_PREDICATE, "1" },
         phase = CompilePhase.BEFORE_LOOP_UNSWITCHING)
-    // After loop unswitching and after removing the killed predicates.
+    // After Loop Unswitching and after removing the killed predicates.
     @IR(counts = { IRNode.OPAQUE_TEMPLATE_ASSERTION_PREDICATE, "4",
                    IRNode.LOOP_PARSE_PREDICATE, "2",
                    IRNode.PROFILED_LOOP_PARSE_PREDICATE, "2",
@@ -150,16 +148,16 @@ public class TestUnswitchPredicateCloning {
     }
 
     @Test
-    // Check that Loop Unswitching doubled the number of all parse predicates.
-    // Since this is not counted loop, the Loop Limit Check parse predicate
+    // Check that Loop Unswitching doubled the number of all Parse Predicates.
+    // Since this is not counted loop, the Loop Limit Check Parse Predicate
     // has to be cloned to both unswitched loops.
     @IR(counts = { IRNode.LOOP_PARSE_PREDICATE, "1",
                    IRNode.PROFILED_LOOP_PARSE_PREDICATE, "1",
                    IRNode.LOOP_LIMIT_CHECK_PARSE_PREDICATE, "1",
                    IRNode.AUTO_VECTORIZATION_CHECK_PARSE_PREDICATE, "1" },
         phase = CompilePhase.BEFORE_LOOP_UNSWITCHING)
-    // After loop unswitching and after removing the killed predicates all
-    // parse predicates are doubled..
+    // After Loop Unswitching and after removing the killed predicates all
+    // Parse Predicates are doubled.
     @IR(counts = { IRNode.LOOP_PARSE_PREDICATE, "2",
                    IRNode.PROFILED_LOOP_PARSE_PREDICATE, "2",
                    IRNode.LOOP_LIMIT_CHECK_PARSE_PREDICATE, "2",

--- a/test/hotspot/jtreg/compiler/loopopts/TestUnswitchPredicateCloning.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestUnswitchPredicateCloning.java
@@ -35,15 +35,15 @@
   */
 
 public class TestUnswitchPredicateCloning {
-    static final int WARMUP = 10_000;
     static final int SIZE = 100;
     static final int IDX = 42;
 
     public static void main(String[] strArr) {
-        TestFramework.runWithFlags("-Xcomp");
+        TestFramework.run();
     }
 
     @Run(test = "test")
+    @Warmup(0)
     private static void check() {
         int res = test(IDX);
         Asserts.assertEQ(res, SIZE * IDX);

--- a/test/hotspot/jtreg/compiler/loopopts/TestUnswitchPredicateCloning.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestUnswitchPredicateCloning.java
@@ -60,8 +60,9 @@ public class TestUnswitchPredicateCloning {
     }
 
     @Test
-    // Check that loop unswitching the number of parse predicates inside the unswitched
-    // loop have doubled.
+    // Check that Loop Unswitching doubled the number of Parse Predicates: We have
+    // them at the true- and false-path-loop. Note that the Loop Limit Check Parse
+    // Predicate is not cloned when we already have a counted loop.
     @IR(counts = {IRNode.LOOP_PARSE_PREDICATE, "3",
                  IRNode.PROFILED_LOOP_PARSE_PREDICATE, "3",
                  IRNode.LOOP_LIMIT_CHECK_PARSE_PREDICATE, "3",

--- a/test/hotspot/jtreg/compiler/loopopts/TestUnswitchPredicateCloning.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestUnswitchPredicateCloning.java
@@ -134,7 +134,7 @@ public class TestUnswitchPredicateCloning {
                    IRNode.PROFILED_LOOP_PARSE_PREDICATE, "2",
                    IRNode.LOOP_LIMIT_CHECK_PARSE_PREDICATE, "1",
                    IRNode.AUTO_VECTORIZATION_CHECK_PARSE_PREDICATE, "2" },
-        phase = CompilePhase.BEFORE_LOOP_PREDICATION_IC)
+        phase = CompilePhase.PHASEIDEALLOOP2)
     static int testPredicationBeforeUnswitching(int j, boolean cond) {
         int[] arr = getArr();
         int res = 0;

--- a/test/hotspot/jtreg/compiler/loopopts/TestUnswitchPredicateCloning.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestUnswitchPredicateCloning.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+ package compiler.loopopts;
+
+ import compiler.lib.ir_framework.*;
+ import jdk.test.lib.Asserts;
+
+ /*
+  * @test
+  * @bug 8346552
+  * @summary Test that all parse predicates are cloned after loop unswitching.
+  * @library /test/lib /
+  * @run driver compiler.loopopts.TestUnswitchPredicateCloning
+  */
+
+public class TestUnswitchPredicateCloning {
+    static final int WARMUP = 10_000;
+    static final int SIZE = 100;
+    static final int IDX = 42;
+
+    public static void main(String[] strArr) {
+        TestFramework.runWithFlags("-Xcomp");
+    }
+
+    @Run(test = "test")
+    private static void check() {
+        int res = test(IDX);
+        Asserts.assertEQ(res, SIZE * IDX);
+    }
+
+    @DontInline
+    private static int[] getArr() {
+        int[] arr = new int[SIZE];
+        for (int i = 0; i < SIZE; i++) {
+            arr[i] = i;
+        }
+
+        return arr;
+    }
+
+    @Test
+    // Check that loop unswitching the number of parse predicates inside the unswitched
+    // loop have doubled.
+    @IR(counts = {IRNode.LOOP_PARSE_PREDICATE, "3",
+                 IRNode.PROFILED_LOOP_PARSE_PREDICATE, "3",
+                 IRNode.LOOP_LIMIT_CHECK_PARSE_PREDICATE, "3",
+                 IRNode.AUTO_VECTORIZATION_CHECK_PARSE_PREDICATE, "3"},
+        phase = CompilePhase.BEFORE_LOOP_UNSWITCHING)
+    @IR(counts = {IRNode.LOOP_PARSE_PREDICATE, "5",
+                 IRNode.PROFILED_LOOP_PARSE_PREDICATE, "5",
+                 IRNode.LOOP_LIMIT_CHECK_PARSE_PREDICATE, "5",
+                 IRNode.AUTO_VECTORIZATION_CHECK_PARSE_PREDICATE, "5"},
+        phase = CompilePhase.AFTER_LOOP_UNSWITCHING)
+    // Check that opaque template assertion predicated are added in loop predication
+    // even if loop predication only happens after loop unswitching.
+    @IR(failOn = { IRNode.OPAQUE_TEMPLATE_ASSERTION_PREDICATE },
+        phase = CompilePhase.AFTER_LOOP_UNSWITCHING)
+    @IR(counts = { IRNode.OPAQUE_TEMPLATE_ASSERTION_PREDICATE, "2" },
+        phase = CompilePhase.AFTER_LOOP_PREDICATION_RC)
+    static int test(int j) {
+        int zero = 34;
+        int limit = 2;
+
+        // Ensure zero == 0 is only known after CCP
+        for (; limit < 4; limit *= 2) {
+        }
+        for (int i = 2; i < limit; i++) {
+            zero = 0;
+        }
+
+        int[] arr = getArr();
+        int res = 0;
+        for (int i = 0; i < arr.length; i++) {
+            // Trigger unswitching only after CCP
+            if (zero == 0) {
+                // Trigger range check after loop unswitching
+                res += arr[j];
+            } else {
+                res += arr[i];
+            }
+        }
+
+        return res;
+    }
+}

--- a/test/hotspot/jtreg/compiler/loopopts/TestUnswitchPredicateCloning.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestUnswitchPredicateCloning.java
@@ -68,11 +68,14 @@ public class TestUnswitchPredicateCloning {
                  IRNode.LOOP_LIMIT_CHECK_PARSE_PREDICATE, "3",
                  IRNode.AUTO_VECTORIZATION_CHECK_PARSE_PREDICATE, "3"},
         phase = CompilePhase.BEFORE_LOOP_UNSWITCHING)
-    @IR(counts = {IRNode.LOOP_PARSE_PREDICATE, "5",
-                 IRNode.PROFILED_LOOP_PARSE_PREDICATE, "5",
-                 IRNode.LOOP_LIMIT_CHECK_PARSE_PREDICATE, "5",
-                 IRNode.AUTO_VECTORIZATION_CHECK_PARSE_PREDICATE, "5"},
-        phase = CompilePhase.AFTER_LOOP_UNSWITCHING)
+    // Since we know that predication happens after unswitching, we can test the
+    // predicate cloning before predication, such that the useless, killed predicates
+    // have already been removed in the beautify loop phase.
+    @IR(counts = {IRNode.LOOP_PARSE_PREDICATE, "4",
+                 IRNode.PROFILED_LOOP_PARSE_PREDICATE, "4",
+                 IRNode.LOOP_LIMIT_CHECK_PARSE_PREDICATE, "3",
+                 IRNode.AUTO_VECTORIZATION_CHECK_PARSE_PREDICATE, "4"},
+        phase = CompilePhase.BEFORE_LOOP_PREDICATION_IC)
     // Check that opaque template assertion predicated are added in loop predication
     // even if loop predication only happens after loop unswitching.
     @IR(failOn = { IRNode.OPAQUE_TEMPLATE_ASSERTION_PREDICATE },


### PR DESCRIPTION
# Issue Summary

When a loop is unswitched, all parse predicates from the original loop must be cloned to the second loop that is created. Forgetting to clone a parse predicate is a common error during development on loop unswitching code that we could not catch previously. Since we have the IR-framework now, this PR introduces a test to catch this error.

# Changes

The main contribution of this PR is a test to ensure that all predicates have been cloned into an unswitched loop. 
Working on this PR revealed that Loop Limit Check Parse Predicates are erroneously cloned when unswitching counted loops. That is because we know that the loop variable increments monotonously in counted loops, so a loop limit check at the loop selector is sufficient for both unswitched loops. However, for uncounted loops we do not know anything about the behavior of the loop variables and they could behave differently in either of the unswitched loops. Hence, cloning the loop limit check is needed in that case. This PR also removes the superfluous cloning.

All changes summarized:
 - add `OPAQUE_TEMPLATE_ASSERTION_PREDICATE_NODE` to the IR-framework,
 - add some missing parse predicate nodes to the IR-framework,
 - change the output of the labels of parse predicate nodes in the ideal graph so they can be recognized reliably by the IR-framework (the main problem was that `Loop ` is a prefix of `Loop Limit Check` that is hard to distinguish with spaces instead of underlines),
 - rework the regex for detecting parse predicates in the IR-framework,
 - add a test to ensure parse predicates are cloned into unswitched loops,
 - only clone loop limit checks when unswitching uncounted loops,
 - add a test which checks that loop limit checks are not cloned when unswitching counted loops,
 - add a test which checks that loop limit checks are cloned when unswitching uncounted loops.

# Testing

- [Github Actions](https://github.com/mhaessig/jdk/actions/runs/14266369099)
- tier1 through tier3 plus Oracle internal testing

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346552](https://bugs.openjdk.org/browse/JDK-8346552): C2: Add IR tests to check that Predicate cloning in Loop Unswitching works as expected (**Enhancement** - P4)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Emanuel Peter](https://openjdk.org/census#epeter) (@eme64 - **Reviewer**)

### Contributors
 * Christian Hagedorn `<chagedorn@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24479/head:pull/24479` \
`$ git checkout pull/24479`

Update a local copy of the PR: \
`$ git checkout pull/24479` \
`$ git pull https://git.openjdk.org/jdk.git pull/24479/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24479`

View PR using the GUI difftool: \
`$ git pr show -t 24479`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24479.diff">https://git.openjdk.org/jdk/pull/24479.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24479#issuecomment-2782348623)
</details>
