### PR TITLE
8354469: Keytool exposes the password in plain text when command is piped using | grep

### DIFF
--- a/src/java.base/share/classes/sun/security/tools/keytool/Main.java
+++ b/src/java.base/share/classes/sun/security/tools/keytool/Main.java
@@ -5273,6 +5273,10 @@ public final class Main {
                     "Use.keytool.help.for.all.available.commands"));
             System.err.println(rb.getString(
                     "Use.keytool.command.name.help.for.usage.of.command.name"));
+            System.err.println();
+            System.err.println(rb.getString("for.more.information.see.the.online.documentation.at."));
+            System.err.println("https://docs.oracle.com/en/java/javase/"
+                    + Runtime.version().feature() + "/docs/specs/man/keytool.html");
         }
     }
 

--- a/src/java.base/share/classes/sun/security/tools/keytool/Main.java
+++ b/src/java.base/share/classes/sun/security/tools/keytool/Main.java
@@ -1043,15 +1043,10 @@ public final class Main {
                         command == IDENTITYDB) {
                     int count = 0;
                     do {
-                        if (command == IMPORTKEYSTORE) {
-                            System.err.print
-                                    (rb.getString("Enter.destination.keystore.password."));
-                        } else {
-                            System.err.print
-                                    (rb.getString("Enter.keystore.password."));
-                        }
-                        System.err.flush();
-                        storePass = Password.readPassword(System.in);
+                        String prompt = command == IMPORTKEYSTORE
+                                ? rb.getString("Enter.destination.keystore.password.")
+                                : rb.getString("Enter.keystore.password.");
+                        storePass = Password.toolReadPassword(prompt);
                         passwords.add(storePass);
 
                         // If we are creating a new non nullStream-based keystore,
@@ -1065,8 +1060,8 @@ public final class Main {
                         // If the keystore file does not exist and needs to be
                         // created, the storepass should be prompted twice.
                         if (storePass != null && !nullStream && ksStream == null) {
-                            System.err.print(rb.getString("Re.enter.new.password."));
-                            char[] storePassAgain = Password.readPassword(System.in);
+                            char[] storePassAgain = Password.toolReadPassword(
+                                    rb.getString("Re.enter.new.password."));
                             passwords.add(storePassAgain);
                             if (!Arrays.equals(storePass, storePassAgain)) {
                                 System.err.println
@@ -1087,9 +1082,8 @@ public final class Main {
                 } else {
                     // here we have EXPORTCERT and LIST (info valid until STOREPASSWD)
                     if (command != PRINTCRL && command != PRINTCERT) {
-                        System.err.print(rb.getString("Enter.keystore.password."));
-                        System.err.flush();
-                        storePass = Password.readPassword(System.in);
+                        storePass = Password.toolReadPassword(
+                                rb.getString("Enter.keystore.password."));
                         passwords.add(storePass);
                     }
                 }
@@ -1728,27 +1722,26 @@ public final class Main {
                 MessageFormat form = new MessageFormat(rb.getString
                         ("Enter.key.password.for.alias."));
                 Object[] source = {alias};
-                System.err.print(form.format(source));
+                String prompt = form.format(source);
                 if (origPass != null) {
-                    System.err.println();
+                    prompt += "\n";
                     if (orig == null) {
-                        System.err.print(rb.getString
-                                (".RETURN.if.same.as.keystore.password."));
+                        prompt += rb.getString
+                                (".RETURN.if.same.as.keystore.password.");
                     } else {
                         form = new MessageFormat(rb.getString
                                 (".RETURN.if.same.as.for.otherAlias."));
                         Object[] src = {orig};
-                        System.err.print(form.format(src));
+                        prompt += form.format(src);
                     }
                 }
-                System.err.flush();
-                char[] entered = Password.readPassword(System.in);
+                char[] entered = Password.toolReadPassword(prompt);
                 passwords.add(entered);
                 if (entered == null && origPass != null) {
                     return origPass;
                 } else if (entered != null && entered.length >= 6) {
-                    System.err.print(rb.getString("Re.enter.new.password."));
-                    char[] passAgain = Password.readPassword(System.in);
+                    char[] passAgain = Password.toolReadPassword(
+                            rb.getString("Re.enter.new.password."));
                     passwords.add(passAgain);
                     if (!Arrays.equals(entered, passAgain)) {
                         System.err.println
@@ -1788,13 +1781,11 @@ public final class Main {
 
         int count;
         for (count = 0; count < 3; count++) {
-            System.err.print(
-                rb.getString("Enter.the.password.to.be.stored."));
-            System.err.flush();
-            char[] entered = Password.readPassword(System.in);
+            char[] entered = Password.toolReadPassword(
+                    rb.getString("Enter.the.password.to.be.stored."));
             passwords.add(entered);
-            System.err.print(rb.getString("Re.enter.password."));
-            char[] passAgain = Password.readPassword(System.in);
+            char[] passAgain = Password.toolReadPassword(
+                    rb.getString("Re.enter.password."));
             passwords.add(passAgain);
             if (!Arrays.equals(entered, passAgain)) {
                 System.err.println(rb.getString("They.don.t.match.Try.again"));
@@ -2402,9 +2393,8 @@ public final class Main {
                     && !srcprotectedPath
                     && !KeyStoreUtil.isWindowsKeyStore(srcstoretype)
                     && !srcIsPasswordless) {
-                System.err.print(rb.getString("Enter.source.keystore.password."));
-                System.err.flush();
-                srcstorePass = Password.readPassword(System.in);
+                srcstorePass = Password.toolReadPassword(
+                        rb.getString("Enter.source.keystore.password."));
                 passwords.add(srcstorePass);
             }
 
@@ -3484,8 +3474,7 @@ public final class Main {
             MessageFormat form = new MessageFormat
                 (rb.getString("New.prompt."));
             Object[] source = {prompt};
-            System.err.print(form.format(source));
-            entered = Password.readPassword(System.in);
+            entered = Password.toolReadPassword(form.format(source));
             passwords.add(entered);
             if (entered == null || entered.length < 6) {
                 System.err.println(rb.getString
@@ -3496,8 +3485,7 @@ public final class Main {
                 form = new MessageFormat
                         (rb.getString("Re.enter.new.prompt."));
                 Object[] src = {prompt};
-                System.err.print(form.format(src));
-                reentered = Password.readPassword(System.in);
+                reentered = Password.toolReadPassword(form.format(src));
                 passwords.add(reentered);
                 if (!Arrays.equals(entered, reentered)) {
                     System.err.println
@@ -3563,18 +3551,15 @@ public final class Main {
             MessageFormat form = new MessageFormat(rb.getString
                     ("Enter.key.password.for.alias."));
             Object[] source = {alias};
+            String prompt = form.format(source);
             if (otherKeyPass != null) {
-                System.err.println(form.format(source));
-
                 form = new MessageFormat(rb.getString
                         (".RETURN.if.same.as.for.otherAlias."));
                 Object[] src = {otherAlias};
-                System.err.print(form.format(src));
-            } else {
-                System.err.print(form.format(source));
+                prompt += form.format(src);
             }
             System.err.flush();
-            keyPass = Password.readPassword(System.in);
+            keyPass = Password.toolReadPassword(prompt);
             passwords.add(keyPass);
             if (keyPass == null) {
                 keyPass = otherKeyPass;

--- a/src/java.base/share/classes/sun/security/tools/keytool/resources/keytool.properties
+++ b/src/java.base/share/classes/sun/security/tools/keytool/resources/keytool.properties
@@ -36,6 +36,7 @@ Key.and.Certificate.Management.Tool=Key and Certificate Management Tool
 Commands.=Commands:
 Use.keytool.command.name.help.for.usage.of.command.name=Use "keytool -command_name --help" for usage of command_name.\n\
 Use the -conf <url> option to specify a pre-configured options file.
+for.more.information.see.the.online.documentation.at.=For more information, see the online documentation at:
 # keytool: help: commands
 Generates.a.certificate.request=Generates a certificate request
 Changes.an.entry.s.alias=Changes an entry's alias

--- a/src/java.base/share/classes/sun/security/tools/keytool/resources/keytool_zh_CN.properties
+++ b/src/java.base/share/classes/sun/security/tools/keytool/resources/keytool_zh_CN.properties
@@ -35,6 +35,7 @@ Use.keytool.help.for.all.available.commands=使用 "keytool -?, -h, or --help" �
 Key.and.Certificate.Management.Tool=密钥和证书管理工具
 Commands.=命令:
 Use.keytool.command.name.help.for.usage.of.command.name=使用 "keytool -command_name --help" 可获取 command_name 的用法。\n使用 -conf <url> 选项可指定预配置的选项文件。
+for.more.information.see.the.online.documentation.at.=如需了解更多信息，请访问在线手册页面：
 # keytool: help: commands
 Generates.a.certificate.request=生成证书请求
 Changes.an.entry.s.alias=更改条目的别名

--- a/src/java.base/share/classes/sun/security/util/Password.java
+++ b/src/java.base/share/classes/sun/security/util/Password.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,6 +36,24 @@ import jdk.internal.access.SharedSecrets;
  *
  */
 public class Password {
+
+    private static final String PASS_ECHO_WARNING
+            = ResourcesMgr.getString("pass.echo.warning");
+
+    /**
+     * Reads user password from stdin. Shows a warning if cannot suppress echo.
+     * Used by keytool and jarsigner.
+     */
+    public static char[] toolReadPassword(String prompt) throws IOException {
+        if (System.in != SharedSecrets.getJavaLangAccess().initialSystemIn() ||
+                System.console() == null) {
+            System.err.println(PASS_ECHO_WARNING);
+        }
+        System.err.print(prompt);
+        System.err.flush();
+        return readPassword(System.in, false);
+    }
+
     /** Reads user password from given input stream. */
     public static char[] readPassword(InputStream in) throws IOException {
         return readPassword(in, false);

--- a/src/java.base/share/classes/sun/security/util/Password.java
+++ b/src/java.base/share/classes/sun/security/util/Password.java
@@ -45,8 +45,10 @@ public class Password {
      * Used by keytool and jarsigner.
      */
     public static char[] toolReadPassword(String prompt) throws IOException {
-        if (System.in != SharedSecrets.getJavaLangAccess().initialSystemIn() ||
-                System.console() == null) {
+        // If the password is piped into the command, typically
+        // System.in.available() will not be zero. We don't show
+        // the warning in this case.
+        if (System.in.available() == 0 && System.console() == null) {
             System.err.println(PASS_ECHO_WARNING);
         }
         System.err.print(prompt);

--- a/src/java.base/share/classes/sun/security/util/resources/security.properties
+++ b/src/java.base/share/classes/sun/security/util/resources/security.properties
@@ -23,6 +23,9 @@
 # questions.
 #
 
+# sun.security.util.Password
+pass.echo.warning=Warning: password will be echoed because output is redirected.
+
 # javax.security.auth.PrivateCredentialPermission
 invalid.null.input.s.=invalid null input(s)
 actions.can.only.be.read.=actions can only be 'read'

--- a/src/java.base/share/classes/sun/security/util/resources/security_zh_CN.properties
+++ b/src/java.base/share/classes/sun/security/util/resources/security_zh_CN.properties
@@ -23,6 +23,9 @@
 # questions.
 #
 
+# sun.security.util.Password
+pass.echo.warning=警告：由于输出被重定向，密码将会被回显。
+
 # javax.security.auth.PrivateCredentialPermission
 invalid.null.input.s.=无效的空输入
 actions.can.only.be.read.=操作只能为 '读取'

--- a/src/java.base/share/man/keytool.md
+++ b/src/java.base/share/man/keytool.md
@@ -1222,7 +1222,8 @@ These options can appear for all commands operating on a keystore:
     -   `env`: Retrieve the password from the environment variable named
         *argument*.
 
-    -   `file`: Retrieve the password from the file named *argument*.
+    -   `file`: Retrieve the password from the file named *argument*. Only
+        the first line of the file is used, with the trailing newline removed.
 
     **Note:** All other options that require passwords, such as `-keypass`,
     `-srckeypass`, `-destkeypass`, `-srcstorepass`, and `-deststorepass`,
@@ -2346,10 +2347,15 @@ then there is no interaction with the user.
 
 Most commands that operate on a keystore require the store password. Some
 commands require a private/secret key password. Passwords can be specified on
-the command line in the `-storepass` and `-keypass` options. However, a
+the command line via options such as `-storepass` and `-keypass`. However, a
 password shouldn't be specified on a command line or in a script unless it is
-for testing, or you are on a secure system. When you don't specify a required
-password option on a command line, you are prompted for it.
+for testing, or you are on a secure system. As a safer alternative, use
+`-storepass:file` or `-storepass:env` to supply the password from a file or an
+environment variable.
+
+When you don't specify a required password option on a command line, you are
+prompted for it. Password input is typically hidden, unless the `keytool`
+output is redirected to a file or pipe, in which case the input may be echoed.
 
 ## Certificate Conformance Warning
 

--- a/src/jdk.jartool/share/classes/sun/security/tools/jarsigner/Main.java
+++ b/src/jdk.jartool/share/classes/sun/security/tools/jarsigner/Main.java
@@ -2726,10 +2726,8 @@ public class Main {
     }
 
     char[] getPass(String prompt) {
-        System.err.print(prompt);
-        System.err.flush();
         try {
-            char[] pass = Password.readPassword(System.in);
+            char[] pass = Password.toolReadPassword(prompt);
 
             if (pass == null) {
                 error(rb.getString("you.must.enter.key.password"));

--- a/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
+++ b/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
@@ -126,6 +126,11 @@ import static javax.swing.SwingUtilities.isEventDispatchThread;
  * the windows or frames registered in the {@code PassFailJFrame} framework
  * are created.
  *
+ * <p id="addButton">
+ * If you call {@link Builder#addButton(JButton)}, a new button will be added
+ * to the left side of the <i>Pass</i> button. This allows some customized
+ * actions to be performed. The method can be called multiple times.
+ *
  * <p id="logArea">
  * If you enable a log area, the instruction UI frame adds a text component
  * to display log messages below the buttons.
@@ -581,6 +586,7 @@ public final class PassFailJFrame {
         frame.add(createInstructionUIPanel(instructions,
                                            testTimeOut,
                                            rows, columns,
+                                           null,
                                            false,
                                            false, 0),
                   BorderLayout.CENTER);
@@ -599,6 +605,7 @@ public final class PassFailJFrame {
                 createInstructionUIPanel(builder.instructions,
                                          builder.testTimeOut,
                                          builder.rows, builder.columns,
+                                         builder.moreButtons,
                                          builder.screenCapture,
                                          builder.addLogArea,
                                          builder.logAreaRows);
@@ -620,6 +627,7 @@ public final class PassFailJFrame {
     private static JComponent createInstructionUIPanel(String instructions,
                                                        long testTimeOut,
                                                        int rows, int columns,
+                                                       List<JButton> moreButtons,
                                                        boolean enableScreenCapture,
                                                        boolean addLogArea,
                                                        int logAreaRows) {
@@ -656,6 +664,12 @@ public final class PassFailJFrame {
 
         JPanel buttonsPanel = new JPanel(new FlowLayout(FlowLayout.CENTER,
                                                         GAP, 0));
+        if (moreButtons != null) {
+            for (JButton title : moreButtons) {
+                buttonsPanel.add(title);
+            }
+        }
+
         buttonsPanel.add(btnPass);
         buttonsPanel.add(btnFail);
 
@@ -1365,6 +1379,7 @@ public final class PassFailJFrame {
         private int rows;
         private int columns;
         private boolean screenCapture;
+        private List<JButton> moreButtons;
         private boolean addLogArea;
         private int logAreaRows = 10;
 
@@ -1442,6 +1457,18 @@ public final class PassFailJFrame {
          */
         public Builder columns(int columns) {
             this.columns = columns;
+            return this;
+        }
+
+        /**
+         * Adds one more button to the left of the "pass" button.
+         *
+         * @param button the new button
+         * @return this builder
+         */
+        public Builder addButton(JButton button) {
+            if (moreButtons == null) moreButtons = new ArrayList<>();
+            moreButtons.add(button);
             return this;
         }
 

--- a/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
+++ b/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
@@ -72,6 +72,7 @@ import javax.swing.JSplitPane;
 import javax.swing.JTextArea;
 import javax.swing.Timer;
 import javax.swing.border.Border;
+import javax.swing.event.HyperlinkListener;
 import javax.swing.text.JTextComponent;
 import javax.swing.text.html.HTMLEditorKit;
 import javax.swing.text.html.StyleSheet;
@@ -98,7 +99,8 @@ import static javax.swing.SwingUtilities.isEventDispatchThread;
  * tester. The instructions can be either plain text or HTML. If the
  * text of the instructions starts with {@code "<html>"}, the
  * instructions are displayed as HTML, as supported by Swing, which
- * provides richer formatting options.
+ * provides richer formatting options. {@link Builder#addHyperlinkListener}
+ * can be called to add a listener to hyperlinks inside the HTML.
  * <p>
  * The instructions are displayed in a text component with word-wrapping
  * so that there's no horizontal scroll bar. If the text doesn't fit, a
@@ -125,11 +127,6 @@ import static javax.swing.SwingUtilities.isEventDispatchThread;
  * If the tester selects the <i>Capture Frames</i> mode, screenshots of all
  * the windows or frames registered in the {@code PassFailJFrame} framework
  * are created.
- *
- * <p id="addButton">
- * If you call {@link Builder#addButton(JButton)}, a new button will be added
- * to the left side of the <i>Pass</i> button. This allows some customized
- * actions to be performed. The method can be called multiple times.
  *
  * <p id="logArea">
  * If you enable a log area, the instruction UI frame adds a text component
@@ -605,7 +602,7 @@ public final class PassFailJFrame {
                 createInstructionUIPanel(builder.instructions,
                                          builder.testTimeOut,
                                          builder.rows, builder.columns,
-                                         builder.moreButtons,
+                                         builder.hyperlinkListener,
                                          builder.screenCapture,
                                          builder.addLogArea,
                                          builder.logAreaRows);
@@ -627,7 +624,7 @@ public final class PassFailJFrame {
     private static JComponent createInstructionUIPanel(String instructions,
                                                        long testTimeOut,
                                                        int rows, int columns,
-                                                       List<JButton> moreButtons,
+                                                       HyperlinkListener hyperlinkListener,
                                                        boolean enableScreenCapture,
                                                        boolean addLogArea,
                                                        int logAreaRows) {
@@ -640,9 +637,13 @@ public final class PassFailJFrame {
         JTextComponent text = instructions.startsWith("<html>")
                               ? configureHTML(instructions, rows, columns)
                               : configurePlainText(instructions, rows, columns);
+        if (hyperlinkListener != null && text instanceof JEditorPane ep) {
+            ep.addHyperlinkListener(hyperlinkListener);
+        }
         text.setEditable(false);
         text.setBorder(createTextBorder());
         text.setCaretPosition(0);
+        text.getCaret().setVisible(false);
 
         JPanel textPanel = new JPanel(new BorderLayout());
         textPanel.setBorder(createEmptyBorder(GAP, 0, GAP, 0));
@@ -664,12 +665,6 @@ public final class PassFailJFrame {
 
         JPanel buttonsPanel = new JPanel(new FlowLayout(FlowLayout.CENTER,
                                                         GAP, 0));
-        if (moreButtons != null) {
-            for (JButton title : moreButtons) {
-                buttonsPanel.add(title);
-            }
-        }
-
         buttonsPanel.add(btnPass);
         buttonsPanel.add(btnFail);
 
@@ -1379,7 +1374,7 @@ public final class PassFailJFrame {
         private int rows;
         private int columns;
         private boolean screenCapture;
-        private List<JButton> moreButtons;
+        HyperlinkListener hyperlinkListener;
         private boolean addLogArea;
         private int logAreaRows = 10;
 
@@ -1461,14 +1456,13 @@ public final class PassFailJFrame {
         }
 
         /**
-         * Adds one more button to the left of the "pass" button.
+         * Set the HyperlinkListener of links inside the instructions pane.
          *
-         * @param button the new button
+         * @param hyperlinkListener the listener
          * @return this builder
          */
-        public Builder addButton(JButton button) {
-            if (moreButtons == null) moreButtons = new ArrayList<>();
-            moreButtons.add(button);
+        public Builder addHyperlinkListener(HyperlinkListener hyperlinkListener) {
+            this.hyperlinkListener = hyperlinkListener;
             return this;
         }
 

--- a/test/jdk/sun/security/tools/keytool/EchoPassword.java
+++ b/test/jdk/sun/security/tools/keytool/EchoPassword.java
@@ -30,10 +30,11 @@
  * @run main/manual/othervm EchoPassword
  */
 
-import javax.swing.*;
+import javax.swing.JEditorPane;
+import javax.swing.JLabel;
 import javax.swing.event.HyperlinkEvent;
 
-import java.awt.*;
+import java.awt.Toolkit;
 import java.awt.datatransfer.StringSelection;
 import java.io.File;
 

--- a/test/jdk/sun/security/tools/keytool/EchoPassword.java
+++ b/test/jdk/sun/security/tools/keytool/EchoPassword.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8354469
+ * @summary keytool password prompt shows warning when cannot suppress echo
+ * @library /test/lib
+ * @run main/manual/othervm EchoPassword
+ */
+import javax.swing.*;
+
+import jdk.test.lib.UIBuilder;
+
+import java.io.File;
+
+public class EchoPassword {
+
+    private static final int TIMEOUT_MS = 240000;
+    private volatile boolean failed = false;
+    private volatile boolean aborted = false;
+    private Thread currentThread = null;
+
+    public static void main(String[] args) throws Exception {
+        final String keytool = String.format("\"%s/bin/keytool\" -keystore 8354469.ks",
+                System.getProperty("java.home").replace("\\", File.separator));
+        boolean testFailed = new EchoPassword().validate(
+                "Please copy and run the following commands in a Terminal or Windows Command Prompt window:",
+                String.format("""
+
+                1. %s -genkeypair
+
+                   When prompted, enter "password" and press Enter. Verify that the input is hidden,
+                   and no warning about password echoing appears. At the Re-enter password prompt,
+                   press Ctrl-C to exit.
+
+                2. %s -genkeypair | type
+
+                   When prompted, enter "password" and press Enter. Verify that the input is echoed,
+                   and a warning about password echoing is shown. At the Re-enter password prompt,
+                   press Ctrl-C to exit.
+
+                Press "pass" if the behavior matches expectations; otherwise, press "fail".
+                """, keytool, keytool));
+        if (testFailed) {
+            throw new RuntimeException("Test has failed");
+        }
+    }
+
+    public boolean validate(String instruction, String message) {
+        failed = false;
+        currentThread = Thread.currentThread();
+        final JDialog dialog = new UIBuilder.DialogBuilder()
+                .setTitle("Password")
+                .setInstruction(instruction)
+                .setMessage(message)
+                .setPassAction(e -> pass())
+                .setFailAction(e -> fail())
+                .setCloseAction(this::abort)
+                .build();
+
+        SwingUtilities.invokeLater(() -> {
+            try {
+                dialog.setVisible(true);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        try {
+            Thread.sleep(TIMEOUT_MS);
+            //Timed out, so fail the test
+            throw new RuntimeException(
+                    "Timed out after " + TIMEOUT_MS / 1000 + " seconds");
+        } catch (final InterruptedException e) {
+            if (aborted) {
+                throw new RuntimeException("TEST ABORTED");
+            }
+
+            if (failed) {
+                System.out.println("TEST FAILED");
+                System.out.println(message);
+            } else {
+                System.out.println("TEST PASSED");
+            }
+        } finally {
+            dialog.dispose();
+        }
+
+        return failed;
+    }
+
+    public void pass() {
+        failed = false;
+        currentThread.interrupt();
+    }
+
+    public void fail() {
+        failed = true;
+        currentThread.interrupt();
+    }
+
+    public void abort() {
+        aborted = true;
+        currentThread.interrupt();
+    }
+}

--- a/test/jdk/sun/security/tools/keytool/KeyToolTest.java
+++ b/test/jdk/sun/security/tools/keytool/KeyToolTest.java
@@ -637,12 +637,12 @@ public class KeyToolTest {
         // when specify keypass, make sure keypass==storepass...
         testOK("changeit\n", "-keystore x.p12 -keypass changeit " +
                 "-storetype PKCS12 -genkeypair -keyalg DSA -alias p3 -dname CN=olala");
-        assertTrue(err.indexOf("Warning") == -1,
+        assertTrue(err.indexOf("Warning:  Different store and key passwords") == -1,
                 "PKCS12 silent when keypass == storepass");
         // otherwise, print a warning
         testOK("changeit\n", "-keystore x.p12 -keypass another" +
                 " -storetype PKCS12 -genkeypair -keyalg DSA -alias p2 -dname CN=olala");
-        assertTrue(err.indexOf("Warning") != -1,
+        assertTrue(err.indexOf("Warning:  Different store and key passwords") != -1,
                 "PKCS12 warning when keypass != storepass");
         // no -keypasswd for PKCS12
         testFail("", "-keystore x.p12 -storepass changeit -storetype PKCS12" +

--- a/test/jdk/sun/security/util/Resources/Usages.java
+++ b/test/jdk/sun/security/util/Resources/Usages.java
@@ -137,6 +137,8 @@ public class Usages {
             List.of(
                     new Pair("jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/SunPKCS11.java",
                             List.of(MGR_GETSTRING)),
+                    new Pair("java.base/share/classes/sun/security/util/Password.java",
+                            List.of(MGR_GETSTRING)),
                     new Pair("java.base/share/classes/sun/security/provider/PolicyParser.java",
                             List.of(LOC_GETNONLOC, NEW_LOC)),
                     new Pair("java.base/share/classes/javax/security/auth/",


### PR DESCRIPTION
Add more description on password handling into the keytool man page. A link to the man page is now added to the keytool help screen.

When keytool output is redirected into a file or file, a warning is shown:
```
$ keytool -genkeypair | type

Warning: password will be echoed because output is redirected.
Enter keystore password:  password
Warning: password will be echoed because output is redirected.
Re-enter new password:
```

A new manual test is added.

Sorry we cannot suppress password echoing in this case at the moment because `System.console()` is not available.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8354469](https://bugs.openjdk.org/browse/JDK-8354469): Keytool exposes the password in plain text when command is piped using | grep (**Enhancement** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24805/head:pull/24805` \
`$ git checkout pull/24805`

Update a local copy of the PR: \
`$ git checkout pull/24805` \
`$ git pull https://git.openjdk.org/jdk.git pull/24805/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24805`

View PR using the GUI difftool: \
`$ git pr show -t 24805`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24805.diff">https://git.openjdk.org/jdk/pull/24805.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24805#issuecomment-2822814731)
</details>
