### PR TITLE
8355739: AssertionError: Invalid CPU feature name after 8353786

### DIFF
--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/CPUFeatures.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/CPUFeatures.java
@@ -42,6 +42,9 @@ import static jdk.internal.vm.vector.Utils.debug;
     private static Set<String> getCPUFeatures() {
         String featuresString = VectorSupport.getCPUFeatures();
         debug(featuresString);
+
+        if (featuresString.equals("")) return Set.of();
+
         String[] features = featuresString.toLowerCase(Locale.ROOT)
                                           .split(",? "); // " " or ", " are used as a delimiter by JVM
         assert validateFeatures(features);


### PR DESCRIPTION
Fix usage of String.split() for getCPUFeatures().

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8355739](https://bugs.openjdk.org/browse/JDK-8355739): AssertionError: Invalid CPU feature name after 8353786 (**Bug** - P4)


### Reviewers
 * [Vladimir Ivanov](https://openjdk.org/census#vlivanov) (@iwanowww - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24931/head:pull/24931` \
`$ git checkout pull/24931`

Update a local copy of the PR: \
`$ git checkout pull/24931` \
`$ git pull https://git.openjdk.org/jdk.git pull/24931/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24931`

View PR using the GUI difftool: \
`$ git pr show -t 24931`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24931.diff">https://git.openjdk.org/jdk/pull/24931.diff</a>

</details>
