### PR TITLE
8352431: java/net/httpclient/EmptyAuthenticate.java uses "localhost"

### DIFF
--- a/test/jdk/java/net/httpclient/EmptyAuthenticate.java
+++ b/test/jdk/java/net/httpclient/EmptyAuthenticate.java
@@ -24,55 +24,118 @@
 /*
  * @test
  * @bug 8263899
- * @summary HttpClient throws NPE in AuthenticationFilter when parsing www-authenticate head
- *
- * @run main/othervm EmptyAuthenticate
+ * @summary Verifies that empty `WWW-Authenticate` header is correctly parsed
+ * @library /test/jdk/java/net/httpclient/lib
+ *          /test/lib
+ * @build jdk.httpclient.test.lib.common.HttpServerAdapters
+ *        jdk.test.lib.net.SimpleSSLContext
+ * @run junit EmptyAuthenticate
  */
-import com.sun.net.httpserver.HttpServer;
+
+import jdk.httpclient.test.lib.common.HttpServerAdapters;
+import jdk.httpclient.test.lib.common.HttpServerAdapters.HttpTestHandler;
+import jdk.httpclient.test.lib.common.HttpServerAdapters.HttpTestServer;
+import jdk.test.lib.net.SimpleSSLContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import javax.net.ssl.SSLContext;
 import java.io.IOException;
-import java.io.OutputStream;
-import java.net.InetSocketAddress;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.net.http.HttpClient;
+import java.net.http.HttpClient.Version;
+import java.net.http.HttpHeaders;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.stream.Stream;
 
-public class EmptyAuthenticate {
+import static java.net.http.HttpClient.Builder.NO_PROXY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-    public static void main(String[] args) throws IOException, URISyntaxException, InterruptedException {
-        int port = 0;
+class EmptyAuthenticate {
 
-        //start server:
-        HttpServer server = HttpServer.create(new InetSocketAddress(port), 0);
-        port = server.getAddress().getPort();
-        server.createContext("/", exchange -> {
-            String response = "test body";
-            //this empty header will make the HttpClient throw NPE
-            exchange.getResponseHeaders().add("www-authenticate", "");
-            exchange.sendResponseHeaders(401, response.length());
-            OutputStream os = exchange.getResponseBody();
-            os.write(response.getBytes());
-            os.close();
-        });
-        server.start();
+    private static final SSLContext SSL_CONTEXT = createSslContext();
 
-        HttpResponse<String> response = null;
-        //run client:
+    private static final String WWW_AUTH_HEADER_NAME = "WWW-Authenticate";
+
+    private static SSLContext createSslContext() {
         try {
-            HttpClient httpClient = HttpClient.newHttpClient();
-            HttpRequest request = HttpRequest.newBuilder(new URI("http://localhost:" + port + "/")).GET().build();
-            //this line will throw NPE (wrapped by IOException) when parsing empty www-authenticate response header in AuthenticationFilter:
-            response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
-            boolean ok = !response.headers().firstValue("WWW-Authenticate").isEmpty();
-            if (!ok) {
-                throw new RuntimeException("WWW-Authenicate missing");
-            }
-        } catch (IOException e) {
-            e.printStackTrace();
-            throw new RuntimeException("Test failed");
-        } finally {
-            server.stop(0);
+            return new SimpleSSLContext().get();
+        } catch (IOException exception) {
+            throw new RuntimeException(exception);
         }
     }
+
+    @ParameterizedTest
+    @MethodSource("args")
+    void test(Version version, boolean secure) throws Exception {
+        HttpTestServer server = createStartedServerRespondingWithEmptyWwwAuthHeader(version, secure);
+        try (HttpClient client = createClient(version, secure)) {
+            HttpRequest request = createRequest(server, secure);
+            HttpResponse<Void> response = client.send(request, HttpResponse.BodyHandlers.discarding());
+            HttpHeaders responseHeaders = response.headers();
+            assertEquals(
+                    "",
+                    responseHeaders.firstValue(WWW_AUTH_HEADER_NAME).orElse(null),
+                    () -> "was expecting empty `%s` header in: %s".formatted(
+                            WWW_AUTH_HEADER_NAME, responseHeaders.map()));
+        } finally {
+            server.stop();
+        }
+    }
+
+    static Stream<Arguments> args() {
+        return Stream
+                .of(Version.HTTP_1_1, Version.HTTP_2)
+                .flatMap(version -> Stream
+                        .of(true, false)
+                        .map(secure -> Arguments.of(version, secure)));
+    }
+
+    private static HttpTestServer createStartedServerRespondingWithEmptyWwwAuthHeader(Version version, boolean secure)
+            throws IOException {
+        HttpTestServer server = secure
+                ? HttpTestServer.create(version, SSL_CONTEXT)
+                : HttpTestServer.create(version);
+        HttpTestHandler handler = new ServerHandlerRespondingWithEmptyWwwAuthHeader();
+        server.addHandler(handler, "/");
+        server.start();
+        return server;
+    }
+
+    private static final class ServerHandlerRespondingWithEmptyWwwAuthHeader implements HttpTestHandler {
+
+        private int responseIndex = 0;
+
+        @Override
+        public synchronized void handle(HttpServerAdapters.HttpTestExchange exchange) throws IOException {
+            try (exchange) {
+                exchange.getResponseHeaders().addHeader(WWW_AUTH_HEADER_NAME, "");
+                byte[] responseBodyBytes = "test body %d"
+                        .formatted(responseIndex)
+                        .getBytes(StandardCharsets.US_ASCII);
+                exchange.sendResponseHeaders(401, responseBodyBytes.length);
+                exchange.getResponseBody().write(responseBodyBytes);
+            } finally {
+                responseIndex++;
+            }
+        }
+
+    }
+
+    private static HttpClient createClient(Version version, boolean secure) {
+        HttpClient.Builder clientBuilder = HttpClient.newBuilder().version(version).proxy(NO_PROXY);
+        if (secure) {
+            clientBuilder.sslContext(SSL_CONTEXT);
+        }
+        return clientBuilder.build();
+    }
+
+    private static HttpRequest createRequest(HttpTestServer server, boolean secure) {
+        URI uri = URI.create("%s://%s/".formatted(secure ? "https" : "http", server.serverAuthority()));
+        return HttpRequest.newBuilder(uri).version(server.getVersion()).GET().build();
+    }
+
 }

--- a/test/jdk/java/net/httpclient/EmptyAuthenticate.java
+++ b/test/jdk/java/net/httpclient/EmptyAuthenticate.java
@@ -71,8 +71,9 @@ class EmptyAuthenticate {
     @ParameterizedTest
     @MethodSource("args")
     void test(Version version, boolean secure) throws Exception {
-        String uriPath = "/%s/%s/%s".formatted(EmptyAuthenticate.class.getSimpleName(), version, secure ? 's' : 'c');
-        HttpTestServer server = createServer(version, secure, uriPath);
+        String handlerPath = "/%s/%s/".formatted(EmptyAuthenticate.class.getSimpleName(), version)
+        String uriPath = handlerPath + (secure ? 's' : 'c');
+        HttpTestServer server = createServer(version, secure, handlerPath);
         try (HttpClient client = createClient(version, secure)) {
             HttpRequest request = createRequest(server, secure, uriPath);
             HttpResponse<Void> response = client.send(request, HttpResponse.BodyHandlers.discarding());

--- a/test/jdk/java/net/httpclient/EmptyAuthenticate.java
+++ b/test/jdk/java/net/httpclient/EmptyAuthenticate.java
@@ -71,7 +71,7 @@ class EmptyAuthenticate {
     @ParameterizedTest
     @MethodSource("args")
     void test(Version version, boolean secure) throws Exception {
-        String handlerPath = "/%s/%s/".formatted(EmptyAuthenticate.class.getSimpleName(), version)
+        String handlerPath = "/%s/%s/".formatted(EmptyAuthenticate.class.getSimpleName(), version);
         String uriPath = handlerPath + (secure ? 's' : 'c');
         HttpTestServer server = createServer(version, secure, handlerPath);
         try (HttpClient client = createClient(version, secure)) {


### PR DESCRIPTION
Overhauls `EmptyAuthenticate` to

- Test all supported HTTP versions (i.e., HTTP/1.1 and HTTP/2)
- Test both clear-text and SSL
- Use `HttpServerAdapters.HttpTestServer::create` to avoid host-related problems

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8352431](https://bugs.openjdk.org/browse/JDK-8352431): java/net/httpclient/EmptyAuthenticate.java uses "localhost" (**Bug** - P4)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**) Review applies to [7b5c8490](https://git.openjdk.org/jdk/pull/24542/files/7b5c849002c2302a3b4d4cdec3fd427fc9a1c4f7)
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24542/head:pull/24542` \
`$ git checkout pull/24542`

Update a local copy of the PR: \
`$ git checkout pull/24542` \
`$ git pull https://git.openjdk.org/jdk.git pull/24542/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24542`

View PR using the GUI difftool: \
`$ git pr show -t 24542`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24542.diff">https://git.openjdk.org/jdk/pull/24542.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24542#issuecomment-2789341905)
</details>
