### PR TITLE
8354310: JFR: Inconsistent metadata in ZPageAllocation

### DIFF
--- a/src/hotspot/share/jfr/metadata/metadata.xml
+++ b/src/hotspot/share/jfr/metadata/metadata.xml
@@ -1159,9 +1159,9 @@
     <Field type="ulong" contentType="bytes" name="size" label="Size" />
     <Field type="ulong" contentType="bytes" name="harvested" label="Harvested" />
     <Field type="ulong" contentType="bytes" name="committed" label="Committed" />
-    <Field type="uint" name="harvestedRanges" label="Harvested Ranges" description="Number of ranges memory is harvested from" />
-    <Field type="boolean" name="multiPartition" label="Multi-Partition Allocation" />
-    <Field type="boolean" name="successful" label="Successful Allocation" />
+    <Field type="uint" name="harvestedRanges" label="Harvested Ranges" description="Number of harvested memory ranges" />
+    <Field type="boolean" name="multiPartition" label="Multi-Partition" />
+    <Field type="boolean" name="successful" label="Successful" />
     <Field type="boolean" name="nonBlocking" label="Non-Blocking" />
   </Event>
 

--- a/src/hotspot/share/jfr/metadata/metadata.xml
+++ b/src/hotspot/share/jfr/metadata/metadata.xml
@@ -1159,10 +1159,10 @@
     <Field type="ulong" contentType="bytes" name="size" label="Size" />
     <Field type="ulong" contentType="bytes" name="harvested" label="Harvested" />
     <Field type="ulong" contentType="bytes" name="committed" label="Committed" />
-    <Field type="uint" name="numHarvested" label="Number of harvested vmems" />
-    <Field type="boolean" name="multiPartition" label="Multi-partition allocation" />
-    <Field type="boolean" name="successful" label="Successful allocation" />
-    <Field type="boolean" name="nonBlocking" label="Non-blocking" />
+    <Field type="uint" name="harvestedRanges" label="Harvested Ranges" description="Number of ranges memory is harvested from" />
+    <Field type="boolean" name="multiPartition" label="Multi-Partition Allocation" />
+    <Field type="boolean" name="successful" label="Successful Allocation" />
+    <Field type="boolean" name="nonBlocking" label="Non-Blocking" />
   </Event>
 
   <Event name="ZRelocationSet" category="Java Virtual Machine, GC, Detailed" label="ZGC Relocation Set" thread="true">


### PR DESCRIPTION
Hello,

This PR fixes JFR metadata for ZPageAllocation after [JDK-8350441](https://bugs.openjdk.org/browse/JDK-8350441).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8354310](https://bugs.openjdk.org/browse/JDK-8354310): JFR: Inconsistent metadata in ZPageAllocation (**Enhancement** - P4)


### Reviewers
 * [Erik Gahlin](https://openjdk.org/census#egahlin) (@egahlin - **Reviewer**)
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**) Review applies to [a99cb2ef](https://git.openjdk.org/jdk/pull/24578/files/a99cb2ef939d942077c09336d514aa0619b48aba)
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24578/head:pull/24578` \
`$ git checkout pull/24578`

Update a local copy of the PR: \
`$ git checkout pull/24578` \
`$ git pull https://git.openjdk.org/jdk.git pull/24578/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24578`

View PR using the GUI difftool: \
`$ git pr show -t 24578`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24578.diff">https://git.openjdk.org/jdk/pull/24578.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24578#issuecomment-2794317245)
</details>
