### PR TITLE
8353485: Jcms should allow to specify streaming_output mode

### DIFF
--- a/src/jdk.attach/aix/classes/sun/tools/attach/VirtualMachineImpl.java
+++ b/src/jdk.attach/aix/classes/sun/tools/attach/VirtualMachineImpl.java
@@ -47,7 +47,6 @@ public class VirtualMachineImpl extends HotSpotVirtualMachine {
     // Any changes to this needs to be synchronized with HotSpot.
     private static final String tmpdir = "/tmp";
     String socket_path;
-    private OperationProperties props = new OperationProperties(VERSION_1);
 
     /**
      * Attaches to the target VM
@@ -108,11 +107,8 @@ public class VirtualMachineImpl extends HotSpotVirtualMachine {
         // bogus process
         checkPermissions(socket_path);
 
-        // Check that we can connect to the process
-        // - this ensures we throw the permission denied error now rather than
-        // later when we attempt to enqueue a command.
         if (isAPIv2Enabled()) {
-            props = getDefaultProps();
+            detectProperties();
          } else {
             // Check that we can connect to the process
             // - this ensures we throw the permission denied error now rather than
@@ -167,7 +163,7 @@ public class VirtualMachineImpl extends HotSpotVirtualMachine {
         // <ver> <cmd> <args...>
         try {
             SocketOutputStream writer = new SocketOutputStream(s);
-            writeCommand(writer, props, cmd, args);
+            writeCommand(writer, cmd, args);
         } catch (IOException x) {
             ioe = x;
         }

--- a/src/jdk.attach/linux/classes/sun/tools/attach/VirtualMachineImpl.java
+++ b/src/jdk.attach/linux/classes/sun/tools/attach/VirtualMachineImpl.java
@@ -56,7 +56,6 @@ public class VirtualMachineImpl extends HotSpotVirtualMachine {
     private static final Path ROOT_TMP = Path.of("root/tmp");
 
     String socket_path;
-    private OperationProperties props = new OperationProperties(VERSION_1); // updated in ctor
 
     /**
      * Attaches to the target VM
@@ -124,7 +123,7 @@ public class VirtualMachineImpl extends HotSpotVirtualMachine {
         checkPermissions(socket_path);
 
         if (isAPIv2Enabled()) {
-            props = getDefaultProps();
+            detectProperties();
         } else {
             // Check that we can connect to the process
             // - this ensures we throw the permission denied error now rather than
@@ -178,7 +177,7 @@ public class VirtualMachineImpl extends HotSpotVirtualMachine {
         // connected - write request
         try {
             SocketOutputStream writer = new SocketOutputStream(s);
-            writeCommand(writer, props, cmd, args);
+            writeCommand(writer, cmd, args);
         } catch (IOException x) {
             ioe = x;
         }

--- a/src/jdk.attach/macosx/classes/sun/tools/attach/VirtualMachineImpl.java
+++ b/src/jdk.attach/macosx/classes/sun/tools/attach/VirtualMachineImpl.java
@@ -48,7 +48,6 @@ public class VirtualMachineImpl extends HotSpotVirtualMachine {
     // Any changes to this needs to be synchronized with HotSpot.
     private static final String tmpdir;
     String socket_path;
-    private OperationProperties props = new OperationProperties(VERSION_1); // updated in ctor
 
     /**
      * Attaches to the target VM
@@ -112,7 +111,7 @@ public class VirtualMachineImpl extends HotSpotVirtualMachine {
         checkPermissions(socket_path);
 
         if (isAPIv2Enabled()) {
-            props = getDefaultProps();
+            detectProperties();
         } else {
             // Check that we can connect to the process
             // - this ensures we throw the permission denied error now rather than
@@ -166,7 +165,7 @@ public class VirtualMachineImpl extends HotSpotVirtualMachine {
         // connected - write request
         try {
             SocketOutputStream writer = new SocketOutputStream(s);
-            writeCommand(writer, props, cmd, args);
+            writeCommand(writer, cmd, args);
         } catch (IOException x) {
             ioe = x;
         }

--- a/src/jdk.attach/windows/classes/sun/tools/attach/VirtualMachineImpl.java
+++ b/src/jdk.attach/windows/classes/sun/tools/attach/VirtualMachineImpl.java
@@ -43,7 +43,6 @@ public class VirtualMachineImpl extends HotSpotVirtualMachine {
     private static byte[] stub;
 
     private volatile long hProcess;     // handle to the process
-    private OperationProperties props = new OperationProperties(VERSION_1); // updated in ctor
 
     VirtualMachineImpl(AttachProvider provider, String id)
         throws AttachNotSupportedException, IOException
@@ -55,7 +54,7 @@ public class VirtualMachineImpl extends HotSpotVirtualMachine {
 
         try {
             if (isAPIv2Enabled()) {
-                props = getDefaultProps();
+                detectProperties();
             } else {
                 // The target VM might be a pre-6.0 VM so we enqueue a "null" command
                 // which minimally tests that the enqueue function exists in the target
@@ -87,6 +86,7 @@ public class VirtualMachineImpl extends HotSpotVirtualMachine {
         String pipeprefix = "\\\\.\\pipe\\javatool";
         String pipename = pipeprefix + r;
         long hPipe;
+        OperationProperties props = getProperties();
         try {
             hPipe = createPipe(props.version(), pipename);
         } catch (IOException ce) {

--- a/src/jdk.jcmd/share/classes/sun/tools/jcmd/Arguments.java
+++ b/src/jdk.jcmd/share/classes/sun/tools/jcmd/Arguments.java
@@ -35,12 +35,14 @@ class Arguments {
     private boolean showUsage     = false;
     private String  command       = null;
     private String  processString = null;
+    private Boolean streamingOutput;
 
     public boolean isListProcesses() { return listProcesses; }
     public boolean isListCounters() { return listCounters; }
     public boolean isShowUsage() { return showUsage; }
     public String getCommand() { return command; }
     public String getProcessString() { return processString; }
+    public Boolean getStreamingOutput() { return streamingOutput; }
 
     public Arguments(String[] args) {
         if (args.length == 0 || args[0].equals("-l")) {
@@ -82,6 +84,19 @@ class Arguments {
                 }
             } else if (args[i].equals("PerfCounter.print")) {
                 listCounters = true;
+            } else if (args[i].startsWith("--streaming_output=")) {
+                // we know args[i] contains "="
+                String value = args[i].substring(args[i].indexOf("=") + 1);
+                switch (value) {
+                case "true":
+                    streamingOutput = Boolean.TRUE;
+                    break;
+                case "false":
+                    streamingOutput = Boolean.FALSE;
+                    break;
+                default:
+                    throw new IllegalArgumentException("Unexpected option value: " + args[i] + " (excepted true|false)");
+                }
             } else {
                 sb.append(args[i]).append(" ");
             }
@@ -108,7 +123,7 @@ class Arguments {
     }
 
     public static void usage() {
-        System.out.println("Usage: jcmd <pid | main class> <command ...|PerfCounter.print|-f file>");
+        System.out.println("Usage: jcmd <pid | main class> [--streaming_output=true|false] <command ...|PerfCounter.print|-f file>");
         System.out.println("   or: jcmd -l                                                    ");
         System.out.println("   or: jcmd -h                                                    ");
         System.out.println("                                                                  ");
@@ -123,5 +138,8 @@ class Arguments {
         System.out.println("  -f  read and execute commands from the file                     ");
         System.out.println("  -l  list JVM processes on the local machine                     ");
         System.out.println("  -? -h --help print this help message                            ");
+        System.out.println("                                                                  ");
+        System.out.println("  --streaming_output option sets streaming/buffered output mode   ");
+        System.out.println("    (if supported by the target JVM).                             ");
     }
 }

--- a/test/jdk/sun/tools/jcmd/TestJcmdStreamingOutput.java
+++ b/test/jdk/sun/tools/jcmd/TestJcmdStreamingOutput.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8353485
+ * @summary Test jcmd "streaming_output" option
+ * @library /test/lib
+ * @run driver TestJcmdStreamingOutput
+ */
+
+import jdk.test.lib.apps.LingeredApp;
+import jdk.test.lib.process.OutputAnalyzer;
+
+public class TestJcmdStreamingOutput {
+
+    private static final String CMD = "VM.version";
+    private static final String OPT = "--streaming_output";
+    private static final String OPT_TRUE = OPT + "=true";
+    private static final String OPT_FALSE = OPT + "=false";
+    private static final String STREAMING_ON = "executing command jcmd, streaming output: 1";
+    private static final String STREAMING_OFF = "executing command jcmd, streaming output: 0";
+
+    public static void main(String[] args) throws Exception {
+        // The option can be at any position after process id.
+        test(STREAMING_ON, (targetPid) -> {
+            jcmd(targetPid, OPT_TRUE, CMD)
+                .shouldHaveExitValue(0);
+        });
+        test(STREAMING_ON, (targetPid) -> {
+            jcmd(targetPid, CMD, OPT_TRUE)
+                .shouldHaveExitValue(0);
+        });
+
+        test(STREAMING_OFF, (targetPid) -> {
+            jcmd(targetPid, OPT_FALSE, CMD)
+                .shouldHaveExitValue(0);
+        });
+        test(STREAMING_OFF, (targetPid) -> {
+            jcmd(targetPid, CMD, OPT_FALSE)
+                .shouldHaveExitValue(0);
+        });
+
+        test(null, (targetPid) -> {
+            jcmd(targetPid, CMD, OPT + "=something_wrong")
+                .shouldNotHaveExitValue(0)
+                .shouldContain("Unexpected option value");
+        });
+    }
+
+    private static OutputAnalyzer jcmd(String... args) throws Exception {
+        return JcmdBase.jcmdNoPid(null, args);
+    }
+
+    private interface JcmdAction {
+        void run(String targetPid) throws Exception;
+    }
+
+    private static void test(String expectedLog, JcmdAction action) throws Exception {
+        System.out.println(">> Test");
+        LingeredApp app = null;
+        try {
+            app = LingeredApp.startApp("-Xlog:attach=trace");
+            action.run(String.valueOf(app.getPid()));
+        } finally {
+            LingeredApp.stopApp(app);
+        }
+
+        if (expectedLog != null) {
+            new OutputAnalyzer(app.getProcessStdout(), "")
+                .stdoutShouldMatch(expectedLog);
+        }
+        System.out.println("<< Test");
+        System.out.println();
+    }
+
+}

--- a/test/jdk/sun/tools/jcmd/usage.out
+++ b/test/jdk/sun/tools/jcmd/usage.out
@@ -1,4 +1,4 @@
-Usage: jcmd <pid | main class> <command ...|PerfCounter.print|-f file>
+Usage: jcmd <pid | main class> [--streaming_output=true|false] <command ...|PerfCounter.print|-f file>
    or: jcmd -l                                                    
    or: jcmd -h                                                    
                                                                   
@@ -13,3 +13,6 @@ Usage: jcmd <pid | main class> <command ...|PerfCounter.print|-f file>
   -f  read and execute commands from the file                     
   -l  list JVM processes on the local machine                     
   -? -h --help print this help message                            
+                                                                  
+  --streaming_output option sets streaming/buffered output mode   
+    (if supported by the target JVM).                             


### PR DESCRIPTION
The fix adds `--streaming_output` jcmd option to manage attach command streaming output.

Testing: tier1..tier4,hs-tier5-svc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8353485](https://bugs.openjdk.org/browse/JDK-8353485)

### Issue
 * [JDK-8353485](https://bugs.openjdk.org/browse/JDK-8353485): Jcmd should allow to specify streaming_output mode (**Enhancement** - P4) ⚠️ Title mismatch between PR and JBS.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24494/head:pull/24494` \
`$ git checkout pull/24494`

Update a local copy of the PR: \
`$ git checkout pull/24494` \
`$ git pull https://git.openjdk.org/jdk.git pull/24494/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24494`

View PR using the GUI difftool: \
`$ git pr show -t 24494`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24494.diff">https://git.openjdk.org/jdk/pull/24494.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24494#issuecomment-2784161866)
</details>
