### PR TITLE
8230016: re-visit test sun/security/pkcs11/Serialize/SerializeProvider.java

### DIFF
--- a/test/jdk/sun/security/pkcs11/Serialize/SerializeProvider.java
+++ b/test/jdk/sun/security/pkcs11/Serialize/SerializeProvider.java
@@ -30,8 +30,6 @@
  * @modules jdk.crypto.cryptoki
  */
 
-import jtreg.SkippedException;
-
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
@@ -43,12 +41,14 @@ import java.security.Security;
 public class SerializeProvider extends PKCS11Test {
 
     public void main(Provider p) throws Exception {
-        if (Security.getProvider(p.getName()) != p) {
-            Security.addProvider(p);
+        // Checking if provider is null in case the
+        // provider supplied by the PKCS11Test is null
+        if (p==null) {
+            throw new RuntimeException("Provider must not be NULL");
         }
 
         if (Security.getProvider(p.getName()) != p) {
-            throw new SkippedException("Provider not installed in Security, skipping");
+            Security.addProvider(p);
         }
 
         ByteArrayOutputStream out = new ByteArrayOutputStream();

--- a/test/jdk/sun/security/pkcs11/Serialize/SerializeProvider.java
+++ b/test/jdk/sun/security/pkcs11/Serialize/SerializeProvider.java
@@ -41,11 +41,6 @@ import java.security.Security;
 public class SerializeProvider extends PKCS11Test {
 
     public void main(Provider p) throws Exception {
-        // Checking if provider is null in case the
-        // provider supplied by the PKCS11Test is null
-        if (p==null) {
-            throw new RuntimeException("Provider must not be NULL");
-        }
 
         if (Security.getProvider(p.getName()) != p) {
             Security.addProvider(p);
@@ -62,7 +57,7 @@ public class SerializeProvider extends PKCS11Test {
         InputStream in = new ByteArrayInputStream(data);
         ObjectInputStream oin = new ObjectInputStream(in);
 
-        Provider p2 = (Provider)oin.readObject();
+        Provider p2 = (Provider) oin.readObject();
 
         System.out.println("Reconstituted: " + p2);
 

--- a/test/jdk/sun/security/pkcs11/Serialize/SerializeProvider.java
+++ b/test/jdk/sun/security/pkcs11/Serialize/SerializeProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,8 @@
  * @modules jdk.crypto.cryptoki
  */
 
+import jtreg.SkippedException;
+
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
@@ -42,8 +44,11 @@ public class SerializeProvider extends PKCS11Test {
 
     public void main(Provider p) throws Exception {
         if (Security.getProvider(p.getName()) != p) {
-            System.out.println("Provider not installed in Security, skipping");
-            return;
+            Security.addProvider(p);
+        }
+
+        if (Security.getProvider(p.getName()) != p) {
+            throw new SkippedException("Provider not installed in Security, skipping");
         }
 
         ByteArrayOutputStream out = new ByteArrayOutputStream();


### PR DESCRIPTION
Provider is now added to the Security before the test

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8230016](https://bugs.openjdk.org/browse/JDK-8230016): re-visit test sun/security/pkcs11/Serialize/SerializeProvider.java (**Bug** - P4)


### Reviewers
 * [Rajan Halade](https://openjdk.org/census#rhalade) (@rhalade - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24750/head:pull/24750` \
`$ git checkout pull/24750`

Update a local copy of the PR: \
`$ git checkout pull/24750` \
`$ git pull https://git.openjdk.org/jdk.git pull/24750/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24750`

View PR using the GUI difftool: \
`$ git pr show -t 24750`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24750.diff">https://git.openjdk.org/jdk/pull/24750.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24750#issuecomment-2815189287)
</details>
