### PR TITLE
8354130: Assert failure at CompilationPolicy::can_be_compiled after JDK-8334046

### DIFF
--- a/src/hotspot/share/compiler/compilationPolicy.cpp
+++ b/src/hotspot/share/compiler/compilationPolicy.cpp
@@ -122,7 +122,7 @@ static inline CompLevel adjust_level_for_compilability_query(CompLevel comp_leve
 // Returns true if m is allowed to be compiled
 bool CompilationPolicy::can_be_compiled(const methodHandle& m, int comp_level) {
   // allow any levels for WhiteBox
-  assert(WhiteBoxAPI || comp_level == CompLevel_any || is_compile(comp_level), "illegal compilation level");
+  assert(WhiteBoxAPI || comp_level == CompLevel_any || comp_level == CompLevel_all || is_compile(comp_level), "illegal compilation level");
 
   if (m->is_abstract()) return false;
   if (DontCompileHugeMethods && m->code_size() > HugeMethodLimit) return false;


### PR DESCRIPTION
With https://github.com/openjdk/jdk/pull/24298 , `CompLevel_any` and `CompLevel_all` are now different, causing an assertion failure in CompilationPolicy::can_be_compiled. This PR includes `CompLevel_all` in the assertion condition.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8354130](https://bugs.openjdk.org/browse/JDK-8354130): Assert failure at CompilationPolicy::can_be_compiled after JDK-8334046 (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24540/head:pull/24540` \
`$ git checkout pull/24540`

Update a local copy of the PR: \
`$ git checkout pull/24540` \
`$ git pull https://git.openjdk.org/jdk.git pull/24540/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24540`

View PR using the GUI difftool: \
`$ git pr show -t 24540`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24540.diff">https://git.openjdk.org/jdk/pull/24540.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24540#issuecomment-2789164974)
</details>
