### PR TITLE
8355441: Remove antipattern from PassFailJFrame.forcePass javadoc

### DIFF
--- a/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
+++ b/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
@@ -1293,21 +1293,16 @@ public final class PassFailJFrame {
 
 
     /**
-     * Forcibly pass the test. This should be used in semi-automatic tests when
+     * Forcibly pass the test. This method should be used in semi-automatic tests when
      * the test determines that all the conditions for passing the test are met.
-     * This should not be used in cases where a resource is unavailable or a
+     * <p>
+     * This method should not be used in cases where a resource is unavailable or a
      * feature isn't supported, instead the test should
      * throw jtreg.SkippedException.
      *
-     * <p>The sample usage:
-     * <pre><code>
-     *     String output = fd.getFile();
-     *     if ("input".equals(output)) {
-     *     PassFailJFrame.forcePass();
-     *     } else {
-     *     PassFailJFrame.forceFail("TEST FAILED (output file - " + output + ")");
-     *     }
-     * </code></pre>
+     * <p> A sample usage can be found in this test :
+     * <a href="https://github.com/openjdk/jdk/blob/master/test/jdk/java/awt/FileDialog/SaveFileNameOverrideTest.java#L84">SaveFileNameOverrideTest.java</a>
+     *
      */
     public static void forcePass() {
         latch.countDown();

--- a/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
+++ b/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
@@ -1302,7 +1302,7 @@ public final class PassFailJFrame {
      * feature isn't supported, throw {@code jtreg.SkippedException} instead.
      *
      * <p>A sample usage can be found in
-     * <a href="https://github.com/openjdk/jdk/blob/7283c8b/test/jdk/java/awt/FileDialog/SaveFileNameOverrideTest.java">{@code
+     * <a href="https://github.com/openjdk/jdk/blob/7283c8b/test/jdk/java/awt/FileDialog/SaveFileNameOverrideTest.java#L84">{@code
      * SaveFileNameOverrideTest.java}</a>
      */
     public static void forcePass() {

--- a/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
+++ b/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
@@ -1293,14 +1293,20 @@ public final class PassFailJFrame {
 
 
     /**
-     * Forcibly pass the test.
+     * Forcibly pass the test. This should be used in semi-automatic tests when
+     * the test determines that all the conditions for passing the test are met.
+     * This should not be used in cases where a resource is unavailable or a
+     * feature isn't supported, instead the test should
+     * throw jtreg.SkippedException.
+     *
      * <p>The sample usage:
      * <pre><code>
-     *      PrinterJob pj = PrinterJob.getPrinterJob();
-     *      if (pj == null || pj.getPrintService() == null) {
-     *          System.out.println(""Printer not configured or available.");
-     *          PassFailJFrame.forcePass();
-     *      }
+     *     String output = fd.getFile();
+     *     if ("input".equals(output)) {
+     *     PassFailJFrame.forcePass();
+     *     } else {
+     *     PassFailJFrame.forceFail("TEST FAILED (output file - " + output + ")");
+     *     }
      * </code></pre>
      */
     public static void forcePass() {

--- a/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
+++ b/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
@@ -1293,16 +1293,17 @@ public final class PassFailJFrame {
 
 
     /**
-     * Forcibly pass the test. This method should be used in semi-automatic tests when
+     * Forcibly pass the test.
+     * <p>
+     * Use this method in semi-automatic tests when
      * the test determines that all the conditions for passing the test are met.
      * <p>
-     * This method should not be used in cases where a resource is unavailable or a
-     * feature isn't supported, instead the test should
-     * throw jtreg.SkippedException.
+     * <strong>Do not use</strong> this method in cases where a resource is unavailable or a
+     * feature isn't supported, throw {@code jtreg.SkippedException} instead.
      *
-     * <p> A sample usage can be found in this test :
-     * <a href="https://github.com/openjdk/jdk/blob/master/test/jdk/java/awt/FileDialog/SaveFileNameOverrideTest.java#L84">SaveFileNameOverrideTest.java</a>
-     *
+     * <p>A sample usage can be found in
+     * <a href="https://github.com/openjdk/jdk/blob/7283c8b/test/jdk/java/awt/FileDialog/SaveFileNameOverrideTest.java">{@code
+     * SaveFileNameOverrideTest.java}</a>
      */
     public static void forcePass() {
         latch.countDown();


### PR DESCRIPTION
The javadoc for PassFailJFrame.forcePass suggests an anti-pattern of forcibly passing the test if a resource is unavailable.

If a resource is unavailable or a feature isn't supported, the test should throw jtreg.SkippedException.

PassFailJFrame.forcePass should be used in semi-automatic tests when the test determines that all the conditions for passing the test are met.
Please refer: JDK-8355366 and https://github.com/openjdk/jdk/pull/24820

Testing
This is a javadoc change, so not testing required.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8355441](https://bugs.openjdk.org/browse/JDK-8355441): Remove antipattern from PassFailJFrame.forcePass javadoc (**Bug** - P4)


### Reviewers
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Harshitha Onkar](https://openjdk.org/census#honkar) (@honkar-jdk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24837/head:pull/24837` \
`$ git checkout pull/24837`

Update a local copy of the PR: \
`$ git checkout pull/24837` \
`$ git pull https://git.openjdk.org/jdk.git pull/24837/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24837`

View PR using the GUI difftool: \
`$ git pr show -t 24837`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24837.diff">https://git.openjdk.org/jdk/pull/24837.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24837#issuecomment-2825799052)
</details>
