### PR TITLE
8355394: ZGC: Windows compile error in ZUtils

### DIFF
--- a/src/hotspot/share/gc/z/zUtils.inline.hpp
+++ b/src/hotspot/share/gc/z/zUtils.inline.hpp
@@ -86,11 +86,10 @@ inline void ZUtils::sort(T* array, size_t count, Comparator comparator) {
   using SortType = int(const void*, const void*);
   using ComparatorType = int(const T*, const T*);
 
-  static constexpr bool IsComparatorCompatible = std::is_assignable<ComparatorType*&, Comparator>::value;
-  static_assert(IsComparatorCompatible, "Incompatible Comparator, must decay to plain function pointer");
+  ComparatorType* const comparator_fn_ptr = comparator;
 
   // We rely on ABI compatibility between ComparatorType and SortType
-  qsort(array, count, sizeof(T), reinterpret_cast<SortType*>(static_cast<ComparatorType*>(comparator)));
+  qsort(array, count, sizeof(T), reinterpret_cast<SortType*>(comparator_fn_ptr));
 }
 
 template <typename T, typename Comparator>


### PR DESCRIPTION
We got a report of an encountered of the following compilation error:
```
src\hotspot\share\gc/z/zUtils.inline.hpp(87): error C2066: cast to function type is illegal
src\hotspot\share\gc/z/zUtils.inline.hpp(97): note: see reference to function template instantiation 'void ZUtils::sort<zbacking_index,sort_zbacking_index_array::<lambda_1>>(T *,size_t,Comparator)' being compiled
        with
        [
            T=zbacking_index,
            Comparator=sort_zbacking_index_array::<lambda_1>
        ]
src\hotspot\share\gc\z\zPhysicalMemoryManager.cpp(303): note: see reference to function template instantiation 'void ZUtils::sort<zbacking_index,sort_zbacking_index_array::<lambda_1>>(T *,int,Comparator)' being compiled
        with
        [
            T=zbacking_index,
            Comparator=sort_zbacking_index_array::<lambda_1>
        ]
make[3]: *** [lib/CompileJvm.gmk:174: jdk/build/windows-x86_64-server-fastdebug/hotspot/variant-server/libjvm/objs/zPhysicalMemoryManager.obj] Error 1
make[3]: *** Waiting for unfinished jobs....
make[2]: *** [make/Main.gmk:236: hotspot-server-libs] Error 2 (edited) 
```

We don't see this failure in our CI runs but with the help of the reporter we managed to tweak the code to get rid of the failure.

Tested with tier1-2 in our CI.