### PR TITLE
8355300: Add final to BitSieve

### DIFF
--- a/src/java.base/share/classes/java/math/BitSieve.java
+++ b/src/java.base/share/classes/java/math/BitSieve.java
@@ -48,7 +48,7 @@ final class BitSieve {
     /**
      * Stores the bits in this bitSieve.
      */
-    private final long bits[];
+    private final long[] bits;
 
     /**
      * Length is how many bits this sieve holds.

--- a/src/java.base/share/classes/java/math/BitSieve.java
+++ b/src/java.base/share/classes/java/math/BitSieve.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,22 +44,22 @@ package java.math;
  * @author  Michael McCloskey
  * @since   1.3
  */
-class BitSieve {
+final class BitSieve {
     /**
      * Stores the bits in this bitSieve.
      */
-    private long bits[];
+    private final long bits[];
 
     /**
      * Length is how many bits this sieve holds.
      */
-    private int length;
+    private final int length;
 
     /**
      * A small sieve used to filter out multiples of small primes in a search
      * sieve.
      */
-    private static BitSieve smallSieve = new BitSieve();
+    private static final BitSieve smallSieve = new BitSieve();
 
     /**
      * Construct a "small sieve" with a base of 0.  This constructor is


### PR DESCRIPTION
As the title says, adding final to fields that do not change and BitSieve that will not be inherited will make C2 optimization more friendly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 2 [Reviewers](https://openjdk.org/bylaws#reviewer))

### Issue
 * [JDK-8355300](https://bugs.openjdk.org/browse/JDK-8355300): Add final to BitSieve (**Enhancement** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)
 * [Per Minborg](https://openjdk.org/census#pminborg) (@minborg - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24796/head:pull/24796` \
`$ git checkout pull/24796`

Update a local copy of the PR: \
`$ git checkout pull/24796` \
`$ git pull https://git.openjdk.org/jdk.git pull/24796/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24796`

View PR using the GUI difftool: \
`$ git pr show -t 24796`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24796.diff">https://git.openjdk.org/jdk/pull/24796.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24796#issuecomment-2821511951)
</details>
