### PR TITLE
8354471: Assertion failure with -XX:-EnableX86ECoreOpts

### DIFF
--- a/src/hotspot/cpu/x86/stubGenerator_x86_64_poly_mont.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64_poly_mont.cpp
@@ -573,7 +573,7 @@ address StubGenerator::generate_intpoly_montgomeryMult_P256() {
 
     montgomeryMultiply(aLimbs, bLimbs, rLimbs, tmp, _masm);
   } else {
-    assert(VM_Version::supports_avxifma(), "Require AVXIFMA support");
+    assert(VM_Version::supports_avxifma(), "Require AVX_IFMA support");
     __ push(r12);
     __ push(r13);
     __ push(r14);

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64_poly_mont.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64_poly_mont.cpp
@@ -564,7 +564,7 @@ address StubGenerator::generate_intpoly_montgomeryMult_P256() {
   address start = __ pc();
   __ enter();
 
-  if (EnableX86ECoreOpts && UseAVX > 1) {
+  if (VM_Version::supports_avxifma()) {
     __ push(r12);
     __ push(r13);
     __ push(r14);
@@ -608,6 +608,7 @@ address StubGenerator::generate_intpoly_montgomeryMult_P256() {
     __ pop(r13);
     __ pop(r12);
   } else {
+    assert(VM_Version::supports_avx512ifma() && VM_Version::supports_avx512vlbw(), "Require AVX512 support");
     // Register Map
     const Register aLimbs  = c_rarg0; // rdi | rcx
     const Register bLimbs  = c_rarg1; // rsi | rdx

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64_poly_mont.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64_poly_mont.cpp
@@ -564,7 +564,16 @@ address StubGenerator::generate_intpoly_montgomeryMult_P256() {
   address start = __ pc();
   __ enter();
 
-  if (VM_Version::supports_avxifma()) {
+  if (VM_Version::supports_avx512ifma() && VM_Version::supports_avx512vlbw()) {
+    // Register Map
+    const Register aLimbs  = c_rarg0; // rdi | rcx
+    const Register bLimbs  = c_rarg1; // rsi | rdx
+    const Register rLimbs  = c_rarg2; // rdx | r8
+    const Register tmp     = r9;
+
+    montgomeryMultiply(aLimbs, bLimbs, rLimbs, tmp, _masm);
+  } else {
+    assert(VM_Version::supports_avxifma(), "Require AVXIFMA support");
     __ push(r12);
     __ push(r13);
     __ push(r14);
@@ -607,15 +616,6 @@ address StubGenerator::generate_intpoly_montgomeryMult_P256() {
     __ pop(r14);
     __ pop(r13);
     __ pop(r12);
-  } else {
-    assert(VM_Version::supports_avx512ifma() && VM_Version::supports_avx512vlbw(), "Require AVX512 support");
-    // Register Map
-    const Register aLimbs  = c_rarg0; // rdi | rcx
-    const Register bLimbs  = c_rarg1; // rsi | rdx
-    const Register rLimbs  = c_rarg2; // rdx | r8
-    const Register tmp     = r9;
-
-    montgomeryMultiply(aLimbs, bLimbs, rLimbs, tmp, _masm);
   }
 
   __ leave();


### PR DESCRIPTION
The check to choose between AVX2 and AVX512 implementation was relying on `EnableX86ECoreOpts`. It should be relying on `supports_avxifma` and mirror the `UseIntPolyIntrinsics` check in `vm_version_x86.cpp`.

Note, in `stubGenerator_x86_64.cpp`, entry to the patched function is protected already:
```
  if (UseIntPolyIntrinsics) {
    StubRoutines::_intpoly_montgomeryMult_P256 = generate_intpoly_montgomeryMult_P256();
    StubRoutines::_intpoly_assign = generate_intpoly_assign();
  }
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8354471](https://bugs.openjdk.org/browse/JDK-8354471): Assertion failure with -XX:-EnableX86ECoreOpts (**Bug** - P3)


### Reviewers
 * [Sandhya Viswanathan](https://openjdk.org/census#sviswanathan) (@sviswa7 - **Reviewer**)
 * [Jatin Bhateja](https://openjdk.org/census#jbhateja) (@jatin-bhateja - **Reviewer**) Review applies to [ee1b099f](https://git.openjdk.org/jdk/pull/24644/files/ee1b099f72962996501157aa789b80522763dd19)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24644/head:pull/24644` \
`$ git checkout pull/24644`

Update a local copy of the PR: \
`$ git checkout pull/24644` \
`$ git pull https://git.openjdk.org/jdk.git pull/24644/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24644`

View PR using the GUI difftool: \
`$ git pr show -t 24644`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24644.diff">https://git.openjdk.org/jdk/pull/24644.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24644#issuecomment-2803706612)
</details>
