### PR TITLE
8355562: RISC-V: Cleanup names of vector-scalar instructions in riscv_v.ad

### DIFF
--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -415,11 +415,11 @@ instruct vadd_fp_masked(vReg dst_src1, vReg src2, vRegMask_V0 v0) %{
 
 // vector-immediate add (unpredicated)
 
-instruct vadd_immI(vReg dst, vReg src1, immI5 con) %{
+instruct vaddI_vi(vReg dst, vReg src1, immI5 con) %{
   match(Set dst (AddVB src1 (Replicate con)));
   match(Set dst (AddVS src1 (Replicate con)));
   match(Set dst (AddVI src1 (Replicate con)));
-  format %{ "vadd_immI $dst, $src1, $con" %}
+  format %{ "vaddI_vi $dst, $src1, $con" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -430,9 +430,9 @@ instruct vadd_immI(vReg dst, vReg src1, immI5 con) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct vadd_immL(vReg dst, vReg src1, immL5 con) %{
+instruct vaddL_vi(vReg dst, vReg src1, immL5 con) %{
   match(Set dst (AddVL src1 (Replicate con)));
-  format %{ "vadd_immL $dst, $src1, $con" %}
+  format %{ "vaddL_vi $dst, $src1, $con" %}
   ins_encode %{
     __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
     __ vadd_vi(as_VectorRegister($dst$$reg),
@@ -444,11 +444,11 @@ instruct vadd_immL(vReg dst, vReg src1, immL5 con) %{
 
 // vector-scalar add (unpredicated)
 
-instruct vadd_regI(vReg dst, vReg src1, iRegIorL2I src2) %{
+instruct vaddI_vx(vReg dst, vReg src1, iRegIorL2I src2) %{
   match(Set dst (AddVB src1 (Replicate src2)));
   match(Set dst (AddVS src1 (Replicate src2)));
   match(Set dst (AddVI src1 (Replicate src2)));
-  format %{ "vadd_regI $dst, $src1, $src2" %}
+  format %{ "vaddI_vx $dst, $src1, $src2" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -459,9 +459,9 @@ instruct vadd_regI(vReg dst, vReg src1, iRegIorL2I src2) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct vadd_regL(vReg dst, vReg src1, iRegL src2) %{
+instruct vaddL_vx(vReg dst, vReg src1, iRegL src2) %{
   match(Set dst (AddVL src1 (Replicate src2)));
-  format %{ "vadd_regL $dst, $src1, $src2" %}
+  format %{ "vaddL_vx $dst, $src1, $src2" %}
   ins_encode %{
     __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
     __ vadd_vx(as_VectorRegister($dst$$reg),
@@ -473,11 +473,11 @@ instruct vadd_regL(vReg dst, vReg src1, iRegL src2) %{
 
 // vector-immediate add (predicated)
 
-instruct vadd_immI_masked(vReg dst_src, immI5 con, vRegMask_V0 v0) %{
+instruct vaddI_vi_masked(vReg dst_src, immI5 con, vRegMask_V0 v0) %{
   match(Set dst_src (AddVB (Binary dst_src (Replicate con)) v0));
   match(Set dst_src (AddVS (Binary dst_src (Replicate con)) v0));
   match(Set dst_src (AddVI (Binary dst_src (Replicate con)) v0));
-  format %{ "vadd_immI_masked $dst_src, $dst_src, $con" %}
+  format %{ "vaddI_vi_masked $dst_src, $dst_src, $con, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -488,9 +488,9 @@ instruct vadd_immI_masked(vReg dst_src, immI5 con, vRegMask_V0 v0) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct vadd_immL_masked(vReg dst_src, immL5 con, vRegMask_V0 v0) %{
+instruct vaddL_vi_masked(vReg dst_src, immL5 con, vRegMask_V0 v0) %{
   match(Set dst_src (AddVL (Binary dst_src (Replicate con)) v0));
-  format %{ "vadd_immL_masked $dst_src, $dst_src, $con" %}
+  format %{ "vaddL_vi_masked $dst_src, $dst_src, $con, $v0" %}
   ins_encode %{
     __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
     __ vadd_vi(as_VectorRegister($dst_src$$reg),
@@ -502,11 +502,11 @@ instruct vadd_immL_masked(vReg dst_src, immL5 con, vRegMask_V0 v0) %{
 
 // vector-scalar add (predicated)
 
-instruct vadd_regI_masked(vReg dst_src, iRegIorL2I src2, vRegMask_V0 v0) %{
+instruct vaddI_vx_masked(vReg dst_src, iRegIorL2I src2, vRegMask_V0 v0) %{
   match(Set dst_src (AddVB (Binary dst_src (Replicate src2)) v0));
   match(Set dst_src (AddVS (Binary dst_src (Replicate src2)) v0));
   match(Set dst_src (AddVI (Binary dst_src (Replicate src2)) v0));
-  format %{ "vadd_regI_masked $dst_src, $dst_src, $src2" %}
+  format %{ "vaddI_vx_masked $dst_src, $dst_src, $src2, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -517,9 +517,9 @@ instruct vadd_regI_masked(vReg dst_src, iRegIorL2I src2, vRegMask_V0 v0) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct vadd_regL_masked(vReg dst_src, iRegL src2, vRegMask_V0 v0) %{
+instruct vaddL_vx_masked(vReg dst_src, iRegL src2, vRegMask_V0 v0) %{
   match(Set dst_src (AddVL (Binary dst_src (Replicate src2)) v0));
-  format %{ "vadd_regL_masked $dst_src, $dst_src, $src2" %}
+  format %{ "vaddL_vx_masked $dst_src, $dst_src, $src2, $v0" %}
   ins_encode %{
     __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
     __ vadd_vx(as_VectorRegister($dst_src$$reg),
@@ -595,11 +595,11 @@ instruct vsub_fp_masked(vReg dst_src1, vReg src2, vRegMask_V0 v0) %{
 
 // vector-scalar sub (unpredicated)
 
-instruct vsub_regI(vReg dst, vReg src1, iRegIorL2I src2) %{
+instruct vsubI_vx(vReg dst, vReg src1, iRegIorL2I src2) %{
   match(Set dst (SubVB src1 (Replicate src2)));
   match(Set dst (SubVS src1 (Replicate src2)));
   match(Set dst (SubVI src1 (Replicate src2)));
-  format %{ "vsub_regI $dst, $src1, $src2" %}
+  format %{ "vsubI_vx $dst, $src1, $src2" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -610,9 +610,9 @@ instruct vsub_regI(vReg dst, vReg src1, iRegIorL2I src2) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct vsub_regL(vReg dst, vReg src1, iRegL src2) %{
+instruct vsubL_vx(vReg dst, vReg src1, iRegL src2) %{
   match(Set dst (SubVL src1 (Replicate src2)));
-  format %{ "vsub_regL $dst, $src1, $src2" %}
+  format %{ "vsubL_vx $dst, $src1, $src2" %}
   ins_encode %{
     __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
     __ vsub_vx(as_VectorRegister($dst$$reg),
@@ -624,11 +624,11 @@ instruct vsub_regL(vReg dst, vReg src1, iRegL src2) %{
 
 // vector-scalar sub (predicated)
 
-instruct vsub_regI_masked(vReg dst_src, iRegIorL2I src2, vRegMask_V0 v0) %{
+instruct vsubI_vx_masked(vReg dst_src, iRegIorL2I src2, vRegMask_V0 v0) %{
   match(Set dst_src (SubVB (Binary dst_src (Replicate src2)) v0));
   match(Set dst_src (SubVS (Binary dst_src (Replicate src2)) v0));
   match(Set dst_src (SubVI (Binary dst_src (Replicate src2)) v0));
-  format %{ "vsub_regI_masked $dst_src, $dst_src, $src2" %}
+  format %{ "vsubI_vx_masked $dst_src, $dst_src, $src2, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -639,9 +639,9 @@ instruct vsub_regI_masked(vReg dst_src, iRegIorL2I src2, vRegMask_V0 v0) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct vsub_regL_masked(vReg dst_src, iRegL src2, vRegMask_V0 v0) %{
+instruct vsubL_vx_masked(vReg dst_src, iRegL src2, vRegMask_V0 v0) %{
   match(Set dst_src (SubVL (Binary dst_src (Replicate src2)) v0));
-  format %{ "vsub_regL_masked $dst_src, $dst_src, $src2" %}
+  format %{ "vsub_vx_masked $dst_src, $dst_src, $src2, $v0" %}
   ins_encode %{
     __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
     __ vsub_vx(as_VectorRegister($dst_src$$reg),
@@ -685,12 +685,12 @@ instruct vand_masked(vReg dst_src1, vReg src2, vRegMask_V0 v0) %{
 
 // vector-immediate and (unpredicated)
 
-instruct vand_immI(vReg dst_src, immI5 con) %{
+instruct vandI_vi(vReg dst_src, immI5 con) %{
   predicate(Matcher::vector_element_basic_type(n) == T_INT ||
             Matcher::vector_element_basic_type(n) == T_BYTE ||
             Matcher::vector_element_basic_type(n) == T_SHORT);
   match(Set dst_src (AndV dst_src (Replicate con)));
-  format %{ "vand_immI $dst_src, $dst_src, $con" %}
+  format %{ "vandI_vi $dst_src, $dst_src, $con" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -701,10 +701,10 @@ instruct vand_immI(vReg dst_src, immI5 con) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct vand_immL(vReg dst_src, immL5 con) %{
+instruct vandL_vi(vReg dst_src, immL5 con) %{
   predicate(Matcher::vector_element_basic_type(n) == T_LONG);
   match(Set dst_src (AndV dst_src (Replicate con)));
-  format %{ "vand_immL $dst_src, $dst_src, $con" %}
+  format %{ "vandL_vi $dst_src, $dst_src, $con" %}
   ins_encode %{
     __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
     __ vand_vi(as_VectorRegister($dst_src$$reg),
@@ -716,12 +716,12 @@ instruct vand_immL(vReg dst_src, immL5 con) %{
 
 // vector-scalar and (unpredicated)
 
-instruct vand_regI(vReg dst_src, iRegIorL2I src) %{
+instruct vandI_vx(vReg dst_src, iRegIorL2I src) %{
   predicate(Matcher::vector_element_basic_type(n) == T_INT ||
             Matcher::vector_element_basic_type(n) == T_BYTE ||
             Matcher::vector_element_basic_type(n) == T_SHORT);
   match(Set dst_src (AndV dst_src (Replicate src)));
-  format %{ "vand_regI $dst_src, $dst_src, $src" %}
+  format %{ "vandI_vx $dst_src, $dst_src, $src" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -732,10 +732,10 @@ instruct vand_regI(vReg dst_src, iRegIorL2I src) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct vand_regL(vReg dst_src, iRegL src) %{
+instruct vandL_vx(vReg dst_src, iRegL src) %{
   predicate(Matcher::vector_element_basic_type(n) == T_LONG);
   match(Set dst_src (AndV dst_src (Replicate src)));
-  format %{ "vand_regL $dst_src, $dst_src, $src" %}
+  format %{ "vandL_vx $dst_src, $dst_src, $src" %}
   ins_encode %{
     __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
     __ vand_vx(as_VectorRegister($dst_src$$reg),
@@ -747,12 +747,12 @@ instruct vand_regL(vReg dst_src, iRegL src) %{
 
 // vector-immediate and (predicated)
 
-instruct vand_immI_masked(vReg dst_src, immI5 con, vRegMask_V0 v0) %{
+instruct vandI_vi_masked(vReg dst_src, immI5 con, vRegMask_V0 v0) %{
   predicate(Matcher::vector_element_basic_type(n) == T_INT ||
             Matcher::vector_element_basic_type(n) == T_BYTE ||
             Matcher::vector_element_basic_type(n) == T_SHORT);
   match(Set dst_src (AndV (Binary dst_src (Replicate con)) v0));
-  format %{ "vand_immI_masked $dst_src, $dst_src, $con" %}
+  format %{ "vandI_vi_masked $dst_src, $dst_src, $con, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -763,10 +763,10 @@ instruct vand_immI_masked(vReg dst_src, immI5 con, vRegMask_V0 v0) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct vand_immL_masked(vReg dst_src, immL5 con, vRegMask_V0 v0) %{
+instruct vandL_vi_masked(vReg dst_src, immL5 con, vRegMask_V0 v0) %{
   predicate(Matcher::vector_element_basic_type(n) == T_LONG);
   match(Set dst_src (AndV (Binary dst_src (Replicate con)) v0));
-  format %{ "vand_immL_masked $dst_src, $dst_src, $con" %}
+  format %{ "vandL_vi_masked $dst_src, $dst_src, $con, $v0" %}
   ins_encode %{
     __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
     __ vand_vi(as_VectorRegister($dst_src$$reg),
@@ -778,12 +778,12 @@ instruct vand_immL_masked(vReg dst_src, immL5 con, vRegMask_V0 v0) %{
 
 // vector-scalar and (predicated)
 
-instruct vand_regI_masked(vReg dst_src, iRegIorL2I src, vRegMask_V0 v0) %{
+instruct vandI_vx_masked(vReg dst_src, iRegIorL2I src, vRegMask_V0 v0) %{
   predicate(Matcher::vector_element_basic_type(n) == T_INT ||
             Matcher::vector_element_basic_type(n) == T_BYTE ||
             Matcher::vector_element_basic_type(n) == T_SHORT);
   match(Set dst_src (AndV (Binary dst_src (Replicate src)) v0));
-  format %{ "vand_regI_masked $dst_src, $dst_src, $src" %}
+  format %{ "vandI_vx_masked $dst_src, $dst_src, $src, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -794,10 +794,10 @@ instruct vand_regI_masked(vReg dst_src, iRegIorL2I src, vRegMask_V0 v0) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct vand_regL_masked(vReg dst_src, iRegL src, vRegMask_V0 v0) %{
+instruct vandL_vx_masked(vReg dst_src, iRegL src, vRegMask_V0 v0) %{
   predicate(Matcher::vector_element_basic_type(n) == T_LONG);
   match(Set dst_src (AndV (Binary dst_src (Replicate src)) v0));
-  format %{ "vand_regL_masked $dst_src, $dst_src, $src" %}
+  format %{ "vandL_vx_masked $dst_src, $dst_src, $src, $v0" %}
   ins_encode %{
     __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
     __ vand_vx(as_VectorRegister($dst_src$$reg),
@@ -841,12 +841,12 @@ instruct vor_masked(vReg dst_src1, vReg src2, vRegMask_V0 v0) %{
 
 // vector-immediate or (unpredicated)
 
-instruct vor_immI(vReg dst_src, immI5 con) %{
+instruct vorI_vi(vReg dst_src, immI5 con) %{
   predicate(Matcher::vector_element_basic_type(n) == T_INT ||
             Matcher::vector_element_basic_type(n) == T_BYTE ||
             Matcher::vector_element_basic_type(n) == T_SHORT);
   match(Set dst_src (OrV dst_src (Replicate con)));
-  format %{ "vor_immI $dst_src, $dst_src, $con" %}
+  format %{ "vorI_vi $dst_src, $dst_src, $con" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -857,10 +857,10 @@ instruct vor_immI(vReg dst_src, immI5 con) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct vor_immL(vReg dst_src, immL5 con) %{
+instruct vorL_vi(vReg dst_src, immL5 con) %{
   predicate(Matcher::vector_element_basic_type(n) == T_LONG);
   match(Set dst_src (OrV dst_src (Replicate con)));
-  format %{ "vor_immL $dst_src, $dst_src, $con" %}
+  format %{ "vorL_vi $dst_src, $dst_src, $con" %}
   ins_encode %{
     __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
     __ vor_vi(as_VectorRegister($dst_src$$reg),
@@ -872,12 +872,12 @@ instruct vor_immL(vReg dst_src, immL5 con) %{
 
 // vector-scalar or (unpredicated)
 
-instruct vor_regI(vReg dst_src, iRegIorL2I src) %{
+instruct vorI_vx(vReg dst_src, iRegIorL2I src) %{
   predicate(Matcher::vector_element_basic_type(n) == T_INT ||
             Matcher::vector_element_basic_type(n) == T_BYTE ||
             Matcher::vector_element_basic_type(n) == T_SHORT);
   match(Set dst_src (OrV dst_src (Replicate src)));
-  format %{ "vor_regI $dst_src, $dst_src, $src" %}
+  format %{ "vorI_vx $dst_src, $dst_src, $src" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -888,10 +888,10 @@ instruct vor_regI(vReg dst_src, iRegIorL2I src) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct vor_regL(vReg dst_src, iRegL src) %{
+instruct vorL_vx(vReg dst_src, iRegL src) %{
   predicate(Matcher::vector_element_basic_type(n) == T_LONG);
   match(Set dst_src (OrV dst_src (Replicate src)));
-  format %{ "vor_regL $dst_src, $dst_src, $src" %}
+  format %{ "vorL_vx $dst_src, $dst_src, $src" %}
   ins_encode %{
     __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
     __ vor_vx(as_VectorRegister($dst_src$$reg),
@@ -903,12 +903,12 @@ instruct vor_regL(vReg dst_src, iRegL src) %{
 
 // vector-immediate or (predicated)
 
-instruct vor_immI_masked(vReg dst_src, immI5 con, vRegMask_V0 v0) %{
+instruct vorI_vi_masked(vReg dst_src, immI5 con, vRegMask_V0 v0) %{
   predicate(Matcher::vector_element_basic_type(n) == T_INT ||
             Matcher::vector_element_basic_type(n) == T_BYTE ||
             Matcher::vector_element_basic_type(n) == T_SHORT);
   match(Set dst_src (OrV (Binary dst_src (Replicate con)) v0));
-  format %{ "vor_immI_masked $dst_src, $dst_src, $con" %}
+  format %{ "vorI_vi_masked $dst_src, $dst_src, $con, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -919,10 +919,10 @@ instruct vor_immI_masked(vReg dst_src, immI5 con, vRegMask_V0 v0) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct vor_immL_masked(vReg dst_src, immL5 con, vRegMask_V0 v0) %{
+instruct vorL_vi_masked(vReg dst_src, immL5 con, vRegMask_V0 v0) %{
   predicate(Matcher::vector_element_basic_type(n) == T_LONG);
   match(Set dst_src (OrV (Binary dst_src (Replicate con)) v0));
-  format %{ "vor_immL_masked $dst_src, $dst_src, $con" %}
+  format %{ "vorL_vi_masked $dst_src, $dst_src, $con, $v0" %}
   ins_encode %{
     __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
     __ vor_vi(as_VectorRegister($dst_src$$reg),
@@ -934,12 +934,12 @@ instruct vor_immL_masked(vReg dst_src, immL5 con, vRegMask_V0 v0) %{
 
 // vector-scalar or (predicated)
 
-instruct vor_regI_masked(vReg dst_src, iRegIorL2I src, vRegMask_V0 v0) %{
+instruct vorI_vx_masked(vReg dst_src, iRegIorL2I src, vRegMask_V0 v0) %{
   predicate(Matcher::vector_element_basic_type(n) == T_INT ||
             Matcher::vector_element_basic_type(n) == T_BYTE ||
             Matcher::vector_element_basic_type(n) == T_SHORT);
   match(Set dst_src (OrV (Binary dst_src (Replicate src)) v0));
-  format %{ "vor_regI_masked $dst_src, $dst_src, $src" %}
+  format %{ "vorI_vx_masked $dst_src, $dst_src, $src, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -950,10 +950,10 @@ instruct vor_regI_masked(vReg dst_src, iRegIorL2I src, vRegMask_V0 v0) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct vor_regL_masked(vReg dst_src, iRegL src, vRegMask_V0 v0) %{
+instruct vorL_vx_masked(vReg dst_src, iRegL src, vRegMask_V0 v0) %{
   predicate(Matcher::vector_element_basic_type(n) == T_LONG);
   match(Set dst_src (OrV (Binary dst_src (Replicate src)) v0));
-  format %{ "vor_regL_masked $dst_src, $dst_src, $src" %}
+  format %{ "vorL_vx_masked $dst_src, $dst_src, $src, $v0" %}
   ins_encode %{
     __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
     __ vor_vx(as_VectorRegister($dst_src$$reg),
@@ -997,12 +997,12 @@ instruct vxor_masked(vReg dst_src1, vReg src2, vRegMask_V0 v0) %{
 
 // vector-immediate xor (unpredicated)
 
-instruct vxor_immI(vReg dst_src, immI5 con) %{
+instruct vxorI_vi(vReg dst_src, immI5 con) %{
   predicate(Matcher::vector_element_basic_type(n) == T_INT ||
             Matcher::vector_element_basic_type(n) == T_BYTE ||
             Matcher::vector_element_basic_type(n) == T_SHORT);
   match(Set dst_src (XorV dst_src (Replicate con)));
-  format %{ "vxor_immI $dst_src, $dst_src, $con" %}
+  format %{ "vxorI_vi $dst_src, $dst_src, $con" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -1013,10 +1013,10 @@ instruct vxor_immI(vReg dst_src, immI5 con) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct vxor_immL(vReg dst_src, immL5 con) %{
+instruct vxorL_vi(vReg dst_src, immL5 con) %{
   predicate(Matcher::vector_element_basic_type(n) == T_LONG);
   match(Set dst_src (XorV dst_src (Replicate con)));
-  format %{ "vxor_immL $dst_src, $dst_src, $con" %}
+  format %{ "vxorL_vi $dst_src, $dst_src, $con" %}
   ins_encode %{
     __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
     __ vxor_vi(as_VectorRegister($dst_src$$reg),
@@ -1028,12 +1028,12 @@ instruct vxor_immL(vReg dst_src, immL5 con) %{
 
 // vector-scalar xor (unpredicated)
 
-instruct vxor_regI(vReg dst_src, iRegIorL2I src) %{
+instruct vxorI_vx(vReg dst_src, iRegIorL2I src) %{
   predicate(Matcher::vector_element_basic_type(n) == T_INT ||
             Matcher::vector_element_basic_type(n) == T_BYTE ||
             Matcher::vector_element_basic_type(n) == T_SHORT);
   match(Set dst_src (XorV dst_src (Replicate src)));
-  format %{ "vxor_regI $dst_src, $dst_src, $src" %}
+  format %{ "vxorI_vx $dst_src, $dst_src, $src" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -1044,10 +1044,10 @@ instruct vxor_regI(vReg dst_src, iRegIorL2I src) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct vxor_regL(vReg dst_src, iRegL src) %{
+instruct vxorL_vx(vReg dst_src, iRegL src) %{
   predicate(Matcher::vector_element_basic_type(n) == T_LONG);
   match(Set dst_src (XorV dst_src (Replicate src)));
-  format %{ "vxor_regL $dst_src, $dst_src, $src" %}
+  format %{ "vxorL_vx $dst_src, $dst_src, $src" %}
   ins_encode %{
     __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
     __ vxor_vx(as_VectorRegister($dst_src$$reg),
@@ -1059,12 +1059,12 @@ instruct vxor_regL(vReg dst_src, iRegL src) %{
 
 // vector-immediate xor (predicated)
 
-instruct vxor_immI_masked(vReg dst_src, immI5 con, vRegMask_V0 v0) %{
+instruct vxorI_vi_masked(vReg dst_src, immI5 con, vRegMask_V0 v0) %{
   predicate(Matcher::vector_element_basic_type(n) == T_INT ||
             Matcher::vector_element_basic_type(n) == T_BYTE ||
             Matcher::vector_element_basic_type(n) == T_SHORT);
   match(Set dst_src (XorV (Binary dst_src (Replicate con)) v0));
-  format %{ "vxor_immI_masked $dst_src, $dst_src, $con" %}
+  format %{ "vxorI_vi_masked $dst_src, $dst_src, $con, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -1075,10 +1075,10 @@ instruct vxor_immI_masked(vReg dst_src, immI5 con, vRegMask_V0 v0) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct vxor_immL_masked(vReg dst_src, immL5 con, vRegMask_V0 v0) %{
+instruct vxorL_vi_masked(vReg dst_src, immL5 con, vRegMask_V0 v0) %{
   predicate(Matcher::vector_element_basic_type(n) == T_LONG);
   match(Set dst_src (XorV (Binary dst_src (Replicate con)) v0));
-  format %{ "vxor_immL_masked $dst_src, $dst_src, $con" %}
+  format %{ "vxorL_vi_masked $dst_src, $dst_src, $con, $v0" %}
   ins_encode %{
     __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
     __ vxor_vi(as_VectorRegister($dst_src$$reg),
@@ -1090,12 +1090,12 @@ instruct vxor_immL_masked(vReg dst_src, immL5 con, vRegMask_V0 v0) %{
 
 // vector-scalar xor (predicated)
 
-instruct vxor_regI_masked(vReg dst_src, iRegIorL2I src, vRegMask_V0 v0) %{
+instruct vxorI_vx_masked(vReg dst_src, iRegIorL2I src, vRegMask_V0 v0) %{
   predicate(Matcher::vector_element_basic_type(n) == T_INT ||
             Matcher::vector_element_basic_type(n) == T_BYTE ||
             Matcher::vector_element_basic_type(n) == T_SHORT);
   match(Set dst_src (XorV (Binary dst_src (Replicate src)) v0));
-  format %{ "vxor_regI_masked $dst_src, $dst_src, $src" %}
+  format %{ "vxorI_vx_masked $dst_src, $dst_src, $src, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -1106,10 +1106,10 @@ instruct vxor_regI_masked(vReg dst_src, iRegIorL2I src, vRegMask_V0 v0) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct vxor_regL_masked(vReg dst_src, iRegL src, vRegMask_V0 v0) %{
+instruct vxorL_vx_masked(vReg dst_src, iRegL src, vRegMask_V0 v0) %{
   predicate(Matcher::vector_element_basic_type(n) == T_LONG);
   match(Set dst_src (XorV (Binary dst_src (Replicate src)) v0));
-  format %{ "vxor_regL_masked $dst_src, $dst_src, $src" %}
+  format %{ "vxorL_vx_masked $dst_src, $dst_src, $src, $v0" %}
   ins_encode %{
     __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
     __ vxor_vx(as_VectorRegister($dst_src$$reg),
@@ -1737,11 +1737,11 @@ instruct vmul_fp_masked(vReg dst_src1, vReg src2, vRegMask_V0 v0) %{
 
 // vector-scalar mul (unpredicated)
 
-instruct vmul_regI(vReg dst, vReg src1, iRegIorL2I src2) %{
+instruct vmulI_vx(vReg dst, vReg src1, iRegIorL2I src2) %{
   match(Set dst (MulVB src1 (Replicate src2)));
   match(Set dst (MulVS src1 (Replicate src2)));
   match(Set dst (MulVI src1 (Replicate src2)));
-  format %{ "vmul_regI $dst, $src1, $src2" %}
+  format %{ "vmulI_vx $dst, $src1, $src2" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -1752,9 +1752,9 @@ instruct vmul_regI(vReg dst, vReg src1, iRegIorL2I src2) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct vmul_regL(vReg dst, vReg src1, iRegL src2) %{
+instruct vmulL_vx(vReg dst, vReg src1, iRegL src2) %{
   match(Set dst (MulVL src1 (Replicate src2)));
-  format %{ "vmul_regL $dst, $src1, $src2" %}
+  format %{ "vmulL_vx $dst, $src1, $src2" %}
   ins_encode %{
     __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
     __ vmul_vx(as_VectorRegister($dst$$reg),
@@ -1766,11 +1766,11 @@ instruct vmul_regL(vReg dst, vReg src1, iRegL src2) %{
 
 // vector-scalar mul (predicated)
 
-instruct vmul_regI_masked(vReg dst_src, iRegIorL2I src2, vRegMask_V0 v0) %{
+instruct vmulI_vx_masked(vReg dst_src, iRegIorL2I src2, vRegMask_V0 v0) %{
   match(Set dst_src (MulVB (Binary dst_src (Replicate src2)) v0));
   match(Set dst_src (MulVS (Binary dst_src (Replicate src2)) v0));
   match(Set dst_src (MulVI (Binary dst_src (Replicate src2)) v0));
-  format %{ "vmul_regI_masked $dst_src, $dst_src, $src2" %}
+  format %{ "vmulI_vx_masked $dst_src, $dst_src, $src2, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -1781,9 +1781,9 @@ instruct vmul_regI_masked(vReg dst_src, iRegIorL2I src2, vRegMask_V0 v0) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct vmul_regL_masked(vReg dst_src, iRegL src2, vRegMask_V0 v0) %{
+instruct vmulL_vx_masked(vReg dst_src, iRegL src2, vRegMask_V0 v0) %{
   match(Set dst_src (MulVL (Binary dst_src (Replicate src2)) v0));
-  format %{ "vmul_regL_masked $dst_src, $dst_src, $src2" %}
+  format %{ "vmulL_vx_masked $dst_src, $dst_src, $src2, $v0" %}
   ins_encode %{
     __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
     __ vmul_vx(as_VectorRegister($dst_src$$reg),
@@ -3058,10 +3058,10 @@ instruct vlsrL_masked(vReg dst_src, vReg shift, vRegMask_V0 v0) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct vasrB_imm(vReg dst, vReg src, immI shift) %{
+instruct vasrB_vi(vReg dst, vReg src, immI shift) %{
   match(Set dst (RShiftVB src (RShiftCntV shift)));
   ins_cost(VEC_COST);
-  format %{ "vasrB_imm $dst, $src, $shift" %}
+  format %{ "vasrB_vi $dst, $src, $shift" %}
   ins_encode %{
     uint32_t con = (unsigned)$shift$$constant & 0x1f;
     __ vsetvli_helper(T_BYTE, Matcher::vector_length(this));
@@ -3076,10 +3076,10 @@ instruct vasrB_imm(vReg dst, vReg src, immI shift) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct vasrS_imm(vReg dst, vReg src, immI shift) %{
+instruct vasrS_vi(vReg dst, vReg src, immI shift) %{
   match(Set dst (RShiftVS src (RShiftCntV shift)));
   ins_cost(VEC_COST);
-  format %{ "vasrS_imm $dst, $src, $shift" %}
+  format %{ "vasrS_vi $dst, $src, $shift" %}
   ins_encode %{
     uint32_t con = (unsigned)$shift$$constant & 0x1f;
     __ vsetvli_helper(T_SHORT, Matcher::vector_length(this));
@@ -3094,10 +3094,10 @@ instruct vasrS_imm(vReg dst, vReg src, immI shift) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct vasrI_imm(vReg dst, vReg src, immI shift) %{
+instruct vasrI_vi(vReg dst, vReg src, immI shift) %{
   match(Set dst (RShiftVI src (RShiftCntV shift)));
   ins_cost(VEC_COST);
-  format %{ "vasrI_imm $dst, $src, $shift" %}
+  format %{ "vasrI_vi $dst, $src, $shift" %}
   ins_encode %{
     uint32_t con = (unsigned)$shift$$constant & 0x1f;
     __ vsetvli_helper(T_INT, Matcher::vector_length(this));
@@ -3111,11 +3111,11 @@ instruct vasrI_imm(vReg dst, vReg src, immI shift) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct vasrL_imm(vReg dst, vReg src, immI shift) %{
+instruct vasrL_vi(vReg dst, vReg src, immI shift) %{
   predicate((n->in(2)->in(1)->get_int() & 0x3f) < 32);
   match(Set dst (RShiftVL src (RShiftCntV shift)));
   ins_cost(VEC_COST);
-  format %{ "vasrL_imm $dst, $src, $shift" %}
+  format %{ "vasrL_vi $dst, $src, $shift" %}
   ins_encode %{
     uint32_t con = (unsigned)$shift$$constant & 0x1f;
     __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
@@ -3129,10 +3129,10 @@ instruct vasrL_imm(vReg dst, vReg src, immI shift) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct vasrB_imm_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
+instruct vasrB_vi_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
   match(Set dst_src (RShiftVB (Binary dst_src (RShiftCntV shift)) v0));
   ins_cost(VEC_COST);
-  format %{ "vasrB_imm_masked $dst_src, $dst_src, $shift, $v0" %}
+  format %{ "vasrB_vi_masked $dst_src, $dst_src, $shift, $v0" %}
   ins_encode %{
     uint32_t con = (unsigned)$shift$$constant & 0x1f;
     if (con == 0) {
@@ -3146,10 +3146,10 @@ instruct vasrB_imm_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct vasrS_imm_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
+instruct vasrS_vi_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
   match(Set dst_src (RShiftVS (Binary dst_src (RShiftCntV shift)) v0));
   ins_cost(VEC_COST);
-  format %{ "vasrS_imm_masked $dst_src, $dst_src, $shift, $v0" %}
+  format %{ "vasrS_vi_masked $dst_src, $dst_src, $shift, $v0" %}
   ins_encode %{
     uint32_t con = (unsigned)$shift$$constant & 0x1f;
     if (con == 0) {
@@ -3163,10 +3163,10 @@ instruct vasrS_imm_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct vasrI_imm_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
+instruct vasrI_vi_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
   match(Set dst_src (RShiftVI (Binary dst_src (RShiftCntV shift)) v0));
   ins_cost(VEC_COST);
-  format %{ "vasrI_imm_masked $dst_src, $dst_src, $shift, $v0" %}
+  format %{ "vasrI_vi_masked $dst_src, $dst_src, $shift, $v0" %}
   ins_encode %{
     uint32_t con = (unsigned)$shift$$constant & 0x1f;
     if (con == 0) {
@@ -3179,11 +3179,11 @@ instruct vasrI_imm_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct vasrL_imm_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
+instruct vasrL_vi_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
   predicate((n->in(1)->in(2)->in(1)->get_int() & 0x3f) < 32);
   match(Set dst_src (RShiftVL (Binary dst_src (RShiftCntV shift)) v0));
   ins_cost(VEC_COST);
-  format %{ "vasrL_imm_masked $dst_src, $dst_src, $shift, $v0" %}
+  format %{ "vasrL_vi_masked $dst_src, $dst_src, $shift, $v0" %}
   ins_encode %{
     uint32_t con = (unsigned)$shift$$constant & 0x1f;
     if (con == 0) {
@@ -3196,10 +3196,10 @@ instruct vasrL_imm_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct vlsrB_imm(vReg dst, vReg src, immI shift) %{
+instruct vlsrB_vi(vReg dst, vReg src, immI shift) %{
   match(Set dst (URShiftVB src (RShiftCntV shift)));
   ins_cost(VEC_COST);
-  format %{ "vlsrB_imm $dst, $src, $shift" %}
+  format %{ "vlsrB_vi $dst, $src, $shift" %}
   ins_encode %{
     uint32_t con = (unsigned)$shift$$constant & 0x1f;
     __ vsetvli_helper(T_BYTE, Matcher::vector_length(this));
@@ -3218,10 +3218,10 @@ instruct vlsrB_imm(vReg dst, vReg src, immI shift) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct vlsrS_imm(vReg dst, vReg src, immI shift) %{
+instruct vlsrS_vi(vReg dst, vReg src, immI shift) %{
   match(Set dst (URShiftVS src (RShiftCntV shift)));
   ins_cost(VEC_COST);
-  format %{ "vlsrS_imm $dst, $src, $shift" %}
+  format %{ "vlsrS_vi $dst, $src, $shift" %}
   ins_encode %{
     uint32_t con = (unsigned)$shift$$constant & 0x1f;
     __ vsetvli_helper(T_SHORT, Matcher::vector_length(this));
@@ -3240,10 +3240,10 @@ instruct vlsrS_imm(vReg dst, vReg src, immI shift) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct vlsrI_imm(vReg dst, vReg src, immI shift) %{
+instruct vlsrI_vi(vReg dst, vReg src, immI shift) %{
   match(Set dst (URShiftVI src (RShiftCntV shift)));
   ins_cost(VEC_COST);
-  format %{ "vlsrI_imm $dst, $src, $shift" %}
+  format %{ "vlsrI_vi $dst, $src, $shift" %}
   ins_encode %{
     uint32_t con = (unsigned)$shift$$constant & 0x1f;
     __ vsetvli_helper(T_INT, Matcher::vector_length(this));
@@ -3257,11 +3257,11 @@ instruct vlsrI_imm(vReg dst, vReg src, immI shift) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct vlsrL_imm(vReg dst, vReg src, immI shift) %{
+instruct vlsrL_vi(vReg dst, vReg src, immI shift) %{
   predicate((n->in(2)->in(1)->get_int() & 0x3f) < 32);
   match(Set dst (URShiftVL src (RShiftCntV shift)));
   ins_cost(VEC_COST);
-  format %{ "vlsrL_imm $dst, $src, $shift" %}
+  format %{ "vlsrL_vi $dst, $src, $shift" %}
   ins_encode %{
     uint32_t con = (unsigned)$shift$$constant & 0x1f;
     __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
@@ -3275,10 +3275,10 @@ instruct vlsrL_imm(vReg dst, vReg src, immI shift) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct vlsrB_imm_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
+instruct vlsrB_vi_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
   match(Set dst_src (URShiftVB (Binary dst_src (RShiftCntV shift)) v0));
   ins_cost(VEC_COST);
-  format %{ "vlsrB_imm_masked $dst_src, $dst_src, $shift, $v0" %}
+  format %{ "vlsrB_vi_masked $dst_src, $dst_src, $shift, $v0" %}
   ins_encode %{
     uint32_t con = (unsigned)$shift$$constant & 0x1f;
     if (con == 0) {
@@ -3296,10 +3296,10 @@ instruct vlsrB_imm_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct vlsrS_imm_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
+instruct vlsrS_vi_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
   match(Set dst_src (URShiftVS (Binary dst_src (RShiftCntV shift)) v0));
   ins_cost(VEC_COST);
-  format %{ "vlsrS_imm_masked $dst_src, $dst_src, $shift, $v0" %}
+  format %{ "vlsrS_vi_masked $dst_src, $dst_src, $shift, $v0" %}
   ins_encode %{
     uint32_t con = (unsigned)$shift$$constant & 0x1f;
     if (con == 0) {
@@ -3317,10 +3317,10 @@ instruct vlsrS_imm_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct vlsrI_imm_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
+instruct vlsrI_vi_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
   match(Set dst_src (URShiftVI (Binary dst_src (RShiftCntV shift)) v0));
   ins_cost(VEC_COST);
-  format %{ "vlsrI_imm_masked $dst_src, $dst_src, $shift, $v0" %}
+  format %{ "vlsrI_vi_masked $dst_src, $dst_src, $shift, $v0" %}
   ins_encode %{
     uint32_t con = (unsigned)$shift$$constant & 0x1f;
     if (con == 0) {
@@ -3333,11 +3333,11 @@ instruct vlsrI_imm_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct vlsrL_imm_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
+instruct vlsrL_vi_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
   predicate((n->in(1)->in(2)->in(1)->get_int() & 0x3f) < 32);
   match(Set dst_src (URShiftVL (Binary dst_src (RShiftCntV shift)) v0));
   ins_cost(VEC_COST);
-  format %{ "vlsrL_imm_masked $dst_src, $dst_src, $shift, $v0" %}
+  format %{ "vlsrL_vi_masked $dst_src, $dst_src, $shift, $v0" %}
   ins_encode %{
     uint32_t con = (unsigned)$shift$$constant & 0x1f;
     if (con == 0) {
@@ -3350,10 +3350,10 @@ instruct vlsrL_imm_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct vlslB_imm(vReg dst, vReg src, immI shift) %{
+instruct vlslB_vi(vReg dst, vReg src, immI shift) %{
   match(Set dst (LShiftVB src (LShiftCntV shift)));
   ins_cost(VEC_COST);
-  format %{ "vlslB_imm $dst, $src, $shift" %}
+  format %{ "vlslB_vi $dst, $src, $shift" %}
   ins_encode %{
     uint32_t con = (unsigned)$shift$$constant & 0x1f;
     __ vsetvli_helper(T_BYTE, Matcher::vector_length(this));
@@ -3367,10 +3367,10 @@ instruct vlslB_imm(vReg dst, vReg src, immI shift) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct vlslS_imm(vReg dst, vReg src, immI shift) %{
+instruct vlslS_vi(vReg dst, vReg src, immI shift) %{
   match(Set dst (LShiftVS src (LShiftCntV shift)));
   ins_cost(VEC_COST);
-  format %{ "vlslS_imm $dst, $src, $shift" %}
+  format %{ "vlslS_vi $dst, $src, $shift" %}
   ins_encode %{
     uint32_t con = (unsigned)$shift$$constant & 0x1f;
     __ vsetvli_helper(T_SHORT, Matcher::vector_length(this));
@@ -3384,10 +3384,10 @@ instruct vlslS_imm(vReg dst, vReg src, immI shift) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct vlslI_imm(vReg dst, vReg src, immI shift) %{
+instruct vlslI_vi(vReg dst, vReg src, immI shift) %{
   match(Set dst (LShiftVI src (LShiftCntV shift)));
   ins_cost(VEC_COST);
-  format %{ "vlslI_imm $dst, $src, $shift" %}
+  format %{ "vlslI_vi $dst, $src, $shift" %}
   ins_encode %{
     uint32_t con = (unsigned)$shift$$constant & 0x1f;
     __ vsetvli_helper(T_INT, Matcher::vector_length(this));
@@ -3396,11 +3396,11 @@ instruct vlslI_imm(vReg dst, vReg src, immI shift) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct vlslL_imm(vReg dst, vReg src, immI shift) %{
+instruct vlslL_vi(vReg dst, vReg src, immI shift) %{
   predicate((n->in(2)->in(1)->get_int() & 0x3f) < 32);
   match(Set dst (LShiftVL src (LShiftCntV shift)));
   ins_cost(VEC_COST);
-  format %{ "vlslL_imm $dst, $src, $shift" %}
+  format %{ "vlslL_vi $dst, $src, $shift" %}
   ins_encode %{
     uint32_t con = (unsigned)$shift$$constant & 0x1f;
     __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
@@ -3409,10 +3409,10 @@ instruct vlslL_imm(vReg dst, vReg src, immI shift) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct vlslB_imm_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
+instruct vlslB_vi_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
   match(Set dst_src (LShiftVB (Binary dst_src (LShiftCntV shift)) v0));
   ins_cost(VEC_COST);
-  format %{ "vlslB_imm_masked $dst_src, $dst_src, $shift, $v0" %}
+  format %{ "vlslB_vi_masked $dst_src, $dst_src, $shift, $v0" %}
   ins_encode %{
     uint32_t con = (unsigned)$shift$$constant & 0x1f;
     __ vsetvli_helper(T_BYTE, Matcher::vector_length(this));
@@ -3427,10 +3427,10 @@ instruct vlslB_imm_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct vlslS_imm_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
+instruct vlslS_vi_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
   match(Set dst_src (LShiftVS (Binary dst_src (LShiftCntV shift)) v0));
   ins_cost(VEC_COST);
-  format %{ "vlslS_imm_masked $dst_src, $dst_src, $shift, $v0" %}
+  format %{ "vlslS_vi_masked $dst_src, $dst_src, $shift, $v0" %}
   ins_encode %{
     uint32_t con = (unsigned)$shift$$constant & 0x1f;
     __ vsetvli_helper(T_SHORT, Matcher::vector_length(this));
@@ -3445,10 +3445,10 @@ instruct vlslS_imm_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct vlslI_imm_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
+instruct vlslI_vi_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
   match(Set dst_src (LShiftVI (Binary dst_src (LShiftCntV shift)) v0));
   ins_cost(VEC_COST);
-  format %{ "vlslI_imm_masked $dst_src, $dst_src, $shift, $v0" %}
+  format %{ "vlslI_vi_masked $dst_src, $dst_src, $shift, $v0" %}
   ins_encode %{
     uint32_t con = (unsigned)$shift$$constant & 0x1f;
     __ vsetvli_helper(T_INT, Matcher::vector_length(this));
@@ -3458,11 +3458,11 @@ instruct vlslI_imm_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct vlslL_imm_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
+instruct vlslL_vi_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
   predicate((n->in(1)->in(2)->in(1)->get_int() & 0x3f) < 32);
   match(Set dst_src (LShiftVL (Binary dst_src (LShiftCntV shift)) v0));
   ins_cost(VEC_COST);
-  format %{ "vlslL_imm_masked $dst_src, $dst_src, $shift, $v0" %}
+  format %{ "vlslL_vi_masked $dst_src, $dst_src, $shift, $v0" %}
   ins_encode %{
     uint32_t con = (unsigned)$shift$$constant & 0x1f;
     __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
@@ -3502,9 +3502,9 @@ instruct vrotate_right(vReg dst, vReg src, vReg shift) %{
 %}
 
 // Only the low log2(SEW) bits of shift value are used, all other bits are ignored.
-instruct vrotate_right_reg(vReg dst, vReg src, iRegIorL2I shift) %{
+instruct vrotate_right_vx(vReg dst, vReg src, iRegIorL2I shift) %{
   match(Set dst (RotateRightV src (Replicate shift)));
-  format %{ "vrotate_right_reg $dst, $src, $shift\t" %}
+  format %{ "vrotate_right_vx $dst, $src, $shift\t" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -3514,9 +3514,9 @@ instruct vrotate_right_reg(vReg dst, vReg src, iRegIorL2I shift) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct vrotate_right_imm(vReg dst, vReg src, immI shift) %{
+instruct vrotate_right_vi(vReg dst, vReg src, immI shift) %{
   match(Set dst (RotateRightV src shift));
-  format %{ "vrotate_right_imm $dst, $src, $shift\t" %}
+  format %{ "vrotate_right_vi $dst, $src, $shift\t" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     uint32_t bits = type2aelembytes(bt) * 8;
@@ -3534,7 +3534,7 @@ instruct vrotate_right_imm(vReg dst, vReg src, immI shift) %{
 
 instruct vrotate_right_masked(vReg dst_src, vReg shift, vRegMask_V0 v0) %{
   match(Set dst_src (RotateRightV (Binary dst_src shift) v0));
-  format %{ "vrotate_right_masked $dst_src, $dst_src, $shift, v0.t\t" %}
+  format %{ "vrotate_right_masked $dst_src, $dst_src, $shift, $v0\t" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -3545,9 +3545,9 @@ instruct vrotate_right_masked(vReg dst_src, vReg shift, vRegMask_V0 v0) %{
 %}
 
 // Only the low log2(SEW) bits of shift value are used, all other bits are ignored.
-instruct vrotate_right_reg_masked(vReg dst_src, iRegIorL2I shift, vRegMask_V0 v0) %{
+instruct vrotate_right_vx_masked(vReg dst_src, iRegIorL2I shift, vRegMask_V0 v0) %{
   match(Set dst_src (RotateRightV (Binary dst_src (Replicate shift)) v0));
-  format %{ "vrotate_right_reg_masked $dst_src, $dst_src, $shift, v0.t\t" %}
+  format %{ "vrotate_right_vx_masked $dst_src, $dst_src, $shift, $v0\t" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -3557,9 +3557,9 @@ instruct vrotate_right_reg_masked(vReg dst_src, iRegIorL2I shift, vRegMask_V0 v0
   ins_pipe(pipe_slow);
 %}
 
-instruct vrotate_right_imm_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
+instruct vrotate_right_vi_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
   match(Set dst_src (RotateRightV (Binary dst_src shift) v0));
-  format %{ "vrotate_right_imm_masked $dst_src, $dst_src, $shift, v0.t\t" %}
+  format %{ "vrotate_right_vi_masked $dst_src, $dst_src, $shift, $v0\t" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     uint32_t bits = type2aelembytes(bt) * 8;
@@ -3589,9 +3589,9 @@ instruct vrotate_left(vReg dst, vReg src, vReg shift) %{
 %}
 
 // Only the low log2(SEW) bits of shift value are used, all other bits are ignored.
-instruct vrotate_left_reg(vReg dst, vReg src, iRegIorL2I shift) %{
+instruct vrotate_left_vx(vReg dst, vReg src, iRegIorL2I shift) %{
   match(Set dst (RotateLeftV src (Replicate shift)));
-  format %{ "vrotate_left_reg $dst, $src, $shift\t" %}
+  format %{ "vrotate_left_vx $dst, $src, $shift\t" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -3601,9 +3601,9 @@ instruct vrotate_left_reg(vReg dst, vReg src, iRegIorL2I shift) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct vrotate_left_imm(vReg dst, vReg src, immI shift) %{
+instruct vrotate_left_vi(vReg dst, vReg src, immI shift) %{
   match(Set dst (RotateLeftV src shift));
-  format %{ "vrotate_left_imm $dst, $src, $shift\t" %}
+  format %{ "vrotate_left_vi $dst, $src, $shift\t" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     uint32_t bits = type2aelembytes(bt) * 8;
@@ -3622,7 +3622,7 @@ instruct vrotate_left_imm(vReg dst, vReg src, immI shift) %{
 
 instruct vrotate_left_masked(vReg dst_src, vReg shift, vRegMask_V0 v0) %{
   match(Set dst_src (RotateLeftV (Binary dst_src shift) v0));
-  format %{ "vrotate_left_masked $dst_src, $dst_src, $shift, v0.t\t" %}
+  format %{ "vrotate_left_masked $dst_src, $dst_src, $shift, $v0\t" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -3633,9 +3633,9 @@ instruct vrotate_left_masked(vReg dst_src, vReg shift, vRegMask_V0 v0) %{
 %}
 
 // Only the low log2(SEW) bits of shift value are used, all other bits are ignored.
-instruct vrotate_left_reg_masked(vReg dst_src, iRegIorL2I shift, vRegMask_V0 v0) %{
+instruct vrotate_left_vx_masked(vReg dst_src, iRegIorL2I shift, vRegMask_V0 v0) %{
   match(Set dst_src (RotateLeftV (Binary dst_src (Replicate shift)) v0));
-  format %{ "vrotate_left_reg_masked $dst_src, $dst_src, $shift, v0.t\t" %}
+  format %{ "vrotate_left_vx_masked $dst_src, $dst_src, $shift, $v0\t" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -3645,9 +3645,9 @@ instruct vrotate_left_reg_masked(vReg dst_src, iRegIorL2I shift, vRegMask_V0 v0)
   ins_pipe(pipe_slow);
 %}
 
-instruct vrotate_left_imm_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
+instruct vrotate_left_vi_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
   match(Set dst_src (RotateLeftV (Binary dst_src shift) v0));
-  format %{ "vrotate_left_imm_masked $dst_src, $dst_src, $shift, v0.t\t" %}
+  format %{ "vrotate_left_vi_masked $dst_src, $dst_src, $shift, $v0\t" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     uint32_t bits = type2aelembytes(bt) * 8;


### PR DESCRIPTION
RISC-V: Cleanup names of vector-scalar instructions in riscv_v.ad

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8355562](https://bugs.openjdk.org/browse/JDK-8355562): RISC-V: Cleanup names of vector-scalar instructions in riscv_v.ad (**Enhancement** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Feilong Jiang](https://openjdk.org/census#fjiang) (@feilongjiang - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24865/head:pull/24865` \
`$ git checkout pull/24865`

Update a local copy of the PR: \
`$ git checkout pull/24865` \
`$ git pull https://git.openjdk.org/jdk.git pull/24865/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24865`

View PR using the GUI difftool: \
`$ git pr show -t 24865`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24865.diff">https://git.openjdk.org/jdk/pull/24865.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24865#issuecomment-2829232774)
</details>
