### PR TITLE
[PATCH] Remove excessive nested synchronized from getHeavyWeightPopupCache

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/PopupFactory.java
+++ b/src/java.desktop/share/classes/javax/swing/PopupFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -449,17 +449,15 @@ public class PopupFactory {
          */
         @SuppressWarnings("unchecked")
         private static Map<Window, List<HeavyWeightPopup>> getHeavyWeightPopupCache() {
-            synchronized (HeavyWeightPopup.class) {
-                Map<Window, List<HeavyWeightPopup>> cache = (Map<Window, List<HeavyWeightPopup>>)SwingUtilities.appContextGet(
-                                  heavyWeightPopupCacheKey);
+            Map<Window, List<HeavyWeightPopup>> cache = (Map<Window, List<HeavyWeightPopup>>)SwingUtilities.appContextGet(
+                              heavyWeightPopupCacheKey);
 
-                if (cache == null) {
-                    cache = new HashMap<>(2);
-                    SwingUtilities.appContextPut(heavyWeightPopupCacheKey,
-                                                 cache);
-                }
-                return cache;
+            if (cache == null) {
+                cache = new HashMap<>(2);
+                SwingUtilities.appContextPut(heavyWeightPopupCacheKey,
+                                             cache);
             }
+            return cache;
         }
 
         /**


### PR DESCRIPTION
The method `javax.swing.PopupFactory.HeavyWeightPopup#getHeavyWeightPopupCache` is always called under `synchronized (HeavyWeightPopup.class)` lock. There is no need in extra `synchronized` inside the method itself.
Removed to be consistent with other similar methods: `javax.swing.PopupFactory.MediumWeightPopup#getMediumWeightPopupCache` and `javax.swing.PopupFactory.LightWeightPopup#getLightWeightPopupCache`. They don't have `synchronized` inside, but instead rely on callers locks.