### PR TITLE
8355335: Avoid pattern matching switches in core ClassFile API

### DIFF
--- a/src/java.base/share/classes/jdk/internal/classfile/impl/BlockCodeBuilderImpl.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/BlockCodeBuilderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -72,11 +72,10 @@ public final class BlockCodeBuilderImpl
     }
 
     private int topLocal(CodeBuilder parent) {
-        return switch (parent) {
-            case BlockCodeBuilderImpl b -> b.topLocal;
-            case ChainedCodeBuilder b -> b.terminal.curTopLocal();
-            case TerminalCodeBuilder b -> b.curTopLocal();
-        };
+        if (parent instanceof BlockCodeBuilderImpl bcb) {
+            return bcb.topLocal;
+        }
+        return findTerminal(parent).curTopLocal();
     }
 
     @Override

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/ChainedClassBuilder.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/ChainedClassBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,10 +39,8 @@ public final class ChainedClassBuilder
     public ChainedClassBuilder(ClassBuilder downstream,
                                Consumer<ClassElement> consumer) {
         this.consumer = consumer;
-        this.terminal = switch (downstream) {
-            case ChainedClassBuilder cb -> cb.terminal;
-            case DirectClassBuilder db -> db;
-        };
+        this.terminal = downstream instanceof ChainedClassBuilder ccb ?
+                ccb.terminal : (DirectClassBuilder) downstream;
     }
 
     @Override

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/ChainedFieldBuilder.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/ChainedFieldBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,10 +38,8 @@ public final class ChainedFieldBuilder implements FieldBuilder {
     public ChainedFieldBuilder(FieldBuilder downstream,
                                Consumer<FieldElement> consumer) {
         this.consumer = consumer;
-        this.terminal = switch (downstream) {
-            case ChainedFieldBuilder cb -> cb.terminal;
-            case TerminalFieldBuilder tb -> tb;
-        };
+        this.terminal = downstream instanceof ChainedFieldBuilder cfb ?
+                cfb.terminal : (TerminalFieldBuilder) downstream;
     }
 
     @Override

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/ChainedMethodBuilder.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/ChainedMethodBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,10 +41,8 @@ public final class ChainedMethodBuilder implements MethodBuilder {
     public ChainedMethodBuilder(MethodBuilder downstream,
                                 Consumer<MethodElement> consumer) {
         this.consumer = consumer;
-        this.terminal = switch (downstream) {
-            case ChainedMethodBuilder cb -> cb.terminal;
-            case TerminalMethodBuilder tb -> tb;
-        };
+        this.terminal = downstream instanceof ChainedMethodBuilder cmb ?
+                cmb.terminal : (TerminalMethodBuilder) downstream;
     }
 
     @Override

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/CodeImpl.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/CodeImpl.java
@@ -264,14 +264,16 @@ public final class CodeImpl
                 //fallback to jump targets inflation without StackMapTableAttribute
                 for (int pos=codeStart; pos<codeEnd; ) {
                     var i = bcToInstruction(classReader.readU1(pos), pos);
-                    switch (i) {
-                        case BranchInstruction br -> br.target();
-                        case DiscontinuedInstruction.JsrInstruction jsr -> jsr.target();
-                        case LookupSwitchInstruction ls -> {
+                    switch (i.opcode().kind()) {
+                        case BRANCH -> ((BranchInstruction) i).target();
+                        case DISCONTINUED_JSR -> ((DiscontinuedInstruction.JsrInstruction) i).target();
+                        case LOOKUP_SWITCH -> {
+                            var ls = (LookupSwitchInstruction) i;
                             ls.defaultTarget();
                             ls.cases();
                         }
-                        case TableSwitchInstruction ts -> {
+                        case TABLE_SWITCH -> {
+                            var ts = (TableSwitchInstruction) i;
                             ts.defaultTarget();
                             ts.cases();
                         }

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/NonterminalCodeBuilder.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/NonterminalCodeBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,10 +35,12 @@ public abstract sealed class NonterminalCodeBuilder implements CodeBuilder
 
     public NonterminalCodeBuilder(CodeBuilder parent) {
         this.parent = parent;
-        this.terminal = switch (parent) {
-            case NonterminalCodeBuilder cb -> cb.terminal;
-            case TerminalCodeBuilder cb -> cb;
-        };
+        this.terminal = findTerminal(parent);
+    }
+
+    static TerminalCodeBuilder findTerminal(CodeBuilder cob) {
+        return cob instanceof NonterminalCodeBuilder ncb ?
+                ncb.terminal : (TerminalCodeBuilder) cob;
     }
 
     @Override


### PR DESCRIPTION
A few pattern matching switches exist in the core parts of ClassFile API responsible for transformations and parsing. They are likely to be used in early bootstrap, and pattern matching switches require bootstrap methods, which depend on core ClassFile API.

For example, currently BlockCodeBuilderImpl prevents BlockCodeBuilder from being used in early bootstrap; luckily we are currently all using manual labels, and as a result this does not surface in lambdas.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8355335](https://bugs.openjdk.org/browse/JDK-8355335): Avoid pattern matching switches in core ClassFile API (**Bug** - P4)


### Reviewers
 * [Adam Sotona](https://openjdk.org/census#asotona) (@asotona - **Reviewer**)

### Reviewers without OpenJDK IDs
 * @abdelhak-zaaim (no known openjdk.org user name / role)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24807/head:pull/24807` \
`$ git checkout pull/24807`

Update a local copy of the PR: \
`$ git checkout pull/24807` \
`$ git pull https://git.openjdk.org/jdk.git pull/24807/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24807`

View PR using the GUI difftool: \
`$ git pr show -t 24807`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24807.diff">https://git.openjdk.org/jdk/pull/24807.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24807#issuecomment-2822706886)
</details>
