### PR TITLE
8354815: RISC-V: Change type of bitwise rotation shift to iRegIorL2I

### DIFF
--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -6445,7 +6445,6 @@ instruct addI_reg_imm(iRegINoSp dst, iRegIorL2I src1, immIAdd src2) %{
   format %{ "addiw  $dst, $src1, $src2\t#@addI_reg_imm" %}
 
   ins_encode %{
-    int32_t con = (int32_t)$src2$$constant;
     __ addiw(as_Register($dst$$reg),
              as_Register($src1$$reg),
              $src2$$constant);
@@ -6507,7 +6506,6 @@ instruct addP_reg_imm(iRegPNoSp dst, iRegP src1, immLAdd src2) %{
   format %{ "addi  $dst, $src1, $src2\t# ptr, #@addP_reg_imm" %}
 
   ins_encode %{
-    // src2 is imm, so actually call the addi
     __ addi(as_Register($dst$$reg),
             as_Register($src1$$reg),
             $src2$$constant);
@@ -6829,7 +6827,7 @@ instruct UmodL(iRegLNoSp dst, iRegL src1, iRegL src2) %{
 // Integer Shifts
 
 // Shift Left Register
-// In RV64I, only the low 5 bits of src2 are considered for the shift amount
+// Only the low 5 bits of src2 are considered for the shift amount, all other bits are ignored.
 instruct lShiftI_reg_reg(iRegINoSp dst, iRegIorL2I src1, iRegIorL2I src2) %{
   match(Set dst (LShiftI src1 src2));
   ins_cost(ALU_COST);
@@ -6862,7 +6860,7 @@ instruct lShiftI_reg_imm(iRegINoSp dst, iRegIorL2I src1, immI src2) %{
 %}
 
 // Shift Right Logical Register
-// In RV64I, only the low 5 bits of src2 are considered for the shift amount
+// Only the low 5 bits of src2 are considered for the shift amount, all other bits are ignored.
 instruct urShiftI_reg_reg(iRegINoSp dst, iRegIorL2I src1, iRegIorL2I src2) %{
   match(Set dst (URShiftI src1 src2));
   ins_cost(ALU_COST);
@@ -6895,7 +6893,7 @@ instruct urShiftI_reg_imm(iRegINoSp dst, iRegIorL2I src1, immI src2) %{
 %}
 
 // Shift Right Arithmetic Register
-// In RV64I, only the low 5 bits of src2 are considered for the shift amount
+// Only the low 5 bits of src2 are considered for the shift amount, all other bits are ignored.
 instruct rShiftI_reg_reg(iRegINoSp dst, iRegIorL2I src1, iRegIorL2I src2) %{
   match(Set dst (RShiftI src1 src2));
   ins_cost(ALU_COST);
@@ -6930,7 +6928,7 @@ instruct rShiftI_reg_imm(iRegINoSp dst, iRegIorL2I src1, immI src2) %{
 // Long Shifts
 
 // Shift Left Register
-// In RV64I, only the low 6 bits of src2 are considered for the shift amount
+// Only the low 6 bits of src2 are considered for the shift amount, all other bits are ignored.
 instruct lShiftL_reg_reg(iRegLNoSp dst, iRegL src1, iRegIorL2I src2) %{
   match(Set dst (LShiftL src1 src2));
 
@@ -6965,7 +6963,7 @@ instruct lShiftL_reg_imm(iRegLNoSp dst, iRegL src1, immI src2) %{
 %}
 
 // Shift Right Logical Register
-// In RV64I, only the low 6 bits of src2 are considered for the shift amount
+// Only the low 6 bits of src2 are considered for the shift amount, all other bits are ignored.
 instruct urShiftL_reg_reg(iRegLNoSp dst, iRegL src1, iRegIorL2I src2) %{
   match(Set dst (URShiftL src1 src2));
 
@@ -7018,7 +7016,7 @@ instruct urShiftP_reg_imm(iRegLNoSp dst, iRegP src1, immI src2) %{
 %}
 
 // Shift Right Arithmetic Register
-// In RV64I, only the low 6 bits of src2 are considered for the shift amount
+// Only the low 6 bits of src2 are considered for the shift amount, all other bits are ignored.
 instruct rShiftL_reg_reg(iRegLNoSp dst, iRegL src1, iRegIorL2I src2) %{
   match(Set dst (RShiftL src1 src2));
 

--- a/src/hotspot/cpu/riscv/riscv_b.ad
+++ b/src/hotspot/cpu/riscv/riscv_b.ad
@@ -25,7 +25,8 @@
 
 // RISCV Bit-Manipulation Extension Architecture Description File
 
-instruct rorI_imm_b(iRegINoSp dst, iRegI src, immI shift) %{
+// Rotate Right Word Immediate
+instruct rorI_imm_b(iRegINoSp dst, iRegIorL2I src, immI shift) %{
   predicate(UseZbb);
   match(Set dst (RotateRight src shift));
 
@@ -39,6 +40,7 @@ instruct rorI_imm_b(iRegINoSp dst, iRegI src, immI shift) %{
   ins_pipe(ialu_reg_shift);
 %}
 
+// Rotate Right Immediate
 instruct rorL_imm_b(iRegLNoSp dst, iRegL src, immI shift) %{
   predicate(UseZbb);
   match(Set dst (RotateRight src shift));
@@ -53,7 +55,9 @@ instruct rorL_imm_b(iRegLNoSp dst, iRegL src, immI shift) %{
   ins_pipe(ialu_reg_shift);
 %}
 
-instruct rorI_reg_b(iRegINoSp dst, iRegI src, iRegI shift) %{
+// Rotate Right Word Register
+// Only the low 5 bits of shift value are used, all other bits are ignored.
+instruct rorI_reg_b(iRegINoSp dst, iRegIorL2I src, iRegIorL2I shift) %{
   predicate(UseZbb);
   match(Set dst (RotateRight src shift));
 
@@ -65,7 +69,9 @@ instruct rorI_reg_b(iRegINoSp dst, iRegI src, iRegI shift) %{
   ins_pipe(ialu_reg_reg);
 %}
 
-instruct rorL_reg_b(iRegLNoSp dst, iRegL src, iRegI shift) %{
+// Rotate Right Register
+// Only the low 6 bits of shift value are used, all other bits are ignored.
+instruct rorL_reg_b(iRegLNoSp dst, iRegL src, iRegIorL2I shift) %{
   predicate(UseZbb);
   match(Set dst (RotateRight src shift));
 
@@ -77,7 +83,9 @@ instruct rorL_reg_b(iRegLNoSp dst, iRegL src, iRegI shift) %{
   ins_pipe(ialu_reg_reg);
 %}
 
-instruct rolI_reg_b(iRegINoSp dst, iRegI src, iRegI shift) %{
+// Rotate Left Word Register
+// Only the low 5 bits of shift value are used, all other bits are ignored.
+instruct rolI_reg_b(iRegINoSp dst, iRegIorL2I src, iRegIorL2I shift) %{
   predicate(UseZbb);
   match(Set dst (RotateLeft src shift));
 
@@ -89,7 +97,9 @@ instruct rolI_reg_b(iRegINoSp dst, iRegI src, iRegI shift) %{
   ins_pipe(ialu_reg_reg);
 %}
 
-instruct rolL_reg_b(iRegLNoSp dst, iRegL src, iRegI shift) %{
+// Rotate Left Register
+// Only the low 6 bits of shift value are used, all other bits are ignored.
+instruct rolL_reg_b(iRegLNoSp dst, iRegL src, iRegIorL2I shift) %{
   predicate(UseZbb);
   match(Set dst (RotateLeft src shift));
 

--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -3431,6 +3431,7 @@ instruct vrotate_right(vReg dst, vReg src, vReg shift) %{
   ins_pipe(pipe_slow);
 %}
 
+// Only the low log2(SEW) bits of shift value are used, all other bits are ignored.
 instruct vrotate_right_reg(vReg dst, vReg src, iRegIorL2I shift) %{
   match(Set dst (RotateRightV src (Replicate shift)));
   format %{ "vrotate_right_reg $dst, $src, $shift\t" %}
@@ -3473,6 +3474,7 @@ instruct vrotate_right_masked(vReg dst_src, vReg shift, vRegMask_V0 v0) %{
   ins_pipe(pipe_slow);
 %}
 
+// Only the low log2(SEW) bits of shift value are used, all other bits are ignored.
 instruct vrotate_right_reg_masked(vReg dst_src, iRegIorL2I shift, vRegMask_V0 v0) %{
   match(Set dst_src (RotateRightV (Binary dst_src (Replicate shift)) v0));
   format %{ "vrotate_right_reg_masked $dst_src, $dst_src, $shift, v0.t\t" %}
@@ -3516,6 +3518,7 @@ instruct vrotate_left(vReg dst, vReg src, vReg shift) %{
   ins_pipe(pipe_slow);
 %}
 
+// Only the low log2(SEW) bits of shift value are used, all other bits are ignored.
 instruct vrotate_left_reg(vReg dst, vReg src, iRegIorL2I shift) %{
   match(Set dst (RotateLeftV src (Replicate shift)));
   format %{ "vrotate_left_reg $dst, $src, $shift\t" %}
@@ -3559,6 +3562,7 @@ instruct vrotate_left_masked(vReg dst_src, vReg shift, vRegMask_V0 v0) %{
   ins_pipe(pipe_slow);
 %}
 
+// Only the low log2(SEW) bits of shift value are used, all other bits are ignored.
 instruct vrotate_left_reg_masked(vReg dst_src, iRegIorL2I shift, vRegMask_V0 v0) %{
   match(Set dst_src (RotateLeftV (Binary dst_src (Replicate shift)) v0));
   format %{ "vrotate_left_reg_masked $dst_src, $dst_src, $shift, v0.t\t" %}


### PR DESCRIPTION
There is no need to do a type conversion when the shift amount of bitwise rotation is an integer converted from long (ConvL2I).
There reason is that these instruction performs a rotate right/left of source by the amount in the least-significant 5/6 bits
of the shift amount depending on the width of the operation (32-bit/64-bit). For 32-bit operations, the resulting 32-bit
value is sign-extended by copying bit 31 to all of the more-significant bits. This means that we could use iRegIorL2I type for
source for these 32-bit operations as well.

Jtreg
hs:tier1-hs:tier3 tested on linux-riscv64 platform equipped with Zbb.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8354815](https://bugs.openjdk.org/browse/JDK-8354815): RISC-V: Change type of bitwise rotation shift to iRegIorL2I (**Enhancement** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Feilong Jiang](https://openjdk.org/census#fjiang) (@feilongjiang - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24618/head:pull/24618` \
`$ git checkout pull/24618`

Update a local copy of the PR: \
`$ git checkout pull/24618` \
`$ git pull https://git.openjdk.org/jdk.git pull/24618/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24618`

View PR using the GUI difftool: \
`$ git pr show -t 24618`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24618.diff">https://git.openjdk.org/jdk/pull/24618.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24618#issuecomment-2809711566)
</details>
