### PR TITLE
8355608: Async UL should take the file lock of stream when outputting

### DIFF
--- a/src/hotspot/share/logging/logFileStreamOutput.cpp
+++ b/src/hotspot/share/logging/logFileStreamOutput.cpp
@@ -168,6 +168,7 @@ int LogFileStreamOutput::write_internal(const LogDecorations& decorations, const
 }
 
 int LogFileStreamOutput::write_blocking(const LogDecorations& decorations, const char* msg) {
+  FileLocker flocker(_stream);
   int written = write_internal(decorations, msg);
   return flush() ? written : -1;
 }
@@ -177,10 +178,7 @@ int LogFileStreamOutput::write(const LogDecorations& decorations, const char* ms
     return 0;
   }
 
-  FileLocker flocker(_stream);
-  int written = write_internal(decorations, msg);
-
-  return flush() ? written : -1;
+  return write_blocking(decorations, msg);
 }
 
 int LogFileStreamOutput::write(LogMessageBuffer::Iterator msg_iterator) {


### PR DESCRIPTION
With the introduction of [JDK-8349755](https://bugs.openjdk.org/browse/JDK-8349755), it is not entirely clear any longer that the Async UL has exclusive access to the files which are being logged to in the JVM. We should take the file lock for the stream being logged to for safety's sake.

If, for example, an unattached thread logs, then it will do so without the help of the Async UL thread.

This is expected to very rarely, if ever, happen. Since taking an uncontested mutex is very cheap, I expect this to have a negligible performance impact.

Testing: GHA, tier1

Cheers,
Johan

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8355608](https://bugs.openjdk.org/browse/JDK-8355608): Async UL should take the file lock of stream when outputting (**Bug** - P4)


### Reviewers
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - **Reviewer**)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24874/head:pull/24874` \
`$ git checkout pull/24874`

Update a local copy of the PR: \
`$ git checkout pull/24874` \
`$ git pull https://git.openjdk.org/jdk.git pull/24874/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24874`

View PR using the GUI difftool: \
`$ git pr show -t 24874`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24874.diff">https://git.openjdk.org/jdk/pull/24874.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24874#issuecomment-2830399054)
</details>
