### PR TITLE
8354447: Missing test for retroactive @SuppressWarnings("dangling-doc-comments") behavior

### DIFF
--- a/test/langtools/tools/javac/danglingDocComments/DanglingDocCommentsClass.java
+++ b/test/langtools/tools/javac/danglingDocComments/DanglingDocCommentsClass.java
@@ -45,4 +45,13 @@ public /** Misplaced: after mods. */ class DanglingDocCommentsClass /** Misplace
         /** Good comment. */
         int i = 0;
     }
+
+    /** Dangling comment X */
+
+    /**
+     * The {@code @SuppressWarnings} annotation below retroactively
+     * silences the warning about "Dangling comment X".
+     */
+    @SuppressWarnings("dangling-doc-comments")
+    public void m5() { }
 }


### PR DESCRIPTION
This PR adds a regression test for the "retroactive" behavior of `@SuppressWarnings("dangling-doc-comments")`, that is,  the warning suppression applies to comments preceding the declaration that the annotation annotates, even though those comments are not within the lexical scope of that declaration. Previously there was no test for this behavior.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8354447](https://bugs.openjdk.org/browse/JDK-8354447): Missing test for retroactive @<!---->SuppressWarnings("dangling-doc-comments") behavior (**Enhancement** - P5)


### Reviewers
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24600/head:pull/24600` \
`$ git checkout pull/24600`

Update a local copy of the PR: \
`$ git checkout pull/24600` \
`$ git pull https://git.openjdk.org/jdk.git pull/24600/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24600`

View PR using the GUI difftool: \
`$ git pr show -t 24600`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24600.diff">https://git.openjdk.org/jdk/pull/24600.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24600#issuecomment-2797909913)
</details>
