### PR TITLE
8351162: Clean up x86 (Macro)Assembler after 32-bit x86 removal

### DIFF
--- a/src/hotspot/cpu/x86/assembler_x86.cpp
+++ b/src/hotspot/cpu/x86/assembler_x86.cpp
@@ -24,6 +24,8 @@
 
 #include "asm/assembler.hpp"
 #include "asm/assembler.inline.hpp"
+#include "asm/codeBuffer.hpp"
+#include "code/codeCache.hpp"
 #include "gc/shared/cardTableBarrierSet.hpp"
 #include "interpreter/interpreter.hpp"
 #include "memory/resourceArea.hpp"

--- a/src/hotspot/cpu/x86/assembler_x86.cpp
+++ b/src/hotspot/cpu/x86/assembler_x86.cpp
@@ -119,8 +119,6 @@ AddressLiteral::AddressLiteral(address target, relocInfo::relocType rtype) {
 
 // Implementation of Address
 
-#ifdef _LP64
-
 Address Address::make_array(ArrayAddress adr) {
   // Not implementable on 64bit machines
   // Should have been handled higher up the call chain.
@@ -157,30 +155,6 @@ Address::Address(int disp, address loc, relocInfo::relocType rtype) {
       ShouldNotReachHere();
   }
 }
-#else // LP64
-
-Address Address::make_array(ArrayAddress adr) {
-  AddressLiteral base = adr.base();
-  Address index = adr.index();
-  assert(index._disp == 0, "must not have disp"); // maybe it can?
-  Address array(index._base, index._index, index._scale, (intptr_t) base.target());
-  array._rspec = base._rspec;
-  return array;
-}
-
-// exceedingly dangerous constructor
-Address::Address(address loc, RelocationHolder spec) {
-  _base  = noreg;
-  _index = noreg;
-  _scale = no_scale;
-  _disp  = (intptr_t) loc;
-  _rspec = spec;
-  _xmmindex = xnoreg;
-  _isxmmindex = false;
-}
-
-#endif // _LP64
-
 
 
 // Convert the raw encoding form into the form expected by the constructor for
@@ -214,7 +188,6 @@ void Assembler::init_attributes(void) {
   _legacy_mode_dq = (VM_Version::supports_avx512dq() == false);
   _legacy_mode_vl = (VM_Version::supports_avx512vl() == false);
   _legacy_mode_vlbw = (VM_Version::supports_avx512vlbw() == false);
-  NOT_LP64(_is_managed = false;)
   _attributes = nullptr;
 }
 
@@ -744,8 +717,8 @@ void Assembler::emit_operand_helper(int reg_enc, int base_enc, int index_enc,
       assert(inst_mark() != nullptr, "must be inside InstructionMark");
       address next_ip = pc() + sizeof(int32_t) + post_addr_length;
       int64_t adjusted = disp;
-      // Do rip-rel adjustment for 64bit
-      LP64_ONLY(adjusted -=  (next_ip - inst_mark()));
+      // Do rip-rel adjustment
+      adjusted -=  (next_ip - inst_mark());
       assert(is_simm32(adjusted),
              "must be 32bit offset (RIP relative address)");
       emit_data((int32_t) adjusted, rspec, disp32_operand);
@@ -846,7 +819,7 @@ address Assembler::locate_operand(address inst, WhichOperand which) {
   case FS_segment:
   case GS_segment:
     // Seems dubious
-    LP64_ONLY(assert(false, "shouldn't have that prefix"));
+    assert(false, "shouldn't have that prefix");
     assert(ip == inst+1, "only one prefix allowed");
     goto again_after_prefix;
 
@@ -859,11 +832,9 @@ address Assembler::locate_operand(address inst, WhichOperand which) {
   case REX_RB:
   case REX_RX:
   case REX_RXB:
-    NOT_LP64(assert(false, "64bit prefixes"));
     goto again_after_prefix;
 
   case REX2:
-    NOT_LP64(assert(false, "64bit prefixes"));
     if ((0xFF & *ip++) & REX2BIT_W) {
       is_64bit = true;
     }
@@ -877,7 +848,6 @@ address Assembler::locate_operand(address inst, WhichOperand which) {
   case REX_WRB:
   case REX_WRX:
   case REX_WRXB:
-    NOT_LP64(assert(false, "64bit prefixes"));
     is_64bit = true;
     goto again_after_prefix;
 
@@ -916,11 +886,9 @@ address Assembler::locate_operand(address inst, WhichOperand which) {
     case REX_WRB:
     case REX_WRX:
     case REX_WRXB:
-      NOT_LP64(assert(false, "64bit prefix found"));
       goto again_after_size_prefix2;
 
     case REX2:
-      NOT_LP64(assert(false, "64bit prefix found"));
       if ((0xFF & *ip++) & REX2BIT_W) {
         is_64bit = true;
       }
@@ -945,14 +913,9 @@ address Assembler::locate_operand(address inst, WhichOperand which) {
   case REP8(0xB8): // movl/q r, #32/#64(oop?)
     if (which == end_pc_operand)  return ip + (is_64bit ? 8 : 4);
     // these asserts are somewhat nonsensical
-#ifndef _LP64
-    assert(which == imm_operand || which == disp32_operand,
-           "which %d is_64_bit %d ip " INTPTR_FORMAT, which, is_64bit, p2i(ip));
-#else
     assert(((which == call32_operand || which == imm_operand) && is_64bit) ||
            (which == narrow_oop_operand && !is_64bit),
            "which %d is_64_bit %d ip " INTPTR_FORMAT, which, is_64bit, p2i(ip));
-#endif // _LP64
     return ip;
 
   case 0x69: // imul r, a, #32
@@ -1113,8 +1076,6 @@ address Assembler::locate_operand(address inst, WhichOperand which) {
     // to check for them in product version.
 
     // Check second byte
-    NOT_LP64(assert((0xC0 & *ip) == 0xC0, "shouldn't have LDS and LES instructions"));
-
     int vex_opcode;
     // First byte
     if ((0xFF & *inst) == VEX_3bytes) {
@@ -1216,8 +1177,8 @@ address Assembler::locate_operand(address inst, WhichOperand which) {
     case REX_WRX:
     case REX_WRXB:
     case REX2:
-      NOT_LP64(assert(false, "found 64bit prefix"));
       ip++;
+      // fall-through
     default:
       ip++;
     }
@@ -1232,12 +1193,7 @@ address Assembler::locate_operand(address inst, WhichOperand which) {
   }
 
   assert(which != call32_operand, "instruction is not a call, jmp, or jcc");
-#ifdef _LP64
   assert(which != imm_operand, "instruction is not a movq reg, imm64");
-#else
-  // assert(which != imm_operand || has_imm32, "instruction has no imm32 field");
-  assert(which != imm_operand || has_disp32, "instruction has no imm32 field");
-#endif // LP64
   assert(which != disp32_operand || has_disp32, "instruction has no disp32 field");
 
   // parse the output of emit_operand
@@ -1292,11 +1248,7 @@ address Assembler::locate_operand(address inst, WhichOperand which) {
     return ip + tail_size;
   }
 
-#ifdef _LP64
   assert(which == narrow_oop_operand && !is_64bit, "instruction is not a movl adr, imm32");
-#else
-  assert(which == imm_operand, "instruction has only an imm field");
-#endif // LP64
   return ip;
 }
 
@@ -1319,8 +1271,7 @@ void Assembler::check_relocation(RelocationHolder const& rspec, int format) {
     // assert(format == imm32_operand, "cannot specify a nonzero format");
     opnd = locate_operand(inst, call32_operand);
   } else if (r->is_data()) {
-    assert(format == imm_operand || format == disp32_operand
-           LP64_ONLY(|| format == narrow_oop_operand), "format ok");
+    assert(format == imm_operand || format == disp32_operand || format == narrow_oop_operand, "format ok");
     opnd = locate_operand(inst, (WhichOperand)format);
   } else {
     assert(format == imm_operand, "cannot specify a format");
@@ -1830,9 +1781,6 @@ void Assembler::blsrl(Register dst, Address src) {
 }
 
 void Assembler::call(Label& L, relocInfo::relocType rtype) {
-  // suspect disp32 is always good
-  int operand = LP64_ONLY(disp32_operand) NOT_LP64(imm_operand);
-
   if (L.is_bound()) {
     const int long_size = 5;
     int offs = (int)( target(L) - pc() );
@@ -1840,14 +1788,14 @@ void Assembler::call(Label& L, relocInfo::relocType rtype) {
     InstructionMark im(this);
     // 1110 1000 #32-bit disp
     emit_int8((unsigned char)0xE8);
-    emit_data(offs - long_size, rtype, operand);
+    emit_data(offs - long_size, rtype, disp32_operand);
   } else {
     InstructionMark im(this);
     // 1110 1000 #32-bit disp
     L.add_patch_at(code(), locator());
 
     emit_int8((unsigned char)0xE8);
-    emit_data(int(0), rtype, operand);
+    emit_data(int(0), rtype, disp32_operand);
   }
 }
 
@@ -1874,8 +1822,7 @@ void Assembler::call_literal(address entry, RelocationHolder const& rspec) {
   // Technically, should use call32_operand, but this format is
   // implied by the fact that we're emitting a call instruction.
 
-  int operand = LP64_ONLY(disp32_operand) NOT_LP64(call32_operand);
-  emit_data((int) disp, rspec, operand);
+  emit_data((int) disp, rspec, disp32_operand);
 }
 
 void Assembler::cdql() {
@@ -1887,7 +1834,6 @@ void Assembler::cld() {
 }
 
 void Assembler::cmovl(Condition cc, Register dst, Register src) {
-  NOT_LP64(guarantee(VM_Version::supports_cmov(), "illegal instruction"));
   int encode = prefix_and_encode(dst->encoding(), src->encoding(), true /* is_map1 */);
   emit_opcode_prefix_and_encoding(0x40 | cc, 0xC0, encode);
 }
@@ -1900,7 +1846,6 @@ void Assembler::ecmovl(Condition cc, Register dst, Register src1, Register src2)
 
 void Assembler::cmovl(Condition cc, Register dst, Address src) {
   InstructionMark im(this);
-  NOT_LP64(guarantee(VM_Version::supports_cmov(), "illegal instruction"));
   prefix(src, dst, false, true /* is_map1 */);
   emit_int8((0x40 | cc));
   emit_operand(dst, src, 0);
@@ -2091,8 +2036,7 @@ void Assembler::crc32(Register crc, Register v, int8_t sizeInBytes) {
     case 2:
     case 4:
       break;
-    LP64_ONLY(case 8:)
-      // This instruction is not valid in 32 bits
+    case 8:
       // Note:
       // http://www.intel.com/content/dam/www/public/us/en/documents/manuals/64-ia-32-architectures-software-developer-instruction-set-reference-manual-325383.pdf
       //
@@ -2111,7 +2055,7 @@ void Assembler::crc32(Register crc, Register v, int8_t sizeInBytes) {
       assert(0, "Unsupported value for a sizeInBytes argument");
       break;
     }
-    LP64_ONLY(prefix(crc, v, p);)
+    prefix(crc, v, p);
     emit_int32(0x0F,
                0x38,
                0xF0 | w,
@@ -2140,15 +2084,14 @@ void Assembler::crc32(Register crc, Address adr, int8_t sizeInBytes) {
     case 2:
     case 4:
       break;
-    LP64_ONLY(case 8:)
-      // This instruction is not valid in 32 bits
+    case 8:
       p = REX_W;
       break;
     default:
       assert(0, "Unsupported value for a sizeInBytes argument");
       break;
     }
-    LP64_ONLY(prefix(crc, adr, p);)
+    prefix(crc, adr, p);
     emit_int24(0x0F, 0x38, (0xF0 | w));
     emit_operand(crc, adr, 0);
   }
@@ -2840,7 +2783,6 @@ void Assembler::leal(Register dst, Address src) {
   emit_operand(dst, src, 0);
 }
 
-#ifdef _LP64
 void Assembler::lea(Register dst, Label& L) {
   emit_prefix_and_int8(get_prefixq(Address(), dst), (unsigned char)0x8D);
   if (!L.is_bound()) {
@@ -2858,7 +2800,6 @@ void Assembler::lea(Register dst, Label& L) {
     emit_int32(disp);
   }
 }
-#endif
 
 void Assembler::lfence() {
   emit_int24(0x0F, (unsigned char)0xAE, (unsigned char)0xE8);
@@ -2916,7 +2857,7 @@ void Assembler::sfence() {
 }
 
 void Assembler::mov(Register dst, Register src) {
-  LP64_ONLY(movq(dst, src)) NOT_LP64(movl(dst, src));
+  movq(dst, src);
 }
 
 void Assembler::movapd(XMMRegister dst, XMMRegister src) {
@@ -2941,7 +2882,6 @@ void Assembler::movlhps(XMMRegister dst, XMMRegister src) {
 }
 
 void Assembler::movb(Register dst, Address src) {
-  NOT_LP64(assert(dst->has_byte_register(), "must have byte register"));
   InstructionMark im(this);
   prefix(src, dst, true);
   emit_int8((unsigned char)0x8A);
@@ -3932,7 +3872,6 @@ void Assembler::movsbl(Register dst, Address src) { // movsxb
 }
 
 void Assembler::movsbl(Register dst, Register src) { // movsxb
-  NOT_LP64(assert(src->has_byte_register(), "must have byte register"));
   int encode = prefix_and_encode(dst->encoding(), false, src->encoding(), true, true /* is_map1 */);
   emit_opcode_prefix_and_encoding((unsigned char)0xBE, 0xC0, encode);
 }
@@ -4082,7 +4021,6 @@ void Assembler::movzbl(Register dst, Address src) { // movzxb
 }
 
 void Assembler::movzbl(Register dst, Register src) { // movzxb
-  NOT_LP64(assert(src->has_byte_register(), "must have byte register"));
   int encode = prefix_and_encode(dst->encoding(), false, src->encoding(), true, true /* is_map1 */);
   emit_opcode_prefix_and_encoding((unsigned char)0xB6, 0xC0, encode);
 }
@@ -5810,16 +5748,6 @@ void Assembler::popf() {
   emit_int8((unsigned char)0x9D);
 }
 
-#ifndef _LP64 // no 32bit push/pop on amd64
-void Assembler::popl(Address dst) {
-  // NOTE: this will adjust stack by 8byte on 64bits
-  InstructionMark im(this);
-  prefix(dst);
-  emit_int8((unsigned char)0x8F);
-  emit_operand(rax, dst, 0);
-}
-#endif
-
 void Assembler::prefetchnta(Address src) {
   InstructionMark im(this);
   prefix(src, true /* is_map1 */);
@@ -6220,7 +6148,6 @@ void Assembler::evpunpckhqdq(XMMRegister dst, KRegister mask, XMMRegister src1, 
   emit_int16(0x6D, (0xC0 | encode));
 }
 
-#ifdef _LP64
 void Assembler::push2(Register src1, Register src2, bool with_ppx) {
   assert(VM_Version::supports_apx_f(), "requires APX");
   InstructionAttr attributes(0, /* rex_w */ with_ppx, /* legacy_mode */ false, /* no_mask_reg */ true, /* uses_vl */ false);
@@ -6282,8 +6209,6 @@ void Assembler::popp(Register dst) {
   int encode = prefixq_and_encode_rex2(dst->encoding());
   emit_int8((unsigned char)0x58 | encode);
 }
-#endif //_LP64
-
 
 void Assembler::push(int32_t imm32) {
   // in 64bits we push 64bits onto the stack but only
@@ -6300,16 +6225,6 @@ void Assembler::push(Register src) {
 void Assembler::pushf() {
   emit_int8((unsigned char)0x9C);
 }
-
-#ifndef _LP64 // no 32bit push/pop on amd64
-void Assembler::pushl(Address src) {
-  // Note this will push 64bit on 64bit
-  InstructionMark im(this);
-  prefix(src);
-  emit_int8((unsigned char)0xFF);
-  emit_operand(rsi, src, 0);
-}
-#endif
 
 void Assembler::rcll(Register dst, int imm8) {
   assert(isShiftCount(imm8), "illegal shift count");
@@ -6353,43 +6268,37 @@ void Assembler::rdtsc() {
 void Assembler::rep_mov() {
   // REP
   // MOVSQ
-  LP64_ONLY(emit_int24((unsigned char)0xF3, REX_W, (unsigned char)0xA5);)
-  NOT_LP64( emit_int16((unsigned char)0xF3,        (unsigned char)0xA5);)
+  emit_int24((unsigned char)0xF3, REX_W, (unsigned char)0xA5);
 }
 
 // sets rcx bytes with rax, value at [edi]
 void Assembler::rep_stosb() {
   // REP
   // STOSB
-  LP64_ONLY(emit_int24((unsigned char)0xF3, REX_W, (unsigned char)0xAA);)
-  NOT_LP64( emit_int16((unsigned char)0xF3,        (unsigned char)0xAA);)
+  emit_int24((unsigned char)0xF3, REX_W, (unsigned char)0xAA);
 }
 
 // sets rcx pointer sized words with rax, value at [edi]
 // generic
 void Assembler::rep_stos() {
   // REP
-  // LP64:STOSQ, LP32:STOSD
-  LP64_ONLY(emit_int24((unsigned char)0xF3, REX_W, (unsigned char)0xAB);)
-  NOT_LP64( emit_int16((unsigned char)0xF3,        (unsigned char)0xAB);)
+  // STOSQ
+  emit_int24((unsigned char)0xF3, REX_W, (unsigned char)0xAB);
 }
 
 // scans rcx pointer sized words at [edi] for occurrence of rax,
 // generic
 void Assembler::repne_scan() { // repne_scan
   // SCASQ
-  LP64_ONLY(emit_int24((unsigned char)0xF2, REX_W, (unsigned char)0xAF);)
-  NOT_LP64( emit_int16((unsigned char)0xF2,        (unsigned char)0xAF);)
+  emit_int24((unsigned char)0xF2, REX_W, (unsigned char)0xAF);
 }
 
-#ifdef _LP64
 // scans rcx 4 byte words at [edi] for occurrence of rax,
 // generic
 void Assembler::repne_scanl() { // repne_scan
   // SCASL
   emit_int16((unsigned char)0xF2, (unsigned char)0xAF);
 }
-#endif
 
 void Assembler::ret(int imm16) {
   if (imm16 == 0) {
@@ -6464,7 +6373,6 @@ void Assembler::erorl(Register dst, Register src, bool no_flags) {
   emit_int16((unsigned char)0xD3, (0xC8 | encode));
 }
 
-#ifdef _LP64
 void Assembler::rorq(Register dst) {
   int encode = prefixq_and_encode(dst->encoding());
   emit_int16((unsigned char)0xD3, (0xC8 | encode));
@@ -6527,15 +6435,6 @@ void Assembler::erolq(Register dst, Register src, int imm8, bool no_flags) {
    } else {
      emit_int24((unsigned char)0xC1, (0xc0 | encode), imm8);
    }
- }
-#endif
-
-void Assembler::sahf() {
-#ifdef _LP64
-  // Not supported in 64bit mode
-  ShouldNotReachHere();
-#endif
-  emit_int8((unsigned char)0x9E);
 }
 
 void Assembler::sall(Address dst, int imm8) {
@@ -6988,7 +6887,6 @@ void Assembler::eshrdl(Register dst, Register src1, Register src2, int8_t imm8, 
   emit_int24(0x2C, (0xC0 | encode), imm8);
 }
 
-#ifdef _LP64
 void Assembler::shldq(Register dst, Register src, int8_t imm8) {
   int encode = prefixq_and_encode(src->encoding(), dst->encoding(), true /* is_map1 */);
   emit_opcode_prefix_and_encoding((unsigned char)0xA4, 0xC0, encode, imm8);
@@ -7014,7 +6912,6 @@ void Assembler::eshrdq(Register dst, Register src1, Register src2, int8_t imm8, 
   int encode = evex_prefix_and_encode_ndd(src2->encoding(), dst->encoding(), src1->encoding(), VEX_SIMD_NONE, /* MAP4 */VEX_OPCODE_0F_3C, &attributes, no_flags);
   emit_int24(0x2C, (0xC0 | encode), imm8);
 }
-#endif
 
 // copies a single word from [esi] to [edi]
 void Assembler::smovl() {
@@ -7208,7 +7105,6 @@ void Assembler::subss(XMMRegister dst, Address src) {
 }
 
 void Assembler::testb(Register dst, int imm8, bool use_ral) {
-  NOT_LP64(assert(dst->has_byte_register(), "must have byte register"));
   if (dst == rax) {
     if (use_ral) {
       emit_int8((unsigned char)0xA8);
@@ -12872,54 +12768,6 @@ void Assembler::emit_farith(int b1, int b2, int i) {
   emit_int16(b1, b2 + i);
 }
 
-#ifndef _LP64
-// 32bit only pieces of the assembler
-
-void Assembler::emms() {
-  NOT_LP64(assert(VM_Version::supports_mmx(), ""));
-  emit_int16(0x0F, 0x77);
-}
-
-void Assembler::vzeroupper() {
-  vzeroupper_uncached();
-}
-
-void Assembler::cmp_literal32(Register src1, int32_t imm32, RelocationHolder const& rspec) {
-  // NO PREFIX AS NEVER 64BIT
-  InstructionMark im(this);
-  emit_int16((unsigned char)0x81, (0xF8 | src1->encoding()));
-  emit_data(imm32, rspec, 0);
-}
-
-void Assembler::cmp_literal32(Address src1, int32_t imm32, RelocationHolder const& rspec) {
-  // NO PREFIX AS NEVER 64BIT (not even 32bit versions of 64bit regs
-  InstructionMark im(this);
-  emit_int8((unsigned char)0x81);
-  emit_operand(rdi, src1, 4);
-  emit_data(imm32, rspec, 0);
-}
-
-// The 64-bit (32bit platform) cmpxchg compares the value at adr with the contents of rdx:rax,
-// and stores rcx:rbx into adr if so; otherwise, the value at adr is loaded
-// into rdx:rax.  The ZF is set if the compared values were equal, and cleared otherwise.
-void Assembler::cmpxchg8(Address adr) {
-  InstructionMark im(this);
-  emit_int16(0x0F, (unsigned char)0xC7);
-  emit_operand(rcx, adr, 0);
-}
-
-void Assembler::decl(Register dst) {
-  // Don't use it directly. Use MacroAssembler::decrementl() instead.
- emit_int8(0x48 | dst->encoding());
-}
-
-void Assembler::edecl(Register dst, Register src, bool no_flags) {
-  InstructionAttr attributes(AVX_128bit, /* vex_w */ false, /* legacy_mode */ false, /* no_mask_reg */ true, /* uses_vl */ false);
-  (void) evex_prefix_and_encode_ndd(0, dst->encoding(), src->encoding(), VEX_SIMD_NONE, VEX_OPCODE_0F_3C, &attributes, no_flags);
-  emit_int8(0x48 | src->encoding());
-}
-#endif // !_LP64
-
 // SSE SIMD prefix byte values corresponding to VexSimdPrefix encoding.
 static int simd_pre[4] = { 0, 0x66, 0xF3, 0xF2 };
 // SSE opcode second byte values (first is 0x0F) corresponding to VexOpcode encoding.
@@ -13053,7 +12901,7 @@ void Assembler::vex_prefix(Address adr, int nds_enc, int xreg_enc, VexSimdPrefix
   // is allowed in legacy mode and has resources which will fit in it.
   // Pure EVEX instructions will have is_evex_instruction set in their definition.
   if (!attributes->is_legacy_mode()) {
-    if (UseAVX > 2 && !attributes->is_evex_instruction() && !is_managed()) {
+    if (UseAVX > 2 && !attributes->is_evex_instruction()) {
       if ((attributes->get_vector_len() != AVX_512bit) && !is_extended) {
           attributes->set_is_legacy_mode();
       }
@@ -13068,7 +12916,6 @@ void Assembler::vex_prefix(Address adr, int nds_enc, int xreg_enc, VexSimdPrefix
     assert((!is_extended || (!attributes->is_legacy_mode())),"XMM register should be 0-15");
   }
 
-  clear_managed();
   if (UseAVX > 2 && !attributes->is_legacy_mode())
   {
     bool evex_r = (xreg_enc >= 16);
@@ -13116,7 +12963,7 @@ int Assembler::vex_prefix_and_encode(int dst_enc, int nds_enc, int src_enc, VexS
   // is allowed in legacy mode and has resources which will fit in it.
   // Pure EVEX instructions will have is_evex_instruction set in their definition.
   if (!attributes->is_legacy_mode()) {
-    if (UseAVX > 2 && !attributes->is_evex_instruction() && !is_managed()) {
+    if (UseAVX > 2 && !attributes->is_evex_instruction()) {
       if ((!attributes->uses_vl() || (attributes->get_vector_len() != AVX_512bit)) &&
            !is_extended) {
           attributes->set_is_legacy_mode();
@@ -13138,7 +12985,6 @@ int Assembler::vex_prefix_and_encode(int dst_enc, int nds_enc, int src_enc, VexS
     assert(((!is_extended) || (!attributes->is_legacy_mode())),"XMM register should be 0-15");
   }
 
-  clear_managed();
   if (UseAVX > 2 && !attributes->is_legacy_mode())
   {
     bool evex_r = (dst_enc >= 16);
@@ -14037,55 +13883,6 @@ void Assembler::evcompresspd(XMMRegister dst, KRegister mask, XMMRegister src, b
   int encode = vex_prefix_and_encode(src->encoding(), 0, dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F_38, &attributes);
   emit_int16((unsigned char)0x8A, (0xC0 | encode));
 }
-
-#ifndef _LP64
-
-void Assembler::incl(Register dst) {
-  // Don't use it directly. Use MacroAssembler::incrementl() instead.
-  emit_int8(0x40 | dst->encoding());
-}
-
-void Assembler::eincl(Register dst, Register src, bool no_flags) {
-  InstructionAttr attributes(AVX_128bit, /* vex_w */ false, /* legacy_mode */ false, /* no_mask_reg */ true, /* uses_vl */ false);
-  (void) evex_prefix_and_encode_ndd(0, dst->encoding(), src->encoding(), VEX_SIMD_NONE, VEX_OPCODE_0F_3C, &attributes, no_flags);
-  emit_int8(0x40 | src->encoding());
-}
-
-void Assembler::lea(Register dst, Address src) {
-  leal(dst, src);
-}
-
-void Assembler::mov_literal32(Address dst, int32_t imm32, RelocationHolder const& rspec) {
-  InstructionMark im(this);
-  emit_int8((unsigned char)0xC7);
-  emit_operand(rax, dst, 4);
-  emit_data((int)imm32, rspec, 0);
-}
-
-void Assembler::mov_literal32(Register dst, int32_t imm32, RelocationHolder const& rspec) {
-  InstructionMark im(this);
-  int encode = prefix_and_encode(dst->encoding());
-  emit_int8((0xB8 | encode));
-  emit_data((int)imm32, rspec, 0);
-}
-
-void Assembler::popa() { // 32bit
-  emit_int8(0x61);
-}
-
-void Assembler::push_literal32(int32_t imm32, RelocationHolder const& rspec) {
-  InstructionMark im(this);
-  emit_int8(0x68);
-  emit_data(imm32, rspec, 0);
-}
-
-void Assembler::pusha() { // 32bit
-  emit_int8(0x60);
-}
-
-#else // LP64
-
-// 64bit only pieces of the assembler
 
 // This should only be used by 64bit instructions that can use rip-relative
 // it cannot be used by instructions that want an immediate value.
@@ -16039,7 +15836,6 @@ void Assembler::rorxq(Register dst, Address src, int imm8) {
   emit_int8(imm8);
 }
 
-#ifdef _LP64
 void Assembler::salq(Address dst, int imm8) {
   InstructionMark im(this);
   assert(isShiftCount(imm8 >> 1), "illegal shift count");
@@ -16194,7 +15990,6 @@ void Assembler::esarq(Register dst, Register src, bool no_flags) {
   int encode = evex_prefix_and_encode_ndd(0, dst->encoding(), src->encoding(), VEX_SIMD_NONE, VEX_OPCODE_0F_3C, &attributes, no_flags);
   emit_int16((unsigned char)0xD3, (0xF8 | encode));
 }
-#endif
 
 void Assembler::sbbq(Address dst, int32_t imm32) {
   InstructionMark im(this);
@@ -16538,8 +16333,6 @@ void Assembler::exorq(Register dst, Address src1, Register src2, bool no_flags) 
   emit_int8(0x31);
   emit_operand(src2, src1, 0);
 }
-
-#endif // !LP64
 
 void InstructionAttr::set_address_attributes(int tuple_type, int input_size_in_bits) {
   if (VM_Version::supports_evex()) {

--- a/src/hotspot/cpu/x86/assembler_x86.hpp
+++ b/src/hotspot/cpu/x86/assembler_x86.hpp
@@ -35,7 +35,6 @@
 class Argument {
  public:
   enum {
-#ifdef _LP64
 #ifdef _WIN64
     n_int_register_parameters_c   = 4, // rcx, rdx, r8, r9 (c_rarg0, c_rarg1, ...)
     n_float_register_parameters_c = 4,  // xmm0 - xmm3 (c_farg0, c_farg1, ... )
@@ -49,16 +48,10 @@ class Argument {
 #endif // _WIN64
     n_int_register_parameters_j   = 6, // j_rarg0, j_rarg1, ...
     n_float_register_parameters_j = 8  // j_farg0, j_farg1, ...
-#else
-    n_register_parameters = 0,   // 0 registers used to pass arguments
-    n_int_register_parameters_j   = 0,
-    n_float_register_parameters_j = 0
-#endif // _LP64
   };
 };
 
 
-#ifdef _LP64
 // Symbolically name the register arguments used by the c calling convention.
 // Windows is different from linux/solaris. So much for standards...
 
@@ -138,15 +131,6 @@ constexpr Register rscratch2 = r11;  // volatile
 constexpr Register r12_heapbase = r12; // callee-saved
 constexpr Register r15_thread   = r15; // callee-saved
 
-#else
-// rscratch1 will appear in 32bit code that is dead but of course must compile
-// Using noreg ensures if the dead code is incorrectly live and executed it
-// will cause an assertion failure
-#define rscratch1 noreg
-#define rscratch2 noreg
-
-#endif // _LP64
-
 // JSR 292
 // On x86, the SP does not have to be saved when invoking method handle intrinsics
 // or compiled lambda forms. We indicate that by setting rbp_mh_SP_save to noreg.
@@ -168,7 +152,7 @@ class Address {
     times_2  =  1,
     times_4  =  2,
     times_8  =  3,
-    times_ptr = LP64_ONLY(times_8) NOT_LP64(times_4)
+    times_ptr = times_8
   };
   static ScaleFactor times(int size) {
     assert(size >= 1 && size <= 8 && is_power_of_2(size), "bad scale size");
@@ -197,7 +181,6 @@ class Address {
 
   // Easily misused constructors make them private
   // %%% can we make these go away?
-  NOT_LP64(Address(address loc, RelocationHolder spec);)
   Address(int disp, address loc, relocInfo::relocType rtype);
   Address(int disp, address loc, RelocationHolder spec);
 
@@ -456,7 +439,7 @@ class InstructionAttr;
 
 // 64-bit reflect the fxsave size which is 512 bytes and the new xsave area on EVEX which is another 2176 bytes
 // See fxsave and xsave(EVEX enabled) documentation for layout
-const int FPUStateSizeInWords = NOT_LP64(27) LP64_ONLY(2688 / wordSize);
+const int FPUStateSizeInWords = 2688 / wordSize;
 
 // The Intel x86/Amd64 Assembler: Pure assembler doing NO optimizations on the instruction
 // level (e.g. mov rax, 0 is not translated into xor rax, rax!); i.e., what you write
@@ -628,12 +611,8 @@ class Assembler : public AbstractAssembler  {
     imm_operand  = 0,            // embedded 32-bit|64-bit immediate operand
     disp32_operand = 1,          // embedded 32-bit displacement or address
     call32_operand = 2,          // embedded 32-bit self-relative displacement
-#ifndef _LP64
-    _WhichOperand_limit = 3
-#else
-     narrow_oop_operand = 3,     // embedded 32-bit immediate narrow oop
+    narrow_oop_operand = 3,      // embedded 32-bit immediate narrow oop
     _WhichOperand_limit = 4
-#endif
   };
 
   // Comparison predicates for integral types & FP types when using SSE
@@ -721,7 +700,6 @@ private:
   bool _legacy_mode_dq;
   bool _legacy_mode_vl;
   bool _legacy_mode_vlbw;
-  NOT_LP64(bool _is_managed;)
 
   InstructionAttr *_attributes;
   void set_attributes(InstructionAttr* attributes);
@@ -907,25 +885,13 @@ private:
   void emit_opcode_prefix_and_encoding(int byte1, int ocp_and_encoding);
   void emit_opcode_prefix_and_encoding(int byte1, int byte2, int ocp_and_encoding);
   void emit_opcode_prefix_and_encoding(int byte1, int byte2, int ocp_and_encoding, int byte3);
-  bool always_reachable(AddressLiteral adr) NOT_LP64( { return true; } );
-  bool        reachable(AddressLiteral adr) NOT_LP64( { return true; } );
+  bool always_reachable(AddressLiteral adr);
+  bool        reachable(AddressLiteral adr);
 
 
   // These are all easily abused and hence protected
 
  public:
-  // 32BIT ONLY SECTION
-#ifndef _LP64
-  // Make these disappear in 64bit mode since they would never be correct
-  void cmp_literal32(Register src1, int32_t imm32, RelocationHolder const& rspec);   // 32BIT ONLY
-  void cmp_literal32(Address src1, int32_t imm32, RelocationHolder const& rspec);    // 32BIT ONLY
-
-  void mov_literal32(Register dst, int32_t imm32, RelocationHolder const& rspec);    // 32BIT ONLY
-  void mov_literal32(Address dst, int32_t imm32, RelocationHolder const& rspec);     // 32BIT ONLY
-
-  void push_literal32(int32_t imm32, RelocationHolder const& rspec);                 // 32BIT ONLY
-#else
-  // 64BIT ONLY SECTION
   void mov_literal64(Register dst, intptr_t imm64, RelocationHolder const& rspec);   // 64BIT ONLY
 
   void cmp_narrow_oop(Register src1, int32_t imm32, RelocationHolder const& rspec);
@@ -933,7 +899,6 @@ private:
 
   void mov_narrow_oop(Register dst, int32_t imm32, RelocationHolder const& rspec);
   void mov_narrow_oop(Address dst, int32_t imm32, RelocationHolder const& rspec);
-#endif // _LP64
 
  protected:
   // These are unique in that we are ensured by the caller that the 32bit
@@ -1017,17 +982,10 @@ private:
   void init_attributes(void);
   void clear_attributes(void) { _attributes = nullptr; }
 
-  void set_managed(void) { NOT_LP64(_is_managed = true;) }
-  void clear_managed(void) { NOT_LP64(_is_managed = false;) }
-  bool is_managed(void) {
-    NOT_LP64(return _is_managed;)
-    LP64_ONLY(return false;) }
-
   void lea(Register dst, Address src);
 
   void mov(Register dst, Register src);
 
-#ifdef _LP64
   // support caching the result of some routines
 
   // must be called before pusha(), popa(), vzeroupper() - checked with asserts
@@ -1047,7 +1005,6 @@ private:
   // New Zero Upper setcc instruction.
   void esetzucc(Condition cc, Register dst);
 
-#endif
   void vzeroupper_uncached();
   void decq(Register dst);
   void edecq(Register dst, Register src, bool no_flags);
@@ -1069,9 +1026,7 @@ private:
   void rep_stos();
   void rep_stosb();
   void repne_scan();
-#ifdef _LP64
   void repne_scanl();
-#endif
 
   // Vanilla instructions in lexical order
 
@@ -1121,7 +1076,6 @@ private:
   void eincq(Register dst, Register src, bool no_flags);
   void eincq(Register dst, Address src, bool no_flags);
 
-#ifdef _LP64
  //Add Unsigned Integers with Carry Flag
   void adcxq(Register dst, Register src);
   void eadcxq(Register dst, Register src1, Register src2);
@@ -1129,7 +1083,6 @@ private:
  //Add Unsigned Integers with Overflow Flag
   void adoxq(Register dst, Register src);
   void eadoxq(Register dst, Register src1, Register src2);
-#endif
 
   void addr_nop_4();
   void addr_nop_5();
@@ -1206,10 +1159,8 @@ private:
   void bsfl(Register dst, Register src);
   void bsrl(Register dst, Register src);
 
-#ifdef _LP64
   void bsfq(Register dst, Register src);
   void bsrq(Register dst, Register src);
-#endif
 
   void bswapl(Register reg);
 
@@ -1395,10 +1346,6 @@ private:
   void emit_farith(int b1, int b2, int i);
 
  public:
-#ifndef _LP64
-  void emms();
-#endif // !_LP64
-
   // operands that only take the original 32bit registers
   void emit_operand32(Register reg, Address adr, int post_addr_length);
 
@@ -1417,12 +1364,10 @@ private:
   void divl(Register src); // Unsigned division
   void edivl(Register src, bool no_flags); // Unsigned division
 
-#ifdef _LP64
   void idivq(Register src);
   void eidivq(Register src, bool no_flags);
   void divq(Register src); // Unsigned division
   void edivq(Register src, bool no_flags); // Unsigned division
-#endif
 
   void imull(Register src);
   void eimull(Register src, bool no_flags);
@@ -1435,7 +1380,6 @@ private:
   void imull(Register dst, Address src);
   void eimull(Register dst, Register src1, Address src2, bool no_flags);
 
-#ifdef _LP64
   void imulq(Register dst, Register src);
   void eimulq(Register dst, Register src, bool no_flags);
   void eimulq(Register dst, Register src1, Register src2, bool no_flags);
@@ -1448,7 +1392,6 @@ private:
   void eimulq(Register dst, Register src1, Address src2, bool no_flags);
   void imulq(Register dst);
   void eimulq(Register dst, bool no_flags);
-#endif
 
   // jcc is the generic conditional branch generator to run-
   // time routines, jcc is used for branches to labels. jcc
@@ -1500,9 +1443,7 @@ private:
 
   void leaq(Register dst, Address src);
 
-#ifdef _LP64
   void lea(Register dst, Label& L);
-#endif
 
   void lfence();
 
@@ -1514,12 +1455,10 @@ private:
   void lzcntl(Register dst, Address src);
   void elzcntl(Register dst, Address src, bool no_flags);
 
-#ifdef _LP64
   void lzcntq(Register dst, Register src);
   void elzcntq(Register dst, Register src, bool no_flags);
   void lzcntq(Register dst, Address src);
   void elzcntq(Register dst, Address src, bool no_flags);
-#endif
 
   enum Membar_mask_bits {
     StoreStore = 1 << 3,
@@ -1679,13 +1618,11 @@ private:
   void movl(Register dst, Address src);
   void movl(Address dst, Register src);
 
-#ifdef _LP64
   void movq(Register dst, Register src);
   void movq(Register dst, Address src);
   void movq(Address  dst, Register src);
   void movq(Address  dst, int32_t imm32);
   void movq(Register  dst, int32_t imm32);
-#endif
 
   // Move Quadword
   void movq(Address     dst, XMMRegister src);
@@ -1700,7 +1637,6 @@ private:
   void vmovw(XMMRegister dst, Register src);
   void vmovw(Register dst, XMMRegister src);
 
-#ifdef _LP64
   void movsbq(Register dst, Address src);
   void movsbq(Register dst, Register src);
 
@@ -1709,15 +1645,12 @@ private:
 
   void movslq(Register dst, Address src);
   void movslq(Register dst, Register src);
-#endif
 
   void movswl(Register dst, Address src);
   void movswl(Register dst, Register src);
 
-#ifdef _LP64
   void movswq(Register dst, Address src);
   void movswq(Register dst, Register src);
-#endif
 
   void movups(XMMRegister dst, Address src);
   void vmovups(XMMRegister dst, Address src, int vector_len);
@@ -1731,18 +1664,14 @@ private:
   void movzbl(Register dst, Address src);
   void movzbl(Register dst, Register src);
 
-#ifdef _LP64
   void movzbq(Register dst, Address src);
   void movzbq(Register dst, Register src);
-#endif
 
   void movzwl(Register dst, Address src);
   void movzwl(Register dst, Register src);
 
-#ifdef _LP64
   void movzwq(Register dst, Address src);
   void movzwq(Register dst, Register src);
-#endif
 
   // Unsigned multiply with RAX destination register
   void mull(Address src);
@@ -1750,13 +1679,11 @@ private:
   void mull(Register src);
   void emull(Register src, bool no_flags);
 
-#ifdef _LP64
   void mulq(Address src);
   void emulq(Address src, bool no_flags);
   void mulq(Register src);
   void emulq(Register src, bool no_flags);
   void mulxq(Register dst1, Register dst2, Register src);
-#endif
 
   // Multiply Scalar Double-Precision Floating-Point Values
   void mulsd(XMMRegister dst, Address src);
@@ -1771,26 +1698,22 @@ private:
   void negl(Address dst);
   void enegl(Register dst, Address src, bool no_flags);
 
-#ifdef _LP64
   void negq(Register dst);
   void enegq(Register dst, Register src, bool no_flags);
   void negq(Address dst);
   void enegq(Register dst, Address src, bool no_flags);
-#endif
 
   void nop(uint i = 1);
 
   void notl(Register dst);
   void enotl(Register dst, Register src);
 
-#ifdef _LP64
   void notq(Register dst);
   void enotq(Register dst, Register src);
 
   void btsq(Address dst, int imm8);
   void btrq(Address dst, int imm8);
   void btq(Register src, int imm8);
-#endif
   void btq(Register dst, Register src);
 
   void eorw(Register dst, Register src1, Register src2, bool no_flags);
@@ -2009,14 +1932,8 @@ private:
   // Multiply add accumulate
   void evpdpwssd(XMMRegister dst, XMMRegister nds, XMMRegister src, int vector_len);
 
-#ifndef _LP64 // no 32bit push/pop on amd64
-  void popl(Address dst);
-#endif
-
-#ifdef _LP64
   void popq(Address dst);
   void popq(Register dst);
-#endif
 
   void popcntl(Register dst, Address src);
   void epopcntl(Register dst, Address src, bool no_flags);
@@ -2028,12 +1945,10 @@ private:
   void evpopcntd(XMMRegister dst, KRegister mask, XMMRegister src, bool merge, int vector_len);
   void evpopcntq(XMMRegister dst, KRegister mask, XMMRegister src, bool merge, int vector_len);
 
-#ifdef _LP64
   void popcntq(Register dst, Address src);
   void epopcntq(Register dst, Address src, bool no_flags);
   void popcntq(Register dst, Register src);
   void epopcntq(Register dst, Register src, bool no_flags);
-#endif
 
   // Prefetches (SSE, SSE2, 3DNOW only)
 
@@ -2125,10 +2040,6 @@ private:
   // Vector sum of absolute difference.
   void vpsadbw(XMMRegister dst, XMMRegister nds, XMMRegister src, int vector_len);
 
-#ifndef _LP64 // no 32bit push/pop on amd64
-  void pushl(Address src);
-#endif
-
   void pushq(Address src);
 
   void rcll(Register dst, int imm8);
@@ -2160,7 +2071,6 @@ private:
   void rorl(Register dst, int imm8);
   void erorl(Register dst, Register src, int imm8, bool no_flags);
 
-#ifdef _LP64
   void rolq(Register dst);
   void erolq(Register dst, Register src, bool no_flags);
   void rolq(Register dst, int imm8);
@@ -2173,9 +2083,6 @@ private:
   void rorxl(Register dst, Address src, int imm8);
   void rorxq(Register dst, Register src, int imm8);
   void rorxq(Register dst, Address src, int imm8);
-#endif
-
-  void sahf();
 
   void sall(Register dst, int imm8);
   void esall(Register dst, Register src, int imm8, bool no_flags);
@@ -2195,7 +2102,6 @@ private:
   void sarl(Register dst);
   void esarl(Register dst, Register src, bool no_flags);
 
-#ifdef _LP64
   void salq(Register dst, int imm8);
   void esalq(Register dst, Register src, int imm8, bool no_flags);
   void salq(Register dst);
@@ -2213,7 +2119,6 @@ private:
   void esarq(Register dst, Register src, int imm8, bool no_flags);
   void sarq(Register dst);
   void esarq(Register dst, Register src, bool no_flags);
-#endif
 
   void sbbl(Address dst, int32_t imm32);
   void sbbl(Register dst, int32_t imm32);
@@ -2254,12 +2159,10 @@ private:
   void eshrdl(Register dst, Register src1, Register src2, bool no_flags);
   void shrdl(Register dst, Register src, int8_t imm8);
   void eshrdl(Register dst, Register src1, Register src2, int8_t imm8, bool no_flags);
-#ifdef _LP64
   void shldq(Register dst, Register src, int8_t imm8);
   void eshldq(Register dst, Register src1, Register src2, int8_t imm8, bool no_flags);
   void shrdq(Register dst, Register src, int8_t imm8);
   void eshrdq(Register dst, Register src1, Register src2, int8_t imm8, bool no_flags);
-#endif
 
   void shll(Register dst, int imm8);
   void eshll(Register dst, Register src, int imm8, bool no_flags);

--- a/src/hotspot/cpu/x86/assembler_x86.inline.hpp
+++ b/src/hotspot/cpu/x86/assembler_x86.inline.hpp
@@ -29,54 +29,6 @@
 #include "asm/codeBuffer.hpp"
 #include "code/codeCache.hpp"
 
-#ifndef _LP64
-inline int Assembler::prefix_and_encode(int reg_enc, bool byteinst, bool is_map1)
-{
-    int opc_prefix = is_map1 ? 0x0F00 : 0;
-    return opc_prefix | reg_enc;
-}
-
-inline int Assembler::prefixq_and_encode(int reg_enc, bool is_map1) {
-    int opc_prefix = is_map1 ? 0xF00 : 0;
-    return opc_prefix | reg_enc;
-}
-
-inline int Assembler::prefix_and_encode(int dst_enc, bool dst_is_byte, int src_enc, bool src_is_byte, bool is_map1) {
-    int opc_prefix = is_map1 ? 0xF00 : 0;
-    return opc_prefix | (dst_enc << 3 | src_enc);
-}
-
-inline int Assembler::prefixq_and_encode(int dst_enc, int src_enc, bool is_map1) {
-    int opc_prefix = is_map1 ? 0xF00 : 0;
-    return opc_prefix | dst_enc << 3 | src_enc;
-}
-
-inline void Assembler::prefix(Register reg) {}
-inline void Assembler::prefix(Register dst, Register src, Prefix p) {}
-inline void Assembler::prefix(Register dst, Address adr, Prefix p) {}
-
-inline void Assembler::prefix(Address adr, bool is_map1) {
-    if (is_map1) {
-        emit_int8(0x0F);
-    }
-}
-
-inline void Assembler::prefixq(Address adr) {}
-
-inline void Assembler::prefix(Address adr, Register reg,  bool byteinst, bool is_map1) {
-    if (is_map1) {
-        emit_int8(0x0F);
-    }
-}
-inline void Assembler::prefixq(Address adr, Register reg, bool is_map1) {
-    if (is_map1) {
-        emit_int8(0x0F);
-    }
-}
-
-inline void Assembler::prefix(Address adr, XMMRegister reg) {}
-inline void Assembler::prefixq(Address adr, XMMRegister reg) {}
-
-#endif // _LP64
+// TODO: Remove?
 
 #endif // CPU_X86_ASSEMBLER_X86_INLINE_HPP

--- a/src/hotspot/cpu/x86/assembler_x86.inline.hpp
+++ b/src/hotspot/cpu/x86/assembler_x86.inline.hpp
@@ -25,10 +25,4 @@
 #ifndef CPU_X86_ASSEMBLER_X86_INLINE_HPP
 #define CPU_X86_ASSEMBLER_X86_INLINE_HPP
 
-#include "asm/assembler.inline.hpp"
-#include "asm/codeBuffer.hpp"
-#include "code/codeCache.hpp"
-
-// TODO: Remove?
-
 #endif // CPU_X86_ASSEMBLER_X86_INLINE_HPP

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -93,375 +93,6 @@ static const Assembler::Condition reverse[] = {
 
 // Implementation of MacroAssembler
 
-// First all the versions that have distinct versions depending on 32/64 bit
-// Unless the difference is trivial (1 line or so).
-
-#ifndef _LP64
-
-// 32bit versions
-
-Address MacroAssembler::as_Address(AddressLiteral adr) {
-  return Address(adr.target(), adr.rspec());
-}
-
-Address MacroAssembler::as_Address(ArrayAddress adr, Register rscratch) {
-  assert(rscratch == noreg, "");
-  return Address::make_array(adr);
-}
-
-void MacroAssembler::call_VM_leaf_base(address entry_point,
-                                       int number_of_arguments) {
-  call(RuntimeAddress(entry_point));
-  increment(rsp, number_of_arguments * wordSize);
-}
-
-void MacroAssembler::cmpklass(Address src1, Metadata* obj) {
-  cmp_literal32(src1, (int32_t)obj, metadata_Relocation::spec_for_immediate());
-}
-
-
-void MacroAssembler::cmpklass(Register src1, Metadata* obj) {
-  cmp_literal32(src1, (int32_t)obj, metadata_Relocation::spec_for_immediate());
-}
-
-void MacroAssembler::cmpoop(Address src1, jobject obj) {
-  cmp_literal32(src1, (int32_t)obj, oop_Relocation::spec_for_immediate());
-}
-
-void MacroAssembler::cmpoop(Register src1, jobject obj, Register rscratch) {
-  assert(rscratch == noreg, "redundant");
-  cmp_literal32(src1, (int32_t)obj, oop_Relocation::spec_for_immediate());
-}
-
-void MacroAssembler::extend_sign(Register hi, Register lo) {
-  // According to Intel Doc. AP-526, "Integer Divide", p.18.
-  if (VM_Version::is_P6() && hi == rdx && lo == rax) {
-    cdql();
-  } else {
-    movl(hi, lo);
-    sarl(hi, 31);
-  }
-}
-
-// 32bit can do a case table jump in one instruction but we no longer allow the base
-// to be installed in the Address class
-void MacroAssembler::jump(ArrayAddress entry, Register rscratch) {
-  assert(rscratch == noreg, "not needed");
-  jmp(as_Address(entry, noreg));
-}
-
-// Note: y_lo will be destroyed
-void MacroAssembler::lcmp2int(Register x_hi, Register x_lo, Register y_hi, Register y_lo) {
-  // Long compare for Java (semantics as described in JVM spec.)
-  Label high, low, done;
-
-  cmpl(x_hi, y_hi);
-  jcc(Assembler::less, low);
-  jcc(Assembler::greater, high);
-  // x_hi is the return register
-  xorl(x_hi, x_hi);
-  cmpl(x_lo, y_lo);
-  jcc(Assembler::below, low);
-  jcc(Assembler::equal, done);
-
-  bind(high);
-  xorl(x_hi, x_hi);
-  increment(x_hi);
-  jmp(done);
-
-  bind(low);
-  xorl(x_hi, x_hi);
-  decrementl(x_hi);
-
-  bind(done);
-}
-
-void MacroAssembler::lea(Register dst, AddressLiteral src) {
-  mov_literal32(dst, (int32_t)src.target(), src.rspec());
-}
-
-void MacroAssembler::lea(Address dst, AddressLiteral adr, Register rscratch) {
-  assert(rscratch == noreg, "not needed");
-
-  // leal(dst, as_Address(adr));
-  // see note in movl as to why we must use a move
-  mov_literal32(dst, (int32_t)adr.target(), adr.rspec());
-}
-
-void MacroAssembler::leave() {
-  mov(rsp, rbp);
-  pop(rbp);
-}
-
-void MacroAssembler::lmul(int x_rsp_offset, int y_rsp_offset) {
-  // Multiplication of two Java long values stored on the stack
-  // as illustrated below. Result is in rdx:rax.
-  //
-  // rsp ---> [  ??  ] \               \
-  //            ....    | y_rsp_offset  |
-  //          [ y_lo ] /  (in bytes)    | x_rsp_offset
-  //          [ y_hi ]                  | (in bytes)
-  //            ....                    |
-  //          [ x_lo ]                 /
-  //          [ x_hi ]
-  //            ....
-  //
-  // Basic idea: lo(result) = lo(x_lo * y_lo)
-  //             hi(result) = hi(x_lo * y_lo) + lo(x_hi * y_lo) + lo(x_lo * y_hi)
-  Address x_hi(rsp, x_rsp_offset + wordSize); Address x_lo(rsp, x_rsp_offset);
-  Address y_hi(rsp, y_rsp_offset + wordSize); Address y_lo(rsp, y_rsp_offset);
-  Label quick;
-  // load x_hi, y_hi and check if quick
-  // multiplication is possible
-  movl(rbx, x_hi);
-  movl(rcx, y_hi);
-  movl(rax, rbx);
-  orl(rbx, rcx);                                 // rbx, = 0 <=> x_hi = 0 and y_hi = 0
-  jcc(Assembler::zero, quick);                   // if rbx, = 0 do quick multiply
-  // do full multiplication
-  // 1st step
-  mull(y_lo);                                    // x_hi * y_lo
-  movl(rbx, rax);                                // save lo(x_hi * y_lo) in rbx,
-  // 2nd step
-  movl(rax, x_lo);
-  mull(rcx);                                     // x_lo * y_hi
-  addl(rbx, rax);                                // add lo(x_lo * y_hi) to rbx,
-  // 3rd step
-  bind(quick);                                   // note: rbx, = 0 if quick multiply!
-  movl(rax, x_lo);
-  mull(y_lo);                                    // x_lo * y_lo
-  addl(rdx, rbx);                                // correct hi(x_lo * y_lo)
-}
-
-void MacroAssembler::lneg(Register hi, Register lo) {
-  negl(lo);
-  adcl(hi, 0);
-  negl(hi);
-}
-
-void MacroAssembler::lshl(Register hi, Register lo) {
-  // Java shift left long support (semantics as described in JVM spec., p.305)
-  // (basic idea for shift counts s >= n: x << s == (x << n) << (s - n))
-  // shift value is in rcx !
-  assert(hi != rcx, "must not use rcx");
-  assert(lo != rcx, "must not use rcx");
-  const Register s = rcx;                        // shift count
-  const int      n = BitsPerWord;
-  Label L;
-  andl(s, 0x3f);                                 // s := s & 0x3f (s < 0x40)
-  cmpl(s, n);                                    // if (s < n)
-  jcc(Assembler::less, L);                       // else (s >= n)
-  movl(hi, lo);                                  // x := x << n
-  xorl(lo, lo);
-  // Note: subl(s, n) is not needed since the Intel shift instructions work rcx mod n!
-  bind(L);                                       // s (mod n) < n
-  shldl(hi, lo);                                 // x := x << s
-  shll(lo);
-}
-
-
-void MacroAssembler::lshr(Register hi, Register lo, bool sign_extension) {
-  // Java shift right long support (semantics as described in JVM spec., p.306 & p.310)
-  // (basic idea for shift counts s >= n: x >> s == (x >> n) >> (s - n))
-  assert(hi != rcx, "must not use rcx");
-  assert(lo != rcx, "must not use rcx");
-  const Register s = rcx;                        // shift count
-  const int      n = BitsPerWord;
-  Label L;
-  andl(s, 0x3f);                                 // s := s & 0x3f (s < 0x40)
-  cmpl(s, n);                                    // if (s < n)
-  jcc(Assembler::less, L);                       // else (s >= n)
-  movl(lo, hi);                                  // x := x >> n
-  if (sign_extension) sarl(hi, 31);
-  else                xorl(hi, hi);
-  // Note: subl(s, n) is not needed since the Intel shift instructions work rcx mod n!
-  bind(L);                                       // s (mod n) < n
-  shrdl(lo, hi);                                 // x := x >> s
-  if (sign_extension) sarl(hi);
-  else                shrl(hi);
-}
-
-void MacroAssembler::movoop(Register dst, jobject obj) {
-  mov_literal32(dst, (int32_t)obj, oop_Relocation::spec_for_immediate());
-}
-
-void MacroAssembler::movoop(Address dst, jobject obj, Register rscratch) {
-  assert(rscratch == noreg, "redundant");
-  mov_literal32(dst, (int32_t)obj, oop_Relocation::spec_for_immediate());
-}
-
-void MacroAssembler::mov_metadata(Register dst, Metadata* obj) {
-  mov_literal32(dst, (int32_t)obj, metadata_Relocation::spec_for_immediate());
-}
-
-void MacroAssembler::mov_metadata(Address dst, Metadata* obj, Register rscratch) {
-  assert(rscratch == noreg, "redundant");
-  mov_literal32(dst, (int32_t)obj, metadata_Relocation::spec_for_immediate());
-}
-
-void MacroAssembler::movptr(Register dst, AddressLiteral src) {
-  if (src.is_lval()) {
-    mov_literal32(dst, (intptr_t)src.target(), src.rspec());
-  } else {
-    movl(dst, as_Address(src));
-  }
-}
-
-void MacroAssembler::movptr(ArrayAddress dst, Register src, Register rscratch) {
-  assert(rscratch == noreg, "redundant");
-  movl(as_Address(dst, noreg), src);
-}
-
-void MacroAssembler::movptr(Register dst, ArrayAddress src) {
-  movl(dst, as_Address(src, noreg));
-}
-
-void MacroAssembler::movptr(Address dst, intptr_t src, Register rscratch) {
-  assert(rscratch == noreg, "redundant");
-  movl(dst, src);
-}
-
-void MacroAssembler::pushoop(jobject obj, Register rscratch) {
-  assert(rscratch == noreg, "redundant");
-  push_literal32((int32_t)obj, oop_Relocation::spec_for_immediate());
-}
-
-void MacroAssembler::pushklass(Metadata* obj, Register rscratch) {
-  assert(rscratch == noreg, "redundant");
-  push_literal32((int32_t)obj, metadata_Relocation::spec_for_immediate());
-}
-
-void MacroAssembler::pushptr(AddressLiteral src, Register rscratch) {
-  assert(rscratch == noreg, "redundant");
-  if (src.is_lval()) {
-    push_literal32((int32_t)src.target(), src.rspec());
-  } else {
-    pushl(as_Address(src));
-  }
-}
-
-static void pass_arg0(MacroAssembler* masm, Register arg) {
-  masm->push(arg);
-}
-
-static void pass_arg1(MacroAssembler* masm, Register arg) {
-  masm->push(arg);
-}
-
-static void pass_arg2(MacroAssembler* masm, Register arg) {
-  masm->push(arg);
-}
-
-static void pass_arg3(MacroAssembler* masm, Register arg) {
-  masm->push(arg);
-}
-
-#ifndef PRODUCT
-extern "C" void findpc(intptr_t x);
-#endif
-
-void MacroAssembler::debug32(int rdi, int rsi, int rbp, int rsp, int rbx, int rdx, int rcx, int rax, int eip, char* msg) {
-  // In order to get locks to work, we need to fake a in_VM state
-  JavaThread* thread = JavaThread::current();
-  JavaThreadState saved_state = thread->thread_state();
-  thread->set_thread_state(_thread_in_vm);
-  if (ShowMessageBoxOnError) {
-    JavaThread* thread = JavaThread::current();
-    JavaThreadState saved_state = thread->thread_state();
-    thread->set_thread_state(_thread_in_vm);
-    if (CountBytecodes || TraceBytecodes || StopInterpreterAt) {
-      ttyLocker ttyl;
-      BytecodeCounter::print();
-    }
-    // To see where a verify_oop failed, get $ebx+40/X for this frame.
-    // This is the value of eip which points to where verify_oop will return.
-    if (os::message_box(msg, "Execution stopped, print registers?")) {
-      print_state32(rdi, rsi, rbp, rsp, rbx, rdx, rcx, rax, eip);
-      BREAKPOINT;
-    }
-  }
-  fatal("DEBUG MESSAGE: %s", msg);
-}
-
-void MacroAssembler::print_state32(int rdi, int rsi, int rbp, int rsp, int rbx, int rdx, int rcx, int rax, int eip) {
-  ttyLocker ttyl;
-  DebuggingContext debugging{};
-  tty->print_cr("eip = 0x%08x", eip);
-#ifndef PRODUCT
-  if ((WizardMode || Verbose) && PrintMiscellaneous) {
-    tty->cr();
-    findpc(eip);
-    tty->cr();
-  }
-#endif
-#define PRINT_REG(rax) \
-  { tty->print("%s = ", #rax); os::print_location(tty, rax); }
-  PRINT_REG(rax);
-  PRINT_REG(rbx);
-  PRINT_REG(rcx);
-  PRINT_REG(rdx);
-  PRINT_REG(rdi);
-  PRINT_REG(rsi);
-  PRINT_REG(rbp);
-  PRINT_REG(rsp);
-#undef PRINT_REG
-  // Print some words near top of staack.
-  int* dump_sp = (int*) rsp;
-  for (int col1 = 0; col1 < 8; col1++) {
-    tty->print("(rsp+0x%03x) 0x%08x: ", (int)((intptr_t)dump_sp - (intptr_t)rsp), (intptr_t)dump_sp);
-    os::print_location(tty, *dump_sp++);
-  }
-  for (int row = 0; row < 16; row++) {
-    tty->print("(rsp+0x%03x) 0x%08x: ", (int)((intptr_t)dump_sp - (intptr_t)rsp), (intptr_t)dump_sp);
-    for (int col = 0; col < 8; col++) {
-      tty->print(" 0x%08x", *dump_sp++);
-    }
-    tty->cr();
-  }
-  // Print some instructions around pc:
-  Disassembler::decode((address)eip-64, (address)eip);
-  tty->print_cr("--------");
-  Disassembler::decode((address)eip, (address)eip+32);
-}
-
-void MacroAssembler::stop(const char* msg) {
-  // push address of message
-  ExternalAddress message((address)msg);
-  pushptr(message.addr(), noreg);
-  { Label L; call(L, relocInfo::none); bind(L); }     // push eip
-  pusha();                                            // push registers
-  call(RuntimeAddress(CAST_FROM_FN_PTR(address, MacroAssembler::debug32)));
-  hlt();
-}
-
-void MacroAssembler::warn(const char* msg) {
-  push_CPU_state();
-
-  // push address of message
-  ExternalAddress message((address)msg);
-  pushptr(message.addr(), noreg);
-
-  call(RuntimeAddress(CAST_FROM_FN_PTR(address, warning)));
-  addl(rsp, wordSize);       // discard argument
-  pop_CPU_state();
-}
-
-void MacroAssembler::print_state() {
-  { Label L; call(L, relocInfo::none); bind(L); }     // push eip
-  pusha();                                            // push registers
-
-  push_CPU_state();
-  call(RuntimeAddress(CAST_FROM_FN_PTR(address, MacroAssembler::print_state32)));
-  pop_CPU_state();
-
-  popa();
-  addl(rsp, wordSize);
-}
-
-#else // _LP64
-
-// 64 bit versions
-
 Address MacroAssembler::as_Address(AddressLiteral adr) {
   // amd64 always does this as a pc-rel
   // we can be absolute or disp based on the instruction type
@@ -1073,20 +704,16 @@ void MacroAssembler::object_move(OopMap* map,
   }
 }
 
-#endif // _LP64
-
-// Now versions that are common to 32/64 bit
-
 void MacroAssembler::addptr(Register dst, int32_t imm32) {
-  LP64_ONLY(addq(dst, imm32)) NOT_LP64(addl(dst, imm32));
+  addq(dst, imm32);
 }
 
 void MacroAssembler::addptr(Register dst, Register src) {
-  LP64_ONLY(addq(dst, src)) NOT_LP64(addl(dst, src));
+  addq(dst, src);
 }
 
 void MacroAssembler::addptr(Address dst, Register src) {
-  LP64_ONLY(addq(dst, src)) NOT_LP64(addl(dst, src));
+  addq(dst, src);
 }
 
 void MacroAssembler::addsd(XMMRegister dst, AddressLiteral src, Register rscratch) {
@@ -1196,10 +823,9 @@ void MacroAssembler::andps(XMMRegister dst, AddressLiteral src, Register rscratc
 }
 
 void MacroAssembler::andptr(Register dst, int32_t imm32) {
-  LP64_ONLY(andq(dst, imm32)) NOT_LP64(andl(dst, imm32));
+  andq(dst, imm32);
 }
 
-#ifdef _LP64
 void MacroAssembler::andq(Register dst, AddressLiteral src, Register rscratch) {
   assert(rscratch != noreg || always_reachable(src), "missing");
 
@@ -1210,7 +836,6 @@ void MacroAssembler::andq(Register dst, AddressLiteral src, Register rscratch) {
     andq(dst, Address(rscratch, 0));
   }
 }
-#endif
 
 void MacroAssembler::atomic_incl(Address counter_addr) {
   lock();
@@ -1228,7 +853,6 @@ void MacroAssembler::atomic_incl(AddressLiteral counter_addr, Register rscratch)
   }
 }
 
-#ifdef _LP64
 void MacroAssembler::atomic_incq(Address counter_addr) {
   lock();
   incrementq(counter_addr);
@@ -1244,7 +868,6 @@ void MacroAssembler::atomic_incq(AddressLiteral counter_addr, Register rscratch)
     atomic_incq(Address(rscratch, 0));
   }
 }
-#endif
 
 // Writes to stack successive pages until offset reached to check for
 // stack overflow + shadow pages.  This clobbers tmp.
@@ -1276,13 +899,11 @@ void MacroAssembler::bang_stack_size(Register size, Register tmp) {
 void MacroAssembler::reserved_stack_check() {
   // testing if reserved zone needs to be enabled
   Label no_reserved_zone_enabling;
-  Register thread = NOT_LP64(rsi) LP64_ONLY(r15_thread);
-  NOT_LP64(get_thread(rsi);)
 
-  cmpptr(rsp, Address(thread, JavaThread::reserved_stack_activation_offset()));
+  cmpptr(rsp, Address(r15_thread, JavaThread::reserved_stack_activation_offset()));
   jcc(Assembler::below, no_reserved_zone_enabling);
 
-  call_VM_leaf(CAST_FROM_FN_PTR(address, SharedRuntime::enable_stack_reserved_zone), thread);
+  call_VM_leaf(CAST_FROM_FN_PTR(address, SharedRuntime::enable_stack_reserved_zone), r15_thread);
   jump(RuntimeAddress(SharedRuntime::throw_delayed_StackOverflowError_entry()));
   should_not_reach_here();
 
@@ -1320,24 +941,19 @@ void MacroAssembler::call(AddressLiteral entry, Register rscratch) {
 
 void MacroAssembler::ic_call(address entry, jint method_index) {
   RelocationHolder rh = virtual_call_Relocation::spec(pc(), method_index);
-#ifdef _LP64
   // Needs full 64-bit immediate for later patching.
   mov64(rax, (int64_t)Universe::non_oop_word());
-#else
-  movptr(rax, (intptr_t)Universe::non_oop_word());
-#endif
   call(AddressLiteral(entry, rh));
 }
 
 int MacroAssembler::ic_check_size() {
-  return
-      LP64_ONLY(UseCompactObjectHeaders ? 17 : 14) NOT_LP64(12);
+  return UseCompactObjectHeaders ? 17 : 14;
 }
 
 int MacroAssembler::ic_check(int end_alignment) {
-  Register receiver = LP64_ONLY(j_rarg0) NOT_LP64(rcx);
+  Register receiver = j_rarg0;
   Register data = rax;
-  Register temp = LP64_ONLY(rscratch1) NOT_LP64(rbx);
+  Register temp = rscratch1;
 
   // The UEP of a code blob ensures that the VEP is padded. However, the padding of the UEP is placed
   // before the inline cache check, so we don't have to execute any nop instructions when dispatching
@@ -1347,13 +963,10 @@ int MacroAssembler::ic_check(int end_alignment) {
 
   int uep_offset = offset();
 
-#ifdef _LP64
   if (UseCompactObjectHeaders) {
     load_narrow_klass_compact(temp, receiver);
     cmpl(temp, Address(data, CompiledICData::speculated_klass_offset()));
-  } else
-#endif
-  if (UseCompressedClassPointers) {
+  } else if (UseCompressedClassPointers) {
     movl(temp, Address(receiver, oopDesc::klass_offset_in_bytes()));
     cmpl(temp, Address(data, CompiledICData::speculated_klass_offset()));
   } else {
@@ -1418,7 +1031,7 @@ void MacroAssembler::call_VM(Register oop_result,
 
   bind(C);
 
-  LP64_ONLY(assert_different_registers(arg_1, c_rarg2));
+  assert_different_registers(arg_1, c_rarg2);
 
   pass_arg2(this, arg_2);
   pass_arg1(this, arg_1);
@@ -1440,8 +1053,8 @@ void MacroAssembler::call_VM(Register oop_result,
 
   bind(C);
 
-  LP64_ONLY(assert_different_registers(arg_1, c_rarg2, c_rarg3));
-  LP64_ONLY(assert_different_registers(arg_2, c_rarg3));
+  assert_different_registers(arg_1, c_rarg2, c_rarg3);
+  assert_different_registers(arg_2, c_rarg3);
   pass_arg3(this, arg_3);
   pass_arg2(this, arg_2);
   pass_arg1(this, arg_1);
@@ -1475,7 +1088,7 @@ void MacroAssembler::call_VM(Register oop_result,
                              Register arg_2,
                              bool check_exceptions) {
 
-  LP64_ONLY(assert_different_registers(arg_1, c_rarg2));
+  assert_different_registers(arg_1, c_rarg2);
   pass_arg2(this, arg_2);
   pass_arg1(this, arg_1);
   call_VM(oop_result, last_java_sp, entry_point, 2, check_exceptions);
@@ -1488,8 +1101,8 @@ void MacroAssembler::call_VM(Register oop_result,
                              Register arg_2,
                              Register arg_3,
                              bool check_exceptions) {
-  LP64_ONLY(assert_different_registers(arg_1, c_rarg2, c_rarg3));
-  LP64_ONLY(assert_different_registers(arg_2, c_rarg3));
+  assert_different_registers(arg_1, c_rarg2, c_rarg3);
+  assert_different_registers(arg_2, c_rarg3);
   pass_arg3(this, arg_3);
   pass_arg2(this, arg_2);
   pass_arg1(this, arg_1);
@@ -1520,7 +1133,7 @@ void MacroAssembler::super_call_VM(Register oop_result,
                                    Register arg_2,
                                    bool check_exceptions) {
 
-  LP64_ONLY(assert_different_registers(arg_1, c_rarg2));
+  assert_different_registers(arg_1, c_rarg2);
   pass_arg2(this, arg_2);
   pass_arg1(this, arg_1);
   super_call_VM(oop_result, last_java_sp, entry_point, 2, check_exceptions);
@@ -1533,8 +1146,8 @@ void MacroAssembler::super_call_VM(Register oop_result,
                                    Register arg_2,
                                    Register arg_3,
                                    bool check_exceptions) {
-  LP64_ONLY(assert_different_registers(arg_1, c_rarg2, c_rarg3));
-  LP64_ONLY(assert_different_registers(arg_2, c_rarg3));
+  assert_different_registers(arg_1, c_rarg2, c_rarg3);
+  assert_different_registers(arg_2, c_rarg3);
   pass_arg3(this, arg_3);
   pass_arg2(this, arg_2);
   pass_arg1(this, arg_1);
@@ -1645,15 +1258,15 @@ void MacroAssembler::call_VM_leaf(address entry_point, Register arg_0) {
 
 void MacroAssembler::call_VM_leaf(address entry_point, Register arg_0, Register arg_1) {
 
-  LP64_ONLY(assert_different_registers(arg_0, c_rarg1));
+  assert_different_registers(arg_0, c_rarg1);
   pass_arg1(this, arg_1);
   pass_arg0(this, arg_0);
   call_VM_leaf(entry_point, 2);
 }
 
 void MacroAssembler::call_VM_leaf(address entry_point, Register arg_0, Register arg_1, Register arg_2) {
-  LP64_ONLY(assert_different_registers(arg_0, c_rarg1, c_rarg2));
-  LP64_ONLY(assert_different_registers(arg_1, c_rarg2));
+  assert_different_registers(arg_0, c_rarg1, c_rarg2);
+  assert_different_registers(arg_1, c_rarg2);
   pass_arg2(this, arg_2);
   pass_arg1(this, arg_1);
   pass_arg0(this, arg_0);
@@ -1661,9 +1274,9 @@ void MacroAssembler::call_VM_leaf(address entry_point, Register arg_0, Register 
 }
 
 void MacroAssembler::call_VM_leaf(address entry_point, Register arg_0, Register arg_1, Register arg_2, Register arg_3) {
-  LP64_ONLY(assert_different_registers(arg_0, c_rarg1, c_rarg2, c_rarg3));
-  LP64_ONLY(assert_different_registers(arg_1, c_rarg2, c_rarg3));
-  LP64_ONLY(assert_different_registers(arg_2, c_rarg3));
+  assert_different_registers(arg_0, c_rarg1, c_rarg2, c_rarg3);
+  assert_different_registers(arg_1, c_rarg2, c_rarg3);
+  assert_different_registers(arg_2, c_rarg3);
   pass_arg3(this, arg_3);
   pass_arg2(this, arg_2);
   pass_arg1(this, arg_1);
@@ -1677,15 +1290,15 @@ void MacroAssembler::super_call_VM_leaf(address entry_point, Register arg_0) {
 }
 
 void MacroAssembler::super_call_VM_leaf(address entry_point, Register arg_0, Register arg_1) {
-  LP64_ONLY(assert_different_registers(arg_0, c_rarg1));
+  assert_different_registers(arg_0, c_rarg1);
   pass_arg1(this, arg_1);
   pass_arg0(this, arg_0);
   MacroAssembler::call_VM_leaf_base(entry_point, 2);
 }
 
 void MacroAssembler::super_call_VM_leaf(address entry_point, Register arg_0, Register arg_1, Register arg_2) {
-  LP64_ONLY(assert_different_registers(arg_0, c_rarg1, c_rarg2));
-  LP64_ONLY(assert_different_registers(arg_1, c_rarg2));
+  assert_different_registers(arg_0, c_rarg1, c_rarg2);
+  assert_different_registers(arg_1, c_rarg2);
   pass_arg2(this, arg_2);
   pass_arg1(this, arg_1);
   pass_arg0(this, arg_0);
@@ -1693,9 +1306,9 @@ void MacroAssembler::super_call_VM_leaf(address entry_point, Register arg_0, Reg
 }
 
 void MacroAssembler::super_call_VM_leaf(address entry_point, Register arg_0, Register arg_1, Register arg_2, Register arg_3) {
-  LP64_ONLY(assert_different_registers(arg_0, c_rarg1, c_rarg2, c_rarg3));
-  LP64_ONLY(assert_different_registers(arg_1, c_rarg2, c_rarg3));
-  LP64_ONLY(assert_different_registers(arg_2, c_rarg3));
+  assert_different_registers(arg_0, c_rarg1, c_rarg2, c_rarg3);
+  assert_different_registers(arg_1, c_rarg2, c_rarg3);
+  assert_different_registers(arg_2, c_rarg3);
   pass_arg3(this, arg_3);
   pass_arg2(this, arg_2);
   pass_arg1(this, arg_1);
@@ -1808,7 +1421,6 @@ void MacroAssembler::cmp8(AddressLiteral src1, int imm, Register rscratch) {
 }
 
 void MacroAssembler::cmpptr(Register src1, AddressLiteral src2, Register rscratch) {
-#ifdef _LP64
   assert(rscratch != noreg || always_reachable(src2), "missing");
 
   if (src2.is_lval()) {
@@ -1820,26 +1432,13 @@ void MacroAssembler::cmpptr(Register src1, AddressLiteral src2, Register rscratc
     lea(rscratch, src2);
     Assembler::cmpq(src1, Address(rscratch, 0));
   }
-#else
-  assert(rscratch == noreg, "not needed");
-  if (src2.is_lval()) {
-    cmp_literal32(src1, (int32_t)src2.target(), src2.rspec());
-  } else {
-    cmpl(src1, as_Address(src2));
-  }
-#endif // _LP64
 }
 
 void MacroAssembler::cmpptr(Address src1, AddressLiteral src2, Register rscratch) {
   assert(src2.is_lval(), "not a mem-mem compare");
-#ifdef _LP64
   // moves src2's literal address
   movptr(rscratch, src2);
   Assembler::cmpq(src1, rscratch);
-#else
-  assert(rscratch == noreg, "not needed");
-  cmp_literal32(src1, (int32_t)src2.target(), src2.rspec());
-#endif // _LP64
 }
 
 void MacroAssembler::cmpoop(Register src1, Register src2) {
@@ -1850,12 +1449,10 @@ void MacroAssembler::cmpoop(Register src1, Address src2) {
   cmpptr(src1, src2);
 }
 
-#ifdef _LP64
 void MacroAssembler::cmpoop(Register src1, jobject src2, Register rscratch) {
   movoop(rscratch, src2);
   cmpptr(src1, rscratch);
 }
-#endif
 
 void MacroAssembler::locked_cmpxchgptr(Register reg, AddressLiteral adr, Register rscratch) {
   assert(rscratch != noreg || always_reachable(adr), "missing");
@@ -1871,7 +1468,7 @@ void MacroAssembler::locked_cmpxchgptr(Register reg, AddressLiteral adr, Registe
 }
 
 void MacroAssembler::cmpxchgptr(Register reg, Address adr) {
-  LP64_ONLY(cmpxchgq(reg, adr)) NOT_LP64(cmpxchgl(reg, adr));
+  cmpxchgq(reg, adr);
 }
 
 void MacroAssembler::comisd(XMMRegister dst, AddressLiteral src, Register rscratch) {
@@ -2193,15 +1790,8 @@ void MacroAssembler::ldmxcsr(AddressLiteral src, Register rscratch) {
 }
 
 int MacroAssembler::load_signed_byte(Register dst, Address src) {
-  int off;
-  if (LP64_ONLY(true ||) VM_Version::is_P6()) {
-    off = offset();
-    movsbl(dst, src); // movsxb
-  } else {
-    off = load_unsigned_byte(dst, src);
-    shll(dst, 24);
-    sarl(dst, 24);
-  }
+  int off = offset();
+  movsbl(dst, src); // movsxb
   return off;
 }
 
@@ -2210,33 +1800,19 @@ int MacroAssembler::load_signed_byte(Register dst, Address src) {
 // manual, which means 16 bits, that usage is found nowhere in HotSpot code.
 // The term "word" in HotSpot means a 32- or 64-bit machine word.
 int MacroAssembler::load_signed_short(Register dst, Address src) {
-  int off;
-  if (LP64_ONLY(true ||) VM_Version::is_P6()) {
-    // This is dubious to me since it seems safe to do a signed 16 => 64 bit
-    // version but this is what 64bit has always done. This seems to imply
-    // that users are only using 32bits worth.
-    off = offset();
-    movswl(dst, src); // movsxw
-  } else {
-    off = load_unsigned_short(dst, src);
-    shll(dst, 16);
-    sarl(dst, 16);
-  }
+  // This is dubious to me since it seems safe to do a signed 16 => 64 bit
+  // version but this is what 64bit has always done. This seems to imply
+  // that users are only using 32bits worth.
+  int off = offset();
+  movswl(dst, src); // movsxw
   return off;
 }
 
 int MacroAssembler::load_unsigned_byte(Register dst, Address src) {
   // According to Intel Doc. AP-526, "Zero-Extension of Short", p.16,
   // and "3.9 Partial Register Penalties", p. 22).
-  int off;
-  if (LP64_ONLY(true || ) VM_Version::is_P6() || src.uses(dst)) {
-    off = offset();
-    movzbl(dst, src); // movzxb
-  } else {
-    xorl(dst, dst);
-    off = offset();
-    movb(dst, src);
-  }
+  int off = offset();
+  movzbl(dst, src); // movzxb
   return off;
 }
 
@@ -2244,29 +1820,14 @@ int MacroAssembler::load_unsigned_byte(Register dst, Address src) {
 int MacroAssembler::load_unsigned_short(Register dst, Address src) {
   // According to Intel Doc. AP-526, "Zero-Extension of Short", p.16,
   // and "3.9 Partial Register Penalties", p. 22).
-  int off;
-  if (LP64_ONLY(true ||) VM_Version::is_P6() || src.uses(dst)) {
-    off = offset();
-    movzwl(dst, src); // movzxw
-  } else {
-    xorl(dst, dst);
-    off = offset();
-    movw(dst, src);
-  }
+  int off = offset();
+  movzwl(dst, src); // movzxw
   return off;
 }
 
 void MacroAssembler::load_sized_value(Register dst, Address src, size_t size_in_bytes, bool is_signed, Register dst2) {
   switch (size_in_bytes) {
-#ifndef _LP64
-  case  8:
-    assert(dst2 != noreg, "second dest register required");
-    movl(dst,  src);
-    movl(dst2, src.plus_disp(BytesPerInt));
-    break;
-#else
   case  8:  movq(dst, src); break;
-#endif
   case  4:  movl(dst, src); break;
   case  2:  is_signed ? load_signed_short(dst, src) : load_unsigned_short(dst, src); break;
   case  1:  is_signed ? load_signed_byte( dst, src) : load_unsigned_byte( dst, src); break;
@@ -2276,15 +1837,7 @@ void MacroAssembler::load_sized_value(Register dst, Address src, size_t size_in_
 
 void MacroAssembler::store_sized_value(Address dst, Register src, size_t size_in_bytes, Register src2) {
   switch (size_in_bytes) {
-#ifndef _LP64
-  case  8:
-    assert(src2 != noreg, "second source register required");
-    movl(dst,                        src);
-    movl(dst.plus_disp(BytesPerInt), src2);
-    break;
-#else
   case  8:  movq(dst, src); break;
-#endif
   case  4:  movl(dst, src); break;
   case  2:  movw(dst, src); break;
   case  1:  movb(dst, src); break;
@@ -2403,16 +1956,15 @@ void MacroAssembler::movflt(XMMRegister dst, AddressLiteral src, Register rscrat
 }
 
 void MacroAssembler::movptr(Register dst, Register src) {
-  LP64_ONLY(movq(dst, src)) NOT_LP64(movl(dst, src));
+  movq(dst, src);
 }
 
 void MacroAssembler::movptr(Register dst, Address src) {
-  LP64_ONLY(movq(dst, src)) NOT_LP64(movl(dst, src));
+  movq(dst, src);
 }
 
 // src should NEVER be a real pointer. Use AddressLiteral for true pointers
 void MacroAssembler::movptr(Register dst, intptr_t src) {
-#ifdef _LP64
   if (is_uimm32(src)) {
     movl(dst, checked_cast<uint32_t>(src));
   } else if (is_simm32(src)) {
@@ -2420,17 +1972,14 @@ void MacroAssembler::movptr(Register dst, intptr_t src) {
   } else {
     mov64(dst, src);
   }
-#else
-  movl(dst, src);
-#endif
 }
 
 void MacroAssembler::movptr(Address dst, Register src) {
-  LP64_ONLY(movq(dst, src)) NOT_LP64(movl(dst, src));
+  movq(dst, src);
 }
 
 void MacroAssembler::movptr(Address dst, int32_t src) {
-  LP64_ONLY(movslq(dst, src)) NOT_LP64(movl(dst, src));
+  movslq(dst, src);
 }
 
 void MacroAssembler::movdqu(Address dst, XMMRegister src) {
@@ -2808,9 +2357,7 @@ void MacroAssembler::unimplemented(const char* what) {
   stop(buf);
 }
 
-#ifdef _LP64
 #define XSTATE_BV 0x200
-#endif
 
 void MacroAssembler::pop_CPU_state() {
   pop_FPU_state();
@@ -2818,17 +2365,13 @@ void MacroAssembler::pop_CPU_state() {
 }
 
 void MacroAssembler::pop_FPU_state() {
-#ifndef _LP64
-  frstor(Address(rsp, 0));
-#else
   fxrstor(Address(rsp, 0));
-#endif
   addptr(rsp, FPUStateSizeInWords * wordSize);
 }
 
 void MacroAssembler::pop_IU_state() {
   popa();
-  LP64_ONLY(addq(rsp, 8));
+  addq(rsp, 8);
   popf();
 }
 
@@ -2841,19 +2384,14 @@ void MacroAssembler::push_CPU_state() {
 
 void MacroAssembler::push_FPU_state() {
   subptr(rsp, FPUStateSizeInWords * wordSize);
-#ifndef _LP64
-  fnsave(Address(rsp, 0));
-  fwait();
-#else
   fxsave(Address(rsp, 0));
-#endif // LP64
 }
 
 void MacroAssembler::push_IU_state() {
   // Push flags first because pusha kills them
   pushf();
   // Make sure rsp stays 16-byte aligned
-  LP64_ONLY(subq(rsp, 8));
+  subq(rsp, 8);
   pusha();
 }
 
@@ -2963,29 +2501,19 @@ void MacroAssembler::set_last_Java_frame(Register last_java_sp,
 }
 
 void MacroAssembler::shlptr(Register dst, int imm8) {
-  LP64_ONLY(shlq(dst, imm8)) NOT_LP64(shll(dst, imm8));
+  shlq(dst, imm8);
 }
 
 void MacroAssembler::shrptr(Register dst, int imm8) {
-  LP64_ONLY(shrq(dst, imm8)) NOT_LP64(shrl(dst, imm8));
+  shrq(dst, imm8);
 }
 
 void MacroAssembler::sign_extend_byte(Register reg) {
-  if (LP64_ONLY(true ||) (VM_Version::is_P6() && reg->has_byte_register())) {
-    movsbl(reg, reg); // movsxb
-  } else {
-    shll(reg, 24);
-    sarl(reg, 24);
-  }
+  movsbl(reg, reg); // movsxb
 }
 
 void MacroAssembler::sign_extend_short(Register reg) {
-  if (LP64_ONLY(true ||) VM_Version::is_P6()) {
-    movswl(reg, reg); // movsxw
-  } else {
-    shll(reg, 16);
-    sarl(reg, 16);
-  }
+  movswl(reg, reg); // movsxw
 }
 
 void MacroAssembler::testl(Address dst, int32_t imm32) {
@@ -3009,8 +2537,6 @@ void MacroAssembler::testl(Register dst, AddressLiteral src) {
   testl(dst, as_Address(src));
 }
 
-#ifdef _LP64
-
 void MacroAssembler::testq(Address dst, int32_t imm32) {
   if (imm32 >= 0) {
     testl(dst, imm32);
@@ -3026,8 +2552,6 @@ void MacroAssembler::testq(Register dst, int32_t imm32) {
     Assembler::testq(dst, imm32);
   }
 }
-
-#endif
 
 void MacroAssembler::pcmpeqb(XMMRegister dst, XMMRegister src) {
   assert(((dst->encoding() < 16 && src->encoding() < 16) || VM_Version::supports_avx512vlbw()),"XMM register should be 0-15");
@@ -3874,16 +3398,16 @@ void MacroAssembler::resolve_global_jobject(Register value,
 }
 
 void MacroAssembler::subptr(Register dst, int32_t imm32) {
-  LP64_ONLY(subq(dst, imm32)) NOT_LP64(subl(dst, imm32));
+  subq(dst, imm32);
 }
 
 // Force generation of a 4 byte immediate value even if it fits into 8bit
 void MacroAssembler::subptr_imm32(Register dst, int32_t imm32) {
-  LP64_ONLY(subq_imm32(dst, imm32)) NOT_LP64(subl_imm32(dst, imm32));
+  subq_imm32(dst, imm32);
 }
 
 void MacroAssembler::subptr(Register dst, Register src) {
-  LP64_ONLY(subq(dst, src)) NOT_LP64(subl(dst, src));
+  subq(dst, src);
 }
 
 // C++ bool manipulation
@@ -3901,7 +3425,7 @@ void MacroAssembler::testbool(Register dst) {
 }
 
 void MacroAssembler::testptr(Register dst, Register src) {
-  LP64_ONLY(testq(dst, src)) NOT_LP64(testl(dst, src));
+  testq(dst, src);
 }
 
 // Defines obj, preserves var_size_in_bytes, okay for t2 == var_size_in_bytes.
@@ -3917,20 +3441,14 @@ void MacroAssembler::tlab_allocate(Register obj,
 
 RegSet MacroAssembler::call_clobbered_gp_registers() {
   RegSet regs;
-#ifdef _LP64
   regs += RegSet::of(rax, rcx, rdx);
 #ifndef _WINDOWS
   regs += RegSet::of(rsi, rdi);
 #endif
   regs += RegSet::range(r8, r11);
-#else
-  regs += RegSet::of(rax, rcx, rdx);
-#endif
-#ifdef _LP64
   if (UseAPX) {
     regs += RegSet::range(r16, as_Register(Register::number_of_registers - 1));
   }
-#endif
   return regs;
 }
 
@@ -4100,27 +3618,12 @@ void MacroAssembler::zero_memory(Register address, Register length_in_bytes, int
     shrptr(index, 2);  // use 2 instructions to avoid partial flag stall
     shrptr(index, 1);
   }
-#ifndef _LP64
-  // index could have not been a multiple of 8 (i.e., bit 2 was set)
-  {
-    Label even;
-    // note: if index was a multiple of 8, then it cannot
-    //       be 0 now otherwise it must have been 0 before
-    //       => if it is even, we don't need to check for 0 again
-    jcc(Assembler::carryClear, even);
-    // clear topmost word (no jump would be needed if conditional assignment worked here)
-    movptr(Address(address, index, Address::times_8, offset_in_bytes - 0*BytesPerWord), temp);
-    // index could be 0 now, must check again
-    jcc(Assembler::zero, done);
-    bind(even);
-  }
-#endif // !_LP64
+
   // initialize remaining object fields: index is a multiple of 2 now
   {
     Label loop;
     bind(loop);
     movptr(Address(address, index, Address::times_8, offset_in_bytes - 1*BytesPerWord), temp);
-    NOT_LP64(movptr(Address(address, index, Address::times_8, offset_in_bytes - 2*BytesPerWord), temp);)
     decrement(index);
     jcc(Assembler::notZero, loop);
   }
@@ -4497,9 +4000,8 @@ void MacroAssembler::check_klass_subtype_slow_path_linear(Register sub_klass,
 #ifndef PRODUCT
   uint* pst_counter = &SharedRuntime::_partial_subtype_ctr;
   ExternalAddress pst_counter_addr((address) pst_counter);
-  NOT_LP64(  incrementl(pst_counter_addr) );
-  LP64_ONLY( lea(rcx, pst_counter_addr) );
-  LP64_ONLY( incrementl(Address(rcx, 0)) );
+  lea(rcx, pst_counter_addr);
+  incrementl(Address(rcx, 0));
 #endif //PRODUCT
 
   // We will consult the secondary-super array.
@@ -4544,22 +4046,6 @@ void MacroAssembler::check_klass_subtype_slow_path_linear(Register sub_klass,
 
   bind(L_fallthrough);
 }
-
-#ifndef _LP64
-
-// 32-bit x86 only: always use the linear search.
-void MacroAssembler::check_klass_subtype_slow_path(Register sub_klass,
-                                                   Register super_klass,
-                                                   Register temp_reg,
-                                                   Register temp2_reg,
-                                                   Label* L_success,
-                                                   Label* L_failure,
-                                                   bool set_cond_codes) {
-  check_klass_subtype_slow_path_linear
-    (sub_klass, super_klass, temp_reg, temp2_reg, L_success, L_failure, set_cond_codes);
-}
-
-#else // _LP64
 
 void MacroAssembler::check_klass_subtype_slow_path(Register sub_klass,
                                                    Register super_klass,
@@ -5144,8 +4630,6 @@ void MacroAssembler::verify_secondary_supers_table(Register r_sub_klass,
 
 #undef LOOKUP_SECONDARY_SUPERS_TABLE_REGISTERS
 
-#endif // LP64
-
 void MacroAssembler::clinit_barrier(Register klass, Label* L_fast_path, Label* L_slow_path) {
   assert(L_fast_path != nullptr || L_slow_path != nullptr, "at least one is required");
 
@@ -5200,9 +4684,7 @@ void MacroAssembler::_verify_oop(Register reg, const char* s, const char* file, 
   if (!VerifyOops) return;
 
   BLOCK_COMMENT("verify_oop {");
-#ifdef _LP64
   push(rscratch1);
-#endif
   push(rax);                          // save rax
   push(reg);                          // pass register argument
 
@@ -5260,9 +4742,7 @@ Address MacroAssembler::argument_address(RegisterOrConstant arg_slot,
 void MacroAssembler::_verify_oop_addr(Address addr, const char* s, const char* file, int line) {
   if (!VerifyOops) return;
 
-#ifdef _LP64
   push(rscratch1);
-#endif
   push(rax); // save rax,
   // addr may contain rsp so we will have to adjust it based on the push
   // we just did (and on 64 bit we do two pushes)
@@ -5270,7 +4750,7 @@ void MacroAssembler::_verify_oop_addr(Address addr, const char* s, const char* f
   // stores rax into addr which is backwards of what was intended.
   if (addr.uses(rsp)) {
     lea(rax, addr);
-    pushptr(Address(rax, LP64_ONLY(2 *) BytesPerWord));
+    pushptr(Address(rax, 2 * BytesPerWord));
   } else {
     pushptr(addr);
   }
@@ -5297,27 +4777,23 @@ void MacroAssembler::verify_tlab() {
   if (UseTLAB && VerifyOops) {
     Label next, ok;
     Register t1 = rsi;
-    Register thread_reg = NOT_LP64(rbx) LP64_ONLY(r15_thread);
 
     push(t1);
-    NOT_LP64(push(thread_reg));
-    NOT_LP64(get_thread(thread_reg));
 
-    movptr(t1, Address(thread_reg, in_bytes(JavaThread::tlab_top_offset())));
-    cmpptr(t1, Address(thread_reg, in_bytes(JavaThread::tlab_start_offset())));
+    movptr(t1, Address(r15_thread, in_bytes(JavaThread::tlab_top_offset())));
+    cmpptr(t1, Address(r15_thread, in_bytes(JavaThread::tlab_start_offset())));
     jcc(Assembler::aboveEqual, next);
     STOP("assert(top >= start)");
     should_not_reach_here();
 
     bind(next);
-    movptr(t1, Address(thread_reg, in_bytes(JavaThread::tlab_end_offset())));
-    cmpptr(t1, Address(thread_reg, in_bytes(JavaThread::tlab_top_offset())));
+    movptr(t1, Address(r15_thread, in_bytes(JavaThread::tlab_end_offset())));
+    cmpptr(t1, Address(r15_thread, in_bytes(JavaThread::tlab_top_offset())));
     jcc(Assembler::aboveEqual, ok);
     STOP("assert(top <= end)");
     should_not_reach_here();
 
     bind(ok);
-    NOT_LP64(pop(thread_reg));
     pop(t1);
   }
 #endif
@@ -5658,27 +5134,23 @@ void MacroAssembler::load_method_holder(Register holder, Register method) {
   movptr(holder, Address(holder, ConstantPool::pool_holder_offset()));          // InstanceKlass*
 }
 
-#ifdef _LP64
 void MacroAssembler::load_narrow_klass_compact(Register dst, Register src) {
   assert(UseCompactObjectHeaders, "expect compact object headers");
   movq(dst, Address(src, oopDesc::mark_offset_in_bytes()));
   shrq(dst, markWord::klass_shift);
 }
-#endif
 
 void MacroAssembler::load_klass(Register dst, Register src, Register tmp) {
   assert_different_registers(src, tmp);
   assert_different_registers(dst, tmp);
-#ifdef _LP64
+
   if (UseCompactObjectHeaders) {
     load_narrow_klass_compact(dst, src);
     decode_klass_not_null(dst, tmp);
   } else if (UseCompressedClassPointers) {
     movl(dst, Address(src, oopDesc::klass_offset_in_bytes()));
     decode_klass_not_null(dst, tmp);
-  } else
-#endif
-  {
+  } else {
     movptr(dst, Address(src, oopDesc::klass_offset_in_bytes()));
   }
 }
@@ -5687,17 +5159,15 @@ void MacroAssembler::store_klass(Register dst, Register src, Register tmp) {
   assert(!UseCompactObjectHeaders, "not with compact headers");
   assert_different_registers(src, tmp);
   assert_different_registers(dst, tmp);
-#ifdef _LP64
   if (UseCompressedClassPointers) {
     encode_klass_not_null(src, tmp);
     movl(Address(dst, oopDesc::klass_offset_in_bytes()), src);
-  } else
-#endif
+  } else {
     movptr(Address(dst, oopDesc::klass_offset_in_bytes()), src);
+  }
 }
 
 void MacroAssembler::cmp_klass(Register klass, Register obj, Register tmp) {
-#ifdef _LP64
   if (UseCompactObjectHeaders) {
     assert(tmp != noreg, "need tmp");
     assert_different_registers(klass, obj, tmp);
@@ -5705,15 +5175,12 @@ void MacroAssembler::cmp_klass(Register klass, Register obj, Register tmp) {
     cmpl(klass, tmp);
   } else if (UseCompressedClassPointers) {
     cmpl(klass, Address(obj, oopDesc::klass_offset_in_bytes()));
-  } else
-#endif
-  {
+  } else {
     cmpptr(klass, Address(obj, oopDesc::klass_offset_in_bytes()));
   }
 }
 
 void MacroAssembler::cmp_klasses_from_objects(Register obj1, Register obj2, Register tmp1, Register tmp2) {
-#ifdef _LP64
   if (UseCompactObjectHeaders) {
     assert(tmp2 != noreg, "need tmp2");
     assert_different_registers(obj1, obj2, tmp1, tmp2);
@@ -5723,9 +5190,7 @@ void MacroAssembler::cmp_klasses_from_objects(Register obj1, Register obj2, Regi
   } else if (UseCompressedClassPointers) {
     movl(tmp1, Address(obj1, oopDesc::klass_offset_in_bytes()));
     cmpl(tmp1, Address(obj2, oopDesc::klass_offset_in_bytes()));
-  } else
-#endif
-  {
+  } else {
     movptr(tmp1, Address(obj1, oopDesc::klass_offset_in_bytes()));
     cmpptr(tmp1, Address(obj2, oopDesc::klass_offset_in_bytes()));
   }
@@ -5774,7 +5239,6 @@ void MacroAssembler::store_heap_oop_null(Address dst) {
   access_store_at(T_OBJECT, IN_HEAP, dst, noreg, noreg, noreg, noreg);
 }
 
-#ifdef _LP64
 void MacroAssembler::store_klass_gap(Register dst, Register src) {
   assert(!UseCompactObjectHeaders, "Don't use with compact headers");
   if (UseCompressedClassPointers) {
@@ -6096,8 +5560,6 @@ void MacroAssembler::reinit_heapbase() {
   }
 }
 
-#endif // _LP64
-
 #if COMPILER2_OR_JVMCI
 
 // clear memory of size 'cnt' qwords, starting at 'base' using XMM/YMM/ZMM registers
@@ -6276,8 +5738,6 @@ void MacroAssembler::clear_mem(Register base, Register cnt, Register tmp, XMMReg
     cmpptr(cnt, InitArrayShortSize/BytesPerLong);
     jccb(Assembler::greater, LONG);
 
-    NOT_LP64(shlptr(cnt, 1);) // convert to number of 32-bit words for 32-bit VM
-
     decrement(cnt);
     jccb(Assembler::negative, DONE); // Zero length
 
@@ -6298,7 +5758,6 @@ void MacroAssembler::clear_mem(Register base, Register cnt, Register tmp, XMMReg
   } else if (UseXMMForObjInit) {
     xmm_clear_mem(base, cnt, tmp, xtmp, mask);
   } else {
-    NOT_LP64(shlptr(cnt, 1);) // convert to number of 32-bit words for 32-bit VM
     rep_stos();
   }
 
@@ -6316,7 +5775,7 @@ void MacroAssembler::generate_fill(BasicType t, bool aligned,
   Label L_exit;
   Label L_fill_2_bytes, L_fill_4_bytes;
 
-#if defined(COMPILER2) && defined(_LP64)
+#if defined(COMPILER2)
   if(MaxVectorSize >=32 &&
      VM_Version::supports_avx512vlbw() &&
      VM_Version::supports_bmi2()) {
@@ -6696,7 +6155,6 @@ void MacroAssembler::encode_iso_array(Register src, Register dst, Register len,
   bind(L_done);
 }
 
-#ifdef _LP64
 /**
  * Helper for multiply_to_len().
  */
@@ -7871,7 +7329,6 @@ void MacroAssembler::mul_add(Register out, Register in, Register offs,
   pop(tmp2);
   pop(tmp1);
 }
-#endif
 
 /**
  * Emits code to update CRC-32 with a byte value according to constants in table
@@ -8094,7 +7551,6 @@ void MacroAssembler::kernel_crc32(Register crc, Register buf, Register len, Regi
   notl(crc); // ~c
 }
 
-#ifdef _LP64
 // Helper function for AVX 512 CRC32
 // Fold 512-bit data chunks
 void MacroAssembler::fold512bit_crc32_avx512(XMMRegister xcrc, XMMRegister xK, XMMRegister xtmp, Register buf,
@@ -8612,155 +8068,7 @@ void MacroAssembler::crc32c_proc_chunk(uint32_t size, uint32_t const_or_pre_comp
 
   bind(L_exit);
 }
-#else
-void MacroAssembler::crc32c_ipl_alg4(Register in_out, uint32_t n,
-                                     Register tmp1, Register tmp2, Register tmp3,
-                                     XMMRegister xtmp1, XMMRegister xtmp2) {
-  lea(tmp3, ExternalAddress(StubRoutines::crc32c_table_addr()));
-  if (n > 0) {
-    addl(tmp3, n * 256 * 8);
-  }
-  //    Q1 = TABLEExt[n][B & 0xFF];
-  movl(tmp1, in_out);
-  andl(tmp1, 0x000000FF);
-  shll(tmp1, 3);
-  addl(tmp1, tmp3);
-  movq(xtmp1, Address(tmp1, 0));
 
-  //    Q2 = TABLEExt[n][B >> 8 & 0xFF];
-  movl(tmp2, in_out);
-  shrl(tmp2, 8);
-  andl(tmp2, 0x000000FF);
-  shll(tmp2, 3);
-  addl(tmp2, tmp3);
-  movq(xtmp2, Address(tmp2, 0));
-
-  psllq(xtmp2, 8);
-  pxor(xtmp1, xtmp2);
-
-  //    Q3 = TABLEExt[n][B >> 16 & 0xFF];
-  movl(tmp2, in_out);
-  shrl(tmp2, 16);
-  andl(tmp2, 0x000000FF);
-  shll(tmp2, 3);
-  addl(tmp2, tmp3);
-  movq(xtmp2, Address(tmp2, 0));
-
-  psllq(xtmp2, 16);
-  pxor(xtmp1, xtmp2);
-
-  //    Q4 = TABLEExt[n][B >> 24 & 0xFF];
-  shrl(in_out, 24);
-  andl(in_out, 0x000000FF);
-  shll(in_out, 3);
-  addl(in_out, tmp3);
-  movq(xtmp2, Address(in_out, 0));
-
-  psllq(xtmp2, 24);
-  pxor(xtmp1, xtmp2); // Result in CXMM
-  //    return Q1 ^ Q2 << 8 ^ Q3 << 16 ^ Q4 << 24;
-}
-
-void MacroAssembler::crc32c_pclmulqdq(XMMRegister w_xtmp1,
-                                      Register in_out,
-                                      uint32_t const_or_pre_comp_const_index, bool is_pclmulqdq_supported,
-                                      XMMRegister w_xtmp2,
-                                      Register tmp1,
-                                      Register n_tmp2, Register n_tmp3) {
-  if (is_pclmulqdq_supported) {
-    movdl(w_xtmp1, in_out);
-
-    movl(tmp1, const_or_pre_comp_const_index);
-    movdl(w_xtmp2, tmp1);
-    pclmulqdq(w_xtmp1, w_xtmp2, 0);
-    // Keep result in XMM since GPR is 32 bit in length
-  } else {
-    crc32c_ipl_alg4(in_out, const_or_pre_comp_const_index, tmp1, n_tmp2, n_tmp3, w_xtmp1, w_xtmp2);
-  }
-}
-
-void MacroAssembler::crc32c_rec_alt2(uint32_t const_or_pre_comp_const_index_u1, uint32_t const_or_pre_comp_const_index_u2, bool is_pclmulqdq_supported, Register in_out, Register in1, Register in2,
-                                     XMMRegister w_xtmp1, XMMRegister w_xtmp2, XMMRegister w_xtmp3,
-                                     Register tmp1, Register tmp2,
-                                     Register n_tmp3) {
-  crc32c_pclmulqdq(w_xtmp1, in_out, const_or_pre_comp_const_index_u1, is_pclmulqdq_supported, w_xtmp3, tmp1, tmp2, n_tmp3);
-  crc32c_pclmulqdq(w_xtmp2, in1, const_or_pre_comp_const_index_u2, is_pclmulqdq_supported, w_xtmp3, tmp1, tmp2, n_tmp3);
-
-  psllq(w_xtmp1, 1);
-  movdl(tmp1, w_xtmp1);
-  psrlq(w_xtmp1, 32);
-  movdl(in_out, w_xtmp1);
-
-  xorl(tmp2, tmp2);
-  crc32(tmp2, tmp1, 4);
-  xorl(in_out, tmp2);
-
-  psllq(w_xtmp2, 1);
-  movdl(tmp1, w_xtmp2);
-  psrlq(w_xtmp2, 32);
-  movdl(in1, w_xtmp2);
-
-  xorl(tmp2, tmp2);
-  crc32(tmp2, tmp1, 4);
-  xorl(in1, tmp2);
-  xorl(in_out, in1);
-  xorl(in_out, in2);
-}
-
-void MacroAssembler::crc32c_proc_chunk(uint32_t size, uint32_t const_or_pre_comp_const_index_u1, uint32_t const_or_pre_comp_const_index_u2, bool is_pclmulqdq_supported,
-                                       Register in_out1, Register in_out2, Register in_out3,
-                                       Register tmp1, Register tmp2, Register tmp3,
-                                       XMMRegister w_xtmp1, XMMRegister w_xtmp2, XMMRegister w_xtmp3,
-                                       Register tmp4, Register tmp5,
-                                       Register n_tmp6) {
-  Label L_processPartitions;
-  Label L_processPartition;
-  Label L_exit;
-
-  bind(L_processPartitions);
-  cmpl(in_out1, 3 * size);
-  jcc(Assembler::less, L_exit);
-    xorl(tmp1, tmp1);
-    xorl(tmp2, tmp2);
-    movl(tmp3, in_out2);
-    addl(tmp3, size);
-
-    bind(L_processPartition);
-      crc32(in_out3, Address(in_out2, 0), 4);
-      crc32(tmp1, Address(in_out2, size), 4);
-      crc32(tmp2, Address(in_out2, size*2), 4);
-      crc32(in_out3, Address(in_out2, 0+4), 4);
-      crc32(tmp1, Address(in_out2, size+4), 4);
-      crc32(tmp2, Address(in_out2, size*2+4), 4);
-      addl(in_out2, 8);
-      cmpl(in_out2, tmp3);
-      jcc(Assembler::less, L_processPartition);
-
-        push(tmp3);
-        push(in_out1);
-        push(in_out2);
-        tmp4 = tmp3;
-        tmp5 = in_out1;
-        n_tmp6 = in_out2;
-
-      crc32c_rec_alt2(const_or_pre_comp_const_index_u1, const_or_pre_comp_const_index_u2, is_pclmulqdq_supported, in_out3, tmp1, tmp2,
-            w_xtmp1, w_xtmp2, w_xtmp3,
-            tmp4, tmp5,
-            n_tmp6);
-
-        pop(in_out2);
-        pop(in_out1);
-        pop(tmp3);
-
-    addl(in_out2, 2 * size);
-    subl(in_out1, 3 * size);
-    jmp(L_processPartitions);
-
-  bind(L_exit);
-}
-#endif //LP64
-
-#ifdef _LP64
 // Algorithm 2: Pipelined usage of the CRC32 instruction.
 // Input: A buffer I of L bytes.
 // Output: the CRC32C value of the buffer.
@@ -8852,84 +8160,6 @@ void MacroAssembler::crc32c_ipl_alg2_alt2(Register in_out, Register in1, Registe
 
   BIND(L_exit);
 }
-#else
-void MacroAssembler::crc32c_ipl_alg2_alt2(Register in_out, Register in1, Register in2,
-                                          Register tmp1, Register  tmp2, Register tmp3,
-                                          Register tmp4, Register  tmp5, Register tmp6,
-                                          XMMRegister w_xtmp1, XMMRegister w_xtmp2, XMMRegister w_xtmp3,
-                                          bool is_pclmulqdq_supported) {
-  uint32_t const_or_pre_comp_const_index[CRC32C_NUM_PRECOMPUTED_CONSTANTS];
-  Label L_wordByWord;
-  Label L_byteByByteProlog;
-  Label L_byteByByte;
-  Label L_exit;
-
-  if (is_pclmulqdq_supported) {
-    const_or_pre_comp_const_index[1] = *(uint32_t *)StubRoutines::crc32c_table_addr();
-    const_or_pre_comp_const_index[0] = *((uint32_t *)StubRoutines::crc32c_table_addr() + 1);
-
-    const_or_pre_comp_const_index[3] = *((uint32_t *)StubRoutines::crc32c_table_addr() + 2);
-    const_or_pre_comp_const_index[2] = *((uint32_t *)StubRoutines::crc32c_table_addr() + 3);
-
-    const_or_pre_comp_const_index[5] = *((uint32_t *)StubRoutines::crc32c_table_addr() + 4);
-    const_or_pre_comp_const_index[4] = *((uint32_t *)StubRoutines::crc32c_table_addr() + 5);
-  } else {
-    const_or_pre_comp_const_index[0] = 1;
-    const_or_pre_comp_const_index[1] = 0;
-
-    const_or_pre_comp_const_index[2] = 3;
-    const_or_pre_comp_const_index[3] = 2;
-
-    const_or_pre_comp_const_index[4] = 5;
-    const_or_pre_comp_const_index[5] = 4;
-  }
-  crc32c_proc_chunk(CRC32C_HIGH, const_or_pre_comp_const_index[0], const_or_pre_comp_const_index[1], is_pclmulqdq_supported,
-                    in2, in1, in_out,
-                    tmp1, tmp2, tmp3,
-                    w_xtmp1, w_xtmp2, w_xtmp3,
-                    tmp4, tmp5,
-                    tmp6);
-  crc32c_proc_chunk(CRC32C_MIDDLE, const_or_pre_comp_const_index[2], const_or_pre_comp_const_index[3], is_pclmulqdq_supported,
-                    in2, in1, in_out,
-                    tmp1, tmp2, tmp3,
-                    w_xtmp1, w_xtmp2, w_xtmp3,
-                    tmp4, tmp5,
-                    tmp6);
-  crc32c_proc_chunk(CRC32C_LOW, const_or_pre_comp_const_index[4], const_or_pre_comp_const_index[5], is_pclmulqdq_supported,
-                    in2, in1, in_out,
-                    tmp1, tmp2, tmp3,
-                    w_xtmp1, w_xtmp2, w_xtmp3,
-                    tmp4, tmp5,
-                    tmp6);
-  movl(tmp1, in2);
-  andl(tmp1, 0x00000007);
-  negl(tmp1);
-  addl(tmp1, in2);
-  addl(tmp1, in1);
-
-  BIND(L_wordByWord);
-  cmpl(in1, tmp1);
-  jcc(Assembler::greaterEqual, L_byteByByteProlog);
-    crc32(in_out, Address(in1,0), 4);
-    addl(in1, 4);
-    jmp(L_wordByWord);
-
-  BIND(L_byteByByteProlog);
-  andl(in2, 0x00000007);
-  movl(tmp2, 1);
-
-  BIND(L_byteByByte);
-  cmpl(tmp2, in2);
-  jccb(Assembler::greater, L_exit);
-    movb(tmp1, Address(in1, 0));
-    crc32(in_out, tmp1, 1);
-    incl(in1);
-    incl(tmp2);
-    jmp(L_byteByByte);
-
-  BIND(L_exit);
-}
-#endif // LP64
 #undef BIND
 #undef BLOCK_COMMENT
 
@@ -9923,7 +9153,6 @@ void MacroAssembler::fill64(Register dst, int disp, XMMRegister xmm, bool use64b
   fill64(Address(dst, disp), xmm, use64byteVector);
 }
 
-#ifdef _LP64
 void MacroAssembler::generate_fill_avx3(BasicType type, Register to, Register value,
                                         Register count, Register rtmp, XMMRegister xtmp) {
   Label L_exit;
@@ -10100,11 +9329,9 @@ void MacroAssembler::generate_fill_avx3(BasicType type, Register to, Register va
   }
   bind(L_exit);
 }
-#endif
 #endif //COMPILER2_OR_JVMCI
 
 
-#ifdef _LP64
 void MacroAssembler::convert_f2i(Register dst, XMMRegister src) {
   Label done;
   cvttss2sil(dst, src);
@@ -10267,8 +9494,6 @@ void MacroAssembler::cache_wbsync(bool is_pre)
     sfence();
   }
 }
-
-#endif // _LP64
 
 Assembler::Condition MacroAssembler::negate_condition(Assembler::Condition cond) {
   switch (cond) {
@@ -10455,7 +9680,6 @@ void MacroAssembler::lightweight_unlock(Register obj, Register reg_rax, Register
   bind(unlocked);
 }
 
-#ifdef _LP64
 // Saves legacy GPRs state on stack.
 void MacroAssembler::save_legacy_gprs() {
   subq(rsp, 16 * wordSize);
@@ -10504,4 +9728,3 @@ void MacroAssembler::setcc(Assembler::Condition comparison, Register dst) {
     movzbl(dst, dst);
   }
 }
-#endif

--- a/src/hotspot/cpu/x86/macroAssembler_x86.hpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.hpp
@@ -140,10 +140,10 @@ class MacroAssembler: public Assembler {
 
   // Support for inc/dec with optimal instruction selection depending on value
 
-  void increment(Register reg, int value = 1) { LP64_ONLY(incrementq(reg, value)) NOT_LP64(incrementl(reg, value)) ; }
-  void decrement(Register reg, int value = 1) { LP64_ONLY(decrementq(reg, value)) NOT_LP64(decrementl(reg, value)) ; }
-  void increment(Address dst, int value = 1)  { LP64_ONLY(incrementq(dst, value)) NOT_LP64(incrementl(dst, value)) ; }
-  void decrement(Address dst, int value = 1)  { LP64_ONLY(decrementq(dst, value)) NOT_LP64(decrementl(dst, value)) ; }
+  void increment(Register reg, int value = 1) { incrementq(reg, value); }
+  void decrement(Register reg, int value = 1) { decrementq(reg, value); }
+  void increment(Address dst, int value = 1)  { incrementq(dst, value); }
+  void decrement(Address dst, int value = 1)  { decrementq(dst, value); }
 
   void decrementl(Address dst, int value = 1);
   void decrementl(Register reg, int value = 1);
@@ -221,7 +221,6 @@ class MacroAssembler: public Assembler {
   // Normally, JavaThread pointer is available in r15_thread, use that where possible.
   void get_thread_slow(Register thread);
 
-#ifdef _LP64
   // Support for argument shuffling
 
   // bias in bytes
@@ -237,7 +236,6 @@ class MacroAssembler: public Assembler {
                    VMRegPair dst,
                    bool is_receiver,
                    int* receiver_offset);
-#endif // _LP64
 
   // Support for VM calls
   //
@@ -351,9 +349,7 @@ class MacroAssembler: public Assembler {
   void load_method_holder(Register holder, Register method);
 
   // oop manipulations
-#ifdef _LP64
   void load_narrow_klass_compact(Register dst, Register src);
-#endif
   void load_klass(Register dst, Register src, Register tmp);
   void store_klass(Register dst, Register src, Register tmp);
 
@@ -379,7 +375,6 @@ class MacroAssembler: public Assembler {
   // stored using routines that take a jobject.
   void store_heap_oop_null(Address dst);
 
-#ifdef _LP64
   void store_klass_gap(Register dst, Register src);
 
   // This dummy is to prevent a call to store_heap_oop from
@@ -413,8 +408,6 @@ class MacroAssembler: public Assembler {
   void reinit_heapbase();
 
   DEBUG_ONLY(void verify_heapbase(const char* msg);)
-
-#endif // _LP64
 
   // Int division/remainder for Java
   // (as idivl, but checks for special case as described in JVM spec.)
@@ -582,7 +575,6 @@ public:
                                      Label* L_failure,
                                      bool set_cond_codes = false);
 
-#ifdef _LP64
   // The 64-bit version, which may do a hashed subclass lookup.
   void check_klass_subtype_slow_path(Register sub_klass,
                                      Register super_klass,
@@ -592,7 +584,6 @@ public:
                                      Register temp4_reg,
                                      Label* L_success,
                                      Label* L_failure);
-#endif
 
   // Three parts of a hashed subclass lookup: a simple linear search,
   // a table lookup, and a fallback that does linear probing in the
@@ -629,7 +620,6 @@ public:
                                            Register result,
                                            u1 super_klass_slot);
 
-#ifdef _LP64
   using Assembler::salq;
   void salq(Register dest, Register count);
   using Assembler::rorq;
@@ -657,7 +647,6 @@ public:
                                      Register temp1,
                                      Register temp2,
                                      Register temp3);
-#endif
 
   void repne_scanq(Register addr, Register value, Register count, Register limit,
                    Label* L_success,
@@ -766,10 +755,10 @@ public:
   // Arithmetics
 
 
-  void addptr(Address dst, int32_t src) { LP64_ONLY(addq(dst, src)) NOT_LP64(addl(dst, src)) ; }
+  void addptr(Address dst, int32_t src) { addq(dst, src); }
   void addptr(Address dst, Register src);
 
-  void addptr(Register dst, Address src) { LP64_ONLY(addq(dst, src)) NOT_LP64(addl(dst, src)); }
+  void addptr(Register dst, Address src) { addq(dst, src); }
   void addptr(Register dst, int32_t src);
   void addptr(Register dst, Register src);
   void addptr(Register dst, RegisterOrConstant src) {
@@ -778,12 +767,10 @@ public:
   }
 
   void andptr(Register dst, int32_t src);
-  void andptr(Register src1, Register src2) { LP64_ONLY(andq(src1, src2)) NOT_LP64(andl(src1, src2)) ; }
+  void andptr(Register src1, Register src2) { andq(src1, src2); }
 
-#ifdef _LP64
   using Assembler::andq;
   void andq(Register dst, AddressLiteral src, Register rscratch = noreg);
-#endif
 
   void cmp8(AddressLiteral src1, int imm, Register rscratch = noreg);
 
@@ -796,12 +783,6 @@ public:
 
   void cmp32(Register src1, Address src2);
 
-#ifndef _LP64
-  void cmpklass(Address dst, Metadata* obj);
-  void cmpklass(Register dst, Metadata* obj);
-  void cmpoop(Address dst, jobject obj);
-#endif // _LP64
-
   void cmpoop(Register src1, Register src2);
   void cmpoop(Register src1, Address src2);
   void cmpoop(Register dst, jobject obj, Register rscratch);
@@ -811,12 +792,11 @@ public:
 
   void cmpptr(Register src1, AddressLiteral src2, Register rscratch = noreg);
 
-  void cmpptr(Register src1, Register src2) { LP64_ONLY(cmpq(src1, src2)) NOT_LP64(cmpl(src1, src2)) ; }
-  void cmpptr(Register src1, Address src2) { LP64_ONLY(cmpq(src1, src2)) NOT_LP64(cmpl(src1, src2)) ; }
-  // void cmpptr(Address src1, Register src2) { LP64_ONLY(cmpq(src1, src2)) NOT_LP64(cmpl(src1, src2)) ; }
+  void cmpptr(Register src1, Register src2) { cmpq(src1, src2); }
+  void cmpptr(Register src1, Address src2) { cmpq(src1, src2); }
 
-  void cmpptr(Register src1, int32_t src2) { LP64_ONLY(cmpq(src1, src2)) NOT_LP64(cmpl(src1, src2)) ; }
-  void cmpptr(Address src1, int32_t src2) { LP64_ONLY(cmpq(src1, src2)) NOT_LP64(cmpl(src1, src2)) ; }
+  void cmpptr(Register src1, int32_t src2) { cmpq(src1, src2); }
+  void cmpptr(Address src1, int32_t src2) { cmpq(src1, src2); }
 
   // cmp64 to avoild hiding cmpq
   void cmp64(Register src1, AddressLiteral src, Register rscratch = noreg);
@@ -825,26 +805,26 @@ public:
 
   void locked_cmpxchgptr(Register reg, AddressLiteral adr, Register rscratch = noreg);
 
-  void imulptr(Register dst, Register src) { LP64_ONLY(imulq(dst, src)) NOT_LP64(imull(dst, src)); }
-  void imulptr(Register dst, Register src, int imm32) { LP64_ONLY(imulq(dst, src, imm32)) NOT_LP64(imull(dst, src, imm32)); }
+  void imulptr(Register dst, Register src) { imulq(dst, src); }
+  void imulptr(Register dst, Register src, int imm32) { imulq(dst, src, imm32); }
 
 
-  void negptr(Register dst) { LP64_ONLY(negq(dst)) NOT_LP64(negl(dst)); }
+  void negptr(Register dst) { negq(dst); }
 
-  void notptr(Register dst) { LP64_ONLY(notq(dst)) NOT_LP64(notl(dst)); }
+  void notptr(Register dst) { notq(dst); }
 
   void shlptr(Register dst, int32_t shift);
-  void shlptr(Register dst) { LP64_ONLY(shlq(dst)) NOT_LP64(shll(dst)); }
+  void shlptr(Register dst) { shlq(dst); }
 
   void shrptr(Register dst, int32_t shift);
-  void shrptr(Register dst) { LP64_ONLY(shrq(dst)) NOT_LP64(shrl(dst)); }
+  void shrptr(Register dst) { shrq(dst); }
 
-  void sarptr(Register dst) { LP64_ONLY(sarq(dst)) NOT_LP64(sarl(dst)); }
-  void sarptr(Register dst, int32_t src) { LP64_ONLY(sarq(dst, src)) NOT_LP64(sarl(dst, src)); }
+  void sarptr(Register dst) { sarq(dst); }
+  void sarptr(Register dst, int32_t src) { sarq(dst, src); }
 
-  void subptr(Address dst, int32_t src) { LP64_ONLY(subq(dst, src)) NOT_LP64(subl(dst, src)); }
+  void subptr(Address dst, int32_t src) { subq(dst, src); }
 
-  void subptr(Register dst, Address src) { LP64_ONLY(subq(dst, src)) NOT_LP64(subl(dst, src)); }
+  void subptr(Register dst, Address src) { subq(dst, src); }
   void subptr(Register dst, int32_t src);
   // Force generation of a 4 byte immediate value even if it fits into 8bit
   void subptr_imm32(Register dst, int32_t src);
@@ -854,13 +834,13 @@ public:
     else                   subptr(dst,       src.as_register());
   }
 
-  void sbbptr(Address dst, int32_t src) { LP64_ONLY(sbbq(dst, src)) NOT_LP64(sbbl(dst, src)); }
-  void sbbptr(Register dst, int32_t src) { LP64_ONLY(sbbq(dst, src)) NOT_LP64(sbbl(dst, src)); }
+  void sbbptr(Address dst, int32_t src) { sbbq(dst, src); }
+  void sbbptr(Register dst, int32_t src) { sbbq(dst, src); }
 
-  void xchgptr(Register src1, Register src2) { LP64_ONLY(xchgq(src1, src2)) NOT_LP64(xchgl(src1, src2)) ; }
-  void xchgptr(Register src1, Address src2) { LP64_ONLY(xchgq(src1, src2)) NOT_LP64(xchgl(src1, src2)) ; }
+  void xchgptr(Register src1, Register src2) { xchgq(src1, src2); }
+  void xchgptr(Register src1, Address src2) { xchgq(src1, src2); }
 
-  void xaddptr(Address src1, Register src2) { LP64_ONLY(xaddq(src1, src2)) NOT_LP64(xaddl(src1, src2)) ; }
+  void xaddptr(Address src1, Register src2) { xaddq(src1, src2); }
 
 
 
@@ -870,12 +850,10 @@ public:
   // Unconditional atomic increment.
   void atomic_incl(Address counter_addr);
   void atomic_incl(AddressLiteral counter_addr, Register rscratch = noreg);
-#ifdef _LP64
   void atomic_incq(Address counter_addr);
   void atomic_incq(AddressLiteral counter_addr, Register rscratch = noreg);
-#endif
-  void atomic_incptr(AddressLiteral counter_addr, Register rscratch = noreg) { LP64_ONLY(atomic_incq(counter_addr, rscratch)) NOT_LP64(atomic_incl(counter_addr, rscratch)) ; }
-  void atomic_incptr(Address counter_addr) { LP64_ONLY(atomic_incq(counter_addr)) NOT_LP64(atomic_incl(counter_addr)) ; }
+  void atomic_incptr(AddressLiteral counter_addr, Register rscratch = noreg) { atomic_incq(counter_addr, rscratch); }
+  void atomic_incptr(Address counter_addr) { atomic_incq(counter_addr); }
 
   using Assembler::lea;
   void lea(Register dst, AddressLiteral adr);
@@ -893,18 +871,18 @@ public:
   void testq(Address dst, int32_t imm32);
   void testq(Register dst, int32_t imm32);
 
-  void orptr(Register dst, Address src) { LP64_ONLY(orq(dst, src)) NOT_LP64(orl(dst, src)); }
-  void orptr(Register dst, Register src) { LP64_ONLY(orq(dst, src)) NOT_LP64(orl(dst, src)); }
-  void orptr(Register dst, int32_t src) { LP64_ONLY(orq(dst, src)) NOT_LP64(orl(dst, src)); }
-  void orptr(Address dst, int32_t imm32) { LP64_ONLY(orq(dst, imm32)) NOT_LP64(orl(dst, imm32)); }
+  void orptr(Register dst, Address src) { orq(dst, src); }
+  void orptr(Register dst, Register src) { orq(dst, src); }
+  void orptr(Register dst, int32_t src) { orq(dst, src); }
+  void orptr(Address dst, int32_t imm32) { orq(dst, imm32); }
 
-  void testptr(Register src, int32_t imm32) {  LP64_ONLY(testq(src, imm32)) NOT_LP64(testl(src, imm32)); }
-  void testptr(Register src1, Address src2) { LP64_ONLY(testq(src1, src2)) NOT_LP64(testl(src1, src2)); }
-  void testptr(Address src, int32_t imm32) {  LP64_ONLY(testq(src, imm32)) NOT_LP64(testl(src, imm32)); }
+  void testptr(Register src, int32_t imm32) { testq(src, imm32); }
+  void testptr(Register src1, Address src2) { testq(src1, src2); }
+  void testptr(Address src, int32_t imm32) { testq(src, imm32); }
   void testptr(Register src1, Register src2);
 
-  void xorptr(Register dst, Register src) { LP64_ONLY(xorq(dst, src)) NOT_LP64(xorl(dst, src)); }
-  void xorptr(Register dst, Address src) { LP64_ONLY(xorq(dst, src)) NOT_LP64(xorl(dst, src)); }
+  void xorptr(Register dst, Register src) { xorq(dst, src); }
+  void xorptr(Register dst, Address src) { xorq(dst, src); }
 
   // Calls
 
@@ -1033,7 +1011,6 @@ public:
   void ldmxcsr(Address src) { Assembler::ldmxcsr(src); }
   void ldmxcsr(AddressLiteral src, Register rscratch = noreg);
 
-#ifdef _LP64
  private:
   void sha256_AVX2_one_round_compute(
     Register  reg_old_h,
@@ -1083,7 +1060,6 @@ public:
                    Register buf, Register state, Register ofs, Register limit, Register rsp, bool multi_block,
                    XMMRegister shuf_mask);
   void sha512_update_ni_x1(Register arg_hash, Register arg_msg, Register ofs, Register limit, bool multi_block);
-#endif // _LP64
 
   void fast_md5(Register buf, Address state, Address ofs, Address limit,
                 bool multi_block);
@@ -1093,67 +1069,14 @@ public:
                  Register buf, Register state, Register ofs, Register limit, Register rsp,
                  bool multi_block);
 
-#ifdef _LP64
   void fast_sha256(XMMRegister msg, XMMRegister state0, XMMRegister state1, XMMRegister msgtmp0,
                    XMMRegister msgtmp1, XMMRegister msgtmp2, XMMRegister msgtmp3, XMMRegister msgtmp4,
                    Register buf, Register state, Register ofs, Register limit, Register rsp,
                    bool multi_block, XMMRegister shuf_mask);
-#else
-  void fast_sha256(XMMRegister msg, XMMRegister state0, XMMRegister state1, XMMRegister msgtmp0,
-                   XMMRegister msgtmp1, XMMRegister msgtmp2, XMMRegister msgtmp3, XMMRegister msgtmp4,
-                   Register buf, Register state, Register ofs, Register limit, Register rsp,
-                   bool multi_block);
-#endif
 
   void fast_exp(XMMRegister xmm0, XMMRegister xmm1, XMMRegister xmm2, XMMRegister xmm3,
                 XMMRegister xmm4, XMMRegister xmm5, XMMRegister xmm6, XMMRegister xmm7,
                 Register rax, Register rcx, Register rdx, Register tmp);
-
-#ifndef _LP64
- private:
-  // Initialized in macroAssembler_x86_constants.cpp
-  static address ONES;
-  static address L_2IL0FLOATPACKET_0;
-  static address PI4_INV;
-  static address PI4X3;
-  static address PI4X4;
-
- public:
-  void fast_log(XMMRegister xmm0, XMMRegister xmm1, XMMRegister xmm2, XMMRegister xmm3,
-                XMMRegister xmm4, XMMRegister xmm5, XMMRegister xmm6, XMMRegister xmm7,
-                Register rax, Register rcx, Register rdx, Register tmp1);
-
-  void fast_log10(XMMRegister xmm0, XMMRegister xmm1, XMMRegister xmm2, XMMRegister xmm3,
-                XMMRegister xmm4, XMMRegister xmm5, XMMRegister xmm6, XMMRegister xmm7,
-                Register rax, Register rcx, Register rdx, Register tmp);
-
-  void fast_pow(XMMRegister xmm0, XMMRegister xmm1, XMMRegister xmm2, XMMRegister xmm3, XMMRegister xmm4,
-                XMMRegister xmm5, XMMRegister xmm6, XMMRegister xmm7, Register rax, Register rcx,
-                Register rdx, Register tmp);
-
-  void fast_sin(XMMRegister xmm0, XMMRegister xmm1, XMMRegister xmm2, XMMRegister xmm3,
-                XMMRegister xmm4, XMMRegister xmm5, XMMRegister xmm6, XMMRegister xmm7,
-                Register rax, Register rbx, Register rdx);
-
-  void fast_cos(XMMRegister xmm0, XMMRegister xmm1, XMMRegister xmm2, XMMRegister xmm3,
-                XMMRegister xmm4, XMMRegister xmm5, XMMRegister xmm6, XMMRegister xmm7,
-                Register rax, Register rcx, Register rdx, Register tmp);
-
-  void libm_sincos_huge(XMMRegister xmm0, XMMRegister xmm1, Register eax, Register ecx,
-                        Register edx, Register ebx, Register esi, Register edi,
-                        Register ebp, Register esp);
-
-  void libm_reduce_pi04l(Register eax, Register ecx, Register edx, Register ebx,
-                         Register esi, Register edi, Register ebp, Register esp);
-
-  void libm_tancot_huge(XMMRegister xmm0, XMMRegister xmm1, Register eax, Register ecx,
-                        Register edx, Register ebx, Register esi, Register edi,
-                        Register ebp, Register esp);
-
-  void fast_tan(XMMRegister xmm0, XMMRegister xmm1, XMMRegister xmm2, XMMRegister xmm3,
-                XMMRegister xmm4, XMMRegister xmm5, XMMRegister xmm6, XMMRegister xmm7,
-                Register rax, Register rcx, Register rdx, Register tmp);
-#endif // !_LP64
 
 private:
 
@@ -1921,8 +1844,8 @@ public:
 
   void cmov(   Condition cc, Register dst, Register src) { cmovptr(cc, dst, src); }
 
-  void cmovptr(Condition cc, Register dst, Address  src) { LP64_ONLY(cmovq(cc, dst, src)) NOT_LP64(cmov32(cc, dst, src)); }
-  void cmovptr(Condition cc, Register dst, Register src) { LP64_ONLY(cmovq(cc, dst, src)) NOT_LP64(cmov32(cc, dst, src)); }
+  void cmovptr(Condition cc, Register dst, Address  src) { cmovq(cc, dst, src); }
+  void cmovptr(Condition cc, Register dst, Register src) { cmovq(cc, dst, src); }
 
   void movoop(Register dst, jobject obj);
   void movoop(Address  dst, jobject obj, Register rscratch);
@@ -1961,15 +1884,15 @@ public:
   // Can push value or effective address
   void pushptr(AddressLiteral src, Register rscratch);
 
-  void pushptr(Address src) { LP64_ONLY(pushq(src)) NOT_LP64(pushl(src)); }
-  void popptr(Address src) { LP64_ONLY(popq(src)) NOT_LP64(popl(src)); }
+  void pushptr(Address src) { pushq(src); }
+  void popptr(Address src) { popq(src); }
 
   void pushoop(jobject obj, Register rscratch);
   void pushklass(Metadata* obj, Register rscratch);
 
   // sign extend as need a l to ptr sized element
-  void movl2ptr(Register dst, Address src) { LP64_ONLY(movslq(dst, src)) NOT_LP64(movl(dst, src)); }
-  void movl2ptr(Register dst, Register src) { LP64_ONLY(movslq(dst, src)) NOT_LP64(if (dst != src) movl(dst, src)); }
+  void movl2ptr(Register dst, Address src) { movslq(dst, src); }
+  void movl2ptr(Register dst, Register src) { movslq(dst, src); }
 
 
  public:
@@ -1992,7 +1915,6 @@ public:
                         XMMRegister tmp1, XMMRegister tmp2, XMMRegister tmp3,
                         XMMRegister tmp4, Register tmp5, Register result, bool ascii);
 
-#ifdef _LP64
   void add2_with_carry(Register dest_hi, Register dest_lo, Register src1, Register src2);
   void multiply_64_x_64_loop(Register x, Register xstart, Register x_xstart,
                              Register y, Register y_idx, Register z,
@@ -2033,32 +1955,22 @@ public:
   void vectorized_mismatch(Register obja, Register objb, Register length, Register log2_array_indxscale,
                            Register result, Register tmp1, Register tmp2,
                            XMMRegister vec1, XMMRegister vec2, XMMRegister vec3);
-#endif
 
   // CRC32 code for java.util.zip.CRC32::updateBytes() intrinsic.
   void update_byte_crc32(Register crc, Register val, Register table);
   void kernel_crc32(Register crc, Register buf, Register len, Register table, Register tmp);
 
-
-#ifdef _LP64
   void kernel_crc32_avx512(Register crc, Register buf, Register len, Register table, Register tmp1, Register tmp2);
   void kernel_crc32_avx512_256B(Register crc, Register buf, Register len, Register key, Register pos,
                                 Register tmp1, Register tmp2, Label& L_barrett, Label& L_16B_reduction_loop,
                                 Label& L_get_last_two_xmms, Label& L_128_done, Label& L_cleanup);
-#endif // _LP64
 
   // CRC32C code for java.util.zip.CRC32C::updateBytes() intrinsic
   // Note on a naming convention:
   // Prefix w = register only used on a Westmere+ architecture
   // Prefix n = register only used on a Nehalem architecture
-#ifdef _LP64
   void crc32c_ipl_alg4(Register in_out, uint32_t n,
                        Register tmp1, Register tmp2, Register tmp3);
-#else
-  void crc32c_ipl_alg4(Register in_out, uint32_t n,
-                       Register tmp1, Register tmp2, Register tmp3,
-                       XMMRegister xtmp1, XMMRegister xtmp2);
-#endif
   void crc32c_pclmulqdq(XMMRegister w_xtmp1,
                         Register in_out,
                         uint32_t const_or_pre_comp_const_index, bool is_pclmulqdq_supported,
@@ -2083,10 +1995,8 @@ public:
   // Fold 128-bit data chunk
   void fold_128bit_crc32(XMMRegister xcrc, XMMRegister xK, XMMRegister xtmp, Register buf, int offset);
   void fold_128bit_crc32(XMMRegister xcrc, XMMRegister xK, XMMRegister xtmp, XMMRegister xbuf);
-#ifdef _LP64
   // Fold 512-bit data chunk
   void fold512bit_crc32_avx512(XMMRegister xcrc, XMMRegister xK, XMMRegister xtmp, Register buf, Register pos, int offset);
-#endif // _LP64
   // Fold 8-bit data
   void fold_8bit_crc32(Register crc, Register table, Register tmp);
   void fold_8bit_crc32(XMMRegister crc, Register table, XMMRegister xtmp, Register tmp);
@@ -2120,7 +2030,6 @@ public:
 
   void fill64(Register dst, int dis, XMMRegister xmm, bool use64byteVector = false);
 
-#ifdef _LP64
   void convert_f2i(Register dst, XMMRegister src);
   void convert_d2i(Register dst, XMMRegister src);
   void convert_f2l(Register dst, XMMRegister src);
@@ -2135,7 +2044,6 @@ public:
   void generate_fill_avx3(BasicType type, Register to, Register value,
                           Register count, Register rtmp, XMMRegister xtmp);
 #endif // COMPILER2_OR_JVMCI
-#endif // _LP64
 
   void vallones(XMMRegister dst, int vector_len);
 
@@ -2144,11 +2052,9 @@ public:
   void lightweight_lock(Register basic_lock, Register obj, Register reg_rax, Register tmp, Label& slow);
   void lightweight_unlock(Register obj, Register reg_rax, Register tmp, Label& slow);
 
-#ifdef _LP64
   void save_legacy_gprs();
   void restore_legacy_gprs();
   void setcc(Assembler::Condition comparison, Register dst);
-#endif
 };
 
 #endif // CPU_X86_MACROASSEMBLER_X86_HPP

--- a/src/hotspot/cpu/x86/macroAssembler_x86_sha.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86_sha.cpp
@@ -235,17 +235,10 @@ void MacroAssembler::fast_sha1(XMMRegister abcd, XMMRegister e0, XMMRegister e1,
 // and state0 and state1 can never use xmm0 register.
 // ofs and limit are used for multi-block byte array.
 // int com.sun.security.provider.DigestBase.implCompressMultiBlock(byte[] b, int ofs, int limit)
-#ifdef _LP64
 void MacroAssembler::fast_sha256(XMMRegister msg, XMMRegister state0, XMMRegister state1, XMMRegister msgtmp0,
   XMMRegister msgtmp1, XMMRegister msgtmp2, XMMRegister msgtmp3, XMMRegister msgtmp4,
   Register buf, Register state, Register ofs, Register limit, Register rsp,
   bool multi_block, XMMRegister shuf_mask) {
-#else
-void MacroAssembler::fast_sha256(XMMRegister msg, XMMRegister state0, XMMRegister state1, XMMRegister msgtmp0,
-  XMMRegister msgtmp1, XMMRegister msgtmp2, XMMRegister msgtmp3, XMMRegister msgtmp4,
-  Register buf, Register state, Register ofs, Register limit, Register rsp,
-  bool multi_block) {
-#endif
   Label done_hash, loop0;
 
   address K256 = StubRoutines::x86::k256_addr();
@@ -260,9 +253,7 @@ void MacroAssembler::fast_sha256(XMMRegister msg, XMMRegister state0, XMMRegiste
   palignr(state0, state1, 8);
   pblendw(state1, msgtmp4, 0xF0);
 
-#ifdef _LP64
   movdqu(shuf_mask, ExternalAddress(pshuffle_byte_flip_mask));
-#endif
   lea(rax, ExternalAddress(K256));
 
   bind(loop0);
@@ -271,11 +262,7 @@ void MacroAssembler::fast_sha256(XMMRegister msg, XMMRegister state0, XMMRegiste
 
   // Rounds 0-3
   movdqu(msg, Address(buf, 0));
-#ifdef _LP64
   pshufb(msg, shuf_mask);
-#else
-  pshufb(msg, ExternalAddress(pshuffle_byte_flip_mask));
-#endif
   movdqa(msgtmp0, msg);
   paddd(msg, Address(rax, 0));
   sha256rnds2(state1, state0);
@@ -284,11 +271,7 @@ void MacroAssembler::fast_sha256(XMMRegister msg, XMMRegister state0, XMMRegiste
 
   // Rounds 4-7
   movdqu(msg, Address(buf, 16));
-#ifdef _LP64
   pshufb(msg, shuf_mask);
-#else
-  pshufb(msg, ExternalAddress(pshuffle_byte_flip_mask));
-#endif
   movdqa(msgtmp1, msg);
   paddd(msg, Address(rax, 16));
   sha256rnds2(state1, state0);
@@ -298,11 +281,7 @@ void MacroAssembler::fast_sha256(XMMRegister msg, XMMRegister state0, XMMRegiste
 
   // Rounds 8-11
   movdqu(msg, Address(buf, 32));
-#ifdef _LP64
   pshufb(msg, shuf_mask);
-#else
-  pshufb(msg, ExternalAddress(pshuffle_byte_flip_mask));
-#endif
   movdqa(msgtmp2, msg);
   paddd(msg, Address(rax, 32));
   sha256rnds2(state1, state0);
@@ -312,11 +291,7 @@ void MacroAssembler::fast_sha256(XMMRegister msg, XMMRegister state0, XMMRegiste
 
   // Rounds 12-15
   movdqu(msg, Address(buf, 48));
-#ifdef _LP64
   pshufb(msg, shuf_mask);
-#else
-  pshufb(msg, ExternalAddress(pshuffle_byte_flip_mask));
-#endif
   movdqa(msgtmp3, msg);
   paddd(msg, Address(rax, 48));
   sha256rnds2(state1, state0);
@@ -491,7 +466,6 @@ void MacroAssembler::fast_sha256(XMMRegister msg, XMMRegister state0, XMMRegiste
 
 }
 
-#ifdef _LP64
 /*
   The algorithm below is based on Intel publication:
   "Fast SHA-256 Implementations on Intel(R) Architecture Processors" by Jim Guilford, Kirk Yap and Vinodh Gopal.
@@ -1696,5 +1670,3 @@ void MacroAssembler::sha512_update_ni_x1(Register arg_hash, Register arg_msg, Re
 
     bind(done_hash);
 }
-
-#endif //#ifdef _LP64

--- a/test/hotspot/gtest/x86/test_assembler_x86.cpp
+++ b/test/hotspot/gtest/x86/test_assembler_x86.cpp
@@ -30,6 +30,7 @@
 #include "asm/assembler.hpp"
 #include "asm/assembler.inline.hpp"
 #include "asm/macroAssembler.hpp"
+#include "code/codeCache.hpp"
 #include "memory/resourceArea.hpp"
 
 #include "unittest.hpp"


### PR DESCRIPTION
This improvement targets x86 `(Macro)Assembler`. We are mostly cleaning up `LP64` predicated code blocks, and a bit of related code.

It is enticing to remove all `*ptr` methods, and rename all uses from `*ptr` to `*q`, but that turns out to be very intrusive. That is left for a future RFE, if we ever consider doing it.

Additional testing:
 - [x] Linux x86_64 server fastdebug, `all`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8351162](https://bugs.openjdk.org/browse/JDK-8351162): Clean up x86 (Macro)Assembler after 32-bit x86 removal (**Sub-task** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24631/head:pull/24631` \
`$ git checkout pull/24631`

Update a local copy of the PR: \
`$ git checkout pull/24631` \
`$ git pull https://git.openjdk.org/jdk.git pull/24631/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24631`

View PR using the GUI difftool: \
`$ git pr show -t 24631`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24631.diff">https://git.openjdk.org/jdk/pull/24631.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24631#issuecomment-2804907001)
</details>
