### PR TITLE
8355328: Improve negative tests coverage for jpackage signing

### DIFF
--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/AdditionalLauncher.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/AdditionalLauncher.java
@@ -320,7 +320,7 @@ public class AdditionalLauncher {
                 TKit.assertTextStream("Comment=" + expectedDescription)
                         .label(String.format("[%s] file", desktopFile))
                         .predicate(String::equals)
-                        .apply(Files.readAllLines(desktopFile).stream());
+                        .apply(Files.readAllLines(desktopFile));
             }
         }
     }

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/LauncherAsServiceVerifier.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/LauncherAsServiceVerifier.java
@@ -316,7 +316,7 @@ public final class LauncherAsServiceVerifier {
         TKit.assertTextStream("ExecStart=" + execStartValue)
                 .label("unit file")
                 .predicate(String::equals)
-                .apply(Files.readAllLines(serviceUnitFile).stream());
+                .apply(Files.readAllLines(serviceUnitFile));
     }
 
     private static void verifyMacDaemonPlistFile(JPackageCommand cmd,

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/LinuxHelper.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/LinuxHelper.java
@@ -427,7 +427,7 @@ public final class LinuxHelper {
 
         Map<String, String> data = lines.stream()
         .skip(1)
-        .peek(str -> TKit.assertTextStream("=").predicate(String::contains).apply(Stream.of(str)))
+        .peek(str -> TKit.assertTextStream("=").predicate(String::contains).apply(List.of(str)))
         .map(str -> {
             String components[] = str.split("=(?=.+)");
             if (components.length == 1) {

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/MacSignVerify.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/MacSignVerify.java
@@ -133,9 +133,12 @@ public final class MacSignVerify {
     }
 
     public static void assertSigned(Path path) {
-        final var verifier = TKit.assertTextStream(": valid on disk").predicate(String::endsWith).andThen(TKit.assertTextStream(": satisfies its Designated Requirement").predicate(String::endsWith));
-        verifier.apply(Executor.of("/usr/bin/codesign", "--verify", "--deep",
-                "--strict", "--verbose=2", path.toString()).executeAndGetOutput().stream());
+        final var verifier = TKit.TextStreamVerifier.group()
+                .add(TKit.assertTextStream(": valid on disk").predicate(String::endsWith))
+                .add(TKit.assertTextStream(": satisfies its Designated Requirement").predicate(String::endsWith))
+                .create();
+        verifier.accept(Executor.of("/usr/bin/codesign", "--verify", "--deep",
+                "--strict", "--verbose=2", path.toString()).executeAndGetOutput().iterator());
     }
 
     public static List<SignIdentity> getPkgCertificateChain(Path path) {

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/TKit.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/TKit.java
@@ -979,7 +979,7 @@ public final class TKit {
             negate = other.negate;
             createException = other.createException;
             anotherVerifier = other.anotherVerifier;
-            value= other.value;
+            value = other.value;
         }
 
         public TextStreamVerifier label(String v) {

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/TKit.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/TKit.java
@@ -969,8 +969,17 @@ public final class TKit {
 
     public static final class TextStreamVerifier {
         TextStreamVerifier(String value) {
-            this.value = value;
+            this.value = Objects.requireNonNull(value);
             predicate(String::contains);
+        }
+
+        TextStreamVerifier(TextStreamVerifier other) {
+            predicate = other.predicate;
+            label = other.label;
+            negate = other.negate;
+            createException = other.createException;
+            anotherVerifier = other.anotherVerifier;
+            value= other.value;
         }
 
         public TextStreamVerifier label(String v) {
@@ -979,7 +988,7 @@ public final class TKit {
         }
 
         public TextStreamVerifier predicate(BiPredicate<String, String> v) {
-            predicate = v;
+            predicate = Objects.requireNonNull(v);
             return this;
         }
 
@@ -988,17 +997,8 @@ public final class TKit {
             return this;
         }
 
-        public TextStreamVerifier andThen(Consumer<? super Stream<String>> anotherVerifier) {
-            this.anotherVerifier = anotherVerifier;
-            return this;
-        }
-
-        public TextStreamVerifier andThen(TextStreamVerifier anotherVerifier) {
-            this.anotherVerifier = anotherVerifier::apply;
-            return this;
-        }
-
         public TextStreamVerifier orElseThrow(RuntimeException v) {
+            Objects.requireNonNull(v);
             return orElseThrow(() -> v);
         }
 
@@ -1007,22 +1007,22 @@ public final class TKit {
             return this;
         }
 
-        public void apply(Stream<String> lines) {
-            final String matchedStr;
-
-            lines = lines.dropWhile(line -> !predicate.test(line, value));
-            if (anotherVerifier == null) {
-                matchedStr = lines.findFirst().orElse(null);
-            } else {
-                var tail = lines.toList();
-                if (tail.isEmpty()) {
-                    matchedStr = null;
-                } else {
-                    matchedStr = tail.get(0);
+        private String findMatch(Iterator<String> lineIt) {
+            while (lineIt.hasNext()) {
+                final var line = lineIt.next();
+                if (predicate.test(line, value)) {
+                    return line;
                 }
-                lines = tail.stream().skip(1);
             }
+            return null;
+        }
 
+        public void apply(List<String> lines) {
+            apply(lines.iterator());
+        }
+
+        public void apply(Iterator<String> lineIt) {
+            final String matchedStr = findMatch(lineIt);
             final String labelStr = Optional.ofNullable(label).orElse("output");
             if (negate) {
                 String msg = String.format(
@@ -1049,15 +1049,67 @@ public final class TKit {
             }
 
             if (anotherVerifier != null) {
-                anotherVerifier.accept(lines);
+                anotherVerifier.accept(lineIt);
             }
+        }
+
+        public static TextStreamVerifier.Group group() {
+            return new TextStreamVerifier.Group();
+        }
+
+        public static final class Group {
+            public Group add(TextStreamVerifier verifier) {
+                if (verifier.anotherVerifier != null) {
+                    throw new IllegalArgumentException();
+                }
+                verifiers.add(verifier);
+                return this;
+            }
+
+            public Group add(Group other) {
+                verifiers.addAll(other.verifiers);
+                return this;
+            }
+
+            public boolean isEmpty() {
+                return verifiers.isEmpty();
+            }
+
+            public Optional<Consumer<Iterator<String>>> tryCreate() {
+                if (isEmpty()) {
+                    return Optional.empty();
+                } else {
+                    return Optional.of(create());
+                }
+            }
+
+            public Consumer<Iterator<String>> create() {
+                if (verifiers.isEmpty()) {
+                    throw new IllegalStateException();
+                }
+
+                if (verifiers.size() == 1) {
+                    return verifiers.getFirst()::apply;
+                }
+
+                final var head = new TextStreamVerifier(verifiers.getFirst());
+                var prev = head;
+                for (var verifier : verifiers.subList(1, verifiers.size())) {
+                    verifier = new TextStreamVerifier(verifier);
+                    prev.anotherVerifier = verifier::apply;
+                    prev = verifier;
+                }
+                return head::apply;
+            }
+
+            private final List<TextStreamVerifier> verifiers = new ArrayList<>();
         }
 
         private BiPredicate<String, String> predicate;
         private String label;
         private boolean negate;
         private Supplier<RuntimeException> createException;
-        private Consumer<? super Stream<String>> anotherVerifier;
+        private Consumer<? super Iterator<String>> anotherVerifier;
         private final String value;
     }
 

--- a/test/jdk/tools/jpackage/linux/ShortcutHintTest.java
+++ b/test/jdk/tools/jpackage/linux/ShortcutHintTest.java
@@ -176,7 +176,7 @@ public class ShortcutHintTest {
             TKit.assertTextStream(expectedVersionString)
                     .label(String.format("[%s] file", desktopFile))
                     .predicate(String::equals)
-                    .apply(Files.readAllLines(desktopFile).stream());
+                    .apply(Files.readAllLines(desktopFile));
         }).run();
     }
 }

--- a/test/jdk/tools/jpackage/macosx/base/SigningBase.java
+++ b/test/jdk/tools/jpackage/macosx/base/SigningBase.java
@@ -22,16 +22,18 @@
  */
 
 import java.nio.file.Path;
+import java.security.cert.X509Certificate;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Stream;
-import jdk.jpackage.test.Executor;
-import jdk.jpackage.test.Executor.Result;
 import jdk.jpackage.test.JPackageCommand;
 import jdk.jpackage.test.MacSign;
-import jdk.jpackage.test.MacSign.CertificateType;
 import jdk.jpackage.test.MacSign.CertificateRequest;
+import jdk.jpackage.test.MacSign.CertificateType;
 import jdk.jpackage.test.MacSign.KeychainWithCertsSpec;
+import jdk.jpackage.test.MacSign.ResolvedKeychain;
+import jdk.jpackage.test.MacSignVerify;
 import jdk.jpackage.test.TKit;
 
 
@@ -64,10 +66,14 @@ import jdk.jpackage.test.TKit;
 public class SigningBase {
 
     public enum StandardCertificateRequest {
-        APP_IMAGE(cert().userName(DEV_NAMES[CertIndex.ASCII_INDEX.value()])),
-        INSTALLER(cert().type(CertificateType.INSTALLER).userName(DEV_NAMES[CertIndex.ASCII_INDEX.value()])),
-        APP_IMAGE_UNICODE(cert().userName(DEV_NAMES[CertIndex.UNICODE_INDEX.value()])),
-        INSTALLER_UNICODE(cert().type(CertificateType.INSTALLER).userName(DEV_NAMES[CertIndex.UNICODE_INDEX.value()]));
+        CODESIGN(cert().userName(DEV_NAMES[CertIndex.ASCII_INDEX.value()])),
+        CODESIGN_COPY(cert().days(100).userName(DEV_NAMES[CertIndex.ASCII_INDEX.value()])),
+        PKG(cert().type(CertificateType.INSTALLER).userName(DEV_NAMES[CertIndex.ASCII_INDEX.value()])),
+        PKG_COPY(cert().type(CertificateType.INSTALLER).days(100).userName(DEV_NAMES[CertIndex.ASCII_INDEX.value()])),
+        CODESIGN_UNICODE(cert().userName(DEV_NAMES[CertIndex.UNICODE_INDEX.value()])),
+        PKG_UNICODE(cert().type(CertificateType.INSTALLER).userName(DEV_NAMES[CertIndex.UNICODE_INDEX.value()])),
+        CODESIGN_EXPIRED(cert().expired().userName("expired jpackage test")),
+        PKG_EXPIRED(cert().expired().type(CertificateType.INSTALLER).userName("expired jpackage test"));
 
         StandardCertificateRequest(CertificateRequest.Builder specBuilder) {
             this.spec = specBuilder.create();
@@ -85,7 +91,21 @@ public class SigningBase {
     }
 
     public enum StandardKeychain {
-        MAIN(DEFAULT_KEYCHAIN, StandardCertificateRequest.values());
+        MAIN(DEFAULT_KEYCHAIN,
+                StandardCertificateRequest.CODESIGN,
+                StandardCertificateRequest.PKG,
+                StandardCertificateRequest.CODESIGN_UNICODE,
+                StandardCertificateRequest.PKG_UNICODE),
+        EXPIRED("jpackagerTest-expired.keychain",
+                StandardCertificateRequest.CODESIGN,
+                StandardCertificateRequest.PKG,
+                StandardCertificateRequest.CODESIGN_EXPIRED,
+                StandardCertificateRequest.PKG_EXPIRED),
+        DUPLICATE("jpackagerTest-duplicate.keychain",
+                StandardCertificateRequest.CODESIGN,
+                StandardCertificateRequest.PKG,
+                StandardCertificateRequest.CODESIGN_COPY,
+                StandardCertificateRequest.PKG_COPY);
 
         StandardKeychain(String keychainName, StandardCertificateRequest... certs) {
             this(keychainName, certs[0].spec(), Stream.of(certs).skip(1).map(StandardCertificateRequest::spec).toArray(CertificateRequest[]::new));
@@ -94,11 +114,15 @@ public class SigningBase {
         StandardKeychain(String keychainName, CertificateRequest cert, CertificateRequest... otherCerts) {
             final var builder = keychain(keychainName).addCert(cert);
             List.of(otherCerts).forEach(builder::addCert);
-            this.spec = builder.create();
+            this.spec = new ResolvedKeychain(builder.create());
         }
 
         public KeychainWithCertsSpec spec() {
-            return spec;
+            return spec.spec();
+        }
+
+        public X509Certificate mapCertificateRequest(CertificateRequest certRequest) {
+            return Objects.requireNonNull(spec.mapCertificateRequests().get(certRequest));
         }
 
         private static KeychainWithCertsSpec.Builder keychain(String name) {
@@ -113,7 +137,7 @@ public class SigningBase {
             return Stream.of(values()).map(StandardKeychain::spec).toList();
         }
 
-        private final KeychainWithCertsSpec spec;
+        private final ResolvedKeychain spec;
     }
 
     public static void setUp() {
@@ -131,7 +155,7 @@ public class SigningBase {
     }
 
     private final class Inner {
-        private final static boolean SIGN_ENV_READY = MacSign.isDeployed(StandardKeychain.signingEnv());
+        private static final boolean SIGN_ENV_READY = MacSign.isDeployed(StandardKeychain.signingEnv());
     }
 
     enum CertIndex {
@@ -199,140 +223,13 @@ public class SigningBase {
         return DEFAULT_KEYCHAIN;
     }
 
-    // Note: It is not clear if we can combine "--verify" and "--display", so
-    // we testing them separately. Since JDK-8298488 unsigned app images are
-    // actually signed with adhoc signature and it will pass "--verify", so in
-    // addition we will check certificate name which was used to sign.
-    private static enum CodesignCheckType {
-        VERIFY, // Runs codesign with "--verify" to check signature and 0 exit code
-        VERIFY_UNSIGNED, // Runs codesign with "--verify" to check signature and 1 exit code
-        DISPLAY // Runs codesign with "--display --verbose=4" to get info about signature
-    };
-
-    private static void checkString(List<String> result, String lookupString) {
-        TKit.assertTextStream(lookupString).predicate(
-                (line, what) -> line.trim().contains(what)).apply(result);
-    }
-
-    @SuppressWarnings("fallthrough")
-    private static List<String> codesignResult(Path target, CodesignCheckType type) {
-        int exitCode = 0;
-        Executor executor = new Executor().setExecutable("/usr/bin/codesign");
-        switch (type) {
-            case VERIFY_UNSIGNED:
-                exitCode = 1;
-            case VERIFY:
-                executor.addArguments("--verify", "--deep", "--strict",
-                                      "--verbose=2", target.toString());
-                break;
-            case DISPLAY:
-                executor.addArguments("--display", "--verbose=4", target.toString());
-                break;
-            default:
-                TKit.error("Unknown CodesignCheckType: " + type);
-                break;
-        }
-        return executor.saveOutput().execute(exitCode).getOutput();
-    }
-
-    private static void verifyCodesignResult(List<String> result, Path target,
-            boolean signed, CodesignCheckType type, int certIndex) {
-        result.stream().forEachOrdered(TKit::trace);
-        String lookupString;
-        switch (type) {
-            case VERIFY:
-                lookupString = target.toString() + ": valid on disk";
-                checkString(result, lookupString);
-                lookupString = target.toString() + ": satisfies its Designated Requirement";
-                checkString(result, lookupString);
-                break;
-            case VERIFY_UNSIGNED:
-                lookupString = target.toString() + ": code object is not signed at all";
-                checkString(result, lookupString);
-                break;
-            case DISPLAY:
-                if (signed) {
-                    lookupString = "Authority=" + getAppCert(certIndex);
-                } else {
-                    lookupString = "Signature=adhoc";
-                }
-                checkString(result, lookupString);
-                break;
-            default:
-                TKit.error("Unknown CodesignCheckType: " + type);
-                break;
-        }
-    }
-
-    private static Result spctlResult(Path target, String type) {
-        Result result = new Executor()
-                .setExecutable("/usr/sbin/spctl")
-                .addArguments("-vvv", "--assess", "--type", type,
-                        target.toString())
-                .saveOutput()
-                .executeWithoutExitCodeCheck();
-
-        // allow exit code 3 for not being notarized
-        if (result.getExitCode() != 3) {
-            result.assertExitCodeIsZero();
-        }
-        return result;
-    }
-
-    private static void verifySpctlResult(List<String> output, Path target,
-            String type, int exitCode, int certIndex) {
-        output.stream().forEachOrdered(TKit::trace);
-        String lookupString;
-
-        if (exitCode == 0) {
-            lookupString = target.toString() + ": accepted";
-            checkString(output, lookupString);
-        } else if (exitCode == 3) {
-            // allow failure purely for not being notarized
-            lookupString = target.toString() + ": rejected";
-            checkString(output, lookupString);
-        }
-
-        if (type.equals("install")) {
-            lookupString = "origin=" + getInstallerCert(certIndex);
-        } else {
-            lookupString = "origin=" + getAppCert(certIndex);
-        }
-        checkString(output, lookupString);
-    }
-
-    private static List<String> pkgutilResult(Path target, boolean signed) {
-        List<String> result = new Executor()
-                .setExecutable("/usr/sbin/pkgutil")
-                .addArguments("--check-signature",
-                        target.toString())
-                .saveOutput()
-                .execute(signed ? 0 : 1)
-                .getOutput();
-
-        return result;
-    }
-
-    private static void verifyPkgutilResult(List<String> result, boolean signed,
-                                            int certIndex) {
-        result.stream().forEachOrdered(TKit::trace);
-        if (signed) {
-            String lookupString = "Status: signed by";
-            checkString(result, lookupString);
-            lookupString = "1. " + getInstallerCert(certIndex);
-            checkString(result, lookupString);
-        } else {
-            String lookupString = "Status: no signature";
-            checkString(result, lookupString);
-        }
-    }
-
     public static void verifyCodesign(Path target, boolean signed, int certIndex) {
-        List<String> result = codesignResult(target, CodesignCheckType.VERIFY);
-        verifyCodesignResult(result, target, signed, CodesignCheckType.VERIFY, certIndex);
-
-        result = codesignResult(target, CodesignCheckType.DISPLAY);
-        verifyCodesignResult(result, target, signed, CodesignCheckType.DISPLAY, certIndex);
+        if (signed) {
+            final var certRequest = getCertRequest(certIndex);
+            MacSignVerify.assertSigned(target, certRequest);
+        } else {
+            MacSignVerify.assertAdhocSigned(target);
+        }
     }
 
     // Since we no longer have unsigned app image, but we need to check
@@ -341,23 +238,45 @@ public class SigningBase {
     // Should not be used to validated anything else.
     public static void verifyDMG(Path target) {
         if (!target.toString().toLowerCase().endsWith(".dmg")) {
-            TKit.error("Unexpected target: " + target);
+            throw new IllegalArgumentException("Unexpected target: " + target);
         }
 
-        List<String> result = codesignResult(target, CodesignCheckType.VERIFY_UNSIGNED);
-        verifyCodesignResult(result, target, false, CodesignCheckType.VERIFY_UNSIGNED, -1);
+        MacSignVerify.assertUnsigned(target);
     }
 
     public static void verifySpctl(Path target, String type, int certIndex) {
-        Result result = spctlResult(target, type);
-        List<String> output = result.getOutput();
+        final var standardCertIndex = Stream.of(CertIndex.values()).filter(v -> {
+            return v.value() == certIndex;
+        }).findFirst().orElseThrow();
 
-        verifySpctlResult(output, target, type, result.getExitCode(), certIndex);
+        final var standardType = Stream.of(MacSignVerify.SpctlType.values()).filter(v -> {
+            return v.value().equals(type);
+        }).findFirst().orElseThrow();
+
+        final String expectedSignOrigin;
+        if (standardCertIndex == CertIndex.INVALID_INDEX) {
+            expectedSignOrigin = null;
+        } else if (standardType == MacSignVerify.SpctlType.EXEC) {
+            expectedSignOrigin = getCertRequest(certIndex).name();
+        } else if (standardType == MacSignVerify.SpctlType.INSTALL) {
+            expectedSignOrigin = getPkgCertRequest(certIndex).name();
+        } else {
+            throw new IllegalArgumentException();
+        }
+
+        final var signOrigin = MacSignVerify.findSpctlSignOrigin(standardType, target).orElse(null);
+
+        TKit.assertEquals(signOrigin, expectedSignOrigin,
+                String.format("Check [%s] has sign origin as expected", target));
     }
 
     public static void verifyPkgutil(Path target, boolean signed, int certIndex) {
-        List<String> result = pkgutilResult(target, signed);
-        verifyPkgutilResult(result, signed, certIndex);
+        if (signed) {
+            final var certRequest = getPkgCertRequest(certIndex);
+            MacSignVerify.assertPkgSigned(target, certRequest, StandardKeychain.MAIN.mapCertificateRequest(certRequest));
+        } else {
+            MacSignVerify.assertUnsigned(target);
+        }
     }
 
     public static void verifyAppImageSignature(JPackageCommand appImageCmd,
@@ -378,4 +297,31 @@ public class SigningBase {
         }
     }
 
+    private static CertificateRequest getCertRequest(int certIndex) {
+        switch (CertIndex.values()[certIndex]) {
+            case ASCII_INDEX -> {
+                return StandardCertificateRequest.CODESIGN.spec();
+            }
+            case UNICODE_INDEX -> {
+                return StandardCertificateRequest.CODESIGN_UNICODE.spec();
+            }
+            default -> {
+                throw new IllegalArgumentException();
+            }
+        }
+    }
+
+    private static CertificateRequest getPkgCertRequest(int certIndex) {
+        switch (CertIndex.values()[certIndex]) {
+            case ASCII_INDEX -> {
+                return StandardCertificateRequest.PKG.spec();
+            }
+            case UNICODE_INDEX -> {
+                return StandardCertificateRequest.PKG_UNICODE.spec();
+            }
+            default -> {
+                throw new IllegalArgumentException();
+            }
+        }
+    }
 }

--- a/test/jdk/tools/jpackage/macosx/base/SigningBase.java
+++ b/test/jdk/tools/jpackage/macosx/base/SigningBase.java
@@ -22,18 +22,16 @@
  */
 
 import java.nio.file.Path;
-import java.security.cert.X509Certificate;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Objects;
 import java.util.stream.Stream;
+import jdk.jpackage.test.Executor;
+import jdk.jpackage.test.Executor.Result;
 import jdk.jpackage.test.JPackageCommand;
 import jdk.jpackage.test.MacSign;
-import jdk.jpackage.test.MacSign.CertificateRequest;
 import jdk.jpackage.test.MacSign.CertificateType;
+import jdk.jpackage.test.MacSign.CertificateRequest;
 import jdk.jpackage.test.MacSign.KeychainWithCertsSpec;
-import jdk.jpackage.test.MacSign.ResolvedKeychain;
-import jdk.jpackage.test.MacSignVerify;
 import jdk.jpackage.test.TKit;
 
 
@@ -66,14 +64,10 @@ import jdk.jpackage.test.TKit;
 public class SigningBase {
 
     public enum StandardCertificateRequest {
-        CODESIGN(cert().userName(DEV_NAMES[CertIndex.ASCII_INDEX.value()])),
-        CODESIGN_COPY(cert().days(100).userName(DEV_NAMES[CertIndex.ASCII_INDEX.value()])),
-        PKG(cert().type(CertificateType.INSTALLER).userName(DEV_NAMES[CertIndex.ASCII_INDEX.value()])),
-        PKG_COPY(cert().type(CertificateType.INSTALLER).days(100).userName(DEV_NAMES[CertIndex.ASCII_INDEX.value()])),
-        CODESIGN_UNICODE(cert().userName(DEV_NAMES[CertIndex.UNICODE_INDEX.value()])),
-        PKG_UNICODE(cert().type(CertificateType.INSTALLER).userName(DEV_NAMES[CertIndex.UNICODE_INDEX.value()])),
-        CODESIGN_EXPIRED(cert().expired().userName("expired jpackage test")),
-        PKG_EXPIRED(cert().expired().type(CertificateType.INSTALLER).userName("expired jpackage test"));
+        APP_IMAGE(cert().userName(DEV_NAMES[CertIndex.ASCII_INDEX.value()])),
+        INSTALLER(cert().type(CertificateType.INSTALLER).userName(DEV_NAMES[CertIndex.ASCII_INDEX.value()])),
+        APP_IMAGE_UNICODE(cert().userName(DEV_NAMES[CertIndex.UNICODE_INDEX.value()])),
+        INSTALLER_UNICODE(cert().type(CertificateType.INSTALLER).userName(DEV_NAMES[CertIndex.UNICODE_INDEX.value()]));
 
         StandardCertificateRequest(CertificateRequest.Builder specBuilder) {
             this.spec = specBuilder.create();
@@ -91,21 +85,7 @@ public class SigningBase {
     }
 
     public enum StandardKeychain {
-        MAIN(DEFAULT_KEYCHAIN,
-                StandardCertificateRequest.CODESIGN,
-                StandardCertificateRequest.PKG,
-                StandardCertificateRequest.CODESIGN_UNICODE,
-                StandardCertificateRequest.PKG_UNICODE),
-        EXPIRED("jpackagerTest-expired.keychain",
-                StandardCertificateRequest.CODESIGN,
-                StandardCertificateRequest.PKG,
-                StandardCertificateRequest.CODESIGN_EXPIRED,
-                StandardCertificateRequest.PKG_EXPIRED),
-        DUPLICATE("jpackagerTest-duplicate.keychain",
-                StandardCertificateRequest.CODESIGN,
-                StandardCertificateRequest.PKG,
-                StandardCertificateRequest.CODESIGN_COPY,
-                StandardCertificateRequest.PKG_COPY);
+        MAIN(DEFAULT_KEYCHAIN, StandardCertificateRequest.values());
 
         StandardKeychain(String keychainName, StandardCertificateRequest... certs) {
             this(keychainName, certs[0].spec(), Stream.of(certs).skip(1).map(StandardCertificateRequest::spec).toArray(CertificateRequest[]::new));
@@ -114,15 +94,11 @@ public class SigningBase {
         StandardKeychain(String keychainName, CertificateRequest cert, CertificateRequest... otherCerts) {
             final var builder = keychain(keychainName).addCert(cert);
             List.of(otherCerts).forEach(builder::addCert);
-            this.spec = new ResolvedKeychain(builder.create());
+            this.spec = builder.create();
         }
 
         public KeychainWithCertsSpec spec() {
-            return spec.spec();
-        }
-
-        public X509Certificate mapCertificateRequest(CertificateRequest certRequest) {
-            return Objects.requireNonNull(spec.mapCertificateRequests().get(certRequest));
+            return spec;
         }
 
         private static KeychainWithCertsSpec.Builder keychain(String name) {
@@ -137,7 +113,7 @@ public class SigningBase {
             return Stream.of(values()).map(StandardKeychain::spec).toList();
         }
 
-        private final ResolvedKeychain spec;
+        private final KeychainWithCertsSpec spec;
     }
 
     public static void setUp() {
@@ -155,7 +131,7 @@ public class SigningBase {
     }
 
     private final class Inner {
-        private static final boolean SIGN_ENV_READY = MacSign.isDeployed(StandardKeychain.signingEnv());
+        private final static boolean SIGN_ENV_READY = MacSign.isDeployed(StandardKeychain.signingEnv());
     }
 
     enum CertIndex {
@@ -223,13 +199,140 @@ public class SigningBase {
         return DEFAULT_KEYCHAIN;
     }
 
-    public static void verifyCodesign(Path target, boolean signed, int certIndex) {
-        if (signed) {
-            final var certRequest = getCertRequest(certIndex);
-            MacSignVerify.assertSigned(target, certRequest);
-        } else {
-            MacSignVerify.assertAdhocSigned(target);
+    // Note: It is not clear if we can combine "--verify" and "--display", so
+    // we testing them separately. Since JDK-8298488 unsigned app images are
+    // actually signed with adhoc signature and it will pass "--verify", so in
+    // addition we will check certificate name which was used to sign.
+    private static enum CodesignCheckType {
+        VERIFY, // Runs codesign with "--verify" to check signature and 0 exit code
+        VERIFY_UNSIGNED, // Runs codesign with "--verify" to check signature and 1 exit code
+        DISPLAY // Runs codesign with "--display --verbose=4" to get info about signature
+    };
+
+    private static void checkString(List<String> result, String lookupString) {
+        TKit.assertTextStream(lookupString).predicate(
+                (line, what) -> line.trim().contains(what)).apply(result);
+    }
+
+    @SuppressWarnings("fallthrough")
+    private static List<String> codesignResult(Path target, CodesignCheckType type) {
+        int exitCode = 0;
+        Executor executor = new Executor().setExecutable("/usr/bin/codesign");
+        switch (type) {
+            case VERIFY_UNSIGNED:
+                exitCode = 1;
+            case VERIFY:
+                executor.addArguments("--verify", "--deep", "--strict",
+                                      "--verbose=2", target.toString());
+                break;
+            case DISPLAY:
+                executor.addArguments("--display", "--verbose=4", target.toString());
+                break;
+            default:
+                TKit.error("Unknown CodesignCheckType: " + type);
+                break;
         }
+        return executor.saveOutput().execute(exitCode).getOutput();
+    }
+
+    private static void verifyCodesignResult(List<String> result, Path target,
+            boolean signed, CodesignCheckType type, int certIndex) {
+        result.stream().forEachOrdered(TKit::trace);
+        String lookupString;
+        switch (type) {
+            case VERIFY:
+                lookupString = target.toString() + ": valid on disk";
+                checkString(result, lookupString);
+                lookupString = target.toString() + ": satisfies its Designated Requirement";
+                checkString(result, lookupString);
+                break;
+            case VERIFY_UNSIGNED:
+                lookupString = target.toString() + ": code object is not signed at all";
+                checkString(result, lookupString);
+                break;
+            case DISPLAY:
+                if (signed) {
+                    lookupString = "Authority=" + getAppCert(certIndex);
+                } else {
+                    lookupString = "Signature=adhoc";
+                }
+                checkString(result, lookupString);
+                break;
+            default:
+                TKit.error("Unknown CodesignCheckType: " + type);
+                break;
+        }
+    }
+
+    private static Result spctlResult(Path target, String type) {
+        Result result = new Executor()
+                .setExecutable("/usr/sbin/spctl")
+                .addArguments("-vvv", "--assess", "--type", type,
+                        target.toString())
+                .saveOutput()
+                .executeWithoutExitCodeCheck();
+
+        // allow exit code 3 for not being notarized
+        if (result.getExitCode() != 3) {
+            result.assertExitCodeIsZero();
+        }
+        return result;
+    }
+
+    private static void verifySpctlResult(List<String> output, Path target,
+            String type, int exitCode, int certIndex) {
+        output.stream().forEachOrdered(TKit::trace);
+        String lookupString;
+
+        if (exitCode == 0) {
+            lookupString = target.toString() + ": accepted";
+            checkString(output, lookupString);
+        } else if (exitCode == 3) {
+            // allow failure purely for not being notarized
+            lookupString = target.toString() + ": rejected";
+            checkString(output, lookupString);
+        }
+
+        if (type.equals("install")) {
+            lookupString = "origin=" + getInstallerCert(certIndex);
+        } else {
+            lookupString = "origin=" + getAppCert(certIndex);
+        }
+        checkString(output, lookupString);
+    }
+
+    private static List<String> pkgutilResult(Path target, boolean signed) {
+        List<String> result = new Executor()
+                .setExecutable("/usr/sbin/pkgutil")
+                .addArguments("--check-signature",
+                        target.toString())
+                .saveOutput()
+                .execute(signed ? 0 : 1)
+                .getOutput();
+
+        return result;
+    }
+
+    private static void verifyPkgutilResult(List<String> result, boolean signed,
+                                            int certIndex) {
+        result.stream().forEachOrdered(TKit::trace);
+        if (signed) {
+            String lookupString = "Status: signed by";
+            checkString(result, lookupString);
+            lookupString = "1. " + getInstallerCert(certIndex);
+            checkString(result, lookupString);
+        } else {
+            String lookupString = "Status: no signature";
+            checkString(result, lookupString);
+        }
+    }
+
+    public static void verifyCodesign(Path target, boolean signed, int certIndex) {
+        List<String> result = codesignResult(target, CodesignCheckType.VERIFY);
+        verifyCodesignResult(result, target, signed, CodesignCheckType.VERIFY, certIndex);
+
+        result = codesignResult(target, CodesignCheckType.DISPLAY);
+        verifyCodesignResult(result, target, signed, CodesignCheckType.DISPLAY, certIndex);
     }
 
     // Since we no longer have unsigned app image, but we need to check
@@ -238,45 +341,23 @@ public class SigningBase {
     // Should not be used to validated anything else.
     public static void verifyDMG(Path target) {
         if (!target.toString().toLowerCase().endsWith(".dmg")) {
-            throw new IllegalArgumentException("Unexpected target: " + target);
+            TKit.error("Unexpected target: " + target);
         }
 
-        MacSignVerify.assertUnsigned(target);
+        List<String> result = codesignResult(target, CodesignCheckType.VERIFY_UNSIGNED);
+        verifyCodesignResult(result, target, false, CodesignCheckType.VERIFY_UNSIGNED, -1);
     }
 
     public static void verifySpctl(Path target, String type, int certIndex) {
-        final var standardCertIndex = Stream.of(CertIndex.values()).filter(v -> {
-            return v.value() == certIndex;
-        }).findFirst().orElseThrow();
+        Result result = spctlResult(target, type);
+        List<String> output = result.getOutput();
 
-        final var standardType = Stream.of(MacSignVerify.SpctlType.values()).filter(v -> {
-            return v.value().equals(type);
-        }).findFirst().orElseThrow();
-
-        final String expectedSignOrigin;
-        if (standardCertIndex == CertIndex.INVALID_INDEX) {
-            expectedSignOrigin = null;
-        } else if (standardType == MacSignVerify.SpctlType.EXEC) {
-            expectedSignOrigin = getCertRequest(certIndex).name();
-        } else if (standardType == MacSignVerify.SpctlType.INSTALL) {
-            expectedSignOrigin = getPkgCertRequest(certIndex).name();
-        } else {
-            throw new IllegalArgumentException();
-        }
-
-        final var signOrigin = MacSignVerify.findSpctlSignOrigin(standardType, target).orElse(null);
-
-        TKit.assertEquals(signOrigin, expectedSignOrigin,
-                String.format("Check [%s] has sign origin as expected", target));
+        verifySpctlResult(output, target, type, result.getExitCode(), certIndex);
     }
 
     public static void verifyPkgutil(Path target, boolean signed, int certIndex) {
-        if (signed) {
-            final var certRequest = getPkgCertRequest(certIndex);
-            MacSignVerify.assertPkgSigned(target, certRequest, StandardKeychain.MAIN.mapCertificateRequest(certRequest));
-        } else {
-            MacSignVerify.assertUnsigned(target);
-        }
+        List<String> result = pkgutilResult(target, signed);
+        verifyPkgutilResult(result, signed, certIndex);
     }
 
     public static void verifyAppImageSignature(JPackageCommand appImageCmd,
@@ -297,31 +378,4 @@ public class SigningBase {
         }
     }
 
-    private static CertificateRequest getCertRequest(int certIndex) {
-        switch (CertIndex.values()[certIndex]) {
-            case ASCII_INDEX -> {
-                return StandardCertificateRequest.CODESIGN.spec();
-            }
-            case UNICODE_INDEX -> {
-                return StandardCertificateRequest.CODESIGN_UNICODE.spec();
-            }
-            default -> {
-                throw new IllegalArgumentException();
-            }
-        }
-    }
-
-    private static CertificateRequest getPkgCertRequest(int certIndex) {
-        switch (CertIndex.values()[certIndex]) {
-            case ASCII_INDEX -> {
-                return StandardCertificateRequest.PKG.spec();
-            }
-            case UNICODE_INDEX -> {
-                return StandardCertificateRequest.PKG_UNICODE.spec();
-            }
-            default -> {
-                throw new IllegalArgumentException();
-            }
-        }
-    }
 }

--- a/test/jdk/tools/jpackage/share/AppLauncherEnvTest.java
+++ b/test/jdk/tools/jpackage/share/AppLauncherEnvTest.java
@@ -82,7 +82,7 @@ public class AppLauncherEnvTest {
         TKit.assertTextStream(expectedEnvVarValue)
             .predicate(TKit.isLinux() ? String::endsWith : String::equals)
             .label(String.format("value of %s env variable", envVarName))
-            .apply(Stream.of(actualEnvVarValue));
+            .apply(List.of(actualEnvVarValue));
 
         final String javaLibraryPath = getValue.apply(2, "java.library.path");
         TKit.assertTrue(

--- a/test/jdk/tools/jpackage/share/BasicTest.java
+++ b/test/jdk/tools/jpackage/share/BasicTest.java
@@ -114,8 +114,8 @@ public final class BasicTest {
 
         List<String> output = HelloApp.executeLauncher(cmd).getOutput();
 
-        TKit.assertTextStream("jpackage.app-version=" + appVersion).apply(output.stream());
-        TKit.assertTextStream("jpackage.app-path=").apply(output.stream());
+        TKit.assertTextStream("jpackage.app-version=" + appVersion).apply(output);
+        TKit.assertTextStream("jpackage.app-path=").apply(output);
     }
 
     @Test
@@ -221,12 +221,12 @@ public final class BasicTest {
         expectedVerboseOutputStrings.forEach(str -> {
             TKit.assertTextStream(str).label("regular output")
                     .predicate(String::contains).negate()
-                    .apply(nonVerboseOutput.stream());
+                    .apply(nonVerboseOutput);
         });
 
         expectedVerboseOutputStrings.forEach(str -> {
             TKit.assertTextStream(str).label("verbose output")
-                    .apply(verboseOutput[0].stream());
+                    .apply(verboseOutput[0]);
         });
     }
 

--- a/test/jdk/tools/jpackage/share/IconTest.java
+++ b/test/jdk/tools/jpackage/share/IconTest.java
@@ -191,7 +191,7 @@ public class IconTest {
             var verifier = createConsoleOutputVerifier(cmd.name(), config.get(
                     Launcher.Main), null);
             if (verifier != null) {
-                verifier.apply(result.getOutput().stream());
+                verifier.apply(result.getOutput());
             }
 
             if (config.containsKey(Launcher.Additional)) {
@@ -199,7 +199,7 @@ public class IconTest {
                         Launcher.Additional.launcherName, config.get(
                                 Launcher.Additional), config.get(Launcher.Main));
                 if (verifier != null) {
-                    verifier.apply(result.getOutput().stream());
+                    verifier.apply(result.getOutput());
                 }
             }
         };

--- a/test/jdk/tools/jpackage/share/JLinkOptionsTest.java
+++ b/test/jdk/tools/jpackage/share/JLinkOptionsTest.java
@@ -129,12 +129,12 @@ public final class JLinkOptionsTest {
         List<String> mods = List.of(release.get(1));
         if (required != null) {
             for (String s : required) {
-                TKit.assertTextStream(s).label("mods").apply(mods.stream());
+                TKit.assertTextStream(s).label("mods").apply(mods);
             }
         }
         if (prohibited != null) {
             for (String s : prohibited) {
-                TKit.assertTextStream(s).label("mods").negate().apply(mods.stream());
+                TKit.assertTextStream(s).label("mods").negate().apply(mods);
             }
         }
     }

--- a/test/jdk/tools/jpackage/share/JavaOptionsEqualsTest.java
+++ b/test/jdk/tools/jpackage/share/JavaOptionsEqualsTest.java
@@ -82,7 +82,7 @@ public class JavaOptionsEqualsTest {
     public void test() {
         cmd.executeAndAssertHelloAppImageCreated();
         List<String> output = HelloApp.executeLauncher(cmd).getOutput();
-        TKit.assertTextStream(WARNING1).apply(output.stream());
-        TKit.assertTextStream(WARNING2).apply(output.stream());
+        TKit.assertTextStream(WARNING1).apply(output);
+        TKit.assertTextStream(WARNING2).apply(output);
     }
 }

--- a/test/jdk/tools/jpackage/share/JavaOptionsTest.java
+++ b/test/jdk/tools/jpackage/share/JavaOptionsTest.java
@@ -91,7 +91,7 @@ public class JavaOptionsTest {
         // 2.) run the launcher it generated
         List<String> output = HelloApp.executeLauncher(cmd).getOutput();
         for (String expect : expected) {
-            TKit.assertTextStream(expect).apply(output.stream());
+            TKit.assertTextStream(expect).apply(output);
         }
     }
 

--- a/test/jdk/tools/jpackage/share/MainClassTest.java
+++ b/test/jdk/tools/jpackage/share/MainClassTest.java
@@ -248,7 +248,7 @@ public final class MainClassTest {
                         .execute().getOutput();
                 TKit.assertTextStream(String.format(
                         "Error: Could not find or load main class %s",
-                        nonExistingMainClass)).apply(output.stream());
+                        nonExistingMainClass)).apply(output);
             }
         }
 

--- a/test/jdk/tools/jpackage/windows/WinL10nTest.java
+++ b/test/jdk/tools/jpackage/windows/WinL10nTest.java
@@ -120,7 +120,7 @@ public class WinL10nTest {
         return getWixTypeFromVerboseJPackageOutput(result) == WIX3;
     }
 
-    private final static Predicate<String> createToolCommandLinePredicate(String wixToolName) {
+    private static final Predicate<String> createToolCommandLinePredicate(String wixToolName) {
         var toolFileName = wixToolName + ".exe";
         return (s) -> {
             s = s.trim();
@@ -198,12 +198,12 @@ public class WinL10nTest {
                         return String.join(" ", "-culture", culture);
                     }).collect(Collectors.joining(" "));
                 }
-                TKit.assertTextStream(expected).apply(wixCmdline.stream());
+                TKit.assertTextStream(expected).apply(wixCmdline);
             }
 
             if (expectedErrorMessage != null) {
                 TKit.assertTextStream(expectedErrorMessage)
-                        .apply(result.getOutput().stream());
+                        .apply(result.getOutput());
             }
 
             if (wxlFileInitializers != null) {
@@ -213,18 +213,18 @@ public class WinL10nTest {
                 if (allWxlFilesValid) {
                     for (var v : wxlFileInitializers) {
                         if (!v.name.startsWith("MsiInstallerStrings_")) {
-                            v.createCmdOutputVerifier(wixSrcDir).apply(wixCmdline.stream());
+                            v.createCmdOutputVerifier(wixSrcDir).apply(wixCmdline);
                         }
                     }
 
                     for (var v : createDefaultL10nFilesLocVerifiers(wixSrcDir)) {
-                        v.apply(wixCmdline.stream());
+                        v.apply(wixCmdline);
                     }
                 } else {
                     Stream.of(wxlFileInitializers)
                             .filter(Predicate.not(WixFileInitializer::isValid))
                             .forEach(v -> v.createCmdOutputVerifier(
-                                    wixSrcDir).apply(result.getOutput().stream()));
+                                    wixSrcDir).apply(result.getOutput()));
                     TKit.assertTrue(wixCmdline.stream().findAny().isEmpty(),
                             String.format("Check %s.exe was not invoked",
                                     isWix3 ? "light" : "wix"));
@@ -251,12 +251,12 @@ public class WinL10nTest {
         test.run();
     }
 
-    final private WixFileInitializer[] wxlFileInitializers;
-    final private String[] expectedCultures;
-    final private String expectedErrorMessage;
-    final private String userLanguage;
-    final private String userCountry;
-    final private boolean enableWixUIExtension;
+    private final WixFileInitializer[] wxlFileInitializers;
+    private final String[] expectedCultures;
+    private final String expectedErrorMessage;
+    private final String userLanguage;
+    private final String userCountry;
+    private final boolean enableWixUIExtension;
     private Path resourceDir;
 
     private static class WixFileInitializer {

--- a/test/jdk/tools/jpackage/windows/WinOSConditionTest.java
+++ b/test/jdk/tools/jpackage/windows/WinOSConditionTest.java
@@ -65,8 +65,10 @@ public class WinOSConditionTest {
             // MSI error code 1603 is generic.
             // Dig into the last msi log file for log messages specific to failed condition.
             try (final var lines = cmd.winMsiLogFileContents().orElseThrow()) {
-                TKit.assertTextStream("Doing action: LaunchConditions").predicate(String::endsWith)
-                    .andThen(TKit.assertTextStream("Not supported on this version of Windows").predicate(String::endsWith)).apply(lines);
+                TKit.TextStreamVerifier.group()
+                        .add(TKit.assertTextStream("Doing action: LaunchConditions").predicate(String::endsWith))
+                        .add(TKit.assertTextStream("Not supported on this version of Windows").predicate(String::endsWith))
+                        .create().accept(lines.iterator());
             }
         })
         .createMsiLog(true)

--- a/test/jdk/tools/jpackage/windows/WinResourceTest.java
+++ b/test/jdk/tools/jpackage/windows/WinResourceTest.java
@@ -95,9 +95,9 @@ public class WinResourceTest {
             TKit.assertTextStream(expectedLogMessage)
                     .predicate(String::startsWith)
                     .apply(JPackageCommand.stripTimestamps(
-                            result.getOutput().stream()));
+                            result.getOutput().stream()).iterator());
             TKit.assertTextStream(expectedWixErrorMsg)
-                    .apply(result.getOutput().stream());
+                    .apply(result.getOutput());
         })
         .setExpectedExitCode(1)
         .run();

--- a/test/jdk/tools/jpackage/windows/WinScriptTest.java
+++ b/test/jdk/tools/jpackage/windows/WinScriptTest.java
@@ -127,19 +127,19 @@ public class WinScriptTest {
         void assertJPackageOutput(List<String> output) {
             TKit.assertTextStream(String.format("    jp: %s", echoText))
                     .predicate(String::equals)
-                    .apply(output.stream());
+                    .apply(output);
 
             String cwdPattern = String.format("    jp: CWD(%s)=", envVarName);
             TKit.assertTextStream(cwdPattern)
                     .predicate(String::startsWith)
-                    .apply(output.stream());
+                    .apply(output);
             String cwd = output.stream().filter(line -> line.startsWith(
                     cwdPattern)).findFirst().get().substring(cwdPattern.length());
 
             String envVarPattern = String.format("    jp: %s=", envVarName);
             TKit.assertTextStream(envVarPattern)
                     .predicate(String::startsWith)
-                    .apply(output.stream());
+                    .apply(output);
             String envVar = output.stream().filter(line -> line.startsWith(
                     envVarPattern)).findFirst().get().substring(envVarPattern.length());
 


### PR DESCRIPTION
Add tests covering `error.explicit-sign-no-cert` error ID to ErrorTest.

If signing identity validation fails, jpackage outputs three messages constructed from the following string IDs: `error.cert.not.found`, `error.explicit-sign-no-cert`, and `error.explicit-sign-no-cert.advice`.

`TKit.TextStreamVerifier.andThen()` method doesn't work correctly when combining more than two instances of `TKit.TextStreamVerifier` class. To address this bug and analyze jpackage's output for three expected strings when a non-existent signing identity is specified, the `TKit.TextStreamVerifier.andThen()` method was replaced with the `TKit.TextStreamVerifier.Group` class. Changes in other tests are a result of this change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8355328](https://bugs.openjdk.org/browse/JDK-8355328): Improve negative tests coverage for jpackage signing (**Enhancement** - P4)


### Reviewers
 * [Alexander Matveev](https://openjdk.org/census#almatvee) (@sashamatveev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24786/head:pull/24786` \
`$ git checkout pull/24786`

Update a local copy of the PR: \
`$ git checkout pull/24786` \
`$ git pull https://git.openjdk.org/jdk.git pull/24786/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24786`

View PR using the GUI difftool: \
`$ git pr show -t 24786`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24786.diff">https://git.openjdk.org/jdk/pull/24786.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24786#issuecomment-2822283007)
</details>
