### PR TITLE
8355646: Optimize ObjectMonitor::exit

### DIFF
--- a/src/hotspot/share/runtime/objectMonitor.cpp
+++ b/src/hotspot/share/runtime/objectMonitor.cpp
@@ -1509,6 +1509,35 @@ void ObjectMonitor::exit(JavaThread* current, bool not_suspended) {
   for (;;) {
     assert(has_owner(current), "invariant");
 
+    // If there is a successor we should release the lock as soon as
+    // posible, so that the successor can aquire the look. If there is
+    // no successor, we might need to wake up a waiting thread.
+    if (!has_successor()) {
+      ObjectWaiter* w = Atomic::load(&_entry_list);
+      if (w != nullptr) {
+        // Other threads are blocked trying to acquire the lock and
+        // there is no successor, so it appears that an heir-
+        // presumptive (successor) must be made ready. Since threads
+        // are woken up in FIFO order, we need to find the tail of the
+        // entry_list.
+        w = entry_list_tail(current);
+        // I'd like to write: guarantee (w->_thread != current).
+        // But in practice an exiting thread may find itself on the entry_list.
+        // Let's say thread T1 calls O.wait().  Wait() enqueues T1 on O's waitset and
+        // then calls exit().  Exit release the lock by setting O._owner to null.
+        // Let's say T1 then stalls.  T2 acquires O and calls O.notify().  The
+        // notify() operation moves T1 from O's waitset to O's entry_list. T2 then
+        // release the lock "O".  T1 resumes immediately after the ST of null into
+        // _owner, above.  T1 notices that the entry_list is populated, so it
+        // reacquires the lock and then finds itself on the entry_list.
+        // Given all that, we have to tolerate the circumstance where "w" is
+        // associated with current.
+        assert(w->TState == ObjectWaiter::TS_ENTER, "invariant");
+        exit_epilog(current, w);
+        return;
+      }
+    }
+
     // Drop the lock.
     // release semantics: prior loads and stores from within the critical section
     // must not float (reorder) past the following store that drops the lock.
@@ -1547,11 +1576,9 @@ void ObjectMonitor::exit(JavaThread* current, bool not_suspended) {
       return;
     }
 
-    // Other threads are blocked trying to acquire the lock and there
-    // is no successor, so it appears that an heir-presumptive
-    // (successor) must be made ready. Only the current lock owner can
-    // detach threads from the entry_list, therefore we need to
-    // reacquire the lock. If we fail to reacquire the lock the
+    // Only the current lock owner can manipulate the entry_list
+    // (except for pushing new threads to the head), therefore we need
+    // to reacquire the lock. If we fail to reacquire the lock the
     // responsibility for ensuring succession falls to the new owner.
 
     if (try_lock(current) != TryLockResult::Success) {
@@ -1561,27 +1588,6 @@ void ObjectMonitor::exit(JavaThread* current, bool not_suspended) {
     }
 
     guarantee(has_owner(current), "invariant");
-
-    ObjectWaiter* w = nullptr;
-
-    w = Atomic::load(&_entry_list);
-    if (w != nullptr) {
-      w = entry_list_tail(current);
-      // I'd like to write: guarantee (w->_thread != current).
-      // But in practice an exiting thread may find itself on the entry_list.
-      // Let's say thread T1 calls O.wait().  Wait() enqueues T1 on O's waitset and
-      // then calls exit().  Exit release the lock by setting O._owner to null.
-      // Let's say T1 then stalls.  T2 acquires O and calls O.notify().  The
-      // notify() operation moves T1 from O's waitset to O's entry_list. T2 then
-      // release the lock "O".  T1 resumes immediately after the ST of null into
-      // _owner, above.  T1 notices that the entry_list is populated, so it
-      // reacquires the lock and then finds itself on the entry_list.
-      // Given all that, we have to tolerate the circumstance where "w" is
-      // associated with current.
-      assert(w->TState == ObjectWaiter::TS_ENTER, "invariant");
-      exit_epilog(current, w);
-      return;
-    }
   }
 }
 


### PR DESCRIPTION
Today ObjectMonitor::exit always releases the lock before checking if it needs to wake up a waiting thread that is queued on the entry_list. In order to unpark a thread from the entry_list it needs to re-acquire the lock again.

If we (before releasing the lock) check if there is no assigned successor but there is a waiting thread in the entry_list we can immediately unpark the thread, thus saving us the trouble of releasing and re-acquiring the lock.

If there already is an assigned successor (spinning and wanting to acquire the lock) we still want to release the lock as soon as possible so that we don't lengthen the critical section thereby delaying any spinning threads from getting the lock in a high contention scenario.

This PR is first and foremost an optimization if the lock is lightly contended. It also removes some source reading confusion, as to why we release and then immediately re-acquire the lock.

When running performance tests we see that the number of test that has improved outnumber the tests that has not.

Passes tier1-7 with no added problems.