### PR TITLE
8356025: Provide a PrintVMInfoAtExit diagnostic switch

### DIFF
--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -703,7 +703,7 @@ const int ObjectAlignmentInBytes = 8;
           "Print the class loader data graph at exit")                      \
                                                                             \
   product(bool, PrintVMInfoAtExit, false, DIAGNOSTIC,                       \
-          "Executes the VM.info diagnostic command at exit")            \
+          "Executes the VM.info diagnostic command at exit")                \
                                                                             \
   product(bool, AllowParallelDefineClass, false,                            \
           "Allow parallel defineClass requests for class loaders "          \

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -703,7 +703,7 @@ const int ObjectAlignmentInBytes = 8;
           "Print the class loader data graph at exit")                      \
                                                                             \
   product(bool, PrintVMInfoAtExit, false, DIAGNOSTIC,                       \
-          "Executes the the VM.info diagnostic command at exit")            \
+          "Executes the VM.info diagnostic command at exit")            \
                                                                             \
   product(bool, AllowParallelDefineClass, false,                            \
           "Allow parallel defineClass requests for class loaders "          \

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -708,7 +708,7 @@ const int ObjectAlignmentInBytes = 8;
   product(bool, AllowParallelDefineClass, false,                            \
           "Allow parallel defineClass requests for class loaders "          \
           "registering as parallel capable")                                \
-	                                                                          \
+                                                                            \
   product(bool, DisablePrimordialThreadGuardPages, false, EXPERIMENTAL,     \
                "Disable the use of stack guard pages if the JVM is loaded " \
                "on the primordial process thread")                          \

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -702,10 +702,13 @@ const int ObjectAlignmentInBytes = 8;
   develop(bool, PrintClassLoaderDataGraphAtExit, false,                     \
           "Print the class loader data graph at exit")                      \
                                                                             \
+  product(bool, PrintVMInfoAtExit, false, DIAGNOSTIC,                       \
+          "Executes the the VM.info diagnostic command at exit")            \
+                                                                            \
   product(bool, AllowParallelDefineClass, false,                            \
           "Allow parallel defineClass requests for class loaders "          \
           "registering as parallel capable")                                \
-                                                                            \
+	                                                                          \
   product(bool, DisablePrimordialThreadGuardPages, false, EXPERIMENTAL,     \
                "Disable the use of stack guard pages if the JVM is loaded " \
                "on the primordial process thread")                          \

--- a/src/hotspot/share/runtime/java.cpp
+++ b/src/hotspot/share/runtime/java.cpp
@@ -332,6 +332,13 @@ void print_statistics() {
 
   print_bytecode_count();
 
+  if (PrintVMInfoAtExit) {
+    // Use an intermediate stream to prevent deadlocking on tty_lock
+    stringStream ss;
+    VMError::print_vm_info(&ss);
+    tty->print_raw(ss.base());
+  }
+
   if (PrintSystemDictionaryAtExit) {
     ResourceMark rm;
     MutexLocker mcld(ClassLoaderDataGraph_lock);

--- a/test/hotspot/jtreg/runtime/ErrorHandling/PrintVMInfoAtExitTest.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/PrintVMInfoAtExitTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, Red Hat Inc.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+
+/*
+ * @test
+ * @summary Test PrintVMInfoAtExit
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ * @requires vm.flagless
+ * @requires vm.bits == "64"
+ * @run driver PrintVMInfoAtExitTest
+ */
+
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+public class PrintVMInfoAtExitTest {
+
+  public static void main(String[] args) throws Exception {
+    ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(
+            "-Xmx64M", "-Xms64M",
+            "-XX:-CreateCoredumpOnCrash",
+            "-XX:+UnlockDiagnosticVMOptions",
+            "-XX:+PrintVMInfoAtExit",
+            "-XX:NativeMemoryTracking=summary",
+            "-XX:CompressedClassSpaceSize=256m",
+            "-version");
+
+    OutputAnalyzer output_detail = new OutputAnalyzer(pb.start());
+    output_detail.shouldContain("# JRE version:");
+    output_detail.shouldContain("--  S U M M A R Y --");
+    output_detail.shouldContain("Command Line: -Xmx64M -Xms64M -XX:-CreateCoredumpOnCrash -XX:+UnlockDiagnosticVMOptions -XX:+PrintVMInfoAtExit -XX:NativeMemoryTracking=summary -XX:CompressedClassSpaceSize=256m");
+    output_detail.shouldContain("Native Memory Tracking:");
+    output_detail.shouldContain("Java Heap (reserved=65536KB, committed=65536KB)");
+  }
+}
+
+


### PR DESCRIPTION
Provides a `PrintVMInfoAtExit` diagnostic switch that, if active, causes the JVM to print out the equivalent of `jcmd VM.info` before exiting.

The `VM.info` output contains a large range of valuable information about the JVM and the process.

The switch can be surprisingly useful, e.g. when analysing short-lived processes that are too quick to be analysed with jcmd, or analysing JVM child processes in a process tree, and so on. Going forward, it can also remove the need for some of the more specific PrintxxxAtExit flags.

It can also make writing tests easier (want to make sure switch XX enables condition YY, and YY is printed as part of VM.info? Just start the VM with PrintVMInfoAtExit and parse the output )

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8356025](https://bugs.openjdk.org/browse/JDK-8356025): Provide a PrintVMInfoAtExit diagnostic switch (**Enhancement** - P4)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)
 * [Joel Sikström](https://openjdk.org/census#jsikstro) (@jsikstro - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24980/head:pull/24980` \
`$ git checkout pull/24980`

Update a local copy of the PR: \
`$ git checkout pull/24980` \
`$ git pull https://git.openjdk.org/jdk.git pull/24980/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24980`

View PR using the GUI difftool: \
`$ git pr show -t 24980`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24980.diff">https://git.openjdk.org/jdk/pull/24980.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24980#issuecomment-2844646388)
</details>
