### PR TITLE
8355775: Improve symbolic sharing in dynamic constant pool entries

### DIFF
--- a/src/java.base/share/classes/java/lang/classfile/CodeBuilder.java
+++ b/src/java.base/share/classes/java/lang/classfile/CodeBuilder.java
@@ -2483,7 +2483,7 @@ public sealed interface CodeBuilder
         var cpArgs = ref.bootstrapArgs();
         List<LoadableConstantEntry> bsArguments = new ArrayList<>(cpArgs.length);
         for (var constantValue : cpArgs) {
-            bsArguments.add(BytecodeHelpers.constantEntry(constantPool(), constantValue));
+            bsArguments.add(constantPool().loadableConstantEntry(requireNonNull(constantValue)));
         }
         BootstrapMethodEntry bm = constantPool().bsmEntry(bsMethod, bsArguments);
         NameAndTypeEntry nameAndType = constantPool().nameAndTypeEntry(ref.invocationName(), ref.invocationType());
@@ -2941,7 +2941,7 @@ public sealed interface CodeBuilder
      * @see ConstantInstruction.LoadConstantInstruction
      */
     default CodeBuilder ldc(ConstantDesc value) {
-        return ldc(BytecodeHelpers.constantEntry(constantPool(), value));
+        return ldc(constantPool().loadableConstantEntry(requireNonNull(value)));
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/classfile/constantpool/ConstantPoolBuilder.java
+++ b/src/java.base/share/classes/java/lang/classfile/constantpool/ConstantPoolBuilder.java
@@ -36,6 +36,7 @@ import java.lang.invoke.MethodHandleInfo;
 import java.util.List;
 import java.util.function.Consumer;
 
+import jdk.internal.classfile.impl.AbstractPoolEntry;
 import jdk.internal.classfile.impl.AbstractPoolEntry.ClassEntryImpl;
 import jdk.internal.classfile.impl.ClassReaderImpl;
 import jdk.internal.classfile.impl.SplitConstantPool;
@@ -385,11 +386,13 @@ public sealed interface ConstantPoolBuilder
     default MethodHandleEntry methodHandleEntry(DirectMethodHandleDesc descriptor) {
         var owner = classEntry(descriptor.owner());
         var nat = nameAndTypeEntry(utf8Entry(descriptor.methodName()), utf8Entry(descriptor.lookupDescriptor()));
-        return methodHandleEntry(descriptor.refKind(), switch (descriptor.kind()) {
+        var ret = methodHandleEntry(descriptor.refKind(), switch (descriptor.kind()) {
             case GETTER, SETTER, STATIC_GETTER, STATIC_SETTER -> fieldRefEntry(owner, nat);
             case INTERFACE_STATIC, INTERFACE_VIRTUAL, INTERFACE_SPECIAL -> interfaceMethodRefEntry(owner, nat);
             case STATIC, VIRTUAL, SPECIAL, CONSTRUCTOR -> methodRefEntry(owner, nat);
         });
+        ((AbstractPoolEntry.MethodHandleEntryImpl) ret).sym = descriptor;
+        return ret;
     }
 
     /**
@@ -414,7 +417,9 @@ public sealed interface ConstantPoolBuilder
      * @see InvokeDynamicEntry#asSymbol() InvokeDynamicEntry::asSymbol
      */
     default InvokeDynamicEntry invokeDynamicEntry(DynamicCallSiteDesc dcsd) {
-        return invokeDynamicEntry(bsmEntry((DirectMethodHandleDesc)dcsd.bootstrapMethod(), List.of(dcsd.bootstrapArgs())), nameAndTypeEntry(dcsd.invocationName(), dcsd.invocationType()));
+        var ret = invokeDynamicEntry(bsmEntry((DirectMethodHandleDesc)dcsd.bootstrapMethod(), List.of(dcsd.bootstrapArgs())), nameAndTypeEntry(dcsd.invocationName(), dcsd.invocationType()));
+        ((AbstractPoolEntry.InvokeDynamicEntryImpl) ret).sym = dcsd;
+        return ret;
     }
 
     /**
@@ -440,7 +445,9 @@ public sealed interface ConstantPoolBuilder
      * @see ConstantDynamicEntry#asSymbol() ConstantDynamicEntry::asSymbol
      */
     default ConstantDynamicEntry constantDynamicEntry(DynamicConstantDesc<?> dcd) {
-        return constantDynamicEntry(bsmEntry(dcd.bootstrapMethod(), List.of(dcd.bootstrapArgs())), nameAndTypeEntry(dcd.constantName(), dcd.constantType()));
+        var ret = constantDynamicEntry(bsmEntry(dcd.bootstrapMethod(), List.of(dcd.bootstrapArgs())), nameAndTypeEntry(dcd.constantName(), dcd.constantType()));
+        ((AbstractPoolEntry.ConstantDynamicEntryImpl) ret).sym = dcd;
+        return ret;
     }
 
     /**

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/BytecodeHelpers.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/BytecodeHelpers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2024, Alibaba Group Holding Limited. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -29,12 +29,10 @@ import java.lang.classfile.BootstrapMethodEntry;
 import java.lang.classfile.Opcode;
 import java.lang.classfile.TypeKind;
 import java.lang.classfile.constantpool.*;
-import java.lang.constant.ClassDesc;
 import java.lang.constant.ConstantDesc;
 import java.lang.constant.ConstantDescs;
 import java.lang.constant.DirectMethodHandleDesc;
 import java.lang.constant.DynamicConstantDesc;
-import java.lang.constant.MethodTypeDesc;
 import java.lang.invoke.MethodHandleInfo;
 import java.util.ArrayList;
 import java.util.List;
@@ -513,38 +511,6 @@ public class BytecodeHelpers {
         return entry.typeKind().slotSize() == 2 ? Opcode.LDC2_W
                 : entry.index() > 0xff ? Opcode.LDC_W
                 : Opcode.LDC;
-    }
-
-    public static LoadableConstantEntry constantEntry(ConstantPoolBuilder constantPool,
-                                                      ConstantDesc constantValue) {
-        // this method is invoked during JVM bootstrap - cannot use pattern switch
-        if (constantValue instanceof Integer value) {
-            return constantPool.intEntry(value);
-        }
-        if (constantValue instanceof String value) {
-            return constantPool.stringEntry(value);
-        }
-        if (constantValue instanceof ClassDesc value && !value.isPrimitive()) {
-            return constantPool.classEntry(value);
-        }
-        if (constantValue instanceof Long value) {
-            return constantPool.longEntry(value);
-        }
-        if (constantValue instanceof Float value) {
-            return constantPool.floatEntry(value);
-        }
-        if (constantValue instanceof Double value) {
-            return constantPool.doubleEntry(value);
-        }
-        if (constantValue instanceof MethodTypeDesc value) {
-            return constantPool.methodTypeEntry(value);
-        }
-        if (constantValue instanceof DirectMethodHandleDesc value) {
-            return handleDescToHandleInfo(constantPool, value);
-        } if (constantValue instanceof DynamicConstantDesc<?> value) {
-            return handleConstantDescToHandleInfo(constantPool, value);
-        }
-        throw new UnsupportedOperationException("not yet: " + requireNonNull(constantValue));
     }
 
     public static ConstantDesc intrinsicConstantValue(Opcode opcode) {

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/SplitConstantPool.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/SplitConstantPool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,7 @@ import java.lang.classfile.ClassReader;
 import java.lang.classfile.attribute.BootstrapMethodsAttribute;
 import java.lang.classfile.constantpool.*;
 import java.lang.constant.ClassDesc;
+import java.lang.constant.DynamicCallSiteDesc;
 import java.lang.constant.MethodTypeDesc;
 import java.util.Arrays;
 import java.util.List;
@@ -521,6 +522,10 @@ public final class SplitConstantPool implements ConstantPoolBuilder {
     AbstractPoolEntry.ClassEntryImpl cloneClassEntry(AbstractPoolEntry.ClassEntryImpl e) {
         var ce = tryFindClassEntry(e.hashCode(), e.ref1);
         if (ce != null) {
+            var mySym = e.sym;
+            if (ce.sym == null && mySym != null) {
+                ce.sym = mySym;
+            }
             return ce;
         }
 

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/StackMapGenerator.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/StackMapGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2024, Alibaba Group Holding Limited. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -716,7 +716,7 @@ public final class StackMapGenerator {
             case TAG_METHOD_TYPE ->
                 currentFrame.pushStack(Type.METHOD_TYPE);
             case TAG_DYNAMIC ->
-                currentFrame.pushStack(cp.entryByIndex(index, ConstantDynamicEntry.class).asSymbol().constantType());
+                currentFrame.pushStack(cp.entryByIndex(index, ConstantDynamicEntry.class).typeSymbol());
             default ->
                 throw generatorError("CP entry #%d %s is not loadable constant".formatted(index, cp.entryByIndex(index).tag()));
         }


### PR DESCRIPTION
Some dynamic constant pool entries with heavy symbolic descriptors currently don't share them, yet they are used by stack map generation, and computing a new descriptor every time introduces a heavy cost.

This cost is obvious if bytecode generation uses constant dynamic - the stack map generator parses the whole dynamic constant symbol to interpret the return type of an ldc condy, such as in FFM downcalls.

Both the lack of expensive symbol caching in dynamic cp entries and the incorrect query in StackMapGenerator should be fixed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8355775](https://bugs.openjdk.org/browse/JDK-8355775): Improve symbolic sharing in dynamic constant pool entries (**Sub-task** - P4)


### Reviewers
 * [Adam Sotona](https://openjdk.org/census#asotona) (@asotona - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24938/head:pull/24938` \
`$ git checkout pull/24938`

Update a local copy of the PR: \
`$ git checkout pull/24938` \
`$ git pull https://git.openjdk.org/jdk.git pull/24938/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24938`

View PR using the GUI difftool: \
`$ git pr show -t 24938`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24938.diff">https://git.openjdk.org/jdk/pull/24938.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24938#issuecomment-2836580545)
</details>
