### PR TITLE
8354446: [BACKOUT] Remove friends for ObjectMonitor

### DIFF
--- a/src/hotspot/share/runtime/objectMonitor.hpp
+++ b/src/hotspot/share/runtime/objectMonitor.hpp
@@ -148,6 +148,9 @@ class ObjectWaiter : public CHeapObj<mtThread> {
 #define OM_CACHE_LINE_SIZE DEFAULT_CACHE_LINE_SIZE
 
 class ObjectMonitor : public CHeapObj<mtObjectMonitor> {
+  friend class LightweightSynchronizer;
+  friend class ObjectSynchronizer;
+  friend class ObjectWaiter;
   friend class VMStructs;
   JVMCI_ONLY(friend class JVMCIVMStructs;)
 
@@ -421,12 +424,13 @@ class ObjectMonitor : public CHeapObj<mtObjectMonitor> {
   bool      short_fixed_spin(JavaThread* current, int spin_count, bool adapt);
   void      exit_epilog(JavaThread* current, ObjectWaiter* Wakee);
 
- public:
   // Deflation support
   bool      deflate_monitor(Thread* current);
+ private:
   void      install_displaced_markword_in_object(const oop obj);
 
   // JFR support
+public:
   static bool is_jfr_excluded(const Klass* monitor_klass);
 };
 

--- a/src/hotspot/share/runtime/synchronizer.cpp
+++ b/src/hotspot/share/runtime/synchronizer.cpp
@@ -423,8 +423,7 @@ bool ObjectSynchronizer::quick_enter_legacy(oop obj, BasicLock* lock, JavaThread
     // Case: TLE inimical operations such as nested/recursive synchronization
 
     if (m->has_owner(current)) {
-      int recursions = m->recursions();
-      m->set_recursions(++recursions);
+      m->_recursions++;
       current->inc_held_monitor_count();
       return true;
     }
@@ -441,7 +440,7 @@ bool ObjectSynchronizer::quick_enter_legacy(oop obj, BasicLock* lock, JavaThread
     lock->set_displaced_header(markWord::unused_mark());
 
     if (!m->has_owner() && m->try_set_owner(current)) {
-      assert(m->recursions() == 0, "invariant");
+      assert(m->_recursions == 0, "invariant");
       current->inc_held_monitor_count();
       return true;
     }


### PR DESCRIPTION
This reverts commit 36069f6efac4fd02393d28f190ab2ab92b113fd3.

I don't know why we can't call ObjectMonitor::recursions() rather than updating it directly.
Rerunning tier3.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8354446](https://bugs.openjdk.org/browse/JDK-8354446): [BACKOUT] Remove friends for ObjectMonitor (**Bug** - P4)


### Reviewers
 * [Patricio Chilano Mateo](https://openjdk.org/census#pchilanomate) (@pchilano - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24599/head:pull/24599` \
`$ git checkout pull/24599`

Update a local copy of the PR: \
`$ git checkout pull/24599` \
`$ git pull https://git.openjdk.org/jdk.git pull/24599/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24599`

View PR using the GUI difftool: \
`$ git pr show -t 24599`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24599.diff">https://git.openjdk.org/jdk/pull/24599.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24599#issuecomment-2797877027)
</details>
