### PR TITLE
8354450: A File should be invalid if an element of its name sequence ends with a space

### DIFF
--- a/src/java.base/windows/classes/java/io/WinNTFileSystem.java
+++ b/src/java.base/windows/classes/java/io/WinNTFileSystem.java
@@ -362,18 +362,13 @@ final class WinNTFileSystem extends FileSystem {
 
     @Override
     public boolean isInvalid(File f) {
-        if (f.getPath().indexOf('\u0000') >= 0)
-            return true;
+        final String pathname = f.getPath();
 
-        // Invalid if the pathname or a directory in it has a trailing space
-        File theFile = f;
-        do {
-            String p = theFile.getPath();
-            int len = p.length();
-            if (len > 0 && p.charAt(len - 1) == ' ')
-                return true;
-            theFile = theFile.getParentFile();
-        } while (theFile != null);
+        // Invalid if the pathname string contains a null character or if
+        // any name in the pathname's name sequence ends with a space
+        if (pathname.indexOf('\u0000') >= 0 || pathname.endsWith(" ")
+            || pathname.contains(" \\"))
+            return true;
 
         // The remaining checks are irrelevant for alternate data streams (ADS)
         if (ENABLE_ADS)
@@ -381,7 +376,6 @@ final class WinNTFileSystem extends FileSystem {
 
         // Invalid if there is a ":" at a position other than 1, or if there
         // is a ":" at position 1 and the first character is not a letter
-        final String pathname = f.getPath();
         int lastColon = pathname.lastIndexOf(":");
         if (lastColon >= 0 &&
             (lastColon != 1 || !isLetter(pathname.charAt(0))))

--- a/src/java.base/windows/classes/java/io/WinNTFileSystem.java
+++ b/src/java.base/windows/classes/java/io/WinNTFileSystem.java
@@ -365,21 +365,26 @@ final class WinNTFileSystem extends FileSystem {
         if (f.getPath().indexOf('\u0000') >= 0)
             return true;
 
+        // Invalid if the pathname has a trailing space
+        String pathname = f.getPath();
+        int len = pathname.length();
+        if (len > 0 && pathname.charAt(len - 1) == ' ')
+            return true;
+
+        // The remaining checks are irrelevant for alternate data streams (ADS)
         if (ENABLE_ADS)
             return false;
 
         // Invalid if there is a ":" at a position other than 1, or if there
         // is a ":" at position 1 and the first character is not a letter
-        String pathname = f.getPath();
         int lastColon = pathname.lastIndexOf(":");
         if (lastColon >= 0 &&
             (lastColon != 1 || !isLetter(pathname.charAt(0))))
             return true;
 
-        // Invalid if path creation fails
-        Path path = null;
+        // Invalid if the path string cannot be converted to a Path
         try {
-            path = sun.nio.fs.DefaultFileSystemProvider.theFileSystem().getPath(pathname);
+            Path path = sun.nio.fs.DefaultFileSystemProvider.theFileSystem().getPath(pathname);
             return false;
         } catch (InvalidPathException ignored) {
         }

--- a/src/java.base/windows/classes/java/io/WinNTFileSystem.java
+++ b/src/java.base/windows/classes/java/io/WinNTFileSystem.java
@@ -368,16 +368,13 @@ final class WinNTFileSystem extends FileSystem {
         if (ENABLE_ADS)
             return false;
 
-        // Invalid if there is a ":" at a position greater than 1, or if there
+        // Invalid if there is a ":" at a position other than 1, or if there
         // is a ":" at position 1 and the first character is not a letter
         String pathname = f.getPath();
         int lastColon = pathname.lastIndexOf(":");
-
-        // Valid if there is no ":" present or if the last ":" present is
-        // at index 1 and the first character is a latter
-        if (lastColon < 0 ||
-            (lastColon == 1 && isLetter(pathname.charAt(0))))
-            return false;
+        if (lastColon >= 0 &&
+            (lastColon != 1 || !isLetter(pathname.charAt(0))))
+            return true;
 
         // Invalid if path creation fails
         Path path = null;

--- a/src/java.base/windows/classes/java/io/WinNTFileSystem.java
+++ b/src/java.base/windows/classes/java/io/WinNTFileSystem.java
@@ -365,11 +365,15 @@ final class WinNTFileSystem extends FileSystem {
         if (f.getPath().indexOf('\u0000') >= 0)
             return true;
 
-        // Invalid if the pathname has a trailing space
-        String pathname = f.getPath();
-        int len = pathname.length();
-        if (len > 0 && pathname.charAt(len - 1) == ' ')
-            return true;
+        // Invalid if the pathname or a directory in it has a trailing space
+        File theFile = f;
+        do {
+            String p = theFile.getPath();
+            int len = p.length();
+            if (len > 0 && p.charAt(len - 1) == ' ')
+                return true;
+            theFile = theFile.getParentFile();
+        } while (theFile != null);
 
         // The remaining checks are irrelevant for alternate data streams (ADS)
         if (ENABLE_ADS)
@@ -377,6 +381,7 @@ final class WinNTFileSystem extends FileSystem {
 
         // Invalid if there is a ":" at a position other than 1, or if there
         // is a ":" at position 1 and the first character is not a letter
+        final String pathname = f.getPath();
         int lastColon = pathname.lastIndexOf(":");
         if (lastColon >= 0 &&
             (lastColon != 1 || !isLetter(pathname.charAt(0))))

--- a/test/jdk/java/io/File/WinTrailingSpace.java
+++ b/test/jdk/java/io/File/WinTrailingSpace.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.io.File;
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+/* @test
+ * @bug 8354450
+ * @requires os.family == "windows"
+ * @summary Verify behavior for file names with a trailing space
+ * @run junit WinTrailingSpace
+ * @run junit/othervm -Djdk.io.File.enableADS WinTrailingSpace
+ * @run junit/othervm -Djdk.io.File.enableADS=false  WinTrailingSpace
+ */
+public class WinTrailingSpace {
+    private static final boolean FAILURE_EXPECTED;
+    private static final String FILENAME_TRAILING_SPACE = "foobargus ";
+    private static final String FILENAME_NO_TRAILING_SPACE = "foobargus";
+
+    static {
+        final String enableADS = System.getProperty("jdk.io.File.enableADS");
+        if (enableADS != null) {
+            FAILURE_EXPECTED = enableADS.equalsIgnoreCase(Boolean.FALSE.toString());
+        } else {
+            FAILURE_EXPECTED = false;
+        }
+    }
+
+    @Test
+    public void noTrailingSpace() throws IOException {
+        File f = null;
+        try {
+            f = new File(".", FILENAME_NO_TRAILING_SPACE);
+            f.delete();
+            f.createNewFile();
+            assertTrue(f.exists());
+        } finally {
+            if (f != null)
+                f.delete();
+        }
+    }
+
+    @Test
+    public void trailingSpace() throws IOException {
+        File f = null;
+        try {
+            f = new File(".", FILENAME_TRAILING_SPACE);
+            f.delete();
+            f.createNewFile();
+            assertEquals(FAILURE_EXPECTED, !f.exists());
+        } catch (IOException e) {
+            if (!FAILURE_EXPECTED)
+                throw e;
+        } finally {
+            if (f != null)
+                f.delete();
+        }
+    }
+}

--- a/test/jdk/java/io/File/WinTrailingSpace.java
+++ b/test/jdk/java/io/File/WinTrailingSpace.java
@@ -25,7 +25,8 @@ import java.io.File;
 import java.io.IOException;
 
 import org.junit.jupiter.api.Test;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /* @test
  * @bug 8354450
@@ -34,8 +35,9 @@ import static org.junit.jupiter.api.Assertions.*;
  * @run junit WinTrailingSpace
  */
 public class WinTrailingSpace {
-    private static final String FILENAME_TRAILING_SPACE = "foobargus ";
     private static final String FILENAME_NO_TRAILING_SPACE = "foobargus";
+    private static final String FILENAME_TRAILING_SPACE = "foobargus ";
+    private static final String DIRNAME_TRAILING_SPACE = "foo \\bar\\gus";
 
     @Test
     public void noTrailingSpace() throws IOException {
@@ -58,8 +60,21 @@ public class WinTrailingSpace {
             f = new File(".", FILENAME_TRAILING_SPACE);
             f.delete();
             f.createNewFile();
-            assertFalse(f.exists()); // should not reach here
+            assertFalse(f.exists(), "Creation of " + f + " should have failed");
         } catch (IOException expected) {
+        } finally {
+            if (f != null)
+                f.delete();
+        }
+    }
+
+    @Test
+    public void dirTrailingSpace() throws IOException {
+        File f = null;
+        try {
+            f = new File(".", DIRNAME_TRAILING_SPACE);
+            f.delete();
+            assertFalse(f.mkdirs(), "Creation of " + f + " should have failed");
         } finally {
             if (f != null)
                 f.delete();

--- a/test/jdk/java/io/File/WinTrailingSpace.java
+++ b/test/jdk/java/io/File/WinTrailingSpace.java
@@ -32,22 +32,10 @@ import static org.junit.jupiter.api.Assertions.*;
  * @requires os.family == "windows"
  * @summary Verify behavior for file names with a trailing space
  * @run junit WinTrailingSpace
- * @run junit/othervm -Djdk.io.File.enableADS WinTrailingSpace
- * @run junit/othervm -Djdk.io.File.enableADS=false  WinTrailingSpace
  */
 public class WinTrailingSpace {
-    private static final boolean FAILURE_EXPECTED;
     private static final String FILENAME_TRAILING_SPACE = "foobargus ";
     private static final String FILENAME_NO_TRAILING_SPACE = "foobargus";
-
-    static {
-        final String enableADS = System.getProperty("jdk.io.File.enableADS");
-        if (enableADS != null) {
-            FAILURE_EXPECTED = enableADS.equalsIgnoreCase(Boolean.FALSE.toString());
-        } else {
-            FAILURE_EXPECTED = false;
-        }
-    }
 
     @Test
     public void noTrailingSpace() throws IOException {
@@ -70,10 +58,8 @@ public class WinTrailingSpace {
             f = new File(".", FILENAME_TRAILING_SPACE);
             f.delete();
             f.createNewFile();
-            assertEquals(FAILURE_EXPECTED, !f.exists());
-        } catch (IOException e) {
-            if (!FAILURE_EXPECTED)
-                throw e;
+            assertFalse(f.exists()); // should not reach here
+        } catch (IOException expected) {
         } finally {
             if (f != null)
                 f.delete();


### PR DESCRIPTION
In `java.io.WinNTFileSystem::isInvalid`, replace an insufficient test for file path validity with a sufficient test for file path invalidity. Also, add a new test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8354450](https://bugs.openjdk.org/browse/JDK-8354450): A File should be invalid if an element of its name sequence ends with a space (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24635/head:pull/24635` \
`$ git checkout pull/24635`

Update a local copy of the PR: \
`$ git checkout pull/24635` \
`$ git pull https://git.openjdk.org/jdk.git pull/24635/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24635`

View PR using the GUI difftool: \
`$ git pr show -t 24635`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24635.diff">https://git.openjdk.org/jdk/pull/24635.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24635#issuecomment-2803025315)
</details>
