### PR TITLE
8357687: Remove unnecessary Map.containsKey from GraphicsEnvironment implementations

### DIFF
--- a/src/java.desktop/macosx/classes/sun/awt/CGraphicsEnvironment.java
+++ b/src/java.desktop/macosx/classes/sun/awt/CGraphicsEnvironment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -175,8 +175,8 @@ public final class CGraphicsEnvironment extends SunGraphicsEnvironment {
             displayIDs = new int[]{mainDisplayID};
         }
         for (int id : displayIDs) {
-            devices.put(id, old.containsKey(id) ? old.remove(id)
-                                                : new CGraphicsDevice(id));
+            CGraphicsDevice d = old.remove(id);
+            devices.put(id, d != null ? d : new CGraphicsDevice(id));
         }
         // fetch the main display again, the old value might be outdated
         mainDisplayID = getMainDisplayID();

--- a/src/java.desktop/unix/classes/sun/awt/X11GraphicsEnvironment.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11GraphicsEnvironment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -232,8 +232,8 @@ public final class X11GraphicsEnvironment extends SunGraphicsEnvironment {
         mainScreen = 0 < index && index < numScreens ? index : 0;
 
         for (int id = 0; id < numScreens; ++id) {
-            devices.put(id, old.containsKey(id) ? old.remove(id) :
-                                                  new X11GraphicsDevice(id));
+            X11GraphicsDevice d = old.remove(id);
+            devices.put(id, d != null ? d : new X11GraphicsDevice(id));
         }
         // if a device was not reused it should be invalidated
         for (X11GraphicsDevice gd : old.values()) {


### PR DESCRIPTION
`devices` contains only non-null values. It means instead of separate `containsKey` call we can just call `HashMap.get` and then compare result with `null`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8357687](https://bugs.openjdk.org/browse/JDK-8357687): Remove unnecessary Map.containsKey from GraphicsEnvironment implementations (**Enhancement** - P5)


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)
 * [Damon Nguyen](https://openjdk.org/census#dnguyen) (@DamonGuy - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24907/head:pull/24907` \
`$ git checkout pull/24907`

Update a local copy of the PR: \
`$ git checkout pull/24907` \
`$ git pull https://git.openjdk.org/jdk.git pull/24907/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24907`

View PR using the GUI difftool: \
`$ git pr show -t 24907`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24907.diff">https://git.openjdk.org/jdk/pull/24907.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24907#issuecomment-2906921267)
</details>
