### PR TITLE
8354320: Changes to jpackage.md cause pandoc warning

### DIFF
--- a/make/autoconf/basic_tools.m4
+++ b/make/autoconf/basic_tools.m4
@@ -468,7 +468,15 @@ AC_DEFUN_ONCE([BASIC_SETUP_PANDOC],
     AC_MSG_CHECKING([if the pandoc smart extension needs to be disabled for markdown])
     if $PANDOC --list-extensions | $GREP -q '+smart'; then
       AC_MSG_RESULT([yes])
-      PANDOC_MARKDOWN_FLAG="markdown-smart"
+      PANDOC_MARKDOWN_FLAG="$PANDOC_MARKDOWN_FLAG-smart"
+    else
+      AC_MSG_RESULT([no])
+    fi
+
+    AC_MSG_CHECKING([if the pandoc tex_math_dollars extension needs to be disabled for markdown])
+    if $PANDOC --list-extensions | $GREP -q '+tex_math_dollars'; then
+      AC_MSG_RESULT([yes])
+      PANDOC_MARKDOWN_FLAG="$PANDOC_MARKDOWN_FLAG-tex_math_dollars"
     else
       AC_MSG_RESULT([no])
     fi

--- a/src/jdk.jpackage/share/man/jpackage.md
+++ b/src/jdk.jpackage/share/man/jpackage.md
@@ -236,7 +236,7 @@ The `jpackage` tool will take as input a Java application and a Java run-time im
     will be ignored, and these expandable substrings will be
     replaced by values calculated by the app launcher.
 
-    Prefix the dollar sign character with the backslash character (\)
+    Prefix the dollar sign character with the backslash character (\\)
     to prevent substring expansion.
 
 <a id="option-java-options">`--java-options` *options*</a>

--- a/src/jdk.jpackage/share/man/jpackage.md
+++ b/src/jdk.jpackage/share/man/jpackage.md
@@ -225,7 +225,7 @@ The `jpackage` tool will take as input a Java application and a Java run-time im
 
     An expandable substring should be enclosed between the dollar
     sign character ($) and the first following non-alphanumeric
-    character. Alternatively, it can be enclosed between "${" and "}"
+    character. Alternatively, it can be enclosed between "\${" and "}"
     substrings.
 
     Expandable substrings are case-sensitive on Unix and

--- a/src/jdk.jpackage/share/man/jpackage.md
+++ b/src/jdk.jpackage/share/man/jpackage.md
@@ -225,7 +225,7 @@ The `jpackage` tool will take as input a Java application and a Java run-time im
 
     An expandable substring should be enclosed between the dollar
     sign character ($) and the first following non-alphanumeric
-    character. Alternatively, it can be enclosed between "\${" and "}"
+    character. Alternatively, it can be enclosed between "${" and "}"
     substrings.
 
     Expandable substrings are case-sensitive on Unix and


### PR DESCRIPTION
Escape the dollar sign.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8354320](https://bugs.openjdk.org/browse/JDK-8354320): Changes to jpackage.md cause pandoc warning (**Bug** - P3)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**) Review applies to [6709a723](https://git.openjdk.org/jdk/pull/24585/files/6709a723d4d12977f50e85e56bdda1dd5a8544a9)
 * [Alexander Matveev](https://openjdk.org/census#almatvee) (@sashamatveev - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24585/head:pull/24585` \
`$ git checkout pull/24585`

Update a local copy of the PR: \
`$ git checkout pull/24585` \
`$ git pull https://git.openjdk.org/jdk.git pull/24585/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24585`

View PR using the GUI difftool: \
`$ git pr show -t 24585`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24585.diff">https://git.openjdk.org/jdk/pull/24585.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24585#issuecomment-2795253040)
</details>
