### PR TITLE
8362067: Remove unnecessary List.contains key from SpringLayout.Constraints.pushConstraint

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/SpringLayout.java
+++ b/src/java.desktop/share/classes/javax/swing/SpringLayout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,10 +27,8 @@ package javax.swing;
 import java.awt.Component;
 import java.awt.Container;
 import java.awt.Dimension;
-import java.awt.FontMetrics;
 import java.awt.Insets;
 import java.awt.LayoutManager2;
-import java.awt.Rectangle;
 import java.util.*;
 
 /**
@@ -403,8 +401,7 @@ public class SpringLayout implements LayoutManager2 {
             boolean valid = true;
             List<String> history = horizontal ? horizontalHistory :
                                                 verticalHistory;
-            if (history.contains(name)) {
-                history.remove(name);
+            if (history.remove(name)) {
                 valid = false;
             } else if (history.size() == 2 && value != null) {
                 history.remove(0);


### PR DESCRIPTION
There is no need to call `List.contains` before `List.remove` call.
`history` is an either `horizontalHistory` or `verticalHistory`. Both of them are ArrayList's.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24852/head:pull/24852` \
`$ git checkout pull/24852`

Update a local copy of the PR: \
`$ git checkout pull/24852` \
`$ git pull https://git.openjdk.org/jdk.git pull/24852/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24852`

View PR using the GUI difftool: \
`$ git pr show -t 24852`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24852.diff">https://git.openjdk.org/jdk/pull/24852.diff</a>

</details>
