### PR TITLE
8354559: gc/g1/TestAllocationFailure.java doesn't need WB API

### DIFF
--- a/test/hotspot/jtreg/gc/g1/TestAllocationFailure.java
+++ b/test/hotspot/jtreg/gc/g1/TestAllocationFailure.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,10 +31,7 @@ package gc.g1;
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management
- * @build jdk.test.whitebox.WhiteBox
- * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
- * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
- *                   gc.g1.TestAllocationFailure
+ * @run main/othervm gc.g1.TestAllocationFailure
  */
 
 import jdk.test.lib.process.OutputAnalyzer;

--- a/test/hotspot/jtreg/gc/g1/TestAllocationFailure.java
+++ b/test/hotspot/jtreg/gc/g1/TestAllocationFailure.java
@@ -31,7 +31,7 @@ package gc.g1;
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management
- * @run main/othervm gc.g1.TestAllocationFailure
+ * @run driver gc.g1.TestAllocationFailure
  */
 
 import jdk.test.lib.process.OutputAnalyzer;


### PR DESCRIPTION
Just minor clean up of WB API usage.
Also changed othervm to driver.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8354559](https://bugs.openjdk.org/browse/JDK-8354559): gc/g1/TestAllocationFailure.java doesn't need WB API (**Enhancement** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24642/head:pull/24642` \
`$ git checkout pull/24642`

Update a local copy of the PR: \
`$ git checkout pull/24642` \
`$ git pull https://git.openjdk.org/jdk.git pull/24642/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24642`

View PR using the GUI difftool: \
`$ git pr show -t 24642`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24642.diff">https://git.openjdk.org/jdk/pull/24642.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24642#issuecomment-2803501114)
</details>
