### PR TITLE
8355649: Missing ResourceMark in ExceptionMark::check_no_pending_exception

### DIFF
--- a/src/hotspot/share/utilities/exceptions.cpp
+++ b/src/hotspot/share/utilities/exceptions.cpp
@@ -540,6 +540,7 @@ inline void ExceptionMark::check_no_pending_exception() {
   if (_thread->has_pending_exception()) {
     oop exception = _thread->pending_exception();
     _thread->clear_pending_exception(); // Needed to avoid infinite recursion
+    ResourceMark rm;
     exception->print();
     fatal("ExceptionMark constructor expects no pending exceptions");
   }
@@ -551,6 +552,7 @@ ExceptionMark::~ExceptionMark() {
     Handle exception(_thread, _thread->pending_exception());
     _thread->clear_pending_exception(); // Needed to avoid infinite recursion
     if (is_init_completed()) {
+      ResourceMark rm;
       exception->print();
       fatal("ExceptionMark destructor expects no pending exceptions");
     } else {


### PR DESCRIPTION
I find during test development. 
I don't think that  separate regression test is needed here.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8355649](https://bugs.openjdk.org/browse/JDK-8355649): Missing ResourceMark in ExceptionMark::check_no_pending_exception (**Bug** - P4)


### Reviewers
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@jdksjolen - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24896/head:pull/24896` \
`$ git checkout pull/24896`

Update a local copy of the PR: \
`$ git checkout pull/24896` \
`$ git pull https://git.openjdk.org/jdk.git pull/24896/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24896`

View PR using the GUI difftool: \
`$ git pr show -t 24896`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24896.diff">https://git.openjdk.org/jdk/pull/24896.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24896#issuecomment-2832349572)
</details>
