### PR TITLE
8355069: Allocation::check_out_of_memory() should support CheckUnhandledOops mode

### DIFF
--- a/src/hotspot/share/gc/shared/memAllocator.cpp
+++ b/src/hotspot/share/gc/shared/memAllocator.cpp
@@ -126,6 +126,10 @@ bool MemAllocator::Allocation::check_out_of_memory() {
     // -XX:+HeapDumpOnOutOfMemoryError and -XX:OnOutOfMemoryError support
     report_java_out_of_memory(message);
     if (JvmtiExport::should_post_resource_exhausted()) {
+#ifdef CHECK_UNHANDLED_OOPS
+      // obj is null, not need to handle, but CheckUnhandledOops not aware about null
+      THREAD->allow_unhandled_oop(_obj_ptr);
+#endif // CHECK_UNHANDLED_OOPS
       JvmtiExport::post_resource_exhausted(
         JVMTI_RESOURCE_EXHAUSTED_OOM_ERROR | JVMTI_RESOURCE_EXHAUSTED_JAVA_HEAP,
         message);

--- a/src/hotspot/share/gc/shared/memAllocator.cpp
+++ b/src/hotspot/share/gc/shared/memAllocator.cpp
@@ -127,7 +127,7 @@ bool MemAllocator::Allocation::check_out_of_memory() {
     report_java_out_of_memory(message);
     if (JvmtiExport::should_post_resource_exhausted()) {
 #ifdef CHECK_UNHANDLED_OOPS
-      // obj is null, not need to handle, but CheckUnhandledOops not aware about null
+      // obj is null, no need to handle, but CheckUnhandledOops is not aware about null
       THREAD->allow_unhandled_oop(_obj_ptr);
 #endif // CHECK_UNHANDLED_OOPS
       JvmtiExport::post_resource_exhausted(


### PR DESCRIPTION
The
CheckUnhandledOops
cause failure if JvmtiExport::post_resource_exhausted(...)
is called in
MemAllocator::Allocation::check_out_of_memory()
The obj is null so it is not a real bug. 

I am fixing it to reduce noise for CheckUnhandledOops mode for jvmti tests execution.
The vmTestbase/nsk/jvmti/ResourceExhausted/resexhausted002/TestDescription.java 
failed with -XX:+CheckUnhandledOops

If define are unwelcome here, the
``` PreserveObj obj_h(_thread, _obj_ptr);```
might be added instead with comment why it is needed for null obj.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8355069](https://bugs.openjdk.org/browse/JDK-8355069): Allocation::check_out_of_memory() should support CheckUnhandledOops mode (**Bug** - P4)


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24766/head:pull/24766` \
`$ git checkout pull/24766`

Update a local copy of the PR: \
`$ git checkout pull/24766` \
`$ git pull https://git.openjdk.org/jdk.git pull/24766/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24766`

View PR using the GUI difftool: \
`$ git pr show -t 24766`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24766.diff">https://git.openjdk.org/jdk/pull/24766.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24766#issuecomment-2816411022)
</details>
