### PR TITLE
8295651: JFR: 'jfr scrub' should summarize what was removed

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/consumer/RecordedObject.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/consumer/RecordedObject.java
@@ -154,7 +154,7 @@ public sealed class RecordedObject
 
             @Override
             public List<RemovedEvents> write(RecordingFile file, Path output, Predicate<RecordedEvent> filter) throws IOException {
-                return file.writeWithResults(output, filter);
+                return file.write(output, filter, true);
             }
         };
         JdkJfrConsumer.setAccess(access);

--- a/src/jdk.jfr/share/classes/jdk/jfr/consumer/RecordedObject.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/consumer/RecordedObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,7 @@ package jdk.jfr.consumer;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.nio.file.Path;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.OffsetDateTime;
@@ -35,6 +36,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
+import java.util.function.Predicate;
 
 import jdk.jfr.Configuration;
 import jdk.jfr.EventType;
@@ -46,6 +48,7 @@ import jdk.jfr.internal.Type;
 import jdk.jfr.internal.consumer.JdkJfrConsumer;
 import jdk.jfr.internal.consumer.ObjectContext;
 import jdk.jfr.internal.consumer.ObjectFactory;
+import jdk.jfr.internal.consumer.filter.ChunkWriter.RemovedEvents;
 import jdk.jfr.internal.tool.PrettyWriter;
 
 /**
@@ -147,6 +150,11 @@ public sealed class RecordedObject
             public MetadataEvent newMetadataEvent(List<EventType> previous, List<EventType> current,
                     List<Configuration> configurations) {
                 return new MetadataEvent(previous, current, configurations);
+            }
+
+            @Override
+            public List<RemovedEvents> write(RecordingFile file, Path output, Predicate<RecordedEvent> filter) throws IOException {
+                return file.writeWithResults(output, filter);
             }
         };
         JdkJfrConsumer.setAccess(access);

--- a/src/jdk.jfr/share/classes/jdk/jfr/consumer/RecordingFile.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/consumer/RecordingFile.java
@@ -46,6 +46,7 @@ import jdk.jfr.internal.consumer.ChunkParser;
 import jdk.jfr.internal.consumer.ParserState;
 import jdk.jfr.internal.consumer.RecordingInput;
 import jdk.jfr.internal.consumer.filter.ChunkWriter;
+import jdk.jfr.internal.consumer.filter.ChunkWriter.RemovedEvents;
 
 /**
  * A recording file.
@@ -229,12 +230,18 @@ public final class RecordingFile implements Closeable {
     public void write(Path destination, Predicate<RecordedEvent> filter) throws IOException {
         Objects.requireNonNull(destination, "destination");
         Objects.requireNonNull(filter, "filter");
+        writeWithResults(destination, filter);
+    }
+
+    // package private
+    List<RemovedEvents> writeWithResults(Path destination, Predicate<RecordedEvent> filter) throws IOException {
         try (ChunkWriter cw = new ChunkWriter(file.toPath(), destination, filter)) {
             try (RecordingFile rf = new RecordingFile(cw)) {
                 while (rf.hasMoreEvents()) {
                     rf.readEvent();
                 }
             }
+            return cw.getRemovedEventTypes();
         }
     }
 

--- a/src/jdk.jfr/share/classes/jdk/jfr/consumer/RecordingFile.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/consumer/RecordingFile.java
@@ -230,12 +230,12 @@ public final class RecordingFile implements Closeable {
     public void write(Path destination, Predicate<RecordedEvent> filter) throws IOException {
         Objects.requireNonNull(destination, "destination");
         Objects.requireNonNull(filter, "filter");
-        writeWithResults(destination, filter);
+        write(destination, filter, false);
     }
 
     // package private
-    List<RemovedEvents> writeWithResults(Path destination, Predicate<RecordedEvent> filter) throws IOException {
-        try (ChunkWriter cw = new ChunkWriter(file.toPath(), destination, filter)) {
+    List<RemovedEvents> write(Path destination, Predicate<RecordedEvent> filter, boolean collectResults) throws IOException {
+        try (ChunkWriter cw = new ChunkWriter(file.toPath(), destination, filter, collectResults)) {
             try (RecordingFile rf = new RecordingFile(cw)) {
                 while (rf.hasMoreEvents()) {
                     rf.readEvent();

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/LongMap.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/LongMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,9 @@
 
 package jdk.jfr.internal;
 
+import java.util.ArrayList;
 import java.util.BitSet;
+import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.LongConsumer;
 
@@ -264,5 +266,16 @@ public final class LongMap<T> {
             sb.append("\n");
         }
         return sb.toString();
+    }
+
+    public List<T> values() {
+        List<T> list = new ArrayList<>(count);
+        for (int i = 0; i < keys.length; i++) {
+            T o = objects[i];
+            if (o != null) {
+                list.add(o);
+            }
+        }
+        return list;
     }
 }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/JdkJfrConsumer.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/JdkJfrConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,8 +26,10 @@
 package jdk.jfr.internal.consumer;
 
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Comparator;
 import java.util.List;
+import java.util.function.Predicate;
 
 import jdk.jfr.Configuration;
 import jdk.jfr.EventType;
@@ -43,6 +45,7 @@ import jdk.jfr.consumer.RecordedThread;
 import jdk.jfr.consumer.RecordedThreadGroup;
 import jdk.jfr.consumer.RecordingFile;
 import jdk.jfr.internal.Type;
+import jdk.jfr.internal.consumer.filter.ChunkWriter.RemovedEvents;;
 
 /*
  * Purpose of this class is to give package private access to
@@ -105,4 +108,5 @@ public abstract class JdkJfrConsumer {
 
     public abstract MetadataEvent newMetadataEvent(List<EventType> previous, List<EventType> current, List<Configuration> configuration);
 
+    public abstract List<RemovedEvents> write(RecordingFile file, Path output, Predicate<RecordedEvent> filter) throws IOException;
 }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/filter/ChunkWriter.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/filter/ChunkWriter.java
@@ -82,16 +82,18 @@ public final class ChunkWriter implements Closeable {
     private final Predicate<RecordedEvent> filter;
     private final Map<String, Long> waste = new HashMap<>();
     private final LongMap<RemovedEvents> removedEvents = new LongMap<>();
+    private final boolean collectResults;
 
     private long chunkStartPosition;
     private boolean chunkComplete;
     private long lastCheckpoint;
 
-    public ChunkWriter(Path source, Path destination, Predicate<RecordedEvent> filter) throws IOException {
+    public ChunkWriter(Path source, Path destination, Predicate<RecordedEvent> filter, boolean collectResults) throws IOException {
         this.destination = destination;
         this.output = new RecordingOutput(destination.toFile());
         this.input = new RecordingInput(source.toFile());
         this.filter = filter;
+        this.collectResults = collectResults;
     }
 
     Constants getPool(Type type) {
@@ -111,6 +113,9 @@ public final class ChunkWriter implements Closeable {
     }
 
     public boolean accept(RecordedEvent event) {
+        if (!collectResults) {
+            return filter.test(event);
+        }
         long id = event.getEventType().getId();
         RemovedEvents r = removedEvents.get(id);
         if (r == null) {

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/filter/ChunkWriter.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/filter/ChunkWriter.java
@@ -32,6 +32,7 @@ import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.Map;
 import java.util.HashMap;
+import java.util.List;
 import java.util.function.Predicate;
 
 import jdk.jfr.consumer.RecordedEvent;
@@ -51,6 +52,28 @@ import jdk.jfr.internal.consumer.Reference;
  * All positional values are relative to file start, not the chunk.
  */
 public final class ChunkWriter implements Closeable {
+    public static class RemovedEvents implements Comparable<RemovedEvents> {
+        public final String name;
+        private long count;
+        private long removed;
+
+        private RemovedEvents(String name) {
+            this.name = name;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public String share() {
+            return removed + "/" + count;
+        }
+
+        @Override
+        public int compareTo(RemovedEvents that) {
+            return this.getName().compareTo(that.getName());
+        }
+    }
     private LongMap<Constants> pools = new LongMap<>();
     private final Deque<CheckpointEvent> checkpoints = new ArrayDeque<>();
     private final Path destination;
@@ -58,6 +81,7 @@ public final class ChunkWriter implements Closeable {
     private final RecordingOutput output;
     private final Predicate<RecordedEvent> filter;
     private final Map<String, Long> waste = new HashMap<>();
+    private final LongMap<RemovedEvents> removedEvents = new LongMap<>();
 
     private long chunkStartPosition;
     private boolean chunkComplete;
@@ -87,7 +111,22 @@ public final class ChunkWriter implements Closeable {
     }
 
     public boolean accept(RecordedEvent event) {
-        return filter.test(event);
+        long id = event.getEventType().getId();
+        RemovedEvents r = removedEvents.get(id);
+        if (r == null) {
+            r = new RemovedEvents(event.getEventType().getName());
+            removedEvents.put(id, r);
+        }
+        r.count++;
+        if (filter.test(event)) {
+            return true;
+        }
+        r.removed++;
+        return false;
+    }
+
+    public List<RemovedEvents> getRemovedEventTypes() {
+        return removedEvents.values().stream().filter(r -> r.removed > 0).sorted().toList();
     }
 
     public void touch(Object object) {

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/Command.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/Command.java
@@ -318,6 +318,10 @@ abstract class Command {
         System.out.println(text);
     }
 
+    protected final void printf(String text, Object ... args) {
+        System.out.printf(text, args);
+    }
+
     public static void checkCommonError(Deque<String> options, String typo, String correct) throws UserSyntaxException {
         if (typo.equals(options.peek())) {
             throw new UserSyntaxException("unknown option " + typo + ", did you mean " + correct + "?");

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/Summary.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/Summary.java
@@ -152,7 +152,7 @@ final class Summary extends Command {
             println(typeHeader + " ".repeat(minWidth - typeHeader.length()) + header);
             println("=".repeat(minWidth + header.length()));
             for (Statistics s : statsList) {
-                System.out.printf(" %-" + minWidth + "s%10d  %12d\n", s.name, s.count, s.size);
+                printf(" %-" + minWidth + "s%10d  %12d\n", s.name, s.count, s.size);
             }
         }
     }


### PR DESCRIPTION
Could I have a review of an enhancement that summarizes the results of `jfr scrub`?

To accommodate this feature, I made some additional changes:

- Added a LongMap::values() method.
- Added a Command::printf(...) method, which is now also used by `jfr summary`.
- Improved TestScrub.java so it now creates a file that spans multiple chunks, including an empty one.

To make it easier to locate the scrubbed file, I also changed so the real path instead of the of the absolute path is displayed in the summary 

See issue for example output.

Testing: jdk/jdk/jfr

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295651](https://bugs.openjdk.org/browse/JDK-8295651): JFR: 'jfr scrub' should summarize what was removed (**Enhancement** - P3)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24669/head:pull/24669` \
`$ git checkout pull/24669`

Update a local copy of the PR: \
`$ git checkout pull/24669` \
`$ git pull https://git.openjdk.org/jdk.git pull/24669/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24669`

View PR using the GUI difftool: \
`$ git pr show -t 24669`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24669.diff">https://git.openjdk.org/jdk/pull/24669.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24669#issuecomment-2807699645)
</details>
