### PR TITLE
8355796: RISC-V: compiler/vectorapi/AllBitsSetVectorMatchRuleTest.java fails after JDK-8355657

### DIFF
--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -1123,16 +1123,38 @@ instruct vxorL_vx_masked(vReg dst_src, iRegL src, vRegMask_V0 v0) %{
 
 // vector and not
 
-instruct vand_not(vReg dst, vReg src1, vReg src2, immI_M1 m1) %{
-  predicate(UseZvbb &&
-            (Matcher::vector_element_basic_type(n) == T_BYTE ||
-             Matcher::vector_element_basic_type(n) == T_SHORT ||
-             Matcher::vector_element_basic_type(n) == T_INT));
+instruct vand_notB(vReg dst, vReg src1, vReg src2, immI_M1 m1) %{
+  predicate(UseZvbb && Matcher::vector_element_basic_type(n) == T_BYTE);
   match(Set dst (AndV src1 (XorV src2 (Replicate m1))));
-  format %{ "vand_not $dst, $src1, $src2" %}
+  format %{ "vand_notB $dst, $src1, $src2" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vsetvli_helper(T_BYTE, Matcher::vector_length(this));
+    __ vandn_vv(as_VectorRegister($dst$$reg),
+                as_VectorRegister($src1$$reg),
+                as_VectorRegister($src2$$reg));
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+instruct vand_notS(vReg dst, vReg src1, vReg src2, immI_M1 m1) %{
+  predicate(UseZvbb && Matcher::vector_element_basic_type(n) == T_SHORT);
+  match(Set dst (AndV src1 (XorV src2 (Replicate m1))));
+  format %{ "vand_notS $dst, $src1, $src2" %}
+  ins_encode %{
+    __ vsetvli_helper(T_SHORT, Matcher::vector_length(this));
+    __ vandn_vv(as_VectorRegister($dst$$reg),
+                as_VectorRegister($src1$$reg),
+                as_VectorRegister($src2$$reg));
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+instruct vand_notI(vReg dst, vReg src1, vReg src2, immI_M1 m1) %{
+  predicate(UseZvbb && Matcher::vector_element_basic_type(n) == T_INT);
+  match(Set dst (AndV src1 (XorV src2 (Replicate m1))));
+  format %{ "vand_notI $dst, $src1, $src2" %}
+  ins_encode %{
+    __ vsetvli_helper(T_INT, Matcher::vector_length(this));
     __ vandn_vv(as_VectorRegister($dst$$reg),
                 as_VectorRegister($src1$$reg),
                 as_VectorRegister($src2$$reg));
@@ -1153,16 +1175,40 @@ instruct vand_notL(vReg dst, vReg src1, vReg src2, immL_M1 m1) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct vand_not_masked(vReg dst_src1, vReg src2, immI_M1 m1, vRegMask_V0 v0) %{
-  predicate(UseZvbb &&
-            (Matcher::vector_element_basic_type(n) == T_BYTE ||
-             Matcher::vector_element_basic_type(n) == T_SHORT ||
-             Matcher::vector_element_basic_type(n) == T_INT));
+instruct vand_notB_masked(vReg dst_src1, vReg src2, immI_M1 m1, vRegMask_V0 v0) %{
+  predicate(UseZvbb && Matcher::vector_element_basic_type(n) == T_BYTE);
   match(Set dst_src1 (AndV (Binary dst_src1 (XorV src2 (Replicate m1))) v0));
-  format %{ "vand_not_masked $dst_src1, $dst_src1, $src2, $v0" %}
+  format %{ "vand_notB_masked $dst_src1, $dst_src1, $src2, $v0" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vsetvli_helper(T_BYTE, Matcher::vector_length(this));
+    __ vandn_vv(as_VectorRegister($dst_src1$$reg),
+                as_VectorRegister($dst_src1$$reg),
+                as_VectorRegister($src2$$reg),
+                Assembler::v0_t);
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+instruct vand_notS_masked(vReg dst_src1, vReg src2, immI_M1 m1, vRegMask_V0 v0) %{
+  predicate(UseZvbb && Matcher::vector_element_basic_type(n) == T_SHORT);
+  match(Set dst_src1 (AndV (Binary dst_src1 (XorV src2 (Replicate m1))) v0));
+  format %{ "vand_notS_masked $dst_src1, $dst_src1, $src2, $v0" %}
+  ins_encode %{
+    __ vsetvli_helper(T_SHORT, Matcher::vector_length(this));
+    __ vandn_vv(as_VectorRegister($dst_src1$$reg),
+                as_VectorRegister($dst_src1$$reg),
+                as_VectorRegister($src2$$reg),
+                Assembler::v0_t);
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+instruct vand_notI_masked(vReg dst_src1, vReg src2, immI_M1 m1, vRegMask_V0 v0) %{
+  predicate(UseZvbb && Matcher::vector_element_basic_type(n) == T_INT);
+  match(Set dst_src1 (AndV (Binary dst_src1 (XorV src2 (Replicate m1))) v0));
+  format %{ "vand_notI_masked $dst_src1, $dst_src1, $src2, $v0" %}
+  ins_encode %{
+    __ vsetvli_helper(T_INT, Matcher::vector_length(this));
     __ vandn_vv(as_VectorRegister($dst_src1$$reg),
                 as_VectorRegister($dst_src1$$reg),
                 as_VectorRegister($src2$$reg),
@@ -1185,16 +1231,38 @@ instruct vand_notL_masked(vReg dst_src1, vReg src2, immL_M1 m1, vRegMask_V0 v0) 
   ins_pipe(pipe_slow);
 %}
 
-instruct vand_not_vx(vReg dst, vReg src1, iRegIorL2I src2, immI_M1 m1) %{
-  predicate(UseZvbb &&
-            (Matcher::vector_element_basic_type(n) == T_BYTE ||
-             Matcher::vector_element_basic_type(n) == T_SHORT ||
-             Matcher::vector_element_basic_type(n) == T_INT));
+instruct vand_notB_vx(vReg dst, vReg src1, iRegIorL2I src2, immI_M1 m1) %{
+  predicate(UseZvbb && Matcher::vector_element_basic_type(n) == T_BYTE);
   match(Set dst (AndV src1 (Replicate (XorI src2 m1))));
-  format %{ "vand_not_vx $dst, $src1, $src2" %}
+    format %{ "vand_notB_vx $dst, $src1, $src2" %}
+    ins_encode %{
+    __ vsetvli_helper(T_BYTE, Matcher::vector_length(this));
+    __ vandn_vx(as_VectorRegister($dst$$reg),
+                as_VectorRegister($src1$$reg),
+                as_Register($src2$$reg));
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+instruct vand_notS_vx(vReg dst, vReg src1, iRegIorL2I src2, immI_M1 m1) %{
+  predicate(UseZvbb && Matcher::vector_element_basic_type(n) == T_SHORT);
+  match(Set dst (AndV src1 (Replicate (XorI src2 m1))));
+  format %{ "vand_notS_vx $dst, $src1, $src2" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vsetvli_helper(T_SHORT, Matcher::vector_length(this));
+    __ vandn_vx(as_VectorRegister($dst$$reg),
+                as_VectorRegister($src1$$reg),
+                as_Register($src2$$reg));
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+instruct vand_notI_vx(vReg dst, vReg src1, iRegIorL2I src2, immI_M1 m1) %{
+  predicate(UseZvbb && Matcher::vector_element_basic_type(n) == T_INT);
+  match(Set dst (AndV src1 (Replicate (XorI src2 m1))));
+  format %{ "vand_notI_vx $dst, $src1, $src2" %}
+  ins_encode %{
+    __ vsetvli_helper(T_INT, Matcher::vector_length(this));
     __ vandn_vx(as_VectorRegister($dst$$reg),
                 as_VectorRegister($src1$$reg),
                 as_Register($src2$$reg));
@@ -1215,16 +1283,40 @@ instruct vand_notL_vx(vReg dst, vReg src1, iRegL src2, immL_M1 m1) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct vand_not_vx_masked(vReg dst_src1, iRegIorL2I src2, immI_M1 m1, vRegMask_V0 v0) %{
-  predicate(UseZvbb &&
-            (Matcher::vector_element_basic_type(n) == T_BYTE ||
-             Matcher::vector_element_basic_type(n) == T_SHORT ||
-             Matcher::vector_element_basic_type(n) == T_INT));
+instruct vand_notB_vx_masked(vReg dst_src1, iRegIorL2I src2, immI_M1 m1, vRegMask_V0 v0) %{
+  predicate(UseZvbb && Matcher::vector_element_basic_type(n) == T_BYTE);
   match(Set dst_src1 (AndV (Binary dst_src1 (Replicate (XorI src2 m1))) v0));
   format %{ "vand_not_vx_masked $dst_src1, $dst_src1, $src2, $v0" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vsetvli_helper(T_BYTE, Matcher::vector_length(this));
+    __ vandn_vx(as_VectorRegister($dst_src1$$reg),
+                as_VectorRegister($dst_src1$$reg),
+                as_Register($src2$$reg),
+                Assembler::v0_t);
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+instruct vand_notS_vx_masked(vReg dst_src1, iRegIorL2I src2, immI_M1 m1, vRegMask_V0 v0) %{
+  predicate(UseZvbb && Matcher::vector_element_basic_type(n) == T_SHORT);
+  match(Set dst_src1 (AndV (Binary dst_src1 (Replicate (XorI src2 m1))) v0));
+  format %{ "vand_notS_vx_masked $dst_src1, $dst_src1, $src2, $v0" %}
+  ins_encode %{
+    __ vsetvli_helper(T_SHORT, Matcher::vector_length(this));
+    __ vandn_vx(as_VectorRegister($dst_src1$$reg),
+                as_VectorRegister($dst_src1$$reg),
+                as_Register($src2$$reg),
+                Assembler::v0_t);
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+instruct vand_notI_vx_masked(vReg dst_src1, iRegIorL2I src2, immI_M1 m1, vRegMask_V0 v0) %{
+  predicate(UseZvbb && Matcher::vector_element_basic_type(n) == T_INT);
+  match(Set dst_src1 (AndV (Binary dst_src1 (Replicate (XorI src2 m1))) v0));
+  format %{ "vand_notI_vx_masked $dst_src1, $dst_src1, $src2, $v0" %}
+  ins_encode %{
+    __ vsetvli_helper(T_INT, Matcher::vector_length(this));
     __ vandn_vx(as_VectorRegister($dst_src1$$reg),
                 as_VectorRegister($dst_src1$$reg),
                 as_Register($src2$$reg),

--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -1234,8 +1234,8 @@ instruct vand_notL_masked(vReg dst_src1, vReg src2, immL_M1 m1, vRegMask_V0 v0) 
 instruct vand_notB_vx(vReg dst, vReg src1, iRegIorL2I src2, immI_M1 m1) %{
   predicate(UseZvbb && Matcher::vector_element_basic_type(n) == T_BYTE);
   match(Set dst (AndV src1 (Replicate (XorI src2 m1))));
-    format %{ "vand_notB_vx $dst, $src1, $src2" %}
-    ins_encode %{
+  format %{ "vand_notB_vx $dst, $src1, $src2" %}
+  ins_encode %{
     __ vsetvli_helper(T_BYTE, Matcher::vector_length(this));
     __ vandn_vx(as_VectorRegister($dst$$reg),
                 as_VectorRegister($src1$$reg),
@@ -1286,7 +1286,7 @@ instruct vand_notL_vx(vReg dst, vReg src1, iRegL src2, immL_M1 m1) %{
 instruct vand_notB_vx_masked(vReg dst_src1, iRegIorL2I src2, immI_M1 m1, vRegMask_V0 v0) %{
   predicate(UseZvbb && Matcher::vector_element_basic_type(n) == T_BYTE);
   match(Set dst_src1 (AndV (Binary dst_src1 (Replicate (XorI src2 m1))) v0));
-  format %{ "vand_not_vx_masked $dst_src1, $dst_src1, $src2, $v0" %}
+  format %{ "vand_notB_vx_masked $dst_src1, $dst_src1, $src2, $v0" %}
   ins_encode %{
     __ vsetvli_helper(T_BYTE, Matcher::vector_length(this));
     __ vandn_vx(as_VectorRegister($dst_src1$$reg),


### PR DESCRIPTION
One or more IR match rules failed in AllBitsSetVectorMatchRuleTest. For the IR testing requirements, the matching rules are split by type. After fix, the test on fastdebug can passed!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8355796](https://bugs.openjdk.org/browse/JDK-8355796): RISC-V: compiler/vectorapi/AllBitsSetVectorMatchRuleTest.java fails after JDK-8355657 (**Bug** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Gui Cao](https://openjdk.org/census#gcao) (@zifeihan - Author)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24918/head:pull/24918` \
`$ git checkout pull/24918`

Update a local copy of the PR: \
`$ git checkout pull/24918` \
`$ git pull https://git.openjdk.org/jdk.git pull/24918/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24918`

View PR using the GUI difftool: \
`$ git pr show -t 24918`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24918.diff">https://git.openjdk.org/jdk/pull/24918.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24918#issuecomment-2837304395)
</details>
