### PR TITLE
8354284: Add more compiler test folders to tier1 runs

### DIFF
--- a/test/hotspot/jtreg/TEST.groups
+++ b/test/hotspot/jtreg/TEST.groups
@@ -171,6 +171,8 @@ tier1_compiler_1 = \
   -compiler/c2/Test6912517.java
 
 tier1_compiler_2 = \
+  compiler/ccp/ \
+  compiler/ciTypeFlow/ \
   compiler/classUnloading/ \
   compiler/codecache/ \
   compiler/codegen/ \
@@ -181,11 +183,11 @@ tier1_compiler_2 = \
   compiler/exceptions/ \
   compiler/floatingpoint/ \
   compiler/gcbarriers/ \
+  compiler/igvn/ \
   compiler/inlining/ \
   compiler/integerArithmetic/ \
   compiler/interpreter/ \
   compiler/jvmci/ \
-  compiler/igvn/ \
   -compiler/classUnloading/methodUnloading/TestOverloadCompileQueues.java \
   -compiler/codecache/stress \
   -compiler/codegen/aes \
@@ -199,9 +201,12 @@ tier1_compiler_3 = \
   compiler/macronodes/ \
   compiler/memoryinitialization/ \
   compiler/osr/ \
+  compiler/predicates/ \
   compiler/profiling \
   compiler/regalloc/ \
   compiler/runtime/ \
+  compiler/sharedstubs/ \
+  compiler/splitif/ \
   compiler/startup/ \
   compiler/types/ \
   compiler/uncommontrap/ \

--- a/test/hotspot/jtreg/compiler/ccp/TestAndConZeroCCP.java
+++ b/test/hotspot/jtreg/compiler/ccp/TestAndConZeroCCP.java
@@ -26,7 +26,7 @@
  * @bug 8350563
  * @summary Test that And nodes are monotonic and added to the CCP worklist if they have a constant as input.
  * @run main/othervm -Xbatch -XX:-TieredCompilation compiler.ccp.TestAndConZeroCCP
- * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:RepeatCompilation=300 -XX:+StressIGVN -XX:+StressCCP -Xcomp
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:RepeatCompilation=100 -XX:+StressIGVN -XX:+StressCCP -Xcomp
  *                   -XX:CompileOnly=java.lang.Integer::parseInt compiler.ccp.TestAndConZeroCCP compileonly
  * @run main compiler.ccp.TestAndConZeroCCP
  */
@@ -42,7 +42,7 @@ public class TestAndConZeroCCP {
             return;
         }
 
-        for (int i = 0; i < 10000; ++i) {
+        for (int i = 0; i < 100; ++i) {
             run();
         }
     }


### PR DESCRIPTION
Some folders in jtreg/compiler have been reported not to be run in any tier, while tier1 was probably intended, but the tier definition was mistakenly not updated. I've checked which folders are not referenced into `TEST.groups`.

The unmentioned ones:
- `ccp`
- `ciReplay`
- `ciTypeFlow`
- `compilercontrol`
- `debug`
- `oracle`
- `predicates`
- `print`
- `relocations`
- `sharedstubs`
- `splitif`
- `tiered`
- `whitebox`

And those, that are not test folders:
- `lib`
- `patches`
- `testlibraries`

I'm adding `ccp`, `ciTypeFlow`, `predicates`, `sharedstubs` and `splitif` to tier1.

The other folders seems to have been around for very long (since at least mid-2021). It's not clear how meaningful it'd be to add them/what the intent from them was. I've rather focused on the recently(-ish) added folders, that one forgot to put in a tier when adding it.

Feel free to tell if other folders should be included (and in which tier).

Thanks,
Marc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8354284](https://bugs.openjdk.org/browse/JDK-8354284): Add more compiler test folders to tier1 runs (**Enhancement** - P4)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24817/head:pull/24817` \
`$ git checkout pull/24817`

Update a local copy of the PR: \
`$ git checkout pull/24817` \
`$ git pull https://git.openjdk.org/jdk.git pull/24817/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24817`

View PR using the GUI difftool: \
`$ git pr show -t 24817`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24817.diff">https://git.openjdk.org/jdk/pull/24817.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24817#issuecomment-2823756043)
</details>
