### PR TITLE
8355290: Aarch64/Linux debug builds on machines not supporting SVE fail because of overzealous assert

### DIFF
--- a/src/hotspot/os_cpu/linux_aarch64/vm_version_linux_aarch64.cpp
+++ b/src/hotspot/os_cpu/linux_aarch64/vm_version_linux_aarch64.cpp
@@ -90,7 +90,6 @@
 #endif
 
 int VM_Version::get_current_sve_vector_length() {
-  assert(VM_Version::supports_sve(), "should not call this");
   return prctl(PR_SVE_GET_VL);
 }
 


### PR DESCRIPTION
Hi all,

  please review removing of an assert that causes failing builds on
linux/aarch64 platforms without SVE support.

Testing: local testing, GHA

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8355290](https://bugs.openjdk.org/browse/JDK-8355290)

### Issue
 * [JDK-8355290](https://bugs.openjdk.org/browse/JDK-8355290): Aarch64/Linux debug builds on machines not supporting SVE but only SME fail because of overzealous assert (**Bug** - P4) ⚠️ Title mismatch between PR and JBS. ⚠️ Issue is not open.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24794/head:pull/24794` \
`$ git checkout pull/24794`

Update a local copy of the PR: \
`$ git checkout pull/24794` \
`$ git pull https://git.openjdk.org/jdk.git pull/24794/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24794`

View PR using the GUI difftool: \
`$ git pr show -t 24794`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24794.diff">https://git.openjdk.org/jdk/pull/24794.diff</a>

</details>
