### PR TITLE
8355034: [JVMCI] assert(static_cast<int>(_jvmci_data_size) == align_up(compiler->is_jvmci() ? jvmci_data->size() : 0, oopSize)) failed: failed: 104 != 16777320

### DIFF
--- a/src/hotspot/share/code/nmethod.cpp
+++ b/src/hotspot/share/code/nmethod.cpp
@@ -112,7 +112,7 @@
 // Cast from int value to narrow type
 #define CHECKED_CAST(result, T, thing)      \
   result = static_cast<T>(thing); \
-  assert(static_cast<int>(result) == thing, "failed: %d != %d", static_cast<int>(result), thing);
+  guarantee(static_cast<int>(result) == thing, "failed: %d != %d", static_cast<int>(result), thing);
 
 //---------------------------------------------------------------------------------
 // NMethod statistics

--- a/src/hotspot/share/jvmci/jvmciCodeInstaller.cpp
+++ b/src/hotspot/share/jvmci/jvmciCodeInstaller.cpp
@@ -825,7 +825,13 @@ JVMCI::CodeInstallResult CodeInstaller::install(JVMCICompiler* compiler,
         // Since this compilation didn't pass through the broker it wasn't logged yet.
         if (PrintCompilation) {
           ttyLocker ttyl;
-          CompileTask::print(tty, nm, "(hosted JVMCI compilation)");
+          if (name != nullptr) {
+            stringStream st;
+            st.print_cr("(hosted JVMCI compilation: %s)", name);
+            CompileTask::print(tty, nm, st.as_string());
+          } else {
+            CompileTask::print(tty, nm, "(hosted JVMCI compilation)");
+          }
         }
       }
 

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/code/InstalledCode.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/code/InstalledCode.java
@@ -59,7 +59,7 @@ public class InstalledCode {
      * @throws IllegalArgumentException if {@code name.length >} {@link #MAX_NAME_LENGTH}
      */
     public InstalledCode(String name) {
-        if (name.length() > MAX_NAME_LENGTH) {
+        if (name != null && name.length() > MAX_NAME_LENGTH) {
             String msg = String.format("name length (%d) is greater than %d (name[0:%s] = %s)",
                                         name.length(), MAX_NAME_LENGTH, MAX_NAME_LENGTH, name.substring(0, MAX_NAME_LENGTH));
             throw new IllegalArgumentException(msg);

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/code/InstalledCode.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/code/InstalledCode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,7 +46,24 @@ public class InstalledCode {
 
     protected final String name;
 
+    /**
+     * The maximum length of an InstalledCode name. This name is typically installed into
+     * the code cache so it should have a reasonable limit.
+     */
+    public static final int MAX_NAME_LENGTH = 2048;
+
+    /**
+     * @param name the name to be associated with the installed code. Can be null and
+     *        must be no longer than {@link #MAX_NAME_LENGTH}.
+     *
+     * @throws IllegalArgumentException if {@code name.length >} {@link #MAX_NAME_LENGTH}
+     */
     public InstalledCode(String name) {
+        if (name.length() > MAX_NAME_LENGTH) {
+            String msg = String.format("name length (%d) is greater than %d (name[0:%s] = %s)",
+                                        name.length(), MAX_NAME_LENGTH, MAX_NAME_LENGTH, name.substring(0, MAX_NAME_LENGTH));
+            throw new IllegalArgumentException(msg);
+        }
         this.name = name;
     }
 

--- a/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/InstalledCodeTest.java
+++ b/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/InstalledCodeTest.java
@@ -22,7 +22,7 @@
  */
 
 /**
- * @test
+ * @test 8355034
  * @requires vm.jvmci
  * @modules jdk.internal.vm.ci/jdk.vm.ci.code
  * @run junit/othervm -XX:+UnlockExperimentalVMOptions -XX:+EnableJVMCI jdk.vm.ci.code.test.InstalledCodeTest

--- a/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/InstalledCodeTest.java
+++ b/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/InstalledCodeTest.java
@@ -37,6 +37,11 @@ import org.junit.Test;
 public class InstalledCodeTest {
 
     @Test
+    public void testNullName() {
+        new InstalledCode(null);
+    }
+
+    @Test
     public void testTooLongName() {
         String longName = new String(new char[InstalledCode.MAX_NAME_LENGTH]).replace('\0', 'A');
         new InstalledCode(longName);

--- a/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/InstalledCodeTest.java
+++ b/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/InstalledCodeTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @requires vm.jvmci
+ * @modules jdk.internal.vm.ci/jdk.vm.ci.code
+ * @run junit/othervm -XX:+UnlockExperimentalVMOptions -XX:+EnableJVMCI jdk.vm.ci.code.test.InstalledCodeTest
+ */
+
+package jdk.vm.ci.code.test;
+
+import jdk.vm.ci.code.InstalledCode;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class InstalledCodeTest {
+
+    @Test
+    public void testTooLongName() {
+        String longName = new String(new char[InstalledCode.MAX_NAME_LENGTH]).replace('\0', 'A');
+        new InstalledCode(longName);
+        try {
+            String tooLongName = longName + "X";
+            new InstalledCode(tooLongName);
+        } catch (IllegalArgumentException iae) {
+            // Threw IllegalArgumentException as expected.
+            return;
+        }
+        Assert.fail("expected IllegalArgumentException");
+    }
+}


### PR DESCRIPTION
After [JDK-8343789](https://bugs.openjdk.org/browse/JDK-8343789), the size of a `JVMCINMethodData` object is limited to `uint16_t`. This object embeds the value of `InstalledCode.name` so effectively imposes a limit on the name length. This PR establishes an upper limit on the name value as this name should only be for informative purposes when inspecting compiled code.

While debugging the problem that exposed the limit, it was confusing that `-XX:+PrintCompilation` did not show the name so this PR builds on [JDK-8336760](https://bugs.openjdk.org/browse/JDK-8336760) to add the name in `PrintCompilation` output for JVMCI "hosted" methods.

<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8355034](https://bugs.openjdk.org/browse/JDK-8355034): [JVMCI] assert(static_cast&lt;int&gt;(_jvmci_data_size) == align_up(compiler-&gt;is_jvmci() ? jvmci_data-&gt;size() : 0, oopSize)) failed: failed: 104 != 16777320 (**Bug** - P4)


### Reviewers
 * [Tom Rodriguez](https://openjdk.org/census#never) (@tkrodriguez - **Reviewer**)
 * [Yudi Zheng](https://openjdk.org/census#yzheng) (@mur47x111 - Committer) Review applies to [f7c01793](https://git.openjdk.org/jdk/pull/24753/files/f7c01793ca916b612b334911aca2c1467b96c590)
 * [Cesar Soares Lucas](https://openjdk.org/census#cslucas) (@JohnTortugo - Committer) Review applies to [f7c01793](https://git.openjdk.org/jdk/pull/24753/files/f7c01793ca916b612b334911aca2c1467b96c590)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24753/head:pull/24753` \
`$ git checkout pull/24753`

Update a local copy of the PR: \
`$ git checkout pull/24753` \
`$ git pull https://git.openjdk.org/jdk.git pull/24753/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24753`

View PR using the GUI difftool: \
`$ git pr show -t 24753`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24753.diff">https://git.openjdk.org/jdk/pull/24753.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24753#issuecomment-2815643066)
</details>
