### PR TITLE
8352926: New test TestDockerMemoryMetricsSubgroup.java fails

### DIFF
--- a/test/hotspot/jtreg/containers/docker/TestMemoryWithSubgroups.java
+++ b/test/hotspot/jtreg/containers/docker/TestMemoryWithSubgroups.java
@@ -26,7 +26,6 @@ import jdk.test.lib.containers.docker.Common;
 import jdk.test.lib.containers.docker.DockerTestUtils;
 import jdk.test.lib.containers.docker.ContainerRuntimeVersionTestUtils;
 import jdk.test.lib.containers.docker.DockerRunOptions;
-import jdk.test.lib.process.OutputAnalyzer;
 import jdk.internal.platform.Metrics;
 
 import java.util.ArrayList;

--- a/test/hotspot/jtreg/containers/docker/TestMemoryWithSubgroups.java
+++ b/test/hotspot/jtreg/containers/docker/TestMemoryWithSubgroups.java
@@ -205,7 +205,7 @@ public class TestMemoryWithSubgroups {
 
         private static TestDockerMemoryMetricsSubgroup.DockerVersion fromVersionString(String version) {
             try {
-                // Example 'podman version 3.2.1'
+                // Example 'docker version 3.2.1'
                 String versNums = version.split("\\s+", 3)[2];
                 String[] numbers = versNums.split("\\.", 3);
                 return new TestDockerMemoryMetricsSubgroup.DockerVersion(Integer.parseInt(numbers[0]),

--- a/test/hotspot/jtreg/containers/docker/TestMemoryWithSubgroups.java
+++ b/test/hotspot/jtreg/containers/docker/TestMemoryWithSubgroups.java
@@ -44,8 +44,6 @@ import jtreg.SkippedException;
  */
 public class TestMemoryWithSubgroups {
     private static final String imageName = Common.imageName("subgroup");
-    private static final boolean IS_DOCKER = Container.ENGINE_COMMAND.contains("docker");
-    private static final boolean IS_PODMAN = Container.ENGINE_COMMAND.contains("podman");
 
     static String getEngineInfo(String format) throws Exception {
         return DockerTestUtils.execute(Container.ENGINE_COMMAND, "info", "-f", format)
@@ -70,12 +68,9 @@ public class TestMemoryWithSubgroups {
             System.out.println("Unable to run docker tests.");
             return;
         }
-        if (IS_DOCKER && ContainerRuntimeVersionTestUtils.DOCKER_VERSION_20_10_0.compareTo(ContainerRuntimeVersionTestUtils.getContainerRuntimeVersion()) > 0) {
-            throw new SkippedException("Docker version too old for this test. Expected >= 20.10.0");
-        }
-        if (IS_PODMAN && ContainerRuntimeVersionTestUtils.PODMAN_VERSION_1_5_0.compareTo(ContainerRuntimeVersionTestUtils.getContainerRuntimeVersion()) > 0) {
-            throw new SkippedException("Podman version too old for this test. Expected >= 1.5.0");
-        }
+
+        ContainerRuntimeVersionTestUtils.checkContainerVersionSupported();
+
         if (isRootless()) {
             throw new SkippedException("Test skipped in rootless mode");
         }

--- a/test/hotspot/jtreg/containers/docker/TestMemoryWithSubgroups.java
+++ b/test/hotspot/jtreg/containers/docker/TestMemoryWithSubgroups.java
@@ -71,7 +71,7 @@ public class TestMemoryWithSubgroups {
             System.out.println("Unable to run docker tests.");
             return;
         }
-        if (IS_DOCKER && TestDockerMemoryMetricsSubgroup.DockerVersion.VERSION_20_10_0.compareTo(getDockerVersion()) > 0) {
+        if (IS_DOCKER && TestMemoryWithSubgroups.DockerVersion.VERSION_20_10_0.compareTo(getDockerVersion()) > 0) {
             throw new SkippedException("Docker version too old for this test. Expected >= 20.10.0");
         }
         if (isRootless()) {
@@ -162,13 +162,13 @@ public class TestMemoryWithSubgroups {
         }
     }
 
-    private static TestDockerMemoryMetricsSubgroup.DockerVersion getDockerVersion() {
-        return TestDockerMemoryMetricsSubgroup.DockerVersion.fromVersionString(getDockerVersionStr());
+    private static TestMemoryWithSubgroups.DockerVersion getDockerVersion() {
+        return TestMemoryWithSubgroups.DockerVersion.fromVersionString(getDockerVersionStr());
     }
 
-    private static class DockerVersion implements Comparable<TestDockerMemoryMetricsSubgroup.DockerVersion> {
-        private static final TestDockerMemoryMetricsSubgroup.DockerVersion DEFAULT = new TestDockerMemoryMetricsSubgroup.DockerVersion(0, 0, 0);
-        private static final TestDockerMemoryMetricsSubgroup.DockerVersion VERSION_20_10_0 = new TestDockerMemoryMetricsSubgroup.DockerVersion(20, 10, 0);
+    private static class DockerVersion implements Comparable<TestMemoryWithSubgroups.DockerVersion> {
+        private static final TestMemoryWithSubgroups.DockerVersion DEFAULT = new TestMemoryWithSubgroups.DockerVersion(0, 0, 0);
+        private static final TestMemoryWithSubgroups.DockerVersion VERSION_20_10_0 = new TestMemoryWithSubgroups.DockerVersion(20, 10, 0);
         private final int major;
         private final int minor;
         private final int micro;
@@ -180,7 +180,7 @@ public class TestMemoryWithSubgroups {
         }
 
         @Override
-        public int compareTo(TestDockerMemoryMetricsSubgroup.DockerVersion other) {
+        public int compareTo(TestMemoryWithSubgroups.DockerVersion other) {
             if (this.major > other.major) {
                 return 1;
             } else if (this.major < other.major) {
@@ -203,12 +203,12 @@ public class TestMemoryWithSubgroups {
             }
         }
 
-        private static TestDockerMemoryMetricsSubgroup.DockerVersion fromVersionString(String version) {
+        private static TestMemoryWithSubgroups.DockerVersion fromVersionString(String version) {
             try {
                 // Example 'docker version 3.2.1'
                 String versNums = version.split("\\s+", 3)[2];
                 String[] numbers = versNums.split("\\.", 3);
-                return new TestDockerMemoryMetricsSubgroup.DockerVersion(Integer.parseInt(numbers[0]),
+                return new TestMemoryWithSubgroups.DockerVersion(Integer.parseInt(numbers[0]),
                         Integer.parseInt(numbers[1]),
                         Integer.parseInt(numbers[2]));
             } catch (Exception e) {

--- a/test/hotspot/jtreg/containers/docker/TestMemoryWithSubgroups.java
+++ b/test/hotspot/jtreg/containers/docker/TestMemoryWithSubgroups.java
@@ -147,21 +147,4 @@ public class TestMemoryWithSubgroups {
         Common.run(opts)
             .shouldMatch("Lowest limit was:.*" + expectedValue);
     }
-    // pre: IS_DOCKER == true
-    private static String getDockerVersionStr() {
-        if (!IS_DOCKER) {
-            return null;
-        }
-        try {
-            ProcessBuilder pb = new ProcessBuilder(Container.ENGINE_COMMAND, "--version");
-            OutputAnalyzer out = new OutputAnalyzer(pb.start())
-                    .shouldHaveExitValue(0);
-            String result = out.asLines().get(0);
-            System.out.println(Container.ENGINE_COMMAND + " --version returning: " + result);
-            return result;
-        } catch (Exception e) {
-            System.out.println(Container.ENGINE_COMMAND + " --version command failed. Returning null");
-            return null;
-        }
-    }
 }

--- a/test/jdk/jdk/internal/platform/docker/TestDockerMemoryMetricsSubgroup.java
+++ b/test/jdk/jdk/internal/platform/docker/TestDockerMemoryMetricsSubgroup.java
@@ -185,7 +185,7 @@ public class TestDockerMemoryMetricsSubgroup {
 
         private static TestDockerMemoryMetricsSubgroup.DockerVersion fromVersionString(String version) {
             try {
-                // Example 'podman version 3.2.1'
+                // Example 'docker version 3.2.1'
                 String versNums = version.split("\\s+", 3)[2];
                 String[] numbers = versNums.split("\\.", 3);
                 return new TestDockerMemoryMetricsSubgroup.DockerVersion(Integer.parseInt(numbers[0]),

--- a/test/jdk/jdk/internal/platform/docker/TestDockerMemoryMetricsSubgroup.java
+++ b/test/jdk/jdk/internal/platform/docker/TestDockerMemoryMetricsSubgroup.java
@@ -28,10 +28,10 @@ import jdk.test.lib.containers.docker.Common;
 import jdk.test.lib.containers.docker.DockerfileConfig;
 import jdk.test.lib.containers.docker.DockerRunOptions;
 import jdk.test.lib.containers.docker.DockerTestUtils;
+import jdk.test.lib.containers.docker.ContainerRuntimeVersionTestUtils;
 
 import java.util.ArrayList;
 
-import jdk.test.lib.process.OutputAnalyzer;
 import jtreg.SkippedException;
 
 /*
@@ -48,6 +48,7 @@ import jtreg.SkippedException;
 
 public class TestDockerMemoryMetricsSubgroup {
     private static final boolean IS_DOCKER = Container.ENGINE_COMMAND.contains("docker");
+    private static final boolean IS_PODMAN = Container.ENGINE_COMMAND.contains("podman");
     private static final String imageName =
             DockerfileConfig.getBaseImageName() + ":" +
             DockerfileConfig.getBaseImageVersion();
@@ -62,8 +63,11 @@ public class TestDockerMemoryMetricsSubgroup {
             System.out.println("Unable to run docker tests.");
             return;
         }
-        if (IS_DOCKER && TestDockerMemoryMetricsSubgroup.DockerVersion.VERSION_20_10_0.compareTo(getDockerVersion()) > 0) {
+        if (IS_DOCKER && ContainerRuntimeVersionTestUtils.DOCKER_VERSION_20_10_0.compareTo(ContainerRuntimeVersionTestUtils.getContainerRuntimeVersion()) > 0) {
             throw new SkippedException("Docker version too old for this test. Expected >= 20.10.0");
+        }
+        if (IS_PODMAN && ContainerRuntimeVersionTestUtils.PODMAN_VERSION_1_5_0.compareTo(ContainerRuntimeVersionTestUtils.getContainerRuntimeVersion()) > 0) {
+            throw new SkippedException("Podman version too old for this test. Expected >= 1.5.0");
         }
         if ("cgroupv1".equals(metrics.getProvider())) {
             testMemoryLimitSubgroupV1("200m", "400m", false);
@@ -122,79 +126,5 @@ public class TestDockerMemoryMetricsSubgroup {
             "MetricsMemoryTester memory " + innerSize);
 
         DockerTestUtils.dockerRunJava(opts).shouldHaveExitValue(0).shouldContain("TEST PASSED!!!");
-    }
-
-    // pre: IS_DOCKER == true
-    private static String getDockerVersionStr() {
-        if (!IS_DOCKER) {
-            return null;
-        }
-        try {
-            ProcessBuilder pb = new ProcessBuilder(Container.ENGINE_COMMAND, "--version");
-            OutputAnalyzer out = new OutputAnalyzer(pb.start())
-                    .shouldHaveExitValue(0);
-            String result = out.asLines().get(0);
-            System.out.println(Container.ENGINE_COMMAND + " --version returning: " + result);
-            return result;
-        } catch (Exception e) {
-            System.out.println(Container.ENGINE_COMMAND + " --version command failed. Returning null");
-            return null;
-        }
-    }
-
-    private static TestDockerMemoryMetricsSubgroup.DockerVersion getDockerVersion() {
-        return TestDockerMemoryMetricsSubgroup.DockerVersion.fromVersionString(getDockerVersionStr());
-    }
-
-    private static class DockerVersion implements Comparable<TestDockerMemoryMetricsSubgroup.DockerVersion> {
-        private static final TestDockerMemoryMetricsSubgroup.DockerVersion DEFAULT = new TestDockerMemoryMetricsSubgroup.DockerVersion(0, 0, 0);
-        private static final TestDockerMemoryMetricsSubgroup.DockerVersion VERSION_20_10_0 = new TestDockerMemoryMetricsSubgroup.DockerVersion(20, 10, 0);
-        private final int major;
-        private final int minor;
-        private final int micro;
-
-        private DockerVersion(int major, int minor, int micro) {
-            this.major = major;
-            this.minor = minor;
-            this.micro = micro;
-        }
-
-        @Override
-        public int compareTo(TestDockerMemoryMetricsSubgroup.DockerVersion other) {
-            if (this.major > other.major) {
-                return 1;
-            } else if (this.major < other.major) {
-                return -1;
-            } else { // equal major
-                if (this.minor > other.minor) {
-                    return 1;
-                } else if (this.minor < other.minor) {
-                    return -1;
-                } else { // equal majors and minors
-                    if (this.micro > other.micro) {
-                        return 1;
-                    } else if (this.micro < other.micro) {
-                        return -1;
-                    } else {
-                        // equal majors, minors, micro
-                        return 0;
-                    }
-                }
-            }
-        }
-
-        private static TestDockerMemoryMetricsSubgroup.DockerVersion fromVersionString(String version) {
-            try {
-                // Example 'docker version 3.2.1'
-                String versNums = version.split("\\s+", 3)[2];
-                String[] numbers = versNums.split("\\.", 3);
-                return new TestDockerMemoryMetricsSubgroup.DockerVersion(Integer.parseInt(numbers[0]),
-                        Integer.parseInt(numbers[1]),
-                        Integer.parseInt(numbers[2]));
-            } catch (Exception e) {
-                System.out.println("Failed to parse docker version: " + version);
-                return DEFAULT;
-            }
-        }
     }
 }

--- a/test/jdk/jdk/internal/platform/docker/TestDockerMemoryMetricsSubgroup.java
+++ b/test/jdk/jdk/internal/platform/docker/TestDockerMemoryMetricsSubgroup.java
@@ -22,7 +22,6 @@
  */
 
 import jdk.internal.platform.Metrics;
-import jdk.test.lib.Container;
 import jdk.test.lib.Utils;
 import jdk.test.lib.containers.docker.Common;
 import jdk.test.lib.containers.docker.DockerfileConfig;
@@ -47,8 +46,6 @@ import jtreg.SkippedException;
  */
 
 public class TestDockerMemoryMetricsSubgroup {
-    private static final boolean IS_DOCKER = Container.ENGINE_COMMAND.contains("docker");
-    private static final boolean IS_PODMAN = Container.ENGINE_COMMAND.contains("podman");
     private static final String imageName =
             DockerfileConfig.getBaseImageName() + ":" +
             DockerfileConfig.getBaseImageVersion();
@@ -63,12 +60,9 @@ public class TestDockerMemoryMetricsSubgroup {
             System.out.println("Unable to run docker tests.");
             return;
         }
-        if (IS_DOCKER && ContainerRuntimeVersionTestUtils.DOCKER_VERSION_20_10_0.compareTo(ContainerRuntimeVersionTestUtils.getContainerRuntimeVersion()) > 0) {
-            throw new SkippedException("Docker version too old for this test. Expected >= 20.10.0");
-        }
-        if (IS_PODMAN && ContainerRuntimeVersionTestUtils.PODMAN_VERSION_1_5_0.compareTo(ContainerRuntimeVersionTestUtils.getContainerRuntimeVersion()) > 0) {
-            throw new SkippedException("Podman version too old for this test. Expected >= 1.5.0");
-        }
+
+        ContainerRuntimeVersionTestUtils.checkContainerVersionSupported();
+
         if ("cgroupv1".equals(metrics.getProvider())) {
             testMemoryLimitSubgroupV1("200m", "400m", false);
             testMemoryLimitSubgroupV1("500m", "1G", false);

--- a/test/lib/jdk/test/lib/containers/docker/ContainerRuntimeVersionTestUtils.java
+++ b/test/lib/jdk/test/lib/containers/docker/ContainerRuntimeVersionTestUtils.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * Methods and definitions related to container runtime version to test container in this directory
+ */
+
+package jdk.test.lib.containers.docker;
+
+import jdk.test.lib.Container;
+import jdk.test.lib.process.OutputAnalyzer;
+
+public class ContainerRuntimeVersionTestUtils implements Comparable<ContainerRuntimeVersionTestUtils> {
+    private final int major;
+    private final int minor;
+    private final int micro;
+    private static final ContainerRuntimeVersionTestUtils DEFAULT = new ContainerRuntimeVersionTestUtils(0, 0, 0);
+    public static final ContainerRuntimeVersionTestUtils DOCKER_VERSION_20_10_0 = new ContainerRuntimeVersionTestUtils(20, 10, 0);
+    public static final ContainerRuntimeVersionTestUtils PODMAN_VERSION_1_5_0 = new ContainerRuntimeVersionTestUtils(1, 5, 0);
+
+    private ContainerRuntimeVersionTestUtils(int major, int minor, int micro) {
+        this.major = major;
+        this.minor = minor;
+        this.micro = micro;
+    }
+
+    @Override
+    public int compareTo(ContainerRuntimeVersionTestUtils other) {
+        if (this.major > other.major) {
+            return 1;
+        } else if (this.major < other.major) {
+            return -1;
+        } else { // equal major
+            if (this.minor > other.minor) {
+                return 1;
+            } else if (this.minor < other.minor) {
+                return -1;
+            } else { // equal majors and minors
+                if (this.micro > other.micro) {
+                    return 1;
+                } else if (this.micro < other.micro) {
+                    return -1;
+                } else {
+                    // equal majors, minors, micro
+                    return 0;
+                }
+            }
+        }
+    }
+
+    public static ContainerRuntimeVersionTestUtils fromVersionString(String version) {
+        try {
+            // Example 'docker version 20.10.0 or podman version 4.9.4-rhel'
+            String versNums = version.split("\\s+", 3)[2];
+            String[] numbers = versNums.split("-")[0].split("\\.", 3);
+            return new ContainerRuntimeVersionTestUtils(Integer.parseInt(numbers[0]),
+                    Integer.parseInt(numbers[1]),
+                    Integer.parseInt(numbers[2]));
+        } catch (Exception e) {
+            System.out.println("Failed to parse container runtime version: " + version);
+            return DEFAULT;
+        }
+    }
+    public static String getContainerRuntimeVersionStr() {
+        try {
+            ProcessBuilder pb = new ProcessBuilder(Container.ENGINE_COMMAND, "--version");
+            OutputAnalyzer out = new OutputAnalyzer(pb.start())
+                    .shouldHaveExitValue(0);
+            String result = out.asLines().get(0);
+            System.out.println(Container.ENGINE_COMMAND + " --version returning: " + result);
+            return result;
+        } catch (Exception e) {
+            System.out.println(Container.ENGINE_COMMAND + " --version command failed. Returning null");
+            return null;
+        }
+    }
+
+    public static ContainerRuntimeVersionTestUtils getContainerRuntimeVersion() {
+        return ContainerRuntimeVersionTestUtils.fromVersionString(getContainerRuntimeVersionStr());
+    }
+}


### PR DESCRIPTION
8352926: New test TestDockerMemoryMetricsSubgroup.java fails

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8352926](https://bugs.openjdk.org/browse/JDK-8352926): New test TestDockerMemoryMetricsSubgroup.java fails (**Bug** - P3)


### Reviewers
 * [Mikhailo Seledtsov](https://openjdk.org/census#mseledtsov) (@mseledts - Committer)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24948/head:pull/24948` \
`$ git checkout pull/24948`

Update a local copy of the PR: \
`$ git checkout pull/24948` \
`$ git pull https://git.openjdk.org/jdk.git pull/24948/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24948`

View PR using the GUI difftool: \
`$ git pr show -t 24948`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24948.diff">https://git.openjdk.org/jdk/pull/24948.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24948#issuecomment-2838828794)
</details>
