### PR TITLE
8353955

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/invokeMethod/invokemethod001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/invokeMethod/invokemethod001.java
@@ -147,6 +147,7 @@ public class invokemethod001 {
         argsHandler     = new ArgumentHandler(argv);
         logHandler      = new Log(out, argsHandler);
         Binder binder   = new Binder(argsHandler, logHandler);
+        binder.includeVirtualThreads();
 
 
         if (argsHandler.verbose()) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/newInstance/newinstance001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/newInstance/newinstance001.java
@@ -159,6 +159,7 @@ public class newinstance001 {
         argsHandler     = new ArgumentHandler(argv);
         logHandler      = new Log(out, argsHandler);
         Binder binder   = new Binder(argsHandler, logHandler);
+        binder.includeVirtualThreads();
 
         if (argsHandler.verbose()) {
             debuggee = binder.bindToDebugee(debuggeeName + " -vbs");

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/getValue/getvalue001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/getValue/getvalue001.java
@@ -143,6 +143,7 @@ public class getvalue001 {
         argsHandler     = new ArgumentHandler(argv);
         logHandler      = new Log(out, argsHandler);
         Binder binder   = new Binder(argsHandler, logHandler);
+        binder.includeVirtualThreads();
 
         if (argsHandler.verbose()) {
             debuggee = binder.bindToDebugee(debuggeeName + " -vbs");

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/getValues/getvalues001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/getValues/getvalues001.java
@@ -144,6 +144,7 @@ public class getvalues001 {
         argsHandler     = new ArgumentHandler(argv);
         logHandler      = new Log(out, argsHandler);
         Binder binder   = new Binder(argsHandler, logHandler);
+        binder.includeVirtualThreads();
 
         if (argsHandler.verbose()) {
             debuggee = binder.bindToDebugee(debuggeeName + " -vbs");  // *** tp

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/forceEarlyReturn/forceEarlyReturn001/forceEarlyReturn001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/forceEarlyReturn/forceEarlyReturn001/forceEarlyReturn001.java
@@ -118,10 +118,6 @@ public class forceEarlyReturn001 extends ForceEarlyReturnDebugger {
         }
     }
 
-    //forceEarlyReturn001() {
-        //  includeVirtualThreads();
-        //}
-
     public static int run(String argv[], PrintStream out) {
         return new forceEarlyReturn001().runIt(argv, out);
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/forceEarlyReturn/forceEarlyReturn001/forceEarlyReturn001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/forceEarlyReturn/forceEarlyReturn001/forceEarlyReturn001.java
@@ -118,6 +118,10 @@ public class forceEarlyReturn001 extends ForceEarlyReturnDebugger {
         }
     }
 
+    //forceEarlyReturn001() {
+        //  includeVirtualThreads();
+        //}
+
     public static int run(String argv[], PrintStream out) {
         return new forceEarlyReturn001().runIt(argv, out);
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/forceEarlyReturn/forceEarlyReturn002/forceEarlyReturn002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/forceEarlyReturn/forceEarlyReturn002/forceEarlyReturn002.java
@@ -76,6 +76,10 @@ public class forceEarlyReturn002 extends ForceEarlyReturnDebugger {
         return forceEarlyReturn002a.class.getName();
     }
 
+    public forceEarlyReturn002() {
+        includeVirtualThreads();
+    }
+
     public static int run(String argv[], PrintStream out) {
         return new forceEarlyReturn002().runIt(argv, out);
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/name/name001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/name/name001.java
@@ -137,6 +137,7 @@ public class name001 {
         argsHandler     = new ArgumentHandler(argv);
         logHandler      = new Log(out, argsHandler);
         Binder binder   = new Binder(argsHandler, logHandler);
+        binder.includeVirtualThreads();
 
         if (argsHandler.verbose()) {
             debuggee = binder.bindToDebugee(debuggeeName + " -vbs");

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/stop/stop001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/stop/stop001.java
@@ -144,6 +144,7 @@ public class stop001 {
         argsHandler     = new ArgumentHandler(argv);
         logHandler      = new Log(out, argsHandler);
         Binder binder   = new Binder(argsHandler, logHandler);
+        binder.includeVirtualThreads();
 
         if (argsHandler.verbose()) {
             debuggee = binder.bindToDebugee(debuggeeName + " -vbs");

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/suspend/suspend001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/suspend/suspend001.java
@@ -142,6 +142,7 @@ public class suspend001 {
         argsHandler     = new ArgumentHandler(argv);
         logHandler      = new Log(out, argsHandler);
         Binder binder   = new Binder(argsHandler, logHandler);
+        binder.includeVirtualThreads();
 
         if (argsHandler.verbose()) {
             debuggee = binder.bindToDebugee(debuggeeName + " -vbs");

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/suspendCount/suspendcount001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/suspendCount/suspendcount001.java
@@ -141,6 +141,7 @@ public class suspendcount001 {
         argsHandler     = new ArgumentHandler(argv);
         logHandler      = new Log(out, argsHandler);
         Binder binder   = new Binder(argsHandler, logHandler);
+        binder.includeVirtualThreads();
 
         if (argsHandler.verbose()) {
             debuggee = binder.bindToDebugee(debuggeeName + " -vbs");

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/dispose/dispose002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/dispose/dispose002.java
@@ -140,6 +140,7 @@ public class dispose002 {
         argsHandler     = new ArgumentHandler(argv);
         logHandler      = new Log(out, argsHandler);
         Binder binder   = new Binder(argsHandler, logHandler);
+        binder.includeVirtualThreads();
 
         if (argsHandler.verbose()) {
             debuggee = binder.bindToDebugee(debuggeeName + " -vbs");

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/dispose/dispose003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/dispose/dispose003.java
@@ -133,6 +133,7 @@ public class dispose003 {
         argsHandler     = new ArgumentHandler(argv);
         logHandler      = new Log(out, argsHandler);
         Binder binder   = new Binder(argsHandler, logHandler);
+        binder.includeVirtualThreads();
 
         if (argsHandler.verbose()) {
             debuggee = binder.bindToDebugee(debuggeeName + " -vbs");

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/dispose/dispose004.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/dispose/dispose004.java
@@ -134,6 +134,7 @@ public class dispose004 {
         argsHandler     = new ArgumentHandler(argv);
         logHandler      = new Log(out, argsHandler);
         Binder binder   = new Binder(argsHandler, logHandler);
+        binder.includeVirtualThreads();
 
         if (argsHandler.verbose()) {
             debuggee = binder.bindToDebugee(debuggeeName + " -vbs");

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/suspend/suspend001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/suspend/suspend001.java
@@ -145,6 +145,7 @@ public class suspend001 {
         argsHandler     = new ArgumentHandler(argv);
         logHandler      = new Log(out, argsHandler);
         Binder binder   = new Binder(argsHandler, logHandler);
+        binder.includeVirtualThreads();
 
         if (argsHandler.verbose()) {
             debuggee = binder.bindToDebugee(debuggeeName + " -vbs");

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/stress/serial/forceEarlyReturn001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/stress/serial/forceEarlyReturn001/TestDescription.java
@@ -71,6 +71,7 @@
  *      -debugee.vmkeys="-Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
  *                       -XX:+WhiteBoxAPI ${test.vm.opts} ${test.java.opts}"
  *      -testClassPath ${test.class.path}
+ *      -includevirtualthreads
  *      -configFile ${test.src}/forceEarlyReturn001.tests
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/stress/serial/forceEarlyReturn002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/stress/serial/forceEarlyReturn002/TestDescription.java
@@ -74,6 +74,7 @@
  *                       -XX:+WhiteBoxAPI ${test.vm.opts} ${test.java.opts}"
  *      -testClassPath ${test.class.path}
  *      -configFile ${test.src}/forceEarlyReturn002.tests
+ *      -includevirtualthreads
  *      -testWorkDir .
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/Binder.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/Binder.java
@@ -63,6 +63,11 @@ public class Binder extends DebugeeBinder {
      */
     public static final String LOG_PREFIX = "binder> ";
 
+    private boolean includeVThreads = false; // true if debuggee should be launched with includevirtualthreads=y
+    public void includeVirtualThreads() {
+        includeVThreads = true;
+    }
+
     /**
      * Get version string.
      */
@@ -518,7 +523,7 @@ public class Binder extends DebugeeBinder {
 
         // This flag is needed so VirtualMachine.allThreads() includes known vthreads.
         arg = (Connector.StringArgument) arguments.get("includevirtualthreads");
-        arg.setValue("y");
+        arg.setValue(includeVThreads ? "y" : "n");
 
         String vmArgs = "";
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/SerialExecutionDebugger.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/SerialExecutionDebugger.java
@@ -111,6 +111,8 @@ public class SerialExecutionDebugger extends TestDebuggerType2 {
             if (args[i].equals("-configFile") && (i < args.length - 1)) {
                 configFileName = args[i + 1];
                 i++;
+            } else if (args[i].equals("-includevirtualthreads")) {
+                includeVirtualThreads();
             } else
                 standardArgs.add(args[i]);
         }

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/TestDebuggerType2.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/TestDebuggerType2.java
@@ -128,6 +128,12 @@ public class TestDebuggerType2 {
 
     protected String testWorkDir;
 
+    private boolean includeVThreads = false; // true if debuggee should be launched with includevirtualthreads=y
+    public void includeVirtualThreads() {
+        includeVThreads = true;
+    }
+
+
     // initialize test and remove unsupported by nsk.share.jdi.ArgumentHandler arguments
     // (ArgumentHandler constructor throws BadOption exception if command line contains unrecognized by ArgumentHandler options)
     // support -testClassPath parameter: path to find classes for custom classloader in debuggee VM
@@ -171,6 +177,9 @@ public class TestDebuggerType2 {
         argHandler = new ArgumentHandler(doInit(args, out));
         log = new Log(out, argHandler);
         Binder binder = new Binder(argHandler, log);
+        if (includeVThreads) {
+            binder.includeVirtualThreads();
+        }
         debuggee = binder.bindToDebugee(debuggeeClassName());
         pipe = debuggee.createIOPipe();
         debuggee.redirectStderr(log, "Debugger.err> ");


### PR DESCRIPTION
This is just a preliminary review. I'd like to get some approval for the approach I'm taking. There are over 300 tests that need to be fixed. I've just fixed a handful in this PR to give a feel for the changes I plan on making. If they look ok to you, then I'll update this PR with the needed changes to the rest of the tests.

What this PR is fixing is the issue with all of our nsk/jdi testing being done with includevirtualthreads=y even though debuggers typically use the default includevirtualthreads=n. As a result we have a testing gap with includevirtualthreads=n. There are nearly 1200 nsk/jdi tests. Only about 350 actually need includevirtualthreads=y. I plan making includevirtualthreads=n the default for nsk/jdi tests unless the test does something to override the default and request includevirtualthreads=y.

includevirtualthreads=y forces the debug agent to track all virtual threads so they are returned by vm.allThreads(). Some tests need this since they use vm.allThreads() to find the debuggee threads. Without includevirtualthreads=y, vm.allThreads() usually won't return any virtual threads (although it might return some for which events have been triggered).
