### PR TITLE
8354016: Update ReentrantReadWriteLock documentation to reflect its new max capacity

### DIFF
--- a/src/java.base/share/classes/java/util/concurrent/locks/ReentrantReadWriteLock.java
+++ b/src/java.base/share/classes/java/util/concurrent/locks/ReentrantReadWriteLock.java
@@ -207,8 +207,8 @@ import jdk.internal.vm.annotation.ReservedStackAccess;
  *
  * <h2>Implementation Notes</h2>
  *
- * <p>This lock supports a maximum of 65535 recursive write locks
- * and 65535 read locks. Attempts to exceed these limits result in
+ * <p>This lock supports a maximum of Integer.MAX_VALUE recursive write locks
+ * and Integer.MAX_VALUE read locks. Attempts to exceed these limits result in
  * {@link Error} throws from locking methods.
  *
  * @since 1.5

--- a/src/java.base/share/classes/java/util/concurrent/locks/ReentrantReadWriteLock.java
+++ b/src/java.base/share/classes/java/util/concurrent/locks/ReentrantReadWriteLock.java
@@ -208,7 +208,7 @@ import jdk.internal.vm.annotation.ReservedStackAccess;
  * <h2>Implementation Notes</h2>
  *
  * <p>This lock supports a maximum of {@link Integer#MAX_VALUE} recursive write locks
- * and {@link Integer#MAX_VALUE } read locks. Attempts to exceed these limits result in
+ * and {@link Integer#MAX_VALUE} read locks. Attempts to exceed these limits result in
  * {@link Error} throws from locking methods.
  *
  * @since 1.5

--- a/src/java.base/share/classes/java/util/concurrent/locks/ReentrantReadWriteLock.java
+++ b/src/java.base/share/classes/java/util/concurrent/locks/ReentrantReadWriteLock.java
@@ -207,8 +207,8 @@ import jdk.internal.vm.annotation.ReservedStackAccess;
  *
  * <h2>Implementation Notes</h2>
  *
- * <p>This lock supports a maximum of Integer.MAX_VALUE recursive write locks
- * and Integer.MAX_VALUE read locks. Attempts to exceed these limits result in
+ * <p>This lock supports a maximum of {@link Integer#MAX_VALUE} recursive write locks
+ * and {@link Integer#MAX_VALUE } read locks. Attempts to exceed these limits result in
  * {@link Error} throws from locking methods.
  *
  * @since 1.5


### PR DESCRIPTION
Updating the ReentrantReadWriteLock documentation

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8354016](https://bugs.openjdk.org/browse/JDK-8354016): Update ReentrantReadWriteLock documentation to reflect its new max capacity (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24502/head:pull/24502` \
`$ git checkout pull/24502`

Update a local copy of the PR: \
`$ git checkout pull/24502` \
`$ git pull https://git.openjdk.org/jdk.git pull/24502/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24502`

View PR using the GUI difftool: \
`$ git pr show -t 24502`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24502.diff">https://git.openjdk.org/jdk/pull/24502.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24502#issuecomment-2785851520)
</details>
