### PR TITLE
8354472: Clean up and open source KeyEvent related tests (Part 3)

### DIFF
--- a/test/jdk/java/awt/event/KeyEvent/CharUndefinedTest.java
+++ b/test/jdk/java/awt/event/KeyEvent/CharUndefinedTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4115484 4164672 4167893
+ * @summary Ensures that KeyEvent has right keyChar for modifier and action keys.
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual CharUndefinedTest
+ */
+
+import java.awt.BorderLayout;
+import java.awt.Frame;
+import java.awt.TextField;
+import java.awt.event.KeyEvent;
+import java.awt.event.KeyListener;
+import java.lang.reflect.InvocationTargetException;
+
+public class CharUndefinedTest extends Frame implements KeyListener {
+
+    static String INSTRUCTIONS = """
+            Click on the text field inside the window named "Check KeyChar values".
+            Of any of the keys mentioned in this list that exist on your keyboard
+            press once every of them and also press them in two-key combinations such as
+            Control-Shift or Alt-Control.
+            The list of keys is: "Control, Shift, Meta, Alt, Command, Option".
+            After that press once all function keys from F1 to F12,
+            Insert, Home, End, PageUp, PageDown and four arrow keys.
+            Check the log area below. If there are no messages starting with word "ERROR"
+            press "Pass" otherwise press "Fail".
+            """;
+
+    public CharUndefinedTest() {
+        super("Check KeyChar values");
+        setLayout(new BorderLayout());
+        TextField tf = new TextField(30);
+        tf.addKeyListener(this);
+        add(tf, BorderLayout.CENTER);
+        pack();
+        tf.requestFocus();
+    }
+
+    public void keyPressed(KeyEvent e) {
+        if (e.getKeyChar() != KeyEvent.CHAR_UNDEFINED) {
+            PassFailJFrame.log("ERROR: KeyPressed: keyChar = " + e.getKeyChar() +
+                    " keyCode = " + e.getKeyCode() + " " + e.getKeyText(e.getKeyCode()));
+        }
+    }
+
+    public void keyTyped(KeyEvent e) {
+        if (e.getKeyChar() != KeyEvent.CHAR_UNDEFINED) {
+            PassFailJFrame.log("ERROR: KeyTyped: keyChar = " + e.getKeyChar() +
+                    " keyCode = " + e.getKeyCode() + " " + e.getKeyText(e.getKeyCode()));
+        }
+    }
+
+    public void keyReleased(KeyEvent e) {
+        if (e.getKeyChar() != KeyEvent.CHAR_UNDEFINED) {
+            PassFailJFrame.log("ERROR: KeyReleased: keyChar = " + e.getKeyChar() +
+                    " keyCode = " + e.getKeyCode() + " " + e.getKeyText(e.getKeyCode()));
+        }
+    }
+
+    public static void main(String[] args) throws InterruptedException,
+            InvocationTargetException {
+        PassFailJFrame.builder()
+                .instructions(INSTRUCTIONS)
+                .columns(45)
+                .logArea(10)
+                .testUI(CharUndefinedTest::new)
+                .build()
+                .awaitAndCheck();
+    }
+}

--- a/test/jdk/java/awt/event/KeyEvent/CharUndefinedTest.java
+++ b/test/jdk/java/awt/event/KeyEvent/CharUndefinedTest.java
@@ -45,7 +45,7 @@ public class CharUndefinedTest extends Frame implements KeyListener {
             press once every of them and also press them in two-key combinations such as
             Control-Shift or Alt-Control.
             The list of keys is: "Control, Shift, Meta, Alt, Command, Option".
-            After that press once all function keys from F1 to F12,
+            After that press all function keys from F1 to F12 once,
             Insert, Home, End, PageUp, PageDown and four arrow keys.
             Check the log area below. If there are no messages starting with word "ERROR"
             press "Pass" otherwise press "Fail".

--- a/test/jdk/java/awt/event/KeyEvent/CharUndefinedTest.java
+++ b/test/jdk/java/awt/event/KeyEvent/CharUndefinedTest.java
@@ -42,7 +42,7 @@ public class CharUndefinedTest extends Frame implements KeyListener {
     static String INSTRUCTIONS = """
             Click on the text field inside the window named "Check KeyChar values".
             Of any of the keys mentioned in this list that exist on your keyboard
-            press once every of them and also press them in two-key combinations such as
+            press each of the listed keys once and also press them in two-key combinations such as
             Control-Shift or Alt-Control.
             The list of keys is: "Control, Shift, Meta, Alt, Command, Option".
             After that press all function keys from F1 to F12 once,

--- a/test/jdk/java/awt/event/KeyEvent/ExtendedKeysTest.java
+++ b/test/jdk/java/awt/event/KeyEvent/ExtendedKeysTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4218892 4191924 4199284
+ * @summary Unable to enter some chars via european keyboard layout(s)
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual ExtendedKeysTest
+ */
+
+import java.awt.BorderLayout;
+import java.awt.Frame;
+import java.awt.TextArea;
+import java.lang.reflect.InvocationTargetException;
+
+public class ExtendedKeysTest extends Frame {
+    static String INSTRUCTIONS = """
+            This test requires Swiss German input. If the Swiss German input
+            can not be installed or configured press "Pass" to skip testing.
+            Click on the text area inside the window named "Check input".
+            Switch to Swiss German input and press key with "\\" on it
+            (usually this key is above or to the left of the main "Enter" key).
+            If you see a dollar sign press "Pass".
+            If you see any other character or question mark press "Fail".
+            """;
+
+    public ExtendedKeysTest() {
+        super("Check input");
+        setLayout(new BorderLayout());
+        add(new TextArea(20, 20), "Center");
+        pack();
+    }
+
+    public static void main(String[] args) throws InterruptedException,
+            InvocationTargetException {
+        PassFailJFrame.builder()
+                .instructions(INSTRUCTIONS)
+                .columns(45)
+                .logArea(10)
+                .testUI(ExtendedKeysTest::new)
+                .build()
+                .awaitAndCheck();
+    }
+}

--- a/test/jdk/java/awt/event/KeyEvent/KeyDownCaptureTest.java
+++ b/test/jdk/java/awt/event/KeyEvent/KeyDownCaptureTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4093998
+ * @summary keyDown not called on subclasses of Component
+ * @key headful
+ * @run main KeyDownCaptureTest
+ */
+
+import java.awt.AWTException;
+import java.awt.BorderLayout;
+import java.awt.Canvas;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
+import java.awt.event.KeyListener;
+import java.lang.reflect.InvocationTargetException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class KeyDownCaptureTest extends Frame implements KeyListener {
+    static AtomicBoolean passed = new AtomicBoolean(false);
+
+    public KeyDownCaptureTest() {
+        super("Key Down Capture Test");
+    }
+
+    public void initUI() {
+        setLayout (new BorderLayout());
+        setSize(200, 200);
+        setLocationRelativeTo(null);
+        Canvas canvas = new Canvas();
+        canvas.setBackground(Color.RED);
+        canvas.addKeyListener(this);
+        add(canvas, BorderLayout.CENTER);
+        setVisible(true);
+    }
+
+    public void middle(Point p) {
+        Point loc = getLocationOnScreen();
+        Dimension size = getSize();
+        p.setLocation(loc.x + (size.width / 2), loc.y + (size.height / 2));
+    }
+
+    @Override
+    public void keyTyped(KeyEvent ignore) {}
+
+    @Override
+    public void keyPressed(KeyEvent e) {
+        passed.set(true);
+    }
+
+    @Override
+    public void keyReleased(KeyEvent ignore) {}
+
+    public static void main(String[] args) throws InterruptedException,
+            InvocationTargetException, AWTException {
+        KeyDownCaptureTest test = new KeyDownCaptureTest();
+        try {
+            EventQueue.invokeAndWait((test::initUI));
+            Robot robot = new Robot();
+            robot.setAutoDelay(50);
+            robot.delay(500);
+            robot.waitForIdle();
+            Point target = new Point();
+            EventQueue.invokeAndWait(() -> {
+                test.middle(target);
+            });
+            robot.mouseMove(target.x, target.y);
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+            robot.keyPress(KeyEvent.VK_SPACE);
+            robot.keyRelease(KeyEvent.VK_SPACE);
+            robot.delay(100);
+            robot.waitForIdle();
+            if (!passed.get()) {
+                throw new RuntimeException("KeyPressed has not arrived to canvas");
+            }
+        } finally {
+            if (test != null) {
+                EventQueue.invokeAndWait(test::dispose);
+            }
+        }
+    }
+}

--- a/test/jdk/java/awt/event/KeyEvent/KeyEventToLightweight.java
+++ b/test/jdk/java/awt/event/KeyEvent/KeyEventToLightweight.java
@@ -91,13 +91,14 @@ public class KeyEventToLightweight extends Frame {
         p.setLocation(loc.x + (size.width / 2), loc.y + (size.height / 2));
     }
 
-    public void performTest() throws AWTException {
+    public void performTest() throws AWTException, InterruptedException,
+            InvocationTargetException {
         Robot robot = new Robot();
         robot.setAutoDelay(50);
         robot.delay(500);
         robot.waitForIdle();
         Point target = new Point();
-        middleOf(lwbutton, target);
+        EventQueue.invokeAndWait(() -> middleOf(lwbutton, target));
         robot.mouseMove(target.x, target.y);
         robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
         robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
@@ -111,7 +112,7 @@ public class KeyEventToLightweight extends Frame {
         robot.keyRelease(KeyEvent.VK_B);
         robot.waitForIdle();
         robot.delay(500);
-        middleOf(hwbutton, target);
+        EventQueue.invokeAndWait(() -> middleOf(hwbutton, target));
         robot.mouseMove(target.x, target.y);
         robot.keyPress(KeyEvent.VK_C);
         robot.keyRelease(KeyEvent.VK_C);

--- a/test/jdk/java/awt/event/KeyEvent/KeyEventToLightweight.java
+++ b/test/jdk/java/awt/event/KeyEvent/KeyEventToLightweight.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4397557
+ * @summary Check that focused lightweight component gets key events
+ *          even if mouse is outside of it or on top of heavyweight component
+ * @key headful
+ * @run main KeyEventToLightweight
+ */
+
+import java.awt.AWTException;
+import java.awt.Button;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.EventQueue;
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyAdapter;
+import java.awt.event.KeyEvent;
+import java.lang.reflect.InvocationTargetException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import javax.swing.JButton;
+
+public class KeyEventToLightweight extends Frame {
+    JButton lwbutton = new JButton("Select Me");
+    Button hwbutton = new Button("Heavyweight");
+
+    AtomicBoolean aTyped = new AtomicBoolean(false);
+    AtomicBoolean bTyped = new AtomicBoolean(false);
+    AtomicBoolean cTyped = new AtomicBoolean(false);
+
+    public static void main(String[] args) throws InterruptedException,
+            InvocationTargetException, AWTException {
+        KeyEventToLightweight test = new KeyEventToLightweight();
+        try {
+            EventQueue.invokeAndWait(test::initUI);
+            test.performTest();
+        } finally {
+            EventQueue.invokeAndWait(test::dispose);
+        }
+    }
+
+    public void initUI() {
+        this.setLayout(new FlowLayout());
+        add(lwbutton);
+        add(hwbutton);
+        setSize(200, 200);
+        setLocationRelativeTo(null);
+        lwbutton.addKeyListener(new KeyAdapter() {
+            public void keyPressed(KeyEvent e) {
+                if (e.getKeyCode() == KeyEvent.VK_A) {
+                    aTyped.set(true);
+                } else if (e.getKeyCode() == KeyEvent.VK_B) {
+                    bTyped.set(true);
+                } else if (e.getKeyCode() == KeyEvent.VK_C) {
+                    cTyped.set(true);
+                }
+            }
+        });
+        setVisible(true);
+    }
+
+    public void middleOf(Component c, Point p) {
+        Point loc = c.getLocationOnScreen();
+        Dimension size = c.getSize();
+        p.setLocation(loc.x + (size.width / 2), loc.y + (size.height / 2));
+    }
+
+    public void performTest() throws AWTException {
+        Robot robot = new Robot();
+        robot.setAutoDelay(50);
+        robot.delay(500);
+        robot.waitForIdle();
+        Point target = new Point();
+        middleOf(lwbutton, target);
+        robot.mouseMove(target.x, target.y);
+        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+        robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+        robot.waitForIdle();
+        robot.delay(500);
+        robot.keyPress(KeyEvent.VK_A);
+        robot.keyRelease(KeyEvent.VK_A);
+        robot.waitForIdle();
+        robot.mouseMove(target.x - 200, target.y);
+        robot.keyPress(KeyEvent.VK_B);
+        robot.keyRelease(KeyEvent.VK_B);
+        robot.waitForIdle();
+        robot.delay(500);
+        middleOf(hwbutton, target);
+        robot.mouseMove(target.x, target.y);
+        robot.keyPress(KeyEvent.VK_C);
+        robot.keyRelease(KeyEvent.VK_C);
+        if (!aTyped.get() || !bTyped.get() || !cTyped.get()) {
+            throw new RuntimeException("Key event was not delivered, case 1: "
+                    + aTyped.get() + ", case 2: " + bTyped.get() + ", case 3: "
+                    + cTyped.get());
+        }
+    }
+}

--- a/test/jdk/java/awt/event/KeyEvent/KeyModifiers.java
+++ b/test/jdk/java/awt/event/KeyEvent/KeyModifiers.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4193779 4174399
+ * @summary Ensures that KeyEvents have the right modifiers set
+ * @library /java/awt/regtesthelpers /test/lib
+ * @build PassFailJFrame jdk.test.lib.Platform
+ * @run main/manual KeyModifiers
+ */
+
+import java.awt.BorderLayout;
+import java.awt.Frame;
+import java.awt.TextField;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
+import java.awt.event.KeyListener;
+import java.lang.reflect.InvocationTargetException;
+
+import jdk.test.lib.Platform;
+
+
+public class KeyModifiers extends Frame implements KeyListener {
+    public KeyModifiers() {
+        super("Check KeyChar values");
+        setLayout(new BorderLayout());
+        TextField tf = new TextField(30);
+        tf.addKeyListener(this);
+        add(tf, BorderLayout.CENTER);
+        pack();
+    }
+
+    public static void main(String[] args) throws InterruptedException,
+            InvocationTargetException {
+
+        String keys;
+        if (Platform.isWindows()) {
+            keys = "\"Shift-n\", \"Alt-n\"\n";
+        } else if (Platform.isOSX()) {
+            keys = "\"Shift-n\", \"Alt-n\", \"Command-n\"\n";
+        } else {
+            keys = "\"Shift-n\", \"Alt-n\", \"Meta-n\"\n";
+        }
+
+        String INSTRUCTIONS1 = """
+                Click on the text field in the window named "Check KeyChar values"
+                and type the following key combinations:
+                """;
+        String INSTRUCTIONS2 = """
+                After each combination check that the KeyPressed and KeyTyped modifiers
+                are correctly displayed. If modifiers are correct press "Pass",
+                otherwise press "Fail".
+                """;
+        PassFailJFrame.builder()
+                .title("KeyModifiers Test Instructions")
+                .instructions(INSTRUCTIONS1 + keys + INSTRUCTIONS2)
+                .columns(45)
+                .logArea(10)
+                .testUI(KeyModifiers::new)
+                .build()
+                .awaitAndCheck();
+    }
+
+    public void keyPressed(KeyEvent evt) {
+        int kc = evt.getKeyCode();
+
+        if (kc == KeyEvent.VK_CONTROL) {
+            return;
+        }
+
+        if ((kc == KeyEvent.VK_SHIFT) || (kc == KeyEvent.VK_META) ||
+                (kc == KeyEvent.VK_ALT) || (kc == KeyEvent.VK_ALT_GRAPH)) {
+            PassFailJFrame.log("Key pressed= " + KeyEvent.getKeyText(kc) +
+                    "   modifiers = " + InputEvent.getModifiersExText(evt.getModifiersEx()));
+        } else {
+            PassFailJFrame.log("Key pressed = " + evt.getKeyChar() +
+                    "   modifiers = " + InputEvent.getModifiersExText(evt.getModifiersEx()));
+        }
+    }
+
+    public void keyTyped(KeyEvent evt) {
+        int kc = evt.getKeyCode();
+
+        if (kc == KeyEvent.VK_CONTROL) {
+            return;
+        }
+
+        if ((kc == KeyEvent.VK_SHIFT) || (kc == KeyEvent.VK_META) ||
+                (kc == KeyEvent.VK_ALT) || (kc == KeyEvent.VK_ALT_GRAPH)) {
+            PassFailJFrame.log("Key typed = " + KeyEvent.getKeyText(kc) +
+                    "   modifiers = " + InputEvent.getModifiersExText(evt.getModifiersEx()));
+        } else {
+            PassFailJFrame.log("Key typed = " + evt.getKeyChar() +
+                    "   modifiers = " + InputEvent.getModifiersExText(evt.getModifiersEx()));
+        }
+    }
+
+    public void keyReleased(KeyEvent evt) {
+        int kc = evt.getKeyCode();
+
+        if (kc == KeyEvent.VK_CONTROL)
+            return;
+
+        if ((kc == KeyEvent.VK_SHIFT) || (kc == KeyEvent.VK_META) ||
+                (kc == KeyEvent.VK_ALT) || (kc == KeyEvent.VK_ALT_GRAPH)) {
+            PassFailJFrame.log("Key = released " + KeyEvent.getKeyText(kc) +
+                    "   modifiers = " + InputEvent.getModifiersExText(evt.getModifiersEx()));
+        } else {
+            PassFailJFrame.log("Key released = " + evt.getKeyChar() +
+                    "   modifiers = " + InputEvent.getModifiersExText(evt.getModifiersEx()));
+        }
+    }
+}


### PR DESCRIPTION
Clean up and publish five more KeyEvent related tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8354472](https://bugs.openjdk.org/browse/JDK-8354472): Clean up and open source KeyEvent related tests (Part 3) (**Bug** - P4)


### Reviewers
 * [Harshitha Onkar](https://openjdk.org/census#honkar) (@honkar-jdk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24764/head:pull/24764` \
`$ git checkout pull/24764`

Update a local copy of the PR: \
`$ git checkout pull/24764` \
`$ git pull https://git.openjdk.org/jdk.git pull/24764/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24764`

View PR using the GUI difftool: \
`$ git pr show -t 24764`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24764.diff">https://git.openjdk.org/jdk/pull/24764.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24764#issuecomment-2816288960)
</details>
