### PR TITLE
Implementation of JEP 506, Scoped Values

### DIFF
--- a/src/java.base/share/classes/java/lang/ScopedValue.java
+++ b/src/java.base/share/classes/java/lang/ScopedValue.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, 2022, Red Hat Inc.
+ * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2025, Red Hat Inc.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -611,10 +611,11 @@ public final class ScopedValue<T> {
      * Returns the value of this scoped value if bound in the current thread, otherwise
      * returns {@code other}.
      *
-     * @param other the value to return if not bound, can be {@code null}
+     * @param other the value to return if not bound
      * @return the value of the scoped value if bound, otherwise {@code other}
      */
     public T orElse(T other) {
+        Objects.requireNonNull(other);
         Object obj = findBinding();
         if (obj != Snapshot.NIL) {
             @SuppressWarnings("unchecked")

--- a/src/java.base/share/classes/java/lang/ScopedValue.java
+++ b/src/java.base/share/classes/java/lang/ScopedValue.java
@@ -34,7 +34,6 @@ import java.util.concurrent.StructureViolationException;
 import java.util.function.Supplier;
 import jdk.internal.access.JavaUtilConcurrentTLRAccess;
 import jdk.internal.access.SharedSecrets;
-import jdk.internal.javac.PreviewFeature;
 import jdk.internal.vm.annotation.ForceInline;
 import jdk.internal.vm.annotation.Hidden;
 import jdk.internal.vm.ScopedValueContainer;
@@ -236,9 +235,8 @@ import jdk.internal.vm.ScopedValueContainer;
  * have to be regenerated after a blocking operation.
  *
  * @param <T> the type of the value
- * @since 21
+ * @since 25
  */
-@PreviewFeature(feature = PreviewFeature.Feature.SCOPED_VALUES)
 public final class ScopedValue<T> {
     private final int hash;
 
@@ -311,7 +309,6 @@ public final class ScopedValue<T> {
      *
      * @since 21
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.SCOPED_VALUES)
     public static final class Carrier {
         // Bit masks: a 1 in position n indicates that this set of bound values
         // hits that slot in the cache.
@@ -498,7 +495,6 @@ public final class ScopedValue<T> {
      * @param <X> type of the exception thrown by the operation
      * @since 23
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.SCOPED_VALUES)
     @FunctionalInterface
     public interface CallableOp<T, X extends Throwable> {
         /**

--- a/src/java.base/share/classes/jdk/internal/javac/PreviewFeature.java
+++ b/src/java.base/share/classes/jdk/internal/javac/PreviewFeature.java
@@ -70,7 +70,6 @@ public @interface PreviewFeature {
         //---
         @JEP(number=495, title="Simple Source Files and Instance Main Methods", status="Fourth Preview")
         IMPLICIT_CLASSES,
-        @JEP(number=487, title="Scoped Values", status="Fourth Preview")
         SCOPED_VALUES,
         @JEP(number=499, title="Structured Concurrency", status="Fourth Preview")
         STRUCTURED_CONCURRENCY,


### PR DESCRIPTION
This is the implementation of [Scoped Values](https://bugs.openjdk.org/browse/JDK-8352695).
We here propose to finalize the scoped values API in JDK 25, without further change.
