### PR TITLE
8355717: Problem list tests until JDK-8355708 is fixed

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -78,6 +78,9 @@ compiler/ciReplay/TestIncrementalInlining.java 8349191 generic-all
 
 compiler/c2/TestVerifyConstraintCasts.java 8355574 generic-all
 
+compiler/c2/irTests/TestFloat16ScalarOperations.java 8355708 linux-aarch64
+compiler/c2/irTests/MulHFNodeIdealizationTests.java 8355708 linux-aarch64
+
 #############################################################################
 
 # :hotspot_gc


### PR DESCRIPTION
Problem listing the tests on AArch64 until [JDK-8355708](https://bugs.openjdk.org/browse/JDK-8355708) is fixed.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8355717](https://bugs.openjdk.org/browse/JDK-8355717): Problem list tests until JDK-8355708 is fixed (**Sub-task** - P2)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24921/head:pull/24921` \
`$ git checkout pull/24921`

Update a local copy of the PR: \
`$ git checkout pull/24921` \
`$ git pull https://git.openjdk.org/jdk.git pull/24921/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24921`

View PR using the GUI difftool: \
`$ git pr show -t 24921`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24921.diff">https://git.openjdk.org/jdk/pull/24921.diff</a>

</details>
