### PR TITLE
8355492: MissedOptCastII is missing UnlockDiagnosticVMOptions flag

### DIFF
--- a/test/hotspot/jtreg/compiler/c2/gvn/MissedOptCastII.java
+++ b/test/hotspot/jtreg/compiler/c2/gvn/MissedOptCastII.java
@@ -32,6 +32,7 @@
  *           -XX:CompileCommand=compileonly,MissedOptCastII::*
  *           -XX:-TieredCompilation -Xcomp
  *           -XX:+IgnoreUnrecognizedVMOptions
+ *           -XX:+UnlockDiagnosticVMOptions
  *           -XX:+StressIGVN -XX:VerifyIterativeGVN=10
  *           MissedOptCastII
  */


### PR DESCRIPTION
As the title says, let's just add the flag! Sorry, my bad.

It now works on my machine.

Thanks,
Marc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8355492](https://bugs.openjdk.org/browse/JDK-8355492): MissedOptCastII is missing UnlockDiagnosticVMOptions flag (**Bug** - P5)


### Reviewers
 * [Roberto Castañeda Lozano](https://openjdk.org/census#rcastanedalo) (@robcasloz - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24849/head:pull/24849` \
`$ git checkout pull/24849`

Update a local copy of the PR: \
`$ git checkout pull/24849` \
`$ git pull https://git.openjdk.org/jdk.git pull/24849/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24849`

View PR using the GUI difftool: \
`$ git pr show -t 24849`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24849.diff">https://git.openjdk.org/jdk/pull/24849.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24849#issuecomment-2827625095)
</details>
