### PR TITLE
8355013: GrowableArray default constructor should not allocate

### DIFF
--- a/src/hotspot/share/utilities/growableArray.hpp
+++ b/src/hotspot/share/utilities/growableArray.hpp
@@ -537,7 +537,7 @@ void GrowableArrayWithAllocator<E, Derived>::expand_to(int new_capacity) {
 template <typename E, typename Derived>
 void GrowableArrayWithAllocator<E, Derived>::grow(int j) {
   // grow the array by increasing _capacity to the first power of two larger than the size we need
-  expand_to(next_power_of_2(j));
+  expand_to(next_power_of_2(MAX2(j, 4)));
 }
 
 template <typename E, typename Derived>
@@ -754,13 +754,21 @@ class GrowableArray : public GrowableArrayWithAllocator<E, GrowableArray<E>> {
   }
 
 public:
-  GrowableArray() : GrowableArray(2 /* initial_capacity */) {}
+  GrowableArray() : GrowableArrayWithAllocator<E, GrowableArray>(nullptr, 0), _metadata() {
+    init_checks();
+  }
 
   explicit GrowableArray(int initial_capacity) :
       GrowableArrayWithAllocator<E, GrowableArray>(
           allocate(initial_capacity),
           initial_capacity),
       _metadata() {
+    init_checks();
+  }
+
+  explicit GrowableArray(MemTag mem_tag) :
+      GrowableArrayWithAllocator<E, GrowableArray>(nullptr, 0),
+      _metadata(mem_tag) {
     init_checks();
   }
 
@@ -825,7 +833,9 @@ class GrowableArrayCHeap : public GrowableArrayWithAllocator<E, GrowableArrayCHe
   }
 
 public:
-  GrowableArrayCHeap(int initial_capacity = 0) :
+  GrowableArrayCHeap() : GrowableArrayWithAllocator<E, GrowableArrayCHeap<E, MT>>(nullptr, 0) {}
+
+  explicit GrowableArrayCHeap(int initial_capacity) :
       GrowableArrayWithAllocator<E, GrowableArrayCHeap<E, MT> >(
           allocate(initial_capacity, MT),
           initial_capacity) {}

--- a/test/hotspot/gtest/utilities/test_growableArray.cpp
+++ b/test/hotspot/gtest/utilities/test_growableArray.cpp
@@ -352,6 +352,12 @@ protected:
     // Stack/Resource allocated
     {
       ResourceMark rm;
+      GrowableArray<int> a;
+      modify_and_test(&a, modify, test);
+    }
+
+    {
+      ResourceMark rm;
       GrowableArray<int> a(max);
       modify_and_test(&a, modify, test);
     }
@@ -434,6 +440,10 @@ protected:
     with_no_cheap_array(Max0, Append1, test);
   }
 };
+
+// static empty vector
+const GrowableArray<int> empty_array(mtTest);
+const GrowableArrayCHeap<int, mtTest> empty_cheap_array;
 
 TEST_VM_F(GrowableArrayTest, append) {
   with_all_types_all_0(Append);
@@ -561,7 +571,7 @@ TEST_VM_ASSERT_MSG(GrowableArrayAssertingTest, assignment_with_embedded_cheap,
 TEST(GrowableArrayCHeap, sanity) {
   // Stack/CHeap
   {
-    GrowableArrayCHeap<int, mtTest> a(0);
+    GrowableArrayCHeap<int, mtTest> a;
 #ifdef ASSERT
     ASSERT_TRUE(a.allocated_on_stack_or_embedded());
 #endif
@@ -574,7 +584,7 @@ TEST(GrowableArrayCHeap, sanity) {
 
   // CHeap/CHeap
   {
-    GrowableArrayCHeap<int, mtTest>* a = new GrowableArrayCHeap<int, mtTest>(0);
+    GrowableArrayCHeap<int, mtTest>* a = new GrowableArrayCHeap<int, mtTest>();
 #ifdef ASSERT
     ASSERT_TRUE(a->allocated_on_C_heap());
 #endif

--- a/test/hotspot/gtest/utilities/test_growableArray.cpp
+++ b/test/hotspot/gtest/utilities/test_growableArray.cpp
@@ -353,6 +353,7 @@ protected:
     {
       ResourceMark rm;
       GrowableArray<int> a;
+      ASSERT_TRUE(a.is_empty());
       modify_and_test(&a, modify, test);
     }
 
@@ -406,6 +407,14 @@ protected:
       WithEmbeddedArray w(max, mtTest);
       modify_and_test(&w._a, modify, test);
     }
+
+    // Static/CHeap allocated
+    {
+      static GrowableArray<int> a(mtTest);
+      ASSERT_TRUE(a.is_empty());
+      modify_and_test(&a, modify, test);
+      a.clear_and_deallocate();
+    }
   }
 
   static void with_all_types(int max, ModifyEnum modify, TestEnum test) {
@@ -445,6 +454,11 @@ protected:
 const GrowableArray<int> empty_array(mtTest);
 const GrowableArrayCHeap<int, mtTest> empty_cheap_array;
 
+TEST_F(GrowableArrayTest, static_empty) {
+  ASSERT_TRUE(empty_array.is_empty());
+  ASSERT_TRUE(empty_cheap_array.is_empty());
+}
+
 TEST_VM_F(GrowableArrayTest, append) {
   with_all_types_all_0(Append);
 }
@@ -479,6 +493,7 @@ TEST_VM_F(GrowableArrayTest, where) {
   {
     ResourceMark rm;
     GrowableArray<int>* a = new GrowableArray<int>();
+    ASSERT_TRUE(a->is_empty());
     ASSERT_TRUE(a->allocated_on_res_area());
     ASSERT_TRUE(elements_on_resource_area(a));
   }


### PR DESCRIPTION
Hi,

This patch changes the default constructors of `GrowableArray` so that it does not allocate. This is helpful because sometimes we create a `GrowableArray` and append another into it immediately, or create a `GrowableArray` to merge the value from several branches. In these cases, the default allocation is not needed. This also aligns the behaviour with that of `std::vector`, which does not allocate for default construction.

Please take a look and leave your reviews, thanks a lot.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8355013](https://bugs.openjdk.org/browse/JDK-8355013): GrowableArray default constructor should not allocate (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24748/head:pull/24748` \
`$ git checkout pull/24748`

Update a local copy of the PR: \
`$ git checkout pull/24748` \
`$ git pull https://git.openjdk.org/jdk.git pull/24748/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24748`

View PR using the GUI difftool: \
`$ git pr show -t 24748`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24748.diff">https://git.openjdk.org/jdk/pull/24748.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24748#issuecomment-2814591528)
</details>
