### PR TITLE
JDK-8355498 : [AIX] Adapt code for C++ VLA rule

### DIFF
--- a/src/hotspot/os/aix/os_perf_aix.cpp
+++ b/src/hotspot/os/aix/os_perf_aix.cpp
@@ -72,7 +72,7 @@ enum {
  * Get info for requested PID from /proc/<pid>/psinfo file
  */
 static bool read_psinfo(const u_longlong_t& pid, psinfo_t& psinfo) {
-  static size_t BUF_LENGTH = 32 + sizeof(u_longlong_t);
+  const size_t BUF_LENGTH = 32 + sizeof(u_longlong_t);
 
   FILE* fp;
   char buf[BUF_LENGTH];


### PR DESCRIPTION
JBS Issue: [JDK-8355498](https://bugs.openjdk.org/browse/JDK-8355498)


The declaration of Variable length array is causing compilation issues for Openxlc 17.1.3 compiler.
1 error generated.
gmake[3]: *** [lib/CompileJvm.gmk:170: /home/jenkins/openjdk-suchi/jdk/build/aix-ppc64-server-fastdebug/hotspot/variant-server/libjvm/objs/os_perf_aix.o] Error 1
gmake[2]: *** [make/Main.gmk:245: hotspot-server-libs] Error 2
gmake[2]: *** Waiting for unfinished jobs....

ERROR: Build failed for target 'images' in configuration 'aix-ppc64-server-fastdebug' (exit code 2)
Stopping javac server

=== Output from failing command(s) repeated here ===
* For target hotspot_variant-server_libjvm_objs_os_perf_aix.o:
/home/jenkins/openjdk-suchi/jdk/src/hotspot/os/aix/os_perf_aix.cpp:79:12: error: variable length arrays in C++ are a Clang extension [-Werror,-Wvla-cxx-extension]
   79 | char buf[BUF_LENGTH];
      | ^~~~~~~~~~
/home/jenkins/openjdk-suchi/jdk/src/hotspot/os/aix/os_perf_aix.cpp:79:12: note: read of non-const variable 'BUF_LENGTH' is not allowed in a constant expression
/home/jenkins/openjdk-suchi/jdk/src/hotspot/os/aix/os_perf_aix.cpp:76:17: note: declared here
   76 | static size_t BUF_LENGTH = 32 + sizeof(u_longlong_t);

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8355498](https://bugs.openjdk.org/browse/JDK-8355498): [AIX] Adapt code for C++ VLA rule (**Bug** - P4)


### Reviewers
 * [Joachim Kern](https://openjdk.org/census#jkern) (@JoKern65 - Committer)
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24851/head:pull/24851` \
`$ git checkout pull/24851`

Update a local copy of the PR: \
`$ git checkout pull/24851` \
`$ git pull https://git.openjdk.org/jdk.git pull/24851/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24851`

View PR using the GUI difftool: \
`$ git pr show -t 24851`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24851.diff">https://git.openjdk.org/jdk/pull/24851.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24851#issuecomment-2827728073)
</details>
