### PR TITLE
8354908: javac mishandles supplementary character in character literal

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavaTokenizer.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavaTokenizer.java
@@ -389,6 +389,10 @@ public class JavaTokenizer extends UnicodeReader {
                     break;
             }
         } else {
+            if (!isString && !Character.isBmpCodePoint(getCodepoint())) {
+                lexError(pos, Errors.IllegalCharLiteralMultipleSurrogates);
+            }
+
             putThenNext();
         }
     }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
@@ -694,6 +694,9 @@ compiler.err.illegal.combination.of.modifiers=\
 compiler.err.illegal.enum.static.ref=\
     illegal reference to static field from initializer
 
+compiler.err.illegal.char.literal.multiple.surrogates=\
+    character literal contains more than one UTF-16 code point
+
 compiler.err.illegal.esc.char=\
     illegal escape character
 

--- a/test/langtools/tools/javac/diags/examples/IllegalCharLiteralMultipleSurrogates.java
+++ b/test/langtools/tools/javac/diags/examples/IllegalCharLiteralMultipleSurrogates.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+// key: compiler.err.illegal.char.literal.multiple.surrogates
+
+class IllegalCharLiteralMultipleSurrogates {
+    char c = '\uD83D\uDE0A';
+}

--- a/test/langtools/tools/javac/lexer/JavaLexerTest.java
+++ b/test/langtools/tools/javac/lexer/JavaLexerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,11 @@
  */
 
 import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 
+import javax.tools.DiagnosticListener;
 import javax.tools.SimpleJavaFileObject;
 
 import com.sun.tools.javac.parser.JavaTokenizer;
@@ -101,17 +104,29 @@ public class JavaLexerTest {
             new TestTuple(ERROR,         "\'\'"),
             new TestTuple(ERROR,         "\'\\q\'", "\'\\q\'"),
             new TestTuple(ERROR,         "\'\\{1+2}\'", "\'\\{1+2}\'"),
+            new TestTuple(ERROR,         "'\uD83D\uDE0A'",
+                          List.of("compiler.err.illegal.char.literal.multiple.surrogates")),
     };
 
     static class TestTuple {
         String input;
         TokenKind kind;
         String expected;
+        List<String> expectedErrors;
 
-        TestTuple(TokenKind kind, String input, String expected) {
+        TestTuple(TokenKind kind, String input, String expected, List<String> expectedErrors) {
             this.input = input;
             this.kind = kind;
             this.expected = expected;
+            this.expectedErrors = expectedErrors;
+        }
+
+        TestTuple(TokenKind kind, String input, List<String> expectedErrors) {
+            this(kind, input, input, expectedErrors);
+        }
+
+        TestTuple(TokenKind kind, String input, String expected) {
+            this(kind, input, expected, null);
         }
 
         TestTuple(TokenKind kind, String input) {
@@ -121,6 +136,12 @@ public class JavaLexerTest {
 
     void test(TestTuple test, boolean willFail) throws Exception {
         Context ctx = new Context();
+        List<String> errors = new ArrayList();
+
+        if (test.expectedErrors != null) {
+            ctx.put(DiagnosticListener.class, (DiagnosticListener) d -> errors.add(d.getCode()));
+        }
+
         Log log = Log.instance(ctx);
 
         log.useSource(SimpleJavaFileObject.forSource(URI.create("mem://Test.java"),
@@ -148,6 +169,10 @@ public class JavaLexerTest {
         if (!Objects.equals(test.expected, actual)) {
             System.err.println("input: " + test.input);
             throw new AssertionError("Unexpected token content: " + actual);
+        }
+
+        if (test.expectedErrors != null && !test.expectedErrors.equals(errors)) {
+            throw new AssertionError("Unexpected errors: " + errors);
         }
     }
 


### PR DESCRIPTION
Some Unicode characters consist of two surrogates, i.e. two `char`s. And, such Unicode characters cannot be part of a char literal, as there's no way to represent them as a character literal. But, javac currently accepts code with such characters, and only puts the char, the high surrogate, into the literal, ignoring the second one.

For example, the JDK 24 behavior is:
```
$ cat /tmp/T.java 
public class T {
    public static void main(String... args) {
       char c = '😊';
       System.err.println(Integer.toHexString((int) c));
       System.err.println(Character.isHighSurrogate(c));
    }
}
$ java /tmp/T.java
d83d
true
```

But, in JDK 11, such literals have been rejected:
```
$ java /tmp/T.java
/tmp/T.java:3: error: unclosed character literal
       char c = '😊';
                ^
/tmp/T.java:3: error: illegal character: '\ude0a'
       char c = '😊';
                  ^
/tmp/T.java:3: error: unclosed character literal
       char c = '😊';
                   ^
3 errors
error: compilation failed
```

The proposal in this PR is to explicitly check for this case when scanning character literal, and produce explicit error when a multi-surrogate character is used. javac will produce an error like:
```
$ java /tmp/T.java
/tmp/T.java:3: error: character literal contains more than one UTF-16 code point
       char c = '😊';
                ^
1 error
error: compilation failed
```
