### PR TITLE
8354424: java/util/logging/LoggingDeadlock5.java fails intermittently in tier6

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -727,7 +727,6 @@ com/sun/jdi/InvokeHangTest.java                                 8218463 linux-al
 
 # jdk_util
 java/util/zip/CloseInflaterDeflaterTest.java  8339216 linux-s390x
-java/util/logging/LoggingDeadlock5.java       8354424 generic-all
 
 ############################################################################
 

--- a/test/jdk/java/util/logging/LoggingDeadlock5.java
+++ b/test/jdk/java/util/logging/LoggingDeadlock5.java
@@ -124,7 +124,7 @@ public class LoggingDeadlock5 {
         // immediately (if it occurs), but tests are run under very high loads
         // in higher tiers, so it's necessary to be a bit pessimistic here.
         private final static Duration JOIN_WAIT =
-                Duration.ofMillis(Utils.adjustTimeout(1000));
+                Duration.ofMillis(Utils.adjustTimeout(2000));
 
         private final Semaphore readyToDeadlock = new Semaphore(0);
         private final Semaphore userLockIsHeld = new Semaphore(0);

--- a/test/jdk/java/util/logging/LoggingDeadlock5.java
+++ b/test/jdk/java/util/logging/LoggingDeadlock5.java
@@ -25,10 +25,13 @@
  * @test
  * @bug     8349206
  * @summary j.u.l.Handler classes create deadlock risk via synchronized publish() method.
+ * @library /test/lib
  * @modules java.base/sun.util.logging
  *          java.logging
  * @run main/othervm LoggingDeadlock5
  */
+
+import jdk.test.lib.Utils;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -115,7 +118,13 @@ public class LoggingDeadlock5 {
     }
 
     private static class DeadLocker {
-        private final static Duration JOIN_WAIT = Duration.ofMillis(500);
+        // Since this is used to self-test for an expected deadlock, it will
+        // delay the test by at least this duration (so being overly large is
+        // a potential issue). The deadlock is set up so it should occur almost
+        // immediately (if it occurs), but tests are run under very high loads
+        // in higher tiers, so it's necessary to be a bit pessimistic here.
+        private final static Duration JOIN_WAIT =
+                Duration.ofMillis(Utils.adjustTimeout(1000));
 
         private final Semaphore readyToDeadlock = new Semaphore(0);
         private final Semaphore userLockIsHeld = new Semaphore(0);


### PR DESCRIPTION
Increasing timeout for deadlock detection and adjusting for the timeout factor in higher tiers.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8354424](https://bugs.openjdk.org/browse/JDK-8354424): java/util/logging/LoggingDeadlock5.java fails intermittently in tier6 (**Bug** - P3)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)
 * [Stuart Marks](https://openjdk.org/census#smarks) (@stuart-marks - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24687/head:pull/24687` \
`$ git checkout pull/24687`

Update a local copy of the PR: \
`$ git checkout pull/24687` \
`$ git pull https://git.openjdk.org/jdk.git pull/24687/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24687`

View PR using the GUI difftool: \
`$ git pr show -t 24687`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24687.diff">https://git.openjdk.org/jdk/pull/24687.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24687#issuecomment-2809402576)
</details>
