### PR TITLE
8355594: Warnings occur when building with clang and enabling ubsan

### DIFF
--- a/make/autoconf/jdk-options.m4
+++ b/make/autoconf/jdk-options.m4
@@ -520,7 +520,10 @@ AC_DEFUN_ONCE([JDKOPT_SETUP_UNDEFINED_BEHAVIOR_SANITIZER],
   # Silence them for now.
   UBSAN_CHECKS="-fsanitize=undefined -fsanitize=float-divide-by-zero -fno-sanitize=shift-base -fno-sanitize=alignment \
       $ADDITIONAL_UBSAN_CHECKS"
-  UBSAN_CFLAGS="$UBSAN_CHECKS -Wno-stringop-truncation -Wno-format-overflow -Wno-array-bounds -Wno-stringop-overflow -fno-omit-frame-pointer -DUNDEFINED_BEHAVIOR_SANITIZER"
+  UBSAN_CFLAGS="$UBSAN_CHECKS -Wno-array-bounds -fno-omit-frame-pointer -DUNDEFINED_BEHAVIOR_SANITIZER"
+  if test "x$TOOLCHAIN_TYPE" = "xgcc"; then
+    UBSAN_CFLAGS="$UBSAN_CFLAGS -Wno-stringop-truncation -Wno-format-overflow -Wno-stringop-overflow"
+  fi
   UBSAN_LDFLAGS="$UBSAN_CHECKS"
   # On AIX, the llvm_symbolizer is not found out of the box, so we have to provide the
   # full qualified llvm_symbolizer path in the __ubsan_default_options() function in

--- a/make/autoconf/jdk-options.m4
+++ b/make/autoconf/jdk-options.m4
@@ -522,7 +522,7 @@ AC_DEFUN_ONCE([JDKOPT_SETUP_UNDEFINED_BEHAVIOR_SANITIZER],
       $ADDITIONAL_UBSAN_CHECKS"
   UBSAN_CFLAGS="$UBSAN_CHECKS -Wno-array-bounds -fno-omit-frame-pointer -DUNDEFINED_BEHAVIOR_SANITIZER"
   if test "x$TOOLCHAIN_TYPE" = "xgcc"; then
-    UBSAN_CFLAGS="$UBSAN_CFLAGS -Wno-stringop-truncation -Wno-format-overflow -Wno-stringop-overflow"
+    UBSAN_CFLAGS="$UBSAN_CFLAGS -Wno-format-overflow -Wno-stringop-overflow -Wno-stringop-truncation"
   fi
   UBSAN_LDFLAGS="$UBSAN_CHECKS"
   # On AIX, the llvm_symbolizer is not found out of the box, so we have to provide the


### PR DESCRIPTION
When building ubsan-enabled binaries with the clang toolchain (e.g. on AIX or Linux), we get the following warnings :

```
warning: unknown warning option '-Wno-stringop-truncation'; did you mean '-Wno-string-concatenation'? [-Wunknown-warning-option]
warning: unknown warning option '-Wno-format-overflow'; did you mean '-Wno-shift-overflow'? [-Wunknown-warning-option]
warning: unknown warning option '-Wno-stringop-overflow'; did you mean '-Wno-shift-overflow'? [-Wunknown-warning-option]
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8355594](https://bugs.openjdk.org/browse/JDK-8355594): Warnings occur when building with clang and enabling ubsan (**Bug** - P4)


### Reviewers
 * [Joachim Kern](https://openjdk.org/census#jkern) (@JoKern65 - Committer) Review applies to [dbfcece2](https://git.openjdk.org/jdk/pull/24924/files/dbfcece2f8a1973a01ad81b0f3a0c8029213b999)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**) Review applies to [dbfcece2](https://git.openjdk.org/jdk/pull/24924/files/dbfcece2f8a1973a01ad81b0f3a0c8029213b999)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24924/head:pull/24924` \
`$ git checkout pull/24924`

Update a local copy of the PR: \
`$ git checkout pull/24924` \
`$ git pull https://git.openjdk.org/jdk.git pull/24924/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24924`

View PR using the GUI difftool: \
`$ git pr show -t 24924`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24924.diff">https://git.openjdk.org/jdk/pull/24924.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24924#issuecomment-2835639123)
</details>
