### PR TITLE
8353950: Clipboard interaction on Windows is unstable

### DIFF
--- a/src/java.desktop/share/classes/sun/awt/datatransfer/SunClipboard.java
+++ b/src/java.desktop/share/classes/sun/awt/datatransfer/SunClipboard.java
@@ -204,8 +204,9 @@ public abstract class SunClipboard extends Clipboard
         byte[] data = null;
         Transferable localeTransferable = null;
 
+        openClipboard(null);
+
         try {
-            openClipboard(null);
 
             long[] formats = getClipboardFormats();
             Long lFormat = DataTransferer.getInstance().
@@ -318,12 +319,7 @@ public abstract class SunClipboard extends Clipboard
      * @since 1.5
      */
     protected long[] getClipboardFormatsOpenClose() {
-        try {
-            openClipboard(null);
-            return getClipboardFormats();
-        } finally {
-            closeClipboard();
-        }
+        return getClipboardFormats();
     }
 
     /**
@@ -356,15 +352,7 @@ public abstract class SunClipboard extends Clipboard
         flavorListeners.add(listener);
 
         if (numberOfFlavorListeners++ == 0) {
-            long[] currentFormats = null;
-            try {
-                openClipboard(null);
-                currentFormats = getClipboardFormats();
-            } catch (final IllegalStateException ignored) {
-            } finally {
-                closeClipboard();
-            }
-            this.currentFormats = currentFormats;
+            this.currentFormats = getClipboardFormats();
 
             registerClipboardViewerChecked();
         }

--- a/src/java.desktop/windows/classes/sun/awt/windows/WClipboard.java
+++ b/src/java.desktop/windows/classes/sun/awt/windows/WClipboard.java
@@ -53,6 +53,8 @@ final class WClipboard extends SunClipboard {
 
     WClipboard() {
         super("System");
+        // Register java side of the clipboard with the native side
+        registerClipboard();
     }
 
     @Override
@@ -214,4 +216,6 @@ final class WClipboard extends SunClipboard {
                 }
             };
     }
+
+    private native void registerClipboard();
 }

--- a/src/java.desktop/windows/native/libawt/windows/awt_Clipboard.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Clipboard.cpp
@@ -127,7 +127,7 @@ Java_sun_awt_windows_WClipboard_init(JNIEnv *env, jclass cls)
  * Signature: (Lsun/awt/windows/WClipboard;)V
  */
 JNIEXPORT void JNICALL
-Java_sun_awt_windows_WClipboard_openClipboard(JNIEnv *env, jobject self,
+Java_sun_awt_windows_WClipboard_openClipboard0(JNIEnv *env, jobject self,
                                               jobject newOwner)
 {
     TRY;
@@ -154,7 +154,7 @@ Java_sun_awt_windows_WClipboard_openClipboard(JNIEnv *env, jobject self,
  * Signature: ()V
  */
 JNIEXPORT void JNICALL
-Java_sun_awt_windows_WClipboard_closeClipboard(JNIEnv *env, jobject self)
+Java_sun_awt_windows_WClipboard_closeClipboard0(JNIEnv *env, jobject self)
 {
     TRY;
 
@@ -294,23 +294,25 @@ Java_sun_awt_windows_WClipboard_getClipboardFormats
 {
     TRY;
 
-    DASSERT(::GetOpenClipboardWindow() == AwtToolkit::GetInstance().GetHWnd());
+    unsigned int cFormats = 128; // Allocate enough space to hold all
+    unsigned int pcFormatsOut = 0;
+    unsigned int lpuiFormats[128] = { 0 };
 
-    jsize nFormats = ::CountClipboardFormats();
-    jlongArray formats = env->NewLongArray(nFormats);
+    VERIFY(::GetUpdatedClipboardFormats(lpuiFormats, 128, &pcFormatsOut));
+
+    jlongArray formats = env->NewLongArray(pcFormatsOut);
     if (formats == NULL) {
         throw std::bad_alloc();
     }
-    if (nFormats == 0) {
+    if (pcFormatsOut == 0) {
         return formats;
     }
     jboolean isCopy;
     jlong *lFormats = env->GetLongArrayElements(formats, &isCopy),
         *saveFormats = lFormats;
-    UINT num = 0;
 
-    for (jsize i = 0; i < nFormats; i++, lFormats++) {
-        *lFormats = num = ::EnumClipboardFormats(num);
+    for (unsigned int i = 0; i < pcFormatsOut; i++, lFormats++) {
+        *lFormats = lpuiFormats[i];
     }
 
     env->ReleaseLongArrayElements(formats, saveFormats, 0);


### PR DESCRIPTION
- Introduce a lock into WClipboard that protects the code between
  openClipboard/closeClipboard invocations.
  The native side does not allow to open the clipboard multiple
  times or share the opened clipboard between multiple threads.

- Remove of need to call openClipboard/closeClipboard from
  getClipboardFormats by using the win32 call
  GetUpdatedClipboardFormats

- Prevent a race-condition by not registering the connection
  between java and native side of clipboard multiple time, but
  just at construction time.
  