### PR TITLE
8355278: Improve debuggability of com/sun/jndi/ldap/LdapPoolTimeoutTest.java test

### DIFF
--- a/test/jdk/com/sun/jndi/ldap/LdapPoolTimeoutTest.java
+++ b/test/jdk/com/sun/jndi/ldap/LdapPoolTimeoutTest.java
@@ -30,10 +30,8 @@
  * @run testng/othervm LdapPoolTimeoutTest
  */
 
-import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import java.io.IOException;
 import javax.naming.Context;
 import javax.naming.NamingException;
 import javax.naming.directory.InitialDirContext;
@@ -44,13 +42,8 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-import java.util.concurrent.TimeoutException;
-import java.util.concurrent.TimeUnit;
 
 import static jdk.test.lib.Utils.adjustTimeout;
-import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.expectThrows;
 
 public class LdapPoolTimeoutTest {
     /*

--- a/test/jdk/com/sun/jndi/ldap/LdapPoolTimeoutTest.java
+++ b/test/jdk/com/sun/jndi/ldap/LdapPoolTimeoutTest.java
@@ -94,12 +94,12 @@ public class LdapPoolTimeoutTest {
             executorService.shutdown();
         }
         int failedCount = 0;
-        for (var f : futures) {
+        for (int i = 0; i < futures.size(); i++) {
             try {
-                f.get();
+                futures.get(i).get();
             } catch (ExecutionException e) {
                 failedCount++;
-                System.err.println("test failure:");
+                System.err.println("task " + (i + 1) + " failed:");
                 e.getCause().printStackTrace();
             }
         }


### PR DESCRIPTION
Can I please get a review of this test only change which proposes to improve the debuggability of `com/sun/jndi/ldap/LdapPoolTimeoutTest.java`?

This test has been failing intermittently in our CI for several years. Detailed are noted in https://bugs.openjdk.org/browse/JDK-8287062. Most of these failures are because the exception message, in an exception that was raised, contains an unexpected value (apparently `null`). The test doesn't propagate the unexpected exception, thus it's not clear why the exception message is different than what the test expects. The commit in this PR propagates the original exception if the message is unexpected. This should help identify the underlying cause of the test failure, if/when it fails the next time.

I have run this test with these changes and the test continues to pass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8355278](https://bugs.openjdk.org/browse/JDK-8355278): Improve debuggability of com/sun/jndi/ldap/LdapPoolTimeoutTest.java test (**Sub-task** - P4)


### Reviewers
 * [Aleksei Efimov](https://openjdk.org/census#aefimov) (@AlekseiEfimov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24793/head:pull/24793` \
`$ git checkout pull/24793`

Update a local copy of the PR: \
`$ git checkout pull/24793` \
`$ git pull https://git.openjdk.org/jdk.git pull/24793/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24793`

View PR using the GUI difftool: \
`$ git pr show -t 24793`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24793.diff">https://git.openjdk.org/jdk/pull/24793.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24793#issuecomment-2820680493)
</details>
