### PR TITLE
8354990: Improve negative tests coverage for jpackage signing

### DIFF
--- a/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/MacAppBundler.java
+++ b/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/MacAppBundler.java
@@ -74,7 +74,7 @@ public class MacAppBundler extends AppImageBundler {
                     }
 
                     if (result != null) {
-                        MacCertificate certificate = new MacCertificate(result);
+                        MacCertificate certificate = new MacCertificate(result, keychain);
 
                         if (!certificate.isValid()) {
                             Log.error(MessageFormat.format(I18N.getString(

--- a/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/MacCertificate.java
+++ b/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/MacCertificate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,21 +39,25 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.HexFormat;
 import java.util.List;
 import java.util.Locale;
-import java.util.HexFormat;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public final class MacCertificate {
     private final String certificate;
+    private final Optional<String> keychainName;
 
-    public MacCertificate(String certificate) {
-        this.certificate = certificate;
+    public MacCertificate(String certificate, String keychainName) {
+        this.certificate = Objects.requireNonNull(certificate);
+        this.keychainName = Optional.ofNullable(keychainName);
     }
 
     public boolean isValid() {
-        return verifyCertificate(this.certificate);
+        return verifyCertificate();
     }
 
     public static String findCertificateKey(String keyPrefix, String teamName,
@@ -295,7 +299,7 @@ public final class MacCertificate {
         return result;
     }
 
-    private boolean verifyCertificate(String certificate) {
+    private boolean verifyCertificate() {
         boolean result = false;
 
         try {
@@ -303,7 +307,7 @@ public final class MacCertificate {
             Date certificateDate = null;
 
             try {
-                file = getFindCertificateOutputPEM(certificate, null);
+                file = getFindCertificateOutputPEM(certificate, keychainName.orElse(null));
 
                 if (file != null) {
                     certificateDate = findCertificateDate(

--- a/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/MacPkgBundler.java
+++ b/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/MacPkgBundler.java
@@ -130,7 +130,7 @@ public class MacPkgBundler extends MacBaseInstallerBundler {
                     }
 
                     if (result != null) {
-                        MacCertificate certificate = new MacCertificate(result);
+                        MacCertificate certificate = new MacCertificate(result, keychain);
 
                         if (!certificate.isValid()) {
                             Log.error(MessageFormat.format(

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/MacSign.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/MacSign.java
@@ -822,7 +822,7 @@ public final class MacSign {
                 .thenComparing(Comparator.comparing(CertificateRequest::trusted, Boolean::compare));
     }
 
-    private record InstalledCertificate(String name, CertificateType type, int days, boolean expired) implements Comparable<InstalledCertificate>{
+    private record InstalledCertificate(String name, CertificateType type, int days, boolean expired) implements Comparable<InstalledCertificate> {
         InstalledCertificate {
             Objects.requireNonNull(name);
             Objects.requireNonNull(type);

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/MacSign.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/MacSign.java
@@ -402,7 +402,7 @@ public final class MacSign {
                 while (in.available() > 0) {
                     final X509Certificate cert;
                     try {
-                        cert = (X509Certificate)CERT_FACTORY.generateCertificate(in);
+                        cert = (X509Certificate) CERT_FACTORY.generateCertificate(in);
                     } catch (Exception ex) {
                         TKit.trace("Failed to parse certificate data: " + ex);
                         continue;
@@ -688,7 +688,7 @@ public final class MacSign {
             this.value = Objects.requireNonNull(value);
         }
 
-        public String value( ) {
+        public String value() {
             return value;
         }
 
@@ -702,7 +702,9 @@ public final class MacSign {
         }
     }
 
-    public record CertificateRequest(String name, CertificateType type, int days, boolean expired, boolean trusted) implements Comparable<CertificateRequest>{
+    public record CertificateRequest(String name, CertificateType type, int days, boolean expired, boolean trusted)
+            implements Comparable<CertificateRequest> {
+
         public CertificateRequest {
             Objects.requireNonNull(name);
             Objects.requireNonNull(type);
@@ -730,7 +732,7 @@ public final class MacSign {
                 return VerifyStatus.VERIFY_UNTRUSTED;
             } else if (expired) {
                 return VerifyStatus.VERIFY_EXPIRED;
-            }else {
+            } else {
                 return VerifyStatus.VERIFY_OK;
             }
         }
@@ -871,7 +873,7 @@ public final class MacSign {
         private static int getDurationInDays(X509Certificate cert) {
             final var notBefore = cert.getNotBefore();
             final var notAfter = cert.getNotAfter();
-            return (int)TimeUnit.DAYS.convert(notAfter.getTime() - notBefore.getTime(), TimeUnit.MILLISECONDS);
+            return (int) TimeUnit.DAYS.convert(notAfter.getTime() - notBefore.getTime(), TimeUnit.MILLISECONDS);
         }
 
         private static boolean getExpired(X509Certificate cert) {
@@ -899,8 +901,8 @@ public final class MacSign {
      * Created certificates will be imported into the keychains, and every
      * certificate will be marked as trusted.
      * <p>
-     * The user will be prompted to enter the user login password as
-     * many times as the number of unique certificates this function will create.
+     * The user will be prompted to enter the user login password as many times as
+     * the number of unique certificates this function will create.
      * <p>
      * Created keychains will NOT be added to the keychain search list.
      *
@@ -1046,7 +1048,7 @@ public final class MacSign {
 
         public Map<CertificateRequest, X509Certificate> mapCertificateRequests() {
             if (certMap == null) {
-                synchronized(this) {
+                synchronized (this) {
                     if (certMap == null) {
                         certMap = MacSign.mapCertificateRequests(spec);
                     }

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/MacSignVerify.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/MacSignVerify.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jdk.jpackage.test;
+
+import static jdk.jpackage.internal.util.function.ThrowingSupplier.toSupplier;
+import static jdk.jpackage.test.MacSign.DigestAlgorithm.SHA256;
+
+import java.nio.file.Path;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Pattern;
+import jdk.jpackage.internal.util.PListReader;
+import jdk.jpackage.test.MacSign.CertificateHash;
+import jdk.jpackage.test.MacSign.CertificateRequest;
+
+/**
+ * Utilities to verify sign signatures.
+ */
+public final class MacSignVerify {
+
+    public static void assertSigned(Path path, CertificateRequest certRequest) {
+        assertSigned(path);
+        TKit.assertEquals(certRequest.name(), findCodesignSignOrigin(path).orElse(null),
+                String.format("Check [%s] signed with certificate", path));
+    }
+
+    public static void assertAdhocSigned(Path path) {
+        assertSigned(path);
+        TKit.assertEquals(ADHOC_SIGN_ORIGIN, findCodesignSignOrigin(path).orElse(null),
+                String.format("Check [%s] signed with adhoc signature", path));
+    }
+
+    public static void assertUnsigned(Path path) {
+        TKit.assertTrue(findSpctlSignOrigin(SpctlType.EXEC, path).isEmpty(),
+                String.format("Check [%s] unsigned", path));
+    }
+
+    public static void assertPkgSigned(Path path, CertificateRequest certRequest, X509Certificate cert) {
+        final var expectedCertChain = List.of(new SignIdentity(certRequest.name(), CertificateHash.of(cert, SHA256)));
+        final var actualCertChain = getPkgCertificateChain(path);
+        TKit.assertStringListEquals(
+                expectedCertChain.stream().map(SignIdentity::toString).toList(),
+                actualCertChain.stream().map(SignIdentity::toString).toList(),
+                String.format("Check certificate chain of [%s] is as expected", path));
+        TKit.assertEquals(certRequest.name(), findSpctlSignOrigin(SpctlType.INSTALL, path).orElse(null),
+                String.format("Check [%s] signed for installation", path));
+    }
+
+    public enum SpctlType {
+        EXEC("exec"), INSTALL("install");
+
+        SpctlType(String value) {
+            this.value = Objects.requireNonNull(value);
+        }
+
+        public String value() {
+            return value;
+        }
+
+        final private String value;
+    }
+
+    public static final String ADHOC_SIGN_ORIGIN = "-";
+
+    public static Optional<String> findSpctlSignOrigin(SpctlType type, Path path) {
+        final var exec = Executor.of("/usr/sbin/spctl", "-vv", "--raw", "--assess", "--type", type.value(), path.toString()).saveOutput().discardStderr();
+        final var result = exec.executeWithoutExitCodeCheck();
+        TKit.assertTrue(Set.of(0, 3).contains(result.exitCode()),
+                String.format("Check exit code of command %s is either 0 or 3", exec.getPrintableCommandLine()));
+        return toSupplier(() -> {
+            try {
+                return Optional.of(new PListReader(String.join("", result.getOutput()).getBytes()).queryValue("assessment:originator"));
+            } catch (NoSuchElementException ex) {
+                return Optional.<String>empty();
+            }
+        }).get();
+    }
+
+    public static Optional<String> findCodesignSignOrigin(Path path) {
+        final var exec = Executor.of("/usr/bin/codesign", "--display", "--verbose=4", path.toString()).saveOutput();
+        final var result = exec.executeWithoutExitCodeCheck();
+        if (result.getExitCode() == 0) {
+            return Optional.of(result.getOutput().stream().map(line -> {
+                if (line.equals("Signature=adhoc")) {
+                    return ADHOC_SIGN_ORIGIN;
+                } else if (line.startsWith("Authority=")) {
+                    return line.substring("Authority=".length());
+                } else {
+                    return null;
+                }
+            }).filter(Objects::nonNull).reduce((x, y) -> {
+                throw new UnsupportedOperationException(String.format(
+                        "Both adhoc [%s] and certificate [%s] signatures found in codesign output", x, y));
+            }).orElseThrow(() -> {
+                final var msg = "Neither adhoc nor certificate signatures found in codesign output";
+                TKit.trace(msg + ":");
+                result.getOutput().forEach(TKit::trace);
+                TKit.trace("Done");
+                return new UnsupportedOperationException(msg);
+            }));
+        } else if (result.getExitCode() == 1 && result.getFirstLineOfOutput().endsWith("code object is not signed at all")) {
+            return Optional.empty();
+        } else {
+            reportUnexpectedCommandOutcome(exec.getPrintableCommandLine(), result);
+            return null; // Unreachable
+        }
+    }
+
+    public static void assertSigned(Path path) {
+        final var verifier = TKit.TextStreamVerifier.group()
+                .add(TKit.assertTextStream(": valid on disk").predicate(String::endsWith))
+                .add(TKit.assertTextStream(": satisfies its Designated Requirement").predicate(String::endsWith))
+                .create();
+        verifier.accept(Executor.of("/usr/bin/codesign", "--verify", "--deep",
+                "--strict", "--verbose=2", path.toString()).executeAndGetOutput().iterator());
+    }
+
+    public static List<SignIdentity> getPkgCertificateChain(Path path) {
+        //
+        // Typical output of `/usr/sbin/pkgutil --check-signature`:
+        // Package "foo.pkg":
+        //    Status: signed by a developer certificate issued by Apple for distribution
+        //    Notarization: trusted by the Apple notary service
+        //    Signed with a trusted timestamp on: 2022-05-10 19:54:56 +0000
+        //    Certificate Chain:
+        //      1. Developer ID Installer: Foo
+        //         SHA256 Fingerprint:
+        //             4A A9 4A 85 20 2A DE 02 B2 9B 36 DA 45 00 B4 40 CF 31 43 4E 96 02
+        //             60 6A 6D BC 02 F4 5D 3A 86 4A
+        //         ------------------------------------------------------------------------
+        //      2. Developer ID Certification Authority
+        //         Expires: 2027-02-01 22:12:15 +0000
+        //         SHA256 Fingerprint:
+        //             7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03
+        //             F2 9C 88 CF B0 B1 BA 63 58 7F
+        //         ------------------------------------------------------------------------
+        //      3. Apple Root CA
+        //         Expires: 2035-02-09 21:40:36 +0000
+        //         SHA256 Fingerprint:
+        //             B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C
+        //             68 C5 BE 91 B5 A1 10 01 F0 24
+        final var exec = Executor.of("/usr/sbin/pkgutil", "--check-signature", path.toString()).saveOutput();
+        final var result = exec.executeWithoutExitCodeCheck();
+        if (result.getExitCode() == 0) {
+            try {
+                final List<SignIdentity> signIdentities = new ArrayList<>();
+                final var lineIt = result.getOutput().iterator();
+                while (!lineIt.next().endsWith("Certificate Chain:")) {
+
+                }
+                do {
+                    final var m = SIGN_IDENTITY_NAME_REGEXP.matcher(lineIt.next());
+                    m.find();
+                    final var name = m.group(1);
+                    while (!lineIt.next().endsWith("SHA256 Fingerprint:")) {
+
+                    }
+                    final var digest = new StringBuilder();
+                    do {
+                        final var line = lineIt.next().strip();
+                        if (line.endsWith("----") || line.isEmpty()) {
+                            break;
+                        }
+                        digest.append(" " + line.strip());
+                    } while (lineIt.hasNext());
+                    final var fingerprint = new CertificateHash(
+                            FINGERPRINT_FORMAT.parseHex(digest.substring(1)), SHA256);
+                    signIdentities.add(new SignIdentity(name, fingerprint));
+                } while (lineIt.hasNext());
+                return signIdentities;
+            } catch (Throwable t) {
+                t.printStackTrace();
+                reportUnexpectedCommandOutcome(exec.getPrintableCommandLine(), result);
+                return null; // Unreachable
+            }
+        } else if (result.getExitCode() == 1 && result.getOutput().getLast().endsWith("Status: no signature")) {
+            return List.of();
+        } else {
+            reportUnexpectedCommandOutcome(exec.getPrintableCommandLine(), result);
+            return null; // Unreachable
+        }
+    }
+
+    public record SignIdentity(String name, CertificateHash fingerprint) {
+        public SignIdentity {
+            Objects.requireNonNull(name);
+            Objects.requireNonNull(fingerprint);
+        }
+    }
+
+    private static void reportUnexpectedCommandOutcome(String printableCommandLine, Executor.Result result) {
+        Objects.requireNonNull(printableCommandLine);
+        Objects.requireNonNull(result);
+        TKit.trace(String.format("Command %s exited with exit code %d and the following output:",
+                printableCommandLine, result.getExitCode()));
+        result.getOutput().forEach(TKit::trace);
+        TKit.trace("Done");
+        TKit.assertUnexpected(String.format("Outcome of command %s", printableCommandLine));
+    }
+
+    private static final Pattern SIGN_IDENTITY_NAME_REGEXP = Pattern.compile("^\\s+\\d+\\.\\s+(.*)$");
+    private static final HexFormat FINGERPRINT_FORMAT = HexFormat.ofDelimiter(" ").withUpperCase();
+}

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/MacSignVerify.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/MacSignVerify.java
@@ -133,12 +133,9 @@ public final class MacSignVerify {
     }
 
     public static void assertSigned(Path path) {
-        final var verifier = TKit.TextStreamVerifier.group()
-                .add(TKit.assertTextStream(": valid on disk").predicate(String::endsWith))
-                .add(TKit.assertTextStream(": satisfies its Designated Requirement").predicate(String::endsWith))
-                .create();
-        verifier.accept(Executor.of("/usr/bin/codesign", "--verify", "--deep",
-                "--strict", "--verbose=2", path.toString()).executeAndGetOutput().iterator());
+        final var verifier = TKit.assertTextStream(": valid on disk").predicate(String::endsWith).andThen(TKit.assertTextStream(": satisfies its Designated Requirement").predicate(String::endsWith));
+        verifier.apply(Executor.of("/usr/bin/codesign", "--verify", "--deep",
+                "--strict", "--verbose=2", path.toString()).executeAndGetOutput().stream());
     }
 
     public static List<SignIdentity> getPkgCertificateChain(Path path) {

--- a/test/jdk/tools/jpackage/macosx/MacSignTest.java
+++ b/test/jdk/tools/jpackage/macosx/MacSignTest.java
@@ -179,7 +179,7 @@ public class MacSignTest {
 
     public static Collection<Object[]> testSelectSigningIdentity() {
         return Stream.of(
-                SigningBase.StandardCertificateRequest.CODESIGN, 
+                SigningBase.StandardCertificateRequest.CODESIGN,
                 SigningBase.StandardCertificateRequest.CODESIGN_UNICODE
         ).map(SigningBase.StandardCertificateRequest::spec).<Object[]>mapMulti((certRequest, acc) -> {
             acc.accept(new Object[] {certRequest.shortName(), certRequest});

--- a/test/jdk/tools/jpackage/macosx/MacSignTest.java
+++ b/test/jdk/tools/jpackage/macosx/MacSignTest.java
@@ -21,15 +21,24 @@
  * questions.
  */
 
+import static jdk.internal.util.OperatingSystem.MACOS;
+
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+import jdk.jpackage.test.Annotations.Parameter;
 import jdk.jpackage.test.Annotations.Test;
 import jdk.jpackage.test.CannedFormattedString;
 import jdk.jpackage.test.JPackageCommand;
 import jdk.jpackage.test.JPackageStringBundle;
 import jdk.jpackage.test.MacHelper;
+import jdk.jpackage.test.MacSign;
+import jdk.jpackage.test.PackageType;
 import jdk.jpackage.test.TKit;
 
 /*
@@ -64,23 +73,144 @@ public class MacSignTest {
             expectedStrings.add(xcodeWarning);
         }
 
-        // --app-content and --type app-image
-        // Expect `message.codesign.failed.reason.app.content` message in the log.
-        // This is not a fatal error, just a warning.
-        // To make jpackage fail, specify bad additional content.
-        final var cmd = JPackageCommand.helloAppImage()
-                .ignoreDefaultVerbose(true)
-                .validateOutput(expectedStrings.toArray(CannedFormattedString[]::new))
-                .addArguments("--app-content", appContent)
-                .addArguments("--mac-sign")
-                .addArguments("--mac-signing-keychain", SigningBase.StandardKeychain.MAIN.spec().keychain().name())
-                .addArguments("--mac-app-image-sign-identity", SigningBase.StandardCertificateRequest.APP_IMAGE.spec().name());
+        final var keychain = SigningBase.StandardKeychain.EXPIRED.spec().keychain();
 
-        if (MacHelper.isXcodeDevToolsInstalled()) {
-            // Check there is no warning about missing xcode command line developer tools.
-            cmd.validateOutput(TKit.assertTextStream(xcodeWarning.getValue()).negate());
+        MacSign.Keychain.withAddedKeychains(List.of(keychain), () -> {
+            // --app-content and --type app-image
+            // Expect `message.codesign.failed.reason.app.content` message in the log.
+            // This is not a fatal error, just a warning.
+            // To make jpackage fail, specify bad additional content.
+            final var cmd = JPackageCommand.helloAppImage()
+                    .ignoreDefaultVerbose(true)
+                    .validateOutput(expectedStrings.toArray(CannedFormattedString[]::new))
+                    .addArguments("--app-content", appContent)
+                    .addArguments("--mac-sign")
+                    .addArguments("--mac-signing-keychain", keychain.name())
+                    .addArguments("--mac-app-image-sign-identity", SigningBase.StandardCertificateRequest.CODESIGN.spec().name());
+
+            if (MacHelper.isXcodeDevToolsInstalled()) {
+                // Check there is no warning about missing xcode command line developer tools.
+                cmd.validateOutput(TKit.assertTextStream(xcodeWarning.getValue()).negate());
+            }
+
+            cmd.execute(1);
+        });
+    }
+
+    @Test(ifOS = MACOS)
+    @Parameter({"IMAGE", "EXPIRED_SIGNING_KEY_USER_NAME"})
+    @Parameter({"MAC_DMG", "EXPIRED_SIGNING_KEY_USER_NAME"})
+    @Parameter({"MAC_PKG", "EXPIRED_SIGNING_KEY_USER_NAME", "EXPIRED_SIGNING_KEY_USER_NAME_PKG"})
+
+    @Parameter({"IMAGE", "EXPIRED_SIGN_IDENTITY"})
+    @Parameter({"MAC_DMG", "EXPIRED_SIGN_IDENTITY"})
+    @Parameter({"MAC_PKG", "EXPIRED_SIGN_IDENTITY"})
+
+    @Parameter({"IMAGE", "EXPIRED_CODESIGN_SIGN_IDENTITY"})
+    @Parameter({"MAC_DMG", "EXPIRED_CODESIGN_SIGN_IDENTITY"})
+    @Parameter({"MAC_PKG", "EXPIRED_CODESIGN_SIGN_IDENTITY"})
+
+    @Parameter({"MAC_PKG", "GOOD_CODESIGN_SIGN_IDENTITY", "EXPIRED_PKG_SIGN_IDENTITY"})
+    @Parameter({"MAC_PKG", "EXPIRED_CODESIGN_SIGN_IDENTITY", "GOOD_PKG_SIGN_IDENTITY"})
+    public static void testExpiredCertificate(PackageType type, SignOption... options) {
+
+        final var keychain = SigningBase.StandardKeychain.EXPIRED.spec().keychain();
+
+        MacSign.Keychain.withAddedKeychains(List.of(keychain), () -> {
+            final var cmd = JPackageCommand.helloAppImage()
+                    .ignoreDefaultVerbose(true)
+                    .addArguments("--mac-sign")
+                    .addArguments("--mac-signing-keychain", keychain.name())
+                    .addArguments(Stream.of(options).map(SignOption::args).flatMap(List::stream).toList())
+                    .setPackageType(type);
+
+            SignOption.configureOutputValidation(cmd, Stream.of(options).filter(SignOption::expired).toList(), opt -> {
+                return JPackageStringBundle.MAIN.cannedFormattedString("error.certificate.expired", opt.identityName());
+            }).execute(1);
+        });
+    }
+
+    @Test(ifOS = MACOS)
+    @Parameter({"IMAGE", "GOOD_SIGNING_KEY_USER_NAME"})
+    @Parameter({"MAC_DMG", "GOOD_SIGNING_KEY_USER_NAME"})
+    @Parameter({"MAC_PKG", "GOOD_SIGNING_KEY_USER_NAME_PKG", "GOOD_SIGNING_KEY_USER_NAME"})
+
+    @Parameter({"IMAGE", "GOOD_CODESIGN_SIGN_IDENTITY"})
+    @Parameter({"MAC_PKG", "GOOD_CODESIGN_SIGN_IDENTITY", "GOOD_PKG_SIGN_IDENTITY"})
+    @Parameter({"MAC_PKG", "GOOD_PKG_SIGN_IDENTITY"})
+    public static void testMultipleCertificates(PackageType type, SignOption... options) {
+
+        final var keychain = SigningBase.StandardKeychain.DUPLICATE.spec().keychain();
+
+        MacSign.Keychain.withAddedKeychains(List.of(keychain), () -> {
+            final var cmd = JPackageCommand.helloAppImage()
+                    .ignoreDefaultVerbose(true)
+                    .addArguments("--mac-sign")
+                    .addArguments("--mac-signing-keychain", keychain.name())
+                    .addArguments(Stream.of(options).map(SignOption::args).flatMap(List::stream).toList())
+                    .setPackageType(type);
+
+            SignOption.configureOutputValidation(cmd, List.of(options), opt -> {
+                return JPackageStringBundle.MAIN.cannedFormattedString("error.multiple.certs.found", opt.identityName(), keychain.name());
+            }).execute(1);
+        });
+    }
+
+    enum SignOption {
+        EXPIRED_SIGNING_KEY_USER_NAME("--mac-signing-key-user-name", SigningBase.StandardCertificateRequest.CODESIGN_EXPIRED.spec(), true, false),
+        EXPIRED_SIGNING_KEY_USER_NAME_PKG("--mac-signing-key-user-name", SigningBase.StandardCertificateRequest.PKG_EXPIRED.spec(), true, false),
+        EXPIRED_SIGN_IDENTITY("--mac-signing-key-user-name", SigningBase.StandardCertificateRequest.CODESIGN_EXPIRED.spec(), false, false),
+        EXPIRED_CODESIGN_SIGN_IDENTITY("--mac-app-image-sign-identity", SigningBase.StandardCertificateRequest.CODESIGN_EXPIRED.spec(), false, true),
+        EXPIRED_PKG_SIGN_IDENTITY("--mac-installer-sign-identity", SigningBase.StandardCertificateRequest.PKG_EXPIRED.spec(), false, true),
+        GOOD_SIGNING_KEY_USER_NAME("--mac-signing-key-user-name", SigningBase.StandardCertificateRequest.CODESIGN.spec(), true, false),
+        GOOD_SIGNING_KEY_USER_NAME_PKG("--mac-signing-key-user-name", SigningBase.StandardCertificateRequest.PKG.spec(), true, false),
+        GOOD_CODESIGN_SIGN_IDENTITY("--mac-app-image-sign-identity", SigningBase.StandardCertificateRequest.CODESIGN.spec(), false, true),
+        GOOD_PKG_SIGN_IDENTITY("--mac-app-image-sign-identity", SigningBase.StandardCertificateRequest.PKG.spec(), false, true);
+
+        SignOption(String option, MacSign.CertificateRequest cert, boolean shortName, boolean passThrough) {
+            this.option = Objects.requireNonNull(option);
+            this.cert = Objects.requireNonNull(cert);
+            this.shortName = shortName;
+            this.passThrough = passThrough;
         }
 
-        cmd.execute(1);
+        boolean passThrough() {
+            return passThrough;
+        }
+
+        boolean expired() {
+            return cert.expired();
+        }
+
+        String identityName() {
+            return cert.name();
+        }
+
+        List<String> args() {
+            return List.of(option, shortName ? cert.shortName() : cert.name());
+        }
+
+        static JPackageCommand configureOutputValidation(JPackageCommand cmd, List<SignOption> options,
+                Function<SignOption, CannedFormattedString> conv) {
+            options.stream().filter(SignOption::passThrough)
+                    .map(conv)
+                    .map(CannedFormattedString::getValue)
+                    .map(TKit::assertTextStream)
+                    .map(TKit.TextStreamVerifier::negate)
+                    .forEach(cmd::validateOutput);
+
+            options.stream().filter(Predicate.not(SignOption::passThrough))
+                    .map(conv)
+                    .map(CannedFormattedString::getValue)
+                    .map(TKit::assertTextStream)
+                    .forEach(cmd::validateOutput);
+
+            return cmd;
+        }
+
+        private final String option;
+        private final MacSign.CertificateRequest cert;
+        private final boolean shortName;
+        private final boolean passThrough;
     }
 }

--- a/test/jdk/tools/jpackage/macosx/base/SigningBase.java
+++ b/test/jdk/tools/jpackage/macosx/base/SigningBase.java
@@ -64,10 +64,14 @@ import jdk.jpackage.test.TKit;
 public class SigningBase {
 
     public enum StandardCertificateRequest {
-        APP_IMAGE(cert().userName(DEV_NAMES[CertIndex.ASCII_INDEX.value()])),
-        INSTALLER(cert().type(CertificateType.INSTALLER).userName(DEV_NAMES[CertIndex.ASCII_INDEX.value()])),
-        APP_IMAGE_UNICODE(cert().userName(DEV_NAMES[CertIndex.UNICODE_INDEX.value()])),
-        INSTALLER_UNICODE(cert().type(CertificateType.INSTALLER).userName(DEV_NAMES[CertIndex.UNICODE_INDEX.value()]));
+        CODESIGN(cert().userName(DEV_NAMES[CertIndex.ASCII_INDEX.value()])),
+        CODESIGN_COPY(cert().days(100).userName(DEV_NAMES[CertIndex.ASCII_INDEX.value()])),
+        PKG(cert().type(CertificateType.INSTALLER).userName(DEV_NAMES[CertIndex.ASCII_INDEX.value()])),
+        PKG_COPY(cert().type(CertificateType.INSTALLER).days(100).userName(DEV_NAMES[CertIndex.ASCII_INDEX.value()])),
+        CODESIGN_UNICODE(cert().userName(DEV_NAMES[CertIndex.UNICODE_INDEX.value()])),
+        PKG_UNICODE(cert().type(CertificateType.INSTALLER).userName(DEV_NAMES[CertIndex.UNICODE_INDEX.value()])),
+        CODESIGN_EXPIRED(cert().expired().userName("expired jpackage test")),
+        PKG_EXPIRED(cert().expired().type(CertificateType.INSTALLER).userName("expired jpackage test"));
 
         StandardCertificateRequest(CertificateRequest.Builder specBuilder) {
             this.spec = specBuilder.create();
@@ -85,7 +89,21 @@ public class SigningBase {
     }
 
     public enum StandardKeychain {
-        MAIN(DEFAULT_KEYCHAIN, StandardCertificateRequest.values());
+        MAIN(DEFAULT_KEYCHAIN,
+                StandardCertificateRequest.CODESIGN,
+                StandardCertificateRequest.PKG,
+                StandardCertificateRequest.CODESIGN_UNICODE,
+                StandardCertificateRequest.PKG_UNICODE),
+        EXPIRED("jpackagerTest-expired.keychain",
+                StandardCertificateRequest.CODESIGN,
+                StandardCertificateRequest.PKG,
+                StandardCertificateRequest.CODESIGN_EXPIRED,
+                StandardCertificateRequest.PKG_EXPIRED),
+        DUPLICATE("jpackagerTest-duplicate.keychain",
+                StandardCertificateRequest.CODESIGN,
+                StandardCertificateRequest.PKG,
+                StandardCertificateRequest.CODESIGN_COPY,
+                StandardCertificateRequest.PKG_COPY);
 
         StandardKeychain(String keychainName, StandardCertificateRequest... certs) {
             this(keychainName, certs[0].spec(), Stream.of(certs).skip(1).map(StandardCertificateRequest::spec).toArray(CertificateRequest[]::new));
@@ -131,7 +149,7 @@ public class SigningBase {
     }
 
     private final class Inner {
-        private final static boolean SIGN_ENV_READY = MacSign.isDeployed(StandardKeychain.signingEnv());
+        private static final boolean SIGN_ENV_READY = MacSign.isDeployed(StandardKeychain.signingEnv());
     }
 
     enum CertIndex {

--- a/test/jdk/tools/jpackage/macosx/base/SigningBase.java
+++ b/test/jdk/tools/jpackage/macosx/base/SigningBase.java
@@ -22,16 +22,18 @@
  */
 
 import java.nio.file.Path;
+import java.security.cert.X509Certificate;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Stream;
-import jdk.jpackage.test.Executor;
-import jdk.jpackage.test.Executor.Result;
 import jdk.jpackage.test.JPackageCommand;
 import jdk.jpackage.test.MacSign;
-import jdk.jpackage.test.MacSign.CertificateType;
 import jdk.jpackage.test.MacSign.CertificateRequest;
+import jdk.jpackage.test.MacSign.CertificateType;
 import jdk.jpackage.test.MacSign.KeychainWithCertsSpec;
+import jdk.jpackage.test.MacSign.ResolvedKeychain;
+import jdk.jpackage.test.MacSignVerify;
 import jdk.jpackage.test.TKit;
 
 
@@ -112,11 +114,15 @@ public class SigningBase {
         StandardKeychain(String keychainName, CertificateRequest cert, CertificateRequest... otherCerts) {
             final var builder = keychain(keychainName).addCert(cert);
             List.of(otherCerts).forEach(builder::addCert);
-            this.spec = builder.create();
+            this.spec = new ResolvedKeychain(builder.create());
         }
 
         public KeychainWithCertsSpec spec() {
-            return spec;
+            return spec.spec();
+        }
+
+        public X509Certificate mapCertificateRequest(CertificateRequest certRequest) {
+            return Objects.requireNonNull(spec.mapCertificateRequests().get(certRequest));
         }
 
         private static KeychainWithCertsSpec.Builder keychain(String name) {
@@ -131,7 +137,7 @@ public class SigningBase {
             return Stream.of(values()).map(StandardKeychain::spec).toList();
         }
 
-        private final KeychainWithCertsSpec spec;
+        private final ResolvedKeychain spec;
     }
 
     public static void setUp() {
@@ -217,140 +223,13 @@ public class SigningBase {
         return DEFAULT_KEYCHAIN;
     }
 
-    // Note: It is not clear if we can combine "--verify" and "--display", so
-    // we testing them separately. Since JDK-8298488 unsigned app images are
-    // actually signed with adhoc signature and it will pass "--verify", so in
-    // addition we will check certificate name which was used to sign.
-    private static enum CodesignCheckType {
-        VERIFY, // Runs codesign with "--verify" to check signature and 0 exit code
-        VERIFY_UNSIGNED, // Runs codesign with "--verify" to check signature and 1 exit code
-        DISPLAY // Runs codesign with "--display --verbose=4" to get info about signature
-    };
-
-    private static void checkString(List<String> result, String lookupString) {
-        TKit.assertTextStream(lookupString).predicate(
-                (line, what) -> line.trim().contains(what)).apply(result.stream());
-    }
-
-    @SuppressWarnings("fallthrough")
-    private static List<String> codesignResult(Path target, CodesignCheckType type) {
-        int exitCode = 0;
-        Executor executor = new Executor().setExecutable("/usr/bin/codesign");
-        switch (type) {
-            case VERIFY_UNSIGNED:
-                exitCode = 1;
-            case VERIFY:
-                executor.addArguments("--verify", "--deep", "--strict",
-                                      "--verbose=2", target.toString());
-                break;
-            case DISPLAY:
-                executor.addArguments("--display", "--verbose=4", target.toString());
-                break;
-            default:
-                TKit.error("Unknown CodesignCheckType: " + type);
-                break;
-        }
-        return executor.saveOutput().execute(exitCode).getOutput();
-    }
-
-    private static void verifyCodesignResult(List<String> result, Path target,
-            boolean signed, CodesignCheckType type, int certIndex) {
-        result.stream().forEachOrdered(TKit::trace);
-        String lookupString;
-        switch (type) {
-            case VERIFY:
-                lookupString = target.toString() + ": valid on disk";
-                checkString(result, lookupString);
-                lookupString = target.toString() + ": satisfies its Designated Requirement";
-                checkString(result, lookupString);
-                break;
-            case VERIFY_UNSIGNED:
-                lookupString = target.toString() + ": code object is not signed at all";
-                checkString(result, lookupString);
-                break;
-            case DISPLAY:
-                if (signed) {
-                    lookupString = "Authority=" + getAppCert(certIndex);
-                } else {
-                    lookupString = "Signature=adhoc";
-                }
-                checkString(result, lookupString);
-                break;
-            default:
-                TKit.error("Unknown CodesignCheckType: " + type);
-                break;
-        }
-    }
-
-    private static Result spctlResult(Path target, String type) {
-        Result result = new Executor()
-                .setExecutable("/usr/sbin/spctl")
-                .addArguments("-vvv", "--assess", "--type", type,
-                        target.toString())
-                .saveOutput()
-                .executeWithoutExitCodeCheck();
-
-        // allow exit code 3 for not being notarized
-        if (result.getExitCode() != 3) {
-            result.assertExitCodeIsZero();
-        }
-        return result;
-    }
-
-    private static void verifySpctlResult(List<String> output, Path target,
-            String type, int exitCode, int certIndex) {
-        output.stream().forEachOrdered(TKit::trace);
-        String lookupString;
-
-        if (exitCode == 0) {
-            lookupString = target.toString() + ": accepted";
-            checkString(output, lookupString);
-        } else if (exitCode == 3) {
-            // allow failure purely for not being notarized
-            lookupString = target.toString() + ": rejected";
-            checkString(output, lookupString);
-        }
-
-        if (type.equals("install")) {
-            lookupString = "origin=" + getInstallerCert(certIndex);
-        } else {
-            lookupString = "origin=" + getAppCert(certIndex);
-        }
-        checkString(output, lookupString);
-    }
-
-    private static List<String> pkgutilResult(Path target, boolean signed) {
-        List<String> result = new Executor()
-                .setExecutable("/usr/sbin/pkgutil")
-                .addArguments("--check-signature",
-                        target.toString())
-                .saveOutput()
-                .execute(signed ? 0 : 1)
-                .getOutput();
-
-        return result;
-    }
-
-    private static void verifyPkgutilResult(List<String> result, boolean signed,
-                                            int certIndex) {
-        result.stream().forEachOrdered(TKit::trace);
-        if (signed) {
-            String lookupString = "Status: signed by";
-            checkString(result, lookupString);
-            lookupString = "1. " + getInstallerCert(certIndex);
-            checkString(result, lookupString);
-        } else {
-            String lookupString = "Status: no signature";
-            checkString(result, lookupString);
-        }
-    }
-
     public static void verifyCodesign(Path target, boolean signed, int certIndex) {
-        List<String> result = codesignResult(target, CodesignCheckType.VERIFY);
-        verifyCodesignResult(result, target, signed, CodesignCheckType.VERIFY, certIndex);
-
-        result = codesignResult(target, CodesignCheckType.DISPLAY);
-        verifyCodesignResult(result, target, signed, CodesignCheckType.DISPLAY, certIndex);
+        if (signed) {
+            final var certRequest = getCertRequest(certIndex);
+            MacSignVerify.assertSigned(target, certRequest);
+        } else {
+            MacSignVerify.assertAdhocSigned(target);
+        }
     }
 
     // Since we no longer have unsigned app image, but we need to check
@@ -359,23 +238,45 @@ public class SigningBase {
     // Should not be used to validated anything else.
     public static void verifyDMG(Path target) {
         if (!target.toString().toLowerCase().endsWith(".dmg")) {
-            TKit.error("Unexpected target: " + target);
+            throw new IllegalArgumentException("Unexpected target: " + target);
         }
 
-        List<String> result = codesignResult(target, CodesignCheckType.VERIFY_UNSIGNED);
-        verifyCodesignResult(result, target, false, CodesignCheckType.VERIFY_UNSIGNED, -1);
+        MacSignVerify.assertUnsigned(target);
     }
 
     public static void verifySpctl(Path target, String type, int certIndex) {
-        Result result = spctlResult(target, type);
-        List<String> output = result.getOutput();
+        final var standardCertIndex = Stream.of(CertIndex.values()).filter(v -> {
+            return v.value() == certIndex;
+        }).findFirst().orElseThrow();
 
-        verifySpctlResult(output, target, type, result.getExitCode(), certIndex);
+        final var standardType = Stream.of(MacSignVerify.SpctlType.values()).filter(v -> {
+            return v.value().equals(type);
+        }).findFirst().orElseThrow();
+
+        final String expectedSignOrigin;
+        if (standardCertIndex == CertIndex.INVALID_INDEX) {
+            expectedSignOrigin = null;
+        } else if (standardType == MacSignVerify.SpctlType.EXEC) {
+            expectedSignOrigin = getCertRequest(certIndex).name();
+        } else if (standardType == MacSignVerify.SpctlType.INSTALL) {
+            expectedSignOrigin = getPkgCertRequest(certIndex).name();
+        } else {
+            throw new IllegalArgumentException();
+        }
+
+        final var signOrigin = MacSignVerify.findSpctlSignOrigin(standardType, target).orElse(null);
+
+        TKit.assertEquals(signOrigin, expectedSignOrigin,
+                String.format("Check [%s] has sign origin as expected", target));
     }
 
     public static void verifyPkgutil(Path target, boolean signed, int certIndex) {
-        List<String> result = pkgutilResult(target, signed);
-        verifyPkgutilResult(result, signed, certIndex);
+        if (signed) {
+            final var certRequest = getPkgCertRequest(certIndex);
+            MacSignVerify.assertPkgSigned(target, certRequest, StandardKeychain.MAIN.mapCertificateRequest(certRequest));
+        } else {
+            MacSignVerify.assertUnsigned(target);
+        }
     }
 
     public static void verifyAppImageSignature(JPackageCommand appImageCmd,
@@ -396,4 +297,31 @@ public class SigningBase {
         }
     }
 
+    private static CertificateRequest getCertRequest(int certIndex) {
+        switch (CertIndex.values()[certIndex]) {
+            case ASCII_INDEX -> {
+                return StandardCertificateRequest.CODESIGN.spec();
+            }
+            case UNICODE_INDEX -> {
+                return StandardCertificateRequest.CODESIGN_UNICODE.spec();
+            }
+            default -> {
+                throw new IllegalArgumentException();
+            }
+        }
+    }
+
+    private static CertificateRequest getPkgCertRequest(int certIndex) {
+        switch (CertIndex.values()[certIndex]) {
+            case ASCII_INDEX -> {
+                return StandardCertificateRequest.PKG.spec();
+            }
+            case UNICODE_INDEX -> {
+                return StandardCertificateRequest.PKG_UNICODE.spec();
+            }
+            default -> {
+                throw new IllegalArgumentException();
+            }
+        }
+    }
 }


### PR DESCRIPTION
Add tests for the following test cases:
 - Expired certificate specified for signing;
 - Multiple certificates with the same name in one keychain.

Adding the new tests revealed an issue with MacCertificate - [JDK-8354989](https://bugs.openjdk.org/browse/JDK-8354989). This issue is also addressed in this PR.

Additionally:
 - Moved code to verify signatures in MacSignVerify class and reworked SigningBase verify functions to use MacSignVerify API.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8354990](https://bugs.openjdk.org/browse/JDK-8354990): Improve negative tests coverage for jpackage signing (**Enhancement** - P4)
 * [JDK-8354989](https://bugs.openjdk.org/browse/JDK-8354989): Bug in MacCertificate class (**Bug** - P4)


### Reviewers
 * [Alexander Matveev](https://openjdk.org/census#almatvee) (@sashamatveev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24762/head:pull/24762` \
`$ git checkout pull/24762`

Update a local copy of the PR: \
`$ git checkout pull/24762` \
`$ git pull https://git.openjdk.org/jdk.git pull/24762/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24762`

View PR using the GUI difftool: \
`$ git pr show -t 24762`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24762.diff">https://git.openjdk.org/jdk/pull/24762.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24762#issuecomment-2816231190)
</details>
