### PR TITLE
8353946: Incorrect WINDOWS ifdef in os::build_agent_function_name

### DIFF
--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -2535,7 +2535,7 @@ char* os::build_agent_function_name(const char *sym_name, const char *lib_name,
       if ((start = strrchr(lib_name, *os::file_separator())) != nullptr) {
         lib_name = ++start;
       }
-#ifdef WINDOWS
+#ifdef _WINDOWS
       else { // Need to check for drive prefix e.g. C:L.dll
         if ((start = strchr(lib_name, ':')) != nullptr) {
           lib_name = ++start;


### PR DESCRIPTION
Trivial fix to add missing underscore: WINDOWS -> _WINDOWS

When the original code was combined into a shared version, the ifdef around this windows-specific part was incorrect.

Testing: sanity builds only. Correctness is by inspection.

There are no tests for static agents that would exercise this code path.

Thanks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8353946](https://bugs.openjdk.org/browse/JDK-8353946): Incorrect WINDOWS ifdef in os::build_agent_function_name (**Bug** - P3)


### Reviewers
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24641/head:pull/24641` \
`$ git checkout pull/24641`

Update a local copy of the PR: \
`$ git checkout pull/24641` \
`$ git pull https://git.openjdk.org/jdk.git pull/24641/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24641`

View PR using the GUI difftool: \
`$ git pr show -t 24641`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24641.diff">https://git.openjdk.org/jdk/pull/24641.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24641#issuecomment-2803448043)
</details>
