### PR TITLE
8355249: Remove the use of WMIC from the entire source code

### DIFF
--- a/make/RunTestsPrebuilt.gmk
+++ b/make/RunTestsPrebuilt.gmk
@@ -217,9 +217,9 @@ else ifeq ($(OPENJDK_TARGET_OS), macosx)
 else ifeq ($(OPENJDK_TARGET_OS), windows)
   NUM_CORES := $(NUMBER_OF_PROCESSORS)
   MEMORY_SIZE := $(shell \
-      $(EXPR) `wmic computersystem get totalphysicalmemory -value \
-          | $(GREP) = | $(SED) 's/\\r//g' \
-          | $(CUT) -d "=" -f 2-` / 1024 / 1024 \
+      $(EXPR) `powershell -Command \
+          "(Get-CimInstance Win32_ComputerSystem).TotalPhysicalMemory" \
+          | $(SED) 's/\\r//g' ` / 1024 / 1024 \
   )
 endif
 ifeq ($(NUM_CORES), )

--- a/make/autoconf/build-performance.m4
+++ b/make/autoconf/build-performance.m4
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -75,7 +75,8 @@ AC_DEFUN([BPERF_CHECK_MEMORY_SIZE],
     FOUND_MEM=yes
   elif test "x$OPENJDK_BUILD_OS" = xwindows; then
     # Windows, but without cygwin
-    MEMORY_SIZE=`wmic computersystem get totalphysicalmemory -value | grep = | cut -d "=" -f 2-`
+    MEMORY_SIZE=`powershell -Command \
+        "(Get-CimInstance Win32_ComputerSystem).TotalPhysicalMemory" | $SED 's/\\r//g' `
     MEMORY_SIZE=`expr $MEMORY_SIZE / 1024 / 1024`
     FOUND_MEM=yes
   fi

--- a/test/failure_handler/src/share/conf/windows.properties
+++ b/test/failure_handler/src/share/conf/windows.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -22,10 +22,10 @@
 #
 
 config.execSuffix=.exe
-config.getChildren.app=bash
+config.getChildren.app=powershell
 config.getChildren.pattern=%p
-config.getChildren.args=-c\0wmic process where ParentProcessId=%p get ProcessId | tail -n+2
 config.getChildren.args.delimiter=\0
+config.getChildren.args=-NoLogo\0-Command\0"Get-CimInstance Win32_Process -Filter \\\"ParentProcessId = %p\\\" | Select-Object ProcessId" | tail -n+4
 ################################################################################
 # process info to gather
 ################################################################################
@@ -39,8 +39,9 @@ native.pattern=%p
 native.javaOnly=false
 native.args=%p
 
-native.info.app=wmic
-native.info.args=process where processId=%p list full
+native.info.app=powershell
+native.info.delimiter=\0
+native.info.args=-NoLogo\0-Command\0"Get-WmiObject Win32_Process -Filter \\\"ProcessId = %p\\\" | Format-List -Property *"
 
 native.pmap.app=pmap
 native.pmap.normal.args=%p
@@ -96,8 +97,9 @@ system.events.delimiter=\0
 system.events.system.args=-NoLogo\0-Command\0Get-EventLog System -After (Get-Date).AddDays(-1) | Format-List
 system.events.application.args=-NoLogo\0-Command\0Get-EventLog Application -After (Get-Date).AddDays(-1) | Format-List
 
-system.os.app=wmic
-system.os.args=os get /format:list
+system.os.app=powershell
+system.os.delimiter=\0
+system.os.args=-NoLogo\0-Command\0Get-WmiObject Win32_OperatingSystem | Format-List -Property *
 
 process.top.app=top
 process.top.args=-b -n 1

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/WindowsHelper.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/WindowsHelper.java
@@ -322,32 +322,33 @@ public class WindowsHelper {
 
     private static long[] findAppLauncherPIDs(JPackageCommand cmd, String launcherName) {
         // Get the list of PIDs and PPIDs of app launcher processes. Run setWinRunWithEnglishOutput(true) for JDK-8344275.
-        // wmic process where (name = "foo.exe") get ProcessID,ParentProcessID
-        final var result = Executor.of("wmic", "process", "where", "(name",
-                "=",
-                "\"" + cmd.appLauncherPath(launcherName).getFileName().toString() + "\"",
-                ")", "get", "ProcessID,ParentProcessID").dumpOutput(true).saveOutput().
-                setWinRunWithEnglishOutput(true).execute();
-        if ("No Instance(s) Available.".equals(result.stderr().findFirstLineOfOutput().map(String::trim).orElse(""))) {
+        // powershell -NoLogo -NoProfile -NonInteractive -Command
+        //   "Get-CimInstance Win32_Process -Filter \"Name = 'foo.exe'\" | select ProcessID,ParentProcessID"
+        String command = "Get-CimInstance Win32_Process -Filter \\\"Name = '"
+                + cmd.appLauncherPath(launcherName).getFileName().toString()
+                + "'\\\" | select ProcessID,ParentProcessID";
+        List<String> output = Executor.of("powershell", "-NoLogo", "-NoProfile", "-NonInteractive", "-Command", command)
+                .dumpOutput(true).saveOutput().setWinRunWithEnglishOutput(true).executeAndGetOutput();
+
+        if (output.size() < 1) {
             return new long[0];
         }
 
-        final var stdout = result.stdout();
-        String[] headers = Stream.of(stdout.getFirstLineOfOutput().split("\\s+", 2)).map(
+        String[] headers = Stream.of(output.get(1).split("\\s+", 2)).map(
                 String::trim).map(String::toLowerCase).toArray(String[]::new);
-        final Pattern pattern;
+        Pattern pattern;
         if (headers[0].equals("parentprocessid") && headers[1].equals(
                 "processid")) {
-            pattern = Pattern.compile("^(?<ppid>\\d+)\\s+(?<pid>\\d+)\\s+$");
+            pattern = Pattern.compile("^\\s+(?<ppid>\\d+)\\s+(?<pid>\\d+)$");
         } else if (headers[1].equals("parentprocessid") && headers[0].equals(
                 "processid")) {
-            pattern = Pattern.compile("^(?<pid>\\d+)\\s+(?<ppid>\\d+)\\s+$");
+            pattern = Pattern.compile("^\\s+(?<pid>\\d+)\\s+(?<ppid>\\d+)$");
         } else {
             throw new RuntimeException(
-                    "Unrecognizable output of \'wmic process\' command");
+                    "Unrecognizable output of \'Get-CimInstance Win32_Process\' command");
         }
 
-        List<long[]> processes = stdout.getOutput().stream().skip(1).map(line -> {
+        List<long[]> processes = output.stream().skip(3).map(line -> {
             Matcher m = pattern.matcher(line);
             long[] pids = null;
             if (m.matches()) {


### PR DESCRIPTION
After searching the entire JDK source code, I found that WMIC is only used in four files. These WMIC calls can be replaced with PowerShell for WMI.

The primary challenge in this replacement is to make it work the same as before, even if the output format of the PowerShell command is different from the original WMIC output. Where necessary, I've adjusted the output formatting to maintain consistency.

Regarding the PowerShell options `-NoLogo`, `-NoProfile`, and `-NonInteractive`, I've included them only when they are already used in the surrounding code within the affected file.
Note: In my environment, it worked correctly even without these options.

The `failure_handler` outputs powershell command execution results directly into HTML. While the number and order of output items may differ slightly after the modification, all previously output items are still included. Therefore, I believe this is not a problem. Specific output changes are located in:

- `environment.html`: `windows/system/os` section
- `process.html`: `[Process ID]/windows/native/info` section

**Testing:**
I have confirmed that all tests in `jdk/tools/jpackage` pass after these changes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 2 [Reviewers](https://openjdk.org/bylaws#reviewer))

### Issue
 * [JDK-8355249](https://bugs.openjdk.org/browse/JDK-8355249): Remove the use of WMIC from the entire source code (**Enhancement** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)
 * [Alexey Semenyuk](https://openjdk.org/census#asemenyuk) (@alexeysemenyukoracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24791/head:pull/24791` \
`$ git checkout pull/24791`

Update a local copy of the PR: \
`$ git checkout pull/24791` \
`$ git pull https://git.openjdk.org/jdk.git pull/24791/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24791`

View PR using the GUI difftool: \
`$ git pr show -t 24791`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24791.diff">https://git.openjdk.org/jdk/pull/24791.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24791#issuecomment-2820401146)
</details>
