### PR TITLE
8354276: Strict HTTP header validation

### DIFF
--- a/src/java.net.http/share/classes/jdk/internal/net/http/Http2Connection.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Http2Connection.java
@@ -90,7 +90,6 @@ import jdk.internal.net.http.hpack.Decoder;
 import jdk.internal.net.http.hpack.DecodingCallback;
 import jdk.internal.net.http.hpack.Encoder;
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static jdk.internal.net.http.frame.SettingsFrame.DEFAULT_INITIAL_WINDOW_SIZE;
 import static jdk.internal.net.http.frame.SettingsFrame.ENABLE_PUSH;
 import static jdk.internal.net.http.frame.SettingsFrame.HEADER_TABLE_SIZE;
 import static jdk.internal.net.http.frame.SettingsFrame.INITIAL_CONNECTION_WINDOW_SIZE;
@@ -341,6 +340,7 @@ class Http2Connection  {
         final AtomicReference<Throwable> errorRef = new AtomicReference<>();
 
         PushPromiseDecoder(int parentStreamId, int pushPromiseStreamId, Stream<?> parent) {
+            super(Context.REQUEST);
             this.parentStreamId = parentStreamId;
             this.pushPromiseStreamId = pushPromiseStreamId;
             this.parent = parent;

--- a/src/java.net.http/share/classes/jdk/internal/net/http/Http2Connection.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Http2Connection.java
@@ -985,7 +985,10 @@ class Http2Connection  {
                     // always decode the headers as they may affect
                     // connection-level HPACK decoding state
                     if (orphanedConsumer == null || frame.getClass() != ContinuationFrame.class) {
-                        orphanedConsumer = new ValidatingHeadersConsumer(Context.RESPONSE);
+                        orphanedConsumer = new ValidatingHeadersConsumer(
+                                frame instanceof PushPromiseFrame ?
+                                        Context.REQUEST :
+                                        Context.RESPONSE);
                     }
                     DecodingCallback decoder = orphanedConsumer::onDecoded;
                     try {

--- a/src/java.net.http/share/classes/jdk/internal/net/http/Http2Connection.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Http2Connection.java
@@ -69,6 +69,7 @@ import jdk.internal.net.http.common.MinimalFuture;
 import jdk.internal.net.http.common.SequentialScheduler;
 import jdk.internal.net.http.common.Utils;
 import jdk.internal.net.http.common.ValidatingHeadersConsumer;
+import jdk.internal.net.http.common.ValidatingHeadersConsumer.Context;
 import jdk.internal.net.http.frame.ContinuationFrame;
 import jdk.internal.net.http.frame.DataFrame;
 import jdk.internal.net.http.frame.ErrorFrame;
@@ -984,7 +985,7 @@ class Http2Connection  {
                     // always decode the headers as they may affect
                     // connection-level HPACK decoding state
                     if (orphanedConsumer == null || frame.getClass() != ContinuationFrame.class) {
-                        orphanedConsumer = new ValidatingHeadersConsumer();
+                        orphanedConsumer = new ValidatingHeadersConsumer(Context.RESPONSE);
                     }
                     DecodingCallback decoder = orphanedConsumer::onDecoded;
                     try {

--- a/src/java.net.http/share/classes/jdk/internal/net/http/Stream.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Stream.java
@@ -1871,7 +1871,12 @@ class Stream<T> extends ExchangeImpl<T> {
         }
     }
 
-    private class HeadersConsumer extends ValidatingHeadersConsumer implements DecodingCallback {
+    private final class HeadersConsumer extends ValidatingHeadersConsumer
+            implements DecodingCallback {
+
+        private HeadersConsumer() {
+            super(Context.RESPONSE);
+        }
 
         boolean maxHeaderListSizeReached;
 

--- a/src/java.net.http/share/classes/jdk/internal/net/http/common/HeaderDecoder.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/common/HeaderDecoder.java
@@ -30,8 +30,8 @@ public class HeaderDecoder extends ValidatingHeadersConsumer {
 
     private final HttpHeadersBuilder headersBuilder;
 
-    public HeaderDecoder() {
-        super(Context.REQUEST);
+    public HeaderDecoder(Context context) {
+        super(context);
         this.headersBuilder = new HttpHeadersBuilder();
     }
 

--- a/src/java.net.http/share/classes/jdk/internal/net/http/common/HeaderDecoder.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/common/HeaderDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,7 @@ public class HeaderDecoder extends ValidatingHeadersConsumer {
     private final HttpHeadersBuilder headersBuilder;
 
     public HeaderDecoder() {
+        super(Context.REQUEST);
         this.headersBuilder = new HttpHeadersBuilder();
     }
 

--- a/src/java.net.http/share/classes/jdk/internal/net/http/common/ValidatingHeadersConsumer.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/common/ValidatingHeadersConsumer.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.ProtocolException;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 /*
@@ -38,7 +39,7 @@ public class ValidatingHeadersConsumer {
     private final Context context;
 
     public ValidatingHeadersConsumer(Context context) {
-        this.context = context;
+        this.context = Objects.requireNonNull(context);
     }
 
     public enum Context {

--- a/src/java.net.http/share/classes/jdk/internal/net/http/common/ValidatingHeadersConsumer.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/common/ValidatingHeadersConsumer.java
@@ -54,7 +54,7 @@ public class ValidatingHeadersConsumer {
 
     // connection-specific, prohibited by RFC 9113 section 8.2.2
     private static final Set<String> PROHIBITED_HEADERS =
-            Set.of("connection","proxy-connection", "keep-alive",
+            Set.of("connection", "proxy-connection", "keep-alive",
                     "transfer-encoding", "upgrade");
 
     /** Used to check that if there are pseudo-headers, they go first */
@@ -84,10 +84,10 @@ public class ValidatingHeadersConsumer {
             } else {
                 Context expectedContext = PSEUDO_HEADERS.get(n);
                 if (expectedContext == null) {
-                throw newException("Unknown pseudo-header '%s'", n);
+                    throw newException("Unknown pseudo-header '%s'", n);
                 } else if (expectedContext != context) {
                     throw newException("Pseudo-header '%s' is not valid in context " + context, n);
-            }
+                }
             }
         } else {
             pseudoHeadersEnded = true;

--- a/src/java.net.http/share/classes/jdk/internal/net/http/common/ValidatingHeadersConsumer.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/common/ValidatingHeadersConsumer.java
@@ -44,6 +44,8 @@ public class ValidatingHeadersConsumer {
         REQUEST,
         RESPONSE,
     }
+    
+    // Map of permitted pseudo headers in requests and responses
     private static final Map<String, Context> PSEUDO_HEADERS =
             Map.of(":authority", Context.REQUEST,
                     ":method", Context.REQUEST,

--- a/src/java.net.http/share/classes/jdk/internal/net/http/common/ValidatingHeadersConsumer.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/common/ValidatingHeadersConsumer.java
@@ -26,6 +26,7 @@ package jdk.internal.net.http.common;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.net.ProtocolException;
 import java.util.Map;
 import java.util.Set;
 
@@ -120,6 +121,6 @@ public class ValidatingHeadersConsumer {
     protected UncheckedIOException newException(String message, String header)
     {
         return new UncheckedIOException(
-                new IOException(formatMessage(message, header)));
+                new ProtocolException(formatMessage(message, header)));
     }
 }

--- a/src/java.net.http/share/classes/jdk/internal/net/http/common/ValidatingHeadersConsumer.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/common/ValidatingHeadersConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@ package jdk.internal.net.http.common;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.util.Map;
 import java.util.Set;
 
 /*
@@ -33,8 +34,28 @@ import java.util.Set;
  */
 public class ValidatingHeadersConsumer {
 
-    private static final Set<String> PSEUDO_HEADERS =
-            Set.of(":authority", ":method", ":path", ":scheme", ":status");
+    private final Context context;
+
+    public ValidatingHeadersConsumer(Context context) {
+        this.context = context;
+    }
+
+    public enum Context {
+        REQUEST,
+        RESPONSE,
+        TRAILER
+    }
+    private static final Map<String, Context> PSEUDO_HEADERS =
+            Map.of(":authority", Context.REQUEST,
+                    ":method", Context.REQUEST,
+                    ":path", Context.REQUEST,
+                    ":scheme", Context.REQUEST,
+                    ":status", Context.RESPONSE);
+
+    // connection-specific, prohibited by RFC 9113 section 8.2.2
+    private static final Set<String> PROHIBITED_HEADERS =
+            Set.of("connection","proxy-connection", "keep-alive",
+                    "transfer-encoding", "upgrade");
 
     /** Used to check that if there are pseudo-headers, they go first */
     private boolean pseudoHeadersEnded;
@@ -60,11 +81,25 @@ public class ValidatingHeadersConsumer {
         if (n.startsWith(":")) {
             if (pseudoHeadersEnded) {
                 throw newException("Unexpected pseudo-header '%s'", n);
-            } else if (!PSEUDO_HEADERS.contains(n)) {
+            } else {
+                Context expectedContext = PSEUDO_HEADERS.get(n);
+                if (expectedContext == null) {
                 throw newException("Unknown pseudo-header '%s'", n);
+                } else if (expectedContext != context) {
+                    throw newException("Pseudo-header '%s' is not valid in context " + context, n);
+            }
             }
         } else {
             pseudoHeadersEnded = true;
+            // Check for prohibited connection-specific headers.
+            // Some servers echo request headers in push promises.
+            // If the request was a HTTP/1.1 upgrade, it included some prohibited headers.
+            // For compatibility, we ignore prohibited headers in push promises.
+            if (context != Context.REQUEST) {
+                if (PROHIBITED_HEADERS.contains(n)) {
+                    throw newException("Prohibited header name '%s'", n);
+                }
+            }
             // RFC-9113, section 8.2.1 for HTTP/2 and RFC-9114, section 4.2 state that
             // header name MUST be lowercase (and allowed characters)
             if (!Utils.isValidLowerCaseName(n)) {

--- a/src/java.net.http/share/classes/jdk/internal/net/http/common/ValidatingHeadersConsumer.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/common/ValidatingHeadersConsumer.java
@@ -43,7 +43,6 @@ public class ValidatingHeadersConsumer {
     public enum Context {
         REQUEST,
         RESPONSE,
-        TRAILER
     }
     private static final Map<String, Context> PSEUDO_HEADERS =
             Map.of(":authority", Context.REQUEST,

--- a/src/java.net.http/share/classes/jdk/internal/net/http/common/ValidatingHeadersConsumer.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/common/ValidatingHeadersConsumer.java
@@ -45,7 +45,7 @@ public class ValidatingHeadersConsumer {
         REQUEST,
         RESPONSE,
     }
-    
+
     // Map of permitted pseudo headers in requests and responses
     private static final Map<String, Context> PSEUDO_HEADERS =
             Map.of(":authority", Context.REQUEST,

--- a/test/jdk/java/net/httpclient/http2/BadHeadersTest.java
+++ b/test/jdk/java/net/httpclient/http2/BadHeadersTest.java
@@ -24,12 +24,12 @@
 /*
  * @test
  * @bug 8303965 8354276
- * @library /test/lib /test/jdk/java/net/httpclient/lib
- * @build jdk.httpclient.test.lib.http2.Http2TestServer jdk.test.lib.net.SimpleSSLContext
- * @run testng/othervm -Djdk.internal.httpclient.debug=true BadHeadersTest
  * @summary This test verifies the behaviour of the HttpClient when presented
  *          with a HEADERS frame followed by CONTINUATION frames, and when presented
  *          with bad header fields.
+ * @library /test/lib /test/jdk/java/net/httpclient/lib
+ * @build jdk.httpclient.test.lib.http2.Http2TestServer jdk.test.lib.net.SimpleSSLContext
+ * @run testng/othervm -Djdk.internal.httpclient.debug=true BadHeadersTest
  */
 
 import jdk.internal.net.http.common.HttpHeadersBuilder;

--- a/test/jdk/java/net/httpclient/http2/BadHeadersTest.java
+++ b/test/jdk/java/net/httpclient/http2/BadHeadersTest.java
@@ -194,12 +194,13 @@ public class BadHeadersTest {
             try {
                 HttpResponse<String> response = cc.sendAsync(request, BodyHandlers.ofString()).get();
                 fail("Expected exception, got :" + response + ", " + response.body());
-            } catch (Throwable t0) {
+            } catch (Exception t0) {
                 System.out.println("Got EXPECTED: " + t0);
                 if (t0 instanceof ExecutionException) {
-                    t0 = t0.getCause();
+                    t = t0.getCause();
+                } else {
+                    t = t0;
                 }
-                t = t0;
             }
             assertDetailMessage(t, i);
         }

--- a/test/jdk/java/net/httpclient/http2/BadHeadersTest.java
+++ b/test/jdk/java/net/httpclient/http2/BadHeadersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,9 @@
  * @library /test/lib /test/jdk/java/net/httpclient/lib
  * @build jdk.httpclient.test.lib.http2.Http2TestServer jdk.test.lib.net.SimpleSSLContext
  * @run testng/othervm -Djdk.internal.httpclient.debug=true BadHeadersTest
+ * @summary This test verifies the behaviour of the HttpClient when presented
+ *          with a HEADERS frame followed by CONTINUATION frames, and when presented
+ *          with bad header fields.
  */
 
 import jdk.internal.net.http.common.HttpHeadersBuilder;
@@ -76,6 +79,8 @@ public class BadHeadersTest {
         of(entry(":status", "200"),  entry("hell o", "value")),                    // Space in the name
         of(entry(":status", "200"),  entry("hello", "line1\r\n  line2\r\n")),      // Multiline value
         of(entry(":status", "200"),  entry("hello", "DE" + ((char) 0x7F) + "L")),  // Bad byte in value
+        of(entry(":status", "200"),  entry("connection", "close")),                // Prohibited connection-specific header
+        of(entry(":status", "200"),  entry(":scheme", "https")),                   // Request pseudo-header in response
         of(entry("hello", "world!"), entry(":status", "200"))                      // Pseudo header is not the first one
     );
 
@@ -86,7 +91,7 @@ public class BadHeadersTest {
     String https2URI;
 
     /**
-     * A function that returns a list of 1) a HEADERS frame ( with an empty
+     * A function that returns a list of 1) one HEADERS frame ( with an empty
      * payload ), and 2) a CONTINUATION frame with the actual headers.
      */
     static BiFunction<Integer,List<ByteBuffer>,List<Http2Frame>> oneContinuation =
@@ -100,7 +105,7 @@ public class BadHeadersTest {
             };
 
     /**
-     * A function that returns a list of a HEADERS frame followed by a number of
+     * A function that returns a list of one HEADERS frame followed by a number of
      * CONTINUATION frames. Each frame contains just a single byte of payload.
      */
     static BiFunction<Integer,List<ByteBuffer>,List<Http2Frame>> byteAtATime =
@@ -212,7 +217,13 @@ public class BadHeadersTest {
             if (iterationIndex == 0) { // unknown
                 assertTrue(throwable.getMessage().contains("Unknown pseudo-header"),
                         "Expected \"Unknown pseudo-header\" in: " + throwable.getMessage());
-            } else if (iterationIndex == 4) { // unexpected
+            } else if (iterationIndex == 4) { // prohibited
+                assertTrue(throwable.getMessage().contains("Prohibited header name"),
+                        "Expected \"Prohibited header name\" in: " + throwable.getMessage());
+            } else if (iterationIndex == 5) { // unexpected type
+                assertTrue(throwable.getMessage().contains("not valid in context"),
+                        "Expected \"not valid in context\" in: " + throwable.getMessage());
+            } else if (iterationIndex == 6) { // unexpected sequence
                 assertTrue(throwable.getMessage().contains(" Unexpected pseudo-header"),
                         "Expected \" Unexpected pseudo-header\" in: " + throwable.getMessage());
             } else {

--- a/test/jdk/java/net/httpclient/http2/BadHeadersTest.java
+++ b/test/jdk/java/net/httpclient/http2/BadHeadersTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8303965
+ * @bug 8303965 8354276
  * @library /test/lib /test/jdk/java/net/httpclient/lib
  * @build jdk.httpclient.test.lib.http2.Http2TestServer jdk.test.lib.net.SimpleSSLContext
  * @run testng/othervm -Djdk.internal.httpclient.debug=true BadHeadersTest

--- a/test/jdk/java/net/httpclient/http2/BadHeadersTest.java
+++ b/test/jdk/java/net/httpclient/http2/BadHeadersTest.java
@@ -47,6 +47,7 @@ import javax.net.ssl.SSLSession;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.ProtocolException;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpHeaders;
@@ -210,8 +211,8 @@ public class BadHeadersTest {
     // sync with implementation.
     static void assertDetailMessage(Throwable throwable, int iterationIndex) {
         try {
-            assertTrue(throwable instanceof IOException,
-                    "Expected IOException, got, " + throwable);
+            assertTrue(throwable instanceof ProtocolException,
+                    "Expected ProtocolException, got " + throwable);
             assertTrue(throwable.getMessage().contains("malformed response"),
                     "Expected \"malformed response\" in: " + throwable.getMessage());
 

--- a/test/jdk/java/net/httpclient/http2/BadPushPromiseTest.java
+++ b/test/jdk/java/net/httpclient/http2/BadPushPromiseTest.java
@@ -82,9 +82,9 @@ public class BadPushPromiseTest {
         HttpServerAdapters.HttpTestHandler handler = new ServerPushHandler(MAIN_RESPONSE_BODY);
         server.addHandler(handler, "/");
         server.start();
-        int port = server.getAddress().getPort();
-        System.err.println("Server listening on port " + port);
-        uri = new URI("http://localhost:" + port + "/foo/a/b/c");
+        String authority = server.serverAuthority();
+        System.err.println("Server listening on address " + authority);
+        uri = new URI("http://" + authority + "/foo/a/b/c");
     }
 
     @AfterTest

--- a/test/jdk/java/net/httpclient/http2/BadPushPromiseTest.java
+++ b/test/jdk/java/net/httpclient/http2/BadPushPromiseTest.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8354276
+ * @library /test/lib /test/jdk/java/net/httpclient/lib
+ * @build jdk.test.lib.net.SimpleSSLContext jdk.httpclient.test.lib.http2.Http2TestServer
+ * @run testng/othervm
+ *      -Djdk.internal.httpclient.debug=true
+ *      -Djdk.httpclient.HttpClient.log=errors,requests,responses,trace
+ *      BadPushPromiseTest
+ */
+
+import jdk.httpclient.test.lib.http2.Http2Handler;
+import jdk.httpclient.test.lib.http2.Http2TestExchange;
+import jdk.httpclient.test.lib.http2.Http2TestServer;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.ProtocolException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpHeaders;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.net.http.HttpResponse.PushPromiseHandler;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.List.of;
+import static org.testng.Assert.*;
+
+public class BadPushPromiseTest {
+
+    private static final List<Map<String, List<String>>> BAD_HEADERS = of(
+            Map.of(":hello", of("GET")),                      // Unknown pseudo-header
+            Map.of("hell o", of("value")),                    // Space in the name
+            Map.of("hello", of("line1\r\n  line2\r\n")),      // Multiline value
+            Map.of("hello", of("DE" + ((char) 0x7F) + "L")),  // Bad byte in value
+            Map.of(":status", of("200"))                     // Response pseudo-header in request
+    );
+
+    static final String MAIN_RESPONSE_BODY = "the main response body";
+
+    Http2TestServer server;
+    URI uri;
+
+    @BeforeTest
+    public void setup() throws Exception {
+        server = new Http2TestServer(false, 0);
+        Http2Handler handler = new ServerPushHandler(MAIN_RESPONSE_BODY
+        );
+        server.addHandler(handler, "/");
+        server.start();
+        int port = server.getAddress().getPort();
+        System.err.println("Server listening on port " + port);
+        uri = new URI("http://localhost:" + port + "/foo/a/b/c");
+    }
+
+    @AfterTest
+    public void teardown() {
+        server.stop();
+    }
+
+    /*
+     * Malformed push promise headers should kill the connection
+     */
+    @Test
+    public void test() throws Exception {
+        HttpClient client = HttpClient.newHttpClient();
+
+        for (int i=0; i< BAD_HEADERS.size(); i++) {
+            URI uriWithQuery = URI.create(uri +  "?BAD_HEADERS=" + i);
+            HttpRequest request = HttpRequest.newBuilder(uriWithQuery)
+                    .build();
+            System.out.println("\nSending request:" + uriWithQuery);
+            final HttpClient cc = client;
+            try {
+                ConcurrentMap<HttpRequest, CompletableFuture<HttpResponse<String>>> promises
+                        = new ConcurrentHashMap<>();
+                PushPromiseHandler<String> pph = PushPromiseHandler
+                        .of((r) -> BodyHandlers.ofString(), promises);
+                HttpResponse<String> response = cc.sendAsync(request, BodyHandlers.ofString(), pph).join();
+                fail("Expected exception, got :" + response + ", " + response.body());
+            } catch (CompletionException ce) {
+                System.out.println("Got EXPECTED: " + ce);
+                assertDetailMessage(ce.getCause(), i);
+            }
+        }
+    }
+
+    // Assertions based on implementation specific detail messages. Keep in
+    // sync with implementation.
+    static void assertDetailMessage(Throwable throwable, int iterationIndex) {
+        try {
+            assertTrue(throwable instanceof ProtocolException,
+                    "Expected ProtocolException, got " + throwable);
+
+            if (iterationIndex == 0) { // unknown
+                assertTrue(throwable.getMessage().contains("Unknown pseudo-header"),
+                        "Expected \"Unknown pseudo-header\" in: " + throwable.getMessage());
+            } else if (iterationIndex == 4) { // unexpected type
+                assertTrue(throwable.getMessage().contains("not valid in context"),
+                        "Expected \"not valid in context\" in: " + throwable.getMessage());
+            } else {
+                assertTrue(throwable.getMessage().contains("Bad header"),
+                        "Expected \"Bad header\" in: " + throwable.getMessage());
+            }
+        } catch (AssertionError e) {
+            System.out.println("Exception does not match expectation: " + throwable);
+            throwable.printStackTrace(System.out);
+            throw e;
+        }
+    }
+
+    // --- server push handler ---
+    static class ServerPushHandler implements Http2Handler {
+
+        private final String mainResponseBody;
+
+        public ServerPushHandler(String mainResponseBody) {
+            this.mainResponseBody = mainResponseBody;
+        }
+
+        public void handle(Http2TestExchange exchange) throws IOException {
+            System.err.println("Server: handle " + exchange);
+            try (InputStream is = exchange.getRequestBody()) {
+                is.readAllBytes();
+            }
+
+            pushPromise(exchange);
+
+            // response data for the main response
+            try (OutputStream os = exchange.getResponseBody()) {
+                byte[] bytes = mainResponseBody.getBytes(UTF_8);
+                exchange.sendResponseHeaders(200, bytes.length);
+                os.write(bytes);
+            }
+        }
+
+        private void pushPromise(Http2TestExchange exchange) {
+            URI requestURI = exchange.getRequestURI();
+            String query = exchange.getRequestURI().getQuery();
+            int badHeadersIndex = Integer.parseInt(query.substring(query.indexOf("=") + 1));
+            URI uri = requestURI.resolve("/push/"+badHeadersIndex);
+            InputStream is = new ByteArrayInputStream(mainResponseBody.getBytes(UTF_8));
+            HttpHeaders headers = HttpHeaders.of(BAD_HEADERS.get(badHeadersIndex), (x, y) -> true);
+            exchange.serverPush(uri, headers, is);
+            System.err.println("Server: push sent");
+        }
+    }
+}


### PR DESCRIPTION
RFC 9113 HTTP/2 mandates certain validation for HTTP headers; the HttpClient don't fully implement the described requirements.

This PR adds the following validation:
- pseudo-headers defined for requests are rejected in responses and push streams
- pseudo-headers defined for responses are rejected in push promises
- connection headers are rejected in responses and push streams

Connection headers are still accepted in push promises; that's because some popular server implementations were found to echo the request headers in push promises, and when the original request was a HTTP/1 upgrade, the push promise could contain one or more headers that were prohibited in HTTP/2 but allowed in HTTP/1.

An existing test was adapted to verify the handling of response headers. The modified test passes with this the changes in this PR, fails without them. Other tier1-3 tests continue to pass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8354299](https://bugs.openjdk.org/browse/JDK-8354299) to be approved

### Issues
 * [JDK-8354276](https://bugs.openjdk.org/browse/JDK-8354276): Strict HTTP header validation (**Bug** - P4)
 * [JDK-8354299](https://bugs.openjdk.org/browse/JDK-8354299): Strict HTTP header validation (**CSR**)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24569/head:pull/24569` \
`$ git checkout pull/24569`

Update a local copy of the PR: \
`$ git checkout pull/24569` \
`$ git pull https://git.openjdk.org/jdk.git pull/24569/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24569`

View PR using the GUI difftool: \
`$ git pr show -t 24569`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24569.diff">https://git.openjdk.org/jdk/pull/24569.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24569#issuecomment-2792469651)
</details>
