### PR TITLE
8354898: jdk/internal/loader/NativeLibraries/Main.java fails on static JDK

### DIFF
--- a/test/jdk/jdk/internal/loader/NativeLibraries/Main.java
+++ b/test/jdk/jdk/internal/loader/NativeLibraries/Main.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 /*
  * @test
  * @bug 8240975 8281335
+ * @library /test/lib
  * @modules java.base/jdk.internal.loader
  * @build java.base/* p.Test Main
  * @run main/othervm/native -Xcheck:jni Main
@@ -31,6 +32,7 @@
  */
 
 import jdk.internal.loader.NativeLibrariesTest;
+import jdk.test.lib.Platform;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -55,7 +57,9 @@ public class Main {
         test.unload();
 
         // load zip library from JDK
-        test.load(System.mapLibraryName("zip"), true /* succeed */);
+        if (!Platform.isStatic()) {
+            test.load(System.mapLibraryName("zip"), true /* succeed */);
+        }
 
         // load non-existent library
         test.load(System.mapLibraryName("NotExist"), false /* fail to load */);


### PR DESCRIPTION
Please review this simple test change that skips the test case loading using JDK `libzip.so` on static JDK in test/jdk/jdk/internal/loader/NativeLibraries/Main.java. AFAICT, the test case using `NativeLibrariesTest.LIB_NAME` (`libnativeLibrariesTest.so`) can provide coverage on static JDK.

Thanks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8354898](https://bugs.openjdk.org/browse/JDK-8354898): jdk/internal/loader/NativeLibraries/Main.java fails on static JDK (**Bug** - P4)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24704/head:pull/24704` \
`$ git checkout pull/24704`

Update a local copy of the PR: \
`$ git checkout pull/24704` \
`$ git pull https://git.openjdk.org/jdk.git pull/24704/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24704`

View PR using the GUI difftool: \
`$ git pr show -t 24704`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24704.diff">https://git.openjdk.org/jdk/pull/24704.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24704#issuecomment-2811159037)
</details>
