### PR TITLE
8355439: Some hotspot/jtreg/serviceability/sa/* tests fail on static JDK due to explicit checks for shared libraries in process memory map

### DIFF
--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbPmap.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbPmap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -74,7 +74,11 @@ public class ClhsdbPmap {
             if (!withCore && Platform.isOSX()) {
                 expStrMap.put("pmap", List.of("Not available for Mac OS X processes"));
             } else {
-                expStrMap.put("pmap", List.of("jvm", "java", "jli", "jimage"));
+                if (Platform.isStatic()) {
+                    expStrMap.put("pmap", List.of("java"));
+                } else {
+                    expStrMap.put("pmap", List.of("jvm", "java", "jli", "jimage"));
+                }
             }
 
             if (withCore) {

--- a/test/hotspot/jtreg/serviceability/sa/sadebugd/PmapOnDebugdTest.java
+++ b/test/hotspot/jtreg/serviceability/sa/sadebugd/PmapOnDebugdTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2021 NTT DATA.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -23,6 +23,7 @@
  */
 
 import jdk.test.lib.JDKToolLauncher;
+import jdk.test.lib.Platform;
 import jdk.test.lib.apps.LingeredApp;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.SA.SATestUtils;
@@ -65,7 +66,12 @@ public class PmapOnDebugdTest {
             System.err.println(out.getStderr());
 
             out.stderrShouldBeEmptyIgnoreDeprecatedWarnings();
-            out.shouldMatch("^0x[0-9a-f]+.+libjvm\\.so$"); // Find libjvm from output
+            if (Platform.isStatic()) {
+                out.shouldMatch("java"); // Find launcher
+                out.shouldNotMatch("^0x[0-9a-f]+.+libjvm\\.so$"); // No libjvm from output
+            } else {
+                out.shouldMatch("^0x[0-9a-f]+.+libjvm\\.so$"); // Find libjvm from output
+            }
             out.shouldHaveExitValue(0);
 
             // This will detect most SA failures, including during the attach.

--- a/test/hotspot/jtreg/serviceability/sa/sadebugd/RunCommandOnServerTest.java
+++ b/test/hotspot/jtreg/serviceability/sa/sadebugd/RunCommandOnServerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2021 NTT DATA.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -25,6 +25,7 @@
 import java.io.PrintStream;
 
 import jdk.test.lib.JDKToolLauncher;
+import jdk.test.lib.Platform;
 import jdk.test.lib.apps.LingeredApp;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.SA.SATestUtils;
@@ -75,7 +76,12 @@ public class RunCommandOnServerTest {
             System.err.println(out.getStderr());
 
             out.stderrShouldBeEmptyIgnoreDeprecatedWarnings();
-            out.shouldMatch("^0x[0-9a-f]+: .+/libjvm\\.(so|dylib) \\+ 0x[0-9a-f]+$");
+            if (Platform.isStatic()) {
+                out.shouldMatch("java");
+                out.shouldNotMatch("^0x[0-9a-f]+: .+/libjvm\\.(so|dylib) \\+ 0x[0-9a-f]+$");
+            } else {
+                out.shouldMatch("^0x[0-9a-f]+: .+/libjvm\\.(so|dylib) \\+ 0x[0-9a-f]+$");
+            }
             out.shouldHaveExitValue(0);
 
             // This will detect most SA failures, including during the attach.


### PR DESCRIPTION
Please review the change for following hotspot/jtreg/serviceability/sa/* tests to not check for JDK/VM shared libraries when running on static JDK.

- test/hotspot/jtreg/serviceability/sa/ClhsdbPmap.java
- test/hotspot/jtreg/serviceability/sa/sadebugd/PmapOnDebugdTest.java
- test/hotspot/jtreg/serviceability/sa/sadebugd/RunCommandOnServerTest.java

I tested the change on a `static-jdk` binary with a `static-jdk/bin/jhsdb` symlink to the `jhsdb` in a regular JDK binary. The tests pass with the change. Example test command:
```
$ make test TEST="serviceability/sa/sadebugd/RunCommandOnServerTest.java" JDK_UNDER_TEST=/<snip>/JDK-8355439/build/linux-x86_64-server-fastdebug/images/static-jdk JDK_FOR_COMPILE=/<snip>/JDK-8355439/build/linux-x86_64-server-fastdebug/images/jdk
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8355439](https://bugs.openjdk.org/browse/JDK-8355439): Some hotspot/jtreg/serviceability/sa/* tests fail on static JDK due to explicit checks for shared libraries in process memory map (**Bug** - P4)


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24836/head:pull/24836` \
`$ git checkout pull/24836`

Update a local copy of the PR: \
`$ git checkout pull/24836` \
`$ git pull https://git.openjdk.org/jdk.git pull/24836/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24836`

View PR using the GUI difftool: \
`$ git pr show -t 24836`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24836.diff">https://git.openjdk.org/jdk/pull/24836.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24836#issuecomment-2825653326)
</details>
