### PR TITLE
8354255: [jittester] Remove TempDir debug output

### DIFF
--- a/test/hotspot/jtreg/testlibrary/jittester/src/jdk/test/lib/jittester/TempDir.java
+++ b/test/hotspot/jtreg/testlibrary/jittester/src/jdk/test/lib/jittester/TempDir.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,14 +47,11 @@ public class TempDir {
         } catch (IOException e) {
             throw new Error("Can't create a tmp dir for " + suffix, e);
         }
-
-        System.out.println("DBG: Temp folder created: '" + path + "'");
     }
 
     private void delete() {
         try {
             FileUtils.deleteFileTreeWithRetry(path);
-            System.out.println("DBG: Temp folder deleted: '" + path + "'");
         } catch (IOException exc) {
             throw new Error("Could not deep delete '" + path + "'", exc);
         }


### PR DESCRIPTION
JITTester's TempDir prints debug information about creation and deletion of a temporary folder, like this:

DBG: Temp folder created: '/tmp/java_tests8412639693749199985'
DBG: Temp folder deleted: '/tmp/java_tests8412639693749199985'

As jittester is a library, TempDir can be used in other tools. Debug outputs mess up logs, confuse output comparison tools, etc. And do not give any valuable information (as temp folder with its contents is deleted after VM shutdown).

This PR removes the debug outputs.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8354255](https://bugs.openjdk.org/browse/JDK-8354255): [jittester] Remove TempDir debug output (**Bug** - P4)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24573/head:pull/24573` \
`$ git checkout pull/24573`

Update a local copy of the PR: \
`$ git checkout pull/24573` \
`$ git pull https://git.openjdk.org/jdk.git pull/24573/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24573`

View PR using the GUI difftool: \
`$ git pr show -t 24573`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24573.diff">https://git.openjdk.org/jdk/pull/24573.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24573#issuecomment-2792921192)
</details>
