### PR TITLE
8355221: Get rid of unnecessary override of JDIBase.breakpointForCommunication in nsk/jdi tests

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassPrepareRequest/addClassExclusionFilter/filter003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassPrepareRequest/addClassExclusionFilter/filter003.java
@@ -311,7 +311,7 @@ public class filter003 extends JDIBase {
 
 
             vm.resume();
-            breakpointForCommunication();
+            breakpointForCommunication(debuggeeName);
 
             int instruction = ((IntegerValue)
                                (debuggeeClass.getValue(debuggeeClass.fieldByName("instruction")))).value();
@@ -325,30 +325,6 @@ public class filter003 extends JDIBase {
         }
         log1("    TESTING ENDS");
         return;
-    }
-
-    protected void breakpointForCommunication()
-            throws JDITestRuntimeException {
-        log2("breakpointForCommunication");
-
-        do {
-            getEventSet();
-
-            Event event = eventIterator.nextEvent();
-            if (event instanceof BreakpointEvent)
-                return;
-
-            log2("      received: " + event);
-
-            if (EventFilters.filtered(event, debuggeeName)) {
-                eventSet.resume();
-            }
-            else {
-                break;
-            }
-        } while (true);
-
-        throw new JDITestRuntimeException("** event IS NOT a breakpoint **");
     }
 
     // ============================== test's additional methods

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassPrepareRequest/addClassFilter_rt/filter_rt002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassPrepareRequest/addClassFilter_rt/filter_rt002.java
@@ -264,7 +264,7 @@ public class filter_rt002 extends JDIBase {
         for (int i = 0; ; i++) {
 
             vm.resume();
-            breakpointForCommunication();
+            breakpointForCommunication(debuggeeName);
 
             int instruction = ((IntegerValue)
                                (debuggeeClass.getValue(debuggeeClass.fieldByName("instruction")))).value();
@@ -332,30 +332,6 @@ public class filter_rt002 extends JDIBase {
         }
         log1("    TESTING ENDS");
         return;
-    }
-
-    protected void breakpointForCommunication()
-            throws JDITestRuntimeException {
-        log2("breakpointForCommunication");
-
-        do {
-            getEventSet();
-
-            Event event = eventIterator.nextEvent();
-            if (event instanceof BreakpointEvent)
-                return;
-
-            log2("      received: " + event);
-
-            if (EventFilters.filtered(event, debuggeeName)) {
-                eventSet.resume();
-            }
-            else {
-                break;
-            }
-        } while (true);
-
-        throw new JDITestRuntimeException("** event IS NOT a breakpoint **");
     }
 
     // ============================== test's additional methods

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassPrepareRequest/addClassFilter_s/filter_s002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassPrepareRequest/addClassFilter_s/filter_s002.java
@@ -267,7 +267,7 @@ public class filter_s002 extends JDIBase {
         for (int i = 0; ; i++) {
 
             vm.resume();
-            breakpointForCommunication();
+            breakpointForCommunication(debuggeeName);
 
             int instruction = ((IntegerValue)
                                (debuggeeClass.getValue(debuggeeClass.fieldByName("instruction")))).value();
@@ -331,29 +331,6 @@ public class filter_s002 extends JDIBase {
         }
         log1("    TESTING ENDS");
         return;
-    }
-    protected void breakpointForCommunication()
-            throws JDITestRuntimeException {
-        log2("breakpointForCommunication");
-
-        do {
-            getEventSet();
-
-            Event event = eventIterator.nextEvent();
-            if (event instanceof BreakpointEvent)
-                return;
-
-            log2("      received: " + event);
-
-            if (EventFilters.filtered(event, debuggeeName)) {
-                eventSet.resume();
-            }
-            else {
-                break;
-            }
-        } while (true);
-
-        throw new JDITestRuntimeException("** event IS NOT a breakpoint **");
     }
 
     // ============================== test's additional methods

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventRequestManager/classPrepareRequests/clsprepreq002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventRequestManager/classPrepareRequests/clsprepreq002.java
@@ -260,7 +260,7 @@ public class clsprepreq002 extends JDIBase {
         for (int i = 0; ; i++) {
 
             vm.resume();
-            breakpointForCommunication();
+            breakpointForCommunication(debuggeeName);
 
             int instruction = ((IntegerValue)
                                (debuggeeClass.getValue(debuggeeClass.fieldByName("instruction")))).value();
@@ -364,30 +364,6 @@ public class clsprepreq002 extends JDIBase {
         }
         log1("    TESTING ENDS");
         return;
-    }
-
-    protected void breakpointForCommunication()
-            throws JDITestRuntimeException {
-        log2("breakpointForCommunication");
-
-        do {
-            getEventSet();
-
-            Event event = eventIterator.nextEvent();
-            if (event instanceof BreakpointEvent)
-                return;
-
-            log2("      received: " + event);
-
-            if (EventFilters.filtered(event, debuggeeName)) {
-                eventSet.resume();
-            }
-            else {
-                break;
-            }
-        } while (true);
-
-        throw new JDITestRuntimeException("** event IS NOT a breakpoint **");
     }
 
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventRequestManager/methodExitRequests/methexitreq002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventRequestManager/methodExitRequests/methexitreq002.java
@@ -259,7 +259,7 @@ public class methexitreq002 extends JDIBase {
         for (int i = 0; ; i++) {
 
             vm.resume();
-            breakpointForCommunication();
+            breakpointForCommunication(debuggeeName);
 
             int instruction = ((IntegerValue)
                                (debuggeeClass.getValue(debuggeeClass.fieldByName("instruction")))).value();
@@ -358,30 +358,6 @@ public class methexitreq002 extends JDIBase {
         }
         log1("    TESTING ENDS");
         return;
-    }
-
-    protected void breakpointForCommunication()
-                 throws JDITestRuntimeException {
-        log2("breakpointForCommunication");
-
-        do {
-            getEventSet();
-
-            Event event = eventIterator.nextEvent();
-            if (event instanceof BreakpointEvent)
-                return;
-
-            log2("      received: " + event);
-
-            if (EventFilters.filtered(event, debuggeeName)) {
-                eventSet.resume();
-            }
-            else {
-                break;
-            }
-        } while (true);
-
-        throw new JDITestRuntimeException("** event IS NOT a breakpoint **");
     }
 
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/MethodEntryRequest/addClassExclusionFilter/filter002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/MethodEntryRequest/addClassExclusionFilter/filter002.java
@@ -263,7 +263,7 @@ public class filter002 extends JDIBase {
         for (int i = 0; ; i++) {
 
             vm.resume();
-            breakpointForCommunication();
+            breakpointForCommunication(debuggeeName);
 
             int instruction = ((IntegerValue)
                                (debuggeeClass.getValue(debuggeeClass.fieldByName("instruction")))).value();
@@ -330,32 +330,6 @@ public class filter002 extends JDIBase {
         log1("    TESTING ENDS");
         return;
     }
-
-    protected void breakpointForCommunication()
-                 throws JDITestRuntimeException {
-        log2("breakpointForCommunication");
-
-        do {
-            getEventSet();
-
-            Event event = eventIterator.nextEvent();
-            if (event instanceof BreakpointEvent)
-                return;
-
-            log2("      received: " + event);
-
-            if (EventFilters.filtered(event, debuggeeName)) {
-                eventSet.resume();
-            }
-            else {
-                break;
-            }
-        } while (true);
-
-        throw new JDITestRuntimeException("** event IS NOT a breakpoint **");
-    }
-
-
 
     // ============================== test's additional methods
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/MethodExitRequest/addClassExclusionFilter/filter002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/MethodExitRequest/addClassExclusionFilter/filter002.java
@@ -263,7 +263,7 @@ public class filter002 extends JDIBase {
         for (int i = 0; ; i++) {
 
             vm.resume();
-            breakpointForCommunication();
+            breakpointForCommunication(debuggeeName);
 
             int instruction = ((IntegerValue)
                                (debuggeeClass.getValue(debuggeeClass.fieldByName("instruction")))).value();
@@ -329,30 +329,6 @@ public class filter002 extends JDIBase {
         }
         log1("    TESTING ENDS");
         return;
-    }
-
-    protected void breakpointForCommunication()
-                   throws JDITestRuntimeException {
-        log2("breakpointForCommunication");
-
-        do {
-            getEventSet();
-
-            Event event = eventIterator.nextEvent();
-            if (event instanceof BreakpointEvent)
-                return;
-
-            log2("      received: " + event);
-
-            if (EventFilters.filtered(event, debuggeeName)) {
-                eventSet.resume();
-            }
-            else {
-                break;
-            }
-        } while (true);
-
-        throw new JDITestRuntimeException("** event IS NOT a breakpoint **");
     }
 
     // ============================== test's additional methods


### PR DESCRIPTION
The following tests all override the JDIBase.breakpointForCommunication() method, but no longer need too:

vmTestbase/nsk/jdi/ClassPrepareRequest/addClassExclusionFilter/filter003.java
vmTestbase/nsk/jdi/ClassPrepareRequest/addClassFilter_rt/filter_rt002.java
vmTestbase/nsk/jdi/ClassPrepareRequest/addClassFilter_s/filter_s002.java
vmTestbase/nsk/jdi/EventRequestManager/classPrepareRequests/clsprepreq002.java
vmTestbase/nsk/jdi/EventRequestManager/methodExitRequests/methexitreq002.java
vmTestbase/nsk/jdi/MethodEntryRequest/addClassExclusionFilter/filter002.java
vmTestbase/nsk/jdi/MethodExitRequest/addClassExclusionFilter/filter002.java

The override was to fix [JDK-8203809](https://bugs.openjdk.org/browse/JDK-8203809). It filters out unexpected events due to system threads (namely Graal java compiler threads). However, there is now a JDIBase.breakpointForCommunication() version that does the same, so the override can be removed. The new version takes the debuggeeName argument that the override versions currently use to filter events based on it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8355221](https://bugs.openjdk.org/browse/JDK-8355221): Get rid of unnecessary override of JDIBase.breakpointForCommunication in nsk/jdi tests (**Enhancement** - P4)


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**)

### Reviewers without OpenJDK IDs
 * @abdelhak-zaaim (no known openjdk.org user name / role)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24813/head:pull/24813` \
`$ git checkout pull/24813`

Update a local copy of the PR: \
`$ git checkout pull/24813` \
`$ git pull https://git.openjdk.org/jdk.git pull/24813/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24813`

View PR using the GUI difftool: \
`$ git pr show -t 24813`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24813.diff">https://git.openjdk.org/jdk/pull/24813.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24813#issuecomment-2823106191)
</details>
