### PR TITLE
8353685: Open some JComboBox bugs 4

### DIFF
--- a/test/jdk/javax/swing/JComboBox/bug4212498.java
+++ b/test/jdk/javax/swing/JComboBox/bug4212498.java
@@ -32,7 +32,7 @@ import javax.swing.JPanel;
  * @test
  * @bug 4212498
  * @key headful
- * @library /open/test/jdk/java/awt/regtesthelpers
+ * @library /java/awt/regtesthelpers
  * @build PassFailJFrame
  * @run main/manual bug4212498
  */

--- a/test/jdk/javax/swing/JComboBox/bug4212498.java
+++ b/test/jdk/javax/swing/JComboBox/bug4212498.java
@@ -31,7 +31,6 @@ import javax.swing.JPanel;
 /*
  * @test
  * @bug 4212498
- * @key headful
  * @library /java/awt/regtesthelpers
  * @build PassFailJFrame
  * @run main/manual bug4212498

--- a/test/jdk/javax/swing/JComboBox/bug4212498.java
+++ b/test/jdk/javax/swing/JComboBox/bug4212498.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.event.ActionListener;
+import javax.swing.JButton;
+import javax.swing.JComboBox;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+
+/*
+ * @test
+ * @bug 4212498
+ * @key headful
+ * @library /open/test/jdk/java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual bug4212498
+ */
+
+public class bug4212498 {
+    static JPanel panel = new JPanel();
+    static JComboBox comboBox = new JComboBox(new Object[]{
+            "Coma Berenices",
+            "Triangulum",
+            "Camelopardis",
+            "Cassiopea"});
+
+    private static final String INSTRUCTIONS = """
+            Edit the value in the text field (without using the popup)
+            and then press the tab key. If the number doesn't increase,
+            then test fails.
+
+            Also, try tabbing out without making a change. The number
+            should NOT increase unless the user changes something.
+            """;
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                .title("Instructions")
+                .instructions(INSTRUCTIONS)
+                .columns(50)
+                .testUI(bug4212498::createTestUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    public static JFrame createTestUI() {
+        JFrame frame = new JFrame("bug4212498");
+        comboBox.setEditable(true);
+
+        final JLabel label = new JLabel("0");
+
+        ActionListener actionListener =
+                e -> label.setText("" + (Integer.parseInt(label.getText()) + 1));
+
+        comboBox.addActionListener(actionListener);
+
+        panel.add(comboBox);
+        panel.add(label);
+        panel.add(new JButton("B"));
+
+        frame.getContentPane().add(panel);
+        frame.setLocationRelativeTo(null);
+        frame.pack();
+        return frame;
+    }
+}

--- a/test/jdk/javax/swing/JComboBox/bug4212498.java
+++ b/test/jdk/javax/swing/JComboBox/bug4212498.java
@@ -80,8 +80,8 @@ public class bug4212498 {
         panel.add(new JButton("B"));
 
         frame.getContentPane().add(panel);
-        frame.setLocationRelativeTo(null);
         frame.pack();
+        frame.setLocationRelativeTo(null);
         return frame;
     }
 }

--- a/test/jdk/javax/swing/JComboBox/bug4459267.java
+++ b/test/jdk/javax/swing/JComboBox/bug4459267.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.BorderLayout;
+import java.awt.Robot;
+import java.awt.event.KeyEvent;
+import javax.swing.JComboBox;
+import javax.swing.JFrame;
+import javax.swing.SwingUtilities;
+
+/*
+ * @test
+ * @bug 4459267
+ * @summary Tests that pressing PageUp in combo popup list doesn't cause
+ *          stack overflow
+ * @key headful
+ * @run main bug4459267
+ */
+
+public class bug4459267 {
+    static JFrame frame;
+
+    public static void main(String[] args) throws Exception {
+        try {
+            Robot robot = new Robot();
+            robot.waitForIdle();
+            robot.delay(250);
+
+            SwingUtilities.invokeAndWait(() -> createTestUI());
+            robot.waitForIdle();
+            robot.delay(250);
+
+            robot.keyPress(KeyEvent.VK_PAGE_UP);
+            robot.keyRelease(KeyEvent.VK_PAGE_UP);
+            robot.waitForIdle();
+            robot.delay(250);
+        } finally {
+            if (frame != null) {
+                frame.dispose();
+            }
+        }
+    }
+
+    public static void createTestUI() {
+        frame = new JFrame("bug4459267");
+        JComboBox jcmb = new JComboBox();
+        jcmb.addItem("JComobo1");
+        jcmb.addItem("Item2");
+        jcmb.addItem("Item3");
+        frame.getContentPane().add( jcmb, BorderLayout.NORTH );
+        frame.setLocationRelativeTo(null);
+        frame.pack();
+        frame.setVisible(true);
+    }
+}

--- a/test/jdk/javax/swing/JComboBox/bug4459267.java
+++ b/test/jdk/javax/swing/JComboBox/bug4459267.java
@@ -47,6 +47,7 @@ public class bug4459267 {
 
             SwingUtilities.invokeAndWait(() -> createTestUI());
             robot.waitForIdle();
+            robot.delay(1000);
 
             robot.keyPress(KeyEvent.VK_PAGE_UP);
             robot.keyRelease(KeyEvent.VK_PAGE_UP);

--- a/test/jdk/javax/swing/JComboBox/bug4459267.java
+++ b/test/jdk/javax/swing/JComboBox/bug4459267.java
@@ -43,21 +43,20 @@ public class bug4459267 {
     public static void main(String[] args) throws Exception {
         try {
             Robot robot = new Robot();
-            robot.waitForIdle();
-            robot.delay(250);
+            robot.setAutoDelay(250);
 
             SwingUtilities.invokeAndWait(() -> createTestUI());
             robot.waitForIdle();
-            robot.delay(250);
 
             robot.keyPress(KeyEvent.VK_PAGE_UP);
             robot.keyRelease(KeyEvent.VK_PAGE_UP);
             robot.waitForIdle();
-            robot.delay(250);
         } finally {
-            if (frame != null) {
-                frame.dispose();
-            }
+            SwingUtilities.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
         }
     }
 
@@ -67,9 +66,9 @@ public class bug4459267 {
         jcmb.addItem("JComobo1");
         jcmb.addItem("Item2");
         jcmb.addItem("Item3");
-        frame.getContentPane().add( jcmb, BorderLayout.NORTH );
-        frame.setLocationRelativeTo(null);
+        frame.getContentPane().add(jcmb, BorderLayout.NORTH);
         frame.pack();
+        frame.setLocationRelativeTo(null);
         frame.setVisible(true);
     }
 }

--- a/test/jdk/javax/swing/JComboBox/bug4519269.java
+++ b/test/jdk/javax/swing/JComboBox/bug4519269.java
@@ -51,9 +51,10 @@ public class bug4519269 {
 
             SwingUtilities.invokeAndWait(() -> createTestUI());
             robot.waitForIdle();
+            robot.delay(1000);
 
-            SwingUtilities.invokeAndWait (() -> p = combo.getLocationOnScreen());
-            robot.mouseMove(p.x+5, p.y+5);
+            SwingUtilities.invokeAndWait(() -> p = combo.getLocationOnScreen());
+            robot.mouseMove(p.x + 5, p.y + 5);
             robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
             robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
             robot.waitForIdle();
@@ -81,9 +82,11 @@ public class bug4519269 {
 
     static class CustomString {
         String string;
+
         public CustomString(String s) {
             string = s;
         }
+
         public String toString() {
             return null;
         }

--- a/test/jdk/javax/swing/JComboBox/bug4519269.java
+++ b/test/jdk/javax/swing/JComboBox/bug4519269.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
+import javax.swing.JComboBox;
+import javax.swing.JFrame;
+import javax.swing.SwingUtilities;
+
+/*
+ * @test
+ * @bug 4519269
+ * @summary Tests that DefaultKeySelectionManager doesn't throw NPE
+ * @key headful
+ * @run main bug4519269
+ */
+
+public class bug4519269 {
+    static JFrame frame;
+    static JComboBox combo;
+    static Point p;
+    static Object[] data = {new CustomString("Item 1"), new CustomString("Item 2"),
+            new CustomString("Item 3"), new CustomString("Item 4")};
+
+    public static void main(String[] args) throws Exception {
+        try {
+            Robot robot = new Robot();
+            robot.waitForIdle();
+            robot.delay(250);
+
+            SwingUtilities.invokeAndWait(() -> createTestUI());
+            robot.waitForIdle();
+            robot.delay(250);
+
+            SwingUtilities.invokeAndWait (() -> p = combo.getLocationOnScreen());
+            robot.mouseMove(p.x+5, p.y+5);
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+            robot.waitForIdle();
+            robot.delay(250);
+
+            robot.keyPress(KeyEvent.VK_SHIFT);
+            robot.keyRelease(KeyEvent.VK_SHIFT);
+            robot.waitForIdle();
+            robot.delay(250);
+        } finally {
+            if (frame != null) {
+                frame.dispose();
+            }
+        }
+    }
+
+    public static void createTestUI() {
+        frame = new JFrame("bug4519269");
+        combo = new JComboBox(data);
+        frame.getContentPane().add(combo);
+        frame.setLocationRelativeTo(null);
+        frame.pack();
+        frame.setVisible(true);
+    }
+
+    static class CustomString {
+        String string;
+        public CustomString(String s) {
+            string = s;
+        }
+        public String toString() {
+            return null;
+        }
+    }
+}

--- a/test/jdk/javax/swing/JComboBox/bug4519269.java
+++ b/test/jdk/javax/swing/JComboBox/bug4519269.java
@@ -47,28 +47,26 @@ public class bug4519269 {
     public static void main(String[] args) throws Exception {
         try {
             Robot robot = new Robot();
-            robot.waitForIdle();
-            robot.delay(250);
+            robot.setAutoDelay(250);
 
             SwingUtilities.invokeAndWait(() -> createTestUI());
             robot.waitForIdle();
-            robot.delay(250);
 
             SwingUtilities.invokeAndWait (() -> p = combo.getLocationOnScreen());
             robot.mouseMove(p.x+5, p.y+5);
             robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
             robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
             robot.waitForIdle();
-            robot.delay(250);
 
             robot.keyPress(KeyEvent.VK_SHIFT);
             robot.keyRelease(KeyEvent.VK_SHIFT);
             robot.waitForIdle();
-            robot.delay(250);
         } finally {
-            if (frame != null) {
-                frame.dispose();
-            }
+            SwingUtilities.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
         }
     }
 
@@ -76,8 +74,8 @@ public class bug4519269 {
         frame = new JFrame("bug4519269");
         combo = new JComboBox(data);
         frame.getContentPane().add(combo);
-        frame.setLocationRelativeTo(null);
         frame.pack();
+        frame.setLocationRelativeTo(null);
         frame.setVisible(true);
     }
 


### PR DESCRIPTION
Updating and opening some JComboBox bugs

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8353685](https://bugs.openjdk.org/browse/JDK-8353685): Open some JComboBox bugs 4 (**Bug** - P4)


### Reviewers
 * [Harshitha Onkar](https://openjdk.org/census#honkar) (@honkar-jdk - **Reviewer**)
 * [Alexander Zuev](https://openjdk.org/census#kizune) (@azuev-java - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24733/head:pull/24733` \
`$ git checkout pull/24733`

Update a local copy of the PR: \
`$ git checkout pull/24733` \
`$ git pull https://git.openjdk.org/jdk.git pull/24733/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24733`

View PR using the GUI difftool: \
`$ git pr show -t 24733`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24733.diff">https://git.openjdk.org/jdk/pull/24733.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24733#issuecomment-2813684727)
</details>
