### PR TITLE
8354766: Test TestUnexported.java javac build fails

### DIFF
--- a/test/langtools/jdk/javadoc/doclet/testUnexported/TestUnexported.java
+++ b/test/langtools/jdk/javadoc/doclet/testUnexported/TestUnexported.java
@@ -27,6 +27,8 @@
  * @summary Hide superclasses from conditionally exported packages
  * @library /tools/lib ../../lib
  * @modules jdk.javadoc/jdk.javadoc.internal.tool
+ *          jdk.compiler/com.sun.tools.javac.api
+ *          jdk.compiler/com.sun.tools.javac.main
  * @build javadoc.tester.* toolbox.ToolBox
  * @run main TestUnexported
  */


### PR DESCRIPTION
Hi all,

The newly added test jdk/javadoc/doclet/testUnexported/TestUnexported.java javac build fails. This PR add depedencies to make javac build success. Test-fix only, change has been verified locally, no risk.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8354766](https://bugs.openjdk.org/browse/JDK-8354766): Test TestUnexported.java javac build fails (**Bug** - P4)


### Reviewers
 * [Nizar Benalla](https://openjdk.org/census#nbenalla) (@nizarbenalla - Committer)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24673/head:pull/24673` \
`$ git checkout pull/24673`

Update a local copy of the PR: \
`$ git checkout pull/24673` \
`$ git pull https://git.openjdk.org/jdk.git pull/24673/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24673`

View PR using the GUI difftool: \
`$ git pr show -t 24673`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24673.diff">https://git.openjdk.org/jdk/pull/24673.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24673#issuecomment-2808181295)
</details>
