### PR TITLE
8355211: nsk/jdi/EventRequest/disable/disable001.java should use JDIBase superclass

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventRequest/disable/disable001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventRequest/disable/disable001.java
@@ -246,6 +246,8 @@ public class disable001 extends JDIBase {
 
         BreakpointRequest bpRequest =
             setupBreakpointForCommunication(debuggeeClass);
+        // setupBreakpointForCommunication() defaults to SUSPEND_EVENT_THREAD. We need
+        // to change this to SUSPEND_ALL.
         bpRequest.disable();
         bpRequest.setSuspendPolicy(EventRequest.SUSPEND_ALL);
         bpRequest.enable();

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventRequest/disable/disable001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventRequest/disable/disable001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -76,20 +76,7 @@ import java.io.*;
  * <BR>
  */
 
-public class disable001 {
-
-    //----------------------------------------------------- templete section
-    static final int PASSED = 0;
-    static final int FAILED = 2;
-    static final int PASS_BASE = 95;
-
-    //----------------------------------------------------- templete parameters
-    static final String
-    sHeader1 = "\n==> nsk/jdi/EventRequest/disable/disable001 ",
-    sHeader2 = "--> debugger: ",
-    sHeader3 = "##> debugger: ";
-
-    //----------------------------------------------------- main method
+public class disable001 extends JDIBase {
 
     public static void main (String argv[]) {
 
@@ -110,20 +97,6 @@ public class disable001 {
         return exitCode;
     }
 
-    //--------------------------------------------------   log procedures
-
-    private static Log  logHandler;
-
-    private static void log1(String message) {
-        logHandler.display(sHeader1 + message);
-    }
-    private static void log2(String message) {
-        logHandler.display(sHeader2 + message);
-    }
-    private static void log3(String message) {
-        logHandler.complain(sHeader3 + message);
-    }
-
     //  ************************************************    test parameters
 
     private String debuggeeName =
@@ -132,28 +105,7 @@ public class disable001 {
     private String testedClassName =
        "nsk.jdi.EventRequest.disable.disable001aTestClass11";
 
-    Location location = null;               // !!!!!!!!!!!!! see settingBreakpoint
-
     //====================================================== test program
-    //------------------------------------------------------ common section
-
-    static Debugee          debuggee;
-    static ArgumentHandler  argsHandler;
-
-    static int waitTime;
-
-    static VirtualMachine      vm            = null;
-    static EventRequestManager eventRManager = null;
-    static EventQueue          eventQueue    = null;
-    static EventSet            eventSet      = null;
-    static EventIterator       eventIterator = null;
-
-    static ReferenceType       debuggeeClass = null;
-
-    static int  testExitCode = PASSED;
-
-
-    //------------------------------------------------------ methods
 
     private int runThis (String argv[], PrintStream out) {
 
@@ -292,14 +244,10 @@ public class disable001 {
 
         log2("      received: ClassPrepareEvent for debuggeeClass");
 
-        String bPointMethod = "methodForCommunication";
-        String lineForComm  = "lineForComm";
-
-        ThreadReference   mainThread = debuggee.threadByNameOrThrow("main");
-
-        BreakpointRequest bpRequest = settingBreakpoint(mainThread,
-                                             debuggeeClass,
-                                            bPointMethod, lineForComm, "zero");
+        BreakpointRequest bpRequest =
+            setupBreakpointForCommunication(debuggeeClass);
+        bpRequest.disable();
+        bpRequest.setSuspendPolicy(EventRequest.SUSPEND_ALL);
         bpRequest.enable();
 
     //------------------------------------------------------  testing section
@@ -405,7 +353,7 @@ public class disable001 {
 
               case 11:
                      log2(".....setting up BreakpointRequest");
-                     eventRequest1 = eventRManager.createBreakpointRequest(location);
+                     eventRequest1 = eventRManager.createBreakpointRequest(breakpLocation);
                      break;
 
 
@@ -432,101 +380,6 @@ public class disable001 {
         }
         log1("    TESTING ENDS");
         return;
-    }
-
-   /*
-    * private BreakpointRequest settingBreakpoint(ThreadReference, ReferenceType,
-    *                                             String, String, String)
-    *
-    * It sets up a breakpoint at given line number within a given method in a given class
-    * for a given thread.
-    *
-    * Return value: BreakpointRequest object  in case of success
-    *
-    * JDITestRuntimeException   in case of an Exception thrown within the method
-    */
-
-    private BreakpointRequest settingBreakpoint ( ThreadReference thread,
-                                                  ReferenceType testedClass,
-                                                  String methodName,
-                                                  String bpLine,
-                                                  String property)
-            throws JDITestRuntimeException {
-
-        log2("......setting up a breakpoint:");
-        log2("       thread: " + thread + "; class: " + testedClass +
-                        "; method: " + methodName + "; line: " + bpLine);
-
-        List              alllineLocations = null;
-        Location          lineLocation     = null;
-        BreakpointRequest breakpRequest    = null;
-
-        try {
-            Method  method  = (Method) testedClass.methodsByName(methodName).get(0);
-
-            alllineLocations = method.allLineLocations();
-
-            int n =
-                ( (IntegerValue) testedClass.getValue(testedClass.fieldByName(bpLine) ) ).value();
-            if (n > alllineLocations.size()) {
-                log3("ERROR:  TEST_ERROR_IN_settingBreakpoint(): number is out of bound of method's lines");
-            } else {
-                lineLocation = (Location) alllineLocations.get(n);
-
-// this is only for this test to get Location object
-location = lineLocation;
-
-                try {
-                    breakpRequest = eventRManager.createBreakpointRequest(lineLocation);
-                    breakpRequest.putProperty("number", property);
-                    breakpRequest.addThreadFilter(thread);
-                    breakpRequest.setSuspendPolicy( EventRequest.SUSPEND_ALL);
-                } catch ( Exception e1 ) {
-                    log3("ERROR: inner Exception within settingBreakpoint() : " + e1);
-                    breakpRequest    = null;
-                }
-            }
-        } catch ( Exception e2 ) {
-            log3("ERROR: ATTENTION:  outer Exception within settingBreakpoint() : " + e2);
-            breakpRequest    = null;
-        }
-
-        if (breakpRequest == null) {
-            log2("      A BREAKPOINT HAS NOT BEEN SET UP");
-            throw new JDITestRuntimeException("**FAILURE to set up a breakpoint**");
-        }
-
-        log2("      a breakpoint has been set up");
-        return breakpRequest;
-    }
-
-
-    private void getEventSet()
-                 throws JDITestRuntimeException {
-        try {
-//            log2("       eventSet = eventQueue.remove(waitTime);");
-            eventSet = eventQueue.remove(waitTime);
-            if (eventSet == null) {
-                throw new JDITestRuntimeException("** TIMEOUT while waiting for event **");
-            }
-//            log2("       eventIterator = eventSet.eventIterator;");
-            eventIterator = eventSet.eventIterator();
-        } catch ( Exception e ) {
-            throw new JDITestRuntimeException("** EXCEPTION while waiting for event ** : " + e);
-        }
-    }
-
-
-    private void breakpointForCommunication()
-                 throws JDITestRuntimeException {
-
-        log2("breakpointForCommunication");
-        getEventSet();
-
-        if (eventIterator.nextEvent() instanceof BreakpointEvent)
-            return;
-
-        throw new JDITestRuntimeException("** event IS NOT a breakpoint **");
     }
 
 }


### PR DESCRIPTION
There is an nsk/jdi superclass called JDIBase that many tests inherit from. It provides common functionality like log support, basic event handling, support for setting a breakpoint, and support for the communication breakpoint that the debugger and debuggee use to synchronize with. disable001 does not inherit from JDIBase and instead implements all this functionality in the test. The reason is because it provides a slightly modified version of the JDIBase.settingBreakpoint() method. The main change is the presence of the following in settingBreakpoint():

```
// this is only for this test to get Location object
location = lineLocation;
```

And then in the test:

```
              case 11:
                     log2(".....setting up BreakpointRequest");
                     eventRequest1 = eventRManager.createBreakpointRequest(location);
                     break;
```

However, now JDIBase.settingBreakpoint() now contains:

```
                lineLocation = (Location) alllineLocations.get(n);
                breakpLocation = lineLocation;
```

So the test can just use breakpLocation instead. This pattern is already replicated in a large number of tests.

The other difference in the disable001 version of settingBreakpoint() is that is uses SUSPEND_ALL rather than SUSPEND_EVENT_THREAD. This is easily fixed after setting up the breakpoint request:

        BreakpointRequest bpRequest = settingBreakpoint(mainThread,
                                             debuggeeClass,
                                            bPointMethod, lineForComm, "zero");
        bpRequest.setSuspendPolicy(EventRequest.SUSPEND_ALL);

The test uses JDIBase now and all the code replicated from JDIBase has been stripped out. It is also updated to use the new JDIBase.setupBreakpointForCommunication() method.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8355211](https://bugs.openjdk.org/browse/JDK-8355211): nsk/jdi/EventRequest/disable/disable001.java should use JDIBase superclass (**Enhancement** - P4)


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24811/head:pull/24811` \
`$ git checkout pull/24811`

Update a local copy of the PR: \
`$ git checkout pull/24811` \
`$ git pull https://git.openjdk.org/jdk.git pull/24811/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24811`

View PR using the GUI difftool: \
`$ git pr show -t 24811`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24811.diff">https://git.openjdk.org/jdk/pull/24811.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24811#issuecomment-2822956731)
</details>
