### PR TITLE
8354473: Incorrect results for compress/expand tests with -XX:+EnableX86ECoreOpts

### DIFF
--- a/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
@@ -5618,7 +5618,7 @@ void C2_MacroAssembler::vector_compress_expand_avx2(int opcode, XMMRegister dst,
   // in a permute table row contains either a valid permute index or a -1 (default)
   // value, this can potentially be used as a blending mask after
   // compressing/expanding the source vector lanes.
-  vblendvps(dst, dst, xtmp, permv, vec_enc, false, permv);
+  vblendvps(dst, dst, xtmp, permv, vec_enc, true, permv);
 }
 
 void C2_MacroAssembler::vector_compress_expand(int opcode, XMMRegister dst, XMMRegister src, KRegister mask,


### PR DESCRIPTION
It looks like the `permv` mask isnt always 'all-ones' or 'all-zeroes'. (Which is OK for real blend, but needs to be enforced via the flag for blend emulation)

Before the fix, `make test TEST="jdk/incubator/vector"` (on ECore machine)
```
==============================
Test summary
==============================
   TEST                                              TOTAL  PASS  FAIL ERROR  SKIP
>> jtreg:test/jdk/jdk/incubator/vector                  83    71    10     0     2 <<
==============================
TEST FAILURE
```
After the fix:
```
==============================
Test summary
==============================
   TEST                                              TOTAL  PASS  FAIL ERROR  SKIP
   jtreg:test/jdk/jdk/incubator/vector                  83    81     0     0     2
==============================
TEST SUCCESS
```
And on an AVX512 machine:
```
==============================
Test summary
==============================
   TEST                                              TOTAL  PASS  FAIL ERROR  SKIP
   jtreg:test/jdk/jdk/incubator/vector                  83    81     0     0     2
==============================
TEST SUCCESS
```