### PR TITLE
8352075: Perf regression accessing fields

### DIFF
--- a/src/hotspot/share/classfile/fieldLayoutBuilder.cpp
+++ b/src/hotspot/share/classfile/fieldLayoutBuilder.cpp
@@ -301,7 +301,7 @@ void FieldLayout::reconstruct_layout(const InstanceKlass* ik, bool& has_instance
   BasicType last_type;
   int last_offset = -1;
   while (ik != nullptr) {
-    for (AllFieldStream fs(ik->fieldinfo_stream(), ik->constants()); !fs.done(); fs.next()) {
+    for (AllFieldStream fs(ik); !fs.done(); fs.next()) {
       BasicType type = Signature::basic_type(fs.signature());
       // distinction between static and non-static fields is missing
       if (fs.access_flags().is_static()) continue;
@@ -461,7 +461,7 @@ void FieldLayout::print(outputStream* output, bool is_static, const InstanceKlas
         bool found = false;
         const InstanceKlass* ik = super;
         while (!found && ik != nullptr) {
-          for (AllFieldStream fs(ik->fieldinfo_stream(), ik->constants()); !fs.done(); fs.next()) {
+          for (AllFieldStream fs(ik); !fs.done(); fs.next()) {
             if (fs.offset() == b->offset()) {
               output->print_cr(" @%d \"%s\" %s %d/%d %s",
                   b->offset(),

--- a/src/hotspot/share/oops/fieldInfo.hpp
+++ b/src/hotspot/share/oops/fieldInfo.hpp
@@ -234,20 +234,19 @@ class FieldInfoReader {
   UNSIGNED5::Reader<const u1*, int> _r;
   int _next_index;
 
-  public:
+public:
   FieldInfoReader(const Array<u1>* fi);
 
-  private:
+private:
   uint32_t next_uint() { return _r.next_uint(); }
   void skip(int n) { int s = _r.try_skip(n); assert(s == n,""); }
-
-public:
   void skip_bytes(int bytes) {
     assert(bytes >= 0, "skipping negative");
     // no bounds checking; r._limit() is not set
     _r.set_position(_r.position() + bytes);
   }
 
+public:
   int has_next() const { return _r.has_next(); }
   int position() const { return _r.position(); }
   int next_index() const { return _next_index; }

--- a/src/hotspot/share/oops/fieldInfo.inline.hpp
+++ b/src/hotspot/share/oops/fieldInfo.inline.hpp
@@ -97,10 +97,13 @@ inline FieldInfoReader::FieldInfoReader(const Array<u1>* fi)
   : _r(fi->data(), 0),
     _next_index(0) { }
 
-inline void FieldInfoReader::read_field_info(FieldInfo& fi) {
+inline void FieldInfoReader::read_name_signature(FieldInfo& fi) {
   fi._index = _next_index++;
   fi._name_index = checked_cast<u2>(next_uint());
   fi._signature_index = checked_cast<u2>(next_uint());
+}
+
+inline void FieldInfoReader::read_partial_record(FieldInfo& fi) {
   fi._offset = next_uint();
   fi._access_flags = AccessFlags(checked_cast<u2>(next_uint()));
   fi._field_flags = FieldInfo::FieldFlags(next_uint());

--- a/src/hotspot/share/oops/fieldStreams.inline.hpp
+++ b/src/hotspot/share/oops/fieldStreams.inline.hpp
@@ -33,6 +33,7 @@
 FieldStreamBase::FieldStreamBase(const Array<u1>* fieldinfo_stream, ConstantPool* constants, int start, int limit) :
          _fieldinfo_stream(fieldinfo_stream),
          _reader(FieldInfoReader(_fieldinfo_stream)),
+         _ctrl_offset(0),
          _constants(constantPoolHandle(Thread::current(), constants)), _index(start) {
   _index = start;
   if (limit < start) {
@@ -43,9 +44,10 @@ FieldStreamBase::FieldStreamBase(const Array<u1>* fieldinfo_stream, ConstantPool
   initialize();
 }
 
-FieldStreamBase::FieldStreamBase(Array<u1>* fieldinfo_stream, ConstantPool* constants) :
+FieldStreamBase::FieldStreamBase(const Array<u1>* fieldinfo_stream, ConstantPool* constants) :
         _fieldinfo_stream(fieldinfo_stream),
         _reader(FieldInfoReader(_fieldinfo_stream)),
+        _ctrl_offset(0),
         _constants(constantPoolHandle(Thread::current(), constants)),
         _index(0),
         _limit(FieldInfoStream::num_total_fields(_fieldinfo_stream)) {
@@ -55,6 +57,7 @@ FieldStreamBase::FieldStreamBase(Array<u1>* fieldinfo_stream, ConstantPool* cons
 FieldStreamBase::FieldStreamBase(InstanceKlass* klass) :
          _fieldinfo_stream(klass->fieldinfo_stream()),
          _reader(FieldInfoReader(_fieldinfo_stream)),
+         _ctrl_offset(0),
          _constants(constantPoolHandle(Thread::current(), klass->constants())),
          _index(0),
          _limit(FieldInfoStream::num_total_fields(_fieldinfo_stream)) {

--- a/src/hotspot/share/utilities/unsigned5.hpp
+++ b/src/hotspot/share/utilities/unsigned5.hpp
@@ -261,7 +261,7 @@ class UNSIGNED5 : AllStatic {
     ARR _array;
     OFF _limit;
     OFF _position;
-    int next_length() {
+    int next_length() const {
       return UNSIGNED5::check_length(_array, _position, _limit, GET());
     }
   public:
@@ -270,7 +270,7 @@ class UNSIGNED5 : AllStatic {
     uint32_t next_uint() {
       return UNSIGNED5::read_uint(_array, _position, _limit, GET());
     }
-    bool has_next() {
+    bool has_next() const {
       return next_length() != 0;
     }
     // tries to skip count logical entries; returns actual number skipped
@@ -284,8 +284,8 @@ class UNSIGNED5 : AllStatic {
       return actual;
     }
     ARR array() { return _array; }
-    OFF limit() { return _limit; }
-    OFF position() { return _position; }
+    OFF limit() const { return _limit; }
+    OFF position() const { return _position; }
     void set_position(OFF position) { _position = position; }
 
     // For debugging, even in product builds (see debug.cpp).
@@ -390,6 +390,9 @@ class UNSIGNED5 : AllStatic {
     void accept_uint(uint32_t value) {
       _position += encoded_length(value);
       _count++;
+    }
+    void accept_bytes(OFF bytes) {
+      _position += bytes;
     }
     OFF position() { return _position; }
     int count() { return _count; }

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/code/CompressedStream.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/code/CompressedStream.java
@@ -63,6 +63,10 @@ public class CompressedStream {
     this.position = position;
   }
 
+  public void skipBytes(int bytes) {
+    this.position += bytes;
+  }
+
   public int encodeSign(int value) {
     return Unsigned5.encodeSign(value);
   }

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/Field.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/Field.java
@@ -111,6 +111,7 @@ public class Field {
     int numJavaFields = crs.readInt();     // read num_java_fields
     int numInjectedFields = crs.readInt(); // read num_injected_fields;
     int numFields = numJavaFields + numInjectedFields;
+    crs.skipBytes(numFields);
     Field[] fields = new Field[numFields];
     for (int i = 0; i < numFields; i++) {
       FieldInfoValues values = readFieldInfoValues(crs);


### PR DESCRIPTION
This optimization is a followup to https://github.com/openjdk/jdk/pull/24290 trying to reduce the performance regression in some scenarios introduced in https://bugs.openjdk.org/browse/JDK-8292818

Iteration through the field stream of several variable-length-encoded items is limited by inherent dependency of fully decoding the field before knowing the position of next field. On the critical codepath addressed by this PR, only the name and signature indices from are used though.
Inspired by the Varint-GB and Varint-G81U encodings, the idea of this change is in adding a control stream to the stream of field infos; each field uses one byte of this control stream, and currently the lower 6 bits encode the length of the encoded field, allowing more efficient skipping through the stream. The most significant bit duplicates the injected field flag (name/signature lookup requires that), one bit is currently unused.

My measurements on the attached reproducer
```
hyperfine -w 50 -r 100 '/path/to/jdk-17/bin/java -cp /tmp CCC'
Benchmark 1: /path/to/jdk-17/bin/java -cp /tmp CCC
  Time (mean ± σ):      51.3 ms ±   2.8 ms    [User: 44.7 ms, System: 13.7 ms]
  Range (min … max):    45.1 ms …  53.9 ms    100 runs
```
```
hyperfine -w 50 -r 100 '/path/to/jdk25-master/bin/java -cp /tmp CCC'
Benchmark 1: /path/to/jdk25-master/bin/java -cp /tmp CCC
  Time (mean ± σ):      78.2 ms ±   1.0 ms    [User: 74.6 ms, System: 17.3 ms]
  Range (min … max):    73.8 ms …  79.7 ms    100 runs
```
(the `jdk25-master` above already contains JDK-8353175)
```
hyperfine -w 50 -r 100 '/path/to/jdk25-this-pr/bin/java -cp /tmp CCC'
Benchmark 1: /path/to/jdk25-this-pr/bin/java -cp /tmp CCC
  Time (mean ± σ):      51.8 ms ±   2.1 ms    [User: 48.9 ms, System: 16.8 ms]
  Range (min … max):    47.4 ms …  55.1 ms    100 runs
```
So in case of the synthetic reproducer we're already on the level of JDK 17. However, the undisclosed production-grade reproducer still shows regression, so there is still space for optimization.
```
JDK 17: 1.6 s
JDK 21 (no patches): 22 s
JDK25-master: 12.3 s
JDK25-this-pr: 3.1 s
```

About the downsides: This PR increases the consumption by 1 byte for each field in loaded classes. I've executed some tests on a simple Spring Boot application with 6800 instance classes loaded -> about 16k fields in total, with NMT on; the memory usage (Class.Metadata.used) seems to have grown by 32kB; this discrepancy could be investigated later on.

Architecturally, I had to remove `const`ness from some methods on `FieldStreamBase`.

I think that the memory usage difference is negligible in the practice; if this matters, though, I have implemented two more optimizations in https://github.com/rvansa/jdk/tree/JDK-8352075-dev that should give the byte back, in average. However these optimizations have reduced performance in all of the benchmarks, hence I would prefer not to apply these.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8352075](https://bugs.openjdk.org/browse/JDK-8352075): Perf regression accessing fields (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24713/head:pull/24713` \
`$ git checkout pull/24713`

Update a local copy of the PR: \
`$ git checkout pull/24713` \
`$ git pull https://git.openjdk.org/jdk.git pull/24713/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24713`

View PR using the GUI difftool: \
`$ git pr show -t 24713`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24713.diff">https://git.openjdk.org/jdk/pull/24713.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24713#issuecomment-2812008971)
</details>
