### PR TITLE
8351443: Improve robustness of StringBuilder

### DIFF
--- a/src/java.base/share/classes/java/lang/AbstractStringBuilder.java
+++ b/src/java.base/share/classes/java/lang/AbstractStringBuilder.java
@@ -318,6 +318,7 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
      * @return the new buffer, the caller is responsible for updates to the coder
      */
     private static byte[] inflateToUTF16(byte[] value, int count) {
+        assert count <= value.length : "count > value.length";
         byte[] newValue = StringUTF16.newBytesFor(value.length);
         StringLatin1.inflate(value, 0, newValue, 0, count);
         return newValue;
@@ -1909,7 +1910,7 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
      * @param coder the original buffer coder
      * @param count the count of characters in the original buffer
      * @param index the insertion point
-     * @param s char[] array to insert from
+     * @param s CharSequence to insert from
      * @param off offset of the first character
      * @param end the offset of the last character (exclusive)
      */
@@ -1961,8 +1962,10 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
 
     /**
      * {@return buffer with new characters appended, possibly inflated}
-     * The buffer may need to be inflated if any character does not fit;
-     * if the returned buffer is different then passed in, the new coder is UTF16.
+     * The value buffer capacity must be large enough to hold the additional (end - off) characters
+     * (assuming they are all latin1).
+     * The buffer will be inflated if any character is UTF16 and the buffer is latin1.
+     * If the returned buffer is different then passed in, the new coder is UTF16.
      * The caller is responsible for updating the count.
      * @param value the current buffer
      * @param coder the coder of the buffer
@@ -1995,8 +1998,10 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
 
     /**
      * {@return buffer with new characters appended, possibly inflated}
-     * The buffer may need to be inflated if any character does not fit;
-     * if the returned buffer is different then passed in, the new coder is UTF16.
+     * The value buffer capacity must be large enough to hold the additional (end - off) characters
+     * (assuming they are all latin1).
+     * The buffer will be inflated if any character is UTF16 and the buffer is latin1.
+     * If the returned buffer is different then passed in, the new coder is UTF16.
      * The caller is responsible for updating the count.
      * @param value the current buffer
      * @param coder the coder of the buffer
@@ -2033,13 +2038,15 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
 
     /**
      * {@return buffer with new characters appended, possibly inflated}
-     * The buffer may need to be inflated if any character does not fit;
-     * if the returned buffer is different then passed in, the new coder is UTF16.
+     * The value buffer capacity must be large enough to hold the additional (end - off) characters
+     * (assuming they are all latin1).
+     * The buffer will be inflated if any character is UTF16 and the buffer is latin1.
+     * If the returned buffer is different then passed in, the new coder is UTF16.
      * The caller is responsible for updating the count.
      * @param value the current buffer
      * @param coder the coder of the buffer
      * @param count the character count
-     * @param s a string
+     * @param s CharSequence to append characters from
      * @param off the offset of the first character to append
      * @param end end last (exclusive) character to append
      */

--- a/src/java.base/share/classes/java/lang/AbstractStringBuilder.java
+++ b/src/java.base/share/classes/java/lang/AbstractStringBuilder.java
@@ -1877,12 +1877,16 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
      */
     private static byte[] putCharsAt(byte[] value, byte coder, int count, int index, char[] s, int off, int end) {
         if (isLatin1(coder)) {
-            for (int i = off, j = index; i < end; i++) {
+            int latin1Len = StringUTF16.compress(s, off, value, index, end - off);
+            for (int i = off + latin1Len, j = index + latin1Len; i < end; i++) {
                 char c = s[i];
                 if (StringLatin1.canEncode(c)) {
                     value[j++] = (byte)c;
                 } else {
                     value = inflateToUTF16(value, count);
+                    // Store c to make sure sb has a UTF16 char
+                    StringUTF16.putCharSB(value, j++, c);
+                    i++;
                     StringUTF16.putCharsSB(value, j, s, i, end);
                     return value;
                 }
@@ -1967,12 +1971,16 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
      */
     private static byte[] appendChars(byte[] value, byte coder, int count, char[] s, int off, int end) {
         if (isLatin1(coder)) {
-            for (int i = off, j = count; i < end; i++) {
+            int latin1Len = StringUTF16.compress(s, off, value, count, end - off);
+            for (int i = off + latin1Len, j = count + latin1Len; i < end; i++) {
                 char c = s[i];
                 if (StringLatin1.canEncode(c)) {
                     value[j++] = (byte)c;
                 } else {
                     value = inflateToUTF16(value, j);
+                    // Store c to make sure sb has a UTF16 char
+                    StringUTF16.putCharSB(value, j++, c);
+                    i++;
                     StringUTF16.putCharsSB(value, j, s, i, end);
                     return value;
                 }

--- a/src/java.base/share/classes/java/lang/AbstractStringBuilder.java
+++ b/src/java.base/share/classes/java/lang/AbstractStringBuilder.java
@@ -120,7 +120,7 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
                 ? length + 16 : Integer.MAX_VALUE;
         final byte initCoder = str.coder();
         coder = initCoder;
-        value = (initCoder == LATIN1)
+        value = (isLatin1(coder))
                 ? new byte[capacity] : StringUTF16.newBytesFor(capacity);
         append(str);
     }
@@ -179,11 +179,12 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
         int count1 = this.count;
         int count2 = another.count;
 
+        byte coder = this.coder;
         if (coder == another.coder) {
-            return isLatin1() ? StringLatin1.compareTo(val1, val2, count1, count2)
+            return isLatin1(coder) ? StringLatin1.compareTo(val1, val2, count1, count2)
                               : StringUTF16.compareTo(val1, val2, count1, count2);
         }
-        return isLatin1() ? StringLatin1.compareToUTF16(val1, val2, count1, count2)
+        return isLatin1(coder) ? StringLatin1.compareToUTF16(val1, val2, count1, count2)
                           : StringUTF16.compareToLatin1(val1, val2, count1, count2);
     }
 
@@ -227,24 +228,99 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
      */
     public void ensureCapacity(int minimumCapacity) {
         if (minimumCapacity > 0) {
-            ensureCapacityInternal(minimumCapacity);
+            value = ensureCapacitySameCoder(value, coder, minimumCapacity);
         }
     }
 
     /**
-     * For positive values of {@code minimumCapacity}, this method
-     * behaves like {@code ensureCapacity}, however it is never
-     * synchronized.
-     * If {@code minimumCapacity} is non positive due to numeric
-     * overflow, this method throws {@code OutOfMemoryError}.
+     * {@return true if the byte array should be replaced due to increased capacity or coder change}
+     * <ul>
+     *     <li>The new coder is the different thn the old coder
+     *     <li>The new length is greater than to the current length
+     *     <li>The new length is non-negative, as it might have overflowed due to an increment
+     * </ul>
+     *
+     * @param value       a byte array
+     * @param coder       old coder
+     * @param newCapacity new capacity in characters
+     * @param newCoder    new coder
      */
-    private void ensureCapacityInternal(int minimumCapacity) {
+    private static boolean needsNewBuffer(byte[] value, byte coder, int newCapacity, byte newCoder) {
+        long newLength = (long) newCapacity << newCoder;
+        return coder != newCoder || newLength > value.length || 0 > newLength;
+    }
+
+
+    /**
+     * {@return a buffer suitable for storing the bytes up to minimum capacity using the new coder}
+     * If the coder matches and there is enough room, the same buffer is returned.
+     * Otherwise, a new buffer is allocated and the string is copied or inflated to match the new coder.
+     * For positive values of {@code minimumCapacity}, this method
+     * behaves like {@code ensureCapacity}, however it is never synchronized.
+     * If {@code minimumCapacity} is non-positive due to numeric
+     * overflow, this method throws {@code OutOfMemoryError}.
+     * @param value the current buffer
+     * @param coder of the current buffer
+     * @param count the count of chars in the current buffer
+     * @param minimumCapacity the new minimum capacity
+     * @param newCoder the desired new coder
+     */
+    private static byte[] ensureCapacityNewCoder(byte[] value, byte coder, int count,
+                                                 int minimumCapacity, byte newCoder) {
+        assert coder == newCoder || newCoder == UTF16 : "bad new coder UTF16 -> LATIN1";
+        // overflow-conscious code
+        int growth = minimumCapacity - (value.length >> coder);
+        if (coder == newCoder) {
+            if (growth > 0) {
+                // copy all bytes to new larger buffer
+                value = Arrays.copyOf(value,
+                        newCapacity(value, newCoder, minimumCapacity) << newCoder);
+            }
+            return value;
+        } else {
+            // inflate (and grow if additional length is requested)
+            // always growing might be better but it breaks current Capacity tests
+            int newCap = (growth > 0)
+                ? newCapacity(value, newCoder, minimumCapacity)
+                : value.length;
+            byte[] newValue = StringUTF16.newBytesFor(newCap);
+            StringLatin1.inflate(value, 0, newValue, 0, count);
+            return newValue;
+        }
+    }
+
+    /**
+     * {@return the value buffer sufficient to hold the minimumCapactity and a copy of the contents}
+     * There is no change to the coder.
+     * The current value buffer is returned if the size is already sufficient.
+     * For positive values of {@code minimumCapacity}, this method
+     * behaves like {@code ensureCapacity}, however it is never synchronized.
+     * If {@code minimumCapacity} is non-positive due to numeric
+     * overflow, this method throws {@code OutOfMemoryError}.
+     * @param value the current buffer
+     * @param coder of the current buffer
+     * @param minimumCapacity the new minimum capacity
+     */
+    private static byte[] ensureCapacitySameCoder(byte[] value, byte coder, int minimumCapacity) {
         // overflow-conscious code
         int oldCapacity = value.length >> coder;
         if (minimumCapacity - oldCapacity > 0) {
             value = Arrays.copyOf(value,
-                    newCapacity(minimumCapacity) << coder);
+                    newCapacity(value, coder, minimumCapacity) << coder);
         }
+        return value;
+    }
+
+    /**
+     * Inflates the internal 8-bit latin1 storage to 16-bit <hi=0, low> pair storage.
+     * @param value the current byte array buffer
+     * @param count the number of latin1 characters to convert to UTF16
+     * @return the new buffer, the caller is responsible for updates to the coder
+     */
+    private static byte[] inflateToUTF16(byte[] value, int count) {
+        byte[] newValue = StringUTF16.newBytesFor(value.length);
+        StringLatin1.inflate(value, 0, newValue, 0, count);
+        return newValue;
     }
 
     /**
@@ -259,7 +335,7 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
      * @throws OutOfMemoryError if minCapacity is less than zero or
      *         greater than (Integer.MAX_VALUE >> coder)
      */
-    private int newCapacity(int minCapacity) {
+    private static int newCapacity(byte[] value, byte coder, int minCapacity) {
         int oldLength = value.length;
         int newLength = minCapacity << coder;
         int growth = newLength - oldLength;
@@ -268,20 +344,6 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
             throw new OutOfMemoryError("Required length exceeds implementation limit");
         }
         return length >> coder;
-    }
-
-    /**
-     * If the coder is "isLatin1", this inflates the internal 8-bit storage
-     * to 16-bit <hi=0, low> pair storage.
-     */
-    private void inflate() {
-        if (!isLatin1()) {
-            return;
-        }
-        byte[] buf = StringUTF16.newBytesFor(value.length);
-        StringLatin1.inflate(value, 0, buf, 0, count);
-        this.value = buf;
-        this.coder = UTF16;
     }
 
     /**
@@ -327,17 +389,16 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
         if (newLength < 0) {
             throw new StringIndexOutOfBoundsException(newLength);
         }
-        ensureCapacityInternal(newLength);
+        byte coder = this.coder;
+        int count = this.count;
+        byte[] value = ensureCapacitySameCoder(this.value, coder, newLength);
         if (count < newLength) {
-            if (isLatin1()) {
-                StringLatin1.fillNull(value, count, newLength);
-            } else {
-                StringUTF16.fillNull(value, count, newLength);
-            }
+            Arrays.fill(value, count << coder, newLength << coder, (byte)0);
         } else if (count > newLength) {
             maybeLatin1 = true;
         }
-        count = newLength;
+        this.count = newLength;
+        this.value = value;
     }
 
     /**
@@ -361,10 +422,10 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
     public char charAt(int index) {
         byte coder = this.coder;
         byte[] value = this.value;
-        // Ensure count is less than or equal to capacity (racy reads and writes can produce inconsistent values)
+        // Count should be less than or equal to capacity (racy reads and writes can produce inconsistent values)
         int count = Math.min(this.count, value.length >> coder);
         checkIndex(index, count);
-        if (coder == LATIN1) {
+        if (isLatin1(coder)) {
             return (char)(value[index] & 0xff);
         }
         return StringUTF16.getChar(value, index);
@@ -392,10 +453,11 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
      *             sequence.
      */
     public int codePointAt(int index) {
+        byte coder = this.coder;
         int count = this.count;
         byte[] value = this.value;
         checkIndex(index, count);
-        if (isLatin1()) {
+        if (isLatin1(coder)) {
             return value[index] & 0xff;
         }
         return StringUTF16.codePointAtSB(value, index, count);
@@ -423,10 +485,12 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
      *            of this sequence.
      */
     public int codePointBefore(int index) {
+        byte coder = this.coder;
+        int count = this.count;
         byte[] value = this.value;
         int i = index - 1;
         checkIndex(i, count);
-        if (isLatin1()) {
+        if (isLatin1(coder)) {
             return value[i] & 0xff;
         }
         return StringUTF16.codePointBeforeSB(value, index);
@@ -453,8 +517,11 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
      * {@code beginIndex} is larger than {@code endIndex}.
      */
     public int codePointCount(int beginIndex, int endIndex) {
-        Preconditions.checkFromToIndex(beginIndex, endIndex, length(), null);
-        if (isLatin1()) {
+        byte coder = this.coder;
+        int count = this.count;
+        byte[] value = this.value;
+        Preconditions.checkFromToIndex(beginIndex, endIndex, count, null);
+        if (isLatin1(coder)) {
             return endIndex - beginIndex;
         }
         return StringUTF16.codePointCountSB(value, beginIndex, endIndex);
@@ -542,14 +609,19 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
      *             negative or greater than or equal to {@code length()}.
      */
     public void setCharAt(int index, char ch) {
+        byte coder = this.coder;
+        int count = this.count;
         checkIndex(index, count);
-        if (isLatin1() && StringLatin1.canEncode(ch)) {
+        byte[] value  = this.value;
+        byte newCoder = (byte)(coder | StringLatin1.coderFromChar(ch));
+        if (needsNewBuffer(value, coder, count, newCoder)) {
+            this.value = value = ensureCapacityNewCoder(value, coder, count, count, newCoder);
+            this.coder = coder = newCoder;
+        }
+        if (isLatin1(coder)) {
             value[index] = (byte)ch;
         } else {
-            if (isLatin1()) {
-                inflate();
-            }
-            StringUTF16.putCharSB(value, index, ch);
+            StringUTF16.putChar(value, index, ch);
             maybeLatin1 = true;
         }
     }
@@ -591,10 +663,17 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
         if (str == null) {
             return appendNull();
         }
+        byte coder = this.coder;
+        int count = this.count;
+        byte[] value = this.value;
         int len = str.length();
-        ensureCapacityInternal(count + len);
-        putStringAt(count, str);
-        count += len;
+        byte newCoder = (byte)(coder | str.coder());
+        if (needsNewBuffer(value, coder, count + len, newCoder)) {
+            this.value = value = ensureCapacityNewCoder(value, coder, count, count + len, newCoder);
+            this.coder = newCoder;
+        }
+        str.getBytes(value, count, newCoder);
+        this.count = count + len;
         return this;
     }
 
@@ -616,10 +695,16 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
             return appendNull();
         }
         int len = asb.length();
-        ensureCapacityInternal(count + len);
-        inflateIfNeededFor(asb);
-        asb.getBytes(value, count, coder);
-        count += len;
+        byte coder = this.coder;
+        int count = this.count;
+        byte[] value = this.value;
+        byte newCoder = (byte)(coder | asb.coder);
+        if (needsNewBuffer(value, coder, count + len, newCoder)) {
+            this.value = value = ensureCapacityNewCoder(value, coder, count, count + len, newCoder);
+            this.coder = newCoder;
+        }
+        asb.getBytes(value, count, newCoder);
+        this.count = count + len;
         maybeLatin1 |= asb.maybeLatin1;
         return this;
     }
@@ -630,28 +715,29 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
         if (s == null) {
             return appendNull();
         }
-        if (s instanceof String) {
-            return this.append((String)s);
+        if (s instanceof String str) {
+            return this.append(str);
         }
-        if (s instanceof AbstractStringBuilder) {
-            return this.append((AbstractStringBuilder)s);
+        if (s instanceof AbstractStringBuilder asb) {
+            return this.append(asb);
         }
         return this.append(s, 0, s.length());
     }
 
     private AbstractStringBuilder appendNull() {
-        ensureCapacityInternal(count + 4);
+        byte coder = this.coder;
         int count = this.count;
-        byte[] val = this.value;
-        if (isLatin1()) {
-            val[count++] = 'n';
-            val[count++] = 'u';
-            val[count++] = 'l';
-            val[count++] = 'l';
+        byte[] value = ensureCapacitySameCoder(this.value, coder, count + 4);
+        if (isLatin1(coder)) {
+            value[count++] = 'n';
+            value[count++] = 'u';
+            value[count++] = 'l';
+            value[count++] = 'l';
         } else {
-            count = StringUTF16.putCharsAt(val, count, 'n', 'u', 'l', 'l');
+            count = StringUTF16.putCharsAt(value, count, 'n', 'u', 'l', 'l');
         }
         this.count = count;
+        this.value = value;
         return this;
     }
 
@@ -695,12 +781,17 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
         }
         Preconditions.checkFromToIndex(start, end, s.length(), Preconditions.IOOBE_FORMATTER);
         int len = end - start;
-        ensureCapacityInternal(count + len);
-        if (s instanceof String) {
-            appendChars((String)s, start, end);
-        } else {
-            appendChars(s, start, end);
+        byte coder = this.coder;
+        int count = this.count;
+        byte[] currValue = ensureCapacitySameCoder(this.value, coder, count + len);
+        byte[] value = (s instanceof String str)
+            ? appendChars(currValue, coder, count, str, start, end)
+            : appendChars(currValue, coder, count, s, start, end);
+        if (currValue != value) {
+            this.coder = UTF16;
         }
+        this.count = count + len;
+        this.value = value;
         return this;
     }
 
@@ -723,8 +814,15 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
      */
     public AbstractStringBuilder append(char[] str) {
         int len = str.length;
-        ensureCapacityInternal(count + len);
-        appendChars(str, 0, len);
+        byte coder = this.coder;
+        int count = this.count;
+        byte[] currValue = ensureCapacitySameCoder(this.value, coder, count + len);
+        byte[] value = appendChars(currValue, coder, count, str, 0, len);
+        if (currValue != value) {
+            this.coder = UTF16;
+        }
+        this.count = count + len;
+        this.value = value;
         return this;
     }
 
@@ -753,8 +851,15 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
     public AbstractStringBuilder append(char[] str, int offset, int len) {
         int end = offset + len;
         Preconditions.checkFromToIndex(offset, end, str.length, Preconditions.IOOBE_FORMATTER);
-        ensureCapacityInternal(count + len);
-        appendChars(str, offset, end);
+        byte coder = this.coder;
+        int count = this.count;
+        byte[] currValue = ensureCapacitySameCoder(value, coder, count + len);
+        byte[] value = appendChars(currValue, coder, count, str, offset, end);
+        if (currValue != value) {
+            this.coder = UTF16;
+        }
+        this.count = count + len;
+        this.value = value;
         return this;
     }
 
@@ -771,30 +876,33 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
      * @return  a reference to this object.
      */
     public AbstractStringBuilder append(boolean b) {
-        ensureCapacityInternal(count + (b ? 4 : 5));
+        byte coder = this.coder;
         int count = this.count;
-        byte[] val = this.value;
-        if (isLatin1()) {
+
+        int newCount = count + (b ? 4 : 5);
+        byte[] value = ensureCapacitySameCoder(this.value, coder, newCount);
+        if (isLatin1(coder)) {
             if (b) {
-                val[count++] = 't';
-                val[count++] = 'r';
-                val[count++] = 'u';
-                val[count++] = 'e';
+                value[count] = 't';
+                value[count + 1] = 'r';
+                value[count + 2] = 'u';
+                value[count + 3] = 'e';
             } else {
-                val[count++] = 'f';
-                val[count++] = 'a';
-                val[count++] = 'l';
-                val[count++] = 's';
-                val[count++] = 'e';
+                value[count] = 'f';
+                value[count + 1] = 'a';
+                value[count + 2] = 'l';
+                value[count + 3] = 's';
+                value[count + 4] = 'e';
             }
         } else {
             if (b) {
-                count = StringUTF16.putCharsAt(val, count, 't', 'r', 'u', 'e');
+                newCount = StringUTF16.putCharsAt(value, count, 't', 'r', 'u', 'e');
             } else {
-                count = StringUTF16.putCharsAt(val, count, 'f', 'a', 'l', 's', 'e');
+                newCount = StringUTF16.putCharsAt(value, count, 'f', 'a', 'l', 's', 'e');
             }
         }
-        this.count = count;
+        this.value = value;
+        this.count = newCount;
         return this;
     }
 
@@ -815,15 +923,20 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
      */
     @Override
     public AbstractStringBuilder append(char c) {
-        ensureCapacityInternal(count + 1);
-        if (isLatin1() && StringLatin1.canEncode(c)) {
+        byte coder = this.coder;
+        int count = this.count;
+        byte[] value = this.value;
+        byte newCoder = (byte) (coder | StringLatin1.coderFromChar(c));
+        if (needsNewBuffer(value, coder, count + 1, newCoder)) {
+            this.value = value = ensureCapacityNewCoder(value, coder, count, count + 1, newCoder);
+            this.coder = coder = newCoder;
+        }
+        if (isLatin1(coder)) {
             value[count++] = (byte)c;
         } else {
-            if (isLatin1()) {
-                inflate();
-            }
-            StringUTF16.putCharSB(value, count++, c);
+            StringUTF16.putChar(value, count++, c);
         }
+        this.count = count;
         return this;
     }
 
@@ -840,14 +953,16 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
      * @return  a reference to this object.
      */
     public AbstractStringBuilder append(int i) {
+        byte coder = this.coder;
         int count = this.count;
         int spaceNeeded = count + DecimalDigits.stringSize(i);
-        ensureCapacityInternal(spaceNeeded);
-        if (isLatin1()) {
+        byte[] value = ensureCapacitySameCoder(this.value, coder, spaceNeeded);
+        if (isLatin1(coder)) {
             DecimalDigits.getCharsLatin1(i, spaceNeeded, value);
         } else {
             DecimalDigits.getCharsUTF16(i, spaceNeeded, value);
         }
+        this.value = value;
         this.count = spaceNeeded;
         return this;
     }
@@ -865,14 +980,16 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
      * @return  a reference to this object.
      */
     public AbstractStringBuilder append(long l) {
+        byte coder = this.coder;
         int count = this.count;
         int spaceNeeded = count + DecimalDigits.stringSize(l);
-        ensureCapacityInternal(spaceNeeded);
-        if (isLatin1()) {
+        byte[] value = ensureCapacitySameCoder(this.value, coder, spaceNeeded);
+        if (isLatin1(coder)) {
             DecimalDigits.getCharsLatin1(l, spaceNeeded, value);
         } else {
             DecimalDigits.getCharsUTF16(l, spaceNeeded, value);
         }
+        this.value = value;
         this.count = spaceNeeded;
         return this;
     }
@@ -890,9 +1007,12 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
      * @return  a reference to this object.
      */
     public AbstractStringBuilder append(float f) {
-        ensureCapacityInternal(count + FloatToDecimal.MAX_CHARS);
-        FloatToDecimal toDecimal = isLatin1() ? FloatToDecimal.LATIN1 : FloatToDecimal.UTF16;
-        count = toDecimal.putDecimal(value, count, f);
+        byte coder = this.coder;
+        int count = this.count;
+        byte[] value = ensureCapacitySameCoder(this.value, coder,count + FloatToDecimal.MAX_CHARS);
+        FloatToDecimal toDecimal = isLatin1(coder) ? FloatToDecimal.LATIN1 : FloatToDecimal.UTF16;
+        this.count = toDecimal.putDecimal(value, count, f);
+        this.value = value;
         return this;
     }
 
@@ -909,9 +1029,12 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
      * @return  a reference to this object.
      */
     public AbstractStringBuilder append(double d) {
-        ensureCapacityInternal(count + DoubleToDecimal.MAX_CHARS);
-        DoubleToDecimal toDecimal = isLatin1() ? DoubleToDecimal.LATIN1 : DoubleToDecimal.UTF16;
-        count = toDecimal.putDecimal(value, count, d);
+        byte coder = this.coder;
+        int count = this.count;
+        byte[] value = ensureCapacitySameCoder(this.value, coder,count + DoubleToDecimal.MAX_CHARS);
+        DoubleToDecimal toDecimal = isLatin1(coder) ? DoubleToDecimal.LATIN1 : DoubleToDecimal.UTF16;
+        this.count = toDecimal.putDecimal(value, count, d);
+        this.value = value;
         return this;
     }
 
@@ -937,7 +1060,7 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
         Preconditions.checkFromToIndex(start, end, count, Preconditions.SIOOBE_FORMATTER);
         int len = end - start;
         if (len > 0) {
-            shift(end, -len);
+            shift(value, coder, count, end, -len);
             this.count = count - len;
             maybeLatin1 = true;
         }
@@ -988,9 +1111,10 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
      *              {@code length()}.
      */
     public AbstractStringBuilder deleteCharAt(int index) {
+        int count = this.count;
         checkIndex(index, count);
-        shift(index + 1, -1);
-        count--;
+        shift(value, coder, count, index + 1, -1);
+        this.count = count - 1;
         maybeLatin1 = true;
         return this;
     }
@@ -1015,6 +1139,7 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
      *             greater than {@code end}.
      */
     public AbstractStringBuilder replace(int start, int end, String str) {
+        byte coder = this.coder;
         int count = this.count;
         if (end > count) {
             end = count;
@@ -1022,10 +1147,15 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
         Preconditions.checkFromToIndex(start, end, count, Preconditions.SIOOBE_FORMATTER);
         int len = str.length();
         int newCount = count + len - (end - start);
-        ensureCapacityInternal(newCount);
-        shift(end, newCount - count);
+        byte newCoder = (byte) (coder | str.coder());
+        byte[] value = this.value;
+        if (needsNewBuffer(value, coder, newCount, newCoder) ) {
+            this.value = value = ensureCapacityNewCoder(value, coder, count, newCount, newCoder);
+            this.coder = coder = newCoder;
+        }
+        shift(value, coder, count, end, newCount - count);
+        str.getBytes(value, start, coder);
         this.count = newCount;
-        putStringAt(start, str);
         maybeLatin1 = true;
         return this;
     }
@@ -1097,7 +1227,7 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
         return StringUTF16.newString(value, start, end - start);
     }
 
-    private void shift(int offset, int n) {
+    private static void shift(byte[] value, byte coder, int count, int offset, int n) {
         System.arraycopy(value, offset << coder,
                          value, (offset + n) << coder, (count - offset) << coder);
     }
@@ -1126,12 +1256,19 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
     public AbstractStringBuilder insert(int index, char[] str, int offset,
                                         int len)
     {
+        byte coder = this.coder;
+        int count = this.count;
         checkOffset(index, count);
         Preconditions.checkFromToIndex(offset, offset + len, str.length, Preconditions.SIOOBE_FORMATTER);
-        ensureCapacityInternal(count + len);
-        shift(index, len);
+        byte[] value = ensureCapacitySameCoder(this.value, coder, count + len);
+        shift(value, coder, count, index, len);
         count += len;
-        putCharsAt(index, str, offset, offset + len);
+        byte[] newValue = putCharsAt(value, coder, count, index, str, offset, offset + len);
+        if  (newValue != value) {
+            this.coder = UTF16;
+        }
+        this.value = newValue;
+        this.count = count;
         return this;
     }
 
@@ -1190,15 +1327,22 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
      * @throws     StringIndexOutOfBoundsException  if the offset is invalid.
      */
     public AbstractStringBuilder insert(int offset, String str) {
+        byte coder = this.coder;
+        int count = this.count;
         checkOffset(offset, count);
         if (str == null) {
             str = "null";
         }
         int len = str.length();
-        ensureCapacityInternal(count + len);
-        shift(offset, len);
-        count += len;
-        putStringAt(offset, str);
+        byte newCoder = (byte) (coder | str.coder());
+        byte[] value = this.value;
+        if (needsNewBuffer(value, coder, count + len, newCoder)) {
+            this.value = value = ensureCapacityNewCoder(value, coder, count, count + len, newCoder);
+            this.coder = coder = newCoder;
+        }
+        shift(value, coder, count, offset, len);
+        this.count = count + len;
+        str.getBytes(value, offset, coder);
         return this;
     }
 
@@ -1227,12 +1371,19 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
      * @throws     StringIndexOutOfBoundsException  if the offset is invalid.
      */
     public AbstractStringBuilder insert(int offset, char[] str) {
+        byte coder = this.coder;
+        int count = this.count;
         checkOffset(offset, count);
         int len = str.length;
-        ensureCapacityInternal(count + len);
-        shift(offset, len);
+        byte[] currValue = ensureCapacitySameCoder(this.value, coder, count + len);
+        shift(currValue, coder, count, offset, len);
         count += len;
-        putCharsAt(offset, str, 0, len);
+        byte[] newValue = putCharsAt(currValue, coder, count, offset, str, 0, len);
+        if (currValue != newValue) {
+            this.coder = UTF16;
+        }
+        this.count = count;
+        this.value = newValue;
         return this;
     }
 
@@ -1292,7 +1443,7 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
      * The {@code dstOffset} argument must be greater than or equal to
      * {@code 0}, and less than or equal to the {@linkplain #length() length}
      * of this sequence.
-     * <p>The start argument must be nonnegative, and not greater than
+     * <p>The start argument must be non-negative, and not greater than
      * {@code end}.
      * <p>The end argument must be greater than or equal to
      * {@code start}, and less than or equal to the length of s.
@@ -1322,17 +1473,23 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
         if (s == null) {
             s = "null";
         }
+        byte coder = this.coder;
+        int count = this.count;
         checkOffset(dstOffset, count);
         Preconditions.checkFromToIndex(start, end, s.length(), Preconditions.IOOBE_FORMATTER);
         int len = end - start;
-        ensureCapacityInternal(count + len);
-        shift(dstOffset, len);
+        byte[] currValue = ensureCapacitySameCoder(this.value, coder, count + len);
+        shift(currValue, coder, count, dstOffset, len);
         count += len;
-        if (s instanceof String) {
-            putStringAt(dstOffset, (String) s, start, end);
-        } else {
-            putCharsAt(dstOffset, s, start, end);
+        // Coder of CharSequence may be a mismatch, requiring the value array to be inflated
+        byte[] newValue = (s instanceof String str)
+            ? putStringAt(currValue, coder, count, dstOffset, str, start, end)
+            : putCharsAt(currValue, coder, count, dstOffset, s, start, end);
+        if (currValue != newValue) {
+            this.coder = UTF16;
         }
+        this.value = newValue;
+        this.count = count;
         return this;
     }
 
@@ -1379,18 +1536,23 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
      * @throws     IndexOutOfBoundsException  if the offset is invalid.
      */
     public AbstractStringBuilder insert(int offset, char c) {
+        byte coder = this.coder;
+        int count = this.count;
         checkOffset(offset, count);
-        ensureCapacityInternal(count + 1);
-        shift(offset, 1);
-        count += 1;
-        if (isLatin1() && StringLatin1.canEncode(c)) {
+        byte newCoder = (byte)(coder | StringLatin1.coderFromChar(c));
+        byte[] value = this.value;
+
+        if (needsNewBuffer(value, coder, count + 1, newCoder)) {
+            this.value = value = ensureCapacityNewCoder(value, coder, count, count + 1, newCoder);
+            this.coder = coder = newCoder;
+        }
+        shift(value, coder, count, offset, 1);
+        if (isLatin1(coder)) {
             value[offset] = (byte)c;
         } else {
-            if (isLatin1()) {
-                inflate();
-            }
             StringUTF16.putCharSB(value, offset, c);
         }
+        this.count = count + 1;
         return this;
     }
 
@@ -1656,7 +1818,7 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
                     byte[] val = this.value;
                     int count = this.count;
                     byte coder = this.coder;
-                    return coder == LATIN1
+                    return isLatin1(coder)
                            ? new StringLatin1.CharsSpliterator(val, 0, count, 0)
                            : new StringUTF16.CodePointsSpliterator(val, 0, count, 0);
                 },
@@ -1706,141 +1868,201 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
         return COMPACT_STRINGS && coder == LATIN1;
     }
 
-    private final void putCharsAt(int index, char[] s, int off, int end) {
-        if (isLatin1()) {
-            byte[] val = this.value;
+    private static boolean isLatin1(byte coder) {
+        return COMPACT_STRINGS && coder == LATIN1;
+    }
+
+    /**
+     * {@return Return the buffer containing the composed string and inserted characters}
+     * If the buffer coder needs to support UTF16 and does not, it is inflated and a different
+     * buffer is returned. TThe caller is responsible for setting the coder and updating the value ref
+     * based solely on the difference in the buffer reference.
+     *
+     * @param value byte array destination for the string (if the coder matches)
+     * @param coder the original buffer coder
+     * @param count the count of characters in the original buffer
+     * @param index the insertion point
+     * @param s char[] array to insert from
+     * @param off offset of the first character
+     * @param end the offset of the last character (exclusive)
+     */
+    private static byte[] putCharsAt(byte[] value, byte coder, int count, int index, char[] s, int off, int end) {
+        if (isLatin1(coder)) {
             for (int i = off, j = index; i < end; i++) {
                 char c = s[i];
                 if (StringLatin1.canEncode(c)) {
-                    val[j++] = (byte)c;
+                    value[j++] = (byte)c;
                 } else {
-                    inflate();
-                    StringUTF16.putCharsSB(this.value, j, s, i, end);
-                    return;
+                    value = inflateToUTF16(value, count);
+                    StringUTF16.putCharsSB(value, j, s, i, end);
+                    return value;
                 }
             }
         } else {
-            StringUTF16.putCharsSB(this.value, index, s, off, end);
+            StringUTF16.putCharsSB(value, index, s, off, end);
         }
+        return value;
     }
 
-    private final void putCharsAt(int index, CharSequence s, int off, int end) {
-        if (isLatin1()) {
-            byte[] val = this.value;
+    /**
+     * {@return Return the buffer containing the composed string and inserted characters}
+     * If the buffer coder needs to support UTF16 and does not, it is inflated and a different
+     * buffer is returned. The caller is responsible for setting the coder and updating the value ref
+     * based solely on the difference in the buffer reference.
+     *
+     * @param value byte array destination for the string (if the coder matches)
+     * @param coder the original buffer coder
+     * @param count the count of characters in the original buffer
+     * @param index the insertion point
+     * @param s char[] array to insert from
+     * @param off offset of the first character
+     * @param end the offset of the last character (exclusive)
+     */
+    private static byte[] putCharsAt(byte[] value, byte coder, int count, int index, CharSequence s, int off, int end) {
+        if (isLatin1(coder)) {
             for (int i = off, j = index; i < end; i++) {
                 char c = s.charAt(i);
                 if (StringLatin1.canEncode(c)) {
-                    val[j++] = (byte)c;
+                    value[j++] = (byte)c;
                 } else {
-                    inflate();
+                    value = inflateToUTF16(value, count);
                     // store c to make sure it has a UTF16 char
-                    StringUTF16.putCharSB(this.value, j++, c);
+                    StringUTF16.putCharSB(value, j++, c);
                     i++;
-                    StringUTF16.putCharsSB(this.value, j, s, i, end);
-                    return;
+                    StringUTF16.putCharsSB(value, j, s, i, end);
+                    return value;
                 }
             }
         } else {
-            StringUTF16.putCharsSB(this.value, index, s, off, end);
+            StringUTF16.putCharsSB(value, index, s, off, end);
         }
+        return value;
     }
 
-    private void inflateIfNeededFor(String input) {
-        if (COMPACT_STRINGS && (coder != input.coder())) {
-            inflate();
+    private static byte[] inflateIfNeededFor(byte[] value, int count, byte coder, byte otherCoder) {
+        if (COMPACT_STRINGS && (coder == LATIN1 && otherCoder == UTF16)) {
+            return inflateToUTF16(value, count);
         }
+        return value;
     }
 
-    private void inflateIfNeededFor(AbstractStringBuilder input) {
-        if (COMPACT_STRINGS && (coder != input.getCoder())) {
-            inflate();
-        }
+    /**
+     * {@return the buffer with the substring inserted}
+     * If the substring contains UTF16 characters and the current coder is LATIN1, inflation occurs
+     * into a new buffer and returned; the caller must update the coder to UTF16.
+     * Since the contents are immutable, a simple copy of characters is sufficient.
+     * @param value an existing buffer to insert into
+     * @param coder the coder of the buffer
+     * @param count the count of characters in the buffer
+     * @param index the index to insert the string
+     * @param str the string
+     */
+     private static byte[] putStringAt(byte[] value, byte coder, int count, int index, String str, int off, int end) {
+        byte[] newValue = inflateIfNeededFor(value, count, coder, str.coder());
+        coder = (newValue == value) ? coder : UTF16;
+        str.getBytes(newValue, off, index, coder, end - off);
+        return newValue;
     }
 
-    private void putStringAt(int index, String str, int off, int end) {
-        inflateIfNeededFor(str);
-        str.getBytes(value, off, index, coder, end - off);
-    }
-
-    private void putStringAt(int index, String str) {
-        inflateIfNeededFor(str);
-        str.getBytes(value, index, coder);
-    }
-
-    private final void appendChars(char[] s, int off, int end) {
-        int count = this.count;
-        if (isLatin1()) {
-            byte[] val = this.value;
+    /**
+     * {@return buffer with new characters appended, possibly inflated}
+     * The buffer may need to be inflated if any character does not fit;
+     * if the returned buffer is different then passed in, the new coder is UTF16.
+     * The caller is responsible for updating the count.
+     * @param value the current buffer
+     * @param coder the coder of the buffer
+     * @param count the character count
+     * @param s a char array
+     * @param off the offset of the first character to append
+     * @param end end last (exclusive) character to append
+     */
+    private static byte[] appendChars(byte[] value, byte coder, int count, char[] s, int off, int end) {
+        if (isLatin1(coder)) {
             for (int i = off, j = count; i < end; i++) {
                 char c = s[i];
                 if (StringLatin1.canEncode(c)) {
-                    val[j++] = (byte)c;
+                    value[j++] = (byte)c;
                 } else {
-                    this.count = count = j;
-                    inflate();
-                    StringUTF16.putCharsSB(this.value, j, s, i, end);
-                    this.count = count + end - i;
-                    return;
+                    value = inflateToUTF16(value, j);
+                    StringUTF16.putCharsSB(value, j, s, i, end);
+                    return value;
                 }
             }
         } else {
-            StringUTF16.putCharsSB(this.value, count, s, off, end);
+            StringUTF16.putCharsSB(value, count, s, off, end);
         }
-        this.count = count + end - off;
+        return value;
     }
 
-    private final void appendChars(String s, int off, int end) {
-        if (isLatin1()) {
+    /**
+     * {@return buffer with new characters appended, possibly inflated}
+     * The buffer may need to be inflated if any character does not fit;
+     * if the returned buffer is different then passed in, the new coder is UTF16.
+     * The caller is responsible for updating the count.
+     * @param value the current buffer
+     * @param coder the coder of the buffer
+     * @param count the character count
+     * @param s a string
+     * @param off the offset of the first character to append
+     * @param end end last (exclusive) character to append
+     */
+    private static byte[] appendChars(byte[] value, byte coder, int count, String s, int off, int end) {
+        if (isLatin1(coder)) {
             if (s.isLatin1()) {
-                System.arraycopy(s.value(), off, this.value, this.count, end - off);
+                System.arraycopy(s.value(), off, value, count, end - off);
             } else {
                 // We might need to inflate, but do it as late as possible since
                 // the range of characters we're copying might all be latin1
-                byte[] val = this.value;
                 for (int i = off, j = count; i < end; i++) {
                     char c = s.charAt(i);
                     if (StringLatin1.canEncode(c)) {
-                        val[j++] = (byte) c;
+                        value[j++] = (byte) c;
                     } else {
-                        count = j;
-                        inflate();
-                        System.arraycopy(s.value(), i << UTF16, this.value, j << UTF16, (end - i) << UTF16);
-                        count += end - i;
-                        return;
+                        value = inflateToUTF16(value, j);
+                        System.arraycopy(s.value(), i << UTF16, value, j << UTF16, (end - i) << UTF16);
+                        return value;
                     }
                 }
             }
         } else if (s.isLatin1()) {
-            StringUTF16.putCharsSB(this.value, this.count, s, off, end);
+            StringUTF16.putCharsSB(value, count, s, off, end);
         } else { // both UTF16
-            System.arraycopy(s.value(), off << UTF16, this.value, this.count << UTF16, (end - off) << UTF16);
+            System.arraycopy(s.value(), off << UTF16, value, count << UTF16, (end - off) << UTF16);
         }
-        count += end - off;
+        return value;
     }
 
-    private final void appendChars(CharSequence s, int off, int end) {
-        if (isLatin1()) {
-            byte[] val = this.value;
+    /**
+     * {@return buffer with new characters appended, possibly inflated}
+     * The buffer may need to be inflated if any character does not fit;
+     * if the returned buffer is different then passed in, the new coder is UTF16.
+     * The caller is responsible for updating the count.
+     * @param value the current buffer
+     * @param coder the coder of the buffer
+     * @param count the character count
+     * @param s a string
+     * @param off the offset of the first character to append
+     * @param end end last (exclusive) character to append
+     */
+    private static byte[] appendChars(byte[] value, byte coder, int count, CharSequence s, int off, int end) {
+        if (isLatin1(coder)) {
             for (int i = off, j = count; i < end; i++) {
                 char c = s.charAt(i);
                 if (StringLatin1.canEncode(c)) {
-                    val[j++] = (byte)c;
+                    value[j++] = (byte)c;
                 } else {
-                    count = j;
-                    inflate();
+                    value = inflateToUTF16(value, j);
                     // Store c to make sure sb has a UTF16 char
-                    StringUTF16.putCharSB(this.value, j++, c);
-                    count = j;
+                    StringUTF16.putCharSB(value, j++, c);
                     i++;
-                    StringUTF16.putCharsSB(this.value, j, s, i, end);
-                    count += end - i;
-                    return;
+                    StringUTF16.putCharsSB(value, j, s, i, end);
+                    return value;
                 }
             }
         } else {
-            StringUTF16.putCharsSB(this.value, count, s, off, end);
+            StringUTF16.putCharsSB(value, count, s, off, end);
         }
-        count += end - off;
+        return value;
     }
 
     /**
@@ -1870,7 +2092,7 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
 
         if (lengthCoder < ((long)UTF16 << 32)) {
             System.arraycopy(value, 0, buffer, (int)lengthCoder, count);
-        } else if (coder == LATIN1) {
+        } else if (isLatin1(coder)) {
             StringUTF16.inflate(value, 0, buffer, (int)lengthCoder, count);
         } else {
             System.arraycopy(value, 0, buffer, (int)lengthCoder << 1, count << 1);
@@ -1880,16 +2102,19 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
     }
 
     private AbstractStringBuilder repeat(char c, int count) {
-        int limit = this.count + count;
-        ensureCapacityInternal(limit);
-        boolean isLatin1 = isLatin1();
-        if (isLatin1 && StringLatin1.canEncode(c)) {
-            Arrays.fill(value, this.count, limit, (byte)c);
+        byte coder = this.coder;
+        int prevCount = this.count;
+        int limit = prevCount + count;
+        byte[] value = this.value;
+        byte newCoder = (byte) (coder | StringLatin1.coderFromChar(c));
+        if (needsNewBuffer(value, coder, limit, newCoder)) {
+            this.value = value = ensureCapacityNewCoder(value, coder, prevCount, limit, newCoder);
+            this.coder = coder = newCoder;
+        }
+        if (isLatin1(coder)) {
+            Arrays.fill(value, prevCount, limit, (byte)c);
         } else {
-            if (isLatin1) {
-                inflate();
-            }
-            for (int index = this.count; index < limit; index++) {
+            for (int index = prevCount; index < limit; index++) {
                 StringUTF16.putCharSB(value, index, c);
             }
         }
@@ -1974,20 +2199,36 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
         } else if (length == 1) {
             return repeat(cs.charAt(0), count);
         }
+        byte coder = this.coder;
         int offset = this.count;
+        byte[] value = this.value;
         int valueLength = length << coder;
         if ((Integer.MAX_VALUE - offset) / count < valueLength) {
             throw new OutOfMemoryError("Required length exceeds implementation limit");
         }
         int total = count * length;
         int limit = offset + total;
-        ensureCapacityInternal(limit);
         if (cs instanceof String str) {
-            putStringAt(offset, str);
+            byte newCoder = (byte)(coder | str.coder());
+            if (needsNewBuffer(value, coder, limit, newCoder)) {
+                this.value = value = ensureCapacityNewCoder(value, coder, offset, limit, newCoder);
+                this.coder = coder = newCoder;
+            }
+            str.getBytes(value, offset, newCoder);
         } else if (cs instanceof AbstractStringBuilder asb) {
-            append(asb);
+            byte newCoder = (byte)(coder | asb.coder);
+            if (needsNewBuffer(value, coder, limit, newCoder)) {
+                this.value = value = ensureCapacityNewCoder(value, coder, offset, limit, newCoder);
+                this.coder = coder = newCoder;
+            }
+            asb.getBytes(value, offset, newCoder);
         } else {
-            appendChars(cs, 0, length);
+            byte[] currValue = ensureCapacitySameCoder(value, coder, limit);
+            value = appendChars(currValue, coder, offset, cs, 0, length);
+            if (currValue != value) {
+                this.coder = coder = UTF16;
+            }
+            this.value = value;
         }
         String.repeatCopyRest(value, offset << coder, total << coder, length << coder);
         this.count = limit;

--- a/src/java.base/share/classes/java/lang/AbstractStringBuilder.java
+++ b/src/java.base/share/classes/java/lang/AbstractStringBuilder.java
@@ -182,10 +182,10 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
         byte coder = this.coder;
         if (coder == another.coder) {
             return isLatin1(coder) ? StringLatin1.compareTo(val1, val2, count1, count2)
-                              : StringUTF16.compareTo(val1, val2, count1, count2);
+                    : StringUTF16.compareTo(val1, val2, count1, count2);
         }
         return isLatin1(coder) ? StringLatin1.compareToUTF16(val1, val2, count1, count2)
-                          : StringUTF16.compareToLatin1(val1, val2, count1, count2);
+                : StringUTF16.compareToLatin1(val1, val2, count1, count2);
     }
 
     /**
@@ -235,9 +235,9 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
     /**
      * {@return true if the byte array should be replaced due to increased capacity or coder change}
      * <ul>
-     *     <li>The new coder is the different thn the old coder
+     *     <li>The new coder is the different than the old coder
      *     <li>The new length is greater than to the current length
-     *     <li>The new length is non-negative, as it might have overflowed due to an increment
+     *     <li>The new length is negative, as it might have overflowed due to an increment
      * </ul>
      *
      * @param value       a byte array
@@ -331,6 +331,8 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
      * {@code (SOFT_MAX_ARRAY_LENGTH >> coder)}
      * unless the given minimum capacity is greater than that.
      *
+     * @param value the current buffer
+     * @param coder of the current buffer
      * @param  minCapacity the desired minimum capacity
      * @throws OutOfMemoryError if minCapacity is less than zero or
      *         greater than (Integer.MAX_VALUE >> coder)
@@ -1864,7 +1866,7 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
     /**
      * {@return Return the buffer containing the composed string and inserted characters}
      * If the buffer coder needs to support UTF16 and does not, it is inflated and a different
-     * buffer is returned. TThe caller is responsible for setting the coder and updating the value ref
+     * buffer is returned. The caller is responsible for setting the coder and updating the value ref
      * based solely on the difference in the buffer reference.
      *
      * @param value byte array destination for the string (if the coder matches)

--- a/src/java.base/share/classes/java/lang/AbstractStringBuilder.java
+++ b/src/java.base/share/classes/java/lang/AbstractStringBuilder.java
@@ -235,7 +235,7 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
     /**
      * {@return true if the byte array should be replaced due to increased capacity or coder change}
      * <ul>
-     *     <li>The new coder is the different than the old coder
+     *     <li>The new coder is different than the old coder
      *     <li>The new length is greater than to the current length
      *     <li>The new length is negative, as it might have overflowed due to an increment
      * </ul>

--- a/src/java.base/share/classes/java/lang/AbstractStringBuilder.java
+++ b/src/java.base/share/classes/java/lang/AbstractStringBuilder.java
@@ -587,7 +587,7 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
         Preconditions.checkFromToIndex(srcBegin, srcEnd, count, Preconditions.SIOOBE_FORMATTER);  // compatible to old version
         int n = srcEnd - srcBegin;
         Preconditions.checkFromToIndex(dstBegin, dstBegin + n, dst.length, Preconditions.IOOBE_FORMATTER);
-        if (isLatin1()) {
+        if (isLatin1(coder)) {
             StringLatin1.getChars(value, srcBegin, srcEnd, dst, dstBegin);
         } else {
             StringUTF16.getChars(value, srcBegin, srcEnd, dst, dstBegin);
@@ -1209,7 +1209,7 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
      */
     public String substring(int start, int end) {
         Preconditions.checkFromToIndex(start, end, count, Preconditions.SIOOBE_FORMATTER);
-        if (isLatin1()) {
+        if (isLatin1(coder)) {
             return StringLatin1.newString(value, start, end - start);
         }
         return StringUTF16.newString(value, start, end - start);
@@ -1741,7 +1741,7 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
         byte[] val = this.value;
         int count = this.count;
         int n = count - 1;
-        if (isLatin1()) {
+        if (isLatin1(this.coder)) {
             for (int j = (n-1) >> 1; j >= 0; j--) {
                 int k = n - j;
                 byte cj = val[j];

--- a/src/java.base/share/classes/java/lang/StringLatin1.java
+++ b/src/java.base/share/classes/java/lang/StringLatin1.java
@@ -54,6 +54,10 @@ final class StringLatin1 {
         return cp >=0 && cp <= 0xff;
     }
 
+    public static byte coderFromChar(char cp) {
+        return (byte)((0xff - cp) >>> Integer.SIZE - 1);
+    }
+
     public static int length(byte[] value) {
         return value.length;
     }
@@ -740,10 +744,6 @@ final class StringLatin1 {
         }
         return new String(Arrays.copyOfRange(val, index, index + len),
                           LATIN1);
-    }
-
-    public static void fillNull(byte[] val, int index, int end) {
-        Arrays.fill(val, index, end, (byte)0);
     }
 
     // inflatedCopy byte[] -> char[]

--- a/src/java.base/share/classes/java/lang/StringLatin1.java
+++ b/src/java.base/share/classes/java/lang/StringLatin1.java
@@ -55,7 +55,7 @@ final class StringLatin1 {
     }
 
     public static byte coderFromChar(char cp) {
-        return (byte)((0xff - cp) >>> Integer.SIZE - 1);
+        return (byte)((0xff - cp) >>> (Integer.SIZE - 1));
     }
 
     public static int length(byte[] value) {
@@ -711,6 +711,21 @@ final class StringLatin1 {
 
     static Stream<String> lines(byte[] value) {
         return StreamSupport.stream(LinesSpliterator.spliterator(value), false);
+    }
+
+    public static void putCharsAt(byte[] value, int i, char c1, char c2, char c3, char c4) {
+        value[i] = (byte)c1;
+        value[i + 1] = (byte)c2;
+        value[i + 2] = (byte)c3;
+        value[i + 3] = (byte)c4;
+    }
+
+    public static void putCharsAt(byte[] value, int i, char c1, char c2, char c3, char c4, char c5) {
+        value[i] = (byte)c1;
+        value[i + 1] = (byte)c2;
+        value[i + 2] = (byte)c3;
+        value[i + 3] = (byte)c4;
+        value[i + 4] = (byte)c5;
     }
 
     public static void putChar(byte[] val, int index, int c) {

--- a/src/java.base/share/classes/java/lang/StringUTF16.java
+++ b/src/java.base/share/classes/java/lang/StringUTF16.java
@@ -1528,7 +1528,7 @@ final class StringUTF16 {
         return true;
     }
 
-    public static int putCharsAt(byte[] value, int i, char c1, char c2, char c3, char c4) {
+    public static void putCharsAt(byte[] value, int i, char c1, char c2, char c3, char c4) {
         int end = i + 4;
         checkBoundsBeginEnd(i, end, value);
         putChar(value, i++, c1);
@@ -1536,10 +1536,9 @@ final class StringUTF16 {
         putChar(value, i++, c3);
         putChar(value, i++, c4);
         assert(i == end);
-        return end;
     }
 
-    public static int putCharsAt(byte[] value, int i, char c1, char c2, char c3, char c4, char c5) {
+    public static void putCharsAt(byte[] value, int i, char c1, char c2, char c3, char c4, char c5) {
         int end = i + 5;
         checkBoundsBeginEnd(i, end, value);
         putChar(value, i++, c1);
@@ -1548,7 +1547,6 @@ final class StringUTF16 {
         putChar(value, i++, c4);
         putChar(value, i++, c5);
         assert(i == end);
-        return end;
     }
 
     public static char charAt(byte[] value, int index) {

--- a/src/java.base/share/classes/java/lang/StringUTF16.java
+++ b/src/java.base/share/classes/java/lang/StringUTF16.java
@@ -1531,22 +1531,20 @@ final class StringUTF16 {
     public static void putCharsAt(byte[] value, int i, char c1, char c2, char c3, char c4) {
         int end = i + 4;
         checkBoundsBeginEnd(i, end, value);
-        putChar(value, i++, c1);
-        putChar(value, i++, c2);
-        putChar(value, i++, c3);
-        putChar(value, i++, c4);
-        assert(i == end);
+        putChar(value, i, c1);
+        putChar(value, i + 1, c2);
+        putChar(value, i + 2, c3);
+        putChar(value, i + 3, c4);
     }
 
     public static void putCharsAt(byte[] value, int i, char c1, char c2, char c3, char c4, char c5) {
         int end = i + 5;
         checkBoundsBeginEnd(i, end, value);
-        putChar(value, i++, c1);
-        putChar(value, i++, c2);
-        putChar(value, i++, c3);
-        putChar(value, i++, c4);
-        putChar(value, i++, c5);
-        assert(i == end);
+        putChar(value, i, c1);
+        putChar(value, i + 1, c2);
+        putChar(value, i + 2, c3);
+        putChar(value, i + 3, c4);
+        putChar(value, i + 4, c5);
     }
 
     public static char charAt(byte[] value, int index) {

--- a/src/java.base/share/classes/java/lang/StringUTF16.java
+++ b/src/java.base/share/classes/java/lang/StringUTF16.java
@@ -1331,10 +1331,6 @@ final class StringUTF16 {
         return new String(Arrays.copyOfRange(val, index << 1, last << 1), UTF16);
     }
 
-    public static void fillNull(byte[] val, int index, int end) {
-        Arrays.fill(val, index << 1, end << 1, (byte)0);
-    }
-
     static class CharsSpliterator implements Spliterator.OfInt {
         private final byte[] array;
         private int index;        // current index, modified on advance/split

--- a/test/hotspot/jtreg/compiler/patches/java.base/java/lang/Helper.java
+++ b/test/hotspot/jtreg/compiler/patches/java.base/java/lang/Helper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/patches/java.base/java/lang/Helper.java
+++ b/test/hotspot/jtreg/compiler/patches/java.base/java/lang/Helper.java
@@ -140,12 +140,12 @@ public class Helper {
         return StringUTF16.contentEquals(value, cs, len);
     }
 
-    public static int putCharsAt(byte[] value, int i, char c1, char c2, char c3, char c4) {
-        return StringUTF16.putCharsAt(value, i, c1, c2, c3, c4);
+    public static void putCharsAt(byte[] value, int i, char c1, char c2, char c3, char c4) {
+        StringUTF16.putCharsAt(value, i, c1, c2, c3, c4);
     }
 
-    public static int putCharsAt(byte[] value, int i, char c1, char c2, char c3, char c4, char c5) {
-        return StringUTF16.putCharsAt(value, i, c1, c2, c3, c4, c5);
+    public static void putCharsAt(byte[] value, int i, char c1, char c2, char c3, char c4, char c5) {
+        StringUTF16.putCharsAt(value, i, c1, c2, c3, c4, c5);
     }
 
     public static char charAt(byte[] value, int index) {

--- a/test/jdk/java/lang/StringBuilder/CompactStringBuilder.java
+++ b/test/jdk/java/lang/StringBuilder/CompactStringBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,7 @@ import static org.testng.Assert.assertTrue;
 
 /*
  * @test
- * @bug 8054307 8077559
+ * @bug 8054307 8077559 8351443
  * @summary Tests Compact String. This test is testing StringBuilder
  *          behavior related to Compact String.
  * @run testng/othervm -XX:+CompactStrings CompactStringBuilder

--- a/test/jdk/java/lang/StringBuilder/CompactStringBuilder.java
+++ b/test/jdk/java/lang/StringBuilder/CompactStringBuilder.java
@@ -35,6 +35,7 @@ import static org.testng.Assert.assertTrue;
  *          behavior related to Compact String.
  * @run testng/othervm -XX:+CompactStrings CompactStringBuilder
  * @run testng/othervm -XX:-CompactStrings CompactStringBuilder
+ * @run testng/othervm -Xcomp CompactStringBuilder
  */
 
 public class CompactStringBuilder {
@@ -406,6 +407,54 @@ public class CompactStringBuilder {
       check(sb, "AB");      // maybeLatin1 become true
       check(new StringBuilder(sb).append('A'), "ABA");
       check(new StringBuilder().append(sb), "AB");
+    }
+
+    // Test cases to force expanding the capacity during replace.
+    // Start with a known capacity and a known initial value that almost fills it.
+    // Use both latin1 and utf16 initial values and replacement values.
+    // Iterate through cases of SB.replace start and end values and various lengths of replacement.
+    // The results are checked by composing the new string using concatenation of the segments.
+    @Test
+    public void testGrowingCapacityReplace() {
+        final int INIT_CAPACITY = 8;
+        final String[] INITIAL_CHARS = {"A", "\u0100"};
+        final String[] REPLACEMENT_CHARS = {"B", "\u0101"};
+        for (String INITIAL : INITIAL_CHARS) {
+            for (String REPLACEMENT : REPLACEMENT_CHARS) {
+                for (int initLen = INIT_CAPACITY - 1; initLen < INIT_CAPACITY + 2; initLen++) {
+                    final String orig = INITIAL.repeat(initLen);
+                    for (int start = INIT_CAPACITY - 4; start < orig.length(); start++) {
+                        for (int end = start; end < orig.length(); end++) {
+                            for (int insLen = 0; insLen < 2; insLen++) {
+                                final String repl = REPLACEMENT.repeat(insLen);
+                                var sb = new StringBuilder(INIT_CAPACITY)
+                                        .append(orig);
+                                int capBefore = sb.capacity();
+                                sb.replace(start, end, repl);
+                                int capAfter = sb.capacity();
+                                String expected = genReplacementString(orig, start, end, repl);
+                                try {
+                                    check(sb, expected);
+                                } catch (Throwable ex) {
+                                    System.out.printf("repl: \"%s\", actual: %s, expected: %s%n", repl, sb, expected);
+                                    System.out.printf("    insLen: %d, gap: %d, beforeLen: %d, afterLen: %d, capBefore: %d, capAfter: %d%n",
+                                            insLen, (end - start), orig.length(), sb.length(),
+                                            capBefore, capAfter);
+                                    throw ex;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Construct the replacement string using string concat of the segments
+    private static String genReplacementString(String orig, int start, int end, String repl) {
+        return orig.substring(0, start) +
+                repl +
+                orig.substring(end, orig.length());
     }
 
     private void checkGetChars(StringBuilder sb, int srcBegin, int srcEnd,

--- a/test/jdk/java/lang/StringBuilder/CompactStringBuilder.java
+++ b/test/jdk/java/lang/StringBuilder/CompactStringBuilder.java
@@ -54,6 +54,10 @@ public class CompactStringBuilder {
         check(new StringBuilder(ORIGIN).append(new StringBuffer("\uFF21")),
                 "A\uFF21");
         check(new StringBuilder(ORIGIN).append("\uFF21"), "A\uFF21");
+        check(new StringBuilder(ORIGIN).append(new char[] { 'a', 'b', 'c'}),
+                "Aabc");
+        check(new StringBuilder(ORIGIN).append(new char[] { 'a', 'b', 'c'}, 1, 2),
+                "Abc");
         check(new StringBuilder(ORIGIN).append(new StringBuffer("\uFF21")),
                 "A\uFF21");
         check(new StringBuilder(ORIGIN).delete(0, 1), "");

--- a/test/jdk/java/lang/StringBuilder/HugeCapacity.java
+++ b/test/jdk/java/lang/StringBuilder/HugeCapacity.java
@@ -27,7 +27,7 @@ import java.util.Arrays;
 
 /**
  * @test
- * @bug 8149330 8218227
+ * @bug 8149330 8218227 8351443
  * @summary Capacity should not get close to Integer.MAX_VALUE unless
  *          necessary
  * @modules java.base/jdk.internal.util

--- a/test/jdk/java/lang/StringBuilder/HugeCapacity.java
+++ b/test/jdk/java/lang/StringBuilder/HugeCapacity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,6 +22,8 @@
  */
 
 import jdk.internal.util.ArraysSupport;
+
+import java.util.Arrays;
 
 /**
  * @test
@@ -47,6 +49,7 @@ public class HugeCapacity {
         testUtf16();
         testHugeInitialString();
         testHugeInitialCharSequence();
+        testHugePlus(isCompact);
         if (failures > 0) {
             throw new RuntimeException(failures + " tests failed");
         }
@@ -107,5 +110,24 @@ public class HugeCapacity {
             throw new UnsupportedOperationException();
         }
         public String toString() { return ""; }
+    }
+
+    // Test creating and appending the max size string for -XX:+CompactStrings and -XX:-CompactStrings
+    private static void testHugePlus(boolean isCompact) {
+        int repeatCount = (isCompact) ? Integer.MAX_VALUE / 2 - 1 : Integer.MAX_VALUE / 4 - 1;
+        char[] chars = new char[repeatCount];
+        char[] aChar = {'A', '\uff21'};
+        for (char ch : aChar) {
+            try {
+                int size = (ch > 0xff) ? repeatCount / 2 : repeatCount;
+                Arrays.fill(chars, 0, size, ch);
+                StringBuilder b = new StringBuilder(0);
+                b.append(chars, 0, size);
+                b.append(chars, 0, size);
+            } catch (Throwable unexpected) {
+                unexpected.printStackTrace();
+                failures++;
+            }
+        }
     }
 }

--- a/test/jdk/java/lang/StringBuilder/StressSBTest.java
+++ b/test/jdk/java/lang/StringBuilder/StressSBTest.java
@@ -1,0 +1,337 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8351443
+ * @summary Randomized test of StringBuilder
+ * @run main StressSBTest
+ */
+
+import java.lang.System.Logger;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.nio.CharBuffer;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.stream.IntStream;
+
+
+public class StressSBTest {
+
+    // Logger for info and errors
+    static final Logger LOG = System.getLogger("StressSBTest");
+    // Number of concurrent platform threads
+    private final static int N_THREADS = 11;
+    // Base length of test run
+    private final static Duration N_Duration = Duration.ofSeconds(2);
+    // Cache jtreg timeout factor to allow test to be run as a standalone main()
+    private static final double TIMEOUT_FACTOR =
+            Double.parseDouble(System.getProperty("test.timeout.factor", "1.0"));
+
+    /**
+     * Run the stress test with a fixed set of parameters.
+     *
+     * @param ignored
+     */
+    public static void main(String[] ignored) {
+        Duration duration = Duration.ofMillis((long) (N_Duration.toMillis() * TIMEOUT_FACTOR));
+        new StressSBTest().stress(N_THREADS, duration);
+    }
+
+    /**
+     * Stress test using a number of platform threads for a duration.
+     * Success is marked by a lack of exceptions.
+     * Logging output indicates the number of operations performed by each thread
+     *
+     * @param numThreads the number of threads
+     * @param duration   a Duratio, typically a few seconds
+     */
+    public void stress(int numThreads, Duration duration) {
+        StressOps stressOps = new StressOps();
+
+        final StringBuilder sb = new StringBuilder("abcdefghijklmnopqrstuvwxyz");
+        // A single StringBuilder is used to exercise the API in the face of racy behavior
+        List<Thread> threads = IntStream.range(0, numThreads).mapToObj(i -> {
+                    try {
+                        Thread t = Thread.ofPlatform().start(() -> stressOps.randomStress(sb, duration));
+                        LOG.log(Logger.Level.DEBUG, t);
+                        return t;
+                    } catch (Throwable t) {
+                        LOG.log(Logger.Level.ERROR, "Thread.ofPlatform", t);
+                    }
+                    return null;
+                })
+                .filter(t -> t != null)
+                .toList();
+        threads.forEach(t -> {
+            try {
+                t.join();
+            } catch (InterruptedException ie) {
+                // ignore
+            }
+        });
+        LOG.log(Logger.Level.INFO, "Completed: threads: %d, duration: %s".formatted(numThreads, duration));
+    }
+
+
+    /**
+     * Methods and support for stress testing StringBuilder.
+     */
+    private static class StressOps {
+
+        private static final Random randomGen = new Random();
+        private static final StringBuilder stringBuilder = new StringBuilder("wxyz");
+        private static final StringBuffer stringBuffer = new StringBuffer("wxyz");
+        private static final CharBuffer charBuffer = CharBuffer.allocate(10).append("charBuffer");
+        private static final char[] charArray = "xyz".toCharArray();
+        private static final CharSequence charSequence = "now is the time";
+        // Cache of mappings of all StringBuilder public instand methods mh -> Method
+        private static Map<MethodHandle, Method> testMethodsCache;
+        // Active map of SB methods mh -> Method
+        private final Map<MethodHandle, Method> testMethods;
+
+        public StressOps() {
+            if (testMethodsCache == null) {
+                testMethodsCache = findTestMethods();
+            }
+            testMethods = testMethodsCache;
+        }
+
+        /**
+         * Stress test randomizes methods acting on a StringBuilder.
+         * Exceptions are logged but do no affect success/failure result.
+         *
+         * @param sb       a StringBuilder
+         * @param duration a Duration of time to stress
+         */
+        public void randomStress(StringBuilder sb, Duration duration) {
+            MethodHandle[] ops = testMethods.keySet().toArray(new MethodHandle[0]);
+            int count = 0;
+            int worked = 0;
+            Instant end = Instant.now().plus(duration);
+            while (Instant.now().isBefore(end)) {
+                int j = randomGen.nextInt(ops.length);
+                var mh = ops[j];
+                String name = testMethods.get(mh).getName();
+                MethodType mt = mh.type();
+                try {
+                    count++;
+                    if (invokeByMethodNameAndType(name, mt, sb)) {
+                        worked++;
+                    }
+
+                } catch (Throwable t) {
+                    LOG.log(Logger.Level.DEBUG, "Exception testing " + name + mt, t);
+                }
+            }
+            LOG.log(Logger.Level.INFO, "StringBuilder method calls: %d, successful: %d".formatted(count, worked));
+        }
+
+
+        /**
+         * {@return Return a map of all the public instance methods of java.lang.StringBuilder
+         * mapping MethodHandle to the Method}
+         */
+        private Map<MethodHandle, Method> findTestMethods() {
+            MethodHandles.Lookup lookup = MethodHandles.lookup();
+            Method[] methods = StringBuilder.class.getDeclaredMethods();
+            Map<MethodHandle, Method> map = new HashMap<>(methods.length);
+            Arrays.stream(methods)
+                    .filter(m -> Modifier.isPublic(m.getModifiers()) &&
+                            !Modifier.isStatic(m.getModifiers()))
+                    .forEach(m -> {
+                        try {
+                            MethodHandle mh = lookup.unreflect(m);
+                            map.put(mh, m);
+                        } catch (IllegalAccessException iae) {
+                            LOG.log(Logger.Level.DEBUG, "AsbTest annotated method not accessible", iae);
+                        }
+                    });
+            LOG.log(Logger.Level.DEBUG, "%d StringBuilder test methods".formatted(map.size()));
+            return map;
+        }
+
+        /**
+         * Invoke the indicated method on the StringBuilder
+         *
+         * @param name the method name
+         * @param mt   the method type
+         * @param sb   a StringBuilder
+         * @return true if the method returned a non-null result
+         */
+        private boolean invokeByMethodNameAndType(String name, MethodType mt, StringBuilder sb) {
+            String s = name + mt.toString();
+            Object o = switch (s) {
+                case "length(StringBuilder)int" -> sb.length();
+                case "toString(StringBuilder)String" -> sb.toString();
+                case "append(StringBuilder,StringBuffer)AbstractStringBuilder" ->
+                        sb.append(stringBuffer);
+                case "append(StringBuilder,StringBuffer)StringBuilder" -> sb.append(stringBuffer);
+                case "append(StringBuilder,CharSequence)AbstractStringBuilder" ->
+                        sb.append(charBuffer);
+                case "append(StringBuilder,CharSequence)StringBuilder" -> sb.append(charBuffer);
+                case "append(StringBuilder,CharSequence)Appendable" -> sb.append(charBuffer);
+                case "append(StringBuilder,CharSequence,int,int)AbstractStringBuilder" ->
+                        sb.append("abc", 1, 2);
+                case "append(StringBuilder,CharSequence,int,int)StringBuilder" ->
+                        sb.append("abc", 1, 2);
+                case "append(StringBuilder,CharSequence,int,int)Appendable" ->
+                        sb.append("abc", 1, 2);
+                case "append(StringBuilder,char[])AbstractStringBuilder" -> sb.append(charArray);
+                case "append(StringBuilder,char[])StringBuilder" -> sb.append(charArray);
+                case "append(StringBuilder,String)AbstractStringBuilder" -> sb.append("Abcdefg");
+                case "append(StringBuilder,String)StringBuilder" -> sb.append("abcdefg");
+                case "append(StringBuilder,Object)AbstractStringBuilder" -> new Object();
+                case "append(StringBuilder,Object)StringBuilder" -> sb.append(new Object());
+                case "append(StringBuilder,char)Appendable" -> sb.append('\uff21');
+                case "append(StringBuilder,char)AbstractStringBuilder" -> sb.append('A');
+                case "append(StringBuilder,char)StringBuilder" -> sb.append('B');
+                case "append(StringBuilder,int)AbstractStringBuilder" -> sb.append(987654321);
+                case "append(StringBuilder,int)StringBuilder" -> sb.append(987654321);
+                case "append(StringBuilder,long)AbstractStringBuilder" ->
+                        sb.append(987654321987654321L);
+                case "append(StringBuilder,long)StringBuilder" -> sb.append(987654321987654321L);
+                case "append(StringBuilder,float)AbstractStringBuilder" -> sb.append(Math.PI);
+                case "append(StringBuilder,float)StringBuilder" -> sb.append(Math.PI);
+                case "append(StringBuilder,double)AbstractStringBuilder" -> sb.append(Math.TAU);
+                case "append(StringBuilder,double)StringBuilder" -> sb.append(Math.TAU);
+                case "append(StringBuilder,boolean)AbstractStringBuilder" -> sb.append(true);
+                case "append(StringBuilder,boolean)StringBuilder" -> sb.append(false);
+                case "append(StringBuilder,char[],int,int)AbstractStringBuilder" ->
+                        sb.append(charArray, 3, 4);
+                case "append(StringBuilder,char[],int,int)StringBuilder" ->
+                        sb.append(charArray, 4, 3);
+                case "reverse(StringBuilder)StringBuilder" -> sb.reverse();
+                case "reverse(StringBuilder)AbstractStringBuilder" -> sb.reverse();
+                case "getChars(StringBuilder,int,int,char[],int)void" -> {
+                    sb.getChars(2, 4, charArray, 3);
+                    yield sb;
+                }
+                case "compareTo(StringBuilder,Object)int" -> sb.compareTo(stringBuilder);
+                case "compareTo(StringBuilder,StringBuilder)int" -> sb.compareTo(stringBuilder);
+                case "indexOf(StringBuilder,String,int)int" -> sb.indexOf("A", 2);
+                case "indexOf(StringBuilder,String)int" -> sb.indexOf("B");
+                case "insert(StringBuilder,int,CharSequence)StringBuilder" ->
+                        sb.insert(2, charSequence);
+                case "insert(StringBuilder,int,CharSequence)AbstractStringBuilder" ->
+                        sb.insert(2, charSequence);
+                case "insert(StringBuilder,int,String)StringBuilder" -> sb.insert(2, "Now");
+                case "insert(StringBuilder,int,String)AbstractStringBuilder" ->
+                        sb.insert(2, "Then");
+                case "insert(StringBuilder,int,char[])StringBuilder" -> sb.insert(4, charArray);
+                case "insert(StringBuilder,int,char[])AbstractStringBuilder" ->
+                        sb.insert(4, charArray);
+                case "insert(StringBuilder,int,Object)AbstractStringBuilder" ->
+                        sb.insert(3, new Object());
+                case "insert(StringBuilder,int,Object)StringBuilder" -> sb.insert(4, "RUST");
+                case "insert(StringBuilder,int,char[],int,int)AbstractStringBuilder" ->
+                        sb.insert(2, charArray, 0, 4);
+                case "insert(StringBuilder,int,char[],int,int)StringBuilder" ->
+                        sb.insert(2, charArray, 0, 4);
+                case "insert(StringBuilder,int,int)StringBuilder" -> sb.insert(2, 46000);
+                case "insert(StringBuilder,int,int)AbstractStringBuilder" -> sb.insert(3, 47000);
+                case "insert(StringBuilder,int,double)StringBuilder" -> sb.insert(2, Math.PI);
+                case "insert(StringBuilder,int,double)AbstractStringBuilder" ->
+                        sb.insert(2, Math.PI);
+                case "insert(StringBuilder,int,float)StringBuilder" -> sb.insert(2, Math.TAU);
+                case "insert(StringBuilder,int,float)AbstractStringBuilder" ->
+                        sb.insert(2, Math.TAU);
+                case "insert(StringBuilder,int,long)StringBuilder" -> sb.insert(2, 42L);
+                case "insert(StringBuilder,int,long)AbstractStringBuilder" -> sb.insert(2, 42L);
+                case "insert(StringBuilder,int,char)StringBuilder" -> sb.insert(2, 'Z');
+                case "insert(StringBuilder,int,char)AbstractStringBuilder" -> sb.insert(2, 'Z');
+                case "insert(StringBuilder,int,boolean)StringBuilder" -> sb.insert(2, true);
+                case "insert(StringBuilder,int,boolean)AbstractStringBuilder" ->
+                        sb.insert(3, false);
+                case "insert(StringBuilder,int,CharSequence,int,int)StringBuilder" ->
+                        sb.insert(4, charSequence, 4, 5);
+                case "insert(StringBuilder,int,CharSequence,int,int)AbstractStringBuilder" ->
+                        sb.insert(4, charSequence, 5, 4);
+                case "charAt(StringBuilder,int)char" -> sb.charAt(5);
+                case "codePointAt(StringBuilder,int)int" -> sb.codePointAt(4);
+                case "codePointBefore(StringBuilder,int)int" -> sb.codePointBefore(3);
+                case "codePointCount(StringBuilder,int,int)int" -> sb.codePointCount(3, 9);
+                case "offsetByCodePoints(StringBuilder,int,int)int" -> sb.offsetByCodePoints(3, 7);
+                case "lastIndexOf(StringBuilder,String,int)int" -> sb.lastIndexOf("A", 45);
+                case "lastIndexOf(StringBuilder,String)int" -> sb.lastIndexOf("B");
+                case "substring(StringBuilder,int)String" -> sb.substring(6);
+                case "substring(StringBuilder,int,int)String" -> sb.substring(6, 9);
+                case "replace(StringBuilder,int,int,String)StringBuilder" ->
+                        sb.replace(2, 5, "xyz");
+                case "replace(StringBuilder,int,int,String)AbstractStringBuilder" ->
+                        sb.replace(2, 5, "XYZ");
+                case "repeat(StringBuilder,CharSequence,int)StringBuilder" -> sb.repeat('Z', 6);
+                case "repeat(StringBuilder,CharSequence,int)AbstractStringBuilder" ->
+                        sb.repeat('X', 42);
+                case "repeat(StringBuilder,int,int)AbstractStringBuilder" -> sb.repeat(101, 25);
+                case "repeat(StringBuilder,int,int)StringBuilder" -> sb.repeat(102, 24);
+                case "codePoints(StringBuilder)IntStream" -> sb.codePoints().count();
+                case "subSequence(StringBuilder,int,int)CharSequence" -> sb.subSequence(3, 9);
+                case "chars(StringBuilder)IntStream" -> sb.chars().count();
+                case "setLength(StringBuilder,int)void" -> {
+                    sb.setLength(45);
+                    yield 45;
+                }
+                case "capacity(StringBuilder)int" -> sb.capacity();
+                case "ensureCapacity(StringBuilder,int)void" -> {
+                    sb.ensureCapacity(150);
+                    yield 150;
+                }
+                case "trimToSize(StringBuilder)void" -> {
+                    sb.trimToSize();
+                    yield sb.length();
+                }
+                case "setCharAt(StringBuilder,int,char)void" -> {
+                    sb.setCharAt(6, 'T');
+                    yield 'T';
+                }
+                case "appendCodePoint(StringBuilder,int)StringBuilder" ->
+                        sb.appendCodePoint(0xff21);
+                case "appendCodePoint(StringBuilder,int)AbstractStringBuilder" ->
+                        sb.appendCodePoint(0xff21);
+                case "delete(StringBuilder,int,int)StringBuilder" -> sb.delete(5, 20);
+                case "delete(StringBuilder,int,int)AbstractStringBuilder" -> sb.delete(6, 21);
+                case "deleteCharAt(StringBuilder,int)AbstractStringBuilder" -> sb.deleteCharAt(7);
+                case "deleteCharAt(StringBuilder,int)StringBuilder" -> sb.deleteCharAt(8);
+                case "equals(Object,Object)boolean" -> false;
+                case "hashCode(Object)int" -> sb.hashCode();
+                case "getClass(Object)Class" -> sb.getClass();
+                case "isEmpty(CharSequence)boolean" -> null;
+                default -> {
+                    System.out.println("not executing: " + s);
+                    yield null;
+                }
+            };
+            return o != null;
+        }
+    }
+}

--- a/test/jdk/java/lang/StringBuilder/StressSBTest.java
+++ b/test/jdk/java/lang/StringBuilder/StressSBTest.java
@@ -73,7 +73,7 @@ public class StressSBTest {
      * Logging output indicates the number of operations performed by each thread
      *
      * @param numThreads the number of threads
-     * @param duration   a Duratio, typically a few seconds
+     * @param duration   a Duration, typically a few seconds
      */
     public void stress(int numThreads, Duration duration) {
         StressOps stressOps = new StressOps();

--- a/test/jdk/java/lang/StringBuilder/StringBuilderRepeat.java
+++ b/test/jdk/java/lang/StringBuilder/StringBuilderRepeat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,7 @@ import java.util.Arrays;
 
 /**
  * @test
- * @bug 8302323
+ * @bug 8302323 8351443
  * @summary Test StringBuilder.repeat sanity tests
  * @run testng/othervm -XX:-CompactStrings StringBuilderRepeat
  * @run testng/othervm -XX:+CompactStrings StringBuilderRepeat

--- a/test/jdk/java/lang/StringBuilder/StringBuilderRepeat.java
+++ b/test/jdk/java/lang/StringBuilder/StringBuilderRepeat.java
@@ -107,7 +107,7 @@ public class StringBuilderRepeat {
 
         String expected = "repeat233333233333-2-3-3-3-3-3\u2461\u2462\u2462\u2462\u2462\u2462\u2461\u2462\u2462\u2462\u2462\u2462-\u2461-\u2462-\u2462-\u2462-\u2462-\u2462abcabcabc" +
                           "nullnullnullnullnullnullnullnullnullnullnullnull";
-        assertEquals(expected, sb.toString());
+        assertEquals(sb.toString(), expected);
 
         // Codepoints
 
@@ -127,7 +127,7 @@ public class StringBuilderRepeat {
         sb.repeat(0x10FFFF, 5);
 
         expected = "\u0000\u0000\u0000\u0000\u0000\u0000\u0020\u0020\u0020\u0020\u0020\u0020\u2461\u2462\u2462\u2462\u2462\u2462\udbff\udfff\udbff\udfff\udbff\udfff\udbff\udfff\udbff\udfff\udbff\udfff";
-        assertEquals(expected, sb.toString());
+        assertEquals(sb.toString(), expected);
 
     }
 


### PR DESCRIPTION
Refactor AbstractStringBuilder to maintain consistency among count, coder, and value buffers while the buffer capacity is being expanded and/or inflated from Latin1 to UTF16 representations. 
The refactoring pattern is to read and write AbstractStringBuilder fields once using locals for all intermediate values. 
Support methods are static, designed to pass all values as arguments and return a value.

The value byte array is reallocated under 3 conditions:
- Increasing the capacity with the same encoder
- Increasing the capacity and inflation to change the coder from LATIN1 to UTF16
- Inflation with the same capacity

Added StressSBTest to exercise public instance methods of StringBuilder.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8351443](https://bugs.openjdk.org/browse/JDK-8351443): Improve robustness of StringBuilder (**Bug** - P4)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**) Review applies to [efd6fed1](https://git.openjdk.org/jdk/pull/24967/files/efd6fed1093794270af3b8d1cdd88a643ccde052)
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)
 * [Raffaello Giulietti](https://openjdk.org/census#rgiulietti) (@rgiulietti - **Reviewer**)
 * [Brent Christian](https://openjdk.org/census#bchristi) (@bchristi-git - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24967/head:pull/24967` \
`$ git checkout pull/24967`

Update a local copy of the PR: \
`$ git checkout pull/24967` \
`$ git pull https://git.openjdk.org/jdk.git pull/24967/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24967`

View PR using the GUI difftool: \
`$ git pr show -t 24967`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24967.diff">https://git.openjdk.org/jdk/pull/24967.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24967#issuecomment-2842153358)
</details>
