### PR TITLE
8355878: RISC-V: jdk/incubator/vector/DoubleMaxVectorTests.java fails when using RVV

### DIFF
--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -1596,7 +1596,8 @@ uint MachSpillCopyNode::implementation(C2_MacroAssembler *masm, PhaseRegAlloc *r
         __ unspill(as_VectorRegister(Matcher::_regEncode[dst_lo]), ra_->reg2offset(src_lo));
       } else if (src_lo_rc == rc_vector && dst_lo_rc == rc_vector) {
         // vpr to vpr
-        __ vmv1r_v(as_VectorRegister(Matcher::_regEncode[dst_lo]), as_VectorRegister(Matcher::_regEncode[src_lo]));
+        __ vsetvli_helper(T_BYTE, MaxVectorSize);
+        __ vmv_v_v(as_VectorRegister(Matcher::_regEncode[dst_lo]), as_VectorRegister(Matcher::_regEncode[src_lo]));
       } else {
         ShouldNotReachHere();
       }
@@ -1614,7 +1615,8 @@ uint MachSpillCopyNode::implementation(C2_MacroAssembler *masm, PhaseRegAlloc *r
         __ unspill_vmask(as_VectorRegister(Matcher::_regEncode[dst_lo]), ra_->reg2offset(src_lo));
       } else if (src_lo_rc == rc_vector && dst_lo_rc == rc_vector) {
         // vmask to vmask
-        __ vmv1r_v(as_VectorRegister(Matcher::_regEncode[dst_lo]), as_VectorRegister(Matcher::_regEncode[src_lo]));
+        __ vsetvli_helper(T_BYTE, MaxVectorSize >> 3);
+        __ vmv_v_v(as_VectorRegister(Matcher::_regEncode[dst_lo]), as_VectorRegister(Matcher::_regEncode[src_lo]));
       } else {
         ShouldNotReachHere();
       }


### PR DESCRIPTION
Hi, when I use the qemu-system mode, the jdk/incubator/vector/DoubleMaxVectorTests.java test run fails.

As discussed on JBS, As discussed on jbs, the SIGILL instruction is vmv1r.v v1,v3. 

I found the cause of the problem on the qemu source code, qemu Add vill check for whole vector register move instructions [1]. 
```
  The ratified version of RISC-V V spec section 16.6 says that `The instructions operate as if EEW=SEW`.

So the whole vector register move instructions depend on the vtype
```
We need to add vsetvli before move vector register. In order not to have a misunderstanding here, maybe Vector Whole Vector Register Move without setting vsetvli, I replaced vmv1r_v with vmv_v_v.


[1] https://patchwork.kernel.org/project/qemu-devel/patch/20231129170400.21251-2-max.chou@sifive.com/#25621160

### Testing

qemu-system 9.1.50 with UseRVV:

- [x] Run test/jdk/jdk/incubator/vector (fastdebug)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8355878](https://bugs.openjdk.org/browse/JDK-8355878): RISC-V: jdk/incubator/vector/DoubleMaxVectorTests.java fails when using RVV (**Bug** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Dingli Zhang](https://openjdk.org/census#dzhang) (@DingliZhang - Author)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24943/head:pull/24943` \
`$ git checkout pull/24943`

Update a local copy of the PR: \
`$ git checkout pull/24943` \
`$ git pull https://git.openjdk.org/jdk.git pull/24943/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24943`

View PR using the GUI difftool: \
`$ git pr show -t 24943`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24943.diff">https://git.openjdk.org/jdk/pull/24943.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24943#issuecomment-2837835665)
</details>
