### PR TITLE
8355658: Allow transforms to run on elements generated by a builder

### DIFF
--- a/make/langtools/src/classes/build/tools/symbolgenerator/CreateSymbols.java
+++ b/make/langtools/src/classes/build/tools/symbolgenerator/CreateSymbols.java
@@ -101,10 +101,8 @@ import javax.tools.StandardLocation;
 
 import com.sun.source.util.JavacTask;
 import com.sun.tools.javac.api.JavacTool;
-import com.sun.tools.javac.jvm.Target;
-import com.sun.tools.javac.util.Assert;
 import com.sun.tools.javac.util.Context;
-import com.sun.tools.javac.util.Pair;
+
 import java.nio.file.DirectoryStream;
 import java.util.Optional;
 import java.util.function.Consumer;
@@ -966,14 +964,12 @@ public class CreateSymbols {
         }
     }
 
-    @SuppressWarnings("unchecked")
-    private void addGenericAttributes(FeatureDescription desc, ClassFileBuilder<?, ?> builder) {
-        addGenericAttributes(desc, (Consumer<? super Attribute<?>>) builder, builder.constantPool());
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private void addGenericAttributes(FeatureDescription desc, ClassFileBuilder builder) {
+        addGenericAttributes(desc, (Consumer<Attribute<?>>) builder, builder.constantPool());
     }
 
-    private void addGenericAttributes(FeatureDescription desc, Consumer<? super Attribute<?>> sink, ConstantPoolBuilder cpb) {
-        @SuppressWarnings("unchecked")
-        var builder = (Consumer<Attribute<?>>) sink;
+    private void addGenericAttributes(FeatureDescription desc, Consumer<Attribute<?>> builder, ConstantPoolBuilder cpb) {
         if (desc.deprecated) {
             builder.accept(DeprecatedAttribute.of());
         }

--- a/src/java.base/share/classes/java/lang/classfile/ClassFile.java
+++ b/src/java.base/share/classes/java/lang/classfile/ClassFile.java
@@ -26,10 +26,7 @@ package java.lang.classfile;
 
 import java.io.IOException;
 import java.lang.classfile.AttributeMapper.AttributeStability;
-import java.lang.classfile.attribute.CharacterRangeInfo;
 import java.lang.classfile.attribute.CodeAttribute;
-import java.lang.classfile.attribute.LocalVariableInfo;
-import java.lang.classfile.attribute.LocalVariableTypeInfo;
 import java.lang.classfile.attribute.ModuleAttribute;
 import java.lang.classfile.attribute.StackMapTableAttribute;
 import java.lang.classfile.attribute.UnknownAttribute;
@@ -680,8 +677,8 @@ public sealed interface ClassFile
      * This is named {@code transformClass} instead of {@code transform} for
      * consistency with {@link ClassBuilder#transformField}, {@link
      * ClassBuilder#transformMethod}, and {@link MethodBuilder#transformCode},
-     * and to distinguish from {@link ClassFileBuilder#transform}, which is
-     * more generic and powerful.
+     * and to distinguish from {@link ClassFileBuilder#transform} and {@link
+     * ClassFileBuilder#transforming}, which are more generic and powerful.
      *
      * @param model the class model to transform
      * @param transform the transform
@@ -704,8 +701,8 @@ public sealed interface ClassFile
      * This is named {@code transformClass} instead of {@code transform} for
      * consistency with {@link ClassBuilder#transformField}, {@link
      * ClassBuilder#transformMethod}, and {@link MethodBuilder#transformCode},
-     * and to distinguish from {@link ClassFileBuilder#transform}, which is
-     * more generic and powerful.
+     * and to distinguish from {@link ClassFileBuilder#transform} and {@link
+     * ClassFileBuilder#transforming}, which are more generic and powerful.
      *
      * @param model the class model to transform
      * @param newClassName new class name
@@ -736,8 +733,8 @@ public sealed interface ClassFile
      * This is named {@code transformClass} instead of {@code transform} for
      * consistency with {@link ClassBuilder#transformField}, {@link
      * ClassBuilder#transformMethod}, and {@link MethodBuilder#transformCode},
-     * and to distinguish from {@link ClassFileBuilder#transform}, which is
-     * more generic and powerful.
+     * and to distinguish from {@link ClassFileBuilder#transform} and {@link
+     * ClassFileBuilder#transforming}, which are more generic and powerful.
      *
      * @param model the class model to transform
      * @param newClassName new class name

--- a/src/java.base/share/classes/java/lang/classfile/ClassFileTransform.java
+++ b/src/java.base/share/classes/java/lang/classfile/ClassFileTransform.java
@@ -26,14 +26,14 @@ package java.lang.classfile;
 
 import java.lang.classfile.attribute.RuntimeVisibleAnnotationsAttribute;
 import java.util.function.Predicate;
-import java.util.function.Supplier;
 
 /**
  * A transformation on a {@link CompoundElement} by processing its individual
  * member elements and sending the results to a {@link ClassFileBuilder},
- * through {@link ClassFileBuilder#transform}.  A subtype of {@code
- * ClassFileTransform} is defined for each subtype of {@link CompoundElement}
- * and {@link ClassFileBuilder}, as shown in the sealed class hierarchy below.
+ * through {@link ClassFileBuilder#transform} and {@link
+ * ClassFileBuilder#transforming}.  A subtype of {@code ClassFileTransform} is
+ * defined for each subtype of {@link CompoundElement} and {@link
+ * ClassFileBuilder}, as shown in the sealed class hierarchy below.
  * <p>
  * For example, this is a basic transformation of a {@link CodeModel} that
  * redirects all calls to static methods in the {@code Foo} class to the {@code
@@ -85,8 +85,9 @@ import java.util.function.Supplier;
  * transform the method body of select methods in the class it runs on.  This
  * allows users to write small transforms and apply to larger scales.
  * <p>
- * Besides {@link ClassFileBuilder#transform}, there are other methods that
- * accepts a transform conveniently, such as {@link ClassFile#transformClass},
+ * Besides {@link ClassFileBuilder#transform} and {@link
+ * ClassFileBuilder#transforming}, there are other methods that accepts a
+ * transform conveniently, such as {@link ClassFile#transformClass},
  * {@link ClassBuilder#transformField}, {@link ClassBuilder#transformMethod}, or
  * {@link MethodBuilder#transformCode}.  They are convenience methods that suit
  * the majority of transformation scenarios.
@@ -101,7 +102,7 @@ import java.util.function.Supplier;
 public sealed interface ClassFileTransform<
         C extends ClassFileTransform<C, E, B>,
         E extends ClassFileElement,
-        B extends ClassFileBuilder<E, B>>
+        B extends ClassFileBuilder<C, E, B>>
         permits ClassTransform, FieldTransform, MethodTransform, CodeTransform {
     /**
      * Transform an element by taking the appropriate actions on the builder.

--- a/src/java.base/share/classes/java/lang/classfile/CodeBuilder.java
+++ b/src/java.base/share/classes/java/lang/classfile/CodeBuilder.java
@@ -36,6 +36,7 @@ import java.lang.constant.DynamicCallSiteDesc;
 import java.lang.constant.MethodTypeDesc;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Consumer;
 
@@ -92,7 +93,7 @@ import static jdk.internal.classfile.impl.BytecodeHelpers.handleDescToHandleInfo
  * @since 24
  */
 public sealed interface CodeBuilder
-        extends ClassFileBuilder<CodeElement, CodeBuilder>
+        extends ClassFileBuilder<CodeTransform, CodeElement, CodeBuilder>
         permits CodeBuilder.BlockCodeBuilder, ChainedCodeBuilder, TerminalCodeBuilder, NonterminalCodeBuilder {
 
     /**
@@ -150,19 +151,16 @@ public sealed interface CodeBuilder
     int allocateLocal(TypeKind typeKind);
 
     /**
-     * Apply a transform to the code built by a handler, directing results to
-     * this builder.
+     * {@inheritDoc}
      *
-     * @apiNote
-     * This is similar to {@link #transform}, but this does not require the
-     * code elements to be viewed as a {@link CodeModel} first.
-     *
-     * @param transform the transform to apply to the code built by the handler
-     * @param handler the handler that receives a {@link CodeBuilder} to
-     * build the code
-     * @return this builder
-     */
-    default CodeBuilder transforming(CodeTransform transform, Consumer<CodeBuilder> handler) {
+     * @param transform {@inheritDoc}
+     * @param handler {@inheritDoc}
+     * @return {@inheritDoc}
+     */ // remove supertype incorrect since
+    @Override
+    default CodeBuilder transforming(CodeTransform transform, Consumer<? super CodeBuilder> handler) {
+        Objects.requireNonNull(handler);
+        Objects.requireNonNull(transform);
         var resolved = TransformImpl.resolve(transform, this);
         resolved.startHandler().run();
         handler.accept(new ChainedCodeBuilder(this, resolved.consumer()));

--- a/src/java.base/share/classes/java/lang/invoke/InvokerBytecodeGenerator.java
+++ b/src/java.base/share/classes/java/lang/invoke/InvokerBytecodeGenerator.java
@@ -201,7 +201,7 @@ class InvokerBytecodeGenerator {
 
     record ClassData(FieldRefEntry field, Object value) {}
 
-    FieldRefEntry classData(ClassFileBuilder<?, ?> cfb, Object arg, ClassDesc desc) {
+    FieldRefEntry classData(ClassFileBuilder<?, ?, ?> cfb, Object arg, ClassDesc desc) {
         // unique static variable name
         String name;
         List<ClassData> classData = this.classData;

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/TransformImpl.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/TransformImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,11 +41,11 @@ public final class TransformImpl {
 
     private static final Runnable NOTHING = () -> { };
 
-    public static <E extends ClassFileElement, B extends ClassFileBuilder<E, B>>
-            ResolvedTransform<E> resolve(ClassFileTransform<?, E, B> transform, B builder) {
+    public static <E extends ClassFileElement, B extends ClassFileBuilder<C, E, B>, C extends ClassFileTransform<C, E, B>>
+            ResolvedTransform<E> resolve(C transform, B builder) {
         if (transform instanceof ResolvableTransform) {
             @SuppressWarnings("unchecked")
-            var ut = (ResolvableTransform<E, B>) transform;
+            var ut = (ResolvableTransform<E, B, C>) transform;
             return ut.resolve(builder);
         }
         return new ResolvedTransform<>(e -> transform.accept(builder, e),
@@ -53,11 +53,11 @@ public final class TransformImpl {
             () -> transform.atStart(builder));
     }
 
-    interface ResolvableTransform<E extends ClassFileElement, B extends ClassFileBuilder<E, B>> {
+    interface ResolvableTransform<E extends ClassFileElement, B extends ClassFileBuilder<C, E, B>, C extends ClassFileTransform<C, E, B>> {
         ResolvedTransform<E> resolve(B builder);
     }
 
-    interface UnresolvedClassTransform extends ClassTransform, ResolvableTransform<ClassElement, ClassBuilder> {
+    interface UnresolvedClassTransform extends ClassTransform, ResolvableTransform<ClassElement, ClassBuilder, ClassTransform> {
         @Override
         default void accept(ClassBuilder builder, ClassElement element) {
             throw new UnsupportedOperationException("transforms must be resolved before running");
@@ -153,7 +153,7 @@ public final class TransformImpl {
 
     // MethodTransform
 
-    interface UnresolvedMethodTransform extends MethodTransform, ResolvableTransform<MethodElement, MethodBuilder> {
+    interface UnresolvedMethodTransform extends MethodTransform, ResolvableTransform<MethodElement, MethodBuilder, MethodTransform> {
         @Override
         default void accept(MethodBuilder builder, MethodElement element) {
             throw new UnsupportedOperationException("transforms must be resolved before running");
@@ -217,7 +217,7 @@ public final class TransformImpl {
 
     // FieldTransform
 
-    interface UnresolvedFieldTransform extends FieldTransform, ResolvableTransform<FieldElement, FieldBuilder> {
+    interface UnresolvedFieldTransform extends FieldTransform, ResolvableTransform<FieldElement, FieldBuilder, FieldTransform> {
         @Override
         default void accept(FieldBuilder builder, FieldElement element) {
             throw new UnsupportedOperationException("transforms must be resolved before running");
@@ -257,7 +257,7 @@ public final class TransformImpl {
 
     // CodeTransform
 
-    interface UnresolvedCodeTransform extends CodeTransform, ResolvableTransform<CodeElement, CodeBuilder> {
+    interface UnresolvedCodeTransform extends CodeTransform, ResolvableTransform<CodeElement, CodeBuilder, CodeTransform> {
         @Override
         default void accept(CodeBuilder builder, CodeElement element) {
             throw new UnsupportedOperationException("transforms must be resolved before running");


### PR DESCRIPTION
Transforms can run on a stream of class file elements. Currently, that stream can only be from a CompoundElement. We can allow a ClassFileBuilder to provide such a stream too; a recent request https://mail.openjdk.org/pipermail/classfile-api-dev/2025-April/000698.html asks for this as well.

With this patch, we can now emulate this ASM pattern easily:

```java
// ASM
ClassVisitor cv = new DelegateClassVisitor(new ClassWriter(...));
cv.visitXxx(); // write elements through the delegate

// ClassFile API
cf.build(..., clb0 -> clb0.transforming((clb, cle) -> /*process */, clb -> {
    // write elements through delegate
}));
```

Notably, this patch introduces a source incompatibility (but not binary) in order to allow users to call `transform(model, (xb, xe) -> {})` or `transforming((xb1, xe) -> {}, xb1 -> {})`. This has little impact if users don't use `ClassFileBuilder` as a type directly (which according to grep.app, there are only two sites on whole GitHub, both updated in this PR). A release note has been created for this incompatibility at https://bugs.openjdk.org/browse/JDK-8355665; please review too.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change requires CSR request [JDK-8355666](https://bugs.openjdk.org/browse/JDK-8355666) to be approved

### Issues
 * [JDK-8355658](https://bugs.openjdk.org/browse/JDK-8355658): Allow transforms to run on elements generated by a builder (**Enhancement** - P4)
 * [JDK-8355666](https://bugs.openjdk.org/browse/JDK-8355666): Allow transforms to run on elements generated by a builder (**CSR**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24908/head:pull/24908` \
`$ git checkout pull/24908`

Update a local copy of the PR: \
`$ git checkout pull/24908` \
`$ git pull https://git.openjdk.org/jdk.git pull/24908/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24908`

View PR using the GUI difftool: \
`$ git pr show -t 24908`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24908.diff">https://git.openjdk.org/jdk/pull/24908.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24908#issuecomment-2833794268)
</details>
