### PR TITLE
8354576: InetAddress.getLocalHost() on macos may return address of an interface which is not UP - leading to "Network is down" error

### DIFF
--- a/src/java.base/unix/native/libnet/Inet6AddressImpl.c
+++ b/src/java.base/unix/native/libnet/Inet6AddressImpl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -126,7 +126,7 @@ lookupIfLocalhost(JNIEnv *env, const char *hostname, jboolean includeV6, int cha
     while (iter) {
         if (iter->ifa_addr != NULL) {
             int family = iter->ifa_addr->sa_family;
-            if (iter->ifa_name[0] != '\0') {
+            if (iter->ifa_name[0] != '\0' && (iter->ifa_flags & IFF_UP) == IFF_UP) {
                 jboolean isLoopback = iter->ifa_flags & IFF_LOOPBACK;
                 if (family == AF_INET) {
                     addrs4++;
@@ -163,7 +163,7 @@ lookupIfLocalhost(JNIEnv *env, const char *hostname, jboolean includeV6, int cha
     // Now loop around the ifaddrs
     iter = ifa;
     while (iter != NULL) {
-        if (iter->ifa_addr != NULL) {
+        if (iter->ifa_addr != NULL && (iter->ifa_flags & IFF_UP) == IFF_UP) {
             jboolean isLoopback = iter->ifa_flags & IFF_LOOPBACK;
             int family = iter->ifa_addr->sa_family;
 


### PR DESCRIPTION
Can I please get a review of this change which proposes to address the issue noted in https://bugs.openjdk.org/browse/JDK-8354576?

As noted in that issue, the current code in the `lookupAllHostAddr()` function of `Inet4AddressImpl.c` and `Inet6AddressImpl.c` has a macos specific implementation, where we call `getifaddrs()` and iterate over the returned addresses. In its current form this code doesn't check to see if the interface is UP or not. This can result in returing an address belonging to an interface which is not UP. That can cause subsequent usage of the address for networking operations to result in a "Network is down" error.

The commit in this PR skips interfaces that are not UP. The change only impacts the result of `getLocalHost()` call and that too only on macos. Given the nature of this change no new regression test has been introduced. Existing tests in tier1, tier2 and tier3 continue to pass with this change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8354576](https://bugs.openjdk.org/browse/JDK-8354576): InetAddress.getLocalHost() on macos may return address of an interface which is not UP - leading to "Network is down" error (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)
 * [Volkan Yazici](https://openjdk.org/census#vyazici) (@vy - Author)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24653/head:pull/24653` \
`$ git checkout pull/24653`

Update a local copy of the PR: \
`$ git checkout pull/24653` \
`$ git pull https://git.openjdk.org/jdk.git pull/24653/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24653`

View PR using the GUI difftool: \
`$ git pr show -t 24653`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24653.diff">https://git.openjdk.org/jdk/pull/24653.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24653#issuecomment-2804350648)
</details>
