### PR TITLE
8183348: Better cleanup for jdk/test/sun/security/pkcs12/P12SecretKey.java

### DIFF
--- a/test/jdk/sun/security/pkcs12/P12SecretKey.java
+++ b/test/jdk/sun/security/pkcs12/P12SecretKey.java
@@ -31,8 +31,6 @@
  * @run main P12SecretKey pkcs12 DESede 168
  */
 
-import jdk.test.lib.Utils;
-
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -41,6 +39,8 @@ import java.util.Arrays;
 
 import javax.crypto.KeyGenerator;
 import javax.crypto.SecretKey;
+
+import static jdk.test.lib.Utils.createTempFile;
 
 public class P12SecretKey {
 
@@ -68,7 +68,12 @@ public class P12SecretKey {
         ks.setEntry(ALIAS, ske, kspp);
 
         // temporary files are created in scratch directory
-        final File ksFile = Utils.createTempFile("test", ".test").toFile();
+        final File ksFile = createTempFile(
+                String.format("%s-%s-%d-",
+                                keystoreType,
+                                algName,
+                                keySize),
+                ".ks").toFile();
 
         try (FileOutputStream fos = new FileOutputStream(ksFile)) {
             ks.store(fos, pw);
@@ -85,8 +90,8 @@ public class P12SecretKey {
                 System.err.println("OK: worked just fine with " + keystoreType +
                                    " keystore");
             } else {
-                System.err.println("ERROR: keys are NOT equal after storing in "
-                                   + keystoreType + " keystore");
+                throw new RuntimeException("ERROR: keys are NOT equal after storing in "
+                                           + keystoreType + " keystore");
             }
         }
     }

--- a/test/jdk/sun/security/pkcs12/P12SecretKey.java
+++ b/test/jdk/sun/security/pkcs12/P12SecretKey.java
@@ -25,10 +25,13 @@
  * @test
  * @bug 8149411 8007632
  * @summary Get AES key from keystore (uses SecretKeySpec not SecretKeyFactory)
+ * @library /test/lib
  * @run main P12SecretKey pkcs12 AES 128
  * @run main P12SecretKey pkcs12 DES 56
  * @run main P12SecretKey pkcs12 DESede 168
  */
+
+import jdk.test.lib.Utils;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -65,7 +68,7 @@ public class P12SecretKey {
         ks.setEntry(ALIAS, ske, kspp);
 
         // temporary files are created in scratch directory
-        final File ksFile = File.createTempFile("test", ".test", new File("."));
+        final File ksFile = Utils.createTempFile("test", ".test").toFile();
 
         try (FileOutputStream fos = new FileOutputStream(ksFile)) {
             ks.store(fos, pw);

--- a/test/jdk/sun/security/pkcs12/P12SecretKey.java
+++ b/test/jdk/sun/security/pkcs12/P12SecretKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,9 +33,7 @@
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
-import java.nio.file.Files;
 import java.security.KeyStore;
-import java.security.cert.CertificateException;
 import java.util.Arrays;
 
 import javax.crypto.KeyGenerator;
@@ -66,30 +64,27 @@ public class P12SecretKey {
         KeyStore.ProtectionParameter kspp = new KeyStore.PasswordProtection(pw);
         ks.setEntry(ALIAS, ske, kspp);
 
-        File ksFile = File.createTempFile("test", ".test");
+        // temporary files are created in scratch directory
+        final File ksFile = File.createTempFile("test", ".test", new File("."));
 
-        try {
-            try (FileOutputStream fos = new FileOutputStream(ksFile)) {
-                ks.store(fos, pw);
-                fos.flush();
-            }
+        try (FileOutputStream fos = new FileOutputStream(ksFile)) {
+            ks.store(fos, pw);
+            fos.flush();
+        }
 
-            // now see if we can get it back
-            try (FileInputStream fis = new FileInputStream(ksFile)) {
-                KeyStore ks2 = KeyStore.getInstance(keystoreType);
-                ks2.load(fis, pw);
-                KeyStore.Entry entry = ks2.getEntry(ALIAS, kspp);
-                SecretKey keyIn = ((KeyStore.SecretKeyEntry) entry).getSecretKey();
-                if (Arrays.equals(key.getEncoded(), keyIn.getEncoded())) {
-                    System.err.println("OK: worked just fine with " + keystoreType +
-                            " keystore");
-                } else {
-                    System.err.println("ERROR: keys are NOT equal after storing in "
-                            + keystoreType + " keystore");
-                }
+        // now see if we can get it back
+        try (FileInputStream fis = new FileInputStream(ksFile)) {
+            KeyStore ks2 = KeyStore.getInstance(keystoreType);
+            ks2.load(fis, pw);
+            KeyStore.Entry entry = ks2.getEntry(ALIAS, kspp);
+            SecretKey keyIn = ((KeyStore.SecretKeyEntry) entry).getSecretKey();
+            if (Arrays.equals(key.getEncoded(), keyIn.getEncoded())) {
+                System.err.println("OK: worked just fine with " + keystoreType +
+                                   " keystore");
+            } else {
+                System.err.println("ERROR: keys are NOT equal after storing in "
+                                   + keystoreType + " keystore");
             }
-        } finally {
-            Files.deleteIfExists(ksFile.toPath());
         }
     }
 }


### PR DESCRIPTION
* Changed the test to use scratch directory
* Cleaned up the imports

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8183348](https://bugs.openjdk.org/browse/JDK-8183348): Better cleanup for jdk/test/sun/security/pkcs12/P12SecretKey.java (**Bug** - P4)


### Reviewers
 * [Weijun Wang](https://openjdk.org/census#weijun) (@wangweij - **Reviewer**) Review applies to [44b39103](https://git.openjdk.org/jdk/pull/24718/files/44b3910379e620ba037681e659aeaf51caee979c)
 * [Rajan Halade](https://openjdk.org/census#rhalade) (@rhalade - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24718/head:pull/24718` \
`$ git checkout pull/24718`

Update a local copy of the PR: \
`$ git checkout pull/24718` \
`$ git pull https://git.openjdk.org/jdk.git pull/24718/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24718`

View PR using the GUI difftool: \
`$ git pr show -t 24718`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24718.diff">https://git.openjdk.org/jdk/pull/24718.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24718#issuecomment-2812376056)
</details>
