### PR TITLE
JDK-8355429 : Open source ProgressMonitor test

### DIFF
--- a/test/jdk/javax/swing/ProgressMonitor/bug4401480.java
+++ b/test/jdk/javax/swing/ProgressMonitor/bug4401480.java
@@ -31,7 +31,6 @@
  */
 
 import java.lang.reflect.InvocationTargetException;
-import java.util.concurrent.CountDownLatch;
 import javax.swing.JButton;
 import javax.swing.JPanel;
 import javax.swing.ProgressMonitor;
@@ -40,7 +39,6 @@ import javax.swing.SwingUtilities;
 public class bug4401480 {
     private static ProgressMonitor monitor;
     private static volatile boolean cancelled = false;
-    private static final CountDownLatch startLatch = new CountDownLatch(1);
 
     private static final String INSTRUCTIONS = """
             This is a semi-automated test which automatically
@@ -79,10 +77,13 @@ public class bug4401480 {
                 for (int i = 0; i < 10; i++) {
                     int count = i;
                     try {
-                        SwingUtilities.invokeAndWait(() -> monitor.setProgress(count));
+                        SwingUtilities.invokeAndWait(() ->
+                                        monitor.setProgress(count));
                         Thread.sleep(2000);
-                        SwingUtilities.invokeAndWait(() -> cancelled = monitor.isCanceled());
-                    } catch (InterruptedException | InvocationTargetException ex) {
+                        SwingUtilities.invokeAndWait(() ->
+                                        cancelled = monitor.isCanceled());
+                    } catch (InterruptedException
+                             | InvocationTargetException ex) {
                         throw new RuntimeException(ex);
                     }
                     if (cancelled) {
@@ -93,7 +94,8 @@ public class bug4401480 {
                 if (cancelled) {
                     PassFailJFrame.forcePass();
                 } else {
-                    PassFailJFrame.forceFail("Test Failed! JProgress Monitor was not cancelled");
+                    PassFailJFrame.forceFail("Test Failed! JProgress Monitor"
+                                             + " was not cancelled");
                 }
             }).start();
         });

--- a/test/jdk/javax/swing/ProgressMonitor/bug4401480.java
+++ b/test/jdk/javax/swing/ProgressMonitor/bug4401480.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4401480
+ * @summary Tests that closing ProgressMonitor dialog cancels it
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual bug4401480
+ */
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import javax.swing.JButton;
+import javax.swing.JPanel;
+import javax.swing.ProgressMonitor;
+import javax.swing.SwingUtilities;
+
+public class bug4401480 {
+    private static ProgressMonitor monitor;
+    private static volatile boolean cancelled = false;
+    private static final CountDownLatch startLatch = new CountDownLatch(1);
+
+    private static final String INSTRUCTIONS = """
+            This is a semi-automated test which automatically
+            passes if closing the JProgressBar dialog cancels it.
+            Read the following test instructions and when ready
+            click on the Start button below.
+
+            After clicking on Start button wait for few seconds for
+            progress monitor (a dialog with progress bar) to appear.
+            Close it by clicking on the window close button.
+            DO NOT click on Cancel button.
+
+            NOTE:
+            Ensure to click on the window close button before
+            progress bar reaches its max limit.
+            """;
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame pfj = PassFailJFrame.builder()
+                .title("JProgress Monitor Instructions")
+                .instructions(INSTRUCTIONS)
+                .columns(40)
+                .splitUIBottom(bug4401480::createTestUI)
+                .build();
+
+        if (startLatch.await(2, TimeUnit.MINUTES)) {
+            for (int i = 0; i < 10; i++) {
+                int count = i;
+                SwingUtilities.invokeAndWait(() -> monitor.setProgress(count));
+                Thread.sleep(2000);
+                SwingUtilities.invokeAndWait(() -> cancelled = monitor.isCanceled());
+                if (cancelled) {
+                    break;
+                }
+            }
+
+            if (cancelled) {
+                PassFailJFrame.forcePass();
+            } else {
+                PassFailJFrame.forceFail("Test Failed! JProgress Monitor was not cancelled");
+            }
+        }
+
+        pfj.awaitAndCheck();
+    }
+
+     private static JPanel createTestUI() {
+        JPanel panel = new JPanel();
+        JButton startButton = new JButton("Start");
+        startButton.addActionListener(e -> {
+            monitor = new ProgressMonitor(null, "Progress", "Running ...", 0, 10);
+            monitor.setProgress(0);
+            startLatch.countDown();
+        });
+        panel.add(startButton);
+        return panel;
+     }
+}


### PR DESCRIPTION
javax/swing/ProgressMonitor/bug4401480.java open-sourced

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8355429](https://bugs.openjdk.org/browse/JDK-8355429): Open source ProgressMonitor test (**Bug** - P4)


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24833/head:pull/24833` \
`$ git checkout pull/24833`

Update a local copy of the PR: \
`$ git checkout pull/24833` \
`$ git pull https://git.openjdk.org/jdk.git pull/24833/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24833`

View PR using the GUI difftool: \
`$ git pr show -t 24833`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24833.diff">https://git.openjdk.org/jdk/pull/24833.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24833#issuecomment-2825172609)
</details>
