### PR TITLE
8339527: Adjust threshold for MemorySegment::fill native invocation

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/SegmentBulkOperations.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/SegmentBulkOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,9 +53,7 @@ public final class SegmentBulkOperations {
 
     // All the threshold values below MUST be a power of two and should preferably be
     // greater or equal to 2^3.
-
-    // Update the FILL value for Aarch64 once 8338975 is fixed.
-    private static final int NATIVE_THRESHOLD_FILL = powerOfPropertyOr("fill", Architecture.isAARCH64() ? 10 : 5);
+    private static final int NATIVE_THRESHOLD_FILL = powerOfPropertyOr("fill", Architecture.isAARCH64() ? 18 : 5);
     private static final int NATIVE_THRESHOLD_MISMATCH = powerOfPropertyOr("mismatch", 6);
     private static final int NATIVE_THRESHOLD_COPY = powerOfPropertyOr("copy", 6);
 


### PR DESCRIPTION
This PR proposes to increase the threshold for `MemorySegment::fill` operations on AArch-64 platforms.

Performance looks good:

![image](https://github.com/user-attachments/assets/56a83541-cb84-4a37-a914-fdddfde343c6)

![image](https://github.com/user-attachments/assets/ff2c33e0-b300-482d-b93e-217a11e07202)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339527](https://bugs.openjdk.org/browse/JDK-8339527): Adjust threshold for MemorySegment::fill native invocation (**Enhancement** - P4)


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24510/head:pull/24510` \
`$ git checkout pull/24510`

Update a local copy of the PR: \
`$ git checkout pull/24510` \
`$ git pull https://git.openjdk.org/jdk.git pull/24510/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24510`

View PR using the GUI difftool: \
`$ git pr show -t 24510`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24510.diff">https://git.openjdk.org/jdk/pull/24510.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24510#issuecomment-2786491523)
</details>
