### PR TITLE
8352422: [ubsan] Out-of-range reported in ciMethod.cpp:917:20: runtime error: 2.68435e+09 is outside the range of representable values of type 'int'

### DIFF
--- a/src/hotspot/share/ci/ciMethod.cpp
+++ b/src/hotspot/share/ci/ciMethod.cpp
@@ -914,8 +914,13 @@ int ciMethod::scale_count(int count, float prof_factor) {
       method_life = counter_life;
     }
     if (counter_life > 0) {
-      count = (int)((double)count * prof_factor * method_life / counter_life + 0.5);
-      count = (count > 0) ? count : 1;
+      double count_d = (double)count * prof_factor * method_life / counter_life + 0.5;
+      if (count_d >= static_cast<double>(INT_MAX)) {
+        count = INT_MAX;
+      } else {
+        count = int(count_d);
+        count = (count > 0) ? count : 1;
+      }
     } else {
       count = 1;
     }


### PR DESCRIPTION
The double `(double)count * prof_factor * method_life / counter_life + 0.5`
can overflow a 32-bit int, causing UB on casting, but in practice computing
a wrong scale, probably.

We just need to compare that the cast is not going to overflow. This is possible
because `INT_MAX` is exactly representable in a `double`. It is also good to
notice that the expression `(double)count * prof_factor * method_life / counter_life + 0.5`
cannot overflow a `double`:
- `count` is a int, max value = 2^31-1 < 2.2e9
- `method_lie` is a int, max value < 2.2e9
- `prof_factor` is a float, max value < 3.5e38
- `counter_life` is a int, positive at this point, so min value = 1
So, the whole expression is bounded by 16.94e56 + 0.5, which is much smaller than the
max value of a double (about 1.8e308). We probably would have precision issues, but
it probably doesn't matter a lot.

The semantic I picked here is basically `min(INT_MAX, count_d)`, so it'd always fit.

Thanks,
Marc
