### PR TITLE
8354230: Wrong boot jdk for alpine-linux-x64 in GHA

### DIFF
--- a/make/conf/github-actions.conf
+++ b/make/conf/github-actions.conf
@@ -33,8 +33,8 @@ LINUX_X64_BOOT_JDK_URL=https://download.java.net/java/GA/jdk24/1f9ff9062db4449d8
 LINUX_X64_BOOT_JDK_SHA256=88b090fa80c6c1d084ec9a755233967458788e2c0777ae2e172230c5c692d7ef
 
 ALPINE_LINUX_X64_BOOT_JDK_EXT=tar.gz
-ALPINE_LINUX_X64_BOOT_JDK_URL=https://github.com/adoptium/temurin24-binaries/releases/download/jdk-24%2B36/OpenJDK24U-jdk_aarch64_alpine-linux_hotspot_24_36.tar.gz
-ALPINE_LINUX_X64_BOOT_JDK_SHA256=4a673456aa6e726b86108a095a21868b7ebcdde050a92b3073d50105ff92f07f
+ALPINE_LINUX_X64_BOOT_JDK_URL=https://github.com/adoptium/temurin24-binaries/releases/download/jdk-24%2B36/OpenJDK24U-jdk_x64_alpine-linux_hotspot_24_36.tar.gz
+ALPINE_LINUX_X64_BOOT_JDK_SHA256=a642608f0da78344ee6812fb1490b8bc1d7ad5a18064c70994d6f330568c51cb
 
 MACOS_AARCH64_BOOT_JDK_EXT=tar.gz
 MACOS_AARCH64_BOOT_JDK_URL=https://download.java.net/java/GA/jdk24/1f9ff9062db4449d8ca828c504ffae90/36/GPL/openjdk-24_macos-aarch64_bin.tar.gz


### PR DESCRIPTION
[JDK-8342984](https://bugs.openjdk.org/browse/JDK-8342984) bumped the minimum boot jdk to JDK 24, and update the boot JDKs used in GHA in the process. Unfortunately the boot jdk for alpine-linux-x64 was incorrectly changed to use the linux-*aarch64* version.

Testing: GHA, incl. explicitly triggering/building of alpine-linux-x64

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8354230](https://bugs.openjdk.org/browse/JDK-8354230): Wrong boot jdk for alpine-linux-x64 in GHA (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - **Reviewer**)
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24557/head:pull/24557` \
`$ git checkout pull/24557`

Update a local copy of the PR: \
`$ git checkout pull/24557` \
`$ git pull https://git.openjdk.org/jdk.git pull/24557/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24557`

View PR using the GUI difftool: \
`$ git pr show -t 24557`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24557.diff">https://git.openjdk.org/jdk/pull/24557.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24557#issuecomment-2790964666)
</details>
