### PR TITLE
8354215: Clean up Loom support after 32-bit x86 removal

### DIFF
--- a/src/hotspot/cpu/x86/continuationFreezeThaw_x86.inline.hpp
+++ b/src/hotspot/cpu/x86/continuationFreezeThaw_x86.inline.hpp
@@ -261,15 +261,12 @@ template<typename FKind> frame ThawBase::new_stack_frame(const frame& hf, frame&
 }
 
 inline intptr_t* ThawBase::align(const frame& hf, intptr_t* frame_sp, frame& caller, bool bottom) {
-#ifdef _LP64
   if (((intptr_t)frame_sp & 0xf) != 0) {
     assert(caller.is_interpreted_frame() || (bottom && hf.compiled_frame_stack_argsize() % 2 != 0), "");
     frame_sp--;
     caller.set_sp(caller.sp() - 1);
   }
   assert(is_aligned(frame_sp, frame::frame_alignment), "");
-#endif
-
   return frame_sp;
 }
 

--- a/src/hotspot/cpu/x86/continuationHelper_x86.inline.hpp
+++ b/src/hotspot/cpu/x86/continuationHelper_x86.inline.hpp
@@ -55,18 +55,11 @@ static inline void patch_return_pc_with_preempt_stub(frame& f) {
 }
 
 inline int ContinuationHelper::frame_align_words(int size) {
-#ifdef _LP64
   return size & 1;
-#else
-  return 0;
-#endif
 }
 
 inline intptr_t* ContinuationHelper::frame_align_pointer(intptr_t* sp) {
-#ifdef _LP64
-  sp = align_down(sp, frame::frame_alignment);
-#endif
-  return sp;
+  return align_down(sp, frame::frame_alignment);
 }
 
 template<typename FKind>

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -3022,16 +3022,12 @@ void MacroAssembler::dec_held_monitor_count() {
 
 #ifdef ASSERT
 void MacroAssembler::stop_if_in_cont(Register cont, const char* name) {
-#ifdef _LP64
   Label no_cont;
   movptr(cont, Address(r15_thread, JavaThread::cont_entry_offset()));
   testl(cont, cont);
   jcc(Assembler::zero, no_cont);
   stop(name);
   bind(no_cont);
-#else
-  Unimplemented();
-#endif
 }
 #endif
 

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -2989,77 +2989,35 @@ void MacroAssembler::push_IU_state() {
 void MacroAssembler::push_cont_fastpath() {
   if (!Continuations::enabled()) return;
 
-#ifndef _LP64
-  Register rthread = rax;
-  Register rrealsp = rbx;
-  push(rthread);
-  push(rrealsp);
-
-  get_thread(rthread);
-
-  // The code below wants the original RSP.
-  // Move it back after the pushes above.
-  movptr(rrealsp, rsp);
-  addptr(rrealsp, 2*wordSize);
-#else
   Register rthread = r15_thread;
   Register rrealsp = rsp;
-#endif
 
   Label done;
   cmpptr(rrealsp, Address(rthread, JavaThread::cont_fastpath_offset()));
   jccb(Assembler::belowEqual, done);
   movptr(Address(rthread, JavaThread::cont_fastpath_offset()), rrealsp);
   bind(done);
-
-#ifndef _LP64
-  pop(rrealsp);
-  pop(rthread);
-#endif
 }
 
 void MacroAssembler::pop_cont_fastpath() {
   if (!Continuations::enabled()) return;
 
-#ifndef _LP64
-  Register rthread = rax;
-  Register rrealsp = rbx;
-  push(rthread);
-  push(rrealsp);
-
-  get_thread(rthread);
-
-  // The code below wants the original RSP.
-  // Move it back after the pushes above.
-  movptr(rrealsp, rsp);
-  addptr(rrealsp, 2*wordSize);
-#else
   Register rthread = r15_thread;
   Register rrealsp = rsp;
-#endif
 
   Label done;
   cmpptr(rrealsp, Address(rthread, JavaThread::cont_fastpath_offset()));
   jccb(Assembler::below, done);
   movptr(Address(rthread, JavaThread::cont_fastpath_offset()), 0);
   bind(done);
-
-#ifndef _LP64
-  pop(rrealsp);
-  pop(rthread);
-#endif
 }
 
 void MacroAssembler::inc_held_monitor_count() {
-#ifdef _LP64
   incrementq(Address(r15_thread, JavaThread::held_monitor_count_offset()));
-#endif
 }
 
 void MacroAssembler::dec_held_monitor_count() {
-#ifdef _LP64
   decrementq(Address(r15_thread, JavaThread::held_monitor_count_offset()));
-#endif
 }
 
 #ifdef ASSERT

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -2989,27 +2989,21 @@ void MacroAssembler::push_IU_state() {
 void MacroAssembler::push_cont_fastpath() {
   if (!Continuations::enabled()) return;
 
-  Register rthread = r15_thread;
-  Register rrealsp = rsp;
-
-  Label done;
-  cmpptr(rrealsp, Address(rthread, JavaThread::cont_fastpath_offset()));
-  jccb(Assembler::belowEqual, done);
-  movptr(Address(rthread, JavaThread::cont_fastpath_offset()), rrealsp);
-  bind(done);
+  Label L_done;
+  cmpptr(rsp, Address(r15_thread, JavaThread::cont_fastpath_offset()));
+  jccb(Assembler::belowEqual, L_done);
+  movptr(Address(r15_thread, JavaThread::cont_fastpath_offset()), rsp);
+  bind(L_done);
 }
 
 void MacroAssembler::pop_cont_fastpath() {
   if (!Continuations::enabled()) return;
 
-  Register rthread = r15_thread;
-  Register rrealsp = rsp;
-
-  Label done;
-  cmpptr(rrealsp, Address(rthread, JavaThread::cont_fastpath_offset()));
-  jccb(Assembler::below, done);
-  movptr(Address(rthread, JavaThread::cont_fastpath_offset()), 0);
-  bind(done);
+  Label L_done;
+  cmpptr(rsp, Address(r15_thread, JavaThread::cont_fastpath_offset()));
+  jccb(Assembler::below, L_done);
+  movptr(Address(r15_thread, JavaThread::cont_fastpath_offset()), 0);
+  bind(L_done);
 }
 
 void MacroAssembler::inc_held_monitor_count() {


### PR DESCRIPTION
Small cleanup, we do not need this code anymore. This effectively reverts [JDK-8288040](https://bugs.openjdk.org/browse/JDK-8288040).

Additional testing:
 - [x] GHA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8354215](https://bugs.openjdk.org/browse/JDK-8354215): Clean up Loom support after 32-bit x86 removal (**Sub-task** - P4)


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)
 * [Patricio Chilano Mateo](https://openjdk.org/census#pchilanomate) (@pchilano - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24591/head:pull/24591` \
`$ git checkout pull/24591`

Update a local copy of the PR: \
`$ git checkout pull/24591` \
`$ git pull https://git.openjdk.org/jdk.git pull/24591/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24591`

View PR using the GUI difftool: \
`$ git pr show -t 24591`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24591.diff">https://git.openjdk.org/jdk/pull/24591.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24591#issuecomment-2796228721)
</details>
