### PR TITLE
8353841: [jittester] Fix JITTester build after asm removal

### DIFF
--- a/test/hotspot/jtreg/testlibrary/jittester/Makefile
+++ b/test/hotspot/jtreg/testlibrary/jittester/Makefile
@@ -102,7 +102,7 @@ compile_asm: INIT
 	${JAVAC} -d $(CLASSES_DIR) @$(CLASSES_DIR)/filelist_asm
 
 compile_testlib: INIT
-	$(JAVAC) -XDignore.symbol.file --add-exports=java.base/jdk.internal.misc=ALL-UNNAMED --add-exports=java.base/org.objectweb.asm=ALL-UNNAMED -Xlint $(TESTLIBRARY_SRC_FILES) -d $(CLASSES_DIR)
+	$(JAVAC) -XDignore.symbol.file --add-exports=java.base/jdk.internal.misc=ALL-UNNAMED -Xlint $(TESTLIBRARY_SRC_FILES) -d $(CLASSES_DIR)
 
 COMPILE: INIT filelist compile_asm compile_testlib
 	$(JAVAC) -cp $(CLASSES_DIR) -XDignore.symbol.file --add-exports=java.base/jdk.internal.misc=ALL-UNNAMED -Xlint -sourcepath $(SRC_DIR) -d $(CLASSES_DIR) @filelist

--- a/test/hotspot/jtreg/testlibrary/jittester/Makefile
+++ b/test/hotspot/jtreg/testlibrary/jittester/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -83,6 +83,8 @@ TESTLIBRARY_SRC_FILES = $(TESTLIBRARY_SRC_DIR)/Asserts.java \
                         $(TESTLIBRARY_SRC_DIR)/util/FileUtils.java \
                         $(TESTLIBRARY_SRC_DIR)/util/Pair.java
 
+ASM_SRC_DIR = ../asm/org/objectweb/asm/
+
 .PHONY: cleantmp
 
 all: $(DIST_JAR)
@@ -95,11 +97,15 @@ manifest:
 	@echo 'X-COMMENT: Main-Class will be added automatically by build' >> $(MANIFEST)
 	@echo 'Main-Class: jdk.test.lib.jittester.Automatic' >> $(MANIFEST)
 
+compile_asm: INIT
+	$(shell find $(ASM_SRC_DIR) -name '*.java' > $(CLASSES_DIR)/filelist_asm)
+	${JAVAC} -d $(CLASSES_DIR) @$(CLASSES_DIR)/filelist_asm
+
 compile_testlib: INIT
 	$(JAVAC) -XDignore.symbol.file --add-exports=java.base/jdk.internal.misc=ALL-UNNAMED --add-exports=java.base/org.objectweb.asm=ALL-UNNAMED -Xlint $(TESTLIBRARY_SRC_FILES) -d $(CLASSES_DIR)
 
-COMPILE: INIT filelist compile_testlib
-	$(JAVAC) -cp $(CLASSES_DIR) -XDignore.symbol.file --add-exports=java.base/jdk.internal.misc=ALL-UNNAMED --add-exports=java.base/org.objectweb.asm=ALL-UNNAMED -Xlint -sourcepath $(SRC_DIR) -d $(CLASSES_DIR) @filelist
+COMPILE: INIT filelist compile_asm compile_testlib
+	$(JAVAC) -cp $(CLASSES_DIR) -XDignore.symbol.file --add-exports=java.base/jdk.internal.misc=ALL-UNNAMED -Xlint -sourcepath $(SRC_DIR) -d $(CLASSES_DIR) @filelist
 
 filelist: $(SRC_FILES)
 		@rm -f $@


### PR DESCRIPTION
[JDK-8346981](https://bugs.openjdk.org/browse/JDK-8346981) removed jdk.internal.objectweb.asm packages from java.base, causing JITTester build to fail.

This PR fixes the build by building ASM prior to the testlibrary and JITTester builds.
Testing: Local runs of targets `COMPILE` and `all`, no errors found.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8353841](https://bugs.openjdk.org/browse/JDK-8353841): [jittester] Fix JITTester build after asm removal (**Bug** - P3)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24487/head:pull/24487` \
`$ git checkout pull/24487`

Update a local copy of the PR: \
`$ git checkout pull/24487` \
`$ git pull https://git.openjdk.org/jdk.git pull/24487/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24487`

View PR using the GUI difftool: \
`$ git pr show -t 24487`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24487.diff">https://git.openjdk.org/jdk/pull/24487.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24487#issuecomment-2783003783)
</details>
