### PR TITLE
8355616: Incorrect ifdef in compilationMemoryStatistic.cpp

### DIFF
--- a/src/hotspot/share/compiler/compilationMemoryStatistic.cpp
+++ b/src/hotspot/share/compiler/compilationMemoryStatistic.cpp
@@ -374,7 +374,7 @@ void ArenaStatCounter::on_arena_chunk_deallocation(size_t size, uint64_t stamp) 
 void ArenaStatCounter::print_peak_state_on(outputStream* st) const {
   st->print("Total Usage: %zu ", _peak);
   if (_peak > 0) {
-#ifdef COMPILER2
+#ifdef COMPILER1
     // C1: print allocations broken down by arena types
     if (_comp_type == CompilerType::compiler_c1) {
       st->print("[");


### PR DESCRIPTION
Hi,

Working on a patch close to this area and saw that the ifdef didn't match the "#endif" just below. The ifdef should be COMPILER1 instead of COMPILER2.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8355616](https://bugs.openjdk.org/browse/JDK-8355616): Incorrect ifdef in compilationMemoryStatistic.cpp (**Enhancement** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24876/head:pull/24876` \
`$ git checkout pull/24876`

Update a local copy of the PR: \
`$ git checkout pull/24876` \
`$ git pull https://git.openjdk.org/jdk.git pull/24876/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24876`

View PR using the GUI difftool: \
`$ git pr show -t 24876`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24876.diff">https://git.openjdk.org/jdk/pull/24876.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24876#issuecomment-2830653458)
</details>
