### PR TITLE
8354510: Skipped gtest cause test failure

### DIFF
--- a/make/RunTests.gmk
+++ b/make/RunTests.gmk
@@ -534,22 +534,21 @@ define SetupRunGtestTestBody
 	  $$(eval $1_PASSED := $$(shell $$(AWK) '/\[  PASSED  \] .* tests?./ \
 	      { print $$$$4 }' $$($1_RESULT_FILE))) \
 	  $$(if $$($1_PASSED), , $$(eval $1_PASSED := 0)) \
-	  $$(eval $1_SKIPPED := $$(shell $$(AWK) \
-	      '/YOU HAVE [0-9]+ DISABLED TEST/ { \
-	          if (match($$$$0, /[0-9]+/, arr)) { \
-	            print arr[0]; \
-	            found=1; \
-	          } \
-	       } \
-	       END { if (!found) print 0; }' \
-	      $$($1_RESULT_FILE))) \
+	  $$(eval $1_GTEST_DISABLED := $$(shell $$(AWK) '/YOU HAVE .* DISABLED TEST/ \
+	      { print $$$$3 }' $$($1_RESULT_FILE))) \
+	  $$(if $$($1_GTEST_DISABLED), , $$(eval $1_GTEST_DISABLED := 0)) \
+	  $$(eval $1_GTEST_SKIPPED := $$(shell $$(AWK) '/\[  SKIPPED \] .* tests?.*/ \
+	      { print $$$$4 }' $$($1_RESULT_FILE))) \
+	  $$(if $$($1_GTEST_SKIPPED), , $$(eval $1_GTEST_SKIPPED := 0)) \
+	  $$(eval $1_SKIPPED := $$(shell \
+	      $$(EXPR) $$($1_GTEST_DISABLED) + $$($1_GTEST_SKIPPED))) \
 	  $$(eval $1_FAILED := $$(shell $$(AWK) '/\[  FAILED  \] .* tests?, \
 	      listed below/ { print $$$$4 }' $$($1_RESULT_FILE))) \
 	  $$(if $$($1_FAILED), , $$(eval $1_FAILED := 0)) \
 	  $$(eval $1_ERROR := $$(shell \
-	      $$(EXPR) $$($1_RUN) - $$($1_PASSED) - $$($1_FAILED))) \
+	      $$(EXPR) $$($1_RUN) - $$($1_PASSED) - $$($1_FAILED) - $$($1_GTEST_SKIPPED))) \
 	  $$(eval $1_TOTAL := $$(shell \
-	      $$(EXPR) $$($1_RUN) + $$($1_SKIPPED))) \
+	      $$(EXPR) $$($1_RUN) + $$($1_GTEST_DISABLED))) \
 	, \
 	  $$(eval $1_PASSED := 0) \
 	  $$(eval $1_FAILED := 0) \


### PR DESCRIPTION
`GTEST_SKIPPED` tests count is accounted in gtests run. But when we calculate the number of GTEST errors we take `ERROR = RUN - PASSED - FAILED`. We need parse and account for the skipped as well. Currently we only account for `DISABLED` gtests (which are not counted as run tests). 

This patch adds support for both `DISABLED` and `GTEST_SKIPPED` tests.

So with this patch we end up with: 
`ERROR = RUN - PASSED - FAILED - GTEST_SKIPPED`
`SKIPPED = GTEST_SKIPPED + GTEST_DISABLED `

Verified that this works locally on MacOS and Linux. Currently running through testing and GHA. 

_The old `match` expression was problematic with some awk, not sure if there was some other reason it was used, rather than the style used elsewhere `maybe set, if unset set=0`_

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8354510](https://bugs.openjdk.org/browse/JDK-8354510): Skipped gtest cause test failure (**Bug** - P4)


### Reviewers
 * [Robbin Ehn](https://openjdk.org/census#rehn) (@robehn - **Reviewer**)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24622/head:pull/24622` \
`$ git checkout pull/24622`

Update a local copy of the PR: \
`$ git checkout pull/24622` \
`$ git pull https://git.openjdk.org/jdk.git pull/24622/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24622`

View PR using the GUI difftool: \
`$ git pr show -t 24622`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24622.diff">https://git.openjdk.org/jdk/pull/24622.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24622#issuecomment-2801730206)
</details>
