### PR TITLE
8354542: Clean up x86 stubs after 32-bit x86 removal

### DIFF
--- a/src/hotspot/cpu/x86/methodHandles_x86.hpp
+++ b/src/hotspot/cpu/x86/methodHandles_x86.hpp
@@ -60,5 +60,5 @@ public:
 
   static Register saved_last_sp_register() {
     // Should be in sharedRuntime, not here.
-    return LP64_ONLY(r13) NOT_LP64(rsi);
+    return r13;
   }

--- a/src/hotspot/cpu/x86/sharedRuntime_x86.cpp
+++ b/src/hotspot/cpu/x86/sharedRuntime_x86.cpp
@@ -73,21 +73,14 @@ void SharedRuntime::inline_check_hashcode_from_object_header(MacroAssembler* mas
   }
 
   // get hash
-#ifdef _LP64
   // Read the header and build a mask to get its hash field.
   // Depend on hash_mask being at most 32 bits and avoid the use of hash_mask_in_place
   // because it could be larger than 32 bits in a 64-bit vm. See markWord.hpp.
   __ shrptr(result, markWord::hash_shift);
   __ andptr(result, markWord::hash_mask);
-#else
-  __ andptr(result, markWord::hash_mask_in_place);
-#endif //_LP64
 
   // test if hashCode exists
-  __ jcc(Assembler::zero, slowCase);
-#ifndef _LP64
-  __ shrptr(result, markWord::hash_shift);
-#endif
+  __ jccb(Assembler::zero, slowCase);
   __ ret(0);
   __ bind(slowCase);
 }

--- a/src/hotspot/cpu/x86/stubDeclarations_x86.hpp
+++ b/src/hotspot/cpu/x86/stubDeclarations_x86.hpp
@@ -34,45 +34,43 @@
   do_stub(initial, verify_mxcsr)                                        \
   do_arch_entry(x86, initial, verify_mxcsr, verify_mxcsr_entry,         \
                 verify_mxcsr_entry)                                     \
-  LP64_ONLY(                                                            \
-    do_stub(initial, get_previous_sp)                                   \
-    do_arch_entry(x86, initial, get_previous_sp,                        \
-                  get_previous_sp_entry,                                \
-                  get_previous_sp_entry)                                \
-    do_stub(initial, f2i_fixup)                                         \
-    do_arch_entry(x86, initial, f2i_fixup, f2i_fixup, f2i_fixup)        \
-    do_stub(initial, f2l_fixup)                                         \
-    do_arch_entry(x86, initial, f2l_fixup, f2l_fixup, f2l_fixup)        \
-    do_stub(initial, d2i_fixup)                                         \
-    do_arch_entry(x86, initial, d2i_fixup, d2i_fixup, d2i_fixup)        \
-    do_stub(initial, d2l_fixup)                                         \
-    do_arch_entry(x86, initial, d2l_fixup, d2l_fixup, d2l_fixup)        \
-    do_stub(initial, float_sign_mask)                                   \
-    do_arch_entry(x86, initial, float_sign_mask, float_sign_mask,       \
-                  float_sign_mask)                                      \
-    do_stub(initial, float_sign_flip)                                   \
-    do_arch_entry(x86, initial, float_sign_flip, float_sign_flip,       \
-                  float_sign_flip)                                      \
-    do_stub(initial, double_sign_mask)                                  \
-    do_arch_entry(x86, initial, double_sign_mask, double_sign_mask,     \
-                  double_sign_mask)                                     \
-    do_stub(initial, double_sign_flip)                                  \
-    do_arch_entry(x86, initial, double_sign_flip, double_sign_flip,     \
-                  double_sign_flip)                                     \
-  )                                                                     \
+  do_stub(initial, get_previous_sp)                                     \
+  do_arch_entry(x86, initial, get_previous_sp,                          \
+                get_previous_sp_entry,                                  \
+                get_previous_sp_entry)                                  \
+  do_stub(initial, f2i_fixup)                                           \
+  do_arch_entry(x86, initial, f2i_fixup, f2i_fixup, f2i_fixup)          \
+  do_stub(initial, f2l_fixup)                                           \
+  do_arch_entry(x86, initial, f2l_fixup, f2l_fixup, f2l_fixup)          \
+  do_stub(initial, d2i_fixup)                                           \
+  do_arch_entry(x86, initial, d2i_fixup, d2i_fixup, d2i_fixup)          \
+  do_stub(initial, d2l_fixup)                                           \
+  do_arch_entry(x86, initial, d2l_fixup, d2l_fixup, d2l_fixup)          \
+  do_stub(initial, float_sign_mask)                                     \
+  do_arch_entry(x86, initial, float_sign_mask, float_sign_mask,         \
+                float_sign_mask)                                        \
+  do_stub(initial, float_sign_flip)                                     \
+  do_arch_entry(x86, initial, float_sign_flip, float_sign_flip,         \
+                float_sign_flip)                                        \
+  do_stub(initial, double_sign_mask)                                    \
+  do_arch_entry(x86, initial, double_sign_mask, double_sign_mask,       \
+                double_sign_mask)                                       \
+  do_stub(initial, double_sign_flip)                                    \
+  do_arch_entry(x86, initial, double_sign_flip, double_sign_flip,       \
+                double_sign_flip)                                       \
 
 #define STUBGEN_CONTINUATION_BLOBS_ARCH_DO(do_stub,                     \
                                            do_arch_blob,                \
                                            do_arch_entry,               \
                                            do_arch_entry_init)          \
-  do_arch_blob(continuation, 1000 LP64_ONLY(+2000))                     \
+  do_arch_blob(continuation, 3000)                                      \
 
 
 #define STUBGEN_COMPILER_BLOBS_ARCH_DO(do_stub,                         \
                                        do_arch_blob,                    \
                                        do_arch_entry,                   \
                                        do_arch_entry_init)              \
-  do_arch_blob(compiler, 20000 LP64_ONLY(+89000) WINDOWS_ONLY(+2000))   \
+  do_arch_blob(compiler, 109000 WINDOWS_ONLY(+2000))                    \
   do_stub(compiler, vector_float_sign_mask)                             \
   do_arch_entry(x86, compiler, vector_float_sign_mask,                  \
                 vector_float_sign_mask, vector_float_sign_mask)         \
@@ -160,90 +158,88 @@
   do_arch_entry(x86, compiler, pshuffle_byte_flip_mask,                 \
                 pshuffle_byte_flip_mask_addr,                           \
                 pshuffle_byte_flip_mask_addr)                           \
-  LP64_ONLY(                                                            \
-    /* x86_64 exposes these 3 stubs via a generic entry array */        \
-    /* oher arches use arch-specific entries */                         \
-    /* this really needs rationalising */                               \
-    do_stub(compiler, string_indexof_linear_ll)                         \
-    do_stub(compiler, string_indexof_linear_uu)                         \
-    do_stub(compiler, string_indexof_linear_ul)                         \
-    do_stub(compiler, pshuffle_byte_flip_mask_sha512)                   \
-    do_arch_entry(x86, compiler, pshuffle_byte_flip_mask_sha512,        \
-                  pshuffle_byte_flip_mask_addr_sha512,                  \
-                  pshuffle_byte_flip_mask_addr_sha512)                  \
-    do_stub(compiler, compress_perm_table32)                            \
-    do_arch_entry(x86, compiler, compress_perm_table32,                 \
-                  compress_perm_table32, compress_perm_table32)         \
-    do_stub(compiler, compress_perm_table64)                            \
-    do_arch_entry(x86, compiler, compress_perm_table64,                 \
-                  compress_perm_table64, compress_perm_table64)         \
-    do_stub(compiler, expand_perm_table32)                              \
-    do_arch_entry(x86, compiler, expand_perm_table32,                   \
-                  expand_perm_table32, expand_perm_table32)             \
-    do_stub(compiler, expand_perm_table64)                              \
-    do_arch_entry(x86, compiler, expand_perm_table64,                   \
-                  expand_perm_table64, expand_perm_table64)             \
-    do_stub(compiler, avx2_shuffle_base64)                              \
-    do_arch_entry(x86, compiler, avx2_shuffle_base64,                   \
-                  avx2_shuffle_base64, base64_avx2_shuffle_addr)        \
-    do_stub(compiler, avx2_input_mask_base64)                           \
-    do_arch_entry(x86, compiler, avx2_input_mask_base64,                \
-                  avx2_input_mask_base64,                               \
-                  base64_avx2_input_mask_addr)                          \
-    do_stub(compiler, avx2_lut_base64)                                  \
-    do_arch_entry(x86, compiler, avx2_lut_base64,                       \
-                  avx2_lut_base64, base64_avx2_lut_addr)                \
-    do_stub(compiler, avx2_decode_tables_base64)                        \
-    do_arch_entry(x86, compiler, avx2_decode_tables_base64,             \
-                  avx2_decode_tables_base64,                            \
-                  base64_AVX2_decode_tables_addr)                       \
-    do_stub(compiler, avx2_decode_lut_tables_base64)                    \
-    do_arch_entry(x86, compiler, avx2_decode_lut_tables_base64,         \
-                  avx2_decode_lut_tables_base64,                        \
-                  base64_AVX2_decode_LUT_tables_addr)                   \
-    do_stub(compiler, shuffle_base64)                                   \
-    do_arch_entry(x86, compiler, shuffle_base64, shuffle_base64,        \
-                  base64_shuffle_addr)                                  \
-    do_stub(compiler, lookup_lo_base64)                                 \
-    do_arch_entry(x86, compiler, lookup_lo_base64, lookup_lo_base64,    \
-                  base64_vbmi_lookup_lo_addr)                           \
-    do_stub(compiler, lookup_hi_base64)                                 \
-    do_arch_entry(x86, compiler, lookup_hi_base64, lookup_hi_base64,    \
-                  base64_vbmi_lookup_hi_addr)                           \
-    do_stub(compiler, lookup_lo_base64url)                              \
-    do_arch_entry(x86, compiler, lookup_lo_base64url,                   \
-                  lookup_lo_base64url,                                  \
-                  base64_vbmi_lookup_lo_url_addr)                       \
-    do_stub(compiler, lookup_hi_base64url)                              \
-    do_arch_entry(x86, compiler, lookup_hi_base64url,                   \
-                  lookup_hi_base64url,                                  \
-                  base64_vbmi_lookup_hi_url_addr)                       \
-    do_stub(compiler, pack_vec_base64)                                  \
-    do_arch_entry(x86, compiler, pack_vec_base64, pack_vec_base64,      \
-                  base64_vbmi_pack_vec_addr)                            \
-    do_stub(compiler, join_0_1_base64)                                  \
-    do_arch_entry(x86, compiler, join_0_1_base64, join_0_1_base64,      \
-                  base64_vbmi_join_0_1_addr)                            \
-    do_stub(compiler, join_1_2_base64)                                  \
-    do_arch_entry(x86, compiler, join_1_2_base64, join_1_2_base64,      \
-                  base64_vbmi_join_1_2_addr)                            \
-    do_stub(compiler, join_2_3_base64)                                  \
-    do_arch_entry(x86, compiler, join_2_3_base64, join_2_3_base64,      \
-                  base64_vbmi_join_2_3_addr)                            \
-    do_stub(compiler, encoding_table_base64)                            \
-    do_arch_entry(x86, compiler, encoding_table_base64,                 \
-                  encoding_table_base64, base64_encoding_table_addr)    \
-    do_stub(compiler, decoding_table_base64)                            \
-    do_arch_entry(x86, compiler, decoding_table_base64,                 \
-                  decoding_table_base64, base64_decoding_table_addr)    \
-  )                                                                     \
+  /* x86_64 exposes these 3 stubs via a generic entry array */          \
+  /* other arches use arch-specific entries */                          \
+  /* this really needs rationalising */                                 \
+  do_stub(compiler, string_indexof_linear_ll)                           \
+  do_stub(compiler, string_indexof_linear_uu)                           \
+  do_stub(compiler, string_indexof_linear_ul)                           \
+  do_stub(compiler, pshuffle_byte_flip_mask_sha512)                     \
+  do_arch_entry(x86, compiler, pshuffle_byte_flip_mask_sha512,          \
+                pshuffle_byte_flip_mask_addr_sha512,                    \
+                pshuffle_byte_flip_mask_addr_sha512)                    \
+  do_stub(compiler, compress_perm_table32)                              \
+  do_arch_entry(x86, compiler, compress_perm_table32,                   \
+                compress_perm_table32, compress_perm_table32)           \
+  do_stub(compiler, compress_perm_table64)                              \
+  do_arch_entry(x86, compiler, compress_perm_table64,                   \
+                compress_perm_table64, compress_perm_table64)           \
+  do_stub(compiler, expand_perm_table32)                                \
+  do_arch_entry(x86, compiler, expand_perm_table32,                     \
+                expand_perm_table32, expand_perm_table32)               \
+  do_stub(compiler, expand_perm_table64)                                \
+  do_arch_entry(x86, compiler, expand_perm_table64,                     \
+                expand_perm_table64, expand_perm_table64)               \
+  do_stub(compiler, avx2_shuffle_base64)                                \
+  do_arch_entry(x86, compiler, avx2_shuffle_base64,                     \
+                avx2_shuffle_base64, base64_avx2_shuffle_addr)          \
+  do_stub(compiler, avx2_input_mask_base64)                             \
+  do_arch_entry(x86, compiler, avx2_input_mask_base64,                  \
+                avx2_input_mask_base64,                                 \
+                base64_avx2_input_mask_addr)                            \
+  do_stub(compiler, avx2_lut_base64)                                    \
+  do_arch_entry(x86, compiler, avx2_lut_base64,                         \
+                avx2_lut_base64, base64_avx2_lut_addr)                  \
+  do_stub(compiler, avx2_decode_tables_base64)                          \
+  do_arch_entry(x86, compiler, avx2_decode_tables_base64,               \
+                avx2_decode_tables_base64,                              \
+                base64_AVX2_decode_tables_addr)                         \
+  do_stub(compiler, avx2_decode_lut_tables_base64)                      \
+  do_arch_entry(x86, compiler, avx2_decode_lut_tables_base64,           \
+                avx2_decode_lut_tables_base64,                          \
+                base64_AVX2_decode_LUT_tables_addr)                     \
+  do_stub(compiler, shuffle_base64)                                     \
+  do_arch_entry(x86, compiler, shuffle_base64, shuffle_base64,          \
+                base64_shuffle_addr)                                    \
+  do_stub(compiler, lookup_lo_base64)                                   \
+  do_arch_entry(x86, compiler, lookup_lo_base64, lookup_lo_base64,      \
+                base64_vbmi_lookup_lo_addr)                             \
+  do_stub(compiler, lookup_hi_base64)                                   \
+  do_arch_entry(x86, compiler, lookup_hi_base64, lookup_hi_base64,      \
+                base64_vbmi_lookup_hi_addr)                             \
+  do_stub(compiler, lookup_lo_base64url)                                \
+  do_arch_entry(x86, compiler, lookup_lo_base64url,                     \
+                lookup_lo_base64url,                                    \
+                base64_vbmi_lookup_lo_url_addr)                         \
+  do_stub(compiler, lookup_hi_base64url)                                \
+  do_arch_entry(x86, compiler, lookup_hi_base64url,                     \
+                lookup_hi_base64url,                                    \
+                base64_vbmi_lookup_hi_url_addr)                         \
+  do_stub(compiler, pack_vec_base64)                                    \
+  do_arch_entry(x86, compiler, pack_vec_base64, pack_vec_base64,        \
+                base64_vbmi_pack_vec_addr)                              \
+  do_stub(compiler, join_0_1_base64)                                    \
+  do_arch_entry(x86, compiler, join_0_1_base64, join_0_1_base64,        \
+                base64_vbmi_join_0_1_addr)                              \
+  do_stub(compiler, join_1_2_base64)                                    \
+  do_arch_entry(x86, compiler, join_1_2_base64, join_1_2_base64,        \
+                base64_vbmi_join_1_2_addr)                              \
+  do_stub(compiler, join_2_3_base64)                                    \
+  do_arch_entry(x86, compiler, join_2_3_base64, join_2_3_base64,        \
+                base64_vbmi_join_2_3_addr)                              \
+  do_stub(compiler, encoding_table_base64)                              \
+  do_arch_entry(x86, compiler, encoding_table_base64,                   \
+                encoding_table_base64, base64_encoding_table_addr)      \
+  do_stub(compiler, decoding_table_base64)                              \
+  do_arch_entry(x86, compiler, decoding_table_base64,                   \
+                decoding_table_base64, base64_decoding_table_addr)      \
 
 
 #define STUBGEN_FINAL_BLOBS_ARCH_DO(do_stub,                            \
                                     do_arch_blob,                       \
                                     do_arch_entry,                      \
                                     do_arch_entry_init)                 \
-  do_arch_blob(final, 11000 LP64_ONLY(+20000)                           \
-               WINDOWS_ONLY(+22000) ZGC_ONLY(+20000))                    \
+  do_arch_blob(final, 31000                                             \
+               WINDOWS_ONLY(+22000) ZGC_ONLY(+20000))                   \
 
 #endif // CPU_X86_STUBDECLARATIONS_HPP

--- a/src/hotspot/cpu/x86/stubRoutines_x86.cpp
+++ b/src/hotspot/cpu/x86/stubRoutines_x86.cpp
@@ -46,10 +46,8 @@ STUBGEN_ARCH_ENTRIES_DO(DEFINE_ARCH_ENTRY, DEFINE_ARCH_ENTRY_INIT)
 #undef DEFINE_ARCH_ENTRY
 
 address StubRoutines::x86::_k256_adr = nullptr;
-#ifdef _LP64
 address StubRoutines::x86::_k256_W_adr = nullptr;
 address StubRoutines::x86::_k512_W_addr = nullptr;
-#endif
 
 const uint64_t StubRoutines::x86::_crc_by128_masks[] =
 {
@@ -146,7 +144,6 @@ const juint StubRoutines::x86::_crc_table[] =
     0x2d02ef8dUL
 };
 
-#ifdef _LP64
 const juint StubRoutines::x86::_crc_table_avx512[] =
 {
     0xe95c1271UL, 0x00000000UL, 0xce3371cbUL, 0x00000000UL,
@@ -193,7 +190,6 @@ const juint StubRoutines::x86::_shuf_table_crc32_avx512[] =
     0x83828100UL, 0x87868584UL, 0x8b8a8988UL, 0x8f8e8d8cUL,
     0x03020100UL, 0x07060504UL, 0x0b0a0908UL, 0x000e0d0cUL
 };
-#endif // _LP64
 
 const jint StubRoutines::x86::_arrays_hashcode_powers_of_31[] =
 {
@@ -356,7 +352,6 @@ ATTRIBUTE_ALIGNED(64) const juint StubRoutines::x86::_k256[] =
     0x90befffaUL, 0xa4506cebUL, 0xbef9a3f7UL, 0xc67178f2UL
 };
 
-#ifdef _LP64
 // used in MacroAssembler::sha256_AVX2
 // dynamically built from _k256
 ATTRIBUTE_ALIGNED(64) juint StubRoutines::x86::_k256_W[2*sizeof(StubRoutines::x86::_k256)];
@@ -405,4 +400,3 @@ ATTRIBUTE_ALIGNED(64) const julong StubRoutines::x86::_k512_W[] =
     0x4cc5d4becb3e42b6ULL, 0x597f299cfc657e2aULL,
     0x5fcb6fab3ad6faecULL, 0x6c44198c4a475817ULL,
 };
-#endif

--- a/src/hotspot/cpu/x86/stubRoutines_x86.hpp
+++ b/src/hotspot/cpu/x86/stubRoutines_x86.hpp
@@ -75,39 +75,16 @@ public:
 #undef DEFINE_ARCH_ENTRY_GETTER_INIT
 #undef DEFINE_ARCH_GETTER_ENTRY
 
-
-#ifndef _LP64
-
-  static jint    _fpu_cntrl_wrd_std;
-  static jint    _fpu_cntrl_wrd_24;
-  static jint    _fpu_cntrl_wrd_trunc;
-
-  static jint    _fpu_subnormal_bias1[3];
-  static jint    _fpu_subnormal_bias2[3];
-
-  static address addr_fpu_cntrl_wrd_std()     { return (address)&_fpu_cntrl_wrd_std;   }
-  static address addr_fpu_cntrl_wrd_24()      { return (address)&_fpu_cntrl_wrd_24;    }
-  static address addr_fpu_cntrl_wrd_trunc()   { return (address)&_fpu_cntrl_wrd_trunc; }
-  static address addr_fpu_subnormal_bias1()   { return (address)&_fpu_subnormal_bias1; }
-  static address addr_fpu_subnormal_bias2()   { return (address)&_fpu_subnormal_bias2; }
-
-  static jint    fpu_cntrl_wrd_std()          { return _fpu_cntrl_wrd_std; }
-#endif // !LP64
-
  private:
   static jint    _mxcsr_std;
-#ifdef _LP64
   static jint    _mxcsr_rz;
-#endif // _LP64
   // masks and table for CRC32
   static const uint64_t _crc_by128_masks[];
   static const juint    _crc_table[];
-#ifdef _LP64
   static const juint    _crc_by128_masks_avx512[];
   static const juint    _crc_table_avx512[];
   static const juint    _crc32c_table_avx512[];
   static const juint    _shuf_table_crc32_avx512[];
-#endif // _LP64
   // table for CRC32C
   static juint* _crc32c_table;
   // table for arrays_hashcode
@@ -115,30 +92,22 @@ public:
   //k256 table for sha256
   static const juint _k256[];
   static address _k256_adr;
-#ifdef _LP64
   static juint _k256_W[];
   static address _k256_W_adr;
   static const julong _k512_W[];
   static address _k512_W_addr;
-#endif
 
  public:
   static address addr_mxcsr_std()        { return (address)&_mxcsr_std; }
-#ifdef _LP64
   static address addr_mxcsr_rz()        { return (address)&_mxcsr_rz; }
-#endif // _LP64
   static address crc_by128_masks_addr()  { return (address)_crc_by128_masks; }
-#ifdef _LP64
   static address crc_by128_masks_avx512_addr()  { return (address)_crc_by128_masks_avx512; }
   static address shuf_table_crc32_avx512_addr()  { return (address)_shuf_table_crc32_avx512; }
   static address crc_table_avx512_addr()  { return (address)_crc_table_avx512; }
   static address crc32c_table_avx512_addr()  { return (address)_crc32c_table_avx512; }
-#endif // _LP64
   static address k256_addr()      { return _k256_adr; }
-#ifdef _LP64
   static address k256_W_addr()    { return _k256_W_adr; }
   static address k512_W_addr()    { return _k512_W_addr; }
-#endif
 
   static address arrays_hashcode_powers_of_31() { return (address)_arrays_hashcode_powers_of_31; }
   static void generate_CRC32C_table(bool is_pclmulqdq_supported);


### PR DESCRIPTION
This cleanup target various x86-specific stubs and related generators. 

Additional testing: 
 - [x] Linux x86_64 server fastdebug, `all`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8354542](https://bugs.openjdk.org/browse/JDK-8354542): Clean up x86 stubs after 32-bit x86 removal (**Sub-task** - P4)


### Reviewers
 * [Andrew Dinn](https://openjdk.org/census#adinn) (@adinn - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24633/head:pull/24633` \
`$ git checkout pull/24633`

Update a local copy of the PR: \
`$ git checkout pull/24633` \
`$ git pull https://git.openjdk.org/jdk.git pull/24633/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24633`

View PR using the GUI difftool: \
`$ git pr show -t 24633`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24633.diff">https://git.openjdk.org/jdk/pull/24633.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24633#issuecomment-2804271440)
</details>
