### PR TITLE
8357226: Remove unnecessary List.indexOf from RepaintManager.removeInvalidComponent

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/RepaintManager.java
+++ b/src/java.desktop/share/classes/javax/swing/RepaintManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -390,11 +390,8 @@ public class RepaintManager
             delegate.removeInvalidComponent(component);
             return;
         }
-        if(invalidComponents != null) {
-            int index = invalidComponents.indexOf(component);
-            if(index != -1) {
-                invalidComponents.remove(index);
-            }
+        if (invalidComponents != null) {
+            invalidComponents.remove(component);
         }
     }
 


### PR DESCRIPTION
No need to call `List.indexOf(Object)` before `List.remove(int)`. Instead we can call `List.remove(Object)` directly. It's faster and cleaner.
`invalidComponents` is an ArrayList.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8357226](https://bugs.openjdk.org/browse/JDK-8357226): Remove unnecessary List.indexOf from RepaintManager.removeInvalidComponent (**Enhancement** - P5)


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24845/head:pull/24845` \
`$ git checkout pull/24845`

Update a local copy of the PR: \
`$ git checkout pull/24845` \
`$ git pull https://git.openjdk.org/jdk.git pull/24845/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24845`

View PR using the GUI difftool: \
`$ git pr show -t 24845`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24845.diff">https://git.openjdk.org/jdk/pull/24845.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24845#issuecomment-2890100059)
</details>
