### PR TITLE
8356022: Migrate descriptor parsing from generics to BytecodeDescriptor

### DIFF
--- a/src/java.base/share/classes/sun/invoke/util/BytecodeDescriptor.java
+++ b/src/java.base/share/classes/sun/invoke/util/BytecodeDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,8 +38,25 @@ public class BytecodeDescriptor {
     private BytecodeDescriptor() { }  // cannot instantiate
 
     /**
+     * @throws IllegalArgumentException if the descriptor is invalid
+     * @throws TypeNotPresentException if the descriptor is valid, but
+     * the class cannot be found by the loader
+     */
+    public static Class<?> parseClass(String descriptor, ClassLoader loader) {
+        int[] i = {0};
+        var ret = parseSig(descriptor, i, descriptor.length(), loader);
+        if (i[0] != descriptor.length() || ret == null) {
+            parseError("not a class descriptor", descriptor);
+        }
+        return ret;
+    }
+
+    /**
      * @param loader the class loader in which to look up the types (null means
      *               bootstrap class loader)
+     * @throws IllegalArgumentException if the descriptor is invalid
+     * @throws TypeNotPresentException if the descriptor is valid, but
+     * a reference type cannot be found by the loader
      */
     public static List<Class<?>> parseMethod(String bytecodeSignature, ClassLoader loader) {
         return parseMethod(bytecodeSignature, 0, bytecodeSignature.length(), loader);
@@ -78,6 +95,13 @@ public class BytecodeDescriptor {
     }
 
     /**
+     * Parse a single type in a descriptor. Results can be:
+     * <ul>
+     *     <li>A {@code Class} for successful parsing
+     *     <li>{@code null} for malformed descriptor format
+     *     <li>Throwing a {@link TypeNotPresentException} for valid class name,
+     *     but class cannot be discovered
+     * </ul>
      * @param loader the class loader in which to look up the types (null means
      *               bootstrap class loader)
      */
@@ -100,7 +124,8 @@ public class BytecodeDescriptor {
                 t = t.arrayType();
             return t;
         } else {
-            return Wrapper.forBasicType(c).primitiveType();
+            var w = Wrapper.forPrimitiveTypeOrNull(c);
+            return w == null ? null : w.primitiveType();
         }
     }
 

--- a/src/java.base/share/classes/sun/invoke/util/Wrapper.java
+++ b/src/java.base/share/classes/sun/invoke/util/Wrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -350,6 +350,19 @@ public enum Wrapper {
             return w;
         }
         throw basicTypeError(type);
+    }
+
+    /**
+     * Return the primitive wrapper for the given char.  Does not return
+     * {@code OBJECT}. Returns {@code null} to allow flexible error messages.
+     * Dedicated for {@link BytecodeDescriptor}.
+     */
+    static Wrapper forPrimitiveTypeOrNull(char type) {
+        Wrapper w = FROM_CHAR[(type + (type >> 1)) & 0xf];
+        if (w != null && w != OBJECT && w.basicTypeChar == type) {
+            return w;
+        }
+        return null;
     }
 
     @DontInline


### PR DESCRIPTION
As another step toward the removal of the old generics infrastructure, I propose to remove the usages of generic parsing utilities and use the facilities provided by BytecodeDescriptor, already used by MethodType.fromDescriptorString. This also prevents extra validation cost in use sites to defend against generic types.

In this patch, BytecodeDescriptor and Wrapper see minor updates, mainly for better exception messages - previously, an unparseable char in the descriptor string just reports that char, and now the whole descriptor string is reported.

These behaviors are already covered by the tests added in JDK-8350704 #23788.

Testing: reflect/annotation/Class, running tier 1+2

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8356022](https://bugs.openjdk.org/browse/JDK-8356022): Migrate descriptor parsing from generics to BytecodeDescriptor (**Sub-task** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24978/head:pull/24978` \
`$ git checkout pull/24978`

Update a local copy of the PR: \
`$ git checkout pull/24978` \
`$ git pull https://git.openjdk.org/jdk.git pull/24978/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24978`

View PR using the GUI difftool: \
`$ git pr show -t 24978`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24978.diff">https://git.openjdk.org/jdk/pull/24978.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24978#issuecomment-2843765431)
</details>
