### PR TITLE
8354513: Bug in j.u.l.Handler deadlock test allows null pointer during race condition

### DIFF
--- a/test/jdk/java/util/logging/LoggingDeadlock5.java
+++ b/test/jdk/java/util/logging/LoggingDeadlock5.java
@@ -59,8 +59,12 @@ public class LoggingDeadlock5 {
         @Override
         public String format(LogRecord record) {
             // All we care about is that our formatter will invoke toString() on user arguments.
-            for (Object p : record.getParameters()) {
-                var unused = p.toString();
+            // This can be called without arguments in one of the threads.
+            Object[] parameters = record.getParameters();
+            if (parameters != null) {
+                for (Object p : parameters) {
+                    var unused = p.toString();
+                }
             }
             return "<formatted string>";
         }


### PR DESCRIPTION
Add null pointer guard in test formatter (since it can be called with a log record without parameters).