### PR TITLE
8356843: Avoid redundant HashMap.get to obtain old value in Toolkit.setDesktopProperty

### DIFF
--- a/src/java.desktop/share/classes/java/awt/Toolkit.java
+++ b/src/java.desktop/share/classes/java/awt/Toolkit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1472,8 +1472,7 @@ public abstract class Toolkit {
         Object oldValue;
 
         synchronized (this) {
-            oldValue = desktopProperties.get(name);
-            desktopProperties.put(name, newValue);
+            oldValue = desktopProperties.put(name, newValue);
         }
 
         // Don't fire change event if old and new values are null.


### PR DESCRIPTION
To obtain previous value of `HashMap` we can use result of `.put` call. In this case we can avoid redundant `.get` call.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8356843](https://bugs.openjdk.org/browse/JDK-8356843): Avoid redundant HashMap.get to obtain old value in Toolkit.setDesktopProperty (**Enhancement** - P5)


### Reviewers
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24691/head:pull/24691` \
`$ git checkout pull/24691`

Update a local copy of the PR: \
`$ git checkout pull/24691` \
`$ git pull https://git.openjdk.org/jdk.git pull/24691/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24691`

View PR using the GUI difftool: \
`$ git pr show -t 24691`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24691.diff">https://git.openjdk.org/jdk/pull/24691.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24691#issuecomment-2875489747)
</details>
