### PR TITLE
8305186: Reference.waitForReferenceProcessing should be more accessible to tests

### DIFF
--- a/test/lib/jdk/test/lib/util/ForceGC.java
+++ b/test/lib/jdk/test/lib/util/ForceGC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,9 +26,6 @@ package jdk.test.lib.util;
 import java.lang.ref.PhantomReference;
 import java.lang.ref.Reference;
 import java.lang.ref.ReferenceQueue;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.util.Arrays;
 import java.util.function.BooleanSupplier;
 
 /**
@@ -107,29 +104,5 @@ public class ForceGC {
         }
         return booleanSupplier.getAsBoolean();
     }
-
-    private static Method wfrp = null;
-    /* Wait for reference processing, via Reference.waitForReferenceProcessing().
-     * Callers of this method will need the
-     * @modules java.base/java.lang.ref:open
-     * jtreg tag.
-     *
-     * This method should usually be called after a call to WhiteBox.fullGC().
-     */
-    public static void waitForReferenceProcessing() {
-        try {
-            if (wfrp == null) {
-                Class refClass = Class.forName("java.lang.ref.Reference");
-                Method[] methods = refClass.getDeclaredMethods();
-                wfrp = Arrays.stream(methods).filter((m) -> m.getName().equals("waitForReferenceProcessing")).findFirst().get();
-                wfrp.setAccessible(true);
-            }
-            wfrp.invoke(null, new Object[0]);
-        } catch (IllegalAccessException iae) {
-            throw new RuntimeException("Need to add @modules java.base/java.lang.ref:open?",
-                    iae);
-        } catch (ClassNotFoundException | InvocationTargetException e) {
-            throw new RuntimeException("Reflection problem", e);
-        }
-    }
 }
+

--- a/test/lib/jdk/test/whitebox/WhiteBox.java
+++ b/test/lib/jdk/test/whitebox/WhiteBox.java
@@ -561,7 +561,7 @@ public class WhiteBox {
   public native void fullGC();
 
   // Infrastructure for waitForReferenceProcessing()
-  private static Method waitForReferenceProcessingMethod = null;
+  private static volatile Method waitForReferenceProcessingMethod = null;
 
   private static Method getWaitForReferenceProcessingMethod() {
     Method wfrp = waitForReferenceProcessingMethod;

--- a/test/lib/jdk/test/whitebox/WhiteBox.java
+++ b/test/lib/jdk/test/whitebox/WhiteBox.java
@@ -595,6 +595,8 @@ public class WhiteBox {
     try {
       Method wfrp = getWaitForReferenceProcessingMethod();
       return (Boolean) wfrp.invoke(null);
+    } catch (IllegalAccessException t) {
+      throw new RuntimeException("Shouldn't happen, we call setAccessible()", t);
     } catch (InvocationTargetException e) {
       Throwable cause = e.getCause();
       if (cause instanceof InterruptedException) {
@@ -602,11 +604,6 @@ public class WhiteBox {
       } else {
         throw new RuntimeException(e);
       }
-    } catch (RuntimeException e) {
-      // Just rethrow any RuntimeExceptions from getWaitForReferenceProcessingMethod()
-      throw e;
-    } catch (Throwable t) {
-      throw new RuntimeException(t);
     }
   }
 

--- a/test/lib/jdk/test/whitebox/WhiteBox.java
+++ b/test/lib/jdk/test/whitebox/WhiteBox.java
@@ -595,8 +595,8 @@ public class WhiteBox {
     try {
       Method wfrp = getWaitForReferenceProcessingMethod();
       return (Boolean) wfrp.invoke(null);
-    } catch (IllegalAccessException t) {
-      throw new RuntimeException("Shouldn't happen, we call setAccessible()", t);
+    } catch (IllegalAccessException e) {
+      throw new RuntimeException("Shouldn't happen, we call setAccessible()", e);
     } catch (InvocationTargetException e) {
       Throwable cause = e.getCause();
       if (cause instanceof InterruptedException) {

--- a/test/lib/jdk/test/whitebox/WhiteBox.java
+++ b/test/lib/jdk/test/whitebox/WhiteBox.java
@@ -563,7 +563,7 @@ public class WhiteBox {
   // Infrastructure for waitForReferenceProcessing()
   private static Method waitForReferenceProcessingMethod = null;
 
-  private Method getWaitForReferenceProcessingMethod() {
+  private static Method getWaitForReferenceProcessingMethod() {
     Method wfrp = waitForReferenceProcessingMethod;
     if (wfrp == null) {
       try {

--- a/test/lib/jdk/test/whitebox/WhiteBox.java
+++ b/test/lib/jdk/test/whitebox/WhiteBox.java
@@ -561,7 +561,7 @@ public class WhiteBox {
   public native void fullGC();
 
   // Infrastructure for waitForReferenceProcessing()
-  private Method waitForReferenceProcessingMethod = null;
+  private static Method waitForReferenceProcessingMethod = null;
 
   private Method getWaitForReferenceProcessingMethod() {
     Method wfrp = waitForReferenceProcessingMethod;

--- a/test/lib/jdk/test/whitebox/WhiteBox.java
+++ b/test/lib/jdk/test/whitebox/WhiteBox.java
@@ -570,7 +570,6 @@ public class WhiteBox {
         wfrp = Reference.class.getDeclaredMethod("waitForReferenceProcessing");
         wfrp.setAccessible(true);
         assert wfrp.getReturnType() == Boolean.class;
-        assert wfrp.getParameterCount() == 0;
         Class<?>[] ev = wfrp.getExceptionTypes();
         assert ev.length == 1;
         assert ev[0] == InterruptedException.class;
@@ -592,10 +591,17 @@ public class WhiteBox {
    *
    * This method should usually be called after a call to WhiteBox.fullGC().
    */
-  public boolean waitForReferenceProcessing() {
+  public boolean waitForReferenceProcessing() throws InterruptedException {
     try {
       Method wfrp = getWaitForReferenceProcessingMethod();
       return (Boolean) wfrp.invoke(null);
+    } catch (InvocationTargetException e) {
+      Throwable cause = e.getCause();
+      if (cause instanceof InterruptedException) {
+        throw (InterruptedException) cause;
+      } else {
+        throw new RuntimeException(e);
+      }
     } catch (RuntimeException e) {
       // Just rethrow any RuntimeExceptions from getWaitForReferenceProcessingMethod()
       throw e;

--- a/test/lib/jdk/test/whitebox/WhiteBox.java
+++ b/test/lib/jdk/test/whitebox/WhiteBox.java
@@ -24,6 +24,7 @@
 package jdk.test.whitebox;
 
 import java.lang.management.MemoryUsage;
+import java.lang.ref.Reference;
 import java.lang.reflect.Executable;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -558,8 +559,8 @@ public class WhiteBox {
   // Force Full GC
   public native void fullGC();
 
-  private static Method wfrp = null;
-  /* Wait for reference processing, via Reference.waitForReferenceProcessing().
+  /**
+   * Wait for reference processing, via Reference.waitForReferenceProcessing().
    * Callers of this method will need the
    * @modules java.base/java.lang.ref:open
    * jtreg tag.
@@ -568,17 +569,13 @@ public class WhiteBox {
    */
   public static void waitForReferenceProcessing() {
     try {
-      if (wfrp == null) {
-        Class refClass = Class.forName("java.lang.ref.Reference");
-        Method[] methods = refClass.getDeclaredMethods();
-        wfrp = Arrays.stream(methods).filter((m) -> m.getName().equals("waitForReferenceProcessing")).findFirst().get();
-        wfrp.setAccessible(true);
-      }
+      Method wfrp = Reference.class.getDeclaredMethod("waitForReferenceProcessing");
+      wfrp.setAccessible(true);
       wfrp.invoke(null, new Object[0]);
     } catch (IllegalAccessException iae) {
       throw new RuntimeException("Need to add @modules java.base/java.lang.ref:open?",
               iae);
-    } catch (ClassNotFoundException | InvocationTargetException e) {
+    } catch (NoSuchMethodException | InvocationTargetException e) {
       throw new RuntimeException("Reflection problem", e);
     }
   }


### PR DESCRIPTION
Certain specific types of tests involving GC and reference processing need to account for the delay between a GC completing (during which the GC clears a Reference), and the Reference being added to its associated queue. At present, ad hoc mechanisms (with delays/timeout) are used, but can lead to intermittent test failures ([JDK-8298783](https://bugs.openjdk.org/browse/JDK-8298783)  is a recent example).

A better mechanism already exists in the private `Reference.waitForReferenceProcessing()` method. This PR makes `waitForReferenceProcessing()` available to tests via the `WhiteBox` and `ForceGC` test libraries.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305186](https://bugs.openjdk.org/browse/JDK-8305186): Reference.waitForReferenceProcessing should be more accessible to tests (**Enhancement** - P4)


### Reviewers
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24527/head:pull/24527` \
`$ git checkout pull/24527`

Update a local copy of the PR: \
`$ git checkout pull/24527` \
`$ git pull https://git.openjdk.org/jdk.git pull/24527/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24527`

View PR using the GUI difftool: \
`$ git pr show -t 24527`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24527.diff">https://git.openjdk.org/jdk/pull/24527.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24527#issuecomment-2787584408)
</details>
