### PR TITLE
Update ConcurrentHashMap.java

### DIFF
--- a/src/java.base/share/classes/java/util/concurrent/ConcurrentHashMap.java
+++ b/src/java.base/share/classes/java/util/concurrent/ConcurrentHashMap.java
@@ -3299,7 +3299,7 @@ public class ConcurrentHashMap<K,V> extends AbstractMap<K,V>
                 return false;
             if (tr != null && (tr.parent != t || tr.hash < t.hash))
                 return false;
-            if (t.red && tl != null && tl.red && tr != null && tr.red)
+            if (t.red && (tl != null && tl.red || tr != null && tr.red))
                 return false;
             if (tl != null && !checkInvariants(tl))
                 return false;


### PR DESCRIPTION
"In Red-Black Trees, a red node cannot have any red children; this rule is violated even if only one child is red, not just when both children are red."