### PR TITLE
8355369: Remove setAccessible usage for setting final fields in java.util.concurrent

### DIFF
--- a/src/java.base/share/classes/java/util/concurrent/ConcurrentSkipListSet.java
+++ b/src/java.base/share/classes/java/util/concurrent/ConcurrentSkipListSet.java
@@ -37,6 +37,7 @@ package java.util.concurrent;
 
 import jdk.internal.misc.Unsafe;
 
+import java.lang.invoke.VarHandle;
 import java.util.AbstractSet;
 import java.util.Collection;
 import java.util.Collections;
@@ -177,6 +178,8 @@ public class ConcurrentSkipListSet<E>
             ConcurrentSkipListSet<E> clone =
                 (ConcurrentSkipListSet<E>) super.clone();
             clone.setMap(new ConcurrentSkipListMap<E,Object>(m));
+            // Needed to ensure safe publication of setMap()
+            VarHandle.releaseFence();
             return clone;
         } catch (CloneNotSupportedException e) {
             throw new InternalError();

--- a/src/java.base/share/classes/java/util/concurrent/ConcurrentSkipListSet.java
+++ b/src/java.base/share/classes/java/util/concurrent/ConcurrentSkipListSet.java
@@ -35,7 +35,8 @@
 
 package java.util.concurrent;
 
-import java.lang.reflect.Field;
+import jdk.internal.misc.Unsafe;
+
 import java.util.AbstractSet;
 import java.util.Collection;
 import java.util.Collections;
@@ -527,12 +528,11 @@ public class ConcurrentSkipListSet<E>
 
     /** Initializes map field; for use in clone. */
     private void setMap(ConcurrentNavigableMap<E,Object> map) {
-        try {
-            Field mapField = ConcurrentSkipListSet.class.getDeclaredField("m");
-            mapField.setAccessible(true);
-            mapField.set(this, map);
-        } catch (IllegalAccessException | NoSuchFieldException e) {
-            throw new Error(e);
-        }
+        final Unsafe U = Unsafe.getUnsafe();
+        U.putReference(
+            this,
+            U.objectFieldOffset(ConcurrentSkipListSet.class, "m"),
+            map
+        );
     }
 }

--- a/src/java.base/share/classes/java/util/concurrent/CopyOnWriteArrayList.java
+++ b/src/java.base/share/classes/java/util/concurrent/CopyOnWriteArrayList.java
@@ -35,7 +35,6 @@
 package java.util.concurrent;
 
 import java.lang.invoke.VarHandle;
-import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -57,6 +56,7 @@ import java.util.function.UnaryOperator;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 import jdk.internal.access.SharedSecrets;
+import jdk.internal.misc.Unsafe;
 import jdk.internal.util.ArraysSupport;
 
 /**
@@ -2095,12 +2095,11 @@ public class CopyOnWriteArrayList<E>
 
     /** Initializes the lock; for use when deserializing or cloning. */
     private void resetLock() {
-        try {
-            Field lockField = CopyOnWriteArrayList.class.getDeclaredField("lock");
-            lockField.setAccessible(true);
-            lockField.set(this, new Object());
-        } catch (IllegalAccessException | NoSuchFieldException e) {
-            throw new Error(e);
-        }
+        final Unsafe U = Unsafe.getUnsafe();
+        U.putReference(
+            this,
+            U.objectFieldOffset(CopyOnWriteArrayList.class, "lock"),
+            new Object()
+        );
     }
 }

--- a/src/java.base/share/classes/java/util/concurrent/atomic/AtomicReferenceArray.java
+++ b/src/java.base/share/classes/java/util/concurrent/atomic/AtomicReferenceArray.java
@@ -35,10 +35,11 @@
 
 package java.util.concurrent.atomic;
 
+import jdk.internal.misc.Unsafe;
+
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
 import java.lang.reflect.Array;
-import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.function.BinaryOperator;
 import java.util.function.UnaryOperator;
@@ -330,14 +331,13 @@ public class AtomicReferenceArray<E> implements java.io.Serializable {
             throw new java.io.InvalidObjectException("Not array type");
         if (a.getClass() != Object[].class)
             a = Arrays.copyOf((Object[])a, Array.getLength(a), Object[].class);
-        try {
 
-            Field arrayField = AtomicReferenceArray.class.getDeclaredField("array");
-            arrayField.setAccessible(true);
-            arrayField.set(this, a);
-        } catch (NoSuchFieldException | IllegalAccessException e) {
-            throw new Error(e);
-        }
+        final Unsafe U = Unsafe.getUnsafe();
+        U.putReference(
+            this,
+            U.objectFieldOffset(AtomicReferenceArray.class, "array"),
+            a
+        );
     }
 
     // jdk9
@@ -523,5 +523,4 @@ public class AtomicReferenceArray<E> implements java.io.Serializable {
     public final boolean weakCompareAndSetRelease(int i, E expectedValue, E newValue) {
         return AA.weakCompareAndSetRelease(array, i, expectedValue, newValue);
     }
-
 }


### PR DESCRIPTION
This Pull Request replaces the uses of Field + setAccessible to modify final fields in java.util.concurrent with Unsafe.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8355369](https://bugs.openjdk.org/browse/JDK-8355369): Remove setAccessible usage for setting final fields in java.util.concurrent (**Enhancement** - P4)


### Reviewers
 * [Per Minborg](https://openjdk.org/census#pminborg) (@minborg - **Reviewer**)
 * [Doug Lea](https://openjdk.org/census#dl) (@DougLea - **Reviewer**)
 * [Raffaello Giulietti](https://openjdk.org/census#rgiulietti) (@rgiulietti - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24821/head:pull/24821` \
`$ git checkout pull/24821`

Update a local copy of the PR: \
`$ git checkout pull/24821` \
`$ git pull https://git.openjdk.org/jdk.git pull/24821/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24821`

View PR using the GUI difftool: \
`$ git pr show -t 24821`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24821.diff">https://git.openjdk.org/jdk/pull/24821.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24821#issuecomment-2823814800)
</details>
