### PR TITLE
8355214

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadStartRequest/addThreadFilter/addthreadfilter002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadStartRequest/addThreadFilter/addthreadfilter002.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -75,20 +75,7 @@ import java.io.*;
  * <BR>
  */
 
-public class addthreadfilter002 {
-
-    //----------------------------------------------------- templete section
-    static final int PASSED = 0;
-    static final int FAILED = 2;
-    static final int PASS_BASE = 95;
-
-    //----------------------------------------------------- templete parameters
-    static final String
-    sHeader1 = "\n==> nsk/jdi/ThreadStartRequest/addThreadFilter/addthreadfilter002 ",
-    sHeader2 = "--> debugger: ",
-    sHeader3 = "##> debugger: ";
-
-    //----------------------------------------------------- main method
+public class addthreadfilter002 extends JDIBase {
 
     public static void main (String argv[]) {
 
@@ -109,43 +96,12 @@ public class addthreadfilter002 {
         return exitCode;
     }
 
-    //--------------------------------------------------   log procedures
-
-    private static Log  logHandler;
-
-    private static void log1(String message) {
-        logHandler.display(sHeader1 + message);
-    }
-    private static void log2(String message) {
-        logHandler.display(sHeader2 + message);
-    }
-    private static void log3(String message) {
-        logHandler.complain(sHeader3 + message);
-    }
-
     //  ************************************************    test parameters
 
     private String debuggeeName =
         "nsk.jdi.ThreadStartRequest.addThreadFilter.addthreadfilter002a";
 
     //====================================================== test program
-    //------------------------------------------------------ common section
-
-    static Debugee          debuggee;
-    static ArgumentHandler  argsHandler;
-
-    static int waitTime;
-
-    static VirtualMachine      vm            = null;
-    static EventRequestManager eventRManager = null;
-    static EventQueue          eventQueue    = null;
-    static EventSet            eventSet      = null;
-    static EventIterator       eventIterator = null;
-
-    static ReferenceType       debuggeeClass = null;
-
-    static int  testExitCode = PASSED;
-
 
     //------------------------------------------------------ methods
 
@@ -287,16 +243,7 @@ public class addthreadfilter002 {
 
         log2("      received: ClassPrepareEvent for debuggeeClass");
 
-        String bPointMethod = "methodForCommunication";
-        String lineForComm  = "lineForComm";
-        BreakpointRequest bpRequest;
-
-        ThreadReference mainThread = debuggee.threadByNameOrThrow("main");
-
-        bpRequest = settingBreakpoint(mainThread,
-                                      debuggeeClass,
-                                      bPointMethod, lineForComm, "zero");
-        bpRequest.enable();
+        setupBreakpointForCommunication(debuggeeClass);
 
     //------------------------------------------------------  testing section
 
@@ -307,6 +254,7 @@ public class addthreadfilter002 {
 
             vm.resume();
             breakpointForCommunication();
+            ThreadReference mainThread = bpEvent.thread(); // bpEvent saved by breakpointForCommunication()
 
             int instruction = ((IntegerValue)
                                (debuggeeClass.getValue(debuggeeClass.fieldByName("instruction")))).value();
@@ -376,110 +324,6 @@ public class addthreadfilter002 {
         }
         log1("    TESTING ENDS");
         return;
-    }
-
-   /*
-    * private BreakpointRequest settingBreakpoint(ThreadReference, ReferenceType,
-    *                                             String, String, String)
-    *
-    * It sets up a breakpoint at given line number within a given method in a given class
-    * for a given thread.
-    *
-    * Return value: BreakpointRequest object  in case of success
-    *
-    * JDITestRuntimeException   in case of an Exception thrown within the method
-    */
-
-    private BreakpointRequest settingBreakpoint ( ThreadReference thread,
-                                                  ReferenceType testedClass,
-                                                  String methodName,
-                                                  String bpLine,
-                                                  String property)
-            throws JDITestRuntimeException {
-
-        log2("......setting up a breakpoint:");
-        log2("       thread: " + thread + "; class: " + testedClass +
-                        "; method: " + methodName + "; line: " + bpLine);
-
-        List              alllineLocations = null;
-        Location          lineLocation     = null;
-        BreakpointRequest breakpRequest    = null;
-
-        try {
-            Method  method  = (Method) testedClass.methodsByName(methodName).get(0);
-
-            alllineLocations = method.allLineLocations();
-
-            int n =
-                ( (IntegerValue) testedClass.getValue(testedClass.fieldByName(bpLine) ) ).value();
-            if (n > alllineLocations.size()) {
-                log3("ERROR:  TEST_ERROR_IN_settingBreakpoint(): number is out of bound of method's lines");
-            } else {
-                lineLocation = (Location) alllineLocations.get(n);
-                try {
-                    breakpRequest = eventRManager.createBreakpointRequest(lineLocation);
-                    breakpRequest.putProperty("number", property);
-                    breakpRequest.addThreadFilter(thread);
-                    breakpRequest.setSuspendPolicy( EventRequest.SUSPEND_EVENT_THREAD);
-                } catch ( Exception e1 ) {
-                    log3("ERROR: inner Exception within settingBreakpoint() : " + e1);
-                    breakpRequest    = null;
-                }
-            }
-        } catch ( Exception e2 ) {
-            log3("ERROR: ATTENTION:  outer Exception within settingBreakpoint() : " + e2);
-            breakpRequest    = null;
-        }
-
-        if (breakpRequest == null) {
-            log2("      A BREAKPOINT HAS NOT BEEN SET UP");
-            throw new JDITestRuntimeException("**FAILURE to set up a breakpoint**");
-        }
-
-        log2("      a breakpoint has been set up");
-        return breakpRequest;
-    }
-
-
-    private void getEventSet()
-                 throws JDITestRuntimeException {
-        try {
-//            log2("       eventSet = eventQueue.remove(waitTime);");
-            eventSet = eventQueue.remove(waitTime);
-            if (eventSet == null) {
-                throw new JDITestRuntimeException("** TIMEOUT while waiting for event **");
-            }
-//            log2("       eventIterator = eventSet.eventIterator;");
-            eventIterator = eventSet.eventIterator();
-        } catch ( Exception e ) {
-            throw new JDITestRuntimeException("** EXCEPTION while waiting for event ** : " + e);
-        }
-    }
-
-
-    private void breakpointForCommunication()
-                 throws JDITestRuntimeException {
-
-        log2("breakpointForCommunication");
-        while (true) {
-            getEventSet();
-            while (eventIterator.hasNext()) {
-                Event event = eventIterator.nextEvent();
-                if (event instanceof BreakpointEvent) {
-                    return;
-                } else if (event instanceof ThreadStartEvent) {
-                    // It might be the case that while the thread start request was enabled
-                    // some threads not related to the test ( e.g. JVMCI threads) were started
-                    // and generated thread start events. We ignore these thread start events
-                    // and keep waiting for a breakpoint event.
-                    ThreadStartEvent tse = (ThreadStartEvent) event;
-                    log2("ThreadStartEvent is received while waiting for a breakpoint" +
-                            " event, thread: : " + tse.thread().name());
-                    continue;
-                }
-                throw new JDITestRuntimeException("** event IS NOT a breakpoint or a thread start **");
-            }
-        }
     }
 
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/EventFilters.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/EventFilters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -341,11 +341,12 @@ public class EventFilters
                 "VirtualThread-unparker",
                 "Cleaner-",
                 "Common-Cleaner",
+                "CompilerThread",
                 "FinalizerThread",
                 "ForkJoinPool"
             };
             for (String s : knownThreads) {
-                if (tname.startsWith(s)) {
+                if (tname.indexOf(s) != -1) {
                     return true;
                 }
             }

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/JDIBase.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/JDIBase.java
@@ -239,6 +239,9 @@ public class JDIBase {
 
             if (EventFilters.filtered(event)) {
                 // We filter out spurious ThreadStartEvents
+                ThreadStartEvent tse = (ThreadStartEvent) event;
+                log2("ThreadStartEvent is received while waiting for a breakpoint" +
+                     " event, thread: : " + tse.thread().name());
                 continue;
             }
 


### PR DESCRIPTION
There is nsk/jdi superclass called JDIBase that many tests inherit from. It provides common functionality like log support, basic event handling, support for setting a breakpoint, and support for the communcation breakpoint that the debugger and debuggee used to synchronize with. addthreadfilter001 does not inherit from JDIBase and instead implements all this functionality in the test. The reason is because it provides a slightly modified version of the JDIBase.breakpointForCommunication() method.

```
                } else if (event instanceof ThreadStartEvent) {
                    // It might be the case that while the thread start request was enabled
                    // some threads not related to the test ( e.g. JVMCI threads) were started
                    // and generated thread start events. We ignore these thread start events
                    // and keep waiting for a breakpoint event.
                    ThreadStartEvent tse = (ThreadStartEvent) event;
                    log2("ThreadStartEvent is received while waiting for a breakpoint" +
                            " event, thread: : " + tse.thread().name());
                    continue;
                }
```

However, this code seems to predate adding similar code to the JDIBase version of breakpointForCommunication():

```
            if (EventFilters.filtered(event)) {
                // We filter out spurious ThreadStartEvents
                continue;
            }
```

The test now uses JDIBase and gets rid of the replicated code that is already in JDIBase. It is also updated to use the new JDIBase.breakpointForCommunication() method. 

Note: The code in the test mentions JVMCI and the CR mentions graal, so this test likely originally failed due to the creation of a graal compiler thread.  EventFilters.filtered() was not handling this thread name, which can have various names but always contains "Compiler", so I updated it the method to also filter out "Compiler" methods.