### PR TITLE
8355558: SJIS.java test is always ignored

### DIFF
--- a/test/jdk/java/io/pathNames/win32/SJIS.java
+++ b/test/jdk/java/io/pathNames/win32/SJIS.java
@@ -29,7 +29,11 @@
    @library /test/lib
 */
 
-import java.io.*;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+
 import jtreg.SkippedException;
 
 

--- a/test/jdk/java/io/pathNames/win32/SJIS.java
+++ b/test/jdk/java/io/pathNames/win32/SJIS.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,9 +26,11 @@
    @summary Check that pathnames containing double-byte characters are not
             corrupted by win32 path processing
    @author Mark Reinhold
+   @library /test/lib
 */
 
 import java.io.*;
+import jtreg.SkippedException;
 
 
 public class SJIS {
@@ -47,8 +49,11 @@ public class SJIS {
         /* This test is only valid on win32 systems
            that use the SJIS encoding */
         if (File.separatorChar != '\\') return;
-        String enc = System.getProperty("file.encoding");
-        if ((enc == null) || !enc.equals("SJIS")) return;
+        String enc = System.getProperty("native.encoding");
+        if ((enc == null) || !enc.equals("MS932")) {
+            throw new SkippedException(
+                "native.encoding(%s) is not MS932".formatted(enc));
+        }
 
         File f = new File("\u30BD");
         if (f.exists()) rm(f);


### PR DESCRIPTION
Stemmed from this PR: https://github.com/openjdk/jdk/pull/24838
After JEP 400, `file.encoding` is always UTF-8, so the test was never run. Using `native.encoding` is appropriate so that the intention of the initial test will hold. Tested on an English Windows in which the system locale is set to `Japanese(Japan)`, and confirmed it succeeded without SkippedException.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8355558](https://bugs.openjdk.org/browse/JDK-8355558): SJIS.java test is always ignored (**Bug** - P4)


### Reviewers
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24881/head:pull/24881` \
`$ git checkout pull/24881`

Update a local copy of the PR: \
`$ git checkout pull/24881` \
`$ git pull https://git.openjdk.org/jdk.git pull/24881/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24881`

View PR using the GUI difftool: \
`$ git pr show -t 24881`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24881.diff">https://git.openjdk.org/jdk/pull/24881.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24881#issuecomment-2830970825)
</details>
