### PR TITLE
8353953: con/sun/jdi tests should be fixed to not always require includevirtualthreads=y

### DIFF
--- a/test/jdk/com/sun/jdi/EventQueueDisconnectTest.java
+++ b/test/jdk/com/sun/jdi/EventQueueDisconnectTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -62,7 +62,7 @@ public class EventQueueDisconnectTest {
     public static void main(String args[]) throws Exception {
         VMConnection connection = new VMConnection(
                                        "com.sun.jdi.CommandLineLaunch:",
-                                       VirtualMachine.TRACE_NONE);
+                                       VirtualMachine.TRACE_NONE, false);
         connection.setConnectorArg("main", "EventQueueDisconnectTarg");
         String debuggeeVMOptions = VMConnection.getDebuggeeVMOptions();
         if (!debuggeeVMOptions.equals("")) {

--- a/test/jdk/com/sun/jdi/RedefineNestmateAttr/TestNestmateAttr.java
+++ b/test/jdk/com/sun/jdi/RedefineNestmateAttr/TestNestmateAttr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/com/sun/jdi/RedefineNestmateAttr/TestNestmateAttr.java
+++ b/test/jdk/com/sun/jdi/RedefineNestmateAttr/TestNestmateAttr.java
@@ -213,6 +213,7 @@ public class TestNestmateAttr extends TestScaffold {
 
     TestNestmateAttr (String[] args) {
         super(args);
+        enableIncludeVirtualthreads(); // need to run debug agent with includevirtualthreads=y
     }
 
     public static void main(String[] args) throws Throwable {

--- a/test/jdk/com/sun/jdi/TestScaffold.java
+++ b/test/jdk/com/sun/jdi/TestScaffold.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,6 +42,9 @@ abstract public class TestScaffold extends TargetAdapter {
     private boolean redefineAsynchronously = false;
     private ReferenceType mainStartClass = null;
 
+    // Set true by tests that need the debug agent to be run with includevirtualthreads=y.
+    private boolean includeVThreads = false;
+
     ThreadReference mainThread;
     /**
      * We create a VMDeathRequest, SUSPEND_ALL, to sync the BE and FE.
@@ -82,6 +85,10 @@ abstract public class TestScaffold extends TargetAdapter {
             Thread.sleep(millis);
         } catch (InterruptedException ee) {
         }
+    }
+
+    void enableIncludeVirtualthreads() {
+        includeVThreads = true;
     }
 
     boolean getExceptionCaught() {
@@ -588,7 +595,8 @@ abstract public class TestScaffold extends TargetAdapter {
 
         argInfo.targetVMArgs = VMConnection.getDebuggeeVMOptions() + " " + argInfo.targetVMArgs;
         connection = new VMConnection(argInfo.connectorSpec,
-                                      argInfo.traceFlags);
+                                      argInfo.traceFlags,
+                                      includeVThreads);
 
         addListener(new TargetAdapter() {
                 public void eventSetComplete(EventSet set) {

--- a/test/jdk/com/sun/jdi/VMConnection.java
+++ b/test/jdk/com/sun/jdi/VMConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 22025023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/com/sun/jdi/VMConnection.java
+++ b/test/jdk/com/sun/jdi/VMConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 22025023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -123,9 +123,9 @@ class VMConnection {
         return arguments;
     }
 
-    VMConnection(String connectSpec, int traceFlags) {
+    VMConnection(String connectSpec, int traceFlags, boolean includeVThreads) {
         String nameString;
-        String argString = "includevirtualthreads=y";
+        String argString = "includevirtualthreads=" + (includeVThreads ? 'y' : 'n');
         int index = connectSpec.indexOf(':');
         if (index == -1) {
             nameString = connectSpec;


### PR DESCRIPTION
Don't use includevirtualthreads=y unless the test requires it. Debuggers don't usually use includevirtualthreads=y, so we should be doing most of our testing without it. The only reason tests use it is because some tests need it so they can find virtual threads in the debuggee by using vm.allThreads(). This change limits the use of includevirtualthreads=y to just those com/sun/jdi tests that need it.

Tested by running com/sun/jdi tests on all supported platforms in both platform threads mode and virtual threads mode. Also tested with tier1 CI.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8353953](https://bugs.openjdk.org/browse/JDK-8353953): con/sun/jdi tests should be fixed to not always require includevirtualthreads=y (**Enhancement** - P3)


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24583/head:pull/24583` \
`$ git checkout pull/24583`

Update a local copy of the PR: \
`$ git checkout pull/24583` \
`$ git pull https://git.openjdk.org/jdk.git pull/24583/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24583`

View PR using the GUI difftool: \
`$ git pr show -t 24583`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24583.diff">https://git.openjdk.org/jdk/pull/24583.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24583#issuecomment-2795055359)
</details>
