### PR TITLE
8355445: [java.nio] Use @requires tag instead of exiting based on os.name property value

### DIFF
--- a/test/jdk/java/nio/channels/Selector/HelperSlowToDie.java
+++ b/test/jdk/java/nio/channels/Selector/HelperSlowToDie.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
  * @bug 6823609
  * @summary Selector.select can hangs on Windows for cases where a helper thread
  *   becomes redudant but a new helper is immediately needed.
+ * @requires (os.family == "windows")
  */
 
 import java.nio.channels.*;
@@ -37,11 +38,6 @@ public class HelperSlowToDie {
     private static volatile boolean done;
 
     public static void main(String[] args) throws IOException {
-        if (!System.getProperty("os.name").startsWith("Windows")) {
-            System.out.println("Test skipped as it verifies a Windows specific bug");
-            return;
-        }
-
         Selector sel = Selector.open();
 
         // register channels

--- a/test/jdk/java/nio/channels/SocketChannel/AsyncCloseChannel.java
+++ b/test/jdk/java/nio/channels/SocketChannel/AsyncCloseChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 /* @test
  * @bug 6285901 6501089
  * @summary Check no data is written to wrong socket channel during async closing.
+ * @requires (os.family != "windows")
  */
 
 import java.io.IOException;
@@ -44,10 +45,6 @@ public class AsyncCloseChannel {
     static int targetPort;
 
     public static void main(String args[]) throws Exception {
-        if (System.getProperty("os.name").startsWith("Windows")) {
-            System.err.println("WARNING: Still does not work on Windows!");
-            return;
-        }
         Thread ss = new SensorServer(); ss.start();
         Thread ts = new TargetServer(); ts.start();
 

--- a/test/jdk/java/nio/channels/SocketChannel/SocketInheritance.java
+++ b/test/jdk/java/nio/channels/SocketChannel/SocketInheritance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 /*
  * @test
  * @summary Sockets shouldn't be inherited when creating a child process
+ * @requires (os.family == "windows")
  */
 import java.nio.ByteBuffer;
 import java.nio.channels.*;
@@ -138,9 +139,6 @@ public class SocketInheritance {
     }
 
     public static void main(String[] args) throws Exception {
-        if (!System.getProperty("os.name").startsWith("Windows"))
-            return;
-
         if (args.length == 0) {
             start();
         } else {

--- a/test/jdk/java/nio/channels/spi/SelectorProvider/inheritedChannel/InheritedChannelTest.java
+++ b/test/jdk/java/nio/channels/spi/SelectorProvider/inheritedChannel/InheritedChannelTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -59,14 +59,8 @@ import static java.util.Arrays.asList;
 
 public class InheritedChannelTest {
 
-    private static final String TEST_SRC = System.getProperty("test.src");
     private static final String TEST_CLASSPATH = System.getProperty("test.class.path");
     private static final String TEST_CLASSES = System.getProperty("test.classes");
-
-    private static final String OS_NAME = System.getProperty("os.name").toLowerCase();
-
-    private static final String ARCH = System.getProperty("os.arch");
-    private static final String OS_ARCH = ARCH.equals("i386") ? "i586" : ARCH;
 
     private static final Path libraryPath
             = Paths.get(System.getProperty("java.library.path"));

--- a/test/jdk/java/nio/charset/RemovingSunIO/TestCOMP.java
+++ b/test/jdk/java/nio/charset/RemovingSunIO/TestCOMP.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 /* @test
    @bug 6176819
    @summary Check if COMPUND_TEXT charset works as expected
+   @requires (os.family != "windows")
    @run main/timeout=1200 TestCOMP
  */
 
@@ -35,9 +36,6 @@ import java.nio.*;
 
 public class TestCOMP {
     public static void main(String[] argv) throws CharacterCodingException {
-        String osName = System.getProperty("os.name");
-        if (osName.startsWith("Windows"))
-            return;
         try {
             String src =
                 "JIS0208\u4eb0" +

--- a/test/jdk/java/nio/file/DirectoryStream/DriveLetter.java
+++ b/test/jdk/java/nio/file/DirectoryStream/DriveLetter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
  * @bug 6808647
  * @summary Checks that a DirectoryStream's iterator returns the expected
  *    path when opening a directory by specifying only the drive letter.
+ * @requires (os.family == "windows")
  * @library ..
  */
 
@@ -35,11 +36,6 @@ import java.io.IOException;
 public class DriveLetter {
 
     public static void main(String[] args) throws IOException {
-        String os = System.getProperty("os.name");
-        if (!os.startsWith("Windows")) {
-            System.out.println("This is Windows specific test");
-            return;
-        }
         String here = System.getProperty("user.dir");
         if (here.length() < 2 || here.charAt(1) != ':')
             throw new RuntimeException("Unable to determine drive letter");

--- a/test/jdk/java/nio/file/Files/StreamTest.java
+++ b/test/jdk/java/nio/file/Files/StreamTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,7 @@
  * @build PassThroughFileSystem FaultyFileSystem
  * @run testng StreamTest
  * @summary Unit test for java.nio.file.Files methods that return a Stream
+ * @requires (os.family == "linux")
  */
 
 import java.io.IOException;
@@ -536,15 +537,13 @@ public class StreamTest {
     }
 
     public void testProcFile() throws IOException {
-        if (System.getProperty("os.name").equals("Linux")) {
-            Path path = Paths.get("/proc/cpuinfo");
-            if (Files.exists(path)) {
-                String NEW_LINE = System.getProperty("line.separator");
-                String s =
-                    Files.lines(path).collect(Collectors.joining(NEW_LINE));
-                if (s.length() == 0) {
-                    fail("Files.lines(\"" + path + "\") returns no data");
-                }
+        Path path = Paths.get("/proc/cpuinfo");
+        if (Files.exists(path)) {
+            String NEW_LINE = System.getProperty("line.separator");
+            String s =
+                Files.lines(path).collect(Collectors.joining(NEW_LINE));
+            if (s.length() == 0) {
+                fail("Files.lines(\"" + path + "\") returns no data");
             }
         }
     }

--- a/test/jdk/java/nio/file/WatchService/FileTreeModifier.java
+++ b/test/jdk/java/nio/file/WatchService/FileTreeModifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 /* @test
  * @bug 4313887 6838333
  * @summary Sanity test for JDK-specific FILE_TREE watch event modifier
+ * @requires (os.family == "windows")
  * @library ..
  * @modules jdk.unsupported
  */
@@ -129,11 +130,6 @@ public class FileTreeModifier {
 
 
     public static void main(String[] args) throws IOException {
-        if (!System.getProperty("os.name").startsWith("Windows")) {
-            System.out.println("This is Windows-only test at this time!");
-            return;
-        }
-
         Path dir = TestUtil.createTemporaryDirectory();
         try {
             doTest(dir);


### PR DESCRIPTION
Use the `@requires` tag instead of obtaining the operating system name from the `os.name` property and then exiting if the test is not run on that operating system.