### PR TITLE
8317012: Explicitly check for 32-bit word size for using libatomic with zero

### DIFF
--- a/make/autoconf/libraries.m4
+++ b/make/autoconf/libraries.m4
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -98,13 +98,7 @@ AC_DEFUN([LIB_SETUP_JVM_LIBS],
   # 32-bit platforms needs fallback library for 8-byte atomic ops on Zero
   if HOTSPOT_CHECK_JVM_VARIANT(zero); then
     if test "x$OPENJDK_$1_OS" = xlinux &&
-        (test "x$OPENJDK_$1_CPU" = xarm ||
-        test "x$OPENJDK_$1_CPU" = xm68k ||
-        test "x$OPENJDK_$1_CPU" = xmips ||
-        test "x$OPENJDK_$1_CPU" = xmipsel ||
-        test "x$OPENJDK_$1_CPU" = xppc ||
-        test "x$OPENJDK_$1_CPU" = xsh ||
-        test "x$OPENJDK_$1_CPU" = xriscv32); then
+        test "x$OPENJDK_TARGET_CPU_BITS" = "x32"; then
       BASIC_JVM_LIBS_$1="$BASIC_JVM_LIBS_$1 -latomic"
     fi
   fi


### PR DESCRIPTION
In libraries.m4, there is a long list of known 32-bit CPU architectures as a condition for using libatomic with zero. We should just check the address size instead.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8317012](https://bugs.openjdk.org/browse/JDK-8317012): Explicitly check for 32-bit word size for using libatomic with zero (**Enhancement** - P5)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24515/head:pull/24515` \
`$ git checkout pull/24515`

Update a local copy of the PR: \
`$ git checkout pull/24515` \
`$ git pull https://git.openjdk.org/jdk.git pull/24515/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24515`

View PR using the GUI difftool: \
`$ git pr show -t 24515`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24515.diff">https://git.openjdk.org/jdk/pull/24515.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24515#issuecomment-2786736496)
</details>
