### PR TITLE
8351757: Test java/foreign/TestDeadlock.java#FileChannel_map timed out after passing

### DIFF
--- a/test/jdk/java/foreign/TestDeadlock.java
+++ b/test/jdk/java/foreign/TestDeadlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,12 +23,12 @@
 
 /*
  * @test id=Arena_allocateFrom
- * @run main/othervm/timeout=5 --enable-native-access=ALL-UNNAMED -Xlog:class+init TestDeadlock Arena
+ * @run main/othervm/timeout=10 --enable-native-access=ALL-UNNAMED -Xlog:class+init TestDeadlock Arena
  */
 
 /*
  * @test id=FileChannel_map
- * @run main/othervm/timeout=5 --enable-native-access=ALL-UNNAMED -Xlog:class+init TestDeadlock FileChannel
+ * @run main/othervm/timeout=60 --enable-native-access=ALL-UNNAMED -Xlog:class+init TestDeadlock FileChannel
  */
 
 import java.lang.foreign.*;


### PR DESCRIPTION
This PR proposes to increase the timeout values for two tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8351757](https://bugs.openjdk.org/browse/JDK-8351757): Test java/foreign/TestDeadlock.java#FileChannel_map timed out after passing (**Bug** - P4)


### Reviewers
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - **Reviewer**)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24511/head:pull/24511` \
`$ git checkout pull/24511`

Update a local copy of the PR: \
`$ git checkout pull/24511` \
`$ git pull https://git.openjdk.org/jdk.git pull/24511/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24511`

View PR using the GUI difftool: \
`$ git pr show -t 24511`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24511.diff">https://git.openjdk.org/jdk/pull/24511.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24511#issuecomment-2786572928)
</details>
