### PR TITLE
8324686: Remove redefinition of NULL for MSVC

### DIFF
--- a/src/hotspot/share/utilities/globalDefinitions_visCPP.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions_visCPP.hpp
@@ -54,25 +54,6 @@
 #error unsupported platform
 #endif
 
-// 4810578: varargs unsafe on 32-bit integer/64-bit pointer architectures
-// When __cplusplus is defined, NULL is defined as 0 (32-bit constant) in
-// system header files.  On 32-bit architectures, there is no problem.
-// On 64-bit architectures, defining NULL as a 32-bit constant can cause
-// problems with varargs functions: C++ integral promotion rules say for
-// varargs, we pass the argument 0 as an int.  So, if NULL was passed to a
-// varargs function it will remain 32-bits.  Depending on the calling
-// convention of the machine, if the argument is passed on the stack then
-// only 32-bits of the "NULL" pointer may be initialized to zero.  The
-// other 32-bits will be garbage.  If the varargs function is expecting a
-// pointer when it extracts the argument, then we may have a problem.
-//
-// Solution: For 64-bit architectures, redefine NULL as 64-bit constant 0.
-#undef NULL
-// 64-bit Windows uses a P64 data model (not LP64, although we define _LP64)
-// Since longs are 32-bit we cannot use 0L here.  Use the Visual C++ specific
-// 64-bit integer-suffix (LL) instead.
-#define NULL 0LL
-
 typedef int64_t ssize_t;
 
 // Non-standard stdlib-like stuff:

--- a/test/hotspot/jtreg/sources/TestNoNULL.java
+++ b/test/hotspot/jtreg/sources/TestNoNULL.java
@@ -74,8 +74,7 @@ public class TestNoNULL {
     private static void initializeExcludedPaths(Path rootDir) {
         List<String> sourceExclusions = List.of(
                 "src/hotspot/share/prims/jvmti.xml",
-                "src/hotspot/share/prims/jvmti.xsl",
-                "src/hotspot/share/utilities/globalDefinitions_visCPP.hpp"
+                "src/hotspot/share/prims/jvmti.xsl"
         );
 
         List<String> testExclusions = List.of(


### PR DESCRIPTION
Please review this change that removes the redefinition of NULL in
globalDefinitions_visCPP.hpp. That redefinition was to support the use of NULL
in a varargs context, because of the size difference for int vs a pointer.
However, we no longer have any direct uses of NULL in HotSpot, and have a test
that ensures there is no backsliding.

There may be indirect uses of NULL via third-party libraries.  Such uses could
have been in the scope of the removed redefinition.  But those uses must have
been correct even without the redefinition, else they would be incorrect for
non-HotSpot users.

Testing: mach5 tier1-3, GHA sanity tests

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8324686](https://bugs.openjdk.org/browse/JDK-8324686): Remove redefinition of NULL for MSVC (**Enhancement** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24537/head:pull/24537` \
`$ git checkout pull/24537`

Update a local copy of the PR: \
`$ git checkout pull/24537` \
`$ git pull https://git.openjdk.org/jdk.git pull/24537/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24537`

View PR using the GUI difftool: \
`$ git pr show -t 24537`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24537.diff">https://git.openjdk.org/jdk/pull/24537.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24537#issuecomment-2788399400)
</details>
