### PR TITLE
8354088: [BACKOUT]  Run jtreg in the work dir

### DIFF
--- a/make/RunTests.gmk
+++ b/make/RunTests.gmk
@@ -995,26 +995,23 @@ define SetupRunJtregTestBody
 	$$(RM) -r $$($1_TEST_SUPPORT_DIR)
 	$$(RM) -r $$($1_TEST_RESULTS_DIR)
 
-  $1_JTREG_ARGUMENTS := \
-      $$($1_JTREG_LAUNCHER_OPTIONS) \
-      -Dprogram=jtreg -jar $$(JT_HOME)/lib/jtreg.jar \
-      $$($1_JTREG_BASIC_OPTIONS) \
-      -testjdk:$$(JDK_UNDER_TEST) \
-      -dir:$$(JTREG_TOPDIR) \
-      -reportDir:$$($1_TEST_RESULTS_DIR) \
-      -workDir:$$($1_TEST_SUPPORT_DIR) \
-      -report:$${JTREG_REPORT} \
-      $$$${JTREG_STATUS} \
-      $$(JTREG_OPTIONS) \
-      $$(JTREG_FAILURE_HANDLER_OPTIONS) \
-      $$(JTREG_COV_OPTIONS) \
-      $$($1_TEST_NAME) \
-      #
-
   $1_COMMAND_LINE := \
-      cd $$($1_TEST_SUPPORT_DIR) && $$(JTREG_JAVA) $$($1_JTREG_ARGUMENTS) \
+      $$(JTREG_JAVA) $$($1_JTREG_LAUNCHER_OPTIONS) \
+          -Dprogram=jtreg -jar $$(JT_HOME)/lib/jtreg.jar \
+          $$($1_JTREG_BASIC_OPTIONS) \
+          -testjdk:$$(JDK_UNDER_TEST) \
+          -dir:$$(JTREG_TOPDIR) \
+          -reportDir:$$($1_TEST_RESULTS_DIR) \
+          -workDir:$$($1_TEST_SUPPORT_DIR) \
+          -report:$${JTREG_REPORT} \
+          $$$${JTREG_STATUS} \
+          $$(JTREG_OPTIONS) \
+          $$(JTREG_FAILURE_HANDLER_OPTIONS) \
+          $$(JTREG_COV_OPTIONS) \
+          $$($1_TEST_NAME) \
       && $$(ECHO) $$$$? > $$($1_EXITCODE) \
       || $$(ECHO) $$$$? > $$($1_EXITCODE)
+
 
   ifneq ($$(JTREG_RETRY_COUNT), 0)
     $1_COMMAND_LINE := \


### PR DESCRIPTION
https://github.com/dholmes-ora/jdk/pull/new/8354088-backout

This reverts commit bd73a0641615d743663ef652bc1f27305af1517b.

It causes problems with paths to ProblemList files no longer being correct.

Re-tested tier3

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8354088](https://bugs.openjdk.org/browse/JDK-8354088): [BACKOUT]  Run jtreg in the work dir (**Sub-task** - P3)


### Reviewers
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24531/head:pull/24531` \
`$ git checkout pull/24531`

Update a local copy of the PR: \
`$ git checkout pull/24531` \
`$ git pull https://git.openjdk.org/jdk.git pull/24531/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24531`

View PR using the GUI difftool: \
`$ git pr show -t 24531`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24531.diff">https://git.openjdk.org/jdk/pull/24531.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24531#issuecomment-2787989428)
</details>
