### PR TITLE
8354448: [REDO] Remove friends for ObjectMonitor

### DIFF
--- a/src/hotspot/share/runtime/objectMonitor.hpp
+++ b/src/hotspot/share/runtime/objectMonitor.hpp
@@ -331,6 +331,7 @@ class ObjectMonitor : public CHeapObj<mtObjectMonitor> {
   void      add_to_contentions(int value);
   intx      recursions() const                                         { return _recursions; }
   void      set_recursions(size_t recursions);
+  void      increment_recursions(JavaThread* current);
 
   // JVM/TI GetObjectMonitorUsage() needs this:
   int waiters() const;

--- a/src/hotspot/share/runtime/objectMonitor.hpp
+++ b/src/hotspot/share/runtime/objectMonitor.hpp
@@ -148,9 +148,6 @@ class ObjectWaiter : public CHeapObj<mtThread> {
 #define OM_CACHE_LINE_SIZE DEFAULT_CACHE_LINE_SIZE
 
 class ObjectMonitor : public CHeapObj<mtObjectMonitor> {
-  friend class LightweightSynchronizer;
-  friend class ObjectSynchronizer;
-  friend class ObjectWaiter;
   friend class VMStructs;
   JVMCI_ONLY(friend class JVMCIVMStructs;)
 
@@ -424,13 +421,12 @@ class ObjectMonitor : public CHeapObj<mtObjectMonitor> {
   bool      short_fixed_spin(JavaThread* current, int spin_count, bool adapt);
   void      exit_epilog(JavaThread* current, ObjectWaiter* Wakee);
 
+ public:
   // Deflation support
   bool      deflate_monitor(Thread* current);
- private:
   void      install_displaced_markword_in_object(const oop obj);
 
   // JFR support
-public:
   static bool is_jfr_excluded(const Klass* monitor_klass);
 };
 

--- a/src/hotspot/share/runtime/objectMonitor.inline.hpp
+++ b/src/hotspot/share/runtime/objectMonitor.inline.hpp
@@ -150,6 +150,11 @@ inline void ObjectMonitor::set_recursions(size_t recursions) {
   _recursions = checked_cast<intx>(recursions);
 }
 
+inline void ObjectMonitor::increment_recursions(JavaThread* current) {
+  assert(has_owner(current), "must be the owner");
+  _recursions++;
+}
+
 // Clear _owner field; current value must match old_value.
 inline void ObjectMonitor::release_clear_owner(JavaThread* old_owner) {
   int64_t old_value = owner_id_from(old_owner);

--- a/src/hotspot/share/runtime/synchronizer.cpp
+++ b/src/hotspot/share/runtime/synchronizer.cpp
@@ -423,8 +423,7 @@ bool ObjectSynchronizer::quick_enter_legacy(oop obj, BasicLock* lock, JavaThread
     // Case: TLE inimical operations such as nested/recursive synchronization
 
     if (m->has_owner(current)) {
-      int recursions = m->recursions();
-      m->set_recursions(++recursions);
+      m->increment_recursions(current);
       current->inc_held_monitor_count();
       return true;
     }

--- a/src/hotspot/share/runtime/synchronizer.cpp
+++ b/src/hotspot/share/runtime/synchronizer.cpp
@@ -423,7 +423,8 @@ bool ObjectSynchronizer::quick_enter_legacy(oop obj, BasicLock* lock, JavaThread
     // Case: TLE inimical operations such as nested/recursive synchronization
 
     if (m->has_owner(current)) {
-      m->_recursions++;
+      int recursions = m->recursions();
+      m->set_recursions(++recursions);
       current->inc_held_monitor_count();
       return true;
     }
@@ -440,7 +441,7 @@ bool ObjectSynchronizer::quick_enter_legacy(oop obj, BasicLock* lock, JavaThread
     lock->set_displaced_header(markWord::unused_mark());
 
     if (!m->has_owner() && m->try_set_owner(current)) {
-      assert(m->_recursions == 0, "invariant");
+      assert(m->recursions() == 0, "invariant");
       current->inc_held_monitor_count();
       return true;
     }


### PR DESCRIPTION
This is a redo of the trivial change that failed.  The second commit is the method I should have added.
Tested with tier1-4, where tier3 has the code to exercise LockingMode=1.
Thanks,
Coleen

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8354448](https://bugs.openjdk.org/browse/JDK-8354448): [REDO] Remove friends for ObjectMonitor (**Bug** - P4)


### Reviewers
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24626/head:pull/24626` \
`$ git checkout pull/24626`

Update a local copy of the PR: \
`$ git checkout pull/24626` \
`$ git pull https://git.openjdk.org/jdk.git pull/24626/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24626`

View PR using the GUI difftool: \
`$ git pr show -t 24626`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24626.diff">https://git.openjdk.org/jdk/pull/24626.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24626#issuecomment-2802080789)
</details>
