### PR TITLE
8354572: Turn off AlwaysMergeDMB for Ampere CPU by default

### DIFF
--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -161,6 +161,9 @@ void VM_Version::initialize() {
         (_model == CPU_MODEL_AMPERE_1A || _model == CPU_MODEL_AMPERE_1B)) {
       FLAG_SET_DEFAULT(CodeEntryAlignment, 32);
     }
+    if (FLAG_IS_DEFAULT(AlwaysMergeDMB)) {
+      FLAG_SET_DEFAULT(AlwaysMergeDMB, false);
+    }
   }
 
   // ThunderX


### PR DESCRIPTION
Hi all, I found that "dmb ishst + dmb ishld" is obviously faster than "dmb ish" on Ampere CPU, so I submit this patch to make the former be default.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8354572](https://bugs.openjdk.org/browse/JDK-8354572): Turn off AlwaysMergeDMB for Ampere CPU by default (**Enhancement** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24652/head:pull/24652` \
`$ git checkout pull/24652`

Update a local copy of the PR: \
`$ git checkout pull/24652` \
`$ git pull https://git.openjdk.org/jdk.git pull/24652/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24652`

View PR using the GUI difftool: \
`$ git pr show -t 24652`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24652.diff">https://git.openjdk.org/jdk/pull/24652.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24652#issuecomment-2804232003)
</details>
