### PR TITLE
8354877: DirectClassBuilder default flags should include ACC_SUPER

### DIFF
--- a/src/java.base/share/classes/jdk/internal/classfile/impl/DirectClassBuilder.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/DirectClassBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2024, Alibaba Group Holding Limited. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -42,7 +42,7 @@ public final class DirectClassBuilder
         implements ClassBuilder {
 
     /** The value of default class access flags */
-    static final int DEFAULT_CLASS_FLAGS = ClassFile.ACC_PUBLIC;
+    static final int DEFAULT_CLASS_FLAGS = ClassFile.ACC_PUBLIC | ClassFile.ACC_SUPER;
     static final Util.Writable[] EMPTY_WRITABLE_ARRAY = {};
     static final ClassEntry[] EMPTY_CLASS_ENTRY_ARRAY = {};
     final ClassEntry thisClassEntry;


### PR DESCRIPTION
In the future value objects JEP, class files must have one of ACC_IDENTITY (now ACC_SUPER), ACC_ABSTRACT, and ACC_FINAL bits set, otherwise they are rejected. The current default flag has none of these bits set, meaning that it will not be suitable in the future. Currently, most class file generation in the JDK explicitly set ACC_SUPER for compatibility; we should also set this bit in the default flags, despite being no-op, in anticipation of future compatibility.

The API specifications of ClassBuilder and AccessFlags already state that an unspecified default flag for class builders are chosen, so changing this flag should be fine without extra specification changes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8354877](https://bugs.openjdk.org/browse/JDK-8354877): DirectClassBuilder default flags should include ACC_SUPER (**Bug** - P4)


### Reviewers
 * [Adam Sotona](https://openjdk.org/census#asotona) (@asotona - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24808/head:pull/24808` \
`$ git checkout pull/24808`

Update a local copy of the PR: \
`$ git checkout pull/24808` \
`$ git pull https://git.openjdk.org/jdk.git pull/24808/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24808`

View PR using the GUI difftool: \
`$ git pr show -t 24808`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24808.diff">https://git.openjdk.org/jdk/pull/24808.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24808#issuecomment-2822742688)
</details>
