### PR TITLE
8356846: Remove unnecessary List.contains key from TIFFDirectory.removeTagSet

### DIFF
--- a/src/java.desktop/share/classes/javax/imageio/plugins/tiff/TIFFDirectory.java
+++ b/src/java.desktop/share/classes/javax/imageio/plugins/tiff/TIFFDirectory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,6 @@ package javax.imageio.plugins.tiff;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
@@ -268,9 +267,7 @@ public class TIFFDirectory implements Cloneable {
             throw new NullPointerException("tagSet == null");
         }
 
-        if(tagSets.contains(tagSet)) {
-            tagSets.remove(tagSet);
-        }
+        tagSets.remove(tagSet);
     }
 
     /**


### PR DESCRIPTION
There is no need to call List.contains before List.remove call.
`tagSets` - is an ArrayList.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8356846](https://bugs.openjdk.org/browse/JDK-8356846): Remove unnecessary List.contains key from TIFFDirectory.removeTagSet (**Enhancement** - P5)


### Reviewers
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24816/head:pull/24816` \
`$ git checkout pull/24816`

Update a local copy of the PR: \
`$ git checkout pull/24816` \
`$ git pull https://git.openjdk.org/jdk.git pull/24816/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24816`

View PR using the GUI difftool: \
`$ git pr show -t 24816`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24816.diff">https://git.openjdk.org/jdk/pull/24816.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24816#issuecomment-2875605842)
</details>
