### PR TITLE
8334016: Make PrintNullString.java automatic

### DIFF
--- a/test/jdk/java/awt/print/PrinterJob/PrintNullString.java
+++ b/test/jdk/java/awt/print/PrinterJob/PrintNullString.java
@@ -53,6 +53,7 @@ public class PrintNullString implements Printable {
         if (PrinterJob.lookupPrintServices().length == 0) {
             throw new RuntimeException("Printer not configured or available.");
         }
+
         new PrintNullString();
     }
 


### PR DESCRIPTION
Hi Reviewers,

I have updated the test and made it semi-automatic (need to click "Print") . Test will initiate a print and result will be generated automatic. 

Please review and let me know your suggestions.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334016](https://bugs.openjdk.org/browse/JDK-8334016): Make PrintNullString.java automatic (**Bug** - P4)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**) Review applies to [5d53c5c9](https://git.openjdk.org/jdk/pull/24501/files/5d53c5c9c1e0265607754385d57a35d614c0831c)
 * [Damon Nguyen](https://openjdk.org/census#dnguyen) (@DamonGuy - Committer) Review applies to [5d53c5c9](https://git.openjdk.org/jdk/pull/24501/files/5d53c5c9c1e0265607754385d57a35d614c0831c)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24501/head:pull/24501` \
`$ git checkout pull/24501`

Update a local copy of the PR: \
`$ git checkout pull/24501` \
`$ git pull https://git.openjdk.org/jdk.git pull/24501/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24501`

View PR using the GUI difftool: \
`$ git pr show -t 24501`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24501.diff">https://git.openjdk.org/jdk/pull/24501.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24501#issuecomment-2785744837)
</details>
