### PR TITLE
8356023: Some nsk/jdi tests can fetch ThreadReference from static field in the debuggee: part 2

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/invokeMethod/invokemethod001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/invokeMethod/invokemethod001.java
@@ -173,6 +173,7 @@ public class invokemethod001 {
         }
 
         VirtualMachine vm = debuggee.VM();
+        ReferenceType debuggeeClass = debuggee.classByName(debuggeeName);
 
     //------------------------------------------------------  testing section
         log1("      TESTING BEGINS");
@@ -209,9 +210,6 @@ public class invokemethod001 {
             //String bpLine2 = "breakpointLineNumber2";
             //String bpLine3 = "breakpointLineNumber3";
 
-
-            List            allThreads   = null;
-            ListIterator    listIterator = null;
             List            classes      = null;
 
             BreakpointRequest breakpRequest1 = null;
@@ -231,7 +229,6 @@ public class invokemethod001 {
 
                 log2("getting ThreadReference object");
                 try {
-                    allThreads  = vm.allThreads();
                     classes     = vm.classesByName(testedClassName);
                     testedclass = (ReferenceType) classes.get(0);
                     classType   = (ClassType) testedclass;
@@ -241,7 +238,7 @@ public class invokemethod001 {
                     break label0;
                 }
 
-                thread2 = debuggee.threadByName(threadName);
+                thread2 = debuggee.threadByFieldNameOrThrow(debuggeeClass, "test_thread", threadName);
 
                 log2("setting up a breakpoint");
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/invokeMethod/invokemethod001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/invokeMethod/invokemethod001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/invokeMethod/invokemethod001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/invokeMethod/invokemethod001a.java
@@ -59,6 +59,8 @@ public class invokemethod001a {
 
     //====================================================== test program
 
+    static Thread test_thread = null;
+
     //    String mName =                        //!!!!!!!!!!!!!!!!!!!!!!
     //    "nsk.jdi.ClassType.invokeMethod";
 
@@ -98,8 +100,8 @@ public class invokemethod001a {
     //------------------------------------------------------  section tested
 
                 case 0:
-                         Thread test_thread =
-                                 JDIThreadFactory.newThread(new Threadinvokemethod001a("testedThread"));
+                         test_thread =
+                             JDIThreadFactory.newThread(new Threadinvokemethod001a("testedThread"));
                          log1("       thread2 is created");
 
                          label:

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/invokeMethod/invokemethod001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/invokeMethod/invokemethod001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/newInstance/newinstance001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/newInstance/newinstance001.java
@@ -184,6 +184,7 @@ public class newinstance001 {
         }
 
         vm = debuggee.VM();
+        ReferenceType debuggeeClass = debuggee.classByName(debuggeeName);
 
     //------------------------------------------------------  testing section
         log1("      TESTING BEGINS");
@@ -216,8 +217,6 @@ public class newinstance001 {
 
             String bpLine1 = "breakpointLineNumber1";
 
-            List            allThreads   = null;
-            ListIterator    listIterator = null;
             List            classes      = null;
 
             BreakpointRequest breakpRequest1 = null;
@@ -228,7 +227,6 @@ public class newinstance001 {
 
                 log2("getting ThreadReference object");
                 try {
-                    allThreads  = vm.allThreads();
                     classes     = vm.classesByName(threadClassName);
                     threadClass = (ReferenceType) classes.get(0);
                 } catch ( Exception e) {
@@ -237,21 +235,7 @@ public class newinstance001 {
                     break label0;
                 }
 
-
-                log2("......getting Thread thread2 - 1-st argument");
-                listIterator = allThreads.listIterator();
-                for (;;) {
-                    try {
-                        thread2 = (ThreadReference) listIterator.next();
-                        if (thread2.name().equals(threadName))
-                            break ;
-                    } catch ( NoSuchElementException e ) {
-                        log3("ERROR: NoSuchElementException for listIterator.next()");
-                        log3("ERROR: NO THREAD2 ?????????!!!!!!!");
-                        expresult = returnCode1;
-                        break label0;
-                    }
-                }
+                thread2 = debuggee.threadByFieldNameOrThrow(debuggeeClass, "test_thread", threadName);
 
                 log2("setting up a breakpoint");
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/newInstance/newinstance001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/newInstance/newinstance001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/newInstance/newinstance001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/newInstance/newinstance001a.java
@@ -59,6 +59,7 @@ public class newinstance001a {
 
     //====================================================== test program
 
+    static Thread test_thread = null;
     static TestClass obj = new TestClass();
 
     //----------------------------------------------------   main method
@@ -96,8 +97,8 @@ public class newinstance001a {
     //------------------------------------------------------  section tested
 
                 case 0:
-                         Thread test_thread =
-                                 JDIThreadFactory.newThread(new Threadnewinstance001a("testedThread"));
+                         test_thread =
+                             JDIThreadFactory.newThread(new Threadnewinstance001a("testedThread"));
                          log1("       thread2 is created");
 
                          label:

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/newInstance/newinstance001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/newInstance/newinstance001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/newInstance/newinstance002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/newInstance/newinstance002.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/newInstance/newinstance002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/newInstance/newinstance002.java
@@ -181,6 +181,7 @@ public class newinstance002 {
         }
 
         vm = debuggee.VM();
+        ReferenceType debuggeeClass = debuggee.classByName(debuggeeName);
 
     //------------------------------------------------------  testing section
         log1("      TESTING BEGINS");
@@ -213,8 +214,6 @@ public class newinstance002 {
 
             String bpLine1 = "breakpointLineNumber1";
 
-            List            allThreads   = null;
-            ListIterator    listIterator = null;
             List            classes      = null;
 
             BreakpointRequest breakpRequest1 = null;
@@ -225,7 +224,6 @@ public class newinstance002 {
 
                 log2("getting ThreadReference object");
                 try {
-                    allThreads  = vm.allThreads();
                     classes     = vm.classesByName(threadClassName);
                     threadClass = (ReferenceType) classes.get(0);
                 } catch ( Exception e) {
@@ -234,20 +232,7 @@ public class newinstance002 {
                     break label0;
                 }
 
-
-                listIterator = allThreads.listIterator();
-                for (;;) {
-                    try {
-                        thread2 = (ThreadReference) listIterator.next();
-                        if (thread2.name().equals(threadName))
-                            break ;
-                    } catch ( NoSuchElementException e ) {
-                        log3("ERROR: NoSuchElementException for listIterator.next()");
-                        log3("ERROR: NO THREAD2 ?????????!!!!!!!");
-                        expresult = returnCode1;
-                        break label0;
-                    }
-                }
+                thread2 = debuggee.threadByFieldNameOrThrow(debuggeeClass, "test_thread", threadName);
 
                 log2("setting up a breakpoint");
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/newInstance/newinstance002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/newInstance/newinstance002a.java
@@ -60,6 +60,7 @@ public class newinstance002a {
 
     //====================================================== test program
 
+    static Threadnewinstance002a test_thread = null;
 //    static TestClass obj = new TestClass();
 
     //----------------------------------------------------   main method
@@ -97,7 +98,7 @@ public class newinstance002a {
     //------------------------------------------------------  section tested
 
                 case 0:
-                         Threadnewinstance002a test_thread =
+                         test_thread =
                              new Threadnewinstance002a("testedThread");
                          log1("       thread2 is created");
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/newInstance/newinstance002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/newInstance/newinstance002a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/getValue/getvalue001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/getValue/getvalue001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/getValue/getvalue001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/getValue/getvalue001.java
@@ -168,6 +168,7 @@ public class getvalue001 {
         }
 
         vm = debuggee.VM();
+        ReferenceType debuggeeClass = debuggee.classByName(debuggeeName);
 
     //------------------------------------------------------  testing section
         log1("      TESTING BEGINS");
@@ -199,8 +200,6 @@ public class getvalue001 {
             String breakpointMethod1 = "runt1";
             String bpLine1           = "breakpointLineNumber1";
 
-            List            allThreads   = null;
-            ListIterator    listIterator = null;
             List            classes      = null;
 
             BreakpointRequest breakpRequest1 = null;
@@ -211,7 +210,6 @@ public class getvalue001 {
 
                 log2("getting ThreadReference object");
                 try {
-                    allThreads  = vm.allThreads();
                     classes     = vm.classesByName(testedClassName);
                     testedClass = (ReferenceType) classes.get(0);
                 } catch ( Exception e) {
@@ -220,19 +218,7 @@ public class getvalue001 {
                     break label0;
                 }
 
-                listIterator = allThreads.listIterator();
-                for (;;) {
-                    try {
-                        thread2 = (ThreadReference) listIterator.next();
-                        if (thread2.name().equals(threadName))
-                            break ;
-                    } catch ( NoSuchElementException e ) {
-                        log3("ERROR: NoSuchElementException for listIterator.next()");
-                        log3("ERROR: NO THREAD2 ?????????!!!!!!!");
-                        expresult = returnCode1;
-                        break label0;
-                    }
-                }
+                thread2 = debuggee.threadByFieldNameOrThrow(debuggeeClass, "test_thread", threadName);
 
                 log2("setting up a breakpoint");
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/getValue/getvalue001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/getValue/getvalue001a.java
@@ -58,6 +58,9 @@ public class getvalue001a {
     }
 
     //====================================================== test program
+
+    static Thread test_thread = null;
+
     //----------------------------------------------------   main method
 
     public static void main (String argv[]) {
@@ -93,8 +96,8 @@ public class getvalue001a {
     //------------------------------------------------------  section tested
 
                 case 0:
-                         Thread test_thread =
-                                 JDIThreadFactory.newThread(new Threadgetvalue001a("testedThread"));
+                         test_thread =
+                             JDIThreadFactory.newThread(new Threadgetvalue001a("testedThread"));
                          log1("       thread2 is created");
 
                          label:

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/getValue/getvalue001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/getValue/getvalue001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/getValue/getvalue002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/getValue/getvalue002.java
@@ -172,6 +172,7 @@ public class getvalue002 {
         }
 
         vm = debuggee.VM();
+        ReferenceType debuggeeClass = debuggee.classByName(debuggeeName);
 
     //------------------------------------------------------  testing section
         log1("      TESTING BEGINS");
@@ -204,8 +205,6 @@ public class getvalue002 {
 
             String bpLine1 = "breakpointLineNumber1";
 
-            List            allThreads   = null;
-            ListIterator    listIterator = null;
             List            classes      = null;
 
             BreakpointRequest breakpRequest1 = null;
@@ -216,7 +215,6 @@ public class getvalue002 {
 
                 log2("getting ThreadReference object");
                 try {
-                    allThreads  = vm.allThreads();
                     classes     = vm.classesByName(threadClassName);
                     threadClass = (ReferenceType) classes.get(0);
                 } catch ( Exception e) {
@@ -225,21 +223,7 @@ public class getvalue002 {
                     break label0;
                 }
 
-
-                log2("......getting Thread thread2 - 1-st argument");
-                listIterator = allThreads.listIterator();
-                for (;;) {
-                    try {
-                        thread2 = (ThreadReference) listIterator.next();
-                        if (thread2.name().equals(threadName))
-                            break ;
-                    } catch ( NoSuchElementException e ) {
-                        log3("ERROR: NoSuchElementException for listIterator.next()");
-                        log3("ERROR: NO THREAD2 ?????????!!!!!!!");
-                        expresult = returnCode1;
-                        break label0;
-                    }
-                }
+                thread2 = debuggee.threadByFieldNameOrThrow(debuggeeClass, "test_thread", threadName);
 
                 log2("setting up a breakpoint");
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/getValue/getvalue002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/getValue/getvalue002.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/getValue/getvalue002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/getValue/getvalue002a.java
@@ -60,6 +60,7 @@ public class getvalue002a {
 
     //====================================================== test program
 
+    static getvalue002aThread test_thread = null;
     static getvalue002aTestClass obj = new getvalue002aTestClass();
 
     //----------------------------------------------------   main method
@@ -97,8 +98,7 @@ public class getvalue002a {
     //------------------------------------------------------  section tested
 
                 case 0:
-                         getvalue002aThread test_thread =
-                             new getvalue002aThread("testedThread");
+                         test_thread = new getvalue002aThread("testedThread");
                          log1("       thread2 is created");
 
                          label:

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/getValue/getvalue002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/getValue/getvalue002a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod001.java
@@ -176,6 +176,7 @@ public class invokemethod001 {
         }
 
         vm = debuggee.VM();
+        ReferenceType debuggeeClass = debuggee.classByName(debuggeeName);
 
     //------------------------------------------------------  testing section
         log1("      TESTING BEGINS");
@@ -233,25 +234,7 @@ public class invokemethod001 {
                     break label0;
                 }
 
-                listIterator = allThreads.listIterator();
-                for (;;) {
-                    try {
-                        thread2 = (ThreadReference) listIterator.next();
-                        if (thread2.name().equals(threadName))
-                            break ;
-                    } catch ( NoSuchElementException e ) {
-                        log3("ERROR: NoSuchElementException for listIterator.next()");
-                        log3("ERROR: NO THREAD2 ?????????!!!!!!!");
-                        expresult = returnCode1;
-                        break label0;
-                    }
-                }
-
-                if (thread2 == null) {
-                    log3("ERROR: didn't find thread '" + threadName + "'");
-                    expresult = returnCode1;
-                    break label0;
-                }
+                thread2 = debuggee.threadByFieldNameOrThrow(debuggeeClass, "test_thread", threadName);
 
                 threadObjRef = thread2;
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod001a.java
@@ -60,6 +60,9 @@ public class invokemethod001a {
     }
 
     //====================================================== test program
+
+    static Threadinvokemethod001a test_thread = null;
+
     //----------------------------------------------------   main method
 
     public static void main (String argv[]) {
@@ -95,8 +98,7 @@ public class invokemethod001a {
     //------------------------------------------------------  section tested
 
                 case 0:
-                         Threadinvokemethod001a test_thread =
-                             new Threadinvokemethod001a("testedThread");
+                         test_thread = new Threadinvokemethod001a("testedThread");
                          log1("       thread2 is created");
 
                          label:

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/referenceType/referencetype001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/referenceType/referencetype001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/referenceType/referencetype001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/referenceType/referencetype001.java
@@ -153,6 +153,7 @@ public class referencetype001 {
         }
 
         vm = debuggee.VM();
+        ReferenceType debuggeeClass = debuggee.classByName(debuggeeName);
 
     //------------------------------------------------------  testing section
         log1("      TESTING BEGINS");
@@ -179,35 +180,9 @@ public class referencetype001 {
 
             String threadName = "testedThread";
 
-
-            List            allThreads   = null;
-            ListIterator    listIterator = null;
-
-
             label0: {
 
-                log2("getting ThreadReference object");
-                try {
-                    allThreads  = vm.allThreads();
-                } catch ( Exception e) {
-                    log3("ERROR: Exception at very beginning !? : " + e);
-                    expresult = returnCode1;
-                    break label0;
-                }
-
-                listIterator = allThreads.listIterator();
-                for (;;) {
-                    try {
-                        thread2 = (ThreadReference) listIterator.next();
-                        if (thread2.name().equals(threadName))
-                            break ;
-                    } catch ( NoSuchElementException e ) {
-                        log3("ERROR: NoSuchElementException for listIterator.next()");
-                        log3("ERROR: NO THREAD2 ?????????!!!!!!!");
-                        expresult = returnCode1;
-                        break label0;
-                    }
-                }
+                thread2 = debuggee.threadByFieldNameOrThrow(debuggeeClass, "test_thread", threadName);
             }
 
             label1: {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/referenceType/referencetype001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/referenceType/referencetype001a.java
@@ -60,6 +60,9 @@ public class referencetype001a {
     }
 
     //====================================================== test program
+
+    static Threadreferencetype001a test_thread = null;
+
     //----------------------------------------------------   main method
 
     public static void main (String argv[]) {
@@ -95,8 +98,7 @@ public class referencetype001a {
     //------------------------------------------------------  section tested
 
                 case 0:
-                         Threadreferencetype001a test_thread =
-                             new Threadreferencetype001a("testedThread");
+                         test_thread = new Threadreferencetype001a("testedThread");
                          log1("       thread2 is created");
 
                          label:

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/referenceType/referencetype001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/referenceType/referencetype001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/getValue/getvalue001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/getValue/getvalue001.java
@@ -168,6 +168,7 @@ public class getvalue001 {
         }
 
         VirtualMachine vm = debuggee.VM();
+        ReferenceType debuggeeClass = debuggee.classByName(debuggeeName);
 
     //------------------------------------------------------  testing section
         log1("      TESTING BEGINS");
@@ -204,9 +205,6 @@ public class getvalue001 {
             //String bpLine2 = "breakpointLineNumber2";
             //String bpLine3 = "breakpointLineNumber3";
 
-
-            List            allThreads   = null;
-            ListIterator    listIterator = null;
             List            classes      = null;
 
             BreakpointRequest breakpRequest1 = null;
@@ -224,7 +222,6 @@ public class getvalue001 {
 
                 log2("getting ThreadReference object");
                 try {
-                    allThreads  = vm.allThreads();
                     classes     = vm.classesByName(testedClassName);
                     testedclass = (ReferenceType) classes.get(0);
                 } catch ( Exception e) {
@@ -233,7 +230,7 @@ public class getvalue001 {
                     break label0;
                 }
 
-                thread2 = debuggee.threadByName(threadName);
+                thread2 = debuggee.threadByFieldNameOrThrow(debuggeeClass, "test_thread", threadName);
 
                 log2("setting up breakpoints");
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/getValue/getvalue001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/getValue/getvalue001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/getValue/getvalue001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/getValue/getvalue001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/getValue/getvalue001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/getValue/getvalue001a.java
@@ -58,6 +58,9 @@ public class getvalue001a {
     }
 
     //====================================================== test program
+
+    static Thread test_thread = null;
+
     //----------------------------------------------------   main method
 
     public static void main (String argv[]) {
@@ -93,7 +96,7 @@ public class getvalue001a {
     //------------------------------------------------------  section tested
 
                 case 0:
-                         Thread test_thread =
+                         test_thread =
                              JDIThreadFactory.newThread(new Threadgetvalue001a("testedThread"));
                          log1("       thread2 is created");
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/getValue/getvalue002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/getValue/getvalue002.java
@@ -174,6 +174,7 @@ public class getvalue002 {
         }
 
         VirtualMachine vm = debuggee.VM();
+        ReferenceType debuggeeClass = debuggee.classByName(debuggeeName);
 
     //------------------------------------------------------  testing section
         log1("      TESTING BEGINS");
@@ -211,8 +212,6 @@ public class getvalue002 {
             //String bpLine3 = "breakpointLineNumber3";
 
 
-            List            allThreads   = null;
-            ListIterator    listIterator = null;
             List            classes      = null;
 
             BreakpointRequest breakpRequest1 = null;
@@ -230,7 +229,6 @@ public class getvalue002 {
 
                 log2("getting ThreadReference object");
                 try {
-                    allThreads  = vm.allThreads();
                     classes     = vm.classesByName(testedClassName);
                     testedclass = (ReferenceType) classes.get(0);
                 } catch ( Exception e) {
@@ -239,7 +237,7 @@ public class getvalue002 {
                     break label0;
                 }
 
-                thread2 = debuggee.threadByName(threadName);
+                thread2 = debuggee.threadByFieldNameOrThrow(debuggeeClass, "test_thread", threadName);
 
                 log2("setting up breakpoints");
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/getValue/getvalue002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/getValue/getvalue002.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/getValue/getvalue002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/getValue/getvalue002a.java
@@ -58,6 +58,9 @@ public class getvalue002a {
     }
 
     //====================================================== test program
+
+    static Thread test_thread = null;
+
     //----------------------------------------------------   main method
 
     public static void main (String argv[]) {
@@ -93,8 +96,8 @@ public class getvalue002a {
     //------------------------------------------------------  section tested
 
                 case 0:
-                         Thread test_thread =
-                                 JDIThreadFactory.newThread(new Threadgetvalue002a("testedThread"));
+                         test_thread =
+                             JDIThreadFactory.newThread(new Threadgetvalue002a("testedThread"));
                          log1("       thread2 is created");
 
                          label:

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/getValue/getvalue002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/getValue/getvalue002a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/getValues/getvalues001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/getValues/getvalues001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/getValues/getvalues001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/getValues/getvalues001.java
@@ -169,6 +169,7 @@ public class getvalues001 {
         }
 
         VirtualMachine vm = debuggee.VM();
+        ReferenceType debuggeeClass = debuggee.classByName(debuggeeName);
 
     //------------------------------------------------------  testing section
         log1("      TESTING BEGINS");
@@ -205,9 +206,6 @@ public class getvalues001 {
             //String bpLine2 = "breakpointLineNumber2";
             //String bpLine3 = "breakpointLineNumber3";
 
-
-            List            allThreads   = null;
-            ListIterator    listIterator = null;
             List            classes      = null;
 
             BreakpointRequest breakpRequest1 = null;
@@ -225,7 +223,6 @@ public class getvalues001 {
 
                 log2("getting ThreadReference object");
                 try {
-                    allThreads  = vm.allThreads();
                     classes     = vm.classesByName(testedClassName);
                     testedclass = (ReferenceType) classes.get(0);
                 } catch ( Exception e) {
@@ -234,7 +231,7 @@ public class getvalues001 {
                     break label0;
                 }
 
-                thread2 = debuggee.threadByName(threadName);
+                thread2 = debuggee.threadByFieldNameOrThrow(debuggeeClass, "test_thread", threadName);
 
                 log2("setting up breakpoints");
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/getValues/getvalues001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/getValues/getvalues001a.java
@@ -58,6 +58,9 @@ public class getvalues001a {
     }
 
     //====================================================== test program
+
+    static Thread test_thread = null;
+
     //----------------------------------------------------   main method
 
     public static void main (String argv[]) {
@@ -93,8 +96,8 @@ public class getvalues001a {
     //------------------------------------------------------  section tested
 
                 case 0:
-                         Thread test_thread =
-                                 JDIThreadFactory.newThread(new Threadgetvalues001a("testedThread"));
+                         test_thread =
+                             JDIThreadFactory.newThread(new Threadgetvalues001a("testedThread"));
                          log1("       thread2 is created");
 
                          label:

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/getValues/getvalues001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/getValues/getvalues001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/getValues/getvalues002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/getValues/getvalues002.java
@@ -176,6 +176,7 @@ public class getvalues002 {
         }
 
         VirtualMachine vm = debuggee.VM();
+        ReferenceType debuggeeClass = debuggee.classByName(debuggeeName);
 
     //------------------------------------------------------  testing section
         log1("      TESTING BEGINS");
@@ -212,9 +213,6 @@ public class getvalues002 {
             String bpLine2 = "breakpointLineNumber2";
             //String bpLine3 = "breakpointLineNumber3";
 
-
-            List            allThreads   = null;
-            ListIterator    listIterator = null;
             List            classes      = null;
 
             BreakpointRequest breakpRequest1 = null;
@@ -232,7 +230,6 @@ public class getvalues002 {
 
                 log2("getting ThreadReference object");
                 try {
-                    allThreads  = vm.allThreads();
                     classes     = vm.classesByName(testedClassName);
                     testedclass = (ReferenceType) classes.get(0);
                 } catch ( Exception e) {
@@ -241,7 +238,7 @@ public class getvalues002 {
                     break label0;
                 }
 
-                thread2 = debuggee.threadByName(threadName);
+                thread2 = debuggee.threadByFieldNameOrThrow(debuggeeClass, "test_thread", threadName);
 
                 log2("setting up breakpoints");
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/getValues/getvalues002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/getValues/getvalues002.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/getValues/getvalues002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/getValues/getvalues002a.java
@@ -58,6 +58,9 @@ public class getvalues002a {
     }
 
     //====================================================== test program
+
+    static Thread test_thread = null;
+
     //----------------------------------------------------   main method
 
     public static void main (String argv[]) {
@@ -93,8 +96,8 @@ public class getvalues002a {
     //------------------------------------------------------  section tested
 
                 case 0:
-                         Thread test_thread =
-                                 JDIThreadFactory.newThread(new Threadgetvalues002a("testedThread"));
+                         test_thread =
+                             JDIThreadFactory.newThread(new Threadgetvalues002a("testedThread"));
                          log1("       thread2 is created");
 
                          label:

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/getValues/getvalues002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/getValues/getvalues002a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/location/location001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/location/location001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/location/location001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/location/location001.java
@@ -174,6 +174,7 @@ public class location001 {
         }
 
         VirtualMachine vm = debuggee.VM();
+        ReferenceType debuggeeClass = debuggee.classByName(debuggeeName);
 
     //------------------------------------------------------  testing section
         log1("      TESTING BEGINS");
@@ -210,9 +211,6 @@ public class location001 {
             //String bpLine2 = "breakpointLineNumber2";
             //String bpLine3 = "breakpointLineNumber3";
 
-
-            List            allThreads   = null;
-            ListIterator    listIterator = null;
             List            classes      = null;
 
             BreakpointRequest breakpRequest1 = null;
@@ -230,7 +228,6 @@ public class location001 {
 
                 log2("getting ThreadReference object");
                 try {
-                    allThreads  = vm.allThreads();
                     classes     = vm.classesByName(testedClassName);
                     testedclass = (ReferenceType) classes.get(0);
                 } catch ( Exception e) {
@@ -239,7 +236,7 @@ public class location001 {
                     break label0;
                 }
 
-                thread2 = debuggee.threadByName(threadName);
+                thread2 = debuggee.threadByFieldNameOrThrow(debuggeeClass, "test_thread", threadName);
 
                 log2("setting up a breakpoint");
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/location/location001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/location/location001a.java
@@ -58,6 +58,9 @@ public class location001a {
     }
 
     //====================================================== test program
+
+    static Thread test_thread = null;
+
     //----------------------------------------------------   main method
 
     public static void main (String argv[]) {
@@ -93,8 +96,8 @@ public class location001a {
     //------------------------------------------------------  section tested
 
                 case 0:
-                         Thread test_thread =
-                                 JDIThreadFactory.newThread(new Threadlocation001a("testedThread"));
+                         test_thread =
+                             JDIThreadFactory.newThread(new Threadlocation001a("testedThread"));
                          log1("       thread2 is created");
 
                          label:

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/location/location001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/location/location001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/setValue/setvalue001/setvalue001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/setValue/setvalue001/setvalue001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/setValue/setvalue001/setvalue001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/setValue/setvalue001/setvalue001.java
@@ -252,6 +252,7 @@ public class setvalue001 {
         }
 
         VirtualMachine vm = debuggee.VM();
+        ReferenceType debuggeeClass = debuggee.classByName(debuggeeName);
 
         //------------------------------------------------------  testing section
 
@@ -289,9 +290,6 @@ public class setvalue001 {
             //String bpLine2 = "breakpointLineNumber2";
             //String bpLine3 = "breakpointLineNumber3";
 
-
-            List            allThreads   = null;
-            ListIterator    listIterator = null;
             List            classes      = null;
 
             BreakpointRequest breakpRequest1 = null;
@@ -309,7 +307,6 @@ public class setvalue001 {
 
                 log2("getting ThreadReference object");
                 try {
-                    allThreads  = vm.allThreads();
                     classes     = vm.classesByName(testedClassName);
                     testedclass = (ReferenceType) classes.get(0);
                 } catch ( Exception e) {
@@ -318,7 +315,7 @@ public class setvalue001 {
                     break label0;
                 }
 
-                thread2 = debuggee.threadByName(threadName);
+                thread2 = debuggee.threadByFieldNameOrThrow(debuggeeClass, "test_thread", threadName);
 
                 log2("setting up breakpoints");
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/setValue/setvalue001/setvalue001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/setValue/setvalue001/setvalue001a.java
@@ -58,7 +58,10 @@ public class setvalue001a {
     }
 
     //====================================================== test program
-    //----------------------------------------------------   main method
+ 
+    static Thread test_thread = null;
+
+   //----------------------------------------------------   main method
 
     public static void main (String argv[]) {
 
@@ -93,7 +96,7 @@ public class setvalue001a {
     //------------------------------------------------------  section tested
 
                 case 0:
-                         Thread test_thread =
+                         test_thread =
                              JDIThreadFactory.newThread(new Threadsetvalue001a("testedThread"));
                          log1("       thread2 is created");
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/setValue/setvalue001/setvalue001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/setValue/setvalue001/setvalue001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/setValue/setvalue001/setvalue001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/setValue/setvalue001/setvalue001a.java
@@ -58,7 +58,7 @@ public class setvalue001a {
     }
 
     //====================================================== test program
- 
+
     static Thread test_thread = null;
 
    //----------------------------------------------------   main method

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/setValue/setvalue002/setvalue002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/setValue/setvalue002/setvalue002.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/setValue/setvalue002/setvalue002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/setValue/setvalue002/setvalue002.java
@@ -266,6 +266,7 @@ public class setvalue002 {
         }
 
         VirtualMachine vm = debuggee.VM();
+        ReferenceType debuggeeClass = debuggee.classByName(debuggeeName);
 
     //------------------------------------------------------  testing section
         log1("      TESTING BEGINS");
@@ -302,9 +303,6 @@ public class setvalue002 {
             String bpLine2 = "breakpointLineNumber2";
             //String bpLine3 = "breakpointLineNumber3";
 
-
-            List            allThreads   = null;
-            ListIterator    listIterator = null;
             List            classes      = null;
 
             BreakpointRequest breakpRequest1 = null;
@@ -322,7 +320,6 @@ public class setvalue002 {
 
                 log2("getting ThreadReference object");
                 try {
-                    allThreads  = vm.allThreads();
                     classes     = vm.classesByName(testedClassName);
                     testedclass = (ReferenceType) classes.get(0);
                 } catch ( Exception e) {
@@ -331,7 +328,7 @@ public class setvalue002 {
                     break label0;
                 }
 
-                thread2 = debuggee.threadByName(threadName);
+                thread2 = debuggee.threadByFieldNameOrThrow(debuggeeClass, "test_thread", threadName);
 
                 log2("setting up breakpoints");
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/setValue/setvalue002/setvalue002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/setValue/setvalue002/setvalue002a.java
@@ -59,7 +59,7 @@ public class setvalue002a {
 
     //====================================================== test program
 
-    static public Thread test_thread = null;
+    static Thread test_thread = null;
 
     //----------------------------------------------------   main method
 
@@ -97,7 +97,7 @@ public class setvalue002a {
 
                 case 0:
                          test_thread =
-                                 JDIThreadFactory.newThread(new Threadsetvalue002a("testedThread"));
+                             JDIThreadFactory.newThread(new Threadsetvalue002a("testedThread"));
                          log1("       thread2 is created");
 
                          label:

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/setValue/setvalue002/setvalue002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/setValue/setvalue002/setvalue002a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/setValue/setvalue003/setvalue003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/setValue/setvalue003/setvalue003.java
@@ -260,6 +260,7 @@ public class setvalue003 {
         }
 
         VirtualMachine vm = debuggee.VM();
+        ReferenceType debuggeeClass = debuggee.classByName(debuggeeName);
 
     //------------------------------------------------------  testing section
         log1("      TESTING BEGINS");
@@ -296,9 +297,6 @@ public class setvalue003 {
             String bpLine2 = "breakpointLineNumber2";
             //String bpLine3 = "breakpointLineNumber3";
 
-
-            List            allThreads   = null;
-            ListIterator    listIterator = null;
             List            classes      = null;
 
             BreakpointRequest breakpRequest1 = null;
@@ -316,7 +314,6 @@ public class setvalue003 {
 
                 log2("getting ThreadReference object");
                 try {
-                    allThreads  = vm.allThreads();
                     classes     = vm.classesByName(testedClassName);
                     testedclass = (ReferenceType) classes.get(0);
                 } catch ( Exception e) {
@@ -325,7 +322,7 @@ public class setvalue003 {
                     break label0;
                 }
 
-                thread2 = debuggee.threadByName(threadName);
+                thread2 = debuggee.threadByFieldNameOrThrow(debuggeeClass, "test_thread", threadName);
 
                 log2("setting up breakpoints");
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/setValue/setvalue003/setvalue003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/setValue/setvalue003/setvalue003.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/setValue/setvalue003/setvalue003a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/setValue/setvalue003/setvalue003a.java
@@ -57,6 +57,9 @@ public class setvalue003a {
     }
 
     //====================================================== test program
+
+    static Thread test_thread = null;
+
     //----------------------------------------------------   main method
 
     public static void main (String argv[]) {
@@ -92,8 +95,8 @@ public class setvalue003a {
     //------------------------------------------------------  section tested
 
                 case 0:
-                         Thread test_thread =
-                                 JDIThreadFactory.newThread(new Threadsetvalue003a("testedThread"));
+                         test_thread =
+                             JDIThreadFactory.newThread(new Threadsetvalue003a("testedThread"));
                          log1("       thread2 is created");
 
                          label:

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/setValue/setvalue003/setvalue003a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/setValue/setvalue003/setvalue003a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/setValue/setvalue004/setvalue004.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/setValue/setvalue004/setvalue004.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/setValue/setvalue004/setvalue004.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/setValue/setvalue004/setvalue004.java
@@ -253,6 +253,7 @@ public class setvalue004 {
         }
 
         VirtualMachine vm = debuggee.VM();
+        ReferenceType debuggeeClass = debuggee.classByName(debuggeeName);
 
     //------------------------------------------------------  testing section
         log1("      TESTING BEGINS");
@@ -289,9 +290,6 @@ public class setvalue004 {
             String bpLine2 = "breakpointLineNumber2";
             //String bpLine3 = "breakpointLineNumber3";
 
-
-            List            allThreads   = null;
-            ListIterator    listIterator = null;
             List            classes      = null;
 
             BreakpointRequest breakpRequest1 = null;
@@ -309,7 +307,6 @@ public class setvalue004 {
 
                 log2("getting ThreadReference object");
                 try {
-                    allThreads  = vm.allThreads();
                     classes     = vm.classesByName(testedClassName);
                     testedclass = (ReferenceType) classes.get(0);
                 } catch ( Exception e) {
@@ -318,7 +315,7 @@ public class setvalue004 {
                     break label0;
                 }
 
-                thread2 = debuggee.threadByName(threadName);
+                thread2 = debuggee.threadByFieldNameOrThrow(debuggeeClass, "test_thread", threadName);
 
                 log2("setting up breakpoints");
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/setValue/setvalue004/setvalue004a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/setValue/setvalue004/setvalue004a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/setValue/setvalue004/setvalue004a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/setValue/setvalue004/setvalue004a.java
@@ -57,6 +57,9 @@ public class setvalue004a {
     }
 
     //====================================================== test program
+
+    static Thread test_thread = null;
+
     //----------------------------------------------------   main method
 
     public static void main (String argv[]) {
@@ -92,8 +95,8 @@ public class setvalue004a {
     //------------------------------------------------------  section tested
 
                 case 0:
-                         Thread test_thread =
-                                 JDIThreadFactory.newThread(new Threadsetvalue004a("testedThread"));
+                         test_thread =
+                             JDIThreadFactory.newThread(new Threadsetvalue004a("testedThread"));
                          log1("       thread2 is created");
 
                          label:

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/thisObject/thisobject001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/thisObject/thisobject001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/thisObject/thisobject001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/thisObject/thisobject001.java
@@ -170,6 +170,7 @@ public class thisobject001 {
         }
 
         VirtualMachine vm = debuggee.VM();
+        ReferenceType debuggeeClass = debuggee.classByName(debuggeeName);
 
     //------------------------------------------------------  testing section
         log1("      TESTING BEGINS");
@@ -206,9 +207,6 @@ public class thisobject001 {
             String bpLine2 = "breakpointLineNumber2";
             //String bpLine3 = "breakpointLineNumber3";
 
-
-            List            allThreads   = null;
-            ListIterator    listIterator = null;
             List            classes      = null;
 
             BreakpointRequest breakpRequest1 = null;
@@ -226,7 +224,6 @@ public class thisobject001 {
 
                 log2("getting ThreadReference object");
                 try {
-                    allThreads  = vm.allThreads();
                     classes     = vm.classesByName(testedClassName);
                     testedclass = (ReferenceType) classes.get(0);
                 } catch ( Exception e) {
@@ -235,7 +232,7 @@ public class thisobject001 {
                     break label0;
                 }
 
-                thread2 = debuggee.threadByName(threadName);
+                thread2 = debuggee.threadByFieldNameOrThrow(debuggeeClass, "test_thread", threadName);
 
                 log2("setting up breakpoints");
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/thisObject/thisobject001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/thisObject/thisobject001a.java
@@ -59,6 +59,9 @@ public class thisobject001a {
     }
 
     //====================================================== test program
+
+    static Threadthisobject001a test_thread = null;
+
     //----------------------------------------------------   main method
 
     public static void main (String argv[]) {
@@ -94,8 +97,7 @@ public class thisobject001a {
     //------------------------------------------------------  section tested
 
                 case 0:
-                         Threadthisobject001a test_thread =
-                             new Threadthisobject001a("testedThread");
+                         test_thread = new Threadthisobject001a("testedThread");
                          log1("       thread2 is created");
 
                          label:

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/thisObject/thisobject001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/thisObject/thisobject001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/thisObject/thisobject002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/thisObject/thisobject002.java
@@ -169,6 +169,7 @@ public class thisobject002 {
         }
 
         VirtualMachine vm = debuggee.VM();
+        ReferenceType debuggeeClass = debuggee.classByName(debuggeeName);
 
     //------------------------------------------------------  testing section
         log1("      TESTING BEGINS");
@@ -205,9 +206,6 @@ public class thisobject002 {
             String bpLine2 = "breakpointLineNumber2";
             //String bpLine3 = "breakpointLineNumber3";
 
-
-            List            allThreads   = null;
-            ListIterator    listIterator = null;
             List            classes      = null;
 
             BreakpointRequest breakpRequest1 = null;
@@ -225,7 +223,6 @@ public class thisobject002 {
 
                 log2("getting ThreadReference object");
                 try {
-                    allThreads  = vm.allThreads();
                     classes     = vm.classesByName(testedClassName);
                     testedclass = (ReferenceType) classes.get(0);
                 } catch ( Exception e) {
@@ -234,7 +231,7 @@ public class thisobject002 {
                     break label0;
                 }
 
-                thread2 = debuggee.threadByName(threadName);
+                thread2 = debuggee.threadByFieldNameOrThrow(debuggeeClass, "test_thread", threadName);
 
                 log2("setting up breakpoints");
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/thisObject/thisobject002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/thisObject/thisobject002.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/thisObject/thisobject002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/thisObject/thisobject002a.java
@@ -58,6 +58,9 @@ public class thisobject002a {
     }
 
     //====================================================== test program
+
+    static Thread test_thread = null;
+
     //----------------------------------------------------   main method
 
     public static void main (String argv[]) {
@@ -94,8 +97,8 @@ public class thisobject002a {
     //------------------------------------------------------  section tested
 
                 case 0:
-                         Thread test_thread =
-                                 JDIThreadFactory.newThread(new Threadthisobject002a("testedThread"));
+                         test_thread =
+                             JDIThreadFactory.newThread(new Threadthisobject002a("testedThread"));
                          log1("       thread2 is created");
 
                          label:

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/thisObject/thisobject002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/thisObject/thisobject002a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/thread/thread001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/thread/thread001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/thread/thread001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/thread/thread001.java
@@ -167,6 +167,7 @@ public class thread001 {
         }
 
         VirtualMachine vm = debuggee.VM();
+        ReferenceType debuggeeClass = debuggee.classByName(debuggeeName);
 
     //------------------------------------------------------  testing section
         log1("      TESTING BEGINS");
@@ -203,9 +204,6 @@ public class thread001 {
             //String bpLine2 = "breakpointLineNumber2";
             //String bpLine3 = "breakpointLineNumber3";
 
-
-            List            allThreads   = null;
-            ListIterator    listIterator = null;
             List            classes      = null;
 
             BreakpointRequest breakpRequest1 = null;
@@ -223,7 +221,6 @@ public class thread001 {
 
                 log2("getting ThreadReference object");
                 try {
-                    allThreads  = vm.allThreads();
                     classes     = vm.classesByName(testedClassName);
                     testedclass = (ReferenceType) classes.get(0);
                 } catch ( Exception e) {
@@ -232,7 +229,7 @@ public class thread001 {
                     break label0;
                 }
 
-                thread2 = debuggee.threadByName(threadName);
+                thread2 = debuggee.threadByFieldNameOrThrow(debuggeeClass, "test_thread", threadName);
 
                 log2("setting up a breakpoint");
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/thread/thread001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/thread/thread001a.java
@@ -58,6 +58,9 @@ public class thread001a {
     }
 
     //====================================================== test program
+
+    static Thread test_thread = null;
+
     //----------------------------------------------------   main method
 
     public static void main (String argv[]) {
@@ -93,8 +96,8 @@ public class thread001a {
     //------------------------------------------------------  section tested
 
                 case 0:
-                         Thread test_thread =
-                                 JDIThreadFactory.newThread(new Threadthread001a("testedThread"));
+                         test_thread =
+                             JDIThreadFactory.newThread(new Threadthread001a("testedThread"));
                          log1("       thread2 is created");
 
                          label:

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/thread/thread001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/thread/thread001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/visibleVariableByName/visiblevarbyname001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/visibleVariableByName/visiblevarbyname001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/visibleVariableByName/visiblevarbyname001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/visibleVariableByName/visiblevarbyname001.java
@@ -172,6 +172,7 @@ public class visiblevarbyname001 {
         }
 
         VirtualMachine vm = debuggee.VM();
+        ReferenceType debuggeeClass = debuggee.classByName(debuggeeName);
 
     //------------------------------------------------------  testing section
         log1("      TESTING BEGINS");
@@ -208,9 +209,6 @@ public class visiblevarbyname001 {
             String bpLine2 = "breakpointLineNumber2";
             //String bpLine3 = "breakpointLineNumber3";
 
-
-            List            allThreads   = null;
-            ListIterator    listIterator = null;
             List            classes      = null;
 
             BreakpointRequest breakpRequest1 = null;
@@ -228,7 +226,6 @@ public class visiblevarbyname001 {
 
                 log2("getting ThreadReference object");
                 try {
-                    allThreads  = vm.allThreads();
                     classes     = vm.classesByName(testedClassName);
                     testedclass = (ReferenceType) classes.get(0);
                 } catch ( Exception e) {
@@ -237,7 +234,7 @@ public class visiblevarbyname001 {
                     break label0;
                 }
 
-                thread2 = debuggee.threadByName(threadName);
+                thread2 = debuggee.threadByFieldNameOrThrow(debuggeeClass, "test_thread", threadName);
 
                 log2("setting up breakpoints");
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/visibleVariableByName/visiblevarbyname001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/visibleVariableByName/visiblevarbyname001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/visibleVariableByName/visiblevarbyname001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/visibleVariableByName/visiblevarbyname001a.java
@@ -58,6 +58,9 @@ public class visiblevarbyname001a {
     }
 
     //====================================================== test program
+
+    static Thread test_thread = null;
+
     //----------------------------------------------------   main method
 
     public static void main (String argv[]) {
@@ -93,8 +96,8 @@ public class visiblevarbyname001a {
     //------------------------------------------------------  section tested
 
                 case 0:
-                         Thread test_thread =
-                                 JDIThreadFactory.newThread(new Threadvisiblevarbyname001a("testedThread"));
+                         test_thread =
+                             JDIThreadFactory.newThread(new Threadvisiblevarbyname001a("testedThread"));
                          log1("       thread2 is created");
 
                          label:

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/visibleVariableByName/visiblevarbyname002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/visibleVariableByName/visiblevarbyname002.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/visibleVariableByName/visiblevarbyname002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/visibleVariableByName/visiblevarbyname002.java
@@ -163,6 +163,7 @@ public class visiblevarbyname002 {
         }
 
         VirtualMachine vm = debuggee.VM();
+        ReferenceType debuggeeClass = debuggee.classByName(debuggeeName);
 
     //------------------------------------------------------  testing section
         log1("      TESTING BEGINS");
@@ -199,9 +200,6 @@ public class visiblevarbyname002 {
             String bpLine2 = "breakpointLineNumber2";
             //String bpLine3 = "breakpointLineNumber3";
 
-
-            List            allThreads   = null;
-            ListIterator    listIterator = null;
             List            classes      = null;
 
             BreakpointRequest breakpRequest1 = null;
@@ -219,7 +217,6 @@ public class visiblevarbyname002 {
 
                 log2("getting ThreadReference object");
                 try {
-                    allThreads  = vm.allThreads();
                     classes     = vm.classesByName(testedClassName);
                     testedclass = (ReferenceType) classes.get(0);
                 } catch ( Exception e) {
@@ -228,7 +225,8 @@ public class visiblevarbyname002 {
                     break label0;
                 }
 
-                thread2 = debuggee.threadByName(threadName);
+                thread2 = debuggee.threadByFieldNameOrThrow(debuggeeClass, "test_thread", threadName);
+
                 log2("setting up breakpoints");
 
                 breakpRequest1 = settingBreakpoint(breakpointMethod1, bpLine1, "one");

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/visibleVariableByName/visiblevarbyname002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/visibleVariableByName/visiblevarbyname002a.java
@@ -58,6 +58,9 @@ public class visiblevarbyname002a {
     }
 
     //====================================================== test program
+
+    static Thread test_thread = null;
+
     //----------------------------------------------------   main method
 
     public static void main (String argv[]) {
@@ -93,8 +96,8 @@ public class visiblevarbyname002a {
     //------------------------------------------------------  section tested
 
                 case 0:
-                         Thread test_thread =
-                                 JDIThreadFactory.newThread(new Threadvisiblevarbyname002a("testedThread"));
+                         test_thread =
+                             JDIThreadFactory.newThread(new Threadvisiblevarbyname002a("testedThread"));
                          log1("       thread2 is created");
 
                          label:

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/visibleVariableByName/visiblevarbyname002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/visibleVariableByName/visiblevarbyname002a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/visibleVariables/visiblevariables001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/visibleVariables/visiblevariables001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/visibleVariables/visiblevariables001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/visibleVariables/visiblevariables001.java
@@ -167,6 +167,7 @@ public class visiblevariables001 {
         }
 
         VirtualMachine vm = debuggee.VM();
+        ReferenceType debuggeeClass = debuggee.classByName(debuggeeName);
 
     //------------------------------------------------------  testing section
         log1("      TESTING BEGINS");
@@ -203,9 +204,6 @@ public class visiblevariables001 {
             String bpLine2 = "breakpointLineNumber2";
             //String bpLine3 = "breakpointLineNumber3";
 
-
-            List            allThreads   = null;
-            ListIterator    listIterator = null;
             List            classes      = null;
 
             BreakpointRequest breakpRequest1 = null;
@@ -223,7 +221,6 @@ public class visiblevariables001 {
 
                 log2("getting ThreadReference object");
                 try {
-                    allThreads  = vm.allThreads();
                     classes     = vm.classesByName(testedClassName);
                     testedclass = (ReferenceType) classes.get(0);
                 } catch ( Exception e) {
@@ -232,7 +229,7 @@ public class visiblevariables001 {
                     break label0;
                 }
 
-                thread2 = debuggee.threadByName(threadName);
+                thread2 = debuggee.threadByFieldNameOrThrow(debuggeeClass, "test_thread", threadName);
 
                 log2("setting up breakpoints");
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/visibleVariables/visiblevariables001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/visibleVariables/visiblevariables001a.java
@@ -58,6 +58,9 @@ public class visiblevariables001a {
     }
 
     //====================================================== test program
+
+    static Thread test_thread = null;
+
     //----------------------------------------------------   main method
 
     public static void main (String argv[]) {
@@ -93,8 +96,8 @@ public class visiblevariables001a {
     //------------------------------------------------------  section tested
 
                 case 0:
-                         Thread test_thread =
-                                 JDIThreadFactory.newThread(new Threadvisiblevariables001a("testedThread"));
+                         test_thread =
+                             JDIThreadFactory.newThread(new Threadvisiblevariables001a("testedThread"));
                          log1("       thread2 is created");
 
                          label:

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/visibleVariables/visiblevariables001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/visibleVariables/visiblevariables001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/visibleVariables/visiblevariables002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/visibleVariables/visiblevariables002.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/visibleVariables/visiblevariables002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/visibleVariables/visiblevariables002.java
@@ -164,6 +164,7 @@ public class visiblevariables002 {
         }
 
         VirtualMachine vm = debuggee.VM();
+        ReferenceType debuggeeClass = debuggee.classByName(debuggeeName);
 
     //------------------------------------------------------  testing section
         log1("      TESTING BEGINS");
@@ -200,9 +201,6 @@ public class visiblevariables002 {
             String bpLine2 = "breakpointLineNumber2";
             //String bpLine3 = "breakpointLineNumber3";
 
-
-            List            allThreads   = null;
-            ListIterator    listIterator = null;
             List            classes      = null;
 
             BreakpointRequest breakpRequest1 = null;
@@ -220,7 +218,6 @@ public class visiblevariables002 {
 
                 log2("getting ThreadReference object");
                 try {
-                    allThreads  = vm.allThreads();
                     classes     = vm.classesByName(testedClassName);
                     testedclass = (ReferenceType) classes.get(0);
                 } catch ( Exception e) {
@@ -229,7 +226,7 @@ public class visiblevariables002 {
                     break label0;
                 }
 
-                thread2 = debuggee.threadByName(threadName);
+                thread2 = debuggee.threadByFieldNameOrThrow(debuggeeClass, "test_thread", threadName);
 
                 log2("setting up breakpoints");
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/visibleVariables/visiblevariables002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/visibleVariables/visiblevariables002a.java
@@ -58,6 +58,9 @@ public class visiblevariables002a {
     }
 
     //====================================================== test program
+
+    static Thread test_thread = null;
+
     //----------------------------------------------------   main method
 
     public static void main (String argv[]) {
@@ -93,7 +96,7 @@ public class visiblevariables002a {
     //------------------------------------------------------  section tested
 
                 case 0:
-                         Thread test_thread =
+                         test_thread =
                              JDIThreadFactory.newThread(new Threadvisiblevariables002a("testedThread"));
                          log1("       thread2 is created");
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/visibleVariables/visiblevariables002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/visibleVariables/visiblevariables002a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/forceEarlyReturn/forceEarlyReturn002/forceEarlyReturn002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/forceEarlyReturn/forceEarlyReturn002/forceEarlyReturn002.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/forceEarlyReturn/forceEarlyReturn002/forceEarlyReturn002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/forceEarlyReturn/forceEarlyReturn002/forceEarlyReturn002.java
@@ -83,6 +83,7 @@ public class forceEarlyReturn002 extends ForceEarlyReturnDebugger {
     public void doTest() {
         // initialize breakpoint
 
+        ReferenceType debuggeeClass = debuggee.classByName(debuggeeClassName());
         ReferenceType referenceType = debuggee.classByName(ClassUsingTestClass.class.getName());
 
         BreakpointRequest breakpointRequest = debuggee.makeBreakpoint(referenceType,
@@ -116,7 +117,8 @@ public class forceEarlyReturn002 extends ForceEarlyReturnDebugger {
             }
         }
 
-        ThreadReference threadReference = debuggee.threadByName(forceEarlyReturn002a.mainThreadName);
+        ThreadReference threadReference =
+            debuggee.threadByFieldNameOrThrow(debuggeeClass, "mainThread", forceEarlyReturn002a.mainThreadName);
 
         try {
             if (testClassIsLoaded) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/forceEarlyReturn/forceEarlyReturn002/forceEarlyReturn002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/forceEarlyReturn/forceEarlyReturn002/forceEarlyReturn002a.java
@@ -59,12 +59,14 @@ public class forceEarlyReturn002a extends AbstractJDIDebuggee {
     public String[] doInit(String args[]) {
         args = super.doInit(args);
 
-        Thread.currentThread().setName(mainThreadName);
+        mainThread = Thread.currentThread();
+        mainThread.setName(mainThreadName);
 
         return args;
     }
 
     public static String mainThreadName = "MainThread";
+    public static Thread mainThread = null;
 
     // call testClassMethod()
     public final static String COMMAND_CALL_OBJECT_METHOD = "callObjectMethod";

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/forceEarlyReturn/forceEarlyReturn002/forceEarlyReturn002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/forceEarlyReturn/forceEarlyReturn002/forceEarlyReturn002a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/frame/frame001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/frame/frame001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/frame/frame001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/frame/frame001.java
@@ -184,6 +184,7 @@ public class frame001 {
         }
 
         vm = debuggee.VM();
+        ReferenceType debuggeeClass = debuggee.classByName(debuggeeName);
 
     //------------------------------------------------------  testing section
         log1("      TESTING BEGINS");
@@ -221,9 +222,6 @@ public class frame001 {
             String bpLine2 = "breakpointLineNumber2";
             String bpLine3 = "breakpointLineNumber3";
 
-
-            List            allThreads   = null;
-            ListIterator    listIterator = null;
             List            classes      = null;
 
             BreakpointRequest breakpRequest1 = null;
@@ -243,7 +241,6 @@ public class frame001 {
 
                 log2("getting ThreadReference objects and setting up breakponts");
                 try {
-                    allThreads  = vm.allThreads();
                     classes     = vm.classesByName(testedClassName);
                     testedclass = (ReferenceType) classes.get(0);
                 } catch ( Exception e) {
@@ -252,19 +249,7 @@ public class frame001 {
                     break label0;
                 }
 
-                listIterator = allThreads.listIterator();
-                for (;;) {
-                    try {
-                        thread2 = (ThreadReference) listIterator.next();
-                        if (thread2.name().equals(threadName))
-                            break ;
-                    } catch ( NoSuchElementException e ) {
-                        log3("ERROR: NoSuchElementException for listIterator.next()");
-                        log3("ERROR: NO THREAD2 ?????????!!!!!!!");
-                        expresult = returnCode1;
-                        break label0;
-                    }
-                }
+                thread2 = debuggee.threadByFieldNameOrThrow(debuggeeClass, "test_thread", threadName);
 
                 log2("setting up breakpoints");
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/frame/frame001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/frame/frame001a.java
@@ -58,6 +58,9 @@ public class frame001a {
     }
 
     //====================================================== test program
+
+    static Thread test_thread = null;
+
     //----------------------------------------------------   main method
 
     public static void main (String argv[]) {
@@ -93,8 +96,8 @@ public class frame001a {
     //------------------------------------------------------  section tested
 
                 case 0:
-                         Thread test_thread =
-                                 JDIThreadFactory.newThread(new Threadframe001a("testedThread"));
+                         test_thread =
+                             JDIThreadFactory.newThread(new Threadframe001a("testedThread"));
                          log1("       thread2 is created");
 
                          label:

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/frame/frame001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/frame/frame001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/frameCount/framecount001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/frameCount/framecount001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/frameCount/framecount001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/frameCount/framecount001.java
@@ -175,6 +175,7 @@ public class framecount001 {
         }
 
         vm = debuggee.VM();
+        ReferenceType debuggeeClass = debuggee.classByName(debuggeeName);
 
     //------------------------------------------------------  testing section
         log1("      TESTING BEGINS");
@@ -212,9 +213,6 @@ public class framecount001 {
             String bpLine2 = "breakpointLineNumber2";
             String bpLine3 = "breakpointLineNumber3";
 
-
-            List            allThreads   = null;
-            ListIterator    listIterator = null;
             List            classes      = null;
 
             BreakpointRequest breakpRequest1 = null;
@@ -232,7 +230,6 @@ public class framecount001 {
 
                 log2("getting ThreadReference objects and setting up breakponts");
                 try {
-                    allThreads  = vm.allThreads();
                     classes     = vm.classesByName(testedClassName);
                     testedclass = (ReferenceType) classes.get(0);
                 } catch ( Exception e) {
@@ -241,19 +238,7 @@ public class framecount001 {
                     break label0;
                 }
 
-                listIterator = allThreads.listIterator();
-                for (;;) {
-                    try {
-                        thread2 = (ThreadReference) listIterator.next();
-                        if (thread2.name().equals(threadName))
-                            break ;
-                    } catch ( NoSuchElementException e ) {
-                        log3("ERROR: NoSuchElementException for listIterator.next()");
-                        log3("ERROR: NO THREAD2 ?????????!!!!!!!");
-                        expresult = returnCode1;
-                        break label0;
-                    }
-                }
+                thread2 = debuggee.threadByFieldNameOrThrow(debuggeeClass, "test_thread", threadName);
 
                 log2("setting up breakpoints");
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/frameCount/framecount001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/frameCount/framecount001a.java
@@ -58,6 +58,9 @@ public class framecount001a {
     }
 
     //====================================================== test program
+
+    static Thread test_thread = null;
+
     //----------------------------------------------------   main method
 
     public static void main (String argv[]) {
@@ -93,8 +96,8 @@ public class framecount001a {
     //------------------------------------------------------  section tested
 
                 case 0:
-                         Thread test_thread =
-                                 JDIThreadFactory.newThread(new Threadframecount001a("testedThread"));
+                         test_thread =
+                             JDIThreadFactory.newThread(new Threadframecount001a("testedThread"));
                          log1("       thread2 is created");
 
                          label:

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/frameCount/framecount001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/frameCount/framecount001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/frames/frames001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/frames/frames001.java
@@ -189,6 +189,7 @@ public class frames001 {
         }
 
         vm = debuggee.VM();
+        ReferenceType debuggeeClass = debuggee.classByName(debuggeeName);
 
     //------------------------------------------------------  testing section
         log1("      TESTING BEGINS");
@@ -226,9 +227,6 @@ public class frames001 {
             String bpLine2 = "breakpointLineNumber2";
             String bpLine3 = "breakpointLineNumber3";
 
-
-            List            allThreads   = null;
-            ListIterator    listIterator = null;
             List            classes      = null;
 
             BreakpointRequest breakpRequest1 = null;
@@ -248,7 +246,6 @@ public class frames001 {
 
                 log2("getting ThreadReference objects and setting up breakponts");
                 try {
-                    allThreads  = vm.allThreads();
                     classes     = vm.classesByName(testedClassName);
                     testedclass = (ReferenceType) classes.get(0);
                 } catch ( Exception e) {
@@ -257,19 +254,7 @@ public class frames001 {
                     break label0;
                 }
 
-                listIterator = allThreads.listIterator();
-                for (;;) {
-                    try {
-                        thread2 = (ThreadReference) listIterator.next();
-                        if (thread2.name().equals(threadName))
-                            break ;
-                    } catch ( NoSuchElementException e ) {
-                        log3("ERROR: NoSuchElementException for listIterator.next()");
-                        log3("ERROR: NO THREAD2 ?????????!!!!!!!");
-                        expresult = returnCode1;
-                        break label0;
-                    }
-                }
+                thread2 = debuggee.threadByFieldNameOrThrow(debuggeeClass, "test_thread", threadName);
 
                 log2("setting up breakpoints");
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/frames/frames001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/frames/frames001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/frames/frames001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/frames/frames001a.java
@@ -59,6 +59,9 @@ public class frames001a {
     }
 
     //====================================================== test program
+
+    static Threadframes001a test_thread = null;
+
     //----------------------------------------------------   main method
 
     public static void main (String argv[]) {
@@ -94,7 +97,7 @@ public class frames001a {
     //------------------------------------------------------  section tested
 
                 case 0:
-                         Threadframes001a test_thread =
+                         test_thread =
                              new Threadframes001a("testedThread");
                          log1("       thread2 is created");
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/frames/frames001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/frames/frames001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/frames_ii/frames_ii001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/frames_ii/frames_ii001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/frames_ii/frames_ii001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/frames_ii/frames_ii001.java
@@ -190,6 +190,7 @@ public class frames_ii001 {
         }
 
         vm = debuggee.VM();
+        ReferenceType debuggeeClass = debuggee.classByName(debuggeeName);
 
     //------------------------------------------------------  testing section
         log1("      TESTING BEGINS");
@@ -228,9 +229,6 @@ public class frames_ii001 {
             String bpLine2 = "breakpointLineNumber2";
             String bpLine3 = "breakpointLineNumber3";
 
-
-            List            allThreads   = null;
-            ListIterator    listIterator = null;
             List            classes      = null;
 
             BreakpointRequest breakpRequest0 = null;
@@ -250,7 +248,6 @@ public class frames_ii001 {
 
                 log2("getting ThreadReference objects and setting up breakponts");
                 try {
-                    allThreads  = vm.allThreads();
                     classes     = vm.classesByName(testedClassName);
                     testedclass = (ReferenceType) classes.get(0);
                 } catch ( Exception e) {
@@ -259,19 +256,7 @@ public class frames_ii001 {
                     break label0;
                 }
 
-                listIterator = allThreads.listIterator();
-                for (;;) {
-                    try {
-                        thread2 = (ThreadReference) listIterator.next();
-                        if (thread2.name().equals(threadName))
-                            break ;
-                    } catch ( NoSuchElementException e ) {
-                        log3("ERROR: NoSuchElementException for listIterator.next()");
-                        log3("ERROR: NO THREAD2 ?????????!!!!!!!");
-                        expresult = returnCode1;
-                        break label0;
-                    }
-                }
+                thread2 = debuggee.threadByFieldNameOrThrow(debuggeeClass, "test_thread", threadName);
 
                 log2("setting up breakpoints");
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/frames_ii/frames_ii001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/frames_ii/frames_ii001a.java
@@ -58,6 +58,9 @@ public class frames_ii001a {
     }
 
     //====================================================== test program
+
+    static Thread test_thread = null;
+
     //----------------------------------------------------   main method
 
     public static void main (String argv[]) {
@@ -93,7 +96,7 @@ public class frames_ii001a {
     //------------------------------------------------------  section tested
 
                 case 0:
-                         Thread test_thread =
+                         test_thread =
                              JDIThreadFactory.newThread(new Threadframes_ii001a("testedThread"));
                          log1("       thread2 is created");
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/frames_ii/frames_ii001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/frames_ii/frames_ii001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/frames_ii/frames_ii002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/frames_ii/frames_ii002.java
@@ -173,6 +173,7 @@ public class frames_ii002 {
         }
 
         vm = debuggee.VM();
+        ReferenceType debuggeeClass = debuggee.classByName(debuggeeName);
 
     //------------------------------------------------------  testing section
         log1("      TESTING BEGINS");
@@ -211,9 +212,6 @@ public class frames_ii002 {
             //String bpLine2 = "breakpointLineNumber2";
             //String bpLine3 = "breakpointLineNumber3";
 
-
-            List            allThreads   = null;
-            ListIterator    listIterator = null;
             List            classes      = null;
 
             BreakpointRequest breakpRequest0 = null;
@@ -234,7 +232,6 @@ public class frames_ii002 {
 
                 log2("getting ThreadReference objects");
                 try {
-                    allThreads  = vm.allThreads();
                     classes     = vm.classesByName(testedClassName);
                     testedclass = (ReferenceType) classes.get(0);
                 } catch ( Exception e) {
@@ -243,19 +240,7 @@ public class frames_ii002 {
                     break label0;
                 }
 
-                listIterator = allThreads.listIterator();
-                for (;;) {
-                    try {
-                        thread2 = (ThreadReference) listIterator.next();
-                        if (thread2.name().equals(threadName))
-                            break ;
-                    } catch ( NoSuchElementException e ) {
-                        log3("ERROR: NoSuchElementException for listIterator.next()");
-                        log3("ERROR: NO THREAD2 ?????????!!!!!!!");
-                        expresult = returnCode1;
-                        break label0;
-                    }
-                }
+                thread2 = debuggee.threadByFieldNameOrThrow(debuggeeClass, "test_thread", threadName);
 
                 log2("setting up a breakpoint");
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/frames_ii/frames_ii002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/frames_ii/frames_ii002.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/frames_ii/frames_ii002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/frames_ii/frames_ii002a.java
@@ -59,6 +59,9 @@ public class frames_ii002a {
     }
 
     //====================================================== test program
+
+    static Threadframes_ii002a test_thread = null;
+
     //----------------------------------------------------   main method
 
     public static void main (String argv[]) {
@@ -94,7 +97,7 @@ public class frames_ii002a {
     //------------------------------------------------------  section tested
 
                 case 0:
-                         Threadframes_ii002a test_thread =
+                         test_thread =
                              new Threadframes_ii002a("testedThread");
                          log1("       thread2 is created");
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/frames_ii/frames_ii002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/frames_ii/frames_ii002a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/isAtBreakpoint/isatbreakpoint001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/isAtBreakpoint/isatbreakpoint001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/isAtBreakpoint/isatbreakpoint001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/isAtBreakpoint/isatbreakpoint001.java
@@ -167,6 +167,7 @@ public class isatbreakpoint001 {
         }
 
         vm = debuggee.VM();
+        ReferenceType debuggeeClass = debuggee.classByName(debuggeeName);
 
     //------------------------------------------------------  testing section
         log1("      TESTING BEGINS");
@@ -204,9 +205,6 @@ public class isatbreakpoint001 {
             //String bpLine2 = "breakpointLineNumber2";
             //String bpLine3 = "breakpointLineNumber3";
 
-
-            List            allThreads   = null;
-            ListIterator    listIterator = null;
             List            classes      = null;
 
             BreakpointRequest breakpRequest1 = null;
@@ -220,7 +218,6 @@ public class isatbreakpoint001 {
 
                 log2("getting ThreadReference objects and setting up breakponts");
                 try {
-                    allThreads  = vm.allThreads();
                     classes     = vm.classesByName(testedClassName);
                     testedclass = (ReferenceType) classes.get(0);
                 } catch ( Exception e) {
@@ -229,19 +226,7 @@ public class isatbreakpoint001 {
                     break label0;
                 }
 
-                listIterator = allThreads.listIterator();
-                for (;;) {
-                    try {
-                        thread2 = (ThreadReference) listIterator.next();
-                        if (thread2.name().equals(threadName))
-                            break ;
-                    } catch ( NoSuchElementException e ) {
-                        log3("ERROR: NoSuchElementException for listIterator.next()");
-                        log3("ERROR: NO THREAD2 ?????????!!!!!!!");
-                        expresult = returnCode1;
-                        break label0;
-                    }
-                }
+                thread2 = debuggee.threadByFieldNameOrThrow(debuggeeClass, "test_thread", threadName);
 
                 log2("setting up breakpoints");
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/isAtBreakpoint/isatbreakpoint001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/isAtBreakpoint/isatbreakpoint001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/isAtBreakpoint/isatbreakpoint001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/isAtBreakpoint/isatbreakpoint001a.java
@@ -58,6 +58,9 @@ public class isatbreakpoint001a {
     }
 
     //====================================================== test program
+
+    static Thread test_thread = null;
+
     //----------------------------------------------------   main method
 
     public static void main (String argv[]) {
@@ -93,7 +96,7 @@ public class isatbreakpoint001a {
     //------------------------------------------------------  section tested
 
                 case 0:
-                         Thread test_thread =
+                         test_thread =
                              JDIThreadFactory.newThread(new Threadisatbreakpoint001a("testedThread"));
                          log1("       thread2 is created");
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/isSuspended/issuspended001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/isSuspended/issuspended001.java
@@ -129,7 +129,6 @@ public class issuspended001 {
 
     ReferenceType     testedclass  = null;
     ThreadReference   thread2      = null;
-    ThreadReference   mainThread   = null;
 
     static int  testExitCode = PASSED;
 
@@ -173,6 +172,7 @@ public class issuspended001 {
         }
 
         vm = debuggee.VM();
+        ReferenceType debuggeeClass = debuggee.classByName(debuggeeName);
 
     //------------------------------------------------------  testing section
         log1("      TESTING BEGINS");
@@ -212,9 +212,6 @@ public class issuspended001 {
             String bpLine2 = "breakpointLineNumber2";
             String bpLine3 = "breakpointLineNumber3";
 
-
-            List            allThreads   = null;
-            ListIterator    listIterator = null;
             List            classes      = null;
 
             BreakpointRequest breakpRequest1 = null;
@@ -229,7 +226,6 @@ public class issuspended001 {
 
                 log2("getting ThreadReference objects and setting up breakponts");
                 try {
-                    allThreads  = vm.allThreads();
                     classes     = vm.classesByName(testedClassName);
                     testedclass = (ReferenceType) classes.get(0);
                 } catch ( Exception e) {
@@ -238,34 +234,7 @@ public class issuspended001 {
                     break label0;
                 }
 
-                listIterator = allThreads.listIterator();
-                for (;;) {
-                    try {
-                        thread2 = (ThreadReference) listIterator.next();
-                        if (thread2.name().equals(threadName))
-                            break ;
-                    } catch ( NoSuchElementException e ) {
-                        log3("ERROR: NoSuchElementException for listIterator.next()");
-                        log3("ERROR: NO THREAD2 ?????????!!!!!!!");
-                        expresult = returnCode1;
-                        break label0;
-                    }
-                }
-
-                log2("getting ThreadReference objects for main thread");
-                listIterator = allThreads.listIterator();
-                for (;;) {
-                    try {
-                        mainThread = (ThreadReference) listIterator.next();
-                        if (mainThread.name().equals("main"))
-                            break ;
-                    } catch ( NoSuchElementException e ) {
-                        log3("ERROR: NoSuchElementException for listIterator.next() for 'mainThread'");
-                        log3("ERROR: NO MAIN THREAD ?????????!!!!!!!");
-                        expresult = returnCode1;
-                        break label0;
-                    }
-                }
+                thread2 = debuggee.threadByFieldNameOrThrow(debuggeeClass, "test_thread", threadName);
 
                 log2("setting up breakpoints");
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/isSuspended/issuspended001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/isSuspended/issuspended001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/isSuspended/issuspended001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/isSuspended/issuspended001a.java
@@ -58,6 +58,9 @@ public class issuspended001a {
     }
 
     //====================================================== test program
+
+    static Thread test_thread = null;
+
     //----------------------------------------------------   main method
 
     public static void main (String argv[]) {
@@ -93,8 +96,8 @@ public class issuspended001a {
     //------------------------------------------------------  section tested
 
                 case 0:
-                         Thread test_thread =
-                                 JDIThreadFactory.newThread(new Threadissuspended001a("testedThread"));
+                         test_thread =
+                             JDIThreadFactory.newThread(new Threadissuspended001a("testedThread"));
                          log1("thread2 is created");
 
                          label:

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/isSuspended/issuspended001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/isSuspended/issuspended001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/isSuspended/issuspended002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/isSuspended/issuspended002.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/isSuspended/issuspended002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/isSuspended/issuspended002.java
@@ -173,6 +173,7 @@ public class issuspended002 {
         }
 
         vm = debuggee.VM();
+        ReferenceType debuggeeClass = debuggee.classByName(debuggeeName);
 
     //------------------------------------------------------  testing section
         log1("      TESTING BEGINS");
@@ -210,9 +211,6 @@ public class issuspended002 {
             //String bpLine2 = "breakpointLineNumber2";
             //String bpLine3 = "breakpointLineNumber3";
 
-
-            List            allThreads   = null;
-            ListIterator    listIterator = null;
             List            classes      = null;
 
             BreakpointRequest breakpRequest1 = null;
@@ -227,7 +225,6 @@ public class issuspended002 {
 
                 log2("getting ThreadReference objects and setting up breakponts");
                 try {
-                    allThreads  = vm.allThreads();
                     classes     = vm.classesByName(testedClassName);
                     testedclass = (ReferenceType) classes.get(0);
                 } catch ( Exception e) {
@@ -236,34 +233,10 @@ public class issuspended002 {
                     break label0;
                 }
 
-                listIterator = allThreads.listIterator();
-                for (;;) {
-                    try {
-                        thread2 = (ThreadReference) listIterator.next();
-                        if (thread2.name().equals(threadName))
-                            break ;
-                    } catch ( NoSuchElementException e ) {
-                        log3("ERROR: NoSuchElementException for listIterator.next()");
-                        log3("ERROR: NO THREAD2 ?????????!!!!!!!");
-                        expresult = returnCode1;
-                        break label0;
-                    }
-                }
+                thread2 = debuggee.threadByFieldNameOrThrow(debuggeeClass, "test_thread", threadName);
 
                 log2("getting ThreadReference objects for main thread");
-                listIterator = allThreads.listIterator();
-                for (;;) {
-                    try {
-                        mainThread = (ThreadReference) listIterator.next();
-                        if (mainThread.name().equals("main"))
-                            break ;
-                    } catch ( NoSuchElementException e ) {
-                        log3("ERROR: NoSuchElementException for listIterator.next() for 'mainThread'");
-                        log3("ERROR: NO MAIN THREAD ?????????!!!!!!!");
-                        expresult = returnCode1;
-                        break label0;
-                    }
-                }
+                mainThread = debuggee.threadByFieldNameOrThrow(debuggeeClass, "mainThread", "main");
 
                 log2("setting up breakpoints");
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/isSuspended/issuspended002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/isSuspended/issuspended002a.java
@@ -58,9 +58,15 @@ public class issuspended002a {
     }
 
     //====================================================== test program
+
+    static Thread test_thread = null;
+    static Thread mainThread = null;
+
     //----------------------------------------------------   main method
 
     public static void main (String argv[]) {
+
+        mainThread = Thread.currentThread();
 
         for (int i = 0; i < argv.length; i++) {
             if (argv[i].equals("-vbs") || argv[i].equals("-verbose")) {
@@ -91,8 +97,8 @@ public class issuspended002a {
     //------------------------------------------------------  section tested
 
                 case 0:
-                    Thread test_thread =
-                            JDIThreadFactory.newThread(new Threadissuspended002a("testedThread"));
+                    test_thread =
+                        JDIThreadFactory.newThread(new Threadissuspended002a("testedThread"));
                     log1("       thread2 is created");
                 label:
                     synchronized (Threadissuspended002a.lockingObject) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/isSuspended/issuspended002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/isSuspended/issuspended002a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/isSuspended/issuspended003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/isSuspended/issuspended003.java
@@ -171,6 +171,7 @@ public class issuspended003 {
         }
 
         VirtualMachine vm = debuggee.VM();
+        ReferenceType debuggeeClass = debuggee.classByName(debuggeeName);
 
     //------------------------------------------------------  testing section
         log1("      TESTING BEGINS");
@@ -207,9 +208,6 @@ public class issuspended003 {
             //String bpLine2 = "breakpointLineNumber2";
             //String bpLine3 = "breakpointLineNumber3";
 
-
-            List            allThreads   = null;
-            ListIterator    listIterator = null;
             List            classes      = null;
 
             BreakpointRequest breakpRequest1 = null;
@@ -223,7 +221,6 @@ public class issuspended003 {
 
                 log2("getting ThreadReference objects and setting up breakponts");
                 try {
-                    allThreads  = vm.allThreads();
                     classes     = vm.classesByName(testedClassName);
                     testedclass = (ReferenceType) classes.get(0);
                 } catch ( Exception e) {
@@ -232,34 +229,7 @@ public class issuspended003 {
                     break label0;
                 }
 
-                listIterator = allThreads.listIterator();
-                for (;;) {
-                    try {
-                        thread2 = (ThreadReference) listIterator.next();
-                        if (thread2.name().equals(threadName))
-                            break ;
-                    } catch ( NoSuchElementException e ) {
-                        log3("ERROR: NoSuchElementException for listIterator.next()");
-                        log3("ERROR: NO THREAD2 ?????????!!!!!!!");
-                        expresult = returnCode1;
-                        break label0;
-                    }
-                }
-
-                log2("getting ThreadReference objects for main thread");
-                listIterator = allThreads.listIterator();
-                for (;;) {
-                    try {
-                        mainThread = (ThreadReference) listIterator.next();
-                        if (mainThread.name().equals("main"))
-                            break ;
-                    } catch ( NoSuchElementException e ) {
-                        log3("ERROR: NoSuchElementException for listIterator.next() for 'mainThread'");
-                        log3("ERROR: NO MAIN THREAD ?????????!!!!!!!");
-                        expresult = returnCode1;
-                        break label0;
-                    }
-                }
+                thread2 = debuggee.threadByFieldNameOrThrow(debuggeeClass, "test_thread", threadName);
 
                 log2("setting up breakpoints");
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/isSuspended/issuspended003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/isSuspended/issuspended003.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/isSuspended/issuspended003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/isSuspended/issuspended003.java
@@ -127,7 +127,6 @@ public class issuspended003 {
 
     ReferenceType     testedclass  = null;
     ThreadReference   thread2      = null;
-    ThreadReference   mainThread   = null;
 
     static int  testExitCode = PASSED;
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/isSuspended/issuspended003a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/isSuspended/issuspended003a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/isSuspended/issuspended003a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/isSuspended/issuspended003a.java
@@ -58,6 +58,9 @@ public class issuspended003a {
     }
 
     //====================================================== test program
+
+    static Thread test_thread = null;
+
     //----------------------------------------------------   main method
 
     public static void main (String argv[]) {
@@ -93,8 +96,8 @@ public class issuspended003a {
     //------------------------------------------------------  section tested
 
                 case 0:
-                         Thread test_thread =
-                                 JDIThreadFactory.newThread(new Threadissuspended003a("testedThread"));
+                         test_thread =
+                             JDIThreadFactory.newThread(new Threadissuspended003a("testedThread"));
                          log1("       thread2 is created");
 
                          label:

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/isSuspended/issuspended004.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/isSuspended/issuspended004.java
@@ -125,7 +125,6 @@ public class issuspended004 {
 
     ReferenceType     testedclass  = null;
     ThreadReference   thread2      = null;
-    ThreadReference   mainThread   = null;
 
     static int  testExitCode = PASSED;
 
@@ -169,6 +168,7 @@ public class issuspended004 {
         }
 
         VirtualMachine vm = debuggee.VM();
+        ReferenceType debuggeeClass = debuggee.classByName(debuggeeName);
 
     //------------------------------------------------------  testing section
         log1("      TESTING BEGINS");
@@ -205,9 +205,6 @@ public class issuspended004 {
             //String bpLine2 = "breakpointLineNumber2";
             //String bpLine3 = "breakpointLineNumber3";
 
-
-            List            allThreads   = null;
-            ListIterator    listIterator = null;
             List            classes      = null;
 
             BreakpointRequest breakpRequest1 = null;
@@ -222,7 +219,6 @@ public class issuspended004 {
 
                 log2("getting ThreadReference objects and setting up breakponts");
                 try {
-                    allThreads  = vm.allThreads();
                     classes     = vm.classesByName(testedClassName);
                     testedclass = (ReferenceType) classes.get(0);
                 } catch ( Exception e) {
@@ -231,34 +227,7 @@ public class issuspended004 {
                     break label0;
                 }
 
-                listIterator = allThreads.listIterator();
-                for (;;) {
-                    try {
-                        thread2 = (ThreadReference) listIterator.next();
-                        if (thread2.name().equals(threadName))
-                            break ;
-                    } catch ( NoSuchElementException e ) {
-                        log3("ERROR: NoSuchElementException for listIterator.next()");
-                        log3("ERROR: NO THREAD2 ?????????!!!!!!!");
-                        expresult = returnCode1;
-                        break label0;
-                    }
-                }
-
-                log2("getting ThreadReference objects for main thread");
-                listIterator = allThreads.listIterator();
-                for (;;) {
-                    try {
-                        mainThread = (ThreadReference) listIterator.next();
-                        if (mainThread.name().equals("main"))
-                            break ;
-                    } catch ( NoSuchElementException e ) {
-                        log3("ERROR: NoSuchElementException for listIterator.next() for 'mainThread'");
-                        log3("ERROR: NO MAIN THREAD ?????????!!!!!!!");
-                        expresult = returnCode1;
-                        break label0;
-                    }
-                }
+                thread2 = debuggee.threadByFieldNameOrThrow(debuggeeClass, "test_thread", threadName);
 
                 log2("setting up breakpoints");
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/isSuspended/issuspended004.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/isSuspended/issuspended004.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/isSuspended/issuspended004a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/isSuspended/issuspended004a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/isSuspended/issuspended004a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/isSuspended/issuspended004a.java
@@ -58,6 +58,9 @@ public class issuspended004a {
     }
 
     //====================================================== test program
+
+    static Thread test_thread = null;
+
     //----------------------------------------------------   main method
 
     public static void main (String argv[]) {
@@ -93,8 +96,8 @@ public class issuspended004a {
     //------------------------------------------------------  section tested
 
                 case 0:
-                         Thread test_thread =
-                                 JDIThreadFactory.newThread(new Threadissuspended004a("testedThread"));
+                         test_thread =
+                             JDIThreadFactory.newThread(new Threadissuspended004a("testedThread"));
                          log1("       thread2 is created");
 
                          label:

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/name/name001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/name/name001.java
@@ -162,6 +162,7 @@ public class name001 {
         }
 
         vm = debuggee.VM();
+        ReferenceType debuggeeClass = debuggee.classByName(debuggeeName);
 
     //------------------------------------------------------  testing section
         log1("      TESTING BEGINS");
@@ -199,9 +200,6 @@ public class name001 {
             //String bpLine2 = "breakpointLineNumber2";
             //String bpLine3 = "breakpointLineNumber3";
 
-
-            List            allThreads   = null;
-            ListIterator    listIterator = null;
             List            classes      = null;
 
             //BreakpointRequest breakpRequest1 = null;
@@ -213,7 +211,6 @@ public class name001 {
 
                 log2("getting ThreadReference objects and setting up breakponts");
                 try {
-                    allThreads  = vm.allThreads();
                     classes     = vm.classesByName(testedClassName);
                     testedclass = (ReferenceType) classes.get(0);
                 } catch ( Exception e) {
@@ -222,19 +219,7 @@ public class name001 {
                     break label0;
                 }
 
-                listIterator = allThreads.listIterator();
-                for (;;) {
-                    try {
-                        thread2 = (ThreadReference) listIterator.next();
-                        if (thread2.name().equals(threadName))
-                            break ;
-                    } catch ( NoSuchElementException e ) {
-                        log3("ERROR: NoSuchElementException for listIterator.next()");
-                        log3("ERROR: NO THREAD2 ?????????!!!!!!!");
-                        expresult = returnCode1;
-                        break label0;
-                    }
-                }
+                thread2 = debuggee.threadByFieldNameOrThrow(debuggeeClass, "test_thread", threadName);
             }
 
             label1: {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/name/name001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/name/name001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/name/name001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/name/name001a.java
@@ -58,6 +58,9 @@ public class name001a {
     }
 
     //====================================================== test program
+
+    static Thread test_thread = null;
+
     //----------------------------------------------------   main method
 
     public static void main (String argv[]) {
@@ -93,8 +96,8 @@ public class name001a {
     //------------------------------------------------------  section tested
 
                 case 0:
-                         Thread test_thread =
-                                 JDIThreadFactory.newThread(new Threadname001a("testedThread"));
+                         test_thread =
+                             JDIThreadFactory.newThread(new Threadname001a("testedThread"));
                          log1("       thread2 is created");
 
                          label:

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/name/name001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/name/name001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/resume/resume001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/resume/resume001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/resume/resume001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/resume/resume001.java
@@ -166,6 +166,7 @@ public class resume001 {
         }
 
         vm = debuggee.VM();
+        ReferenceType debuggeeClass = debuggee.classByName(debuggeeName);
 
     //------------------------------------------------------  testing section
         log1("      TESTING BEGINS");
@@ -203,9 +204,6 @@ public class resume001 {
             String bpLine2 = "breakpointLineNumber2";
             String bpLine3 = "breakpointLineNumber3";
 
-
-            List            allThreads   = null;
-            ListIterator    listIterator = null;
             List            classes      = null;
 
             BreakpointRequest breakpRequest1 = null;
@@ -219,7 +217,6 @@ public class resume001 {
 
                 log2("getting ThreadReference objects and setting up breakponts");
                 try {
-                    allThreads  = vm.allThreads();
                     classes     = vm.classesByName(testedClassName);
                     testedclass = (ReferenceType) classes.get(0);
                 } catch ( Exception e) {
@@ -228,19 +225,7 @@ public class resume001 {
                     break label0;
                 }
 
-                listIterator = allThreads.listIterator();
-                for (;;) {
-                    try {
-                        thread2 = (ThreadReference) listIterator.next();
-                        if (thread2.name().equals(threadName))
-                            break ;
-                    } catch ( NoSuchElementException e ) {
-                        log3("ERROR: NoSuchElementException for listIterator.next()");
-                        log3("ERROR: NO THREAD2 ?????????!!!!!!!");
-                        expresult = returnCode1;
-                        break label0;
-                    }
-                }
+                thread2 = debuggee.threadByFieldNameOrThrow(debuggeeClass, "test_thread", threadName);
 
                 log2("setting up breakpoints");
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/resume/resume001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/resume/resume001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/resume/resume001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/resume/resume001a.java
@@ -58,6 +58,9 @@ public class resume001a {
     }
 
     //====================================================== test program
+
+    static Thread test_thread = null;
+
     //----------------------------------------------------   main method
 
     public static void main (String argv[]) {
@@ -99,8 +102,8 @@ public class resume001a {
     //------------------------------------------------------  section tested
 
                 case 0:
-                         Thread test_thread =
-                                 JDIThreadFactory.newThread(new Threadresume001a("testedThread"));
+                         test_thread =
+                             JDIThreadFactory.newThread(new Threadresume001a("testedThread"));
                          log1("       thread2 is created");
 
                          label:

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/stop/stop001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/stop/stop001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/stop/stop001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/stop/stop001.java
@@ -169,6 +169,7 @@ public class stop001 {
         }
 
         vm = debuggee.VM();
+        ReferenceType debuggeeClass = debuggee.classByName(debuggeeName);
 
     //------------------------------------------------------  testing section
 
@@ -196,8 +197,6 @@ public class stop001 {
 
             String threadName = "Thread2";
 
-            List            allThreads    = null;
-            ListIterator    listIterator  = null;
             List            classes       = null;
             ReferenceType mainthreadClass = null;
             ObjectReference throwableObj  = null;
@@ -207,7 +206,6 @@ public class stop001 {
 
                 log2("getting ThreadReference objects and setting up breakponts");
                 try {
-                    allThreads  = vm.allThreads();
                     classes     = vm.classesByName(debuggeeName);
                     mainthreadClass = (ReferenceType) classes.get(0);
                 } catch ( Exception e) {
@@ -216,19 +214,7 @@ public class stop001 {
                     break label0;
                 }
 
-                listIterator = allThreads.listIterator();
-                for (;;) {
-                    try {
-                        thread2 = (ThreadReference) listIterator.next();
-                        if (thread2.name().equals(threadName))
-                            break ;
-                    } catch ( NoSuchElementException e ) {
-                        log3("ERROR: NoSuchElementException for listIterator.next()");
-                        log3("ERROR: NO THREAD2 ?????????!!!!!!!");
-                        expresult = returnCode1;
-                        break label0;
-                    }
-                }
+                thread2 = debuggee.threadByFieldNameOrThrow(debuggeeClass, "thread2", threadName);
             }
 
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/suspend/suspend001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/suspend/suspend001.java
@@ -167,6 +167,7 @@ public class suspend001 {
         }
 
         vm = debuggee.VM();
+        ReferenceType debuggeeClass = debuggee.classByName(debuggeeName);
 
     //------------------------------------------------------  testing section
 
@@ -205,9 +206,6 @@ public class suspend001 {
             String bpLine2 = "breakpointLineNumber2";
             //String bpLine3 = "breakpointLineNumber3";
 
-
-            List            allThreads   = null;
-            ListIterator    listIterator = null;
             List            classes      = null;
 
             BreakpointRequest breakpRequest1 = null;
@@ -219,7 +217,6 @@ public class suspend001 {
 
                 log2("getting ThreadReference objects and setting up breakponts");
                 try {
-                    allThreads  = vm.allThreads();
                     classes     = vm.classesByName(testedClassName);
                     testedclass = (ReferenceType) classes.get(0);
                 } catch ( Exception e) {
@@ -228,19 +225,7 @@ public class suspend001 {
                     break label0;
                 }
 
-                listIterator = allThreads.listIterator();
-                for (;;) {
-                    try {
-                        thread2 = (ThreadReference) listIterator.next();
-                        if (thread2.name().equals(threadName))
-                            break ;
-                    } catch ( NoSuchElementException e ) {
-                        log3("ERROR: NoSuchElementException for listIterator.next()");
-                        log3("ERROR: NO THREAD2 ?????????!!!!!!!");
-                        expresult = returnCode1;
-                        break label0;
-                    }
-                }
+                thread2 = debuggee.threadByFieldNameOrThrow(debuggeeClass, "test_thread", threadName);
 
                 log2("setting up breakpoints");
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/suspend/suspend001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/suspend/suspend001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/suspend/suspend001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/suspend/suspend001a.java
@@ -57,6 +57,9 @@ public class suspend001a {
     }
 
     //====================================================== test program
+
+    static Thread test_thread = null;
+
     //----------------------------------------------------   main method
 
     public static void main (String argv[]) {
@@ -92,8 +95,8 @@ public class suspend001a {
     //------------------------------------------------------  section tested
 
                 case 0:
-                         Thread test_thread =
-                                 JDIThreadFactory.newThread(new Threadsuspend001a("testedThread"));
+                         test_thread =
+                             JDIThreadFactory.newThread(new Threadsuspend001a("testedThread"));
                          log1("       thread2 is created");
 
                          label:

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/suspend/suspend001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/suspend/suspend001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/suspendCount/suspendcount001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/suspendCount/suspendcount001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/suspendCount/suspendcount001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/suspendCount/suspendcount001.java
@@ -166,6 +166,7 @@ public class suspendcount001 {
         }
 
         vm = debuggee.VM();
+        ReferenceType debuggeeClass = debuggee.classByName(debuggeeName);
 
     //------------------------------------------------------  testing section
         log1("      TESTING BEGINS");
@@ -203,9 +204,6 @@ public class suspendcount001 {
             //String bpLine2 = "breakpointLineNumber2";
             //String bpLine3 = "breakpointLineNumber3";
 
-
-            List            allThreads   = null;
-            ListIterator    listIterator = null;
             List            classes      = null;
 
             //BreakpointRequest breakpRequest1 = null;
@@ -217,7 +215,6 @@ public class suspendcount001 {
 
                 log2("getting ThreadReference objects and setting up breakponts");
                 try {
-                    allThreads  = vm.allThreads();
                     classes     = vm.classesByName(testedClassName);
                     testedclass = (ReferenceType) classes.get(0);
                 } catch ( Exception e) {
@@ -226,19 +223,7 @@ public class suspendcount001 {
                     break label0;
                 }
 
-                listIterator = allThreads.listIterator();
-                for (;;) {
-                    try {
-                        thread2 = (ThreadReference) listIterator.next();
-                        if (thread2.name().equals(threadName))
-                            break ;
-                    } catch ( NoSuchElementException e ) {
-                        log3("ERROR: NoSuchElementException for listIterator.next()");
-                        log3("ERROR: NO THREAD2 ?????????!!!!!!!");
-                        expresult = returnCode1;
-                        break label0;
-                    }
-                }
+                thread2 = debuggee.threadByFieldNameOrThrow(debuggeeClass, "test_thread", threadName);
             }
 
             label1: {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/suspendCount/suspendcount001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/suspendCount/suspendcount001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/suspendCount/suspendcount001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/suspendCount/suspendcount001a.java
@@ -58,6 +58,9 @@ public class suspendcount001a {
     }
 
     //====================================================== test program
+
+    static Thread test_thread = null;
+
     //----------------------------------------------------   main method
 
     public static void main (String argv[]) {
@@ -93,7 +96,7 @@ public class suspendcount001a {
     //------------------------------------------------------  section tested
 
                 case 0:
-                         Thread test_thread =
+                         test_thread =
                              JDIThreadFactory.newThread(new Threadsuspendcount001a("testedThread"));
                          log1("       thread2 is created");
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/canGetCurrentContendedMonitor/cangccm001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/canGetCurrentContendedMonitor/cangccm001.java
@@ -165,6 +165,7 @@ public class cangccm001 {
         }
 
         vm = debuggee.VM();
+        ReferenceType debuggeeClass = debuggee.classByName(debuggeeName);
 
     //------------------------------------------------------  testing section
         log1("      TESTING BEGINS");
@@ -189,11 +190,7 @@ public class cangccm001 {
 
             int expresult = returnCode0;
 
-            String threadName = "testedThread";
-
-            List            allThreads   = null;
             ObjectReference monitor      = null;
-            ListIterator    listIterator = null;
             List            classes      = null;
 
 
@@ -201,7 +198,6 @@ public class cangccm001 {
 
                 log2("getting ThreadReference objects");
                 try {
-                    allThreads  = vm.allThreads();
                     classes     = vm.classesByName(testedClassName);
                     testedclass = (ReferenceType) classes.get(0);
                 } catch ( Exception e) {
@@ -210,19 +206,7 @@ public class cangccm001 {
                     break label0;
                 }
 
-                listIterator = allThreads.listIterator();
-                for (;;) {
-                    try {
-                        mainThread = (ThreadReference) listIterator.next();
-                        if (mainThread.name().equals("main"))
-                            break ;
-                    } catch ( NoSuchElementException e ) {
-                        log3("ERROR: NoSuchElementException for listIterator.next()");
-                        log3("ERROR: NO 'main' thread  ?????????!!!!!!!");
-                        expresult = returnCode1;
-                        break label0;
-                    }
-                }
+                mainThread = debuggee.threadByFieldNameOrThrow(debuggeeClass, "mainThread", "main");
             }
 
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/canGetCurrentContendedMonitor/cangccm001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/canGetCurrentContendedMonitor/cangccm001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/canGetCurrentContendedMonitor/cangccm001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/canGetCurrentContendedMonitor/cangccm001a.java
@@ -60,11 +60,14 @@ public class cangccm001a {
     //====================================================== test program
 
     private static Thread thread2 = null;
+    static Thread mainThread = null;
 
     //----------------------------------------------------   main method
 
     public static void main (String argv[]) {
 
+        mainThread = Thread.currentThread();
+        
         for (int i=0; i<argv.length; i++) {
             if ( argv[i].equals("-vbs") || argv[i].equals("-verbose") ) {
                 verbMode = true;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/canGetCurrentContendedMonitor/cangccm001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/canGetCurrentContendedMonitor/cangccm001a.java
@@ -67,7 +67,7 @@ public class cangccm001a {
     public static void main (String argv[]) {
 
         mainThread = Thread.currentThread();
-        
+
         for (int i=0; i<argv.length; i++) {
             if ( argv[i].equals("-vbs") || argv[i].equals("-verbose") ) {
                 verbMode = true;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/canGetCurrentContendedMonitor/cangccm001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/canGetCurrentContendedMonitor/cangccm001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/canGetMonitorInfo/cangetmonitorinfo001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/canGetMonitorInfo/cangetmonitorinfo001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/canGetMonitorInfo/cangetmonitorinfo001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/canGetMonitorInfo/cangetmonitorinfo001.java
@@ -173,6 +173,7 @@ public class cangetmonitorinfo001 {
         }
 
         vm = debuggee.VM();
+        ReferenceType debuggeeClass = debuggee.classByName(debuggeeName);
 
     //------------------------------------------------------  testing section
         log1("      TESTING BEGINS");
@@ -199,9 +200,7 @@ public class cangetmonitorinfo001 {
 
             String threadName = "Thread2";
 
-            List            allThreads   = null;
             ObjectReference monitor      = null;
-            ListIterator    listIterator = null;
             List            classes      = null;
 
 
@@ -209,7 +208,6 @@ public class cangetmonitorinfo001 {
 
                 log2("getting ThreadReference objects");
                 try {
-                    allThreads  = vm.allThreads();
                     classes     = vm.classesByName(testedClassName);
                     testedclass = (ReferenceType) classes.get(0);
                 } catch ( Exception e) {
@@ -218,19 +216,7 @@ public class cangetmonitorinfo001 {
                     break label0;
                 }
 
-                listIterator = allThreads.listIterator();
-                for (;;) {
-                    try {
-                        thread2 = (ThreadReference) listIterator.next();
-                        if (thread2.name().equals(threadName))
-                            break ;
-                    } catch ( NoSuchElementException e ) {
-                        log3("ERROR: NoSuchElementException for listIterator.next()");
-                        log3("ERROR: NO 'main' thread  ?????????!!!!!!!");
-                        expresult = returnCode1;
-                        break label0;
-                    }
-                }
+                thread2 = debuggee.threadByFieldNameOrThrow(debuggeeClass, "thread2", threadName);
             }
 
             label1: {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/canGetMonitorInfo/cangetmonitorinfo001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/canGetMonitorInfo/cangetmonitorinfo001a.java
@@ -69,7 +69,7 @@ public class cangetmonitorinfo001a {
     //----------------------------------------------------   main method
 
     public static void main (String argv[]) {
- 
+
         for (int i=0; i<argv.length; i++) {
             if ( argv[i].equals("-vbs") || argv[i].equals("-verbose") ) {
                 verbMode = true;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/canGetMonitorInfo/cangetmonitorinfo001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/canGetMonitorInfo/cangetmonitorinfo001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/canGetMonitorInfo/cangetmonitorinfo001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/canGetMonitorInfo/cangetmonitorinfo001a.java
@@ -69,7 +69,7 @@ public class cangetmonitorinfo001a {
     //----------------------------------------------------   main method
 
     public static void main (String argv[]) {
-
+ 
         for (int i=0; i<argv.length; i++) {
             if ( argv[i].equals("-vbs") || argv[i].equals("-verbose") ) {
                 verbMode = true;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/canGetMonitorInfo/cangetmonitorinfo001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/canGetMonitorInfo/cangetmonitorinfo001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/canGetOwnedMonitorInfo/cangetinfo001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/canGetOwnedMonitorInfo/cangetinfo001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/canGetOwnedMonitorInfo/cangetinfo001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/canGetOwnedMonitorInfo/cangetinfo001.java
@@ -165,6 +165,7 @@ public class cangetinfo001 {
         }
 
         vm = debuggee.VM();
+        ReferenceType debuggeeClass = debuggee.classByName(debuggeeName);
 
     //------------------------------------------------------  testing section
         log1("      TESTING BEGINS");
@@ -191,9 +192,7 @@ public class cangetinfo001 {
 
             String threadName = "testedThread";
 
-            List            allThreads   = null;
             List            monitors     = null;
-            ListIterator    listIterator = null;
             List            classes      = null;
 
 
@@ -201,7 +200,6 @@ public class cangetinfo001 {
 
                 log2("getting ThreadReference objects and setting up breakponts");
                 try {
-                    allThreads  = vm.allThreads();
                     classes     = vm.classesByName(testedClassName);
                     testedclass = (ReferenceType) classes.get(0);
                 } catch ( Exception e) {
@@ -210,19 +208,7 @@ public class cangetinfo001 {
                     break label0;
                 }
 
-                listIterator = allThreads.listIterator();
-                for (;;) {
-                    try {
-                        mainThread = (ThreadReference) listIterator.next();
-                        if (mainThread.name().equals("main"))
-                            break ;
-                    } catch ( NoSuchElementException e ) {
-                        log3("ERROR: NoSuchElementException for listIterator.next()");
-                        log3("ERROR: NO 'main' thread  ?????????!!!!!!!");
-                        expresult = returnCode1;
-                        break label0;
-                    }
-                }
+                mainThread = debuggee.threadByFieldNameOrThrow(debuggeeClass, "mainThread", "main");
             }
 
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/canGetOwnedMonitorInfo/cangetinfo001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/canGetOwnedMonitorInfo/cangetinfo001a.java
@@ -60,10 +60,13 @@ public class cangetinfo001a {
     //====================================================== test program
 
     private static Thread thread2 = null;
+    static Thread mainThread = null;
 
     //----------------------------------------------------   main method
 
     public static void main (String argv[]) {
+
+        mainThread = Thread.currentThread();
 
         for (int i=0; i<argv.length; i++) {
             if ( argv[i].equals("-vbs") || argv[i].equals("-verbose") ) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/canGetOwnedMonitorInfo/cangetinfo001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/canGetOwnedMonitorInfo/cangetinfo001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/dispose/dispose002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/dispose/dispose002.java
@@ -165,6 +165,7 @@ public class dispose002 {
         }
 
         vm = debuggee.VM();
+        ReferenceType debuggeeClass = debuggee.classByName(debuggeeName);
 
     //------------------------------------------------------  testing section
         log1("      TESTING BEGINS");
@@ -203,8 +204,6 @@ public class dispose002 {
             //String bpLine3 = "breakpointLineNumber3";
 
 
-            List            allThreads   = null;
-            ListIterator    listIterator = null;
             List            classes      = null;
 
             BreakpointRequest breakpRequest1 = null;
@@ -216,7 +215,6 @@ public class dispose002 {
 
                 log2("getting ThreadReference object");
                 try {
-                    allThreads  = vm.allThreads();
                     classes     = vm.classesByName(testedClassName);
                     testedclass = (ReferenceType) classes.get(0);
                 } catch ( Exception e) {
@@ -225,19 +223,7 @@ public class dispose002 {
                     break label0;
                 }
 
-                listIterator = allThreads.listIterator();
-                for (;;) {
-                    try {
-                        thread2 = (ThreadReference) listIterator.next();
-                        if (thread2.name().equals(threadName))
-                            break ;
-                    } catch ( NoSuchElementException e ) {
-                        log3("ERROR: NoSuchElementException for listIterator.next()");
-                        log3("ERROR: NO THREAD2 ?????????!!!!!!!");
-                        expresult = returnCode1;
-                        break label0;
-                    }
-                }
+                thread2 = debuggee.threadByFieldNameOrThrow(debuggeeClass, "test_thread", threadName);
 
                 log2("setting up breakpoints");
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/dispose/dispose002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/dispose/dispose002.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/dispose/dispose002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/dispose/dispose002a.java
@@ -59,6 +59,9 @@ public class dispose002a {
     }
 
     //====================================================== test program
+
+    static Thread test_thread = null;
+
     //----------------------------------------------------   main method
 
     public static void main (String argv[]) {
@@ -94,8 +97,8 @@ public class dispose002a {
     //------------------------------------------------------  section tested
 
                 case 0:
-                         Thread test_thread =
-                                 JDIThreadFactory.newThread(new Threaddispose002a("testedThread"));
+                        test_thread =
+                            JDIThreadFactory.newThread(new Threaddispose002a("testedThread"));
                          log1("       thread2 is created");
 
                          label:

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/dispose/dispose002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/dispose/dispose002a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/dispose/dispose003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/dispose/dispose003.java
@@ -158,6 +158,7 @@ public class dispose003 {
         }
 
         vm = debuggee.VM();
+        ReferenceType debuggeeClass = debuggee.classByName(debuggeeName);
 
     //------------------------------------------------------  testing section
         log1("      TESTING BEGINS");
@@ -185,8 +186,6 @@ public class dispose003 {
 
             String threadName = "testedThread";
 
-            List            allThreads   = null;
-            ListIterator    listIterator = null;
             List            classes      = null;
 
 
@@ -194,7 +193,6 @@ public class dispose003 {
 
                 log2("getting ThreadReference object");
                 try {
-                    allThreads  = vm.allThreads();
                     classes     = vm.classesByName(testedClassName);
                     testedclass = (ReferenceType) classes.get(0);
                 } catch ( Exception e) {
@@ -203,19 +201,7 @@ public class dispose003 {
                     break label0;
                 }
 
-                listIterator = allThreads.listIterator();
-                for (;;) {
-                    try {
-                        thread2 = (ThreadReference) listIterator.next();
-                        if (thread2.name().equals(threadName))
-                            break ;
-                    } catch ( NoSuchElementException e ) {
-                        log3("ERROR: NoSuchElementException for listIterator.next()");
-                        log3("ERROR: NO THREAD2 ?????????!!!!!!!");
-                        expresult = returnCode1;
-                        break label0;
-                    }
-                }
+                thread2 = debuggee.threadByFieldNameOrThrow(debuggeeClass, "test_thread", threadName);
             }
 
             label1: {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/dispose/dispose003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/dispose/dispose003.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/dispose/dispose003a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/dispose/dispose003a.java
@@ -59,6 +59,9 @@ public class dispose003a {
     }
 
     //====================================================== test program
+
+    static Thread test_thread = null;
+
     //----------------------------------------------------   main method
 
     public static void main (String argv[]) {
@@ -94,8 +97,8 @@ public class dispose003a {
     //------------------------------------------------------  section tested
 
                 case 0:
-                         Thread test_thread =
-                                 JDIThreadFactory.newThread(new Threaddispose003a("testedThread"));
+                         test_thread =
+                             JDIThreadFactory.newThread(new Threaddispose003a("testedThread"));
                          log1("       thread2 is created");
 
                          label:

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/dispose/dispose003a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/dispose/dispose003a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/dispose/dispose004.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/dispose/dispose004.java
@@ -159,6 +159,7 @@ public class dispose004 {
         }
 
         vm = debuggee.VM();
+        ReferenceType debuggeeClass = debuggee.classByName(debuggeeName);
 
     //------------------------------------------------------  testing section
         log1("      TESTING BEGINS");
@@ -185,8 +186,6 @@ public class dispose004 {
 
             String threadName = "testedThread";
 
-            List            allThreads   = null;
-            ListIterator    listIterator = null;
             List            classes      = null;
 
 
@@ -194,7 +193,6 @@ public class dispose004 {
 
                 log2("getting ThreadReference object");
                 try {
-                    allThreads  = vm.allThreads();
                     classes     = vm.classesByName(testedClassName);
                     testedclass = (ReferenceType) classes.get(0);
                 } catch ( Exception e) {
@@ -203,32 +201,8 @@ public class dispose004 {
                     break label0;
                 }
 
-                listIterator = allThreads.listIterator();
-                for (;;) {
-                    try {
-                        thread2 = (ThreadReference) listIterator.next();
-                        if (thread2.name().equals(threadName))
-                            break ;
-                    } catch ( NoSuchElementException e ) {
-                        log3("ERROR: NoSuchElementException for listIterator.next()");
-                        log3("ERROR: NO THREAD2 ?????????!!!!!!!");
-                        expresult = returnCode1;
-                        break label0;
-                    }
-                }
-                listIterator = allThreads.listIterator();
-                for (;;) {
-                    try {
-                        mainThread = (ThreadReference) listIterator.next();
-                        if (mainThread.name().equals("main"))
-                            break ;
-                    } catch ( NoSuchElementException e ) {
-                        log3("ERROR: NoSuchElementException for listIterator.next()");
-                        log3("ERROR: NO MAIN THREAD ?????????!!!!!!!");
-                        expresult = returnCode1;
-                        break label0;
-                    }
-                }
+                thread2 = debuggee.threadByFieldNameOrThrow(debuggeeClass, "test_thread", threadName);
+                mainThread = debuggee.threadByFieldNameOrThrow(debuggeeClass, "mainThread", "main");
             }
 
             label1: {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/dispose/dispose004.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/dispose/dispose004.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/dispose/dispose004a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/dispose/dispose004a.java
@@ -60,9 +60,15 @@ public class dispose004a {
     }
 
     //====================================================== test program
+
+    static Thread mainThread = null;
+    static Thread test_thread = null;
+
     //----------------------------------------------------   main method
 
     public static void main (String argv[]) {
+
+        mainThread = Thread.currentThread();
 
         for (int i=0; i<argv.length; i++) {
             if ( argv[i].equals("-vbs") || argv[i].equals("-verbose") ) {
@@ -95,8 +101,8 @@ public class dispose004a {
     //------------------------------------------------------  section tested
 
                 case 0:
-                         Thread test_thread =
-                                 JDIThreadFactory.newThread(new Threaddispose004a("testedThread"));
+                         test_thread =
+                             JDIThreadFactory.newThread(new Threaddispose004a("testedThread"));
                          log1("       thread2 is created");
 
                          label:

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/dispose/dispose004a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/dispose/dispose004a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/dispose/dispose005.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/dispose/dispose005.java
@@ -206,6 +206,7 @@ public class dispose005 {
         }
 
         vm = debuggee.VM();
+        ReferenceType debuggeeClass = debuggee.classByName(debuggeeName);
 
     //------------------------------------------------------  testing section
         log1("      TESTING BEGINS");
@@ -242,9 +243,6 @@ public class dispose005 {
             //String bpLine2 = "breakpointLineNumber2";
             //String bpLine3 = "breakpointLineNumber3";
 
-
-            List            allThreads   = null;
-            ListIterator    listIterator = null;
             List            classes      = null;
 
             BreakpointRequest breakpRequest1 = null;
@@ -259,7 +257,6 @@ public class dispose005 {
 
                 log2("getting ThreadReference object");
                 try {
-                    allThreads  = vm.allThreads();
                     classes     = vm.classesByName(testedClassName);
                     testedclass = (ReferenceType) classes.get(0);
                     classType   = (ClassType) testedclass;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/dispose/dispose005.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/dispose/dispose005.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/suspend/suspend001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/suspend/suspend001.java
@@ -170,6 +170,7 @@ public class suspend001 {
         }
 
         vm = debuggee.VM();
+        ReferenceType debuggeeClass = debuggee.classByName(debuggeeName);
 
     //------------------------------------------------------  testing section
         log1("      TESTING BEGINS");
@@ -206,8 +207,6 @@ public class suspend001 {
             String bpLine1 = "breakpointLineNumber1";
             String bpLine2 = "breakpointLineNumber2";
 
-            List            allThreads   = null;
-            ListIterator    listIterator = null;
             List            classes      = null;
 
             BreakpointRequest breakpRequest1 = null;
@@ -218,7 +217,6 @@ public class suspend001 {
 
                 log2("getting ThreadReference objects and setting up breakponts");
                 try {
-                    allThreads  = vm.allThreads();
                     classes     = vm.classesByName(testedClassName);
                     testedclass = (ReferenceType) classes.get(0);
                 } catch ( Exception e) {
@@ -227,32 +225,8 @@ public class suspend001 {
                     break label0;
                 }
 
-                listIterator = allThreads.listIterator();
-                for (;;) {
-                    try {
-                        thread2 = (ThreadReference) listIterator.next();
-                        if (thread2.name().equals(threadName))
-                            break ;
-                    } catch ( NoSuchElementException e ) {
-                        log3("ERROR: NoSuchElementException for listIterator.next()");
-                        log3("ERROR: NO THREAD2 ?????????!!!!!!!");
-                        expresult = returnCode1;
-                        break label0;
-                    }
-                }
-                listIterator = allThreads.listIterator();
-                for (;;) {
-                    try {
-                        mainThread = (ThreadReference) listIterator.next();
-                        if (mainThread.name().equals("main"))
-                            break ;
-                    } catch ( NoSuchElementException e ) {
-                        log3("ERROR: NoSuchElementException for listIterator.next()");
-                        log3("ERROR: NO MAIN THREAD ?????????!!!!!!!");
-                        expresult = returnCode1;
-                        break label0;
-                    }
-                }
+                thread2 = debuggee.threadByFieldNameOrThrow(debuggeeClass, "thread2", threadName);
+                mainThread = debuggee.threadByFieldNameOrThrow(debuggeeClass, "mainThread", "main");
 
                 log2("setting up breakpoints");
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/suspend/suspend001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/suspend/suspend001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/suspend/suspend001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/suspend/suspend001a.java
@@ -57,9 +57,15 @@ public class suspend001a {
     }
 
     //====================================================== test program
+
+    static Thread mainThread = null;
+    static Thread thread2 = null;
+
     //----------------------------------------------------   main method
 
     public static void main (String argv[]) {
+
+        mainThread = Thread.currentThread();
 
         for (int i=0; i<argv.length; i++) {
             if ( argv[i].equals("-vbs") || argv[i].equals("-verbose") ) {
@@ -92,7 +98,7 @@ public class suspend001a {
     //------------------------------------------------------  section tested
 
                 case 0:
-                         Thread thread2 =
+                         thread2 =
                              JDIThreadFactory.newThread(new VMsuspend001a("Thread2"));
                          log1("       thread2 is created");
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/suspend/suspend001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/suspend/suspend001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/Debugee.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/Debugee.java
@@ -293,20 +293,27 @@ public class Debugee extends DebugeeProcess {
     public ThreadReference threadByFieldNameOrThrow(ReferenceType debuggeeClass,
                                                     String threadFieldName)
             throws JDITestRuntimeException {
+        return threadByFieldNameOrThrow(debuggeeClass, threadFieldName, threadFieldName);
+    }
+
+    public ThreadReference threadByFieldNameOrThrow(ReferenceType debuggeeClass,
+                                                    String threadFieldName,
+                                                    String threadName)
+            throws JDITestRuntimeException {
 
         Field field = debuggeeClass.fieldByName(threadFieldName);
         if (field == null) {
             throw new JDITestRuntimeException("** Thread field not found ** : "
-                                              + threadFieldName);
+                                              + debuggeeClass.name() + "." + threadFieldName);
         }
 
         ThreadReference thread = (ThreadReference)debuggeeClass.getValue(field);
         if (thread == null) {
             throw new JDITestRuntimeException("** Thread field is null ** : "
-                                              + threadFieldName);
+                                              + debuggeeClass.name() + "." + threadFieldName);
         }
 
-        if (!thread.name().equals(threadFieldName)) {
+        if (!thread.name().equals(threadName)) {
             throw new JDITestRuntimeException("** Thread names do not match ** : "
                                               + threadFieldName + " vs. " + thread.name());
         }

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/Debugee.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/Debugee.java
@@ -315,7 +315,7 @@ public class Debugee extends DebugeeProcess {
 
         if (!thread.name().equals(threadName)) {
             throw new JDITestRuntimeException("** Thread names do not match ** : "
-                                              + threadFieldName + " vs. " + thread.name());
+                                              + threadName + " vs. " + thread.name());
         }
 
         return thread;


### PR DESCRIPTION
A followup to [JDK-8355773](https://bugs.openjdk.org/browse/JDK-8355773). Convert a bunch more tests to fetch the ThreadReference from a static field in the debuggee. [JDK-8355773](https://bugs.openjdk.org/browse/JDK-8355773) focused on the easier tests that already had a static field, and the name of the field was the same as the thread name. This batch takes care of a bunch of harder to convert tests where in many cases static field has to be added and usually does not have the same name as the thread name.

Note there was a lot of template copy-n-paste code that I deleted because it was never used. For example, most tests were not using the `listIterator` variable. There were also many deletions of calls to vm.allThreads(). Some were because the need to iterate over the threads went away, but most were because the result was never used.

There are many places where the original code iterated over all the threads looking for a particular thread rather than calling on of the existing threadByName() APIs, and you'll see this being replaced by calls to the new threadByFieldNameOrThrow() API. One thing to keep in mind is that the old code tried to continue running the test if it failed to find the thread. This would lead to a timeout. threadByFieldNameOrThrow() will throw an exception which forces the test to quickly exit.

I added a 2nd threadByFieldNameOrThrow() API. The original one just took a threadFieldName argument, assuming that the name of the static field and the name of the thread were the same. The new one adds a threadName argument, allowing for the two to be different. The threadName is used just to double check that the Thread fetched from the static field has the expected name. It is not used as part of the lookup.

Tested with CI tier5, which is where all the nsk/jdi testing is done. Also ran locally on linux-x64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8356023](https://bugs.openjdk.org/browse/JDK-8356023): Some nsk/jdi tests can fetch ThreadReference from static field in the debuggee: part 2 (**Enhancement** - P4)


### Reviewers
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24979/head:pull/24979` \
`$ git checkout pull/24979`

Update a local copy of the PR: \
`$ git checkout pull/24979` \
`$ git pull https://git.openjdk.org/jdk.git pull/24979/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24979`

View PR using the GUI difftool: \
`$ git pr show -t 24979`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24979.diff">https://git.openjdk.org/jdk/pull/24979.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24979#issuecomment-2843979843)
</details>
