### PR TITLE
8343739: Test java/awt/event/KeyEvent/ExtendedKeyCode/ExtendedKeyCodeTest.java failed: Wrong extended key code

### DIFF
--- a/test/jdk/java/awt/event/KeyEvent/ExtendedKeyCode/ExtendedKeyCodeTest.java
+++ b/test/jdk/java/awt/event/KeyEvent/ExtendedKeyCode/ExtendedKeyCodeTest.java
@@ -70,7 +70,8 @@ public class ExtendedKeyCodeTest {
             robot.waitForIdle();
 
             if (eventsCount != 2 || !setExtendedKeyCode) {
-                throw new RuntimeException("Wrong extended key code");
+                throw new RuntimeException("Wrong extended key code\n" +
+                        "eventsCount: " + eventsCount);
             }
         } finally {
             EventQueue.invokeAndWait(() -> frame.dispose());

--- a/test/jdk/java/awt/event/KeyEvent/ExtendedKeyCode/ExtendedKeyCodeTest.java
+++ b/test/jdk/java/awt/event/KeyEvent/ExtendedKeyCode/ExtendedKeyCodeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,7 +21,6 @@
  * questions.
  */
 
-import java.awt.EventQueue;
 import java.awt.Frame;
 import java.awt.Robot;
 import java.awt.event.KeyEvent;
@@ -32,93 +31,76 @@ import java.awt.event.KeyAdapter;
  * @key headful
  * @bug 8007156 8025126
  * @summary Extended key code is not set for a key event
+ * @author Alexandr Scherbatiy
+ * @library /lib/client
+ * @build ExtendedRobot
  * @run main ExtendedKeyCodeTest
  */
-
 public class ExtendedKeyCodeTest {
-    private static Frame frame;
-    private static volatile boolean setExtendedKeyCode;
-    private static volatile int eventsCount;
+
+    private static volatile boolean setExtendedKeyCode = true;
+    private static volatile int eventsCount = 0;
 
     public static void main(String[] args) throws Exception {
-        Robot robot = new Robot();
+        ExtendedRobot robot = new ExtendedRobot();
         robot.setAutoDelay(50);
 
-        try {
-            EventQueue.invokeAndWait(() -> createTestGUI());
-            robot.waitForIdle();
-            robot.delay(1000);
+        Frame frame = new Frame();
+        frame.setSize(300, 300);
 
-            robot.keyPress(KeyEvent.VK_D);
-            robot.keyRelease(KeyEvent.VK_D);
-            robot.waitForIdle();
-
-            if (!setExtendedKeyCode) {
-                throw new RuntimeException("Wrong extended key code!");
-            }
-        } finally {
-            EventQueue.invokeAndWait(() -> frame.dispose());
-        }
-
-        try {
-            EventQueue.invokeAndWait(() -> createTestGUI2());
-            robot.waitForIdle();
-            robot.delay(1000);
-
-            robot.keyPress(KeyEvent.VK_LEFT);
-            robot.keyRelease(KeyEvent.VK_LEFT);
-            robot.waitForIdle();
-
-            if (eventsCount != 2 || !setExtendedKeyCode) {
-                throw new RuntimeException("Wrong extended key code\n" +
-                        "eventsCount: " + eventsCount);
-            }
-        } finally {
-            EventQueue.invokeAndWait(() -> frame.dispose());
-        }
-    }
-
-    public static void createTestGUI() {
-        eventsCount = 0;
-        setExtendedKeyCode = true;
-        frame = new Frame("ExtendedKeyCodeTest1");
         frame.addKeyListener(new KeyAdapter() {
+
             @Override
             public void keyPressed(KeyEvent e) {
                 eventsCount++;
-                int keyCode = KeyEvent.getExtendedKeyCodeForChar(e.getKeyChar());
-                setExtendedKeyCode = setExtendedKeyCode && (e.getExtendedKeyCode() == keyCode);
-                System.out.println("Test 1 keyPressed " + keyCode);
+                setExtendedKeyCode = setExtendedKeyCode && (e.getExtendedKeyCode()
+                        == KeyEvent.getExtendedKeyCodeForChar(e.getKeyChar()));
             }
 
             @Override
             public void keyReleased(KeyEvent e) {
                 eventsCount++;
-                int keyCode = KeyEvent.getExtendedKeyCodeForChar(e.getKeyChar());
-                setExtendedKeyCode = setExtendedKeyCode && (e.getExtendedKeyCode() == keyCode);
-                System.out.println("Test 1 keyReleased " + keyCode);
+                setExtendedKeyCode = setExtendedKeyCode && (e.getExtendedKeyCode()
+                        == KeyEvent.getExtendedKeyCodeForChar(e.getKeyChar()));
             }
         });
 
-        frame.setLocationRelativeTo(null);
-        frame.setSize(300, 300);
         frame.setVisible(true);
-    }
+        robot.waitForIdle();
 
-    public static void createTestGUI2() {
+        robot.keyPress(KeyEvent.VK_D);
+        robot.keyRelease(KeyEvent.VK_D);
+        robot.waitForIdle();
+
+        frame.dispose();
+
+        if (eventsCount != 2 || !setExtendedKeyCode) {
+            throw new RuntimeException("Wrong extended key code\n" +
+                    "eventsCount: " + eventsCount);
+        }
+
+        frame = new Frame();
+        frame.setSize(300, 300);
         setExtendedKeyCode = false;
-        frame = new Frame("ExtendedKeyCodeTest2");
+
         frame.addKeyListener(new KeyAdapter() {
+
             @Override
             public void keyPressed(KeyEvent e) {
-                int keyCode = e.getExtendedKeyCode();
-                setExtendedKeyCode = keyCode == KeyEvent.VK_LEFT;
-                System.out.println("Test 2 keyPressed " + keyCode);
+                setExtendedKeyCode = e.getExtendedKeyCode() == KeyEvent.VK_LEFT;
             }
         });
 
-        frame.setLocationRelativeTo(null);
-        frame.setSize(300, 300);
         frame.setVisible(true);
+        robot.waitForIdle();
+
+        robot.keyPress(KeyEvent.VK_LEFT);
+        robot.keyRelease(KeyEvent.VK_LEFT);
+        robot.waitForIdle();
+        frame.dispose();
+
+        if (!setExtendedKeyCode) {
+            throw new RuntimeException("Wrong extended key code!");
+        }
     }
 }

--- a/test/jdk/java/awt/event/KeyEvent/ExtendedKeyCode/ExtendedKeyCodeTest.java
+++ b/test/jdk/java/awt/event/KeyEvent/ExtendedKeyCode/ExtendedKeyCodeTest.java
@@ -30,8 +30,7 @@ import java.awt.event.KeyAdapter;
  * @test
  * @key headful
  * @bug 8007156 8025126
- * @summary Extended key code is not set for a key event
- * @author Alexandr Scherbatiy
+ * @summary Tests that ExtendedKeyCode is set for key events
  * @library /lib/client
  * @build ExtendedRobot
  * @run main ExtendedKeyCodeTest

--- a/test/jdk/java/awt/event/KeyEvent/ExtendedKeyCode/ExtendedKeyCodeTest.java
+++ b/test/jdk/java/awt/event/KeyEvent/ExtendedKeyCode/ExtendedKeyCodeTest.java
@@ -21,11 +21,11 @@
  * questions.
  */
 
+import java.awt.EventQueue;
 import java.awt.Frame;
 import java.awt.Robot;
 import java.awt.event.KeyEvent;
 import java.awt.event.KeyAdapter;
-import javax.swing.SwingUtilities;
 
 /*
  * @test
@@ -45,7 +45,7 @@ public class ExtendedKeyCodeTest {
         robot.setAutoDelay(50);
 
         try {
-            SwingUtilities.invokeAndWait(() -> createTestGUI());
+            EventQueue.invokeAndWait(() -> createTestGUI());
             robot.waitForIdle();
             robot.delay(1000);
 
@@ -57,11 +57,11 @@ public class ExtendedKeyCodeTest {
                 throw new RuntimeException("Wrong extended key code!");
             }
         } finally {
-            SwingUtilities.invokeAndWait(() -> frame.dispose());
+            EventQueue.invokeAndWait(() -> frame.dispose());
         }
 
         try {
-            SwingUtilities.invokeAndWait(() -> createTestGUI2());
+            EventQueue.invokeAndWait(() -> createTestGUI2());
             robot.waitForIdle();
             robot.delay(1000);
 
@@ -73,7 +73,7 @@ public class ExtendedKeyCodeTest {
                 throw new RuntimeException("Wrong extended key code");
             }
         } finally {
-            SwingUtilities.invokeAndWait(() -> frame.dispose());
+            EventQueue.invokeAndWait(() -> frame.dispose());
         }
     }
 
@@ -85,15 +85,17 @@ public class ExtendedKeyCodeTest {
             @Override
             public void keyPressed(KeyEvent e) {
                 eventsCount++;
-                setExtendedKeyCode = setExtendedKeyCode && (e.getExtendedKeyCode()
-                        == KeyEvent.getExtendedKeyCodeForChar(e.getKeyChar()));
+                int keyCode = KeyEvent.getExtendedKeyCodeForChar(e.getKeyChar());
+                setExtendedKeyCode = setExtendedKeyCode && (e.getExtendedKeyCode() == keyCode);
+                System.out.println("Test 1 keyPressed " + keyCode);
             }
 
             @Override
             public void keyReleased(KeyEvent e) {
                 eventsCount++;
-                setExtendedKeyCode = setExtendedKeyCode && (e.getExtendedKeyCode()
-                        == KeyEvent.getExtendedKeyCodeForChar(e.getKeyChar()));
+                int keyCode = KeyEvent.getExtendedKeyCodeForChar(e.getKeyChar());
+                setExtendedKeyCode = setExtendedKeyCode && (e.getExtendedKeyCode() == keyCode);
+                System.out.println("Test 1 keyReleased " + keyCode);
             }
         });
 
@@ -108,7 +110,9 @@ public class ExtendedKeyCodeTest {
         frame.addKeyListener(new KeyAdapter() {
             @Override
             public void keyPressed(KeyEvent e) {
-                setExtendedKeyCode = e.getExtendedKeyCode() == KeyEvent.VK_LEFT;
+                int keyCode = e.getExtendedKeyCode();
+                setExtendedKeyCode = keyCode == KeyEvent.VK_LEFT;
+                System.out.println("Test 2 keyPressed " + keyCode);
             }
         });
 


### PR DESCRIPTION
Test was failing on Ubuntu, looks to be a synchronous error in the test so I rewrote it to improve stability.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343739](https://bugs.openjdk.org/browse/JDK-8343739): Test java/awt/event/KeyEvent/ExtendedKeyCode/ExtendedKeyCodeTest.java failed: Wrong extended key code (**Bug** - P4)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**) Review applies to [711bd81f](https://git.openjdk.org/jdk/pull/24885/files/711bd81f4a50f0a5bc3a95fb0a9c0d168095a8c4)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24885/head:pull/24885` \
`$ git checkout pull/24885`

Update a local copy of the PR: \
`$ git checkout pull/24885` \
`$ git pull https://git.openjdk.org/jdk.git pull/24885/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24885`

View PR using the GUI difftool: \
`$ git pr show -t 24885`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24885.diff">https://git.openjdk.org/jdk/pull/24885.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24885#issuecomment-2831316258)
</details>
