### PR TITLE
8355262: Test sun/security/ssl/SSLSessionImpl/NoInvalidateSocketException.java failed: accept timed out

### DIFF
--- a/test/jdk/sun/security/ssl/SSLSessionImpl/NoInvalidateSocketException.java
+++ b/test/jdk/sun/security/ssl/SSLSessionImpl/NoInvalidateSocketException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,7 @@
 
 /*
  * @test
- * @bug 8274736 8277970
+ * @bug 8274736 8277970 8355262
  * @summary Concurrent read/close of SSLSockets causes SSLSessions to be
  *          invalidated unnecessarily
  * @library /javax/net/ssl/templates
@@ -285,7 +285,7 @@ public class NoInvalidateSocketException extends SSLSocketTemplate {
         // Signal the client, the server is ready to accept connection.
         serverCondition.countDown();
 
-        // Try to accept a connection in 5 seconds.
+        // Try to accept a connection in 10 seconds.
         // We will do this in a loop until the client flips the
         // finished variable to true
         SSLSocket sslSocket;
@@ -351,7 +351,7 @@ public class NoInvalidateSocketException extends SSLSocketTemplate {
     public void configureServerSocket(SSLServerSocket socket) {
         try {
             socket.setReuseAddress(true);
-            socket.setSoTimeout(5000);
+            socket.setSoTimeout(10000);
         } catch (SocketException se) {
             // Rethrow as unchecked to satisfy the override signature
             throw new RuntimeException(se);


### PR DESCRIPTION
I wasn't able to reproduce the issue. Most likely it was caused by unusually high CPU load in test environment. Increasing the server's "accept" call time-out value from 5 to 10 seconds to make the test more robust.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8355262](https://bugs.openjdk.org/browse/JDK-8355262): Test sun/security/ssl/SSLSessionImpl/NoInvalidateSocketException.java failed: accept timed out (**Bug** - P4)


### Reviewers
 * [Jamil Nimeh](https://openjdk.org/census#jnimeh) (@jnimeh - **Reviewer**)
 * [Bradford Wetmore](https://openjdk.org/census#wetmore) (@bradfordwetmore - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24857/head:pull/24857` \
`$ git checkout pull/24857`

Update a local copy of the PR: \
`$ git checkout pull/24857` \
`$ git pull https://git.openjdk.org/jdk.git pull/24857/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24857`

View PR using the GUI difftool: \
`$ git pr show -t 24857`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24857.diff">https://git.openjdk.org/jdk/pull/24857.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24857#issuecomment-2828475591)
</details>
