### PR TITLE
8338194: ubsan: mulnode.cpp:862:59: runtime error: shift exponent 64 is too large for 64-bit type 'long unsigned int'

### DIFF
--- a/src/hotspot/share/opto/mulnode.cpp
+++ b/src/hotspot/share/opto/mulnode.cpp
@@ -924,13 +924,15 @@ Node *AndLNode::Ideal(PhaseGVN *phase, bool can_reshape) {
     if( t12 && t12->is_con() ) { // Shift is by a constant
       int shift = t12->get_con();
       shift &= BitsPerJavaLong - 1;  // semantics of Java shifts
-      const julong sign_bits_mask = ~(((julong)CONST64(1) << (julong)(BitsPerJavaLong - shift)) -1);
-      // If the AND'ing of the 2 masks has no bits, then only original shifted
-      // bits survive.  NO sign-extension bits survive the maskings.
-      if( (sign_bits_mask & mask) == 0 ) {
-        // Use zero-fill shift instead
-        Node *zshift = phase->transform(new URShiftLNode(in1->in(1), in1->in(2)));
-        return new AndLNode(zshift, in(2));
+      if (shift != 0) {
+        const julong sign_bits_mask = ~(((julong)CONST64(1) << (julong)(BitsPerJavaLong - shift)) -1);
+        // If the AND'ing of the 2 masks has no bits, then only original shifted
+        // bits survive.  NO sign-extension bits survive the maskings.
+        if( (sign_bits_mask & mask) == 0 ) {
+          // Use zero-fill shift instead
+          Node *zshift = phase->transform(new URShiftLNode(in1->in(1), in1->in(2)));
+          return new AndLNode(zshift, in(2));
+        }
       }
     }
   }


### PR DESCRIPTION
We have a UB when the shift is equal to or bigger than the number of bits in
the type. Our expression is
```cpp
(julong)CONST64(1) << (julong)(BitsPerJavaLong - shift)
```
so we have a UB when the RHS is `>= 64`, that is when `shift` is `<= 0`. Since shift is masked to
be in `[0, BitPerJavaLong - 1]`, we actually have a UB when `shift == 0`. The
code doesn't forbid it, indeed, and it doesn't seem to be enforced by more global
invariants.

This UB doesn't reproduce anymore with the provided cases.
I've replaced the UB with an explicit assert to try to find another failing
case. No hit when run with tier1, tier2, tier3, hs-precheckin-comp and hs-comp-stress.

Nevertheless, the assert indeed hit on the master of when the issue was filed.
More precisely, I've bisect for the two tests `java/foreign/StdLibTest.java`
and `java/lang/invoke/PermuteArgsTest.java` and the assert hits until
[8339196: Optimize BufWriterImpl#writeU1/U2/Int/Long](https://bugs.openjdk.org/browse/JDK-8339196).

It is not clear to me why the issue stopped reproducing after this commit, but given
the lack of reproducer, I went with a semi-blind fix: it fixes the issue back then,
and still removes a chance of UB. It simply makes sure the RHS of this shift cannot be
64 by making sure `shift` cannot be 0.

If `shift` is indeed 0, since it is the RHS of a `RShiftLNode`, `RShiftLNode::Identity`
should simply returns the LHS of the shift, and entirely eliminate the RShiftLNode.

The implementation of `AndINode::Ideal` is, on the other hand, safe. Indeed, it uses
`right_n_bits(BitsPerJavaInteger - shift)` instead of doing manually
`(1 << (BitsPerJavaInteger - shift)) - 1`. This macro is safe as it would return `-1` if
the shift is too large rather than causing a UB. Yet, I didn't use this way since it would
cause the replacement of `AndI(X, RShiftI(Y, 0))` by `AndI(X, URShiftI(Y, 0))` before
simplifying the `URShiftI` into `Y`. In between, it also implies that all users of the
And node will be enqueued for IGVN for a not-very-interesting change. Simply skipping
the replacement of RShiftL into URShiftL allows to directly come to `AndL(X, Y)` without
useless steps.

Thanks,
Marc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338194](https://bugs.openjdk.org/browse/JDK-8338194): ubsan: mulnode.cpp:862:59: runtime error: shift exponent 64 is too large for 64-bit type 'long unsigned int' (**Bug** - P4)


### Reviewers
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**)
 * [Damon Fenacci](https://openjdk.org/census#dfenacci) (@dafedafe - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24841/head:pull/24841` \
`$ git checkout pull/24841`

Update a local copy of the PR: \
`$ git checkout pull/24841` \
`$ git pull https://git.openjdk.org/jdk.git pull/24841/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24841`

View PR using the GUI difftool: \
`$ git pr show -t 24841`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24841.diff">https://git.openjdk.org/jdk/pull/24841.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24841#issuecomment-2826780590)
</details>
