### PR TITLE
8356000: C1/C2-only modes use 2 compiler threads on 1 CPU machine

### DIFF
--- a/test/hotspot/jtreg/compiler/arguments/TestCompilerCounts.java
+++ b/test/hotspot/jtreg/compiler/arguments/TestCompilerCounts.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @library /test/lib /
+ * @bug 8356000
+ * @requires vm.flagless
+ * @requires vm.debug
+ * @requires os.arch=="amd64" | os.arch=="x86_64"
+ *
+ * @summary Test compiler counts selection, verified by internal assertions
+ * @run driver compiler.arguments.TestCompilerCounts
+ */
+
+package compiler.arguments;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Arrays;
+import java.util.ArrayList;
+import jdk.test.lib.process.ProcessTools;
+import jdk.test.lib.process.OutputAnalyzer;
+
+public class TestCompilerCounts {
+
+    public static void main(String[] args) throws IOException {
+        if (args.length > 0) {
+            System.out.println("Pass");
+            return;
+        }
+
+        testWith("-XX:TieredStopAtLevel=0");
+        testWith("-XX:TieredStopAtLevel=1");
+        testWith("-XX:TieredStopAtLevel=2");
+        testWith("-XX:TieredStopAtLevel=3");
+        testWith("-XX:TieredStopAtLevel=4");
+        testWith("-XX:-TieredCompilation");
+    }
+
+    public static void testWith(String mode) throws IOException {
+        for (int cpus = 1; cpus < Runtime.getRuntime().availableProcessors(); cpus++) {
+            String[] args = new String[] {
+                mode,
+                "-XX:ActiveProcessorCount=" + cpus,
+                "compiler.arguments.TestCompilerCounts",
+                "run"
+            };
+            ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(args);
+            OutputAnalyzer output = new OutputAnalyzer(pb.start());
+            output.shouldHaveExitValue(0);
+        }
+    }
+
+}


### PR DESCRIPTION
There is an unfortunate limitation with default tiered policy that we would have at least 2 threads on 1 CPU machine: 1 thread for C1, and 1 thread for C2.

But if we select C1-only or C2-only modes, we _also_ get 2 compiler threads, for which we have no good reason. These threads would just step on each other toes.

```
$ build/linux-x86_64-server-release/images/jdk/bin/java -XX:-TieredCompilation -XX:ActiveProcessorCount=1 -XX:+PrintFlagsFinal 2>&1 | grep CICompilerCount
     intx CICompilerCount = 2 {product} {ergonomic}
     bool CICompilerCountPerCPU = true {product} {default}

$ build/linux-x86_64-server-release/images/jdk/bin/java -XX:TieredStopAtLevel=1 -XX:ActiveProcessorCount=1 -XX:+PrintFlagsFinal 2>&1 | grep CICompilerCount
     intx CICompilerCount = 2 {product} {ergonomic}
     bool CICompilerCountPerCPU = true {product} {default}
```

It is a minor bug in `CompilationPolicy::initialize`, but it gets in the way studying Leyden in tight CPU scenarios. 

Additional testing:
 - [x] New regression test passes with the fix, fails without it
 - [ ] GHA