### PR TITLE
8354653: Clean up and open source KeyEvent related tests (Part 4)

### DIFF
--- a/test/jdk/java/awt/event/KeyEvent/AltGrTest.java
+++ b/test/jdk/java/awt/event/KeyEvent/AltGrTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4122687 4209844
+ * @summary Characters typed with AltGr have Alt bit set on
+ *                 KEY_TYPED events
+ * @requires (os.family == "windows")
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual AltGrTest
+ */
+
+import java.awt.BorderLayout;
+import java.awt.Frame;
+import java.awt.TextField;
+import java.awt.event.KeyEvent;
+import java.awt.event.KeyListener;
+import java.lang.reflect.InvocationTargetException;
+
+public class AltGrTest extends Frame implements KeyListener {
+    static String INSTRUCTIONS = """
+            Switch to German (Germany) keyboard layout and type
+            few characters using <AltGr> key.
+            Note: on windows keyboards without an AltGr key,
+            you should use Ctrl-Alt to synthesize AltGr.
+            For example, on German keyboards, `@' is AltGr-Q
+            `{' is AltGr-7 and '[' is AltGr-8
+            If you see the corresponding symbols appear in the text field
+            and there are no entries in log area starting with word "FAIL:"
+            press "Pass", otherwise press "Fail".
+            """;
+
+    public AltGrTest() {
+        setLayout(new BorderLayout());
+        TextField entry = new TextField();
+        entry.addKeyListener(this);
+        add(entry, BorderLayout.CENTER);
+        pack();
+    }
+
+    public void keyTyped(KeyEvent e) {
+        PassFailJFrame.log("----");
+        PassFailJFrame.log("Got " + e);
+
+        if (e.isControlDown() || e.isAltDown()) {
+            PassFailJFrame.log("FAIL: character typed has following modifiers bits set:");
+            PassFailJFrame.log((e.isControlDown() ? " Control" : "")
+                             + (e.isAltDown() ? " Alt" : ""));
+        }
+
+        if (!(e.isAltGraphDown())) {
+            PassFailJFrame.log("FAIL: AltGraph modifier is missing");
+        }
+    }
+
+    public void keyPressed(KeyEvent ignore)  {}
+    public void keyReleased(KeyEvent ignore) {}
+
+    public static void main(String[] args) throws InterruptedException,
+            InvocationTargetException {
+        PassFailJFrame.builder()
+                .instructions(INSTRUCTIONS)
+                .logArea(10)
+                .testUI(AltGrTest::new)
+                .build()
+                .awaitAndCheck();
+    }
+}

--- a/test/jdk/java/awt/event/KeyEvent/CRTest.java
+++ b/test/jdk/java/awt/event/KeyEvent/CRTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4257434
+ * @summary Ensures that the right results are produced by the
+ *          carriage return keys.
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual CRTest
+ */
+
+import java.awt.BorderLayout;
+import java.awt.Button;
+import java.awt.Frame;
+import java.awt.TextField;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.KeyEvent;
+import java.awt.event.KeyListener;
+import java.lang.reflect.InvocationTargetException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class CRTest extends Frame implements KeyListener, ActionListener {
+    StringBuilder error = new StringBuilder();
+    AtomicBoolean actionCompleted = new AtomicBoolean(false);
+    static String INSTRUCTIONS = """
+            This test requires keyboard with the numeric keypad (numpad).
+            If your keyboard does not have numpad press "Pass" to skip testing.
+            Click on the text field in window named "Check KeyChar values".
+            Press Enter on keypad. Then press Return key on a standard keyboard.
+            Then click on "Done" button. Test will pass or fail automatically.
+            """;
+
+    public CRTest() {
+        super("Check KeyChar values");
+        setLayout(new BorderLayout());
+        TextField tf = new TextField(30);
+
+        tf.addKeyListener(this);
+        tf.addActionListener(this);
+
+        add(tf, BorderLayout.CENTER);
+
+        Button done = new Button("Done");
+        done.addActionListener((event) -> {
+            checkAndComplete();
+        });
+        add(done, BorderLayout.SOUTH);
+        pack();
+    }
+
+    public void checkAndComplete() {
+        if (!actionCompleted.get()) {
+            error.append("\nNo action received!");
+        }
+
+        if (!error.isEmpty()) {
+            PassFailJFrame.forceFail(error.toString());
+        } else {
+            PassFailJFrame.forcePass();
+        }
+    }
+
+    public void keyPressed(KeyEvent evt) {
+        if ((evt.getKeyChar() != '\n') || (evt.getKeyCode() != KeyEvent.VK_ENTER)) {
+            error.append("\nKeyPressed: Unexpected code " + evt.getKeyCode());
+        } else {
+            PassFailJFrame.log("KeyPressed Test PASSED");
+        }
+    }
+
+    public void keyTyped(KeyEvent evt) {
+        if ((evt.getKeyChar() != '\n') || (evt.getKeyCode() != KeyEvent.VK_UNDEFINED)) {
+            error.append("\nKeyTyped: Unexpected code " + evt.getKeyCode());
+        } else {
+            PassFailJFrame.log("KeyTyped Test PASSED");
+        }
+    }
+
+    public void keyReleased(KeyEvent evt) {
+        if ((evt.getKeyChar() != '\n') || (evt.getKeyCode() != KeyEvent.VK_ENTER)) {
+            error.append("\nKeyReleased: Unexpected code " + evt.getKeyCode());
+        } else {
+            PassFailJFrame.log("KeyReleased Test PASSED");
+        }
+    }
+
+    public void actionPerformed(ActionEvent evt) {
+        PassFailJFrame.log("ActionPerformed Test PASSED");
+        actionCompleted.set(true);
+    }
+
+    public static void main(String[] args) throws InterruptedException,
+            InvocationTargetException {
+        PassFailJFrame.builder()
+                .instructions(INSTRUCTIONS)
+                .logArea(10)
+                .testUI(CRTest::new)
+                .build()
+                .awaitAndCheck();
+    }
+}

--- a/test/jdk/java/awt/event/KeyEvent/NumpadTest2.java
+++ b/test/jdk/java/awt/event/KeyEvent/NumpadTest2.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4279566
+ * @summary Tests that numpad keys produce the correct key codes and
+ *           key chars when both the NumLock and CapsLock are on.
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual NumpadTest2
+*/
+
+import java.awt.BorderLayout;
+import java.awt.Frame;
+import java.awt.TextField;
+import java.awt.event.KeyEvent;
+import java.awt.event.KeyListener;
+import java.lang.reflect.InvocationTargetException;
+
+public class NumpadTest2 extends Frame implements KeyListener {
+    static String INSTRUCTIONS = """
+           Make sure that the NumLock and CapsLock are both ON.
+           Click on the text field inside the window named "Check KeyChar values"
+           Then, type the NumPad 7 key (not the regular 7 key).
+           Verify that the keyChar and keyCode is correct for each key pressed.
+           Remember that the keyCode for the KEY_TYPED event should be zero.
+           If 7 appears in the text field and the key code printed is correct
+           press "Pass", otherwise press "Fail".
+
+           Key               Name             keyChar    Keycode
+           -------------------------------------------------
+           Numpad-7     Numpad-7      55         103
+           """;
+
+    public NumpadTest2() {
+        super("Check KeyChar values");
+        setLayout(new BorderLayout());
+        TextField tf = new TextField(30);
+        tf.addKeyListener(this);
+        add(tf, BorderLayout.CENTER);
+        pack();
+    }
+
+    public void keyPressed(KeyEvent evt) {
+        printKey(evt);
+    }
+
+    public void keyTyped(KeyEvent evt) {
+        printKey(evt);
+    }
+
+    public void keyReleased(KeyEvent evt) {
+        printKey(evt);
+    }
+
+    protected void printKey(KeyEvent evt) {
+        switch (evt.getID()) {
+            case KeyEvent.KEY_TYPED:
+                break;
+            case KeyEvent.KEY_PRESSED:
+                break;
+            case KeyEvent.KEY_RELEASED:
+                break;
+            default:
+                System.out.println("Other Event ");
+                return;
+        }
+
+        if (evt.isActionKey()) {
+            PassFailJFrame.log("params= " + evt.paramString() + "  KeyChar: " +
+                    (int) evt.getKeyChar() + " Action Key");
+        } else {
+            PassFailJFrame.log("params= " + evt.paramString() + "  KeyChar: " +
+                    (int) evt.getKeyChar());
+        }
+    }
+
+    public static void main(String[] args) throws InterruptedException,
+            InvocationTargetException {
+        PassFailJFrame.builder()
+                .instructions(INSTRUCTIONS)
+                .logArea(10)
+                .testUI(NumpadTest2::new)
+                .build()
+                .awaitAndCheck();
+    }
+}

--- a/test/jdk/java/awt/event/KeyEvent/TestDoubleKeyEvent.java
+++ b/test/jdk/java/awt/event/KeyEvent/TestDoubleKeyEvent.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4495473
+ * @summary Tests that when you press key on canvas-type heavyweight only one key event arrives
+ * @key headful
+ * @run main TestDoubleKeyEvent
+ */
+
+import java.awt.AWTException;
+import java.awt.BorderLayout;
+import java.awt.EventQueue;
+import java.awt.FlowLayout;
+import java.awt.Robot;
+import java.awt.event.KeyEvent;
+import java.lang.reflect.InvocationTargetException;
+import javax.swing.JFrame;
+import javax.swing.JWindow;
+import javax.swing.JTextField;
+
+public class TestDoubleKeyEvent extends JFrame {
+    JWindow w;
+    JTextField tf;
+
+    public void initUI() {
+        setLayout(new BorderLayout());
+        setTitle("Double Key Event Test");
+        setLocationRelativeTo(null);
+        setVisible(true);
+        w = new JWindow(this);
+        w.setLayout(new FlowLayout());
+        tf = new JTextField(20);
+        w.add(tf);
+        w.pack();
+        w.setLocationRelativeTo(null);
+        w.setVisible(true);
+        tf.requestFocus();
+    }
+
+    public void testAndClean() {
+        String str = tf.getText();
+        w.dispose();
+        dispose();
+        if (str.length() != str.chars().distinct().count()) {
+            throw new RuntimeException("Duplicate characters found!");
+        }
+    }
+
+    public static void main(String[] args) throws InterruptedException,
+            InvocationTargetException, AWTException {
+        TestDoubleKeyEvent test = new TestDoubleKeyEvent();
+        EventQueue.invokeAndWait(test::initUI);
+        Robot robot = new Robot();
+        robot.setAutoDelay(50);
+        robot.waitForIdle();
+        robot.delay(1000);
+        for (int i = 0; i < 15; i++) {
+            robot.keyPress(KeyEvent.VK_A + i);
+            robot.keyRelease(KeyEvent.VK_A + i);
+            robot.waitForIdle();
+        }
+        robot.delay(1000);
+        EventQueue.invokeAndWait(test::testAndClean);
+    }
+}


### PR DESCRIPTION
Clean up four more KeyEvent related tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8354653](https://bugs.openjdk.org/browse/JDK-8354653): Clean up and open source KeyEvent related tests (Part 4) (**Bug** - P4)


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24763/head:pull/24763` \
`$ git checkout pull/24763`

Update a local copy of the PR: \
`$ git checkout pull/24763` \
`$ git pull https://git.openjdk.org/jdk.git pull/24763/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24763`

View PR using the GUI difftool: \
`$ git pr show -t 24763`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24763.diff">https://git.openjdk.org/jdk/pull/24763.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24763#issuecomment-2816214947)
</details>
