### PR TITLE
8354216: Small cleanups relating to Log.DiagnosticHandler

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/api/JavacTrees.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/api/JavacTrees.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -357,8 +357,7 @@ public class JavacTrees extends DocTrees {
         if (tree instanceof DCReference dcReference) {
             JCTree qexpr = dcReference.qualifierExpression;
             if (qexpr != null) {
-                Log.DeferredDiagnosticHandler deferredDiagnosticHandler =
-                        new Log.DeferredDiagnosticHandler(log);
+                Log.DeferredDiagnosticHandler deferredDiagnosticHandler = log.new DeferredDiagnosticHandler();
                 try {
                     Env<AttrContext> env = getAttrContext(path.getTreePath());
                     Type t = attr.attribType(dcReference.qualifierExpression, env);
@@ -388,8 +387,7 @@ public class JavacTrees extends DocTrees {
             // module name and member name without type
             return null;
         }
-        Log.DeferredDiagnosticHandler deferredDiagnosticHandler =
-                new Log.DeferredDiagnosticHandler(log);
+        Log.DeferredDiagnosticHandler deferredDiagnosticHandler = log.new DeferredDiagnosticHandler();
         try {
             final TypeSymbol tsym;
             final Name memberName;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Analyzer.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Analyzer.java
@@ -730,7 +730,7 @@ public class Analyzer {
          * Simple deferred diagnostic handler which filters out all messages and keep track of errors.
          */
         Log.DeferredDiagnosticHandler diagHandler() {
-            return new Log.DeferredDiagnosticHandler(log, d -> {
+            return log.new DeferredDiagnosticHandler(d -> {
                 if (d.getType() == DiagnosticType.ERROR) {
                     erroneous = true;
                 }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -2038,7 +2038,7 @@ public class Attr extends JCTree.Visitor {
             types.asSuper(resource, syms.autoCloseableType.tsym) != null &&
             !types.isSameType(resource, syms.autoCloseableType)) { // Don't emit warning for AutoCloseable itself
             Symbol close = syms.noSymbol;
-            Log.DiagnosticHandler discardHandler = new Log.DiscardDiagnosticHandler(log);
+            Log.DiagnosticHandler discardHandler = log.new DiscardDiagnosticHandler();
             try {
                 close = rs.resolveQualifiedMethod(pos,
                         env,

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
@@ -3675,7 +3675,7 @@ public class Check {
      */
     public boolean validateAnnotationDeferErrors(JCAnnotation a) {
         boolean res = false;
-        final Log.DiagnosticHandler diagHandler = new Log.DiscardDiagnosticHandler(log);
+        final Log.DiagnosticHandler diagHandler = log.new DiscardDiagnosticHandler();
         try {
             res = validateAnnotation(a);
         } finally {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/DeferredAttr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/DeferredAttr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -547,7 +547,7 @@ public class DeferredAttr extends JCTree.Visitor {
             }
 
             DeferredAttrDiagHandler(Log log, JCTree newTree) {
-                super(log, d -> {
+                log.super(d -> {
                     PosScanner posScanner = new PosScanner(d.getDiagnosticPosition());
                     posScanner.scan(newTree);
                     return posScanner.found;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Flow.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Flow.java
@@ -239,7 +239,7 @@ public class Flow {
         //step - if we suppress diagnostics, we won't stop at Attr for flow-analysis
         //related errors, which will allow for more errors to be detected
         if (!speculative) {
-            diagHandler = new Log.DiscardDiagnosticHandler(log);
+            diagHandler = log.new DiscardDiagnosticHandler();
         }
         try {
             new LambdaAliveAnalyzer().analyzeTree(env, that, make);
@@ -257,7 +257,7 @@ public class Flow {
         //message will be reported and will cause compilation to skip the flow analysis
         //step - if we suppress diagnostics, we won't stop at Attr for flow-analysis
         //related errors, which will allow for more errors to be detected
-        Log.DiagnosticHandler diagHandler = new Log.DiscardDiagnosticHandler(log);
+        Log.DiagnosticHandler diagHandler = log.new DiscardDiagnosticHandler();
         try {
             new LambdaAssignAnalyzer(env).analyzeTree(env, that, make);
             LambdaFlowAnalyzer flowAnalyzer = new LambdaFlowAnalyzer();
@@ -274,7 +274,7 @@ public class Flow {
         //message will be reported and will cause compilation to skip the flow analysis
         //step - if we suppress diagnostics, we won't stop at Attr for flow-analysis
         //related errors, which will allow for more errors to be detected
-        Log.DiagnosticHandler diagHandler = new Log.DiscardDiagnosticHandler(log);
+        Log.DiagnosticHandler diagHandler = log.new DiscardDiagnosticHandler();
         try {
             SnippetAliveAnalyzer analyzer = new SnippetAliveAnalyzer();
 
@@ -291,7 +291,7 @@ public class Flow {
         //message will be reported and will cause compilation to skip the flow analysis
         //step - if we suppress diagnostics, we won't stop at Attr for flow-analysis
         //related errors, which will allow for more errors to be detected
-        Log.DiagnosticHandler diagHandler = new Log.DiscardDiagnosticHandler(log);
+        Log.DiagnosticHandler diagHandler = log.new DiscardDiagnosticHandler();
         try {
             SnippetBreakToAnalyzer analyzer = new SnippetBreakToAnalyzer(breakTo);
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/main/JavaCompiler.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/main/JavaCompiler.java
@@ -1166,7 +1166,7 @@ public class JavaCompiler {
                 genEndPos = true;
                 if (!taskListener.isEmpty())
                     taskListener.started(new TaskEvent(TaskEvent.Kind.ANNOTATION_PROCESSING));
-                deferredDiagnosticHandler = new Log.DeferredDiagnosticHandler(log);
+                deferredDiagnosticHandler = log.new DeferredDiagnosticHandler();
                 procEnvImpl.getFiler().setInitialState(initialFiles, initialClassNames);
             }
         } else { // free resources
@@ -1898,7 +1898,7 @@ public class JavaCompiler {
 
     private Name parseAndGetName(JavaFileObject fo,
                                  Function<JCTree.JCCompilationUnit, Name> tree2Name) {
-        DiagnosticHandler dh = new DiscardDiagnosticHandler(log);
+        DiagnosticHandler dh = log.new DiscardDiagnosticHandler();
         JavaFileObject prevSource = log.useSource(fo);
         try {
             JCTree.JCCompilationUnit t = parse(fo, fo.getCharContent(false), true);

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/ReferenceParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/ReferenceParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -119,7 +119,7 @@ public class ReferenceParser {
         Name member;
         List<JCTree> paramTypes;
 
-        Log.DeferredDiagnosticHandler dh = new Log.DeferredDiagnosticHandler(fac.log);
+        Log.DeferredDiagnosticHandler dh = fac.log.new DeferredDiagnosticHandler();
 
         try {
             int slash = sig.indexOf("/");
@@ -278,9 +278,10 @@ public class ReferenceParser {
     }
 
     private void checkDiags(Log.DeferredDiagnosticHandler h, int offset) throws ParseException {
-        JCDiagnostic d = h.getDiagnostics().peek();
-        if (d != null) {
-            throw new ParseException(offset + ((int) d.getPosition()), "dc.ref.syntax.error");
+        java.util.List<JCDiagnostic> diagnostics = h.getDiagnostics();
+        if (!diagnostics.isEmpty()) {
+            int pos = offset + (int)diagnostics.get(0).getPosition();
+            throw new ParseException(pos, "dc.ref.syntax.error");
         }
     }
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/processing/JavacProcessingEnvironment.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/processing/JavacProcessingEnvironment.java
@@ -39,6 +39,7 @@ import javax.annotation.processing.*;
 import javax.lang.model.SourceVersion;
 import javax.lang.model.element.*;
 import javax.lang.model.util.*;
+import javax.tools.Diagnostic;
 import javax.tools.JavaFileManager;
 import javax.tools.JavaFileObject;
 import javax.tools.JavaFileObject.Kind;
@@ -1004,7 +1005,7 @@ public class JavacProcessingEnvironment implements ProcessingEnvironment, Closea
                 Assert.checkNonNull(deferredDiagnosticHandler);
                 this.deferredDiagnosticHandler = deferredDiagnosticHandler;
             } else {
-                this.deferredDiagnosticHandler = new Log.DeferredDiagnosticHandler(log);
+                this.deferredDiagnosticHandler = log.new DeferredDiagnosticHandler();
                 compiler.setDeferredDiagnosticHandler(this.deferredDiagnosticHandler);
             }
 
@@ -1107,21 +1108,9 @@ public class JavacProcessingEnvironment implements ProcessingEnvironment, Closea
             if (messager.errorRaised())
                 return true;
 
-            for (JCDiagnostic d: deferredDiagnosticHandler.getDiagnostics()) {
-                switch (d.getKind()) {
-                    case WARNING:
-                        if (werror)
-                            return true;
-                        break;
-
-                    case ERROR:
-                        if (fatalErrors || !d.isFlagSet(RECOVERABLE))
-                            return true;
-                        break;
-                }
-            }
-
-            return false;
+            return deferredDiagnosticHandler.getDiagnostics().stream()
+              .anyMatch(d -> (d.getKind() == Diagnostic.Kind.WARNING && werror) ||
+                             (d.getKind() == Diagnostic.Kind.ERROR && (fatalErrors || !d.isFlagSet(RECOVERABLE))));
         }
 
         /** Find the set of annotations present in the set of top level

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Log.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Log.java
@@ -181,7 +181,7 @@ public class Log extends AbstractLog {
 
         /** Report all deferred diagnostics in the specified order. */
         public void reportDeferredDiagnostics(Comparator<JCDiagnostic> order) {
-            deferred.sort(order);
+            deferred.sort(order);   // ok to sort in place: reportDeferredDiagnostics() is going to discard it
             reportDeferredDiagnostics();
         }
     }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Log.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Log.java
@@ -26,12 +26,14 @@
 package com.sun.tools.javac.util;
 
 import java.io.*;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.EnumMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
-import java.util.Queue;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
 
@@ -83,26 +85,26 @@ public class Log extends AbstractLog {
     /**
      * DiagnosticHandler's provide the initial handling for diagnostics.
      * When a diagnostic handler is created and has been initialized, it
-     * should install itself as the current diagnostic handler. When a
+     * will install itself as the current diagnostic handler. When a
      * client has finished using a handler, the client should call
      * {@code log.removeDiagnosticHandler();}
      *
      * Note that javax.tools.DiagnosticListener (if set) is called later in the
      * diagnostic pipeline.
      */
-    public abstract static class DiagnosticHandler {
+    public abstract class DiagnosticHandler {
         /**
          * The previously installed diagnostic handler.
          */
-        protected DiagnosticHandler prev;
+        protected final DiagnosticHandler prev;
 
         /**
          * Install this diagnostic handler as the current one,
          * recording the previous one.
          */
-        protected void install(Log log) {
-            prev = log.diagnosticHandler;
-            log.diagnosticHandler = this;
+        protected DiagnosticHandler() {
+            prev = diagnosticHandler;
+            diagnosticHandler = this;
         }
 
         /**
@@ -114,11 +116,7 @@ public class Log extends AbstractLog {
     /**
      * A DiagnosticHandler that discards all diagnostics.
      */
-    public static class DiscardDiagnosticHandler extends DiagnosticHandler {
-        @SuppressWarnings("this-escape")
-        public DiscardDiagnosticHandler(Log log) {
-            install(log);
-        }
+    public class DiscardDiagnosticHandler extends DiagnosticHandler {
 
         @Override
         public void report(JCDiagnostic diag) { }
@@ -131,39 +129,38 @@ public class Log extends AbstractLog {
      * with reportAllDiagnostics(), it will be reported to the previously
      * active diagnostic handler.
      */
-    public static class DeferredDiagnosticHandler extends DiagnosticHandler {
-        private Queue<JCDiagnostic> deferred = new ListBuffer<>();
+    public class DeferredDiagnosticHandler extends DiagnosticHandler {
+        private List<JCDiagnostic> deferred = new ArrayList<>();
         private final Predicate<JCDiagnostic> filter;
         private final boolean passOnNonDeferrable;
 
-        public DeferredDiagnosticHandler(Log log) {
-            this(log, null);
+        public DeferredDiagnosticHandler() {
+            this(null);
         }
 
-        public DeferredDiagnosticHandler(Log log, Predicate<JCDiagnostic> filter) {
-            this(log, filter, true);
+        public DeferredDiagnosticHandler(Predicate<JCDiagnostic> filter) {
+            this(filter, true);
         }
 
-        @SuppressWarnings("this-escape")
-        public DeferredDiagnosticHandler(Log log, Predicate<JCDiagnostic> filter, boolean passOnNonDeferrable) {
-            this.filter = filter;
+        public DeferredDiagnosticHandler(Predicate<JCDiagnostic> filter, boolean passOnNonDeferrable) {
+            this.filter = Optional.ofNullable(filter).orElse(d -> true);
             this.passOnNonDeferrable = passOnNonDeferrable;
-            install(log);
+        }
+
+        private boolean deferrable(JCDiagnostic diag) {
+            return !(diag.isFlagSet(DiagnosticFlag.NON_DEFERRABLE) && passOnNonDeferrable) && filter.test(diag);
         }
 
         @Override
         public void report(JCDiagnostic diag) {
-            boolean deferrable = !passOnNonDeferrable ||
-                                 !diag.isFlagSet(JCDiagnostic.DiagnosticFlag.NON_DEFERRABLE);
-            if (deferrable &&
-                (filter == null || filter.test(diag))) {
+            if (deferrable(diag)) {
                 deferred.add(diag);
             } else {
                 prev.report(diag);
             }
         }
 
-        public Queue<JCDiagnostic> getDiagnostics() {
+        public List<JCDiagnostic> getDiagnostics() {
             return deferred;
         }
 
@@ -174,22 +171,18 @@ public class Log extends AbstractLog {
 
         /** Report selected deferred diagnostics. */
         public void reportDeferredDiagnostics(Predicate<JCDiagnostic> accepter) {
-            JCDiagnostic d;
-            while ((d = deferred.poll()) != null) {
-                if (accepter.test(d))
-                    prev.report(d);
-            }
+
+            // Flush matching reports to the previous handler
+            deferred.stream()
+              .filter(accepter)
+              .forEach(prev::report);
             deferred = null; // prevent accidental ongoing use
         }
 
-        /** Report selected deferred diagnostics. */
+        /** Report all deferred diagnostics in the specified order. */
         public void reportDeferredDiagnostics(Comparator<JCDiagnostic> order) {
-            JCDiagnostic[] diags = deferred.toArray(s -> new JCDiagnostic[s]);
-            Arrays.sort(diags, order);
-            for (JCDiagnostic d : diags) {
-                prev.report(d);
-            }
-            deferred = null; // prevent accidental ongoing use
+            deferred.sort(order);
+            reportDeferredDiagnostics();
         }
     }
 
@@ -483,6 +476,7 @@ public class Log extends AbstractLog {
      */
     public void popDiagnosticHandler(DiagnosticHandler h) {
         Assert.check(diagnosticHandler == h);
+        Assert.check(h.prev != null);
         diagnosticHandler = h.prev;
     }
 

--- a/src/jdk.jshell/share/classes/jdk/jshell/TaskFactory.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/TaskFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -717,7 +717,7 @@ class TaskFactory {
                 //if it was not enhanced yet:
                 //ignore any errors:
                 JavaFileObject prev = log.useSource(null);
-                DiscardDiagnosticHandler h = new DiscardDiagnosticHandler(log);
+                DiscardDiagnosticHandler h = log.new DiscardDiagnosticHandler();
                 parserFactory.runPermitIntersectionTypes(() -> {
                     try {
                         //parse the type as a cast, i.e. "(<typeName>) x". This is to support


### PR DESCRIPTION
This is split off as a sub-task of [JDK-8224228](https://bugs.openjdk.org/browse/JDK-8224228), which seeks to add `@SuppressWarnings` support for lexical features. 

There are a few of small refactoring cleanups possible relating to the nested class `Log.DiagnosticHandler`.

First, this class is currently declared as a static inner class with an explicit field reference to its outer class (`Log`) instance. Although protected and non final, this field really should never be changed. Therefore, there is no reason not to just make `DiagnosticHandler` a non-static inner class. This will slightly simplify the code and eliminate an obscure corner case by which a bug could possibly occur someday.

Secondly, the deferred diagnostics are currently stored in a linked list, and in cases where they must be sorted before being reported, they have to be copied into an array first. A simpler and more space efficient approach would be to just use an `ArrayList`. Then the sorting variant of the method can just sort the list in place and delegate directly to the non-sorting variant.

Finally, the code can be simplified by replacing a null `filter` predicate with an always true predicate at construction time instead of at filter time.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8354216](https://bugs.openjdk.org/browse/JDK-8354216): Small cleanups relating to Log.DiagnosticHandler (**Sub-task** - P4)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24553/head:pull/24553` \
`$ git checkout pull/24553`

Update a local copy of the PR: \
`$ git checkout pull/24553` \
`$ git pull https://git.openjdk.org/jdk.git pull/24553/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24553`

View PR using the GUI difftool: \
`$ git pr show -t 24553`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24553.diff">https://git.openjdk.org/jdk/pull/24553.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24553#issuecomment-2790181069)
</details>
