### PR TITLE
8332368: ubsan aarch64: immediate_aarch64.cpp:298:31: runtime error: shift exponent 32 is too large for 32-bit type 'int'

### DIFF
--- a/src/hotspot/share/adlc/output_h.cpp
+++ b/src/hotspot/share/adlc/output_h.cpp
@@ -870,7 +870,8 @@ void ArchDesc::declare_pipe_classes(FILE *fp_hpp) {
   fprintf(fp_hpp, "  }\n\n");
   fprintf(fp_hpp, "  void step(uint cycles) {\n");
   fprintf(fp_hpp, "    _used = 0;\n");
-  fprintf(fp_hpp, "    _mask <<= cycles;\n");
+  fprintf(fp_hpp, "    uint max_shift = 8 * sizeof(_mask) - 1;\n");
+  fprintf(fp_hpp, "    _mask <<= (cycles < max_shift) ? cycles : max_shift;\n");
   fprintf(fp_hpp, "  }\n\n");
   fprintf(fp_hpp, "  friend class Pipeline_Use;\n");
   fprintf(fp_hpp, "};\n\n");


### PR DESCRIPTION
Running a linux-aarch64-server-fastdebug build with UBSAN (--enable-ubsan configure option) gives the following runtime error immediately on JVM start:

```
ad_aarch64.hpp:7114:11: runtime error: shift exponent 100 is too large for 32-bit type 'unsigned int'
# Pipeline_Use_Cycle_Mask::operator<<=(int) make/hotspot/ad_aarch64.hpp:7114
# Pipeline_Use_Element::step(unsigned int) make/hotspot/ad_aarch64.hpp:7168
# Pipeline_Use::step(unsigned int) make/hotspot/ad_aarch64.hpp:7216
# Scheduling::step(unsigned int) src/hotspot/share/opto/output.cpp:2116
# Scheduling::AddNodeToBundle(Node*, Block const*) src/hotspot/share/opto/output.cpp:2553
```

The value of 100 comes from fixed_latency, defined in AD files:
```
// Pipeline class for call.
pipe_class pipe_class_call()
%{
  single_instruction;
  fixed_latency(100);
%}
```

The fixed_latency value is used by the scheduler to model the occupancy of functional units over time. The occupancy is tracked using a uint mask value:
```
  fprintf(fp_hpp, "class Pipeline_Use_Element {\n");
  fprintf(fp_hpp, "protected:\n");
  fprintf(fp_hpp, "  // Mask of used functional units\n");
  fprintf(fp_hpp, "  uint _used;\n\n");
```
When the scheduler virtually steps over the instruction, it shifts the masks left by the instruction's latency. The problem is that 100 is greater than sizeof(uint), and left-shifting by 100 effectively zeroes the _mask, but, according to the C++ standard, this is undefined behavior.

We can find a number of fixed_latency(100) expressions in aarch64.ad, arm.ad, ppc.ad, riscv.ad, x86_64.ad files. Perhaps all of them deserve correction. I suggest leaving the AD files as they are, but limiting the shift value in case it exceeds the allowed maximum in a generated code:
```diff
 void step(uint cycles) {
   _used = 0;
-  _mask <<= cycles;
+  uint max_shift = 8 * sizeof(_mask) - 1;
+  _mask <<= (cycles < max_shift) ? cycles : max_shift;
 }
```
In fact, this change does not affect the current behavior; we just eliminate the undefined behavior while preserving the intended semantics.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8332368: ubsan aarch64: immediate_aarch64.cpp:298:31: runtime error: shift exponent 32 is too large for 32-bit type 'int'`

### Issue
 * [JDK-8332368](https://bugs.openjdk.org/browse/JDK-8332368): ubsan aarch64: immediate_aarch64.cpp:298:31: runtime error: shift exponent 32 is too large for 32-bit type 'int' (**Bug** - P4)


### Reviewers
 * [Andrew Dinn](https://openjdk.org/census#adinn) (@adinn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24696/head:pull/24696` \
`$ git checkout pull/24696`

Update a local copy of the PR: \
`$ git checkout pull/24696` \
`$ git pull https://git.openjdk.org/jdk.git pull/24696/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24696`

View PR using the GUI difftool: \
`$ git pr show -t 24696`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24696.diff">https://git.openjdk.org/jdk/pull/24696.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24696#issuecomment-2812720617)
</details>
