### PR TITLE
8355773: Some nsk/jdi tests can fetch ThreadReference from static field in the debuggee

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventRequest/addCountFilter/addcountfilter001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventRequest/addCountFilter/addcountfilter001.java
@@ -291,7 +291,7 @@ public class addcountfilter001 extends JDIBase {
             switch (i) {
 
               case 0:
-                     thread1 = debuggee.threadByNameOrThrow(threadName1);
+                     thread1 = debuggee.threadByFieldNameOrThrow(debuggeeClass, threadName1);
 
                      log2("......setting up StepRequest");
                      eventRequest1 = eventRManager.createStepRequest

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventRequest/disable/disable001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventRequest/disable/disable001.java
@@ -289,7 +289,7 @@ public class disable001 extends JDIBase {
             switch (i) {
 
               case 0:
-                     thread1 = debuggee.threadByNameOrThrow(threadName1);
+                     thread1 = debuggee.threadByFieldNameOrThrow(debuggeeClass, threadName1);
 
                      log2("......setting up StepRequest");
                      eventRequest1 = eventRManager.createStepRequest

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventRequest/disable/disable002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventRequest/disable/disable002.java
@@ -283,8 +283,7 @@ public class disable002 extends JDIBase {
             switch (i) {
 
               case 0:
-                     thread1 = debuggee.threadByNameOrThrow(threadName1);
-
+                  thread1 = debuggee.threadByFieldNameOrThrow(debuggeeClass, threadName1);
                      log2("......setting up StepRequest");
                      eventRequest1 = eventRManager.createStepRequest
                                      (thread1, StepRequest.STEP_MIN, StepRequest.STEP_INTO);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventRequest/enable/enable001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventRequest/enable/enable001.java
@@ -283,7 +283,7 @@ public class enable001 extends JDIBase {
             switch (i) {
 
               case 0:
-                     thread1 = debuggee.threadByNameOrThrow(threadName1);
+                     thread1 = debuggee.threadByFieldNameOrThrow(debuggeeClass, threadName1);
 
                      log2("......setting up StepRequest");
                      eventRequest1 = eventRManager.createStepRequest

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventRequest/enable/enable002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventRequest/enable/enable002.java
@@ -285,7 +285,7 @@ public class enable002 extends JDIBase {
             switch (i) {
 
               case 0:
-                     thread1 = debuggee.threadByNameOrThrow(threadName1);
+                     thread1 = debuggee.threadByFieldNameOrThrow(debuggeeClass, threadName1);
 
                      log2("......setting up StepRequest");
                      eventRequest1 = eventRManager.createStepRequest

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventRequest/getProperty/getproperty001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventRequest/getProperty/getproperty001.java
@@ -289,7 +289,7 @@ public class getproperty001 extends JDIBase {
             switch (i) {
 
               case 0:
-                     thread1 = debuggee.threadByNameOrThrow(threadName1);
+                     thread1 = debuggee.threadByFieldNameOrThrow(debuggeeClass, threadName1);
 
                      log2("......setting up StepRequest");
                      eventRequest1 = eventRManager.createStepRequest

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventRequest/hashCode/hashcode001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventRequest/hashCode/hashcode001.java
@@ -118,7 +118,7 @@ public class hashcode001 {
             switch (i) {
 
                 case 0:
-                       ThreadReference thread = debuggee.mainThread();
+                       ThreadReference thread = debuggee.threadByNameOrThrow(methodName());
 
                        display(".....setting up StepRequest");
                        eventRequest = eventRequestManager.createStepRequest

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventRequest/hashCode/hashcode001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventRequest/hashCode/hashcode001.java
@@ -118,7 +118,7 @@ public class hashcode001 {
             switch (i) {
 
                 case 0:
-                       ThreadReference thread = debuggee.threadByNameOrThrow(methodName());
+                       ThreadReference thread = debuggee.threadByNameOrThrow(methodName);
 
                        display(".....setting up StepRequest");
                        eventRequest = eventRequestManager.createStepRequest

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventRequest/hashCode/hashcode001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventRequest/hashCode/hashcode001.java
@@ -118,7 +118,7 @@ public class hashcode001 {
             switch (i) {
 
                 case 0:
-                       ThreadReference thread = debuggee.threadByNameOrThrow(methodName);
+                       ThreadReference thread = debuggee.mainThread();
 
                        display(".....setting up StepRequest");
                        eventRequest = eventRequestManager.createStepRequest

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventRequest/isEnabled/isenabled001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventRequest/isEnabled/isenabled001.java
@@ -284,7 +284,7 @@ public class isenabled001 extends JDIBase {
             switch (i) {
 
               case 0:
-                     thread1 = debuggee.threadByNameOrThrow(threadName1);
+                     thread1 = debuggee.threadByFieldNameOrThrow(debuggeeClass, threadName1);
 
                      log2("......setting up StepRequest");
                      eventRequest1 = eventRManager.createStepRequest

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventRequest/putProperty/putproperty001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventRequest/putProperty/putproperty001.java
@@ -289,7 +289,7 @@ public class putproperty001 extends JDIBase {
             switch (i) {
 
               case 0:
-                     thread1 = debuggee.threadByNameOrThrow(threadName1);
+                     thread1 = debuggee.threadByFieldNameOrThrow(debuggeeClass, threadName1);
 
                      log2("......setting up StepRequest");
                      eventRequest1 = eventRManager.createStepRequest

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventRequest/setEnabled/setenabled001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventRequest/setEnabled/setenabled001.java
@@ -282,7 +282,7 @@ public class setenabled001 extends JDIBase {
             switch (i) {
 
               case 0:
-                     thread1 = debuggee.threadByNameOrThrow(threadName1);
+                     thread1 = debuggee.threadByFieldNameOrThrow(debuggeeClass, threadName1);
 
                      log2("......setting up StepRequest");
                      eventRequest1 = eventRManager.createStepRequest

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventRequest/setEnabled/setenabled002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventRequest/setEnabled/setenabled002.java
@@ -286,7 +286,7 @@ public class setenabled002 extends JDIBase {
             switch (i) {
 
               case 0:
-                     thread1 = debuggee.threadByNameOrThrow(threadName1);
+                     thread1 = debuggee.threadByFieldNameOrThrow(debuggeeClass, threadName1);
 
                      log2("......setting up StepRequest");
                      eventRequest1 = eventRManager.createStepRequest

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventRequest/setSuspendPolicy/setsuspendpolicy001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventRequest/setSuspendPolicy/setsuspendpolicy001.java
@@ -291,7 +291,7 @@ public class setsuspendpolicy001 extends JDIBase {
             switch (i) {
 
               case 0:
-                     thread1 = debuggee.threadByNameOrThrow(threadName1);
+                     thread1 = debuggee.threadByFieldNameOrThrow(debuggeeClass, threadName1);
 
                      log2("......setting up StepRequest");
                      eventRequest1 = eventRManager.createStepRequest

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventRequest/suspendPolicy/suspendpolicy001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventRequest/suspendPolicy/suspendpolicy001.java
@@ -287,7 +287,7 @@ public class suspendpolicy001 extends JDIBase {
             switch (i) {
 
               case 0:
-                     thread1 = debuggee.threadByNameOrThrow(threadName1);
+                     thread1 = debuggee.threadByFieldNameOrThrow(debuggeeClass, threadName1);
 
                      log2("......setting up StepRequest");
                      eventRequest1 = eventRManager.createStepRequest

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventRequestManager/createStepRequest/crstepreq002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventRequestManager/createStepRequest/crstepreq002.java
@@ -275,7 +275,7 @@ public class crstepreq002 extends JDIBase {
 
             //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ variable part
 
-            thread = debuggee.threadByNameOrThrow(threadName);
+            thread = debuggee.threadByFieldNameOrThrow(debuggeeClass, threadName);
 
             if (StepRequest.STEP_MIN > StepRequest.STEP_LINE) {
                 maxSize = StepRequest.STEP_MIN;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventRequestManager/createStepRequest/crstepreq003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventRequestManager/createStepRequest/crstepreq003.java
@@ -77,8 +77,8 @@ public class crstepreq003 {
 
     //------------------------------------------------------ test specific fields
 
-    static final int lineForBreakInThread    = 137;
-    static final int[] checkedLines = { 138, 138, 178 };
+    static final int lineForBreakInThread    = 141;
+    static final int[] checkedLines = { 142, 142, 182 };
 
     //------------------------------------------------------ mutable common methods
 
@@ -247,7 +247,7 @@ public class crstepreq003 {
             exitCode = FAILED;
         }
 
-        ThreadReference thread = debuggee.threadByNameOrThrow(threadName);
+        ThreadReference thread = debuggee.threadByFieldNameOrThrow(debuggeeClass, threadName);
         StepRequest stepRequest = setStepRequest( thread,
                                                   StepRequest.STEP_LINE,
                                                   stepDepth,

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventRequestManager/createStepRequest/crstepreq003a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventRequestManager/createStepRequest/crstepreq003a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventRequestManager/createStepRequest/crstepreq003a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventRequestManager/createStepRequest/crstepreq003a.java
@@ -55,6 +55,10 @@ public class crstepreq003a {
 
     static Object waitnotifyObj = new Object();
 
+    static Thread thread0;
+    static Thread thread1;
+    static Thread thread2;
+
     //------------------------------------------------------ mutable common method
 
     public static void main (String argv[]) {
@@ -72,21 +76,21 @@ public class crstepreq003a {
             //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ test case section
                 case 0:
 
-                    Thread thread0 = JDIThreadFactory.newThread(new Thread0crstepreq003a("thread0"));
+                    thread0 = JDIThreadFactory.newThread(new Thread0crstepreq003a("thread0"));
                     threadStart(thread0);
                     threadJoin (thread0, "0");
                     break;
 
                 case 1:
 
-                    Thread thread1 = JDIThreadFactory.newThread(new Thread0crstepreq003a("thread1"));
+                    thread1 = JDIThreadFactory.newThread(new Thread0crstepreq003a("thread1"));
                     threadStart(thread1);
                     threadJoin (thread1, "1");
                     break;
 
                 case 2:
 
-                    Thread thread2 = JDIThreadFactory.newThread(new Thread0crstepreq003a("thread2"));
+                    thread2 = JDIThreadFactory.newThread(new Thread0crstepreq003a("thread2"));
                     threadStart(thread2);
                     threadJoin (thread2, "2");
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventRequestManager/createStepRequest/crstepreq004.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventRequestManager/createStepRequest/crstepreq004.java
@@ -77,9 +77,9 @@ public class crstepreq004 {
 
     //------------------------------------------------------ test specific fields
 
-    static final int lineForBreakInThread = 146;
-    static final int[] checkedLines = { 160, 160, 193 };
-    static final int[] checkedLinesAlt = { 161, 161, 193 };
+    static final int lineForBreakInThread = 149;
+    static final int[] checkedLines = { 163, 163, 196 };
+    static final int[] checkedLinesAlt = { 164, 164, 196 };
 
     //------------------------------------------------------ mutable common methods
 
@@ -248,7 +248,7 @@ public class crstepreq004 {
             exitCode = FAILED;
         }
 
-        ThreadReference thread = debuggee.threadByNameOrThrow(threadName);
+        ThreadReference thread = debuggee.threadByFieldNameOrThrow(debuggeeClass, threadName);
         StepRequest stepRequest = setStepRequest( thread,
                                                   StepRequest.STEP_LINE,
                                                   stepDepth,

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventRequestManager/createStepRequest/crstepreq004a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventRequestManager/createStepRequest/crstepreq004a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventRequestManager/createStepRequest/crstepreq004a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventRequestManager/createStepRequest/crstepreq004a.java
@@ -58,6 +58,9 @@ public class crstepreq004a {
     private static volatile boolean isFirstThreadReady = false;
     private static volatile boolean isSecondThreadReady = false;
 
+    static Thread thread1;
+    static Thread thread2;
+
     //------------------------------------------------------ mutable common method
 
     public static void main (String argv[]) {
@@ -95,8 +98,8 @@ public class crstepreq004a {
     private static void runTestCase(int testCaseId) {
         isFirstThreadReady = false;
         isSecondThreadReady = false;
-        Thread thread1 = JDIThreadFactory.newThread(new Thread1crstepreq004a("thread1"));
-        Thread thread2 = JDIThreadFactory.newThread(new Thread2crstepreq004a("thread2"));
+        thread1 = JDIThreadFactory.newThread(new Thread1crstepreq004a("thread1"));
+        thread2 = JDIThreadFactory.newThread(new Thread2crstepreq004a("thread2"));
         synchronized (lockObj) {
             thread1.start();
             while (!isFirstThreadReady) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StepRequest/addClassFilter_rt/filter_rt002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StepRequest/addClassFilter_rt/filter_rt002.java
@@ -290,7 +290,7 @@ public class filter_rt002 extends JDIBase {
                      testClassReference =
                           (ReferenceType) vm.classesByName(testedClassName).get(0);
 
-                     thread1 = debuggee.threadByNameOrThrow(threadName1);
+                     thread1 = debuggee.threadByFieldNameOrThrow(debuggeeClass, threadName1);
 
                      eventRequest1 = setting21StepRequest(thread1, testClassReference,
                                               EventRequest.SUSPEND_NONE, property1);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StepRequest/addClassFilter_s/filter_s002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StepRequest/addClassFilter_s/filter_s002.java
@@ -282,7 +282,7 @@ public class filter_s002 extends JDIBase {
             switch (i) {
 
               case 0:
-                     ThreadReference thread1 = debuggee.threadByNameOrThrow("thread1");
+                     ThreadReference thread1 = debuggee.threadByFieldNameOrThrow(debuggeeClass, "thread1");
                      eventRequest1 = setting23StepRequest(thread1, testedClassName1,
                                               EventRequest.SUSPEND_NONE, property1);
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StepRequest/depth/depth001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StepRequest/depth/depth001.java
@@ -281,7 +281,7 @@ public class depth001 extends JDIBase {
             switch (i) {
 
               case 0:
-                     thread1 = debuggee.threadByNameOrThrow(threadName1);
+                    thread1 = debuggee.threadByFieldNameOrThrow(debuggeeClass, threadName1);
 
                      log2("......setting up StepRequest with depth StepRequest.STEP_INTO");
                      eventRequest1 = setting24StepRequest(thread1, StepRequest.STEP_LINE,

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StepRequest/depth/depth002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StepRequest/depth/depth002.java
@@ -281,7 +281,7 @@ public class depth002 extends JDIBase {
             switch (i) {
 
               case 0:
-                     thread1 = debuggee.threadByNameOrThrow(threadName1);
+                     thread1 = debuggee.threadByFieldNameOrThrow(debuggeeClass, threadName1);
 
                      log2("......setting up StepRequest with depth StepRequest.STEP_OVER");
                      eventRequest1 = setting24StepRequest(thread1, StepRequest.STEP_LINE,

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StepRequest/depth/depth003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StepRequest/depth/depth003.java
@@ -281,7 +281,7 @@ public class depth003 extends JDIBase {
             switch (i) {
 
               case 0:
-                     thread1 = debuggee.threadByNameOrThrow(threadName1);
+                     thread1 = debuggee.threadByFieldNameOrThrow(debuggeeClass, threadName1);
 
                      log2("......setting up StepRequest with depth StepRequest.STEP_OUT");
                      eventRequest1 = setting24StepRequest(thread1, StepRequest.STEP_LINE,

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StepRequest/size/size001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StepRequest/size/size001.java
@@ -281,7 +281,7 @@ public class size001 extends JDIBase {
             switch (i) {
 
               case 0:
-                     thread1 = debuggee.threadByNameOrThrow(threadName1);
+                     thread1 = debuggee.threadByFieldNameOrThrow(debuggeeClass, threadName1);
 
                      log2("......setting up StepRequest with size StepRequest.STEP_MIN");
                      eventRequest1 = setting24StepRequest(thread1, StepRequest.STEP_MIN,

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StepRequest/size/size002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StepRequest/size/size002.java
@@ -281,7 +281,7 @@ public class size002 extends JDIBase {
             switch (i) {
 
               case 0:
-                     thread1 = debuggee.threadByNameOrThrow(threadName1);
+                     thread1 = debuggee.threadByFieldNameOrThrow(debuggeeClass, threadName1);
 
                      log2("......setting up StepRequest with size StepRequest.STEP_LINE");
                      eventRequest1 = setting24StepRequest(thread1, StepRequest.STEP_LINE,

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StepRequest/thread/thread001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StepRequest/thread/thread001.java
@@ -283,7 +283,7 @@ public class thread001 extends JDIBase {
             switch (i) {
 
               case 0:
-                     thread1 = debuggee.threadByNameOrThrow(threadName1);
+                     thread1 = debuggee.threadByFieldNameOrThrow(debuggeeClass, threadName1);
 
                      log2("......setting up StepRequest with size StepRequest.STEP_MIN");
                      eventRequest1 = setting24StepRequest(thread1, StepRequest.STEP_MIN,

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/popFrames/popframes001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/popFrames/popframes001.java
@@ -302,7 +302,7 @@ public class popframes001 extends JDIBase {
             }
 
             String thread2Name         = "thread2";
-            ThreadReference thread2Ref = debuggee.threadByNameOrThrow(thread2Name);
+            ThreadReference thread2Ref = debuggee.threadByFieldNameOrThrow(debuggeeClass, thread2Name);
 
 
             String poppedMethod    = "poppedMethod";
@@ -311,7 +311,7 @@ public class popframes001 extends JDIBase {
 
             log2("......setting breakpoint in poppedMethod");
             try {
-                breakpointRequest = settingBreakpoint(debuggee.threadByNameOrThrow(thread2Name),
+                breakpointRequest = settingBreakpoint(thread2Ref,
                                           debuggeeClass,
                                           poppedMethod, breakpointLine, "one");
             } catch ( Exception e ) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/popFrames/popframes002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/popFrames/popframes002.java
@@ -270,10 +270,10 @@ public class popframes002 extends JDIBase {
             breakpointForCommunication();
 
             String thread2Name         = "thread2";
-            ThreadReference thread2Ref = debuggee.threadByNameOrThrow(thread2Name);
+            ThreadReference thread2Ref = debuggee.threadByFieldNameOrThrow(debuggeeClass, thread2Name);
 
             String thread3Name         = "thread3";
-            ThreadReference thread3Ref = debuggee.threadByNameOrThrow(thread3Name);
+            ThreadReference thread3Ref = debuggee.threadByFieldNameOrThrow(debuggeeClass, thread3Name);
 
             String poppedMethod    = "poppedMethod";
             String breakpointLine  = "breakpointLine";

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/popFrames/popframes003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/popFrames/popframes003.java
@@ -283,10 +283,10 @@ public class popframes003 extends JDIBase {
 
 
         String thread2Name         = "thread2";
-        ThreadReference thread2Ref = debuggee.threadByNameOrThrow(thread2Name);
+        ThreadReference thread2Ref = debuggee.threadByFieldNameOrThrow(debuggeeClass, thread2Name);
 
         String thread3Name         = "thread3";
-        ThreadReference thread3Ref = debuggee.threadByNameOrThrow(thread3Name);
+        ThreadReference thread3Ref = debuggee.threadByFieldNameOrThrow(debuggeeClass, thread3Name);
 
         String poppedMethod    = "poppedMethod";
         String breakpointLine  = "breakpointLine";

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/popFrames/popframes004.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/popFrames/popframes004.java
@@ -270,7 +270,7 @@ public class popframes004 extends JDIBase {
             breakpointForCommunication();
 
             String thread2Name         = "thread2";
-            ThreadReference thread2Ref = debuggee.threadByNameOrThrow(thread2Name);
+            ThreadReference thread2Ref = debuggee.threadByFieldNameOrThrow(debuggeeClass, thread2Name);
 
             StackFrame stackFrame = null;
             int var;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/popFrames/popframes005.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/popFrames/popframes005.java
@@ -274,7 +274,7 @@ public class popframes005 extends JDIBase {
             breakpointForCommunication();
 
             String thread2Name         = "thread2";
-            ThreadReference thread2Ref = debuggee.threadByNameOrThrow(thread2Name);
+            ThreadReference thread2Ref = debuggee.threadByFieldNameOrThrow(debuggeeClass, thread2Name);
 
             StackFrame stackFrame0 = null;
             StackFrame stackFrame1 = null;

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/Debugee.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/Debugee.java
@@ -270,13 +270,13 @@ public class Debugee extends DebugeeProcess {
     public ThreadReference threadByFieldNameOrThrow(ReferenceType debuggeeClass,
                                                     String threadFieldName)
             throws JDITestRuntimeException {
-        
+
         Field field = debuggeeClass.fieldByName(threadFieldName);
         if (field == null) {
             throw new JDITestRuntimeException("** Thread field not found ** : "
                                               + threadFieldName);
         }
-        
+
         ThreadReference thread = (ThreadReference)debuggeeClass.getValue(field);
         if (thread == null) {
             throw new JDITestRuntimeException("** Thread field is null ** : "
@@ -287,23 +287,8 @@ public class Debugee extends DebugeeProcess {
             throw new JDITestRuntimeException("** Thread names do not match ** : "
                                               + threadFieldName + " vs. " + thread.name());
         }
-        
+
         return thread;
-    }
-
-    public void setMainThread(ThreadReference thread) {
-        String threadName = thread.name();
-        if (!threadName.equals("main")) {
-            throw new TestBug("Thread is not \"main\" thread: " + threadName);
-        }
-        mainThread = thread;
-    }
-
-    public ThreadReference mainThread() {
-        if (mainThread == null) {
-            throw new JDITestRuntimeException("** mainThrad has not been set **");
-        }
-        return mainThread;
     }
 
     // --------------------------------------------------- //

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/Debugee.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/Debugee.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/Debugee.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/Debugee.java
@@ -264,6 +264,48 @@ public class Debugee extends DebugeeProcess {
         throw new JDITestRuntimeException("** Thread IS NOT found ** : " + name);
     }
 
+    /**
+     * Return a debuggee thread by fetching it from a static field in the debuggee.
+     */
+    public ThreadReference threadByFieldNameOrThrow(ReferenceType debuggeeClass,
+                                                    String threadFieldName)
+            throws JDITestRuntimeException {
+        
+        Field field = debuggeeClass.fieldByName(threadFieldName);
+        if (field == null) {
+            throw new JDITestRuntimeException("** Thread field not found ** : "
+                                              + threadFieldName);
+        }
+        
+        ThreadReference thread = (ThreadReference)debuggeeClass.getValue(field);
+        if (thread == null) {
+            throw new JDITestRuntimeException("** Thread field is null ** : "
+                                              + threadFieldName);
+        }
+
+        if (!thread.name().equals(threadFieldName)) {
+            throw new JDITestRuntimeException("** Thread names do not match ** : "
+                                              + threadFieldName + " vs. " + thread.name());
+        }
+        
+        return thread;
+    }
+
+    public void setMainThread(ThreadReference thread) {
+        String threadName = thread.name();
+        if (!threadName.equals("main")) {
+            throw new TestBug("Thread is not \"main\" thread: " + threadName);
+        }
+        mainThread = thread;
+    }
+
+    public ThreadReference mainThread() {
+        if (mainThread == null) {
+            throw new JDITestRuntimeException("** mainThrad has not been set **");
+        }
+        return mainThread;
+    }
+
     // --------------------------------------------------- //
 
     /**


### PR DESCRIPTION
In an effort go get rid of calls to Debugee.threadByName() or Debugee.threadByNameOrThrow(), I found that many tests store the thread being looked up in a static field of the debuggee. The test can fetch the ThreadReference from the static field instead of looking it up using APIs that rely on vm.allThreads().

Most of the changes take advantage of the following common pattern:

In the debugger:

    String          threadName1 = "thread1";
    thread1 = debuggee.threadByNameOrThrow(threadName1);

In the debuggee:

    static Thread thread1 = null;
    thread1 = JDIThreadFactory.newThread(new Thread1addcountfilter001a("thread1"));

Note that the static field name for the Thread is the same as the thread name. Thus we can easily switch from looking up by thread name to instead looking up by static field name since they both use the same name.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8355773](https://bugs.openjdk.org/browse/JDK-8355773): Some nsk/jdi tests can fetch ThreadReference from static field in the debuggee (**Enhancement** - P4)


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24935/head:pull/24935` \
`$ git checkout pull/24935`

Update a local copy of the PR: \
`$ git checkout pull/24935` \
`$ git pull https://git.openjdk.org/jdk.git pull/24935/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24935`

View PR using the GUI difftool: \
`$ git pr show -t 24935`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24935.diff">https://git.openjdk.org/jdk/pull/24935.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24935#issuecomment-2839716953)
</details>
