### PR TITLE
8353332: Test jdk/jshell/ToolProviderTest.java failed in relation to enable-preview

### DIFF
--- a/src/jdk.jshell/share/classes/jdk/internal/jshell/tool/JShellToolProvider.java
+++ b/src/jdk.jshell/share/classes/jdk/internal/jshell/tool/JShellToolProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,7 @@ import java.io.PrintStream;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.Set;
+import java.util.function.Function;
 import javax.lang.model.SourceVersion;
 import javax.tools.Tool;
 import jdk.jshell.tool.JavaShellToolBuilder;
@@ -39,6 +40,10 @@ import jdk.jshell.tool.JavaShellToolBuilder;
  * Provider for launching the jshell tool.
  */
 public class JShellToolProvider implements Tool {
+
+    //for tests, so that they can tweak the builder (typically set persistence):
+    private static Function<JavaShellToolBuilder, JavaShellToolBuilder> augmentToolBuilder =
+            builder -> builder;
 
     /**
      * Returns the name of this Java shell tool provider.
@@ -86,11 +91,12 @@ public class JShellToolProvider implements Tool {
                                 ? (PrintStream) err
                                 : new PrintStream(err);
         try {
-            return JavaShellToolBuilder
-                    .builder()
-                    .in(xin, null)
-                    .out(xout)
-                    .err(xerr)
+            return augmentToolBuilder.apply(
+                    JavaShellToolBuilder
+                        .builder()
+                        .in(xin, null)
+                        .out(xout)
+                        .err(xerr))
                     .start(arguments);
         } catch (Throwable ex) {
             xerr.println(ex.getMessage());

--- a/test/langtools/jdk/jshell/ToolProviderTest.java
+++ b/test/langtools/jdk/jshell/ToolProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,20 +21,25 @@
  * questions.
  */
 
+import java.lang.reflect.Field;
+import java.util.HashMap;
 import java.util.ServiceLoader;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import javax.tools.Tool;
+import jdk.internal.jshell.tool.JShellToolProvider;
+import jdk.jshell.tool.JavaShellToolBuilder;
 import org.testng.annotations.Test;
 import static org.testng.Assert.assertTrue;
 
 /*
  * @test
- * @bug 8170044 8171343 8179856 8185840 8190383
+ * @bug 8170044 8171343 8179856 8185840 8190383 8353332
  * @summary Test ServiceLoader launching of jshell tool
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.main
  *          jdk.jdeps/com.sun.tools.javap
- *          jdk.jshell/jdk.internal.jshell.tool
+ *          jdk.jshell/jdk.internal.jshell.tool:+open
  * @library /tools/lib
  * @build Compiler toolbox.ToolBox
  * @run testng ToolProviderTest
@@ -68,13 +73,20 @@ public class ToolProviderTest extends StartOptionTest {
 
     @Override
     protected int runShell(String... args) {
-        ServiceLoader<Tool> sl = ServiceLoader.load(Tool.class);
-        for (Tool provider : sl) {
-            if (provider.name().equals("jshell")) {
-                return provider.run(cmdInStream, cmdout, cmderr, args);
+        //make sure the JShell running during the test is not using persisted preferences from the machine:
+        Function<JavaShellToolBuilder, JavaShellToolBuilder> prevAugmentedToolBuilder =
+                getAndSetAugmentedToolBuilder(builder -> builder.persistence(new HashMap<>()));
+        try {
+            ServiceLoader<Tool> sl = ServiceLoader.load(Tool.class);
+            for (Tool provider : sl) {
+                if (provider.name().equals("jshell")) {
+                    return provider.run(cmdInStream, cmdout, cmderr, args);
+                }
             }
+            throw new AssertionError("Repl tool not found by ServiceLoader: " + sl);
+        } finally {
+            getAndSetAugmentedToolBuilder(prevAugmentedToolBuilder);
         }
-        throw new AssertionError("Repl tool not found by ServiceLoader: " + sl);
     }
 
     // Test --show-version
@@ -86,5 +98,23 @@ public class ToolProviderTest extends StartOptionTest {
             assertTrue(s.trim().contains("jshell>"), "Expected prompt, got: " + s);
         },
                 "--show-version");
+    }
+
+    private Function<JavaShellToolBuilder, JavaShellToolBuilder> getAndSetAugmentedToolBuilder
+        (Function<JavaShellToolBuilder, JavaShellToolBuilder> augmentToolBuilder) {
+        try {
+            Field f = JShellToolProvider.class.getDeclaredField("augmentToolBuilder");
+
+            f.setAccessible(true);
+
+            Function<JavaShellToolBuilder, JavaShellToolBuilder> prev =
+                    (Function<JavaShellToolBuilder, JavaShellToolBuilder>) f.get(null);
+
+            f.set(null, augmentToolBuilder);
+
+            return prev;
+        } catch (ReflectiveOperationException ex) {
+            throw new IllegalStateException(ex);
+        }
     }
 }


### PR DESCRIPTION
JShell keeps persisted preferences in `java.util.prefs.Preferences`. But, during tests, an empty persistence is typically used, to avoid values persisted on the test machine to affect the test.

But, in case of `jdk/jshell/ToolProviderTest.java`, this is not done, as JShell is started using the `Tool` interface.

This patch strives to fix that, by adding indirection in building JShell in `JShellToolProvider`, and using that in the test to inject empty persistence.

Thanks to @jaikiran for figuring out the probable cause.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8353332](https://bugs.openjdk.org/browse/JDK-8353332): Test jdk/jshell/ToolProviderTest.java failed in relation to enable-preview (**Bug** - P3)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Adam Sotona](https://openjdk.org/census#asotona) (@asotona - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24492/head:pull/24492` \
`$ git checkout pull/24492`

Update a local copy of the PR: \
`$ git checkout pull/24492` \
`$ git pull https://git.openjdk.org/jdk.git pull/24492/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24492`

View PR using the GUI difftool: \
`$ git pr show -t 24492`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24492.diff">https://git.openjdk.org/jdk/pull/24492.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24492#issuecomment-2783831874)
</details>
