### PR TITLE
8355635: Do not collect C strings in C2 scratch buffer

### DIFF
--- a/src/hotspot/share/asm/codeBuffer.cpp
+++ b/src/hotspot/share/asm/codeBuffer.cpp
@@ -1042,6 +1042,9 @@ void CodeBuffer::shared_stub_to_interp_for(ciMethod* callee, csize_t call_offset
 
 #ifndef PRODUCT
 void CodeBuffer::block_comment(ptrdiff_t offset, const char* comment) {
+  if (insts()->scratch_emit()) {
+    return;
+  }
   if (_collect_comments) {
     const char* str = _asm_remarks.insert(offset, comment);
     postcond(str != comment);
@@ -1049,6 +1052,9 @@ void CodeBuffer::block_comment(ptrdiff_t offset, const char* comment) {
 }
 
 const char* CodeBuffer::code_string(const char* str) {
+  if (insts()->scratch_emit()) {
+    return str;
+  }
   const char* tmp = _dbg_strings.insert(str);
   postcond(tmp != str);
   return tmp;


### PR DESCRIPTION
[JDK-8349479](https://bugs.openjdk.org/browse/JDK-8349479) added call to `code_string()` for Halt node mach node.
I am observing several more creation and clearing C strings collections during C2 compilation:
[17.405s][debug][codestrings] Clear 2 asm-remarks.
[17.405s][debug][codestrings] Clear 1 dbg-string.

Most are coming from temporary scratch buffer C2 uses for code size calculation. I suggest to not collect strings in this buffer.

Note, `CodeSection::set_scratch_emit()` is only called from [PhaseOutput::scratch_emit_size()](https://github.com/openjdk/jdk/blob/master/src/hotspot/share/opto/output.cpp#L3368) for scratch buffer.

I verified with `-XX:CompileCommand=print,<classpath>::<method>` that hsdis output is the same.

Running on linux-x64 with fastdebug VM:
```
before:
$  java -XX:-TieredCompilation -Xlog:codestrings=debug com.sun.tools.javac.Main HelloWorld.java | grep codestrings |wc
   1644    6576   80618

after again:
$  java -XX:-TieredCompilation -Xlog:codestrings=debug com.sun.tools.javac.Main HelloWorld.java | grep codestrings |wc
      0       0       0
```

It is more dramatic with `-Xcomp` we use for testing:
```
Before
$  java -XX:-TieredCompilation -Xcomp -Xlog:codestrings=debug com.sun.tools.javac.Main HelloWorld.java | grep codestrings |wc
  70924  283696 3533261

After fix
$  java -XX:-TieredCompilation -Xcomp -Xlog:codestrings=debug com.sun.tools.javac.Main HelloWorld.java | grep codestrings |wc
      0       0       0
```

I was curious why it is 0 - we do deoptimize nmethod. But with big default CodeCache GC does not collect them.
Reducing CodeCache to 8Mb shows deallocation:
```
$ java -XX:-TieredCompilation -Xcomp -Xlog:codestrings=debug -Xlog:codecache=debug -XX:+PrintCodeCache -XX:ReservedCodeCacheSize=8M com.sun.tools.javac.Main HelloWorld.java
...
[40.196s][debug][codestrings] Clear 42 asm-remarks.
[40.196s][debug][codestrings] Clear 1 dbg-string.
[40.196s][debug][codecache  ] *flushing  nmethod 5811/0x00007f71d74b7188. Live blobs:3370/Free CodeCache:2953Kb
```

Tested tier1-5, Xcomp,comp-stress.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8355635](https://bugs.openjdk.org/browse/JDK-8355635): Do not collect C strings in C2 scratch buffer (**Enhancement** - P4)


### Reviewers
 * [John R Rose](https://openjdk.org/census#jrose) (@rose00 - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24893/head:pull/24893` \
`$ git checkout pull/24893`

Update a local copy of the PR: \
`$ git checkout pull/24893` \
`$ git pull https://git.openjdk.org/jdk.git pull/24893/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24893`

View PR using the GUI difftool: \
`$ git pr show -t 24893`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24893.diff">https://git.openjdk.org/jdk/pull/24893.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24893#issuecomment-2831773957)
</details>
