### PR TITLE
8285888: Clarify that java.net.http.HttpClient do NOT support Digest authentication

### DIFF
--- a/src/java.net.http/share/classes/java/net/http/HttpClient.java
+++ b/src/java.net.http/share/classes/java/net/http/HttpClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.net.http/share/classes/java/net/http/HttpClient.java
+++ b/src/java.net.http/share/classes/java/net/http/HttpClient.java
@@ -389,6 +389,8 @@ public abstract class HttpClient implements AutoCloseable {
          * the {@link Authenticator} is not invoked for the corresponding
          * authentication. In this case, any authentication errors are returned
          * to the user and requests are not automatically retried.
+         * Additionally, the JDK built-in implementation currently only supports HTTP
+         * {@code Basic} authentication.
          *
          * @param authenticator the Authenticator
          * @return this builder


### PR DESCRIPTION
Hi,

This is a minor doc change to clarify that java.net.http.HttpClient only supports HTTP Basic authentication.

Thanks,
Michael

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8354190](https://bugs.openjdk.org/browse/JDK-8354190) to be approved

### Issues
 * [JDK-8285888](https://bugs.openjdk.org/browse/JDK-8285888): Clarify that java.net.http.HttpClient do NOT support Digest authentication (**Enhancement** - P4)
 * [JDK-8354190](https://bugs.openjdk.org/browse/JDK-8354190): Clarify that java.net.http.HttpClient do NOT support Digest authentication (**CSR**)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24550/head:pull/24550` \
`$ git checkout pull/24550`

Update a local copy of the PR: \
`$ git checkout pull/24550` \
`$ git pull https://git.openjdk.org/jdk.git pull/24550/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24550`

View PR using the GUI difftool: \
`$ git pr show -t 24550`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24550.diff">https://git.openjdk.org/jdk/pull/24550.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24550#issuecomment-2789890982)
</details>
