### PR TITLE
8353938: hotspot/jtreg/serviceability/dcmd/jvmti/LoadAgentDcmdTest.java fails on static JDK

### DIFF
--- a/test/hotspot/jtreg/serviceability/dcmd/jvmti/LoadAgentDcmdTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/jvmti/LoadAgentDcmdTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/serviceability/dcmd/jvmti/LoadAgentDcmdTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/jvmti/LoadAgentDcmdTest.java
@@ -40,6 +40,7 @@ import org.testng.annotations.Test;
  *
  * @test
  * @bug 8147388
+ * @requires !jdk.static
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.compiler
@@ -53,12 +54,6 @@ import org.testng.annotations.Test;
 public class LoadAgentDcmdTest {
 
     public String getLibInstrumentPath() throws FileNotFoundException {
-        if (Platform.isStatic()) {
-            // libinstrument is statically linked with the launcher. Don't
-            // locate the libinstrument shared library on static JDK.
-            return "libinstrument." + Platform.sharedLibraryExt();
-        }
-
         String jdkPath = System.getProperty("test.jdk");
 
         if (jdkPath == null) {

--- a/test/hotspot/jtreg/serviceability/dcmd/jvmti/LoadAgentDcmdTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/jvmti/LoadAgentDcmdTest.java
@@ -56,7 +56,7 @@ public class LoadAgentDcmdTest {
         if (Platform.isStatic()) {
             // libinstrument is statically linked with the launcher. Don't
             // locate the libinstrument shared library on static JDK.
-            return "libinstrument.so";
+            return "libinstrument." + Platform.sharedLibraryExt();
         }
 
         String jdkPath = System.getProperty("test.jdk");

--- a/test/hotspot/jtreg/serviceability/dcmd/jvmti/LoadAgentDcmdTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/jvmti/LoadAgentDcmdTest.java
@@ -53,6 +53,12 @@ import org.testng.annotations.Test;
 public class LoadAgentDcmdTest {
 
     public String getLibInstrumentPath() throws FileNotFoundException {
+        if (Platform.isStatic()) {
+            // libinstrument is statically linked with the launcher. Don't
+            // locate the libinstrument shared library on static JDK.
+            return "libinstrument.so";
+        }
+
         String jdkPath = System.getProperty("test.jdk");
 
         if (jdkPath == null) {


### PR DESCRIPTION
Please review this PR that changes `LoadAgentDcmdTest.getLibInstrumentPath()` to not locate `libinstrument` shared library if running on static JDK, instead just returns "libinstrument.<ext>" directly. Both test case #1 and #2 in `LoadAgentDcmdTest.run()` run ok on static JDK with the change:

Commands:
Test case #1: `JVMTI.agent_load libinstrument.so agent.jar`
Test case #2: `JVMTI.agent_load libinstrument.so "agent.jar=foo=bar"`

Additional notes/considerations:

1. I notice [JDKToolFinder.getJDKTool()](https://github.com/openjdk/jdk/blob/80ff7b9c9406c7845ecb3bc40910e92ccdd23ff2/test/lib/jdk/test/lib/JDKToolFinder.java#L41) is used by the test to find the `jcmd` tool. `JDKToolFinder.getJDKTool()` looks for the requested tool in both `test.jdk` and `compile.jdk`. When running the jtreg test on static JDK, it's able to locate the `jcmd` from `compile.jdk` even though the static JDK binary (`test.jdk`) does not provide the tool. For tools used by jtreg tests at runtime, how about change to always do that?

2. From https://docs.oracle.com/en/java/javase/21/docs/specs/man/jcmd.html:
```
JVMTI.agent_load [arguments]
Loads JVMTI native agent.
  Impact: Low
arguments:
  library path: Absolute path of the JVMTI agent to load. (STRING, no default value)
  agent option: (Optional) Option string to pass the agent. (STRING, no default value)
```
The command spec requires the absolute path of the JVMTI agent for the `library path` argument. On static JDK, if the agent library is built-in (statically linked), passing the shared library name works and allows the VM to find the built-in agent. There would be no need to specify the absolute path. Please see  https://bugs.openjdk.org/browse/JDK-8353938?focusedId=14767737&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-14767737 for more details.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8353938](https://bugs.openjdk.org/browse/JDK-8353938): hotspot/jtreg/serviceability/dcmd/jvmti/LoadAgentDcmdTest.java fails on static JDK (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24497/head:pull/24497` \
`$ git checkout pull/24497`

Update a local copy of the PR: \
`$ git checkout pull/24497` \
`$ git pull https://git.openjdk.org/jdk.git pull/24497/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24497`

View PR using the GUI difftool: \
`$ git pr show -t 24497`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24497.diff">https://git.openjdk.org/jdk/pull/24497.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24497#issuecomment-2785072867)
</details>
