### PR TITLE
8353840: JNativeScan should not abort for missing classes

### DIFF
--- a/src/jdk.jdeps/share/classes/com/sun/tools/jnativescan/JNativeScanTask.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/jnativescan/JNativeScanTask.java
@@ -42,15 +42,17 @@ import java.util.zip.ZipFile;
 class JNativeScanTask {
 
     private final PrintWriter out;
+    private final PrintWriter err;
     private final List<Path> classPaths;
     private final List<Path> modulePaths;
     private final List<String> cmdRootModules;
     private final Runtime.Version version;
     private final Action action;
 
-    public JNativeScanTask(PrintWriter out, List<Path> classPaths, List<Path> modulePaths,
+    public JNativeScanTask(PrintWriter out, PrintWriter err, List<Path> classPaths, List<Path> modulePaths,
                            List<String> cmdRootModules, Runtime.Version version, Action action) {
         this.out = out;
+        this.err = err;
         this.classPaths = classPaths;
         this.modulePaths = modulePaths;
         this.version = version;
@@ -74,7 +76,7 @@ class JNativeScanTask {
         SortedMap<ClassFileSource, SortedMap<ClassDesc, List<RestrictedUse>>> allRestrictedMethods;
         try(ClassResolver classesToScan = ClassResolver.forClassFileSources(toScan, version);
             ClassResolver systemClassResolver = ClassResolver.forSystemModules(version)) {
-            NativeMethodFinder finder = NativeMethodFinder.create(classesToScan, systemClassResolver);
+            NativeMethodFinder finder = NativeMethodFinder.create(err, classesToScan, systemClassResolver);
             allRestrictedMethods = finder.findAll();
         } catch (IOException e) {
             throw new RuntimeException(e);

--- a/src/jdk.jdeps/share/classes/com/sun/tools/jnativescan/Main.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/jnativescan/Main.java
@@ -165,7 +165,7 @@ public class Main {
             action = JNativeScanTask.Action.PRINT;
         }
 
-        new JNativeScanTask(out, classPathJars, modulePaths, rootModules, version, action).run();
+        new JNativeScanTask(out, err, classPathJars, modulePaths, rootModules, version, action).run();
     }
 
     private static String[] expandArgFiles(String[] args) throws JNativeScanFatalError {

--- a/src/jdk.jdeps/share/classes/com/sun/tools/jnativescan/NativeMethodFinder.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/jnativescan/NativeMethodFinder.java
@@ -28,6 +28,7 @@ import com.sun.tools.jnativescan.RestrictedUse.NativeMethodDecl;
 import com.sun.tools.jnativescan.RestrictedUse.RestrictedMethodRefs;
 
 import java.io.IOException;
+import java.io.PrintWriter;
 import java.lang.classfile.Attributes;
 import java.lang.classfile.ClassModel;
 import java.lang.classfile.MethodModel;
@@ -44,16 +45,19 @@ class NativeMethodFinder {
     private static final String RESTRICTED_NAME = "Ljdk/internal/javac/Restricted+Annotation;";
 
     private final Map<MethodRef, Boolean> cache = new HashMap<>();
+    private final PrintWriter err;
     private final ClassResolver classesToScan;
     private final ClassResolver systemClassResolver;
 
-    private NativeMethodFinder(ClassResolver classesToScan, ClassResolver systemClassResolver) {
+    private NativeMethodFinder(PrintWriter err, ClassResolver classesToScan, ClassResolver systemClassResolver) {
+        this.err = err;
         this.classesToScan = classesToScan;
         this.systemClassResolver = systemClassResolver;
     }
 
-    public static NativeMethodFinder create(ClassResolver classesToScan, ClassResolver systemClassResolver) throws JNativeScanFatalError, IOException {
-        return new NativeMethodFinder(classesToScan, systemClassResolver);
+    public static NativeMethodFinder create(PrintWriter err, ClassResolver classesToScan,
+                                            ClassResolver systemClassResolver) throws JNativeScanFatalError, IOException {
+        return new NativeMethodFinder(err, classesToScan, systemClassResolver);
     }
 
     public SortedMap<ClassFileSource, SortedMap<ClassDesc, List<RestrictedUse>>> findAll() throws JNativeScanFatalError {
@@ -82,8 +86,8 @@ class NativeMethodFinder {
                                  }
                              });
                          } catch (JNativeScanFatalError e) {
-                             throw new JNativeScanFatalError("Error while processing method: " +
-                                     MethodRef.ofModel(methodModel), e);
+                             err.println("Error while processing method: " +
+                                     MethodRef.ofModel(methodModel) + ": " + e.getMessage());
                          }
                     });
                     if (!perMethod.isEmpty()) {

--- a/test/langtools/tools/jnativescan/TestMissingSystemClass.java
+++ b/test/langtools/tools/jnativescan/TestMissingSystemClass.java
@@ -35,6 +35,9 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TestMissingSystemClass extends JNativeScanTestBase {
 
@@ -49,11 +52,15 @@ public class TestMissingSystemClass extends JNativeScanTestBase {
 
     @Test
     public void testSingleJarClassPath() {
-        assertSuccess(jnativescan("--class-path", MISSING_SYSTEM.toString(), "--release", "21"))
+        final List<String> stderr = assertSuccess(jnativescan("--class-path", MISSING_SYSTEM.toString(), "--release", "21"))
                 .stdoutShouldContain("<no restricted methods>")
+                .stderrShouldContain("Error(s) while processing classes")
                 .stderrShouldContain("Error while processing method")
                 .stderrShouldContain("missingsystem.App::main(String[])void")
                 .stderrShouldContain("System class can not be found")
-                .stderrShouldContain("java.lang.Compiler");
+                .stderrShouldContain("java.lang.Compiler")
+                .stderrAsLines();
+
+        assertEquals(2, stderr.size(), "Unexpected number of lines in stderr");
     }
 }

--- a/test/langtools/tools/jnativescan/TestMissingSystemClass.java
+++ b/test/langtools/tools/jnativescan/TestMissingSystemClass.java
@@ -49,11 +49,10 @@ public class TestMissingSystemClass extends JNativeScanTestBase {
 
     @Test
     public void testSingleJarClassPath() {
-        assertFailure(jnativescan("--class-path", MISSING_SYSTEM.toString(), "--release", "21"))
-                .stdoutShouldBeEmpty()
+        assertSuccess(jnativescan("--class-path", MISSING_SYSTEM.toString(), "--release", "21"))
+                .stdoutShouldContain("<no restricted methods>")
                 .stderrShouldContain("Error while processing method")
                 .stderrShouldContain("missingsystem.App::main(String[])void")
-                .stderrShouldContain("CAUSED BY:")
                 .stderrShouldContain("System class can not be found")
                 .stderrShouldContain("java.lang.Compiler");
     }

--- a/test/langtools/tools/jnativescan/TestMissingSystemClass.java
+++ b/test/langtools/tools/jnativescan/TestMissingSystemClass.java
@@ -52,7 +52,7 @@ public class TestMissingSystemClass extends JNativeScanTestBase {
 
     @Test
     public void testSingleJarClassPath() {
-        final List<String> stderr = assertSuccess(jnativescan("--class-path", MISSING_SYSTEM.toString(), "--release", "21"))
+        List<String> stderr = assertSuccess(jnativescan("--class-path", MISSING_SYSTEM.toString(), "--release", "21"))
                 .stdoutShouldContain("<no restricted methods>")
                 .stderrShouldContain("Error(s) while processing classes")
                 .stderrShouldContain("Error while processing method")

--- a/test/langtools/tools/jnativescan/cases/classpath/missingsystem/App.java
+++ b/test/langtools/tools/jnativescan/cases/classpath/missingsystem/App.java
@@ -28,5 +28,6 @@ public class App {
         // if we compile with --release 20, but run jnativescan
         // with --release 21, we should get an error
         java.lang.Compiler.enable();
+        java.lang.Compiler.enable(); // should be de-duplicated in the error logs
     }
 }


### PR DESCRIPTION
## Description

https://bugs.openjdk.org/browse/JDK-8353840 

### Existing behavior
Log the error message and terminate in case of missing system class

```
$ jnativescan --class-path reactor-core-3.7.4.jar; echo "Exit code: $?"

ERROR: Error while processing method: reactor.core.publisher.CallSiteSupplierFactory$SharedSecretsCallSiteSupplierFactory$TracingException::get()String
CAUSED BY: System class can not be found: sun.misc.JavaLangAccess
Exit code: 1
```

### New behavior
Still log the error message about the missing system class, but continue the analysis

```
$ build/macosx-aarch64-server-release/jdk/bin/jnativescan --class-path reactor-core-3.7.4.jar; echo "Exit code: $?" 

  <no restricted methods>
Error while processing method: reactor.core.publisher.CallSiteSupplierFactory$SharedSecretsCallSiteSupplierFactory$TracingException::get()String: System class can not be found: sun.misc.JavaLangAccess
Error while processing method: reactor.core.publisher.CallSiteSupplierFactory$SharedSecretsCallSiteSupplierFactory$TracingException::<clinit>()void: System class can not be found: sun.misc.SharedSecrets
Error while processing method: reactor.core.publisher.CallSiteSupplierFactory$SharedSecretsCallSiteSupplierFactory::<clinit>()void: System class can not be found: sun.misc.SharedSecrets
Exit code: 0
```

## Design choices

Propagate `err` all the way to `NativeMethodFinder` which can log the error to it, but continue with the analysis

### Alternatives considered

- Instead of propagating `err` downstream, adapt the outer try-catch in `com.sun.tools.jnativescan.Main#run`.
    - Con: This would require complicated error recovery synchronization between Main and `JNativeScanTask` to resume the scanning after the exception 
- Instead of adapting the catch block in `com.sun.tools.jnativescan.NativeMethodFinder#findAll`, don't even surface the exception from `com.sun.tools.jnativescan.ClassResolver.SystemModuleClassResolver#lookup` rather log it right in `ClassResolver`
    - Con: We don't have access to `MethodRef`/`MethodModel` in ClassResolver#lookup which will make the error message less detailed/useful

### stdout vs stderr 

One could argue that since this is a non-terminal error, perhaps it should be logged to stdout. However, my thinking was that while it may be non-terminal, it is still an "error", and thus should be logged to stderr. I am happy to revisit this decision, if needed.

## Testing

The existing test `TestMissingSystemClass#testSingleJarClassPath` has been adapted to test for successful execution, as well as verify the stdout output. 
I considered briefly to update the test setup in a way that we see some restricted methods on the stdout instead of just `<no restricted methods>`, but it was unclear if that would really add any additional value since the main purpose of this test is just to ascertain the missing system class (with successful execution from now onward).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8353840](https://bugs.openjdk.org/browse/JDK-8353840): JNativeScan should not abort for missing classes (**Enhancement** - P4)


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - **Reviewer**)
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24499/head:pull/24499` \
`$ git checkout pull/24499`

Update a local copy of the PR: \
`$ git checkout pull/24499` \
`$ git pull https://git.openjdk.org/jdk.git pull/24499/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24499`

View PR using the GUI difftool: \
`$ git pr show -t 24499`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24499.diff">https://git.openjdk.org/jdk/pull/24499.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24499#issuecomment-2785644222)
</details>
