### PR TITLE
8354900: javax/swing/AbstractButton/bug4133768.java failing on macosx-aarch64

### DIFF
--- a/test/jdk/javax/swing/AbstractButton/bug4133768.java
+++ b/test/jdk/javax/swing/AbstractButton/bug4133768.java
@@ -50,7 +50,8 @@ import javax.swing.JToggleButton;
 import javax.swing.SwingUtilities;
 
 public class bug4133768 {
-    private static Icon RED, GREEN;
+    private static Icon RED;
+    private static Icon GREEN;
     private static JFrame f;
     private static AbstractButton[] buttons;
     private static volatile Point buttonLocation;
@@ -58,7 +59,8 @@ public class bug4133768 {
     private static volatile int buttonHeight;
     private static Robot robot;
     private static int ROLLOVER_Y_OFFSET = 4;
-    private static CountDownLatch frameGainedFocusLatch = new CountDownLatch(1);
+    private static CountDownLatch frameGainedFocusLatch =
+        new CountDownLatch(1);
 
     public static void main(String[] args) throws Exception {
         try {

--- a/test/jdk/javax/swing/AbstractButton/bug4133768.java
+++ b/test/jdk/javax/swing/AbstractButton/bug4133768.java
@@ -34,8 +34,11 @@ import java.awt.Graphics2D;
 import java.awt.GridLayout;
 import java.awt.Point;
 import java.awt.Robot;
+import java.awt.event.FocusAdapter;
+import java.awt.event.FocusEvent;
 import java.awt.image.BufferedImage;
-import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import javax.swing.AbstractButton;
 import javax.swing.Icon;
 import javax.swing.ImageIcon;
@@ -54,13 +57,19 @@ public class bug4133768 {
     private static volatile int buttonWidth;
     private static volatile int buttonHeight;
     private static Robot robot;
+    private static int ROLLOVER_Y_OFFSET = 4;
+    private static CountDownLatch frameGainedFocusLatch = new CountDownLatch(1);
 
     public static void main(String[] args) throws Exception {
         try {
             createTestImages();
             createUI();
+            f.requestFocus();
+            if (!frameGainedFocusLatch.await(5, TimeUnit.SECONDS)) {
+                throw new RuntimeException("Waited too long, but can't gain" +
+                    " focus for frame");
+            }
             robot = new Robot();
-            robot.delay(1000);
             for (AbstractButton b : buttons) {
                 testEnabledButton(b);
             }
@@ -78,9 +87,9 @@ public class bug4133768 {
         }
     }
 
-    private static void createTestImages() throws IOException {
-        int imageWidth = 32;
-        int imageHeight = 32;
+    private static void createTestImages() {
+        int imageWidth = 100;
+        int imageHeight = 100;
         BufferedImage redImg = new BufferedImage(imageWidth, imageHeight,
             BufferedImage.TYPE_INT_RGB);
         Graphics2D g = redImg.createGraphics();
@@ -114,6 +123,12 @@ public class bug4133768 {
                 b.setRolloverSelectedIcon(GREEN);
                 buttonPanel.add(b);
             }
+            f.addFocusListener(new FocusAdapter() {
+                @Override
+                public void focusGained(FocusEvent e) {
+                    frameGainedFocusLatch.countDown();
+                }
+            });
             f.setLayout(new GridLayout(2, 1));
             f.add(buttonPanel);
             f.pack();
@@ -123,7 +138,8 @@ public class bug4133768 {
         });
     }
 
-    private static void testEnabledButton(AbstractButton button) throws Exception {
+    private static void testEnabledButton(AbstractButton button)
+        throws Exception {
         robot.waitForIdle();
         SwingUtilities.invokeAndWait(() -> {
             buttonLocation = button.getLocationOnScreen();
@@ -131,7 +147,7 @@ public class bug4133768 {
             buttonHeight = button.getHeight();
         });
         robot.mouseMove(buttonLocation.x + buttonWidth / 2,
-            buttonLocation.y + buttonHeight / 2 );
+            buttonLocation.y + ROLLOVER_Y_OFFSET);
         robot.delay(1000);
         Color buttonColor = robot.getPixelColor(buttonLocation.x +
             buttonWidth / 2, buttonLocation.y + buttonHeight / 2);
@@ -141,16 +157,15 @@ public class bug4133768 {
         }
     }
 
-    private static void testDisabledButton(AbstractButton button) throws Exception {
+    private static void testDisabledButton(AbstractButton button)
+        throws Exception {
         robot.waitForIdle();
         SwingUtilities.invokeAndWait(() -> {
             buttonLocation = button.getLocationOnScreen();
             buttonWidth = button.getWidth();
             buttonHeight = button.getHeight();
         });
-        robot.mouseMove(buttonLocation.x + buttonWidth / 2,
-            buttonLocation.y + buttonHeight / 2 );
-        robot.delay(1000);
+        robot.delay(200);
         Color buttonColor = robot.getPixelColor(buttonLocation.x +
             buttonWidth / 2, buttonLocation.y + buttonHeight / 2);
         if (buttonColor.equals(Color.GREEN) ||


### PR DESCRIPTION
javax/swing/AbstractButton/bug4133768.java was automated and open-sourced recently and it fails intermittently in CI.

Looks like when we have mouse pointer at same location from where we are picking UI color from robot, it picks wrong color.

Updated test to have mouse pointer to be at different place from where we are picking roll-over color of buttons.
Also made other changes to make test more robust. With all these changes test now passes all the time in CI.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8354900](https://bugs.openjdk.org/browse/JDK-8354900): javax/swing/AbstractButton/bug4133768.java failing on macosx-aarch64 (**Bug** - P3)


### Reviewers
 * [Abhishek Kumar](https://openjdk.org/census#abhiscxk) (@kumarabhi006 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24712/head:pull/24712` \
`$ git checkout pull/24712`

Update a local copy of the PR: \
`$ git checkout pull/24712` \
`$ git pull https://git.openjdk.org/jdk.git pull/24712/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24712`

View PR using the GUI difftool: \
`$ git pr show -t 24712`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24712.diff">https://git.openjdk.org/jdk/pull/24712.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24712#issuecomment-2811859995)
</details>
