### PR TITLE
8297727: Forcing LF interpretation lead to StackOverflowError in reflection code

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/DirectMethodHandle.java
+++ b/src/java.base/share/classes/java/lang/invoke/DirectMethodHandle.java
@@ -214,7 +214,6 @@ sealed class DirectMethodHandle extends MethodHandle {
             which = LF_INVSPECIAL_IFC;
         }
         LambdaForm lform = preparedLambdaForm(mtype, which);
-        maybeCompile(lform, m);
         assert(lform.methodType().dropParameterTypes(0, 1)
                 .equals(m.getInvocationType().basicType()))
                 : Arrays.asList(m, m.getInvocationType().basicType(), lform, lform.methodType());
@@ -318,12 +317,6 @@ sealed class DirectMethodHandle extends MethodHandle {
             return name.arguments[0];
         }
         return null;
-    }
-
-    private static void maybeCompile(LambdaForm lform, MemberName m) {
-        if (lform.vmentry == null && VerifyAccess.isSamePackage(m.getDeclaringClass(), MethodHandle.class))
-            // Help along bootstrapping...
-            lform.compileToBytecode();
     }
 
     /** Static wrapper for DirectMethodHandle.internalMemberName. */
@@ -667,7 +660,6 @@ sealed class DirectMethodHandle extends MethodHandle {
             formOp += (AF_GETSTATIC_INIT - AF_GETSTATIC);
         }
         LambdaForm lform = preparedFieldLambdaForm(formOp, isVolatile, ftype);
-        maybeCompile(lform, m);
         assert(lform.methodType().dropParameterTypes(0, 1)
                 .equals(m.getInvocationType().basicType()))
                 : Arrays.asList(m, m.getInvocationType().basicType(), lform, lform.methodType());
@@ -842,6 +834,9 @@ sealed class DirectMethodHandle extends MethodHandle {
             }
             LambdaForm.associateWithDebugName(form, nameBuilder.toString());
         }
+
+        // NF_UNSAFE uses field form, avoid circular dependency in interpreter
+        form.compileToBytecode();
         return form;
     }
 

--- a/test/jdk/java/lang/invoke/LFInterpret/ReflectionInInterpretTest.java
+++ b/test/jdk/java/lang/invoke/LFInterpret/ReflectionInInterpretTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+
+/*
+ * @test
+ * @bug 8297727
+ * @summary MethodHandle field access fails with bytecode compilation disabled
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+ShowHiddenFrames
+ *     -Djava.lang.invoke.MethodHandle.COMPILE_THRESHOLD=-1
+ *     ReflectionInInterpretTest
+ */
+public class ReflectionInInterpretTest {
+    private static Integer f; // non-Object type is required to find a non-compiled form
+
+    public static void main(String... args) throws Throwable {
+        MethodHandle mh = MethodHandles.lookup().findStaticGetter(ReflectionInInterpretTest.class, "f", Integer.class);
+        var _ = (Integer) mh.invokeExact();
+    }
+}


### PR DESCRIPTION
When LambdaForms are interpreted, so are field lambda forms. When this happens, we may get into an infinite recursion due to field lambda forms using `MethodHandleStatics.UNSAFE` via field lambda form.

I think the best solution here is to always eagerly compile field DMH forms - we already do so for all method forms, and there is a finite number of field forms, mostly pregenerated. The reference with cast form is erroneously missed, and it is actually the culprit of this issue. Will pregenerate that in another patch.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297727](https://bugs.openjdk.org/browse/JDK-8297727): Forcing LF interpretation lead to StackOverflowError in reflection code (**Bug** - P4)


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24835/head:pull/24835` \
`$ git checkout pull/24835`

Update a local copy of the PR: \
`$ git checkout pull/24835` \
`$ git pull https://git.openjdk.org/jdk.git pull/24835/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24835`

View PR using the GUI difftool: \
`$ git pr show -t 24835`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24835.diff">https://git.openjdk.org/jdk/pull/24835.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24835#issuecomment-2825652215)
</details>
