### PR TITLE
8353832: Opensource FontClass, Selection and Icon tests

### DIFF
--- a/test/jdk/java/awt/FontClass/FontTransformAttributeTest.java
+++ b/test/jdk/java/awt/FontClass/FontTransformAttributeTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.font.TextAttribute;
+import java.awt.font.TransformAttribute;
+import java.awt.geom.AffineTransform;
+import java.text.AttributedCharacterIterator;
+import java.text.AttributedString;
+
+import javax.swing.JPanel;
+
+/*
+ * @test
+ * @bug 4650042
+ * @summary Draw text using a transform to simulate superscript, it should look like a superscript
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual FontTransformAttributeTest
+ */
+
+public class FontTransformAttributeTest extends JPanel {
+    AttributedCharacterIterator iter;
+
+    public static void main(String[] args) throws Exception {
+        final String INSTRUCTIONS = """
+                This test should display a string ending with the superscripted number '11'.
+                Pass the test if you see the superscript.""";
+
+        PassFailJFrame.builder()
+                .title("FontTransformAttributeTest Instruction")
+                .instructions(INSTRUCTIONS)
+                .columns(35)
+                .splitUI(FontTransformAttributeTest::new)
+                .build()
+                .awaitAndCheck();
+    }
+
+    FontTransformAttributeTest() {
+        AffineTransform superTransform = AffineTransform.getScaleInstance(0.65, 0.65);
+        superTransform.translate(0, -7);
+        TransformAttribute superAttribute = new TransformAttribute(superTransform);
+        String s = "a big number 7 11";
+        AttributedString as = new AttributedString(s);
+        as.addAttribute(TextAttribute.TRANSFORM, superAttribute, 15, 17);
+        iter = as.getIterator();
+        setBackground(Color.WHITE);
+    }
+
+    @Override
+    public Dimension getPreferredSize() {
+        return new Dimension(200, 100);
+    }
+
+    @Override
+    public void paint(Graphics g) {
+        Graphics2D g2 = (Graphics2D) g;
+        Dimension d = getSize();
+        g2.drawString(iter, 20, d.height / 2 + 8);
+    }
+}

--- a/test/jdk/java/awt/FontClass/FontUnderscoreTest.java
+++ b/test/jdk/java/awt/FontClass/FontUnderscoreTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Dimension;
+import java.awt.Font;
+import java.awt.Graphics;
+
+import javax.swing.JPanel;
+
+/*
+ * @test
+ * @bug 4248579
+ * @summary Make sure the underscore glyph appears in the different strings
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual FontUnderscoreTest
+ */
+
+public class FontUnderscoreTest extends JPanel {
+    public static void main(String[] args) throws Exception {
+        final String INSTRUCTIONS = """
+                Make sure all 8 underscore characters appear in each
+                of the 3 strings.
+
+                Press PASS if all 8 are there, else FAIL.""";
+
+        PassFailJFrame.builder()
+                .title("FontUnderscoreTest Instruction")
+                .instructions(INSTRUCTIONS)
+                .columns(35)
+                .splitUI(FontUnderscoreTest::new)
+                .build()
+                .awaitAndCheck();
+    }
+
+    @Override
+    public Dimension getPreferredSize() {
+        return new Dimension(550, 230);
+    }
+
+    @Override
+    public void paint(Graphics g) {
+        Font f = new Font(Font.SANS_SERIF, Font.PLAIN, 24);
+        g.setFont(f);
+        g.drawString ("8 underscore characters appear in each string", 5, 200);
+
+        g.drawString("J_A_V_A_2_j_a_v_a", 25, 50);
+
+        f = new Font(Font.SERIF, Font.PLAIN, 24);
+        g.setFont(f);
+        g.drawString("J_A_V_A_2_j_a_v_a", 25, 100);
+
+        f = new Font(Font.MONOSPACED, Font.PLAIN, 24);
+        g.setFont(f);
+        g.drawString("J_A_V_A_2_j_a_v_a", 25, 150);
+    }
+}

--- a/test/jdk/java/awt/Icon/ChildFrameIconTest.java
+++ b/test/jdk/java/awt/Icon/ChildFrameIconTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+
+import javax.swing.JButton;
+import javax.swing.JDialog;
+import javax.swing.JFrame;
+import javax.swing.JOptionPane;
+
+/*
+ * @test
+ * @bug 4284610
+ * @summary Tests that a child of the non-resizable dialog acquires valid icon.
+ * @requires (os.family == "windows")
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual ChildFrameIconTest
+ */
+
+public class ChildFrameIconTest {
+    public static void main(String[] args) throws Exception {
+        final String INSTRUCTIONS = """
+                Press "Show Dialog" button to open a dialog with this message:
+                    Do you see a coffee cup icon in the upper left corner ?
+
+                Look at the icon in the upper left corner of the message dialog.
+
+                Press Pass if you see default coffee cup icon else press Fail.""";
+
+        PassFailJFrame.builder()
+                .title("ChildFrameIconTest Instruction")
+                .instructions(INSTRUCTIONS)
+                .columns(35)
+                .testUI(ChildFrameIconTest::createUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static JFrame createUI() {
+        JFrame f = new JFrame("ChildFrameIconTest UI");
+        JButton b = new JButton("Show Dialog");
+        b.addActionListener(new ActionListener() {
+            public void actionPerformed(ActionEvent e) {
+                String msg = "Do you see a coffee cup icon in the upper left corner ?";
+                JDialog dlg = new JDialog(f, "Non-resizable JDialog", false);
+                dlg.setResizable(false);
+                JOptionPane.showMessageDialog(dlg, msg);
+            }
+        });
+        f.add(b);
+        f.setSize(250, 100);
+        return f;
+    }
+}

--- a/test/jdk/java/awt/Selection/TestClipboard.java
+++ b/test/jdk/java/awt/Selection/TestClipboard.java
@@ -104,9 +104,9 @@ public class TestClipboard {
             // Get the current contents of the clipboard
             Transferable theTransfer = theClipboard.getContents(this);
 
-            // See if the flavor is supported. This will result in a null
-            // pointer exception on Solaris, but not NT
-            boolean isSupported = theTransfer.isDataFlavorSupported(myFlavor);
+            // See if the flavor is supported. This may result in a null
+            // pointer exception.
+            theTransfer.isDataFlavorSupported(myFlavor);
             PassFailJFrame.log("Test Passed");
         }
     }

--- a/test/jdk/java/awt/Selection/TestClipboard.java
+++ b/test/jdk/java/awt/Selection/TestClipboard.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Toolkit;
+import java.awt.datatransfer.Clipboard;
+import java.awt.datatransfer.DataFlavor;
+import java.awt.datatransfer.Transferable;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+
+import java.io.Serializable;
+
+import javax.swing.JButton;
+import javax.swing.JFrame;
+import javax.swing.JOptionPane;
+
+/*
+ * @test
+ * @bug 4139552
+ * @summary Checks to see if 'isDataFlavorSupported' throws exception.
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual TestClipboard
+ */
+
+public class TestClipboard {
+
+    public static void main(String[] args) throws Exception {
+        final String INSTRUCTIONS = """
+                This test has two steps:
+
+                1. you need to place some text onto the system clipboard,
+                for example,
+                    on Windows, you could highlight some text in notepad, and do a Ctrl-C
+                    or select menu Edit->Copy;
+
+                    on Linux or Mac, you can do the same with any Terminal or Console or
+                    Text application.
+
+                2. After you copy to system clipboard, press "Click Me" button.
+
+                Test will fail if any exception is thrown.
+
+                Press Pass if you see "Test Passed" in log area.""";
+
+        PassFailJFrame.builder()
+                .title("TestClipboard Instruction")
+                .instructions(INSTRUCTIONS)
+                .columns(45)
+                .testUI(TestClipboard::createUI)
+                .logArea(4)
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static JFrame createUI() {
+        JFrame f = new JFrame("ChildFrameIconTest UI");
+        JButton b = new JButton("Click Me");
+        b.addActionListener(new ActionListener() {
+            public void actionPerformed(ActionEvent e) {
+                try {
+                    new MyTest();
+                } catch (Exception ex) {
+                    throw new RuntimeException("Exception Thrown : " + ex);
+                }
+            }
+        });
+        f.add(b);
+        f.setSize(200, 100);
+        return f;
+    }
+
+    static class MyFlavor extends Object implements Serializable {
+        // Stub class needed in order to define the data flavor type
+    }
+
+    static class MyTest {
+        public MyTest() throws Exception {
+            // Create an arbitrary dataflavor
+            DataFlavor myFlavor = new DataFlavor(MyFlavor.class, "TestClipboard");
+            // Get the system clipboard
+            Clipboard theClipboard =
+                    Toolkit.getDefaultToolkit().getSystemClipboard();
+            // Get the current contents of the clipboard
+            Transferable theTransfer = theClipboard.getContents(this);
+
+            // See if the flavor is supported. This will result in a null
+            // pointer exception on Solaris, but not NT
+            boolean isSupported = theTransfer.isDataFlavorSupported(myFlavor);
+            PassFailJFrame.log("Test Passed");
+        }
+    }
+}


### PR DESCRIPTION
Font Class, Selection adn Icon related Applet tests are converted to manual and open sourced.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8353832](https://bugs.openjdk.org/browse/JDK-8353832): Opensource FontClass, Selection and Icon tests (**Bug** - P4)


### Reviewers
 * [Jayathirth D V](https://openjdk.org/census#jdv) (@jayathirthrao - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24615/head:pull/24615` \
`$ git checkout pull/24615`

Update a local copy of the PR: \
`$ git checkout pull/24615` \
`$ git pull https://git.openjdk.org/jdk.git pull/24615/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24615`

View PR using the GUI difftool: \
`$ git pr show -t 24615`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24615.diff">https://git.openjdk.org/jdk/pull/24615.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24615#issuecomment-2801619147)
</details>
