### PR TITLE
8355657: RISC-V: Improve PrintOptoAssembly output of vector-scalar instructions

### DIFF
--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -415,11 +415,11 @@ instruct vadd_fp_masked(vReg dst_src1, vReg src2, vRegMask_V0 v0) %{
 
 // vector-immediate add (unpredicated)
 
-instruct vaddI_vi(vReg dst, vReg src1, immI5 con) %{
+instruct vadd_vi(vReg dst, vReg src1, immI5 con) %{
   match(Set dst (AddVB src1 (Replicate con)));
   match(Set dst (AddVS src1 (Replicate con)));
   match(Set dst (AddVI src1 (Replicate con)));
-  format %{ "vaddI_vi $dst, $src1, $con" %}
+  format %{ "vadd_vi $dst, $src1, $con" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -444,11 +444,11 @@ instruct vaddL_vi(vReg dst, vReg src1, immL5 con) %{
 
 // vector-scalar add (unpredicated)
 
-instruct vaddI_vx(vReg dst, vReg src1, iRegIorL2I src2) %{
+instruct vadd_vx(vReg dst, vReg src1, iRegIorL2I src2) %{
   match(Set dst (AddVB src1 (Replicate src2)));
   match(Set dst (AddVS src1 (Replicate src2)));
   match(Set dst (AddVI src1 (Replicate src2)));
-  format %{ "vaddI_vx $dst, $src1, $src2" %}
+  format %{ "vadd_vx $dst, $src1, $src2" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -473,11 +473,11 @@ instruct vaddL_vx(vReg dst, vReg src1, iRegL src2) %{
 
 // vector-immediate add (predicated)
 
-instruct vaddI_vi_masked(vReg dst_src, immI5 con, vRegMask_V0 v0) %{
+instruct vadd_vi_masked(vReg dst_src, immI5 con, vRegMask_V0 v0) %{
   match(Set dst_src (AddVB (Binary dst_src (Replicate con)) v0));
   match(Set dst_src (AddVS (Binary dst_src (Replicate con)) v0));
   match(Set dst_src (AddVI (Binary dst_src (Replicate con)) v0));
-  format %{ "vaddI_vi_masked $dst_src, $dst_src, $con, $v0" %}
+  format %{ "vadd_vi_masked $dst_src, $dst_src, $con, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -502,11 +502,11 @@ instruct vaddL_vi_masked(vReg dst_src, immL5 con, vRegMask_V0 v0) %{
 
 // vector-scalar add (predicated)
 
-instruct vaddI_vx_masked(vReg dst_src, iRegIorL2I src2, vRegMask_V0 v0) %{
+instruct vadd_vx_masked(vReg dst_src, iRegIorL2I src2, vRegMask_V0 v0) %{
   match(Set dst_src (AddVB (Binary dst_src (Replicate src2)) v0));
   match(Set dst_src (AddVS (Binary dst_src (Replicate src2)) v0));
   match(Set dst_src (AddVI (Binary dst_src (Replicate src2)) v0));
-  format %{ "vaddI_vx_masked $dst_src, $dst_src, $src2, $v0" %}
+  format %{ "vadd_vx_masked $dst_src, $dst_src, $src2, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -595,11 +595,11 @@ instruct vsub_fp_masked(vReg dst_src1, vReg src2, vRegMask_V0 v0) %{
 
 // vector-scalar sub (unpredicated)
 
-instruct vsubI_vx(vReg dst, vReg src1, iRegIorL2I src2) %{
+instruct vsub_vx(vReg dst, vReg src1, iRegIorL2I src2) %{
   match(Set dst (SubVB src1 (Replicate src2)));
   match(Set dst (SubVS src1 (Replicate src2)));
   match(Set dst (SubVI src1 (Replicate src2)));
-  format %{ "vsubI_vx $dst, $src1, $src2" %}
+  format %{ "vsub_vx $dst, $src1, $src2" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -624,11 +624,11 @@ instruct vsubL_vx(vReg dst, vReg src1, iRegL src2) %{
 
 // vector-scalar sub (predicated)
 
-instruct vsubI_vx_masked(vReg dst_src, iRegIorL2I src2, vRegMask_V0 v0) %{
+instruct vsub_vx_masked(vReg dst_src, iRegIorL2I src2, vRegMask_V0 v0) %{
   match(Set dst_src (SubVB (Binary dst_src (Replicate src2)) v0));
   match(Set dst_src (SubVS (Binary dst_src (Replicate src2)) v0));
   match(Set dst_src (SubVI (Binary dst_src (Replicate src2)) v0));
-  format %{ "vsubI_vx_masked $dst_src, $dst_src, $src2, $v0" %}
+  format %{ "vsub_vx_masked $dst_src, $dst_src, $src2, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -685,12 +685,12 @@ instruct vand_masked(vReg dst_src1, vReg src2, vRegMask_V0 v0) %{
 
 // vector-immediate and (unpredicated)
 
-instruct vandI_vi(vReg dst_src, immI5 con) %{
+instruct vand_vi(vReg dst_src, immI5 con) %{
   predicate(Matcher::vector_element_basic_type(n) == T_INT ||
             Matcher::vector_element_basic_type(n) == T_BYTE ||
             Matcher::vector_element_basic_type(n) == T_SHORT);
   match(Set dst_src (AndV dst_src (Replicate con)));
-  format %{ "vandI_vi $dst_src, $dst_src, $con" %}
+  format %{ "vand_vi $dst_src, $dst_src, $con" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -716,12 +716,12 @@ instruct vandL_vi(vReg dst_src, immL5 con) %{
 
 // vector-scalar and (unpredicated)
 
-instruct vandI_vx(vReg dst_src, iRegIorL2I src) %{
+instruct vand_vx(vReg dst_src, iRegIorL2I src) %{
   predicate(Matcher::vector_element_basic_type(n) == T_INT ||
             Matcher::vector_element_basic_type(n) == T_BYTE ||
             Matcher::vector_element_basic_type(n) == T_SHORT);
   match(Set dst_src (AndV dst_src (Replicate src)));
-  format %{ "vandI_vx $dst_src, $dst_src, $src" %}
+  format %{ "vand_vx $dst_src, $dst_src, $src" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -747,12 +747,12 @@ instruct vandL_vx(vReg dst_src, iRegL src) %{
 
 // vector-immediate and (predicated)
 
-instruct vandI_vi_masked(vReg dst_src, immI5 con, vRegMask_V0 v0) %{
+instruct vand_vi_masked(vReg dst_src, immI5 con, vRegMask_V0 v0) %{
   predicate(Matcher::vector_element_basic_type(n) == T_INT ||
             Matcher::vector_element_basic_type(n) == T_BYTE ||
             Matcher::vector_element_basic_type(n) == T_SHORT);
   match(Set dst_src (AndV (Binary dst_src (Replicate con)) v0));
-  format %{ "vandI_vi_masked $dst_src, $dst_src, $con, $v0" %}
+  format %{ "vand_vi_masked $dst_src, $dst_src, $con, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -778,12 +778,12 @@ instruct vandL_vi_masked(vReg dst_src, immL5 con, vRegMask_V0 v0) %{
 
 // vector-scalar and (predicated)
 
-instruct vandI_vx_masked(vReg dst_src, iRegIorL2I src, vRegMask_V0 v0) %{
+instruct vand_vx_masked(vReg dst_src, iRegIorL2I src, vRegMask_V0 v0) %{
   predicate(Matcher::vector_element_basic_type(n) == T_INT ||
             Matcher::vector_element_basic_type(n) == T_BYTE ||
             Matcher::vector_element_basic_type(n) == T_SHORT);
   match(Set dst_src (AndV (Binary dst_src (Replicate src)) v0));
-  format %{ "vandI_vx_masked $dst_src, $dst_src, $src, $v0" %}
+  format %{ "vand_vx_masked $dst_src, $dst_src, $src, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -841,12 +841,12 @@ instruct vor_masked(vReg dst_src1, vReg src2, vRegMask_V0 v0) %{
 
 // vector-immediate or (unpredicated)
 
-instruct vorI_vi(vReg dst_src, immI5 con) %{
+instruct vor_vi(vReg dst_src, immI5 con) %{
   predicate(Matcher::vector_element_basic_type(n) == T_INT ||
             Matcher::vector_element_basic_type(n) == T_BYTE ||
             Matcher::vector_element_basic_type(n) == T_SHORT);
   match(Set dst_src (OrV dst_src (Replicate con)));
-  format %{ "vorI_vi $dst_src, $dst_src, $con" %}
+  format %{ "vor_vi $dst_src, $dst_src, $con" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -872,12 +872,12 @@ instruct vorL_vi(vReg dst_src, immL5 con) %{
 
 // vector-scalar or (unpredicated)
 
-instruct vorI_vx(vReg dst_src, iRegIorL2I src) %{
+instruct vor_vx(vReg dst_src, iRegIorL2I src) %{
   predicate(Matcher::vector_element_basic_type(n) == T_INT ||
             Matcher::vector_element_basic_type(n) == T_BYTE ||
             Matcher::vector_element_basic_type(n) == T_SHORT);
   match(Set dst_src (OrV dst_src (Replicate src)));
-  format %{ "vorI_vx $dst_src, $dst_src, $src" %}
+  format %{ "vor_vx $dst_src, $dst_src, $src" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -903,12 +903,12 @@ instruct vorL_vx(vReg dst_src, iRegL src) %{
 
 // vector-immediate or (predicated)
 
-instruct vorI_vi_masked(vReg dst_src, immI5 con, vRegMask_V0 v0) %{
+instruct vor_vi_masked(vReg dst_src, immI5 con, vRegMask_V0 v0) %{
   predicate(Matcher::vector_element_basic_type(n) == T_INT ||
             Matcher::vector_element_basic_type(n) == T_BYTE ||
             Matcher::vector_element_basic_type(n) == T_SHORT);
   match(Set dst_src (OrV (Binary dst_src (Replicate con)) v0));
-  format %{ "vorI_vi_masked $dst_src, $dst_src, $con, $v0" %}
+  format %{ "vor_vi_masked $dst_src, $dst_src, $con, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -934,12 +934,12 @@ instruct vorL_vi_masked(vReg dst_src, immL5 con, vRegMask_V0 v0) %{
 
 // vector-scalar or (predicated)
 
-instruct vorI_vx_masked(vReg dst_src, iRegIorL2I src, vRegMask_V0 v0) %{
+instruct vor_vx_masked(vReg dst_src, iRegIorL2I src, vRegMask_V0 v0) %{
   predicate(Matcher::vector_element_basic_type(n) == T_INT ||
             Matcher::vector_element_basic_type(n) == T_BYTE ||
             Matcher::vector_element_basic_type(n) == T_SHORT);
   match(Set dst_src (OrV (Binary dst_src (Replicate src)) v0));
-  format %{ "vorI_vx_masked $dst_src, $dst_src, $src, $v0" %}
+  format %{ "vor_vx_masked $dst_src, $dst_src, $src, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -997,12 +997,12 @@ instruct vxor_masked(vReg dst_src1, vReg src2, vRegMask_V0 v0) %{
 
 // vector-immediate xor (unpredicated)
 
-instruct vxorI_vi(vReg dst_src, immI5 con) %{
+instruct vxor_vi(vReg dst_src, immI5 con) %{
   predicate(Matcher::vector_element_basic_type(n) == T_INT ||
             Matcher::vector_element_basic_type(n) == T_BYTE ||
             Matcher::vector_element_basic_type(n) == T_SHORT);
   match(Set dst_src (XorV dst_src (Replicate con)));
-  format %{ "vxorI_vi $dst_src, $dst_src, $con" %}
+  format %{ "vxor_vi $dst_src, $dst_src, $con" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -1028,12 +1028,12 @@ instruct vxorL_vi(vReg dst_src, immL5 con) %{
 
 // vector-scalar xor (unpredicated)
 
-instruct vxorI_vx(vReg dst_src, iRegIorL2I src) %{
+instruct vxor_vx(vReg dst_src, iRegIorL2I src) %{
   predicate(Matcher::vector_element_basic_type(n) == T_INT ||
             Matcher::vector_element_basic_type(n) == T_BYTE ||
             Matcher::vector_element_basic_type(n) == T_SHORT);
   match(Set dst_src (XorV dst_src (Replicate src)));
-  format %{ "vxorI_vx $dst_src, $dst_src, $src" %}
+  format %{ "vxor_vx $dst_src, $dst_src, $src" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -1059,12 +1059,12 @@ instruct vxorL_vx(vReg dst_src, iRegL src) %{
 
 // vector-immediate xor (predicated)
 
-instruct vxorI_vi_masked(vReg dst_src, immI5 con, vRegMask_V0 v0) %{
+instruct vxor_vi_masked(vReg dst_src, immI5 con, vRegMask_V0 v0) %{
   predicate(Matcher::vector_element_basic_type(n) == T_INT ||
             Matcher::vector_element_basic_type(n) == T_BYTE ||
             Matcher::vector_element_basic_type(n) == T_SHORT);
   match(Set dst_src (XorV (Binary dst_src (Replicate con)) v0));
-  format %{ "vxorI_vi_masked $dst_src, $dst_src, $con, $v0" %}
+  format %{ "vxor_vi_masked $dst_src, $dst_src, $con, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -1090,12 +1090,12 @@ instruct vxorL_vi_masked(vReg dst_src, immL5 con, vRegMask_V0 v0) %{
 
 // vector-scalar xor (predicated)
 
-instruct vxorI_vx_masked(vReg dst_src, iRegIorL2I src, vRegMask_V0 v0) %{
+instruct vxor_vx_masked(vReg dst_src, iRegIorL2I src, vRegMask_V0 v0) %{
   predicate(Matcher::vector_element_basic_type(n) == T_INT ||
             Matcher::vector_element_basic_type(n) == T_BYTE ||
             Matcher::vector_element_basic_type(n) == T_SHORT);
   match(Set dst_src (XorV (Binary dst_src (Replicate src)) v0));
-  format %{ "vxorI_vx_masked $dst_src, $dst_src, $src, $v0" %}
+  format %{ "vxor_vx_masked $dst_src, $dst_src, $src, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -1123,13 +1123,13 @@ instruct vxorL_vx_masked(vReg dst_src, iRegL src, vRegMask_V0 v0) %{
 
 // vector and not
 
-instruct vand_notI(vReg dst, vReg src1, vReg src2, immI_M1 m1) %{
+instruct vand_not(vReg dst, vReg src1, vReg src2, immI_M1 m1) %{
   predicate(UseZvbb);
   predicate(Matcher::vector_element_basic_type(n) == T_INT ||
             Matcher::vector_element_basic_type(n) == T_BYTE ||
             Matcher::vector_element_basic_type(n) == T_SHORT);
   match(Set dst (AndV src1 (XorV src2 (Replicate m1))));
-  format %{ "vand_notI $dst, $src1, $src2" %}
+  format %{ "vand_not $dst, $src1, $src2" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -1154,13 +1154,13 @@ instruct vand_notL(vReg dst, vReg src1, vReg src2, immL_M1 m1) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct vand_notI_masked(vReg dst_src1, vReg src2, immI_M1 m1, vRegMask_V0 v0) %{
+instruct vand_not_masked(vReg dst_src1, vReg src2, immI_M1 m1, vRegMask_V0 v0) %{
   predicate(UseZvbb);
   predicate(Matcher::vector_element_basic_type(n) == T_INT ||
             Matcher::vector_element_basic_type(n) == T_BYTE ||
             Matcher::vector_element_basic_type(n) == T_SHORT);
   match(Set dst_src1 (AndV (Binary dst_src1 (XorV src2 (Replicate m1))) v0));
-  format %{ "vand_notI_masked $dst_src1, $dst_src1, $src2, $v0" %}
+  format %{ "vand_not_masked $dst_src1, $dst_src1, $src2, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -1187,13 +1187,13 @@ instruct vand_notL_masked(vReg dst_src1, vReg src2, immL_M1 m1, vRegMask_V0 v0) 
   ins_pipe(pipe_slow);
 %}
 
-instruct vand_notI_vx(vReg dst, vReg src1, iRegIorL2I src2, immI_M1 m1) %{
+instruct vand_not_vx(vReg dst, vReg src1, iRegIorL2I src2, immI_M1 m1) %{
   predicate(UseZvbb);
   predicate(Matcher::vector_element_basic_type(n) == T_INT ||
             Matcher::vector_element_basic_type(n) == T_BYTE ||
             Matcher::vector_element_basic_type(n) == T_SHORT);
   match(Set dst (AndV src1 (Replicate (XorI src2 m1))));
-  format %{ "vand_notI_vx $dst, $src1, $src2" %}
+  format %{ "vand_not_vx $dst, $src1, $src2" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -1218,13 +1218,13 @@ instruct vand_notL_vx(vReg dst, vReg src1, iRegL src2, immL_M1 m1) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct vand_notI_vx_masked(vReg dst_src1, iRegIorL2I src2, immI_M1 m1, vRegMask_V0 v0) %{
+instruct vand_not_vx_masked(vReg dst_src1, iRegIorL2I src2, immI_M1 m1, vRegMask_V0 v0) %{
   predicate(UseZvbb);
   predicate(Matcher::vector_element_basic_type(n) == T_INT ||
             Matcher::vector_element_basic_type(n) == T_BYTE ||
             Matcher::vector_element_basic_type(n) == T_SHORT);
   match(Set dst_src1 (AndV (Binary dst_src1 (Replicate (XorI src2 m1))) v0));
-  format %{ "vand_notI_vx_masked $dst_src1, $dst_src1, $src2, $v0" %}
+  format %{ "vand_not_vx_masked $dst_src1, $dst_src1, $src2, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -1255,12 +1255,12 @@ instruct vand_notL_vx_masked(vReg dst_src1, iRegL src2, immL_M1 m1, vRegMask_V0 
 
 // vector not
 
-instruct vnotI(vReg dst, vReg src, immI_M1 m1) %{
+instruct vnot(vReg dst, vReg src, immI_M1 m1) %{
   predicate(Matcher::vector_element_basic_type(n) == T_INT ||
             Matcher::vector_element_basic_type(n) == T_BYTE ||
             Matcher::vector_element_basic_type(n) == T_SHORT);
   match(Set dst (XorV src (Replicate m1)));
-  format %{ "vnotI $dst, $src" %}
+  format %{ "vnot $dst, $src" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -1286,12 +1286,12 @@ instruct vnotL(vReg dst, vReg src, immL_M1 m1) %{
 
 // vector not - predicated
 
-instruct vnotI_masked(vReg dst_src, immI_M1 m1, vRegMask_V0 v0) %{
+instruct vnot_masked(vReg dst_src, immI_M1 m1, vRegMask_V0 v0) %{
   predicate(Matcher::vector_element_basic_type(n) == T_INT ||
             Matcher::vector_element_basic_type(n) == T_BYTE ||
             Matcher::vector_element_basic_type(n) == T_SHORT);
   match(Set dst_src (XorV (Binary dst_src (Replicate m1)) v0));
-  format %{ "vnotI_masked $dst_src, $dst_src, $v0" %}
+  format %{ "vnot_masked $dst_src, $dst_src, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -1801,11 +1801,11 @@ instruct vmul_fp_masked(vReg dst_src1, vReg src2, vRegMask_V0 v0) %{
 
 // vector-scalar mul (unpredicated)
 
-instruct vmulI_vx(vReg dst, vReg src1, iRegIorL2I src2) %{
+instruct vmul_vx(vReg dst, vReg src1, iRegIorL2I src2) %{
   match(Set dst (MulVB src1 (Replicate src2)));
   match(Set dst (MulVS src1 (Replicate src2)));
   match(Set dst (MulVI src1 (Replicate src2)));
-  format %{ "vmulI_vx $dst, $src1, $src2" %}
+  format %{ "vmul_vx $dst, $src1, $src2" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -1830,11 +1830,11 @@ instruct vmulL_vx(vReg dst, vReg src1, iRegL src2) %{
 
 // vector-scalar mul (predicated)
 
-instruct vmulI_vx_masked(vReg dst_src, iRegIorL2I src2, vRegMask_V0 v0) %{
+instruct vmul_vx_masked(vReg dst_src, iRegIorL2I src2, vRegMask_V0 v0) %{
   match(Set dst_src (MulVB (Binary dst_src (Replicate src2)) v0));
   match(Set dst_src (MulVS (Binary dst_src (Replicate src2)) v0));
   match(Set dst_src (MulVI (Binary dst_src (Replicate src2)) v0));
-  format %{ "vmulI_vx_masked $dst_src, $dst_src, $src2, $v0" %}
+  format %{ "vmul_vx_masked $dst_src, $dst_src, $src2, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -1921,14 +1921,14 @@ instruct vfneg_masked(vReg dst_src, vRegMask_V0 v0) %{
 
 // vector and reduction
 
-instruct reduce_andI(iRegINoSp dst, iRegIorL2I src1, vReg src2, vReg tmp) %{
+instruct reduce_and(iRegINoSp dst, iRegIorL2I src1, vReg src2, vReg tmp) %{
   predicate(Matcher::vector_element_basic_type(n->in(2)) == T_BYTE ||
             Matcher::vector_element_basic_type(n->in(2)) == T_SHORT ||
             Matcher::vector_element_basic_type(n->in(2)) == T_INT);
   match(Set dst (AndReductionV src1 src2));
   effect(TEMP tmp);
   ins_cost(VEC_COST);
-  format %{ "reduce_andI $dst, $src1, $src2\t# KILL $tmp" %}
+  format %{ "reduce_and $dst, $src1, $src2\t# KILL $tmp" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
     __ reduce_integral_v($dst$$Register, $src1$$Register,
@@ -1955,14 +1955,14 @@ instruct reduce_andL(iRegLNoSp dst, iRegL src1, vReg src2, vReg tmp) %{
 
 // vector and reduction - predicated
 
-instruct reduce_andI_masked(iRegINoSp dst, iRegIorL2I src1, vReg src2, vRegMask_V0 v0, vReg tmp) %{
+instruct reduce_and_masked(iRegINoSp dst, iRegIorL2I src1, vReg src2, vRegMask_V0 v0, vReg tmp) %{
   predicate(Matcher::vector_element_basic_type(n->in(2)) == T_BYTE ||
             Matcher::vector_element_basic_type(n->in(2)) == T_SHORT ||
             Matcher::vector_element_basic_type(n->in(2)) == T_INT);
   match(Set dst (AndReductionV (Binary src1 src2) v0));
   effect(TEMP tmp);
   ins_cost(VEC_COST);
-  format %{ "reduce_andI_masked $dst, $src1, $src2, $v0\t# KILL $tmp" %}
+  format %{ "reduce_and_masked $dst, $src1, $src2, $v0\t# KILL $tmp" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
     __ reduce_integral_v($dst$$Register, $src1$$Register,
@@ -1991,14 +1991,14 @@ instruct reduce_andL_masked(iRegLNoSp dst, iRegL src1, vReg src2, vRegMask_V0 v0
 
 // vector or reduction
 
-instruct reduce_orI(iRegINoSp dst, iRegIorL2I src1, vReg src2, vReg tmp) %{
+instruct reduce_or(iRegINoSp dst, iRegIorL2I src1, vReg src2, vReg tmp) %{
   predicate(Matcher::vector_element_basic_type(n->in(2)) == T_BYTE ||
             Matcher::vector_element_basic_type(n->in(2)) == T_SHORT ||
             Matcher::vector_element_basic_type(n->in(2)) == T_INT);
   match(Set dst (OrReductionV src1 src2));
   effect(TEMP tmp);
   ins_cost(VEC_COST);
-  format %{ "reduce_orI $dst, $src1, $src2\t# KILL $tmp" %}
+  format %{ "reduce_or $dst, $src1, $src2\t# KILL $tmp" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
     __ reduce_integral_v($dst$$Register, $src1$$Register,
@@ -2025,14 +2025,14 @@ instruct reduce_orL(iRegLNoSp dst, iRegL src1, vReg src2, vReg tmp) %{
 
 // vector or reduction - predicated
 
-instruct reduce_orI_masked(iRegINoSp dst, iRegIorL2I src1, vReg src2, vRegMask_V0 v0, vReg tmp) %{
+instruct reduce_or_masked(iRegINoSp dst, iRegIorL2I src1, vReg src2, vRegMask_V0 v0, vReg tmp) %{
   predicate(Matcher::vector_element_basic_type(n->in(2)) == T_BYTE ||
             Matcher::vector_element_basic_type(n->in(2)) == T_SHORT ||
             Matcher::vector_element_basic_type(n->in(2)) == T_INT);
   match(Set dst (OrReductionV (Binary src1 src2) v0));
   effect(TEMP tmp);
   ins_cost(VEC_COST);
-  format %{ "reduce_orI_masked $dst, $src1, $src2, $v0\t# KILL $tmp" %}
+  format %{ "reduce_or_masked $dst, $src1, $src2, $v0\t# KILL $tmp" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
     __ reduce_integral_v($dst$$Register, $src1$$Register,
@@ -2061,14 +2061,14 @@ instruct reduce_orL_masked(iRegLNoSp dst, iRegL src1, vReg src2, vRegMask_V0 v0,
 
 // vector xor reduction
 
-instruct reduce_xorI(iRegINoSp dst, iRegIorL2I src1, vReg src2, vReg tmp) %{
+instruct reduce_xor(iRegINoSp dst, iRegIorL2I src1, vReg src2, vReg tmp) %{
   predicate(Matcher::vector_element_basic_type(n->in(2)) == T_BYTE ||
             Matcher::vector_element_basic_type(n->in(2)) == T_SHORT ||
             Matcher::vector_element_basic_type(n->in(2)) == T_INT);
   match(Set dst (XorReductionV src1 src2));
   effect(TEMP tmp);
   ins_cost(VEC_COST);
-  format %{ "reduce_xorI $dst, $src1, $src2\t# KILL $tmp" %}
+  format %{ "reduce_xor $dst, $src1, $src2\t# KILL $tmp" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
     __ reduce_integral_v($dst$$Register, $src1$$Register,
@@ -2095,14 +2095,14 @@ instruct reduce_xorL(iRegLNoSp dst, iRegL src1, vReg src2, vReg tmp) %{
 
 // vector xor reduction - predicated
 
-instruct reduce_xorI_masked(iRegINoSp dst, iRegIorL2I src1, vReg src2, vRegMask_V0 v0, vReg tmp) %{
+instruct reduce_xor_masked(iRegINoSp dst, iRegIorL2I src1, vReg src2, vRegMask_V0 v0, vReg tmp) %{
   predicate(Matcher::vector_element_basic_type(n->in(2)) == T_BYTE ||
             Matcher::vector_element_basic_type(n->in(2)) == T_SHORT ||
             Matcher::vector_element_basic_type(n->in(2)) == T_INT);
   match(Set dst (XorReductionV (Binary src1 src2) v0));
   effect(TEMP tmp);
   ins_cost(VEC_COST);
-  format %{ "reduce_xorI_masked $dst, $src1, $src2, $v0\t# KILL $tmp" %}
+  format %{ "reduce_xor_masked $dst, $src1, $src2, $v0\t# KILL $tmp" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
     __ reduce_integral_v($dst$$Register, $src1$$Register,
@@ -2131,14 +2131,14 @@ instruct reduce_xorL_masked(iRegLNoSp dst, iRegL src1, vReg src2, vRegMask_V0 v0
 
 // vector add reduction
 
-instruct reduce_addI(iRegINoSp dst, iRegIorL2I src1, vReg src2, vReg tmp) %{
+instruct reduce_add(iRegINoSp dst, iRegIorL2I src1, vReg src2, vReg tmp) %{
   predicate(Matcher::vector_element_basic_type(n->in(2)) == T_BYTE ||
             Matcher::vector_element_basic_type(n->in(2)) == T_SHORT ||
             Matcher::vector_element_basic_type(n->in(2)) == T_INT);
   match(Set dst (AddReductionVI src1 src2));
   effect(TEMP tmp);
   ins_cost(VEC_COST);
-  format %{ "reduce_addI $dst, $src1, $src2\t# KILL $tmp" %}
+  format %{ "reduce_add $dst, $src1, $src2\t# KILL $tmp" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
     __ reduce_integral_v($dst$$Register, $src1$$Register,
@@ -2237,14 +2237,14 @@ instruct reduce_addD_unordered(fRegD dst, fRegD src1, vReg src2, vReg tmp) %{
 
 // vector add reduction - predicated
 
-instruct reduce_addI_masked(iRegINoSp dst, iRegIorL2I src1, vReg src2, vRegMask_V0 v0, vReg tmp) %{
+instruct reduce_add_masked(iRegINoSp dst, iRegIorL2I src1, vReg src2, vRegMask_V0 v0, vReg tmp) %{
   predicate(Matcher::vector_element_basic_type(n->in(2)) == T_BYTE ||
             Matcher::vector_element_basic_type(n->in(2)) == T_SHORT ||
             Matcher::vector_element_basic_type(n->in(2)) == T_INT);
   match(Set dst (AddReductionVI (Binary src1 src2) v0));
   effect(TEMP tmp);
   ins_cost(VEC_COST);
-  format %{ "reduce_addI_masked $dst, $src1, $src2, $v0\t# KILL $tmp" %}
+  format %{ "reduce_add_masked $dst, $src1, $src2, $v0\t# KILL $tmp" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
     __ reduce_integral_v($dst$$Register, $src1$$Register,
@@ -2303,14 +2303,14 @@ instruct reduce_addD_masked(fRegD dst, fRegD src1, vReg src2, vRegMask_V0 v0, vR
 
 // vector integer max reduction
 
-instruct vreduce_maxI(iRegINoSp dst, iRegIorL2I src1, vReg src2, vReg tmp) %{
+instruct vreduce_max(iRegINoSp dst, iRegIorL2I src1, vReg src2, vReg tmp) %{
   predicate(Matcher::vector_element_basic_type(n->in(2)) == T_BYTE ||
             Matcher::vector_element_basic_type(n->in(2)) == T_SHORT ||
             Matcher::vector_element_basic_type(n->in(2)) == T_INT);
   match(Set dst (MaxReductionV src1 src2));
   ins_cost(VEC_COST);
   effect(TEMP tmp);
-  format %{ "vreduce_maxI $dst, $src1, $src2\t# KILL $tmp" %}
+  format %{ "vreduce_max $dst, $src1, $src2\t# KILL $tmp" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
     __ reduce_integral_v($dst$$Register, $src1$$Register,
@@ -2337,14 +2337,14 @@ instruct vreduce_maxL(iRegLNoSp dst, iRegL src1, vReg src2, vReg tmp) %{
 
 // vector integer max reduction - predicated
 
-instruct vreduce_maxI_masked(iRegINoSp dst, iRegIorL2I src1, vReg src2, vRegMask_V0 v0, vReg tmp) %{
+instruct vreduce_max_masked(iRegINoSp dst, iRegIorL2I src1, vReg src2, vRegMask_V0 v0, vReg tmp) %{
   predicate(Matcher::vector_element_basic_type(n->in(2)) == T_BYTE ||
             Matcher::vector_element_basic_type(n->in(2)) == T_SHORT ||
             Matcher::vector_element_basic_type(n->in(2)) == T_INT);
   match(Set dst (MaxReductionV (Binary src1 src2) v0));
   effect(TEMP tmp);
   ins_cost(VEC_COST);
-  format %{ "vreduce_maxI_masked $dst, $src1, $src2, $v0\t# KILL $tmp" %}
+  format %{ "vreduce_max_masked $dst, $src1, $src2, $v0\t# KILL $tmp" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
     __ reduce_integral_v($dst$$Register, $src1$$Register,
@@ -2373,14 +2373,14 @@ instruct vreduce_maxL_masked(iRegLNoSp dst, iRegL src1, vReg src2, vRegMask_V0 v
 
 // vector integer min reduction
 
-instruct vreduce_minI(iRegINoSp dst, iRegIorL2I src1, vReg src2, vReg tmp) %{
+instruct vreduce_min(iRegINoSp dst, iRegIorL2I src1, vReg src2, vReg tmp) %{
   predicate(Matcher::vector_element_basic_type(n->in(2)) == T_BYTE ||
             Matcher::vector_element_basic_type(n->in(2)) == T_SHORT ||
             Matcher::vector_element_basic_type(n->in(2)) == T_INT);
   match(Set dst (MinReductionV src1 src2));
   ins_cost(VEC_COST);
   effect(TEMP tmp);
-  format %{ "vreduce_minI $dst, $src1, $src2\t# KILL $tmp" %}
+  format %{ "vreduce_min $dst, $src1, $src2\t# KILL $tmp" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
     __ reduce_integral_v($dst$$Register, $src1$$Register,
@@ -2407,14 +2407,14 @@ instruct vreduce_minL(iRegLNoSp dst, iRegL src1, vReg src2, vReg tmp) %{
 
 // vector integer min reduction - predicated
 
-instruct vreduce_minI_masked(iRegINoSp dst, iRegIorL2I src1, vReg src2, vRegMask_V0 v0, vReg tmp) %{
+instruct vreduce_min_masked(iRegINoSp dst, iRegIorL2I src1, vReg src2, vRegMask_V0 v0, vReg tmp) %{
   predicate(Matcher::vector_element_basic_type(n->in(2)) == T_BYTE ||
             Matcher::vector_element_basic_type(n->in(2)) == T_SHORT ||
             Matcher::vector_element_basic_type(n->in(2)) == T_INT);
   match(Set dst (MinReductionV (Binary src1 src2) v0));
   effect(TEMP tmp);
   ins_cost(VEC_COST);
-  format %{ "vreduce_minI_masked $dst, $src1, $src2, $v0\t# KILL $tmp" %}
+  format %{ "vreduce_min_masked $dst, $src1, $src2, $v0\t# KILL $tmp" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
     __ reduce_integral_v($dst$$Register, $src1$$Register,
@@ -5157,14 +5157,14 @@ instruct populateindex(vReg dst, iRegIorL2I src1, iRegIorL2I src2, vReg tmp) %{
 
 // BYTE, SHORT, INT
 
-instruct insertI_index_lt32(vReg dst, vReg src, iRegIorL2I val, immI idx, vRegMask_V0 v0) %{
+instruct insert_index_lt32(vReg dst, vReg src, iRegIorL2I val, immI idx, vRegMask_V0 v0) %{
   predicate(n->in(2)->get_int() < 32 &&
             (Matcher::vector_element_basic_type(n) == T_BYTE ||
              Matcher::vector_element_basic_type(n) == T_SHORT ||
              Matcher::vector_element_basic_type(n) == T_INT));
   match(Set dst (VectorInsert (Binary src val) idx));
   effect(TEMP v0);
-  format %{ "insertI_index_lt32 $dst, $src, $val, $idx" %}
+  format %{ "insert_index_lt32 $dst, $src, $val, $idx" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -5176,14 +5176,14 @@ instruct insertI_index_lt32(vReg dst, vReg src, iRegIorL2I val, immI idx, vRegMa
   ins_pipe(pipe_slow);
 %}
 
-instruct insertI_index(vReg dst, vReg src, iRegIorL2I val, iRegIorL2I idx, vReg tmp, vRegMask_V0 v0) %{
+instruct insert_index(vReg dst, vReg src, iRegIorL2I val, iRegIorL2I idx, vReg tmp, vRegMask_V0 v0) %{
   predicate(n->in(2)->get_int() >= 32 &&
             (Matcher::vector_element_basic_type(n) == T_BYTE ||
              Matcher::vector_element_basic_type(n) == T_SHORT ||
              Matcher::vector_element_basic_type(n) == T_INT));
   match(Set dst (VectorInsert (Binary src val) idx));
   effect(TEMP tmp, TEMP v0);
-  format %{ "insertI_index $dst, $src, $val, $idx\t# KILL $tmp" %}
+  format %{ "insert_index $dst, $src, $val, $idx\t# KILL $tmp" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));

--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -641,7 +641,7 @@ instruct vsub_vx_masked(vReg dst_src, iRegIorL2I src2, vRegMask_V0 v0) %{
 
 instruct vsubL_vx_masked(vReg dst_src, iRegL src2, vRegMask_V0 v0) %{
   match(Set dst_src (SubVL (Binary dst_src (Replicate src2)) v0));
-  format %{ "vsub_vx_masked $dst_src, $dst_src, $src2, $v0" %}
+  format %{ "vsubL_vx_masked $dst_src, $dst_src, $src2, $v0" %}
   ins_encode %{
     __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
     __ vsub_vx(as_VectorRegister($dst_src$$reg),


### PR DESCRIPTION
As the issue describe, some match rule and predict match not only type I, in case of the misleading, try to delete some "I" in the format and instruct name

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8355657](https://bugs.openjdk.org/browse/JDK-8355657): RISC-V: Improve PrintOptoAssembly output of vector-scalar instructions (**Enhancement** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Gui Cao](https://openjdk.org/census#gcao) (@zifeihan - Author)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24904/head:pull/24904` \
`$ git checkout pull/24904`

Update a local copy of the PR: \
`$ git checkout pull/24904` \
`$ git pull https://git.openjdk.org/jdk.git pull/24904/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24904`

View PR using the GUI difftool: \
`$ git pr show -t 24904`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24904.diff">https://git.openjdk.org/jdk/pull/24904.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24904#issuecomment-2833278249)
</details>
