### PR TITLE
8354431: gc/logging/TestGCId fails on Shenandoah

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
@@ -299,7 +299,10 @@ void ShenandoahControlThread::service_concurrent_normal_cycle(GCCause::Cause cau
   //                                      Full GC  --------------------------/
   //
   ShenandoahHeap* heap = ShenandoahHeap::heap();
-  if (check_cancellation_or_degen(ShenandoahGC::_degenerated_outside_cycle)) return;
+  if (check_cancellation_or_degen(ShenandoahGC::_degenerated_outside_cycle)) {
+    log_info(gc)("Cancelled");
+    return;
+  }
 
   ShenandoahGCSession session(cause, heap->global_generation());
 


### PR DESCRIPTION
I can't reproduce the issue in Linux, but based on the gc log shared in JBS bug and the related code, it is easy to find the root cause of it.

```
[0.133s][info][gc] GC(0) Concurrent reset after collect (unload classes) 0.033ms
[0.135s][info][gc] Trigger: Learning 2 of 5. Free (3958K) is below initial threshold (7167K)
[0.135s][info][gc] Failed to allocate Shared, 128K
[0.137s][info][gc] Trigger: Handle Allocation Failure
[0.148s][info][gc] GC(2) Degenerated GC upgrading to Full GC
[0.167s][info][gc] GC(2) Pause Degenerated GC (Outside of Cycle) 5M->1M(10M) 30.323ms

```
At 0.135s, a concurrent cycle was triggered: `[0.135s][info][gc] Trigger: Learning 2 of 5.`, meanwhile there was allocation failure causing degen: `[0.135s][info][gc] Failed to allocate Shared, 128K`.
In the implementation of ShenandoahControlThread::service_concurrent_normal_cycle, it checks if there degen or cancellation before starting the concurrent cycle and return w/o any gc log, which causes the missing GCID 1 in the GC log.

Since technically it is not a bug, to fix the potential failure of test `gc/logging/TestGCId` I'll add one line code to print GC log like "[0.135s][info][gc] GC(1) Cancelled"

### Test
- [x] gc/logging/TestGCId
- [x] hotspot_gc_shenandoah

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8354431](https://bugs.openjdk.org/browse/JDK-8354431): gc/logging/TestGCId fails on Shenandoah (**Bug** - P4)


### Reviewers
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - **Reviewer**)
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24856/head:pull/24856` \
`$ git checkout pull/24856`

Update a local copy of the PR: \
`$ git checkout pull/24856` \
`$ git pull https://git.openjdk.org/jdk.git pull/24856/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24856`

View PR using the GUI difftool: \
`$ git pr show -t 24856`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24856.diff">https://git.openjdk.org/jdk/pull/24856.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24856#issuecomment-2829021809)
</details>
