### PR TITLE
8356175: Remove unnecessary Map.get from XWM.getInsets

### DIFF
--- a/src/java.desktop/unix/classes/sun/awt/X11/XWM.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11/XWM.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1737,9 +1737,7 @@ final class XWM
         correctWM.left = win.scaleUp(correctWM.left);
         correctWM.right = win.scaleUp(correctWM.right);
 
-        if (storedInsets.get(win.getClass()) == null) {
-            storedInsets.put(win.getClass(), correctWM);
-        }
+        storedInsets.putIfAbsent(win.getClass(), correctWM);
         return correctWM;
     }
     boolean isDesktopWindow( long w ) {


### PR DESCRIPTION
Cleanup code to use Map.putIfAbsent. It's clearer and faster.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8356175](https://bugs.openjdk.org/browse/JDK-8356175): Remove unnecessary Map.get from XWM.getInsets (**Enhancement** - P5)


### Reviewers
 * [Tejesh R](https://openjdk.org/census#tr) (@TejeshR13 - **Reviewer**)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24906/head:pull/24906` \
`$ git checkout pull/24906`

Update a local copy of the PR: \
`$ git checkout pull/24906` \
`$ git pull https://git.openjdk.org/jdk.git pull/24906/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24906`

View PR using the GUI difftool: \
`$ git pr show -t 24906`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24906.diff">https://git.openjdk.org/jdk/pull/24906.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24906#issuecomment-2850863038)
</details>
