### PR TITLE
8352568: Test gtest/AsyncLogGtest.java failed at droppingMessage_vm

### DIFF
--- a/src/hotspot/share/logging/logAsyncWriter.cpp
+++ b/src/hotspot/share/logging/logAsyncWriter.cpp
@@ -354,27 +354,3 @@ void AsyncLogWriter::flush() {
     _instance->_flush_sem.wait();
   }
 }
-
-AsyncLogWriter::BufferUpdater::BufferUpdater(size_t newsize) {
-  ConsumerLocker clocker;
-  auto p = AsyncLogWriter::_instance;
-
-  _buf1 = p->_buffer;
-  _buf2 = p->_buffer_staging;
-  p->_buffer = new Buffer(newsize);
-  p->_buffer_staging = new Buffer(newsize);
-}
-
-AsyncLogWriter::BufferUpdater::~BufferUpdater() {
-  AsyncLogWriter::flush();
-  auto p = AsyncLogWriter::_instance;
-
-  {
-    ConsumerLocker clocker;
-
-    delete p->_buffer;
-    delete p->_buffer_staging;
-    p->_buffer = _buf1;
-    p->_buffer_staging = _buf2;
-  }
-}

--- a/src/hotspot/share/logging/logAsyncWriter.hpp
+++ b/src/hotspot/share/logging/logAsyncWriter.hpp
@@ -199,16 +199,6 @@ class AsyncLogWriter : public NonJavaThread {
     st->cr();
   }
 
-  // for testing-only
-  class BufferUpdater {
-    Buffer* _buf1;
-    Buffer* _buf2;
-
-   public:
-    BufferUpdater(size_t newsize);
-    ~BufferUpdater();
-  };
-
   static bool is_enqueue_allowed();
 
 public:

--- a/test/hotspot/gtest/logging/test_asynclog.cpp
+++ b/test/hotspot/gtest/logging/test_asynclog.cpp
@@ -79,12 +79,12 @@ LOG_LEVEL_LIST
 
     // write more messages than its capacity in burst
     for (size_t i = 0; i < (sz / str_size); ++i) {
-      lm.debug("%s", "a lot of log...");
+      lm.debug("%s", str);
     }
-    lm.debug("%s","a lot of log...");
-    lm.debug("%s","a lot of log...");
-    lm.debug("%s","a lot of log...");
-    lm.debug("%s","a lot of log...");
+    lm.debug("%s", str);
+    lm.debug("%s", str);
+    lm.debug("%s", str);
+    lm.debug("%s", str);
     lm.flush();
   }
 

--- a/test/hotspot/gtest/logging/test_asynclog.cpp
+++ b/test/hotspot/gtest/logging/test_asynclog.cpp
@@ -69,21 +69,22 @@ LOG_LEVEL_LIST
     log_debug(logging)("log_debug-test");
   }
 
-  // Caveat: BufferUpdater is not MT-safe. We use it only for testing.
-  // We would observe missing loglines if we interleaved buffers.
-  // Emit all logs between constructor and destructor of BufferUpdater.
   void test_asynclog_drop_messages() {
-    const size_t sz = 2000;
+    const size_t sz = AsyncLogBufferSize / 2;
+    const char* str = "a lot of log...";
+    const size_t str_size = strlen(str);
 
-    // shrink async buffer.
-    AsyncLogWriter::BufferUpdater saver(1024);
     test_asynclog_ls(); // roughly 200 bytes.
     LogMessage(logging) lm;
 
     // write more messages than its capacity in burst
-    for (size_t i = 0; i < sz; ++i) {
-      lm.debug("a lot of log...");
+    for (size_t i = 0; i < (sz / str_size); ++i) {
+      lm.debug("%s", "a lot of log...");
     }
+    lm.debug("%s","a lot of log...");
+    lm.debug("%s","a lot of log...");
+    lm.debug("%s","a lot of log...");
+    lm.debug("%s","a lot of log...");
     lm.flush();
   }
 

--- a/test/hotspot/gtest/logging/test_asynclog.cpp
+++ b/test/hotspot/gtest/logging/test_asynclog.cpp
@@ -247,7 +247,7 @@ TEST_VM_F(AsyncLogTest, logBuffer) {
 TEST_VM_F(AsyncLogTest, droppingMessage) {
   if (AsyncLogWriter::instance() == nullptr) return;
   if (LogConfiguration::async_mode() != LogConfiguration::AsyncMode::Drop) {
-    EXPECT_TRUE(false) << "This test must be run in drop mode if async UL is activated";
+    FAIL() << "This test must be run in drop mode if async UL is activated";
     return;
   }
 

--- a/test/hotspot/jtreg/gtest/AsyncLogGtest.java
+++ b/test/hotspot/jtreg/gtest/AsyncLogGtest.java
@@ -35,6 +35,6 @@
  * @modules java.base/jdk.internal.misc
  *          java.xml
  * @requires vm.flagless
- * @run main/native GTestWrapper --gtest_filter=AsyncLogTest* -Xlog:async
- * @run main/native GTestWrapper --gtest_filter=Log*Test* -Xlog:async
+ * @run main/native GTestWrapper --gtest_filter=AsyncLogTest* -Xlog:async -XX:AsyncLogBufferSize=100K
+ * @run main/native GTestWrapper --gtest_filter=Log*Test* -Xlog:async -XX:AsyncLogBufferSize=100K
  */


### PR DESCRIPTION
Hi,

The test for dropping messages have started to fail on aarch64 fast debug on Linux only when run as part of a test group. This seems to be a multi-threading issue with the `BufferUpdater`. When the `BufferUpdater` is removed, the issue disappears. This PR changes the code in a few other ways as well:

1. Fail if the asynchronous mode isn't "drop" (the test makes no sense with stalling mode)
2. Print the entirety of the log file produced if no missing messages are found
3. If the thread running the test is unattached, then async UL will emit log messages in synchronous mode. Therefore, if the thread is unattached, the test now fails with an error message.

If the test fails in the future, then these will give important diagnostic information regarding the state of the test.

This is a re-worked version of https://github.com/openjdk/jdk/pull/24411

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8352568](https://bugs.openjdk.org/browse/JDK-8352568): Test gtest/AsyncLogGtest.java failed at droppingMessage_vm (**Bug** - P3)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) Review applies to [6071f65b](https://git.openjdk.org/jdk/pull/24508/files/6071f65bfa7f53399fcf3432152c945657bca2dc)
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24508/head:pull/24508` \
`$ git checkout pull/24508`

Update a local copy of the PR: \
`$ git checkout pull/24508` \
`$ git pull https://git.openjdk.org/jdk.git pull/24508/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24508`

View PR using the GUI difftool: \
`$ git pr show -t 24508`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24508.diff">https://git.openjdk.org/jdk/pull/24508.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24508#issuecomment-2789501196)
</details>
