### PR TITLE
8354536: Problem-list java/util/logging/LoggingDeadlock5.java due to JDK-8354424

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -727,6 +727,7 @@ com/sun/jdi/InvokeHangTest.java                                 8218463 linux-al
 
 # jdk_util
 java/util/zip/CloseInflaterDeflaterTest.java  8339216 linux-s390x
+java/util/logging/LoggingDeadlock5.java       8354424 generic-all
 
 ############################################################################
 


### PR DESCRIPTION
Hi,

Please find here a change that proposes to problem lists  java/util/logging/LoggingDeadlock5.java until 8354424 is fixed.

The test is failling quite consistently in higher tiers.

best regards,

-- daniel