### PR TITLE
8352682: Opensource JComponent tests

### DIFF
--- a/test/jdk/javax/swing/JComponent/bug4235215.java
+++ b/test/jdk/javax/swing/JComponent/bug4235215.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4235215
+ * @summary Tests that Toolkit.getPrintJob() do not throw NPE
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual bug4235215
+ */
+
+import java.awt.Toolkit;
+import javax.swing.JButton;
+import javax.swing.JFrame;
+
+public class bug4235215 {
+
+    private static final String INSTRUCTIONS = """
+        Press "Print Dialog" button.
+        If you see a print dialog, test passes.
+        Click "Cancel" button to close it.""";
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                .title("bug4235215 Instructions")
+                .instructions(INSTRUCTIONS)
+                .columns(35)
+                .testUI(bug4235215::createTestUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static JFrame createTestUI() {
+        JFrame frame = new JFrame("bug4235215");
+        JButton button = new JButton("Print Dialog");
+        button.addActionListener(ev -> {
+            Toolkit.getDefaultToolkit().getPrintJob(frame, "Test Printing", null);
+        });
+        frame.add(button);
+        frame.pack();
+        return frame;
+    }
+}

--- a/test/jdk/javax/swing/JComponent/bug4247610.java
+++ b/test/jdk/javax/swing/JComponent/bug4247610.java
@@ -52,6 +52,8 @@ public class bug4247610 {
     private static JButton damager;
     private static volatile Point loc;
     private static volatile Dimension size;
+    private static volatile boolean traced;
+    private static volatile boolean failed;
 
     public static void main(String[] args) throws Exception {
         Robot robot = new Robot();
@@ -81,8 +83,8 @@ public class bug4247610 {
             final Random random = new Random();
 
             damager.addActionListener((e) -> {
-                System.out.println("traceRepaints called");
-                traceRepaints();
+                System.out.println("trace paints enabled");
+                traced = true;
                 damagee.setText(Integer.toString(random.nextInt()));
             });
             frame.setContentPane(pane);
@@ -101,27 +103,11 @@ public class bug4247610 {
         robot.delay(200);
         robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
         robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
-        if (failed()) {
+        if (failed) {
             throw new RuntimeException("Failed: unnecessary repaint occured");
         }
     }
 
-    private static volatile boolean traceFlag;
-    private static volatile boolean passFlag = true;
-
-    private static synchronized void traceRepaints() {
-        traceFlag = true;
-    }
-    private static synchronized boolean repaintsTraced() {
-        return traceFlag;
-    }
-
-    private static synchronized boolean failed() {
-        return !passFlag;
-    }
-    private static synchronized void fail() {
-        passFlag = false;
-    }
 
     static class InternalFramePanel extends JPanel {
         final AtomicInteger repaintCounter = new AtomicInteger(0);
@@ -134,8 +120,8 @@ public class bug4247610 {
             super.paintComponent(g);
             repaintCounter.incrementAndGet();
             System.out.println("repaintCounter " + repaintCounter.intValue());
-            if (repaintsTraced()) {
-                fail();
+            if (traced) {
+                failed = true;
             }
         }
     }

--- a/test/jdk/javax/swing/JComponent/bug4247610.java
+++ b/test/jdk/javax/swing/JComponent/bug4247610.java
@@ -34,8 +34,6 @@ import java.awt.FlowLayout;
 import java.awt.Graphics;
 import java.awt.Point;
 import java.awt.Robot;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.awt.event.InputEvent;
 import javax.swing.JButton;
 import javax.swing.JDesktopPane;
@@ -82,12 +80,10 @@ public class bug4247610 {
 
             final Random random = new Random();
 
-            damager.addActionListener(new ActionListener() {
-                public void actionPerformed(ActionEvent event) {
-                    System.out.println("traceRepaints called");
-                    traceRepaints();
-                    damagee.setText(Integer.toString(random.nextInt()));
-                }
+            damager.addActionListener((e) -> {
+                System.out.println("traceRepaints called");
+                traceRepaints();
+                damagee.setText(Integer.toString(random.nextInt()));
             });
             frame.setContentPane(pane);
             frame.setSize(500, 500);
@@ -106,7 +102,7 @@ public class bug4247610 {
         robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
         robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
         if (failed()) {
-            throw new RuntimeException("Failed: unnesessary repaint occured");
+            throw new RuntimeException("Failed: unnecessary repaint occured");
         }
     }
 

--- a/test/jdk/javax/swing/JComponent/bug4247610.java
+++ b/test/jdk/javax/swing/JComponent/bug4247610.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4247610
+ * @summary Tests an unnecessary repaint issue
+ * @key headful
+ * @run main bug4247610
+ */
+
+import java.awt.Dimension;
+import java.awt.FlowLayout;
+import java.awt.Graphics;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.InputEvent;
+import javax.swing.JButton;
+import javax.swing.JDesktopPane;
+import javax.swing.JFrame;
+import javax.swing.JInternalFrame;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.SwingUtilities;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.Random;
+
+public class bug4247610 {
+
+    private static JFrame frame;
+    private static JButton damager;
+    private static volatile Point loc;
+    private static volatile Dimension size;
+
+    public static void main(String[] args) throws Exception {
+        Robot robot = new Robot();
+        SwingUtilities.invokeAndWait(() -> {
+            frame = new JFrame("bug4247610");
+            JDesktopPane pane = new JDesktopPane();
+
+            JInternalFrame jif = new JInternalFrame(
+                                 "Damager", true, true, true, true);
+            InternalFramePanel ifp = new InternalFramePanel();
+            damager = new JButton("Damage!");
+            ifp.add(damager);
+            jif.setContentPane(ifp);
+            jif.setBounds(0, 0, 300, 300);
+            jif.setVisible(true);
+            pane.add(jif);
+
+            jif = new JInternalFrame("Damagee", true, true, true, true);
+            JPanel panel = new JPanel(new FlowLayout(FlowLayout.LEFT));
+            final JLabel damagee = new JLabel("");
+            panel.add(damagee);
+            jif.setContentPane(panel);
+            jif.setBounds(60, 220, 300, 100);
+            jif.setVisible(true);
+            pane.add(jif);
+
+            final Random random = new Random();
+
+            damager.addActionListener(new ActionListener() {
+                public void actionPerformed(ActionEvent event) {
+                    System.out.println("traceRepaints called");
+                    traceRepaints();
+                    damagee.setText(Integer.toString(random.nextInt()));
+                }
+            });
+            frame.setContentPane(pane);
+            frame.setSize(500, 500);
+            frame.setLocationRelativeTo(null);
+            frame.setVisible(true);
+        });
+        robot.waitForIdle();
+        robot.delay(1000);
+        SwingUtilities.invokeAndWait(() -> {
+            loc = damager.getLocationOnScreen();
+            size = damager.getSize();
+        });
+        robot.mouseMove(loc.x + size.width / 2, loc.y + size.height / 2);
+        robot.waitForIdle();
+        robot.delay(200);
+        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+        robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+        if (failed()) {
+            throw new RuntimeException("Failed: unnesessary repaint occured");
+        }
+    }
+
+    private static volatile boolean traceFlag;
+    private static volatile boolean passFlag = true;
+
+    private static synchronized void traceRepaints() {
+        traceFlag = true;
+    }
+    private static synchronized boolean repaintsTraced() {
+        return traceFlag;
+    }
+
+    private static synchronized boolean failed() {
+        return !passFlag;
+    }
+    private static synchronized void fail() {
+        passFlag = false;
+    }
+
+    static class InternalFramePanel extends JPanel {
+        final AtomicInteger repaintCounter = new AtomicInteger(0);
+        InternalFramePanel() {
+            super(new FlowLayout());
+            setOpaque(true);
+        }
+
+        public synchronized void paintComponent(Graphics g) {
+            super.paintComponent(g);
+            repaintCounter.incrementAndGet();
+            System.out.println("repaintCounter " + repaintCounter.intValue());
+            if (repaintsTraced()) {
+                fail();
+            }
+        }
+    }
+}

--- a/test/jdk/javax/swing/JComponent/bug4254995.java
+++ b/test/jdk/javax/swing/JComponent/bug4254995.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4254995
+ * @summary Tests that html in renderer works correctly
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual bug4254995
+ */
+
+import javax.swing.JFrame;
+import javax.swing.JList;
+import javax.swing.JScrollPane;
+
+public class bug4254995 {
+
+    private static final String INSTRUCTIONS = """
+        If you see a list containing digits from one to seven, test passes.
+        Otherwise it fails.""";
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                .title("bug4254995 Instructions")
+                .instructions(INSTRUCTIONS)
+                .columns(35)
+                .testUI(bug4254995::createTestUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static JFrame createTestUI() {
+        JFrame frame = new JFrame("bug4254995");
+        String[] data = { "1", "2", "3", "4", "<html>5", "6", "7" };
+        frame.add(new JScrollPane(new JList(data)));
+        frame.pack();
+        return frame;
+    }
+}


### PR DESCRIPTION
Few JComponent tests are opensourced

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8352682](https://bugs.openjdk.org/browse/JDK-8352682): Opensource JComponent tests (**Bug** - P4)


### Reviewers
 * [Jayathirth D V](https://openjdk.org/census#jdv) (@jayathirthrao - **Reviewer**)
 * [Harshitha Onkar](https://openjdk.org/census#honkar) (@honkar-jdk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24562/head:pull/24562` \
`$ git checkout pull/24562`

Update a local copy of the PR: \
`$ git checkout pull/24562` \
`$ git pull https://git.openjdk.org/jdk.git pull/24562/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24562`

View PR using the GUI difftool: \
`$ git pr show -t 24562`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24562.diff">https://git.openjdk.org/jdk/pull/24562.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24562#issuecomment-2791714724)
</details>
