### PR TITLE
8354362: Use automatic indentation in CollectedHeap printing

### DIFF
--- a/src/hotspot/share/gc/epsilon/epsilonHeap.cpp
+++ b/src/hotspot/share/gc/epsilon/epsilonHeap.cpp
@@ -37,6 +37,7 @@
 #include "memory/universe.hpp"
 #include "runtime/atomic.hpp"
 #include "runtime/globals.hpp"
+#include "utilities/ostream.hpp"
 
 jint EpsilonHeap::initialize() {
   size_t align = HeapAlignment;
@@ -300,24 +301,19 @@ void EpsilonHeap::object_iterate(ObjectClosure *cl) {
 void EpsilonHeap::print_on(outputStream *st) const {
   st->print_cr("Epsilon Heap");
 
+  StreamAutoIndentor indentor(st, 1);
+
   _virtual_space.print_on(st);
 
   if (_space != nullptr) {
     st->print_cr("Allocation space:");
+
+    StreamAutoIndentor indentor(st, 1);
     _space->print_on(st);
   }
-
-  MetaspaceUtils::print_on(st);
 }
 
 void EpsilonHeap::print_on_error(outputStream *st) const {
-  print_on(st);
-  st->cr();
-
-  BarrierSet* bs = BarrierSet::barrier_set();
-  if (bs != nullptr) {
-    bs->print_on(st);
-  }
 }
 
 bool EpsilonHeap::print_location(outputStream* st, void* addr) const {

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -2114,14 +2114,16 @@ void G1CollectedHeap::print_heap_regions() const {
 
 void G1CollectedHeap::print_on(outputStream* st) const {
   size_t heap_used = Heap_lock->owned_by_self() ? used() : used_unlocked();
-  st->print(" %-20s", "garbage-first heap");
+  st->print("%-20s", "garbage-first heap");
   st->print(" total reserved %zuK, committed %zuK, used %zuK",
             _hrm.reserved().byte_size()/K, capacity()/K, heap_used/K);
   st->print(" [" PTR_FORMAT ", " PTR_FORMAT ")",
             p2i(_hrm.reserved().start()),
             p2i(_hrm.reserved().end()));
   st->cr();
-  st->print("  region size %zuK, ", G1HeapRegion::GrainBytes / K);
+
+  StreamAutoIndentor indentor(st, 1);
+  st->print("region size %zuK, ", G1HeapRegion::GrainBytes / K);
   uint young_regions = young_regions_count();
   st->print("%u young (%zuK), ", young_regions,
             (size_t) young_regions * G1HeapRegion::GrainBytes / K);
@@ -2131,7 +2133,7 @@ void G1CollectedHeap::print_on(outputStream* st) const {
   st->cr();
   if (_numa->is_enabled()) {
     uint num_nodes = _numa->num_active_nodes();
-    st->print("  remaining free region(s) on each NUMA node: ");
+    st->print("remaining free region(s) on each NUMA node: ");
     const uint* node_ids = _numa->node_ids();
     for (uint node_index = 0; node_index < num_nodes; node_index++) {
       uint num_free_regions = _hrm.num_free_regions(node_index);
@@ -2139,7 +2141,6 @@ void G1CollectedHeap::print_on(outputStream* st) const {
     }
     st->cr();
   }
-  MetaspaceUtils::print_on(st);
 }
 
 void G1CollectedHeap::print_regions_on(outputStream* st) const {
@@ -2161,7 +2162,8 @@ void G1CollectedHeap::print_extended_on(outputStream* st) const {
 }
 
 void G1CollectedHeap::print_on_error(outputStream* st) const {
-  print_extended_on(st);
+  // Print the per-region information.
+  print_regions_on(st);
   st->cr();
 
   BarrierSet* bs = BarrierSet::barrier_set();

--- a/src/hotspot/share/gc/parallel/mutableSpace.cpp
+++ b/src/hotspot/share/gc/parallel/mutableSpace.cpp
@@ -232,7 +232,7 @@ void MutableSpace::object_iterate(ObjectClosure* cl) {
 
 void MutableSpace::print_short() const { print_short_on(tty); }
 void MutableSpace::print_short_on( outputStream* st) const {
-  st->print(" space %zuK, %d%% used", capacity_in_bytes() / K,
+  st->print("space %zuK, %d%% used", capacity_in_bytes() / K,
             (int) ((double) used_in_bytes() * 100 / capacity_in_bytes()));
 }
 

--- a/src/hotspot/share/gc/parallel/parMarkBitMap.hpp
+++ b/src/hotspot/share/gc/parallel/parMarkBitMap.hpp
@@ -60,7 +60,9 @@ public:
 
   void print_on_error(outputStream* st) const {
     st->print_cr("Marking Bits: (ParMarkBitMap*) " PTR_FORMAT, p2i(this));
-    _beg_bits.print_on_error(st, " Begin Bits: ");
+
+    StreamAutoIndentor indentor(st, 1);
+    _beg_bits.print_on_error(st, "Begin Bits: ");
   }
 
 #ifdef  ASSERT

--- a/src/hotspot/share/gc/parallel/parallelScavengeHeap.cpp
+++ b/src/hotspot/share/gc/parallel/parallelScavengeHeap.cpp
@@ -669,19 +669,15 @@ void ParallelScavengeHeap::print_on(outputStream* st) const {
   if (old_gen() != nullptr) {
     old_gen()->print_on(st);
   }
-  MetaspaceUtils::print_on(st);
 }
 
 void ParallelScavengeHeap::print_on_error(outputStream* st) const {
-  print_on(st);
-  st->cr();
-
   BarrierSet* bs = BarrierSet::barrier_set();
   if (bs != nullptr) {
     bs->print_on(st);
   }
-
   st->cr();
+
   PSParallelCompact::print_on_error(st);
 }
 

--- a/src/hotspot/share/gc/parallel/psOldGen.cpp
+++ b/src/hotspot/share/gc/parallel/psOldGen.cpp
@@ -358,15 +358,13 @@ void PSOldGen::post_resize() {
 
 void PSOldGen::print() const { print_on(tty);}
 void PSOldGen::print_on(outputStream* st) const {
-  st->print(" %-15s", name());
-  st->print(" total %zuK, used %zuK",
+  st->print("%-15s", name());
+  st->print(" total %zuK, used %zuK ",
               capacity_in_bytes()/K, used_in_bytes()/K);
-  st->print_cr(" [" PTR_FORMAT ", " PTR_FORMAT ", " PTR_FORMAT ")",
-                p2i(virtual_space()->low_boundary()),
-                p2i(virtual_space()->high()),
-                p2i(virtual_space()->high_boundary()));
+  virtual_space()->print_space_boundaries_on(st);
 
-  st->print("  object"); object_space()->print_on(st);
+  StreamAutoIndentor indentor(st, 1);
+  st->print("object "); object_space()->print_on(st);
 }
 
 void PSOldGen::update_counters() {

--- a/src/hotspot/share/gc/parallel/psVirtualspace.cpp
+++ b/src/hotspot/share/gc/parallel/psVirtualspace.cpp
@@ -124,6 +124,6 @@ void PSVirtualSpace::verify() const {
 #endif // #ifndef PRODUCT
 
 void PSVirtualSpace::print_space_boundaries_on(outputStream* st) const {
-  st->print_cr(" [" PTR_FORMAT ", " PTR_FORMAT ", " PTR_FORMAT ")",
+  st->print_cr("[" PTR_FORMAT ", " PTR_FORMAT ", " PTR_FORMAT ")",
                p2i(low_boundary()), p2i(high()), p2i(high_boundary()));
 }

--- a/src/hotspot/share/gc/parallel/psYoungGen.cpp
+++ b/src/hotspot/share/gc/parallel/psYoungGen.cpp
@@ -700,13 +700,15 @@ void PSYoungGen::object_iterate(ObjectClosure* blk) {
 
 void PSYoungGen::print() const { print_on(tty); }
 void PSYoungGen::print_on(outputStream* st) const {
-  st->print(" %-15s", "PSYoungGen");
-  st->print(" total %zuK, used %zuK",
+  st->print("%-15s", name());
+  st->print(" total %zuK, used %zuK ",
              capacity_in_bytes()/K, used_in_bytes()/K);
   virtual_space()->print_space_boundaries_on(st);
-  st->print("  eden"); eden_space()->print_on(st);
-  st->print("  from"); from_space()->print_on(st);
-  st->print("  to  "); to_space()->print_on(st);
+
+  StreamAutoIndentor indentor(st, 1);
+  st->print("eden "); eden_space()->print_on(st);
+  st->print("from "); from_space()->print_on(st);
+  st->print("to   "); to_space()->print_on(st);
 }
 
 size_t PSYoungGen::available_to_min_gen() {

--- a/src/hotspot/share/gc/serial/defNewGeneration.cpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.cpp
@@ -825,21 +825,16 @@ void DefNewGeneration::verify() {
 }
 
 void DefNewGeneration::print_on(outputStream* st) const {
-  st->print(" %-10s", name());
+  st->print("%-10s", name());
 
-  st->print(" total %zuK, used %zuK",
+  st->print(" total %zuK, used %zuK ",
             capacity()/K, used()/K);
-  st->print_cr(" [" PTR_FORMAT ", " PTR_FORMAT ", " PTR_FORMAT ")",
-               p2i(_virtual_space.low_boundary()),
-               p2i(_virtual_space.high()),
-               p2i(_virtual_space.high_boundary()));
+  _virtual_space.print_space_boundaries_on(st);
 
-  st->print("  eden");
-  eden()->print_on(st);
-  st->print("  from");
-  from()->print_on(st);
-  st->print("  to  ");
-  to()->print_on(st);
+  StreamAutoIndentor indentor(st, 1);
+  st->print("eden "); eden()->print_on(st);
+  st->print("from "); from()->print_on(st);
+  st->print("to   "); to()->print_on(st);
 }
 
 HeapWord* DefNewGeneration::allocate(size_t word_size) {

--- a/src/hotspot/share/gc/serial/serialHeap.cpp
+++ b/src/hotspot/share/gc/serial/serialHeap.cpp
@@ -806,14 +806,9 @@ void SerialHeap::print_on(outputStream* st) const {
 
   _young_gen->print_on(st);
   _old_gen->print_on(st);
-
-  MetaspaceUtils::print_on(st);
 }
 
 void SerialHeap::print_on_error(outputStream* st) const {
-  print_on(st);
-  st->cr();
-
   BarrierSet* bs = BarrierSet::barrier_set();
   if (bs != nullptr) {
     bs->print_on(st);

--- a/src/hotspot/share/gc/serial/tenuredGeneration.cpp
+++ b/src/hotspot/share/gc/serial/tenuredGeneration.cpp
@@ -439,15 +439,12 @@ void TenuredGeneration::verify() {
 }
 
 void TenuredGeneration::print_on(outputStream* st)  const {
-  st->print(" %-10s", name());
+  st->print("%-10s", name());
 
-  st->print(" total %zuK, used %zuK",
+  st->print(" total %zuK, used %zuK ",
             capacity()/K, used()/K);
-  st->print_cr(" [" PTR_FORMAT ", " PTR_FORMAT ", " PTR_FORMAT ")",
-               p2i(_virtual_space.low_boundary()),
-               p2i(_virtual_space.high()),
-               p2i(_virtual_space.high_boundary()));
+  _virtual_space.print_space_boundaries_on(st);
 
-  st->print("   the");
-  _the_space->print_on(st);
+  StreamAutoIndentor indentor(st, 1);
+  st->print("the  "); _the_space->print_on(st);
 }

--- a/src/hotspot/share/gc/shared/collectedHeap.cpp
+++ b/src/hotspot/share/gc/shared/collectedHeap.cpp
@@ -59,6 +59,7 @@
 #include "utilities/align.hpp"
 #include "utilities/copy.hpp"
 #include "utilities/events.hpp"
+#include "utilities/ostream.hpp"
 
 class ClassLoaderData;
 
@@ -111,7 +112,12 @@ void GCHeapLog::log_heap(CollectedHeap* heap, bool before) {
                  heap->total_collections(),
                  heap->total_full_collections());
 
-  heap->print_on(&st);
+  {
+    StreamAutoIndentor indentor(&st, 1);
+    heap->print_on(&st);
+    MetaspaceUtils::print_on(&st);
+  }
+
   st.print_cr("}");
 }
 
@@ -164,7 +170,10 @@ void CollectedHeap::print_heap_before_gc() {
     LogStream ls(lt);
     ls.print_cr("Heap before GC invocations=%u (full %u):", total_collections(), total_full_collections());
     ResourceMark rm;
+
+    StreamAutoIndentor indentor(&ls, 1);
     print_on(&ls);
+    MetaspaceUtils::print_on(&ls);
   }
 
   if (_gc_heap_log != nullptr) {
@@ -178,7 +187,10 @@ void CollectedHeap::print_heap_after_gc() {
     LogStream ls(lt);
     ls.print_cr("Heap after GC invocations=%u (full %u):", total_collections(), total_full_collections());
     ResourceMark rm;
+
+    StreamAutoIndentor indentor(&ls, 1);
     print_on(&ls);
+    MetaspaceUtils::print_on(&ls);
   }
 
   if (_gc_heap_log != nullptr) {

--- a/src/hotspot/share/gc/shared/space.cpp
+++ b/src/hotspot/share/gc/shared/space.cpp
@@ -79,7 +79,7 @@ void ContiguousSpace::mangle_unused_area(MemRegion mr) {
 void ContiguousSpace::print() const { print_on(tty); }
 
 void ContiguousSpace::print_on(outputStream* st) const {
-  st->print_cr(" space %zuK, %3d%% used [" PTR_FORMAT ", " PTR_FORMAT ", " PTR_FORMAT ")",
+  st->print_cr("space %zuK, %3d%% used [" PTR_FORMAT ", " PTR_FORMAT ", " PTR_FORMAT ")",
                capacity() / K, (int) ((double) used() * 100 / capacity()),
                p2i(bottom()), p2i(top()), p2i(end()));
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -639,7 +639,6 @@ void ShenandoahHeap::print_on(outputStream* st) const {
   }
 
   st->cr();
-  MetaspaceUtils::print_on(st);
 
   if (Verbose) {
     st->cr();
@@ -648,8 +647,6 @@ void ShenandoahHeap::print_on(outputStream* st) const {
 }
 
 void ShenandoahHeap::print_on_error(outputStream* st) const {
-  print_on(st);
-  st->cr();
   print_heap_regions_on(st);
 }
 

--- a/src/hotspot/share/gc/z/zCollectedHeap.cpp
+++ b/src/hotspot/share/gc/z/zCollectedHeap.cpp
@@ -356,14 +356,10 @@ void ZCollectedHeap::prepare_for_verify() {
 }
 
 void ZCollectedHeap::print_on(outputStream* st) const {
-  StreamAutoIndentor auto_indentor(st);
-
   _heap.print_on(st);
 }
 
 void ZCollectedHeap::print_on_error(outputStream* st) const {
-  StreamAutoIndentor auto_indentor(st);
-
   _heap.print_on_error(st);
 }
 

--- a/src/hotspot/share/gc/z/zHeap.cpp
+++ b/src/hotspot/share/gc/z/zHeap.cpp
@@ -315,32 +315,17 @@ ZServiceabilityCounters* ZHeap::serviceability_counters() {
 }
 
 void ZHeap::print_on(outputStream* st) const {
-  streamIndentor indentor(st, 1);
   _page_allocator.print_on(st);
-
-  // Metaspace printing prepends spaces instead of using outputStream indentation
-  streamIndentor indentor_back(st, -1);
-  MetaspaceUtils::print_on(st);
 }
 
 void ZHeap::print_on_error(outputStream* st) const {
-  {
-    streamIndentor indentor(st, 1);
-    _page_allocator.print_on_error(st);
-
-    // Metaspace printing prepends spaces instead of using outputStream indentation
-    streamIndentor indentor_back(st, -1);
-    MetaspaceUtils::print_on(st);
-  }
-  st->cr();
-
   print_globals_on(st);
   st->cr();
 
   print_page_table_on(st);
   st->cr();
 
-  _page_allocator.print_extended_on_error(st);
+  _page_allocator.print_on_error(st);
 }
 
 void ZHeap::print_globals_on(outputStream* st) const {
@@ -373,12 +358,12 @@ void ZHeap::print_page_table_on(outputStream* st) const {
 
   // Print all pages
   st->print_cr("ZGC Page Table:");
-  {
-    streamIndentor indentor(st, 1);
-    ZPageTableIterator iter(&_page_table);
-    for (ZPage* page; iter.next(&page);) {
-      page->print_on(st);
-    }
+
+  StreamAutoIndentor indentor(st, 1);
+
+  ZPageTableIterator iter(&_page_table);
+  for (ZPage* page; iter.next(&page);) {
+    page->print_on(st);
   }
 
   // Allow pages to be deleted

--- a/src/hotspot/share/gc/z/zMappedCache.cpp
+++ b/src/hotspot/share/gc/z/zMappedCache.cpp
@@ -30,6 +30,7 @@
 #include "utilities/align.hpp"
 #include "utilities/debug.hpp"
 #include "utilities/globalDefinitions.hpp"
+#include "utilities/ostream.hpp"
 #include "utilities/powerOfTwo.hpp"
 
 class ZMappedCacheEntry {
@@ -591,7 +592,7 @@ void ZMappedCache::print_on(outputStream* st) const {
   }
 
   // Print information on size classes
-  streamIndentor indentor(st, 1);
+  StreamAutoIndentor indentor(st, 1);
 
   st->print("size classes");
   st->fill_to(17);

--- a/src/hotspot/share/gc/z/zPageAllocator.cpp
+++ b/src/hotspot/share/gc/z/zPageAllocator.cpp
@@ -1153,7 +1153,7 @@ void ZPartition::print_on(outputStream* st) const {
   st->print_cr("used %zuM, capacity %zuM, max capacity %zuM",
                _used / M, _capacity / M, _max_capacity / M);
 
-  streamIndentor indentor(st, 1);
+  StreamAutoIndentor indentor(st, 1);
   print_cache_on(st);
 }
 
@@ -1164,8 +1164,7 @@ void ZPartition::print_cache_on(outputStream* st) const {
 void ZPartition::print_extended_on_error(outputStream* st) const {
   st->print_cr("Partition %u", _numa_id);
 
-  streamIndentor indentor(st, 1);
-
+  StreamAutoIndentor indentor(st, 1);
   _cache.print_extended_on(st);
 }
 
@@ -2384,11 +2383,6 @@ void ZPageAllocator::threads_do(ThreadClosure* tc) const {
   }
 }
 
-void ZPageAllocator::print_on(outputStream* st) const {
-  ZLocker<ZLock> lock(&_lock);
-  print_on_inner(st);
-}
-
 static bool try_lock_on_error(ZLock* lock) {
   if (VMError::is_error_reported() && VMError::is_error_reported_in_current_thread()) {
     return lock->try_lock();
@@ -2399,10 +2393,52 @@ static bool try_lock_on_error(ZLock* lock) {
   return true;
 }
 
-void ZPageAllocator::print_extended_on_error(outputStream* st) const {
+void ZPageAllocator::print_on(outputStream* st) const {
+  const bool locked = try_lock_on_error(&_lock);
+
+  if (!locked) {
+    st->print_cr("<Without lock>");
+  }
+
+  // Print information even though we may not have successfully taken the lock.
+  // This is thread-safe, but may produce inconsistent results.
+
+  print_heap_info_on(st);
+
+  StreamAutoIndentor indentor(st, 1);
+  print_partition_info_on(st);
+
+  if (locked) {
+    _lock.unlock();
+  }
+}
+
+void ZPageAllocator::print_heap_info_on(outputStream* st) const {
+  // Print total usage
+  st->print("ZHeap");
+  st->fill_to(17);
+  st->print_cr("used %zuM, capacity %zuM, max capacity %zuM",
+               used() / M, capacity() / M, max_capacity() / M);
+}
+
+void ZPageAllocator::print_partition_info_on(outputStream* st) const {
+  if (_partitions.count() == 1) {
+    // The summary printing is redundant if we only have one partition
+    _partitions.get(0).print_cache_on(st);
+    return;
+  }
+
+  // Print all partitions
+  ZPartitionConstIterator iter = partition_iterator();
+  for (const ZPartition* partition; iter.next(&partition);) {
+    partition->print_on(st);
+  }
+}
+
+void ZPageAllocator::print_on_error(outputStream* st) const {
   st->print_cr("ZMappedCache:");
 
-  streamIndentor indentor(st, 1);
+  StreamAutoIndentor indentor(st, 1);
 
   if (!try_lock_on_error(&_lock)) {
     // We can't print without taking the lock since printing the contents of
@@ -2420,43 +2456,4 @@ void ZPageAllocator::print_extended_on_error(outputStream* st) const {
   }
 
   _lock.unlock();
-}
-
-void ZPageAllocator::print_on_error(outputStream* st) const {
-  const bool locked = try_lock_on_error(&_lock);
-
-  if (!locked) {
-    st->print_cr("<Without lock>");
-  }
-
-  // Print information even though we have not successfully taken the lock.
-  // This is thread-safe, but may produce inconsistent results.
-  print_on_inner(st);
-
-  if (locked) {
-    _lock.unlock();
-  }
-}
-
-void ZPageAllocator::print_on_inner(outputStream* st) const {
-  // Print total usage
-  st->print("ZHeap");
-  st->fill_to(17);
-  st->print_cr("used %zuM, capacity %zuM, max capacity %zuM",
-               used() / M, capacity() / M, max_capacity() / M);
-
-  // Print per-partition
-
-  streamIndentor indentor(st, 1);
-
-  if (_partitions.count() == 1) {
-    // The summary printing is redundant if we only have one partition
-    _partitions.get(0).print_cache_on(st);
-    return;
-  }
-
-  ZPartitionConstIterator iter = partition_iterator();
-  for (const ZPartition* partition; iter.next(&partition);) {
-    partition->print_on(st);
-  }
 }

--- a/src/hotspot/share/gc/z/zPageAllocator.hpp
+++ b/src/hotspot/share/gc/z/zPageAllocator.hpp
@@ -235,8 +235,6 @@ private:
   void notify_out_of_memory();
   void restart_gc() const;
 
-  void print_on_inner(outputStream* st) const;
-
 public:
   ZPageAllocator(size_t min_capacity,
                  size_t initial_capacity,
@@ -284,7 +282,8 @@ public:
   void threads_do(ThreadClosure* tc) const;
 
   void print_on(outputStream* st) const;
-  void print_extended_on_error(outputStream* st) const;
+  void print_heap_info_on(outputStream* st) const;
+  void print_partition_info_on(outputStream* st) const;
   void print_on_error(outputStream* st) const;
 };
 

--- a/src/hotspot/share/memory/metaspace.cpp
+++ b/src/hotspot/share/memory/metaspace.cpp
@@ -63,6 +63,7 @@
 #include "utilities/debug.hpp"
 #include "utilities/formatBuffer.hpp"
 #include "utilities/globalDefinitions.hpp"
+#include "utilities/ostream.hpp"
 
 using metaspace::ChunkManager;
 using metaspace::CommitLimiter;
@@ -214,10 +215,11 @@ void MetaspaceUtils::print_report(outputStream* out, size_t scale) {
 
 void MetaspaceUtils::print_on(outputStream* out) {
 
-  // Used from all GCs. It first prints out totals, then, separately, the class space portion.
+  // First prints out totals, then, separately, the class space portion.
   MetaspaceCombinedStats stats = get_combined_statistics();
-  out->print_cr(" Metaspace       "
-                "used %zuK, "
+  out->print("Metaspace");
+  out->fill_to(17);
+  out->print_cr("used %zuK, "
                 "committed %zuK, "
                 "reserved %zuK",
                 stats.used()/K,
@@ -225,8 +227,10 @@ void MetaspaceUtils::print_on(outputStream* out) {
                 stats.reserved()/K);
 
   if (Metaspace::using_class_space()) {
-    out->print_cr("  class space    "
-                  "used %zuK, "
+    StreamAutoIndentor indentor(out, 1);
+    out->print("class space");
+    out->fill_to(17);
+    out->print_cr("used %zuK, "
                   "committed %zuK, "
                   "reserved %zuK",
                   stats.class_space_stats().used()/K,

--- a/src/hotspot/share/memory/universe.cpp
+++ b/src/hotspot/share/memory/universe.cpp
@@ -1159,7 +1159,10 @@ void Universe::compute_base_vtable_size() {
 void Universe::print_on(outputStream* st) {
   GCMutexLocker hl(Heap_lock); // Heap_lock might be locked by caller thread.
   st->print_cr("Heap");
+
+  StreamAutoIndentor indentor(st, 1);
   heap()->print_on(st);
+  MetaspaceUtils::print_on(st);
 }
 
 void Universe::print_heap_at_SIGBREAK() {

--- a/src/hotspot/share/memory/virtualspace.cpp
+++ b/src/hotspot/share/memory/virtualspace.cpp
@@ -422,13 +422,15 @@ void VirtualSpace::check_for_contiguity() {
 }
 
 void VirtualSpace::print_on(outputStream* out) const {
-  out->print   ("Virtual space:");
+  out->print("Virtual space:");
   if (special()) out->print(" (pinned in memory)");
   out->cr();
-  out->print_cr(" - committed: %zu", committed_size());
-  out->print_cr(" - reserved:  %zu", reserved_size());
-  out->print_cr(" - [low, high]:     [" PTR_FORMAT ", " PTR_FORMAT "]",  p2i(low()), p2i(high()));
-  out->print_cr(" - [low_b, high_b]: [" PTR_FORMAT ", " PTR_FORMAT "]",  p2i(low_boundary()), p2i(high_boundary()));
+
+  StreamAutoIndentor indentor(out, 1);
+  out->print_cr("- committed: %zu", committed_size());
+  out->print_cr("- reserved:  %zu", reserved_size());
+  out->print_cr("- [low, high]:     [" PTR_FORMAT ", " PTR_FORMAT "]",  p2i(low()), p2i(high()));
+  out->print_cr("- [low_b, high_b]: [" PTR_FORMAT ", " PTR_FORMAT "]",  p2i(low_boundary()), p2i(high_boundary()));
 }
 
 void VirtualSpace::print() const {
@@ -436,3 +438,8 @@ void VirtualSpace::print() const {
 }
 
 #endif
+
+void VirtualSpace::print_space_boundaries_on(outputStream* out) const {
+  out->print_cr("[" PTR_FORMAT ", " PTR_FORMAT ", " PTR_FORMAT ")",
+                p2i(low_boundary()), p2i(high()), p2i(high_boundary()));
+}

--- a/src/hotspot/share/memory/virtualspace.hpp
+++ b/src/hotspot/share/memory/virtualspace.hpp
@@ -124,6 +124,8 @@ class VirtualSpace {
   // Debugging
   void print_on(outputStream* out) const PRODUCT_RETURN;
   void print() const;
+
+  void print_space_boundaries_on(outputStream* out) const;
 };
 
 #endif // SHARE_MEMORY_VIRTUALSPACE_HPP

--- a/src/hotspot/share/services/diagnosticCommand.cpp
+++ b/src/hotspot/share/services/diagnosticCommand.cpp
@@ -37,6 +37,7 @@
 #include "compiler/directivesParser.hpp"
 #include "gc/shared/gcVMOperations.hpp"
 #include "jvm.h"
+#include "memory/metaspaceUtils.hpp"
 #include "memory/metaspace/metaspaceDCmd.hpp"
 #include "memory/resourceArea.hpp"
 #include "memory/universe.hpp"
@@ -412,6 +413,7 @@ void RunFinalizationDCmd::execute(DCmdSource source, TRAPS) {
 void HeapInfoDCmd::execute(DCmdSource source, TRAPS) {
   MutexLocker hl(THREAD, Heap_lock);
   Universe::heap()->print_on(output());
+  MetaspaceUtils::print_on(output());
 }
 
 void FinalizerInfoDCmd::execute(DCmdSource source, TRAPS) {

--- a/src/hotspot/share/utilities/ostream.hpp
+++ b/src/hotspot/share/utilities/ostream.hpp
@@ -176,6 +176,7 @@ class outputStream : public CHeapObjBase {
 extern outputStream* tty;           // tty output
 
 class streamIndentor : public StackObj {
+protected:
   outputStream* const _str;
   const int _amount;
   NONCOPYABLE(streamIndentor);
@@ -186,14 +187,13 @@ public:
   ~streamIndentor() { _str->dec(_amount); }
 };
 
-class StreamAutoIndentor : public StackObj {
-  outputStream* const _os;
+class StreamAutoIndentor : public streamIndentor {
   const bool _old;
   NONCOPYABLE(StreamAutoIndentor);
  public:
-  StreamAutoIndentor(outputStream* os) :
-    _os(os), _old(os->set_autoindent(true)) {}
-  ~StreamAutoIndentor() { _os->set_autoindent(_old); }
+  StreamAutoIndentor(outputStream* os, int indentation = 0) :
+    streamIndentor(os, indentation), _old(os->set_autoindent(true)) {}
+  ~StreamAutoIndentor() { _str->set_autoindent(_old); }
 };
 
 // advisory locking for the shared tty stream:

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -1199,7 +1199,13 @@ void VMError::report(outputStream* st, bool _verbose) {
     GCLogPrecious::print_on_error(st);
 
     if (Universe::heap() != nullptr) {
-      st->print_cr("Heap:");
+      {
+        st->print_cr("Heap:");
+        StreamAutoIndentor indentor(st, 1);
+        Universe::heap()->print_on(st);
+        MetaspaceUtils::print_on(st);
+        st->cr();
+      }
       Universe::heap()->print_on_error(st);
       st->cr();
     }
@@ -1383,7 +1389,13 @@ void VMError::print_vm_info(outputStream* st) {
   if (Universe::is_fully_initialized()) {
     MutexLocker hl(Heap_lock);
     GCLogPrecious::print_on_error(st);
-    st->print_cr("Heap:");
+    {
+      st->print_cr("Heap:");
+      StreamAutoIndentor indentor(st, 1);
+      Universe::heap()->print_on(st);
+      MetaspaceUtils::print_on(st);
+      st->cr();
+    }
     Universe::heap()->print_on_error(st);
     st->cr();
     st->print_cr("Polling page: " PTR_FORMAT, p2i(SafepointMechanism::get_polling_page()));


### PR DESCRIPTION
Hello,

> This PR only focuses on fixing indentation and re-arranging some callsites. It does *not* change the contents of any output, apart from some (IMO relevant) indentation/whitespace additions.

Currently, the CollectedHeap printing code (print_on and print_on_error, with calls "below") prepends spaces in messages in a way that only makes sense if you write the code and then check the output to see if you've done everything correctly. To make writing and maintaining printing code easy, I propose we move to a system where each printing method, starting at callers of print_on and print_on_error, uses the indentation API in outputStream and does not rely on prepending spaces like is done right now.

What I propose is that any (GC) printing method should not make any assumptions of the indentation level of its caller(s). This means that each function shall:
1. Not prepend any spaces to its printing, and instead expect that the caller(s) should handle any indentation before calling this function.
2. Enforce its own indentation, by enabling auto indentation in its own context and for its "lower level" calls (which is often the desired outcome).

Combining these two rules means that *any* (GC) printing method can be called from anywhere and give sensible output, without (seemingly random) indentation of expectations elsewhere.

I have aggregated calls that print on the same indentation level to the same callsite. This makes it clear where to look in the code and also makes it easier to add/enforce indendation. To this end, I have re-arranged print_on_error so that it never includes print_on. The new system I propose is that print_on and print_on_error can be called separately for different information, which aligns well with having the same callsite for the same indentation. See changes in vmError.cpp for how this is implemented.

Instead of prepending spaces, I use StreamAutoIndentor, defined in ostream.hpp. To make using automatic indentation easier, I've made some changes to StreamAutoIndentor so that it inherits from streamIndentor and also add an *optional* argument to StreamAutoIndentor to apply an indentation. My reasoning for this is that most places that use streamIndentor also want to use StreamAutoIndentor (either immediately or some time before) so that it is automatically applied. A downside of this change is that any previous uses of StreamAutoIndentor now also needs to store an extra int worth of memory. To me, this is a trade-off worth making, considering that memory for buffers of strings usually outweigh this extra memory cost. Additionally, when factoring in the improved code understandability and maintainability, I feel like it's a change worth making.

Some new changes in the way the printing looks are:
* Epsilon has received indentation in its print_on, which was not there before, in an effort to look similar to other GCs and also improve readability.
* Shenandoah has also received indentation to behave similar to other GCs.
* "the space" in Serial's output was indented by two spaces, now it's one.
* With the removal of print_on from print_on_error, I've also removed Epsilon's barrier set printing, making it's print_on_error empty. Before this, Serial printed two spaces between the sections in the hs_err file.

Code re-structure:
* PSOldGen::print_on had an inlined version of virtual_space()->print_space_boundaries_on(st), which is now called instead.
* PSYoungGen::print_on had its name inlined. Now, name() is called instead, which is how PSOldGen::print_on does it.
* I've added a common print_space_boundaries_on for the virtual space used in Serial's DefNewGeneration and TenuredGeneration, like how Parallel does it.
* I've opted to use fill_to() in Metaspace printing so that it works well with ZGC printing. This does not really affect other GCs since only ZGC aligns with the same column as Metaspace.

Testing:
* GHA, Oracle's tier 1-3
* Manual inspection of printed content 
  * Exit printing `-Xlog:gc+heap+exit=info`
  * Periodic printing `-Xlog:gc+heap=debug`
  * jcmd `jcmd <pid> GC.heap_info`
  * jcmd `jcmd <pid> VM.info`
  * hs_err file, both "Heap:" and "Heap before/after invocations=" printing, `-XX:ErrorHandlerTest=14`