### PR TITLE
8354115: NMT: VMATree should not accept `uncommit` a `released` region

### DIFF
--- a/src/hotspot/share/nmt/vmatree.cpp
+++ b/src/hotspot/share/nmt/vmatree.cpp
@@ -59,6 +59,9 @@ VMATree::SummaryDiff VMATree::register_mapping(position A, position B, StateType
   AddressState LEQ_A;
   TreapNode* leqA_n = _tree.closest_leq(A);
   if (leqA_n == nullptr) {
+    if (is_uncommit_operation) {
+      return SummaryDiff(-1);
+    }
     assert(!use_tag_inplace, "Cannot use the tag inplace if no pre-existing tag exists. From: " PTR_FORMAT " To: " PTR_FORMAT, A, B);
     if (use_tag_inplace) {
       log_debug(nmt)("Cannot use the tag inplace if no pre-existing tag exists. From: " PTR_FORMAT " To: " PTR_FORMAT, A, B);

--- a/src/hotspot/share/nmt/vmatree.cpp
+++ b/src/hotspot/share/nmt/vmatree.cpp
@@ -143,18 +143,20 @@ VMATree::SummaryDiff VMATree::register_mapping(position A, position B, StateType
     if (is_uncommit_operation && head->val().out.type() == StateType::Released)  {
       is_remove_ok = false;
     }
-    if (cmp_B < 0) {
-      // Record all nodes preceding B.
-      to_be_deleted_inbetween_a_b.push({head->key(), head->val()});
-    } else if (cmp_B == 0) {
-      // Re-purpose B node, unless it would result in a noop node, in
-      // which case record old node at B for deletion and summary accounting.
-      if (stB.is_noop()) {
-        to_be_deleted_inbetween_a_b.push(AddressState{B, head->val()});
-      } else {
-        head->val() = stB;
+    if (is_remove_ok) {
+      if (cmp_B < 0) {
+        // Record all nodes preceding B.
+        to_be_deleted_inbetween_a_b.push({head->key(), head->val()});
+      } else if (cmp_B == 0) {
+        // Re-purpose B node, unless it would result in a noop node, in
+        // which case record old node at B for deletion and summary accounting.
+        if (stB.is_noop()) {
+          to_be_deleted_inbetween_a_b.push(AddressState{B, head->val()});
+        } else {
+          head->val() = stB;
+        }
+        B_needs_insert = false;
       }
-      B_needs_insert = false;
     }
   });
   if (!is_remove_ok) {

--- a/src/hotspot/share/nmt/vmatree.hpp
+++ b/src/hotspot/share/nmt/vmatree.hpp
@@ -175,18 +175,13 @@ public:
 
   struct SummaryDiff {
     SingleDiff tag[mt_number_of_tags];
-    SummaryDiff(int init = 0) {
+
+    SummaryDiff() {
       for (int i = 0; i < mt_number_of_tags; i++) {
-        tag[i] = SingleDiff{init, init};
+        tag[i] = SingleDiff{0, 0};
       }
     }
-    bool has_error() const {
-      for (int i = 0; i < mt_number_of_tags; i++) {
-        if (tag[i].reserve >= 0 || tag[i].commit >= 0)
-          return false;
-      }
-      return true;
-    }
+
     void add(SummaryDiff& other) {
       for (int i = 0; i < mt_number_of_tags; i++) {
         tag[i].reserve += other.tag[i].reserve;

--- a/src/hotspot/share/nmt/vmatree.hpp
+++ b/src/hotspot/share/nmt/vmatree.hpp
@@ -175,12 +175,18 @@ public:
 
   struct SummaryDiff {
     SingleDiff tag[mt_number_of_tags];
-    SummaryDiff() {
+    SummaryDiff(int init = 0) {
       for (int i = 0; i < mt_number_of_tags; i++) {
-        tag[i] = SingleDiff{0, 0};
+        tag[i] = SingleDiff{init, init};
       }
     }
-
+    bool is_valid() const {
+      for (int i = 0; i < mt_number_of_tags; i++) {
+        if (tag[i].reserve >= 0 || tag[i].commit >= 0)
+          return true;
+      }
+      return false;
+    }
     void add(SummaryDiff& other) {
       for (int i = 0; i < mt_number_of_tags; i++) {
         tag[i].reserve += other.tag[i].reserve;

--- a/src/hotspot/share/nmt/vmatree.hpp
+++ b/src/hotspot/share/nmt/vmatree.hpp
@@ -180,12 +180,12 @@ public:
         tag[i] = SingleDiff{init, init};
       }
     }
-    bool is_valid() const {
+    bool has_error() const {
       for (int i = 0; i < mt_number_of_tags; i++) {
         if (tag[i].reserve >= 0 || tag[i].commit >= 0)
-          return true;
+          return false;
       }
-      return false;
+      return true;
     }
     void add(SummaryDiff& other) {
       for (int i = 0; i < mt_number_of_tags; i++) {

--- a/test/hotspot/gtest/nmt/test_vmatree.cpp
+++ b/test/hotspot/gtest/nmt/test_vmatree.cpp
@@ -744,10 +744,10 @@ TEST_VM_F(NMTVMATreeTest, SummaryAccountingWhenUseFlagInplace) {
 TEST_VM_F(NMTVMATreeTest, UncommmitReleasedRegion) {
   {
     Tree tree;
-    VMATree::RegionData rd(si[0], mtTest);
-    VMATree::RegionData rd2(si[0], mtNone);
-    VMATree::SummaryDiff diff = tree.uncommit_mapping(40, 20, rd2);
-    EXPECT_TRUE(diff.has_error());
+    VMATree::RegionData rd(si[0], mtNone);
+    VMATree::SummaryDiff diff = tree.uncommit_mapping(40, 20, rd);
+    EXPECT_EQ(0, diff.tag[NMTUtil::tag_to_index(mtNone)].reserve);
+    EXPECT_EQ(0, diff.tag[NMTUtil::tag_to_index(mtNone)].commit);
   }
   {
     Tree tree;
@@ -758,7 +758,40 @@ TEST_VM_F(NMTVMATreeTest, UncommmitReleasedRegion) {
     //0-----50....70-----100
     //   40----60
     VMATree::SummaryDiff diff = tree.uncommit_mapping(40, 20, rd2);
-    EXPECT_TRUE(diff.has_error());
+    EXPECT_EQ(0, diff.tag[NMTUtil::tag_to_index(mtTest)].reserve);
+    EXPECT_EQ(0, diff.tag[NMTUtil::tag_to_index(mtTest)].commit);
+    EXPECT_EQ(0, diff.tag[NMTUtil::tag_to_index(mtNone)].reserve);
+    EXPECT_EQ(0, diff.tag[NMTUtil::tag_to_index(mtNone)].commit);
+  }
+  {
+    Tree tree;
+    VMATree::RegionData rd(si[0], mtTest);
+    VMATree::RegionData rd2(si[0], mtNone);
+    tree.commit_mapping(0, 10, rd);
+    tree.commit_mapping(20, 10, rd);
+    //0-----10....20-----30
+    //0----------------------------100
+    tree.print_on(tty);
+    VMATree::SummaryDiff diff = tree.uncommit_mapping(0, 100, rd2);
+    tree.print_on(tty);
+    EXPECT_EQ(0, diff.tag[NMTUtil::tag_to_index(mtTest)].reserve);
+    EXPECT_EQ(-20, diff.tag[NMTUtil::tag_to_index(mtTest)].commit);
+    EXPECT_EQ(0, diff.tag[NMTUtil::tag_to_index(mtNone)].reserve);
+    EXPECT_EQ(0, diff.tag[NMTUtil::tag_to_index(mtNone)].commit);
+  }
+  {
+    Tree tree;
+    VMATree::RegionData rd(si[0], mtTest);
+    VMATree::RegionData rd2(si[0], mtNone);
+    tree.reserve_mapping(40, 60, rd);
+    tree.release_mapping(50, 20);
+    //....40---50....70-----100
+    // 20---------60
+    VMATree::SummaryDiff diff = tree.uncommit_mapping(20, 40, rd2);
+    EXPECT_EQ(0, diff.tag[NMTUtil::tag_to_index(mtTest)].reserve);
+    EXPECT_EQ(0, diff.tag[NMTUtil::tag_to_index(mtTest)].commit);
+    EXPECT_EQ(0, diff.tag[NMTUtil::tag_to_index(mtNone)].reserve);
+    EXPECT_EQ(0, diff.tag[NMTUtil::tag_to_index(mtNone)].commit);
   }
   {
     Tree tree;
@@ -769,7 +802,10 @@ TEST_VM_F(NMTVMATreeTest, UncommmitReleasedRegion) {
     //0-----50....70-----100
     //         60----80
     VMATree::SummaryDiff diff = tree.uncommit_mapping(60, 20, rd2);
-    EXPECT_TRUE(diff.has_error());
+    EXPECT_EQ(0, diff.tag[NMTUtil::tag_to_index(mtTest)].reserve);
+    EXPECT_EQ(0, diff.tag[NMTUtil::tag_to_index(mtTest)].commit);
+    EXPECT_EQ(0, diff.tag[NMTUtil::tag_to_index(mtNone)].reserve);
+    EXPECT_EQ(0, diff.tag[NMTUtil::tag_to_index(mtNone)].commit);
   }
   {
     Tree tree;
@@ -781,9 +817,12 @@ TEST_VM_F(NMTVMATreeTest, UncommmitReleasedRegion) {
     // mtTest    mtNone     mtClass
     //0-------50.........70---------100
     //    40-------------70
-    // Node 70 should not be changed
     VMATree::SummaryDiff diff = tree.uncommit_mapping(40, 30, rd2);
-    EXPECT_TRUE(diff.has_error());
+    EXPECT_EQ(0, diff.tag[NMTUtil::tag_to_index(mtTest)].reserve);
+    EXPECT_EQ(0, diff.tag[NMTUtil::tag_to_index(mtTest)].commit);
+    EXPECT_EQ(0, diff.tag[NMTUtil::tag_to_index(mtNone)].reserve);
+    EXPECT_EQ(0, diff.tag[NMTUtil::tag_to_index(mtNone)].commit);
+    // Node 70 should not be changed
     VMATree::VMATreap::Range r = tree.tree().find_enclosing_range(70);
     ASSERT_TRUE(r.start != nullptr);
     EXPECT_TRUE(r.start->val().out.type() == VMATree::StateType::Reserved);

--- a/test/hotspot/gtest/nmt/test_vmatree.cpp
+++ b/test/hotspot/gtest/nmt/test_vmatree.cpp
@@ -764,4 +764,22 @@ TEST_VM_F(NMTVMATreeTest, UncommmitReleasedRegion) {
     VMATree::SummaryDiff diff = tree.uncommit_mapping(60, 20, rd2);
     EXPECT_FALSE(diff.is_valid());
   }
+  {
+    Tree tree;
+    VMATree::RegionData rd(si[0], mtTest);
+    VMATree::RegionData rd2(si[0], mtNone);
+    tree.reserve_mapping(0, 100, rd);
+    tree.release_mapping(50, 20);
+    tree.set_tag(70, 30, mtClass);
+    // mtTest    mtNone     mtClass
+    //0-------50.........70---------100
+    //    40-------------70
+    // Node 70 should not be changed
+    VMATree::SummaryDiff diff = tree.uncommit_mapping(40, 30, rd2);
+    EXPECT_FALSE(diff.is_valid());
+    VMATree::VMATreap::Range r = tree.tree().find_enclosing_range(70);
+    ASSERT_TRUE(r.start != nullptr);
+    EXPECT_TRUE(r.start->val().out.type() == VMATree::StateType::Reserved);
+    EXPECT_EQ(r.start->val().out.mem_tag(), mtClass);
+  }
 }

--- a/test/hotspot/gtest/nmt/test_vmatree.cpp
+++ b/test/hotspot/gtest/nmt/test_vmatree.cpp
@@ -740,3 +740,26 @@ TEST_VM_F(NMTVMATreeTest, SummaryAccountingWhenUseFlagInplace) {
   EXPECT_EQ(0, diff.tag[NMTUtil::tag_to_index(mtTest)].reserve);
   EXPECT_EQ(-50, diff.tag[NMTUtil::tag_to_index(mtTest)].commit);
 }
+
+TEST_VM_F(NMTVMATreeTest, UncommmitReleasedRegion) {
+  {
+    Tree tree;
+    VMATree::RegionData rd(si[0], mtTest);
+    VMATree::RegionData rd2(si[0], mtNone);
+    tree.reserve_mapping(0, 100, rd);
+    tree.release_mapping(50, 20);
+    //0-----50....70-----100
+    //   40----60
+    EXPECT_DEATH(tree.uncommit_mapping(40, 20, rd2), "");
+  }
+  {
+    Tree tree;
+    VMATree::RegionData rd(si[0], mtTest);
+    VMATree::RegionData rd2(si[0], mtNone);
+    tree.reserve_mapping(0, 100, rd);
+    tree.release_mapping(50, 20);
+    //0-----50....70-----100
+    //         60----80
+    EXPECT_DEATH(tree.uncommit_mapping(60, 20, rd2), "");
+  }
+}

--- a/test/hotspot/gtest/nmt/test_vmatree.cpp
+++ b/test/hotspot/gtest/nmt/test_vmatree.cpp
@@ -746,12 +746,19 @@ TEST_VM_F(NMTVMATreeTest, UncommmitReleasedRegion) {
     Tree tree;
     VMATree::RegionData rd(si[0], mtTest);
     VMATree::RegionData rd2(si[0], mtNone);
+    VMATree::SummaryDiff diff = tree.uncommit_mapping(40, 20, rd2);
+    EXPECT_TRUE(diff.has_error());
+  }
+  {
+    Tree tree;
+    VMATree::RegionData rd(si[0], mtTest);
+    VMATree::RegionData rd2(si[0], mtNone);
     tree.reserve_mapping(0, 100, rd);
     tree.release_mapping(50, 20);
     //0-----50....70-----100
     //   40----60
     VMATree::SummaryDiff diff = tree.uncommit_mapping(40, 20, rd2);
-    EXPECT_FALSE(diff.is_valid());
+    EXPECT_TRUE(diff.has_error());
   }
   {
     Tree tree;
@@ -762,7 +769,7 @@ TEST_VM_F(NMTVMATreeTest, UncommmitReleasedRegion) {
     //0-----50....70-----100
     //         60----80
     VMATree::SummaryDiff diff = tree.uncommit_mapping(60, 20, rd2);
-    EXPECT_FALSE(diff.is_valid());
+    EXPECT_TRUE(diff.has_error());
   }
   {
     Tree tree;
@@ -776,7 +783,7 @@ TEST_VM_F(NMTVMATreeTest, UncommmitReleasedRegion) {
     //    40-------------70
     // Node 70 should not be changed
     VMATree::SummaryDiff diff = tree.uncommit_mapping(40, 30, rd2);
-    EXPECT_FALSE(diff.is_valid());
+    EXPECT_TRUE(diff.has_error());
     VMATree::VMATreap::Range r = tree.tree().find_enclosing_range(70);
     ASSERT_TRUE(r.start != nullptr);
     EXPECT_TRUE(r.start->val().out.type() == VMATree::StateType::Reserved);

--- a/test/hotspot/gtest/nmt/test_vmatree.cpp
+++ b/test/hotspot/gtest/nmt/test_vmatree.cpp
@@ -750,7 +750,8 @@ TEST_VM_F(NMTVMATreeTest, UncommmitReleasedRegion) {
     tree.release_mapping(50, 20);
     //0-----50....70-----100
     //   40----60
-    EXPECT_DEATH(tree.uncommit_mapping(40, 20, rd2), "");
+    VMATree::SummaryDiff diff = tree.uncommit_mapping(40, 20, rd2);
+    EXPECT_FALSE(diff.is_valid());
   }
   {
     Tree tree;
@@ -760,6 +761,7 @@ TEST_VM_F(NMTVMATreeTest, UncommmitReleasedRegion) {
     tree.release_mapping(50, 20);
     //0-----50....70-----100
     //         60----80
-    EXPECT_DEATH(tree.uncommit_mapping(60, 20, rd2), "");
+    VMATree::SummaryDiff diff = tree.uncommit_mapping(60, 20, rd2);
+    EXPECT_FALSE(diff.is_valid());
   }
 }


### PR DESCRIPTION
At `uncommit` we change the state of the regions to `Reserved`. This is not acceptable to uncommit a  `Released` region and change its state to `Reserved`.
This case is detected and an invalid `SummaryDiff` (all its contents are -1) is returned. 

Two test-cases added and run.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8354115](https://bugs.openjdk.org/browse/JDK-8354115): NMT: VMATree should not accept `uncommit` a `released` region (**Enhancement** - P4) ⚠️ Issue is not open.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24572/head:pull/24572` \
`$ git checkout pull/24572`

Update a local copy of the PR: \
`$ git checkout pull/24572` \
`$ git pull https://git.openjdk.org/jdk.git pull/24572/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24572`

View PR using the GUI difftool: \
`$ git pr show -t 24572`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24572.diff">https://git.openjdk.org/jdk/pull/24572.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24572#issuecomment-2792534235)
</details>
