### PR TITLE
8357686: Remove unnecessary Map.get from AWTAutoShutdown.unregisterPeer

### DIFF
--- a/src/java.desktop/share/classes/sun/awt/AWTAutoShutdown.java
+++ b/src/java.desktop/share/classes/sun/awt/AWTAutoShutdown.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -358,8 +358,7 @@ public final class AWTAutoShutdown implements Runnable {
     void unregisterPeer(final Object target, final Object peer) {
         synchronized (activationLock) {
             synchronized (mainLock) {
-                if (peerMap.get(target) == peer) {
-                    peerMap.remove(target);
+                if (peerMap.remove(target, peer)) {
                     notifyPeerMapUpdated();
                 }
             }


### PR DESCRIPTION
Instead of separate `.get(Key)`+`.remove(Key)` calls we can call `.remove(Key, Value)`.
`peerMap` is an `IdentityHashMap`. IdentityHashMap.remove compares values with == since Java 20 ([JDK-8178355](https://bugs.openjdk.org/browse/JDK-8178355))

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8357686](https://bugs.openjdk.org/browse/JDK-8357686): Remove unnecessary Map.get from AWTAutoShutdown.unregisterPeer (**Enhancement** - P5)


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24858/head:pull/24858` \
`$ git checkout pull/24858`

Update a local copy of the PR: \
`$ git checkout pull/24858` \
`$ git pull https://git.openjdk.org/jdk.git pull/24858/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24858`

View PR using the GUI difftool: \
`$ git pr show -t 24858`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24858.diff">https://git.openjdk.org/jdk/pull/24858.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24858#issuecomment-2906918457)
</details>
