### PR TITLE
8354145: G1GC: keep the CompressedOops same as before when not setting HeapRegionSize explicitly

### DIFF
--- a/src/hotspot/share/gc/g1/g1Arguments.cpp
+++ b/src/hotspot/share/gc/g1/g1Arguments.cpp
@@ -71,6 +71,9 @@ void G1Arguments::initialize_alignments() {
 }
 
 size_t G1Arguments::conservative_max_heap_alignment() {
+  if (FLAG_IS_DEFAULT(G1HeapRegionSize)) {
+    return G1HeapRegion::max_ergonomics_size();
+  }
   return G1HeapRegion::max_region_size();
 }
 

--- a/src/hotspot/share/gc/g1/g1HeapRegion.cpp
+++ b/src/hotspot/share/gc/g1/g1HeapRegion.cpp
@@ -57,6 +57,10 @@ size_t G1HeapRegion::max_region_size() {
   return G1HeapRegionBounds::max_size();
 }
 
+size_t G1HeapRegion::max_ergonomics_size() {
+  return G1HeapRegionBounds::max_ergonomics_size();
+}
+
 size_t G1HeapRegion::min_region_size_in_words() {
   return G1HeapRegionBounds::min_size() >> LogHeapWordSize;
 }

--- a/src/hotspot/share/gc/g1/g1HeapRegion.hpp
+++ b/src/hotspot/share/gc/g1/g1HeapRegion.hpp
@@ -316,6 +316,7 @@ public:
   }
 
   static size_t max_region_size();
+  static size_t max_ergonomics_size();
   static size_t min_region_size_in_words();
 
   // It sets up the heap region size (GrainBytes / GrainWords), as well as


### PR DESCRIPTION
After JDK-8275056, The max heap region size became 512M, and the calculation of CompressedOops based on the max_heap_size - max_heap_region_size.
So before this patch, the CompressedOops will turn on below 32G - 32m, After this patch is 32G -512m.

When our Apps migrating from JDK11 to JDK21, the heap size parameters(Xmx32736m) will turn off the CompressedOops.

Since the current max ergonomics size is still 32m, We hoped that the original behavior will not be changed if HeapRegionSize is not explicitly set.

before this patch:
```
./build/linux-x86_64-server-release/images/jdk/bin/java -Xmx32736m -XX:+PrintFlagsFinal -version | grep CompressedOops
     bool UseCompressedOops                        = false                          {product lp64_product} {default}
openjdk version "25-internal" 2025-09-16
OpenJDK Runtime Environment (build 25-internal-adhoc.root.jdk)
OpenJDK 64-Bit Server VM (build 25-internal-adhoc.root.jdk, mixed mode, sharing)
```

after this patch:
```
./build/linux-x86_64-server-release/images/jdk/bin/java -Xmx32736m -XX:+PrintFlagsFinal -version | grep CompressedOops
     bool UseCompressedOops                        = true                           {product lp64_product} {ergonomic}
openjdk version "25-internal" 2025-09-16
OpenJDK Runtime Environment (build 25-internal-adhoc.root.jdk)
OpenJDK 64-Bit Server VM (build 25-internal-adhoc.root.jdk, mixed mode, sharing)
```
