### PR TITLE
Optimize keySet / values for Map1

### DIFF
--- a/src/java.base/share/classes/java/util/ImmutableCollections.java
+++ b/src/java.base/share/classes/java/util/ImmutableCollections.java
@@ -1160,6 +1160,26 @@ class ImmutableCollections {
         }
 
         @Override
+        public Set<K> keySet() {
+            Set<K> ks = keySet;
+            if (ks == null) {
+                ks = Set.of(k0);
+                this.keySet = ks;
+            }
+            return ks;
+        }
+
+        @Override
+        public Collection<V> values() {
+            Collection<V> vs = values;
+            if (vs == null) {
+                vs = List.of(v0);
+                this.values = vs;
+            }
+            return vs;
+        }
+
+        @Override
         public V get(Object o) {
             return o.equals(k0) ? v0 : null; // implicit nullcheck of o
         }


### PR DESCRIPTION
Override keySet and values methods for ImmutableCollections.Map1 to return singleton collections.

Map1 inherits from the keySet / values methods from AbstractMap, which both cache and return implementations based on the entrySet iterator. Provide overrides to return specialized implementations for singletons (Set.of / List.of).

Note: Collections.singletonMap already provides [similar overrides](https://github.com/openjdk/jdk/blob/5280b7b031bb3dc44fb923c3be7ae04ec22fd364/src/java.base/share/classes/java/util/Collections.java#L5283-L5300).