### PR TITLE
8354811: clock_tics_per_sec code duplication between os_linux and os_posix

### DIFF
--- a/src/hotspot/os/aix/os_perf_aix.cpp
+++ b/src/hotspot/os/aix/os_perf_aix.cpp
@@ -118,7 +118,6 @@ static OSReturn get_lcpu_ticks(perfstat_id_t* lcpu_name, cpu_tick_store_t* ptick
  * Return CPU load caused by the currently executing process (the jvm).
  */
 static OSReturn get_jvm_load(double* jvm_uload, double* jvm_sload) {
-  static clock_t ticks_per_sec = sysconf(_SC_CLK_TCK);
   static u_longlong_t last_timebase = 0;
 
   perfstat_process_t jvm_stats;
@@ -204,8 +203,6 @@ static bool populate_lcpu_names(int ncpus, perfstat_id_t* lcpu_names) {
  * (Context Switches / Tick) * (Tick / s) = Context Switches per second
  */
 static OSReturn perf_context_switch_rate(double* rate) {
-  static clock_t ticks_per_sec = sysconf(_SC_CLK_TCK);
-
   u_longlong_t ticks;
   perfstat_cpu_total_t cpu_stats;
 
@@ -214,7 +211,7 @@ static OSReturn perf_context_switch_rate(double* rate) {
    }
 
    ticks = cpu_stats.user + cpu_stats.sys + cpu_stats.idle + cpu_stats.wait;
-   *rate = (cpu_stats.pswitch / ticks) * ticks_per_sec;
+   *rate = (cpu_stats.pswitch / ticks) * os::Posix::clock_tics_per_second();
 
    return OS_OK;
 }

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -5130,11 +5130,10 @@ static jlong slow_thread_cpu_time(Thread *thread, bool user_sys_cpu_time) {
                  &ldummy, &ldummy, &ldummy, &ldummy, &ldummy,
                  &user_time, &sys_time);
   if (count != 13) return -1;
-  double clock_tics_factor = 1000000000 / os::Posix::clock_tics_per_second();
   if (user_sys_cpu_time) {
-    return ((jlong)sys_time + (jlong)user_time) * clock_tics_factor;
+    return ((jlong)sys_time + (jlong)user_time) * (1000000000 / os::Posix::clock_tics_per_second());
   } else {
-    return (jlong)user_time * clock_tics_factor;
+    return (jlong)user_time * (1000000000 / os::Posix::clock_tics_per_second());
   }
 }
 

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -5145,7 +5145,6 @@ void os::current_thread_cpu_time_info(jvmtiTimerInfo *info_ptr) {
   info_ptr->kind = JVMTI_TIMER_TOTAL_CPU;  // user+system time is returned
 }
 
-
 void os::thread_cpu_time_info(jvmtiTimerInfo *info_ptr) {
   info_ptr->max_value = ALL_64_BITS;       // will not wrap in less than 64 bits
   info_ptr->may_skip_backward = false;     // elapsed time not wall time

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -213,8 +213,6 @@ typedef int (*malloc_info_func_t)(int options, FILE *stream);
 static malloc_info_func_t g_malloc_info = nullptr;
 #endif // __GLIBC__
 
-static int clock_tics_per_sec = 100;
-
 // If the VM might have been created on the primordial thread, we need to resolve the
 // primordial thread stack bounds and check if the current thread might be the
 // primordial thread in places. If we know that the primordial thread is never used,
@@ -4381,8 +4379,6 @@ static void check_pax(void) {
 // this is called _before_ most of the global arguments have been parsed
 void os::init(void) {
   char dummy;   // used to get a guess on initial stack address
-
-  clock_tics_per_sec = checked_cast<int>(sysconf(_SC_CLK_TCK));
   int sys_pg_size = checked_cast<int>(sysconf(_SC_PAGESIZE));
   if (sys_pg_size < 0) {
     fatal("os_linux.cpp: os::init: sysconf failed (%s)",
@@ -5134,10 +5130,11 @@ static jlong slow_thread_cpu_time(Thread *thread, bool user_sys_cpu_time) {
                  &ldummy, &ldummy, &ldummy, &ldummy, &ldummy,
                  &user_time, &sys_time);
   if (count != 13) return -1;
+  double clock_tics_factor = 1000000000 / os::Posix::clock_tics_per_second();
   if (user_sys_cpu_time) {
-    return ((jlong)sys_time + (jlong)user_time) * (1000000000 / clock_tics_per_sec);
+    return ((jlong)sys_time + (jlong)user_time) * clock_tics_factor;
   } else {
-    return (jlong)user_time * (1000000000 / clock_tics_per_sec);
+    return (jlong)user_time * clock_tics_factor;
   }
 }
 
@@ -5147,6 +5144,7 @@ void os::current_thread_cpu_time_info(jvmtiTimerInfo *info_ptr) {
   info_ptr->may_skip_forward = false;      // elapsed time not wall time
   info_ptr->kind = JVMTI_TIMER_TOTAL_CPU;  // user+system time is returned
 }
+
 
 void os::thread_cpu_time_info(jvmtiTimerInfo *info_ptr) {
   info_ptr->max_value = ALL_64_BITS;       // will not wrap in less than 64 bits

--- a/src/hotspot/os/posix/os_posix.cpp
+++ b/src/hotspot/os/posix/os_posix.cpp
@@ -1325,6 +1325,10 @@ void os::Posix::init_2(void) {
                _use_clock_monotonic_condattr ? "CLOCK_MONOTONIC" : "the default clock");
 }
 
+int os::Posix::clock_tics_per_second() {
+  return clock_tics_per_sec;
+}
+
 // Utility to convert the given timeout to an absolute timespec
 // (based on the appropriate clock) to use with pthread_cond_timewait,
 // and sem_timedwait().

--- a/src/hotspot/os/posix/os_posix.hpp
+++ b/src/hotspot/os/posix/os_posix.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -90,6 +90,9 @@ public:
   static void    ucontext_set_pc(ucontext_t* ctx, address pc);
 
   static void to_RTC_abstime(timespec* abstime, int64_t millis);
+
+  // clock ticks per second of the system
+  static int clock_tics_per_second();
 
   static bool handle_stack_overflow(JavaThread* thread, address addr, address pc,
                                     const void* ucVoid,


### PR DESCRIPTION
Seems some of the clock_tics_per_sec code can be unified (e.g. in os_posix) between os_linux and os_posix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8354811](https://bugs.openjdk.org/browse/JDK-8354811): clock_tics_per_sec code duplication between os_linux and os_posix (**Enhancement** - P4)


### Reviewers
 * [Andreas Steiner](https://openjdk.org/census#asteiner) (@ansteiner - Author) Review applies to [5bc249ae](https://git.openjdk.org/jdk/pull/24720/files/5bc249ae991774d6c6c8ebb49e6349bd1475c195)
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24720/head:pull/24720` \
`$ git checkout pull/24720`

Update a local copy of the PR: \
`$ git checkout pull/24720` \
`$ git pull https://git.openjdk.org/jdk.git pull/24720/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24720`

View PR using the GUI difftool: \
`$ git pr show -t 24720`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24720.diff">https://git.openjdk.org/jdk/pull/24720.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24720#issuecomment-2812574409)
</details>
