### PR TITLE
[PATCH] Remove unnecessary List.indexOf key from Track.remove

### DIFF
--- a/src/java.desktop/share/classes/javax/sound/midi/Track.java
+++ b/src/java.desktop/share/classes/javax/sound/midi/Track.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -199,9 +199,7 @@ public final class Track {
         // by deleting events (unless the EOT event is removed)
         synchronized(eventsList) {
             if (set.remove(event)) {
-                int i = eventsList.indexOf(event);
-                if (i >= 0) {
-                    eventsList.remove(i);
+                if (eventsList.remove(event)) {
                     return true;
                 }
             }


### PR DESCRIPTION
No need to call `List.indexOf(Object)` before `List.remove(int)`. Instead we can call `List.remove(Object)` directly. It's faster and cleaner.