### PR TITLE
8355366: Fix the wrong usage of PassFailJFrame.forcePass() in some manual tests

### DIFF
--- a/test/jdk/java/awt/Desktop/BrowseTest.java
+++ b/test/jdk/java/awt/Desktop/BrowseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,8 +25,8 @@
  * @test
  * @bug 6255196
  * @summary  Verifies the function of method browse(java.net.URI uri).
- * @library /java/awt/regtesthelpers
- * @build PassFailJFrame
+ * @library /java/awt/regtesthelpers /test/lib
+ * @build PassFailJFrame jtreg.SkippedException
  * @run main/manual BrowseTest
  */
 
@@ -35,6 +35,8 @@ import java.io.File;
 import java.lang.reflect.InvocationTargetException;
 import java.net.URI;
 import javax.swing.JPanel;
+
+import jtreg.SkippedException;
 
 public class BrowseTest extends JPanel {
     static final String INSTRUCTIONS = """
@@ -47,12 +49,6 @@ public class BrowseTest extends JPanel {
             """;
 
     public BrowseTest() {
-        if (!Desktop.isDesktopSupported()) {
-            PassFailJFrame.log("Class java.awt.Desktop is not supported on " +
-                    "current platform. Farther testing will not be performed");
-            PassFailJFrame.forcePass();
-        }
-
         Desktop desktop = Desktop.getDesktop();
 
         URI dirURI = new File(System.getProperty("user.home")).toURI();
@@ -77,6 +73,11 @@ public class BrowseTest extends JPanel {
 
     public static void main(String[] args) throws InterruptedException,
             InvocationTargetException {
+        if (!Desktop.isDesktopSupported()) {
+            throw new SkippedException("Class java.awt.Desktop is not supported " +
+                    "on current platform. Further testing will not be performed");
+        }
+
         PassFailJFrame.builder()
                 .title("Browser Test")
                 .splitUI(BrowseTest::new)

--- a/test/jdk/java/awt/Desktop/EditAndPrintTest/EditAndPrintTest.java
+++ b/test/jdk/java/awt/Desktop/EditAndPrintTest/EditAndPrintTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,8 +27,8 @@
  * @bug 6255196
  * @summary  Verifies the function of methods edit(java.io.File file) and
  *           print(java.io.File file)
- * @library /java/awt/regtesthelpers
- * @build PassFailJFrame
+ * @library /java/awt/regtesthelpers /test/lib
+ * @build PassFailJFrame jtreg.SkippedException
  * @run main/manual EditAndPrintTest
  */
 
@@ -40,6 +40,8 @@ import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import javax.swing.JPanel;
 
+import jtreg.SkippedException;
+
 public class EditAndPrintTest extends JPanel {
 
     static final String INSTRUCTIONS = """
@@ -49,20 +51,9 @@ public class EditAndPrintTest extends JPanel {
             If you see any EXCEPTION messages in the output press FAIL.
             """;
 
+    static Desktop desktop;
+
     public EditAndPrintTest() {
-        if (!Desktop.isDesktopSupported()) {
-            PassFailJFrame.log("Class java.awt.Desktop is not supported on " +
-                    "current platform. Further testing will not be performed");
-            PassFailJFrame.forcePass();
-        }
-
-        Desktop desktop = Desktop.getDesktop();
-
-        if (!desktop.isSupported(Action.PRINT) && !desktop.isSupported(Action.EDIT)) {
-            PassFailJFrame.log("Neither EDIT nor PRINT actions are supported. Nothing to test.");
-            PassFailJFrame.forcePass();
-        }
-
         /*
          * Part 1: print or edit a directory, which should throw an IOException.
          */
@@ -111,7 +102,7 @@ public class EditAndPrintTest extends JPanel {
             writer.write("This is a temp file used to test print() method of Desktop.");
             writer.flush();
             writer.close();
-        } catch (java.io.IOException ioe){
+        } catch (IOException ioe){
             PassFailJFrame.log("EXCEPTION: " + ioe.getMessage());
             PassFailJFrame.forceFail("Failed to create temp file for testing.");
         }
@@ -139,6 +130,16 @@ public class EditAndPrintTest extends JPanel {
 
     public static void main(String args[]) throws InterruptedException,
             InvocationTargetException {
+        if (!Desktop.isDesktopSupported()) {
+            throw new SkippedException("Class java.awt.Desktop is not supported " +
+                    "on current platform. Further testing will not be performed");
+        }
+
+        desktop = Desktop.getDesktop();
+        if (!desktop.isSupported(Action.PRINT) && !desktop.isSupported(Action.EDIT)) {
+            throw new SkippedException("Neither EDIT nor PRINT actions are supported. Nothing to test.");
+        }
+
         PassFailJFrame.builder()
                 .title("Edit and Print test")
                 .splitUI(EditAndPrintTest::new)

--- a/test/jdk/java/awt/Desktop/OpenTest.java
+++ b/test/jdk/java/awt/Desktop/OpenTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,8 +25,8 @@
  * @test
  * @bug 6255196
  * @summary Verifies the function of method open(java.io.File file).
- * @library /java/awt/regtesthelpers
- * @build PassFailJFrame
+ * @library /java/awt/regtesthelpers /test/lib
+ * @build PassFailJFrame jtreg.SkippedException
  * @run main/manual/othervm OpenTest
  */
 
@@ -35,6 +35,8 @@ import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import javax.swing.JPanel;
+
+import jtreg.SkippedException;
 
 public class OpenTest extends JPanel {
 
@@ -48,12 +50,6 @@ public class OpenTest extends JPanel {
             """;
 
     public OpenTest() {
-        if (!Desktop.isDesktopSupported()) {
-            PassFailJFrame.log("Class java.awt.Desktop is not supported on " +
-                    "current platform. Further testing will not be performed");
-            PassFailJFrame.forcePass();
-        }
-
         Desktop desktop = Desktop.getDesktop();
 
         /*
@@ -85,7 +81,7 @@ public class OpenTest extends JPanel {
             testFile = File.createTempFile("JDIC-test", ".txt",
                     new File(System.getProperty("java.io.tmpdir")));
             testFile.deleteOnExit();
-        } catch (java.io.IOException ioe) {
+        } catch (IOException ioe) {
             PassFailJFrame.log("EXCEPTION: " + ioe.getMessage());
             PassFailJFrame.log("Failed to create test file");
         }
@@ -101,6 +97,11 @@ public class OpenTest extends JPanel {
 
     public static void main(String[] args) throws InterruptedException,
             InvocationTargetException {
+        if (!Desktop.isDesktopSupported()) {
+            throw new SkippedException("Class java.awt.Desktop is not supported " +
+                    "on current platform. Further testing will not be performed");
+        }
+
         PassFailJFrame.builder()
                 .title("Mail Test")
                 .splitUI(OpenTest::new)


### PR DESCRIPTION
Fix the wrong usage of PassFailJFrame.forcePass() in some manual tests from java.awt.Desktop package. These tests should be fixed similar to [JDK-8352109](https://bugs.openjdk.org/browse/JDK-8352109) and jtreg.SkippedException should be used instead of PassFailJFrame.forcePass().
Affected tests:
1. https://github.com/openjdk/jdk/blob/master/test/jdk/java/awt/Desktop/BrowseTest.java
2. https://github.com/openjdk/jdk/blob/master/test/jdk/java/awt/Desktop/OpenTest.java
3. https://github.com/openjdk/jdk/blob/master/test/jdk/java/awt/Desktop/EditAndPrintTest/EditAndPrintTest.java

I have opened this PR because my other PR https://github.com/openjdk/jdk/pull/24820 got accidentally closed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8355366](https://bugs.openjdk.org/browse/JDK-8355366): Fix the wrong usage of PassFailJFrame.forcePass() in some manual tests (**Bug** - P4)


### Reviewers
 * [Harshitha Onkar](https://openjdk.org/census#honkar) (@honkar-jdk - **Reviewer**)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24853/head:pull/24853` \
`$ git checkout pull/24853`

Update a local copy of the PR: \
`$ git checkout pull/24853` \
`$ git pull https://git.openjdk.org/jdk.git pull/24853/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24853`

View PR using the GUI difftool: \
`$ git pr show -t 24853`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24853.diff">https://git.openjdk.org/jdk/pull/24853.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24853#issuecomment-2828246716)
</details>
