### PR TITLE
8355179: Reinstate javax/swing/JScrollBar/4865918/bug4865918.java headful and macos run

### DIFF
--- a/test/jdk/javax/swing/JScrollBar/4865918/bug4865918.java
+++ b/test/jdk/javax/swing/JScrollBar/4865918/bug4865918.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug 4865918
- * @requires (os.family != "mac")
+ * @key headful
  * @summary REGRESSION:JCK1.4a-runtime api/javax_swing/interactive/JScrollBarTests.html#JScrollBar
  * @run main bug4865918
  */
@@ -32,6 +32,8 @@
 import java.awt.Dimension;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
+import java.awt.Robot;
+import javax.swing.JFrame;
 import javax.swing.JScrollBar;
 import javax.swing.SwingUtilities;
 import java.util.concurrent.CountDownLatch;
@@ -41,24 +43,33 @@ import java.util.Date;
 
 public class bug4865918 {
 
+    private static JFrame frame;
     private static TestScrollBar sbar;
     private static final CountDownLatch mousePressLatch = new CountDownLatch(1);
 
     public static void main(String[] argv) throws Exception {
-        String osName = System.getProperty("os.name");
-        if (osName.toLowerCase().contains("os x")) {
-            System.out.println("This test is not for MacOS, considered passed.");
-            return;
-        }
-        SwingUtilities.invokeAndWait(() -> setupTest());
+        try {
+            Robot robot = new Robot();
+            SwingUtilities.invokeAndWait(() -> createAndShowGUI());
 
-        SwingUtilities.invokeAndWait(() -> sbar.pressMouse());
-        if (!mousePressLatch.await(2, TimeUnit.SECONDS)) {
-            throw new RuntimeException("Timed out waiting for mouse press");
-        }
+            robot.waitForIdle();
+            robot.delay(1000);
 
-        if (getValue() != 9) {
-            throw new RuntimeException("The scrollbar block increment is incorrect");
+            SwingUtilities.invokeAndWait(() -> sbar.pressMouse());
+            if (!mousePressLatch.await(2, TimeUnit.SECONDS)) {
+                throw new RuntimeException("Timed out waiting for mouse press");
+            }
+
+            if (getValue() != 9) {
+                throw new RuntimeException("The scrollbar block increment " +
+                                            getValue() + " is incorrect");
+            }
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
         }
     }
 
@@ -73,8 +84,8 @@ public class bug4865918 {
         return result[0];
     }
 
-    private static void setupTest() {
-
+    private static void createAndShowGUI() {
+        frame = new JFrame("bug4865918");
         sbar = new TestScrollBar(JScrollBar.HORIZONTAL, -1, 10, -100, 100);
         sbar.setPreferredSize(new Dimension(200, 20));
         sbar.setBlockIncrement(10);
@@ -83,7 +94,11 @@ public class bug4865918 {
                 mousePressLatch.countDown();
             }
         });
-
+        frame.getContentPane().add(sbar);
+        frame.pack();
+        frame.setLocationRelativeTo(null);
+        frame.setVisible(true);
+        frame.toFront();
     }
 
     static class TestScrollBar extends JScrollBar {

--- a/test/jdk/javax/swing/JScrollBar/4865918/bug4865918.java
+++ b/test/jdk/javax/swing/JScrollBar/4865918/bug4865918.java
@@ -30,9 +30,9 @@
  */
 
 import java.awt.Dimension;
+import java.awt.Robot;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
-import java.awt.Robot;
 import javax.swing.JFrame;
 import javax.swing.JScrollBar;
 import javax.swing.SwingUtilities;


### PR DESCRIPTION
Now that CI linux system is transitioned, the [JDK-8346828](https://bugs.openjdk.org/browse/JDK-8346828) changes is reverted and test is made headful and run on all platforms including macos.
CI testing is ok now..

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8355179](https://bugs.openjdk.org/browse/JDK-8355179): Reinstate javax/swing/JScrollBar/4865918/bug4865918.java headful and macos run (**Bug** - P4)


### Reviewers
 * [Abhishek Kumar](https://openjdk.org/census#abhiscxk) (@kumarabhi006 - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24774/head:pull/24774` \
`$ git checkout pull/24774`

Update a local copy of the PR: \
`$ git checkout pull/24774` \
`$ git pull https://git.openjdk.org/jdk.git pull/24774/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24774`

View PR using the GUI difftool: \
`$ git pr show -t 24774`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24774.diff">https://git.openjdk.org/jdk/pull/24774.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24774#issuecomment-2818233242)
</details>
