### PR TITLE
8341275: Explicit counter support for Code attribute building

### DIFF
--- a/src/java.base/share/classes/java/lang/classfile/CodeBuilder.java
+++ b/src/java.base/share/classes/java/lang/classfile/CodeBuilder.java
@@ -3416,4 +3416,32 @@ public sealed interface CodeBuilder
         }
         return tableswitch(low, high, defaultTarget, cases);
     }
+
+    // advanced user hints
+
+    /**
+     * Provides this builder with explicit {@code max_stack} and {@code
+     * max_locals} values when {@link StackMapsOption#DROP_STACK_MAPS} is set.
+     * No automatic counting for the two max values will be done; the resulting
+     * {@code Code} attribute will instead use the provided values.
+     * <p>
+     * This call does not affect the two max values if any of the following is
+     * true:
+     * <ul>
+     * <li>{@code DROP_STACK_MAPS} is not set;
+     * <li>this builder does not build a complete {@code Code} attribute;
+     * <li>this builder's output is redirected to a {@link CodeTransform};
+     * <li>the built {@code Code} attribute is subsequently inflated in a
+     * transformation;
+     * </ul>
+     * <p>
+     * This call always validates the provided max values.
+     *
+     * @param maxStack the max stack slots used by this method body
+     * @param maxLocals the max local variable slots used by this method body
+     * @return this builder
+     * @throws IllegalArgumentException if any of the values is not a {@code u2}
+     * @since 25
+     */
+    CodeBuilder withExplicitStackAndLocals(int maxStack, int maxLocals);
 }

--- a/src/java.base/share/classes/java/lang/runtime/SwitchBootstraps.java
+++ b/src/java.base/share/classes/java/lang/runtime/SwitchBootstraps.java
@@ -511,8 +511,8 @@ public final class SwitchBootstraps {
             if (labelConstants.length == 0) {
                 cb.loadConstant(0)
                   .ireturn()
-                  .with(StackMapTableAttribute.of(stackMapFrames));
-                DirectCodeBuilder.withMaxs(cb, 2, locals.size()); // checkIndex uses 2
+                  .with(StackMapTableAttribute.of(stackMapFrames))
+                  .withExplicitStackAndLocals(2, locals.size()); // checkIndex uses 2
                 return;
             }
             cb.iload(RESTART_IDX);
@@ -712,8 +712,8 @@ public final class SwitchBootstraps {
             cb.labelBinding(dflt)
               .loadConstant(labelConstants.length)
               .ireturn()
-              .with(StackMapTableAttribute.of(stackMapFrames));
-            DirectCodeBuilder.withMaxs(cb, 3, locals.size()); // enum labels use 3 stack, others use 2
+              .with(StackMapTableAttribute.of(stackMapFrames))
+              .withExplicitStackAndLocals(3, locals.size()); // enum labels use 3 stack, others use 2
         };
     }
 

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/BytecodeHelpers.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/BytecodeHelpers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2024, Alibaba Group Holding Limited. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -54,8 +54,12 @@ public class BytecodeHelpers {
         return new IllegalArgumentException(String.format("convert %s -> %s", from, to));
     }
 
+    public static IllegalArgumentException u2OutOfBounds(int u2) {
+        return new IllegalArgumentException("Invalid value for u2:".concat(Integer.toString(u2)));
+    }
+
     public static IllegalArgumentException slotOutOfBounds(int slot) {
-        return new IllegalArgumentException("Invalid slot index :".concat(Integer.toString(slot)));
+        return new IllegalArgumentException("Invalid slot index:".concat(Integer.toString(slot)));
     }
 
     public static IllegalArgumentException slotOutOfBounds(Opcode opcode, int slot) {
@@ -435,6 +439,11 @@ public class BytecodeHelpers {
     public static void validateSlot(int slot) {
         if ((slot & ~0xFFFF) != 0)
             throw slotOutOfBounds(slot);
+    }
+
+    public static void validateU2(int u2) {
+        if ((u2 & ~0xFFFF) != 0)
+            throw u2OutOfBounds(u2);
     }
 
     public static boolean validateAndIsWideIinc(int slot, int val) {

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/DirectCodeBuilder.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/DirectCodeBuilder.java
@@ -174,10 +174,15 @@ public final class DirectCodeBuilder
         return methodInfo;
     }
 
-    public static void withMaxs(CodeBuilder cob, int stacks, int locals) {
-        var dcb = (DirectCodeBuilder) cob;
-        dcb.maxStackHint = stacks;
-        dcb.maxLocalsHint = locals;
+    @Override
+    public CodeBuilder withExplicitStackAndLocals(int maxStack, int maxLocals) {
+        BytecodeHelpers.validateU2(maxStack);
+        BytecodeHelpers.validateU2(maxLocals);
+        if (context.dropStackMaps()) {
+            this.maxStackHint = maxStack;
+            this.maxLocalsHint = maxLocals;
+        }
+        return this;
     }
 
     private UnboundAttribute<CodeAttribute> content = null;

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/NonterminalCodeBuilder.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/NonterminalCodeBuilder.java
@@ -62,4 +62,11 @@ public abstract sealed class NonterminalCodeBuilder implements CodeBuilder
     public Label newLabel() {
         return terminal.newLabel();
     }
+
+    @Override
+    public CodeBuilder withExplicitStackAndLocals(int maxStack, int maxLocals) {
+        BytecodeHelpers.validateU2(maxStack);
+        BytecodeHelpers.validateU2(maxLocals);
+        return this;
+    }
 }

--- a/test/jdk/jdk/classfile/BuilderExplicitMaxsTest.java
+++ b/test/jdk/jdk/classfile/BuilderExplicitMaxsTest.java
@@ -64,9 +64,10 @@ class BuilderExplicitMaxsTest {
     @ParameterizedTest
     void testValidArgs(ClassFile.StackMapsOption stackMapsOption, CodeBuilderType builderType) {
         var cc = ClassFile.of(stackMapsOption);
-        var bytes = cc.build(ClassDesc.of("Foo"), builderType.asClassHandler("foo", MTD_void, 0, cob -> cob
-                .return_()
-                .withExplicitStackAndLocals(2, 3)));
+        var bytes = cc.build(ClassDesc.of("Foo"),
+                             builderType.asClassHandler("foo", MTD_void, 0, cob ->
+                                     cob.return_()
+                                        .withExplicitStackAndLocals(2, 3)));
         var clz = ClassFile.of().parse(bytes);
         var code = clz.methods().getFirst().findAttribute(Attributes.code()).orElseThrow();
         if (builderType.terminal && stackMapsOption == ClassFile.StackMapsOption.DROP_STACK_MAPS) {
@@ -82,11 +83,15 @@ class BuilderExplicitMaxsTest {
     @ParameterizedTest
     void testInvalidArgs(ClassFile.StackMapsOption stackMapsOption, CodeBuilderType builderType) {
         var cc = ClassFile.of(stackMapsOption);
-        assertThrows(IllegalArgumentException.class, () -> cc.build(ClassDesc.of("Foo"), builderType.asClassHandler("foo", MTD_void, 0, cob -> cob
-                .return_()
-                .withExplicitStackAndLocals(-1, 2))));
-        assertThrows(IllegalArgumentException.class, () -> cc.build(ClassDesc.of("Foo"), builderType.asClassHandler("foo", MTD_void, 0, cob -> cob
-                .return_()
-                .withExplicitStackAndLocals(2, 100000))));
+        assertThrows(IllegalArgumentException.class, () ->
+                cc.build(ClassDesc.of("Foo"),
+                         builderType.asClassHandler("foo", MTD_void, 0, cob ->
+                                 cob.return_()
+                                    .withExplicitStackAndLocals(-1, 2))));
+        assertThrows(IllegalArgumentException.class, () ->
+                cc.build(ClassDesc.of("Foo"),
+                         builderType.asClassHandler("foo", MTD_void, 0, cob ->
+                                 cob.return_()
+                                    .withExplicitStackAndLocals(2, 100000))));
     }
 }

--- a/test/jdk/jdk/classfile/BuilderExplicitMaxsTest.java
+++ b/test/jdk/jdk/classfile/BuilderExplicitMaxsTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8341275
+ * @summary Testing CodeBuilder::withExplicitStackAndLocals
+ * @run junit BuilderExplicitMaxsTest
+ */
+
+import java.lang.classfile.*;
+import java.lang.constant.ClassDesc;
+import java.util.Arrays;
+import java.util.stream.Stream;
+
+import helpers.CodeBuilderType;
+import jdk.internal.classfile.impl.BufferedCodeBuilder;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static java.lang.constant.ConstantDescs.MTD_void;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Testing explicit max stacks and locals setter. Configurations:
+ * <ul>
+ * <li>Builder Type: Direct, Buffered, Block, Chained
+ * <li>Argument validity
+ * <li>Whether DROP_STACK_MAPS is set
+ * </ul>
+ */
+class BuilderExplicitMaxsTest {
+
+    static Stream<Arguments> arguments() {
+        return Arrays.stream(CodeBuilderType.values()).mapMulti((t, sink) -> {
+            sink.accept(Arguments.of(ClassFile.StackMapsOption.DROP_STACK_MAPS, t));
+            sink.accept(Arguments.of(ClassFile.StackMapsOption.STACK_MAPS_WHEN_REQUIRED, t));
+        });
+    }
+
+    @MethodSource("arguments")
+    @ParameterizedTest
+    void testValidArgs(ClassFile.StackMapsOption stackMapsOption, CodeBuilderType builderType) {
+        var cc = ClassFile.of(stackMapsOption);
+        var bytes = cc.build(ClassDesc.of("Foo"), builderType.asClassHandler("foo", MTD_void, 0, cob -> cob
+                .return_()
+                .withExplicitStackAndLocals(2, 3)));
+        var clz = ClassFile.of().parse(bytes);
+        var code = clz.methods().getFirst().findAttribute(Attributes.code()).orElseThrow();
+        if (builderType.terminal && stackMapsOption == ClassFile.StackMapsOption.DROP_STACK_MAPS) {
+            assertEquals(2, code.maxStack());
+            assertEquals(3, code.maxLocals());
+        } else {
+            assertEquals(0, code.maxStack());
+            assertEquals(1, code.maxLocals());
+        }
+    }
+
+    @MethodSource("arguments")
+    @ParameterizedTest
+    void testInvalidArgs(ClassFile.StackMapsOption stackMapsOption, CodeBuilderType builderType) {
+        var cc = ClassFile.of(stackMapsOption);
+        assertThrows(IllegalArgumentException.class, () -> cc.build(ClassDesc.of("Foo"), builderType.asClassHandler("foo", MTD_void, 0, cob -> cob
+                .return_()
+                .withExplicitStackAndLocals(-1, 2))));
+        assertThrows(IllegalArgumentException.class, () -> cc.build(ClassDesc.of("Foo"), builderType.asClassHandler("foo", MTD_void, 0, cob -> cob
+                .return_()
+                .withExplicitStackAndLocals(2, 100000))));
+    }
+}

--- a/test/jdk/jdk/classfile/BuilderParamTest.java
+++ b/test/jdk/jdk/classfile/BuilderParamTest.java
@@ -46,18 +46,20 @@ class BuilderParamTest {
     @ParameterizedTest
     void test(CodeBuilderType type) {
         var cc = ClassFile.of();
-        cc.build(ClassDesc.of("Foo"), type.asClassHandler("foo", MethodTypeDesc.ofDescriptor("(IJI)V"), 0, xb -> {
-            assertEquals(0, xb.receiverSlot(), "this");
-            assertEquals(1, xb.parameterSlot(0), "int");
-            assertEquals(2, xb.parameterSlot(1), "long");
-            assertEquals(4, xb.parameterSlot(2), "int");
-            xb.return_();
-        }));
-        cc.build(ClassDesc.of("Foo"), type.asClassHandler("foo", MethodTypeDesc.ofDescriptor("(IJI)V"), ACC_STATIC, xb -> {
-            assertEquals(0, xb.parameterSlot(0), "int");
-            assertEquals(1, xb.parameterSlot(1), "long");
-            assertEquals(3, xb.parameterSlot(2), "int");
-            xb.return_();
-        }));
+        cc.build(ClassDesc.of("Foo"),
+                 type.asClassHandler("foo", MethodTypeDesc.ofDescriptor("(IJI)V"), 0, xb -> {
+                     assertEquals(0, xb.receiverSlot(), "this");
+                     assertEquals(1, xb.parameterSlot(0), "int");
+                     assertEquals(2, xb.parameterSlot(1), "long");
+                     assertEquals(4, xb.parameterSlot(2), "int");
+                     xb.return_();
+                 }));
+        cc.build(ClassDesc.of("Foo"),
+                 type.asClassHandler("foo", MethodTypeDesc.ofDescriptor("(IJI)V"), ACC_STATIC, xb -> {
+                     assertEquals(0, xb.parameterSlot(0), "int");
+                     assertEquals(1, xb.parameterSlot(1), "long");
+                     assertEquals(3, xb.parameterSlot(2), "int");
+                     xb.return_();
+                 }));
     }
 }

--- a/test/jdk/jdk/classfile/BuilderParamTest.java
+++ b/test/jdk/jdk/classfile/BuilderParamTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,9 +30,11 @@ import java.lang.constant.ClassDesc;
 import java.lang.constant.MethodTypeDesc;
 
 import java.lang.classfile.ClassFile;
-import org.junit.jupiter.api.Test;
 
-import static java.lang.constant.ConstantDescs.CD_void;
+import helpers.CodeBuilderType;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
 import static java.lang.classfile.ClassFile.ACC_STATIC;
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -40,27 +42,22 @@ import static org.junit.jupiter.api.Assertions.*;
  * BuilderParamTest
  */
 class BuilderParamTest {
-    @Test
-    void testDirectBuilder() {
+    @EnumSource
+    @ParameterizedTest
+    void test(CodeBuilderType type) {
         var cc = ClassFile.of();
-        cc.build(ClassDesc.of("Foo"), cb -> {
-            cb.withMethod("foo", MethodTypeDesc.ofDescriptor("(IJI)V"), 0,
-                          mb -> mb.withCode(xb -> {
-                assertEquals(xb.receiverSlot(), 0);
-                assertEquals(xb.parameterSlot(0), 1);
-                assertEquals(xb.parameterSlot(1), 2);
-                assertEquals(xb.parameterSlot(2), 4);
-                xb.return_();
-            }));
-        });
-        cc.build(ClassDesc.of("Foo"), cb -> {
-            cb.withMethod("foo", MethodTypeDesc.ofDescriptor("(IJI)V"), ACC_STATIC,
-                          mb -> mb.withCode(xb -> {
-                              assertEquals(xb.parameterSlot(0), 0);
-                              assertEquals(xb.parameterSlot(1), 1);
-                              assertEquals(xb.parameterSlot(2), 3);
-                              xb.return_();
-                          }));
-        });
+        cc.build(ClassDesc.of("Foo"), type.asClassHandler("foo", MethodTypeDesc.ofDescriptor("(IJI)V"), 0, xb -> {
+            assertEquals(0, xb.receiverSlot(), "this");
+            assertEquals(1, xb.parameterSlot(0), "int");
+            assertEquals(2, xb.parameterSlot(1), "long");
+            assertEquals(4, xb.parameterSlot(2), "int");
+            xb.return_();
+        }));
+        cc.build(ClassDesc.of("Foo"), type.asClassHandler("foo", MethodTypeDesc.ofDescriptor("(IJI)V"), ACC_STATIC, xb -> {
+            assertEquals(0, xb.parameterSlot(0), "int");
+            assertEquals(1, xb.parameterSlot(1), "long");
+            assertEquals(3, xb.parameterSlot(2), "int");
+            xb.return_();
+        }));
     }
 }

--- a/test/jdk/jdk/classfile/helpers/CodeBuilderType.java
+++ b/test/jdk/jdk/classfile/helpers/CodeBuilderType.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package helpers;
+
+import java.lang.classfile.*;
+import java.lang.constant.ClassDesc;
+import java.lang.constant.MethodTypeDesc;
+import java.util.function.Consumer;
+
+import jdk.internal.classfile.impl.BlockCodeBuilderImpl;
+import jdk.internal.classfile.impl.BufferedCodeBuilder;
+import jdk.internal.classfile.impl.ChainedCodeBuilder;
+import jdk.internal.classfile.impl.DirectCodeBuilder;
+
+/**
+ * A utility to test behavior of an API across all implementations of CodeBuilder.
+ */
+public enum CodeBuilderType {
+    DIRECT(DirectCodeBuilder.class, true) {
+        @Override
+        Consumer<ClassBuilder> asClassHandler0(String name, MethodTypeDesc mtd, int flags, Consumer<CodeBuilder> codeHandler) {
+            return clb -> clb.withMethodBody(name, mtd, flags, codeHandler);
+        }
+    },
+    BUFFERED(BufferedCodeBuilder.class, true) {
+        @Override
+        Consumer<ClassBuilder> asClassHandler0(String name, MethodTypeDesc mtd, int flags, Consumer<CodeBuilder> codeHandler) {
+            var bytes = ClassFile.of().build(ClassDesc.of("Dummy"), clb -> clb.withMethod(name, mtd, flags, _ -> {
+            }));
+            var mm = ClassFile.of().parse(bytes).methods().getFirst();
+            return clb -> clb.transformMethod(mm, new MethodTransform() {
+                @Override
+                public void accept(MethodBuilder builder, MethodElement element) {
+                }
+
+                @Override
+                public void atEnd(MethodBuilder builder) {
+                    builder.withCode(codeHandler);
+                }
+            }.andThen(MethodTransform.ACCEPT_ALL));
+        }
+    },
+    CHAINED(ChainedCodeBuilder.class, false) {
+        @Override
+        Consumer<ClassBuilder> asClassHandler0(String name, MethodTypeDesc mtd, int flags, Consumer<CodeBuilder> codeHandler) {
+            return clb -> clb.withMethodBody(name, mtd, flags, cob -> cob.transforming(CodeTransform.ACCEPT_ALL, codeHandler));
+        }
+    },
+    BLOCK(BlockCodeBuilderImpl.class, false) {
+        @Override
+        Consumer<ClassBuilder> asClassHandler0(String name, MethodTypeDesc mtd, int flags, Consumer<CodeBuilder> codeHandler) {
+            return clb -> clb.withMethodBody(name, mtd, flags, cob -> cob.block(codeHandler::accept));
+        }
+    };
+
+    public final Class<? extends CodeBuilder> clz;
+    public final boolean terminal;
+
+    CodeBuilderType(Class<? extends CodeBuilder> clz, boolean operational) {
+        this.clz = clz;
+        this.terminal = operational;
+    }
+
+    public Consumer<ClassBuilder> asClassHandler(String name, MethodTypeDesc mtd, int flags, Consumer<CodeBuilder> codeHandler) {
+        Consumer<CodeBuilder> actualHandler = cob -> {
+            assert clz.isInstance(cob) : cob.getClass() + " != " + clz;
+            codeHandler.accept(cob);
+        };
+        return asClassHandler0(name, mtd, flags, actualHandler);
+    }
+    abstract Consumer<ClassBuilder> asClassHandler0(String name, MethodTypeDesc mtd, int flags, Consumer<CodeBuilder> codeHandler);
+}


### PR DESCRIPTION
Internal explicit counter support for Code max_stack and max_locals has been already added in #24807. Since that example works well, we may consider opening this functionality up to general users under strict restrictions.

This is an advanced API; thus, I chose a more complex name `withExplicitStackAndLocals` that discourages accidental use, and indicates the exact order of stack and locals arguments. For integrity, the argument checks are unconditional. And this is also barred behind `DROP_STACK_MAPS` advanced option.

I have enhanced the tests with a `CodeBuilderType` utility to test all types of code builders; it is already effective at increasing coverage in some of our existing tests that only cover DirectCodeBuilder, and simplify other tests. It is particularly helpful for my new `BuilderExplicitMaxsTest`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Change requires CSR request [JDK-8355653](https://bugs.openjdk.org/browse/JDK-8355653) to be approved
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8341275](https://bugs.openjdk.org/browse/JDK-8341275): Explicit counter support for Code attribute building (**Enhancement** - P4)
 * [JDK-8355653](https://bugs.openjdk.org/browse/JDK-8355653): Explicit counter support for Code attribute building (**CSR**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24903/head:pull/24903` \
`$ git checkout pull/24903`

Update a local copy of the PR: \
`$ git checkout pull/24903` \
`$ git pull https://git.openjdk.org/jdk.git pull/24903/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24903`

View PR using the GUI difftool: \
`$ git pr show -t 24903`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24903.diff">https://git.openjdk.org/jdk/pull/24903.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24903#issuecomment-2832897956)
</details>
