### PR TITLE
JDK-8355979: ATTRIBUTE_NO_UBSAN needs to be extended to handle float divisions by zero on AIX

### DIFF
--- a/src/hotspot/share/sanitizers/ub.hpp
+++ b/src/hotspot/share/sanitizers/ub.hpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2024 SAP SE. All rights reserved.
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2025 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,7 +33,10 @@
 // Useful if the function or method is known to do something special or even 'dangerous', for
 // example causing desired signals/crashes.
 #ifdef UNDEFINED_BEHAVIOR_SANITIZER
-#if defined(__clang__) || defined(__GNUC__)
+#if defined(__clang__)
+#define ATTRIBUTE_NO_UBSAN __attribute__((no_sanitize("undefined","float-divide-by-zero")))
+#endif
+#if defined(__GNUC__) && !defined(__clang__)
 #define ATTRIBUTE_NO_UBSAN __attribute__((no_sanitize("undefined")))
 #endif
 #endif

--- a/src/java.base/share/native/libjava/ub.h
+++ b/src/java.base/share/native/libjava/ub.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2024 SAP SE. All rights reserved.
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2025 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,7 +32,10 @@
  * following function or method.
  */
 #ifdef UNDEFINED_BEHAVIOR_SANITIZER
-#if defined(__clang__) || defined(__GNUC__)
+#if defined(__clang__)
+#define ATTRIBUTE_NO_UBSAN __attribute__((no_sanitize("undefined","float-divide-by-zero")))
+#endif
+#if defined(__GNUC__) && !defined(__clang__)
 #define ATTRIBUTE_NO_UBSAN __attribute__((no_sanitize("undefined")))
 #endif
 #endif


### PR DESCRIPTION
Seems the currently used ATTRIBUTE_NO_UBSAN does not handle the exclusion of float divisions by zero.
At least this is the case on AIX.

(seen in the jtreg test java/lang/Math/PowTests.java )