### PR TITLE
8354235: Test javax/net/ssl/SSLSocket/Tls13PacketSize.java failed with java.net.SocketException: An established connection was aborted by the software in your host machine

### DIFF
--- a/test/jdk/javax/net/ssl/templates/SSLSocketTemplate.java
+++ b/test/jdk/javax/net/ssl/templates/SSLSocketTemplate.java
@@ -168,7 +168,7 @@ public class SSLSocketTemplate extends SSLContextTemplate {
     /*
      * What's the server address?  null means binding to the wildcard.
      */
-    protected volatile InetAddress serverAddress = null;
+    protected volatile InetAddress serverAddress = InetAddress.getLoopbackAddress();
 
     /*
      * Define the server side of the test.
@@ -177,13 +177,8 @@ public class SSLSocketTemplate extends SSLContextTemplate {
         // kick start the server side service
         SSLContext context = createServerSSLContext();
         SSLServerSocketFactory sslssf = context.getServerSocketFactory();
-        InetAddress serverAddress = this.serverAddress;
-        SSLServerSocket sslServerSocket = serverAddress == null ?
-                (SSLServerSocket)sslssf.createServerSocket(serverPort)
-                : (SSLServerSocket)sslssf.createServerSocket();
-        if (serverAddress != null) {
-            sslServerSocket.bind(new InetSocketAddress(serverAddress, serverPort));
-        }
+        SSLServerSocket sslServerSocket = (SSLServerSocket)sslssf.createServerSocket(
+                serverPort, 0, serverAddress);
         configureServerSocket(sslServerSocket);
         serverPort = sslServerSocket.getLocalPort();
 
@@ -271,10 +266,8 @@ public class SSLSocketTemplate extends SSLContextTemplate {
         try (SSLSocket sslSocket = (SSLSocket)sslsf.createSocket()) {
             try {
                 configureClientSocket(sslSocket);
-                InetAddress serverAddress = this.serverAddress;
-                InetSocketAddress connectAddress = serverAddress == null
-                        ? new InetSocketAddress(InetAddress.getLoopbackAddress(), serverPort)
-                        : new InetSocketAddress(serverAddress, serverPort);
+                InetSocketAddress connectAddress = new InetSocketAddress(serverAddress,
+                        serverPort);
                 sslSocket.connect(connectAddress, 15000);
             } catch (IOException ioe) {
                 // The server side may be impacted by naughty test cases or


### PR DESCRIPTION
In this PR, I updated the default `serverAddress` field to use the loopback interface. I also removed some unnecessary logic around creating the server interface and the client connecting code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8354235](https://bugs.openjdk.org/browse/JDK-8354235): Test javax/net/ssl/SSLSocket/Tls13PacketSize.java failed with java.net.SocketException: An established connection was aborted by the software in your host machine (**Bug** - P4)


### Reviewers
 * [Rajan Halade](https://openjdk.org/census#rhalade) (@rhalade - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24776/head:pull/24776` \
`$ git checkout pull/24776`

Update a local copy of the PR: \
`$ git checkout pull/24776` \
`$ git pull https://git.openjdk.org/jdk.git pull/24776/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24776`

View PR using the GUI difftool: \
`$ git pr show -t 24776`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24776.diff">https://git.openjdk.org/jdk/pull/24776.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24776#issuecomment-2819243355)
</details>
