### PR TITLE
8350703: Add standard system property stdin.encoding

### DIFF
--- a/src/java.base/share/classes/java/lang/System.java
+++ b/src/java.base/share/classes/java/lang/System.java
@@ -118,8 +118,8 @@ public final class System {
      * The "standard" input stream. This stream is already
      * open and ready to supply input data. This stream
      * corresponds to keyboard input or another input source specified by
-     * the host environment or user. The encoding specified by the
-     * {@link ##stdin.encoding stdin.encoding} property should be used
+     * the host environment or user. Applications should use the encoding
+     * specified by the {@link ##stdin.encoding stdin.encoding} property
      * to convert input bytes to character data.
      *
      * @apiNote

--- a/src/java.base/share/classes/java/lang/System.java
+++ b/src/java.base/share/classes/java/lang/System.java
@@ -126,8 +126,8 @@ public final class System {
      * The typical approach to read character data is to wrap {@code System.in}
      * within an {@link java.io.InputStreamReader InputStreamReader} or other object
      * that handles character encoding. If this is done, subsequent reading should
-     * only use the wrapper object; additional operations directly on {@code System.in}
-     * may result in unspecified behavior.
+     * use only the wrapper object; additional operations directly on {@code System.in}
+     * result in unspecified behavior.
      * <p>
      * For handling interactive input, consider using {@link Console}.
      *

--- a/src/java.base/share/classes/java/lang/System.java
+++ b/src/java.base/share/classes/java/lang/System.java
@@ -125,9 +125,9 @@ public final class System {
      * @apiNote
      * The typical approach to read character data is to wrap {@code System.in}
      * within an {@link java.io.InputStreamReader InputStreamReader} or other object
-     * that handles character encoding. If this is done, subsequent reading should
-     * use only the wrapper object; additional operations directly on {@code System.in}
-     * result in unspecified behavior.
+     * that handles character encoding. After this is done, subsequent reading should
+     * use only the wrapper object; operating directly on {@code System.in} results
+     * in unspecified behavior.
      * <p>
      * For handling interactive input, consider using {@link Console}.
      *

--- a/src/java.base/share/classes/java/lang/System.java
+++ b/src/java.base/share/classes/java/lang/System.java
@@ -124,7 +124,7 @@ public final class System {
      *
      * @apiNote
      * The typical approach to read character data is to wrap {@code System.in}
-     * within an {@link java.io.InputStreamReader InputStreamReader} or other class
+     * within an {@link java.io.InputStreamReader InputStreamReader} or other object
      * that handles character encoding. If this is done, subsequent reading should
      * only use the wrapper object; additional operations directly on {@code System.in}
      * may result in unspecified behavior.

--- a/src/java.base/share/classes/java/lang/System.java
+++ b/src/java.base/share/classes/java/lang/System.java
@@ -116,15 +116,23 @@ public final class System {
 
     /**
      * The "standard" input stream. This stream is already
-     * open and ready to supply input data. Typically this stream
+     * open and ready to supply input data. This stream
      * corresponds to keyboard input or another input source specified by
-     * the host environment or user. In case this stream is wrapped
-     * in a {@link java.io.InputStreamReader}, {@link Console#charset()}
-     * should be used for the charset, or consider using
-     * {@link Console#reader()}.
+     * the host environment or user. The encoding specified by the
+     * {@link ##stdin.encoding stdin.encoding} property should be used
+     * to convert input bytes to character data.
      *
-     * @see Console#charset()
-     * @see Console#reader()
+     * @apiNote
+     * The typical approach to read character data is to wrap {@code System.in}
+     * within an {@link java.io.InputStreamReader InputStreamReader} or other class
+     * that handles character encoding. If this is done, subsequent reading should
+     * only use the wrapper object; additional operations directly on {@code System.in}
+     * may result in unspecified behavior.
+     * <p>
+     * For handling interactive input, consider using {@link Console}.
+     *
+     * @see Console
+     * @see ##stdin.encoding stdin.encoding
      */
     public static final InputStream in = null;
 

--- a/src/java.base/share/classes/java/lang/System.java
+++ b/src/java.base/share/classes/java/lang/System.java
@@ -575,17 +575,22 @@ public final class System {
      * <tr><th scope="row">{@systemProperty user.dir}</th>
      *     <td>User's current working directory</td></tr>
      * <tr><th scope="row">{@systemProperty native.encoding}</th>
-     *     <td>Character encoding name derived from the host environment and/or
-     *     the user's settings. Setting this system property has no effect.</td></tr>
+     *     <td>Character encoding name derived from the host environment and
+     *     the user's settings. Setting this system property on the command line
+     *     has no effect.</td></tr>
+     * <tr><th scope="row">{@systemProperty stdin.encoding}</th>
+     *     <td>Character encoding name for {@link System#in System.in}.
+     *     The Java runtime can be started with the system property set to {@code UTF-8}.
+     *     Starting it with the property set to another value results in unspecified behavior.
      * <tr><th scope="row">{@systemProperty stdout.encoding}</th>
      *     <td>Character encoding name for {@link System#out System.out} and
      *     {@link System#console() System.console()}.
-     *     The Java runtime can be started with the system property set to {@code UTF-8},
-     *     starting it with the property set to another value leads to undefined behavior.
+     *     The Java runtime can be started with the system property set to {@code UTF-8}.
+     *     Starting it with the property set to another value results in unspecified behavior.
      * <tr><th scope="row">{@systemProperty stderr.encoding}</th>
      *     <td>Character encoding name for {@link System#err System.err}.
-     *     The Java runtime can be started with the system property set to {@code UTF-8},
-     *     starting it with the property set to another value leads to undefined behavior.
+     *     The Java runtime can be started with the system property set to {@code UTF-8}.
+     *     Starting it with the property set to another value results in unspecified behavior.
      * </tbody>
      * </table>
      * <p>
@@ -639,7 +644,7 @@ public final class System {
      *     the value {@code COMPAT} then the value is replaced with the
      *     value of the {@code native.encoding} property during startup.
      *     Setting the property to a value other than {@code UTF-8} or
-     *     {@code COMPAT} leads to unspecified behavior.
+     *     {@code COMPAT} results in unspecified behavior.
      *     </td></tr>
      * </tbody>
      * </table>

--- a/src/java.base/share/classes/jdk/internal/util/SystemProps.java
+++ b/src/java.base/share/classes/jdk/internal/util/SystemProps.java
@@ -89,8 +89,8 @@ public final class SystemProps {
         }
 
         // Encoding properties for stdin, stdout, and stderr. For stdout and stderr,
-        // check "sun.*.encoding" properties before falling back to the
-        // "native.encoding" property.
+        // check "sun.stdout.encoding" and "sun.stderr.encoding" properties for backward
+        // compatibility reasons before falling back to the "native.encoding" property.
         putIfAbsent(props, "stdin.encoding",
                 raw.propDefault(Raw._stdin_encoding_NDX));
         putIfAbsent(props, "stdin.encoding", nativeEncoding);

--- a/src/java.base/share/classes/jdk/internal/util/SystemProps.java
+++ b/src/java.base/share/classes/jdk/internal/util/SystemProps.java
@@ -93,7 +93,7 @@ public final class SystemProps {
         // "native.encoding" property.
         putIfAbsent(props, "stdin.encoding",
                 raw.propDefault(Raw._stdin_encoding_NDX));
-        putIfAbsent(props, "stdout.encoding", nativeEncoding);
+        putIfAbsent(props, "stdin.encoding", nativeEncoding);
         putIfAbsent(props, "stdout.encoding", props.getOrDefault("sun.stdout.encoding",
                 raw.propDefault(Raw._stdout_encoding_NDX)));
         putIfAbsent(props, "stdout.encoding", nativeEncoding);

--- a/src/java.base/share/classes/jdk/internal/util/SystemProps.java
+++ b/src/java.base/share/classes/jdk/internal/util/SystemProps.java
@@ -88,9 +88,12 @@ public final class SystemProps {
             put(props, "file.encoding", nativeEncoding);
         }
 
-        // "stdout/err.encoding", prepared for System.out/err. For compatibility
-        // purposes, substitute them with "sun.*" if they don't exist. If "sun.*" aren't
-        // available either, fall back to "native.encoding".
+        // Encoding properties for stdin, stdout, and stderr. For stdout and stderr,
+        // check "sun.*.encoding" properties before falling back to the
+        // "native.encoding" property.
+        putIfAbsent(props, "stdin.encoding",
+                raw.propDefault(Raw._stdin_encoding_NDX));
+        putIfAbsent(props, "stdout.encoding", nativeEncoding);
         putIfAbsent(props, "stdout.encoding", props.getOrDefault("sun.stdout.encoding",
                 raw.propDefault(Raw._stdout_encoding_NDX)));
         putIfAbsent(props, "stdout.encoding", nativeEncoding);
@@ -241,7 +244,8 @@ public final class SystemProps {
         @Native private static final int _socksProxyHost_NDX = 1 + _socksNonProxyHosts_NDX;
         @Native private static final int _socksProxyPort_NDX = 1 + _socksProxyHost_NDX;
         @Native private static final int _stderr_encoding_NDX = 1 + _socksProxyPort_NDX;
-        @Native private static final int _stdout_encoding_NDX = 1 + _stderr_encoding_NDX;
+        @Native private static final int _stdin_encoding_NDX = 1 + _stderr_encoding_NDX;
+        @Native private static final int _stdout_encoding_NDX = 1 + _stdin_encoding_NDX;
         @Native private static final int _sun_arch_abi_NDX = 1 + _stdout_encoding_NDX;
         @Native private static final int _sun_arch_data_model_NDX = 1 + _sun_arch_abi_NDX;
         @Native private static final int _sun_cpu_endian_NDX = 1 + _sun_arch_data_model_NDX;

--- a/src/java.base/share/native/libjava/System.c
+++ b/src/java.base/share/native/libjava/System.c
@@ -154,6 +154,7 @@ Java_jdk_internal_util_SystemProps_00024Raw_platformProperties(JNIEnv *env, jcla
     PUTPROP(propArray, _sun_jnu_encoding_NDX, sprops->sun_jnu_encoding);
 
     /* encodings for standard streams, may be NULL */
+    PUTPROP(propArray, _stdin_encoding_NDX, sprops->stdin_encoding);
     PUTPROP(propArray, _stdout_encoding_NDX, sprops->stdout_encoding);
     PUTPROP(propArray, _stderr_encoding_NDX, sprops->stderr_encoding);
 

--- a/src/java.base/share/native/libjava/java_props.h
+++ b/src/java.base/share/native/libjava/java_props.h
@@ -65,6 +65,7 @@ typedef struct {
     char *display_variant;
     char *encoding;             /* always set non-NULL by platform code */
     char *sun_jnu_encoding;     /* always set non-NULL by platform code */
+    char *stdin_encoding;
     char *stdout_encoding;
     char *stderr_encoding;
 

--- a/src/java.base/unix/native/libjava/java_props_md.c
+++ b/src/java.base/unix/native/libjava/java_props_md.c
@@ -464,6 +464,9 @@ GetJavaProperties(JNIEnv *env)
     sprops.sun_jnu_encoding = sprops.encoding;
 #endif
 
+    if (isatty(STDIN_FILENO) == 1) {
+        sprops.stdin_encoding = sprops.encoding;
+    }
     if (isatty(STDOUT_FILENO) == 1) {
         sprops.stdout_encoding = sprops.encoding;
     }

--- a/src/java.base/windows/native/libjava/java_props_md.c
+++ b/src/java.base/windows/native/libjava/java_props_md.c
@@ -634,8 +634,7 @@ GetJavaProperties(JNIEnv* env)
         LCID userDefaultUILCID = MAKELCID(userDefaultUILang, SORTIDFROMLCID(userDefaultLCID));
 
         {
-            HANDLE hStdIn;
-            HANDLE hStdOutErr;
+            HANDLE hStdHandle;
 
             // Windows UI Language selection list only cares "language"
             // information of the UI Language. For example, the list
@@ -678,19 +677,19 @@ GetJavaProperties(JNIEnv* env)
                 sprops.sun_jnu_encoding = "MS950_HKSCS";
             }
 
-            hStdIn = GetStdHandle(STD_INPUT_HANDLE);
-            if (hStdIn != INVALID_HANDLE_VALUE &&
-                GetFileType(hStdIn) == FILE_TYPE_CHAR) {
+            hStdHandle = GetStdHandle(STD_INPUT_HANDLE);
+            if (hStdHandle != INVALID_HANDLE_VALUE &&
+                GetFileType(hStdHandle) == FILE_TYPE_CHAR) {
                 sprops.stdin_encoding = getConsoleEncoding(FALSE);
             }
-            hStdOutErr = GetStdHandle(STD_OUTPUT_HANDLE);
-            if (hStdOutErr != INVALID_HANDLE_VALUE &&
-                GetFileType(hStdOutErr) == FILE_TYPE_CHAR) {
+            hStdHandle = GetStdHandle(STD_OUTPUT_HANDLE);
+            if (hStdHandle != INVALID_HANDLE_VALUE &&
+                GetFileType(hStdHandle) == FILE_TYPE_CHAR) {
                 sprops.stdout_encoding = getConsoleEncoding(TRUE);
             }
-            hStdOutErr = GetStdHandle(STD_ERROR_HANDLE);
-            if (hStdOutErr != INVALID_HANDLE_VALUE &&
-                GetFileType(hStdOutErr) == FILE_TYPE_CHAR) {
+            hStdHandle = GetStdHandle(STD_ERROR_HANDLE);
+            if (hStdHandle != INVALID_HANDLE_VALUE &&
+                GetFileType(hStdHandle) == FILE_TYPE_CHAR) {
                 if (sprops.stdout_encoding != NULL)
                     sprops.stderr_encoding = sprops.stdout_encoding;
                 else

--- a/src/java.base/windows/native/libjava/java_props_md.c
+++ b/src/java.base/windows/native/libjava/java_props_md.c
@@ -634,6 +634,7 @@ GetJavaProperties(JNIEnv* env)
         LCID userDefaultUILCID = MAKELCID(userDefaultUILang, SORTIDFROMLCID(userDefaultLCID));
 
         {
+            HANDLE hStdIn;
             HANDLE hStdOutErr;
 
             // Windows UI Language selection list only cares "language"
@@ -677,6 +678,11 @@ GetJavaProperties(JNIEnv* env)
                 sprops.sun_jnu_encoding = "MS950_HKSCS";
             }
 
+            hStdIn = GetStdHandle(STD_INPUT_HANDLE);
+            if (hStdIn != INVALID_HANDLE_VALUE &&
+                GetFileType(hStdIn) == FILE_TYPE_CHAR) {
+                sprops.stdin_encoding = getConsoleEncoding(FALSE);
+            }
             hStdOutErr = GetStdHandle(STD_OUTPUT_HANDLE);
             if (hStdOutErr != INVALID_HANDLE_VALUE &&
                 GetFileType(hStdOutErr) == FILE_TYPE_CHAR) {

--- a/test/jdk/java/lang/System/PropertyTest.java
+++ b/test/jdk/java/lang/System/PropertyTest.java
@@ -81,6 +81,7 @@ public class PropertyTest {
                 {"java.runtime.version"},
                 {"java.runtime.name"},
                 {"native.encoding"},
+                {"stdin.encoding"},
                 {"stdout.encoding"},
                 {"stderr.encoding"},
         };


### PR DESCRIPTION
* Windows and Unix: set sprops.stdin_encoding if connected to a console
* Add specs for stdin.encoding
* Adjust specs to change "undefined" to "unspecified"
* Rewrite System.in spec to refer to new property and to clarify usage with classes that perform encoding
* Update property test

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Change requires CSR request [JDK-8355357](https://bugs.openjdk.org/browse/JDK-8355357) to be approved
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8350703](https://bugs.openjdk.org/browse/JDK-8350703): Add standard system property stdin.encoding (**Enhancement** - P4)
 * [JDK-8355357](https://bugs.openjdk.org/browse/JDK-8355357): Add standard system property stdin.encoding (**CSR**)


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24738/head:pull/24738` \
`$ git checkout pull/24738`

Update a local copy of the PR: \
`$ git checkout pull/24738` \
`$ git pull https://git.openjdk.org/jdk.git pull/24738/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24738`

View PR using the GUI difftool: \
`$ git pr show -t 24738`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24738.diff">https://git.openjdk.org/jdk/pull/24738.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24738#issuecomment-2822657793)
</details>
