### PR TITLE
8354057: Odd debug output in -Xlog:os+container=debug on certain systems

### DIFF
--- a/src/hotspot/os/linux/cgroupSubsystem_linux.cpp
+++ b/src/hotspot/os/linux/cgroupSubsystem_linux.cpp
@@ -357,7 +357,7 @@ bool CgroupSubsystemFactory::determine_type(CgroupInfo* cg_infos,
         all_required_controllers_enabled = all_required_controllers_enabled && cg_infos[i]._enabled;
       }
       if (log_is_enabled(Debug, os, container) && !cg_infos[i]._enabled) {
-        log_debug(os, container)("controller %s is not enabled\n", cg_controller_name[i]);
+        log_debug(os, container)("controller %s is not enabled", cg_controller_name[i]);
       }
     }
   }


### PR DESCRIPTION
The issue was a trailing newline in a message argument to:

```
log_debug(os, container)(...)
```

`log_debug` implicitly appends a newline to the message, so the extra newline resulted in empty lines in the trace output.

The old vs new output on my `Alpine Linux v3.21` virtual machine is:

```diff
--- tt-old-alpine-legacy.txt	2025-04-08 21:49:31.847415499 -0400
+++ tt-new-alpine-legacy.txt	2025-04-08 21:48:51.486322068 -0400
@@ -1,10 +1,8 @@
 [0.000s][trace][os,container] OSContainer::init: Initializing Container Support
 [0.000s][debug][os,container] Detected optional pids controller entry in /proc/cgroups
 [0.000s][debug][os,container] controller cpuset is not enabled
-[                           ] 
 [0.000s][debug][os,container] controller memory is not enabled
-[                           ] 
 [0.000s][debug][os,container] One or more required controllers disabled at kernel level.
 openjdk version "25-internal" 2025-09-16
-OpenJDK Runtime Environment (fastdebug build 25-internal-adhoc.fitzsim.jdk-old)
-OpenJDK 64-Bit Server VM (fastdebug build 25-internal-adhoc.fitzsim.jdk-old, mixed mode)
+OpenJDK Runtime Environment (fastdebug build 25-internal-adhoc.fitzsim.jdk)
+OpenJDK 64-Bit Server VM (fastdebug build 25-internal-adhoc.fitzsim.jdk, mixed mode)
```

Regression-tested with:

```
make exploded-test TEST="test/hotspot/jtreg/containers test/jdk/jdk/internal/platform/cgroup gtest:cgroupTest*"
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8354057](https://bugs.openjdk.org/browse/JDK-8354057): Odd debug output in -Xlog:os+container=debug on certain systems (**Bug** - P4)


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)
 * [Ashutosh Mehra](https://openjdk.org/census#asmehra) (@ashu-mehra - Committer)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24533/head:pull/24533` \
`$ git checkout pull/24533`

Update a local copy of the PR: \
`$ git checkout pull/24533` \
`$ git pull https://git.openjdk.org/jdk.git pull/24533/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24533`

View PR using the GUI difftool: \
`$ git pr show -t 24533`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24533.diff">https://git.openjdk.org/jdk/pull/24533.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24533#issuecomment-2790183932)
</details>
