### PR TITLE
JDK-8354426: [ubsan] applying non-zero offset 34359738368 to null pointer in CompressedKlassPointers::encoding_range_end

### DIFF
--- a/src/hotspot/share/oops/compressedKlass.inline.hpp
+++ b/src/hotspot/share/oops/compressedKlass.inline.hpp
@@ -95,7 +95,7 @@ inline void CompressedKlassPointers::check_valid_narrow_klass_id(narrowKlass nk)
 
 inline address CompressedKlassPointers::encoding_range_end() {
   const int max_bits = narrow_klass_pointer_bits() + _shift;
-  return _base + nth_bit(max_bits);
+  return (address)((uintptr_t)_base + nth_bit(max_bits));
 }
 
 #endif // SHARE_OOPS_COMPRESSEDKLASS_INLINE_HPP


### PR DESCRIPTION
When running with ubsan enabled binaries on AIX, the HS jtreg test gc/epsilon/TestClasses (and some other tests too) show the following issue :

```
/srcdir/jdk/src/hotspot/share/oops/compressedKlass.inline.hpp:98:16: runtime error: applying non-zero offset 34359738368 to null pointer
    #0 0x90000001185d7ec in CompressedKlassPointers::encoding_range_end() make/hotspot/src/hotspot/share/oops/compressedKlass.inline.hpp:98
    #1 0x90000001185d7ec in CompressedKlassPointers::print_mode(outputStream*) make/hotspot/src/hotspot/share/oops/compressedKlass.cpp:299
    #2 0x900000012b6eb90 in Metaspace::global_initialize() make/hotspot/src/hotspot/share/memory/metaspace.cpp:847
    #3 0x900000012b6d7d8 in universe_init() make/hotspot/src/hotspot/share/memory/universe.cpp:887
    #4 0x900000012c3aa58 in init_globals() make/hotspot/src/hotspot/share/runtime/init.cpp:132
    #5 0x900000012c6af7c in Threads::create_vm(JavaVMInitArgs*, bool*) make/hotspot/src/hotspot/share/runtime/threads.cpp:576
    #6 0x900000012cb0548 in JNI_CreateJavaVM_inner(JavaVM_**, void**, void*) make/hotspot/src/hotspot/share/prims/jni.cpp:3587
    #7 0x900000012cb0548 in JNI_CreateJavaVM make/hotspot/src/hotspot/share/prims/jni.cpp:3678
```

Seems we add to a base (== nullptr) some offset which is reported as undefined behavior.
On other OS the base might be different so we do not see it there.