### PR TITLE
8354629: Test tools/jlink/ClassFileInMetaInfo.java fails on builds with configure option --enable-linkable-runtime

### DIFF
--- a/test/jdk/tools/jlink/ClassFileInMetaInfo.java
+++ b/test/jdk/tools/jlink/ClassFileInMetaInfo.java
@@ -29,7 +29,7 @@
  * @modules java.base/jdk.internal.module
  *          jdk.jlink
  *          jdk.jartool
- * @run junit ClassFileInMetaInfo
+ * @run junit/othervm ClassFileInMetaInfo
  */
 
 import java.lang.module.ModuleDescriptor;


### PR DESCRIPTION
Please review this trivial test-only fix. A new test introduced with [JDK-8353267](https://bugs.openjdk.org/browse/JDK-8353267) runs `jlink` using the `ToolProvider` API in-process. This is problematic for JEP 493 enabled builds which don't allow to be run on a patched JDK. Note that JTREG patches the JDK's `java.base` module with `JTRegModuleHelper` class. The fix is to run in `othervm` instead.

Testing:
- [x] GHA
- [x] jlink tests on a build with `--enable-linkable-runtime`. Shows the failure before and passes after.

Thoughts?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8354629](https://bugs.openjdk.org/browse/JDK-8354629): Test tools/jlink/ClassFileInMetaInfo.java fails on builds with configure option --enable-linkable-runtime (**Bug** - P3)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24661/head:pull/24661` \
`$ git checkout pull/24661`

Update a local copy of the PR: \
`$ git checkout pull/24661` \
`$ git pull https://git.openjdk.org/jdk.git pull/24661/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24661`

View PR using the GUI difftool: \
`$ git pr show -t 24661`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24661.diff">https://git.openjdk.org/jdk/pull/24661.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24661#issuecomment-2805022091)
</details>
