### PR TITLE
8355228: Improve runtime/CompressedOops/CompressedClassPointersEncodingScheme.java to support JDK build with -XX:+UseCompactObjectHeaders

### DIFF
--- a/test/hotspot/jtreg/runtime/CompressedOops/CompressedClassPointersEncodingScheme.java
+++ b/test/hotspot/jtreg/runtime/CompressedOops/CompressedClassPointersEncodingScheme.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -74,7 +74,9 @@ public class CompressedClassPointersEncodingScheme {
     private static void testFailure(String forceAddressString) throws IOException {
         ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(
                 "-Xshare:off", // to make CompressedClassSpaceBaseAddress work
+                "-XX:+UnlockExperimentalVMOptions",
                 "-XX:+UnlockDiagnosticVMOptions",
+                "-XX:-UseCompactObjectHeaders",
                 "-XX:CompressedClassSpaceBaseAddress=" + forceAddressString,
                 "-Xmx128m",
                 "-Xlog:metaspace*",


### PR DESCRIPTION
Sometimes it is easier to test JDK by building it with
 -XX:+UseCompactObjectHeaders
enabled by default. So CDS archives are generated and all tests including flagless are executed.
The option is transparent fand all tests even flagless tests are expected to  pass.

The only test runtime/CompressedOops/CompressedClassPointersEncodingScheme.java
start failing because expects to be executed with -XX:-UseCompactObjectHeaders

Please, note that it is a not a bug, just RFE. Test works  correctly.   

The fix improves test  to support testing of JDK build with -XX:+UseCompactObjectHeaders.

Tested with JDK build with UseCompactObjectHeaders enabled by default.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8355228](https://bugs.openjdk.org/browse/JDK-8355228): Improve runtime/CompressedOops/CompressedClassPointersEncodingScheme.java to support JDK build with -XX:+UseCompactObjectHeaders (**Enhancement** - P4)


### Reviewers
 * [SendaoYan](https://openjdk.org/census#syan) (@sendaoYan - Committer)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24781/head:pull/24781` \
`$ git checkout pull/24781`

Update a local copy of the PR: \
`$ git checkout pull/24781` \
`$ git pull https://git.openjdk.org/jdk.git pull/24781/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24781`

View PR using the GUI difftool: \
`$ git pr show -t 24781`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24781.diff">https://git.openjdk.org/jdk/pull/24781.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24781#issuecomment-2819533852)
</details>
