### PR TITLE
8355698: JDK not supporting sleef could cause exception at runtime after JDK-8353786

### DIFF
--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/VectorMathLibrary.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/VectorMathLibrary.java
@@ -272,11 +272,10 @@ import static jdk.internal.vm.vector.Utils.debug;
                 T impl = implSupplier.apply(opc); // TODO: should call the very same native implementation eventually (once FFM API supports vectors)
                 return new Entry<>(symbol, addr, impl);
             } catch (RuntimeException e) {
-              throw new InternalError("not supported: " + op + " " + vspecies + " " + symbol, e);
+              debug("Symbol not found for vector operation: " + op + " " + vspecies + " " + symbol);
             }
-        } else {
-            return new Entry<>(null, MemorySegment.NULL, implSupplier.apply(opc));
         }
+        return new Entry<>(null, MemorySegment.NULL, implSupplier.apply(opc));
     }
 
     @ForceInline


### PR DESCRIPTION
Hi,
Can you help to review this patch?

Before [JDK-8353786](https://bugs.openjdk.org/browse/JDK-8353786), when a released jdk not supportting sleef (for any reason, e.g. low gcc version, intrinsic not supported, rvv not supported, and so on) runs on machine support vector operation (e.g. on riscv, it supports rvv), it can not call into sleef, but will not fail either, it falls back to java scalar version implementation.
But after [JDK-8353786](https://bugs.openjdk.org/browse/JDK-8353786), it will cause an exception thrown at runtime.

This change the behaviour of existing jdk, and it should not throw exception anyway.

@iwanowww @RealFYang 

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8355698](https://bugs.openjdk.org/browse/JDK-8355698): JDK not supporting sleef could cause exception at runtime after JDK-8353786 (**Bug** - P4)
 * [JDK-8355656](https://bugs.openjdk.org/browse/JDK-8355656): Several vector tests fail when built with clang (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24914/head:pull/24914` \
`$ git checkout pull/24914`

Update a local copy of the PR: \
`$ git checkout pull/24914` \
`$ git pull https://git.openjdk.org/jdk.git pull/24914/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24914`

View PR using the GUI difftool: \
`$ git pr show -t 24914`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24914.diff">https://git.openjdk.org/jdk/pull/24914.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24914#issuecomment-2843103708)
</details>
