### PR TITLE
8355323: JShell LocalExecutionControl should add stopCheck() at method entry

### DIFF
--- a/src/jdk.jshell/share/classes/jdk/jshell/execution/LocalExecutionControl.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/execution/LocalExecutionControl.java
@@ -31,11 +31,12 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 import java.lang.classfile.ClassFile;
 import java.lang.classfile.ClassTransform;
+import java.lang.classfile.CodeBuilder;
+import java.lang.classfile.CodeElement;
 import java.lang.classfile.CodeTransform;
 import java.lang.classfile.Label;
 import java.lang.classfile.instruction.BranchInstruction;
@@ -91,41 +92,52 @@ public class LocalExecutionControl extends DirectExecutionControl {
 
     private static final String CANCEL_CLASS = "REPL.$Cancel$";
     private static final ClassDesc CD_Cancel = ClassDesc.of(CANCEL_CLASS);
+    private static final String STOP_CHECK = "stopCheck";
     private static final ClassDesc CD_ThreadDeath = ClassDesc.of("java.lang.ThreadDeath");
 
     private static byte[] instrument(byte[] classFile) {
         var cc = ClassFile.of();
         return cc.transformClass(cc.parse(classFile),
                         ClassTransform.transformingMethodBodies(
-                            CodeTransform.ofStateful(() -> {
-                                Set<Label> priorLabels = new HashSet<>();
-                                AtomicBoolean methodEntry = new AtomicBoolean();
-                                return (builder, element) -> {
-                                    boolean insertStopCheck = methodEntry.compareAndSet(false, true);
-                                    switch (element) {
-                                        case LabelTarget target -> priorLabels.add(target.label());
-                                        case BranchInstruction branch when priorLabels.contains(branch.target())
-                                            -> insertStopCheck = true;
-                                        default -> { }
-                                    }
-                                    if (insertStopCheck)
-                                        builder.invokestatic(CD_Cancel, "stopCheck", ConstantDescs.MTD_void);
-                                    builder.with(element);
-                                };
-                            })));
+                            CodeTransform.ofStateful(StopCheckWeaver::new)));
     }
 
     private static ClassBytecodes genCancelClass() {
         return new ClassBytecodes(CANCEL_CLASS, ClassFile.of().build(CD_Cancel, clb ->
              clb.withFlags(ClassFile.ACC_PUBLIC)
                 .withField("allStop", ConstantDescs.CD_boolean, ClassFile.ACC_PUBLIC | ClassFile.ACC_STATIC | ClassFile.ACC_VOLATILE)
-                .withMethodBody("stopCheck", ConstantDescs.MTD_void, ClassFile.ACC_PUBLIC | ClassFile.ACC_STATIC, cob ->
+                .withMethodBody(STOP_CHECK, ConstantDescs.MTD_void, ClassFile.ACC_PUBLIC | ClassFile.ACC_STATIC, cob ->
                         cob.getstatic(CD_Cancel, "allStop", ConstantDescs.CD_boolean)
                            .ifThenElse(tb -> tb.new_(CD_ThreadDeath)
                                                .dup()
                                                .invokespecial(CD_ThreadDeath, ConstantDescs.INIT_NAME, ConstantDescs.MTD_void)
                                                .athrow(),
                                        eb -> eb.return_()))));
+    }
+
+    // This inserts calls to REPL.$Cancel$.stopCheck() at method start and prior to any backward branch
+    private static class StopCheckWeaver implements CodeTransform {
+
+        private final Set<Label> priorLabels = new HashSet<>();
+
+        @Override
+        public void atStart(CodeBuilder builder) {
+            stopCheck(builder);
+        }
+
+        @Override
+        public void accept(CodeBuilder builder, CodeElement element) {
+            switch (element) {
+                case LabelTarget target -> priorLabels.add(target.label());
+                case BranchInstruction branch when priorLabels.contains(branch.target()) -> stopCheck(builder);
+                default -> { }
+            }
+            builder.with(element);
+        };
+
+        private void stopCheck(CodeBuilder builder) {
+            builder.invokestatic(CD_Cancel, STOP_CHECK, ConstantDescs.MTD_void);
+        }
     }
 
     @Override

--- a/test/langtools/jdk/jshell/AbstractStopExecutionTest.java
+++ b/test/langtools/jdk/jshell/AbstractStopExecutionTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+import jdk.jshell.JShell;
+
+import static org.testng.Assert.fail;
+
+public abstract class AbstractStopExecutionTest extends KullaTesting {
+
+    private final Object lock = new Object();
+    private boolean isStopped;
+
+    protected void scheduleStop(String src) throws InterruptedException {
+        JShell state = getState();
+        isStopped = false;
+        StringWriter writer = new StringWriter();
+        PrintWriter out = new PrintWriter(writer);
+        Thread t = new Thread(() -> {
+            int i = 1;
+            int n = 30;
+            synchronized (lock) {
+                do {
+                    state.stop();
+                    if (!isStopped) {
+                        out.println("Not stopped. Try again: " + i);
+                        try {
+                            lock.wait(1000);
+                        } catch (InterruptedException ignored) {
+                        }
+                    }
+                } while (i++ < n && !isStopped);
+                if (!isStopped) {
+                    System.err.println(writer.toString());
+                    fail("Evaluation was not stopped: '" + src + "'");
+                }
+            }
+        });
+        t.start();
+        assertEval(src);
+        synchronized (lock) {
+            out.println("Evaluation was stopped successfully: '" + src + "'");
+            isStopped = true;
+            lock.notify();
+        }
+        // wait until the background thread finishes to prevent from calling 'stop' on closed state.
+        t.join();
+    }
+}

--- a/test/langtools/jdk/jshell/AbstractStopExecutionTest.java
+++ b/test/langtools/jdk/jshell/AbstractStopExecutionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/langtools/jdk/jshell/LocalStopExecutionTest.java
+++ b/test/langtools/jdk/jshell/LocalStopExecutionTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8355323
+ * @summary Verify local execution can stop execution when there are no backward branches
+ * @modules jdk.jshell/jdk.internal.jshell.tool
+ * @build KullaTesting TestingInputStream
+ * @run testng LocalStopExecutionTest
+ */
+
+import java.io.IOException;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
+import java.util.Random;
+import java.util.concurrent.CountDownLatch;
+
+import jdk.internal.jshell.tool.StopDetectingInputStream;
+import jdk.internal.jshell.tool.StopDetectingInputStream.State;
+import jdk.jshell.JShell;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+@Test
+public class LocalStopExecutionTest extends AbstractStopExecutionTest {
+
+    @BeforeMethod
+    @Override
+    public void setUp() {
+        setUp(b -> b.executionEngine("local"));
+    }
+
+    @Test
+    public void testVeryLongRecursion() throws InterruptedException {
+        scheduleStop(
+            """
+            // Note: there are no backward branches in this class
+            new Runnable() {
+                public void run() {
+                    recurse(1);
+                    recurse(10);
+                    recurse(100);
+                    recurse(1000);
+                    recurse(10000);
+                    recurse(100000);
+                    recurse(1000000);
+                }
+                public void recurse(int depth) {
+                    if (depth == 0)
+                        return;
+                    recurse(depth - 1); recurse(depth - 1); recurse(depth - 1); recurse(depth - 1); recurse(depth - 1);
+                    recurse(depth - 1); recurse(depth - 1); recurse(depth - 1); recurse(depth - 1); recurse(depth - 1);
+                    recurse(depth - 1); recurse(depth - 1); recurse(depth - 1); recurse(depth - 1); recurse(depth - 1);
+                    recurse(depth - 1); recurse(depth - 1); recurse(depth - 1); recurse(depth - 1); recurse(depth - 1);
+                    recurse(depth - 1); recurse(depth - 1); recurse(depth - 1); recurse(depth - 1); recurse(depth - 1);
+                    recurse(depth - 1); recurse(depth - 1); recurse(depth - 1); recurse(depth - 1); recurse(depth - 1);
+                    recurse(depth - 1); recurse(depth - 1); recurse(depth - 1); recurse(depth - 1); recurse(depth - 1);
+                    recurse(depth - 1); recurse(depth - 1); recurse(depth - 1); recurse(depth - 1); recurse(depth - 1);
+                    recurse(depth - 1); recurse(depth - 1); recurse(depth - 1); recurse(depth - 1); recurse(depth - 1);
+                    recurse(depth - 1); recurse(depth - 1); recurse(depth - 1); recurse(depth - 1); recurse(depth - 1);
+                    recurse(depth - 1); recurse(depth - 1); recurse(depth - 1); recurse(depth - 1); recurse(depth - 1);
+                    recurse(depth - 1); recurse(depth - 1); recurse(depth - 1); recurse(depth - 1); recurse(depth - 1);
+                    recurse(depth - 1); recurse(depth - 1); recurse(depth - 1); recurse(depth - 1); recurse(depth - 1);
+                    recurse(depth - 1); recurse(depth - 1); recurse(depth - 1); recurse(depth - 1); recurse(depth - 1);
+                    recurse(depth - 1); recurse(depth - 1); recurse(depth - 1); recurse(depth - 1); recurse(depth - 1);
+                    recurse(depth - 1); recurse(depth - 1); recurse(depth - 1); recurse(depth - 1); recurse(depth - 1);
+                    recurse(depth - 1); recurse(depth - 1); recurse(depth - 1); recurse(depth - 1); recurse(depth - 1);
+                    recurse(depth - 1); recurse(depth - 1); recurse(depth - 1); recurse(depth - 1); recurse(depth - 1);
+                    recurse(depth - 1); recurse(depth - 1); recurse(depth - 1); recurse(depth - 1); recurse(depth - 1);
+                    recurse(depth - 1); recurse(depth - 1); recurse(depth - 1); recurse(depth - 1); recurse(depth - 1);
+                }
+            }.run();
+            """
+        );
+    }
+}

--- a/test/langtools/jdk/jshell/LocalStopExecutionTest.java
+++ b/test/langtools/jdk/jshell/LocalStopExecutionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/langtools/jdk/jshell/StopExecutionTest.java
+++ b/test/langtools/jdk/jshell/StopExecutionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,25 +33,18 @@
 import java.io.IOException;
 import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
-import java.io.PrintWriter;
-import java.io.StringWriter;
 import java.util.Random;
 import java.util.concurrent.CountDownLatch;
 import java.util.function.Consumer;
 
 import jdk.internal.jshell.tool.StopDetectingInputStream;
 import jdk.internal.jshell.tool.StopDetectingInputStream.State;
-import jdk.jshell.JShell;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.fail;
 
 @Test
-public class StopExecutionTest extends KullaTesting {
-
-    private final Object lock = new Object();
-    private boolean isStopped;
+public class StopExecutionTest extends AbstractStopExecutionTest {
 
     @Test(enabled = false) // TODO 8129546
     public void testStopLoop() throws InterruptedException {
@@ -66,42 +59,6 @@ public class StopExecutionTest extends KullaTesting {
     @Test(enabled = false) // TODO 8129546
     public void testScriptCatchesStop() throws Exception {
         scheduleStop("for (int i = 0; i < 30; i++) { try { Thread.sleep(100); } catch (Throwable ex) { } }");
-    }
-
-    private void scheduleStop(String src) throws InterruptedException {
-        JShell state = getState();
-        isStopped = false;
-        StringWriter writer = new StringWriter();
-        PrintWriter out = new PrintWriter(writer);
-        Thread t = new Thread(() -> {
-            int i = 1;
-            int n = 30;
-            synchronized (lock) {
-                do {
-                    state.stop();
-                    if (!isStopped) {
-                        out.println("Not stopped. Try again: " + i);
-                        try {
-                            lock.wait(1000);
-                        } catch (InterruptedException ignored) {
-                        }
-                    }
-                } while (i++ < n && !isStopped);
-                if (!isStopped) {
-                    System.err.println(writer.toString());
-                    fail("Evaluation was not stopped: '" + src + "'");
-                }
-            }
-        });
-        t.start();
-        assertEval(src);
-        synchronized (lock) {
-            out.println("Evaluation was stopped successfully: '" + src + "'");
-            isStopped = true;
-            lock.notify();
-        }
-        // wait until the background thread finishes to prevent from calling 'stop' on closed state.
-        t.join();
     }
 
     public void testStopDetectingInputRandom() throws IOException {


### PR DESCRIPTION
This PR addresses [JDK-8355323](https://bugs.openjdk.org/browse/JDK-8355323), which inserts a "stop check" at the start of each method when JShell is running in local execution mode. This augments the existing stop checks that are added at each backward branch, which, while helpful, do not guarantee the snippet thread will notice a stop request in a bounded length of time, because a snippet could be executing some recursive method(s) that have no backward branches (an example is given in the new regression test). This fix closes that loophole.

Side notes:
* The existing `StopExecutionTest` unit test was split/refactored to create an `AbstractStopExecutionTest` superclass which could be reused by the new `LocalStopExecutionTest`.
* There are three disabled tests in `StopExecutionTest` that seem to be working now and maybe could be re-enabled.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 2 [Reviewers](https://openjdk.org/bylaws#reviewer))

### Issue
 * [JDK-8355323](https://bugs.openjdk.org/browse/JDK-8355323): JShell LocalExecutionControl should add stopCheck() at method entry (**Enhancement** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24859/head:pull/24859` \
`$ git checkout pull/24859`

Update a local copy of the PR: \
`$ git checkout pull/24859` \
`$ git pull https://git.openjdk.org/jdk.git pull/24859/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24859`

View PR using the GUI difftool: \
`$ git pr show -t 24859`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24859.diff">https://git.openjdk.org/jdk/pull/24859.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24859#issuecomment-2828812921)
</details>
