### PR TITLE
8354625: Compile::igv_print_graph_to_network doesn't use its second parameter

### DIFF
--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -5265,10 +5265,10 @@ void Compile::igv_print_method_to_file(const char* phase_name, bool append) {
 void Compile::igv_print_method_to_network(const char* phase_name) {
   ResourceMark rm;
   GrowableArray<const Node*> empty_list;
-  igv_print_graph_to_network(phase_name, (Node*) C->root(), empty_list);
+  igv_print_graph_to_network(phase_name, empty_list);
 }
 
-void Compile::igv_print_graph_to_network(const char* name, Node* node, GrowableArray<const Node*>& visible_nodes) {
+void Compile::igv_print_graph_to_network(const char* name, GrowableArray<const Node*>& visible_nodes) {
   if (_debug_network_printer == nullptr) {
     _debug_network_printer = new IdealGraphPrinter(C);
   } else {

--- a/src/hotspot/share/opto/compile.hpp
+++ b/src/hotspot/share/opto/compile.hpp
@@ -680,7 +680,7 @@ public:
 
   void igv_print_method_to_file(const char* phase_name = "Debug", bool append = false);
   void igv_print_method_to_network(const char* phase_name = "Debug");
-  void igv_print_graph_to_network(const char* name, Node* node, GrowableArray<const Node*>& visible_nodes);
+  void igv_print_graph_to_network(const char* name, GrowableArray<const Node*>& visible_nodes);
   static IdealGraphPrinter* debug_file_printer() { return _debug_file_printer; }
   static IdealGraphPrinter* debug_network_printer() { return _debug_network_printer; }
 #endif

--- a/src/hotspot/share/opto/node.cpp
+++ b/src/hotspot/share/opto/node.cpp
@@ -2057,7 +2057,7 @@ void PrintBFS::print() {
     if (_print_igv) {
       Compile* C = Compile::current();
       C->init_igv();
-      C->igv_print_graph_to_network("PrintBFS", (Node*) C->root(), _print_list);
+      C->igv_print_graph_to_network("PrintBFS", _print_list);
     }
   } else {
     _output->print_cr("No nodes to print.");


### PR DESCRIPTION
Remove the second (unused) parameter of `Compile::igv_print_graph_to_network`. It also makes it more consistent with `Compile::igv_print_method_to_file` that always print from root.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8354625](https://bugs.openjdk.org/browse/JDK-8354625): Compile::igv_print_graph_to_network doesn't use its second parameter (**Enhancement** - P4)


### Reviewers
 * [Roberto Castañeda Lozano](https://openjdk.org/census#rcastanedalo) (@robcasloz - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24675/head:pull/24675` \
`$ git checkout pull/24675`

Update a local copy of the PR: \
`$ git checkout pull/24675` \
`$ git pull https://git.openjdk.org/jdk.git pull/24675/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24675`

View PR using the GUI difftool: \
`$ git pr show -t 24675`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24675.diff">https://git.openjdk.org/jdk/pull/24675.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24675#issuecomment-2808958963)
</details>
