### PR TITLE
8345874: Run make doctor automatically on failed CI builds

### DIFF
--- a/make/Init.gmk
+++ b/make/Init.gmk
@@ -181,7 +181,13 @@ on-failure:
 	$(call PrintFailureReports)
 	$(call PrintBuildLogFailures)
 	$(call ReportProfileTimes)
-	$(PRINTF) "HELP: Run 'make doctor' to diagnose build problems.\n\n"
+        ifeq ($(BUILD_ENV), ci)
+	  $(ECHO) ""
+	  $(ECHO) "=== Running 'make doctor' [ci build] ==="
+	  $(MAKE) $(MAKE_ARGS) -j 1 -f make/Main.gmk doctor
+        else
+	  $(PRINTF) "HELP: Run 'make doctor' to diagnose build problems.\n\n"
+        endif
         ifneq ($(COMPARE_BUILD), )
 	  $(call CleanupCompareBuild)
         endif

--- a/make/autoconf/spec.gmk.template
+++ b/make/autoconf/spec.gmk.template
@@ -169,6 +169,9 @@ endif
 SYSROOT_CFLAGS := @SYSROOT_CFLAGS@
 SYSROOT_LDFLAGS := @SYSROOT_LDFLAGS@
 
+# dev or ci
+BUILD_ENV := @BUILD_ENV@
+
 # The top-level directory of the source repository
 TOPDIR := @TOPDIR@
 # Usually the top level directory, but could be something else if a custom


### PR DESCRIPTION
If there is something wrong with the build, the user can run "make doctor". That is hard to do in a CI setting. Instead, if the build environment is detected to be a CI, we should run the doctor automatically in case of a failed build. 