### PR TITLE
8353949: HttpHeaders.firstValueAsLong unnecessarily boxes to Long

### DIFF
--- a/src/java.net.http/share/classes/java/net/http/HttpHeaders.java
+++ b/src/java.net.http/share/classes/java/net/http/HttpHeaders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -94,7 +94,7 @@ public final class HttpHeaders {
      *                               a Long
      */
     public OptionalLong firstValueAsLong(String name) {
-        return allValues(name).stream().mapToLong(Long::valueOf).findFirst();
+        return allValues(name).stream().mapToLong(Long::parseLong).findFirst();
     }
 
     /**


### PR DESCRIPTION
Avoid unnecessary boxing in `HttpHeaders::firstValueAsLong`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8353949](https://bugs.openjdk.org/browse/JDK-8353949): HttpHeaders.firstValueAsLong unnecessarily boxes to Long (**Enhancement** - P4)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - **Reviewer**)
 * [Michael McMahon](https://openjdk.org/census#michaelm) (@Michael-Mc-Mahon - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24561/head:pull/24561` \
`$ git checkout pull/24561`

Update a local copy of the PR: \
`$ git checkout pull/24561` \
`$ git pull https://git.openjdk.org/jdk.git pull/24561/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24561`

View PR using the GUI difftool: \
`$ git pr show -t 24561`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24561.diff">https://git.openjdk.org/jdk/pull/24561.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24561#issuecomment-2791631578)
</details>
