### PR TITLE
8354802: MAX_SECS definition is unused in os_linux

### DIFF
--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -139,8 +139,6 @@
 
 #define MAX_PATH    (2 * K)
 
-#define MAX_SECS 100000000
-
 // for timer info max values which include all bits
 #define ALL_64_BITS CONST64(0xFFFFFFFFFFFFFFFF)
 


### PR DESCRIPTION
Seems the MAX_SECS definition in os_linux.cpp is not needed any more, related code was moved or deleted.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8354802](https://bugs.openjdk.org/browse/JDK-8354802): MAX_SECS definition is unused in os_linux (**Bug** - P4)


### Reviewers
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24686/head:pull/24686` \
`$ git checkout pull/24686`

Update a local copy of the PR: \
`$ git checkout pull/24686` \
`$ git pull https://git.openjdk.org/jdk.git pull/24686/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24686`

View PR using the GUI difftool: \
`$ git pr show -t 24686`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24686.diff">https://git.openjdk.org/jdk/pull/24686.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24686#issuecomment-2809374321)
</details>
