### PR TITLE
8356021: Use Double::hashCode in java.util.Locale::hashCode

### DIFF
--- a/src/java.base/share/classes/java/util/Locale.java
+++ b/src/java.base/share/classes/java/util/Locale.java
@@ -3497,7 +3497,7 @@ public final class Locale implements Cloneable, Serializable {
             if (h == 0) {
                 h = 17;
                 h = 37*h + range.hashCode();
-                h = 37*h + Long.hashCode(Double.doubleToLongBits(weight));
+                h = 37*h + Double.hashCode(weight);
                 if (h != 0) {
                     hash = h;
                 }

--- a/src/java.base/share/classes/java/util/Locale.java
+++ b/src/java.base/share/classes/java/util/Locale.java
@@ -3497,8 +3497,7 @@ public final class Locale implements Cloneable, Serializable {
             if (h == 0) {
                 h = 17;
                 h = 37*h + range.hashCode();
-                long bitsWeight = Double.doubleToLongBits(weight);
-                h = 37*h + (int)(bitsWeight ^ (bitsWeight >>> 32));
+                h = 37*h + Long.hashCode(Double.doubleToLongBits(weight));
                 if (h != 0) {
                     hash = h;
                 }


### PR DESCRIPTION
Similar to #24959, java.util.Locale.hashCode can also make the same improvement.

Replace manual bitwise operations in hashCode implementations of java.util.Locale with Double::hashCode.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8356021](https://bugs.openjdk.org/browse/JDK-8356021): Use Double::hashCode in java.util.Locale::hashCode (**Enhancement** - P4)


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24971/head:pull/24971` \
`$ git checkout pull/24971`

Update a local copy of the PR: \
`$ git checkout pull/24971` \
`$ git pull https://git.openjdk.org/jdk.git pull/24971/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24971`

View PR using the GUI difftool: \
`$ git pr show -t 24971`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24971.diff">https://git.openjdk.org/jdk/pull/24971.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24971#issuecomment-2843665156)
</details>
