### PR TITLE
8355391: Use Long::hashCode in java.time

### DIFF
--- a/src/java.base/share/classes/java/time/Clock.java
+++ b/src/java.base/share/classes/java/time/Clock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -61,8 +61,6 @@
  */
 package java.time;
 
-import java.io.IOException;
-import java.io.ObjectInputStream;
 import java.io.ObjectStreamException;
 
 import static java.time.LocalTime.NANOS_PER_MINUTE;
@@ -780,7 +778,7 @@ public abstract class Clock implements InstantSource {
         }
         @Override
         public int hashCode() {
-            return baseClock.hashCode() ^ ((int) (tickNanos ^ (tickNanos >>> 32)));
+            return baseClock.hashCode() ^ Long.hashCode(tickNanos);
         }
         @Override
         public String toString() {

--- a/src/java.base/share/classes/java/time/Duration.java
+++ b/src/java.base/share/classes/java/time/Duration.java
@@ -1460,7 +1460,7 @@ public final class Duration
      */
     @Override
     public int hashCode() {
-        return ((int) (seconds ^ (seconds >>> 32))) + (51 * nanos);
+        return Long.hashCode(seconds) + (51 * nanos);
     }
 
     //-----------------------------------------------------------------------

--- a/src/java.base/share/classes/java/time/Instant.java
+++ b/src/java.base/share/classes/java/time/Instant.java
@@ -1363,7 +1363,7 @@ public final class Instant
      */
     @Override
     public int hashCode() {
-        return ((int) (seconds ^ (seconds >>> 32))) + 51 * nanos;
+        return Long.hashCode(seconds) + 51 * nanos;
     }
 
     //-----------------------------------------------------------------------

--- a/src/java.base/share/classes/java/time/LocalDate.java
+++ b/src/java.base/share/classes/java/time/LocalDate.java
@@ -2133,10 +2133,7 @@ public final class LocalDate
      */
     @Override
     public int hashCode() {
-        int yearValue = year;
-        int monthValue = month;
-        int dayValue = day;
-        return (yearValue & 0xFFFFF800) ^ ((yearValue << 11) + (monthValue << 6) + (dayValue));
+        return (year & 0xFFFFF800) ^ ((year << 11) + (month << 6) + day);
     }
 
     //-----------------------------------------------------------------------

--- a/src/java.base/share/classes/java/time/chrono/ChronoLocalDateImpl.java
+++ b/src/java.base/share/classes/java/time/chrono/ChronoLocalDateImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -421,7 +421,7 @@ abstract class ChronoLocalDateImpl<D extends ChronoLocalDate>
     @Override
     public int hashCode() {
         long epDay = toEpochDay();
-        return getChronology().hashCode() ^ ((int) (epDay ^ (epDay >>> 32)));
+        return getChronology().hashCode() ^ Long.hashCode(epDay);
     }
 
     @Override


### PR DESCRIPTION
Replace manual bitwise operations in `hashCode` implementations of `java.time` with `Long::hashCode`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8355391](https://bugs.openjdk.org/browse/JDK-8355391): Use Long::hashCode in java.time (**Enhancement** - P4)


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Per Minborg](https://openjdk.org/census#pminborg) (@minborg - **Reviewer**)
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24959/head:pull/24959` \
`$ git checkout pull/24959`

Update a local copy of the PR: \
`$ git checkout pull/24959` \
`$ git pull https://git.openjdk.org/jdk.git pull/24959/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24959`

View PR using the GUI difftool: \
`$ git pr show -t 24959`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24959.diff">https://git.openjdk.org/jdk/pull/24959.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24959#issuecomment-2840983698)
</details>
