### PR TITLE
835538: [jittester] Disable downcasts by default

### DIFF
--- a/test/hotspot/jtreg/testlibrary/jittester/src/jdk/test/lib/jittester/ProductionParams.java
+++ b/test/hotspot/jtreg/testlibrary/jittester/src/jdk/test/lib/jittester/ProductionParams.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -121,7 +121,7 @@ public class ProductionParams {
         disableExternalSymbols = optionResolver.addBooleanOption("disable-external-symbols", "Don\'t use external symbols");
         addExternalSymbols = optionResolver.addStringOption("add-external-symbols", "all", "Add symbols for listed classes (comma-separated list)");
         disableInheritance = optionResolver.addBooleanOption("disable-inheritance", "Disable inheritance");
-        disableDowncasts = optionResolver.addBooleanOption("disable-downcasts", "Disable downcasting of objects");
+        disableDowncasts = optionResolver.addBooleanOption(null, "disable-downcasts", true, "Disable downcasting of objects");
         disableStatic = optionResolver.addBooleanOption("disable-static", "Disable generation of static objects and functions");
         disableInterfaces = optionResolver.addBooleanOption("disable-interfaces", "Disable generation of interfaces");
         disableClasses = optionResolver.addBooleanOption("disable-classes", "Disable generation of classes");


### PR DESCRIPTION
Currently, JITTester's love to downcast often produces something like this:

`ArrayList<Integer> someVar = (TreeSet)(Object)(List)(new ArrayList<Integer>());`

... which is possible because it goes up to Object and then starts downcasting to some totally unrelated class / type.

Considering the JITTester's love to casts (they are more-or-less 'safe' expressions), it means a high probability (30-50%) of a gentest to fail compilation. Even worse is the situation for ByteCode tests - that they're faulty is only recognized during the run phase.

I suggest to disable the downcasts for now.
Testing: 50-100 generated tests in different combinations (default, with the flag set to 'false' or 'true') with artificially increased chance to casts.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Failed to retrieve information on issue `835538`. Please make sure it exists and is accessible.

### Issue
 * ⚠️ Failed to retrieve information on issue `835538`.


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24830/head:pull/24830` \
`$ git checkout pull/24830`

Update a local copy of the PR: \
`$ git checkout pull/24830` \
`$ git pull https://git.openjdk.org/jdk.git pull/24830/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24830`

View PR using the GUI difftool: \
`$ git pr show -t 24830`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24830.diff">https://git.openjdk.org/jdk/pull/24830.diff</a>

</details>
