### PR TITLE
JDK-8353942 : Open source Swing Tests - Set 5

### DIFF
--- a/test/jdk/javax/swing/DataTransfer/DragOverFeedbackTest.java
+++ b/test/jdk/javax/swing/DataTransfer/DragOverFeedbackTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4514071
+ * @summary Tests that JTable, JList and JTree provide drag-over feedback.
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual DragOverFeedbackTest
+ */
+
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.GridLayout;
+import java.awt.datatransfer.DataFlavor;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import javax.swing.BorderFactory;
+import javax.swing.JComponent;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JList;
+import javax.swing.JPanel;
+import javax.swing.JTable;
+import javax.swing.JTree;
+import javax.swing.TransferHandler;
+
+public class DragOverFeedbackTest {
+    private static final String INSTRUCTIONS = """
+        This test is designed to make sure that JTable, JTree, and JList
+        provide visual feedback when a DnD drag operation occurs over them.
+
+        Click on the label where it says "DRAG FROM HERE" and begin dragging.
+        Drag over each of the three components (JTable, JTree, JList).
+        While you're dragging over them, they should visually indicate the
+        location where a drop would occur. This visual indication may use the
+        selection but could be some other visual.
+
+        If above is true press PASS else press FAIL.
+        """;
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                .instructions(INSTRUCTIONS)
+                .columns(50)
+                .testUI(DragOverFeedbackTest::createTestUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static final TransferHandler handler = new TransferHandler() {
+        public boolean canImport(JComponent comp, DataFlavor[] flavors) {
+            return true;
+        }
+    };
+
+    private static JFrame createTestUI() {
+        JFrame frame = new JFrame("DragOverFeedbackTest");
+        final JLabel label = new JLabel("DRAG FROM HERE");
+        label.setPreferredSize(new Dimension(400, 25));
+        label.setTransferHandler(new TransferHandler("text"));
+        label.addMouseListener(new MouseAdapter() {
+            public void mousePressed(MouseEvent me) {
+                label.getTransferHandler().exportAsDrag(label, me, TransferHandler.COPY);
+            }
+        });
+        JTable table = new JTable(
+                            new String[][] {{"one"}, {"two"}, {"three"}, {"four"}},
+                            new String[] {"1"});
+        table.setRowSelectionInterval(1, 1);
+        table.setTransferHandler(handler);
+
+        JList list = new JList(new String[] {"one", "two", "three", "four"});
+        list.setSelectedIndex(1);
+        list.setTransferHandler(handler);
+
+        JTree tree = new JTree();
+        tree.setSelectionRow(1);
+        tree.setTransferHandler(handler);
+
+        frame.add(label, BorderLayout.NORTH);
+
+        JPanel wrapper = new JPanel();
+        wrapper.setLayout(new GridLayout(3, 1));
+        table.setBorder(BorderFactory.createLineBorder(Color.BLACK));
+        wrapper.add(table);
+        list.setBorder(BorderFactory.createLineBorder(Color.BLACK));
+        wrapper.add(list);
+        tree.setBorder(BorderFactory.createLineBorder(Color.BLACK));
+        wrapper.add(tree);
+        frame.add(wrapper);
+        frame.setSize(500, 500);
+        return frame;
+    }
+}

--- a/test/jdk/javax/swing/DataTransfer/ListDragOverFeedbackTest.java
+++ b/test/jdk/javax/swing/DataTransfer/ListDragOverFeedbackTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4546134
+ * @summary Tests that JList shows the right drop location when it has multiple columns.
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual ListDragOverFeedbackTest
+ */
+
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.GridLayout;
+import java.awt.datatransfer.DataFlavor;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import javax.swing.BorderFactory;
+import javax.swing.JComponent;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JList;
+import javax.swing.JPanel;
+import javax.swing.TransferHandler;
+
+public class ListDragOverFeedbackTest {
+    private static final String INSTRUCTIONS = """
+        JList should provide visual feedback when a DnD drag operation is
+        occurring over it. This test is to check that it provides the
+        feedback about the drop location correctly.
+
+        Click on the label where it says "DRAG FROM HERE" and begin dragging.
+        Drag over each column in each of the three JLists and make sure that
+        the drop location indicated is appropriate for the mouse location. For
+        instance, if the mouse is in the first column, the drop location should
+        also be indicated in that first column.
+
+        If above is true press PASS else press FAIL.
+        """;
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                .instructions(INSTRUCTIONS)
+                .columns(50)
+                .testUI(ListDragOverFeedbackTest::createTestUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static final TransferHandler handler = new TransferHandler() {
+        public boolean canImport(JComponent comp, DataFlavor[] flavors) {
+            return true;
+        }
+    };
+
+    private static JFrame createTestUI() {
+        String[] vals = new String[] {
+                "one", "two", "three", "four", "five", "six", "seven", "eight",
+                "nine", "ten", "eleven", "twelve", "thirteen", "fourteen"};
+
+        JFrame frame = new JFrame("ListDragOverFeedbackTest");
+        final JLabel label = new JLabel("DRAG FROM HERE");
+        label.setPreferredSize(new Dimension(400, 25));
+        label.setTransferHandler(new TransferHandler("text"));
+        label.addMouseListener(new MouseAdapter() {
+            public void mousePressed(MouseEvent me) {
+                label.getTransferHandler().exportAsDrag(label, me,
+                                              TransferHandler.COPY);
+            }
+        });
+
+        JList list1 = new JList(vals);
+        list1.setTransferHandler(handler);
+        list1.setBorder(BorderFactory.createLineBorder(Color.BLACK));
+
+        JList list2 = new JList(vals);
+        list2.setLayoutOrientation(JList.VERTICAL_WRAP);
+        list2.setTransferHandler(handler);
+        list2.setBorder(BorderFactory.createLineBorder(Color.BLACK));
+
+        JList list3 = new JList(vals);
+        list3.setLayoutOrientation(JList.HORIZONTAL_WRAP);
+        list3.setTransferHandler(handler);
+        list3.setBorder(BorderFactory.createLineBorder(Color.BLACK));
+
+        JPanel wrapper = new JPanel();
+        wrapper.setLayout(new GridLayout(3, 1));
+        wrapper.add(list1);
+        wrapper.add(list2);
+        wrapper.add(list3);
+
+        frame.add(label, BorderLayout.NORTH);
+        frame.add(wrapper);
+        frame.setSize(400, 450);
+        return frame;
+    }
+}

--- a/test/jdk/javax/swing/DataTransfer/ListDragOverFeedbackTest.java
+++ b/test/jdk/javax/swing/DataTransfer/ListDragOverFeedbackTest.java
@@ -113,7 +113,7 @@ public class ListDragOverFeedbackTest {
 
         frame.add(label, BorderLayout.NORTH);
         frame.add(wrapper);
-        frame.setSize(400, 450);
+        frame.setSize(400, 500);
         return frame;
     }
 }

--- a/test/jdk/javax/swing/DataTransfer/bug4655513.java
+++ b/test/jdk/javax/swing/DataTransfer/bug4655513.java
@@ -51,8 +51,8 @@ import javax.swing.SwingUtilities;
 
 public class bug4655513 {
     private static final String LINK_URL = "http://www.example.com";
-    private static JEditorPane editor;
-    private static JLabel dragSource;
+    private static volatile JEditorPane editor;
+    private static volatile JLabel dragSource;
     private static JFrame frame;
 
     public static void main(String[] args) throws Exception {

--- a/test/jdk/javax/swing/DataTransfer/bug4655513.java
+++ b/test/jdk/javax/swing/DataTransfer/bug4655513.java
@@ -73,9 +73,11 @@ public class bug4655513 {
             robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
             robot.delay(500);
 
-            if (!editor.getText().contains(LINK_URL)) {
-                throw new RuntimeException("Test Failed! Drag & Drop did not work.");
-            }
+            SwingUtilities.invokeAndWait(() -> {
+                if (!editor.getText().contains(LINK_URL)) {
+                    throw new RuntimeException("Test Failed! Drag & Drop did not work.");
+                }
+            });
         } finally {
             SwingUtilities.invokeAndWait(frame::dispose);
         }

--- a/test/jdk/javax/swing/DataTransfer/bug4655513.java
+++ b/test/jdk/javax/swing/DataTransfer/bug4655513.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @key headful
+ * @bug 4655513
+ * @summary TransferHandler doesn't recognize ACTION_LINK
+            as a valid drop action
+ * @library /javax/swing/regtesthelpers
+ * @build Util
+ * @run main bug4655513
+ */
+
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.datatransfer.StringSelection;
+import java.awt.dnd.DnDConstants;
+import java.awt.dnd.DragGestureRecognizer;
+import java.awt.dnd.DragSource;
+import java.awt.event.InputEvent;
+import java.awt.event.MouseEvent;
+import javax.swing.JEditorPane;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JScrollPane;
+import javax.swing.SwingUtilities;
+
+public class bug4655513 {
+    private static final String LINK_URL = "http://www.example.com";
+    private static JEditorPane editor;
+    private static JLabel dragSource;
+    private static JFrame frame;
+
+    public static void main(String[] args) throws Exception {
+        try {
+            Robot robot = new Robot();
+            SwingUtilities.invokeAndWait(bug4655513::createAndShowGUI);
+            robot.waitForIdle();
+            robot.delay(1000);
+
+            Point dragStartLoc = Util.getCenterPoint(dragSource);
+            Point dragEndLoc = Util.getCenterPoint(editor);
+            robot.mouseMove(dragStartLoc.x, dragStartLoc.y);
+            robot.mousePress(MouseEvent.BUTTON1_DOWN_MASK);
+            for (int y = dragStartLoc.y; y < dragEndLoc.y; y += 3) {
+                robot.mouseMove(dragStartLoc.x, y);
+                robot.delay(50);
+            }
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+            robot.delay(500);
+
+            if (!editor.getText().contains(LINK_URL)) {
+                throw new RuntimeException("Test Failed! Drag & Drop did not work.");
+            }
+        } finally {
+            SwingUtilities.invokeAndWait(frame::dispose);
+        }
+    }
+
+    private static void createAndShowGUI() {
+        frame = new JFrame("Bug4655513 - Data Transfer");
+        dragSource = new JLabel("To Test DnD, drag this label.");
+        dragSource.setForeground(Color.RED);
+        dragSource.setPreferredSize(new Dimension(250, 50));
+        frame.add(dragSource, BorderLayout.NORTH);
+
+        editor = new JEditorPane("text/plain", "Drop here.");
+        editor.setPreferredSize(new Dimension(250, 50));
+        frame.add(new JScrollPane(editor), BorderLayout.CENTER);
+
+        DragSource ds = new DragSource();
+        DragGestureRecognizer rec =
+            ds.createDefaultDragGestureRecognizer(dragSource,
+                    DnDConstants.ACTION_LINK,
+                    dge -> dge.startDrag(null, new StringSelection(LINK_URL)));
+        frame.setSize(300, 150);
+        frame.setLocationRelativeTo(null);
+        frame.setVisible(true);
+    }
+}

--- a/test/jdk/javax/swing/SwingUtilities/bug4369355.java
+++ b/test/jdk/javax/swing/SwingUtilities/bug4369355.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @key headful
+ * @bug 4369355
+ * @summary To verify if SwingUtilities.convertPointToScreen() (for invisible frame)
+ *          and SwingUtilities.convertPointFromScreen() return correct values
+ * @run main bug4369355
+ */
+
+import java.awt.Point;
+import java.awt.Robot;
+import javax.swing.JFrame;
+import javax.swing.SwingUtilities;
+
+public class bug4369355 {
+    private static JFrame frame;
+
+    private static volatile Point frameToScreenLoc;
+    private static volatile Point frameFromScreenLoc;
+
+    private static final Point EXPECTED_FROM_SCREEN_LOC = new Point(0, 0);
+    private static final Point EXPECTED_TO_SCREEN_LOC = new Point(100, 100);
+
+    public static void main (String[] args) throws Exception {
+        try {
+            Robot robot = new Robot();
+            SwingUtilities.invokeAndWait(() -> {
+                frame = new JFrame("bug4369355");
+                frame.setBounds(100, 100, 100, 100);
+            });
+            robot.waitForIdle();
+            robot.delay(1000);
+
+            SwingUtilities.invokeAndWait(() -> {
+                frameToScreenLoc = new Point(0, 0);
+                SwingUtilities.convertPointToScreen(frameToScreenLoc, frame);
+            });
+            robot.delay(100);
+
+            if (!frameToScreenLoc.equals(EXPECTED_TO_SCREEN_LOC)) {
+                throw new RuntimeException("SwingUtilities.convertPointToScreen()"
+                        + " returns incorrect point " + frameToScreenLoc + "\n"
+                        + "Should be " + EXPECTED_TO_SCREEN_LOC);
+            }
+
+            SwingUtilities.invokeAndWait(() -> frame.setVisible(true));
+            robot.delay(500);
+
+            SwingUtilities.invokeAndWait(() -> {
+                frameFromScreenLoc = frame.getLocationOnScreen();
+                SwingUtilities.convertPointFromScreen(frameFromScreenLoc, frame);
+            });
+            robot.delay(100);
+
+            if (!frameFromScreenLoc.equals(EXPECTED_FROM_SCREEN_LOC)) {
+                throw new RuntimeException("SwingUtilities.convertPointFromScreen()"
+                        + " returns incorrect point " + frameFromScreenLoc + "\n"
+                        + "Should be " + EXPECTED_FROM_SCREEN_LOC);
+            }
+        } finally {
+            SwingUtilities.invokeAndWait(frame::dispose);
+        }
+    }
+}
+

--- a/test/jdk/javax/swing/SwingUtilities/bug4369355.java
+++ b/test/jdk/javax/swing/SwingUtilities/bug4369355.java
@@ -85,4 +85,3 @@ public class bug4369355 {
         }
     }
 }
-

--- a/test/jdk/javax/swing/SwingUtilities/bug4967768.java
+++ b/test/jdk/javax/swing/SwingUtilities/bug4967768.java
@@ -24,6 +24,7 @@
 /*
  * @test
  * @bug 4967768
+ * @requires (os.family != "mac")
  * @summary Tests that underline is painted correctly in mnemonics
  * @library /java/awt/regtesthelpers
  * @build PassFailJFrame

--- a/test/jdk/javax/swing/SwingUtilities/bug4967768.java
+++ b/test/jdk/javax/swing/SwingUtilities/bug4967768.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2004, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4967768
+ * @summary Tests that underline is painted correctly in mnemonics
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual bug4967768
+ */
+
+import java.awt.Font;
+import javax.swing.JButton;
+import javax.swing.JPanel;
+
+public class bug4967768 {
+    private static final String INSTRUCTIONS = """
+            When the test starts you'll see a button "Oops"
+            with the "p" letter underlined at the bottom
+            of the instruction frame.
+
+            Ensure the underline cuts through the descender
+            of letter "p", i.e. the underline is painted
+            not below the letter but below the baseline.
+            """;
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                .instructions(INSTRUCTIONS)
+                .columns(35)
+                .splitUIBottom(bug4967768::createTestUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static JPanel createTestUI() {
+        JPanel panel = new JPanel();
+        JButton but = new JButton("Oops");
+        but.setFont(new Font("Dialog", Font.BOLD, 24));
+        but.setMnemonic('p');
+        panel.add(but);
+        return panel;
+    }
+}


### PR DESCRIPTION
Following test are open-sourced in this PR:

- javax/swing/DataTransfer/DragOverFeedbackTest.java - manual
- javax/swing/DataTransfer/ListDragOverFeedbackTest.java - manual
- javax/swing/DataTransfer/bug4655513.java - automated
- javax/swing/SwingUtilities/bug4369355.java - automated
- javax/swing/SwingUtilities/bug4967768.java - manual

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8353942](https://bugs.openjdk.org/browse/JDK-8353942): Open source Swing Tests - Set 5 (**Bug** - P4)


### Reviewers
 * [Damon Nguyen](https://openjdk.org/census#dnguyen) (@DamonGuy - Committer) Review applies to [32ad29e7](https://git.openjdk.org/jdk/pull/24698/files/32ad29e70ec87154c67511ac8ec2a1af55f5102e)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24698/head:pull/24698` \
`$ git checkout pull/24698`

Update a local copy of the PR: \
`$ git checkout pull/24698` \
`$ git pull https://git.openjdk.org/jdk.git pull/24698/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24698`

View PR using the GUI difftool: \
`$ git pr show -t 24698`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24698.diff">https://git.openjdk.org/jdk/pull/24698.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24698#issuecomment-2810724158)
</details>
