### PR TITLE
8352003: Support --add-opens with -XX:+AOTClassLinking

### DIFF
--- a/src/hotspot/share/classfile/modules.cpp
+++ b/src/hotspot/share/classfile/modules.cpp
@@ -580,13 +580,14 @@ public:
 };
 
 Modules::ArchivedProperty Modules::_archived_props[] = {
-  // numbered
+  // non-numbered
   {"jdk.module.main", false},
 
-  // non-numbered
+  // numbered
   {"jdk.module.addexports", true},             // --add-exports
   {"jdk.module.addmods", true},                // --add-modules
   {"jdk.module.enable.native.access", true},   // --enable-native-access
+  {"jdk.module.addopens", true},               // --add-opens
 };
 
 constexpr size_t Modules::num_archived_props() {

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -332,7 +332,6 @@ bool Arguments::internal_module_property_helper(const char* property, bool check
   if (strncmp(property, MODULE_PROPERTY_PREFIX, MODULE_PROPERTY_PREFIX_LEN) == 0) {
     const char* property_suffix = property + MODULE_PROPERTY_PREFIX_LEN;
     if (matches_property_suffix(property_suffix, ADDREADS, ADDREADS_LEN) ||
-        matches_property_suffix(property_suffix, ADDOPENS, ADDOPENS_LEN) ||
         matches_property_suffix(property_suffix, PATCH, PATCH_LEN) ||
         matches_property_suffix(property_suffix, LIMITMODS, LIMITMODS_LEN) ||
         matches_property_suffix(property_suffix, UPGRADE_PATH, UPGRADE_PATH_LEN) ||
@@ -343,6 +342,7 @@ bool Arguments::internal_module_property_helper(const char* property, bool check
     if (!check_for_cds) {
       // CDS notes: these properties are supported by CDS archived full module graph.
       if (matches_property_suffix(property_suffix, ADDEXPORTS, ADDEXPORTS_LEN) ||
+          matches_property_suffix(property_suffix, ADDOPENS, ADDOPENS_LEN) ||
           matches_property_suffix(property_suffix, PATH, PATH_LEN) ||
           matches_property_suffix(property_suffix, ADDMODS, ADDMODS_LEN) ||
           matches_property_suffix(property_suffix, ENABLE_NATIVE_ACCESS, ENABLE_NATIVE_ACCESS_LEN)) {

--- a/src/java.base/share/classes/java/lang/System.java
+++ b/src/java.base/share/classes/java/lang/System.java
@@ -2059,9 +2059,6 @@ public final class System {
             public void addOpensToAllUnnamed(Module m, String pn) {
                 m.implAddOpensToAllUnnamed(pn);
             }
-            public void addOpensToAllUnnamed(Module m, Set<String> concealedPackages, Set<String> exportedPackages) {
-                m.implAddOpensToAllUnnamed(concealedPackages, exportedPackages);
-            }
             public void addUses(Module m, Class<?> service) {
                 m.implAddUses(service);
             }

--- a/src/java.base/share/classes/jdk/internal/access/JavaLangAccess.java
+++ b/src/java.base/share/classes/jdk/internal/access/JavaLangAccess.java
@@ -231,11 +231,6 @@ public interface JavaLangAccess {
     void addOpensToAllUnnamed(Module m, String pkg);
 
     /**
-     * Updates module m to open all packages in the given sets.
-     */
-    void addOpensToAllUnnamed(Module m, Set<String> concealedPkgs, Set<String> exportedPkgs);
-
-    /**
      * Updates module m to use a service.
      */
     void addUses(Module m, Class<?> service);

--- a/src/java.base/share/classes/jdk/internal/module/ModuleBootstrap.java
+++ b/src/java.base/share/classes/jdk/internal/module/ModuleBootstrap.java
@@ -162,7 +162,6 @@ public final class ModuleBootstrap {
             bootLayer = archivedBootLayer.bootLayer();
             BootLoader.getUnnamedModule(); // trigger <clinit> of BootLoader.
             CDS.defineArchivedModules(ClassLoaders.platformClassLoader(), ClassLoaders.appClassLoader());
-            addExtraExportsAndOpens(bootLayer);
 
             // assume boot layer has at least one module providing a service
             // that is mapped to the application class loader.

--- a/src/java.base/share/classes/jdk/internal/module/ModuleBootstrap.java
+++ b/src/java.base/share/classes/jdk/internal/module/ModuleBootstrap.java
@@ -162,6 +162,7 @@ public final class ModuleBootstrap {
             bootLayer = archivedBootLayer.bootLayer();
             BootLoader.getUnnamedModule(); // trigger <clinit> of BootLoader.
             CDS.defineArchivedModules(ClassLoaders.platformClassLoader(), ClassLoaders.appClassLoader());
+            boolean extraExportsOrOpens = addExtraExportsAndOpens(bootLayer);
 
             // assume boot layer has at least one module providing a service
             // that is mapped to the application class loader.

--- a/src/java.base/share/classes/jdk/internal/module/ModuleBootstrap.java
+++ b/src/java.base/share/classes/jdk/internal/module/ModuleBootstrap.java
@@ -162,7 +162,7 @@ public final class ModuleBootstrap {
             bootLayer = archivedBootLayer.bootLayer();
             BootLoader.getUnnamedModule(); // trigger <clinit> of BootLoader.
             CDS.defineArchivedModules(ClassLoaders.platformClassLoader(), ClassLoaders.appClassLoader());
-            boolean extraExportsOrOpens = addExtraExportsAndOpens(bootLayer);
+            addExtraExportsAndOpens(bootLayer);
 
             // assume boot layer has at least one module providing a service
             // that is mapped to the application class loader.
@@ -452,7 +452,7 @@ public final class ModuleBootstrap {
 
         // --add-reads, --add-exports/--add-opens
         addExtraReads(bootLayer);
-        boolean extraExportsOrOpens = addExtraExportsAndOpens(bootLayer);
+        addExtraExportsAndOpens(bootLayer);
 
         // add enable native access
         addEnableNativeAccess(bootLayer);
@@ -722,15 +722,13 @@ public final class ModuleBootstrap {
      * Process the --add-exports and --add-opens options to export/open
      * additional packages specified on the command-line.
      */
-    private static boolean addExtraExportsAndOpens(ModuleLayer bootLayer) {
-        boolean extraExportsOrOpens = false;
+    private static void addExtraExportsAndOpens(ModuleLayer bootLayer) {
 
         // --add-exports
         String prefix = "jdk.module.addexports.";
         Map<String, List<String>> extraExports = decode(prefix);
         if (!extraExports.isEmpty()) {
             addExtraExportsOrOpens(bootLayer, extraExports, false);
-            extraExportsOrOpens = true;
         }
 
 
@@ -739,10 +737,8 @@ public final class ModuleBootstrap {
         Map<String, List<String>> extraOpens = decode(prefix);
         if (!extraOpens.isEmpty()) {
             addExtraExportsOrOpens(bootLayer, extraOpens, true);
-            extraExportsOrOpens = true;
         }
 
-        return extraExportsOrOpens;
     }
 
     private static void addExtraExportsOrOpens(ModuleLayer bootLayer,

--- a/src/java.base/share/classes/jdk/internal/module/ModuleBootstrap.java
+++ b/src/java.base/share/classes/jdk/internal/module/ModuleBootstrap.java
@@ -142,8 +142,7 @@ public final class ModuleBootstrap {
         return getProperty("jdk.module.upgrade.path") == null &&
                getProperty("jdk.module.patch.0") == null &&       // --patch-module
                getProperty("jdk.module.limitmods") == null &&     // --limit-modules
-               getProperty("jdk.module.addreads.0") == null &&    // --add-reads
-               getProperty("jdk.module.addopens.0") == null;      // --add-opens
+               getProperty("jdk.module.addreads.0") == null;      // --add-reads
     }
 
     /**

--- a/test/hotspot/jtreg/runtime/cds/appcds/jigsaw/ExactOptionMatch.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/jigsaw/ExactOptionMatch.java
@@ -39,6 +39,10 @@ public class ExactOptionMatch {
     record Option(String cmdLine, String property, String valueA, String valueB) {}
 
     static Option[] allOptions = new Option[] {
+        new Option("--add-opens",
+                   "jdk.module.addopens",
+                   "java.base/java.util.concurrent.regex=ALL-UNNAMED",
+                   "java.base/sun.security.x509=ALL-UNNAMED"),
         new Option("--add-exports",
                    "jdk.module.addexports",
                    "java.base/jdk.internal.misc=ALL-UNNAMED",

--- a/test/hotspot/jtreg/runtime/cds/appcds/jigsaw/addopens/AddopensOption.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/jigsaw/addopens/AddopensOption.java
@@ -111,7 +111,7 @@ public class AddopensOption {
           .shouldMatch(versionPattern)
           .shouldContain(subgraphCannotBeUsed);
 
-        // dump an archive with -add-opens java.base/java.nio=ALL-UNNAMED 
+        // dump an archive with -add-opens java.base/java.nio=ALL-UNNAMED
         archiveName = TestCommon.getNewArchiveName("addopens-java-nio");
         TestCommon.setCurrentArchiveName(archiveName);
         oa = TestCommon.dumpBaseArchive(

--- a/test/hotspot/jtreg/runtime/cds/appcds/jigsaw/addopens/AddopensOption.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/jigsaw/addopens/AddopensOption.java
@@ -34,7 +34,6 @@
  */
 
 import jdk.test.lib.process.OutputAnalyzer;
-import jdk.test.whitebox.code.Compiler;
 
 public class AddopensOption {
 
@@ -49,7 +48,7 @@ public class AddopensOption {
         String archiveName = TestCommon.getNewArchiveName("addopens-option");
         TestCommon.setCurrentArchiveName(archiveName);
 
-        // dump a base archive with --add-opens jdk.jconsole -m jdk.httpserver
+        // dump a base archive with --add-opens jdk.java.base/java.time.format -m jdk.httpserver
         OutputAnalyzer oa = TestCommon.dumpBaseArchive(
             archiveName,
             loggingOption,
@@ -67,7 +66,6 @@ public class AddopensOption {
         oa.shouldHaveExitValue(0)
           // version of the jdk.httpserver module, e.g. java 22-ea
           .shouldMatch(versionPattern)
-          //.shouldMatch("cds,module.*Restored from archive: entry.0x.*name jdk.jconsole")
           .shouldMatch("cds,module.*Restored from archive: entry.0x.*name jdk.httpserver");
 
         // different --add-opens specified during runtime
@@ -153,6 +151,6 @@ public class AddopensOption {
             "-m", moduleOption,
             "-version");
         oa.shouldHaveExitValue(0)
-          .shouldMatch("cds,module.*Restored from archive: entry.0x.*name jdk.compiler");
+          .shouldMatch("cds,module.*Restored from archive: entry.0x.*name jdk.httpserver");
     }
 }

--- a/test/hotspot/jtreg/runtime/cds/appcds/jigsaw/addopens/AddopensOption.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/jigsaw/addopens/AddopensOption.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8352003
+ * @summary Test handling of the --add-opens option.
+ * @requires vm.cds.write.archived.java.heap
+ * @requires vm.flagless
+ * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI AddopensOption
+ */
+
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.whitebox.code.Compiler;
+
+public class AddopensOption {
+
+    public static void main(String[] args) throws Exception {
+        final String moduleOption = "jdk.httpserver/sun.net.httpserver.simpleserver.Main";
+        final String addOpensNio = "java.base/java.nio=ALL-UNNAMED";
+        final String addOpensTimeFormat = "java.base/java.time.format=ALL-UNNAMED";
+        final String loggingOption = "-Xlog:cds=debug,cds+module=debug,cds+heap=info,module=trace";
+        final String versionPattern = "java.[0-9][0-9].*";
+        final String subgraphCannotBeUsed = "subgraph jdk.internal.module.ArchivedBootLayer cannot be used because full module graph is disabled";
+        final String warningIncubator = "WARNING: Using incubator modules: jdk.incubator.vector";
+        String archiveName = TestCommon.getNewArchiveName("addopens-option");
+        TestCommon.setCurrentArchiveName(archiveName);
+
+        // dump a base archive with --add-opens jdk.jconsole -m jdk.httpserver
+        OutputAnalyzer oa = TestCommon.dumpBaseArchive(
+            archiveName,
+            loggingOption,
+            "--add-opens", addOpensTimeFormat,
+            "-m", moduleOption,
+            "-version");
+        oa.shouldHaveExitValue(0);
+
+        // same modules specified during runtime
+        oa = TestCommon.execCommon(
+            loggingOption,
+            "--add-opens", addOpensTimeFormat,
+            "-m", moduleOption,
+            "-version");
+        oa.shouldHaveExitValue(0)
+          // version of the jdk.httpserver module, e.g. java 22-ea
+          .shouldMatch(versionPattern)
+          //.shouldMatch("cds,module.*Restored from archive: entry.0x.*name jdk.jconsole")
+          .shouldMatch("cds,module.*Restored from archive: entry.0x.*name jdk.httpserver");
+
+        // different --add-opens specified during runtime
+        oa = TestCommon.execCommon(
+            loggingOption,
+            "--add-opens", addOpensNio,
+            "-m", moduleOption,
+            "-version");
+        oa.shouldHaveExitValue(0)
+          .shouldContain("Mismatched values for property jdk.module.addopens")
+          .shouldContain("runtime java.base/java.nio=ALL-UNNAMED dump time java.base/java.time.format=ALL-UNNAMED")
+          .shouldContain(subgraphCannotBeUsed);
+
+        // no module specified during runtime
+        oa = TestCommon.execCommon(
+            loggingOption,
+            "-version");
+        oa.shouldHaveExitValue(0)
+          .shouldContain("jdk.httpserver specified during dump time but not during runtime")
+          .shouldContain(subgraphCannotBeUsed);
+
+        // dump an archive without the --add-opens option
+        archiveName = TestCommon.getNewArchiveName("no-addopens-option");
+        TestCommon.setCurrentArchiveName(archiveName);
+        oa = TestCommon.dumpBaseArchive(
+            archiveName,
+            loggingOption,
+            "-m", moduleOption,
+            "-version");
+        oa.shouldHaveExitValue(0);
+
+        // run with --add-opens option
+        oa = TestCommon.execCommon(
+            loggingOption,
+            "--add-opens", addOpensTimeFormat,
+            "-m", moduleOption,
+            "-version");
+        oa.shouldHaveExitValue(0)
+          .shouldContain("java.base/java.time.format=ALL-UNNAMED specified during runtime but not during dump time")
+          // version of the jdk.httpserver module, e.g. java 22-ea
+          .shouldMatch(versionPattern)
+          .shouldContain(subgraphCannotBeUsed);
+
+        // dump an archive with -add-opens java.base/java.nio=ALL-UNNAMED 
+        archiveName = TestCommon.getNewArchiveName("addopens-java-nio");
+        TestCommon.setCurrentArchiveName(archiveName);
+        oa = TestCommon.dumpBaseArchive(
+            archiveName,
+            loggingOption,
+            "--add-opens", addOpensNio,
+            "-m", moduleOption,
+            "-version");
+        oa.shouldHaveExitValue(0)
+          .shouldContain("Full module graph = enabled");
+
+        // run with the same --add-opens
+        oa = TestCommon.execCommon(
+            loggingOption,
+            "--add-opens", addOpensNio,
+            "-m", moduleOption,
+            "-version");
+        oa.shouldContain("optimized module handling: enabled")
+          .shouldHaveExitValue(0);
+
+        // dump an archive with multiple --add-modules args
+        archiveName = TestCommon.getNewArchiveName("muti-addopens");
+        TestCommon.setCurrentArchiveName(archiveName);
+        oa = TestCommon.dumpBaseArchive(
+            archiveName,
+            loggingOption,
+            "--add-opens", addOpensNio,
+            "--add-opens", addOpensTimeFormat,
+            "-m", moduleOption,
+            "-version");
+        oa.shouldHaveExitValue(0);
+
+        // run with the same multiple --add-modules args with a duplicate --add-opens entry
+        oa = TestCommon.execCommon(
+            loggingOption,
+            "--add-opens", addOpensTimeFormat,
+            "--add-opens", addOpensNio,
+            "--add-opens", addOpensTimeFormat,
+            "-m", moduleOption,
+            "-version");
+        oa.shouldHaveExitValue(0)
+          .shouldMatch("cds,module.*Restored from archive: entry.0x.*name jdk.compiler");
+    }
+}

--- a/test/hotspot/jtreg/runtime/cds/appcds/jigsaw/modulepath/AddOpens.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/jigsaw/modulepath/AddOpens.java
@@ -61,7 +61,7 @@ public class AddOpens {
     private static String addOpensAllUnnamed = "java.base/java.lang=ALL-UNNAMED";
     private static String extraOpts[][] =
         {{"-Xlog:cds", "-Xlog:cds"},
-         {"--add-opens", addOpensArg}}; 
+         {"--add-opens", addOpensArg}};
     private static String expectedOutput[] =
         { "[class,load] com.simple.Main source: shared objects file",
           "method.setAccessible succeeded!"};


### PR DESCRIPTION
This RFE allows --add-opens to be specified for AOT cache creation. AOT cache can be used during production run with --add-opens option as long as the same set of options is used during assembly phase.

Passed tiers 1 - 4 testing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8352003](https://bugs.openjdk.org/browse/JDK-8352003): Support --add-opens with -XX:+AOTClassLinking (**Enhancement** - P4)


### Reviewers
 * [Matias Saavedra Silva](https://openjdk.org/census#matsaave) (@matias9927 - **Reviewer**) Review applies to [4fa5f8fb](https://git.openjdk.org/jdk/pull/24695/files/4fa5f8fbef9d2075a0f7e835d57e319da611219f)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Contributors
 * Alan Bateman `<alanb@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24695/head:pull/24695` \
`$ git checkout pull/24695`

Update a local copy of the PR: \
`$ git checkout pull/24695` \
`$ git pull https://git.openjdk.org/jdk.git pull/24695/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24695`

View PR using the GUI difftool: \
`$ git pr show -t 24695`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24695.diff">https://git.openjdk.org/jdk/pull/24695.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24695#issuecomment-2810800618)
</details>
