### PR TITLE
8354106: Clean up and open source KeyEvent related tests (Part 2)

### DIFF
--- a/test/jdk/java/awt/event/KeyEvent/KeyPressedModifiers.java
+++ b/test/jdk/java/awt/event/KeyEvent/KeyPressedModifiers.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4174399
+ * @summary Check that modifier values are set on a KeyPressed event
+ *          when a modifier key is pressed.
+ * @key headful
+ * @run main KeyPressedModifiers
+ */
+
+import java.awt.AWTException;
+import java.awt.BorderLayout;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Robot;
+import java.awt.TextField;
+import java.awt.event.KeyEvent;
+import java.awt.event.KeyListener;
+import java.lang.reflect.InvocationTargetException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class KeyPressedModifiers extends Frame implements KeyListener {
+    static AtomicBoolean shiftDown = new AtomicBoolean(false);
+    static AtomicBoolean controlDown = new AtomicBoolean(false);
+    static AtomicBoolean altDown = new AtomicBoolean(false);
+
+    public static void main(String[] args) throws InterruptedException,
+            InvocationTargetException, AWTException {
+        KeyPressedModifiers test = new KeyPressedModifiers();
+        try {
+            EventQueue.invokeAndWait(test::initUI);
+            Robot robot = new Robot();
+            robot.setAutoDelay(100);
+            robot.delay(500);
+            robot.waitForIdle();
+            robot.keyPress(KeyEvent.VK_SHIFT);
+            robot.keyRelease(KeyEvent.VK_SHIFT);
+            robot.keyPress(KeyEvent.VK_CONTROL);
+            robot.keyRelease(KeyEvent.VK_CONTROL);
+            robot.keyPress(KeyEvent.VK_ALT);
+            robot.keyRelease(KeyEvent.VK_ALT);
+            robot.delay(500);
+            robot.waitForIdle();
+            if (!shiftDown.get() || !controlDown.get() || !altDown.get()) {
+                String error = "Following key modifiers were not registered:" +
+                        (shiftDown.get() ? "" : " SHIFT") +
+                        (controlDown.get() ? "" : " CONTROL") +
+                        (altDown.get() ? "" : " ALT");
+                throw new RuntimeException(error);
+            }
+        } finally {
+            EventQueue.invokeAndWait(test::dispose);
+        }
+    }
+
+    public void initUI() {
+        setLayout(new BorderLayout());
+        TextField tf = new TextField(30);
+        tf.addKeyListener(this);
+        add(tf, BorderLayout.CENTER);
+        setSize(350, 100);
+        setVisible(true);
+        tf.requestFocus();
+    }
+
+    public void keyTyped(KeyEvent ignore) {
+    }
+
+    public void keyReleased(KeyEvent ignore) {
+    }
+
+    public void keyPressed(KeyEvent e) {
+        System.out.println(e);
+        switch (e.getKeyCode()) {
+            case KeyEvent.VK_SHIFT:
+                shiftDown.set(e.isShiftDown());
+                break;
+            case KeyEvent.VK_CONTROL:
+                controlDown.set(e.isControlDown());
+                break;
+            case KeyEvent.VK_ALT:
+                altDown.set(e.isAltDown());
+                break;
+        }
+    }
+}

--- a/test/jdk/java/awt/event/KeyEvent/KeyTest.java
+++ b/test/jdk/java/awt/event/KeyEvent/KeyTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 4151419, 4090870, 4169733
+ * @bug 4151419 4090870 4169733
  * @summary Ensures that KeyEvent has right results for the following
  *          keys  -=\[];,./
  * @library /java/awt/regtesthelpers

--- a/test/jdk/java/awt/event/KeyEvent/KeyTest.java
+++ b/test/jdk/java/awt/event/KeyEvent/KeyTest.java
@@ -26,7 +26,7 @@
  * @bug 4151419, 4090870, 4169733
  * @summary Ensures that KeyEvent has right results for the following
  *          keys  -=\[];,./
- * @library /open/test/jdk/java/awt/regtesthelpers
+ * @library /java/awt/regtesthelpers
  * @build PassFailJFrame
  * @run main/manual KeyTest
  */

--- a/test/jdk/java/awt/event/KeyEvent/KeyTest.java
+++ b/test/jdk/java/awt/event/KeyEvent/KeyTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4151419, 4090870, 4169733
+ * @summary Ensures that KeyEvent has right results for the following
+ *          keys  -=\[];,./
+ * @library /open/test/jdk/java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual KeyTest
+ */
+
+import java.awt.BorderLayout;
+import java.awt.Frame;
+import java.awt.TextField;
+import java.awt.event.KeyEvent;
+import java.awt.event.KeyListener;
+import java.lang.reflect.InvocationTargetException;
+
+public class KeyTest extends Frame implements KeyListener {
+
+    static String INSTRUCTIONS = """
+           Click on the text field in window named "Check KeyChar values"
+           Type the following keys/characters in the TextField:
+           - = \\ [ ] ; , . /
+           Verify that the keyChar and keyCode is correct for each key pressed.
+           Remember that the keyCode for the KEY_TYPED event should be zero.
+           Also verify that the character you typed appears in the TextField.
+
+           Key    Name        keyChar    Keycode
+           -------------------------------------
+            -     Minus        -  45        45
+            =     Equals       =  61        61
+            \\    Slash        \\   92        92
+            [     Left Brace   [  91        91
+            ]     Right Brace  ]  93        93
+            ;     Semicolon    ;  59        59
+            ,     Comma        ,  44        44
+            .     Period       .  46        46
+            /     Front Slash  /  47        47
+           """;
+    public KeyTest() {
+        super("Check KeyChar values");
+        setLayout(new BorderLayout());
+        TextField tf = new TextField(30);
+        tf.addKeyListener(this);
+        add(tf, BorderLayout.CENTER);
+        pack();
+
+    }
+
+    public void keyPressed(KeyEvent evt) {
+        printKey(evt);
+    }
+
+    public void keyTyped(KeyEvent evt) {
+        printKey(evt);
+    }
+
+    public void keyReleased(KeyEvent evt) {
+        printKey(evt);
+    }
+
+    protected void printKey(KeyEvent evt) {
+        if (evt.isActionKey()) {
+            PassFailJFrame.log("params= " + evt.paramString() + "  KeyChar:  " +
+                    (int) evt.getKeyChar() + "   Action Key");
+        } else {
+            PassFailJFrame.log("params= " + evt.paramString() + "  KeyChar:  " +
+                    (int) evt.getKeyChar());
+        }
+    }
+
+    public static void main(String[] args) throws InterruptedException, InvocationTargetException {
+        PassFailJFrame.builder()
+                .title("KeyTest Instructions")
+                .instructions(INSTRUCTIONS)
+                .logArea(20)
+                .testUI(KeyTest::new)
+                .build()
+                .awaitAndCheck();
+    }
+}


### PR DESCRIPTION
Clean up and open source two more tests related to KeyEvent mechanics.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8354106](https://bugs.openjdk.org/browse/JDK-8354106): Clean up and open source KeyEvent related tests (Part 2) (**Bug** - P4)


### Reviewers
 * [Abhishek Kumar](https://openjdk.org/census#abhiscxk) (@kumarabhi006 - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24610/head:pull/24610` \
`$ git checkout pull/24610`

Update a local copy of the PR: \
`$ git checkout pull/24610` \
`$ git pull https://git.openjdk.org/jdk.git pull/24610/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24610`

View PR using the GUI difftool: \
`$ git pr show -t 24610`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24610.diff">https://git.openjdk.org/jdk/pull/24610.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24610#issuecomment-2799647519)
</details>
