### PR TITLE
8354111: JavaDoc states that Iterator.remove() is linear in the LinkedBlockingDeque

### DIFF
--- a/src/java.base/share/classes/java/util/concurrent/LinkedBlockingDeque.java
+++ b/src/java.base/share/classes/java/util/concurrent/LinkedBlockingDeque.java
@@ -61,8 +61,8 @@ import java.util.function.Predicate;
  * blocking).  Exceptions include {@link #remove(Object) remove},
  * {@link #removeFirstOccurrence removeFirstOccurrence}, {@link
  * #removeLastOccurrence removeLastOccurrence}, {@link #contains
- * contains}, {@link #iterator iterator.remove()}, and the bulk
- * operations, all of which run in linear time.
+ * contains}, and the bulk operations, all of which run in linear
+ * time.
  *
  * <p>This class and its iterator implement all of the <em>optional</em>
  * methods of the {@link Collection} and {@link Iterator} interfaces.


### PR DESCRIPTION
One of the features of the LinkedBlockingDeque is that it is a doubly-linked node queue, with pointers in each node to "prev" and "next", which allows remove() in the Iterator to remove the node in constant time. However, in the JavaDoc of the class, it lists Iterator.remove() as an example of a method that takes linear time.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change requires CSR request [JDK-8354174](https://bugs.openjdk.org/browse/JDK-8354174) to be approved
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8354111](https://bugs.openjdk.org/browse/JDK-8354111): JavaDoc states that Iterator.remove() is linear in the LinkedBlockingDeque (**Bug** - P4)
 * [JDK-8354174](https://bugs.openjdk.org/browse/JDK-8354174): JavaDoc states that Iterator.remove() is linear in the LinkedBlockingDeque (**CSR**)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)
 * [Stuart Marks](https://openjdk.org/census#smarks) (@stuart-marks - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24500/head:pull/24500` \
`$ git checkout pull/24500`

Update a local copy of the PR: \
`$ git checkout pull/24500` \
`$ git pull https://git.openjdk.org/jdk.git pull/24500/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24500`

View PR using the GUI difftool: \
`$ git pr show -t 24500`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24500.diff">https://git.openjdk.org/jdk/pull/24500.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24500#issuecomment-2789240599)
</details>
