### PR TITLE
8354282: C2: more crashes in compiled code because of dependency on removed range check CastIIs

### DIFF
--- a/src/hotspot/share/opto/castnode.cpp
+++ b/src/hotspot/share/opto/castnode.cpp
@@ -33,10 +33,15 @@
 #include "castnode.hpp"
 #include "utilities/checkedCast.hpp"
 
+const ConstraintCastNode::DependencyType ConstraintCastNode::RegularDependency(true, true, "regular dependency"); // not pinned, narrows type
+const ConstraintCastNode::DependencyType ConstraintCastNode::WidenTypeDependency(true, false, "widen type dependency"); // not pinned, doesn't narrow type
+const ConstraintCastNode::DependencyType ConstraintCastNode::StrongDependency(false, true, "strong dependency"); // pinned, narrows type
+const ConstraintCastNode::DependencyType ConstraintCastNode::UnconditionalDependency(false, false, "unconditional dependency"); // pinned, doesn't narrow type
+
 //=============================================================================
 // If input is already higher or equal to cast type, then this is an identity.
 Node* ConstraintCastNode::Identity(PhaseGVN* phase) {
-  if (_dependency == UnconditionalDependency) {
+  if (!_dependency.narrows_type()) {
     return this;
   }
   Node* dom = dominating_cast(phase, phase);
@@ -107,7 +112,7 @@ Node* ConstraintCastNode::Ideal(PhaseGVN* phase, bool can_reshape) {
 }
 
 uint ConstraintCastNode::hash() const {
-  return TypeNode::hash() + (int)_dependency + (_extra_types != nullptr ? _extra_types->hash() : 0);
+  return TypeNode::hash() + _dependency.hash() + (_extra_types != nullptr ? _extra_types->hash() : 0);
 }
 
 bool ConstraintCastNode::cmp(const Node &n) const {
@@ -115,7 +120,7 @@ bool ConstraintCastNode::cmp(const Node &n) const {
     return false;
   }
   ConstraintCastNode& cast = (ConstraintCastNode&) n;
-  if (cast._dependency != _dependency) {
+  if (!cast._dependency.cmp(_dependency)) {
     return false;
   }
   if (_extra_types == nullptr || cast._extra_types == nullptr) {
@@ -128,7 +133,7 @@ uint ConstraintCastNode::size_of() const {
   return sizeof(*this);
 }
 
-Node* ConstraintCastNode::make_cast_for_basic_type(Node* c, Node* n, const Type* t, DependencyType dependency, BasicType bt) {
+Node* ConstraintCastNode::make_cast_for_basic_type(Node* c, Node* n, const Type* t, const DependencyType& dependency, BasicType bt) {
   switch(bt) {
   case T_INT:
     return new CastIINode(c, n, t, dependency);
@@ -141,7 +146,7 @@ Node* ConstraintCastNode::make_cast_for_basic_type(Node* c, Node* n, const Type*
 }
 
 TypeNode* ConstraintCastNode::dominating_cast(PhaseGVN* gvn, PhaseTransform* pt) const {
-  if (_dependency == UnconditionalDependency) {
+  if (!_dependency.narrows_type()) {
     return nullptr;
   }
   Node* val = in(1);
@@ -203,30 +208,21 @@ void ConstraintCastNode::dump_spec(outputStream *st) const {
     st->print(" extra types: ");
     _extra_types->dump_on(st);
   }
-  if (_dependency != RegularDependency) {
-    st->print(" %s dependency", _dependency == StrongDependency ? "strong" : "unconditional");
-  }
+  st->print(" ");
+  _dependency.dump_on(st);
 }
 #endif
 
-const Type* CastIINode::Value(PhaseGVN* phase) const {
-  const Type *res = ConstraintCastNode::Value(phase);
-  if (res == Type::TOP) {
-    return Type::TOP;
-  }
-  assert(res->isa_int(), "res must be int");
-
-  // Similar to ConvI2LNode::Value() for the same reasons
-  // see if we can remove type assertion after loop opts
-  res = widen_type(phase, res, T_INT);
-
-  return res;
+CastIINode* CastIINode::make_with(Node* parent, const TypeInteger* type, const DependencyType& dependency) const {
+  return new CastIINode(in(0), parent, type, dependency, _range_check_dependency, _extra_types);
 }
 
-Node* ConstraintCastNode::find_or_make_integer_cast(PhaseIterGVN* igvn, Node* parent, const TypeInteger* type) const {
-  Node* n = clone();
-  n->set_req(1, parent);
-  n->as_ConstraintCast()->set_type(type);
+CastLLNode* CastLLNode::make_with(Node* parent, const TypeInteger* type, const DependencyType& dependency) const {
+  return new CastLLNode(in(0), parent, type, dependency, _extra_types);
+}
+
+Node* ConstraintCastNode::find_or_make_integer_cast(PhaseIterGVN* igvn, Node* parent, const TypeInteger* type, const DependencyType& dependency) const {
+  Node* n = make_with(parent, type, dependency);
   Node* existing = igvn->hash_find_insert(n);
   if (existing != nullptr) {
     n->destruct(igvn);
@@ -240,14 +236,13 @@ Node *CastIINode::Ideal(PhaseGVN *phase, bool can_reshape) {
   if (progress != nullptr) {
     return progress;
   }
-  if (can_reshape && !phase->C->post_loop_opts_phase()) {
-    // makes sure we run ::Value to potentially remove type assertion after loop opts
+  if (!phase->C->post_loop_opts_phase()) {
+    // makes sure we run widen_type() to potentially common type assertions after loop opts
     phase->C->record_for_post_loop_opts_igvn(this);
   }
   if (!_range_check_dependency || phase->C->post_loop_opts_phase()) {
     return optimize_integer_cast(phase, T_INT);
   }
-  phase->C->record_for_post_loop_opts_igvn(this);
   return nullptr;
 }
 
@@ -277,9 +272,9 @@ void CastIINode::dump_spec(outputStream* st) const {
 #endif
 
 CastIINode* CastIINode::pin_array_access_node() const {
-  assert(_dependency == RegularDependency, "already pinned");
+  assert(depends_only_on_test(), "already pinned");
   if (has_range_check()) {
-    return new CastIINode(in(0), in(1), bottom_type(), StrongDependency, has_range_check());
+    return new CastIINode(in(0), in(1), bottom_type(), _dependency.pinned_dependency(), has_range_check());
   }
   return nullptr;
 }
@@ -313,23 +308,13 @@ void CastIINode::remove_range_check_cast(Compile* C) {
 }
 
 
-const Type* CastLLNode::Value(PhaseGVN* phase) const {
-  const Type* res = ConstraintCastNode::Value(phase);
-  if (res == Type::TOP) {
-    return Type::TOP;
-  }
-  assert(res->isa_long(), "res must be long");
-
-  return widen_type(phase, res, T_LONG);
-}
-
 Node* CastLLNode::Ideal(PhaseGVN* phase, bool can_reshape) {
   Node* progress = ConstraintCastNode::Ideal(phase, can_reshape);
   if (progress != nullptr) {
     return progress;
   }
   if (!phase->C->post_loop_opts_phase()) {
-    // makes sure we run ::Value to potentially remove type assertion after loop opts
+    // makes sure we run widen_type() to potentially common type assertions after loop opts
     phase->C->record_for_post_loop_opts_igvn(this);
   }
   // transform (CastLL (ConvI2L ..)) into (ConvI2L (CastII ..)) if the type of the CastLL is narrower than the type of
@@ -475,7 +460,7 @@ Node* CastP2XNode::Identity(PhaseGVN* phase) {
   return this;
 }
 
-Node* ConstraintCastNode::make_cast_for_type(Node* c, Node* in, const Type* type, DependencyType dependency,
+Node* ConstraintCastNode::make_cast_for_type(Node* c, Node* in, const Type* type, const DependencyType& dependency,
                                              const TypeTuple* types) {
   if (type->isa_int()) {
     return new CastIINode(c, in, type, dependency, false, types);
@@ -496,7 +481,7 @@ Node* ConstraintCastNode::make_cast_for_type(Node* c, Node* in, const Type* type
   return nullptr;
 }
 
-Node* ConstraintCastNode::optimize_integer_cast(PhaseGVN* phase, BasicType bt) {
+Node* ConstraintCastNode::optimize_integer_cast_of_add(PhaseGVN* phase, BasicType bt) {
   PhaseIterGVN *igvn = phase->is_IterGVN();
   const TypeInteger* this_type = this->type()->is_integer(bt);
   Node* z = in(1);
@@ -514,8 +499,14 @@ Node* ConstraintCastNode::optimize_integer_cast(PhaseGVN* phase, BasicType bt) {
     Node* x = z->in(1);
     Node* y = z->in(2);
 
-    Node* cx = find_or_make_integer_cast(igvn, x, rx);
-    Node* cy = find_or_make_integer_cast(igvn, y, ry);
+    const TypeInteger* tx = phase->type(x)->is_integer(bt);
+    const TypeInteger* ty = phase->type(y)->is_integer(bt);
+
+    // If both inputs are not constant then, with the Cast pushed through the Add/Sub, the cast gets less precised types,
+    // and the resulting Add/Sub's type is wider than that of the Cast before pushing.
+    const DependencyType& dependency = (!tx->is_con() && !ty->is_con()) ? _dependency.widen_type_dependency() : _dependency;
+    Node* cx = find_or_make_integer_cast(igvn, x, rx, dependency);
+    Node* cy = find_or_make_integer_cast(igvn, y, ry, dependency);
     if (op == Op_Add(bt)) {
       return AddNode::make(cx, cy, bt);
     } else {
@@ -527,11 +518,28 @@ Node* ConstraintCastNode::optimize_integer_cast(PhaseGVN* phase, BasicType bt) {
   return nullptr;
 }
 
-const Type* ConstraintCastNode::widen_type(const PhaseGVN* phase, const Type* res, BasicType bt) const {
-  if (!phase->C->post_loop_opts_phase()) {
+Node* ConstraintCastNode::optimize_integer_cast(PhaseGVN* phase, BasicType bt) {
+  Node* res = optimize_integer_cast_of_add(phase, bt);
+  if (res != nullptr) {
     return res;
   }
+  const Type* t = Value(phase);
+  if (t != Type::TOP) {
+    const TypeInteger* wide_t = widen_type(phase, t, bt);
+    if (wide_t != t) {
+      // Widening the type of the Cast (to allow some commoning) causes the Cast to change how it can be optimized (if
+      // type of its input is narrower than the Cast's type, we can't remove it to not loose the dependency).
+      return make_with(in(1), wide_t, _dependency.widen_type_dependency());
+    }
+  }
+  return nullptr;
+}
+
+const TypeInteger* ConstraintCastNode::widen_type(const PhaseGVN* phase, const Type* res, BasicType bt) const {
   const TypeInteger* this_type = res->is_integer(bt);
+  if (!phase->C->post_loop_opts_phase()) {
+    return this_type;
+  }
   const TypeInteger* in_type = phase->type(in(1))->isa_integer(bt);
   if (in_type != nullptr &&
       (in_type->lo_as_long() != this_type->lo_as_long() ||
@@ -552,5 +560,5 @@ const Type* ConstraintCastNode::widen_type(const PhaseGVN* phase, const Type* re
                              MIN2(in_type->hi_as_long(), hi1),
                              MAX2((int)in_type->_widen, w1), bt);
   }
-  return res;
+  return this_type;
 }

--- a/src/hotspot/share/opto/castnode.hpp
+++ b/src/hotspot/share/opto/castnode.hpp
@@ -32,22 +32,87 @@
 //------------------------------ConstraintCastNode-----------------------------
 // cast to a different range
 class ConstraintCastNode: public TypeNode {
-public:
-  enum DependencyType {
-    RegularDependency, // if cast doesn't improve input type, cast can be removed
-    StrongDependency,  // leave cast in even if _type doesn't improve input type, can be replaced by stricter dominating cast if one exist
-    UnconditionalDependency // leave cast in unconditionally
+protected:
+  // Cast nodes are subject to a few optimizations:
+  //
+  // 1- if the type carried by the Cast doesn't narrow the type of its input, the cast can be replaced by its input.
+  // Similarly, if a dominating Cast with the same input and a narrower type constraint is found, it can replace the
+  // current cast.
+  //
+  // 2- if the condition that the Cast is control dependent is hoisted, the Cast is hoisted as well
+  //
+  // 1- and 2- are not always applied depending on what constraint are applied to the Cast: there are cases where 1-
+  // and 2- apply, where neither 1- nor 2- apply and where one or the other apply. This class abstract away these
+  // details.
+  class DependencyType {
+  public:
+    DependencyType(bool depends_on_test, bool narrows_type, const char* desc)
+      : _depends_only_on_test(depends_on_test),
+        _narrows_type(narrows_type),
+        _desc(desc) {
+    }
+    NONCOPYABLE(DependencyType);
+
+    bool depends_only_on_test() const {
+      return _depends_only_on_test;
+    }
+
+    bool narrows_type() const {
+      return _narrows_type;
+    }
+    void dump_on(outputStream *st) const {
+      st->print("%s", _desc);
+    }
+
+    uint hash() const {
+      return (_depends_only_on_test ? 1 : 0) + (_narrows_type ? 2 : 0);
+    }
+
+    bool cmp(const DependencyType& other) const {
+      return _depends_only_on_test == other._depends_only_on_test && _narrows_type == other._narrows_type;
+    }
+
+    const DependencyType& widen_type_dependency() const {
+      if (_depends_only_on_test) {
+        return WidenTypeDependency;
+      }
+      return UnconditionalDependency;
+    }
+
+    const DependencyType& pinned_dependency() const {
+      if (_narrows_type) {
+        return StrongDependency;
+      }
+      return UnconditionalDependency;
+    }
+
+  private:
+    const bool _depends_only_on_test; // Does this Cast depends on its control input or is it pinned?
+    const bool _narrows_type; // Does this Cast narrows the type i.e. if input type is narrower can it be removed?
+    const char* _desc;
   };
 
+public:
+
+  static const DependencyType RegularDependency;
+  static const DependencyType WidenTypeDependency;
+  static const DependencyType StrongDependency;
+  static const DependencyType UnconditionalDependency;
+
   protected:
-  const DependencyType _dependency;
+  const DependencyType& _dependency;
   virtual bool cmp( const Node &n ) const;
   virtual uint size_of() const;
   virtual uint hash() const;    // Check the type
-  const Type* widen_type(const PhaseGVN* phase, const Type* res, BasicType bt) const;
-  Node* find_or_make_integer_cast(PhaseIterGVN* igvn, Node* parent, const TypeInteger* type) const;
+  const TypeInteger* widen_type(const PhaseGVN* phase, const Type* res, BasicType bt) const;
 
-  private:
+  virtual ConstraintCastNode* make_with(Node* parent, const TypeInteger* type, const DependencyType& dependency) const {
+    ShouldNotReachHere();
+    return nullptr;
+  }
+
+  Node* find_or_make_integer_cast(PhaseIterGVN* igvn, Node* parent, const TypeInteger* type, const DependencyType& dependency) const;
+
   // PhiNode::Ideal() transforms a Phi that merges a single uncasted value into a single cast pinned at the region.
   // The types of cast nodes eliminated as a consequence of this transformation are collected and stored here so the
   // type dependencies carried by the cast are known. The cast can then be eliminated if the type of its input is
@@ -55,7 +120,7 @@ public:
   const TypeTuple* _extra_types;
 
   public:
-  ConstraintCastNode(Node* ctrl, Node* n, const Type* t, ConstraintCastNode::DependencyType dependency,
+  ConstraintCastNode(Node* ctrl, Node* n, const Type* t, const DependencyType& dependency,
                      const TypeTuple* extra_types)
           : TypeNode(t,2), _dependency(dependency), _extra_types(extra_types) {
     init_class_id(Class_ConstraintCast);
@@ -67,18 +132,20 @@ public:
   virtual Node *Ideal(PhaseGVN *phase, bool can_reshape);
   virtual int Opcode() const;
   virtual uint ideal_reg() const = 0;
-  virtual bool depends_only_on_test() const { return _dependency == RegularDependency; }
-  bool carry_dependency() const { return _dependency != RegularDependency; }
+  bool carry_dependency() const { return !_dependency.cmp(RegularDependency); }
+  virtual bool depends_only_on_test() const { return _dependency.depends_only_on_test(); }
+  const DependencyType& dependency() const { return _dependency; }
   TypeNode* dominating_cast(PhaseGVN* gvn, PhaseTransform* pt) const;
-  static Node* make_cast_for_basic_type(Node* c, Node* n, const Type* t, DependencyType dependency, BasicType bt);
+  static Node* make_cast_for_basic_type(Node* c, Node* n, const Type* t, const DependencyType& dependency, BasicType bt);
 
 #ifndef PRODUCT
   virtual void dump_spec(outputStream *st) const;
 #endif
 
-  static Node* make_cast_for_type(Node* c, Node* in, const Type* type, DependencyType dependency,
+  static Node* make_cast_for_type(Node* c, Node* in, const Type* type, const DependencyType& dependency,
                                   const TypeTuple* types);
 
+  Node* optimize_integer_cast_of_add(PhaseGVN* phase, BasicType bt);
   Node* optimize_integer_cast(PhaseGVN* phase, BasicType bt);
 
   bool higher_equal_types(PhaseGVN* phase, const Node* other) const;
@@ -102,7 +169,7 @@ class CastIINode: public ConstraintCastNode {
   virtual uint size_of() const;
 
   public:
-  CastIINode(Node* ctrl, Node* n, const Type* t, DependencyType dependency = RegularDependency, bool range_check_dependency = false, const TypeTuple* types = nullptr)
+  CastIINode(Node* ctrl, Node* n, const Type* t, const DependencyType& dependency = RegularDependency, bool range_check_dependency = false, const TypeTuple* types = nullptr)
     : ConstraintCastNode(ctrl, n, t, dependency, types), _range_check_dependency(range_check_dependency) {
     assert(ctrl != nullptr, "control must be set");
     init_class_id(Class_CastII);
@@ -110,7 +177,7 @@ class CastIINode: public ConstraintCastNode {
   virtual int Opcode() const;
   virtual uint ideal_reg() const { return Op_RegI; }
   virtual Node* Identity(PhaseGVN* phase);
-  virtual const Type* Value(PhaseGVN* phase) const;
+
   virtual Node *Ideal(PhaseGVN *phase, bool can_reshape);
   bool has_range_check() const {
 #ifdef _LP64
@@ -122,6 +189,7 @@ class CastIINode: public ConstraintCastNode {
   }
 
   CastIINode* pin_array_access_node() const;
+  CastIINode* make_with(Node* parent, const TypeInteger* type, const DependencyType& dependency) const;
   void remove_range_check_cast(Compile* C);
 
 #ifndef PRODUCT
@@ -131,21 +199,21 @@ class CastIINode: public ConstraintCastNode {
 
 class CastLLNode: public ConstraintCastNode {
 public:
-  CastLLNode(Node* ctrl, Node* n, const Type* t, DependencyType dependency = RegularDependency, const TypeTuple* types = nullptr)
+  CastLLNode(Node* ctrl, Node* n, const Type* t, const DependencyType& dependency = RegularDependency, const TypeTuple* types = nullptr)
           : ConstraintCastNode(ctrl, n, t, dependency, types) {
     assert(ctrl != nullptr, "control must be set");
     init_class_id(Class_CastLL);
   }
 
-  virtual const Type* Value(PhaseGVN* phase) const;
   virtual Node* Ideal(PhaseGVN* phase, bool can_reshape);
   virtual int Opcode() const;
   virtual uint ideal_reg() const { return Op_RegL; }
+  CastLLNode* make_with(Node* parent, const TypeInteger* type, const DependencyType& dependency) const;
 };
 
 class CastHHNode: public ConstraintCastNode {
 public:
-  CastHHNode(Node* ctrl, Node* n, const Type* t, DependencyType dependency = RegularDependency, const TypeTuple* types = nullptr)
+  CastHHNode(Node* ctrl, Node* n, const Type* t, const DependencyType& dependency = RegularDependency, const TypeTuple* types = nullptr)
           : ConstraintCastNode(ctrl, n, t, dependency, types) {
     assert(ctrl != nullptr, "control must be set");
     init_class_id(Class_CastHH);
@@ -156,7 +224,7 @@ public:
 
 class CastFFNode: public ConstraintCastNode {
 public:
-  CastFFNode(Node* ctrl, Node* n, const Type* t, DependencyType dependency = RegularDependency, const TypeTuple* types = nullptr)
+  CastFFNode(Node* ctrl, Node* n, const Type* t, const DependencyType& dependency = RegularDependency, const TypeTuple* types = nullptr)
           : ConstraintCastNode(ctrl, n, t, dependency, types) {
     assert(ctrl != nullptr, "control must be set");
     init_class_id(Class_CastFF);
@@ -167,7 +235,7 @@ public:
 
 class CastDDNode: public ConstraintCastNode {
 public:
-  CastDDNode(Node* ctrl, Node* n, const Type* t, DependencyType dependency = RegularDependency, const TypeTuple* types = nullptr)
+  CastDDNode(Node* ctrl, Node* n, const Type* t, const DependencyType& dependency = RegularDependency, const TypeTuple* types = nullptr)
           : ConstraintCastNode(ctrl, n, t, dependency, types) {
     assert(ctrl != nullptr, "control must be set");
     init_class_id(Class_CastDD);
@@ -178,7 +246,7 @@ public:
 
 class CastVVNode: public ConstraintCastNode {
 public:
-  CastVVNode(Node* ctrl, Node* n, const Type* t, DependencyType dependency = RegularDependency, const TypeTuple* types = nullptr)
+  CastVVNode(Node* ctrl, Node* n, const Type* t, const DependencyType& dependency = RegularDependency, const TypeTuple* types = nullptr)
           : ConstraintCastNode(ctrl, n, t, dependency, types) {
     assert(ctrl != nullptr, "control must be set");
     init_class_id(Class_CastVV);
@@ -192,7 +260,7 @@ public:
 // cast pointer to pointer (different type)
 class CastPPNode: public ConstraintCastNode {
   public:
-  CastPPNode (Node* ctrl, Node* n, const Type* t, DependencyType dependency = RegularDependency, const TypeTuple* types = nullptr)
+  CastPPNode (Node* ctrl, Node* n, const Type* t, const DependencyType& dependency = RegularDependency, const TypeTuple* types = nullptr)
     : ConstraintCastNode(ctrl, n, t, dependency, types) {
     init_class_id(Class_CastPP);
   }
@@ -204,7 +272,7 @@ class CastPPNode: public ConstraintCastNode {
 // for _checkcast, cast pointer to pointer (different type), without JOIN,
 class CheckCastPPNode: public ConstraintCastNode {
   public:
-  CheckCastPPNode(Node* ctrl, Node* n, const Type* t, DependencyType dependency = RegularDependency, const TypeTuple* types = nullptr)
+  CheckCastPPNode(Node* ctrl, Node* n, const Type* t, const DependencyType& dependency = RegularDependency, const TypeTuple* types = nullptr)
     : ConstraintCastNode(ctrl, n, t, dependency, types) {
     assert(ctrl != nullptr, "control must be set");
     init_class_id(Class_CheckCastPP);

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestPushAddThruCast.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestPushAddThruCast.java
@@ -44,13 +44,13 @@ public class TestPushAddThruCast {
         TestFramework.run();
     }
 
-    final static int length = RANDOM.nextInt(Integer.MAX_VALUE);
-    final static long llength = RANDOM.nextInt(Integer.MAX_VALUE);
+    final static int length = RANDOM.nextInt(5, Integer.MAX_VALUE);
+    final static long llength = RANDOM.nextInt(2, Integer.MAX_VALUE);
     static int i;
     static long l;
 
     @Test
-    @IR(counts = { IRNode.CAST_II, "1" })
+    @IR(counts = { IRNode.CAST_II, "2" })
     public static int test1() {
         int j = Objects.checkIndex(i, length);
         int k = Objects.checkIndex(i + 1, length);
@@ -67,7 +67,7 @@ public class TestPushAddThruCast {
     }
 
     @Test
-    @IR(counts = { IRNode.CAST_LL, "1" })
+    @IR(counts = { IRNode.CAST_LL, "2" })
     public static long test2() {
         long j = Objects.checkIndex(l, llength);
         long k = Objects.checkIndex(l + 1, llength);
@@ -80,6 +80,26 @@ public class TestPushAddThruCast {
         long res = test2();
         if (res != l * 2 + 1) {
             throw new RuntimeException("incorrect result: " + res);
+        }
+    }
+
+    // Test commoning of Casts after loop opts when they are at the same control
+    @Test
+    @IR(counts = { IRNode.CAST_II, "2" })
+    public static int test3() {
+        int j = Objects.checkIndex(i - 3, length);
+        j += Objects.checkIndex(i, length);
+        j += Objects.checkIndex(i - 2, length);
+        j += Objects.checkIndex(i - 1, length);
+        return j;
+    }
+
+    @Run(test = "test3")
+    public static void test3_runner() {
+        i = RANDOM.nextInt(3, length-1);
+        int res = test3();
+        if (res != i * 4 - 6) {
+            throw new RuntimeException("incorrect result: " + res + " for i = " + i);
         }
     }
 }

--- a/test/hotspot/jtreg/compiler/rangechecks/TestArrayAccessAboveRCAfterRCCastIIEliminated.java
+++ b/test/hotspot/jtreg/compiler/rangechecks/TestArrayAccessAboveRCAfterRCCastIIEliminated.java
@@ -44,7 +44,6 @@ public class TestArrayAccessAboveRCAfterRCCastIIEliminated {
     private static volatile int volatileField;
 
     public static void main(String[] args) {
-        int[] array = new int[100];
         for (int i = 0; i < 20_000; i++) {
             test1(9, 10, 1, true);
             test1(9, 10, 1, false);
@@ -72,6 +71,13 @@ public class TestArrayAccessAboveRCAfterRCCastIIEliminated {
             test12(9, 10, 1, false);
             test13(9, 10, 1, true);
             test13(9, 10, 1, false);
+            test14(8, 0, 1, true);
+            test14(8, 0, 1, false);
+            inlined14(0, 0);
+            test15(8, 0, 1, true);
+            test15(8, 0, 1, false);
+            inlined15(0, 0);
+
         }
         try {
             test1(-1, 10, 1, true);
@@ -123,6 +129,14 @@ public class TestArrayAccessAboveRCAfterRCCastIIEliminated {
         }
         try {
             test13(-1, 10, 1, true);
+        } catch (ArrayIndexOutOfBoundsException arrayIndexOutOfBoundsException) {
+        }
+        try {
+            test14(Integer.MAX_VALUE, 10, 1, true);
+        } catch (ArrayIndexOutOfBoundsException arrayIndexOutOfBoundsException) {
+        }
+        try {
+            test15(Integer.MAX_VALUE, 10, 1, true);
         } catch (ArrayIndexOutOfBoundsException arrayIndexOutOfBoundsException) {
         }
     }
@@ -466,6 +480,72 @@ public class TestArrayAccessAboveRCAfterRCCastIIEliminated {
         for (int k = 0; k < 10; k++) {
 
         }
+    }
+
+    // Range check cast type widen after loop opts causes control dependency to be lost
+    private static void test14(int i, int j, int flag, boolean flag2) {
+        int l = 0;
+        for (; l < 10; l++);
+        j = inlined14(j, l);
+        int[] array = new int[10];
+        notInlined(array);
+        if (flag == 0) {
+        }
+        if (flag2) {
+            float[] newArray = new float[10];
+            newArray[i+j] = 42; // i+j in [0, 9]
+            float[] otherArray = new float[i+j]; // i+j in [0, max]
+            if (flag == 0) {
+            }
+            intField = array[otherArray.length];
+        } else {
+            float[] newArray = new float[10];
+            newArray[i+j] = 42; // i+j in [0, 9]
+            float[] otherArray = new float[i+j]; // i+j in [0, max]
+            if (flag == 0) {
+            }
+            intField = array[otherArray.length];
+        }
+    }
+
+    private static int inlined14(int j, int l) {
+        if (l == 10) {
+            j = 1;
+        }
+        return j;
+    }
+
+    private static void test15(int i, int j, int flag, boolean flag2) {
+        i = Integer.max(i, Integer.MIN_VALUE + 1);
+        int l = 0;
+        for (; l < 10; l++);
+        j = inlined15(j, l);
+        int[] array = new int[10];
+        notInlined(array);
+        if (flag == 0) {
+        }
+        if (flag2) {
+            float[] newArray = new float[10];
+            newArray[i+j] = 42; // i+j in [0, 9]
+            float[] otherArray = new float[i+j]; // i+j in [0, max]
+            if (flag == 0) {
+            }
+            intField = array[otherArray.length];
+        } else {
+            float[] newArray = new float[10];
+            newArray[i+j] = 42; // i+j in [0, 9]
+            float[] otherArray = new float[i+j]; // i+j in [0, max]
+            if (flag == 0) {
+            }
+            intField = array[otherArray.length];
+        }
+    }
+
+    private static int inlined15(int j, int l) {
+        if (l == 10) {
+            j = Integer.max(j, Integer.MIN_VALUE + 10);
+        }
+        return j;
     }
 
     private static void notInlined(int[] array) {


### PR DESCRIPTION
This is a variant of 8332827. In 8332827, an array access becomes
dependent on a range check `CastII` for another array access. When,
after loop opts are over, that RC `CastII` was removed, the array
access could float and an out of bound access happened. With the fix
for 8332827, RC `CastII`s are no longer removed.

With this one what happens is that some transformations applied after
loop opts are over widen the type of the RC `CastII`. As a result, the
type of the RC `CastII` is no longer narrower than that of its input,
the `CastII` is removed and the dependency is lost.

There are 2 transformations that cause this to happen:

- after loop opts are over, the type of the `CastII` nodes are widen
  so nodes that have the same inputs but a slightly different type can
  common.
  
- When pushing a `CastII` through an `Add`, if of the type both inputs
  of the `Add`s are non constant, then we end up widening the type
  (the resulting `Add` has a type that's wider than that of the
  initial `CastII`).
  
There are already 3 types of `Cast` nodes depending on the
optimizations that are allowed. Either the `Cast` is floating
(`depends_only_test()` returns `true`) or pinned. Either the `Cast`
can be removed if it no longer narrows the type of its input or
not. We already have variants of the `CastII`:

- if the Cast can float and be removed when it doesn't narrow the type
of its input.

- if the Cast is pinned and be removed when it doesn't narrow the type
of its input.

- if the Cast is pinned and can't be removed when it doesn't narrow
the type of its input.

What we need here, I think, is the 4th combination:

- if the Cast can float and can't be removed when it doesn't narrow
the type of its input.

Anyway, things are becoming confusing with all these different
variants named in ways that don't always help figure out what
constraints one of them operate under. So I refactored this and that's
the biggest part of this change. The fix consists in marking `Cast`
nodes when their type is widen in a way that prevents them from being
optimized out.

Tobias ran performance testing with a slightly different version of
this change and there was no regression.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warnings
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/java/awt/doc-files/BorderLayout-1.gif)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/java/awt/doc-files/FlowLayout-1.gif)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/java/awt/doc-files/GridBagLayout-1.gif)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/java/awt/doc-files/GridBagLayout-2.gif)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/java/awt/doc-files/GridLayout-1.gif)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/java/awt/doc-files/GridLayout-2.gif)
&nbsp;⚠️ Patch contains a binary file (test/hotspot/jtreg/runtime/ClassFile/JsrRewritingTestCase.jar)
&nbsp;⚠️ Patch contains a binary file (test/hotspot/jtreg/runtime/ClassFile/testcase.jar)

### Issue
 * [JDK-8354282](https://bugs.openjdk.org/browse/JDK-8354282): C2: more crashes in compiled code because of dependency on removed range check CastIIs (**Bug** - P3)(⚠️ The fixVersion in this issue is [26] but the fixVersion in .jcheck/conf is 25, a new backport will be created when this pr is integrated.)


### Reviewers
 * [Galder Zamarreño](https://openjdk.org/census#galder) (@galderz - Author)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24575/head:pull/24575` \
`$ git checkout pull/24575`

Update a local copy of the PR: \
`$ git checkout pull/24575` \
`$ git pull https://git.openjdk.org/jdk.git pull/24575/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24575`

View PR using the GUI difftool: \
`$ git pr show -t 24575`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24575.diff">https://git.openjdk.org/jdk/pull/24575.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24575#issuecomment-2794222992)
</details>
