### PR TITLE
8354565: jtreg failure handler GatherProcessInfoTimeoutHandler has a leftover call to System.loadLibrary

### DIFF
--- a/test/failure_handler/src/share/classes/jdk/test/failurehandler/jtreg/GatherProcessInfoTimeoutHandler.java
+++ b/test/failure_handler/src/share/classes/jdk/test/failurehandler/jtreg/GatherProcessInfoTimeoutHandler.java
@@ -36,19 +36,7 @@ import java.nio.file.Path;
  * A timeout handler for jtreg, which gathers information about the timed out
  * process and its children.
  */
-@SuppressWarnings("restricted")
 public class GatherProcessInfoTimeoutHandler extends TimeoutHandler {
-    private static final boolean HAS_NATIVE_LIBRARY;
-    static {
-        boolean value = true;
-        try {
-            System.loadLibrary("timeoutHandler");
-        } catch (UnsatisfiedLinkError ignore) {
-            // not all os need timeoutHandler native-library
-            value = false;
-        }
-        HAS_NATIVE_LIBRARY = value;
-    }
     private static final String LOG_FILENAME = "processes.log";
     private static final String OUTPUT_FILENAME = "processes.html";
 


### PR DESCRIPTION
Can I please get a review of this cleanup in the jtreg timeout handler `GatherProcessInfoTimeoutHandler`?

As noted in https://bugs.openjdk.org/browse/JDK-8354565, this is a leftover after the change done in https://bugs.openjdk.java.net/browse/JDK-8268626. The `timeoutHandler` native test library is no longer built in the JDK, nor it is required by this `GatherProcessInfoTimeoutHandler`. 

I've verified that the `GatherProcessInfoTimeoutHandler` continues to function normally on macosx (x64/aarch64), linux(x64/aarch64) and windows (x64), by intentionally timing out a test and verifying that the `GatherProcessInfoTimeoutHandler` continues to gather the relevant diagnostics.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8354565: jtreg failure handler GatherProcessInfoTimeoutHandler has a leftover call to System.loadLibrary`

### Issue
 * [JDK-8354565](https://bugs.openjdk.org/browse/JDK-8354565): jtreg failure handler GatherProcessInfoTimeoutHandler has a leftover call to System.loadLibrary (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24648/head:pull/24648` \
`$ git checkout pull/24648`

Update a local copy of the PR: \
`$ git checkout pull/24648` \
`$ git pull https://git.openjdk.org/jdk.git pull/24648/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24648`

View PR using the GUI difftool: \
`$ git pr show -t 24648`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24648.diff">https://git.openjdk.org/jdk/pull/24648.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24648#issuecomment-2803894671)
</details>
