### PR TITLE
8355648: Thread.SpinAcquire()'s lock name parameter is not used

### DIFF
--- a/src/hotspot/share/jfr/utilities/jfrSpinlockHelper.hpp
+++ b/src/hotspot/share/jfr/utilities/jfrSpinlockHelper.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,11 +33,7 @@ class JfrSpinlockHelper {
 
  public:
   JfrSpinlockHelper(volatile int* lock) : _lock(lock) {
-    Thread::SpinAcquire(_lock, nullptr);
-  }
-
-  JfrSpinlockHelper(volatile int* const lock, const char* name) : _lock(lock) {
-    Thread::SpinAcquire(_lock, name);
+    Thread::SpinAcquire(_lock);
   }
 
   ~JfrSpinlockHelper() {

--- a/src/hotspot/share/runtime/objectMonitor.cpp
+++ b/src/hotspot/share/runtime/objectMonitor.cpp
@@ -1805,7 +1805,7 @@ void ObjectMonitor::wait(jlong millis, bool interruptible, TRAPS) {
   // returns because of a timeout of interrupt.  Contention is exceptionally rare
   // so we use a simple spin-lock instead of a heavier-weight blocking lock.
 
-  Thread::SpinAcquire(&_wait_set_lock, "wait_set - add");
+  Thread::SpinAcquire(&_wait_set_lock);
   add_waiter(&node);
   Thread::SpinRelease(&_wait_set_lock);
 
@@ -1864,7 +1864,7 @@ void ObjectMonitor::wait(jlong millis, bool interruptible, TRAPS) {
     // That is, we fail toward safety.
 
     if (node.TState == ObjectWaiter::TS_WAIT) {
-      Thread::SpinAcquire(&_wait_set_lock, "wait_set - unlink");
+      Thread::SpinAcquire(&_wait_set_lock);
       if (node.TState == ObjectWaiter::TS_WAIT) {
         dequeue_specific_waiter(&node);       // unlink from wait_set
         assert(!node._notified, "invariant");
@@ -1980,7 +1980,7 @@ void ObjectMonitor::wait(jlong millis, bool interruptible, TRAPS) {
 
 bool ObjectMonitor::notify_internal(JavaThread* current) {
   bool did_notify = false;
-  Thread::SpinAcquire(&_wait_set_lock, "wait_set - notify");
+  Thread::SpinAcquire(&_wait_set_lock);
   ObjectWaiter* iterator = dequeue_waiter();
   if (iterator != nullptr) {
     guarantee(iterator->TState == ObjectWaiter::TS_WAIT, "invariant");
@@ -2120,7 +2120,7 @@ void ObjectMonitor::vthread_wait(JavaThread* current, jlong millis) {
   // returns because of a timeout or interrupt.  Contention is exceptionally rare
   // so we use a simple spin-lock instead of a heavier-weight blocking lock.
 
-  Thread::SpinAcquire(&_wait_set_lock, "wait_set - add");
+  Thread::SpinAcquire(&_wait_set_lock);
   add_waiter(node);
   Thread::SpinRelease(&_wait_set_lock);
 
@@ -2143,7 +2143,7 @@ bool ObjectMonitor::vthread_wait_reenter(JavaThread* current, ObjectWaiter* node
   // need to check if we were interrupted or the wait timed-out, and
   // in that case remove ourselves from the _wait_set queue.
   if (node->TState == ObjectWaiter::TS_WAIT) {
-    Thread::SpinAcquire(&_wait_set_lock, "wait_set - unlink");
+    Thread::SpinAcquire(&_wait_set_lock);
     if (node->TState == ObjectWaiter::TS_WAIT) {
       dequeue_specific_waiter(node);       // unlink from wait_set
       assert(!node->_notified, "invariant");

--- a/src/hotspot/share/runtime/park.cpp
+++ b/src/hotspot/share/runtime/park.cpp
@@ -60,7 +60,7 @@ ParkEvent * ParkEvent::Allocate (Thread * t) {
   // Using a spin lock since we are part of the mutex impl.
   // 8028280: using concurrent free list without memory management can leak
   // pretty badly it turns out.
-  Thread::SpinAcquire(&ListLock, "ParkEventFreeListAllocate");
+  Thread::SpinAcquire(&ListLock);
   {
     ev = FreeList;
     if (ev != nullptr) {
@@ -88,7 +88,7 @@ void ParkEvent::Release (ParkEvent * ev) {
   ev->AssociatedWith = nullptr ;
   // Note that if we didn't have the TSM/immortal constraint, then
   // when reattaching we could trim the list.
-  Thread::SpinAcquire(&ListLock, "ParkEventFreeListRelease");
+  Thread::SpinAcquire(&ListLock);
   {
     ev->FreeNext = FreeList;
     FreeList = ev;

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -562,7 +562,7 @@ bool Thread::set_as_starting_thread(JavaThread* jt) {
 // short-duration critical sections where we're concerned
 // about native mutex_t or HotSpot Mutex:: latency.
 
-void Thread::SpinAcquire(volatile int * adr, const char * LockName) {
+void Thread::SpinAcquire(volatile int * adr) {
   if (Atomic::cmpxchg(adr, 0, 1) == 0) {
     return;   // normal fast-path return
   }

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -605,7 +605,7 @@ protected:
 
   // Low-level leaf-lock primitives used to implement synchronization.
   // Not for general synchronization use.
-  static void SpinAcquire(volatile int * Lock, const char * Name);
+  static void SpinAcquire(volatile int * Lock);
   static void SpinRelease(volatile int * Lock);
 
 #if defined(__APPLE__) && defined(AARCH64)


### PR DESCRIPTION
Please review this trivial change that removes unused lock name parameter.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8355648](https://bugs.openjdk.org/browse/JDK-8355648): Thread.SpinAcquire()'s lock name parameter is not used (**Enhancement** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24901/head:pull/24901` \
`$ git checkout pull/24901`

Update a local copy of the PR: \
`$ git checkout pull/24901` \
`$ git pull https://git.openjdk.org/jdk.git pull/24901/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24901`

View PR using the GUI difftool: \
`$ git pr show -t 24901`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24901.diff">https://git.openjdk.org/jdk/pull/24901.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24901#issuecomment-2832833534)
</details>
