### PR TITLE
8355896: Lossy narrowing cast of JVMCINMethodData::size

### DIFF
--- a/src/hotspot/share/code/nmethod.cpp
+++ b/src/hotspot/share/code/nmethod.cpp
@@ -1323,8 +1323,9 @@ nmethod::nmethod(
     _unwind_handler_offset   = 0;
 
     CHECKED_CAST(_oops_size, uint16_t, align_up(code_buffer->total_oop_size(), oopSize));
-    int metadata_size = align_up(code_buffer->total_metadata_size(), wordSize);
-    JVMCI_ONLY( _jvmci_data_size = 0; )
+    uint16_t metadata_size;
+    CHECKED_CAST(metadata_size, uint16_t, align_up(code_buffer->total_metadata_size(), wordSize));
+    JVMCI_ONLY( _metadata_size = metadata_size; )
     assert(_mutable_data_size == _relocation_size + metadata_size,
            "wrong mutable data size: %d != %d + %d",
            _mutable_data_size, _relocation_size, metadata_size);
@@ -1497,9 +1498,10 @@ nmethod::nmethod(
     }
 
     CHECKED_CAST(_oops_size, uint16_t, align_up(code_buffer->total_oop_size(), oopSize));
-    uint16_t metadata_size = (uint16_t)align_up(code_buffer->total_metadata_size(), wordSize);
-    JVMCI_ONLY(CHECKED_CAST(_jvmci_data_size, uint16_t, align_up(compiler->is_jvmci() ? jvmci_data->size() : 0, oopSize)));
-    int jvmci_data_size = 0 JVMCI_ONLY(+ _jvmci_data_size);
+    uint16_t metadata_size;
+    CHECKED_CAST(metadata_size, uint16_t, align_up(code_buffer->total_metadata_size(), wordSize));
+    JVMCI_ONLY( _metadata_size = metadata_size; )
+    int jvmci_data_size = 0 JVMCI_ONLY( + align_up(compiler->is_jvmci() ? jvmci_data->size() : 0, oopSize));
     assert(_mutable_data_size == _relocation_size + metadata_size + jvmci_data_size,
            "wrong mutable data size: %d != %d + %d + %d",
            _mutable_data_size, _relocation_size, metadata_size, jvmci_data_size);

--- a/src/hotspot/share/code/nmethod.hpp
+++ b/src/hotspot/share/code/nmethod.hpp
@@ -237,7 +237,9 @@ class nmethod : public CodeBlob {
 
   uint16_t _oops_size;
 #if INCLUDE_JVMCI
-  uint16_t _jvmci_data_size;
+  // _metadata_size is not specific to JVMCI. In the non-JVMCI case, it can be derived as:
+  // _metadata_size = mutable_data_size - relocation_size
+  uint16_t _metadata_size;
 #endif
 
   // Offset in immutable data section
@@ -537,8 +539,8 @@ public:
   // mutable data
   Metadata** metadata_begin     () const { return (Metadata**) (mutable_data_begin() + _relocation_size); }
 #if INCLUDE_JVMCI
-  Metadata** metadata_end       () const { return (Metadata**) (mutable_data_end() - _jvmci_data_size); }
-  address jvmci_data_begin      () const { return               mutable_data_end() - _jvmci_data_size; }
+  Metadata** metadata_end       () const { return (Metadata**) (mutable_data_begin() + _relocation_size + _metadata_size); }
+  address jvmci_data_begin      () const { return               mutable_data_begin() + _relocation_size + _metadata_size; }
   address jvmci_data_end        () const { return               mutable_data_end(); }
 #else
   Metadata** metadata_end       () const { return (Metadata**)  mutable_data_end(); }


### PR DESCRIPTION
In https://github.com/openjdk/jdk/pull/21276 mutable_data, which includes relocations, metadata, and jvmci_data, was moved to a separately malloc'ed blob. The nmethod (a CodeBlob) holds a pointer to the mutable_data blob and stores its internal offsets.

As part of that change, I reused the former uint16_t offset field to store jvmci_data_size. This turned out to be incorrect, since jvmci_data can exceed 64 KB (as shown in https://github.com/openjdk/jdk/pull/24753).

The most direct fix would be to change jvmci_data_size to uint, placing it alongside other int fields to avoid padding. However, in fact on my build this increases the size of the nmethod structure from 240 to 248 bytes, which I would prefer to avoid.

Instead, I propose storing metadata_size in the existing uint16_t field. The average metadata_size is approximately 140 bytes, and the maximum observed in practice is around 4 KB. While, like oops_size, this value is not formally guaranteed to remain below 64 KB, no cases have been observed where this limit is exceeded. A GUARANTEE check is included to immediately catch any overflow if it ever occurs.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8355896](https://bugs.openjdk.org/browse/JDK-8355896): Lossy narrowing cast of JVMCINMethodData::size (**Bug** - P3)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Doug Simon](https://openjdk.org/census#dnsimon) (@dougxc - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24965/head:pull/24965` \
`$ git checkout pull/24965`

Update a local copy of the PR: \
`$ git checkout pull/24965` \
`$ git pull https://git.openjdk.org/jdk.git pull/24965/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24965`

View PR using the GUI difftool: \
`$ git pr show -t 24965`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24965.diff">https://git.openjdk.org/jdk/pull/24965.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24965#issuecomment-2843079050)
</details>
