### PR TITLE
8354919: Move HotSpot .editorconfig into the global .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,3 +5,7 @@ trim_trailing_whitespace = true
 
 [Makefile]
 trim_trailing_whitespace = true
+
+[src/hotspot/**.{cpp,hpp,h}]
+indent_style = space
+indent_size = 2

--- a/src/hotspot/.editorconfig
+++ b/src/hotspot/.editorconfig
@@ -1,3 +1,0 @@
-[*.{cpp,hpp,c,h}]
-indent_style = space
-indent_size = 2


### PR DESCRIPTION
The src/hotspot directory should ideally only be used for HotSpot source files, and we should avoid polluting it with an .editorconfig. A cleaner solution exists since we can just specify the desired code formatting for HotSpot as an override in the root .editorconfig

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8354919](https://bugs.openjdk.org/browse/JDK-8354919): Move HotSpot .editorconfig into the global .editorconfig (**Enhancement** - P5)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24714/head:pull/24714` \
`$ git checkout pull/24714`

Update a local copy of the PR: \
`$ git checkout pull/24714` \
`$ git pull https://git.openjdk.org/jdk.git pull/24714/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24714`

View PR using the GUI difftool: \
`$ git pr show -t 24714`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24714.diff">https://git.openjdk.org/jdk/pull/24714.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24714#issuecomment-2812053805)
</details>
