### PR TITLE
Using UTF16::compress & Unsafe::copyMemory to speed up StringBuilder UTF16 append(char[])

### DIFF
--- a/src/java.base/share/classes/java/lang/AbstractStringBuilder.java
+++ b/src/java.base/share/classes/java/lang/AbstractStringBuilder.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, Alibaba Group Holding Limited. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1767,6 +1768,9 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
         int count = this.count;
         if (isLatin1()) {
             byte[] val = this.value;
+            int compressed = StringUTF16.compress(s, off, val, count, end - off);
+            count += compressed;
+            off += compressed;
             for (int i = off, j = count; i < end; i++) {
                 char c = s[i];
                 if (StringLatin1.canEncode(c)) {

--- a/src/java.base/share/classes/java/lang/StringUTF16.java
+++ b/src/java.base/share/classes/java/lang/StringUTF16.java
@@ -1314,9 +1314,12 @@ final class StringUTF16 {
     }
 
     private static void putChars(byte[] val, int index, char[] str, int off, int end) {
-        while (off < end) {
-            putChar(val, index++, str[off++]);
-        }
+        Unsafe.getUnsafe().copyMemory(
+                str,
+                Unsafe.ARRAY_CHAR_BASE_OFFSET + ((long) off << 1),
+                val,
+                Unsafe.ARRAY_BYTE_BASE_OFFSET + ((long) index << 1),
+                ((long) (end - off)) << 1);
     }
 
     public static String newString(byte[] val, int index, int len) {
@@ -1491,6 +1494,7 @@ final class StringUTF16 {
 
     public static void putCharsSB(byte[] val, int index, char[] ca, int off, int end) {
         checkBoundsBeginEnd(index, index + end - off, val);
+        checkBoundsBeginEnd(off, end, ca);
         putChars(val, index, ca, off, end);
     }
 
@@ -1665,6 +1669,10 @@ final class StringUTF16 {
 
     public static void checkBoundsBeginEnd(int begin, int end, byte[] val) {
         String.checkBoundsBeginEnd(begin, end, length(val));
+    }
+
+    private static void checkBoundsBeginEnd(int begin, int end, char[] val) {
+        String.checkBoundsBeginEnd(begin, end, val.length);
     }
 
     public static void checkBoundsOffCount(int offset, int count, byte[] val) {

--- a/test/micro/org/openjdk/bench/java/lang/StringBuilders.java
+++ b/test/micro/org/openjdk/bench/java/lang/StringBuilders.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, Alibaba Group Holding Limited. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,6 +51,7 @@ public class StringBuilders {
     private String[] str16p8p7;
     private String[] str3p9p8;
     private String[] str22p40p31;
+    private char[][] charArray22p40p31;
     private StringBuilder sbLatin1;
     private StringBuilder sbLatin2;
     private StringBuilder sbUtf16;
@@ -63,10 +65,15 @@ public class StringBuilders {
                 "advise", "you", "to", "drive", "at", "top", "speed", "it'll",
                 "be", "a", "god", "damn", "miracle", "if", "we", "can", "get",
                 "there", "before", "you", "turn", "into", "a", "wild", "animal."};
+
         str3p4p2 = new String[]{"123", "1234", "12"};
         str16p8p7 = new String[]{"1234567890123456", "12345678", "1234567"};
         str3p9p8 = new String[]{"123", "123456789", "12345678"};
         str22p40p31 = new String[]{"1234567890123456789012", "1234567890123456789012345678901234567890", "1234567890123456789012345678901"};
+        charArray22p40p31 = new char[str22p40p31.length][];
+        for (int i = 0; i < str22p40p31.length; i++) {
+            charArray22p40p31[i] = str22p40p31[i].toCharArray();
+        }
         sbLatin1 = new StringBuilder("Latin1 string");
         sbLatin2 = new StringBuilder("Latin1 string");
         sbUtf16 = new StringBuilder("UTF-\uFF11\uFF16 string");
@@ -269,6 +276,26 @@ public class StringBuilders {
         buf.setLength(0);
         for (long l : longArray) {
             buf.append(l);
+        }
+        return buf.length();
+    }
+
+    @Benchmark
+    public int appendWithCharArrayLatin1() {
+        StringBuilder buf = sbLatin1;
+        buf.delete(0, buf.length());
+        for (char[] charArray : charArray22p40p31) {
+            buf.append(charArray);
+        }
+        return buf.length();
+    }
+
+    @Benchmark
+    public int appendWithCharArrayUTF16() {
+        StringBuilder buf = sbUtf16;
+        buf.delete(0, buf.length());
+        for (char[] charArray : charArray22p40p31) {
+            buf.append(charArray);
         }
         return buf.length();
     }


### PR DESCRIPTION
In BufferedReader.readLine and other similar scenarios, we need to use StringBuilder.append(char[]) to build the string.

For these scenarios, we can use the intrinsic method StringUTF16.compress and Unsafe.copyMemory instead of the character copy of the char-by-char loop to improve the speed.