### PR TITLE
8354358: ZGC: ZPartition::prime handle discontiguous reservations correctly

### DIFF
--- a/src/hotspot/share/gc/z/zPageAllocator.cpp
+++ b/src/hotspot/share/gc/z/zPageAllocator.cpp
@@ -1008,7 +1008,7 @@ bool ZPartition::prime(ZWorkers* workers, size_t size) {
   // Claim virtual memory
   const size_t claimed_size = claim_virtual(size, &vmems);
 
-  // Each partition must have at least size total vmems available when priming.
+  // The partition must have size available in virtual memory when priming.
   assert(claimed_size == size, "must succeed %zx == %zx", claimed_size, size);
 
   // Increase capacity

--- a/src/hotspot/share/gc/z/zPageAllocator.cpp
+++ b/src/hotspot/share/gc/z/zPageAllocator.cpp
@@ -1003,36 +1003,43 @@ bool ZPartition::prime(ZWorkers* workers, size_t size) {
     return true;
   }
 
+  ZArray<ZVirtualMemory> vmems;
+
   // Claim virtual memory
-  const ZVirtualMemory vmem = claim_virtual(size);
+  const size_t claimed_size = claim_virtual(size, &vmems);
+
+  // Each partition must have at least size total vmems available when priming.
+  assert(claimed_size == size, "must succeed %zx == %zx", claimed_size, size);
 
   // Increase capacity
-  increase_capacity(size);
+  increase_capacity(claimed_size);
 
-  // Claim the backing physical memory
-  claim_physical(vmem);
+  for (ZVirtualMemory vmem : vmems) {
+    // Claim the backing physical memory
+    claim_physical(vmem);
 
-  // Commit the claimed physical memory
-  const size_t committed = commit_physical(vmem);
+    // Commit the claimed physical memory
+    const size_t committed = commit_physical(vmem);
 
-  if (committed != vmem.size()) {
-    // This is a failure state. We do not cleanup the maybe partially committed memory.
-    return false;
+    if (committed != vmem.size()) {
+      // This is a failure state. We do not cleanup the maybe partially committed memory.
+      return false;
+    }
+
+    map_virtual(vmem);
+
+    check_numa_mismatch(vmem, _numa_id);
+
+    if (AlwaysPreTouch) {
+      // Pre-touch memory
+      ZPreTouchTask task(vmem.start(), vmem.end());
+      workers->run_all(&task);
+    }
+
+    // We don't have to take a lock here as no other threads will access the cache
+    // until we're finished
+    _cache.insert(vmem);
   }
-
-  map_virtual(vmem);
-
-  check_numa_mismatch(vmem, _numa_id);
-
-  if (AlwaysPreTouch) {
-    // Pre-touch memory
-    ZPreTouchTask task(vmem.start(), vmem.end());
-    workers->run_all(&task);
-  }
-
-  // We don't have to take a lock here as no other threads will access the cache
-  // until we're finished
-  _cache.insert(vmem);
 
   return true;
 }

--- a/test/hotspot/jtreg/gc/z/TestZForceDiscontiguousHeapReservations.java
+++ b/test/hotspot/jtreg/gc/z/TestZForceDiscontiguousHeapReservations.java
@@ -39,12 +39,10 @@ public class TestZForceDiscontiguousHeapReservations {
     private static void testValue(int n) throws Exception  {
         /**
          *  Xmx is picked so that it is divisible by 'ZForceDiscontiguousHeapReservations * ZGranuleSize'
-         *  Xms is picked so that it is less than '16 * Xmx / ZForceDiscontiguousHeapReservations' as ZGC
-         *   cannot currently handle a discontiguous heap with an initial size larger than the individual
-         *   reservations.
+         *  Xms is picked to be the same as Xmx
          */
         final int XmxInM = 2000;
-        final int XmsInM = Math.min(16 * XmxInM / (n + 1), XmxInM);
+        final int XmsInM = XmxInM;
         OutputAnalyzer oa = ProcessTools.executeTestJava(
             "-XX:+UseZGC",
             "-Xms" + XmsInM + "M",

--- a/test/hotspot/jtreg/gc/z/TestZNMT.java
+++ b/test/hotspot/jtreg/gc/z/TestZNMT.java
@@ -63,9 +63,7 @@ public class TestZNMT {
     private static void testValue(int zForceDiscontiguousHeapReservations) throws Exception  {
         /**
          *  Xmx is picked so that it is divisible by 'ZForceDiscontiguousHeapReservations * ZGranuleSize'
-         *  Xms is picked so that it is less than '16 * Xmx / ZForceDiscontiguousHeapReservations' as ZGC
-         *   cannot currently handle a discontiguous heap with an initial size larger than the individual
-         *   reservations.
+         *  Xms is picked so that it is less than '16 * Xmx / ZForceDiscontiguousHeapReservations'
          */
         final int XmsInM = Math.min(16 * XmxInM / (zForceDiscontiguousHeapReservations + 1), XmxInM);
         OutputAnalyzer oa = ProcessTools.executeTestJava(


### PR DESCRIPTION
Prior to [JDK-8350441](https://bugs.openjdk.org/browse/JDK-8350441) the VM would not have started if we received a discontiguous heap reservation with all reservations smaller than the inital heap capacity. Now we crash because `ZPartition::prime` does not take this into account.

However in contrast to the page cache, the mapped cache makes it trivial to support this scenario. So I propose fixing `ZPartition::prime` to handle any discontiguous heap reservation.

Can be provoked in a debug build by using ZForceDiscontiguousHeapReservations > 16
`java -XX:+UseZGC -XX:ZForceDiscontiguousHeapReservations=17 -Xmx128m -Xms128m --version`

Currently running this through testing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8354358](https://bugs.openjdk.org/browse/JDK-8354358): ZGC: ZPartition::prime handle discontiguous reservations correctly (**Bug** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Joel Sikström](https://openjdk.org/census#jsikstro) (@jsikstro - Committer) Review applies to [70b0e923](https://git.openjdk.org/jdk/pull/24589/files/70b0e92346ee76fefda94f469a50cd813abdefe3)
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**) Review applies to [70b0e923](https://git.openjdk.org/jdk/pull/24589/files/70b0e92346ee76fefda94f469a50cd813abdefe3)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24589/head:pull/24589` \
`$ git checkout pull/24589`

Update a local copy of the PR: \
`$ git checkout pull/24589` \
`$ git pull https://git.openjdk.org/jdk.git pull/24589/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24589`

View PR using the GUI difftool: \
`$ git pr show -t 24589`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24589.diff">https://git.openjdk.org/jdk/pull/24589.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24589#issuecomment-2795939478)
</details>
