### PR TITLE
8354922: ZGC: Use MAP_FIXED_NOREPLACE when reserving memory

### DIFF
--- a/src/hotspot/os/linux/gc/z/zSyscall_linux.hpp
+++ b/src/hotspot/os/linux/gc/z/zSyscall_linux.hpp
@@ -35,6 +35,10 @@
 #define MPOL_F_ADDR        (1<<1)
 #endif
 
+#ifndef MAP_FIXED_NOREPLACE
+#define MAP_FIXED_NOREPLACE 0x100000
+#endif
+
 class ZSyscall : public AllStatic {
 public:
   static int memfd_create(const char* name, unsigned int flags);

--- a/src/hotspot/os/posix/gc/z/zVirtualMemoryManager_posix.cpp
+++ b/src/hotspot/os/posix/gc/z/zVirtualMemoryManager_posix.cpp
@@ -24,6 +24,9 @@
 #include "gc/z/zAddress.inline.hpp"
 #include "gc/z/zVirtualMemoryManager.hpp"
 #include "logging/log.hpp"
+#ifdef LINUX
+#include "gc/z/zSyscall_linux.hpp"
+#endif
 
 #include <sys/mman.h>
 
@@ -32,7 +35,9 @@ void ZVirtualMemoryReserver::pd_register_callbacks(ZVirtualMemoryRegistry* regis
 }
 
 bool ZVirtualMemoryReserver::pd_reserve(zaddress_unsafe addr, size_t size) {
-  void* const res = mmap((void*)untype(addr), size, PROT_NONE, MAP_ANONYMOUS|MAP_PRIVATE|MAP_NORESERVE, -1, 0);
+  const int flags = MAP_ANONYMOUS|MAP_PRIVATE|MAP_NORESERVE LINUX_ONLY(|MAP_FIXED_NOREPLACE);
+
+  void* const res = mmap((void*)untype(addr), size, PROT_NONE, flags, -1, 0);
   if (res == MAP_FAILED) {
     // Failed to reserve memory
     return false;


### PR DESCRIPTION
We have seen that some versions of the Linux kernel does not honor the address hint when mmapping memory without MAP_FIXED, if there is an adjacent memory area above the requested memory area. If we use MAP_FIXED_NOREPLACE, the reservation succeeds. I propose that we start using MAP_FIXED_NOREPLACE.

Tested via GHA, which runs the gtest that performs a discontiguous, but adjacent reservation. I will run this through a bunch of tiers before integrating.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8354922](https://bugs.openjdk.org/browse/JDK-8354922): ZGC: Use MAP_FIXED_NOREPLACE when reserving memory (**Enhancement** - P4)


### Reviewers
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - **Reviewer**)
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24716/head:pull/24716` \
`$ git checkout pull/24716`

Update a local copy of the PR: \
`$ git checkout pull/24716` \
`$ git pull https://git.openjdk.org/jdk.git pull/24716/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24716`

View PR using the GUI difftool: \
`$ git pr show -t 24716`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24716.diff">https://git.openjdk.org/jdk/pull/24716.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24716#issuecomment-2812558663)
</details>
