### PR TITLE
8354507: [ubsan] subnode.cpp:406:36: runtime error: negation of -9223372036854775808 cannot be represented in type 'long int'

### DIFF
--- a/src/hotspot/share/opto/subnode.cpp
+++ b/src/hotspot/share/opto/subnode.cpp
@@ -403,7 +403,7 @@ Node *SubLNode::Ideal(PhaseGVN *phase, bool can_reshape) {
       return new SubLNode(sub2, in21);
     } else {
       Node* sub2 = phase->transform(new SubLNode(in1, in21));
-      Node* neg_c0 = phase->longcon(-c0);
+      Node* neg_c0 = phase->longcon(java_negate(c0));
       return new AddLNode(sub2, neg_c0);
     }
   }


### PR DESCRIPTION
When running with ubsan enabled binaries (e.g. on Linux x86_64 or macOS aarch) and e.g. executing test
java/lang/Thread/virtual/CancelTimerWithContention

we run into this issue :

```
/priv/jenkins/client-home/workspace/openjdk-jdk-weekly-linux_x86_64-opt/jdk/src/hotspot/share/opto/subnode.cpp:406:36: runtime error: negation of -9223372036854775808 cannot be represented in type 'long int'; cast to an unsigned type to negate this value to itself
    #0 0x7facfee00605 in SubLNode::Ideal(PhaseGVN*, bool) src/hotspot/share/opto/subnode.cpp:406
    #1 0x7facfea644bc in PhaseGVN::transform(Node*) src/hotspot/share/opto/phaseX.cpp:681
    #2 0x7facfea1e4b9 in Parse::do_one_bytecode() src/hotspot/share/opto/parse2.cpp:2502
    #3 0x7facfe9f1064 in Parse::do_one_block() src/hotspot/share/opto/parse1.cpp:1586
    #4 0x7facfe9f35d6 in Parse::do_all_blocks() src/hotspot/share/opto/parse1.cpp:724
    #5 0x7facfe9f71e0 in Parse::Parse(JVMState*, ciMethod*, float) src/hotspot/share/opto/parse1.cpp:628
    #6 0x7facfd2c7925 in ParseGenerator::generate(JVMState*) src/hotspot/share/opto/callGenerator.cpp:97
    #7 0x7facfd5e928f in Compile::Compile(ciEnv*, ciMethod*, int, Options, DirectiveSet*) src/hotspot/share/opto/compile.cpp:805
    #8 0x7facfd2c4428 in C2Compiler::compile_method(ciEnv*, ciMethod*, int, bool, DirectiveSet*) src/hotspot/share/opto/c2compiler.cpp:141
    #9 0x7facfd5fe1db in CompileBroker::invoke_compiler_on_method(CompileTask*) src/hotspot/share/compiler/compileBroker.cpp:2307
    #10 0x7facfd600a06 in CompileBroker::compiler_thread_loop() src/hotspot/share/compiler/compileBroker.cpp:1951
    #11 0x7facfde5a3c4 in JavaThread::thread_main_inner() src/hotspot/share/runtime/javaThread.cpp:773
    #12 0x7facfde5a3c4 in JavaThread::thread_main_inner() src/hotspot/share/runtime/javaThread.cpp:761
    #13 0x7facfeefc786 in Thread::call_run() src/hotspot/share/runtime/thread.cpp:231
    #14 0x7facfe9492d4 in thread_native_entry src/hotspot/os/linux/os_linux.cpp:877
    #15 0x7fad023366e9 in start_thread (/lib64/libpthread.so.0+0xa6e9) (BuildId: 7bac999c115902a23312484de77ffcce60812e74)
    #16 0x7fad0246f53e in clone (/lib64/libc.so.6+0x11853e) (BuildId: d9396455d6e682402e73ddda7af317d3c69e317c)

```
Seems the issue is rather new and came in with  [JDK-8351927](https://bugs.openjdk.org/browse/JDK-8351927)  recently.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8354507](https://bugs.openjdk.org/browse/JDK-8354507): [ubsan] subnode.cpp:406:36: runtime error: negation of -9223372036854775808 cannot be represented in type 'long int' (**Bug** - P4)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24623/head:pull/24623` \
`$ git checkout pull/24623`

Update a local copy of the PR: \
`$ git checkout pull/24623` \
`$ git pull https://git.openjdk.org/jdk.git pull/24623/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24623`

View PR using the GUI difftool: \
`$ git pr show -t 24623`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24623.diff">https://git.openjdk.org/jdk/pull/24623.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24623#issuecomment-2801786676)
</details>
