### PR TITLE
Clones of DecimalFormat can share state

### DIFF
--- a/src/java.base/share/classes/java/text/DigitList.java
+++ b/src/java.base/share/classes/java/text/DigitList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -725,6 +725,7 @@ final class DigitList implements Cloneable {
             char[] newDigits = new char[digits.length];
             System.arraycopy(digits, 0, newDigits, 0, digits.length);
             other.digits = newDigits;
+            other.data = null;
             other.tempBuilder = null;
             return other;
         } catch (CloneNotSupportedException e) {


### PR DESCRIPTION
The `DigitList` class used in `DecimalFormat` does not reset the `data` array in its clone method. This can cause interference when clones are used concurrently.
