### PR TITLE
8354920: SA core file support on Linux only prints error messages when debug logging is enabled

### DIFF
--- a/src/jdk.hotspot.agent/linux/native/libsaproc/libproc_impl.c
+++ b/src/jdk.hotspot.agent/linux/native/libsaproc/libproc_impl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -349,7 +349,7 @@ const char* symbol_for_pc(struct ps_prochandle* ph, uintptr_t addr, uintptr_t* p
 thread_info* add_thread_info(struct ps_prochandle* ph, lwpid_t lwp_id) {
    thread_info* newthr;
    if ( (newthr = (thread_info*) calloc(1, sizeof(thread_info))) == NULL) {
-      print_debug("can't allocate memory for thread_info\n");
+      print_error("can't allocate memory for thread_info\n");
       return NULL;
    }
 

--- a/src/jdk.hotspot.agent/linux/native/libsaproc/ps_core.c
+++ b/src/jdk.hotspot.agent/linux/native/libsaproc/ps_core.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.hotspot.agent/linux/native/libsaproc/ps_core.c
+++ b/src/jdk.hotspot.agent/linux/native/libsaproc/ps_core.c
@@ -318,7 +318,7 @@ static bool read_core_segments(struct ps_prochandle* ph, ELF_EHDR* core_ehdr) {
    ELF_PHDR* phbuf = NULL;
    ELF_PHDR* core_php = NULL;
 
-   if ((phbuf =  read_program_header_table(ph->core->core_fd, core_ehdr)) == NULL) {
+   if ((phbuf = read_program_header_table(ph->core->core_fd, core_ehdr)) == NULL) {
       print_error("failed to read program header table\n");
       return false;
    }

--- a/src/jdk.hotspot.agent/linux/native/libsaproc/ps_core.c
+++ b/src/jdk.hotspot.agent/linux/native/libsaproc/ps_core.c
@@ -386,6 +386,7 @@ static bool read_lib_segments(struct ps_prochandle* ph, int lib_fd, ELF_EHDR* li
   int page_size = sysconf(_SC_PAGE_SIZE);
 
   if ((phbuf = read_program_header_table(lib_fd, lib_ehdr)) == NULL) {
+    print_error("failed to read program header table\n");
     return false;
   }
 
@@ -401,6 +402,7 @@ static bool read_lib_segments(struct ps_prochandle* ph, int lib_fd, ELF_EHDR* li
       if (existing_map == NULL){
         if (add_map_info(ph, lib_fd, lib_php->p_offset,
                          target_vaddr, lib_php->p_memsz, lib_php->p_flags) == NULL) {
+          print_error("failed to add map info\n");
           goto err;
         }
       } else if (lib_php->p_flags != existing_map->flags) {
@@ -422,7 +424,7 @@ static bool read_lib_segments(struct ps_prochandle* ph, int lib_fd, ELF_EHDR* li
             (existing_map->fd != lib_fd) &&
             (ROUNDUP(existing_map->memsz, page_size) != ROUNDUP(lib_php->p_memsz, page_size))) {
 
-          print_debug("address conflict @ 0x%lx (existing map size = %ld, size = %ld, flags = %d)\n",
+          print_error("address conflict @ 0x%lx (existing map size = %ld, size = %ld, flags = %d)\n",
                         target_vaddr, existing_map->memsz, lib_php->p_memsz, lib_php->p_flags);
           goto err;
         }

--- a/src/jdk.hotspot.agent/linux/native/libsaproc/ps_core.c
+++ b/src/jdk.hotspot.agent/linux/native/libsaproc/ps_core.c
@@ -68,7 +68,7 @@ static bool sort_map_array(struct ps_prochandle* ph) {
   // allocate map_array
   map_info** array;
   if ( (array = (map_info**) malloc(sizeof(map_info*) * num_maps)) == NULL) {
-    print_debug("can't allocate memory for map array\n");
+    print_error("can't allocate memory for map array\n");
     return false;
   }
 

--- a/src/jdk.hotspot.agent/linux/native/libsaproc/ps_proc.c
+++ b/src/jdk.hotspot.agent/linux/native/libsaproc/ps_proc.c
@@ -453,9 +453,8 @@ Pgrab(pid_t pid, char* err_buf, size_t err_buf_len) {
 
   if ((attach_status = ptrace_attach(pid, err_buf, err_buf_len)) != ATTACH_SUCCESS) {
     if (attach_status == ATTACH_THREAD_DEAD) {
-       print_error("The process with pid %d does not exist.\n", pid);
-    } else {
-       print_error("Failed to attach to the process with pid %d.\n", pid);
+       snprintf(err_buf, err_buf_len, "The process with pid %d does not exist.", pid);
+       print_error("%s\n", err_buf);
     }
     free(ph);
     return NULL;
@@ -464,7 +463,8 @@ Pgrab(pid_t pid, char* err_buf, size_t err_buf_len) {
   // initialize ps_prochandle
   ph->pid = pid;
   if (add_thread_info(ph, ph->pid) == NULL) {
-    print_error("failed to add thread info\n");
+    snprintf(err_buf, err_buf_len, "failed to add thread info");
+    print_error("%s\n", err_buf);
     free(ph);
     return NULL;
   }
@@ -476,7 +476,7 @@ Pgrab(pid_t pid, char* err_buf, size_t err_buf_len) {
   // as the symbols in the pthread library will be used to figure out
   // the list of threads within the same process.
   if (read_lib_info(ph) == false) {
-    print_error("failed to read lib info\n");
+    snprintf(err_buf, err_buf_len, "failed to read lib info");
     goto err;
   }
 
@@ -501,7 +501,7 @@ Pgrab(pid_t pid, char* err_buf, size_t err_buf_len) {
     }
     if (!process_doesnt_exist(lwp_id)) {
       if (add_thread_info(ph, lwp_id) == NULL) {
-        print_error("failed to add thread info\n");
+        snprintf(err_buf, err_buf_len, "failed to add thread info");
         goto err;
       }
     }
@@ -522,7 +522,7 @@ Pgrab(pid_t pid, char* err_buf, size_t err_buf_len) {
           delete_thread_info(ph, current_thr);
         }
         else {
-          print_error("Failed to attach to the thread with lwp_id %d.\n", current_thr->lwp_id);
+          snprintf(err_buf, err_buf_len, "Failed to attach to the thread with lwp_id %d.", current_thr->lwp_id);
           goto err;
         } // ATTACH_THREAD_DEAD
       } // !ATTACH_SUCCESS
@@ -530,6 +530,7 @@ Pgrab(pid_t pid, char* err_buf, size_t err_buf_len) {
   }
   return ph;
 err:
+  print_error("%s\n", err_buf);
   Prelease(ph);
   return NULL;
 }

--- a/src/jdk.hotspot.agent/linux/native/libsaproc/ps_proc.c
+++ b/src/jdk.hotspot.agent/linux/native/libsaproc/ps_proc.c
@@ -447,13 +447,15 @@ Pgrab(pid_t pid, char* err_buf, size_t err_buf_len) {
 
   if ( (ph = (struct ps_prochandle*) calloc(1, sizeof(struct ps_prochandle))) == NULL) {
     snprintf(err_buf, err_buf_len, "can't allocate memory for ps_prochandle");
-    print_debug("%s\n", err_buf);
+    print_error("%s\n", err_buf);
     return NULL;
   }
 
   if ((attach_status = ptrace_attach(pid, err_buf, err_buf_len)) != ATTACH_SUCCESS) {
     if (attach_status == ATTACH_THREAD_DEAD) {
        print_error("The process with pid %d does not exist.\n", pid);
+    } else {
+       print_error("Failed to attach to the process with pid %d.\n", pid);
     }
     free(ph);
     return NULL;
@@ -464,7 +466,7 @@ Pgrab(pid_t pid, char* err_buf, size_t err_buf_len) {
   if (add_thread_info(ph, ph->pid) == NULL) {
     print_error("failed to add thread info\n");
     free(ph);
-    return false;
+    return NULL;
   }
 
   // initialize vtable
@@ -517,6 +519,7 @@ Pgrab(pid_t pid, char* err_buf, size_t err_buf_len) {
           delete_thread_info(ph, current_thr);
         }
         else {
+          print_error("Failed to attach to the thread with lwp_id %d.\n", current_thr->lwp_id);
           goto err;
         } // ATTACH_THREAD_DEAD
       } // !ATTACH_SUCCESS

--- a/src/jdk.hotspot.agent/linux/native/libsaproc/ps_proc.c
+++ b/src/jdk.hotspot.agent/linux/native/libsaproc/ps_proc.c
@@ -349,7 +349,7 @@ static bool read_lib_info(struct ps_prochandle* ph) {
   snprintf(fname, sizeof(fname), "/proc/%d/maps", ph->pid);
   fp = fopen(fname, "r");
   if (fp == NULL) {
-    print_debug("can't open /proc/%d/maps file\n", ph->pid);
+    print_error("can't open /proc/%d/maps file\n", ph->pid);
     return false;
   }
 
@@ -475,7 +475,10 @@ Pgrab(pid_t pid, char* err_buf, size_t err_buf_len) {
   // read library info and symbol tables, must do this before attaching threads,
   // as the symbols in the pthread library will be used to figure out
   // the list of threads within the same process.
-  read_lib_info(ph);
+  if (read_lib_info(ph) == false) {
+    print_error("failed to read lib info\n");
+    goto err;
+  }
 
   /*
    * Read thread info.

--- a/src/jdk.hotspot.agent/macosx/native/libsaproc/libproc_impl.c
+++ b/src/jdk.hotspot.agent/macosx/native/libsaproc/libproc_impl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -323,7 +323,7 @@ const char* symbol_for_pc(struct ps_prochandle* ph, uintptr_t addr, uintptr_t* p
 sa_thread_info* add_thread_info(struct ps_prochandle* ph, pthread_t pthread_id, lwpid_t lwp_id) {
   sa_thread_info* newthr;
   if ( (newthr = (sa_thread_info*) calloc(1, sizeof(sa_thread_info))) == NULL) {
-    print_debug("can't allocate memory for thread_info\n");
+    print_error("can't allocate memory for thread_info\n");
     return NULL;
   }
 

--- a/src/jdk.hotspot.agent/macosx/native/libsaproc/ps_core.c
+++ b/src/jdk.hotspot.agent/macosx/native/libsaproc/ps_core.c
@@ -633,6 +633,7 @@ static bool read_shared_lib_info(struct ps_prochandle* ph) {
       lseek(fd, -sizeof(uint32_t), SEEK_CUR);
       // This is the beginning of the mach-o file in the segment.
       if (read(fd, (void *)&header, sizeof(mach_header_64)) != sizeof(mach_header_64)) {
+        print_error("Failed to file header\n");
         goto err;
       }
       fpos = ltell(fd);
@@ -643,6 +644,7 @@ static bool read_shared_lib_info(struct ps_prochandle* ph) {
         // LC_ID_DYLIB is the file itself for a .dylib
         lseek(fd, fpos, SEEK_SET);
         if (read(fd, (void *)&lcmd, sizeof(load_command)) != sizeof(load_command)) {
+          print_error("Failed to read command\n");
           return false;   // error
         }
         fpos += lcmd.cmdsize;  // next command position
@@ -654,6 +656,7 @@ static bool read_shared_lib_info(struct ps_prochandle* ph) {
         if (lcmd.cmd == LC_ID_DYLIB) {
           lseek(fd, -sizeof(load_command), SEEK_CUR);
           if (read(fd, (void *)&dylibcmd, sizeof(dylib_command)) != sizeof(dylib_command)) {
+            print_error("Failed to read command\n");
             return false;
           }
           /**** name stored at dylib_command.dylib.name.offset, is a C string  */

--- a/src/jdk.hotspot.agent/macosx/native/libsaproc/ps_core.c
+++ b/src/jdk.hotspot.agent/macosx/native/libsaproc/ps_core.c
@@ -710,13 +710,13 @@ struct ps_prochandle* Pgrab_core(const char* exec_file, const char* core_file) {
 
   struct ps_prochandle* ph = (struct ps_prochandle*) calloc(1, sizeof(struct ps_prochandle));
   if (ph == NULL) {
-    print_debug("can't allocate ps_prochandle\n");
+    print_error("can't allocate ps_prochandle\n");
     return NULL;
   }
 
   if ((ph->core = (struct core_data*) calloc(1, sizeof(struct core_data))) == NULL) {
     free(ph);
-    print_debug("can't allocate ps_prochandle\n");
+    print_error("can't allocate ps_prochandle\n");
     return NULL;
   }
 
@@ -738,12 +738,12 @@ struct ps_prochandle* Pgrab_core(const char* exec_file, const char* core_file) {
 
   // read core file header
   if (read_macho64_header(ph->core->core_fd, &core_header) != true || core_header.filetype != MH_CORE) {
-    print_debug("core file is not a valid Mach-O file\n");
+    print_error("core file is not a valid Mach-O file\n");
     goto err;
   }
 
   if ((ph->core->exec_fd = open(exec_file, O_RDONLY)) < 0) {
-    print_error("can't open executable file\n");
+    print_error("can't open executable file: %s\n", strerror(errno));
     goto err;
   }
 
@@ -779,7 +779,7 @@ struct ps_prochandle* Pgrab_core(const char* exec_file, const char* core_file) {
   }
 
   if (init_classsharing_workaround(ph) != true) {
-    print_error("failed to workaround classshareing\n");
+    print_error("failed to workaround class sharing\n");
     goto err;
   }
 

--- a/src/jdk.hotspot.agent/macosx/native/libsaproc/ps_core.c
+++ b/src/jdk.hotspot.agent/macosx/native/libsaproc/ps_core.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2021, Azul Systems, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/src/jdk.hotspot.agent/macosx/native/libsaproc/ps_core.c
+++ b/src/jdk.hotspot.agent/macosx/native/libsaproc/ps_core.c
@@ -74,7 +74,7 @@ static bool sort_map_array(struct ps_prochandle* ph) {
   // allocate map_array
   map_info** array;
   if ( (array = (map_info**) malloc(sizeof(map_info*) * num_maps)) == NULL) {
-    print_debug("can't allocate memory for map array\n");
+    print_error("can't allocate memory for map array\n");
     return false;
   }
 

--- a/src/jdk.hotspot.agent/share/native/libsaproc/ps_core_common.c
+++ b/src/jdk.hotspot.agent/share/native/libsaproc/ps_core_common.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.hotspot.agent/share/native/libsaproc/ps_core_common.c
+++ b/src/jdk.hotspot.agent/share/native/libsaproc/ps_core_common.c
@@ -141,6 +141,7 @@ map_info* add_map_info(struct ps_prochandle* ph, int fd, off_t offset,
                        uintptr_t vaddr, size_t memsz, uint32_t flags) {
   map_info* map;
   if ((map = allocate_init_map(fd, offset, vaddr, memsz, flags)) == NULL) {
+    print_error("failed to allocate map\n");
     return NULL;
   }
 
@@ -158,6 +159,7 @@ static map_info* add_class_share_map_info(struct ps_prochandle* ph, off_t offset
   map_info* map;
   if ((map = allocate_init_map(ph->core->classes_jsa_fd,
                                offset, vaddr, memsz, MAP_R_FLAG)) == NULL) {
+    print_debug("failed to allocate class share map\n");
     return NULL;
   }
 


### PR DESCRIPTION
Currently if loading a core file fails, the diagnostic information provided on different systems is different; on MacOS we produce an error message, while on Linux we only print information if debug logging is enabled.

This PR adds some new messages on Linux to match MacOSX, and changes some of the diagnostic output to error level instead of debug. Additionally, if opening the core or the exe file fails, the system error message (strerror) is printed.

Tier1-3 testing clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8354920](https://bugs.openjdk.org/browse/JDK-8354920): SA core file support on Linux only prints error messages when debug logging is enabled (**Bug** - P4)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24722/head:pull/24722` \
`$ git checkout pull/24722`

Update a local copy of the PR: \
`$ git checkout pull/24722` \
`$ git pull https://git.openjdk.org/jdk.git pull/24722/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24722`

View PR using the GUI difftool: \
`$ git pr show -t 24722`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24722.diff">https://git.openjdk.org/jdk/pull/24722.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24722#issuecomment-2812733154)
</details>
