### PR TITLE
8355689: Wrong native entry name for FloatMaxVector vector math stubs with -XX:MaxVectorSize=8

### DIFF
--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/VectorMathLibrary.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/VectorMathLibrary.java
@@ -140,7 +140,8 @@ import static jdk.internal.vm.vector.Utils.debug;
         public String symbolName(Operator op, VectorSpecies<?> vspecies) {
             String suffix = suffix(vspecies);
             String elemType = (vspecies.elementType() == float.class ? "f" : "");
-            int vlen = (vspecies == FloatVector.SPECIES_64 ? 4 : vspecies.length()); // reuse 128-bit variant for 64-bit float vectors
+            boolean isFloat64Vector = (vspecies.elementType() == float.class) && (vspecies.length() == 2); // Float64Vector or FloatMaxVector
+            int vlen = (isFloat64Vector ? 4 : vspecies.length()); // reuse 128-bit variant for 64-bit float vectors
             return String.format("__jsvml_%s%s%d_ha_%s", op.operatorName(), elemType, vlen, suffix);
         }
 
@@ -211,7 +212,8 @@ import static jdk.internal.vm.vector.Utils.debug;
 
         @Override
         public String symbolName(Operator op, VectorSpecies<?> vspecies) {
-            int vlen = (vspecies == FloatVector.SPECIES_64 ? 4 : vspecies.length()); // reuse 128-bit variant for 64-bit float vectors
+            boolean isFloat64Vector = (vspecies.elementType() == float.class) && (vspecies.length() == 2); // Float64Vector or FloatMaxVector
+            int vlen = (isFloat64Vector ? 4 : vspecies.length()); // reuse 128-bit variant for 64-bit float vectors
             boolean isShapeAgnostic = isRISCV64() || (isAARCH64() && vspecies.vectorBitSize() > 128);
             return String.format("%s%s%s_%s%s", op.operatorName(),
                                  (vspecies.elementType() == float.class ? "f" : "d"),


### PR DESCRIPTION
Both SVML and SLEEF libraries reuse 128-bit versions for vector of 2 floats. Usually, only `Float64Vector` shape satisfies that condiditon, but with`-XX:MaxVectorSize=8` `FloatMaxVector` becomes 2 element vector as well. 

Adjust the relevant logic to match vector of 2 floats shape structurally. 

Testing: failing regression test, hs-tier1 - hs-tier4

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8355689](https://bugs.openjdk.org/browse/JDK-8355689): Wrong native entry name for FloatMaxVector vector math stubs with -XX:MaxVectorSize=8 (**Bug** - P4)


### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)
 * [Hao Sun](https://openjdk.org/census#haosun) (@shqking - Committer)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24936/head:pull/24936` \
`$ git checkout pull/24936`

Update a local copy of the PR: \
`$ git checkout pull/24936` \
`$ git pull https://git.openjdk.org/jdk.git pull/24936/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24936`

View PR using the GUI difftool: \
`$ git pr show -t 24936`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24936.diff">https://git.openjdk.org/jdk/pull/24936.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24936#issuecomment-2836356512)
</details>
