### PR TITLE
8354667: [TESTBUG] AccessZeroNKlassHitsProtectionZone cds tests require cds

### DIFF
--- a/test/hotspot/jtreg/runtime/ErrorHandling/AccessZeroNKlassHitsProtectionZone.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/AccessZeroNKlassHitsProtectionZone.java
@@ -38,7 +38,7 @@
 /*
  * @test id=no_coh_cds
  * @summary Test that dereferencing a Klass that is the result of a decode(0) crashes accessing the nKlass guard zone
- * @requires vm.bits == 64 & vm.debug == true & vm.flagless
+ * @requires vm.cds & vm.bits == 64 & vm.debug == true & vm.flagless
  * @requires os.family != "aix"
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
@@ -64,7 +64,7 @@
 /*
  * @test id=coh_cds
  * @summary Test that dereferencing a Klass that is the result of a decode(0) crashes accessing the nKlass guard zone
- * @requires vm.bits == 64 & vm.debug == true & vm.flagless
+ * @requires vm.cds & vm.bits == 64 & vm.debug == true & vm.flagless
  * @requires os.family != "aix"
  * @library /test/lib
  * @modules java.base/jdk.internal.misc


### PR DESCRIPTION
Hi, please consider.

If the vm is built with --disable-jvm-feature-cds these two versions of the test fails.
Locally tested with a "--disable-jvm-feature-cds" build of the vm.

Thanks, Robbin

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8354667](https://bugs.openjdk.org/browse/JDK-8354667): [TESTBUG] AccessZeroNKlassHitsProtectionZone cds tests require cds (**Bug** - P4)


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)
 * [SendaoYan](https://openjdk.org/census#syan) (@sendaoYan - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24659/head:pull/24659` \
`$ git checkout pull/24659`

Update a local copy of the PR: \
`$ git checkout pull/24659` \
`$ git pull https://git.openjdk.org/jdk.git pull/24659/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24659`

View PR using the GUI difftool: \
`$ git pr show -t 24659`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24659.diff">https://git.openjdk.org/jdk/pull/24659.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24659#issuecomment-2804888224)
</details>
