### PR TITLE
Add `final` & `sealed` to `jdk.internal.reflect`

### DIFF
--- a/src/java.base/share/classes/jdk/internal/reflect/AccessorUtils.java
+++ b/src/java.base/share/classes/jdk/internal/reflect/AccessorUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,7 @@ import java.util.Set;
 /**
  * Utility methods used by DirectMethodHandleAccessor and DirectConstructorHandleAccessor
  */
-public class AccessorUtils {
+public final class AccessorUtils {
     /**
      * Determines if the given exception thrown by MethodHandle::invokeExact
      * is caused by an illegal argument passed to Method::invoke or

--- a/src/java.base/share/classes/jdk/internal/reflect/ConstantPool.java
+++ b/src/java.base/share/classes/jdk/internal/reflect/ConstantPool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,7 +32,7 @@ import java.util.Set;
     Currently this is needed to provide reflective access to annotations
     but may be used by other internal subsystems in the future. */
 
-public class ConstantPool {
+public final class ConstantPool {
   // Number of entries in this constant pool (= maximum valid constant pool index)
   public int      getSize()                      { return getSize0            (constantPoolOop);        }
   public Class<?> getClassAt         (int index) { return getClassAt0         (constantPoolOop, index); }

--- a/src/java.base/share/classes/jdk/internal/reflect/ConstructorAccessor.java
+++ b/src/java.base/share/classes/jdk/internal/reflect/ConstructorAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,7 +32,7 @@ import java.lang.reflect.InvocationTargetException;
     configured with a (possibly dynamically-generated) class which
     implements this interface. */
 
-public interface ConstructorAccessor {
+public sealed interface ConstructorAccessor permits ConstructorAccessorImpl {
     /** Matches specification in {@link java.lang.reflect.Constructor} */
     public Object newInstance(Object[] args)
         throws InstantiationException,

--- a/src/java.base/share/classes/jdk/internal/reflect/ConstructorAccessorImpl.java
+++ b/src/java.base/share/classes/jdk/internal/reflect/ConstructorAccessorImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,8 @@ package jdk.internal.reflect;
 
 import java.lang.reflect.InvocationTargetException;
 
-abstract class ConstructorAccessorImpl implements ConstructorAccessor {
+abstract sealed class ConstructorAccessorImpl implements ConstructorAccessor
+        permits DirectConstructorHandleAccessor, DirectConstructorHandleAccessor.NativeAccessor, InstantiationExceptionConstructorAccessorImpl {
     /** Matches specification in {@link java.lang.reflect.Constructor} */
     public abstract Object newInstance(Object[] args)
         throws InstantiationException,

--- a/src/java.base/share/classes/jdk/internal/reflect/CsMethodAccessorAdapter.java
+++ b/src/java.base/share/classes/jdk/internal/reflect/CsMethodAccessorAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,7 +41,7 @@ import java.lang.reflect.Method;
  * the adapter method with the caller class parameter will be called
  * instead.
  */
-class CsMethodAccessorAdapter extends MethodAccessorImpl {
+final class CsMethodAccessorAdapter extends MethodAccessorImpl {
     private final Method csmAdapter;
     private final MethodAccessor accessor;
 

--- a/src/java.base/share/classes/jdk/internal/reflect/DirectConstructorHandleAccessor.java
+++ b/src/java.base/share/classes/jdk/internal/reflect/DirectConstructorHandleAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,7 +35,7 @@ import java.lang.reflect.InvocationTargetException;
 
 import static jdk.internal.reflect.MethodHandleAccessorFactory.SPECIALIZED_PARAM_COUNT;
 
-class DirectConstructorHandleAccessor extends ConstructorAccessorImpl {
+final class DirectConstructorHandleAccessor extends ConstructorAccessorImpl {
     static ConstructorAccessorImpl constructorAccessor(Constructor<?> ctor, MethodHandle target) {
         return new DirectConstructorHandleAccessor(ctor, target);
     }
@@ -94,7 +94,7 @@ class DirectConstructorHandleAccessor extends ConstructorAccessorImpl {
     /**
      * Invoke the constructor via native VM reflection
      */
-    static class NativeAccessor extends ConstructorAccessorImpl {
+    static final class NativeAccessor extends ConstructorAccessorImpl {
         private final Constructor<?> ctor;
         NativeAccessor(Constructor<?> ctor) {
             this.ctor = ctor;

--- a/src/java.base/share/classes/jdk/internal/reflect/DirectMethodHandleAccessor.java
+++ b/src/java.base/share/classes/jdk/internal/reflect/DirectMethodHandleAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,7 +42,7 @@ import java.lang.reflect.Modifier;
 import static java.lang.invoke.MethodType.genericMethodType;
 import static jdk.internal.reflect.MethodHandleAccessorFactory.LazyStaticHolder.JLIA;
 
-class DirectMethodHandleAccessor extends MethodAccessorImpl {
+final class DirectMethodHandleAccessor extends MethodAccessorImpl {
     /**
      * Creates a MethodAccessorImpl for a non-native method.
      */
@@ -203,7 +203,7 @@ class DirectMethodHandleAccessor extends MethodAccessorImpl {
     /**
      * Invoke the method via native VM reflection
      */
-    static class NativeAccessor extends MethodAccessorImpl {
+    static final class NativeAccessor extends MethodAccessorImpl {
         private final Method method;
         private final Method csmAdapter;
         private final boolean callerSensitive;

--- a/src/java.base/share/classes/jdk/internal/reflect/FieldAccessor.java
+++ b/src/java.base/share/classes/jdk/internal/reflect/FieldAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,7 @@ package jdk.internal.reflect;
     (possibly dynamically-generated) class which implements this
     interface. */
 
-public interface FieldAccessor {
+public sealed interface FieldAccessor permits FieldAccessorImpl {
     /** Matches specification in {@link java.lang.reflect.Field} */
     public Object get(Object obj) throws IllegalArgumentException;
 

--- a/src/java.base/share/classes/jdk/internal/reflect/FieldAccessorImpl.java
+++ b/src/java.base/share/classes/jdk/internal/reflect/FieldAccessorImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,7 @@ package jdk.internal.reflect;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 
-abstract class FieldAccessorImpl implements FieldAccessor {
+abstract sealed class FieldAccessorImpl implements FieldAccessor permits MethodHandleFieldAccessorImpl {
     protected final Field field;
 
     FieldAccessorImpl(Field field) {

--- a/src/java.base/share/classes/jdk/internal/reflect/InstantiationExceptionConstructorAccessorImpl.java
+++ b/src/java.base/share/classes/jdk/internal/reflect/InstantiationExceptionConstructorAccessorImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,7 @@ import java.lang.reflect.InvocationTargetException;
 /** Throws an InstantiationException with given error message upon
     newInstance() call */
 
-class InstantiationExceptionConstructorAccessorImpl
+final class InstantiationExceptionConstructorAccessorImpl
     extends ConstructorAccessorImpl {
     private final String message;
 

--- a/src/java.base/share/classes/jdk/internal/reflect/MethodAccessor.java
+++ b/src/java.base/share/classes/jdk/internal/reflect/MethodAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,7 +33,7 @@ import java.lang.reflect.InvocationTargetException;
     implements this interface.
 */
 
-public interface MethodAccessor {
+public sealed interface MethodAccessor permits MethodAccessorImpl {
     /** Matches specification in {@link java.lang.reflect.Method} */
     public Object invoke(Object obj, Object[] args)
         throws IllegalArgumentException, InvocationTargetException;

--- a/src/java.base/share/classes/jdk/internal/reflect/MethodAccessorImpl.java
+++ b/src/java.base/share/classes/jdk/internal/reflect/MethodAccessorImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,8 @@ import java.lang.reflect.InvocationTargetException;
     methods for java.lang.reflect.Method.invoke(). </P>
 */
 
-abstract class MethodAccessorImpl implements MethodAccessor {
+abstract sealed class MethodAccessorImpl implements MethodAccessor
+        permits DirectMethodHandleAccessor, DirectMethodHandleAccessor.NativeAccessor, CsMethodAccessorAdapter {
     /** Matches specification in {@link java.lang.reflect.Method} */
     public abstract Object invoke(Object obj, Object[] args)
         throws IllegalArgumentException, InvocationTargetException;

--- a/src/java.base/share/classes/jdk/internal/reflect/MethodHandleAccessorFactory.java
+++ b/src/java.base/share/classes/jdk/internal/reflect/MethodHandleAccessorFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -438,7 +438,7 @@ final class MethodHandleAccessorFactory {
     /*
      * Delay initializing these static fields until java.lang.invoke is fully initialized.
      */
-    static class LazyStaticHolder {
+    static final class LazyStaticHolder {
         static final JavaLangInvokeAccess JLIA = SharedSecrets.getJavaLangInvokeAccess();
     }
 

--- a/src/java.base/share/classes/jdk/internal/reflect/MethodHandleBooleanFieldAccessorImpl.java
+++ b/src/java.base/share/classes/jdk/internal/reflect/MethodHandleBooleanFieldAccessorImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,7 @@ import java.lang.invoke.MethodType;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 
-class MethodHandleBooleanFieldAccessorImpl extends MethodHandleFieldAccessorImpl {
+final class MethodHandleBooleanFieldAccessorImpl extends MethodHandleFieldAccessorImpl {
     static FieldAccessorImpl fieldAccessor(Field field, MethodHandle getter, MethodHandle setter, boolean isReadOnly) {
         boolean isStatic = Modifier.isStatic(field.getModifiers());
         if (isStatic) {

--- a/src/java.base/share/classes/jdk/internal/reflect/MethodHandleByteFieldAccessorImpl.java
+++ b/src/java.base/share/classes/jdk/internal/reflect/MethodHandleByteFieldAccessorImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,7 @@ import java.lang.invoke.MethodType;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 
-class MethodHandleByteFieldAccessorImpl extends MethodHandleFieldAccessorImpl {
+final class MethodHandleByteFieldAccessorImpl extends MethodHandleFieldAccessorImpl {
     static FieldAccessorImpl fieldAccessor(Field field, MethodHandle getter, MethodHandle setter, boolean isReadOnly) {
         boolean isStatic = Modifier.isStatic(field.getModifiers());
         if (isStatic) {

--- a/src/java.base/share/classes/jdk/internal/reflect/MethodHandleCharacterFieldAccessorImpl.java
+++ b/src/java.base/share/classes/jdk/internal/reflect/MethodHandleCharacterFieldAccessorImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,7 @@ import java.lang.invoke.MethodType;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 
-class MethodHandleCharacterFieldAccessorImpl extends MethodHandleFieldAccessorImpl {
+final class MethodHandleCharacterFieldAccessorImpl extends MethodHandleFieldAccessorImpl {
     static FieldAccessorImpl fieldAccessor(Field field, MethodHandle getter, MethodHandle setter, boolean isReadOnly) {
         boolean isStatic = Modifier.isStatic(field.getModifiers());
         if (isStatic) {

--- a/src/java.base/share/classes/jdk/internal/reflect/MethodHandleDoubleFieldAccessorImpl.java
+++ b/src/java.base/share/classes/jdk/internal/reflect/MethodHandleDoubleFieldAccessorImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,7 @@ import java.lang.invoke.MethodType;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 
-class MethodHandleDoubleFieldAccessorImpl extends MethodHandleFieldAccessorImpl {
+final class MethodHandleDoubleFieldAccessorImpl extends MethodHandleFieldAccessorImpl {
     static FieldAccessorImpl fieldAccessor(Field field, MethodHandle getter, MethodHandle setter, boolean isReadOnly) {
         boolean isStatic = Modifier.isStatic(field.getModifiers());
         if (isStatic) {

--- a/src/java.base/share/classes/jdk/internal/reflect/MethodHandleFieldAccessorImpl.java
+++ b/src/java.base/share/classes/jdk/internal/reflect/MethodHandleFieldAccessorImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,16 @@ import java.lang.invoke.MethodHandle;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 
-abstract class MethodHandleFieldAccessorImpl extends FieldAccessorImpl {
+abstract sealed class MethodHandleFieldAccessorImpl extends FieldAccessorImpl
+        permits MethodHandleBooleanFieldAccessorImpl,
+                MethodHandleCharacterFieldAccessorImpl,
+                MethodHandleByteFieldAccessorImpl,
+                MethodHandleShortFieldAccessorImpl,
+                MethodHandleIntegerFieldAccessorImpl,
+                MethodHandleLongFieldAccessorImpl,
+                MethodHandleFloatFieldAccessorImpl,
+                MethodHandleDoubleFieldAccessorImpl,
+                MethodHandleObjectFieldAccessorImpl {
     private static final int IS_READ_ONLY_BIT = 0x0001;
     private static final int IS_STATIC_BIT = 0x0002;
     private static final int NONZERO_BIT = 0x8000;

--- a/src/java.base/share/classes/jdk/internal/reflect/MethodHandleFloatFieldAccessorImpl.java
+++ b/src/java.base/share/classes/jdk/internal/reflect/MethodHandleFloatFieldAccessorImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,7 @@ import java.lang.invoke.MethodType;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 
-class MethodHandleFloatFieldAccessorImpl extends MethodHandleFieldAccessorImpl {
+final class MethodHandleFloatFieldAccessorImpl extends MethodHandleFieldAccessorImpl {
     static FieldAccessorImpl fieldAccessor(Field field, MethodHandle getter, MethodHandle setter, boolean isReadOnly) {
         boolean isStatic = Modifier.isStatic(field.getModifiers());
         if (isStatic) {

--- a/src/java.base/share/classes/jdk/internal/reflect/MethodHandleIntegerFieldAccessorImpl.java
+++ b/src/java.base/share/classes/jdk/internal/reflect/MethodHandleIntegerFieldAccessorImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,7 @@ import java.lang.invoke.MethodType;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 
-class MethodHandleIntegerFieldAccessorImpl extends MethodHandleFieldAccessorImpl {
+final class MethodHandleIntegerFieldAccessorImpl extends MethodHandleFieldAccessorImpl {
     static FieldAccessorImpl fieldAccessor(Field field, MethodHandle getter, MethodHandle setter, boolean isReadOnly) {
         boolean isStatic = Modifier.isStatic(field.getModifiers());
         if (isStatic) {

--- a/src/java.base/share/classes/jdk/internal/reflect/MethodHandleLongFieldAccessorImpl.java
+++ b/src/java.base/share/classes/jdk/internal/reflect/MethodHandleLongFieldAccessorImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,7 @@ import java.lang.invoke.MethodType;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 
-class MethodHandleLongFieldAccessorImpl extends MethodHandleFieldAccessorImpl {
+final class MethodHandleLongFieldAccessorImpl extends MethodHandleFieldAccessorImpl {
     static FieldAccessorImpl fieldAccessor(Field field, MethodHandle getter, MethodHandle setter, boolean isReadOnly) {
         boolean isStatic = Modifier.isStatic(field.getModifiers());
         if (isStatic) {

--- a/src/java.base/share/classes/jdk/internal/reflect/MethodHandleObjectFieldAccessorImpl.java
+++ b/src/java.base/share/classes/jdk/internal/reflect/MethodHandleObjectFieldAccessorImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,7 @@ import java.lang.invoke.MethodType;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 
-class MethodHandleObjectFieldAccessorImpl extends MethodHandleFieldAccessorImpl {
+final class MethodHandleObjectFieldAccessorImpl extends MethodHandleFieldAccessorImpl {
     static FieldAccessorImpl fieldAccessor(Field field, MethodHandle getter, MethodHandle setter, boolean isReadOnly) {
         boolean isStatic = Modifier.isStatic(field.getModifiers());
         if (isStatic) {

--- a/src/java.base/share/classes/jdk/internal/reflect/MethodHandleShortFieldAccessorImpl.java
+++ b/src/java.base/share/classes/jdk/internal/reflect/MethodHandleShortFieldAccessorImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,7 @@ import java.lang.invoke.MethodType;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 
-class MethodHandleShortFieldAccessorImpl extends MethodHandleFieldAccessorImpl {
+final class MethodHandleShortFieldAccessorImpl extends MethodHandleFieldAccessorImpl {
     static FieldAccessorImpl fieldAccessor(Field field, MethodHandle getter, MethodHandle setter, boolean isReadOnly) {
         boolean isStatic = Modifier.isStatic(field.getModifiers());
         if (isStatic) {

--- a/src/java.base/share/classes/jdk/internal/reflect/Reflection.java
+++ b/src/java.base/share/classes/jdk/internal/reflect/Reflection.java
@@ -41,7 +41,7 @@ import jdk.internal.vm.annotation.IntrinsicCandidate;
 /** Common utility routines used by both java.lang and
     java.lang.reflect */
 
-public class Reflection {
+public final class Reflection {
 
     /** Used to filter out fields and methods from certain classes from public
         view, where they are sensitive or they may contain VM-internal objects.

--- a/src/java.base/share/classes/jdk/internal/reflect/ReflectionFactory.java
+++ b/src/java.base/share/classes/jdk/internal/reflect/ReflectionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,7 +60,7 @@ import jdk.internal.vm.annotation.Stable;
     {@link jdk.internal.misc.Unsafe}. </P>
 */
 
-public class ReflectionFactory {
+public final class ReflectionFactory {
 
     private static final ReflectionFactory soleInstance = new ReflectionFactory();
 

--- a/test/hotspot/jtreg/runtime/classFileParserBug/FakeMethodAcc.java
+++ b/test/hotspot/jtreg/runtime/classFileParserBug/FakeMethodAcc.java
@@ -31,7 +31,7 @@
 
 /*
  * Test that trying to create a sub-type of a 'magic' jdk.internal.reflect
- * class should fail with an IllegalAccessError exception.
+ * class should fail with an IncompatibleClassChangeError exception.
 */
 public class FakeMethodAcc {
     public static void main(String args[]) throws Throwable {
@@ -40,8 +40,8 @@ public class FakeMethodAcc {
         try {
             Class newClass = Class.forName("fakeMethodAccessor");
             throw new RuntimeException(
-                "Missing expected IllegalAccessError exception");
-        } catch (java.lang.IllegalAccessError e) {
+                "Missing expected IncompatibleClassChangeError exception");
+        } catch (java.lang.IncompatibleClassChangeError e) {
         }
     }
 }


### PR DESCRIPTION
I have discussed with @liach that we can improve the code of jdk.internal by adding final and sealed. 

I will submit a series of PRs to do this, and this is one of them, `jdk.internal.reflect`

Adding final allows JIT to do more optimization and remove virtual function calls. Adding sealed makes the inheritance system clearer, and JIT may also make optimizations in the future.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24900/head:pull/24900` \
`$ git checkout pull/24900`

Update a local copy of the PR: \
`$ git checkout pull/24900` \
`$ git pull https://git.openjdk.org/jdk.git pull/24900/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24900`

View PR using the GUI difftool: \
`$ git pr show -t 24900`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24900.diff">https://git.openjdk.org/jdk/pull/24900.diff</a>

</details>
