### PR TITLE
8355704: RISC-V: enable TestIRFma.java

### DIFF
--- a/test/hotspot/jtreg/compiler/c2/irTests/TestIRFma.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestIRFma.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2023, Arm Limited. All rights reserved.
+ * Copyright (c) 2025, Rivos Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -85,99 +86,99 @@ public class TestIRFma {
     }
 
     @Test
-    @IR(counts = {IRNode.FMSUB, "> 0"},
-        applyIfCPUFeature = {"asimd", "true"})
+    @IR(counts = {IRNode.FMSUB_F, "> 0", IRNode.NEG_F, "> 0"},
+        applyIfCPUFeatureOr = {"asimd", "true", "rvv", "true"})
     static float test1(float a, float b, float c) {
         return Math.fma(-a, -b, c);
     }
 
     @Test
-    @IR(counts = {IRNode.FMSUB, "> 0"},
-        applyIfCPUFeature = {"asimd", "true"})
+    @IR(counts = {IRNode.FMSUB_D, "> 0", IRNode.NEG_D, "> 0"},
+        applyIfCPUFeatureOr = {"asimd", "true", "rvv", "true"})
     static double test2(double a, double b, double c) {
         return Math.fma(-a, -b, c);
     }
 
     @Test
-    @IR(counts = {IRNode.FMSUB, "> 0"},
-        applyIfCPUFeature = {"asimd", "true"})
+    @IR(counts = {IRNode.FMSUB_F, "> 0", IRNode.NEG_F, "> 0"},
+        applyIfCPUFeatureOr = {"asimd", "true", "rvv", "true"})
     static float test3(float a, float b, float c) {
         return Math.fma(-a, b, c);
     }
 
     @Test
-    @IR(counts = {IRNode.FMSUB, "> 0"},
-        applyIfCPUFeature = {"asimd", "true"})
+    @IR(counts = {IRNode.FMSUB_D, "> 0", IRNode.NEG_D, "> 0"},
+        applyIfCPUFeatureOr = {"asimd", "true", "rvv", "true"})
     static double test4(double a, double b, double c) {
         return Math.fma(-a, b, c);
     }
 
     @Test
-    @IR(counts = {IRNode.FMSUB, "> 0"},
-        applyIfCPUFeature = {"asimd", "true"})
+    @IR(counts = {IRNode.FMSUB_F, "> 0", IRNode.NEG_F, "> 0"},
+        applyIfCPUFeatureOr = {"asimd", "true", "rvv", "true"})
     static float test5(float a, float b, float c) {
         return Math.fma(a, -b, c);
     }
 
     @Test
-    @IR(counts = {IRNode.FMSUB, "> 0"},
-        applyIfCPUFeature = {"asimd", "true"})
+    @IR(counts = {IRNode.FMSUB_D, "> 0", IRNode.NEG_D, "> 0"},
+        applyIfCPUFeatureOr = {"asimd", "true", "rvv", "true"})
     static double test6(double a, double b, double c) {
         return Math.fma(a, -b, c);
     }
 
     @Test
-    @IR(counts = {IRNode.FNMADD, "> 0"},
-        applyIfCPUFeature = {"asimd", "true"})
+    @IR(counts = {IRNode.FNMADD_F, "> 0", IRNode.NEG_F, "> 0"},
+        applyIfCPUFeatureOr = {"asimd", "true", "rvv", "true"})
     static float test7(float a, float b, float c) {
         return Math.fma(-a, b, -c);
     }
 
     @Test
-    @IR(counts = {IRNode.FNMADD, "> 0"},
-        applyIfCPUFeature = {"asimd", "true"})
+    @IR(counts = {IRNode.FNMADD_D, "> 0", IRNode.NEG_D, "> 0"},
+        applyIfCPUFeatureOr = {"asimd", "true", "rvv", "true"})
     static double test8(double a, double b, double c) {
         return Math.fma(-a, b, -c);
     }
 
     @Test
-    @IR(counts = {IRNode.FNMADD, "> 0"},
-        applyIfCPUFeature = {"asimd", "true"})
+    @IR(counts = {IRNode.FNMADD_F, "> 0", IRNode.NEG_F, "> 0"},
+        applyIfCPUFeatureOr = {"asimd", "true", "rvv", "true"})
     static float test9(float a, float b, float c) {
         return Math.fma(a, -b, -c);
     }
 
     @Test
-    @IR(counts = {IRNode.FNMADD, "> 0"},
-        applyIfCPUFeature = {"asimd", "true"})
+    @IR(counts = {IRNode.FNMADD_D, "> 0", IRNode.NEG_D, "> 0"},
+        applyIfCPUFeatureOr = {"asimd", "true", "rvv", "true"})
     static double test10(double a, double b, double c) {
         return Math.fma(a, -b, -c);
     }
 
     @Test
-    @IR(counts = {IRNode.FNMSUB, "> 0"},
-        applyIfCPUFeature = {"asimd", "true"})
+    @IR(counts = {IRNode.FNMSUB_F, "> 0", IRNode.NEG_F, "> 0"},
+        applyIfCPUFeatureOr = {"asimd", "true", "rvv", "true"})
     static float test11(float a, float b, float c) {
         return Math.fma(a, b, -c);
     }
 
     @Test
-    @IR(counts = {IRNode.FNMSUB, "> 0"},
-        applyIfCPUFeature = {"asimd", "true"})
+    @IR(counts = {IRNode.FNMSUB_D, "> 0", IRNode.NEG_D, "> 0"},
+        applyIfCPUFeatureOr = {"asimd", "true", "rvv", "true"})
     static double test12(double a, double b, double c) {
         return Math.fma(a, b, -c);
     }
 
     @Test
-    @IR(counts = {IRNode.FNMADD, "> 0"},
-        applyIfCPUFeature = {"asimd", "true"})
+    @IR(counts = {IRNode.FNMADD_F, "> 0", IRNode.NEG_F, "> 0"},
+        applyIfCPUFeatureOr = {"asimd", "true", "rvv", "true"})
     static float test13(float a, float b, float c) {
         return Math.fma(-a, -b, -c);
     }
 
     @Test
-    @IR(counts = {IRNode.FNMADD, "> 0"},
-        applyIfCPUFeature = {"asimd", "true"})
+    @IR(counts = {IRNode.FNMADD_D, "> 0", IRNode.NEG_D, "> 0"},
+        applyIfCPUFeatureOr = {"asimd", "true", "rvv", "true"})
     static double test14(double a, double b, double c) {
         return Math.fma(-a, -b, -c);
     }

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
@@ -2438,32 +2438,32 @@ public class IRNode {
 
     public static final String FMSUB_F = PREFIX + "FMSUB_F" + POSTFIX;
     static {
-        machOnlyNameRegex(FMSUB_F, "FmaF");
+        beforeMatchingNameRegex(FMSUB_F, "FmaF");
     }
 
     public static final String FMSUB_D = PREFIX + "FMSUB_D" + POSTFIX;
     static {
-        machOnlyNameRegex(FMSUB_D, "FmaD");
+        beforeMatchingNameRegex(FMSUB_D, "FmaD");
     }
 
     public static final String FNMADD_F = PREFIX + "FNMADD_F" + POSTFIX;
     static {
-        machOnlyNameRegex(FNMADD_F, "FmaF");
+        beforeMatchingNameRegex(FNMADD_F, "FmaF");
     }
 
     public static final String FNMADD_D = PREFIX + "FNMADD_D" + POSTFIX;
     static {
-        machOnlyNameRegex(FNMADD_D, "FmaD");
+        beforeMatchingNameRegex(FNMADD_D, "FmaD");
     }
 
     public static final String FNMSUB_F = PREFIX + "FNFNMSUB_FMSUB" + POSTFIX;
     static {
-        machOnlyNameRegex(FNMSUB_F, "FmaF");
+        beforeMatchingNameRegex(FNMSUB_F, "FmaF");
     }
 
     public static final String FNMSUB_D = PREFIX + "FNMSUB_D" + POSTFIX;
     static {
-        machOnlyNameRegex(FNMSUB_D, "FmaD");
+        beforeMatchingNameRegex(FNMSUB_D, "FmaD");
     }
 
     public static final String VFMLA = PREFIX + "VFMLA" + POSTFIX;

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
@@ -2436,19 +2436,34 @@ public class IRNode {
         machOnlyNameRegex(VMLA_MASKED, "vmla_masked");
     }
 
-    public static final String FMSUB = PREFIX + "FMSUB" + POSTFIX;
+    public static final String FMSUB_F = PREFIX + "FMSUB_F" + POSTFIX;
     static {
-        machOnlyNameRegex(FMSUB, "msub(F|D)_reg_reg");
+        machOnlyNameRegex(FMSUB_F, "FmaF");
     }
 
-    public static final String FNMADD = PREFIX + "FNMADD" + POSTFIX;
+    public static final String FMSUB_D = PREFIX + "FMSUB_D" + POSTFIX;
     static {
-        machOnlyNameRegex(FNMADD, "mnadd(F|D)_reg_reg");
+        machOnlyNameRegex(FMSUB_D, "FmaD");
     }
 
-    public static final String FNMSUB = PREFIX + "FNMSUB" + POSTFIX;
+    public static final String FNMADD_F = PREFIX + "FNMADD_F" + POSTFIX;
     static {
-        machOnlyNameRegex(FNMSUB, "mnsub(F|D)_reg_reg");
+        machOnlyNameRegex(FNMADD_F, "FmaF");
+    }
+
+    public static final String FNMADD_D = PREFIX + "FNMADD_D" + POSTFIX;
+    static {
+        machOnlyNameRegex(FNMADD_D, "FmaD");
+    }
+
+    public static final String FNMSUB_F = PREFIX + "FNFNMSUB_FMSUB" + POSTFIX;
+    static {
+        machOnlyNameRegex(FNMSUB_F, "FmaF");
+    }
+
+    public static final String FNMSUB_D = PREFIX + "FNMSUB_D" + POSTFIX;
+    static {
+        machOnlyNameRegex(FNMSUB_D, "FmaD");
     }
 
     public static final String VFMLA = PREFIX + "VFMLA" + POSTFIX;


### PR DESCRIPTION
Hi,
Can you help to review this patch to enable TestIRFma.java?
FmaF/D (checked by TestIRFma.java) are supported on riscv, but for some reason we can not enable it easily, but we should enable it.

Also tested on machine with `asimd` support.

Thanks!