### PR TITLE
8334742: Change java.time month/day field types to 'byte'

### DIFF
--- a/src/java.base/share/classes/java/time/LocalDate.java
+++ b/src/java.base/share/classes/java/time/LocalDate.java
@@ -182,11 +182,11 @@ public final class LocalDate
     /**
      * @serial The month-of-year.
      */
-    private final short month;
+    private final byte month;
     /**
      * @serial The day-of-month.
      */
-    private final short day;
+    private final byte day;
 
     //-----------------------------------------------------------------------
     /**
@@ -490,8 +490,8 @@ public final class LocalDate
      */
     private LocalDate(int year, int month, int dayOfMonth) {
         this.year = year;
-        this.month = (short) month;
-        this.day = (short) dayOfMonth;
+        this.month = (byte) month;
+        this.day = (byte) dayOfMonth;
     }
 
     //-----------------------------------------------------------------------

--- a/src/java.base/share/classes/java/time/MonthDay.java
+++ b/src/java.base/share/classes/java/time/MonthDay.java
@@ -146,11 +146,11 @@ public final class MonthDay
     /**
      * @serial The month-of-year, not null.
      */
-    private final int month;
+    private final byte month;
     /**
      * @serial The day-of-month.
      */
-    private final int day;
+    private final byte day;
 
     //-----------------------------------------------------------------------
     /**
@@ -319,8 +319,8 @@ public final class MonthDay
      * @param dayOfMonth  the day-of-month to represent, validated from 1 to 29-31
      */
     private MonthDay(int month, int dayOfMonth) {
-        this.month = month;
-        this.day = dayOfMonth;
+        this.month = (byte) month;
+        this.day = (byte) dayOfMonth;
     }
 
     //-----------------------------------------------------------------------

--- a/src/java.base/share/classes/java/time/YearMonth.java
+++ b/src/java.base/share/classes/java/time/YearMonth.java
@@ -153,7 +153,7 @@ public final class YearMonth
     /**
      * @serial The month-of-year, not null.
      */
-    private final int month;
+    private final byte month;
 
     //-----------------------------------------------------------------------
     /**
@@ -306,7 +306,7 @@ public final class YearMonth
      */
     private YearMonth(int year, int month) {
         this.year = year;
-        this.month = month;
+        this.month = (byte) month;
     }
 
     /**

--- a/src/java.base/share/classes/java/time/chrono/HijrahDate.java
+++ b/src/java.base/share/classes/java/time/chrono/HijrahDate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/time/chrono/HijrahDate.java
+++ b/src/java.base/share/classes/java/time/chrono/HijrahDate.java
@@ -137,11 +137,11 @@ public final class HijrahDate
     /**
      * The month-of-year.
      */
-    private final transient int monthOfYear;
+    private final transient byte monthOfYear;
     /**
      * The day-of-month.
      */
-    private final transient int dayOfMonth;
+    private final transient byte dayOfMonth;
 
     //-------------------------------------------------------------------------
     /**
@@ -273,8 +273,8 @@ public final class HijrahDate
 
         this.chrono = chrono;
         this.prolepticYear = prolepticYear;
-        this.monthOfYear = monthOfYear;
-        this.dayOfMonth = dayOfMonth;
+        this.monthOfYear = (byte) monthOfYear;
+        this.dayOfMonth = (byte) dayOfMonth;
     }
 
     /**
@@ -287,8 +287,8 @@ public final class HijrahDate
 
         this.chrono = chrono;
         this.prolepticYear = dateInfo[0];
-        this.monthOfYear = dateInfo[1];
-        this.dayOfMonth = dateInfo[2];
+        this.monthOfYear = (byte) dateInfo[1];
+        this.dayOfMonth = (byte) dateInfo[2];
     }
 
     //-----------------------------------------------------------------------


### PR DESCRIPTION
In the following classes, month and day values are stored in fields of type 'int' or 'short'. The range of allowed values is small enough that the type can be 'byte' instead.

java.time.YearMonth
java.time.MonthDay
java.time.LocalDate
java.time.chono.HijrahDate

Refactoring the type will give the JVM a little more layout flexibility, and will be especially useful when these classes become value classes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334742](https://bugs.openjdk.org/browse/JDK-8334742): Change java.time month/day field types to 'byte' (**Bug** - P4)


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24975/head:pull/24975` \
`$ git checkout pull/24975`

Update a local copy of the PR: \
`$ git checkout pull/24975` \
`$ git pull https://git.openjdk.org/jdk.git pull/24975/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24975`

View PR using the GUI difftool: \
`$ git pr show -t 24975`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24975.diff">https://git.openjdk.org/jdk/pull/24975.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24975#issuecomment-2843218602)
</details>
