### PR TITLE
8355524: Only every second line in upgradeable files is being used

### DIFF
--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/LinkableRuntimeImage.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/LinkableRuntimeImage.java
@@ -93,7 +93,7 @@ public class LinkableRuntimeImage {
                     // Skip comments
                     continue;
                 }
-                upgradeableFiles.add(scanner.nextLine());
+                upgradeableFiles.add(line);
             }
         } catch (IOException e) {
             throw new AssertionError("Failure to retrieve upgradeable files for " +

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/runtimelink/upgrade_files_java.base.conf
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/runtimelink/upgrade_files_java.base.conf
@@ -1,4 +1,4 @@
 # Configuration for resource paths of files allowed to be
 # upgraded (in java.base)
-lib/tzdb.dat
 lib/security/cacerts
+lib/tzdb.dat


### PR DESCRIPTION
Please review this fix to [JDK-8353185](https://bugs.openjdk.org/browse/JDK-8353185). The reading logic for the config file would erroneously use `scanner.nextLine()` when the current line to be added is in `line`. `line` is not being added, but `scanner.nextLine()` unintentionally skipping lines. The config file has a change too. It moves the `tzdb.dat` line last so that the existing test verifies that the `cacerts` one isn't being skipped. This slipped through because `tzdb.dat` updates aren't automatically tested.

Testing:
- [x] GHA
- [x] The test from [JDK-8353185](https://bugs.openjdk.org/browse/JDK-8353185), `UpgradeableFileCacertsTest.java` fails with the config file change only (without the product fix) and passes with the one-liner. Also some manual testing when both files have been upgraded.

Thoughts?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8355524](https://bugs.openjdk.org/browse/JDK-8355524): Only every second line in upgradeable files is being used (**Bug** - P3)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24855/head:pull/24855` \
`$ git checkout pull/24855`

Update a local copy of the PR: \
`$ git checkout pull/24855` \
`$ git pull https://git.openjdk.org/jdk.git pull/24855/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24855`

View PR using the GUI difftool: \
`$ git pr show -t 24855`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24855.diff">https://git.openjdk.org/jdk/pull/24855.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24855#issuecomment-2828376163)
</details>
