### PR TITLE
8354944: Remove unnecessary PartiallyOrderedSet.nodes

### DIFF
--- a/src/java.desktop/share/classes/javax/imageio/spi/PartiallyOrderedSet.java
+++ b/src/java.desktop/share/classes/javax/imageio/spi/PartiallyOrderedSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,6 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * A set of {@code Object}s with pairwise orderings between them.
@@ -58,10 +57,7 @@ class PartiallyOrderedSet<E> extends AbstractSet<E> {
     // p. 315.
 
     // Maps Objects to DigraphNodes that contain them
-    private Map<E, DigraphNode<E>> poNodes = new HashMap<>();
-
-    // The set of Objects
-    private Set<E> nodes = poNodes.keySet();
+    private final Map<E, DigraphNode<E>> poNodes = new HashMap<>();
 
     /**
      * Constructs a {@code PartiallyOrderedSet}.
@@ -69,11 +65,11 @@ class PartiallyOrderedSet<E> extends AbstractSet<E> {
     public PartiallyOrderedSet() {}
 
     public int size() {
-        return nodes.size();
+        return poNodes.size();
     }
 
     public boolean contains(Object o) {
-        return nodes.contains(o);
+        return poNodes.containsKey(o);
     }
 
     /**
@@ -90,7 +86,7 @@ class PartiallyOrderedSet<E> extends AbstractSet<E> {
      * {@code PartiallyOrderedSet}.
      */
     public boolean add(E o) {
-        if (nodes.contains(o)) {
+        if (poNodes.containsKey(o)) {
             return false;
         }
 


### PR DESCRIPTION
We can use `javax.imageio.spi.PartiallyOrderedSet#poNodes` directly

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8354944](https://bugs.openjdk.org/browse/JDK-8354944): Remove unnecessary PartiallyOrderedSet.nodes (**Enhancement** - P5)


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24699/head:pull/24699` \
`$ git checkout pull/24699`

Update a local copy of the PR: \
`$ git checkout pull/24699` \
`$ git pull https://git.openjdk.org/jdk.git pull/24699/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24699`

View PR using the GUI difftool: \
`$ git pr show -t 24699`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24699.diff">https://git.openjdk.org/jdk/pull/24699.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24699#issuecomment-2812688010)
</details>
