### PR TITLE
8355239: RISC-V: Do not support subword scatter store

### DIFF
--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -89,6 +89,8 @@ source %{
         return UseZvbb;
       case Op_LoadVectorGather:
       case Op_LoadVectorGatherMasked:
+      case Op_StoreVectorScatter:
+      case Op_StoreVectorScatterMasked:
         if (is_subword_type(bt)) {
           return false;
         }


### PR DESCRIPTION
Hi, please consider this small enhancement change.

Currently, only word and double-word gather load and scatter store are supported on riscv.
Both subword gather load and scatter store are not supported due to constraint of riscv vector extension.
[JDK-8331150](https://bugs.openjdk.org/browse/JDK-8331150) makes this constraint explicit for subword gather load.
For parity and consistency, this also makes it explicit for subword scatter store as well.

Testing: `jdk_vector` tested with QEMU vector extension.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8355239](https://bugs.openjdk.org/browse/JDK-8355239): RISC-V: Do not support subword scatter store (**Enhancement** - P4)


### Reviewers
 * [Hamlin Li](https://openjdk.org/census#mli) (@Hamlin-Li - **Reviewer**)
 * [Feilong Jiang](https://openjdk.org/census#fjiang) (@feilongjiang - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24787/head:pull/24787` \
`$ git checkout pull/24787`

Update a local copy of the PR: \
`$ git checkout pull/24787` \
`$ git pull https://git.openjdk.org/jdk.git pull/24787/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24787`

View PR using the GUI difftool: \
`$ git pr show -t 24787`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24787.diff">https://git.openjdk.org/jdk/pull/24787.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24787#issuecomment-2820134746)
</details>
