### PR TITLE
8355370: Include server name in HTTP test server thread names to improve diagnostics

### DIFF
--- a/src/jdk.httpserver/share/classes/sun/net/httpserver/ServerImpl.java
+++ b/src/jdk.httpserver/share/classes/sun/net/httpserver/ServerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -183,7 +183,7 @@ class ServerImpl {
             throw new IllegalStateException ("server in wrong state");
         }
         if (executor == null) {
-            executor = new DefaultExecutor();
+            executor = new ImmediateExecutor();
         }
         dispatcherThread = new Thread(null, dispatcher, "HTTP-Dispatcher", 0, false);
         started = true;
@@ -197,10 +197,16 @@ class ServerImpl {
         this.executor = executor;
     }
 
-    private static class DefaultExecutor implements Executor {
+    /**
+     * An {@link Executor} that executes submitted tasks immediately on the caller thread.
+     */
+    private static final class ImmediateExecutor implements Executor {
+
+        @Override
         public void execute (Runnable task) {
             task.run();
         }
+
     }
 
     public Executor getExecutor () {

--- a/src/jdk.httpserver/share/classes/sun/net/httpserver/ServerImpl.java
+++ b/src/jdk.httpserver/share/classes/sun/net/httpserver/ServerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -183,7 +183,7 @@ class ServerImpl {
             throw new IllegalStateException ("server in wrong state");
         }
         if (executor == null) {
-            executor = new ImmediateExecutor();
+            executor = new DefaultExecutor();
         }
         dispatcherThread = new Thread(null, dispatcher, "HTTP-Dispatcher", 0, false);
         started = true;
@@ -197,16 +197,10 @@ class ServerImpl {
         this.executor = executor;
     }
 
-    /**
-     * An {@link Executor} that executes submitted tasks immediately on the caller thread.
-     */
-    private static final class ImmediateExecutor implements Executor {
-
-        @Override
+    private static class DefaultExecutor implements Executor {
         public void execute (Runnable task) {
             task.run();
         }
-
     }
 
     public Executor getExecutor () {

--- a/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/common/HttpServerAdapters.java
+++ b/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/common/HttpServerAdapters.java
@@ -59,9 +59,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ThreadFactory;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -768,7 +765,7 @@ public interface HttpServerAdapters {
     /**
      * A version agnostic adapter class for HTTP Servers.
      */
-    public static abstract class HttpTestServer implements AutoCloseable {
+    public static abstract class HttpTestServer {
         private static final class ServerLogging {
             private static final Logger logger = Logger.getLogger("com.sun.net.httpserver");
             static void enableLogging() {
@@ -784,11 +781,6 @@ public interface HttpServerAdapters {
         public abstract InetSocketAddress getAddress();
         public abstract Version getVersion();
         public abstract void setRequestApprover(final Predicate<String> approver);
-
-        @Override
-        public void close() throws Exception {
-            stop();
-        }
 
         public String serverAuthority() {
             InetSocketAddress address = getAddress();
@@ -1038,19 +1030,6 @@ public interface HttpServerAdapters {
         System.setProperty("java.util.logging.SimpleFormatter.format",
                 "%4$s [%1$tb %1$td, %1$tl:%1$tM:%1$tS.%1$tN] %2$s: %5$s%6$s%n");
         HttpTestServer.ServerLogging.enableLogging();
-    }
-
-    static ExecutorService createExecutor(String threadNamePrefix) {
-        ThreadFactory threadFactory = createThreadFactory(threadNamePrefix);
-        return Executors.newCachedThreadPool(threadFactory);
-    }
-
-    private static ThreadFactory createThreadFactory(String threadNamePrefix) {
-        AtomicInteger threadCounter = new AtomicInteger();
-        return (Runnable task) -> {
-            String name = "%s-%d".formatted(threadNamePrefix, threadCounter.incrementAndGet());
-            return new Thread(task, name);
-        };
     }
 
 }

--- a/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/common/HttpServerAdapters.java
+++ b/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/common/HttpServerAdapters.java
@@ -976,6 +976,13 @@ public interface HttpServerAdapters {
                 System.out.println("Http2TestServerImpl: stop");
                 impl.stop();
             }
+
+            @Override
+            public void close() {
+                System.out.println("Http2TestServerImpl: close");
+                impl.stop();
+            }
+
             @Override
             public HttpTestContext addHandler(HttpTestHandler handler, String path) {
                 System.out.println("Http2TestServerImpl[" + getAddress()

--- a/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/common/HttpServerAdapters.java
+++ b/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/common/HttpServerAdapters.java
@@ -765,7 +765,7 @@ public interface HttpServerAdapters {
     /**
      * A version agnostic adapter class for HTTP Servers.
      */
-    public static abstract class HttpTestServer {
+    abstract class HttpTestServer implements AutoCloseable {
         private static final class ServerLogging {
             private static final Logger logger = Logger.getLogger("com.sun.net.httpserver");
             static void enableLogging() {
@@ -781,6 +781,11 @@ public interface HttpServerAdapters {
         public abstract InetSocketAddress getAddress();
         public abstract Version getVersion();
         public abstract void setRequestApprover(final Predicate<String> approver);
+
+        @Override
+        public void close() throws Exception {
+            stop();
+        }
 
         public String serverAuthority() {
             InetSocketAddress address = getAddress();

--- a/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/common/HttpServerAdapters.java
+++ b/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/common/HttpServerAdapters.java
@@ -978,9 +978,9 @@ public interface HttpServerAdapters {
             }
 
             @Override
-            public void close() {
+            public void close() throws Exception {
                 System.out.println("Http2TestServerImpl: close");
-                impl.stop();
+                impl.close();
             }
 
             @Override

--- a/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/http2/Http2TestServer.java
+++ b/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/http2/Http2TestServer.java
@@ -65,11 +65,11 @@ public class Http2TestServer implements AutoCloseable {
     private volatile Predicate<String> newRequestApprover;
 
     public Http2TestServer(String serverName, boolean secure, int port) throws Exception {
-        this(serverName, secure, port, createExecutor(serverName), 50, null, null);
+        this(serverName, secure, port, null, 50, null, null);
     }
 
     public Http2TestServer(boolean secure, int port) throws Exception {
-        this(null, secure, port, createExecutor(null), 50, null, null);
+        this(null, secure, port, null, 50, null, null);
     }
 
     public InetSocketAddress getAddress() {
@@ -191,8 +191,8 @@ public class Http2TestServer implements AutoCloseable {
         this.connections = ConcurrentHashMap.newKeySet();
     }
 
-    private static ExecutorService createExecutor(String serverName) {
-        String threadNamePrefix = "http2-test-server-worker" + (serverName != null ? "[%s]".formatted(serverName) : "");
+    private static ExecutorService createExecutor(String name) {
+        String threadNamePrefix = "http2-test-server-worker" + (name != null ? "[%s]".formatted(name) : "");
         return HttpServerAdapters.createExecutor(threadNamePrefix);
     }
 

--- a/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/http2/Http2TestServer.java
+++ b/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/http2/Http2TestServer.java
@@ -30,7 +30,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Predicate;
@@ -68,16 +67,8 @@ public class Http2TestServer implements AutoCloseable {
 
     private static ExecutorService createExecutor(String name) {
         String threadNamePrefix = "%s-pool".formatted(name == null ? "TestServer" : name);
-        ThreadFactory threadFactory = createThreadFactory(threadNamePrefix);
+        ThreadFactory threadFactory = Thread.ofPlatform().name(threadNamePrefix, 0).factory();
         return Executors.newCachedThreadPool(threadFactory);
-    }
-
-    private static ThreadFactory createThreadFactory(String threadNamePrefix) {
-        AtomicInteger threadCounter = new AtomicInteger();
-        return (Runnable task) -> {
-            String name = "%s-%d".formatted(threadNamePrefix, threadCounter.incrementAndGet());
-            return new Thread(task, name);
-        };
     }
 
     public Http2TestServer(String serverName, boolean secure, int port) throws Exception {

--- a/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/http2/Http2TestServer.java
+++ b/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/http2/Http2TestServer.java
@@ -66,7 +66,7 @@ public class Http2TestServer implements AutoCloseable {
     private volatile Predicate<String> newRequestApprover;
 
     private static ExecutorService createExecutor(String name) {
-        String threadNamePrefix = "%s-pool".formatted(name == null ? "TestServer" : name);
+        String threadNamePrefix = "%s-pool".formatted(name);
         ThreadFactory threadFactory = Thread.ofPlatform().name(threadNamePrefix, 0).factory();
         return Executors.newCachedThreadPool(threadFactory);
     }

--- a/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/http2/Http2TestServer.java
+++ b/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/http2/Http2TestServer.java
@@ -40,7 +40,6 @@ import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLParameters;
 import javax.net.ssl.SSLServerSocket;
 
-import jdk.httpclient.test.lib.common.HttpServerAdapters;
 import jdk.internal.net.http.frame.ErrorFrame;
 
 /**
@@ -68,7 +67,7 @@ public class Http2TestServer implements AutoCloseable {
     private volatile Predicate<String> newRequestApprover;
 
     private static ExecutorService createExecutor(String name) {
-        String threadNamePrefix = "http2-test-server-worker" + (name != null ? "[%s]".formatted(name) : "");
+        String threadNamePrefix = "%s-pool".formatted(name == null ? "TestServer" : name);
         ThreadFactory threadFactory = createThreadFactory(threadNamePrefix);
         return Executors.newCachedThreadPool(threadFactory);
     }


### PR DESCRIPTION
Incorporates the test server name while deriving the HTTP/2 test server (i.e., `jdk.httpclient.test.lib.http2.Http2TestServer`) thread names to improve diagnostics.

### Making `HttpTestServer` implement `AutoCloseable`

I carried out this out-of-scope enhancement along with this PR, since this one-liner gives nice try-with-resources convenience while writing tests using HTTP test servers. Note that [this change is already implemented for the in-progress HTTP/3 work](/dfuch/jdk/blob/9c2da664d2875b7e7986831fd716d05b7a8306f4/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/common/HttpServerAdapters.java#L1119).

### Improving HTTP/2 test server thread names

The HTTP/2 server thread names are improved by modifying the server default executor to include the HTTP/2 server name in its thread names. We deliberately did nothing for the HTTP/1.1 server (provided by the `jdk.httpserver` module). `ServerImpl`, the default HTTP/1.1 server implementation, has only one thread by default: the dispatcher and it is named `HTTP-Dispatcher`. Since factory methods in `com.sun.net.httpserver.Http[s]Server` don’t have the notion of a _name_, introducing a name would require a public API change.
Instead the calling code that creates the server can supply an Executor which creates threads with whatever name
is appropriate for the application/test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8355370](https://bugs.openjdk.org/browse/JDK-8355370): Include server name in HTTP test server thread names to improve diagnostics (**Enhancement** - P4)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24822/head:pull/24822` \
`$ git checkout pull/24822`

Update a local copy of the PR: \
`$ git checkout pull/24822` \
`$ git pull https://git.openjdk.org/jdk.git pull/24822/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24822`

View PR using the GUI difftool: \
`$ git pr show -t 24822`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24822.diff">https://git.openjdk.org/jdk/pull/24822.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24822#issuecomment-2823822713)
</details>
