### PR TITLE
8340185: Use make -k on GHA to catch more build errors

### DIFF
--- a/.github/actions/do-build/action.yml
+++ b/.github/actions/do-build/action.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -42,7 +42,7 @@ runs:
     - name: 'Build'
       id: build
       run: >
-        make LOG=info ${{ inputs.make-target }}
+        make -k LOG=info ${{ inputs.make-target }}
         || bash ./.github/scripts/gen-build-failure-report.sh "$GITHUB_STEP_SUMMARY"
       shell: bash
 


### PR DESCRIPTION
When building the JDK on GHA, we should use `make -k` to continue building as much as possible in case of failure, to avoid having developers resubmitting one fix after another.

The additional cost of continuing to build even in a failed build is pretty small compared to the overhead of having to resubmit the entire GHA several times.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340185](https://bugs.openjdk.org/browse/JDK-8340185): Use make -k on GHA to catch more build errors (**Enhancement** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24512/head:pull/24512` \
`$ git checkout pull/24512`

Update a local copy of the PR: \
`$ git checkout pull/24512` \
`$ git pull https://git.openjdk.org/jdk.git pull/24512/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24512`

View PR using the GUI difftool: \
`$ git pr show -t 24512`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24512.diff">https://git.openjdk.org/jdk/pull/24512.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24512#issuecomment-2786747456)
</details>
