### PR TITLE
8355726: LinkedBlockingDeque fixes and improvements

### DIFF
--- a/src/java.base/share/classes/java/util/concurrent/LinkedBlockingDeque.java
+++ b/src/java.base/share/classes/java/util/concurrent/LinkedBlockingDeque.java
@@ -373,7 +373,7 @@ public class LinkedBlockingDeque<E>
         if (e == null) throw new NullPointerException();
         Node<E> node = new Node<E>(e);
         final ReentrantLock lock = this.lock;
-        lock.lock();
+        lock.lockInterruptibly();
         try {
             while (count >= capacity)
                 notFull.await();
@@ -391,7 +391,7 @@ public class LinkedBlockingDeque<E>
         if (e == null) throw new NullPointerException();
         Node<E> node = new Node<E>(e);
         final ReentrantLock lock = this.lock;
-        lock.lock();
+        lock.lockInterruptibly();
         try {
             while (count >= capacity)
                 notFull.await();
@@ -491,7 +491,7 @@ public class LinkedBlockingDeque<E>
 
     public E takeFirst() throws InterruptedException {
         final ReentrantLock lock = this.lock;
-        lock.lock();
+        lock.lockInterruptibly();
         try {
             E x;
             while ( (x = unlinkFirst()) == null)
@@ -504,7 +504,7 @@ public class LinkedBlockingDeque<E>
 
     public E takeLast() throws InterruptedException {
         final ReentrantLock lock = this.lock;
-        lock.lock();
+        lock.lockInterruptibly();
         try {
             E x;
             while ( (x = unlinkLast()) == null)

--- a/src/java.base/share/classes/java/util/concurrent/LinkedBlockingDeque.java
+++ b/src/java.base/share/classes/java/util/concurrent/LinkedBlockingDeque.java
@@ -996,8 +996,8 @@ public class LinkedBlockingDeque<E>
             for (Node<E> f = first; f != null; ) {
                 f.item = null;
                 Node<E> n = f.next;
-                f.prev = null;
-                f.next = null;
+                f.prev = f;
+                f.next = f;
                 f = n;
             }
             first = last = null;

--- a/src/java.base/share/classes/java/util/concurrent/LinkedBlockingDeque.java
+++ b/src/java.base/share/classes/java/util/concurrent/LinkedBlockingDeque.java
@@ -860,7 +860,7 @@ public class LinkedBlockingDeque<E>
 
         // Copy c into a private chain of Nodes
         Node<E> beg = null, end = null;
-        int n = 0;
+        long n = 0;
         for (E e : c) {
             Objects.requireNonNull(e);
             n++;
@@ -887,7 +887,7 @@ public class LinkedBlockingDeque<E>
                 else
                     last.next = beg;
                 last = end;
-                count += n;
+                count = (int) (count + n);
                 notEmpty.signalAll();
                 return true;
             }
@@ -896,6 +896,7 @@ public class LinkedBlockingDeque<E>
         }
         // Fall back to historic non-atomic implementation, failing
         // with IllegalStateException when the capacity is exceeded.
+        beg = end = null; // help GC
         return super.addAll(c);
     }
 

--- a/src/java.base/share/classes/java/util/concurrent/LinkedBlockingDeque.java
+++ b/src/java.base/share/classes/java/util/concurrent/LinkedBlockingDeque.java
@@ -888,7 +888,7 @@ public class LinkedBlockingDeque<E>
                 else
                     last.next = beg;
                 last = end;
-                count = (int) (cnt + n);
+                count = (int)cnt;
                 notEmpty.signalAll();
                 return true;
             }

--- a/src/java.base/share/classes/java/util/concurrent/LinkedBlockingDeque.java
+++ b/src/java.base/share/classes/java/util/concurrent/LinkedBlockingDeque.java
@@ -211,7 +211,8 @@ public class LinkedBlockingDeque<E>
      */
     private boolean linkFirst(Node<E> node) {
         // assert lock.isHeldByCurrentThread();
-        if (count >= capacity)
+        int c;
+        if ((c = count) >= capacity)
             return false;
         Node<E> f = first;
         node.next = f;
@@ -220,7 +221,7 @@ public class LinkedBlockingDeque<E>
             last = node;
         else
             f.prev = node;
-        ++count;
+        count = c + 1;
         notEmpty.signal();
         return true;
     }
@@ -242,7 +243,7 @@ public class LinkedBlockingDeque<E>
             first = node;
         else
             l.next = node;
-        ++count;
+        count = c + 1;
         notEmpty.signal();
         return true;
     }
@@ -879,14 +880,15 @@ public class LinkedBlockingDeque<E>
         final ReentrantLock lock = this.lock;
         lock.lock();
         try {
-            if (count + n <= capacity) {
+            int cnt;
+            if ((cnt = count) + n <= capacity) {
                 beg.prev = last;
                 if (first == null)
                     first = beg;
                 else
                     last.next = beg;
                 last = end;
-                count = (int) (count + n);
+                count = (int) (cnt + n);
                 notEmpty.signalAll();
                 return true;
             }

--- a/src/java.base/share/classes/java/util/concurrent/LinkedBlockingDeque.java
+++ b/src/java.base/share/classes/java/util/concurrent/LinkedBlockingDeque.java
@@ -880,8 +880,8 @@ public class LinkedBlockingDeque<E>
         final ReentrantLock lock = this.lock;
         lock.lock();
         try {
-            int cnt;
-            if ((cnt = count) + n <= capacity) {
+            long cnt;
+            if ((cnt = count + n) <= capacity) {
                 beg.prev = last;
                 if (first == null)
                     first = beg;

--- a/src/java.base/share/classes/java/util/concurrent/LinkedBlockingDeque.java
+++ b/src/java.base/share/classes/java/util/concurrent/LinkedBlockingDeque.java
@@ -232,7 +232,8 @@ public class LinkedBlockingDeque<E>
      */
     private boolean linkLast(Node<E> node) {
         // assert lock.isHeldByCurrentThread();
-        if (count >= capacity)
+        int c;
+        if ((c = count) >= capacity)
             return false;
         Node<E> l = last;
         node.prev = l;

--- a/src/java.base/share/classes/java/util/concurrent/LinkedBlockingDeque.java
+++ b/src/java.base/share/classes/java/util/concurrent/LinkedBlockingDeque.java
@@ -211,7 +211,8 @@ public class LinkedBlockingDeque<E>
      */
     private boolean linkFirst(Node<E> node) {
         // assert lock.isHeldByCurrentThread();
-        if (count >= capacity) return false;
+        if (count >= capacity)
+            return false;
         Node<E> f = first;
         node.next = f;
         first = node;
@@ -231,7 +232,8 @@ public class LinkedBlockingDeque<E>
      */
     private boolean linkLast(Node<E> node) {
         // assert lock.isHeldByCurrentThread();
-        if (count >= capacity) return false;
+        if (count >= capacity)
+            return false;
         Node<E> l = last;
         node.prev = l;
         last = node;

--- a/test/jdk/java/util/concurrent/tck/LinkedBlockingDequeTest.java
+++ b/test/jdk/java/util/concurrent/tck/LinkedBlockingDequeTest.java
@@ -1944,4 +1944,22 @@ public class LinkedBlockingDequeTest extends JSR166TestCase {
             }
         }
     }
+
+    public void testWeaklyConsistentIterationWithClear() {
+        final LinkedBlockingDeque<Item> q = new LinkedBlockingDeque<>(3);
+        q.add(one);
+        q.add(two);
+        q.add(three);
+        final Iterator<Item> it = q.iterator();
+        mustEqual(one, it.next());
+        q.clear();
+        q.add(four);
+        q.add(five);
+        q.add(six);
+        mustEqual(two, it.next());
+        mustEqual(four, it.next());
+        mustEqual(five, it.next());
+        mustEqual(six, it.next());
+        mustEqual(3, q.size());
+    }
 }

--- a/test/jdk/java/util/concurrent/tck/LinkedBlockingDequeTest.java
+++ b/test/jdk/java/util/concurrent/tck/LinkedBlockingDequeTest.java
@@ -1946,7 +1946,7 @@ public class LinkedBlockingDequeTest extends JSR166TestCase {
     }
 
     public void testWeaklyConsistentIterationWithClear() {
-        final LinkedBlockingDeque<Item> q = new LinkedBlockingDeque<>(3);
+        final LinkedBlockingDeque<Item> q = new LinkedBlockingDeque<>();
         q.add(one);
         q.add(two);
         q.add(three);
@@ -1964,7 +1964,7 @@ public class LinkedBlockingDequeTest extends JSR166TestCase {
     }
 
     public void testWeaklyConsistentIterationWithIteratorRemove() {
-        final LinkedBlockingDeque<Item> q = new LinkedBlockingDeque<>(15);
+        final LinkedBlockingDeque<Item> q = new LinkedBlockingDeque<>();
         q.add(one);
         q.add(two);
         q.add(three);

--- a/test/jdk/java/util/concurrent/tck/LinkedBlockingDequeTest.java
+++ b/test/jdk/java/util/concurrent/tck/LinkedBlockingDequeTest.java
@@ -1928,6 +1928,7 @@ public class LinkedBlockingDequeTest extends JSR166TestCase {
                     fail("Expected InterruptedException in takeLast()");
                 } catch (InterruptedException expected) {
                     // good that's what we want
+                    assertFalse(Thread.currentThread().isInterrupted());
                 }
                 return null;
             });

--- a/test/jdk/java/util/concurrent/tck/LinkedBlockingDequeTest.java
+++ b/test/jdk/java/util/concurrent/tck/LinkedBlockingDequeTest.java
@@ -1962,4 +1962,34 @@ public class LinkedBlockingDequeTest extends JSR166TestCase {
         mustEqual(six, it.next());
         mustEqual(3, q.size());
     }
+
+    public void testWeaklyConsistentIterationWithIteratorRemove() {
+        final LinkedBlockingDeque<Item> q = new LinkedBlockingDeque<>(15);
+        q.add(one);
+        q.add(two);
+        q.add(three);
+        q.add(four);
+        q.add(five);
+        final Iterator<Item> it1 = q.iterator();
+        final Iterator<Item> it2 = q.iterator();
+        final Iterator<Item> it3 = q.iterator();
+        mustEqual(one, it1.next());
+        mustEqual(two, it1.next());
+        it1.remove(); // removing "two"
+        mustEqual(one, it2.next());
+        it2.remove(); // removing "one"
+        mustEqual(three, it2.next());
+        mustEqual(four, it2.next());
+        it2.remove(); // removing "four"
+        mustEqual(one, it3.next());
+        mustEqual(three, it3.next());
+        mustEqual(five, it3.next());
+        assertFalse(it3.hasNext());
+        mustEqual(three, it1.next());
+        mustEqual(five, it1.next());
+        assertFalse(it1.hasNext());
+        mustEqual(five, it2.next());
+        assertFalse(it2.hasNext());
+        mustEqual(2, q.size());
+    }
 }

--- a/test/jdk/java/util/concurrent/tck/LinkedBlockingDequeTest.java
+++ b/test/jdk/java/util/concurrent/tck/LinkedBlockingDequeTest.java
@@ -1919,6 +1919,7 @@ public class LinkedBlockingDequeTest extends JSR166TestCase {
                     fail("Expected InterruptedException in takeFirst()");
                 } catch (InterruptedException expected) {
                     // good that's what we want
+                    assertFalse(Thread.currentThread().isInterrupted());
                 }
 
                 queue.add(42);

--- a/test/jdk/java/util/concurrent/tck/LinkedBlockingDequeTest.java
+++ b/test/jdk/java/util/concurrent/tck/LinkedBlockingDequeTest.java
@@ -1910,6 +1910,7 @@ public class LinkedBlockingDequeTest extends JSR166TestCase {
                     fail("Expected InterruptedException in putLast()");
                 } catch (InterruptedException expected) {
                     // good that's what we want
+                    assertFalse(Thread.currentThread().isInterrupted());
                 }
 
                 queue.add(42);

--- a/test/jdk/java/util/concurrent/tck/LinkedBlockingDequeTest.java
+++ b/test/jdk/java/util/concurrent/tck/LinkedBlockingDequeTest.java
@@ -1902,6 +1902,7 @@ public class LinkedBlockingDequeTest extends JSR166TestCase {
                     fail("Expected InterruptedException in putFirst()");
                 } catch (InterruptedException expected) {
                     // good that's what we want
+                    assertFalse(Thread.currentThread().isInterrupted());
                 }
 
                 Thread.currentThread().interrupt();


### PR DESCRIPTION
We logged several bugs on the LinkedBlockingDeque. This aggregates them into a single bug report and PR.

1. LinkedBlockingDeque does not immediately throw InterruptedException in put/take

The LinkedBlockingDeque does not behave consistently with other concurrency components. If we call putFirst(), putLast(), takeFirst(), or takeLast() with a thread that is interrupted, it does not immediately throw an InterruptedException, the way that ArrayBlockingQueue and LInkedBlockingQueue does, because instead of lockInterruptibly(), we call lock(). It will only throw an InterruptedException if the queue is full (on put) or empty (on take). Since interruptions are frequently used as a shutdown mechanism, this might prevent code from ever shutting down.

2. LinkedBlockingDeque.clear() should preserve weakly-consistent iterators

LinkedBlockingDeque.clear() should preserve weakly-consistent iterators by linking f.prev and f.next back to f, allowing the iterators to continue from the first or last respectively. This would be consistent with how the other node-based weakly consistent queues LinkedBlockingQueue LinkedTransferQueue, ConcurrentLinkedQueue/Deque work.

The LBD already supports self-linking, since that is done by the unlinkFirst() and unlinkLast() methods, and the iterators and spliterator thus all support self-linking.

This can be fixed very easily by linking both f.prev and f.next back to f.

3. LinkedBlockingDeque offer() creates nodes even if capacity has been reached

In the JavaDoc of LinkedBlockingDeque, it states: "Linked nodes are dynamically created upon each insertion unless this would bring the deque above capacity." However, in the current implementation, nodes are always created, even if the deque is full. This is because count is non-volatile, and we only check inside the linkFirst/Last() methods whether the queue is full. At this point we have already locked and have created the Node. Instead, the count could be volatile, and we could check before locking.

In the current version, calling offer() on a full LinkedBlockingDeque creates unnecessary objects and contention. Similarly for poll() and peek(), we could exit prior to locking by checking the count field.

4. LinkedBlockingDeque allows us to overflow size with addAll()

In LinkedBlockingDeque.addAll() we first build up the chain of nodes and then add that chain in bulk to the existing nodes. We count the nodes in "int n" and then whilst holding the lock, we check that we haven't exceeded the capacity with "if (count + n <= capacity)". However, if we pass in a collection that has more than Integer.MAX_VALUE items in it, then we can overflow n, making it negative. Since "count + n" is also negative, we can add the chain to our last item, and thus we end up with a LinkedBlockingDeque with more than Integer.MAX_VALUE of items and a negative size(). stream().count() gives the correct number of items.

This happens both via the bulk add constructor LinkedBlockingDeque(Collection) and when we call addAll(Collection) directly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8355726](https://bugs.openjdk.org/browse/JDK-8355726): LinkedBlockingDeque fixes and improvements (**Bug** - P4)


### Reviewers
 * [Doug Lea](https://openjdk.org/census#dl) (@DougLea - **Reviewer**) Review applies to [76282a43](https://git.openjdk.org/jdk/pull/24925/files/76282a43919566e14819f4af9685d0e1b5be9b4c)
 * [Viktor Klang](https://openjdk.org/census#vklang) (@viktorklang-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24925/head:pull/24925` \
`$ git checkout pull/24925`

Update a local copy of the PR: \
`$ git checkout pull/24925` \
`$ git pull https://git.openjdk.org/jdk.git pull/24925/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24925`

View PR using the GUI difftool: \
`$ git pr show -t 24925`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24925.diff">https://git.openjdk.org/jdk/pull/24925.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24925#issuecomment-2835640853)
</details>
