### PR TITLE
8354248: Open source several AWT GridBagLayout and List tests

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -461,7 +461,7 @@ java/awt/TrayIcon/RightClickWhenBalloonDisplayed/RightClickWhenBalloonDisplayed.
 java/awt/PopupMenu/PopupMenuLocation.java 8259913,8315878 windows-all,macosx-aarch64
 java/awt/GridLayout/ComponentPreferredSize/ComponentPreferredSize.java 8238720,8324782 windows-all,macosx-all
 java/awt/GridLayout/ChangeGridSize/ChangeGridSize.java   8238720,8324782 windows-all,macosx-all
-java/awt/GridLayout/GridBagLayout/ComponentShortage.java 8355280 windows-all,linux-all
+java/awt/GridBagLayout/ComponentShortage.java 8355280 windows-all,linux-all
 java/awt/event/MouseEvent/FrameMouseEventAbsoluteCoordsTest/FrameMouseEventAbsoluteCoordsTest.java 8238720 windows-all
 
 # Several tests which fail sometimes on macos11

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -461,6 +461,7 @@ java/awt/TrayIcon/RightClickWhenBalloonDisplayed/RightClickWhenBalloonDisplayed.
 java/awt/PopupMenu/PopupMenuLocation.java 8259913,8315878 windows-all,macosx-aarch64
 java/awt/GridLayout/ComponentPreferredSize/ComponentPreferredSize.java 8238720,8324782 windows-all,macosx-all
 java/awt/GridLayout/ChangeGridSize/ChangeGridSize.java   8238720,8324782 windows-all,macosx-all
+java/awt/GridLayout/GridBagLayout/ComponentShortage.java 8355280 windows-all,linux-all
 java/awt/event/MouseEvent/FrameMouseEventAbsoluteCoordsTest/FrameMouseEventAbsoluteCoordsTest.java 8238720 windows-all
 
 # Several tests which fail sometimes on macos11

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -804,6 +804,7 @@ java/awt/PopupMenu/PopupHangTest.java 8340022 windows-all
 java/awt/Focus/MinimizeNonfocusableWindowTest.java 8024487 windows-all
 java/awt/Focus/InactiveFocusRace.java 8023263 linux-all
 java/awt/List/HandlingKeyEventIfMousePressedTest.java 6848358 macosx-all,windows-all
+java/awt/List/ListScrollbarCursorTest.java 8066410 generic-all
 java/awt/Checkbox/CheckboxBoxSizeTest.java 8340870 windows-all
 java/awt/Checkbox/CheckboxIndicatorSizeTest.java 8340870 windows-all
 java/awt/Checkbox/CheckboxNullLabelTest.java 8340870 windows-all

--- a/test/jdk/java/awt/GridBagLayout/ComponentShortage.java
+++ b/test/jdk/java/awt/GridBagLayout/ComponentShortage.java
@@ -67,19 +67,23 @@ public class ComponentShortage {
             });
             robot.waitForIdle();
             robot.delay(1000);
+
             EventQueue.invokeAndWait(() -> {
                 size = jtf.getSize();
             });
             System.out.println("TextField size before Frame's width reduction : " + size);
+
             EventQueue.invokeAndWait(() -> {
                 frame.setSize(frame.getSize().width - WIDTH_REDUCTION, frame.getSize().height);
             });
             frame.repaint();
+
             EventQueue.invokeAndWait(() -> {
                 size = jtf.getSize();
                 fSize = frame.getSize();
             });
             System.out.println("TextField size after Frame's width reduction : " + size);
+
             if (size.width < fSize.width - WIDTH_REDUCTION) {
                 throw new RuntimeException("Width of JTextField is too small to be visible.");
             }

--- a/test/jdk/java/awt/GridBagLayout/ComponentShortage.java
+++ b/test/jdk/java/awt/GridBagLayout/ComponentShortage.java
@@ -41,8 +41,8 @@ public class ComponentShortage {
     static final int WIDTH_REDUCTION = 50;
     static JFrame frame;
     static JTextField jtf;
-    static Dimension size;
-    static Dimension fSize;
+    static volatile Dimension size;
+    static volatile Dimension fSize;
 
     public static void main(String[] args) throws Exception {
         Robot robot = new Robot();

--- a/test/jdk/java/awt/GridBagLayout/ComponentShortage.java
+++ b/test/jdk/java/awt/GridBagLayout/ComponentShortage.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2008, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4238932
+ * @summary JTextField in gridBagLayout does not properly set MinimumSize
+ * @key headful
+ * @run main ComponentShortage
+ */
+
+import java.awt.Dimension;
+import java.awt.EventQueue;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Robot;
+import javax.swing.JFrame;
+import javax.swing.JTextField;
+
+public class ComponentShortage {
+    static final int WIDTH_REDUCTION = 50;
+    static JFrame frame;
+    static JTextField jtf;
+    static Dimension size;
+    static Dimension fSize;
+
+    public static void main(String[] args) throws Exception {
+        Robot robot = new Robot();
+        try {
+            EventQueue.invokeAndWait(() -> {
+                frame = new JFrame();
+                frame.setLayout(new GridBagLayout());
+                GridBagConstraints gBC = new GridBagConstraints();
+
+                gBC.gridx = 1;
+                gBC.gridy = 0;
+                gBC.gridwidth = 1;
+                gBC.gridheight = 1;
+                gBC.weightx = 1.0;
+                gBC.weighty = 0.0;
+                gBC.fill = GridBagConstraints.NONE;
+                gBC.anchor = GridBagConstraints.NORTHWEST;
+                jtf = new JTextField(16);
+                frame.add(jtf, gBC);
+                frame.pack();
+                frame.setVisible(true);
+            });
+            robot.waitForIdle();
+            robot.delay(1000);
+            EventQueue.invokeAndWait(() -> {
+                size = jtf.getSize();
+            });
+            System.out.println("TextField size before Frame's width reduction : " + size);
+            EventQueue.invokeAndWait(() -> {
+                frame.setSize(frame.getSize().width - WIDTH_REDUCTION, frame.getSize().height);
+            });
+            frame.repaint();
+            EventQueue.invokeAndWait(() -> {
+                size = jtf.getSize();
+                fSize = frame.getSize();
+            });
+            System.out.println("TextField size after Frame's width reduction : " + size);
+            if (size.width < fSize.width - WIDTH_REDUCTION) {
+                throw new RuntimeException("Width of JTextField is too small to be visible.");
+            }
+            System.out.println("Test passed.");
+        } finally {
+            EventQueue.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+    }
+}

--- a/test/jdk/java/awt/List/ListScrollbarCursorTest.java
+++ b/test/jdk/java/awt/List/ListScrollbarCursorTest.java
@@ -46,7 +46,6 @@ public class ListScrollbarCursorTest {
                 4. Press PASS if you see the default arrow cursor else press FAIL.
                 """;
         PassFailJFrame.builder()
-                .title("Test Instructions")
                 .instructions(INSTRUCTIONS)
                 .columns(35)
                 .testUI(ListScrollbarCursorTest::initialize)

--- a/test/jdk/java/awt/List/ListScrollbarCursorTest.java
+++ b/test/jdk/java/awt/List/ListScrollbarCursorTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4290684
+ * @summary Tests that cursor on the scrollbar of the list is set to default.
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual ListScrollbarCursorTest
+ */
+
+import java.awt.Cursor;
+import java.awt.Frame;
+import java.awt.List;
+import java.awt.Panel;
+
+public class ListScrollbarCursorTest {
+    public static void main(String[] args) throws Exception {
+        String INSTRUCTIONS = """
+                1. You see the list in the middle of the panel.
+                   This list has two scrollbars.
+                2. The cursor should have a shape of hand over the main area
+                   and a shape of arrow over scrollbars.
+                3. Move the mouse cursor to either horizontal or vertical scrollbar.
+                4. Press PASS if you see the default arrow cursor else press FAIL.
+                """;
+        PassFailJFrame.builder()
+                .title("Test Instructions")
+                .instructions(INSTRUCTIONS)
+                .columns(35)
+                .testUI(ListScrollbarCursorTest::initialize)
+                .build()
+                .awaitAndCheck();
+    }
+
+    static Frame initialize() {
+        Frame frame = new Frame("List Scrollbar Cursor Test");
+        Panel panel = new Panel();
+        List list = new List(3);
+        list.add("List item with a very long name" +
+                "(just to make the horizontal scrollbar visible)");
+        list.add("Item 2");
+        list.add("Item 3");
+        list.setCursor(new Cursor(Cursor.HAND_CURSOR));
+        panel.add(list);
+        frame.add(panel);
+        frame.setSize(200, 200);
+        return frame;
+    }
+}

--- a/test/jdk/java/awt/List/ListScrollbarTest.java
+++ b/test/jdk/java/awt/List/ListScrollbarTest.java
@@ -157,6 +157,7 @@ public class ListScrollbarTest extends Frame {
         }
     }
 
+    @Override
     public boolean action(Event evt, Object arg) {
         if (">".equals(arg)) {
             move(ltList, rtList, false);
@@ -180,6 +181,7 @@ public class ListScrollbarTest extends Frame {
         return true;
     }
 
+    @Override
     public boolean handleEvent(Event evt) {
         if (evt.id == Event.LIST_SELECT
                 || evt.id == Event.LIST_DESELECT) {

--- a/test/jdk/java/awt/List/ListScrollbarTest.java
+++ b/test/jdk/java/awt/List/ListScrollbarTest.java
@@ -66,7 +66,6 @@ public class ListScrollbarTest extends Frame {
                    click PASS else click FAIL.
                 """;
         PassFailJFrame.builder()
-                .title("Test Instructions")
                 .instructions(INSTRUCTIONS)
                 .columns(35)
                 .testUI(ListScrollbarTest::new)
@@ -139,15 +138,15 @@ public class ListScrollbarTest extends Frame {
             for (int i = 0; i < l1.countItems(); i++) {
                 l2.addItem(l1.getItem(i));
             }
-            l1.delItems(0, l1.countItems() - 1);    // or l1.clear();
-        } else { //else move the selected items
+            l1.delItems(0, l1.countItems() - 1);
+        } else { // else move the selected items
             String[] items = l1.getSelectedItems();
             int[] itemIndexes = l1.getSelectedIndexes();
 
             deselectAll(l2);
             for (int i = 0; i < items.length; i++) {
-                l2.addItem(items[i]);        // add it
-                l2.select(l2.countItems() - 1);// and select it
+                l2.addItem(items[i]);
+                l2.select(l2.countItems() - 1);
                 if (i == 0) {
                     l2.makeVisible(l2.countItems() - 1);
                 }

--- a/test/jdk/java/awt/List/ListScrollbarTest.java
+++ b/test/jdk/java/awt/List/ListScrollbarTest.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4096445
+ * @summary Test to verify List Scollbar appears/disappears automatically
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual ListScrollbarTest
+ */
+
+import java.awt.Button;
+import java.awt.Component;
+import java.awt.Event;
+import java.awt.Frame;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.List;
+
+public class ListScrollbarTest extends Frame {
+    static final int ITEMS = 10;
+    List ltList;
+    List rtList;
+
+    public static void main(String[] args) throws Exception {
+        String INSTRUCTIONS = """
+                1. There are two lists added to the Frame separated by
+                   a column of buttons
+                2. Double click on any item(s) on the left list, you would see
+                   a '*' added at the end of the item
+                3. Keep double clicking on the same item till the length of the
+                   item exceeds the width of the list
+                4. Now, if you don't get the horizontal scrollbar on
+                   the left list click FAIL.
+                5. If you get horizontal scrollbar, select the item
+                   (that you double clicked) and press the '>' button
+                   to move the item to the right list.
+                6. If horizontal scroll bar appears on the right list
+                   as well as disappears from the left list [only if both
+                   happen] proceed with step 8 else click FAIL
+                7. Now move the same item to the left list, by pressing
+                     '<' button
+                8. If the horizontal scrollbar appears on the left list
+                   and disappears from the right list[only if both happen]
+                   click PASS else click FAIL.
+                """;
+        PassFailJFrame.builder()
+                .title("Test Instructions")
+                .instructions(INSTRUCTIONS)
+                .columns(35)
+                .testUI(ListScrollbarTest::new)
+                .build()
+                .awaitAndCheck();
+    }
+
+    public ListScrollbarTest() {
+        super("List scroll bar test");
+        GridBagLayout gbl = new GridBagLayout();
+        ltList = new List(ITEMS, true);
+        rtList = new List(0, true);
+        setLayout(gbl);
+        add(ltList, 0, 0, 1, 5, 1.0, 1.0);
+        add(rtList, 2, 0, 1, 5, 1.0, 1.0);
+        add(new Button(">"), 1, 0, 1, 1, 0, 1.0);
+        add(new Button(">>"), 1, 1, 1, 1, 0, 1.0);
+        add(new Button("<"), 1, 2, 1, 1, 0, 1.0);
+        add(new Button("<<"), 1, 3, 1, 1, 0, 1.0);
+        add(new Button("!"), 1, 4, 1, 1, 0, 1.0);
+
+        for (int i = 0; i < ITEMS; i++) {
+            ltList.addItem("item " + i);
+        }
+        setSize(220, 250);
+    }
+
+    void add(Component comp, int x, int y, int w, int h, double weightx, double weighty) {
+        GridBagLayout gbl = (GridBagLayout) getLayout();
+        GridBagConstraints c = new GridBagConstraints();
+        c.fill = GridBagConstraints.BOTH;
+        c.gridx = x;
+        c.gridy = y;
+        c.gridwidth = w;
+        c.gridheight = h;
+        c.weightx = weightx;
+        c.weighty = weighty;
+        add(comp);
+        gbl.setConstraints(comp, c);
+    }
+
+    void reverseSelections(List l) {
+        for (int i = 0; i < l.countItems(); i++) {
+            if (l.isSelected(i)) {
+                l.deselect(i);
+            } else {
+                l.select(i);
+            }
+        }
+    }
+
+    void deselectAll(List l) {
+        for (int i = 0; i < l.countItems(); i++) {
+            l.deselect(i);
+        }
+    }
+
+    void replaceItem(List l, String item) {
+        for (int i = 0; i < l.countItems(); i++) {
+            if (l.getItem(i).equals(item)) {
+                l.replaceItem(item + "*", i);
+            }
+        }
+    }
+
+    void move(List l1, List l2, boolean all) {
+
+        // if all the items are to be moved
+        if (all) {
+            for (int i = 0; i < l1.countItems(); i++) {
+                l2.addItem(l1.getItem(i));
+            }
+            l1.delItems(0, l1.countItems() - 1);    // or l1.clear();
+        } else { //else move the selected items
+            String[] items = l1.getSelectedItems();
+            int[] itemIndexes = l1.getSelectedIndexes();
+
+            deselectAll(l2);
+            for (int i = 0; i < items.length; i++) {
+                l2.addItem(items[i]);        // add it
+                l2.select(l2.countItems() - 1);// and select it
+                if (i == 0) {
+                    l2.makeVisible(l2.countItems() - 1);
+                }
+            }
+            for (int i = itemIndexes.length - 1; i >= 0; i--) {
+                l1.delItem(itemIndexes[i]);
+            }
+        }
+    }
+
+    public boolean action(Event evt, Object arg) {
+        if (">".equals(arg)) {
+            move(ltList, rtList, false);
+        } else if (">>".equals(arg)) {
+            move(ltList, rtList, true);
+        } else if ("<".equals(arg)) {
+            move(rtList, ltList, false);
+        } else if ("<<".equals(arg)) {
+            move(rtList, ltList, true);
+        } else if ("!".equals(arg)) {
+            if (ltList.getSelectedItems().length > 0) {
+                reverseSelections(ltList);
+            } else if (rtList.getSelectedItems().length > 0) {
+                reverseSelections(rtList);
+            }
+        } else if (evt.target == rtList || evt.target == ltList) {
+            replaceItem((List) evt.target, (String) arg);
+        } else {
+            return false;
+        }
+        return true;
+    }
+
+    public boolean handleEvent(Event evt) {
+        if (evt.id == Event.LIST_SELECT
+                || evt.id == Event.LIST_DESELECT) {
+            if (evt.target == ltList) {
+                deselectAll(rtList);
+            } else if (evt.target == rtList) {
+                deselectAll(ltList);
+            }
+            return true;
+        }
+        return super.handleEvent(evt);
+    }
+}


### PR DESCRIPTION
Open source these AWT GridBagLayout and List tests:

java/awt/GridBagLayout/ComponentShortage/ComponentShortage.java
java/awt/List/ListScrollbarCursorTest/ListScrollbarCursorTest.java
java/awt/List/ListScrollbarTest/ListScrollbarTest.java

ComponentShortage.java test fails in Windows and linux after converting to main based. On investigation its found that the test was not running through jtreg, it failed to run with this error - 
`Error: Not a test or directory containing tests: java/awt/GridBagLayout/ComponentShortage/ComponentShortage.html
`
Hence it was gone unnoticed without been problem listed.
I've created a new JBS for this issue since it needs further investigation - [JDK-8355280](https://bugs.openjdk.org/browse/JDK-8355280) .

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8354248](https://bugs.openjdk.org/browse/JDK-8354248): Open source several AWT GridBagLayout and List tests (**Bug** - P4)


### Reviewers
 * [Abhishek Kumar](https://openjdk.org/census#abhiscxk) (@kumarabhi006 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24749/head:pull/24749` \
`$ git checkout pull/24749`

Update a local copy of the PR: \
`$ git checkout pull/24749` \
`$ git pull https://git.openjdk.org/jdk.git pull/24749/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24749`

View PR using the GUI difftool: \
`$ git pr show -t 24749`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24749.diff">https://git.openjdk.org/jdk/pull/24749.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24749#issuecomment-2814851284)
</details>
