### PR TITLE
8354254: Remove the linux ppc64 -minsert-sched-nops=regroup_exact compile flag

### DIFF
--- a/make/autoconf/flags-cflags.m4
+++ b/make/autoconf/flags-cflags.m4
@@ -721,7 +721,7 @@ AC_DEFUN([FLAGS_SETUP_CFLAGS_CPU_DEP],
       $1_CFLAGS_CPU="-fsigned-char -Wno-psabi $ARM_ARCH_TYPE_FLAGS $ARM_FLOAT_TYPE_FLAGS -DJDK_ARCH_ABI_PROP_NAME='\"\$(JDK_ARCH_ABI_PROP_NAME)\"'"
       $1_CFLAGS_CPU_JVM="-DARM"
     elif test "x$FLAGS_CPU_ARCH" = xppc; then
-      $1_CFLAGS_CPU_JVM="-minsert-sched-nops=regroup_exact -mno-multiple -mno-string"
+      $1_CFLAGS_CPU_JVM="-mno-multiple -mno-string"
       if test "x$FLAGS_CPU" = xppc64; then
         # -mminimal-toc fixes `relocation truncated to fit' error for gcc 4.1.
         # Use ppc64 instructions, but schedule for power5


### PR DESCRIPTION
On linux ppc64 / gcc , we build with the compile flag -minsert-sched-nops=regroup_exact ; this is most likely outdated, maybe it was still useful for old Power6 machines.

See https://gcc.gnu.org/onlinedocs/gcc-11.1.0/gcc/RS_002f6000-and-PowerPC-Options.html
-minsert-sched-nops=scheme : This option controls which NOP insertion scheme is used during the second scheduling pass. The argument scheme takes one of the following values:
‘regroup_exact’ : Insert NOPs to force costly dependent insns into separate groups. Insert exactly as many NOPs as needed to force an insn to a new group, according to the estimated processor grouping.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8354254](https://bugs.openjdk.org/browse/JDK-8354254): Remove the linux ppc64 -minsert-sched-nops=regroup_exact compile flag (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24564/head:pull/24564` \
`$ git checkout pull/24564`

Update a local copy of the PR: \
`$ git checkout pull/24564` \
`$ git pull https://git.openjdk.org/jdk.git pull/24564/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24564`

View PR using the GUI difftool: \
`$ git pr show -t 24564`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24564.diff">https://git.openjdk.org/jdk/pull/24564.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24564#issuecomment-2791959737)
</details>
