### PR TITLE
8354071: Add LintCategory property indicating whether @SuppressWarnings is supported

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Lint.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Lint.java
@@ -212,9 +212,12 @@ public class Lint {
         CAST("cast"),
 
         /**
-         * Warn about issues related to classfile contents
+         * Warn about issues related to classfile contents.
+         *
+         * <p>
+         * This category is not supported by {@code @SuppressWarnings}.
          */
-        CLASSFILE("classfile"),
+        CLASSFILE("classfile", false),
 
         /**
          * Warn about "dangling" documentation comments,
@@ -260,8 +263,11 @@ public class Lint {
 
         /**
          * Warn about use of incubating modules.
+         *
+         * <p>
+         * This category is not supported by {@code @SuppressWarnings}.
          */
-        INCUBATING("incubating"),
+        INCUBATING("incubating", false),
 
         /**
           * Warn about compiler possible lossy conversions.
@@ -284,14 +290,20 @@ public class Lint {
         OPENS("opens"),
 
         /**
-         * Warn about issues relating to use of command line options
+         * Warn about issues relating to use of command line options.
+         *
+         * <p>
+         * This category is not supported by {@code @SuppressWarnings}.
          */
-        OPTIONS("options"),
+        OPTIONS("options", false),
 
         /**
          * Warn when any output file is written to more than once.
+         *
+         * <p>
+         * This category is not supported by {@code @SuppressWarnings}.
          */
-        OUTPUT_FILE_CLASH("output-file-clash"),
+        OUTPUT_FILE_CLASH("output-file-clash", false),
 
         /**
          * Warn about issues regarding method overloads.
@@ -305,10 +317,11 @@ public class Lint {
 
         /**
          * Warn about invalid path elements on the command line.
-         * Such warnings cannot be suppressed with the SuppressWarnings
-         * annotation.
+         *
+         * <p>
+         * This category is not supported by {@code @SuppressWarnings}.
          */
-        PATH("path"),
+        PATH("path", false),
 
         /**
          * Warn about issues regarding annotation processing.
@@ -357,8 +370,11 @@ public class Lint {
 
         /**
          * Warn about issues relating to use of text blocks
+         *
+         * <p>
+         * This category is not supported by {@code @SuppressWarnings}.
          */
-        TEXT_BLOCKS("text-blocks"),
+        TEXT_BLOCKS("text-blocks", false),
 
         /**
          * Warn about possible 'this' escapes before subclass instance is fully initialized.
@@ -391,7 +407,12 @@ public class Lint {
         RESTRICTED("restricted");
 
         LintCategory(String option) {
+            this(option, true);
+        }
+
+        LintCategory(String option, boolean annotationSuppression) {
             this.option = option;
+            this.annotationSuppression = annotationSuppression;
             map.put(option, this);
         }
 
@@ -411,6 +432,9 @@ public class Lint {
 
         /** Get the string representing this category in @SuppressAnnotations and -Xlint options. */
         public final String option;
+
+        /** Does this category support being suppressed by the {@code @SuppressWarnings} annotation? */
+        public final boolean annotationSuppression;
     }
 
     /**
@@ -504,6 +528,7 @@ public class Lint {
         for (Attribute value : values.values) {
             Optional.of((String)((Attribute.Constant)value).value)
               .flatMap(LintCategory::get)
+              .filter(lc -> lc.annotationSuppression)
               .ifPresent(result::add);
         }
         return result;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Lint.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Lint.java
@@ -372,7 +372,7 @@ public class Lint {
          * Warn about issues relating to use of text blocks
          *
          * <p>
-         * This category is not supported by {@code @SuppressWarnings}.
+         * This category is not supported by {@code @SuppressWarnings} (yet - see JDK-8224228).
          */
         TEXT_BLOCKS("text-blocks", false),
 


### PR DESCRIPTION
This is split off as a sub-task of [JDK-8224228](https://bugs.openjdk.org/browse/JDK-8224228), which seeks to add `@SuppressWarnings` support for lexical features.

Lint warnings that are subject to suppression via `@SuppressWarnings` must be deferred until attribution, because until then we can't determine whether they are suppressed or not.

Whether a lint warning is subject to suppression via `@SuppressWarnings` is a function of the associated `LintCategory`, not the warning itself. For example `LintCategory.OPTIONS` is not, so an occurrence of `@SuppressWarnings("options")` is meaningless and would be ignored.

This information is needed in the upcoming refactoring. We can facilitate that very simply by adding a boolean property to the `LintCategory` enum.

In addition, this permits a small optimization to be added to `Lint.suppressionsFrom()`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8354071](https://bugs.openjdk.org/browse/JDK-8354071): Add LintCategory property indicating whether @<!---->SuppressWarnings is supported (**Sub-task** - P4)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24529/head:pull/24529` \
`$ git checkout pull/24529`

Update a local copy of the PR: \
`$ git checkout pull/24529` \
`$ git pull https://git.openjdk.org/jdk.git pull/24529/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24529`

View PR using the GUI difftool: \
`$ git pr show -t 24529`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24529.diff">https://git.openjdk.org/jdk/pull/24529.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24529#issuecomment-2787645907)
</details>
