### PR TITLE
8354484: SIGSEGV when supertype of an AOT-cached class is excluded

### DIFF
--- a/src/hotspot/share/cds/aotArtifactFinder.cpp
+++ b/src/hotspot/share/cds/aotArtifactFinder.cpp
@@ -207,11 +207,36 @@ void AOTArtifactFinder::add_aot_inited_class(InstanceKlass* ik) {
   }
 }
 
+void AOTArtifactFinder::append_to_all_cached_classes(Klass* k) {
+  precond(!SystemDictionaryShared::should_be_excluded(k));
+  _all_cached_classes->append(k);
+}
+
 void AOTArtifactFinder::add_cached_instance_class(InstanceKlass* ik) {
+  if (CDSConfig::is_dumping_dynamic_archive() && ik->is_shared()) {
+    // This class is already included in the base archive. No need to cache
+    // it again in the dynamic archive.
+    return;
+  }
+
   bool created;
   _seen_classes->put_if_absent(ik, &created);
   if (created) {
-    _all_cached_classes->append(ik);
+    append_to_all_cached_classes(ik);
+
+    // All super types must be added.
+    InstanceKlass* s = ik->java_super();
+    if (s != nullptr) {
+      add_cached_instance_class(s);
+    }
+
+    Array<InstanceKlass*>* interfaces = ik->local_interfaces();
+    int len = interfaces->length();
+    for (int i = 0; i < len; i++) {
+      InstanceKlass* intf = interfaces->at(i);
+      add_cached_instance_class(intf);
+    }
+
     if (CDSConfig::is_dumping_final_static_archive() && ik->is_shared_unregistered_class()) {
       // The following are not appliable to unregistered classes
       return;
@@ -229,7 +254,7 @@ void AOTArtifactFinder::add_cached_type_array_class(TypeArrayKlass* tak) {
   bool created;
   _seen_classes->put_if_absent(tak, &created);
   if (created) {
-    _all_cached_classes->append(tak);
+    append_to_all_cached_classes(tak);
     scan_oops_in_array_class(tak);
   }
 }

--- a/src/hotspot/share/cds/aotArtifactFinder.hpp
+++ b/src/hotspot/share/cds/aotArtifactFinder.hpp
@@ -79,6 +79,7 @@ class AOTArtifactFinder : AllStatic {
   static void scan_oops_in_array_class(ArrayKlass* ak);
   static void add_cached_type_array_class(TypeArrayKlass* tak);
   static void add_cached_instance_class(InstanceKlass* ik);
+  static void append_to_all_cached_classes(Klass* k);
 public:
   static void initialize();
   static void find_artifacts();


### PR DESCRIPTION
Since [JDK-8353014](https://bugs.openjdk.org/browse/JDK-8353014), some classes that are loaded inside `LambdaFormInvokers::regenerate_holder_classes()` are marked as "AOT tooling classes". These classes are excluded from the AOT configuration file (which is generated at the end of the training run).

However, in the training run, application threads can run in parallel of `LambdaFormInvokers::regenerate_holder_classes()` and could load a subtype `C` of an "AOT tooling class" `S`.

This bug happened because `C` is included in the AOT configuration file, but `S`is excluded.

The fix in this PR -- for any `C` that is included, we also include all of its super types, even for the super types that are marked as "AOT tooling classes".

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8354484](https://bugs.openjdk.org/browse/JDK-8354484): SIGSEGV when supertype of an AOT-cached class is excluded (**Bug** - P3)


### Reviewers
 * [Calvin Cheung](https://openjdk.org/census#ccheung) (@calvinccheung - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24780/head:pull/24780` \
`$ git checkout pull/24780`

Update a local copy of the PR: \
`$ git checkout pull/24780` \
`$ git pull https://git.openjdk.org/jdk.git pull/24780/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24780`

View PR using the GUI difftool: \
`$ git pr show -t 24780`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24780.diff">https://git.openjdk.org/jdk/pull/24780.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24780#issuecomment-2819465494)
</details>
