### PR TITLE
8347515: C2: assert(!success || (C->macro_count() == (old_macro_count - 1))) failed: elimination must have deleted one node from macro list

### DIFF
--- a/src/hotspot/share/opto/macro.cpp
+++ b/src/hotspot/share/opto/macro.cpp
@@ -2468,7 +2468,6 @@ void PhaseMacroExpand::eliminate_macro_nodes() {
 //------------------------------expand_macro_nodes----------------------
 //  Returns true if a failure occurred.
 bool PhaseMacroExpand::expand_macro_nodes() {
-  // Perform refining of strip mined loop before expanding macro nodes.
   refine_strip_mined_loop_macro_node();
   // Do not allow new macro nodes once we started to expand
   C->reset_allow_macro_nodes();

--- a/src/hotspot/share/opto/macro.cpp
+++ b/src/hotspot/share/opto/macro.cpp
@@ -2457,6 +2457,13 @@ void PhaseMacroExpand::eliminate_macro_nodes() {
 //------------------------------expand_macro_nodes----------------------
 //  Returns true if a failure occurred.
 bool PhaseMacroExpand::expand_macro_nodes() {
+  // Perform refining of strip mined loop node before we start to expand.
+  for (int i = C->macro_count(); i > 0; i--) {
+    Node* n = C->macro_node(i-1);
+    if (n->Opcode() == Op_OuterStripMinedLoop) {
+      n->as_OuterStripMinedLoop()->adjust_strip_mined_loop(&_igvn);
+    }
+  }
   // Do not allow new macro nodes once we started to expand
   C->reset_allow_macro_nodes();
   if (StressMacroExpansion) {
@@ -2509,7 +2516,6 @@ bool PhaseMacroExpand::expand_macro_nodes() {
         _igvn.replace_node(n, _igvn.intcon(1));
 #endif // ASSERT
       } else if (n->Opcode() == Op_OuterStripMinedLoop) {
-        n->as_OuterStripMinedLoop()->adjust_strip_mined_loop(&_igvn);
         C->remove_macro_node(n);
         success = true;
       } else if (n->Opcode() == Op_MaxL) {

--- a/src/hotspot/share/opto/macro.cpp
+++ b/src/hotspot/share/opto/macro.cpp
@@ -2350,8 +2350,9 @@ void PhaseMacroExpand::expand_subtypecheck_node(SubTypeCheckNode *check) {
   _igvn.replace_node(check, C->top());
 }
 
+//------------------refine_strip_mined_loop_macro_node-------------------
+// Perform refining of strip mined loop node in the macro nodes list.
 void PhaseMacroExpand::refine_strip_mined_loop_macro_node() {
-   // Perform refining of strip mined loop node in the  macro nodes list.
    for (int i = C->macro_count(); i > 0; i--) {
     Node* n = C->macro_node(i - 1);
     if (n->is_OuterStripMinedLoop()) {

--- a/src/hotspot/share/opto/macro.cpp
+++ b/src/hotspot/share/opto/macro.cpp
@@ -2350,9 +2350,8 @@ void PhaseMacroExpand::expand_subtypecheck_node(SubTypeCheckNode *check) {
   _igvn.replace_node(check, C->top());
 }
 
-//------------------refine_strip_mined_loop_macro_node-------------------
-// Perform refining of strip mined loop node in the macro nodes list.
-void PhaseMacroExpand::refine_strip_mined_loop_macro_node() {
+// Perform refining of strip mined loop nodes in the macro nodes list.
+void PhaseMacroExpand::refine_strip_mined_loop_macro_nodes() {
    for (int i = C->macro_count(); i > 0; i--) {
     Node* n = C->macro_node(i - 1);
     if (n->is_OuterStripMinedLoop()) {
@@ -2468,7 +2467,7 @@ void PhaseMacroExpand::eliminate_macro_nodes() {
 //------------------------------expand_macro_nodes----------------------
 //  Returns true if a failure occurred.
 bool PhaseMacroExpand::expand_macro_nodes() {
-  refine_strip_mined_loop_macro_node();
+  refine_strip_mined_loop_macro_nodes();
   // Do not allow new macro nodes once we started to expand
   C->reset_allow_macro_nodes();
   if (StressMacroExpansion) {

--- a/src/hotspot/share/opto/macro.cpp
+++ b/src/hotspot/share/opto/macro.cpp
@@ -2350,6 +2350,16 @@ void PhaseMacroExpand::expand_subtypecheck_node(SubTypeCheckNode *check) {
   _igvn.replace_node(check, C->top());
 }
 
+void PhaseMacroExpand::refine_strip_mined_loop_macro_node() {
+   // Perform refining of strip mined loop node in the  macro nodes list.
+   for (int i = C->macro_count(); i > 0; i--) {
+    Node* n = C->macro_node(i - 1);
+    if (n->is_OuterStripMinedLoop()) {
+      n->as_OuterStripMinedLoop()->adjust_strip_mined_loop(&_igvn);
+    }
+  }
+}
+
 //---------------------------eliminate_macro_nodes----------------------
 // Eliminate scalar replaced allocations and associated locks.
 void PhaseMacroExpand::eliminate_macro_nodes() {
@@ -2457,13 +2467,8 @@ void PhaseMacroExpand::eliminate_macro_nodes() {
 //------------------------------expand_macro_nodes----------------------
 //  Returns true if a failure occurred.
 bool PhaseMacroExpand::expand_macro_nodes() {
-  // Perform refining of strip mined loop node before we start to expand.
-  for (int i = C->macro_count(); i > 0; i--) {
-    Node* n = C->macro_node(i-1);
-    if (n->Opcode() == Op_OuterStripMinedLoop) {
-      n->as_OuterStripMinedLoop()->adjust_strip_mined_loop(&_igvn);
-    }
-  }
+  // Perform refining of strip mined loop before expanding macro nodes.
+  refine_strip_mined_loop_macro_node();
   // Do not allow new macro nodes once we started to expand
   C->reset_allow_macro_nodes();
   if (StressMacroExpansion) {

--- a/src/hotspot/share/opto/macro.hpp
+++ b/src/hotspot/share/opto/macro.hpp
@@ -202,6 +202,7 @@ public:
   PhaseMacroExpand(PhaseIterGVN &igvn) : Phase(Macro_Expand), _igvn(igvn), _has_locks(false) {
     _igvn.set_delay_transform(true);
   }
+
   void refine_strip_mined_loop_macro_node();
   void eliminate_macro_nodes();
   bool expand_macro_nodes();

--- a/src/hotspot/share/opto/macro.hpp
+++ b/src/hotspot/share/opto/macro.hpp
@@ -202,6 +202,7 @@ public:
   PhaseMacroExpand(PhaseIterGVN &igvn) : Phase(Macro_Expand), _igvn(igvn), _has_locks(false) {
     _igvn.set_delay_transform(true);
   }
+  void refine_strip_mined_loop_macro_node();
   void eliminate_macro_nodes();
   bool expand_macro_nodes();
 

--- a/src/hotspot/share/opto/macro.hpp
+++ b/src/hotspot/share/opto/macro.hpp
@@ -203,7 +203,7 @@ public:
     _igvn.set_delay_transform(true);
   }
 
-  void refine_strip_mined_loop_macro_node();
+  void refine_strip_mined_loop_macro_nodes();
   void eliminate_macro_nodes();
   bool expand_macro_nodes();
 

--- a/test/hotspot/jtreg/compiler/macronodes/TestLoopStripMiningInMacroElimination.java
+++ b/test/hotspot/jtreg/compiler/macronodes/TestLoopStripMiningInMacroElimination.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8347515
+ * @summary Regression test for an assert triggered during elimination of OuterStripMinedLoop node. This happens
+ * due to a MaxL node being added to the macro list during refining of the OuterStripMinedLoop node prior to its
+ * elimination.
+ * @run main/othervm -XX:-TieredCompilation compiler.macronodes.TestLoopStripMiningInMacroElimination
+ */
+package compiler.macronodes;
+
+public class TestLoopStripMiningInMacroElimination {
+    static long l1 = 3434;
+    static long l2;
+    public static void main(String[] strArr) {
+        for (int i = 0; i < 1000; i++) {
+            test();
+        }
+    }
+
+    static void test() {
+        for (int i = 0; i < 100; i++) {
+            l2 = Math.max(i, 56 % l1);
+        }
+    }
+
+}


### PR DESCRIPTION
Issue: The assertion failure , `assert(!success || (C->macro_count() == (old_macro_count - 1))) failed: elimination must have deleted one node from macro list`, occurs when [loop striping mining  ](https://bugs.openjdk.org/browse/JDK-8186027)may create a [MaxL](https://bugs.openjdk.org/browse/JDK-8324655)  after macro expansion.

Analysis : Before the macro nodes are expanded in` expand_macro_nodes`, there is a process where nodes from the macro list are eliminated. This also includes elimination of  any `OuterStripMinedLoop` node in the macro list. The bug occurs due to the refining of the strip mined loop in `adjust_strip_mined_loop` function just before it is eliminated. In this case, a` MaxL` node is added to the macro list in `adjust_strip_mined_loop`. 

Fix: The fix involves performing the refining of the strip mined loop before elimination process. More specifically, moving the `adjust_strip_mined_loop` function outside the elimination loop.

Improvement:  The process of eliminating macro nodes by calling `eliminate_macro_nodes` and performing additional Opaque and LoopLimit nodes elimination in ` expand_macro_nodes` is unintuitive as suggested in [JDK-8325478 ](https://bugs.openjdk.org/browse/JDK-8325478) and the current fix should be moved along with the other elimination code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347515](https://bugs.openjdk.org/browse/JDK-8347515): C2: assert(!success || (C-&gt;macro_count() == (old_macro_count - 1))) failed: elimination must have deleted one node from macro list (**Bug** - P3)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**) Review applies to [e8bcbc9b](https://git.openjdk.org/jdk/pull/24890/files/e8bcbc9b07ff2310d747e112b692910158bf5432)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24890/head:pull/24890` \
`$ git checkout pull/24890`

Update a local copy of the PR: \
`$ git checkout pull/24890` \
`$ git pull https://git.openjdk.org/jdk.git pull/24890/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24890`

View PR using the GUI difftool: \
`$ git pr show -t 24890`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24890.diff">https://git.openjdk.org/jdk/pull/24890.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24890#issuecomment-2838169136)
</details>
