### PR TITLE
8355473: Clean up x86 globals/VM_Version after 32-bit x86 removal

### DIFF
--- a/src/hotspot/cpu/x86/globalDefinitions_x86.hpp
+++ b/src/hotspot/cpu/x86/globalDefinitions_x86.hpp
@@ -34,9 +34,7 @@ const bool CCallingConventionRequiresIntsAsLongs = false;
 
 #define SUPPORTS_NATIVE_CX8
 
-#ifdef _LP64
 #define SUPPORT_MONITOR_COUNT
-#endif
 
 #define CPU_MULTI_COPY_ATOMIC
 
@@ -44,15 +42,11 @@ const bool CCallingConventionRequiresIntsAsLongs = false;
 #define DEFAULT_CACHE_LINE_SIZE 64
 
 // The default padding size for data structures to avoid false sharing.
-#ifdef _LP64
 // The common wisdom is that adjacent cache line prefetchers on some hardware
 // may pull two cache lines on access, so we have to pessimistically assume twice
 // the cache line size for padding. TODO: Check if this is still true for modern
 // hardware. If not, DEFAULT_CACHE_LINE_SIZE might as well suffice.
 #define DEFAULT_PADDING_SIZE (DEFAULT_CACHE_LINE_SIZE*2)
-#else
-#define DEFAULT_PADDING_SIZE DEFAULT_CACHE_LINE_SIZE
-#endif
 
 #if defined(LINUX) || defined(__APPLE__)
 #define SUPPORT_RESERVED_STACK_AREA

--- a/src/hotspot/cpu/x86/globals_x86.hpp
+++ b/src/hotspot/cpu/x86/globals_x86.hpp
@@ -61,29 +61,19 @@ define_pd_global(intx, InlineSmallCode,          1000);
 #define MIN_STACK_RED_PAGES DEFAULT_STACK_RED_PAGES
 #define MIN_STACK_RESERVED_PAGES (0)
 
-#ifdef _LP64
 // Java_java_net_SocketOutputStream_socketWrite0() uses a 64k buffer on the
-// stack if compiled for unix and LP64. To pass stack overflow tests we need
-// 20 shadow pages.
+// stack if compiled for unix. To pass stack overflow tests we need 20 shadow pages.
 #define DEFAULT_STACK_SHADOW_PAGES (NOT_WIN64(20) WIN64_ONLY(8) DEBUG_ONLY(+4))
 // For those clients that do not use write socket, we allow
 // the min range value to be below that of the default
 #define MIN_STACK_SHADOW_PAGES (NOT_WIN64(10) WIN64_ONLY(8) DEBUG_ONLY(+4))
-#else
-#define DEFAULT_STACK_SHADOW_PAGES (4 DEBUG_ONLY(+5))
-#define MIN_STACK_SHADOW_PAGES DEFAULT_STACK_SHADOW_PAGES
-#endif // _LP64
 
 define_pd_global(intx, StackYellowPages, DEFAULT_STACK_YELLOW_PAGES);
 define_pd_global(intx, StackRedPages, DEFAULT_STACK_RED_PAGES);
 define_pd_global(intx, StackShadowPages, DEFAULT_STACK_SHADOW_PAGES);
 define_pd_global(intx, StackReservedPages, DEFAULT_STACK_RESERVED_PAGES);
 
-#ifdef _LP64
 define_pd_global(bool, VMContinuations, true);
-#else
-define_pd_global(bool, VMContinuations, false);
-#endif
 
 define_pd_global(bool, RewriteBytecodes,     true);
 define_pd_global(bool, RewriteFrequentPairs, true);

--- a/src/hotspot/cpu/x86/vm_version_x86.cpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.cpp
@@ -72,8 +72,6 @@ static get_cpu_info_stub_t get_cpu_info_stub = nullptr;
 static detect_virt_stub_t detect_virt_stub = nullptr;
 static clear_apx_test_state_t clear_apx_test_state_stub = nullptr;
 
-#ifdef _LP64
-
 bool VM_Version::supports_clflush() {
   // clflush should always be available on x86_64
   // if not we are in real trouble because we rely on it
@@ -87,7 +85,6 @@ bool VM_Version::supports_clflush() {
   assert ((!Universe::is_fully_initialized() || (_features & CPU_FLUSH) != 0), "clflush should be available");
   return true;
 }
-#endif
 
 #define CPUID_STANDARD_FN   0x0
 #define CPUID_STANDARD_FN_1 0x1
@@ -107,7 +104,6 @@ class VM_Version_StubGenerator: public StubCodeGenerator {
 
   VM_Version_StubGenerator(CodeBuffer *c) : StubCodeGenerator(c) {}
 
-#if defined(_LP64)
   address clear_apx_test_state() {
 #   define __ _masm->
     address start = __ pc();
@@ -126,7 +122,6 @@ class VM_Version_StubGenerator: public StubCodeGenerator {
     __ ret(0);
     return start;
   }
-#endif
 
   address generate_get_cpu_info() {
     // Flags to test CPU type.
@@ -151,14 +146,10 @@ class VM_Version_StubGenerator: public StubCodeGenerator {
     //
     // void get_cpu_info(VM_Version::CpuidInfo* cpuid_info);
     //
-    // LP64: rcx and rdx are first and second argument registers on windows
+    // rcx and rdx are first and second argument registers on windows
 
     __ push(rbp);
-#ifdef _LP64
     __ mov(rbp, c_rarg0); // cpuid_info address
-#else
-    __ movptr(rbp, Address(rsp, 8)); // cpuid_info address
-#endif
     __ push(rbx);
     __ push(rsi);
     __ pushf();          // preserve rbx, and flags
@@ -418,7 +409,6 @@ class VM_Version_StubGenerator: public StubCodeGenerator {
     __ movl(Address(rsi, 8), rcx);
     __ movl(Address(rsi,12), rdx);
 
-#if defined(_LP64)
     //
     // Check if OS has enabled XGETBV instruction to access XCR0
     // (OSXSAVE feature flag) and CPU supports APX
@@ -453,7 +443,6 @@ class VM_Version_StubGenerator: public StubCodeGenerator {
     __ movq(Address(rsi, 8), r31);
 
     UseAPX = save_apx;
-#endif
 #endif
     __ bind(vector_save_restore);
     //
@@ -527,10 +516,8 @@ class VM_Version_StubGenerator: public StubCodeGenerator {
       __ movdl(xmm0, rcx);
       __ vpbroadcastd(xmm0, xmm0, Assembler::AVX_512bit);
       __ evmovdqul(xmm7, xmm0, Assembler::AVX_512bit);
-#ifdef _LP64
       __ evmovdqul(xmm8, xmm0, Assembler::AVX_512bit);
       __ evmovdqul(xmm31, xmm0, Assembler::AVX_512bit);
-#endif
       VM_Version::clean_cpuFeatures();
       __ jmp(save_restore_except);
     }
@@ -556,10 +543,8 @@ class VM_Version_StubGenerator: public StubCodeGenerator {
     __ pshufd(xmm0, xmm0, 0x00);
     __ vinsertf128_high(xmm0, xmm0);
     __ vmovdqu(xmm7, xmm0);
-#ifdef _LP64
     __ vmovdqu(xmm8, xmm0);
     __ vmovdqu(xmm15, xmm0);
-#endif
     VM_Version::clean_cpuFeatures();
 
     __ bind(save_restore_except);
@@ -600,10 +585,8 @@ class VM_Version_StubGenerator: public StubCodeGenerator {
       __ lea(rsi, Address(rbp, in_bytes(VM_Version::zmm_save_offset())));
       __ evmovdqul(Address(rsi, 0), xmm0, Assembler::AVX_512bit);
       __ evmovdqul(Address(rsi, 64), xmm7, Assembler::AVX_512bit);
-#ifdef _LP64
       __ evmovdqul(Address(rsi, 128), xmm8, Assembler::AVX_512bit);
       __ evmovdqul(Address(rsi, 192), xmm31, Assembler::AVX_512bit);
-#endif
 
 #ifdef _WINDOWS
       __ evmovdqul(xmm31, Address(rsp, 0), Assembler::AVX_512bit);
@@ -628,10 +611,8 @@ class VM_Version_StubGenerator: public StubCodeGenerator {
     __ lea(rsi, Address(rbp, in_bytes(VM_Version::ymm_save_offset())));
     __ vmovdqu(Address(rsi, 0), xmm0);
     __ vmovdqu(Address(rsi, 32), xmm7);
-#ifdef _LP64
     __ vmovdqu(Address(rsi, 64), xmm8);
     __ vmovdqu(Address(rsi, 96), xmm15);
-#endif
 
 #ifdef _WINDOWS
     __ vmovdqu(xmm15, Address(rsp, 0));
@@ -687,13 +668,8 @@ class VM_Version_StubGenerator: public StubCodeGenerator {
     __ push(rbx);
     __ push(rsi); // for Windows
 
-#ifdef _LP64
     __ mov(rax, c_rarg0); // CPUID leaf
     __ mov(rsi, c_rarg1); // register array address (eax, ebx, ecx, edx)
-#else
-    __ movptr(rax, Address(rsp, 16)); // CPUID leaf
-    __ movptr(rsi, Address(rsp, 20)); // register array address
-#endif
 
     __ cpuid();
 
@@ -734,14 +710,10 @@ class VM_Version_StubGenerator: public StubCodeGenerator {
     //
     // void getCPUIDBrandString(VM_Version::CpuidInfo* cpuid_info);
     //
-    // LP64: rcx and rdx are first and second argument registers on windows
+    // rcx and rdx are first and second argument registers on windows
 
     __ push(rbp);
-#ifdef _LP64
     __ mov(rbp, c_rarg0); // cpuid_info address
-#else
-    __ movptr(rbp, Address(rsp, 8)); // cpuid_info address
-#endif
     __ push(rbx);
     __ push(rsi);
     __ pushf();          // preserve rbx, and flags
@@ -889,19 +861,16 @@ void VM_Version::get_processor_features() {
   // xchg and xadd instructions
   _supports_atomic_getset4 = true;
   _supports_atomic_getadd4 = true;
-  LP64_ONLY(_supports_atomic_getset8 = true);
-  LP64_ONLY(_supports_atomic_getadd8 = true);
+  _supports_atomic_getset8 = true;
+  _supports_atomic_getadd8 = true;
 
-#ifdef _LP64
   // OS should support SSE for x64 and hardware should support at least SSE2.
   if (!VM_Version::supports_sse2()) {
     vm_exit_during_initialization("Unknown x64 processor: SSE2 not supported");
   }
   // in 64 bit the use of SSE2 is the minimum
   if (UseSSE < 2) UseSSE = 2;
-#endif
 
-#ifdef AMD64
   // flush_icache_stub have to be generated first.
   // That is why Icache line size is hard coded in ICache class,
   // see icache_x86.hpp. It is also the reason why we can't use
@@ -913,9 +882,7 @@ void VM_Version::get_processor_features() {
   guarantee(_cpuid_info.std_cpuid1_edx.bits.clflush != 0, "clflush is not supported");
   // clflush_size is size in quadwords (8 bytes).
   guarantee(_cpuid_info.std_cpuid1_ebx.bits.clflush_size == 8, "such clflush size is not supported");
-#endif
 
-#ifdef _LP64
   // assigning this field effectively enables Unsafe.writebackMemory()
   // by initing UnsafeConstant.DATA_CACHE_LINE_FLUSH_SIZE to non-zero
   // that is only implemented on x86_64 and only if the OS plays ball
@@ -924,7 +891,6 @@ void VM_Version::get_processor_features() {
     // let if default to zero thereby disabling writeback
     _data_cache_line_flush_size = _cpuid_info.std_cpuid1_ebx.bits.clflush_size * 8;
   }
-#endif
 
   // Check if processor has Intel Ecore
   if (FLAG_IS_DEFAULT(EnableX86ECoreOpts) && is_intel() && cpu_family() == 6 &&
@@ -1206,7 +1172,6 @@ void VM_Version::get_processor_features() {
     FLAG_SET_DEFAULT(UseCRC32Intrinsics, false);
   }
 
-#ifdef _LP64
   if (supports_avx2()) {
     if (FLAG_IS_DEFAULT(UseAdler32Intrinsics)) {
       UseAdler32Intrinsics = true;
@@ -1217,12 +1182,6 @@ void VM_Version::get_processor_features() {
     }
     FLAG_SET_DEFAULT(UseAdler32Intrinsics, false);
   }
-#else
-  if (UseAdler32Intrinsics) {
-    warning("Adler32Intrinsics not available on this CPU.");
-    FLAG_SET_DEFAULT(UseAdler32Intrinsics, false);
-  }
-#endif
 
   if (supports_sse4_2() && supports_clmul()) {
     if (FLAG_IS_DEFAULT(UseCRC32CIntrinsics)) {
@@ -1246,7 +1205,6 @@ void VM_Version::get_processor_features() {
     FLAG_SET_DEFAULT(UseGHASHIntrinsics, false);
   }
 
-#ifdef _LP64
   // ChaCha20 Intrinsics
   // As long as the system supports AVX as a baseline we can do a
   // SIMD-enabled block function.  StubGenerator makes the determination
@@ -1262,24 +1220,14 @@ void VM_Version::get_processor_features() {
       }
       FLAG_SET_DEFAULT(UseChaCha20Intrinsics, false);
   }
-#else
-  // No support currently for ChaCha20 intrinsics on 32-bit platforms
-  if (UseChaCha20Intrinsics) {
-      warning("ChaCha20 intrinsics are not available on this CPU.");
-      FLAG_SET_DEFAULT(UseChaCha20Intrinsics, false);
-  }
-#endif // _LP64
 
   // Dilithium Intrinsics
   // Currently we only have them for AVX512
-#ifdef _LP64
   if (supports_evex() && supports_avx512bw()) {
       if (FLAG_IS_DEFAULT(UseDilithiumIntrinsics)) {
           UseDilithiumIntrinsics = true;
       }
-  } else
-#endif
-   if (UseDilithiumIntrinsics) {
+  } else if (UseDilithiumIntrinsics) {
       warning("Intrinsics for ML-DSA are not available on this CPU.");
       FLAG_SET_DEFAULT(UseDilithiumIntrinsics, false);
   }
@@ -1308,7 +1256,7 @@ void VM_Version::get_processor_features() {
     UseMD5Intrinsics = true;
   }
 
-  if (supports_sha() LP64_ONLY(|| (supports_avx2() && supports_bmi2()))) {
+  if (supports_sha() || (supports_avx2() && supports_bmi2())) {
     if (FLAG_IS_DEFAULT(UseSHA)) {
       UseSHA = true;
     }
@@ -1335,27 +1283,20 @@ void VM_Version::get_processor_features() {
     FLAG_SET_DEFAULT(UseSHA256Intrinsics, false);
   }
 
-#ifdef _LP64
-  // These are only supported on 64-bit
   if (UseSHA && supports_avx2() && (supports_bmi2() || supports_sha512())) {
     if (FLAG_IS_DEFAULT(UseSHA512Intrinsics)) {
       FLAG_SET_DEFAULT(UseSHA512Intrinsics, true);
     }
-  } else
-#endif
-  if (UseSHA512Intrinsics) {
+  } else if (UseSHA512Intrinsics) {
     warning("Intrinsics for SHA-384 and SHA-512 crypto hash functions not available on this CPU.");
     FLAG_SET_DEFAULT(UseSHA512Intrinsics, false);
   }
 
-#ifdef _LP64
   if (supports_evex() && supports_avx512bw()) {
       if (FLAG_IS_DEFAULT(UseSHA3Intrinsics)) {
           UseSHA3Intrinsics = true;
       }
-  } else
-#endif
-   if (UseSHA3Intrinsics) {
+  } else if (UseSHA3Intrinsics) {
       warning("Intrinsics for SHA3-224, SHA3-256, SHA3-384 and SHA3-512 crypto hash functions not available on this CPU.");
       FLAG_SET_DEFAULT(UseSHA3Intrinsics, false);
   }
@@ -1377,11 +1318,7 @@ void VM_Version::get_processor_features() {
     max_vector_size = 64;
   }
 
-#ifdef _LP64
   int min_vector_size = 4; // We require MaxVectorSize to be at least 4 on 64bit
-#else
-  int min_vector_size = 0;
-#endif
 
   if (!FLAG_IS_DEFAULT(MaxVectorSize)) {
     if (MaxVectorSize < min_vector_size) {
@@ -1405,7 +1342,7 @@ void VM_Version::get_processor_features() {
   if (MaxVectorSize > 0) {
     if (supports_avx() && PrintMiscellaneous && Verbose && TraceNewVectors) {
       tty->print_cr("State of YMM registers after signal handle:");
-      int nreg = 2 LP64_ONLY(+2);
+      int nreg = 4;
       const char* ymm_name[4] = {"0", "7", "8", "15"};
       for (int i = 0; i < nreg; i++) {
         tty->print("YMM%s:", ymm_name[i]);
@@ -1418,31 +1355,24 @@ void VM_Version::get_processor_features() {
   }
 #endif // COMPILER2 && ASSERT
 
-#ifdef _LP64
   if ((supports_avx512ifma() && supports_avx512vlbw()) || supports_avxifma())  {
     if (FLAG_IS_DEFAULT(UsePoly1305Intrinsics)) {
       FLAG_SET_DEFAULT(UsePoly1305Intrinsics, true);
     }
-  } else
-#endif
-  if (UsePoly1305Intrinsics) {
+  } else if (UsePoly1305Intrinsics) {
     warning("Intrinsics for Poly1305 crypto hash functions not available on this CPU.");
     FLAG_SET_DEFAULT(UsePoly1305Intrinsics, false);
   }
 
-#ifdef _LP64
   if ((supports_avx512ifma() && supports_avx512vlbw()) || supports_avxifma()) {
     if (FLAG_IS_DEFAULT(UseIntPolyIntrinsics)) {
       FLAG_SET_DEFAULT(UseIntPolyIntrinsics, true);
     }
-  } else
-#endif
-  if (UseIntPolyIntrinsics) {
+  } else if (UseIntPolyIntrinsics) {
     warning("Intrinsics for Polynomial crypto functions not available on this CPU.");
     FLAG_SET_DEFAULT(UseIntPolyIntrinsics, false);
   }
 
-#ifdef _LP64
   if (FLAG_IS_DEFAULT(UseMultiplyToLenIntrinsic)) {
     UseMultiplyToLenIntrinsic = true;
   }
@@ -1458,38 +1388,6 @@ void VM_Version::get_processor_features() {
   if (FLAG_IS_DEFAULT(UseMontgomerySquareIntrinsic)) {
     UseMontgomerySquareIntrinsic = true;
   }
-#else
-  if (UseMultiplyToLenIntrinsic) {
-    if (!FLAG_IS_DEFAULT(UseMultiplyToLenIntrinsic)) {
-      warning("multiplyToLen intrinsic is not available in 32-bit VM");
-    }
-    FLAG_SET_DEFAULT(UseMultiplyToLenIntrinsic, false);
-  }
-  if (UseMontgomeryMultiplyIntrinsic) {
-    if (!FLAG_IS_DEFAULT(UseMontgomeryMultiplyIntrinsic)) {
-      warning("montgomeryMultiply intrinsic is not available in 32-bit VM");
-    }
-    FLAG_SET_DEFAULT(UseMontgomeryMultiplyIntrinsic, false);
-  }
-  if (UseMontgomerySquareIntrinsic) {
-    if (!FLAG_IS_DEFAULT(UseMontgomerySquareIntrinsic)) {
-      warning("montgomerySquare intrinsic is not available in 32-bit VM");
-    }
-    FLAG_SET_DEFAULT(UseMontgomerySquareIntrinsic, false);
-  }
-  if (UseSquareToLenIntrinsic) {
-    if (!FLAG_IS_DEFAULT(UseSquareToLenIntrinsic)) {
-      warning("squareToLen intrinsic is not available in 32-bit VM");
-    }
-    FLAG_SET_DEFAULT(UseSquareToLenIntrinsic, false);
-  }
-  if (UseMulAddIntrinsic) {
-    if (!FLAG_IS_DEFAULT(UseMulAddIntrinsic)) {
-      warning("mulAdd intrinsic is not available in 32-bit VM");
-    }
-    FLAG_SET_DEFAULT(UseMulAddIntrinsic, false);
-  }
-#endif // _LP64
 #endif // COMPILER2_OR_JVMCI
 
   // On new cpus instructions which update whole XMM register should be used
@@ -1766,7 +1664,6 @@ void VM_Version::get_processor_features() {
   }
 #endif
 
-#ifdef _LP64
   if (UseSSE42Intrinsics) {
     if (FLAG_IS_DEFAULT(UseVectorizedMismatchIntrinsic)) {
       UseVectorizedMismatchIntrinsic = true;
@@ -1783,20 +1680,6 @@ void VM_Version::get_processor_features() {
       warning("vectorizedHashCode intrinsics are not available on this CPU");
     FLAG_SET_DEFAULT(UseVectorizedHashCodeIntrinsic, false);
   }
-#else
-  if (UseVectorizedMismatchIntrinsic) {
-    if (!FLAG_IS_DEFAULT(UseVectorizedMismatchIntrinsic)) {
-      warning("vectorizedMismatch intrinsic is not available in 32-bit VM");
-    }
-    FLAG_SET_DEFAULT(UseVectorizedMismatchIntrinsic, false);
-  }
-  if (UseVectorizedHashCodeIntrinsic) {
-    if (!FLAG_IS_DEFAULT(UseVectorizedHashCodeIntrinsic)) {
-      warning("vectorizedHashCode intrinsic is not available in 32-bit VM");
-    }
-    FLAG_SET_DEFAULT(UseVectorizedHashCodeIntrinsic, false);
-  }
-#endif // _LP64
 
   // Use count leading zeros count instruction if available.
   if (supports_lzcnt()) {
@@ -1945,7 +1828,6 @@ void VM_Version::get_processor_features() {
 #endif
   }
 
-#ifdef _LP64
   // Prefetch settings
 
   // Prefetch interval for gc copy/scan == 9 dcache lines.  Derived from
@@ -1964,7 +1846,6 @@ void VM_Version::get_processor_features() {
   if (FLAG_IS_DEFAULT(PrefetchScanIntervalInBytes)) {
     FLAG_SET_DEFAULT(PrefetchScanIntervalInBytes, 576);
   }
-#endif
 
   if (FLAG_IS_DEFAULT(ContendedPaddingWidth) &&
      (cache_line_size > ContendedPaddingWidth))
@@ -2195,11 +2076,9 @@ int VM_Version::avx3_threshold() {
           FLAG_IS_DEFAULT(AVX3Threshold)) ? 0 : AVX3Threshold;
 }
 
-#if defined(_LP64)
 void VM_Version::clear_apx_test_state() {
   clear_apx_test_state_stub();
 }
-#endif
 
 static bool _vm_version_initialized = false;
 
@@ -2217,14 +2096,11 @@ void VM_Version::initialize() {
                                      g.generate_get_cpu_info());
   detect_virt_stub = CAST_TO_FN_PTR(detect_virt_stub_t,
                                      g.generate_detect_virt());
-
-#if defined(_LP64)
   clear_apx_test_state_stub = CAST_TO_FN_PTR(clear_apx_test_state_t,
                                      g.clear_apx_test_state());
-#endif
   get_processor_features();
 
-  LP64_ONLY(Assembler::precompute_instructions();)
+  Assembler::precompute_instructions();
 
   if (VM_Version::supports_hv()) { // Supports hypervisor
     check_virtualizations();
@@ -2991,12 +2867,10 @@ uint64_t VM_Version::CpuidInfo::feature_flags() const {
     result |= CPU_CMOV;
   if (std_cpuid1_edx.bits.clflush != 0)
     result |= CPU_FLUSH;
-#ifdef _LP64
   // clflush should always be available on x86_64
   // if not we are in real trouble because we rely on it
   // to flush the code cache.
   assert ((result & CPU_FLUSH) != 0, "clflush should be available");
-#endif
   if (std_cpuid1_edx.bits.fxsr != 0 || (is_amd_family() &&
       ext_cpuid1_edx.bits.fxsr != 0))
     result |= CPU_FXSR;
@@ -3168,7 +3042,7 @@ uint64_t VM_Version::CpuidInfo::feature_flags() const {
 
 bool VM_Version::os_supports_avx_vectors() {
   bool retVal = false;
-  int nreg = 2 LP64_ONLY(+2);
+  int nreg = 4;
   if (supports_evex()) {
     // Verify that OS save/restore all bits of EVEX registers
     // during signal processing.
@@ -3324,11 +3198,7 @@ int VM_Version::allocate_prefetch_distance(bool use_watermark_prefetch) {
       if (supports_sse4_2() && supports_ht()) { // Nehalem based cpus
         return 192;
       } else if (use_watermark_prefetch) { // watermark prefetching on Core
-#ifdef _LP64
         return 384;
-#else
-        return 320;
-#endif
       }
     }
     if (supports_sse2()) {

--- a/src/hotspot/cpu/x86/vm_version_x86.hpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.hpp
@@ -642,7 +642,7 @@ public:
   static void set_cpuinfo_cont_addr_apx(address pc) { _cpuinfo_cont_addr_apx = pc; }
   static address  cpuinfo_cont_addr_apx()           { return _cpuinfo_cont_addr_apx; }
 
-  LP64_ONLY(static void clear_apx_test_state());
+  static void clear_apx_test_state();
 
   static void clean_cpuFeatures()   { _features = 0; }
   static void set_avx_cpuFeatures() { _features |= (CPU_SSE | CPU_SSE2 | CPU_AVX | CPU_VZEROUPPER ); }
@@ -839,12 +839,12 @@ public:
 
   // x86_64 supports fast class initialization checks
   static bool supports_fast_class_init_checks() {
-    return LP64_ONLY(true) NOT_LP64(false); // not implemented on x86_32
+    return true;
   }
 
   // x86_64 supports secondary supers table
   constexpr static bool supports_secondary_supers_table() {
-    return LP64_ONLY(true) NOT_LP64(false); // not implemented on x86_32
+    return true;
   }
 
   constexpr static bool supports_stack_watermark_barrier() {
@@ -879,11 +879,7 @@ public:
   // synchronize with other memory ops. so, it needs preceding
   // and trailing StoreStore fences.
 
-#ifdef _LP64
   static bool supports_clflush(); // Can't inline due to header file conflict
-#else
-  static bool supports_clflush() { return  ((_features & CPU_FLUSH) != 0); }
-#endif // _LP64
 
   // Note: CPU_FLUSHOPT and CPU_CLWB bits should always be zero for 32-bit
   static bool supports_clflushopt() { return ((_features & CPU_FLUSHOPT) != 0); }


### PR DESCRIPTION
This cleanup targets `globals_x86.*` and `vmVersion_x86.*`.

Additional testing:
 - [x] Linux x86_64 server fastdebug, `all`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8355473](https://bugs.openjdk.org/browse/JDK-8355473): Clean up x86 globals/VM_Version after 32-bit x86 removal (**Sub-task** - P4)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24844/head:pull/24844` \
`$ git checkout pull/24844`

Update a local copy of the PR: \
`$ git checkout pull/24844` \
`$ git pull https://git.openjdk.org/jdk.git pull/24844/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24844`

View PR using the GUI difftool: \
`$ git pr show -t 24844`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24844.diff">https://git.openjdk.org/jdk/pull/24844.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24844#issuecomment-2826943989)
</details>
