### PR TITLE
8353945: Test javax/security/auth/x500/X500Principal/NameFormat.java fails after JDK-8349890

### DIFF
--- a/test/jdk/javax/security/auth/x500/X500Principal/NameFormat.java
+++ b/test/jdk/javax/security/auth/x500/X500Principal/NameFormat.java
@@ -118,22 +118,23 @@ public class NameFormat {
         testName("CN=Before\\0dAfter,DC=example,DC=net", "toString",
                 "CN=Before\\0DAfter, DC=example, DC=net", 22);
         testName("CN=Before\\0dAfter,DC=example,DC=net", "RFC1779",
-                "CN=Before\\0DAfter, " +
+                "CN=Before\r" + "After, " +
                 "OID.0.9.2342.19200300.100.1.25=example, " +
                 "OID.0.9.2342.19200300.100.1.25=net", 23);
+
         testName("CN=Before\\0dAfter,DC=example,DC=net", "RFC2253",
-                "CN=Before\\0DAfter,DC=example,DC=net", 24);
+                "CN=Before\r" + "After,DC=example,DC=net", 24);
         testName("CN=Before\\0dAfter,DC=example,DC=net", "CANONICAL",
-                "cn=before\\0dafter,dc=#16076578616d706c65,dc=#16036e6574", 25);
+                "cn=before\r" +"after,dc=#16076578616d706c65,dc=#16036e6574", 25);
 
         testName("CN=Lu\\C4\\8Di\\C4\\87", "toString",
                 "CN=Lu\\C4\\8Di\\C4\\87", 26);
         testName("CN=Lu\\C4\\8Di\\C4\\87", "RFC1779",
-                "CN=Lu\\C4\\8Di\\C4\\87", 27);
+                "CN=Lu\u010di\u0107", 27);
         testName("CN=Lu\\C4\\8Di\\C4\\87", "RFC2253",
-                "CN=Lu\\C4\\8Di\\C4\\87", 28);
+                "CN=Lu\u010di\u0107", 28);
         testName("CN=Lu\\C4\\8Di\\C4\\87", "CANONICAL",
-                "cn=lu\\c4\\8di\\c4\\87", 29);
+                "cn=luc\u030cic\u0301", 29);
 
         try {
             p = new X500Principal("cn=\\gg");

--- a/test/jdk/javax/security/auth/x500/X500Principal/NameFormat.java
+++ b/test/jdk/javax/security/auth/x500/X500Principal/NameFormat.java
@@ -125,7 +125,7 @@ public class NameFormat {
         testName("CN=Before\\0dAfter,DC=example,DC=net", "RFC2253",
                 "CN=Before\r" + "After,DC=example,DC=net", 24);
         testName("CN=Before\\0dAfter,DC=example,DC=net", "CANONICAL",
-                "cn=before\r" +"after,dc=#16076578616d706c65,dc=#16036e6574", 25);
+                "cn=before\r" + "after,dc=#16076578616d706c65,dc=#16036e6574", 25);
 
         testName("CN=Lu\\C4\\8Di\\C4\\87", "toString",
                 "CN=Lu\\C4\\8Di\\C4\\87", 26);


### PR DESCRIPTION
Test javax/security/auth/x500/X500Principal/NameFormat.java fails after JDK-8349890. The expected results of the failing tests will now change according to the fix in JDK-8349890.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8353945](https://bugs.openjdk.org/browse/JDK-8353945): Test javax/security/auth/x500/X500Principal/NameFormat.java fails after JDK-8349890 (**Bug** - P4)


### Reviewers
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24498/head:pull/24498` \
`$ git checkout pull/24498`

Update a local copy of the PR: \
`$ git checkout pull/24498` \
`$ git pull https://git.openjdk.org/jdk.git pull/24498/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24498`

View PR using the GUI difftool: \
`$ git pr show -t 24498`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24498.diff">https://git.openjdk.org/jdk/pull/24498.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24498#issuecomment-2785118045)
</details>
