### PR TITLE
8354938: ZGC: Disable UseNUMA when ZFakeNUMA is used

### DIFF
--- a/src/hotspot/share/gc/z/zArguments.cpp
+++ b/src/hotspot/share/gc/z/zArguments.cpp
@@ -121,9 +121,19 @@ void ZArguments::select_max_gc_threads() {
 void ZArguments::initialize() {
   GCArguments::initialize();
 
-  // Enable NUMA by default
-  if (FLAG_IS_DEFAULT(UseNUMA) && FLAG_IS_DEFAULT(ZFakeNUMA)) {
-    FLAG_SET_DEFAULT(UseNUMA, true);
+  // NUMA settings
+  if (FLAG_IS_DEFAULT(ZFakeNUMA)) {
+    // Enable NUMA by default
+    if (FLAG_IS_DEFAULT(UseNUMA)) {
+      FLAG_SET_DEFAULT(UseNUMA, true);
+    }
+  } else {
+    if (UseNUMA) {
+      if (!FLAG_IS_DEFAULT(UseNUMA)) {
+        warning("ZFakeNUMA is enabled; turning off UseNUMA");
+      }
+      FLAG_SET_ERGO(UseNUMA, false);
+    }
   }
 
   select_max_gc_threads();


### PR DESCRIPTION
ZFakeNUMA is used to fake a number of NUMA nodes within ZGC. The intention was to make ZFakeNUMA mutually exclusive with UseNUMA, but the current code allows the user to enable UseNUMA and set ZFakeNUMA, which will trigger to the "mutual exclusion" assert in ZNUMA::initialize.

Verified on NUMA machine with -XX:+UseNUMA -XX:ZFakeNUMA=<count>. Will run this through our lower tiers.