### PR TITLE
8354461: Update tests to disable streaming output for attach tools

### DIFF
--- a/test/hotspot/jtreg/runtime/CommandLine/PrintClasses.java
+++ b/test/hotspot/jtreg/runtime/CommandLine/PrintClasses.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2022, Alibaba Group Holding Limited. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -39,20 +40,19 @@
  * @run main/othervm -XX:StartFlightRecording PrintClasses
  */
 
+import jdk.test.lib.dcmd.PidJcmdExecutor;
 import jdk.test.lib.process.OutputAnalyzer;
-import jdk.test.lib.JDKToolFinder;
 
 public class PrintClasses {
   public static void main(String args[]) throws Exception {
-    var pid = Long.toString(ProcessHandle.current().pid());
     var pb = new ProcessBuilder();
 
-    pb.command(new String[] { JDKToolFinder.getJDKTool("jcmd"), pid, "VM.classes"});
+    pb.command(new PidJcmdExecutor().getCommandLine("VM.classes"));
     var output = new OutputAnalyzer(pb.start());
     output.shouldNotContain("instance size");
     output.shouldContain(PrintClasses.class.getSimpleName());
 
-    pb.command(new String[] { JDKToolFinder.getJDKTool("jcmd"), pid, "VM.classes", "-verbose"});
+    pb.command(new PidJcmdExecutor().getCommandLine("VM.classes", "-verbose"));
     output = new OutputAnalyzer(pb.start());
     output.shouldContain("instance size");
     output.shouldContain(PrintClasses.class.getSimpleName());

--- a/test/hotspot/jtreg/runtime/ElfDecoder/TestElfDirectRead.java
+++ b/test/hotspot/jtreg/runtime/ElfDecoder/TestElfDirectRead.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -57,9 +57,8 @@
                                  -XX:NativeMemoryTracking=detail TestElfDirectRead
  */
 
-import jdk.test.lib.process.ProcessTools;
+import jdk.test.lib.dcmd.PidJcmdExecutor;
 import jdk.test.lib.process.OutputAnalyzer;
-import jdk.test.lib.JDKToolFinder;
 import jdk.test.whitebox.WhiteBox;
 
 public class TestElfDirectRead {
@@ -68,10 +67,8 @@ public class TestElfDirectRead {
     wb.disableElfSectionCache();
     ProcessBuilder pb = new ProcessBuilder();
     OutputAnalyzer output;
-    // Grab my own PID
-    String pid = Long.toString(ProcessTools.getProcessId());
 
-    pb.command(new String[] { JDKToolFinder.getJDKTool("jcmd"), pid, "VM.native_memory", "detail"});
+    pb.command(new PidJcmdExecutor().getCommandLine("VM.native_memory", "detail"));
     output = new OutputAnalyzer(pb.start());
     // This is a pre-populated stack frame, should always exist if can decode
     output.shouldContain("MallocSiteTable::new_entry");

--- a/test/hotspot/jtreg/runtime/Metaspace/PrintMetaspaceDcmd.java
+++ b/test/hotspot/jtreg/runtime/Metaspace/PrintMetaspaceDcmd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2018, SAP and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -22,9 +22,8 @@
  * questions.
  */
 
-import jdk.test.lib.process.ProcessTools;
+import jdk.test.lib.dcmd.PidJcmdExecutor;
 import jdk.test.lib.process.OutputAnalyzer;
-import jdk.test.lib.JDKToolFinder;
 
 /*
  * @test id=test-64bit-ccs
@@ -71,10 +70,8 @@ public class PrintMetaspaceDcmd {
     private static void doTheNoSpecifiedPropTest() throws Exception {
         ProcessBuilder pb = new ProcessBuilder();
         OutputAnalyzer output;
-        // Grab my own PID
-        String pid = Long.toString(ProcessTools.getProcessId());
 
-        pb.command(new String[] { JDKToolFinder.getJDKTool("jcmd"), pid, "VM.metaspace", "basic"});
+        pb.command(new PidJcmdExecutor().getCommandLine("VM.metaspace", "basic"));
         output = new OutputAnalyzer(pb.start());
         output.shouldHaveExitValue(0);
         output.shouldMatch("MaxMetaspaceSize: unlimited");
@@ -83,10 +80,8 @@ public class PrintMetaspaceDcmd {
     private static void doTheCCSPropTest(boolean usesCompressedClassSpace) throws Exception {
         ProcessBuilder pb = new ProcessBuilder();
         OutputAnalyzer output;
-        // Grab my own PID
-        String pid = Long.toString(ProcessTools.getProcessId());
 
-        pb.command(new String[] { JDKToolFinder.getJDKTool("jcmd"), pid, "VM.metaspace", "basic"});
+        pb.command(new PidJcmdExecutor().getCommandLine("VM.metaspace", "basic"));
         output = new OutputAnalyzer(pb.start());
         output.shouldHaveExitValue(0);
         if (usesCompressedClassSpace) {
@@ -97,7 +92,7 @@ public class PrintMetaspaceDcmd {
         output.shouldContain("Chunk freelists:");
         output.shouldMatch("MaxMetaspaceSize:.*201.00.*MB");
 
-        pb.command(new String[] { JDKToolFinder.getJDKTool("jcmd"), pid, "VM.metaspace"});
+        pb.command(new PidJcmdExecutor().getCommandLine("VM.metaspace"));
         output = new OutputAnalyzer(pb.start());
         output.shouldHaveExitValue(0);
         if (usesCompressedClassSpace) {
@@ -109,12 +104,12 @@ public class PrintMetaspaceDcmd {
         output.shouldContain("Waste");
         output.shouldMatch("MaxMetaspaceSize:.*201.00.*MB");
 
-        pb.command(new String[] { JDKToolFinder.getJDKTool("jcmd"), pid, "VM.metaspace", "show-loaders"});
+        pb.command(new PidJcmdExecutor().getCommandLine("VM.metaspace", "show-loaders"));
         output = new OutputAnalyzer(pb.start());
         output.shouldHaveExitValue(0);
         output.shouldMatch("CLD.*<bootstrap>");
 
-        pb.command(new String[] { JDKToolFinder.getJDKTool("jcmd"), pid, "VM.metaspace", "by-chunktype"});
+        pb.command(new PidJcmdExecutor().getCommandLine("VM.metaspace", "by-chunktype"));
         output = new OutputAnalyzer(pb.start());
         output.shouldHaveExitValue(0);
         output.shouldContain("1k:");
@@ -131,13 +126,13 @@ public class PrintMetaspaceDcmd {
         output.shouldContain("2m:");
         output.shouldContain("4m:");
 
-        pb.command(new String[] { JDKToolFinder.getJDKTool("jcmd"), pid, "VM.metaspace", "vslist"});
+        pb.command(new PidJcmdExecutor().getCommandLine("VM.metaspace", "vslist"));
         output = new OutputAnalyzer(pb.start());
         output.shouldHaveExitValue(0);
         output.shouldContain("Virtual space list");
         output.shouldMatch("node.*reserved.*committed.*used.*");
 
-        pb.command(new String[] { JDKToolFinder.getJDKTool("jcmd"), pid, "VM.metaspace", "chunkfreelist"});
+        pb.command(new PidJcmdExecutor().getCommandLine("VM.metaspace", "chunkfreelist"));
         // Output should look somewhat like this...
         // vvvvvvvvvvvvvvvv
         // Chunk freelist details:
@@ -161,17 +156,17 @@ public class PrintMetaspaceDcmd {
         output.shouldMatch(".*total chunks.*total word size.*");
 
         // Test with different scales
-        pb.command(new String[] { JDKToolFinder.getJDKTool("jcmd"), pid, "VM.metaspace", "scale=G"});
+        pb.command(new PidJcmdExecutor().getCommandLine("VM.metaspace", "scale=G"));
         output = new OutputAnalyzer(pb.start());
         output.shouldHaveExitValue(0);
         output.shouldMatch("MaxMetaspaceSize:.*0.2.*GB");
 
-        pb.command(new String[] { JDKToolFinder.getJDKTool("jcmd"), pid, "VM.metaspace", "scale=K"});
+        pb.command(new PidJcmdExecutor().getCommandLine("VM.metaspace", "scale=K"));
         output = new OutputAnalyzer(pb.start());
         output.shouldHaveExitValue(0);
         output.shouldMatch("MaxMetaspaceSize:.*205824.00 KB");
 
-        pb.command(new String[] { JDKToolFinder.getJDKTool("jcmd"), pid, "VM.metaspace", "scale=1"});
+        pb.command(new PidJcmdExecutor().getCommandLine("VM.metaspace", "scale=1"));
         output = new OutputAnalyzer(pb.start());
         output.shouldHaveExitValue(0);
         output.shouldMatch("MaxMetaspaceSize:.*210763776 bytes");

--- a/test/hotspot/jtreg/runtime/NMT/CommitOverlappingRegions.java
+++ b/test/hotspot/jtreg/runtime/NMT/CommitOverlappingRegions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,9 +32,8 @@
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -XX:NativeMemoryTracking=detail CommitOverlappingRegions
  */
 
-import jdk.test.lib.process.ProcessTools;
+import jdk.test.lib.dcmd.PidJcmdExecutor;
 import jdk.test.lib.process.OutputAnalyzer;
-import jdk.test.lib.JDKToolFinder;
 import jdk.test.whitebox.WhiteBox;
 
 public class CommitOverlappingRegions {
@@ -49,10 +48,9 @@ public class CommitOverlappingRegions {
 
         long addr = wb.NMTReserveMemory(8*size);
 
-        String pid = Long.toString(ProcessTools.getProcessId());
         ProcessBuilder pb = new ProcessBuilder();
 
-        pb.command(new String[] { JDKToolFinder.getJDKTool("jcmd"), pid, "VM.native_memory", "detail"});
+        pb.command(new PidJcmdExecutor().getCommandLine("VM.native_memory", "detail"));
         System.out.println("Address is " + Long.toHexString(addr));
 
         // Start: . . . . . . . .

--- a/test/hotspot/jtreg/runtime/NMT/MallocSiteTypeChange.java
+++ b/test/hotspot/jtreg/runtime/NMT/MallocSiteTypeChange.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2019, Red Hat, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -32,8 +33,6 @@
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -XX:NativeMemoryTracking=detail MallocSiteTypeChange
  */
 
-import jdk.test.lib.JDKToolFinder;
-import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.whitebox.WhiteBox;
 
@@ -42,26 +41,19 @@ public class MallocSiteTypeChange {
         OutputAnalyzer output;
         WhiteBox wb = WhiteBox.getWhiteBox();
 
-        // Grab my own PID
-        String pid = Long.toString(ProcessTools.getProcessId());
-        ProcessBuilder pb = new ProcessBuilder();
-
         int pc = 1;
         long addr = wb.NMTMallocWithPseudoStack(4 * 1024, pc);
 
         // Verify that current tracking level is "detail"
-        pb.command(new String[] { JDKToolFinder.getJDKTool("jcmd"), pid, "VM.native_memory", "detail"});
-        output = new OutputAnalyzer(pb.start());
+        output = NMTTestUtils.startJcmdVMNativeMemory("detail");
         output.shouldContain("Test (reserved=4KB, committed=4KB)");
 
-        pb.command(new String[] { JDKToolFinder.getJDKTool("jcmd"), pid, "VM.native_memory", "baseline"});
-        output = new OutputAnalyzer(pb.start());
+        output = NMTTestUtils.startJcmdVMNativeMemory("baseline");
         output.shouldContain("Baseline taken");
 
         wb.NMTFree(addr);
         addr = wb.NMTMallocWithPseudoStackAndType(2 * 1024, pc, 9 /* mtInternal */ );
-        pb.command(new String[] { JDKToolFinder.getJDKTool("jcmd"), pid, "VM.native_memory", "detail.diff"});
-        output = new OutputAnalyzer(pb.start());
+        output = NMTTestUtils.startJcmdVMNativeMemory("detail.diff");
         output.shouldContain("(malloc=0KB type=Test -4KB)");
         output.shouldContain("(malloc=2KB type=Internal +2KB #1 +1)");
         output.shouldHaveExitValue(0);

--- a/test/hotspot/jtreg/runtime/NMT/NMTTestUtils.java
+++ b/test/hotspot/jtreg/runtime/NMT/NMTTestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2023 Red Hat, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -22,9 +22,9 @@
  * questions.
  */
 
-import jdk.test.lib.JDKToolFinder;
+import jdk.test.lib.StringArrayUtils;
+import jdk.test.lib.dcmd.PidJcmdExecutor;
 import jdk.test.lib.process.OutputAnalyzer;
-import jdk.test.lib.process.ProcessTools;
 
 public class NMTTestUtils {
 
@@ -32,13 +32,9 @@ public class NMTTestUtils {
         if (additional_args == null) {
             additional_args = new String[] {};
         }
-        String fullargs[] = new String[3 + additional_args.length];
-        fullargs[0] = JDKToolFinder.getJDKTool("jcmd");
-        fullargs[1] = Long.toString(ProcessTools.getProcessId());
-        fullargs[2] = "VM.native_memory";
-        System.arraycopy(additional_args, 0, fullargs, 3, additional_args.length);
+        String fullargs[] = StringArrayUtils.concat("VM.native_memory", additional_args);
         ProcessBuilder pb = new ProcessBuilder();
-        pb.command(fullargs);
+        pb.command(new PidJcmdExecutor().getCommandLine(fullargs));
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         return output;
     }

--- a/test/hotspot/jtreg/runtime/NMT/VirtualAllocAttemptReserveMemoryAt.java
+++ b/test/hotspot/jtreg/runtime/NMT/VirtualAllocAttemptReserveMemoryAt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,9 +33,8 @@
  *
  */
 
-import jdk.test.lib.process.ProcessTools;
+import jdk.test.lib.dcmd.PidJcmdExecutor;
 import jdk.test.lib.process.OutputAnalyzer;
-import jdk.test.lib.JDKToolFinder;
 
 import jdk.test.whitebox.WhiteBox;
 
@@ -48,7 +47,6 @@ public class VirtualAllocAttemptReserveMemoryAt {
     public static void main(String args[]) throws Exception {
         long reserveSize = 4 * 1024 * 1024; // 4096KB
 
-        String pid = Long.toString(ProcessTools.getProcessId());
         ProcessBuilder pb = new ProcessBuilder();
 
         // Find an address
@@ -67,8 +65,7 @@ public class VirtualAllocAttemptReserveMemoryAt {
 
         assertEQ(addr, attempt_addr);
 
-        pb.command(new String[] { JDKToolFinder.getJDKTool("jcmd"), pid,
-                "VM.native_memory", "detail" });
+        pb.command(new PidJcmdExecutor().getCommandLine("VM.native_memory", "detail"));
 
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
 

--- a/test/hotspot/jtreg/runtime/Thread/TestThreadDumpClassInitMonitor.java
+++ b/test/hotspot/jtreg/runtime/Thread/TestThreadDumpClassInitMonitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,6 +43,8 @@ public class TestThreadDumpClassInitMonitor {
     // so use getTestJDKTool() instead of getCompileJDKTool() or even
     // getJDKTool() which can fall back to "compile.jdk".
     final static String JSTACK = JDKToolFinder.getTestJDKTool("jstack");
+    // jstack output may be lengthy, disable streaming output to avoid deadlocks
+    final static String DISABLE_STREAMING_OUTPUT = "-J-Djdk.attach.allowStreamingOutput=false";
     final static String PID = "" + ProcessHandle.current().pid();
 
     final static Thread current = Thread.currentThread();
@@ -111,7 +113,7 @@ public class TestThreadDumpClassInitMonitor {
 
             // Now run jstack
             try {
-                ProcessBuilder pb = new ProcessBuilder(JSTACK, PID);
+                ProcessBuilder pb = new ProcessBuilder(JSTACK, DISABLE_STREAMING_OUTPUT, PID);
                 OutputAnalyzer output = new OutputAnalyzer(pb.start());
                 output.shouldHaveExitValue(0);
                 stackDump = output.asLines();

--- a/test/hotspot/jtreg/runtime/Thread/TestThreadDumpSMRInfo.java
+++ b/test/hotspot/jtreg/runtime/Thread/TestThreadDumpSMRInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,6 +40,8 @@ public class TestThreadDumpSMRInfo {
     // so use getTestJDKTool() instead of getCompileJDKTool() or even
     // getJDKTool() which can fall back to "compile.jdk".
     final static String JSTACK = JDKToolFinder.getTestJDKTool("jstack");
+    // jstack output may be lengthy, disable streaming output to avoid deadlocks
+    final static String DISABLE_STREAMING_OUTPUT = "-J-Djdk.attach.allowStreamingOutput=false";
     final static String PID = "" + ProcessHandle.current().pid();
 
     // Here's a sample "Threads class SMR info" section:
@@ -70,7 +72,7 @@ public class TestThreadDumpSMRInfo {
             }
         }
 
-        ProcessBuilder pb = new ProcessBuilder(JSTACK, PID);
+        ProcessBuilder pb = new ProcessBuilder(JSTACK, DISABLE_STREAMING_OUTPUT, PID);
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
 
         if (verbose) {

--- a/test/hotspot/jtreg/runtime/Thread/ThreadPriorities.java
+++ b/test/hotspot/jtreg/runtime/Thread/ThreadPriorities.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -74,6 +74,8 @@ public class ThreadPriorities {
         ArrayList<String> failed = new ArrayList<>();
         ProcessBuilder pb = new ProcessBuilder(
                 JDKToolFinder.getJDKTool("jstack"),
+                // jstack output may be lengthy, disable streaming output to avoid deadlocks
+                "-J-Djdk.attach.allowStreamingOutput=false",
                 String.valueOf(ProcessTools.getProcessId()));
 
         String[] output = new OutputAnalyzer(pb.start()).getOutput().split("\\R");

--- a/test/hotspot/jtreg/runtime/cds/DumpSharedDictionary.java
+++ b/test/hotspot/jtreg/runtime/cds/DumpSharedDictionary.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,9 +32,8 @@
 
 import jdk.test.lib.cds.CDSOptions;
 import jdk.test.lib.cds.CDSTestUtils;
-import jdk.test.lib.process.ProcessTools;
+import jdk.test.lib.dcmd.PidJcmdExecutor;
 import jdk.test.lib.process.OutputAnalyzer;
-import jdk.test.lib.JDKToolFinder;
 
 public class DumpSharedDictionary {
 
@@ -55,11 +54,8 @@ public class DumpSharedDictionary {
             CDSTestUtils.run(opts)
                         .assertNormalExit();
         } else {
-            // Grab my own PID
-            String pid = Long.toString(ProcessTools.getProcessId());
-
             ProcessBuilder pb = new ProcessBuilder();
-            pb.command(new String[] {JDKToolFinder.getJDKTool("jcmd"), pid, "VM.systemdictionary"});
+            pb.command(new PidJcmdExecutor().getCommandLine("VM.systemdictionary"));
             OutputAnalyzer output = CDSTestUtils.executeAndLog(pb, "jcmd-systemdictionary");
             try {
                 output.shouldContain("Shared Dictionary statistics:");
@@ -70,7 +66,7 @@ public class DumpSharedDictionary {
                 output.shouldContain("Unknown diagnostic command");
             }
 
-            pb.command(new String[] {JDKToolFinder.getJDKTool("jcmd"), pid, "VM.systemdictionary", "-verbose"});
+            pb.command(new PidJcmdExecutor().getCommandLine("VM.systemdictionary", "-verbose"));
             output = CDSTestUtils.executeAndLog(pb, "jcmd-systemdictionary-verbose");
             try {
                 output.shouldContain("Shared Dictionary");

--- a/test/hotspot/jtreg/runtime/cds/DumpSymbolAndStringTable.java
+++ b/test/hotspot/jtreg/runtime/cds/DumpSymbolAndStringTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,21 +32,17 @@
  *                   -XX:+WhiteBoxAPI DumpSymbolAndStringTable
  */
 import jdk.test.lib.cds.CDSTestUtils;
-import jdk.test.lib.process.ProcessTools;
+import jdk.test.lib.dcmd.PidJcmdExecutor;
 import jdk.test.lib.process.OutputAnalyzer;
-import jdk.test.lib.JDKToolFinder;
 import jdk.test.whitebox.WhiteBox;
 
 public class DumpSymbolAndStringTable {
     public static void main(String[] args) throws Exception {
-        // Grab my own PID
-        String pid = Long.toString(ProcessTools.getProcessId());
-
         WhiteBox wb = WhiteBox.getWhiteBox();
         boolean sharingEnabled = wb.isSharingEnabled();
 
         ProcessBuilder pb = new ProcessBuilder();
-        pb.command(new String[] {JDKToolFinder.getJDKTool("jcmd"), pid, "VM.symboltable", "-verbose"});
+        pb.command(new PidJcmdExecutor().getCommandLine("VM.symboltable", "-verbose"));
         OutputAnalyzer output = CDSTestUtils.executeAndLog(pb, "jcmd-symboltable");
         final String sharedSymbolsHeader = "Shared symbols:\n";
         try {
@@ -59,7 +55,7 @@ public class DumpSymbolAndStringTable {
             output.shouldContain("Unknown diagnostic command");
         }
 
-        pb.command(new String[] {JDKToolFinder.getJDKTool("jcmd"), pid, "VM.stringtable", "-verbose"});
+        pb.command(new PidJcmdExecutor().getCommandLine("VM.stringtable", "-verbose"));
         output = CDSTestUtils.executeAndLog(pb, "jcmd-stringtable");
         final String sharedStringsHeader = "Shared strings:\n";
         try {
@@ -74,7 +70,7 @@ public class DumpSymbolAndStringTable {
             output.shouldContain("Unknown diagnostic command");
         }
 
-        pb.command(new String[] {JDKToolFinder.getJDKTool("jcmd"), pid, "VM.systemdictionary"});
+        pb.command(new PidJcmdExecutor().getCommandLine("VM.systemdictionary"));
         output = CDSTestUtils.executeAndLog(pb, "jcmd-systemdictionary");
         try {
             output.shouldContain("System Dictionary for 'app' class loader statistics:");
@@ -85,7 +81,7 @@ public class DumpSymbolAndStringTable {
             output.shouldContain("Unknown diagnostic command");
         }
 
-        pb.command(new String[] {JDKToolFinder.getJDKTool("jcmd"), pid, "VM.systemdictionary", "-verbose"});
+        pb.command(new PidJcmdExecutor().getCommandLine("VM.systemdictionary", "-verbose"));
         output = CDSTestUtils.executeAndLog(pb, "jcmd-systemdictionary");
         try {
             output.shouldContain("Dictionary for loader data: 0x");

--- a/test/hotspot/jtreg/serviceability/tmtools/jstack/JstackThreadTest.java
+++ b/test/hotspot/jtreg/serviceability/tmtools/jstack/JstackThreadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -70,6 +70,8 @@ public class JstackThreadTest {
     ProcessBuilder processBuilder = new ProcessBuilder();
     JDKToolLauncher launcher = JDKToolLauncher.createUsingTestJDK("jstack");
     launcher.addVMArgs(jdk.test.lib.Utils.getTestJavaOpts());
+    // jstack output may be lengthy, disable streaming output to avoid deadlocks
+    launcher.addVMArg("-Djdk.attach.allowStreamingOutput=false");
     launcher.addToolArg("-l");
     launcher.addToolArg(Long.toString(ProcessTools.getProcessId()));
     processBuilder.command(launcher.getCommand());

--- a/test/jdk/sun/tools/jcmd/JcmdOutputEncodingTest.java
+++ b/test/jdk/sun/tools/jcmd/JcmdOutputEncodingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,6 +53,8 @@ public class JcmdOutputEncodingTest {
         launcher.addVMArgs(Utils.getTestJavaOpts());
         launcher.addVMArg("-Dfile.encoding=" + cs);
         launcher.addVMArg("-Dsun.stdout.encoding=" + cs);
+        // Thread.print command output may be lengthy, disable streaming output to avoid deadlocks
+        launcher.addVMArg("-Djdk.attach.allowStreamingOutput=false");
         launcher.addToolArg(Long.toString(ProcessTools.getProcessId()));
         boolean isVirtualThread = Thread.currentThread().isVirtual();
         Path threadDumpFile = null;

--- a/test/jdk/sun/tools/jmap/BasicJMapTest.java
+++ b/test/jdk/sun/tools/jmap/BasicJMapTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -290,6 +290,8 @@ public class BasicJMapTest {
     private static OutputAnalyzer jmap(String... toolArgs) throws Exception {
         JDKToolLauncher launcher = JDKToolLauncher.createUsingTestJDK("jmap");
         launcher.addVMArgs(Utils.getTestJavaOpts());
+        // jmap output may be lengthy, disable streaming output to avoid deadlocks
+        launcher.addVMArg("-Djdk.attach.allowStreamingOutput=false");
         if (toolArgs != null) {
             for (String toolArg : toolArgs) {
                 launcher.addToolArg(toolArg);

--- a/test/jdk/sun/tools/jstack/BasicJStackTest.java
+++ b/test/jdk/sun/tools/jstack/BasicJStackTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -85,6 +85,8 @@ public class BasicJStackTest {
         launcher.addVMArg("-XX:+UsePerfData");
         launcher.addVMArg("-Dfile.encoding=" + cs);
         launcher.addVMArg("-Dsun.stdout.encoding=" + cs);
+        // jstack output may be lengthy, disable output streaming to avoid deadlocks
+        launcher.addVMArg("-Djdk.attach.allowStreamingOutput=false");
         if (toolArgs != null) {
             for (String toolArg : toolArgs) {
                 launcher.addToolArg(toolArg);

--- a/test/lib/jdk/test/lib/dcmd/JcmdExecutor.java
+++ b/test/lib/jdk/test/lib/dcmd/JcmdExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,11 +34,17 @@ import java.util.List;
  */
 public abstract class JcmdExecutor extends CommandExecutor {
     protected String jcmdBinary;
+    // VM option to disable streaming output
+    protected String jcmdDisableStreamingOption = "-J-Djdk.attach.allowStreamingOutput=false";
 
     protected abstract List<String> createCommandLine(String cmd) throws CommandExecutorException;
 
     protected JcmdExecutor() {
         jcmdBinary = JDKToolFinder.getJDKTool("jcmd");
+    }
+
+    public List<String> getCommandLine(String... cmds) {
+        return createCommandLine(String.join(" ", cmds));
     }
 
     protected OutputAnalyzer executeImpl(String cmd) throws CommandExecutorException {

--- a/test/lib/jdk/test/lib/dcmd/PidJcmdExecutor.java
+++ b/test/lib/jdk/test/lib/dcmd/PidJcmdExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@ package jdk.test.lib.dcmd;
 
 import jdk.test.lib.process.ProcessTools;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -33,17 +34,15 @@ import java.util.List;
  */
 public class PidJcmdExecutor extends JcmdExecutor {
     protected final long pid;
+    // jcmd output for many commands may be lengthy when command is executed against main test process
+    protected boolean disableStreamingOutput = true;
 
     /**
      * Instantiates a new PidJcmdExecutor targeting the current VM
      */
     public PidJcmdExecutor() {
         super();
-        try {
-            pid = ProcessTools.getProcessId();
-        } catch (Exception e) {
-            throw new CommandExecutorException("Could not determine own pid", e);
-        }
+        pid = getCurrentPid();
     }
 
     /**
@@ -54,10 +53,27 @@ public class PidJcmdExecutor extends JcmdExecutor {
     public PidJcmdExecutor(String target) {
         super();
         pid = Long.valueOf(target);
+        disableStreamingOutput = (pid == getCurrentPid());
+    }
+
+    private static long getCurrentPid() {
+        try {
+            return ProcessTools.getProcessId();
+        } catch (Exception e) {
+            throw new CommandExecutorException("Could not determine own pid", e);
+        }
     }
 
     protected List<String> createCommandLine(String cmd) throws CommandExecutorException {
-        return Arrays.asList(jcmdBinary, Long.toString(pid), cmd);
+        List<String> commandLine = new ArrayList<>();
+        commandLine.add(jcmdBinary);
+        if (disableStreamingOutput) {
+            commandLine.add(jcmdDisableStreamingOption);
+        }
+        commandLine.add(Long.toString(pid));
+        commandLine.add(cmd);
+        return commandLine;
+        //return Arrays.asList(jcmdBinary, Long.toString(pid), cmd);
     }
 
 }


### PR DESCRIPTION
The change is a preparation step to enable attach streaming output by default.
The fix updates a number of tests which fail with timeout in tier1..tier7 when attach streaming output is enabled.
Details in the first comment.
Testing: tier1..7 with enabled attach streaming output

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8354461](https://bugs.openjdk.org/browse/JDK-8354461): Update tests to disable streaming output for attach tools (**Sub-task** - P4)


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24672/head:pull/24672` \
`$ git checkout pull/24672`

Update a local copy of the PR: \
`$ git checkout pull/24672` \
`$ git pull https://git.openjdk.org/jdk.git pull/24672/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24672`

View PR using the GUI difftool: \
`$ git pr show -t 24672`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24672.diff">https://git.openjdk.org/jdk/pull/24672.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24672#issuecomment-2807797714)
</details>
