### PR TITLE
Bsm refactor

### DIFF
--- a/src/hotspot/share/cds/aotConstantPoolResolver.cpp
+++ b/src/hotspot/share/cds/aotConstantPoolResolver.cpp
@@ -392,7 +392,7 @@ bool AOTConstantPoolResolver::check_lambda_metafactory_signature(ConstantPool* c
 }
 
 bool AOTConstantPoolResolver::check_lambda_metafactory_methodtype_arg(ConstantPool* cp, int bsms_attribute_index, int arg_i) {
-  int mt_index = cp->operand_argument_index_at(bsms_attribute_index, arg_i);
+  int mt_index = cp->bsm_attribute_entry(bsms_attribute_index)->argument_index(arg_i);
   if (!cp->tag_at(mt_index).is_method_type()) {
     // malformed class?
     return false;
@@ -408,7 +408,7 @@ bool AOTConstantPoolResolver::check_lambda_metafactory_methodtype_arg(ConstantPo
 }
 
 bool AOTConstantPoolResolver::check_lambda_metafactory_methodhandle_arg(ConstantPool* cp, int bsms_attribute_index, int arg_i) {
-  int mh_index = cp->operand_argument_index_at(bsms_attribute_index, arg_i);
+  int mh_index = cp->bsm_attribute_entry(bsms_attribute_index)->argument_index(arg_i);
   if (!cp->tag_at(mh_index).is_method_handle()) {
     // malformed class?
     return false;
@@ -433,7 +433,8 @@ bool AOTConstantPoolResolver::is_indy_resolution_deterministic(ConstantPool* cp,
     return false;
   }
 
-  int bsm = cp->bootstrap_method_ref_index_at(cp_index);
+  int bsms_attribute_index = cp->bootstrap_methods_attribute_index(cp_index);
+  int bsm = cp->bsm_attribute_entry(bsms_attribute_index)->bootstrap_method_index();
   int bsm_ref = cp->method_handle_index_at(bsm);
   Symbol* bsm_name = cp->uncached_name_ref_at(bsm_ref);
   Symbol* bsm_signature = cp->uncached_signature_ref_at(bsm_ref);
@@ -513,8 +514,7 @@ bool AOTConstantPoolResolver::is_indy_resolution_deterministic(ConstantPool* cp,
       return false;
     }
 
-    int bsms_attribute_index = cp->bootstrap_methods_attribute_index(cp_index);
-    int arg_count = cp->operand_argument_count_at(bsms_attribute_index);
+    int arg_count = cp->bsm_attribute_entry(bsms_attribute_index)->argument_count();
     if (arg_count != 3) {
       // Malformed class?
       return false;

--- a/src/hotspot/share/cds/classListParser.cpp
+++ b/src/hotspot/share/cds/classListParser.cpp
@@ -570,23 +570,22 @@ void ClassListParser::populate_cds_indy_info(const constantPoolHandle &pool, int
   cii->add_item(pool->symbol_at(name_index)->as_C_string());
   int sig_index = pool->signature_ref_index_at(type_index);
   cii->add_item(pool->symbol_at(sig_index)->as_C_string());
-  int argc = pool->bootstrap_argument_count_at(cp_index);
-  if (argc > 0) {
-    for (int arg_i = 0; arg_i < argc; arg_i++) {
-      int arg = pool->bootstrap_argument_index_at(cp_index, arg_i);
-      jbyte tag = pool->tag_at(arg).value();
-      if (tag == JVM_CONSTANT_MethodType) {
-        cii->add_item(pool->method_type_signature_at(arg)->as_C_string());
-      } else if (tag == JVM_CONSTANT_MethodHandle) {
-        cii->add_ref_kind(pool->method_handle_ref_kind_at(arg));
-        int callee_index = pool->method_handle_klass_index_at(arg);
-        Klass* callee = pool->klass_at(callee_index, CHECK);
-        cii->add_item(callee->name()->as_C_string());
-        cii->add_item(pool->method_handle_name_ref_at(arg)->as_C_string());
-        cii->add_item(pool->method_handle_signature_ref_at(arg)->as_C_string());
-      } else {
-        ShouldNotReachHere();
-      }
+  BSMAttributeEntry* bsme = pool->bootstrap_methods_attribute_entry(cp_index);
+  int argc = bsme->argument_count();
+  for (int arg_i = 0; arg_i < argc; arg_i++) {
+    int arg = bsme->argument_index(arg_i);
+    jbyte tag = pool->tag_at(arg).value();
+    if (tag == JVM_CONSTANT_MethodType) {
+      cii->add_item(pool->method_type_signature_at(arg)->as_C_string());
+    } else if (tag == JVM_CONSTANT_MethodHandle) {
+      cii->add_ref_kind(pool->method_handle_ref_kind_at(arg));
+      int callee_index = pool->method_handle_klass_index_at(arg);
+      Klass* callee = pool->klass_at(callee_index, CHECK);
+      cii->add_item(callee->name()->as_C_string());
+      cii->add_item(pool->method_handle_name_ref_at(arg)->as_C_string());
+      cii->add_item(pool->method_handle_signature_ref_at(arg)->as_C_string());
+    } else {
+      ShouldNotReachHere();
     }
   }
 }

--- a/src/hotspot/share/ci/ciEnv.cpp
+++ b/src/hotspot/share/ci/ciEnv.cpp
@@ -821,7 +821,8 @@ ciMethod* ciEnv::get_method_by_index_impl(const constantPoolHandle& cpool,
     // Patch the call site to the nmethod entry point of the static compiled lambda form.
     // As with other two-component call sites, both values must be independently verified.
     assert(index < cpool->cache()->resolved_indy_entries_length(), "impossible");
-    Method* adapter = cpool->resolved_indy_entry_at(index)->method();
+    ResolvedIndyEntry* rie = cpool->resolved_indy_entry_at(index);
+    Method* adapter = rie->method();
     // Resolved if the adapter is non null.
     if (adapter != nullptr) {
       return get_method(adapter);
@@ -830,7 +831,7 @@ ciMethod* ciEnv::get_method_by_index_impl(const constantPoolHandle& cpool,
     // Fake a method that is equivalent to a declared method.
     ciInstanceKlass* holder    = get_instance_klass(vmClasses::MethodHandle_klass());
     ciSymbol*        name      = ciSymbols::invokeBasic_name();
-    ciSymbol*        signature = get_symbol(cpool->signature_ref_at(index, bc));
+    ciSymbol*        signature = get_symbol(rie->signature(cpool()));
     return get_unloaded_method(holder, name, signature, accessor);
   } else {
     const int holder_index = cpool->klass_ref_index_at(index, bc);

--- a/src/hotspot/share/classfile/verifier.cpp
+++ b/src/hotspot/share/classfile/verifier.cpp
@@ -2808,9 +2808,9 @@ void ClassVerifier::verify_invoke_instructions(
     default:
       types = 1 << JVM_CONSTANT_Methodref;
   }
-  verify_cp_type(bcs->bci(), index, cp, types, CHECK_VERIFY(this));
 
   // Get method name and signature
+  verify_cp_type(bcs->bci(), index, cp, types, CHECK_VERIFY(this));
   Symbol* method_name = cp->uncached_name_ref_at(index);
   Symbol* method_sig = cp->uncached_signature_ref_at(index);
 

--- a/src/hotspot/share/interpreter/bootstrapInfo.hpp
+++ b/src/hotspot/share/interpreter/bootstrapInfo.hpp
@@ -34,7 +34,7 @@ class BootstrapInfo : public StackObj {
   constantPoolHandle _pool;     // constant pool containing the bootstrap specifier
   const int   _bss_index;       // index of bootstrap specifier in CP (condy or indy)
   const int   _indy_index;      // internal index of indy call site, or -1 if a condy call
-  const int   _argc;            // number of static arguments
+  int         _bsm_attr_index;  // index in the BootstrapMethods attribute
   Symbol*     _name;            // extracted from JVM_CONSTANT_NameAndType
   Symbol*     _signature;
 
@@ -43,7 +43,7 @@ class BootstrapInfo : public StackObj {
   Handle      _name_arg;        // resolved String
   Handle      _type_arg;        // resolved Class or MethodType
   Handle      _arg_values;      // array of static arguments; null implies either
-                                // uresolved or zero static arguments are specified
+                                // unresolved or zero static arguments are specified
 
   // post-bootstrap resolution state:
   bool        _is_resolved;       // set true when any of the next fields are set
@@ -58,7 +58,7 @@ class BootstrapInfo : public StackObj {
   const constantPoolHandle& pool() const{ return _pool; }
   int bss_index() const                 { return _bss_index; }
   int indy_index() const                { return _indy_index; }
-  int argc() const                      { return _argc; }
+  int bsm_attr_index() const            { return _bsm_attr_index; }
   bool is_method_call() const           { return (_indy_index != -1); }
   Symbol* name() const                  { return _name; }
   Symbol* signature() const             { return _signature; }
@@ -76,10 +76,11 @@ class BootstrapInfo : public StackObj {
   // derived accessors
   InstanceKlass* caller() const         { return _pool->pool_holder(); }
   oop caller_mirror() const             { return caller()->java_mirror(); }
-  int bsms_attr_index() const           { return _pool->bootstrap_methods_attribute_index(_bss_index); }
-  int bsm_index() const                 { return _pool->bootstrap_method_ref_index_at(_bss_index); }
-  //int argc() is eagerly cached in _argc
-  int arg_index(int i) const            { return _pool->bootstrap_argument_index_at(_bss_index, i); }
+  BSMAttributeEntry& bsm_attr() const   { return *_pool->bsm_attribute_entry(_bsm_attr_index); }
+  int bsm_index() const                 { return bsm_attr().bootstrap_method_index(); }
+  int arg_count() const                 { return bsm_attr().argument_count(); }
+  int arg_index(int j) const            { return bsm_attr().argument_index(j); }
+  ResolvedIndyEntry* indy_entry() const;
 
   // If there is evidence this call site was already linked, set the
   // existing linkage data into result, or throw previous exception.

--- a/src/hotspot/share/interpreter/bytecodeTracer.cpp
+++ b/src/hotspot/share/interpreter/bytecodeTracer.cpp
@@ -284,7 +284,7 @@ void BytecodePrinter::print_dynamic(int cp_index, outputStream* st) {
     return;
   }
 
-  int bsm = constants->bootstrap_method_ref_index_at(cp_index);
+  int bsm = constants->bootstrap_methods_attribute_index(cp_index);
   st->print(" bsm=%d", bsm);
 
   Symbol* name = constants->uncached_name_ref_at(cp_index);
@@ -310,7 +310,7 @@ void BytecodePrinter::print_invokedynamic(int indy_index, int cp_index, outputSt
 // cp_index: must be the cp_index of a JVM_CONSTANT_{Dynamic, DynamicInError, InvokeDynamic}
 void BytecodePrinter::print_bsm(int cp_index, outputStream* st) {
   assert(constants()->tag_at(cp_index).has_bootstrap(), "must be");
-  int bsm = constants()->bootstrap_method_ref_index_at(cp_index);
+  int bsm = constants()->bootstrap_methods_attribute_index(cp_index);
   const char* ref_kind = "";
   switch (constants()->method_handle_ref_kind_at(bsm)) {
   case JVM_REF_getField         : ref_kind = "REF_getField"; break;
@@ -326,12 +326,13 @@ void BytecodePrinter::print_bsm(int cp_index, outputStream* st) {
   }
   st->print("  BSM: %s", ref_kind);
   print_field_or_method(constants()->method_handle_index_at(bsm), st);
-  int argc = constants()->bootstrap_argument_count_at(cp_index);
+  BSMAttributeEntry* bsme = constants()->bootstrap_methods_attribute_entry(cp_index);
+  int argc = bsme->argument_count();
   st->print("  arguments[%d] = {", argc);
   if (argc > 0) {
     st->cr();
     for (int arg_i = 0; arg_i < argc; arg_i++) {
-      int arg = constants()->bootstrap_argument_index_at(cp_index, arg_i);
+      int arg = bsme->argument_index(arg_i);
       st->print("    ");
       print_constant(arg, st);
     }

--- a/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
@@ -890,7 +890,7 @@ C2V_END
 
 C2V_VMENTRY_0(jint, bootstrapArgumentIndexAt, (JNIEnv* env, jobject, ARGUMENT_PAIR(cp), jint cpi, jint index))
   constantPoolHandle cp(THREAD, UNPACK_PAIR(ConstantPool, cp));
-  return cp->bootstrap_argument_index_at(cpi, index);
+  return cp->bootstrap_methods_attribute_entry(cpi)->argument_index(index);
 C2V_END
 
 C2V_VMENTRY_0(jint, lookupNameAndTypeRefIndexInPool, (JNIEnv* env, jobject, ARGUMENT_PAIR(cp), jint index, jint opcode))

--- a/src/hotspot/share/oops/array.hpp
+++ b/src/hotspot/share/oops/array.hpp
@@ -126,6 +126,7 @@ protected:
   T    at(int i) const                 { assert(i >= 0 && i< _length, "oob: 0 <= %d < %d", i, _length); return data()[i]; }
   void at_put(const int i, const T& x) { assert(i >= 0 && i< _length, "oob: 0 <= %d < %d", i, _length); data()[i] = x; }
   T*   adr_at(const int i)             { assert(i >= 0 && i< _length, "oob: 0 <= %d < %d", i, _length); return &data()[i]; }
+  const T* adr_at(const int i) const   { assert(i >= 0 && i< _length, "oob: 0 <= %d < %d", i, _length); return &data()[i]; }
   int  find(const T& x)                { return index_of(x); }
 
   T at_acquire(const int i)            { return Atomic::load_acquire(adr_at(i)); }

--- a/src/hotspot/share/oops/constMethod.cpp
+++ b/src/hotspot/share/oops/constMethod.cpp
@@ -191,13 +191,14 @@ u2* ConstMethod::last_u2_element() const {
 u2* ConstMethod::generic_signature_index_addr() const {
   // Located at the end of the constMethod.
   assert(has_generic_signature(), "called only if generic signature exists");
-  return last_u2_element();
+  int offset = 0;  // this is always the last u2 (before possible pointers)
+  return last_u2_element() - offset;
 }
 
 u2* ConstMethod::method_parameters_length_addr() const {
   assert(has_method_parameters(), "called only if table is present");
-  return has_generic_signature() ? (last_u2_element() - 1) :
-                                    last_u2_element();
+  int offset = has_generic_signature() ? 1 : 0;
+  return last_u2_element() - offset;
 }
 
 u2* ConstMethod::checked_exceptions_length_addr() const {

--- a/src/hotspot/share/oops/constMethod.hpp
+++ b/src/hotspot/share/oops/constMethod.hpp
@@ -81,7 +81,7 @@
 //     (access flags bit tells whether table is present)
 //     (indexed from end of ConstMethod*)
 //    [EMBEDDED generic signature index (u2)]
-//     (indexed from end of constMethodOop)
+//     (indexed from end of ConstMethod*)
 //    [EMBEDDED annotations arrays - method, parameter, type, default]
 //      pointer to Array<u1> if annotation is present
 //

--- a/src/hotspot/share/oops/constantPool.inline.hpp
+++ b/src/hotspot/share/oops/constantPool.inline.hpp
@@ -68,10 +68,6 @@ inline oop ConstantPool::appendix_if_resolved(int method_index) const {
   return resolved_reference_at(ref_index);
 }
 
-inline u2 ConstantPool::invokedynamic_bootstrap_ref_index_at(int indy_index) const {
-  return cache()->resolved_indy_entry_at(indy_index)->constant_pool_index();
-}
-
 inline ResolvedIndyEntry* ConstantPool::resolved_indy_entry_at(int index) {
   return cache()->resolved_indy_entry_at(index);
 }

--- a/src/hotspot/share/oops/cpCache.cpp
+++ b/src/hotspot/share/oops/cpCache.cpp
@@ -520,7 +520,8 @@ void ConstantPoolCache::remove_resolved_indy_entries_if_non_deterministic() {
       LogStreamHandle(Trace, cds, resolve) log;
       if (log.is_enabled()) {
         ResourceMark rm;
-        int bsm = cp->bootstrap_method_ref_index_at(cp_index);
+        int bsms_attribute_index = cp->bootstrap_methods_attribute_index(cp_index);
+        int bsm = cp->bsm_attribute_entry(bsms_attribute_index)->bootstrap_method_index();
         int bsm_ref = cp->method_handle_index_at(bsm);
         Symbol* bsm_name = cp->uncached_name_ref_at(bsm_ref);
         Symbol* bsm_signature = cp->uncached_signature_ref_at(bsm_ref);
@@ -809,7 +810,7 @@ oop ConstantPoolCache::set_dynamic_call(const CallInfo &call_info, int index) {
 
   // Populate entry with resolved information
   assert(resolved_indy_entries() != nullptr, "Invokedynamic array is empty, cannot fill with resolved information");
-  resolved_indy_entry_at(index)->fill_in(adapter, adapter->size_of_parameters(), as_TosState(adapter->result_type()), has_appendix);
+  resolved_indy_entry_at(index)->fill_in(adapter, has_appendix);
 
   if (log_stream != nullptr) {
     resolved_indy_entry_at(index)->print_on(log_stream);

--- a/src/hotspot/share/oops/resolvedIndyEntry.cpp
+++ b/src/hotspot/share/oops/resolvedIndyEntry.cpp
@@ -27,6 +27,20 @@
 #include "oops/method.hpp"
 #include "oops/resolvedIndyEntry.hpp"
 
+u2 ResolvedIndyEntry::name_index(ConstantPool* cp) const {
+  int nti = cp->uncached_name_and_type_ref_index_at(constant_pool_index());
+  return cp->name_ref_index_at(nti);
+}
+
+u2 ResolvedIndyEntry::signature_index(ConstantPool* cp) const {
+  int nti = cp->uncached_name_and_type_ref_index_at(constant_pool_index());
+  return cp->signature_ref_index_at(nti);
+}
+
+u2 ResolvedIndyEntry::bsme_index(ConstantPool* cp) const {
+  return cp->bootstrap_methods_attribute_index(constant_pool_index());
+}
+
 bool ResolvedIndyEntry::check_no_old_or_obsolete_entry() {
   // return false if m refers to a non-deleted old or obsolete method
   if (_method != nullptr) {
@@ -39,11 +53,8 @@ bool ResolvedIndyEntry::check_no_old_or_obsolete_entry() {
 
 #if INCLUDE_CDS
 void ResolvedIndyEntry::remove_unshareable_info() {
-  u2 saved_resolved_references_index = _resolved_references_index;
-  u2 saved_cpool_index = _cpool_index;
-  memset(this, 0, sizeof(*this));
-  _resolved_references_index = saved_resolved_references_index;
-  _cpool_index = saved_cpool_index;
+  _method = nullptr;  // resolution sets this pointer; the rest is static
+  _flags &= ~(1 << resolution_failed_shift);
 }
 
 void ResolvedIndyEntry::mark_and_relocate() {

--- a/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
+++ b/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
@@ -399,7 +399,7 @@ void VM_RedefineClasses::append_entry(const constantPoolHandle& scratch_cp,
       if (scratch_i != *merge_cp_length_p) {
         // The new entry in *merge_cp_p is at a different index than
         // the new entry in scratch_cp so we need to map the index values.
-        map_index(scratch_cp, scratch_i, *merge_cp_length_p);
+        map_cp_index(scratch_cp, scratch_i, *merge_cp_length_p);
       }
       (*merge_cp_length_p)++;
     } break;
@@ -414,7 +414,7 @@ void VM_RedefineClasses::append_entry(const constantPoolHandle& scratch_cp,
       if (scratch_i != *merge_cp_length_p) {
         // The new entry in *merge_cp_p is at a different index than
         // the new entry in scratch_cp so we need to map the index values.
-        map_index(scratch_cp, scratch_i, *merge_cp_length_p);
+        map_cp_index(scratch_cp, scratch_i, *merge_cp_length_p);
       }
       (*merge_cp_length_p) += 2;
     } break;
@@ -433,7 +433,7 @@ void VM_RedefineClasses::append_entry(const constantPoolHandle& scratch_cp,
       if (scratch_i != *merge_cp_length_p) {
         // The new entry in *merge_cp_p is at a different index than
         // the new entry in scratch_cp so we need to map the index values.
-        map_index(scratch_cp, scratch_i, *merge_cp_length_p);
+        map_cp_index(scratch_cp, scratch_i, *merge_cp_length_p);
       }
       (*merge_cp_length_p)++;
     } break;
@@ -468,7 +468,7 @@ void VM_RedefineClasses::append_entry(const constantPoolHandle& scratch_cp,
       if (scratch_i != *merge_cp_length_p) {
         // The new entry in *merge_cp_p is at a different index than
         // the new entry in scratch_cp so we need to map the index values.
-        map_index(scratch_cp, scratch_i, *merge_cp_length_p);
+        map_cp_index(scratch_cp, scratch_i, *merge_cp_length_p);
       }
       (*merge_cp_length_p)++;
     } break;
@@ -521,7 +521,7 @@ void VM_RedefineClasses::append_entry(const constantPoolHandle& scratch_cp,
       if (scratch_i != *merge_cp_length_p) {
         // The new entry in *merge_cp_p is at a different index than
         // the new entry in scratch_cp so we need to map the index values.
-        map_index(scratch_cp, scratch_i, *merge_cp_length_p);
+        map_cp_index(scratch_cp, scratch_i, *merge_cp_length_p);
       }
       (*merge_cp_length_p)++;
     } break;
@@ -540,7 +540,7 @@ void VM_RedefineClasses::append_entry(const constantPoolHandle& scratch_cp,
       if (scratch_i != *merge_cp_length_p) {
         // The new entry in *merge_cp_p is at a different index than
         // the new entry in scratch_cp so we need to map the index values.
-        map_index(scratch_cp, scratch_i, *merge_cp_length_p);
+        map_cp_index(scratch_cp, scratch_i, *merge_cp_length_p);
       }
       (*merge_cp_length_p)++;
     } break;
@@ -560,7 +560,7 @@ void VM_RedefineClasses::append_entry(const constantPoolHandle& scratch_cp,
       if (scratch_i != *merge_cp_length_p) {
         // The new entry in *merge_cp_p is at a different index than
         // the new entry in scratch_cp so we need to map the index values.
-        map_index(scratch_cp, scratch_i, *merge_cp_length_p);
+        map_cp_index(scratch_cp, scratch_i, *merge_cp_length_p);
       }
       (*merge_cp_length_p)++;
     } break;
@@ -569,18 +569,18 @@ void VM_RedefineClasses::append_entry(const constantPoolHandle& scratch_cp,
     case JVM_CONSTANT_Dynamic:  // fall through
     case JVM_CONSTANT_InvokeDynamic:
     {
-      // Index of the bootstrap specifier in the operands array
-      int old_bs_i = scratch_cp->bootstrap_methods_attribute_index(scratch_i);
-      int new_bs_i = find_or_append_operand(scratch_cp, old_bs_i, merge_cp_p,
-                                            merge_cp_length_p);
+      // Index of the bootstrap specifier in the BSM data arrays
+      int old_bsme_i = scratch_cp->bootstrap_methods_attribute_index(scratch_i);
+      int new_bsme_i = find_or_append_bsm_data(scratch_cp, old_bsme_i, merge_cp_p,
+                                               merge_cp_length_p);
       // The bootstrap method NameAndType_info index
       int old_ref_i = scratch_cp->bootstrap_name_and_type_ref_index_at(scratch_i);
       int new_ref_i = find_or_append_indirect_entry(scratch_cp, old_ref_i, merge_cp_p,
                                                     merge_cp_length_p);
-      if (new_bs_i != old_bs_i) {
+      if (new_bsme_i != old_bsme_i) {
         log_trace(redefine, class, constantpool)
-          ("Dynamic entry@%d bootstrap_method_attr_index change: %d to %d",
-           *merge_cp_length_p, old_bs_i, new_bs_i);
+          ("Dynamic entry@%d BootstrapMethods entry change: %d to %d",
+           *merge_cp_length_p, old_bsme_i, new_bsme_i);
       }
       if (new_ref_i != old_ref_i) {
         log_trace(redefine, class, constantpool)
@@ -588,13 +588,13 @@ void VM_RedefineClasses::append_entry(const constantPoolHandle& scratch_cp,
       }
 
       if (scratch_cp->tag_at(scratch_i).is_dynamic_constant())
-        (*merge_cp_p)->dynamic_constant_at_put(*merge_cp_length_p, new_bs_i, new_ref_i);
+        (*merge_cp_p)->dynamic_constant_at_put(*merge_cp_length_p, new_bsme_i, new_ref_i);
       else
-        (*merge_cp_p)->invoke_dynamic_at_put(*merge_cp_length_p, new_bs_i, new_ref_i);
+        (*merge_cp_p)->invoke_dynamic_at_put(*merge_cp_length_p, new_bsme_i, new_ref_i);
       if (scratch_i != *merge_cp_length_p) {
         // The new entry in *merge_cp_p is at a different index than
         // the new entry in scratch_cp so we need to map the index values.
-        map_index(scratch_cp, scratch_i, *merge_cp_length_p);
+        map_cp_index(scratch_cp, scratch_i, *merge_cp_length_p);
       }
       (*merge_cp_length_p)++;
     } break;
@@ -639,7 +639,7 @@ u2 VM_RedefineClasses::find_or_append_indirect_entry(const constantPoolHandle& s
       guarantee(found_i != ref_i, "compare_entry_to() and find_matching_entry() do not agree");
       // Found a matching entry somewhere else in *merge_cp_p so just need a mapping entry.
       new_ref_i = found_i;
-      map_index(scratch_cp, ref_i, found_i);
+      map_cp_index(scratch_cp, ref_i, found_i);
     } else {
       // no match found so we have to append this entry to *merge_cp_p
       append_entry(scratch_cp, ref_i, merge_cp_p, merge_cp_length_p);
@@ -656,101 +656,106 @@ u2 VM_RedefineClasses::find_or_append_indirect_entry(const constantPoolHandle& s
 } // end find_or_append_indirect_entry()
 
 
-// Append a bootstrap specifier into the merge_cp operands that is semantically equal
-// to the scratch_cp operands bootstrap specifier passed by the old_bs_i index.
+// Append a BSM attribute entry into merge_cp that is semantically equal
+// to the scratch_cp BSM entry passed by the old_bsme_i index.
 // Recursively append new merge_cp entries referenced by the new bootstrap specifier.
-void VM_RedefineClasses::append_operand(const constantPoolHandle& scratch_cp, int old_bs_i,
+void VM_RedefineClasses::append_bsm_data(const constantPoolHandle& scratch_cp, int old_bsme_i,
        constantPoolHandle *merge_cp_p, int *merge_cp_length_p) {
 
-  u2 old_ref_i = scratch_cp->operand_bootstrap_method_ref_index_at(old_bs_i);
+  const auto old_bsme = scratch_cp->bsm_attribute_entry(old_bsme_i);
+  u2 old_ref_i = old_bsme->bootstrap_method_index();
   u2 new_ref_i = find_or_append_indirect_entry(scratch_cp, old_ref_i, merge_cp_p,
                                                merge_cp_length_p);
   if (new_ref_i != old_ref_i) {
     log_trace(redefine, class, constantpool)
-      ("operands entry@%d bootstrap method ref_index change: %d to %d", _operands_cur_length, old_ref_i, new_ref_i);
+      ("bsm_data entry@%d bootstrap method ref_index change: %d to %d", _bsm_data_cur_length, old_ref_i, new_ref_i);
   }
 
-  Array<u2>* merge_ops = (*merge_cp_p)->operands();
-  int new_bs_i = _operands_cur_length;
-  // We have _operands_cur_length == 0 when the merge_cp operands is empty yet.
-  // However, the operand_offset_at(0) was set in the extend_operands() call.
-  int new_base = (new_bs_i == 0) ? (*merge_cp_p)->operand_offset_at(0)
-                                 : (*merge_cp_p)->operand_next_offset_at(new_bs_i - 1);
-  u2 argc      = scratch_cp->operand_argument_count_at(old_bs_i);
+  const auto merge_offs = (*merge_cp_p)->bsm_attribute_offsets();
+  const auto merge_data = (*merge_cp_p)->bsm_attribute_entries();
 
-  ConstantPool::operand_offset_at_put(merge_ops, _operands_cur_length, new_base);
-  merge_ops->at_put(new_base++, new_ref_i);
-  merge_ops->at_put(new_base++, argc);
+  int new_bsme_i = _bsm_data_cur_length;
+  int new_base   = _bsm_data_next_offset;
+  u2 argc        = old_bsme->argument_count();
+
+  merge_offs->at_put(new_bsme_i, new_base);
+  merge_data->at_put(new_base++, new_ref_i);
+  merge_data->at_put(new_base++, argc);
 
   for (int i = 0; i < argc; i++) {
-    u2 old_arg_ref_i = scratch_cp->operand_argument_index_at(old_bs_i, i);
+    u2 old_arg_ref_i = old_bsme->argument_index(i);
     u2 new_arg_ref_i = find_or_append_indirect_entry(scratch_cp, old_arg_ref_i, merge_cp_p,
                                                      merge_cp_length_p);
-    merge_ops->at_put(new_base++, new_arg_ref_i);
+    merge_data->at_put(new_base++, new_arg_ref_i);
     if (new_arg_ref_i != old_arg_ref_i) {
       log_trace(redefine, class, constantpool)
-        ("operands entry@%d bootstrap method argument ref_index change: %d to %d",
-         _operands_cur_length, old_arg_ref_i, new_arg_ref_i);
+        ("bsm_data entry@%d bootstrap method argument ref_index change: %d to %d",
+         _bsm_data_cur_length, old_arg_ref_i, new_arg_ref_i);
     }
   }
-  if (old_bs_i != _operands_cur_length) {
+  if (old_bsme_i != _bsm_data_cur_length) {
     // The bootstrap specifier in *merge_cp_p is at a different index than
     // that in scratch_cp so we need to map the index values.
-    map_operand_index(old_bs_i, new_bs_i);
+    map_bsm_index(old_bsme_i, new_bsme_i);
   }
-  _operands_cur_length++;
-} // end append_operand()
+  _bsm_data_cur_length = new_bsme_i + 1;
+  _bsm_data_next_offset = new_base;
+} // end append_bsm_data()
 
 
-int VM_RedefineClasses::find_or_append_operand(const constantPoolHandle& scratch_cp,
-      int old_bs_i, constantPoolHandle *merge_cp_p, int *merge_cp_length_p) {
+// Try to Find a BSM attribute entry in merge_cp that is semantically equal
+// to the scratch_cp BSM entry passed by the old_bsme_i index.
+// If none is found, call append_bsm_data to add one into merge_cp.
+int VM_RedefineClasses::find_or_append_bsm_data(const constantPoolHandle& scratch_cp,
+      int old_bsme_i, constantPoolHandle *merge_cp_p, int *merge_cp_length_p) {
 
-  int new_bs_i = old_bs_i; // bootstrap specifier index
-  bool match = (old_bs_i < _operands_cur_length) &&
-               scratch_cp->compare_operand_to(old_bs_i, *merge_cp_p, old_bs_i);
+  int new_bsme_i = old_bsme_i; // bootstrap specifier index
+  bool match = (old_bsme_i < _bsm_data_cur_length) &&
+               scratch_cp->compare_bsme_to(old_bsme_i, *merge_cp_p, old_bsme_i);
 
   if (!match) {
     // forward reference in *merge_cp_p or not a direct match
-    int found_i = scratch_cp->find_matching_operand(old_bs_i, *merge_cp_p,
-                                                    _operands_cur_length);
+    int found_i = scratch_cp->find_matching_bsme(old_bsme_i, *merge_cp_p,
+                                                    _bsm_data_cur_length);
     if (found_i != -1) {
-      guarantee(found_i != old_bs_i, "compare_operand_to() and find_matching_operand() disagree");
-      // found a matching operand somewhere else in *merge_cp_p so just need a mapping
-      new_bs_i = found_i;
-      map_operand_index(old_bs_i, found_i);
+      guarantee(found_i != old_bsme_i, "compare_bsme_to() and find_matching_bsme() disagree");
+      // found a matching bsme somewhere else in *merge_cp_p so just need a mapping
+      new_bsme_i = found_i;
+      map_bsm_index(old_bsme_i, found_i);
     } else {
       // no match found so we have to append this bootstrap specifier to *merge_cp_p
-      append_operand(scratch_cp, old_bs_i, merge_cp_p, merge_cp_length_p);
-      new_bs_i = _operands_cur_length - 1;
+      append_bsm_data(scratch_cp, old_bsme_i, merge_cp_p, merge_cp_length_p);
+      new_bsme_i = _bsm_data_cur_length - 1;
     }
   }
-  return new_bs_i;
-} // end find_or_append_operand()
+  return new_bsme_i;
+} // end find_or_append_bsm_data()
 
 
-void VM_RedefineClasses::finalize_operands_merge(const constantPoolHandle& merge_cp, TRAPS) {
-  if (merge_cp->operands() == nullptr) {
+void VM_RedefineClasses::finalize_bsm_data_merge(const constantPoolHandle& merge_cp, TRAPS) {
+  if (merge_cp->bsm_attribute_count() == 0) {
     return;
   }
-  // Shrink the merge_cp operands
-  merge_cp->shrink_operands(_operands_cur_length, CHECK);
+  // Shrink the merge_cp bsm_data
+  merge_cp->shrink_bsm_data(_bsm_data_cur_length, CHECK);
 
   if (log_is_enabled(Trace, redefine, class, constantpool)) {
     // don't want to loop unless we are tracing
     int count = 0;
-    for (int i = 1; i < _operands_index_map_p->length(); i++) {
-      int value = _operands_index_map_p->at(i);
+    for (int i = 1; i < _bsm_data_index_map_p->length(); i++) {
+      int value = _bsm_data_index_map_p->at(i);
       if (value != -1) {
-        log_trace(redefine, class, constantpool)("operands_index_map[%d]: old=%d new=%d", count, i, value);
+        log_trace(redefine, class, constantpool)("bsm_data_index_map[%d]: old=%d new=%d", count, i, value);
         count++;
       }
     }
   }
   // Clean-up
-  _operands_index_map_p = nullptr;
-  _operands_cur_length = 0;
-  _operands_index_map_count = 0;
-} // end finalize_operands_merge()
+  _bsm_data_index_map_p = nullptr;
+  _bsm_data_cur_length = 0;
+  _bsm_data_next_offset = 0;
+  _bsm_data_index_map_count = 0;
+} // end finalize_bsm_data_merge()
 
 // Symbol* comparator for qsort
 // The caller must have an active ResourceMark.
@@ -1240,7 +1245,7 @@ jvmtiError VM_RedefineClasses::compare_and_normalize_class_versions(
 // Find new constant pool index value for old constant pool index value
 // by searching the index map. Returns zero (0) if there is no mapped
 // value for the old constant pool index.
-u2 VM_RedefineClasses::find_new_index(int old_index) {
+u2 VM_RedefineClasses::find_new_cp_index(int old_index) {
   if (_index_map_count == 0) {
     // map is empty so nothing can be found
     return 0;
@@ -1262,32 +1267,32 @@ u2 VM_RedefineClasses::find_new_index(int old_index) {
   // constant pool indices are u2, unless the merged constant pool overflows which
   // we don't check for.
   return checked_cast<u2>(value);
-} // end find_new_index()
+} // end find_new_cp_index()
 
 
 // Find new bootstrap specifier index value for old bootstrap specifier index
 // value by searching the index map. Returns unused index (-1) if there is
 // no mapped value for the old bootstrap specifier index.
-int VM_RedefineClasses::find_new_operand_index(int old_index) {
-  if (_operands_index_map_count == 0) {
+int VM_RedefineClasses::find_new_bsm_index(int old_index) {
+  if (_bsm_data_index_map_count == 0) {
     // map is empty so nothing can be found
     return -1;
   }
 
-  if (old_index == -1 || old_index >= _operands_index_map_p->length()) {
+  if (old_index == -1 || old_index >= _bsm_data_index_map_p->length()) {
     // The old_index is out of range so it is not mapped.
     // This should not happen in regular constant pool merging use.
     return -1;
   }
 
-  int value = _operands_index_map_p->at(old_index);
+  int value = _bsm_data_index_map_p->at(old_index);
   if (value == -1) {
     // the old_index is not mapped
     return -1;
   }
 
   return value;
-} // end find_new_operand_index()
+} // end find_new_bsm_index()
 
 
 // The bug 6214132 caused the verification to fail.
@@ -1532,9 +1537,9 @@ jvmtiError VM_RedefineClasses::load_new_class_versions() {
 
 // Map old_index to new_index as needed. scratch_cp is only needed
 // for log calls.
-void VM_RedefineClasses::map_index(const constantPoolHandle& scratch_cp,
+void VM_RedefineClasses::map_cp_index(const constantPoolHandle& scratch_cp,
        int old_index, int new_index) {
-  if (find_new_index(old_index) != 0) {
+  if (find_new_cp_index(old_index) != 0) {
     // old_index is already mapped
     return;
   }
@@ -1549,12 +1554,12 @@ void VM_RedefineClasses::map_index(const constantPoolHandle& scratch_cp,
 
   log_trace(redefine, class, constantpool)
     ("mapped tag %d at index %d to %d", scratch_cp->tag_at(old_index).value(), old_index, new_index);
-} // end map_index()
+} // end map_cp_index()
 
 
 // Map old_index to new_index as needed.
-void VM_RedefineClasses::map_operand_index(int old_index, int new_index) {
-  if (find_new_operand_index(old_index) != -1) {
+void VM_RedefineClasses::map_bsm_index(int old_index, int new_index) {
+  if (find_new_bsm_index(old_index) != -1) {
     // old_index is already mapped
     return;
   }
@@ -1564,28 +1569,28 @@ void VM_RedefineClasses::map_operand_index(int old_index, int new_index) {
     return;
   }
 
-  _operands_index_map_p->at_put(old_index, new_index);
-  _operands_index_map_count++;
+  _bsm_data_index_map_p->at_put(old_index, new_index);
+  _bsm_data_index_map_count++;
 
   log_trace(redefine, class, constantpool)("mapped bootstrap specifier at index %d to %d", old_index, new_index);
-} // end map_index()
+} // end map_bsm_index()
 
 
 // Merge old_cp and scratch_cp and return the results of the merge via
-// merge_cp_p. The number of entries in merge_cp_p is returned via
-// merge_cp_length_p. The entries in old_cp occupy the same locations
-// in merge_cp_p. Also creates a map of indices from entries in
-// scratch_cp to the corresponding entry in merge_cp_p. Index map
+// merge_cp. The number of entries in merge_cp_p is returned via
+// merge_cp_length. The entries in old_cp occupy the same locations
+// in merge_cp. Also creates a map of indices from entries in
+// scratch_cp to the corresponding entry in merge_cp. Index map
 // entries are only created for entries in scratch_cp that occupy a
-// different location in merged_cp_p.
+// different location in merged_cp.
 bool VM_RedefineClasses::merge_constant_pools(const constantPoolHandle& old_cp,
-       const constantPoolHandle& scratch_cp, constantPoolHandle& merge_cp_p,
-       int& merge_cp_length_p, TRAPS) {
+       const constantPoolHandle& scratch_cp, constantPoolHandle& merge_cp,
+       int& merge_cp_length, TRAPS) {
 
   // Worst case we need old_cp->length() + scratch_cp()->length(),
   // but the caller might be smart so make sure we have at least
   // the minimum.
-  if (merge_cp_p->length() < old_cp->length()) {
+  if (merge_cp->length() < old_cp->length()) {
     assert(false, "merge area too small");
     return false; // robustness
   }
@@ -1594,9 +1599,9 @@ bool VM_RedefineClasses::merge_constant_pools(const constantPoolHandle& old_cp,
 
   {
     // Pass 0:
-    // The old_cp is copied to *merge_cp_p; this means that any code
+    // The old_cp is copied to merge_cp; this means that any code
     // using old_cp does not have to change. This work looks like a
-    // perfect fit for ConstantPool*::copy_cp_to(), but we need to
+    // perfect fit for ConstantPool::copy_cp_to(), but we need to
     // handle one special case:
     // - revert JVM_CONSTANT_Class to JVM_CONSTANT_UnresolvedClass
     // This will make verification happy.
@@ -1613,7 +1618,7 @@ bool VM_RedefineClasses::merge_constant_pools(const constantPoolHandle& old_cp,
         // revert the copy to JVM_CONSTANT_UnresolvedClass
         // May be resolving while calling this so do the same for
         // JVM_CONSTANT_UnresolvedClass (klass_name_at() deals with transition)
-        merge_cp_p->temp_unresolved_klass_at_put(old_i,
+        merge_cp->temp_unresolved_klass_at_put(old_i,
           old_cp->klass_name_index_at(old_i));
         break;
 
@@ -1621,28 +1626,28 @@ bool VM_RedefineClasses::merge_constant_pools(const constantPoolHandle& old_cp,
       case JVM_CONSTANT_Long:
         // just copy the entry to merge_cp_p, but double and long take
         // two constant pool entries
-        ConstantPool::copy_entry_to(old_cp, old_i, merge_cp_p, old_i);
+        ConstantPool::copy_entry_to(old_cp, old_i, merge_cp, old_i);
         old_i++;
         break;
 
       default:
         // just copy the entry to merge_cp_p
-        ConstantPool::copy_entry_to(old_cp, old_i, merge_cp_p, old_i);
+        ConstantPool::copy_entry_to(old_cp, old_i, merge_cp, old_i);
         break;
       }
     } // end for each old_cp entry
 
-    ConstantPool::copy_operands(old_cp, merge_cp_p, CHECK_false);
-    merge_cp_p->extend_operands(scratch_cp, CHECK_false);
+    ConstantPool::copy_bsm_data(old_cp, merge_cp, CHECK_false);
+    merge_cp->extend_bsm_data(scratch_cp, CHECK_false);
 
-    // We don't need to sanity check that *merge_cp_length_p is within
-    // *merge_cp_p bounds since we have the minimum on-entry check above.
-    merge_cp_length_p = old_i;
+    // We don't need to sanity check that merge_cp_length is within
+    // merge_cp bounds since we have the minimum on-entry check above.
+    merge_cp_length = old_i;
   }
 
   // merge_cp_len should be the same as old_cp->length() at this point
   // so this trace message is really a "warm-and-breathing" message.
-  log_debug(redefine, class, constantpool)("after pass 0: merge_cp_len=%d", merge_cp_length_p);
+  log_debug(redefine, class, constantpool)("after pass 0: merge_cp_len=%d", merge_cp_length);
 
   int scratch_i;  // index into scratch_cp
   {
@@ -1666,32 +1671,32 @@ bool VM_RedefineClasses::merge_constant_pools(const constantPoolHandle& old_cp,
         break;
       }
 
-      bool match = scratch_cp->compare_entry_to(scratch_i, merge_cp_p, scratch_i);
+      bool match = scratch_cp->compare_entry_to(scratch_i, merge_cp, scratch_i);
       if (match) {
         // found a match at the same index so nothing more to do
         continue;
       }
 
-      int found_i = scratch_cp->find_matching_entry(scratch_i, merge_cp_p);
+      int found_i = scratch_cp->find_matching_entry(scratch_i, merge_cp);
       if (found_i != 0) {
         guarantee(found_i != scratch_i,
           "compare_entry_to() and find_matching_entry() do not agree");
 
         // Found a matching entry somewhere else in *merge_cp_p so
         // just need a mapping entry.
-        map_index(scratch_cp, scratch_i, found_i);
+        map_cp_index(scratch_cp, scratch_i, found_i);
         continue;
       }
 
       // No match found so we have to append this entry and any unique
       // referenced entries to merge_cp_p.
-      append_entry(scratch_cp, scratch_i, &merge_cp_p, &merge_cp_length_p);
+      append_entry(scratch_cp, scratch_i, &merge_cp, &merge_cp_length);
     }
   }
 
   log_debug(redefine, class, constantpool)
     ("after pass 1a: merge_cp_len=%d, scratch_i=%d, index_map_len=%d",
-     merge_cp_length_p, scratch_i, _index_map_count);
+     merge_cp_length, scratch_i, _index_map_count);
 
   if (scratch_i < scratch_cp->length()) {
     // Pass 1b:
@@ -1713,24 +1718,24 @@ bool VM_RedefineClasses::merge_constant_pools(const constantPoolHandle& old_cp,
       }
 
       int found_i =
-        scratch_cp->find_matching_entry(scratch_i, merge_cp_p);
+        scratch_cp->find_matching_entry(scratch_i, merge_cp);
       if (found_i != 0) {
         // Found a matching entry somewhere else in merge_cp_p so
         // just need a mapping entry.
-        map_index(scratch_cp, scratch_i, found_i);
+        map_cp_index(scratch_cp, scratch_i, found_i);
         continue;
       }
 
       // No match found so we have to append this entry and any unique
       // referenced entries to merge_cp_p.
-      append_entry(scratch_cp, scratch_i, &merge_cp_p, &merge_cp_length_p);
+      append_entry(scratch_cp, scratch_i, &merge_cp, &merge_cp_length);
     }
 
     log_debug(redefine, class, constantpool)
       ("after pass 1b: merge_cp_len=%d, scratch_i=%d, index_map_len=%d",
-       merge_cp_length_p, scratch_i, _index_map_count);
+       merge_cp_length, scratch_i, _index_map_count);
   }
-  finalize_operands_merge(merge_cp_p, CHECK_false);
+  finalize_bsm_data_merge(merge_cp, CHECK_false);
 
   return true;
 } // end merge_constant_pools()
@@ -1800,15 +1805,16 @@ jvmtiError VM_RedefineClasses::merge_cp_and_rewrite(
   _index_map_count = 0;
   _index_map_p = new intArray(scratch_cp->length(), scratch_cp->length(), -1);
 
-  _operands_cur_length = ConstantPool::operand_array_length(old_cp->operands());
-  _operands_index_map_count = 0;
-  int operands_index_map_len = ConstantPool::operand_array_length(scratch_cp->operands());
-  _operands_index_map_p = new intArray(operands_index_map_len, operands_index_map_len, -1);
+  _bsm_data_cur_length = old_cp->bsm_attribute_count();
+  _bsm_data_next_offset = old_cp->bsm_entry_count();
+  _bsm_data_index_map_count = 0;
+  int bsm_data_index_map_len = scratch_cp->bsm_attribute_count();
+  _bsm_data_index_map_p = new intArray(bsm_data_index_map_len, bsm_data_index_map_len, -1);
 
-  // reference to the cp holder is needed for copy_operands()
+  // reference to the cp holder is needed for copy_bsm_data()
   merge_cp->set_pool_holder(scratch_class);
   bool result = merge_constant_pools(old_cp, scratch_cp, merge_cp,
-                  merge_cp_length, THREAD);
+                                     merge_cp_length, THREAD);
   merge_cp->set_pool_holder(nullptr);
 
   if (!result) {
@@ -1990,7 +1996,7 @@ bool VM_RedefineClasses::rewrite_cp_refs(InstanceKlass* scratch_class) {
   // rewrite source file name index:
   u2 source_file_name_idx = scratch_class->source_file_name_index();
   if (source_file_name_idx != 0) {
-    u2 new_source_file_name_idx = find_new_index(source_file_name_idx);
+    u2 new_source_file_name_idx = find_new_cp_index(source_file_name_idx);
     if (new_source_file_name_idx != 0) {
       scratch_class->set_source_file_name_index(new_source_file_name_idx);
     }
@@ -1999,7 +2005,7 @@ bool VM_RedefineClasses::rewrite_cp_refs(InstanceKlass* scratch_class) {
   // rewrite class generic signature index:
   u2 generic_signature_index = scratch_class->generic_signature_index();
   if (generic_signature_index != 0) {
-    u2 new_generic_signature_index = find_new_index(generic_signature_index);
+    u2 new_generic_signature_index = find_new_cp_index(generic_signature_index);
     if (new_generic_signature_index != 0) {
       scratch_class->set_generic_signature_index(new_generic_signature_index);
     }
@@ -2014,12 +2020,12 @@ bool VM_RedefineClasses::rewrite_cp_refs_in_nest_attributes(
 
   u2 cp_index = scratch_class->nest_host_index();
   if (cp_index != 0) {
-    scratch_class->set_nest_host_index(find_new_index(cp_index));
+    scratch_class->set_nest_host_index(find_new_cp_index(cp_index));
   }
   Array<u2>* nest_members = scratch_class->nest_members();
   for (int i = 0; i < nest_members->length(); i++) {
     u2 cp_index = nest_members->at(i);
-    nest_members->at_put(i, find_new_index(cp_index));
+    nest_members->at_put(i, find_new_cp_index(cp_index));
   }
   return true;
 }
@@ -2031,12 +2037,12 @@ bool VM_RedefineClasses::rewrite_cp_refs_in_record_attribute(InstanceKlass* scra
     for (int i = 0; i < components->length(); i++) {
       RecordComponent* component = components->at(i);
       u2 cp_index = component->name_index();
-      component->set_name_index(find_new_index(cp_index));
+      component->set_name_index(find_new_cp_index(cp_index));
       cp_index = component->descriptor_index();
-      component->set_descriptor_index(find_new_index(cp_index));
+      component->set_descriptor_index(find_new_cp_index(cp_index));
       cp_index = component->generic_signature_index();
       if (cp_index != 0) {
-        component->set_generic_signature_index(find_new_index(cp_index));
+        component->set_generic_signature_index(find_new_cp_index(cp_index));
       }
 
       AnnotationArray* annotations = component->annotations();
@@ -2071,7 +2077,7 @@ bool VM_RedefineClasses::rewrite_cp_refs_in_permitted_subclasses_attribute(
   assert(permitted_subclasses != nullptr, "unexpected null permitted_subclasses");
   for (int i = 0; i < permitted_subclasses->length(); i++) {
     u2 cp_index = permitted_subclasses->at(i);
-    permitted_subclasses->at_put(i, find_new_index(cp_index));
+    permitted_subclasses->at_put(i, find_new_cp_index(cp_index));
   }
   return true;
 }
@@ -2150,7 +2156,7 @@ void VM_RedefineClasses::rewrite_cp_refs_in_method(methodHandle method,
       case Bytecodes::_ldc:
       {
         u1 cp_index = *(bcp + 1);
-        u2 new_index = find_new_index(cp_index);
+        u2 new_index = find_new_cp_index(cp_index);
 
         if (StressLdcRewrite && new_index == 0) {
           // If we are stressing ldc -> ldc_w rewriting, then we
@@ -2224,7 +2230,7 @@ void VM_RedefineClasses::rewrite_cp_refs_in_method(methodHandle method,
       {
         address p = bcp + 1;
         int cp_index = Bytes::get_Java_u2(p);
-        u2 new_index = find_new_index(cp_index);
+        u2 new_index = find_new_cp_index(cp_index);
         if (new_index != 0) {
           // the original index is mapped so update w/ new value
           log_trace(redefine, class, constantpool)
@@ -2370,7 +2376,7 @@ u2 VM_RedefineClasses::rewrite_cp_ref_in_annotation_data(
   address cp_index_addr = (address)
     annotations_typeArray->adr_at(byte_i_ref);
   u2 old_cp_index = Bytes::get_Java_u2(cp_index_addr);
-  u2 new_cp_index = find_new_index(old_cp_index);
+  u2 new_cp_index = find_new_cp_index(old_cp_index);
   if (new_cp_index != 0) {
     log_debug(redefine, class, annotation)("mapped old %s=%d", trace_mesg, old_cp_index);
     Bytes::put_Java_u2(cp_index_addr, new_cp_index);
@@ -3439,7 +3445,7 @@ void VM_RedefineClasses::rewrite_cp_refs_in_verification_type_info(
   {
     assert(stackmap_p_ref + 2 <= stackmap_end, "no room for cpool_index");
     u2 cpool_index = Bytes::get_Java_u2(stackmap_p_ref);
-    u2 new_cp_index = find_new_index(cpool_index);
+    u2 new_cp_index = find_new_cp_index(cpool_index);
     if (new_cp_index != 0) {
       log_debug(redefine, class, stackmap)("mapped old cpool_index=%d", cpool_index);
       Bytes::put_Java_u2(stackmap_p_ref, new_cp_index);
@@ -3489,7 +3495,7 @@ void VM_RedefineClasses::set_new_constant_pool(
   smaller_cp->set_version(version);
 
   // attach klass to new constant pool
-  // reference to the cp holder is needed for copy_operands()
+  // reference to the cp holder is needed for copy_bsm_data()
   smaller_cp->set_pool_holder(scratch_class);
 
   smaller_cp->copy_fields(scratch_cp());
@@ -3516,28 +3522,28 @@ void VM_RedefineClasses::set_new_constant_pool(
   for (int i = 0; i < java_fields; i++) {
     FieldInfo* fi = fields->adr_at(i);
     jshort cur_index = fi->name_index();
-    jshort new_index = find_new_index(cur_index);
+    jshort new_index = find_new_cp_index(cur_index);
     if (new_index != 0) {
       log_trace(redefine, class, constantpool)("field-name_index change: %d to %d", cur_index, new_index);
       fi->set_name_index(new_index);
       update_required = true;
     }
     cur_index = fi->signature_index();
-    new_index = find_new_index(cur_index);
+    new_index = find_new_cp_index(cur_index);
     if (new_index != 0) {
       log_trace(redefine, class, constantpool)("field-signature_index change: %d to %d", cur_index, new_index);
       fi->set_signature_index(new_index);
       update_required = true;
     }
     cur_index = fi->initializer_index();
-    new_index = find_new_index(cur_index);
+    new_index = find_new_cp_index(cur_index);
     if (new_index != 0) {
       log_trace(redefine, class, constantpool)("field-initval_index change: %d to %d", cur_index, new_index);
       fi->set_initializer_index(new_index);
       update_required = true;
     }
     cur_index = fi->generic_signature_index();
-    new_index = find_new_index(cur_index);
+    new_index = find_new_cp_index(cur_index);
     if (new_index != 0) {
       log_trace(redefine, class, constantpool)("field-generic_signature change: %d to %d", cur_index, new_index);
       fi->set_generic_signature_index(new_index);
@@ -3562,19 +3568,19 @@ void VM_RedefineClasses::set_new_constant_pool(
     if (cur_index == 0) {
       continue;  // JVM spec. allows null inner class refs so skip it
     }
-    u2 new_index = find_new_index(cur_index);
+    u2 new_index = find_new_cp_index(cur_index);
     if (new_index != 0) {
       log_trace(redefine, class, constantpool)("inner_class_info change: %d to %d", cur_index, new_index);
       iter.set_inner_class_info_index(new_index);
     }
     cur_index = iter.outer_class_info_index();
-    new_index = find_new_index(cur_index);
+    new_index = find_new_cp_index(cur_index);
     if (new_index != 0) {
       log_trace(redefine, class, constantpool)("outer_class_info change: %d to %d", cur_index, new_index);
       iter.set_outer_class_info_index(new_index);
     }
     cur_index = iter.inner_name_index();
-    new_index = find_new_index(cur_index);
+    new_index = find_new_cp_index(cur_index);
     if (new_index != 0) {
       log_trace(redefine, class, constantpool)("inner_name change: %d to %d", cur_index, new_index);
       iter.set_inner_name_index(new_index);
@@ -3588,19 +3594,19 @@ void VM_RedefineClasses::set_new_constant_pool(
     methodHandle method(THREAD, methods->at(i));
     method->set_constants(scratch_cp());
 
-    u2 new_index = find_new_index(method->name_index());
+    u2 new_index = find_new_cp_index(method->name_index());
     if (new_index != 0) {
       log_trace(redefine, class, constantpool)
         ("method-name_index change: %d to %d", method->name_index(), new_index);
       method->set_name_index(new_index);
     }
-    new_index = find_new_index(method->signature_index());
+    new_index = find_new_cp_index(method->signature_index());
     if (new_index != 0) {
       log_trace(redefine, class, constantpool)
         ("method-signature_index change: %d to %d", method->signature_index(), new_index);
       method->set_signature_index(new_index);
     }
-    new_index = find_new_index(method->generic_signature_index());
+    new_index = find_new_cp_index(method->generic_signature_index());
     if (new_index != 0) {
       log_trace(redefine, class, constantpool)
         ("method-generic_signature_index change: %d to %d", method->generic_signature_index(), new_index);
@@ -3615,7 +3621,7 @@ void VM_RedefineClasses::set_new_constant_pool(
         method->checked_exceptions_start();
       for (int j = 0; j < cext_length; j++) {
         int cur_index = cext_table[j].class_cp_index;
-        int new_index = find_new_index(cur_index);
+        int new_index = find_new_cp_index(cur_index);
         if (new_index != 0) {
           log_trace(redefine, class, constantpool)("cext-class_cp_index change: %d to %d", cur_index, new_index);
           cext_table[j].class_cp_index = (u2)new_index;
@@ -3633,7 +3639,7 @@ void VM_RedefineClasses::set_new_constant_pool(
 
     for (int j = 0; j < ext_length; j ++) {
       int cur_index = ex_table.catch_type_index(j);
-      u2 new_index = find_new_index(cur_index);
+      u2 new_index = find_new_cp_index(cur_index);
       if (new_index != 0) {
         log_trace(redefine, class, constantpool)("ext-klass_index change: %d to %d", cur_index, new_index);
         ex_table.set_catch_type_index(j, new_index);
@@ -3650,19 +3656,19 @@ void VM_RedefineClasses::set_new_constant_pool(
         method->localvariable_table_start();
       for (int j = 0; j < lvt_length; j++) {
         int cur_index = lv_table[j].name_cp_index;
-        int new_index = find_new_index(cur_index);
+        int new_index = find_new_cp_index(cur_index);
         if (new_index != 0) {
           log_trace(redefine, class, constantpool)("lvt-name_cp_index change: %d to %d", cur_index, new_index);
           lv_table[j].name_cp_index = (u2)new_index;
         }
         cur_index = lv_table[j].descriptor_cp_index;
-        new_index = find_new_index(cur_index);
+        new_index = find_new_cp_index(cur_index);
         if (new_index != 0) {
           log_trace(redefine, class, constantpool)("lvt-descriptor_cp_index change: %d to %d", cur_index, new_index);
           lv_table[j].descriptor_cp_index = (u2)new_index;
         }
         cur_index = lv_table[j].signature_cp_index;
-        new_index = find_new_index(cur_index);
+        new_index = find_new_cp_index(cur_index);
         if (new_index != 0) {
           log_trace(redefine, class, constantpool)("lvt-signature_cp_index change: %d to %d", cur_index, new_index);
           lv_table[j].signature_cp_index = (u2)new_index;
@@ -3676,7 +3682,7 @@ void VM_RedefineClasses::set_new_constant_pool(
       MethodParametersElement* elem = method->method_parameters_start();
       for (int j = 0; j < mp_length; j++) {
         const int cp_index = elem[j].name_cp_index;
-        const int new_cp_index = find_new_index(cp_index);
+        const int new_cp_index = find_new_cp_index(cp_index);
         if (new_cp_index != 0) {
           elem[j].name_cp_index = (u2)new_cp_index;
         }

--- a/src/hotspot/share/prims/jvmtiRedefineClasses.hpp
+++ b/src/hotspot/share/prims/jvmtiRedefineClasses.hpp
@@ -363,11 +363,12 @@ class VM_RedefineClasses: public VM_Operation {
   int                         _index_map_count;
   intArray *                  _index_map_p;
 
-  // _operands_index_map_count is just an optimization for knowing if
-  // _operands_index_map_p contains any entries.
-  int                         _operands_cur_length;
-  int                         _operands_index_map_count;
-  intArray *                  _operands_index_map_p;
+  // _bsm_data_index_map_count is just an optimization for knowing if
+  // _bsm_data_index_map_p contains any entries.
+  int                         _bsm_data_cur_length;   // bsm_attribute_offsets fillp
+  int                         _bsm_data_next_offset;  // bsm_attribute_entries fillp
+  int                         _bsm_data_index_map_count;
+  intArray*                   _bsm_data_index_map_p;
 
   // ptr to _class_count scratch_classes
   InstanceKlass**             _scratch_classes;
@@ -429,17 +430,17 @@ class VM_RedefineClasses: public VM_Operation {
   // Support for constant pool merging (these routines are in alpha order):
   void append_entry(const constantPoolHandle& scratch_cp, int scratch_i,
     constantPoolHandle *merge_cp_p, int *merge_cp_length_p);
-  void append_operand(const constantPoolHandle& scratch_cp, int scratch_bootstrap_spec_index,
+  void append_bsm_data(const constantPoolHandle& scratch_cp, int scratch_bsm_attr_entry_index,
     constantPoolHandle *merge_cp_p, int *merge_cp_length_p);
-  void finalize_operands_merge(const constantPoolHandle& merge_cp, TRAPS);
+  void finalize_bsm_data_merge(const constantPoolHandle& merge_cp, TRAPS);
   u2 find_or_append_indirect_entry(const constantPoolHandle& scratch_cp, int scratch_i,
     constantPoolHandle *merge_cp_p, int *merge_cp_length_p);
-  int find_or_append_operand(const constantPoolHandle& scratch_cp, int scratch_bootstrap_spec_index,
+  int find_or_append_bsm_data(const constantPoolHandle& scratch_cp, int scratch_bsm_attr_entry_index,
     constantPoolHandle *merge_cp_p, int *merge_cp_length_p);
-  u2 find_new_index(int old_index);
-  int find_new_operand_index(int old_bootstrap_spec_index);
-  void map_index(const constantPoolHandle& scratch_cp, int old_index, int new_index);
-  void map_operand_index(int old_bootstrap_spec_index, int new_bootstrap_spec_index);
+  u2 find_new_cp_index(int old_cp_index);
+  int find_new_bsm_index(int old_bsme_index);
+  void map_cp_index(const constantPoolHandle& scratch_cp, int old_index, int new_index);
+  void map_bsm_index(int old_bsme_index, int new_bsme_index);
   bool merge_constant_pools(const constantPoolHandle& old_cp,
     const constantPoolHandle& scratch_cp, constantPoolHandle& merge_cp_p,
     int& merge_cp_length_p, TRAPS);

--- a/src/hotspot/share/prims/methodComparator.cpp
+++ b/src/hotspot/share/prims/methodComparator.cpp
@@ -133,17 +133,19 @@ bool MethodComparator::args_same(Bytecodes::Code const c_old,  Bytecodes::Code c
         (old_cp->uncached_signature_ref_at(cpi_old) != new_cp->uncached_signature_ref_at(cpi_new)))
       return false;
 
-    int bsm_old = old_cp->bootstrap_method_ref_index_at(cpi_old);
-    int bsm_new = new_cp->bootstrap_method_ref_index_at(cpi_new);
+    BSMAttributeEntry* bsme_old = old_cp->bootstrap_methods_attribute_entry(cpi_old);
+    BSMAttributeEntry* bsme_new = new_cp->bootstrap_methods_attribute_entry(cpi_new);
+    int bsm_old = bsme_old->bootstrap_method_index();
+    int bsm_new = bsme_new->bootstrap_method_index();
     if (!pool_constants_same(bsm_old, bsm_new, old_cp, new_cp))
       return false;
-    int cnt_old = old_cp->bootstrap_argument_count_at(cpi_old);
-    int cnt_new = new_cp->bootstrap_argument_count_at(cpi_new);
+    int cnt_old = bsme_old->argument_count();
+    int cnt_new = bsme_new->argument_count();
     if (cnt_old != cnt_new)
       return false;
     for (int arg_i = 0; arg_i < cnt_old; arg_i++) {
-      int idx_old = old_cp->bootstrap_argument_index_at(cpi_old, arg_i);
-      int idx_new = new_cp->bootstrap_argument_index_at(cpi_new, arg_i);
+      int idx_old = bsme_old->argument_index(arg_i);
+      int idx_new = bsme_new->argument_index(arg_i);
       if (!pool_constants_same(idx_old, idx_new, old_cp, new_cp))
         return false;
     }

--- a/src/hotspot/share/prims/nativeLookup.cpp
+++ b/src/hotspot/share/prims/nativeLookup.cpp
@@ -399,6 +399,12 @@ address NativeLookup::lookup_base(const methodHandle& method, TRAPS) {
   entry = lookup_entry_prefixed(method, CHECK_NULL);
   if (entry != nullptr) return entry;
 
+  if (log_is_enabled(Trace, jni, resolve)) {
+    log_trace(jni, resolve)("[Dynamic-linking native method %s.%s ... FAILED]",
+                            method->method_holder()->external_name(),
+                            method->name()->as_C_string());
+  }
+
   if (THREAD->has_pending_exception()) {
     oop exception = THREAD->pending_exception();
     if (exception->is_a(vmClasses::IllegalCallerException_klass())) {

--- a/src/hotspot/share/runtime/vmStructs.cpp
+++ b/src/hotspot/share/runtime/vmStructs.cpp
@@ -174,7 +174,8 @@
   nonstatic_field(ConstantPool,                _tags,                                         Array<u1>*)                            \
   nonstatic_field(ConstantPool,                _cache,                                        ConstantPoolCache*)                    \
   nonstatic_field(ConstantPool,                _pool_holder,                                  InstanceKlass*)                        \
-  nonstatic_field(ConstantPool,                _operands,                                     Array<u2>*)                            \
+  nonstatic_field(ConstantPool,                _bsm_attribute_offsets,                        Array<u4>*)                            \
+  nonstatic_field(ConstantPool,                _bsm_attribute_entries,                        Array<u2>*)                            \
   nonstatic_field(ConstantPool,                _resolved_klasses,                             Array<Klass*>*)                        \
   nonstatic_field(ConstantPool,                _length,                                       int)                                   \
   nonstatic_field(ConstantPool,                _minor_version,                                u2)                                    \
@@ -189,7 +190,7 @@
   nonstatic_field(ConstantPoolCache,           _resolved_method_entries,                      Array<ResolvedMethodEntry>*)           \
   nonstatic_field(ResolvedMethodEntry,         _cpool_index,                                  u2)                                    \
   nonstatic_field(ConstantPoolCache,           _resolved_indy_entries,                        Array<ResolvedIndyEntry>*)             \
-  nonstatic_field(ResolvedIndyEntry,           _cpool_index,                                  u2)                                    \
+  nonstatic_field(ResolvedIndyEntry,           _cp_index,                                     u2)                                    \
   volatile_nonstatic_field(InstanceKlass,      _array_klasses,                                ObjArrayKlass*)                        \
   nonstatic_field(InstanceKlass,               _methods,                                      Array<Method*>*)                       \
   nonstatic_field(InstanceKlass,               _default_methods,                              Array<Method*>*)                       \
@@ -1481,14 +1482,6 @@
   /*********************************/                                     \
                                                                           \
   declare_constant(Symbol::max_symbol_length)                             \
-                                                                          \
-  /***********************************************/                       \
-  /* ConstantPool* layout enum for InvokeDynamic */                       \
-  /***********************************************/                       \
-                                                                          \
-  declare_constant(ConstantPool::_indy_bsm_offset)                        \
-  declare_constant(ConstantPool::_indy_argc_offset)                       \
-  declare_constant(ConstantPool::_indy_argv_offset)                       \
                                                                           \
   /***************************************/                               \
   /* JavaThreadStatus enum               */                               \


### PR DESCRIPTION
Hi,

This is the first commit in https://github.com/openjdk/jdk/pull/23250 (hash 616f9411d2a50b3dee4539ac3dd4459d5b04dfc4 ) with some small changes.

### Change to `BootstrapMethods` attribute storage
This refactoring changes how we store and access the  `BootstrapMethods` attribute in the constant pool.

As a reminder, the BSMs attribute has the following format[0]:

```
BootstrapMethods_attribute {
    u2 attribute_name_index;
    u4 attribute_length;
    u2 num_bootstrap_methods;
    {   u2 bootstrap_method_ref;
        u2 num_bootstrap_arguments;
        u2 bootstrap_arguments[num_bootstrap_arguments];
    } bootstrap_methods[num_bootstrap_methods];
}
```

Note that each entry in the `bootstraps_methods` array may have a different size, as they may have a different `num_bootstrap_arguments`. That means that in order to access the `n`th element in the `bootstraps_methods` array you need to know at what byte offset that `n`th element starts. The way we can do that is to have a supplementary array consisting of `u4`s which indicate at which byte offset each entry starts. **This PR** changes where we store that array.

We used to have one single array, called `operands`, which stored both the offsets and BSM attribute together, one after the other. It looked a bit like this:

```
operands
     +-----------------------\+/
+--+-++--+--+--+-o-+----+----++---+-----+-----+-----+
|  |  |  |  |  |u2 |u2  | a0 | u2 | u2  | a0  | a1  |  ...
|  |  |offsets |  Entry #1   |   Entry #2           |
++-+--+--+--+--++--+----+----+----+-----+-----+-----+
 |             /|\
 |              |
 +--------------+
```

This PR splits them into two: `_bsm_attribute_entries` for storing the actual entries, and `_bsm_attribute_offsets` for storing the offsets of each entry into that array.

It looks like this:

```
offsets
+--+--+-------------------------+
|  |  |  ...                    |
++-+\-+-------------------------+
 |   |
\|/  ---------------\+/
++---+---+----+----+-+-+----+----+-----+------+
| u2 | u2|  a0| a1 | u2| u2 | a0 | a1  |   a2 |...
+----+---+----+----+---+----+---- -----+------+
entries
```

### Add `BootstrapMethodAttributeEntry`

Instead of having many BSM attribute specific methods in the ConstantPool class, we introduce the BSMAE class and use that instead. You ask the constant pool for a particular `BSMAE` and you use that to get out the arguments, arg count, etc. 

### The other stuff

There's some other stuff in here, still figuring that out.

[0] https://docs.oracle.com/javase/specs/jvms/se24/html/jvms-4.html#jvms-4.7.23

<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Warnings
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/java/awt/doc-files/BorderLayout-1.gif)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/java/awt/doc-files/FlowLayout-1.gif)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/java/awt/doc-files/GridBagLayout-1.gif)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/java/awt/doc-files/GridBagLayout-2.gif)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/java/awt/doc-files/GridLayout-1.gif)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/java/awt/doc-files/GridLayout-2.gif)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/javax/swing/beaninfo/images/JAppletColor16.gif)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/javax/swing/beaninfo/images/JAppletColor32.gif)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/javax/swing/beaninfo/images/JAppletMono16.gif)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/javax/swing/beaninfo/images/JAppletMono32.gif)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/javax/swing/doc-files/JRootPane-1.gif)
&nbsp;⚠️ Patch contains a binary file (test/jdk/javax/rmi/ssl/keystore)
&nbsp;⚠️ Patch contains a binary file (test/jdk/javax/rmi/ssl/truststore)
&nbsp;⚠️ Patch contains a binary file (test/jdk/jdk/internal/loader/URLClassPath/testclasses.jar)
&nbsp;⚠️ Patch contains a binary file (test/jdk/sun/net/www/protocol/https/HttpsClient/dnsstore)
&nbsp;⚠️ Patch contains a binary file (test/jdk/sun/net/www/protocol/https/HttpsClient/ipstore)

### Contributors
 * John R Rose `<jrose@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24878/head:pull/24878` \
`$ git checkout pull/24878`

Update a local copy of the PR: \
`$ git checkout pull/24878` \
`$ git pull https://git.openjdk.org/jdk.git pull/24878/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24878`

View PR using the GUI difftool: \
`$ git pr show -t 24878`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24878.diff">https://git.openjdk.org/jdk/pull/24878.diff</a>

</details>
