### PR TITLE
8355637: SSLSessionImpl's "serialization" list documentation is incorrectly ordered

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/SSLSessionImpl.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLSessionImpl.java
@@ -27,7 +27,6 @@ package sun.security.ssl;
 import sun.security.provider.X509Factory;
 
 import java.io.IOException;
-import java.math.BigInteger;
 import java.net.InetAddress;
 import java.nio.ByteBuffer;
 import java.security.Principal;
@@ -279,6 +278,8 @@ final class SSLSessionImpl extends ExtendedSSLSession {
      * < 1 byte > Number of requestedServerNames entries
      *   < 1 byte > ServerName length
      *   < length in bytes > ServerName
+     * < 4 bytes > maximumPacketSize
+     * < 4 bytes > negotiatedMaxFragSize
      * < 4 bytes > creationTime
      * < 2 byte > status response length
      *   < 2 byte > status response entry length
@@ -304,8 +305,6 @@ final class SSLSessionImpl extends ExtendedSSLSession {
      *       < length in bytes> PSK identity
      *   Anonymous
      *     < 1 byte >
-     * < 4 bytes > maximumPacketSize
-     * < 4 bytes > negotiatedMaxFragSize
      */
 
     SSLSessionImpl(HandshakeContext hc, ByteBuffer buf) throws IOException {
@@ -1300,12 +1299,12 @@ final class SSLSessionImpl extends ExtendedSSLSession {
     /**
      * Use large packet sizes now or follow RFC 2246 packet sizes (2^14)
      * until changed.
-     *
+     * <P>
      * In the TLS specification (section 6.2.1, RFC2246), it is not
      * recommended that the plaintext has more than 2^14 bytes.
      * However, some TLS implementations violate the specification.
      * This is a workaround for interoperability with these stacks.
-     *
+     * <P>
      * Application could accept large fragments up to 2^15 bytes by
      * setting the system property jsse.SSLEngine.acceptLargeFragments
      * to "true".
@@ -1318,7 +1317,7 @@ final class SSLSessionImpl extends ExtendedSSLSession {
      * Expand the buffer size of both SSL/TLS network packet and
      * application data.
      */
-    protected void expandBufferSizes() {
+    void expandBufferSizes() {
         sessionLock.lock();
         try {
             acceptLargeFragments = true;


### PR DESCRIPTION
Minor error in the `SSLSessionImpl` comments as to how the class is "serialized. Fix the ordering.

Do a little cleaning on the class on some obvious errors.

No testing needed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8355637](https://bugs.openjdk.org/browse/JDK-8355637): SSLSessionImpl's "serialization" list documentation is incorrectly ordered (**Bug** - P4)


### Reviewers
 * [Anthony Scarpino](https://openjdk.org/census#ascarpino) (@ascarpino - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24894/head:pull/24894` \
`$ git checkout pull/24894`

Update a local copy of the PR: \
`$ git checkout pull/24894` \
`$ git pull https://git.openjdk.org/jdk.git pull/24894/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24894`

View PR using the GUI difftool: \
`$ git pr show -t 24894`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24894.diff">https://git.openjdk.org/jdk/pull/24894.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24894#issuecomment-2831852826)
</details>
