### PR TITLE
8355077: Compiler error at splashscreen_gif.c due to unterminated string initialization

### DIFF
--- a/src/java.desktop/share/native/libsplashscreen/splashscreen_gif.c
+++ b/src/java.desktop/share/native/libsplashscreen/splashscreen_gif.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,7 +48,7 @@
                                 // restore the area overwritten by the graphic with
                                 // what was there prior to rendering the graphic.
 
-static const char szNetscape20ext[11] = "NETSCAPE2.0";
+static const char szNetscape20ext[] = "NETSCAPE2.0";
 
 #define NSEXT_LOOP      0x01    // Loop Count field code
 
@@ -181,7 +181,7 @@ SplashDecodeGif(Splash * splash, GifFileType * gif)
                 }
             case APPLICATION_EXT_FUNC_CODE:
                 {
-                    if (size == sizeof(szNetscape20ext)
+                    if (size == strlen(szNetscape20ext)
                         && memcmp(pExtension, szNetscape20ext, size) == 0) {
                         int iSubCode;
 


### PR DESCRIPTION
I tried to build OpenJDK with GCC 15.0.1 on Fedora 42 x86_64, however I saw following error.

```
* For target support_native_java.desktop_libsplashscreen_splashscreen_gif.o:
/home/ysuenaga/github-forked/jdk/src/java.desktop/share/native/libsplashscreen/splashscreen_gif.c:51:41: error: initializer-string for array of ‘char’ truncates NUL terminator but destination lacks ‘nonstring’ attribute (12 chars into 11 available) [-Werror=unterminated-string-initialization]
   51 | static const char szNetscape20ext[11] = "NETSCAPE2.0";
      | ^~~~~~~~~~~~~
cc1: all warnings being treated as errors
```

This constant seems to be used to detect Netscape 2.0 extension in GIF image. It should be used to compare with extension block without NUL char, but we should tweak initialization to avoid this error for safety code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8355077](https://bugs.openjdk.org/browse/JDK-8355077): Compiler error at splashscreen_gif.c due to unterminated string initialization (**Bug** - P4)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24770/head:pull/24770` \
`$ git checkout pull/24770`

Update a local copy of the PR: \
`$ git checkout pull/24770` \
`$ git pull https://git.openjdk.org/jdk.git pull/24770/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24770`

View PR using the GUI difftool: \
`$ git pr show -t 24770`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24770.diff">https://git.openjdk.org/jdk/pull/24770.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24770#issuecomment-2816996307)
</details>
