### PR TITLE
8355301: Simplify Throwable::printStackTrace by using record

### DIFF
--- a/src/java.base/share/classes/java/lang/Throwable.java
+++ b/src/java.base/share/classes/java/lang/Throwable.java
@@ -683,30 +683,43 @@ public class Throwable implements Serializable {
      * @param s {@code PrintStream} to use for output
      */
     public void printStackTrace(PrintStream s) {
-        printStackTrace(new WrappedPrintStream(s));
+        printStackTrace(s);
     }
 
-    private void printStackTrace(PrintStreamOrWriter s) {
+    private void printStackTrace(Object printer) {
         // Guard against malicious overrides of Throwable.equals by
         // using a Set with identity equality semantics.
         Set<Throwable> dejaVu = Collections.newSetFromMap(new IdentityHashMap<>());
         dejaVu.add(this);
 
-        synchronized(s.lock()) {
+        synchronized(printer) {
             // Print our stack trace
-            s.println(this);
+            println(printer, this);
             StackTraceElement[] trace = getOurStackTrace();
             for (StackTraceElement traceElement : trace)
-                s.println("\tat " + traceElement);
+                println(printer, "\tat " + traceElement);
 
             // Print suppressed exceptions, if any
             for (Throwable se : getSuppressed())
-                se.printEnclosedStackTrace(s, trace, SUPPRESSED_CAPTION, "\t", dejaVu);
+                se.printEnclosedStackTrace(printer, trace, SUPPRESSED_CAPTION, "\t", dejaVu);
 
             // Print cause, if any
             Throwable ourCause = getCause();
             if (ourCause != null)
-                ourCause.printEnclosedStackTrace(s, trace, CAUSE_CAPTION, "", dejaVu);
+                ourCause.printEnclosedStackTrace(printer, trace, CAUSE_CAPTION, "", dejaVu);
+        }
+    }
+
+    /**
+     * Prints the specified string as a line on this StreamOrWriter
+     * @param printer PrintStream or PrintWriter to use for output
+     * @param o String to print
+     */
+    private static void println(Object printer, Object o) {
+        if (printer instanceof PrintStream ps) {
+            ps.println(o);
+        } else {
+            ((PrintWriter) printer).println(o);
         }
     }
 
@@ -714,14 +727,14 @@ public class Throwable implements Serializable {
      * Print our stack trace as an enclosed exception for the specified
      * stack trace.
      */
-    private void printEnclosedStackTrace(PrintStreamOrWriter s,
+    private void printEnclosedStackTrace(Object printer,
                                          StackTraceElement[] enclosingTrace,
                                          String caption,
                                          String prefix,
                                          Set<Throwable> dejaVu) {
-        assert Thread.holdsLock(s.lock());
+        assert Thread.holdsLock(printer);
         if (dejaVu.contains(this)) {
-            s.println(prefix + caption + "[CIRCULAR REFERENCE: " + this + "]");
+            println(printer, prefix + caption + "[CIRCULAR REFERENCE: " + this + "]");
         } else {
             dejaVu.add(this);
             // Compute number of frames in common between this and enclosing trace
@@ -734,21 +747,21 @@ public class Throwable implements Serializable {
             int framesInCommon = trace.length - 1 - m;
 
             // Print our stack trace
-            s.println(prefix + caption + this);
+            println(printer, prefix + caption + this);
             for (int i = 0; i <= m; i++)
-                s.println(prefix + "\tat " + trace[i]);
+                println(printer, prefix + "\tat " + trace[i]);
             if (framesInCommon != 0)
-                s.println(prefix + "\t... " + framesInCommon + " more");
+                println(printer, prefix + "\t... " + framesInCommon + " more");
 
             // Print suppressed exceptions, if any
             for (Throwable se : getSuppressed())
-                se.printEnclosedStackTrace(s, trace, SUPPRESSED_CAPTION,
+                se.printEnclosedStackTrace(printer, trace, SUPPRESSED_CAPTION,
                                            prefix +"\t", dejaVu);
 
             // Print cause, if any
             Throwable ourCause = getCause();
             if (ourCause != null)
-                ourCause.printEnclosedStackTrace(s, trace, CAUSE_CAPTION, prefix, dejaVu);
+                ourCause.printEnclosedStackTrace(printer, trace, CAUSE_CAPTION, prefix, dejaVu);
         }
     }
 
@@ -760,39 +773,7 @@ public class Throwable implements Serializable {
      * @since   1.1
      */
     public void printStackTrace(PrintWriter s) {
-        printStackTrace(new WrappedPrintWriter(s));
-    }
-
-    /**
-     * Wrapper class for PrintStream and PrintWriter to enable a single
-     * implementation of printStackTrace.
-     */
-    private interface PrintStreamOrWriter {
-        /** Returns the object to be locked when using this StreamOrWriter */
-        abstract Object lock();
-
-        /** Prints the specified string as a line on this StreamOrWriter */
-        abstract void println(Object o);
-    }
-
-    private record WrappedPrintStream(PrintStream printStream) implements PrintStreamOrWriter {
-        public Object lock() {
-            return printStream;
-        }
-
-        public void println(Object o) {
-            printStream.println(o);
-        }
-    }
-
-    private record WrappedPrintWriter(PrintWriter printWriter) implements PrintStreamOrWriter {
-        public Object lock() {
-            return printWriter;
-        }
-
-        public void println(Object o) {
-            printWriter.println(o);
-        }
+        printStackTrace(s);
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/Throwable.java
+++ b/src/java.base/share/classes/java/lang/Throwable.java
@@ -683,7 +683,7 @@ public class Throwable implements Serializable {
      * @param s {@code PrintStream} to use for output
      */
     public void printStackTrace(PrintStream s) {
-        printStackTrace(s);
+        printStackTrace((Object) s);
     }
 
     private void printStackTrace(Object printer) {
@@ -773,7 +773,7 @@ public class Throwable implements Serializable {
      * @since   1.1
      */
     public void printStackTrace(PrintWriter s) {
-        printStackTrace(s);
+        printStackTrace((Object) s);
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/Throwable.java
+++ b/src/java.base/share/classes/java/lang/Throwable.java
@@ -683,10 +683,10 @@ public class Throwable implements Serializable {
      * @param s {@code PrintStream} to use for output
      */
     public void printStackTrace(PrintStream s) {
-        printStackTrace((Object) s);
+        printStackTrace0(s);
     }
 
-    private void printStackTrace(Object printer) {
+    private void printStackTrace0(Object printer) {
         // Guard against malicious overrides of Throwable.equals by
         // using a Set with identity equality semantics.
         Set<Throwable> dejaVu = Collections.newSetFromMap(new IdentityHashMap<>());
@@ -773,7 +773,7 @@ public class Throwable implements Serializable {
      * @since   1.1
      */
     public void printStackTrace(PrintWriter s) {
-        printStackTrace((Object) s);
+        printStackTrace0(s);
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/Throwable.java
+++ b/src/java.base/share/classes/java/lang/Throwable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -767,7 +767,7 @@ public class Throwable implements Serializable {
      * Wrapper class for PrintStream and PrintWriter to enable a single
      * implementation of printStackTrace.
      */
-    private abstract static class PrintStreamOrWriter {
+    private interface PrintStreamOrWriter {
         /** Returns the object to be locked when using this StreamOrWriter */
         abstract Object lock();
 
@@ -775,34 +775,22 @@ public class Throwable implements Serializable {
         abstract void println(Object o);
     }
 
-    private static class WrappedPrintStream extends PrintStreamOrWriter {
-        private final PrintStream printStream;
-
-        WrappedPrintStream(PrintStream printStream) {
-            this.printStream = printStream;
-        }
-
-        Object lock() {
+    private record WrappedPrintStream(PrintStream printStream) implements PrintStreamOrWriter {
+        public Object lock() {
             return printStream;
         }
 
-        void println(Object o) {
+        public void println(Object o) {
             printStream.println(o);
         }
     }
 
-    private static class WrappedPrintWriter extends PrintStreamOrWriter {
-        private final PrintWriter printWriter;
-
-        WrappedPrintWriter(PrintWriter printWriter) {
-            this.printWriter = printWriter;
-        }
-
-        Object lock() {
+    private record WrappedPrintWriter(PrintWriter printWriter) implements PrintStreamOrWriter {
+        public Object lock() {
             return printWriter;
         }
 
-        void println(Object o) {
+        public void println(Object o) {
             printWriter.println(o);
         }
     }


### PR DESCRIPTION
The current Throwable::printStackTrace implementation uses three inner classes PrintStreamOrWriter/WrappedPrintStream/WrappedPrintWriter. We can introduce a static method println to replace these three embedded classes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8355301](https://bugs.openjdk.org/browse/JDK-8355301): Simplify Throwable::printStackTrace by using record (**Enhancement** - P5)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24795/head:pull/24795` \
`$ git checkout pull/24795`

Update a local copy of the PR: \
`$ git checkout pull/24795` \
`$ git pull https://git.openjdk.org/jdk.git pull/24795/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24795`

View PR using the GUI difftool: \
`$ git pr show -t 24795`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24795.diff">https://git.openjdk.org/jdk/pull/24795.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24795#issuecomment-2821514943)
</details>
