### PR TITLE
Fix: Address vulnerability in getDocumentBuilder()

### DIFF
--- a/test/jaxp/javax/xml/jaxp/functional/test/astro/DocumentLSTest.java
+++ b/test/jaxp/javax/xml/jaxp/functional/test/astro/DocumentLSTest.java
@@ -37,6 +37,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Writer;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -177,6 +178,15 @@ public class DocumentLSTest {
     private DocumentBuilder getDocumentBuilder() throws ParserConfigurationException {
         DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
         dbf.setNamespaceAware(true);
+         // Security fixes to prevent XXE attacks
+        dbf.setFeature("http://javax.xml.XMLConstants/feature/secure-processing", true);
+        dbf.setFeature("http://xml.org/sax/features/external-general-entities", false);
+        dbf.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+        dbf.setExpandEntityReferences(false);
+        
+        // Disable external DTD and schema access
+        dbf.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+        dbf.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
         return dbf.newDocumentBuilder();
     }
 }


### PR DESCRIPTION
This PR fixes a XXE vulnerability in getDocumentBuilder(). The PR disable external entity processing and enables secure processing by setting the XMLConstants.FEATURE_SECURE_PROCESSING feature.

Something similar can be found here https://github.com/soartech/jsoar/commit/ae6a2ecf1c86488504c498759d9258973cc68387

References
https://github.com/soartech/jsoar/commit/ae6a2ecf1c86488504c498759d9258973cc68387 
https://nvd.nist.gov/vuln/detail/CVE-2023-34610

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [ ] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24643/head:pull/24643` \
`$ git checkout pull/24643`

Update a local copy of the PR: \
`$ git checkout pull/24643` \
`$ git pull https://git.openjdk.org/jdk.git pull/24643/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24643`

View PR using the GUI difftool: \
`$ git pr show -t 24643`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24643.diff">https://git.openjdk.org/jdk/pull/24643.diff</a>

</details>
