### PR TITLE
8354061: Update copyright in NameFormat.java fix after JDK-8349890

### DIFF
--- a/test/jdk/javax/security/auth/x500/X500Principal/NameFormat.java
+++ b/test/jdk/javax/security/auth/x500/X500Principal/NameFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
8354061: Update copyright in NameFormat.java fix after JDK-8349890

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8354061](https://bugs.openjdk.org/browse/JDK-8354061): Update copyright in NameFormat.java fix after JDK-8349890 (**Bug** - P4)


### Reviewers
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24523/head:pull/24523` \
`$ git checkout pull/24523`

Update a local copy of the PR: \
`$ git checkout pull/24523` \
`$ git pull https://git.openjdk.org/jdk.git pull/24523/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24523`

View PR using the GUI difftool: \
`$ git pr show -t 24523`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24523.diff">https://git.openjdk.org/jdk/pull/24523.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24523#issuecomment-2787507759)
</details>
