### PR TITLE
8355400: Better git detection in update_copyright_year.sh

### DIFF
--- a/make/scripts/update_copyright_year.sh
+++ b/make/scripts/update_copyright_year.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -f
 
 #
-# Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2010, 2025, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -40,10 +40,6 @@ set -e
 
 # To allow total changes counting
 shopt -s lastpipe
-
-# Get an absolute path to this script, since that determines the top-level directory.
-this_script_dir=`dirname $0`
-this_script_dir=`cd $this_script_dir > /dev/null && pwd`
 
 # Temp area
 tmp=/tmp/`basename $0`.${USER}.$$
@@ -98,10 +94,16 @@ while getopts "c:fhy:" option; do
 done
 
 # VCS check
+git_installed=false
+which git > /dev/null && git_installed=true
+if [ "$git_installed" != "true" ]; then
+  echo "Error: This script requires git. Please install it."
+  exit 1
+fi
 git_found=false
-[ -d "${this_script_dir}/../../.git" ] && git_found=true
+git status &> /dev/null && git_found=true
 if [ "$git_found" != "true" ]; then
-  echo "Error: Please execute script from within make/scripts."
+  echo "Error: Please execute script from within a JDK git repository."
   exit 1
 else
   echo "Using Git version control system"


### PR DESCRIPTION
The script `make/scripts/update_copyright.sh` relies on the path to the script for git detection, which is fragile or does not work at all or git worktrees. This PR uses git itself to detect whether the script is running in a git repository. This has the added benefit that the script can be executed from anywhere in the repository.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8355400](https://bugs.openjdk.org/browse/JDK-8355400): Better git detection in update_copyright_year.sh (**Enhancement** - P5)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24828/head:pull/24828` \
`$ git checkout pull/24828`

Update a local copy of the PR: \
`$ git checkout pull/24828` \
`$ git pull https://git.openjdk.org/jdk.git pull/24828/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24828`

View PR using the GUI difftool: \
`$ git pr show -t 24828`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24828.diff">https://git.openjdk.org/jdk/pull/24828.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24828#issuecomment-2824300166)
</details>
