### PR TITLE
8344251: C2: remove blackholes with dead control input

### DIFF
--- a/src/hotspot/share/opto/cfgnode.cpp
+++ b/src/hotspot/share/opto/cfgnode.cpp
@@ -3112,6 +3112,7 @@ void NeverBranchNode::format( PhaseRegAlloc *ra_, outputStream *st) const {
 Node* BlackholeNode::Ideal(PhaseGVN* phase, bool can_reshape) {
   return remove_dead_region(phase, can_reshape) ? this : nullptr;
 }
+
 #ifndef PRODUCT
 void BlackholeNode::format(PhaseRegAlloc* ra, outputStream* st) const {
   st->print("blackhole ");

--- a/src/hotspot/share/opto/cfgnode.cpp
+++ b/src/hotspot/share/opto/cfgnode.cpp
@@ -3109,7 +3109,7 @@ void NeverBranchNode::format( PhaseRegAlloc *ra_, outputStream *st) const {
 }
 #endif
 
-Node* BlackholeNode::Ideal(PhaseGVN *phase, bool can_reshape) {
+Node* BlackholeNode::Ideal(PhaseGVN* phase, bool can_reshape) {
   return remove_dead_region(phase, can_reshape) ? this : nullptr;
 }
 #ifndef PRODUCT

--- a/src/hotspot/share/opto/cfgnode.cpp
+++ b/src/hotspot/share/opto/cfgnode.cpp
@@ -3109,6 +3109,9 @@ void NeverBranchNode::format( PhaseRegAlloc *ra_, outputStream *st) const {
 }
 #endif
 
+Node* BlackholeNode::Ideal(PhaseGVN *phase, bool can_reshape) {
+  return remove_dead_region(phase, can_reshape) ? this : nullptr;
+}
 #ifndef PRODUCT
 void BlackholeNode::format(PhaseRegAlloc* ra, outputStream* st) const {
   st->print("blackhole ");

--- a/src/hotspot/share/opto/cfgnode.hpp
+++ b/src/hotspot/share/opto/cfgnode.hpp
@@ -735,6 +735,7 @@ public:
   virtual int   Opcode() const;
   virtual uint ideal_reg() const { return 0; } // not matched in the AD file
   virtual const Type* bottom_type() const { return TypeTuple::MEMBAR; }
+  virtual Node *Ideal(PhaseGVN *phase, bool can_reshape);
 
   const RegMask &in_RegMask(uint idx) const {
     // Fake the incoming arguments mask for blackholes: accept all registers

--- a/src/hotspot/share/opto/cfgnode.hpp
+++ b/src/hotspot/share/opto/cfgnode.hpp
@@ -735,7 +735,7 @@ public:
   virtual int   Opcode() const;
   virtual uint ideal_reg() const { return 0; } // not matched in the AD file
   virtual const Type* bottom_type() const { return TypeTuple::MEMBAR; }
-  virtual Node *Ideal(PhaseGVN *phase, bool can_reshape);
+  virtual Node* Ideal(PhaseGVN* phase, bool can_reshape);
 
   const RegMask &in_RegMask(uint idx) const {
     // Fake the incoming arguments mask for blackholes: accept all registers

--- a/test/hotspot/jtreg/compiler/blackhole/DeadBhElimination.java
+++ b/test/hotspot/jtreg/compiler/blackhole/DeadBhElimination.java
@@ -36,7 +36,7 @@ import compiler.lib.ir_framework.*;
 public class DeadBhElimination {
     public static void main(String[] args) {
         TestFramework.runWithFlags(
-                "-Xcomp",
+                "-XX:CompileThreshold=100",
                 "-XX:-TieredCompilation",
                 "-XX:+UnlockExperimentalVMOptions",
                 "-XX:CompileCommand=blackhole,compiler.blackhole.DeadBhElimination::iAmABlackhole"

--- a/test/hotspot/jtreg/compiler/blackhole/DeadBhElimination.java
+++ b/test/hotspot/jtreg/compiler/blackhole/DeadBhElimination.java
@@ -36,9 +36,12 @@ import compiler.lib.ir_framework.*;
 public class DeadBhElimination {
     public static void main(String[] args) {
         TestFramework.runWithFlags(
-                "-XX:CompileThreshold=100",
                 "-XX:-TieredCompilation",
                 "-XX:+UnlockExperimentalVMOptions",
+                // Prevent the dead branches to be compiled into an uncommon trap
+                // instead of generating a BlackholeNode.
+                "-XX:PerMethodTrapLimit=0",
+                "-XX:PerMethodSpecTrapLimit=0",
                 "-XX:CompileCommand=blackhole,compiler.blackhole.DeadBhElimination::iAmABlackhole"
         );
     }

--- a/test/hotspot/jtreg/compiler/blackhole/DeadBhElimination.java
+++ b/test/hotspot/jtreg/compiler/blackhole/DeadBhElimination.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2025, Red Hat and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8344251
+ * @summary Test that blackhole without control input are removed
+ * @library /test/lib /
+ * @run driver compiler.blackhole.DeadBhElimination
+ */
+
+package compiler.blackhole;
+
+import compiler.lib.ir_framework.*;
+
+public class DeadBhElimination {
+    public static void main(String[] args) {
+        TestFramework.runWithFlags(
+                "-Xcomp",
+                "-XX:-TieredCompilation",
+                "-XX:+UnlockExperimentalVMOptions",
+                "-XX:CompileCommand=blackhole,compiler.blackhole.DeadBhElimination::iAmABlackhole"
+        );
+    }
+
+    static public void iAmABlackhole(int x) {}
+
+    @Test
+    @IR(counts = {IRNode.BLACKHOLE, "1"}, phase = CompilePhase.AFTER_PARSING)
+    @IR(failOn = {IRNode.BLACKHOLE}, phase = CompilePhase.FINAL_CODE)
+    static void removalAfterLoopOpt() {
+        int a = 77;
+        int b = 0;
+        do {
+            a--;
+            b++;
+        } while (a > 0);
+        // b == 77, known after first loop opts round
+        // loop is detected as empty loop
+
+        if(b == 78) { // dead
+            iAmABlackhole(a);
+        }
+    }
+
+
+}

--- a/test/hotspot/jtreg/compiler/blackhole/DeadBhElimination.java
+++ b/test/hotspot/jtreg/compiler/blackhole/DeadBhElimination.java
@@ -61,7 +61,7 @@ public class DeadBhElimination {
         // b == 77, known after first loop opts round
         // loop is detected as empty loop
 
-        if(b == 78) { // dead
+        if (b == 78) { // dead
             iAmABlackhole(a);
         }
     }

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
@@ -2707,6 +2707,11 @@ public class IRNode {
         macroNodes(MOD_D, regex);
     }
 
+    public static final String BLACKHOLE = PREFIX + "BLACKHOLE" + POSTFIX;
+    static {
+        fromBeforeRemoveUselessToFinalCode(BLACKHOLE, "Blackhole");
+    }
+
     /*
      * Utility methods to set up IR_NODE_MAPPINGS.
      */
@@ -2831,6 +2836,13 @@ public class IRNode {
     private static void storeOfNodes(String irNodePlaceholder, String irNodeRegex) {
         String regex = START + irNodeRegex + MID + "@\\S*" + IS_REPLACED + STORE_OF_CLASS_POSTFIX;
         beforeMatching(irNodePlaceholder, regex);
+    }
+
+    private static void fromBeforeRemoveUselessToFinalCode(String irNodePlaceholder, String irNodeRegex) {
+        String regex = START + irNodeRegex + MID + END;
+        IR_NODE_MAPPINGS.put(irNodePlaceholder, new SinglePhaseRangeEntry(CompilePhase.PRINT_IDEAL, regex,
+                CompilePhase.BEFORE_REMOVEUSELESS,
+                CompilePhase.FINAL_CODE));
     }
 
     /**


### PR DESCRIPTION
When a BlackholeNode's control input becomes dead, the node is not removed causing the crash
```
 assert(!in->is_CFG()) failed: CFG Node with no controlling input?
```
In the case reported in the issue, after a round of peeling, a condition becomes constant, and the branch containing the blackhole becomes dead:

<img src="https://github.com/user-attachments/assets/f8e5ec85-ddf5-4018-a01e-30ea90d9d74f" width="400">
<img src="https://github.com/user-attachments/assets/626e40a1-be2f-4b1c-bc56-9760a26660f2" width="400">

I simply use `Node::remove_dead_region(PhaseGVN*, bool)` to remove the blackhole, as many other node types do.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344251](https://bugs.openjdk.org/browse/JDK-8344251): C2: remove blackholes with dead control input (**Bug** - P3)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**) Review applies to [a71abe7d](https://git.openjdk.org/jdk/pull/24663/files/a71abe7df4fbde41f1fa9ca6b154ef51642c2483)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24663/head:pull/24663` \
`$ git checkout pull/24663`

Update a local copy of the PR: \
`$ git checkout pull/24663` \
`$ git pull https://git.openjdk.org/jdk.git pull/24663/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24663`

View PR using the GUI difftool: \
`$ git pr show -t 24663`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24663.diff">https://git.openjdk.org/jdk/pull/24663.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24663#issuecomment-2805577166)
</details>
