### PR TITLE
8354257: xctracenorm profiler not working with JDK JMH benchmarks

### DIFF
--- a/make/test/BuildMicrobenchmark.gmk
+++ b/make/test/BuildMicrobenchmark.gmk
@@ -119,7 +119,6 @@ $(JMH_UNPACKED_JARS_DONE): $(JMH_RUNTIME_JARS)
 	$(foreach jar, $(JMH_RUNTIME_JARS), \
             $$($(UNZIP) -oq $(jar) -d $(JMH_UNPACKED_DIR)))
 	$(RM) -r $(JMH_UNPACKED_DIR)/META-INF
-	$(RM) $(JMH_UNPACKED_DIR)/*.xml
 	$(TOUCH) $@
 
 # Copy dependency files for inclusion in the benchmark JARs


### PR DESCRIPTION
Avoid filtering out xml files at the root of the JMH folder, in order to get the `default.instruments.template.xml` file bundled in the JMH core jar to support xtrace profiler.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8354257: xctracenorm profiler not working with JDK JMH benchmarks`

### Issue
 * [JDK-8354257](https://bugs.openjdk.org/browse/JDK-8354257): xctracenorm profiler not working with JDK JMH benchmarks (**Bug** - P4)


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24571/head:pull/24571` \
`$ git checkout pull/24571`

Update a local copy of the PR: \
`$ git checkout pull/24571` \
`$ git pull https://git.openjdk.org/jdk.git pull/24571/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24571`

View PR using the GUI difftool: \
`$ git pr show -t 24571`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24571.diff">https://git.openjdk.org/jdk/pull/24571.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24571#issuecomment-2792528271)
</details>
