### PR TITLE
JDK-8353011 : Open source Swing JButton tests - Set 1

### DIFF
--- a/test/jdk/javax/swing/JButton/bug4151763.java
+++ b/test/jdk/javax/swing/JButton/bug4151763.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4151763
+ * @summary Tests that button icon is not drawn upon button border
+ * @library /java/awt/regtesthelpers /test/lib
+ * @build PassFailJFrame jtreg.SkippedException
+ * @run main/manual bug4151763
+ */
+
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.FlowLayout;
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+import javax.swing.ImageIcon;
+import javax.swing.JButton;
+import javax.swing.JFrame;
+import javax.swing.UIManager;
+import javax.swing.border.CompoundBorder;
+import javax.swing.border.EmptyBorder;
+import javax.swing.border.LineBorder;
+import jtreg.SkippedException;
+
+public class bug4151763 {
+    private static final int IMAGE_SIZE = 150;
+    private static final String INSTRUCTIONS = """
+            Verify that image icon is NOT painted outside
+            the black rectangle.
+
+            If above is true press PASS else FAIL.
+            """;
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                .instructions(INSTRUCTIONS)
+                .columns(40)
+                .testUI(bug4151763::createAndShowUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static JFrame createAndShowUI() {
+        try {
+            UIManager.setLookAndFeel("com.sun.java.swing.plaf.motif.MotifLookAndFeel");
+        } catch (Exception e) {
+            throw new SkippedException("Unsupported LaF", e);
+        }
+
+        JFrame frame = new JFrame("bug4151763");
+        final JButton b = new JButton(createImageIcon());
+        b.setBorder(new CompoundBorder(
+                           new EmptyBorder(20, 20, 20, 20),
+                           new LineBorder(Color.BLACK)));
+        b.setPreferredSize(new Dimension(100, 100));
+
+        frame.setLayout(new FlowLayout());
+        frame.add(b);
+        frame.setSize(400, 300);
+        return frame;
+    }
+
+    private static ImageIcon createImageIcon() {
+        BufferedImage redImg = new BufferedImage(IMAGE_SIZE, IMAGE_SIZE,
+                                                 BufferedImage.TYPE_INT_RGB);
+        Graphics2D g = redImg.createGraphics();
+        g.setColor(Color.RED);
+        g.fillRect(0, 0, IMAGE_SIZE, IMAGE_SIZE);
+        g.dispose();
+        return new ImageIcon(redImg);
+    }
+}

--- a/test/jdk/javax/swing/JButton/bug4415505.java
+++ b/test/jdk/javax/swing/JButton/bug4415505.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4415505
+ * @requires (os.family == "windows")
+ * @summary Tests JButton appearance under Windows LAF
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual bug4415505
+ */
+
+import java.awt.FlowLayout;
+import javax.swing.JButton;
+import javax.swing.JFrame;
+import javax.swing.JToggleButton;
+import javax.swing.UIManager;
+
+public class bug4415505 {
+    private static final String INSTRUCTIONS = """
+            <html>
+            <p>This test is for Windows LaF.
+            Press the button named "Button" using mouse and check that it has
+            "pressed" look. It should look like the selected toggle button
+            near it.</p>
+
+            <p>If above is true press PASS else FAIL.</p>
+            <html>
+            """;
+
+    public static void main(String[] args) throws Exception {
+        UIManager.setLookAndFeel("com.sun.java.swing.plaf.windows.WindowsLookAndFeel");
+
+        PassFailJFrame.builder()
+                .instructions(INSTRUCTIONS)
+                .rows(5)
+                .columns(40)
+                .testUI(bug4415505::createAndShowUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static JFrame createAndShowUI() {
+        JButton button = new JButton("Button");
+        button.setFocusPainted(false);
+        JToggleButton tbutton = new JToggleButton("ToggleButton");
+        tbutton.setSelected(true);
+
+        JFrame jFrame = new JFrame("bug4415505");
+        jFrame.setLayout(new FlowLayout(FlowLayout.CENTER));
+        jFrame.add(button);
+        jFrame.add(tbutton);
+        jFrame.setSize(300, 100);
+        return jFrame;
+    }
+}

--- a/test/jdk/javax/swing/JButton/bug4978274.java
+++ b/test/jdk/javax/swing/JButton/bug4978274.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2004, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4978274
+ * @summary Tests that JButton is painted with same visible height
+ *          as toggle buttons
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual bug4978274
+ */
+
+import java.awt.BorderLayout;
+import java.awt.FlowLayout;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import javax.swing.JButton;
+import javax.swing.JFrame;
+import javax.swing.JPanel;
+import javax.swing.JToggleButton;
+import javax.swing.UIManager;
+import javax.swing.border.EmptyBorder;
+import javax.swing.plaf.metal.MetalLookAndFeel;
+import javax.swing.plaf.metal.OceanTheme;
+
+public class bug4978274 {
+    private static final String INSTRUCTIONS = """
+            The toggle buttons must be painted to the same visible
+            height as button. In addition to that verify the following:
+
+            a) All three buttons - "Button", "Toggle Btn" and
+               "Selected Toggle Btn" have the same border.
+
+            b) Verify that when "Button" is pressed and moused over
+               it has the EXACT same border as "Toggle Btn" and
+               "Selected Toggle Btn" on press & mouse over.
+
+            c) Click to the test window (panel) to disable/enable all
+               three buttons. In disabled state verify that all three
+               buttons have the exact same border.
+
+            If all of the above conditions are true press PASS, else FAIL.
+            """;
+
+    public static void main(String[] args) throws Exception {
+        MetalLookAndFeel.setCurrentTheme(new OceanTheme());
+        UIManager.setLookAndFeel(UIManager.getCrossPlatformLookAndFeelClassName());
+
+        PassFailJFrame.builder()
+                .instructions(INSTRUCTIONS)
+                .columns(40)
+                .testUI(createAndShowUI())
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static JFrame createAndShowUI() {
+        JFrame frame = new JFrame("bug4978274");
+        frame.setLayout(new BorderLayout());
+
+        JPanel panel = new JPanel();
+        panel.setLayout(new FlowLayout());
+        panel.setBorder(new EmptyBorder(12, 12, 12, 12));
+        JButton jButton = new JButton("Button");
+        JToggleButton jToggleButton = new JToggleButton("Selected Toggle Btn");
+        jToggleButton.setSelected(true);
+
+        panel.add(jButton);
+        panel.add(new JToggleButton("Toggle Btn"));
+        panel.add(jToggleButton);
+
+        panel.addMouseListener(new MouseAdapter() {
+            @Override
+            public void mouseClicked(MouseEvent event) {
+              jButton.setEnabled(!jButton.isEnabled());
+              jToggleButton.setEnabled(jButton.isEnabled());
+                for(int i = 0; i < panel.getComponentCount(); i++) {
+                    panel.getComponent(i).setEnabled(jButton.isEnabled());
+                }
+            }
+        });
+
+        frame.add(panel);
+        frame.pack();
+        return frame;
+    }
+}

--- a/test/jdk/javax/swing/JRadioButton/bug4673850.java
+++ b/test/jdk/javax/swing/JRadioButton/bug4673850.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2004, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4673850
+ * @summary Tests that JRadioButton and JCheckBox checkmarks are painted entirely
+ *          inside circular/rectangle checkboxes for Motif LaF.
+ * @library /java/awt/regtesthelpers /test/lib
+ * @build PassFailJFrame jtreg.SkippedException
+ * @run main/manual bug4673850
+ */
+
+import java.awt.FlowLayout;
+import javax.swing.JCheckBox;
+import javax.swing.JFrame;
+import javax.swing.JRadioButton;
+import javax.swing.SwingConstants;
+import javax.swing.UIManager;
+import jtreg.SkippedException;
+
+public class bug4673850 {
+    private static final String INSTRUCTIONS = """
+            <html>
+            <head>
+            <style>
+            p {
+              font: sans-serif;
+            }
+            </style>
+            </head>
+            <body>
+            <p><b>This test is for Motif LaF.</b></p>
+
+            <p><b>
+            When the test starts, you'll see 2 radio buttons and 2 check boxes
+            with the checkmarks painted.</b></p>
+
+            <p><b>
+            Ensure that all the button's checkmarks are painted entirely
+            within the circular/rectangle checkbox, NOT over them or outside them.
+            </b></p>
+            </body>
+            """;
+
+    public static void main(String[] args) throws Exception {
+        try {
+            UIManager.setLookAndFeel("com.sun.java.swing.plaf.motif.MotifLookAndFeel");
+        } catch (Exception e) {
+            throw new SkippedException("Unsupported LaF", e);
+        }
+
+        PassFailJFrame.builder()
+                .instructions(INSTRUCTIONS)
+                .rows(10)
+                .columns(45)
+                .testUI(createAndShowUI())
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static JFrame createAndShowUI() {
+        JFrame frame = new JFrame("bug4673850");
+        frame.setLayout(new FlowLayout());
+
+        JRadioButton rb = new JRadioButton("RadioButt");
+        rb.setSelected(true);
+        frame.add(rb);
+        JRadioButton rb2 = new JRadioButton("RadioButt");
+        rb2.setHorizontalTextPosition(SwingConstants.LEFT);
+        rb2.setSelected(true);
+        frame.add(rb2);
+
+        JCheckBox cb = new JCheckBox("CheckBox");
+        cb.setSelected(true);
+        frame.add(cb);
+        JCheckBox cb2 = new JCheckBox("CheckBox");
+        cb2.setHorizontalTextPosition(SwingConstants.LEFT);
+        cb2.setSelected(true);
+        frame.add(cb2);
+        frame.setSize(200, 150);
+        return frame;
+    }
+}

--- a/test/jdk/javax/swing/JTable/bug4188504.java
+++ b/test/jdk/javax/swing/JTable/bug4188504.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4188504
+ * @summary setResizable for specified column.
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual bug4188504
+ */
+
+import javax.swing.JFrame;
+import javax.swing.JScrollPane;
+import javax.swing.JTable;
+
+public class bug4188504 {
+    private static final String INSTRUCTIONS = """
+            1. A table is displayed with 3 columns - A, B, C.
+
+            2. Try to resize second column of table (Move mouse to the position
+            between "B" and "C" headers, press left mouse button and move to
+            right/left).
+            PLEASE NOTE: You may be able to swap the columns but make sure the
+            width of column B stays the same.
+
+            3. If the second column does not change its width then press PASS
+            otherwise press FAIL.
+            """;
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                .title("Test Instructions")
+                .instructions(INSTRUCTIONS)
+                .columns(40)
+                .testUI(createAndShowUI())
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static JFrame createAndShowUI() {
+        JFrame jFrame = new JFrame("bug4188504");
+        JTable tableView = new JTable(4, 3);
+        tableView.setAutoResizeMode(JTable.AUTO_RESIZE_OFF);
+        tableView.getColumnModel().getColumn(1).setResizable(false);
+
+        jFrame.add(new JScrollPane(tableView));
+        jFrame.setSize(300, 150);
+        return jFrame;
+    }
+}


### PR DESCRIPTION
Following tests are open sourced in this PR:

javax/swing/JButton/bug4151763.java
javax/swing/JButton/bug4415505.java
javax/swing/JButton/bug4978274.java
javax/swing/JRadioButton/bug4673850.java
javax/swing/JTable/bug4188504.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8353011](https://bugs.openjdk.org/browse/JDK-8353011): Open source Swing JButton tests - Set 1 (**Bug** - P4)


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24765/head:pull/24765` \
`$ git checkout pull/24765`

Update a local copy of the PR: \
`$ git checkout pull/24765` \
`$ git pull https://git.openjdk.org/jdk.git pull/24765/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24765`

View PR using the GUI difftool: \
`$ git pr show -t 24765`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24765.diff">https://git.openjdk.org/jdk/pull/24765.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24765#issuecomment-2816364610)
</details>
