### PR TITLE
8352942: jdk/jfr/startupargs/TestMemoryOptions.java fails with 32-bit build

### DIFF
--- a/test/jdk/jdk/jfr/startupargs/TestMemoryOptions.java
+++ b/test/jdk/jdk/jfr/startupargs/TestMemoryOptions.java
@@ -485,6 +485,7 @@ public class TestMemoryOptions {
             if (flightRecorderOptions != null) {
                 pb = ProcessTools.createTestJavaProcessBuilder("--add-exports=jdk.jfr/jdk.jfr.internal=ALL-UNNAMED",
                                                                "--add-exports=java.base/jdk.internal.misc=ALL-UNNAMED",
+                                                               "-Xmx256m",
                                                                flightRecorderOptions,
                                                                "-XX:StartFlightRecording",
                                                                SUT.class.getName(),
@@ -493,6 +494,7 @@ public class TestMemoryOptions {
                 // default, no FlightRecorderOptions passed
                 pb = ProcessTools.createTestJavaProcessBuilder("--add-exports=jdk.jfr/jdk.jfr.internal=ALL-UNNAMED",
                                                                "--add-exports=java.base/jdk.internal.misc=ALL-UNNAMED",
+                                                               "-Xmx256m",
                                                                "-XX:StartFlightRecording",
                                                                SUT.class.getName(),
                                                                tc.getTestName());


### PR DESCRIPTION
Hi All,
I would like to add this bug fix for the bug in jdk/jfr/startupargs/TestMemoryOptions.java. 
I was unable to reproduce the reported problem in java versions 11 and later. Therefore, I made a pull request for 8u before.
https://github.com/openjdk/jdk8u-dev/pull/641
However, the latest java should be fixed, as the bugs described below will potentially remain in the test.

This test contains 24 test cases and fails the "ThreadBufferSizeExceedMemorySize" case.
The cause of this bug is the memory allocation issue, which occurs only on 32-bit Server VM, not on Client VM or 64-bit JDK. The failure happens because Server VM's default heap size reduces available memory space, causing JFR to fail memory allocation.
To resolve this issue, -Xmx256M is explicitly set, matching the Client VM default heap size, ensuring sufficient memory space remains available for JFR.
I believe that this test verifies that the combination of memory options for JFR is valid or invalid and that the MaxHeapSize setting does not affect the verification.
Change has been verified locally, test-fix only, no risk.

Would someone please review this fix?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8352942](https://bugs.openjdk.org/browse/JDK-8352942): jdk/jfr/startupargs/TestMemoryOptions.java fails with 32-bit build (**Bug** - P4)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24646/head:pull/24646` \
`$ git checkout pull/24646`

Update a local copy of the PR: \
`$ git checkout pull/24646` \
`$ git pull https://git.openjdk.org/jdk.git pull/24646/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24646`

View PR using the GUI difftool: \
`$ git pr show -t 24646`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24646.diff">https://git.openjdk.org/jdk/pull/24646.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24646#issuecomment-2803842530)
</details>
