### PR TITLE
8354317: [XWayland] Problem list two tests crashing XWayland server

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -499,6 +499,8 @@ java/awt/image/multiresolution/MultiResolutionJOptionPaneIconTest.java 8274106 m
 # Wayland related
 
 java/awt/FullScreen/SetFullScreenTest.java 8332155 linux-x64
+sun/java2d/ClassCastExceptionForInvalidSurface.java 8354097 linux-x64
+sun/java2d/GdiRendering/ClipShapeRendering.java 8354097 linux-x64
 
 ############################################################################
 


### PR DESCRIPTION
Problem list two tests crashing XWayland server
Corresponding issue [JDK-8354097](https://bugs.openjdk.org/browse/JDK-8354097)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8354317](https://bugs.openjdk.org/browse/JDK-8354317): [XWayland] Problem list two tests crashing XWayland server (**Sub-task** - P4)


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)
 * [Jayathirth D V](https://openjdk.org/census#jdv) (@jayathirthrao - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24582/head:pull/24582` \
`$ git checkout pull/24582`

Update a local copy of the PR: \
`$ git checkout pull/24582` \
`$ git pull https://git.openjdk.org/jdk.git pull/24582/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24582`

View PR using the GUI difftool: \
`$ git pr show -t 24582`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24582.diff">https://git.openjdk.org/jdk/pull/24582.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24582#issuecomment-2794484746)
</details>
