### PR TITLE
8355697: Create windows devkit on wsl and msys2

### DIFF
--- a/make/devkit/createWindowsDevkit.sh
+++ b/make/devkit/createWindowsDevkit.sh
@@ -56,20 +56,20 @@ BUILD_DIR="${SCRIPT_DIR}/../../build/devkit"
 
 UNAME_SYSTEM=`uname -s`
 UNAME_RELEASE=`uname -r`
+UNAME_OS=`uname -o`
 
 # Detect cygwin or WSL
 IS_CYGWIN=`echo $UNAME_SYSTEM | grep -i CYGWIN`
 IS_WSL=`echo $UNAME_RELEASE | grep Microsoft`
-IS_MSYS=`echo $UNAME_SYSTEM | grep MSYS_NT`
+IS_MSYS=`echo $UNAME_OS | grep -i Msys`
+MSYS2_ARG_CONV_EXCL="*"          # make "cmd.exe /c" work for msys2
+CMD_EXE="cmd.exe /c"
 if test "x$IS_CYGWIN" != "x"; then
     BUILD_ENV="cygwin"
-    CMD_EXE="cmd.exe /c"
 elif test "x$IS_MSYS" != "x"; then
     BUILD_ENV="cygwin"
-    CMD_EXE="cmd.exe //c"
 elif test "x$IS_WSL" != "x"; then
     BUILD_ENV="wsl"
-    CMD_EXE="cmd.exe /c"
 else
     echo "Unknown environment; only Cygwin/MSYS2/WSL are supported."
     exit 1

--- a/make/devkit/createWindowsDevkit.sh
+++ b/make/devkit/createWindowsDevkit.sh
@@ -188,7 +188,11 @@ cp $DEVKIT_ROOT/VC/redist/arm64/$MSVCP_DLL $DEVKIT_ROOT/VC/bin/arm64
 ################################################################################
 # Copy SDK files
 
-SDK_INSTALL_DIR="$PROGRAMFILES_X86/Windows Kits/$SDK_VERSION"
+SDK_INSTALL_DIR=`${CMD_EXE} echo %WindowsSdkDir% | tr -d '\r'`
+SDK_INSTALL_DIR="$($WINDOWS_PATH_TO_UNIX_PATH "$SDK_INSTALL_DIR")"
+if [ ! -d "$SDK_INSTALL_DIR" ]; then
+    SDK_INSTALL_DIR="$PROGRAMFILES_X86/Windows Kits/$SDK_VERSION"
+fi
 echo "SDK_INSTALL_DIR: $SDK_INSTALL_DIR"
 
 SDK_FULL_VERSION="$(ls "$SDK_INSTALL_DIR/bin" | sort -r -n | head -n1)"


### PR DESCRIPTION
The patch fix error when creating devkit on wsl/msys2 .
* Msys2 can be supported like cygwin
* In wsl, it can not test path name in windows format, like `if [ -d "d:/VisualStuio"]` . The path must be converted as linux style before testing.
* In msys2, `cmd.exe /c` doesn't work because "/c" is converted as "c:\", it can be work around with `cmd.exe //c`. see https://superuser.com/questions/526736/how-to-run-internal-cmd-command-from-the-msys-shell

I tested it with win10 + wsl/msys2 + VisualStudio 2022(17.13.6)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8355697](https://bugs.openjdk.org/browse/JDK-8355697): Create windows devkit on wsl and msys2 (**Enhancement** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**) Review applies to [187e7016](https://git.openjdk.org/jdk/pull/24916/files/187e701618e90281caacafa87fdd272269165d28)
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24916/head:pull/24916` \
`$ git checkout pull/24916`

Update a local copy of the PR: \
`$ git checkout pull/24916` \
`$ git pull https://git.openjdk.org/jdk.git pull/24916/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24916`

View PR using the GUI difftool: \
`$ git pr show -t 24916`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24916.diff">https://git.openjdk.org/jdk/pull/24916.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24916#issuecomment-2834889593)
</details>
