### PR TITLE
8350661: PKCS11 HKDF throws ProviderException when requesting a 31-byte AES key

### DIFF
--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11HKDF.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11HKDF.java
@@ -221,7 +221,8 @@ final class P11HKDF extends KDFSpi {
         } catch (PKCS11Exception e) {
             if (e.match(CKR_KEY_SIZE_RANGE)) {
                 throw new InvalidAlgorithmParameterException("Invalid key " +
-                        "size for algorithm '" + alg + "'.", e);
+                        "size (" + outLen + " bytes) for algorithm '" + alg +
+                        "'.", e);
             }
             throw new ProviderException("HKDF derivation for algorithm '" +
                     alg + "' failed.", e);

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11HKDF.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11HKDF.java
@@ -38,7 +38,7 @@ import java.util.List;
 import static sun.security.pkcs11.TemplateManager.*;
 import sun.security.pkcs11.wrapper.*;
 import static sun.security.pkcs11.wrapper.PKCS11Constants.*;
-import static sun.security.pkcs11.wrapper.PKCS11Exception.RV.*;
+import static sun.security.pkcs11.wrapper.PKCS11Exception.RV.CKR_KEY_SIZE_RANGE;
 
 final class P11HKDF extends KDFSpi {
     private final Token token;

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11HKDF.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11HKDF.java
@@ -38,6 +38,7 @@ import java.util.List;
 import static sun.security.pkcs11.TemplateManager.*;
 import sun.security.pkcs11.wrapper.*;
 import static sun.security.pkcs11.wrapper.PKCS11Constants.*;
+import static sun.security.pkcs11.wrapper.PKCS11Exception.RV.*;
 
 final class P11HKDF extends KDFSpi {
     private final Token token;
@@ -216,6 +217,10 @@ final class P11HKDF extends KDFSpi {
             }
             return retType.cast(ret);
         } catch (PKCS11Exception e) {
+            if (e.match(CKR_KEY_SIZE_RANGE)) {
+                throw new InvalidAlgorithmParameterException("Invalid key " +
+                        "size for algorithm '" + alg + "'.", e);
+            }
             throw new ProviderException("HKDF derivation for algorithm '" +
                     alg + "' failed.", e);
         } finally {

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11KeyGenerator.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11KeyGenerator.java
@@ -137,8 +137,8 @@ final class P11KeyGenerator extends KeyGeneratorSpi {
         switch ((int)keyGenMech) {
             case (int)CKM_DES_KEY_GEN:
                 if ((keySize != 64) && (keySize != 56)) {
-                    throw new InvalidAlgorithmParameterException
-                            ("DES key length must be 56 bits");
+                    throw new InvalidAlgorithmParameterException("DES key " +
+                            "length was " + keySize + " but must be 56 bits");
                 }
                 sigKeySize = 56;
                 break;
@@ -149,23 +149,26 @@ final class P11KeyGenerator extends KeyGeneratorSpi {
                 } else if ((keySize == 168) || (keySize == 192)) {
                     sigKeySize = 168;
                 } else {
-                    throw new InvalidAlgorithmParameterException
-                            ("DESede key length must be 112, or 168 bits");
+                    throw new InvalidAlgorithmParameterException("DESede key " +
+                            "length was " + keySize + " but must be 112, or " +
+                            "168 bits");
                 }
                 break;
             default:
                 // Handle all variable-key-length algorithms here
                 if (range != null && (keySize < range.iMinKeySize
                     || keySize > range.iMaxKeySize)) {
-                    throw new InvalidAlgorithmParameterException
-                        ("Key length must be between " + range.iMinKeySize +
-                        " and " + range.iMaxKeySize + " bits");
+                    throw new InvalidAlgorithmParameterException("Key length " +
+                            "was " + keySize + " but must be between " +
+                            range.iMinKeySize + " and " + range.iMaxKeySize +
+                            " bits");
                 }
                 if (keyGenMech == CKM_AES_KEY_GEN) {
                     if ((keySize != 128) && (keySize != 192) &&
                         (keySize != 256)) {
-                        throw new InvalidAlgorithmParameterException
-                            ("AES key length must be 128, 192, or 256 bits");
+                        throw new InvalidAlgorithmParameterException("AES key" +
+                                " length was " + keySize + " but must be 128," +
+                                " 192, or 256 bits");
                     }
                 }
                 sigKeySize = keySize;

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11SecretKeyFactory.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11SecretKeyFactory.java
@@ -245,6 +245,19 @@ final class P11SecretKeyFactory extends SecretKeyFactorySpi {
         putKeyInfo(new TLSKeyInfo("TlsPremasterSecret"));
         putKeyInfo(new TLSKeyInfo("TlsRsaPremasterSecret"));
         putKeyInfo(new TLSKeyInfo("TlsMasterSecret"));
+        putKeyInfo(new TLSKeyInfo("TlsBinderKey"));
+        putKeyInfo(new TLSKeyInfo("TlsClientAppTrafficSecret"));
+        putKeyInfo(new TLSKeyInfo("TlsClientHandshakeTrafficSecret"));
+        putKeyInfo(new TLSKeyInfo("TlsEarlySecret"));
+        putKeyInfo(new TLSKeyInfo("TlsFinishedSecret"));
+        putKeyInfo(new TLSKeyInfo("TlsHandshakeSecret"));
+        putKeyInfo(new TLSKeyInfo("TlsKey"));
+        putKeyInfo(new TLSKeyInfo("TlsResumptionMasterSecret"));
+        putKeyInfo(new TLSKeyInfo("TlsSaltSecret"));
+        putKeyInfo(new TLSKeyInfo("TlsServerAppTrafficSecret"));
+        putKeyInfo(new TLSKeyInfo("TlsServerHandshakeTrafficSecret"));
+        putKeyInfo(new TLSKeyInfo("TlsUpdateNplus1"));
+
         putKeyInfo(new KeyInfo("Generic", CKK_GENERIC_SECRET,
                 CKM_GENERIC_SECRET_KEY_GEN));
 

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11SecretKeyFactory.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11SecretKeyFactory.java
@@ -103,6 +103,13 @@ final class P11SecretKeyFactory extends SecretKeyFactorySpi {
         keyInfo.put(ki.algo.toUpperCase(Locale.ENGLISH), ki);
     }
 
+    /*
+     * The KeyInfo class represents information about a symmetric PKCS #11 key
+     * type or about the output of a key-based computation (e.g. HMAC). A
+     * KeyInfo instance may describe the key/output itself, or the type of
+     * key/output that a service accepts/produces. Used by P11SecretKeyFactory,
+     * P11PBECipher, P11Mac, and P11HKDF.
+     */
     static sealed class KeyInfo permits PBEKeyInfo, HMACKeyInfo, HKDFKeyInfo,
             TLSKeyInfo {
         // Java Standard Algorithm Name.
@@ -151,14 +158,26 @@ final class P11SecretKeyFactory extends SecretKeyFactorySpi {
         }
     }
 
+    /*
+     * KeyInfo specialization for keys that are either input or result of a TLS
+     * key derivation. Keys of this type are typically handled by JSSE and their
+     * algorithm name start with "Tls". Used by P11HKDF.
+     */
     static final class TLSKeyInfo extends KeyInfo {
         TLSKeyInfo(String algo) {
             super(algo, CKK_GENERIC_SECRET);
         }
     }
 
+    /*
+     * KeyInfo specialization for outputs of a HMAC computation. Used by
+     * P11SecretKeyFactory and P11Mac.
+     */
     static final class HMACKeyInfo extends KeyInfo {
+        // HMAC mechanism (CKM_*) to generate the output.
         public final long mech;
+
+        // HMAC output length (in bits).
         public final int keyLen;
 
         HMACKeyInfo(String algo, long mech, int keyLen) {
@@ -168,6 +187,10 @@ final class P11SecretKeyFactory extends SecretKeyFactorySpi {
         }
     }
 
+    /*
+     * KeyInfo specialization for HKDF key derivation. Used by
+     * P11SecretKeyFactory and P11HKDF.
+     */
     static final class HKDFKeyInfo extends KeyInfo {
         public static final long UNKNOWN_KEY_TYPE = -1;
         public final long hmacMech;
@@ -180,6 +203,10 @@ final class P11SecretKeyFactory extends SecretKeyFactorySpi {
         }
     }
 
+    /*
+     * KeyInfo specialization for PBE key derivation. Used by
+     * P11SecretKeyFactory, P11PBECipher and P11Mac.
+     */
     abstract static sealed class PBEKeyInfo extends KeyInfo
             permits AESPBEKeyInfo, PBKDF2KeyInfo, P12MacPBEKeyInfo {
         public static final long INVALID_PRF = -1;

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11SecretKeyFactory.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11SecretKeyFactory.java
@@ -620,13 +620,13 @@ final class P11SecretKeyFactory extends SecretKeyFactorySpi {
                             token);
                     if (keyType == CKK_DES || keyType == CKK_DES3) {
                         fixDESParity(encoded, 0);
-                    }
-                    if (keyType == CKK_DES3) {
-                        fixDESParity(encoded, 8);
-                        if (keyLength == 112) {
-                            keyType = CKK_DES2;
-                        } else {
-                            fixDESParity(encoded, 16);
+                        if (keyType == CKK_DES3) {
+                            fixDESParity(encoded, 8);
+                            if (keyLength == 112) {
+                                keyType = CKK_DES2;
+                            } else {
+                                fixDESParity(encoded, 16);
+                            }
                         }
                     }
                 }

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/wrapper/PKCS11Constants.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/wrapper/PKCS11Constants.java
@@ -311,10 +311,6 @@ public interface PKCS11Constants {
     // pseudo key type ANY (for template manager)
     public static final long  PCKK_ANY                 = 0x7FFFFF22L;
 
-    public static final long  PCKK_TLSPREMASTER        = 0x7FFFFF25L;
-    public static final long  PCKK_TLSRSAPREMASTER     = 0x7FFFFF26L;
-    public static final long  PCKK_TLSMASTER           = 0x7FFFFF27L;
-
     /* Uncomment when actually used
     public static final long  CK_CERTIFICATE_CATEGORY_UNSPECIFIED   = 0L;
     public static final long  CK_CERTIFICATE_CATEGORY_TOKEN_USER    = 1L;

--- a/test/jdk/sun/security/pkcs11/KDF/TestHKDF.java
+++ b/test/jdk/sun/security/pkcs11/KDF/TestHKDF.java
@@ -610,6 +610,22 @@ public final class TestHKDF extends PKCS11Test {
                 "6e09");
     }
 
+    private static void test_invalid_AES_key_size() {
+        printTestHeader("Test derivation of an invalid AES key size");
+        try {
+            KDF k = KDF.getInstance("HKDF-SHA256", p11Provider);
+            k.deriveKey("AES", HKDFParameterSpec.ofExtract()
+                    .thenExpand(null, 31));
+            throw new Exception("No exception thrown.");
+        } catch (InvalidAlgorithmParameterException iape) {
+            // Expected.
+        } catch (Exception e) {
+            reportTestFailure(new Exception("Derivation of an AES key of " +
+                    "invalid size (31 bytes) expected to throw " +
+                    "InvalidAlgorithmParameterException.", e));
+        }
+    }
+
     public void main(Provider p) throws Exception {
         p11Provider = p;
         p11GenericSkf = SecretKeyFactory.getInstance("Generic", p11Provider);

--- a/test/jdk/sun/security/pkcs11/KDF/TestHKDF.java
+++ b/test/jdk/sun/security/pkcs11/KDF/TestHKDF.java
@@ -302,6 +302,22 @@ public final class TestHKDF extends PKCS11Test {
         executeDerivation(ctx, KdfParamSpecType.EXPAND);
     }
 
+    private static void executeInvalidKeyDerivationTest(String testHeader,
+            String keyAlg, int keySize, String errorMsg) {
+        printTestHeader(testHeader);
+        try {
+            KDF k = KDF.getInstance("HKDF-SHA256", p11Provider);
+            k.deriveKey(keyAlg, HKDFParameterSpec.ofExtract()
+                    .thenExpand(null, keySize));
+            throw new Exception("No exception thrown.");
+        } catch (InvalidAlgorithmParameterException iape) {
+            // Expected.
+        } catch (Exception e) {
+            reportTestFailure(new Exception(errorMsg + " expected to throw " +
+                    "InvalidAlgorithmParameterException.", e));
+        }
+    }
+
     private static void printTestHeader(String testHeader) {
         debugPrinter.println();
         debugPrinter.println("=".repeat(testHeader.length()));
@@ -610,20 +626,28 @@ public final class TestHKDF extends PKCS11Test {
                 "6e09");
     }
 
+    private static void test_unknown_key_algorithm_derivation() {
+        executeInvalidKeyDerivationTest(
+                "Test derivation of an unknown key algorithm",
+                "UnknownAlgorithm",
+                32,
+                "Derivation of an unknown key algorithm");
+    }
+
+    private static void test_invalid_key_algorithm_derivation() {
+        executeInvalidKeyDerivationTest(
+                "Test derivation of an invalid key algorithm",
+                "PBKDF2WithHmacSHA1",
+                32,
+                "Derivation of an invalid key algorithm");
+    }
+
     private static void test_invalid_AES_key_size() {
-        printTestHeader("Test derivation of an invalid AES key size");
-        try {
-            KDF k = KDF.getInstance("HKDF-SHA256", p11Provider);
-            k.deriveKey("AES", HKDFParameterSpec.ofExtract()
-                    .thenExpand(null, 31));
-            throw new Exception("No exception thrown.");
-        } catch (InvalidAlgorithmParameterException iape) {
-            // Expected.
-        } catch (Exception e) {
-            reportTestFailure(new Exception("Derivation of an AES key of " +
-                    "invalid size (31 bytes) expected to throw " +
-                    "InvalidAlgorithmParameterException.", e));
-        }
+        executeInvalidKeyDerivationTest(
+                "Test derivation of an invalid AES key size",
+                "AES",
+                31,
+                "Derivation of an AES key of invalid size (31 bytes)");
     }
 
     public void main(Provider p) throws Exception {

--- a/test/jdk/sun/security/pkcs11/KDF/TestHKDF.java
+++ b/test/jdk/sun/security/pkcs11/KDF/TestHKDF.java
@@ -314,7 +314,8 @@ public final class TestHKDF extends PKCS11Test {
             // Expected.
         } catch (Exception e) {
             reportTestFailure(new Exception(errorMsg + " expected to throw " +
-                    "InvalidAlgorithmParameterException.", e));
+                    "InvalidAlgorithmParameterException for key algorithm '" +
+                    keyAlg + "'.", e));
         }
     }
 
@@ -640,6 +641,14 @@ public final class TestHKDF extends PKCS11Test {
                 "PBKDF2WithHmacSHA1",
                 32,
                 "Derivation of an invalid key algorithm");
+    }
+
+    private static void test_invalid_aes_key_algorithm_derivation() {
+        executeInvalidKeyDerivationTest(
+                "Test derivation of an invalid AES key",
+                "PBEWithHmacSHA224AndAES_256",
+                32,
+                "Derivation of an invalid AES key");
     }
 
     private static void test_invalid_AES_key_size() {


### PR DESCRIPTION
Hi,

I would like to request a review for the fix of JDK-8350661. In this fix, we translate the native PKCS 11 error code into an `InvalidAlgorithmParameterException`, as documented in the `KDF::deriveKey` API. With that said, different PKCS 11 libraries may throw different errors and may even (in theory) delay the error until the key is used, as _SunJCE_ does. I believe that this is an improvement but further adjustments may be needed in the future.

No regressions observed in `test/jdk/sun/security/pkcs11/KDF/TestHKDF.java`.

Thanks,
Martin.-

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350661](https://bugs.openjdk.org/browse/JDK-8350661): PKCS11 HKDF throws ProviderException when requesting a 31-byte AES key (**Bug** - P3)


### Reviewers
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - **Reviewer**) Review applies to [8feb31ea](https://git.openjdk.org/jdk/pull/24526/files/8feb31eaa11861bc4d5b2e39451f01e43c20f882)
 * [Francisco Ferrari Bihurriet](https://openjdk.org/census#fferrari) (@franferrax - Committer)
 * [Valerie Peng](https://openjdk.org/census#valeriep) (@valeriepeng - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24526/head:pull/24526` \
`$ git checkout pull/24526`

Update a local copy of the PR: \
`$ git checkout pull/24526` \
`$ git pull https://git.openjdk.org/jdk.git pull/24526/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24526`

View PR using the GUI difftool: \
`$ git pr show -t 24526`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24526.diff">https://git.openjdk.org/jdk/pull/24526.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24526#issuecomment-2787545304)
</details>
