### PR TITLE
8355372: GenShen: Test gc/shenandoah/generational/TestOldGrowthTriggers.java fails with UseCompactObjectHeaders enabled

### DIFF
--- a/test/hotspot/jtreg/gc/shenandoah/generational/TestOldGrowthTriggers.java
+++ b/test/hotspot/jtreg/gc/shenandoah/generational/TestOldGrowthTriggers.java
@@ -58,14 +58,17 @@ public class TestOldGrowthTriggers {
                 int replaceIndex = r.nextInt(ArraySize);
                 int deriveIndex = r.nextInt(ArraySize);
                 switch (i & 0x3) {
-                    case 2:
+                    case 0:
                         // creates new old BigInteger, releases old BigInteger,
                         // may create ephemeral data while computing gcd
                         array[replaceIndex] = array[replaceIndex].gcd(array[deriveIndex]);
                         break;
-                    case 3:
+                    case 1:
                         // creates new old BigInteger, releases old BigInteger
                         array[replaceIndex] = array[replaceIndex].multiply(array[deriveIndex]);
+                        break;
+                    case 2,3:
+                        // do nothing, let all objects in the array age to increase pressure on old generation
                         break;
                 }
             }

--- a/test/hotspot/jtreg/gc/shenandoah/generational/TestOldGrowthTriggers.java
+++ b/test/hotspot/jtreg/gc/shenandoah/generational/TestOldGrowthTriggers.java
@@ -58,14 +58,6 @@ public class TestOldGrowthTriggers {
                 int replaceIndex = r.nextInt(ArraySize);
                 int deriveIndex = r.nextInt(ArraySize);
                 switch (i & 0x3) {
-                    case 0:
-                        // 50% chance of creating garbage
-                        array[replaceIndex] = array[replaceIndex].max(array[deriveIndex]);
-                        break;
-                    case 1:
-                        // 50% chance of creating garbage
-                        array[replaceIndex] = array[replaceIndex].min(array[deriveIndex]);
-                        break;
                     case 2:
                         // creates new old BigInteger, releases old BigInteger,
                         // may create ephemeral data while computing gcd
@@ -105,6 +97,18 @@ public class TestOldGrowthTriggers {
                 "-XX:ShenandoahGCMode=generational",
                 "-XX:ShenandoahGuaranteedYoungGCInterval=0",
                 "-XX:ShenandoahGuaranteedOldGCInterval=0"
+        );
+
+        testOld("-Xlog:gc",
+                "-Xms96m",
+                "-Xmx96m",
+                "-XX:+UnlockDiagnosticVMOptions",
+                "-XX:+UnlockExperimentalVMOptions",
+                "-XX:+UseShenandoahGC",
+                "-XX:ShenandoahGCMode=generational",
+                "-XX:ShenandoahGuaranteedYoungGCInterval=0",
+                "-XX:ShenandoahGuaranteedOldGCInterval=0",
+                "-XX:+UseCompactObjectHeaders"
         );
     }
 }


### PR DESCRIPTION
Add a test case for `-XX:+UseCompactObjectHeaders`, increase pressure on old generation. I ran the test (which includes a compact object headers case now) fifty times without failure.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8355372](https://bugs.openjdk.org/browse/JDK-8355372): GenShen: Test gc/shenandoah/generational/TestOldGrowthTriggers.java fails with UseCompactObjectHeaders enabled (**Bug** - P4)


### Reviewers
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - **Reviewer**)
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - Committer) Review applies to [9c991cfa](https://git.openjdk.org/jdk/pull/24888/files/9c991cfa525e66bac978bacc65429c8779682f87)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24888/head:pull/24888` \
`$ git checkout pull/24888`

Update a local copy of the PR: \
`$ git checkout pull/24888` \
`$ git pull https://git.openjdk.org/jdk.git pull/24888/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24888`

View PR using the GUI difftool: \
`$ git pr show -t 24888`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24888.diff">https://git.openjdk.org/jdk/pull/24888.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24888#issuecomment-2831399320)
</details>
