### PR TITLE
8345225: AARCH64: VM crashes with -NearCpool +UseShenandoahGC options

### DIFF
--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -1003,9 +1003,6 @@ void MacroAssembler::c2bool(Register x) {
 
 address MacroAssembler::ic_call(address entry, jint method_index) {
   RelocationHolder rh = virtual_call_Relocation::spec(pc(), method_index);
-  // address const_ptr = long_constant((jlong)Universe::non_oop_word());
-  // uintptr_t offset;
-  // ldr_constant(rscratch2, const_ptr);
   movptr(rscratch2, (intptr_t)Universe::non_oop_word());
   return trampoline_call(Address(entry, rh));
 }
@@ -5520,9 +5517,8 @@ void MacroAssembler::movoop(Register dst, jobject obj) {
     mov(dst, Address((address)obj, rspec));
   } else {
     address dummy = address(uintptr_t(pc()) & -wordSize); // A nearby aligned address
-    ldr_constant(dst, Address(dummy, rspec));
+    ldr(dst, Address(dummy, rspec));
   }
-
 }
 
 // Move a metadata address into a register.

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
@@ -1472,16 +1472,6 @@ public:
 
   public:
 
-  void ldr_constant(Register dest, const Address &const_addr) {
-    if (NearCpool) {
-      ldr(dest, const_addr);
-    } else {
-      uint64_t offset;
-      adrp(dest, InternalAddress(const_addr.target()), offset);
-      ldr(dest, Address(dest, offset));
-    }
-  }
-
   address read_polling_page(Register r, relocInfo::relocType rtype);
   void get_polling_page(Register dest, relocInfo::relocType rtype);
 


### PR DESCRIPTION
The -XX:-NearCpool option enables the use of an adrp + ldr sequence in the ldr_constant function. This legacy code assumed that constants could be outside the nmethod (though it is important that they remain inside the CodeHeap; otherwise, adrp offset limits could be violated). The description of NearCpool says: "constant pool is close to instructions". By "constant pool" it probably means the nmethod's consts section or possibly it's oops/metadata, not the constant pool of the class.

In any case, the NearCpool option value is used in the MacroAssembler::ldr_constant function to load oops. This creates a problem: the relocation patcher is not designed to handle an adrp + ldr sequence for relocInfo::oop_type entries. It causes the JVM to crash. The relocation patcher can be fixed, but the case with distant (but not too distant) oops does not correspond to any real VM configuration, so I prefer to eliminate the code path.

I suggest the following:
- Use a direct load in MacroAssembler::movoop
- Remove the ldr_constant function, as it is no longer needed
- Follow up: deprecate NearCpool option, as it is no longer used
- Follow up: update RISC-V accordingly

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345225](https://bugs.openjdk.org/browse/JDK-8345225): AARCH64: VM crashes with -NearCpool +UseShenandoahGC options (**Bug** - P4)


### Reviewers
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24883/head:pull/24883` \
`$ git checkout pull/24883`

Update a local copy of the PR: \
`$ git checkout pull/24883` \
`$ git pull https://git.openjdk.org/jdk.git pull/24883/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24883`

View PR using the GUI difftool: \
`$ git pr show -t 24883`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24883.diff">https://git.openjdk.org/jdk/pull/24883.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24883#issuecomment-2831592203)
</details>
