### PR TITLE
8355636: Reuse StringBuilder in printStackTrace

### DIFF
--- a/src/java.base/share/classes/java/lang/StackTraceElement.java
+++ b/src/java.base/share/classes/java/lang/StackTraceElement.java
@@ -358,15 +358,27 @@ public final class StackTraceElement implements java.io.Serializable {
      */
     @Override
     public String toString() {
-        int estimatedLength = length(classLoaderName) + 1
+        return appendTo(
+                new StringBuilder(
+                        estimatedLength()))
+                .toString();
+    }
+
+    int estimatedLength() {
+        return length(classLoaderName) + 1
                 + length(moduleName) + 1
                 + length(moduleVersion) + 1
                 + declaringClass.length() + 1
                 + methodName.length() + 1
                 + Math.max(UNKNOWN_SOURCE.length(), length(fileName)) + 1
                 + 12;
+    }
 
-        StringBuilder sb = new StringBuilder(estimatedLength);
+    /**
+     * Prints the toString result to the given buf, avoiding extra string allocations.
+     */
+    StringBuilder appendTo(StringBuilder sb) {
+        int length = sb.length();
         if (!dropClassLoaderName() && classLoaderName != null && !classLoaderName.isEmpty()) {
             sb.append(classLoaderName).append('/');
         }
@@ -378,7 +390,7 @@ public final class StackTraceElement implements java.io.Serializable {
             }
         }
 
-        if (sb.length() > 0) {
+        if (sb.length() != length) {
             sb.append('/');
         }
 
@@ -393,9 +405,7 @@ public final class StackTraceElement implements java.io.Serializable {
                 sb.append(':').append(lineNumber);
             }
         }
-        sb.append(')');
-
-        return sb.toString();
+        return sb.append(')');
     }
 
     private static int length(String s) {

--- a/src/java.base/share/classes/java/lang/StackTraceElement.java
+++ b/src/java.base/share/classes/java/lang/StackTraceElement.java
@@ -358,27 +358,23 @@ public final class StackTraceElement implements java.io.Serializable {
      */
     @Override
     public String toString() {
-        return appendTo(
-                new StringBuilder(
-                        estimatedLength()))
-                .toString();
-    }
-
-    int estimatedLength() {
-        return length(classLoaderName) + 1
+        int estimatedLength = length(classLoaderName) + 1
                 + length(moduleName) + 1
                 + length(moduleVersion) + 1
                 + declaringClass.length() + 1
                 + methodName.length() + 1
                 + Math.max(UNKNOWN_SOURCE.length(), length(fileName)) + 1
                 + 12;
+        return appendTo(
+                new StringBuilder(estimatedLength))
+                .toString();
     }
 
     /**
      * Prints the toString result to the given buf, avoiding extra string allocations.
      */
     StringBuilder appendTo(StringBuilder sb) {
-        int length = sb.length();
+        int startingLength = sb.length();
         if (!dropClassLoaderName() && classLoaderName != null && !classLoaderName.isEmpty()) {
             sb.append(classLoaderName).append('/');
         }
@@ -390,7 +386,7 @@ public final class StackTraceElement implements java.io.Serializable {
             }
         }
 
-        if (sb.length() != length) {
+        if (sb.length() != startingLength) {
             sb.append('/');
         }
 

--- a/src/java.base/share/classes/java/lang/Throwable.java
+++ b/src/java.base/share/classes/java/lang/Throwable.java
@@ -794,16 +794,15 @@ public class Throwable implements Serializable {
                 sb.setLength(prefixAndAtLength);
             }
             printer.println(trace[i]
-                            .appendTo(sb)
-                            .toString());
+                            .appendTo(sb));
         }
 
         if (framesInCommon != 0) {
             sb.setLength(prefix == null ? 0 : prefix.length());
-            sb.append("\t... ")
-              .append(framesInCommon)
-              .append(" more");
-            printer.println(sb.toString());
+            printer.println(
+                    sb.append("\t... ")
+                      .append(framesInCommon)
+                      .append(" more"));
         }
     }
 

--- a/src/java.base/share/classes/java/lang/Throwable.java
+++ b/src/java.base/share/classes/java/lang/Throwable.java
@@ -744,14 +744,19 @@ public class Throwable implements Serializable {
             printStackTrace0(s, prefix, trace, m);
 
             // Print suppressed exceptions, if any
-            for (Throwable se : getSuppressed())
-                se.printEnclosedStackTrace(s, trace, SUPPRESSED_CAPTION,
-                                           prefix.concat("\t"), dejaVu);
+            Throwable[] suppressed = getSuppressed();
+            if (suppressed != null) {
+                String prefixT = prefix.concat("\t");
+                for (Throwable se : suppressed) {
+                    se.printEnclosedStackTrace(s, trace, prefixT.concat(SUPPRESSED_CAPTION),
+                            prefixT, dejaVu);
+                }
+            }
 
             // Print cause, if any
             Throwable ourCause = getCause();
             if (ourCause != null)
-                ourCause.printEnclosedStackTrace(s, trace, CAUSE_CAPTION, prefix, dejaVu);
+                ourCause.printEnclosedStackTrace(s, trace, prefix.concat(CAUSE_CAPTION), prefix, dejaVu);
         }
     }
 

--- a/src/java.base/share/classes/java/lang/Throwable.java
+++ b/src/java.base/share/classes/java/lang/Throwable.java
@@ -719,7 +719,6 @@ public class Throwable implements Serializable {
                     se.printEnclosedStackTrace(s, lineBuffer, trace, SUPPRESSED_CAPTION, "\t", dejaVu);
 
                 // Print cause, if any
-
                 if (ourCause != null) {
                     ourCause.printEnclosedStackTrace(s, lineBuffer, trace, CAUSE_CAPTION, "", dejaVu);
                 }

--- a/src/java.base/share/classes/java/lang/Throwable.java
+++ b/src/java.base/share/classes/java/lang/Throwable.java
@@ -696,24 +696,23 @@ public class Throwable implements Serializable {
             java.lang.Throwable[] suppressed = getSuppressed();
             Throwable ourCause = getCause();
 
-            /*
-             * Guard against malicious overrides of Throwable.equals by
-             * using a Set with identity equality semantics.
-             */
-            Set<Throwable> dejaVu = null;
             if (suppressed.length > 0 || ourCause != null) {
-                dejaVu = Collections.newSetFromMap(new IdentityHashMap<>());
+                /*
+                 * Guard against malicious overrides of Throwable.equals by
+                 * using a Set with identity equality semantics.
+                 */
+                Set<Throwable> dejaVu = Collections.newSetFromMap(new IdentityHashMap<>());
                 dejaVu.add(this);
-            }
 
-            // Print suppressed exceptions, if any
-            for (Throwable se : suppressed)
-                se.printEnclosedStackTrace(s, trace, "\t".concat(SUPPRESSED_CAPTION), "\t", dejaVu);
+                // Print suppressed exceptions, if any
+                for (Throwable se : suppressed)
+                    se.printEnclosedStackTrace(s, trace, "\t".concat(SUPPRESSED_CAPTION), "\t", dejaVu);
 
-            // Print cause, if any
+                // Print cause, if any
 
-            if (ourCause != null) {
-                ourCause.printEnclosedStackTrace(s, trace, CAUSE_CAPTION, "", dejaVu);
+                if (ourCause != null) {
+                    ourCause.printEnclosedStackTrace(s, trace, CAUSE_CAPTION, "", dejaVu);
+                }
             }
         }
     }

--- a/src/java.base/share/classes/java/lang/Throwable.java
+++ b/src/java.base/share/classes/java/lang/Throwable.java
@@ -783,20 +783,15 @@ public class Throwable implements Serializable {
             StackTraceElement[] trace,
             int traceEnd,
             int framesInCommon) {
-        String at = "\tat ";
-        int prefixAndAtLength = at.length();
-        if (prefix != null) {
-            prefixAndAtLength += prefix.length();
-        }
-
         var sb = new StringBuilder(128);
         if (prefix != null) {
             sb.append(prefix);
         }
-        sb.append(at);
+        sb.append("\tat ");
+        int prefixAndAtLength = sb.length();
         for (int i = 0; i <= traceEnd; i++) {
             if (i != 0) {
-                sb.delete(prefixAndAtLength, sb.length());
+                sb.setLength(prefixAndAtLength);
             }
             printer.println(trace[i]
                             .appendTo(sb)
@@ -804,8 +799,8 @@ public class Throwable implements Serializable {
         }
 
         if (framesInCommon != 0) {
-            sb.delete(prefix.length(), sb.length())
-              .append("\t... ")
+            sb.setLength(prefix == null ? 0 : prefix.length());
+            sb.append("\t... ")
               .append(framesInCommon)
               .append(" more");
             printer.println(sb.toString());

--- a/src/java.base/share/classes/java/lang/Throwable.java
+++ b/src/java.base/share/classes/java/lang/Throwable.java
@@ -706,7 +706,7 @@ public class Throwable implements Serializable {
 
                 // Print suppressed exceptions, if any
                 for (Throwable se : suppressed)
-                    se.printEnclosedStackTrace(s, trace, "\t".concat(SUPPRESSED_CAPTION), "\t", dejaVu);
+                    se.printEnclosedStackTrace(s, trace, "\t" + SUPPRESSED_CAPTION, "\t", dejaVu);
 
                 // Print cause, if any
 
@@ -738,11 +738,10 @@ public class Throwable implements Serializable {
             while (m >= 0 && n >=0 && trace[m].equals(enclosingTrace[n])) {
                 m--; n--;
             }
-            int framesInCommon = trace.length - 1 - m;
 
             // Print our stack trace
             s.println(prefixCaption.concat(this.toString()));
-            printStackTrace0(s, prefix, trace, m, framesInCommon);
+            printStackTrace0(s, prefix, trace, m);
 
             // Print suppressed exceptions, if any
             for (Throwable se : getSuppressed())
@@ -771,7 +770,7 @@ public class Throwable implements Serializable {
      * Use a StringBuilder to print multiple StackTraceElements
      */
     private static void printStackTrace0(PrintStreamOrWriter printer, StackTraceElement[] trace) {
-        printStackTrace0(printer, null, trace, trace.length - 1, 0);
+        printStackTrace0(printer, null, trace, trace.length - 1);
     }
 
     /**
@@ -781,8 +780,7 @@ public class Throwable implements Serializable {
             PrintStreamOrWriter printer,
             String prefix,
             StackTraceElement[] trace,
-            int traceEnd,
-            int framesInCommon) {
+            int traceEnd) {
         var sb = new StringBuilder(128);
         if (prefix != null) {
             sb.append(prefix);
@@ -797,6 +795,7 @@ public class Throwable implements Serializable {
                             .appendTo(sb));
         }
 
+        int framesInCommon = trace.length - 1 - traceEnd;
         if (framesInCommon != 0) {
             sb.setLength(prefix == null ? 0 : prefix.length());
             printer.println(

--- a/src/java.base/share/classes/java/lang/Throwable.java
+++ b/src/java.base/share/classes/java/lang/Throwable.java
@@ -744,14 +744,9 @@ public class Throwable implements Serializable {
             printStackTrace0(s, prefix, trace, m);
 
             // Print suppressed exceptions, if any
-            Throwable[] suppressed = getSuppressed();
-            if (suppressed != null) {
-                String prefixT = prefix.concat("\t");
-                for (Throwable se : suppressed) {
-                    se.printEnclosedStackTrace(s, trace, prefixT.concat(SUPPRESSED_CAPTION),
-                            prefixT, dejaVu);
-                }
-            }
+            for (Throwable se : getSuppressed())
+                se.printEnclosedStackTrace(s, trace, prefix.concat("\t" + SUPPRESSED_CAPTION),
+                        prefix.concat("\t"), dejaVu);
 
             // Print cause, if any
             Throwable ourCause = getCause();

--- a/src/java.base/share/classes/java/lang/Throwable.java
+++ b/src/java.base/share/classes/java/lang/Throwable.java
@@ -693,7 +693,7 @@ public class Throwable implements Serializable {
             StackTraceElement[] trace = getOurStackTrace();
             printStackTrace0(s, trace);
 
-            java.lang.Throwable[] suppressed = getSuppressed();
+            Throwable[] suppressed = getSuppressed();
             Throwable ourCause = getCause();
 
             if (suppressed.length > 0 || ourCause != null) {

--- a/test/jdk/java/lang/Throwable/PrintStackTrace.java
+++ b/test/jdk/java/lang/Throwable/PrintStackTrace.java
@@ -192,47 +192,49 @@ public class PrintStackTrace {
         PrintStream printStream = new PrintStream(byteout, true, charset);
         error.printStackTrace(printStream);
 
+        var lineSeparator = System.lineSeparator();
+
         String expect = "java.lang.RuntimeException: java.lang.RuntimeException: java.lang.RuntimeException\n" +
-                "\tat PrintStackTrace.xn(PrintStackTrace.java:139)\n" +
-                "\tat PrintStackTrace.x9(PrintStackTrace.java:144)\n" +
-                "\tat PrintStackTrace.x8(PrintStackTrace.java:148)\n" +
-                "\tat PrintStackTrace.x7(PrintStackTrace.java:152)\n" +
-                "\tat PrintStackTrace.x6(PrintStackTrace.java:156)\n" +
-                "\tat PrintStackTrace.x5(PrintStackTrace.java:160)\n" +
-                "\tat PrintStackTrace.x4(PrintStackTrace.java:164)\n" +
-                "\tat PrintStackTrace.x3(PrintStackTrace.java:168)\n" +
-                "\tat PrintStackTrace.x2(PrintStackTrace.java:172)\n" +
-                "\tat PrintStackTrace.x1(PrintStackTrace.java:176)\n" +
-                "\tat PrintStackTrace.x0(PrintStackTrace.java:180)\n" +
-                "\tat PrintStackTrace.main(PrintStackTrace.java:186)\n" +
-                "Caused by: java.lang.RuntimeException: java.lang.RuntimeException\n" +
-                "\tat PrintStackTrace.yn(PrintStackTrace.java:91)\n" +
-                "\tat PrintStackTrace.y9(PrintStackTrace.java:96)\n" +
-                "\tat PrintStackTrace.y8(PrintStackTrace.java:100)\n" +
-                "\tat PrintStackTrace.y7(PrintStackTrace.java:104)\n" +
-                "\tat PrintStackTrace.y6(PrintStackTrace.java:108)\n" +
-                "\tat PrintStackTrace.y5(PrintStackTrace.java:112)\n" +
-                "\tat PrintStackTrace.y4(PrintStackTrace.java:116)\n" +
-                "\tat PrintStackTrace.y3(PrintStackTrace.java:120)\n" +
-                "\tat PrintStackTrace.y2(PrintStackTrace.java:124)\n" +
-                "\tat PrintStackTrace.y1(PrintStackTrace.java:128)\n" +
-                "\tat PrintStackTrace.y0(PrintStackTrace.java:132)\n" +
-                "\tat PrintStackTrace.xn(PrintStackTrace.java:137)\n" +
-                "\t... 11 more\n" +
-                "Caused by: java.lang.RuntimeException\n" +
-                "\tat PrintStackTrace.fn(PrintStackTrace.java:43)\n" +
-                "\tat PrintStackTrace.f9(PrintStackTrace.java:47)\n" +
-                "\tat PrintStackTrace.f8(PrintStackTrace.java:51)\n" +
-                "\tat PrintStackTrace.f7(PrintStackTrace.java:55)\n" +
-                "\tat PrintStackTrace.f6(PrintStackTrace.java:59)\n" +
-                "\tat PrintStackTrace.f5(PrintStackTrace.java:63)\n" +
-                "\tat PrintStackTrace.f4(PrintStackTrace.java:67)\n" +
-                "\tat PrintStackTrace.f3(PrintStackTrace.java:71)\n" +
-                "\tat PrintStackTrace.f2(PrintStackTrace.java:75)\n" +
-                "\tat PrintStackTrace.f1(PrintStackTrace.java:79)\n" +
-                "\tat PrintStackTrace.f0(PrintStackTrace.java:83)\n" +
-                "\tat PrintStackTrace.yn(PrintStackTrace.java:89)\n" +
-                "\t... 22 more\n";
+                "\tat PrintStackTrace.xn(PrintStackTrace.java:139)" + lineSeparator +
+                "\tat PrintStackTrace.x9(PrintStackTrace.java:144)" + lineSeparator +
+                "\tat PrintStackTrace.x8(PrintStackTrace.java:148)" + lineSeparator +
+                "\tat PrintStackTrace.x7(PrintStackTrace.java:152)" + lineSeparator +
+                "\tat PrintStackTrace.x6(PrintStackTrace.java:156)" + lineSeparator +
+                "\tat PrintStackTrace.x5(PrintStackTrace.java:160)" + lineSeparator +
+                "\tat PrintStackTrace.x4(PrintStackTrace.java:164)" + lineSeparator +
+                "\tat PrintStackTrace.x3(PrintStackTrace.java:168)" + lineSeparator +
+                "\tat PrintStackTrace.x2(PrintStackTrace.java:172)" + lineSeparator +
+                "\tat PrintStackTrace.x1(PrintStackTrace.java:176)" + lineSeparator +
+                "\tat PrintStackTrace.x0(PrintStackTrace.java:180)" + lineSeparator +
+                "\tat PrintStackTrace.main(PrintStackTrace.java:186)" + lineSeparator +
+                "Caused by: java.lang.RuntimeException: java.lang.RuntimeException" + lineSeparator +
+                "\tat PrintStackTrace.yn(PrintStackTrace.java:91)" + lineSeparator +
+                "\tat PrintStackTrace.y9(PrintStackTrace.java:96)" + lineSeparator +
+                "\tat PrintStackTrace.y8(PrintStackTrace.java:100)" + lineSeparator +
+                "\tat PrintStackTrace.y7(PrintStackTrace.java:104)" + lineSeparator +
+                "\tat PrintStackTrace.y6(PrintStackTrace.java:108)" + lineSeparator +
+                "\tat PrintStackTrace.y5(PrintStackTrace.java:112)" + lineSeparator +
+                "\tat PrintStackTrace.y4(PrintStackTrace.java:116)" + lineSeparator +
+                "\tat PrintStackTrace.y3(PrintStackTrace.java:120)" + lineSeparator +
+                "\tat PrintStackTrace.y2(PrintStackTrace.java:124)" + lineSeparator +
+                "\tat PrintStackTrace.y1(PrintStackTrace.java:128)" + lineSeparator +
+                "\tat PrintStackTrace.y0(PrintStackTrace.java:132)" + lineSeparator +
+                "\tat PrintStackTrace.xn(PrintStackTrace.java:137)" + lineSeparator +
+                "\t... 11 more" + lineSeparator +
+                "Caused by: java.lang.RuntimeException" + lineSeparator +
+                "\tat PrintStackTrace.fn(PrintStackTrace.java:43)" + lineSeparator +
+                "\tat PrintStackTrace.f9(PrintStackTrace.java:47)" + lineSeparator +
+                "\tat PrintStackTrace.f8(PrintStackTrace.java:51)" + lineSeparator +
+                "\tat PrintStackTrace.f7(PrintStackTrace.java:55)" + lineSeparator +
+                "\tat PrintStackTrace.f6(PrintStackTrace.java:59)" + lineSeparator +
+                "\tat PrintStackTrace.f5(PrintStackTrace.java:63)" + lineSeparator +
+                "\tat PrintStackTrace.f4(PrintStackTrace.java:67)" + lineSeparator +
+                "\tat PrintStackTrace.f3(PrintStackTrace.java:71)" + lineSeparator +
+                "\tat PrintStackTrace.f2(PrintStackTrace.java:75)" + lineSeparator +
+                "\tat PrintStackTrace.f1(PrintStackTrace.java:79)" + lineSeparator +
+                "\tat PrintStackTrace.f0(PrintStackTrace.java:83)" + lineSeparator +
+                "\tat PrintStackTrace.yn(PrintStackTrace.java:89)" + lineSeparator +
+                "\t... 22 more" + lineSeparator;
         String s = byteout.toString();
         if (!expect.equals(s)) {
             System.err.println(s);

--- a/test/jdk/java/lang/Throwable/PrintStackTrace.java
+++ b/test/jdk/java/lang/Throwable/PrintStackTrace.java
@@ -194,7 +194,7 @@ public class PrintStackTrace {
 
         var lineSeparator = System.lineSeparator();
 
-        String expect = "java.lang.RuntimeException: java.lang.RuntimeException: java.lang.RuntimeException\n" +
+        String expect = "java.lang.RuntimeException: java.lang.RuntimeException: java.lang.RuntimeException" + lineSeparator +
                 "\tat PrintStackTrace.xn(PrintStackTrace.java:139)" + lineSeparator +
                 "\tat PrintStackTrace.x9(PrintStackTrace.java:144)" + lineSeparator +
                 "\tat PrintStackTrace.x8(PrintStackTrace.java:148)" + lineSeparator +

--- a/test/jdk/java/lang/Throwable/PrintStackTrace.java
+++ b/test/jdk/java/lang/Throwable/PrintStackTrace.java
@@ -1,0 +1,257 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, Alibaba Group Holding Limited. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
+import org.testng.annotations.Test;
+import static org.testng.Assert.*;
+/*
+ * @test
+ * @bug     8355636
+ * @library /test/lib
+ * @run testng PrintStackTrace
+ * @summary Verify PrintStackTrace results
+ */
+
+public class PrintStackTrace {
+
+    private static void fn() {
+        throw new RuntimeException();
+    }
+
+    private static void f9() {
+        fn();
+    }
+
+    private static void f8() {
+        f9();
+    }
+
+    private static void f7() {
+        f8();
+    }
+
+    private static void f6() {
+        f7();
+    }
+
+    private static void f5() {
+        f6();
+    }
+
+    private static void f4() {
+        f5();
+    }
+
+    private static void f3() {
+        f4();
+    }
+
+    private static void f2() {
+        f3();
+    }
+
+    private static void f1() {
+        f2();
+    }
+
+    private static void f0() {
+        f1();
+    }
+
+
+    private static void yn() {
+        try {
+            f0();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static void y9() {
+        yn();
+    }
+
+    private static void y8() {
+        y9();
+    }
+
+    private static void y7() {
+        y8();
+    }
+
+    private static void y6() {
+        y7();
+    }
+
+    private static void y5() {
+        y6();
+    }
+
+    private static void y4() {
+        y5();
+    }
+
+    private static void y3() {
+        y4();
+    }
+
+    private static void y2() {
+        y3();
+    }
+
+    private static void y1() {
+        y2();
+    }
+
+    private static void y0() {
+        y1();
+    }
+
+    private static void xn() {
+        try {
+            y0();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static void x9() {
+        xn();
+    }
+
+    private static void x8() {
+        x9();
+    }
+
+    private static void x7() {
+        x8();
+    }
+
+    private static void x6() {
+        x7();
+    }
+
+    private static void x5() {
+        x6();
+    }
+
+    private static void x4() {
+        x5();
+    }
+
+    private static void x3() {
+        x4();
+    }
+
+    private static void x2() {
+        x3();
+    }
+
+    private static void x1() {
+        x2();
+    }
+
+    private static void x0() {
+        x1();
+    }
+
+    public static void main(String[] args) {
+        Exception error = null;
+        try {
+            x0();
+        } catch (Exception e1) {
+            error = e1;
+        }
+        var byteout = new ByteArrayOutputStream();
+        Charset charset = StandardCharsets.UTF_8;
+        PrintStream printStream = new PrintStream(byteout, true, charset);
+        error.printStackTrace(printStream);
+
+        String expect =
+                """
+                        java.lang.RuntimeException: java.lang.RuntimeException: java.lang.RuntimeException
+                        	at PrintStackTrace.xn(PrintStackTrace.java:139)
+                        	at PrintStackTrace.x9(PrintStackTrace.java:144)
+                        	at PrintStackTrace.x8(PrintStackTrace.java:148)
+                        	at PrintStackTrace.x7(PrintStackTrace.java:152)
+                        	at PrintStackTrace.x6(PrintStackTrace.java:156)
+                        	at PrintStackTrace.x5(PrintStackTrace.java:160)
+                        	at PrintStackTrace.x4(PrintStackTrace.java:164)
+                        	at PrintStackTrace.x3(PrintStackTrace.java:168)
+                        	at PrintStackTrace.x2(PrintStackTrace.java:172)
+                        	at PrintStackTrace.x1(PrintStackTrace.java:176)
+                        	at PrintStackTrace.x0(PrintStackTrace.java:180)
+                        	at PrintStackTrace.main(PrintStackTrace.java:186)
+                        Caused by: java.lang.RuntimeException: java.lang.RuntimeException
+                        	at PrintStackTrace.yn(PrintStackTrace.java:91)
+                        	at PrintStackTrace.y9(PrintStackTrace.java:96)
+                        	at PrintStackTrace.y8(PrintStackTrace.java:100)
+                        	at PrintStackTrace.y7(PrintStackTrace.java:104)
+                        	at PrintStackTrace.y6(PrintStackTrace.java:108)
+                        	at PrintStackTrace.y5(PrintStackTrace.java:112)
+                        	at PrintStackTrace.y4(PrintStackTrace.java:116)
+                        	at PrintStackTrace.y3(PrintStackTrace.java:120)
+                        	at PrintStackTrace.y2(PrintStackTrace.java:124)
+                        	at PrintStackTrace.y1(PrintStackTrace.java:128)
+                        	at PrintStackTrace.y0(PrintStackTrace.java:132)
+                        	at PrintStackTrace.xn(PrintStackTrace.java:137)
+                        	... 11 more
+                        Caused by: java.lang.RuntimeException
+                        	at PrintStackTrace.fn(PrintStackTrace.java:43)
+                        	at PrintStackTrace.f9(PrintStackTrace.java:47)
+                        	at PrintStackTrace.f8(PrintStackTrace.java:51)
+                        	at PrintStackTrace.f7(PrintStackTrace.java:55)
+                        	at PrintStackTrace.f6(PrintStackTrace.java:59)
+                        	at PrintStackTrace.f5(PrintStackTrace.java:63)
+                        	at PrintStackTrace.f4(PrintStackTrace.java:67)
+                        	at PrintStackTrace.f3(PrintStackTrace.java:71)
+                        	at PrintStackTrace.f2(PrintStackTrace.java:75)
+                        	at PrintStackTrace.f1(PrintStackTrace.java:79)
+                        	at PrintStackTrace.f0(PrintStackTrace.java:83)
+                        	at PrintStackTrace.yn(PrintStackTrace.java:89)
+                        	... 22 more
+                        """;
+        String s = byteout.toString();
+        if (!expect.equals(s)) {
+            System.err.println(s);
+            throw new RuntimeException("stackTrace error");
+        }
+    }
+
+    /**
+     * Execute "java" with the given arguments, returning the exit code.
+     */
+    @Test
+    public void exec() throws Exception {
+        int exitValue = jdk.test.lib.process.ProcessTools.executeTestJava("PrintStackTrace")
+                .outputTo(System.out)
+                .errorTo(System.out)
+                .getExitValue();
+        assertTrue(exitValue == 0);
+    }
+}

--- a/test/jdk/java/lang/Throwable/PrintStackTrace.java
+++ b/test/jdk/java/lang/Throwable/PrintStackTrace.java
@@ -192,50 +192,47 @@ public class PrintStackTrace {
         PrintStream printStream = new PrintStream(byteout, true, charset);
         error.printStackTrace(printStream);
 
-        String expect =
-                """
-                        java.lang.RuntimeException: java.lang.RuntimeException: java.lang.RuntimeException
-                        	at PrintStackTrace.xn(PrintStackTrace.java:139)
-                        	at PrintStackTrace.x9(PrintStackTrace.java:144)
-                        	at PrintStackTrace.x8(PrintStackTrace.java:148)
-                        	at PrintStackTrace.x7(PrintStackTrace.java:152)
-                        	at PrintStackTrace.x6(PrintStackTrace.java:156)
-                        	at PrintStackTrace.x5(PrintStackTrace.java:160)
-                        	at PrintStackTrace.x4(PrintStackTrace.java:164)
-                        	at PrintStackTrace.x3(PrintStackTrace.java:168)
-                        	at PrintStackTrace.x2(PrintStackTrace.java:172)
-                        	at PrintStackTrace.x1(PrintStackTrace.java:176)
-                        	at PrintStackTrace.x0(PrintStackTrace.java:180)
-                        	at PrintStackTrace.main(PrintStackTrace.java:186)
-                        Caused by: java.lang.RuntimeException: java.lang.RuntimeException
-                        	at PrintStackTrace.yn(PrintStackTrace.java:91)
-                        	at PrintStackTrace.y9(PrintStackTrace.java:96)
-                        	at PrintStackTrace.y8(PrintStackTrace.java:100)
-                        	at PrintStackTrace.y7(PrintStackTrace.java:104)
-                        	at PrintStackTrace.y6(PrintStackTrace.java:108)
-                        	at PrintStackTrace.y5(PrintStackTrace.java:112)
-                        	at PrintStackTrace.y4(PrintStackTrace.java:116)
-                        	at PrintStackTrace.y3(PrintStackTrace.java:120)
-                        	at PrintStackTrace.y2(PrintStackTrace.java:124)
-                        	at PrintStackTrace.y1(PrintStackTrace.java:128)
-                        	at PrintStackTrace.y0(PrintStackTrace.java:132)
-                        	at PrintStackTrace.xn(PrintStackTrace.java:137)
-                        	... 11 more
-                        Caused by: java.lang.RuntimeException
-                        	at PrintStackTrace.fn(PrintStackTrace.java:43)
-                        	at PrintStackTrace.f9(PrintStackTrace.java:47)
-                        	at PrintStackTrace.f8(PrintStackTrace.java:51)
-                        	at PrintStackTrace.f7(PrintStackTrace.java:55)
-                        	at PrintStackTrace.f6(PrintStackTrace.java:59)
-                        	at PrintStackTrace.f5(PrintStackTrace.java:63)
-                        	at PrintStackTrace.f4(PrintStackTrace.java:67)
-                        	at PrintStackTrace.f3(PrintStackTrace.java:71)
-                        	at PrintStackTrace.f2(PrintStackTrace.java:75)
-                        	at PrintStackTrace.f1(PrintStackTrace.java:79)
-                        	at PrintStackTrace.f0(PrintStackTrace.java:83)
-                        	at PrintStackTrace.yn(PrintStackTrace.java:89)
-                        	... 22 more
-                        """;
+        String expect = "java.lang.RuntimeException: java.lang.RuntimeException: java.lang.RuntimeException\n" +
+                "\tat PrintStackTrace.xn(PrintStackTrace.java:139)\n" +
+                "\tat PrintStackTrace.x9(PrintStackTrace.java:144)\n" +
+                "\tat PrintStackTrace.x8(PrintStackTrace.java:148)\n" +
+                "\tat PrintStackTrace.x7(PrintStackTrace.java:152)\n" +
+                "\tat PrintStackTrace.x6(PrintStackTrace.java:156)\n" +
+                "\tat PrintStackTrace.x5(PrintStackTrace.java:160)\n" +
+                "\tat PrintStackTrace.x4(PrintStackTrace.java:164)\n" +
+                "\tat PrintStackTrace.x3(PrintStackTrace.java:168)\n" +
+                "\tat PrintStackTrace.x2(PrintStackTrace.java:172)\n" +
+                "\tat PrintStackTrace.x1(PrintStackTrace.java:176)\n" +
+                "\tat PrintStackTrace.x0(PrintStackTrace.java:180)\n" +
+                "\tat PrintStackTrace.main(PrintStackTrace.java:186)\n" +
+                "Caused by: java.lang.RuntimeException: java.lang.RuntimeException\n" +
+                "\tat PrintStackTrace.yn(PrintStackTrace.java:91)\n" +
+                "\tat PrintStackTrace.y9(PrintStackTrace.java:96)\n" +
+                "\tat PrintStackTrace.y8(PrintStackTrace.java:100)\n" +
+                "\tat PrintStackTrace.y7(PrintStackTrace.java:104)\n" +
+                "\tat PrintStackTrace.y6(PrintStackTrace.java:108)\n" +
+                "\tat PrintStackTrace.y5(PrintStackTrace.java:112)\n" +
+                "\tat PrintStackTrace.y4(PrintStackTrace.java:116)\n" +
+                "\tat PrintStackTrace.y3(PrintStackTrace.java:120)\n" +
+                "\tat PrintStackTrace.y2(PrintStackTrace.java:124)\n" +
+                "\tat PrintStackTrace.y1(PrintStackTrace.java:128)\n" +
+                "\tat PrintStackTrace.y0(PrintStackTrace.java:132)\n" +
+                "\tat PrintStackTrace.xn(PrintStackTrace.java:137)\n" +
+                "\t... 11 more\n" +
+                "Caused by: java.lang.RuntimeException\n" +
+                "\tat PrintStackTrace.fn(PrintStackTrace.java:43)\n" +
+                "\tat PrintStackTrace.f9(PrintStackTrace.java:47)\n" +
+                "\tat PrintStackTrace.f8(PrintStackTrace.java:51)\n" +
+                "\tat PrintStackTrace.f7(PrintStackTrace.java:55)\n" +
+                "\tat PrintStackTrace.f6(PrintStackTrace.java:59)\n" +
+                "\tat PrintStackTrace.f5(PrintStackTrace.java:63)\n" +
+                "\tat PrintStackTrace.f4(PrintStackTrace.java:67)\n" +
+                "\tat PrintStackTrace.f3(PrintStackTrace.java:71)\n" +
+                "\tat PrintStackTrace.f2(PrintStackTrace.java:75)\n" +
+                "\tat PrintStackTrace.f1(PrintStackTrace.java:79)\n" +
+                "\tat PrintStackTrace.f0(PrintStackTrace.java:83)\n" +
+                "\tat PrintStackTrace.yn(PrintStackTrace.java:89)\n" +
+                "\t... 22 more\n";
         String s = byteout.toString();
         if (!expect.equals(s)) {
             System.err.println(s);

--- a/test/micro/org/openjdk/bench/java/lang/Throwables.java
+++ b/test/micro/org/openjdk/bench/java/lang/Throwables.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) 2025, Alibaba Group Holding Limited. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.java.lang;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.CompilerControl;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Thread)
+@Warmup(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 5, time = 1000, timeUnit = TimeUnit.MILLISECONDS)
+@Fork(3)
+public class Throwables {
+    private OutputStream byteArrayOutputStream;
+
+    @Setup
+    public void setup() {
+        byteArrayOutputStream = new OutputStream() {
+            @Override
+            public void write(int b) throws IOException {}
+        };
+    }
+
+    @Benchmark
+    public PrintStream printStackTrace() {
+        Exception error = null;
+        try {
+            x0();
+        } catch (Exception e1) {
+            error = e1;
+        }
+        PrintStream printStream = new PrintStream(byteArrayOutputStream);
+        error.printStackTrace(printStream);
+        return printStream;
+    }
+
+    @Benchmark
+    public PrintStream printEnclosedStackTrace() {
+        Exception error = null;
+        try {
+            f0();
+        } catch (Exception e1) {
+            error = e1;
+        }
+        PrintStream printStream = new PrintStream(byteArrayOutputStream);
+        error.printStackTrace(printStream);
+        return printStream;
+    }
+
+    private static void fN() {
+        throw new RuntimeException();
+    }
+
+    private static void f9() {
+        fN();
+    }
+
+    private static void f8() {
+        f9();
+    }
+
+    private static void f7() {
+        f8();
+    }
+
+    private static void f6() {
+        f7();
+    }
+
+    private static void f5() {
+        f6();
+    }
+
+    private static void f4() {
+        f5();
+    }
+
+    private static void f3() {
+        f4();
+    }
+
+    private static void f2() {
+        f3();
+    }
+
+    private static void f1() {
+        f2();
+    }
+
+    private static void f0() {
+        f1();
+    }
+
+    private static void xn() {
+        try {
+            f0();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static void x9() {
+        xn();
+    }
+
+    private static void x8() {
+        x9();
+    }
+
+    private static void x7() {
+        x8();
+    }
+
+    private static void x6() {
+        x7();
+    }
+
+    private static void x5() {
+        x6();
+    }
+
+    private static void x4() {
+        x5();
+    }
+
+    private static void x3() {
+        x4();
+    }
+
+    private static void x2() {
+        x3();
+    }
+
+    private static void x1() {
+        x2();
+    }
+
+    private static void x0() {
+        x1();
+    }
+}

--- a/test/micro/org/openjdk/bench/java/lang/Throwables.java
+++ b/test/micro/org/openjdk/bench/java/lang/Throwables.java
@@ -35,9 +35,7 @@ import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
 
-import java.io.IOException;
-import java.io.OutputStream;
-import java.io.PrintStream;
+import java.io.*;
 import java.util.concurrent.TimeUnit;
 
 @BenchmarkMode(Mode.AverageTime)
@@ -51,10 +49,12 @@ public class Throwables {
 
     @Setup
     public void setup() {
-        byteArrayOutputStream = new OutputStream() {
-            @Override
-            public void write(int b) throws IOException {}
-        };
+        try {
+            File file = new File(File.createTempFile("PrintStackTrace", ".tmp").getAbsolutePath());
+            byteArrayOutputStream = new FileOutputStream(file);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     @Benchmark


### PR DESCRIPTION
In the Throwable::printStackTrace method, StringBuilder is created multiple times to build String. By sharing StringBuilder to build String, object allocation and copying are reduced.

In the scenario without suppressed and ourCause, unused IdentityHashMap is not created.

Through these optimizations, the performance of `new Exception().printStackTrace()` can be improved by about 10%.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (3 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 2 [Authors](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8355636](https://bugs.openjdk.org/browse/JDK-8355636): Reuse StringBuilder in printStackTrace (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24864/head:pull/24864` \
`$ git checkout pull/24864`

Update a local copy of the PR: \
`$ git checkout pull/24864` \
`$ git pull https://git.openjdk.org/jdk.git pull/24864/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24864`

View PR using the GUI difftool: \
`$ git pr show -t 24864`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24864.diff">https://git.openjdk.org/jdk/pull/24864.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24864#issuecomment-2831818048)
</details>
