### PR TITLE
8355913: RISC-V: improve hotspot/jtreg/compiler/vectorization/runner/BasicFloatOpTest.java

### DIFF
--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -1914,9 +1914,10 @@ bool Matcher::match_rule_supported(int opcode) {
 
     case Op_FmaF:
     case Op_FmaD:
+      return UseFMA;
     case Op_FmaVF:
     case Op_FmaVD:
-      return UseFMA;
+      return UseRVV && UseFMA;
 
     case Op_ConvHF2F:
     case Op_ConvF2HF:

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/TestFramework.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/TestFramework.java
@@ -142,6 +142,7 @@ public class TestFramework {
                     "Xlog",
                     "LogCompilation",
                     "UseCompactObjectHeaders",
+                    "UseFMA",
                     // Riscv
                     "UseRVV",
                     "UseZbb",

--- a/test/hotspot/jtreg/compiler/vectorization/runner/BasicFloatOpTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/BasicFloatOpTest.java
@@ -35,7 +35,7 @@
  *                   -XX:+WhiteBoxAPI
  *                   compiler.vectorization.runner.BasicFloatOpTest
  *
- * @requires (os.simpleArch == "x64") | (os.simpleArch == "aarch64")
+ * @requires (os.simpleArch == "x64") | (os.simpleArch == "aarch64") | (os.simpleArch == "riscv64")
  * @requires vm.compiler2.enabled
  */
 
@@ -229,7 +229,7 @@ public class BasicFloatOpTest extends VectorizationTestRunner {
         counts = {IRNode.FMA_VF, ">0", IRNode.VFMLA, ">0"})
     @IR(applyIfCPUFeatureAnd = {"fma", "true", "avx", "true"},
         counts = {IRNode.FMA_VF, ">0"})
-    @IR(applyIfCPUFeature = {"rvv", "true"},
+    @IR(applyIfCPUFeature = {"rvv", "true"}, applyIf = {"UseFMA", "true"},
         counts = {IRNode.FMA_VF, ">0"})
     public float[] vectorMulAdd() {
         float[] res = new float[SIZE];
@@ -244,7 +244,7 @@ public class BasicFloatOpTest extends VectorizationTestRunner {
         counts = {IRNode.FMA_VF, ">0", IRNode.VFMLS, ">0"})
     @IR(applyIfCPUFeatureAnd = {"fma", "true", "avx", "true"},
         counts = {IRNode.FMA_VF, ">0"})
-    @IR(applyIfCPUFeature = {"rvv", "true"},
+    @IR(applyIfCPUFeature = {"rvv", "true"}, applyIf = {"UseFMA", "true"},
         counts = {IRNode.FMA_VF, ">0"})
     public float[] vectorMulSub1() {
         float[] res = new float[SIZE];
@@ -259,7 +259,7 @@ public class BasicFloatOpTest extends VectorizationTestRunner {
         counts = {IRNode.FMA_VF, ">0", IRNode.VFMLS, ">0"})
     @IR(applyIfCPUFeatureAnd = {"fma", "true", "avx", "true"},
         counts = {IRNode.FMA_VF, ">0"})
-    @IR(applyIfCPUFeature = {"rvv", "true"},
+    @IR(applyIfCPUFeature = {"rvv", "true"}, applyIf = {"UseFMA", "true"},
         counts = {IRNode.FMA_VF, ">0"})
     public float[] vectorMulSub2() {
         float[] res = new float[SIZE];
@@ -276,7 +276,7 @@ public class BasicFloatOpTest extends VectorizationTestRunner {
         counts = {IRNode.VFNMLA, ">0"})
     @IR(applyIfCPUFeatureAnd = {"fma", "true", "avx", "true"},
         counts = {IRNode.FMA_VF, ">0"})
-    @IR(applyIfCPUFeature = {"rvv", "true"},
+    @IR(applyIfCPUFeature = {"rvv", "true"}, applyIf = {"UseFMA", "true"},
         counts = {IRNode.FMA_VF, ">0"})
     public float[] vectorNegateMulAdd1() {
         float[] res = new float[SIZE];
@@ -293,7 +293,7 @@ public class BasicFloatOpTest extends VectorizationTestRunner {
         counts = {IRNode.VFNMLA, ">0"})
     @IR(applyIfCPUFeatureAnd = {"fma", "true", "avx", "true"},
         counts = {IRNode.FMA_VF, ">0"})
-    @IR(applyIfCPUFeature = {"rvv", "true"},
+    @IR(applyIfCPUFeature = {"rvv", "true"}, applyIf = {"UseFMA", "true"},
         counts = {IRNode.FMA_VF, ">0"})
     public float[] vectorNegateMulAdd2() {
         float[] res = new float[SIZE];
@@ -308,7 +308,7 @@ public class BasicFloatOpTest extends VectorizationTestRunner {
         counts = {IRNode.FMA_VF, ">0"})
     @IR(applyIfCPUFeatureAnd = {"fma", "true", "avx", "true"},
         counts = {IRNode.FMA_VF, ">0"})
-    @IR(applyIfCPUFeature = {"rvv", "true"},
+    @IR(applyIfCPUFeature = {"rvv", "true"}, applyIf = {"UseFMA", "true"},
         counts = {IRNode.FMA_VF, ">0"})
     public float[] vectorNegateMulSub() {
         float[] res = new float[SIZE];


### PR DESCRIPTION
Hi,
Can you help to review this simple patch?
Previously, BasicFloatOpTest.java is accidently not really enabled on riscv.
And FmaVF/FmaVD depends on both UseFMA and UseRVV, the code should make it clear in this sense.
And IR verification of FmaVF in BasicFloatOpTest.java should only be enabled when UseFMA && rvv.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8355913](https://bugs.openjdk.org/browse/JDK-8355913): RISC-V: improve hotspot/jtreg/compiler/vectorization/runner/BasicFloatOpTest.java (**Enhancement** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Robbin Ehn](https://openjdk.org/census#rehn) (@robehn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24950/head:pull/24950` \
`$ git checkout pull/24950`

Update a local copy of the PR: \
`$ git checkout pull/24950` \
`$ git pull https://git.openjdk.org/jdk.git pull/24950/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24950`

View PR using the GUI difftool: \
`$ git pr show -t 24950`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24950.diff">https://git.openjdk.org/jdk/pull/24950.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24950#issuecomment-2838999169)
</details>
