### PR TITLE
8355971: Build warnings after the changes for JDK-8354996

### DIFF
--- a/make/GenerateLinkOptData.gmk
+++ b/make/GenerateLinkOptData.gmk
@@ -66,7 +66,7 @@ endif
 #   default classlist is minimal, let's filter out the '@cp' lines until we can
 #   find a proper solution.
 CLASSLIST_FILE_VM_OPTS = \
-    -Duser.language=en -Duser.country=US
+    -Duser.language=en -Duser.country=US --enable-native-access=ALL-UNNAMED
 
 # Save the stderr output of the command and print it along with stdout in case
 # something goes wrong.


### PR DESCRIPTION
There were a few warnings related to illegal native access in HelloClasslist after adding some of the downcall infrastructure. Did a clean build and there were no warning associated with the 
```
Compiling up to 2 files for CLASSLIST_JAR
Creating support/classlist.jar
```
steps.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8355971](https://bugs.openjdk.org/browse/JDK-8355971): Build warnings after the changes for JDK-8354996 (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24970/head:pull/24970` \
`$ git checkout pull/24970`

Update a local copy of the PR: \
`$ git checkout pull/24970` \
`$ git pull https://git.openjdk.org/jdk.git pull/24970/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24970`

View PR using the GUI difftool: \
`$ git pr show -t 24970`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24970.diff">https://git.openjdk.org/jdk/pull/24970.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24970#issuecomment-2842804016)
</details>
