### PR TITLE
8353552: Opensource Several Font related tests - Batch 3

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -235,6 +235,7 @@ java/awt/Window/AlwaysOnTop/AutoTestOnTop.java 6847593 linux-all
 java/awt/Window/GrabSequence/GrabSequence.java 6848409 macosx-all,linux-all
 java/awt/Window/LocationAtScreenCorner/LocationAtScreenCorner.java 8203371 linux-all
 java/awt/font/TextLayout/TextLayoutBounds.java 8169188 generic-all
+java/awt/font/GlyphVector/TestGlyphVectorLayout.java 8354987 generic-all
 java/awt/image/BufferedImage/ICMColorDataTest/ICMColorDataTest.java 8233028 generic-all
 java/awt/image/DrawImage/IncorrectAlphaSurface2SW.java 8056077 linux-all
 java/awt/print/Headless/HeadlessPrinterJob.java 8196088 windows-all

--- a/test/jdk/java/awt/font/BoldItalicFontTest.java
+++ b/test/jdk/java/awt/font/BoldItalicFontTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2004, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Font;
+import java.awt.Frame;
+import java.awt.GridLayout;
+import java.awt.Label;
+
+/*
+ * @test
+ * @bug 4935871
+ * @summary Check that correct type faces are used regardless of bold/italic styles
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual/othervm -Duser.language=ja -Duser.country=JP BoldItalicFontTest
+ */
+
+public class BoldItalicFontTest {
+
+    public static void main(String[] args) throws Exception {
+        final String INSTRUCTIONS = """
+                This test is reproduced with a non-English user locale only.
+                All the letters "X" in the first line should be in serif font.
+                All the letters "X" in the second line should be in sans-serif font.
+
+                If so, press Pass, else press Fail.""";
+
+        PassFailJFrame.builder()
+                .instructions(INSTRUCTIONS)
+                .columns(35)
+                .testUI(BoldItalicFontTest::createUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static Frame createUI() {
+        String[] faces = { Font.SERIF, Font.SANS_SERIF };
+        int[] styles = { 0, Font.BOLD, Font.ITALIC, Font.BOLD | Font.ITALIC };
+
+        Frame f = new Frame("BoldItalicFontTest Test UI");
+        f.setLayout(new GridLayout(faces.length, styles.length));
+        for (int fn = 0; fn < faces.length; fn++) {
+            for (int sn = 0; sn < styles.length; sn++) {
+                Label l = new Label("X");
+                Font f1 = new Font(faces[fn], styles[sn], 36);
+                l.setFont(f1);
+                f.add(l);
+            }
+        }
+        f.setSize(300, 300);
+        return f;
+    }
+}

--- a/test/jdk/java/awt/font/GlyphVector/TestGlyphVectorLayout.java
+++ b/test/jdk/java/awt/font/GlyphVector/TestGlyphVectorLayout.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Font;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.Rectangle;
+import java.awt.RenderingHints;
+import java.awt.font.GlyphVector;
+import java.awt.font.FontRenderContext;
+import java.awt.geom.AffineTransform;
+import java.awt.geom.Rectangle2D;
+
+import javax.swing.JPanel;
+
+/*
+ * @test
+ * @bug 4615017
+ * @summary Display two GlyphVectors, and ensure they are of the same length.
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual TestGlyphVectorLayout
+ */
+
+public class TestGlyphVectorLayout extends JPanel {
+    private final Font font;
+    private final FontRenderContext frc;
+    private final String text;
+
+    private GlyphVector aftergv;
+    private Rectangle pbounds;
+    private Rectangle2D vbounds;
+
+    public static void main(String[] args) throws Exception {
+        final String INSTRUCTIONS = """
+                Two lines of text should appear, the top one with boxes
+                (red and blue) around it.
+                The two lines should be of the same length, and the boxes around the
+                top line should 'fit' the text with no empty space between the end
+                of the text and the box.
+
+                Pass the test if this is true.""";
+
+        PassFailJFrame.builder()
+                .instructions(INSTRUCTIONS)
+                .columns(45)
+                .testUI(TestGlyphVectorLayout::new)
+                .build()
+                .awaitAndCheck();
+    }
+
+    private TestGlyphVectorLayout() {
+        setBackground(Color.WHITE);
+        font = new Font(Font.DIALOG, Font.PLAIN, 24);
+        frc = new FontRenderContext(null, false, false);
+        text = "this is a test of glyph vector";
+    }
+
+    @Override
+    public Dimension getPreferredSize() {
+        return new Dimension(550, 150);
+    }
+
+    @Override
+    public void paint(Graphics g) {
+        super.paint(g);
+        Graphics2D g2d = (Graphics2D) g;
+
+        float x = 50;
+        float y = 50;
+        AffineTransform oldtx = g2d.getTransform();
+        g2d.translate(x, y);
+        g2d.scale(1.5, 1.5);
+
+        g2d.setRenderingHint(RenderingHints.KEY_FRACTIONALMETRICS,
+                             RenderingHints.VALUE_FRACTIONALMETRICS_OFF);
+        g2d.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING,
+                             RenderingHints.VALUE_TEXT_ANTIALIAS_OFF);
+
+        g2d.setColor(Color.BLACK);
+
+        GlyphVector gv = font.createGlyphVector(frc, text); // new each time
+        g2d.drawGlyphVector(gv, 0, 0);
+
+        if (vbounds == null) {
+            vbounds = gv.getVisualBounds();
+            pbounds = gv.getPixelBounds(g2d.getFontRenderContext(), 0, 0);
+            aftergv = gv;
+        }
+        g2d.drawGlyphVector(aftergv, 0, 30);
+
+        g2d.setColor(Color.BLUE);
+        g2d.draw(vbounds);
+
+        g2d.setTransform(oldtx);
+        g2d.setColor(Color.RED);
+        g2d.draw(pbounds);
+    }
+}

--- a/test/jdk/java/awt/font/GlyphVector/TestSetGlyphPositions.java
+++ b/test/jdk/java/awt/font/GlyphVector/TestSetGlyphPositions.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Font;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.font.GlyphVector;
+import java.awt.font.FontRenderContext;
+import java.awt.geom.Point2D;
+
+import javax.swing.JPanel;
+
+/*
+ * @test
+ * @bug 4180379
+ * @summary set the positions of glyphs in the GlyphVector to other than
+ *          their default x, y positions, and verify that the rendered glyphs are
+ *          in the new positions, not the default positions.
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual TestSetGlyphPositions
+ */
+
+public class TestSetGlyphPositions extends JPanel {
+    GlyphVector gv = null;
+
+    public static void main(String[] args) throws Exception {
+        final String INSTRUCTIONS = """
+            'TopLeft text and >' should appear towards the top left of the frame,
+            and '< and BottomRight text' should appear towards the bottom right.
+
+            There should be some space between the '>' and '<' symbols, both vertically
+            and horizontally.
+
+            Pass the test if this is true.""";
+
+        PassFailJFrame.builder()
+                .instructions(INSTRUCTIONS)
+                .columns(45)
+                .testUI(TestSetGlyphPositions::new)
+                .build()
+                .awaitAndCheck();
+    }
+
+    public TestSetGlyphPositions() {
+        setBackground(Color.WHITE);
+        setSize(550, 150);
+    }
+
+    @Override
+    public Dimension getPreferredSize() {
+        return new Dimension(550, 150);
+    }
+
+    @Override
+    public void paint(Graphics g) {
+        super.paint(g);
+        Graphics2D g2d = (Graphics2D) g;
+
+        if (gv == null) {
+            Font font = new Font(Font.DIALOG, Font.PLAIN, 36);
+            FontRenderContext frc = g2d.getFontRenderContext();
+            String str = "TopLeft><BottomRight";
+
+            gv = font.createGlyphVector(frc, str);
+            for (int i = str.indexOf("<"); i < gv.getNumGlyphs(); ++i) {
+                Point2D loc = gv.getGlyphPosition(i);
+                loc.setLocation(loc.getX() + 50, loc.getY() + 50);
+                gv.setGlyphPosition(i, loc);
+            }
+        }
+        g2d.drawGlyphVector(gv, 50f, 50f);
+    }
+}

--- a/test/jdk/java/awt/font/Rotate/RotateTest1.java
+++ b/test/jdk/java/awt/font/Rotate/RotateTest1.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.text.AttributedString;
+import java.awt.font.TextAttribute;
+
+import javax.swing.JPanel;
+
+/*
+ * @test
+ * @bug 4188328
+ * @summary In this bug, a text string is displayed rotated. Without the
+ *          fix, on Windows, the string was not displayed (boxes were
+ *          displayed which denote an unprintable character). On Solaris
+ *          2.5.1, the characters were displayed, but not rotated. Now
+ *          on all platforms, the string is displayed correctly rotated.
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual RotateTest1
+ */
+
+public class RotateTest1 extends JPanel {
+    public static void main(String[] args) throws Exception {
+        final String INSTRUCTIONS = """
+                In this test, a text string is displayed rotated.
+
+                Without the fix, on Windows, the string was not displayed
+                (boxes were displayed which denote an unprintable character).
+
+                On Solaris 2.5.1, the characters were displayed, but not rotated.
+
+                Now on all platforms, the string is displayed rotated.""";
+
+        PassFailJFrame.builder()
+                .instructions(INSTRUCTIONS)
+                .columns(45)
+                .testUI(RotateTest1::new)
+                .build()
+                .awaitAndCheck();
+    }
+
+    public RotateTest1() {
+        setBackground(Color.WHITE);
+        setDoubleBuffered(true);
+    }
+
+    @Override
+    public Dimension getPreferredSize() {
+        return new Dimension(400, 520);
+    }
+
+    @Override
+    public void paint(Graphics g) {
+        Graphics2D g2d = (Graphics2D) g;
+        Dimension d = getSize();
+
+        g.setColor(getBackground());
+        g.fillRect(0, 0, d.width, d.height);
+
+        // start java2d test code
+        paintRotatedTextTest(g2d);
+    }
+
+    private void paintRotatedTextTest(Graphics2D g2d) {
+        AttributedString testString =
+                new AttributedString("This is some text. Blablablabla");
+        testString.addAttribute(TextAttribute.SIZE, 32f);
+
+        g2d.setPaint(Color.BLACK);
+        g2d.rotate(Math.PI / 3);
+        g2d.drawString(testString.getIterator(), 100.0f, 10.0f);
+    }
+}

--- a/test/jdk/java/awt/font/TestGraphicPlacement.java
+++ b/test/jdk/java/awt/font/TestGraphicPlacement.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ *
+ * Copyright 1999 IBM Corp.  All Rights Reserved.
+ */
+
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.Image;
+import java.awt.Shape;
+import java.text.AttributedString;
+import java.awt.font.FontRenderContext;
+import java.awt.font.GraphicAttribute;
+import java.awt.font.ImageGraphicAttribute;
+import java.awt.font.ShapeGraphicAttribute;
+import java.awt.font.TextLayout;
+import java.awt.font.TextAttribute;
+import java.awt.geom.Rectangle2D;
+import java.awt.image.BufferedImage;
+
+import javax.swing.JPanel;
+
+/*
+ * @test
+ * @bug 4202637
+ * @summary This test ensures that graphics in a TextLayout are positioned correctly.
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual TestGraphicPlacement
+ */
+
+public class TestGraphicPlacement extends JPanel {
+    private static final int GRAPHIC_COUNT = 5;
+    private static final float BASE_SIZE = 5;
+    private static final boolean SHAPE = false;
+    private static final boolean IMAGE = true;
+
+    private final AttributedString[] strings;
+
+    public static void main(String[] args) throws Exception {
+        final String INSTRUCTIONS = """
+                This test has text strings enclosed in boxes, in each box there is
+                a sequence of square graphics to the right of the text string.
+
+                This test is concerned with the placement of these graphics relative
+                to the text string.
+
+                Squares after 'TOP' should be placed in the top-right corner of the
+                box with their tops aligned to the top of the box.
+
+                Graphics after 'BOTTOM' should be placed in the bottom-right corner of its
+                box with their bottoms aligned to the bottom of the box.
+
+                Graphics after 'BASELINE' should have their tops (not bottoms) aligned to
+                the baseline of the text.
+
+                If all these are true, pass the test.""";
+
+        PassFailJFrame.builder()
+                .instructions(INSTRUCTIONS)
+                .columns(45)
+                .testUI(TestGraphicPlacement::new)
+                .build()
+                .awaitAndCheck();
+    }
+
+    public TestGraphicPlacement() {
+        setBackground(Color.WHITE);
+
+        strings = new AttributedString[]{
+                makeString(GraphicAttribute.TOP_ALIGNMENT, SHAPE),
+                makeString(GraphicAttribute.BOTTOM_ALIGNMENT, SHAPE),
+                makeString(GraphicAttribute.ROMAN_BASELINE, SHAPE),
+                makeString(GraphicAttribute.TOP_ALIGNMENT, IMAGE),
+                makeString(GraphicAttribute.BOTTOM_ALIGNMENT, IMAGE),
+                makeString(GraphicAttribute.ROMAN_BASELINE, IMAGE),
+        };
+    }
+
+    @Override
+    public Dimension getPreferredSize() {
+        return new Dimension(350, 450);
+    }
+
+    private Image makeImage(int size) {
+        Image img = new BufferedImage(size, size, BufferedImage.TYPE_INT_RGB);
+        Graphics2D g2d = (Graphics2D) img.getGraphics();
+        g2d.setColor(Color.BLUE);
+        g2d.fillRect(0, 0, size, size);
+        g2d.setColor(Color.RED);
+        g2d.drawRect(0, 0, size - 1, size - 1);
+        return img;
+    }
+
+    /**
+     * Create an AttributedString with a descriptive word (TOP, BOTTOM,
+     * or BASELINE) and several graphics of varying sizes following the
+     * word.
+     *
+     * @param alignment the alignment of the graphics
+     * @param image     whether to create Shape or Image graphics
+     */
+    private AttributedString makeString(int alignment, boolean image) {
+        String name;
+        if (alignment == GraphicAttribute.TOP_ALIGNMENT) {
+            name = "TOP";
+        } else if (alignment == GraphicAttribute.BOTTOM_ALIGNMENT) {
+            name = "BOTTOM";
+        } else {
+            name = "BASELINE";
+        }
+
+        // Append the Unicode graphic replacement character to the name.
+        String nameWithUnicode = name.concat("\uFFFC".repeat(GRAPHIC_COUNT));
+
+        AttributedString as = new AttributedString(nameWithUnicode);
+
+        // Make the descriptive text large.
+        as.addAttribute(TextAttribute.SIZE, 48f, 0, name.length());
+
+        // Add the graphic attributes to the end of the AttributedString.
+        for (int i = 0; i < GRAPHIC_COUNT; i++) {
+
+            float size = (i + 1) * BASE_SIZE;
+            GraphicAttribute attribute;
+
+            if (image == IMAGE) {
+                Image img = makeImage((int) size);
+                attribute = new ImageGraphicAttribute(img, alignment);
+            } else {
+                Shape shape = new Rectangle2D.Float(0, 0, size, size);
+                attribute = new ShapeGraphicAttribute(shape,
+                                                      alignment,
+                                                      ShapeGraphicAttribute.STROKE);
+            }
+
+            as.addAttribute(TextAttribute.CHAR_REPLACEMENT,
+                    attribute,
+                    i + name.length(),
+                    i + name.length() + 1);
+        }
+
+        return as;
+    }
+
+    /**
+     * Draw each AttributedString, with a bounding box enclosing
+     * the string.
+     */
+    @Override
+    public void paint(Graphics g) {
+        super.paint(g);
+        Graphics2D g2d = (Graphics2D) g;
+        FontRenderContext frc = g2d.getFontRenderContext();
+
+        final float drawX = 20;
+        float drawY = 20;
+
+        for (int i = 0; i < strings.length; i++) {
+            TextLayout layout = new TextLayout(strings[i].getIterator(), frc);
+            float ascent = layout.getAscent();
+            drawY += ascent;
+
+            Rectangle2D boundsRect = new Rectangle2D.Float(drawX,
+                    drawY - ascent,
+                    layout.getAdvance(),
+                    ascent + layout.getDescent());
+            g2d.draw(boundsRect);
+            layout.draw(g2d, drawX, drawY);
+            drawY += layout.getDescent() + layout.getLeading();
+        }
+    }
+}


### PR DESCRIPTION
Few more font related tests are converted from applet and open-sourced.

TestGlyphVectorLayout.java doesn't behave as per the instruction and hence problem-listed under [JDK-8354987](https://bugs.openjdk.org/browse/JDK-8354987).

