### PR TITLE
8355235: Clean out old versions from Tools.gmk

### DIFF
--- a/make/devkit/Tools.gmk
+++ b/make/devkit/Tools.gmk
@@ -39,6 +39,8 @@
 # Fix this...
 #
 
+uppercase = $(shell echo $1 | tr a-z A-Z)
+
 $(info TARGET=$(TARGET))
 $(info HOST=$(HOST))
 $(info BUILD=$(BUILD))
@@ -91,99 +93,28 @@ endif
 ################################################################################
 # Define external dependencies
 
-# Latest that could be made to work.
-GCC_VER := 14.2.0
-ifeq ($(GCC_VER), 14.2.0)
-  gcc_ver := gcc-14.2.0
-  binutils_ver := binutils-2.43
-  ccache_ver := ccache-4.10.2
-  CCACHE_CMAKE_BASED := 1
-  mpfr_ver := mpfr-4.2.1
-  gmp_ver := gmp-6.3.0
-  mpc_ver := mpc-1.3.1
-  gdb_ver := gdb-15.2
-  REQUIRED_MIN_MAKE_MAJOR_VERSION := 4
-else ifeq ($(GCC_VER), 13.2.0)
-  gcc_ver := gcc-13.2.0
-  binutils_ver := binutils-2.41
-  ccache_ver := ccache-3.7.12
-  mpfr_ver := mpfr-4.2.0
-  gmp_ver := gmp-6.3.0
-  mpc_ver := mpc-1.3.1
-  gdb_ver := gdb-13.2
-  REQUIRED_MIN_MAKE_MAJOR_VERSION := 4
-else ifeq ($(GCC_VER), 11.3.0)
-  gcc_ver := gcc-11.3.0
-  binutils_ver := binutils-2.39
-  ccache_ver := ccache-3.7.12
-  mpfr_ver := mpfr-4.1.1
-  gmp_ver := gmp-6.2.1
-  mpc_ver := mpc-1.2.1
-  gdb_ver := gdb-11.2
-  REQUIRED_MIN_MAKE_MAJOR_VERSION := 4
-else ifeq ($(GCC_VER), 11.2.0)
-  gcc_ver := gcc-11.2.0
-  binutils_ver := binutils-2.37
-  ccache_ver := ccache-3.7.12
-  mpfr_ver := mpfr-4.1.0
-  gmp_ver := gmp-6.2.1
-  mpc_ver := mpc-1.2.1
-  gdb_ver := gdb-11.1
-  REQUIRED_MIN_MAKE_MAJOR_VERSION := 4
-else ifeq ($(GCC_VER), 10.3.0)
-  gcc_ver := gcc-10.3.0
-  binutils_ver := binutils-2.36.1
-  ccache_ver := ccache-3.7.11
-  mpfr_ver := mpfr-4.1.0
-  gmp_ver := gmp-6.2.0
-  mpc_ver := mpc-1.1.0
-  gdb_ver := gdb-10.1
-  REQUIRED_MIN_MAKE_MAJOR_VERSION := 4
-else ifeq ($(GCC_VER), 10.2.0)
-  gcc_ver := gcc-10.2.0
-  binutils_ver := binutils-2.35
-  ccache_ver := ccache-3.7.11
-  mpfr_ver := mpfr-4.1.0
-  gmp_ver := gmp-6.2.0
-  mpc_ver := mpc-1.1.0
-  gdb_ver := gdb-9.2
-  REQUIRED_MIN_MAKE_MAJOR_VERSION := 4
-else ifeq ($(GCC_VER), 9.2.0)
-  gcc_ver := gcc-9.2.0
-  binutils_ver := binutils-2.34
-  ccache_ver := ccache-3.7.3
-  mpfr_ver := mpfr-3.1.5
-  gmp_ver := gmp-6.1.2
-  mpc_ver := mpc-1.0.3
-  gdb_ver := gdb-8.3
-else ifeq ($(GCC_VER), 8.3.0)
-  gcc_ver := gcc-8.3.0
-  binutils_ver := binutils-2.32
-  ccache_ver := ccache-3.7.3
-  mpfr_ver := mpfr-3.1.5
-  gmp_ver := gmp-6.1.2
-  mpc_ver := mpc-1.0.3
-  gdb_ver := gdb-8.3
-else ifeq ($(GCC_VER), 7.3.0)
-  gcc_ver := gcc-7.3.0
-  binutils_ver := binutils-2.30
-  ccache_ver := ccache-3.3.6
-  mpfr_ver := mpfr-3.1.5
-  gmp_ver := gmp-6.1.2
-  mpc_ver := mpc-1.0.3
-  gdb_ver := gdb-8.1
-else ifeq ($(GCC_VER), 4.9.2)
-  gcc_ver := gcc-4.9.2
-  binutils_ver := binutils-2.25
-  ccache_ver := ccache-3.2.1
-  mpfr_ver := mpfr-3.0.1
-  gmp_ver := gmp-4.3.2
-  mpc_ver := mpc-1.0.1
-  gdb_ver := gdb-7.12.1
-else
-  $(error Unsupported GCC version)
-endif
+gcc_ver_only := 14.2.0
+binutils_ver_only := 2.43
+ccache_ver_only := 4.10.2
+CCACHE_CMAKE_BASED := 1
+mpfr_ver_only := 4.2.1
+gmp_ver_only := 6.3.0
+mpc_ver_only := 1.3.1
+gdb_ver_only := 15.2
 
+dependencies := gcc binutils ccache mpfr gmp mpc gdb
+
+$(foreach dep,$(dependencies),$(eval $(dep)_ver := $(dep)-$($(dep)_ver_only)))
+
+GCC := http://ftp.gnu.org/pub/gnu/gcc/$(gcc_ver)/$(gcc_ver).tar.xz
+BINUTILS := http://ftp.gnu.org/pub/gnu/binutils/$(binutils_ver).tar.gz
+CCACHE := https://github.com/ccache/ccache/releases/download/v$(ccache_ver_only)/$(ccache_ver).tar.xz
+MPFR := https://www.mpfr.org/$(mpfr_ver)/$(mpfr_ver).tar.bz2
+GMP := http://ftp.gnu.org/pub/gnu/gmp/$(gmp_ver).tar.bz2
+MPC := http://ftp.gnu.org/pub/gnu/mpc/$(mpc_ver).tar.gz
+GDB := http://ftp.gnu.org/gnu/gdb/$(gdb_ver).tar.xz
+
+REQUIRED_MIN_MAKE_MAJOR_VERSION := 4
 ifneq ($(REQUIRED_MIN_MAKE_MAJOR_VERSION),)
   MAKE_MAJOR_VERSION := $(word 1,$(subst ., ,$(MAKE_VERSION)))
   SUPPORTED_MAKE_VERSION := $(shell [ $(MAKE_MAJOR_VERSION) -ge $(REQUIRED_MIN_MAKE_MAJOR_VERSION) ] && echo true)
@@ -191,17 +122,6 @@ ifneq ($(REQUIRED_MIN_MAKE_MAJOR_VERSION),)
     $(error "Make v$(MAKE_VERSION) is too old, must use v$(REQUIRED_MIN_MAKE_MAJOR_VERSION) or above")
   endif
 endif
-
-ccache_ver_only := $(patsubst ccache-%,%,$(ccache_ver))
-
-
-GCC := http://ftp.gnu.org/pub/gnu/gcc/$(gcc_ver)/$(gcc_ver).tar.xz
-BINUTILS := http://ftp.gnu.org/pub/gnu/binutils/$(binutils_ver).tar.gz
-CCACHE := https://github.com/ccache/ccache/releases/download/v$(ccache_ver_only)/$(ccache_ver).tar.xz
-MPFR := https://www.mpfr.org/${mpfr_ver}/${mpfr_ver}.tar.bz2
-GMP := http://ftp.gnu.org/pub/gnu/gmp/${gmp_ver}.tar.bz2
-MPC := http://ftp.gnu.org/pub/gnu/mpc/${mpc_ver}.tar.gz
-GDB := http://ftp.gnu.org/gnu/gdb/${gdb_ver}.tar.xz
 
 # RPMs used by all BASE_OS
 RPM_LIST := \
@@ -297,7 +217,7 @@ define Download
 endef
 
 # Download and unpack all source packages
-$(foreach p,GCC BINUTILS CCACHE MPFR GMP MPC GDB,$(eval $(call Download,$(p))))
+$(foreach dep,$(dependencies),$(eval $(call Download,$(call uppercase,$(dep)))))
 
 ################################################################################
 # Unpack RPMS
@@ -374,7 +294,7 @@ endif
 ################################################################################
 
 # Define marker files for each source package to be compiled
-$(foreach t,binutils mpfr gmp mpc gcc ccache gdb,$(eval $(t) = $(TARGETDIR)/$($(t)_ver).done))
+$(foreach dep,$(dependencies),$(eval $(dep) = $(TARGETDIR)/$($(dep)_ver).done))
 
 ################################################################################
 
@@ -721,12 +641,12 @@ ifeq ($(TARGET), $(HOST))
 	ln -s $(TARGET)-$* $@
 
   missing-links := $(addprefix $(PREFIX)/bin/, \
-      addr2line ar as c++ c++filt dwp elfedit g++ gcc gcc-$(GCC_VER) gprof ld ld.bfd \
+      addr2line ar as c++ c++filt dwp elfedit g++ gcc gcc-$(gcc_ver_only) gprof ld ld.bfd \
       ld.gold nm objcopy objdump ranlib readelf size strings strip)
 endif
 
 # Add link to work around "plugin needed to handle lto object" (JDK-8344272)
-$(PREFIX)/lib/bfd-plugins/liblto_plugin.so: $(PREFIX)/libexec/gcc/$(TARGET)/$(GCC_VER)/liblto_plugin.so
+$(PREFIX)/lib/bfd-plugins/liblto_plugin.so: $(PREFIX)/libexec/gcc/$(TARGET)/$(gcc_ver_only)/liblto_plugin.so
 	@echo 'Creating missing $(@F) soft link'
 	@mkdir -p $(@D)
 	ln -s $$(realpath -s --relative-to=$(@D) $<) $@


### PR DESCRIPTION
Traditionally, when upgrading the versions of the components (gcc, binutils, etc.) in Tools.gmk, the old versions/definitions have been preserved. The list is now starting to be on the long side, it's unlikely that anybody would be using anything but the latest/default version, and if they do it is possible to get it from the source/version history.

Let's clean out the old version information, leaving only the latest/default.

Testing: tier1, manually built devkits for `x86_64-linux-gnu-to-{x86_64,aarch64,ppc64le,riscv64,s390x}-linux-gnu` and then built the JDK using those devkits.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8355235](https://bugs.openjdk.org/browse/JDK-8355235): Clean out old versions from Tools.gmk (**Enhancement** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24784/head:pull/24784` \
`$ git checkout pull/24784`

Update a local copy of the PR: \
`$ git checkout pull/24784` \
`$ git pull https://git.openjdk.org/jdk.git pull/24784/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24784`

View PR using the GUI difftool: \
`$ git pr show -t 24784`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24784.diff">https://git.openjdk.org/jdk/pull/24784.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24784#issuecomment-2821786753)
</details>
