### PR TITLE
8355627: Don't use ThreadCritical for EventLog list

### DIFF
--- a/src/hotspot/share/utilities/events.cpp
+++ b/src/hotspot/share/utilities/events.cpp
@@ -26,15 +26,14 @@
 #include "memory/allocation.inline.hpp"
 #include "oops/instanceKlass.hpp"
 #include "oops/symbol.hpp"
+#include "runtime/atomic.hpp"
 #include "runtime/javaThread.hpp"
 #include "runtime/mutexLocker.hpp"
 #include "runtime/osThread.hpp"
-#include "runtime/threadCritical.hpp"
 #include "runtime/timer.hpp"
 #include "utilities/events.hpp"
-#include "utilities/lockFreeStack.hpp"
 
-
+EventLog* Events::_logs = nullptr;
 StringEventLog* Events::_messages = nullptr;
 StringEventLog* Events::_memprotect_messages = nullptr;
 StringEventLog* Events::_nmethod_flush_messages = nullptr;
@@ -47,24 +46,22 @@ StringEventLog* Events::_class_loading = nullptr;
 StringEventLog* Events::_deopt_messages = nullptr;
 StringEventLog* Events::_dll_messages = nullptr;
 
-// Contain lockFreeStack in mtInternal allocation
-class EventLogStack : public CHeapObj<mtInternal> {
- public:
-    LockFreeStack<EventLog, &EventLog::next_ptr> _list;
-};
+static EventLog* _event_logs = nullptr;
 
-static EventLogStack* _event_logs = nullptr;
-
-EventLog::EventLog() : _next(nullptr) {
+EventLog::EventLog() {
   // This normally done during bootstrap when we're only single threaded,
-  // but use a lockFreeStack because there are some events that are created later.
-  _event_logs->_list.push(*this);
+  // but use lock free add because there are some events that are created later.
+  EventLog* old_head;
+  do {
+    old_head = Atomic::load(&Events::_logs);
+    _next = old_head;
+  } while (Atomic::cmpxchg(&Events::_logs, old_head, this, memory_order_relaxed) != old_head);
 }
 
 // For each registered event logger, print out the current contents of
 // the buffer.
 void Events::print_all(outputStream* out, int max) {
-  EventLog* log = _event_logs->_list.top();
+  EventLog* log = Atomic::load(&Events::_logs);
   while (log != nullptr) {
     log->print_log_on(out, max);
     log = log->next();
@@ -73,7 +70,7 @@ void Events::print_all(outputStream* out, int max) {
 
 // Print a single event log specified by name.
 void Events::print_one(outputStream* out, const char* log_name, int max) {
-  EventLog* log = _event_logs->_list.top();
+  EventLog* log = Atomic::load(&Events::_logs);
   int num_printed = 0;
   while (log != nullptr) {
     if (log->matches_name_or_handle(log_name)) {
@@ -86,7 +83,7 @@ void Events::print_one(outputStream* out, const char* log_name, int max) {
   if (num_printed == 0) {
     out->print_cr("The name \"%s\" did not match any known event log. "
                   "Valid event log names are:", log_name);
-    EventLog* log = _event_logs->_list.top();
+    EventLog* log = Atomic::load(&Events::_logs);
     while (log != nullptr) {
       log->print_names(out);
       out->cr();
@@ -102,7 +99,6 @@ void Events::print() {
 
 void Events::init() {
   if (LogEvents) {
-    _event_logs = new EventLogStack();
     _messages = new StringEventLog("Events", "events");
     _nmethod_flush_messages = new StringEventLog("Nmethod flushes", "nmethodflushes");
     _memprotect_messages = new StringEventLog("Memory protections", "memprotects");

--- a/src/hotspot/share/utilities/events.cpp
+++ b/src/hotspot/share/utilities/events.cpp
@@ -47,13 +47,13 @@ StringEventLog* Events::_deopt_messages = nullptr;
 StringEventLog* Events::_dll_messages = nullptr;
 
 EventLog::EventLog() {
-  // This normally done during bootstrap when we're only single threaded,
+  // This is normally done during bootstrap when we're only single threaded,
   // but use lock free add because there are some events that are created later.
   EventLog* old_head;
   do {
     old_head = Atomic::load(&Events::_logs);
     _next = old_head;
-  } while (Atomic::cmpxchg(&Events::_logs, old_head, this, memory_order_relaxed) != old_head);
+  } while (Atomic::cmpxchg(&Events::_logs, old_head, this) != old_head);
 }
 
 // For each registered event logger, print out the current contents of

--- a/src/hotspot/share/utilities/events.cpp
+++ b/src/hotspot/share/utilities/events.cpp
@@ -46,8 +46,6 @@ StringEventLog* Events::_class_loading = nullptr;
 StringEventLog* Events::_deopt_messages = nullptr;
 StringEventLog* Events::_dll_messages = nullptr;
 
-static EventLog* _event_logs = nullptr;
-
 EventLog::EventLog() {
   // This normally done during bootstrap when we're only single threaded,
   // but use lock free add because there are some events that are created later.

--- a/src/hotspot/share/utilities/events.cpp
+++ b/src/hotspot/share/utilities/events.cpp
@@ -57,7 +57,7 @@ static EventLogStack* _event_logs = nullptr;
 
 EventLog::EventLog() : _next(nullptr) {
   // This normally done during bootstrap when we're only single threaded,
-  // but a lockFreeStack in case some are created slightly late.
+  // but use a lockFreeStack because there are some events that are created later.
   _event_logs->_list.push(*this);
 }
 

--- a/src/hotspot/share/utilities/events.hpp
+++ b/src/hotspot/share/utilities/events.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/utilities/events.hpp
+++ b/src/hotspot/share/utilities/events.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -70,6 +70,7 @@ class EventLog : public CHeapObj<mtInternal> {
   // Print log names (for help output of VM.events).
   virtual void print_names(outputStream* out) const = 0;
 
+  static EventLog* volatile* next_ptr(EventLog& el) { return &el._next; }
 };
 
 
@@ -217,8 +218,6 @@ class Events : AllStatic {
   friend class EventLog;
 
  private:
-  static EventLog* _logs;
-
   // A log for generic messages that aren't well categorized.
   static StringEventLog* _messages;
 

--- a/src/hotspot/share/utilities/events.hpp
+++ b/src/hotspot/share/utilities/events.hpp
@@ -70,7 +70,6 @@ class EventLog : public CHeapObj<mtInternal> {
   // Print log names (for help output of VM.events).
   virtual void print_names(outputStream* out) const = 0;
 
-  static EventLog* volatile* next_ptr(EventLog& el) { return &el._next; }
 };
 
 
@@ -218,6 +217,8 @@ class Events : AllStatic {
   friend class EventLog;
 
  private:
+  static EventLog* _logs;
+
   // A log for generic messages that aren't well categorized.
   static StringEventLog* _messages;
 

--- a/test/hotspot/jtreg/runtime/ErrorHandling/ShowEventsOnCrashTest.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/ShowEventsOnCrashTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+
+/*
+ * @test
+ * @bug 8355627
+ * @summary Test that events are listed in the hs_err_pid file
+ * @library /test/lib
+ * @requires vm.flagless
+ * @requires vm.debug == true & (os.family == "linux" | os.family == "windows")
+ * @modules java.base/jdk.internal.misc
+ * @run driver ShowEventsOnCrashTest
+ */
+
+// Note: this test can only run on debug since it relies on VMError::controlled_crash() which
+// only exists in debug builds.
+import java.io.File;
+import java.util.regex.Pattern;
+
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+public class ShowEventsOnCrashTest {
+
+    public static void main(String[] args) throws Exception {
+
+        ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(
+            "-XX:+UnlockDiagnosticVMOptions", "-Xmx100M", "-XX:-CreateCoredumpOnCrash",
+            "-XX:ErrorHandlerTest=2",
+            "-version");
+
+        OutputAnalyzer output_detail = new OutputAnalyzer(pb.start());
+
+        // we should have crashed with an internal error. We should definitely NOT have crashed with a segfault
+        // (which would be a sign that the assert poison page mechanism does not work).
+        output_detail.shouldMatch("# A fatal error has been detected by the Java Runtime Environment:.*");
+        output_detail.shouldMatch("# +Internal Error.*");
+        File hs_err_file = HsErrFileUtils.openHsErrFileFromOutput(output_detail);
+        // Pattern match the hs_err_pid file.
+        Pattern[] patterns = new Pattern[] {
+            Pattern.compile("Compilation events \\([0-9]* events\\):"),
+            Pattern.compile("GC Heap History \\([0-9]* events\\):"),
+            Pattern.compile("Dll operation events \\([0-9]* events\\):"),
+            Pattern.compile("Deoptimization events \\([0-9]* events\\):"),
+            Pattern.compile("Classes loaded \\([0-9]* events\\):"),
+            Pattern.compile("Classes unloaded \\([0-9]* events\\):"),
+            Pattern.compile("Classes redefined \\([0-9]* events\\):"),
+            Pattern.compile("Internal exceptions \\([0-9]* events\\):"),
+            Pattern.compile("VM Operations \\([0-9]* events\\):"),
+            Pattern.compile("Memory protections \\([0-9]* events\\):")
+        };
+
+        HsErrFileUtils.checkHsErrFileContent(hs_err_file, patterns, false);
+
+    }
+}
+


### PR DESCRIPTION
Use LockFreeStack to link events on the eventLog queue.  They are never popped so this requires no further synchronization.
Tested by tier1-4.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8355627](https://bugs.openjdk.org/browse/JDK-8355627): Don't use ThreadCritical for EventLog list (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)
 * [Zhengyu Gu](https://openjdk.org/census#zgu) (@zhengyu123 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24954/head:pull/24954` \
`$ git checkout pull/24954`

Update a local copy of the PR: \
`$ git checkout pull/24954` \
`$ git pull https://git.openjdk.org/jdk.git pull/24954/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24954`

View PR using the GUI difftool: \
`$ git pr show -t 24954`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24954.diff">https://git.openjdk.org/jdk/pull/24954.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24954#issuecomment-2839985352)
</details>
