### PR TITLE
8354926: Remove remnants of debugging in the fix for JDK-8348561 and JDK-8349721

### DIFF
--- a/src/hotspot/cpu/aarch64/stubDeclarations_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/stubDeclarations_aarch64.hpp
@@ -44,7 +44,7 @@
                                        do_arch_blob,                    \
                                        do_arch_entry,                   \
                                        do_arch_entry_init)              \
-  do_arch_blob(compiler, 75000 ZGC_ONLY(+5000))                         \
+  do_arch_blob(compiler, 65000 ZGC_ONLY(+5000))                         \
   do_stub(compiler, vector_iota_indices)                                \
   do_arch_entry(aarch64, compiler, vector_iota_indices,                 \
                 vector_iota_indices, vector_iota_indices)               \

--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -714,7 +714,6 @@ void VM_Version::initialize_cpu_information(void) {
   get_compatible_board(_cpu_desc + desc_len, CPU_DETAILED_DESC_BUF_SIZE - desc_len);
   desc_len = (int)strlen(_cpu_desc);
   snprintf(_cpu_desc + desc_len, CPU_DETAILED_DESC_BUF_SIZE - desc_len, " %s", _features_string);
-  fprintf(stderr, "_features_string = \"%s\"", _features_string);
 
   _initialized = true;
 }


### PR DESCRIPTION
…JDK-8349721

Trivial modifications fixing changes used during debugging and ment to (but had been forgatten to) be  fixed before integration.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8354926](https://bugs.openjdk.org/browse/JDK-8354926): Remove remnants of debugging in the fix for JDK-8348561 and JDK-8349721 (**Bug** - P3)


### Reviewers
 * [Andrew Dinn](https://openjdk.org/census#adinn) (@adinn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24717/head:pull/24717` \
`$ git checkout pull/24717`

Update a local copy of the PR: \
`$ git checkout pull/24717` \
`$ git pull https://git.openjdk.org/jdk.git pull/24717/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24717`

View PR using the GUI difftool: \
`$ git pr show -t 24717`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24717.diff">https://git.openjdk.org/jdk/pull/24717.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24717#issuecomment-2812335148)
</details>
