### PR TITLE
8353923: (fs) Further improve performance of URI -> Path conversion (win)

### DIFF
--- a/test/micro/org/openjdk/bench/java/nio/file/PathOfURI.java
+++ b/test/micro/org/openjdk/bench/java/nio/file/PathOfURI.java
@@ -22,6 +22,8 @@
  */
 package org.openjdk.bench.java.nio.file;
 
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.file.Path;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Param;
@@ -29,23 +31,15 @@ import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
 
 @State(Scope.Benchmark)
-public class PathOfString {
-    @Param({"C:\\Users\\foo\\bar\\gus.txt",              // absolute
-            "C:\\Users\\\\foo\\\\bar\\gus.txt",          // ... with extra '\\'s
-            "\\\\.\\UNC\\localhost\\C$\\Users\\foo",     // UNC
-            "\\\\.\\UNC\\localhost\\C$\\\\Users\\\\foo", // ... with extra '\\'s
-            "\\\\?\\C:\\Users\\foo\\bar\\gus.txt",       // long path prefix
-            "\\\\?\\C:\\Users\\\\foo\\bar\\\\gus.txt",   // ... with extra '\\'s
-            ".\\foo\\bar\\gus.txt",                      // relative
-            ".\\foo\\\\bar\\\\gus.txt",                  // ... with extra '\\'s
-            "\\foo\\bar\\gus.txt",                     // current drive-relative
-            "\\foo\\\\bar\\\\gus.txt",                 // ... with extra '\\'s
-            "C:foo\\bar\\gus.txt",         // drive's current directory-relative
-            "C:foo\\\\bar\\\\gus.txt"})    // ... with extra '\\'s
-    public String path;
+public class PathOfURI {
+    @Param({"file:/C:/Users/bpb/git/foo/bar/classes/gus/dir/",
+            "file:/C:/Users/bpb/git/foo/bar/classes/gus/dir",
+            "file:/C:/Users/bpb/git/foo/bar/classes//gus/dir/",
+            "file:/C:/Users/bpb/git/foo/bar/classes//gus/dir"})
+    public String uri;
 
     @Benchmark
-    public Path ofString() {
-        return Path.of(path);
+    public Path ofURI() throws URISyntaxException {
+        return Path.of(new URI(uri));
     }
 }


### PR DESCRIPTION
If the path portion of a `URI` permits, then simply replace all `'\\'` with `'/'` instead of completely parsing the path.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8353923](https://bugs.openjdk.org/browse/JDK-8353923): (fs) Further improve performance of URI -&gt; Path conversion (win) (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24638/head:pull/24638` \
`$ git checkout pull/24638`

Update a local copy of the PR: \
`$ git checkout pull/24638` \
`$ git pull https://git.openjdk.org/jdk.git pull/24638/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24638`

View PR using the GUI difftool: \
`$ git pr show -t 24638`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24638.diff">https://git.openjdk.org/jdk/pull/24638.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24638#issuecomment-2803349866)
</details>
