### PR TITLE
8355387: [jittester] Disable downcasts by default

### DIFF
--- a/test/hotspot/jtreg/testlibrary/jittester/src/jdk/test/lib/jittester/ProductionParams.java
+++ b/test/hotspot/jtreg/testlibrary/jittester/src/jdk/test/lib/jittester/ProductionParams.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -121,7 +121,7 @@ public class ProductionParams {
         disableExternalSymbols = optionResolver.addBooleanOption("disable-external-symbols", "Don\'t use external symbols");
         addExternalSymbols = optionResolver.addStringOption("add-external-symbols", "all", "Add symbols for listed classes (comma-separated list)");
         disableInheritance = optionResolver.addBooleanOption("disable-inheritance", "Disable inheritance");
-        disableDowncasts = optionResolver.addBooleanOption("disable-downcasts", "Disable downcasting of objects");
+        disableDowncasts = optionResolver.addBooleanOption(null, "disable-downcasts", true, "Disable downcasting of objects");
         disableStatic = optionResolver.addBooleanOption("disable-static", "Disable generation of static objects and functions");
         disableInterfaces = optionResolver.addBooleanOption("disable-interfaces", "Disable generation of interfaces");
         disableClasses = optionResolver.addBooleanOption("disable-classes", "Disable generation of classes");


### PR DESCRIPTION
Currently, JITTester's love to downcast often produces something like this:

ArrayList<Integer> someVar = (TreeSet)(Object)(List)(new ArrayList<Integer>());

... which is possible because it goes up to Object and then starts downcasting to some totally unrelated class / type.

Considering the JITTester's love to casts (they are more-or-less 'safe' expressions), it means a high probability (30-50%) of a gentest to fail compilation. Even worse is the situation for ByteCode tests - that they're faulty is only recognized during the run phase.

I suggest to disable the downcasts for now.
Testing: 50-100 generated tests in different combinations (default, with the flag set to 'false' or 'true') with artificially increased chance to casts.