### PR TITLE
8355559: Benchmark modification/extension shouldn't affect the behavior of other benchmarks

### DIFF
--- a/test/micro/org/openjdk/bench/javax/crypto/full/AESExtraBench.java
+++ b/test/micro/org/openjdk/bench/javax/crypto/full/AESExtraBench.java
@@ -61,26 +61,12 @@ public class AESExtraBench extends AESBench {
         outBuffer = new byte[dataSize + 128]; // extra space for tag, etc
     }
 
-//    @Benchmark
-//    public byte[] encrypt() throws BadPaddingException, IllegalBlockSizeException {
-//        byte[] d = data[index];
-//        index = (index +1) % SET_SIZE;
-//        return encryptCipher.doFinal(d);
-//    }
-
     @Benchmark
     public int encrypt2() throws GeneralSecurityException {
         byte[] d = data[index];
         index = (index +1) % SET_SIZE;
         return encryptCipher.doFinal(d, 0, d.length, outBuffer);
     }
-//
-//    @Benchmark
-//    public byte[] decrypt() throws BadPaddingException, IllegalBlockSizeException {
-//        byte[] e = encryptedData[index];
-//        index = (index +1) % SET_SIZE;
-//        return decryptCipher.doFinal(e);
-//    }
 
     @Benchmark
     public int decrypt2() throws GeneralSecurityException {

--- a/test/micro/org/openjdk/bench/javax/crypto/full/AESExtraBench.java
+++ b/test/micro/org/openjdk/bench/javax/crypto/full/AESExtraBench.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.javax.crypto.full;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.infra.Blackhole;
+
+import javax.crypto.BadPaddingException;
+import javax.crypto.Cipher;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.NoSuchPaddingException;
+import javax.crypto.spec.SecretKeySpec;
+import java.security.GeneralSecurityException;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.spec.InvalidParameterSpecException;
+
+public class AESExtraBench extends AESBench {
+
+    public static final int SET_SIZE = 8;
+
+    @Param({"AES/CBC/NoPadding"})
+    private String algorithm;
+
+    @Param({"128", "192", "256"})
+    private int keyLength;
+
+    @Param({"" + 16 * 1024})
+    private int dataSize;
+
+    private byte[] outBuffer;
+    int index = 0;
+
+    @Setup
+    public void setup() throws NoSuchAlgorithmException, NoSuchPaddingException, InvalidKeyException, BadPaddingException, IllegalBlockSizeException, InvalidAlgorithmParameterException, InvalidParameterSpecException {
+        super.setup();
+        outBuffer = new byte[dataSize + 128]; // extra space for tag, etc
+    }
+
+//    @Benchmark
+//    public byte[] encrypt() throws BadPaddingException, IllegalBlockSizeException {
+//        byte[] d = data[index];
+//        index = (index +1) % SET_SIZE;
+//        return encryptCipher.doFinal(d);
+//    }
+
+    @Benchmark
+    public int encrypt2() throws GeneralSecurityException {
+        byte[] d = data[index];
+        index = (index +1) % SET_SIZE;
+        return encryptCipher.doFinal(d, 0, d.length, outBuffer);
+    }
+//
+//    @Benchmark
+//    public byte[] decrypt() throws BadPaddingException, IllegalBlockSizeException {
+//        byte[] e = encryptedData[index];
+//        index = (index +1) % SET_SIZE;
+//        return decryptCipher.doFinal(e);
+//    }
+
+    @Benchmark
+    public int decrypt2() throws GeneralSecurityException {
+        byte[] e = encryptedData[index];
+        index = (index +1) % SET_SIZE;
+        return decryptCipher.doFinal(e, 0, e.length, outBuffer);
+    }
+
+}


### PR DESCRIPTION
Benchmark modification/extension shouldn't affect the behavior of other benchmarks.
Precisely: [JDK-8344144](https://bugs.openjdk.org/browse/JDK-8344144) modified AESBench in that way, which caused significant changes in the behavior of other benchmarks that extend AESBench.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8355559](https://bugs.openjdk.org/browse/JDK-8355559): Benchmark modification/extension shouldn't affect the behavior of other benchmarks (**Enhancement** - P4)


### Reviewers
 * [Eric Caspole](https://openjdk.org/census#ecaspole) (@ericcaspole - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24863/head:pull/24863` \
`$ git checkout pull/24863`

Update a local copy of the PR: \
`$ git checkout pull/24863` \
`$ git pull https://git.openjdk.org/jdk.git pull/24863/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24863`

View PR using the GUI difftool: \
`$ git pr show -t 24863`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24863.diff">https://git.openjdk.org/jdk/pull/24863.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24863#issuecomment-2829064993)
</details>
