### PR TITLE
8353847: Remove extra args to System.out.printf in open/test/jdk/java/net/httpclient tests

### DIFF
--- a/test/jdk/java/net/httpclient/AsyncShutdownNow.java
+++ b/test/jdk/java/net/httpclient/AsyncShutdownNow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -208,7 +208,7 @@ public class AsyncShutdownNow implements HttpServerAdapters {
                     Thread.sleep(sleep);
                 }
                 if (i == step) {
-                    out.printf("%d: shutting down client now%n", i, sleep);
+                    out.printf("%d: shutting down client now%n", i);
                     client.shutdownNow();
                 }
                 var cf = bodyCF.exceptionally((t) -> {
@@ -304,7 +304,7 @@ public class AsyncShutdownNow implements HttpServerAdapters {
                     Thread.sleep(sleep);
                 }
                 if (i == step) {
-                    out.printf("%d: shutting down client now%n", i, sleep);
+                    out.printf("%d: shutting down client now%n", i);
                     client.shutdownNow();
                 }
                 bodyCF.handle((r, t) -> {

--- a/test/jdk/java/net/httpclient/HttpClientShutdown.java
+++ b/test/jdk/java/net/httpclient/HttpClientShutdown.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -192,7 +192,7 @@ public class HttpClientShutdown implements HttpServerAdapters {
                 out.println(now() + step + ":  Got response: " + response);
                 assertEquals(response.statusCode(), 200);
             } catch (AssertionError error) {
-                out.printf(now() + "%s:  Closing body due to assertion - %s", error);
+                out.printf(now() + "%s:  Closing body due to assertion - %s", step, error);
                 ensureClosed(this);
                 throw error;
             }
@@ -276,7 +276,7 @@ public class HttpClientShutdown implements HttpServerAdapters {
                     continue;
                 }
                 if (i == step) {
-                    out.printf(now() + "%d: shutting down client%n", i, sleep);
+                    out.printf(now() + "%d: shutting down client%n", i);
                     client.shutdown();
                 }
                 var cf = bodyCF.exceptionally((t) -> {
@@ -375,7 +375,7 @@ public class HttpClientShutdown implements HttpServerAdapters {
                     continue;
                 }
                 if (i == step) {
-                    out.printf(now() + "%d: shutting down client%n", i, sleep);
+                    out.printf(now() + "%d: shutting down client%n", i);
                     client.shutdown();
                 }
                 bodyCF.handle((r, t) -> {

--- a/test/jdk/java/net/httpclient/ShutdownNow.java
+++ b/test/jdk/java/net/httpclient/ShutdownNow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -182,7 +182,7 @@ public class ShutdownNow implements HttpServerAdapters {
                     Thread.sleep(sleep);
                 }
                 if (i == step) {
-                    out.printf("%d: shutting down client now%n", i, sleep);
+                    out.printf("%d: shutting down client now%n", i);
                     client.shutdownNow();
                 }
                 final int si = i;
@@ -242,7 +242,7 @@ public class ShutdownNow implements HttpServerAdapters {
                     Thread.sleep(sleep);
                 }
                 if (i == step) {
-                    out.printf("%d: shutting down client now%n", i, sleep);
+                    out.printf("%d: shutting down client now%n", i);
                     client.shutdownNow();
                 }
                 final int si = i;


### PR DESCRIPTION
Remove extra args to System.out.printf in open/test/jsk/java/net/httpclient tests

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8353847](https://bugs.openjdk.org/browse/JDK-8353847): Remove extra args to System.out.printf in open/test/jdk/java/net/httpclient tests (**Bug** - P4)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24507/head:pull/24507` \
`$ git checkout pull/24507`

Update a local copy of the PR: \
`$ git checkout pull/24507` \
`$ git pull https://git.openjdk.org/jdk.git pull/24507/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24507`

View PR using the GUI difftool: \
`$ git pr show -t 24507`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24507.diff">https://git.openjdk.org/jdk/pull/24507.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24507#issuecomment-2786305734)
</details>
