### PR TITLE
8353214: Add testing with --enable-preview

### DIFF
--- a/make/RunTests.gmk
+++ b/make/RunTests.gmk
@@ -929,6 +929,11 @@ define SetupRunJtregTestBody
     JTREG_AUTO_PROBLEM_LISTS += ProblemList-shenandoah.txt
   endif
 
+  ifneq ($$(findstring --enable-preview, $$(JTREG_ALL_OPTIONS)), )
+    JTREG_AUTO_PROBLEM_LISTS += ProblemList-enable-preview.txt
+  endif
+
+
   ifneq ($$(JTREG_EXTRA_PROBLEM_LISTS), )
     # Accept both absolute paths as well as relative to the current test root.
     $1_JTREG_BASIC_OPTIONS += $$(addprefix $$(JTREG_PROBLEM_LIST_PREFIX), $$(wildcard \

--- a/test/hotspot/jtreg/ProblemList-enable-preview.txt
+++ b/test/hotspot/jtreg/ProblemList-enable-preview.txt
@@ -1,0 +1,31 @@
+#
+# Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+#
+
+#############################################################################
+#
+# List of quarantined tests for testing with --enable-preview
+#
+#############################################################################
+
+vmTestbase/nsk/jdi/ClassType/invokeMethod/invokemethod009/TestDescription.java  8351188 generic-all
+

--- a/test/jdk/ProblemList-enable-preview.txt
+++ b/test/jdk/ProblemList-enable-preview.txt
@@ -1,0 +1,32 @@
+#
+# Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+#
+
+#############################################################################
+#
+# List of quarantined tests for testing with --enable-preview
+#
+#############################################################################
+
+java/lang/System/SecurityManagerWarnings.java                                        8351188 generic-all
+java/lang/System/LoggerFinder/SignedLoggerFinderTest/SignedLoggerFinderTest.java     8351188 generic-all
+

--- a/test/jdk/jdk/modules/etc/DefaultModules.java
+++ b/test/jdk/jdk/modules/etc/DefaultModules.java
@@ -24,6 +24,7 @@
 /**
  * @test
  * @bug 8197532
+ * @requires !java.enablePreview
  * @modules jdk.compiler
  *          jdk.jlink
  *          jdk.zipfs


### PR DESCRIPTION
Added problemlists and and requires for execution tests with --enable-preview.

The --enable-preview features might significantly change VM/JDK behavior and sometimes it is useful to run tests with preview features enabled. Eventually preview features should be made default and it is expected that all tests should still work. 

The tests that are not compatible with --enable-preview, usually because of compilation mode are marked with corresponding requires tag.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8353214](https://bugs.openjdk.org/browse/JDK-8353214): Add testing with --enable-preview (**Enhancement** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24706/head:pull/24706` \
`$ git checkout pull/24706`

Update a local copy of the PR: \
`$ git checkout pull/24706` \
`$ git pull https://git.openjdk.org/jdk.git pull/24706/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24706`

View PR using the GUI difftool: \
`$ git pr show -t 24706`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24706.diff">https://git.openjdk.org/jdk/pull/24706.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24706#issuecomment-2811364594)
</details>
