### PR TITLE
8355938: Addressed rare lost unpark bug 8074773 by pre-loading LockSupport.class

### DIFF
--- a/src/java.base/share/classes/java/util/concurrent/Exchanger.java
+++ b/src/java.base/share/classes/java/util/concurrent/Exchanger.java
@@ -537,6 +537,8 @@ public class Exchanger<V> {
         MATCH = MhUtil.findVarHandle(l, Node.class, "match", Object.class);
         ENTRY = MhUtil.findVarHandle(l, Slot.class, "entry", Node.class);
         AA = MethodHandles.arrayElementVarHandle(Slot[].class);
+        // Prevent rare disastrous classloading in first call to LockSupport.park.
+        // See: https://bugs.openjdk.java.net/browse/JDK-8074773
+        Class<?> ensureLoaded = LockSupport.class;
     }
-
 }

--- a/src/java.base/share/classes/java/util/concurrent/ThreadPerTaskExecutor.java
+++ b/src/java.base/share/classes/java/util/concurrent/ThreadPerTaskExecutor.java
@@ -554,4 +554,10 @@ class ThreadPerTaskExecutor extends ThreadContainer implements ExecutorService {
             return exceptionCount;
         }
     }
+
+    static {
+        // Prevent rare disastrous classloading in first call to LockSupport.park.
+        // See: https://bugs.openjdk.java.net/browse/JDK-8074773
+        Class<?> ensureLoaded = LockSupport.class;
+    }
 }

--- a/src/java.base/share/classes/jdk/internal/misc/ThreadFlock.java
+++ b/src/java.base/share/classes/jdk/internal/misc/ThreadFlock.java
@@ -585,4 +585,10 @@ public class ThreadFlock implements AutoCloseable {
             return flock.scopedValueBindings();
         }
     }
+
+    static {
+        // Prevent rare disastrous classloading in first call to LockSupport.park.
+        // See: https://bugs.openjdk.java.net/browse/JDK-8074773
+        Class<?> ensureLoaded = LockSupport.class;
+    }
 }

--- a/src/java.base/share/classes/sun/nio/ch/Poller.java
+++ b/src/java.base/share/classes/sun/nio/ch/Poller.java
@@ -470,4 +470,10 @@ public abstract class Poller {
     public static List<Poller> writePollers() {
         return POLLERS.writePollers();
     }
+
+    static {
+        // Prevent rare disastrous classloading in first call to LockSupport.park.
+        // See: https://bugs.openjdk.java.net/browse/JDK-8074773
+        Class<?> ensureLoaded = LockSupport.class;
+    }
 }


### PR DESCRIPTION
In 2015, Google discovered a rare disastrous classloading bug in first call to LockSupport.park() that occurred in the AppClassLoader using the Java 7 ConcurrentHashMap, which used ReentrantLock for the synchronization.

Since then, the recommended fix for this bug seems to be this code snippet in any class that directly calls LockSupport.park():

```
static {
    // Prevent rare disastrous classloading in first call to LockSupport.park.
    // See: https://bugs.openjdk.java.net/browse/JDK-8074773
    Class<?> ensureLoaded = LockSupport.class;
}
```

Since the bug was logged, we have seen new classes in the JDK that call LockSupport.park(), but that do not have this code snippet. For example:

sun.nio.ch.Poller
jdk.internal.misc.ThreadFlock
java.util.concurrent.ThreadPerTaskExecutor

It should probably also be in:

java.util.concurrent.Exchanger

Considering how hard this bug is to detect and solve, it would probably be safer to add the code snippet into these newer classes.