### PR TITLE
8349716: IllegalAccessError when Proxy methods return object of a package-private type

### DIFF
--- a/test/jdk/java/lang/annotation/WithPackagePrivateTest.java
+++ b/test/jdk/java/lang/annotation/WithPackagePrivateTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8349716
+ * @summary Test behaviors with public annotations that have elements of package
+ *          private accessibility
+ * @library /test/lib
+ * @run junit WithPackagePrivateTest
+ */
+
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Test public annotations that has elements of package-private types.
+ */
+@WithPackagePrivateTest.InaccessibleElement(WithPackagePrivateTest.MySecretEnum.FIRST)
+@WithPackagePrivateTest.InaccessibleElement(WithPackagePrivateTest.MySecretEnum.SECOND)
+@WithPackagePrivateTest.InaccessibleElement(WithPackagePrivateTest.MySecretEnum.THIRD)
+@WithPackagePrivateTest.DummyPublicAnnotation(WithPackagePrivateTest.MySecretEnum.FIRST)
+class WithPackagePrivateTest {
+
+    // element of array of package-private interface
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface InaccessibleContainer {
+        InaccessibleElement[] value();
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Repeatable(InaccessibleContainer.class)
+    @interface InaccessibleElement {
+        MySecretEnum value();
+    }
+
+    // element of package-private (enum) class
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface DummyPublicAnnotation {
+        MySecretEnum value();
+    }
+
+    /**
+     * A package-private enum. Annotation member implementations must be able to
+     * access this enum.
+     */
+    enum MySecretEnum {
+        FIRST,
+        SECOND,
+        THIRD
+    }
+
+    /**
+     * Ensures the elements work for public/package-private annotation interfaces
+     * with elements of package-private types.
+     */
+    @Test
+    void testElements() {
+        var container = WithPackagePrivateTest.class.getDeclaredAnnotation(InaccessibleContainer.class);
+        assertEquals(List.of(MySecretEnum.FIRST, MySecretEnum.SECOND, MySecretEnum.THIRD),
+                     Arrays.stream(container.value()).map(InaccessibleElement::value).toList());
+        var dummyPublic = WithPackagePrivateTest.class.getDeclaredAnnotation(DummyPublicAnnotation.class);
+        assertSame(MySecretEnum.FIRST, dummyPublic.value());
+    }
+}

--- a/test/jdk/java/lang/annotation/WithPackagePrivateTest.java
+++ b/test/jdk/java/lang/annotation/WithPackagePrivateTest.java
@@ -41,7 +41,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * Test public annotations that has elements of package-private types.
+ * Test public annotations that have elements of package-private types.
  */
 @WithPackagePrivateTest.InaccessibleElement(WithPackagePrivateTest.MySecretEnum.FIRST)
 @WithPackagePrivateTest.InaccessibleElement(WithPackagePrivateTest.MySecretEnum.SECOND)

--- a/test/jdk/java/lang/reflect/Proxy/NonPublicMethodTypeTest.java
+++ b/test/jdk/java/lang/reflect/Proxy/NonPublicMethodTypeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/lang/reflect/Proxy/ProxyClassAccessTest.java
+++ b/test/jdk/java/lang/reflect/Proxy/ProxyClassAccessTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,6 +38,7 @@ import static org.testng.Assert.*;
 
 /**
  * @test
+ * @bug 8349716
  * @library /test/lib
  * @modules jdk.compiler
  * @build ProxyClassAccessTest q.NP

--- a/test/jdk/java/lang/reflect/Proxy/src/m2/module-info.java
+++ b/test/jdk/java/lang/reflect/Proxy/src/m2/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,5 +23,6 @@
 
 module m2 {
     exports p.two;
+    exports p.two.alt;
     exports p.two.internal to test;
 }

--- a/test/jdk/java/lang/reflect/Proxy/src/m2/p/two/Bar.java
+++ b/test/jdk/java/lang/reflect/Proxy/src/m2/p/two/Bar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 package p.two;
 
-public class Bar {
+public class Bar implements B {
     public Bar() {
     }
 

--- a/test/jdk/java/lang/reflect/Proxy/src/m2/p/two/WithPackageReference.java
+++ b/test/jdk/java/lang/reflect/Proxy/src/m2/p/two/WithPackageReference.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,8 +23,14 @@
 
 package p.two;
 
-// Package-private interface, exposed in public methods.
-// Has publicly accessible supertype and subtype for
-// proxy public method usage.
-interface B extends Cloneable {
+/**
+ * A public interface with package-private types in signatures.
+ * In the language, external code cannot access package-private
+ * types unless passing a public subtypes or null, or using an
+ * instance as one of its supertype (such as Object).
+ */
+public interface WithPackageReference {
+    // For example, this call type can be converted to
+    // (Bar) => Cloneable
+    B process(B input);
 }

--- a/test/jdk/java/lang/reflect/Proxy/src/m2/p/two/alt/AltPackageReference.java
+++ b/test/jdk/java/lang/reflect/Proxy/src/m2/p/two/alt/AltPackageReference.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,10 +21,14 @@
  * questions.
  */
 
-package p.two;
+package p.two.alt;
 
-// Package-private interface, exposed in public methods.
-// Has publicly accessible supertype and subtype for
-// proxy public method usage.
-interface B extends Cloneable {
+/**
+ * Used in combination with WithPackageReference to test rejection
+ * behavior.
+ */
+public interface AltPackageReference extends PackageInterface {
+    void process(PackageInterface input);
 }
+
+interface PackageInterface {}


### PR DESCRIPTION
Proxy currently places proxy classes that proxy interfaces with package-private return types in dynamic modules. This means that if a return value is non-null, Proxy cannot return it and throws IllegalAccessError.

This patch changes strategy so proxy classes for any reference to package-private types (in parameter or return) are now considered as package-private, tightening the restrictions on proxy factories.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change requires CSR request [JDK-8354474](https://bugs.openjdk.org/browse/JDK-8354474) to be approved
- [ ] Change must be properly reviewed (2 reviews required, with at least 2 [Reviewers](https://openjdk.org/bylaws#reviewer))

### Issues
 * [JDK-8349716](https://bugs.openjdk.org/browse/JDK-8349716): IllegalAccessError when Proxy methods return object of a package-private type (**Bug** - P4)
 * [JDK-8354474](https://bugs.openjdk.org/browse/JDK-8354474): Proxy package membership to respect referenced package-private types (**CSR**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24611/head:pull/24611` \
`$ git checkout pull/24611`

Update a local copy of the PR: \
`$ git checkout pull/24611` \
`$ git pull https://git.openjdk.org/jdk.git pull/24611/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24611`

View PR using the GUI difftool: \
`$ git pr show -t 24611`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24611.diff">https://git.openjdk.org/jdk/pull/24611.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24611#issuecomment-2800007003)
</details>
