### PR TITLE
8354219 : Automate javax/swing/JComboBox/ComboPopupBug.java

### DIFF
--- a/test/jdk/javax/swing/JComboBox/ComboPopupBug.java
+++ b/test/jdk/javax/swing/JComboBox/ComboPopupBug.java
@@ -61,9 +61,9 @@ public class ComboPopupBug {
 
             closeButton = new JButton("Close");
             closeButton.addActionListener((e) -> {
-                        clickComboBox();
-                        frame.setVisible(false);
-                    });
+                clickComboBox();
+                frame.setVisible(false);
+            });
 
             frame.getContentPane().add(comboBox, "North");
             frame.getContentPane().add(closeButton, "South");

--- a/test/jdk/javax/swing/JComboBox/ComboPopupBug.java
+++ b/test/jdk/javax/swing/JComboBox/ComboPopupBug.java
@@ -56,6 +56,8 @@ public class ComboPopupBug {
             robot.delay(1000);
 
             SwingUtilities.invokeAndWait(() -> closeButton.doClick());
+
+            robot.waitForIdle();
         } finally {
             SwingUtilities.invokeAndWait(() -> {
                 if (frame != null) {

--- a/test/jdk/javax/swing/JComboBox/ComboPopupBug.java
+++ b/test/jdk/javax/swing/JComboBox/ComboPopupBug.java
@@ -88,7 +88,7 @@ public class ComboPopupBug {
 
         robot.mouseMove(comboBoxLocation.x + comboBoxSize.width - PADDING,
                 comboBoxLocation.y + comboBoxSize.height / 2);
-        robot.mousePress(InputEvent.BUTTON1_MASK);
-        robot.mouseRelease(InputEvent.BUTTON1_MASK);
+        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+        robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
     }
 }

--- a/test/jdk/javax/swing/JComboBox/ComboPopupBug.java
+++ b/test/jdk/javax/swing/JComboBox/ComboPopupBug.java
@@ -76,8 +76,7 @@ public class ComboPopupBug {
 
         try {
             SwingUtilities.invokeAndWait(() -> closeButton.doClick());
-        }
-        finally {
+        } finally {
             SwingUtilities.invokeAndWait(() -> frame.dispose());
         }
     }

--- a/test/jdk/javax/swing/JComboBox/ComboPopupBug.java
+++ b/test/jdk/javax/swing/JComboBox/ComboPopupBug.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/javax/swing/JComboBox/ComboPopupBug.java
+++ b/test/jdk/javax/swing/JComboBox/ComboPopupBug.java
@@ -91,6 +91,7 @@ public class ComboPopupBug {
         frame.getContentPane().add(comboBox, "North");
         frame.getContentPane().add(closeButton, "South");
         frame.setSize(200, 200);
+        frame.setLocationRelativeTo(null);
         frame.setVisible(true);
     }
 }

--- a/test/jdk/javax/swing/JComboBox/ComboPopupBug.java
+++ b/test/jdk/javax/swing/JComboBox/ComboPopupBug.java
@@ -82,7 +82,7 @@ public class ComboPopupBug {
         }
     }
 
-    public static void clickComboBox() {
+    private static void clickComboBox() {
         comboBoxLocation = comboBox.getLocationOnScreen();
         comboBoxSize = comboBox.getSize();
 

--- a/test/jdk/javax/swing/JComboBox/ComboPopupBug.java
+++ b/test/jdk/javax/swing/JComboBox/ComboPopupBug.java
@@ -43,51 +43,55 @@ public class ComboPopupBug {
     private static JFrame frame;
     private static JButton closeButton;
     private static JComboBox<String> comboBox;
-    private static Point comboBoxLocation;
-    private static Dimension comboBoxSize;
     private static Robot robot;
     private static final int PADDING = 10;
 
     public static void main(String[] args) throws Exception {
-        robot = new Robot();
-        SwingUtilities.invokeAndWait(() -> {
-            frame = new JFrame("ComboPopup");
-
-            comboBox = new JComboBox<>();
-            comboBox.setEditable(true);
-            comboBox.addItem("test");
-            comboBox.addItem("test2");
-            comboBox.addItem("test3");
-
-            closeButton = new JButton("Close");
-            closeButton.addActionListener((e) -> {
-                clickComboBox();
-                frame.setVisible(false);
-            });
-
-            frame.getContentPane().add(comboBox, "North");
-            frame.getContentPane().add(closeButton, "South");
-            frame.setSize(200, 200);
-            frame.setVisible(true);
-        });
-
-        robot.waitForIdle();
-        robot.delay(1000);
-
         try {
+            robot = new Robot();
+            robot.setAutoDelay(50);
+
+            SwingUtilities.invokeAndWait(ComboPopupBug::createUI);
+
+            robot.waitForIdle();
+            robot.delay(1000);
+
             SwingUtilities.invokeAndWait(() -> closeButton.doClick());
         } finally {
-            SwingUtilities.invokeAndWait(() -> frame.dispose());
+            if (frame != null) {
+                SwingUtilities.invokeAndWait(() -> frame.dispose());
+            }
         }
     }
 
     private static void clickComboBox() {
-        comboBoxLocation = comboBox.getLocationOnScreen();
-        comboBoxSize = comboBox.getSize();
+        Point comboBoxLocation = comboBox.getLocationOnScreen();
+        Dimension comboBoxSize = comboBox.getSize();
 
         robot.mouseMove(comboBoxLocation.x + comboBoxSize.width - PADDING,
                 comboBoxLocation.y + comboBoxSize.height / 2);
         robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
         robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+    }
+
+    private static void createUI() {
+        frame = new JFrame("ComboPopup");
+
+        comboBox = new JComboBox<>();
+        comboBox.setEditable(true);
+        comboBox.addItem("test");
+        comboBox.addItem("test2");
+        comboBox.addItem("test3");
+
+        closeButton = new JButton("Close");
+        closeButton.addActionListener((e) -> {
+            clickComboBox();
+            frame.setVisible(false);
+        });
+
+        frame.getContentPane().add(comboBox, "North");
+        frame.getContentPane().add(closeButton, "South");
+        frame.setSize(200, 200);
+        frame.setVisible(true);
     }
 }

--- a/test/jdk/javax/swing/JComboBox/ComboPopupBug.java
+++ b/test/jdk/javax/swing/JComboBox/ComboPopupBug.java
@@ -35,7 +35,6 @@ import javax.swing.SwingUtilities;
  * @bug 8322754
  * @key headful
  * @summary Verifies clicking JComboBox during frame closure causes Exception
- * @library /javax/swing/regtesthelpers
  * @run main ComboPopupBug
  */
 

--- a/test/jdk/javax/swing/JComboBox/ComboPopupBug.java
+++ b/test/jdk/javax/swing/JComboBox/ComboPopupBug.java
@@ -57,9 +57,11 @@ public class ComboPopupBug {
 
             SwingUtilities.invokeAndWait(() -> closeButton.doClick());
         } finally {
-            if (frame != null) {
-                SwingUtilities.invokeAndWait(() -> frame.dispose());
-            }
+            SwingUtilities.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
         }
     }
 

--- a/test/jdk/javax/swing/JComboBox/ComboPopupBug.java
+++ b/test/jdk/javax/swing/JComboBox/ComboPopupBug.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 import java.awt.Dimension;
 import java.awt.Point;
+import java.awt.Robot;
 import java.awt.event.InputEvent;
 import javax.swing.JButton;
 import javax.swing.JComboBox;
@@ -35,7 +36,6 @@ import javax.swing.SwingUtilities;
  * @key headful
  * @summary Verifies clicking JComboBox during frame closure causes Exception
  * @library /javax/swing/regtesthelpers
- * @build JRobot
  * @run main ComboPopupBug
  */
 
@@ -45,10 +45,11 @@ public class ComboPopupBug {
     private static JComboBox<String> comboBox;
     private static Point comboBoxLocation;
     private static Dimension comboBoxSize;
-    private static JRobot robot;
+    private static Robot robot;
+    private static final int PADDING = 10;
 
     public static void main(String[] args) throws Exception {
-        robot = JRobot.getRobot();
+        robot = new Robot();
         SwingUtilities.invokeAndWait(() -> {
             frame = new JFrame("ComboPopup");
 
@@ -70,14 +71,15 @@ public class ComboPopupBug {
             frame.setVisible(true);
         });
 
-        comboBoxLocation = comboBox.getLocationOnScreen();
-        comboBoxSize = comboBox.getSize();
+        robot.waitForIdle();
+        robot.delay(1000);
 
         try {
-            SwingUtilities.invokeAndWait(() -> closeButton.doClick());
-        }
-        catch (Exception e) {
-            throw new RuntimeException(e);
+            SwingUtilities.invokeAndWait(() -> {
+                comboBoxLocation = comboBox.getLocationOnScreen();
+                comboBoxSize = comboBox.getSize();
+                closeButton.doClick();
+            });
         }
         finally {
             SwingUtilities.invokeAndWait(() -> frame.dispose());
@@ -85,8 +87,9 @@ public class ComboPopupBug {
     }
 
     public static void clickComboBox() {
-        int padding = 10;
-        robot.mouseMove(comboBoxLocation.x + comboBoxSize.width - padding, comboBoxLocation.y + comboBoxSize.height / 2);
-        robot.clickMouse(InputEvent.BUTTON1_MASK);
+        robot.mouseMove(comboBoxLocation.x + comboBoxSize.width - PADDING,
+                comboBoxLocation.y + comboBoxSize.height / 2);
+        robot.mousePress(InputEvent.BUTTON1_MASK);
+        robot.mouseRelease(InputEvent.BUTTON1_MASK);
     }
 }

--- a/test/jdk/javax/swing/JComboBox/ComboPopupBug.java
+++ b/test/jdk/javax/swing/JComboBox/ComboPopupBug.java
@@ -75,11 +75,7 @@ public class ComboPopupBug {
         robot.delay(1000);
 
         try {
-            SwingUtilities.invokeAndWait(() -> {
-                comboBoxLocation = comboBox.getLocationOnScreen();
-                comboBoxSize = comboBox.getSize();
-                closeButton.doClick();
-            });
+            SwingUtilities.invokeAndWait(() -> closeButton.doClick());
         }
         finally {
             SwingUtilities.invokeAndWait(() -> frame.dispose());
@@ -87,6 +83,9 @@ public class ComboPopupBug {
     }
 
     public static void clickComboBox() {
+        comboBoxLocation = comboBox.getLocationOnScreen();
+        comboBoxSize = comboBox.getSize();
+
         robot.mouseMove(comboBoxLocation.x + comboBoxSize.width - PADDING,
                 comboBoxLocation.y + comboBoxSize.height / 2);
         robot.mousePress(InputEvent.BUTTON1_MASK);


### PR DESCRIPTION
This test was designed to manually verify that clicking on the JComboBox when the frame containing it is about to close does not cause an IllegalStateException.

The test allowed the tester extra time to click on the JComboBox when closing the frame by adding a Thread.sleep() in the close button handler.

In this test, a JComboBox is displayed with a Close button at the bottom. The tester should click the Close button, then try to click the JComboBox arrow button to display the popup.

In the automated test, we save the JComboBox  location size before closing the frame. We then use this information to click on the JComboBox right before the frame is closed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8354219](https://bugs.openjdk.org/browse/JDK-8354219): Automate javax/swing/JComboBox/ComboPopupBug.java (**Bug** - P4)


### Reviewers
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Alisen Chung](https://openjdk.org/census#achung) (@alisenchung - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24624/head:pull/24624` \
`$ git checkout pull/24624`

Update a local copy of the PR: \
`$ git checkout pull/24624` \
`$ git pull https://git.openjdk.org/jdk.git pull/24624/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24624`

View PR using the GUI difftool: \
`$ git pr show -t 24624`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24624.diff">https://git.openjdk.org/jdk/pull/24624.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24624#issuecomment-2801802448)
</details>
