### PR TITLE
8355711: Remove incorrect overflow check in RawBytecodeStream::raw_next

### DIFF
--- a/src/hotspot/share/interpreter/bytecodeStream.hpp
+++ b/src/hotspot/share/interpreter/bytecodeStream.hpp
@@ -136,11 +136,7 @@ class RawBytecodeStream: public BaseBytecodeStream {
       assert(code != Bytecodes::_wide && code != Bytecodes::_tableswitch
              && code != Bytecodes::_lookupswitch, "can't be special bytecode");
       _is_wide = false;
-      if (INT_MAX - len <= _next_bci) { // Check for integer overflow
-        code = Bytecodes::_illegal;
-      } else {
-        _next_bci += len;
-      }
+      _next_bci += len;
       _raw_code = code;
       return code;
     } else {

--- a/src/hotspot/share/interpreter/bytecodeStream.hpp
+++ b/src/hotspot/share/interpreter/bytecodeStream.hpp
@@ -136,9 +136,10 @@ class RawBytecodeStream: public BaseBytecodeStream {
       assert(code != Bytecodes::_wide && code != Bytecodes::_tableswitch
              && code != Bytecodes::_lookupswitch, "can't be special bytecode");
       _is_wide = false;
-      _next_bci += len;
-      if (_next_bci <= _bci) { // Check for integer overflow
+      if (INT_MAX - len <= _next_bci) { // Check for integer overflow
         code = Bytecodes::_illegal;
+      } else {
+      _next_bci += len;
       }
       _raw_code = code;
       return code;

--- a/src/hotspot/share/interpreter/bytecodeStream.hpp
+++ b/src/hotspot/share/interpreter/bytecodeStream.hpp
@@ -139,7 +139,7 @@ class RawBytecodeStream: public BaseBytecodeStream {
       if (INT_MAX - len <= _next_bci) { // Check for integer overflow
         code = Bytecodes::_illegal;
       } else {
-      _next_bci += len;
+        _next_bci += len;
       }
       _raw_code = code;
       return code;


### PR DESCRIPTION
Hi,

This fixes a typical wrong overflow check. `_bci` and `_next_bci` are both `int`, so any overflow is undefined, therefore an optimizing C++ compiler is allowed to remove this check. When looking at the x64 assembly for this, I could not find the check, so I guess that it was actually removed as well.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8355711](https://bugs.openjdk.org/browse/JDK-8355711): Remove incorrect overflow check in RawBytecodeStream::raw_next (**Bug** - P4)


### Reviewers
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**)
 * [Matias Saavedra Silva](https://openjdk.org/census#matsaave) (@matias9927 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24920/head:pull/24920` \
`$ git checkout pull/24920`

Update a local copy of the PR: \
`$ git checkout pull/24920` \
`$ git pull https://git.openjdk.org/jdk.git pull/24920/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24920`

View PR using the GUI difftool: \
`$ git pr show -t 24920`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24920.diff">https://git.openjdk.org/jdk/pull/24920.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24920#issuecomment-2835261979)
</details>
