### PR TITLE
8348978: Regression ~8% on J2dBench-vimg_text_aa-ParGC only on linux aarch64

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
@@ -162,9 +162,14 @@ public abstract sealed class AbstractMemorySegmentImpl
 
     // Using a static helper method ensures there is no unintended lambda capturing of `this`
     private static Runnable cleanupAction(long address, long newSize, Consumer<MemorySegment> cleanup) {
-        return cleanup != null ?
-                () -> cleanup.accept(SegmentFactories.makeNativeSegmentUnchecked(address, newSize)) :
-                null;
+        return cleanup != null
+                ? new Runnable() {
+                    @Override
+                    public void run() {
+                        cleanup.accept(SegmentFactories.makeNativeSegmentUnchecked(address, newSize));
+                    }
+                }
+                : null;
     }
 
     private AbstractMemorySegmentImpl asSliceNoCheck(long offset, long newSize) {


### PR DESCRIPTION
This PR proposes to use an anonymous class rather than a lambda in order to improve startup time.

We need to make sure the regression is fixed by this. It might be the case that the regression is there because [JDK-8347047](https://bugs.openjdk.org/browse/JDK-8347047) actually fixed an issue so that the segments could be collected by the GC.