### PR TITLE
8355789: GenShen: assert(_degen_point == ShenandoahGC::_degenerated_unset) failed: Should not be set yet: Outside of Cycle

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalControlThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalControlThread.cpp
@@ -482,17 +482,14 @@ bool ShenandoahGenerationalControlThread::resume_concurrent_old_cycle(Shenandoah
   }
 
   if (_heap->cancelled_gc()) {
-    // It's possible the gc cycle was cancelled after the last time
-    // the collection checked for cancellation. In which case, the
-    // old gc cycle is still completed, and we have to deal with this
-    // cancellation. We set the degeneration point to be outside
-    // the cycle because if this is an allocation failure, that is
-    // what must be done (there is no degenerated old cycle). If the
-    // cancellation was due to a heuristic wanting to start a young
-    // cycle, then we are not actually going to a degenerated cycle,
-    // so the degenerated point doesn't matter here.
-    check_cancellation_or_degen(ShenandoahGC::_degenerated_outside_cycle);
-    if (cause == GCCause::_shenandoah_concurrent_gc) {
+    // It's possible the gc cycle was cancelled after the last time the collection checked for cancellation. In which
+    // case, the old gc cycle is still completed, and we have to deal with this cancellation. We set the degeneration
+    // point to be outside the cycle because if this is an allocation failure, that is what must be done (there is no
+    // degenerated old cycle). If the cancellation was due to a heuristic wanting to start a young cycle, then we are
+    // not actually going to a degenerated cycle, so don't set the degeneration point here.
+    if (ShenandoahCollectorPolicy::is_allocation_failure(cause)) {
+      check_cancellation_or_degen(ShenandoahGC::_degenerated_outside_cycle);
+    } else if (cause == GCCause::_shenandoah_concurrent_gc) {
       _heap->shenandoah_policy()->record_interrupted_old();
     }
     return false;


### PR DESCRIPTION
When old generation marking is cancelled to run a young collection. we still set a `_degen_point ` for reasons that became vestigial after [JDK-8349094](https://bugs.openjdk.org/browse/JDK-8349094). When old marking is cancelled, the `_degen_point` should only be set if the marking was cancelled because of an allocation failure (and it should still only be set to "outside of cycle"). The following sequence could lead to this assertion failure:
1. Control thread is marking old
2. Young GC preempts it
3. Control thread sets the degen point because the old GC was "cancelled"
4. The concurrent young GC fails and attempts to set a degenerated point
5. This trips the assert because we already (incorrectly) set the degen point in `3`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8355789](https://bugs.openjdk.org/browse/JDK-8355789): GenShen: assert(_degen_point == ShenandoahGC::_degenerated_unset) failed: Should not be set yet: Outside of Cycle (**Bug** - P4)


### Reviewers
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - Committer)
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24940/head:pull/24940` \
`$ git checkout pull/24940`

Update a local copy of the PR: \
`$ git checkout pull/24940` \
`$ git pull https://git.openjdk.org/jdk.git pull/24940/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24940`

View PR using the GUI difftool: \
`$ git pr show -t 24940`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24940.diff">https://git.openjdk.org/jdk/pull/24940.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24940#issuecomment-2837052547)
</details>
