### PR TITLE
8356030: RISC-V: enable (part of) BasicDoubleOpTest.java

### DIFF
--- a/test/hotspot/jtreg/compiler/vectorization/runner/BasicDoubleOpTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/BasicDoubleOpTest.java
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2022, 2023, Arm Limited. All rights reserved.
  * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, Rivos Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -151,7 +152,7 @@ public class BasicDoubleOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx", "true", "rvv", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx", "true"},
         counts = {IRNode.ROUND_DOUBLE_MODE_V, ">0"})
     public double[] vectorCeil() {
         double[] res = new double[SIZE];
@@ -162,7 +163,7 @@ public class BasicDoubleOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx", "true", "rvv", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx", "true"},
         counts = {IRNode.ROUND_DOUBLE_MODE_V, ">0"})
     public double[] vectorFloor() {
         double[] res = new double[SIZE];
@@ -173,7 +174,7 @@ public class BasicDoubleOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx", "true", "rvv", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx", "true"},
         counts = {IRNode.ROUND_DOUBLE_MODE_V, ">0"})
     public double[] vectorRint() {
         double[] res = new double[SIZE];

--- a/test/hotspot/jtreg/compiler/vectorization/runner/BasicDoubleOpTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/BasicDoubleOpTest.java
@@ -36,7 +36,7 @@
  *                   -XX:+WhiteBoxAPI
  *                   compiler.vectorization.runner.BasicDoubleOpTest
  *
- * @requires (os.simpleArch == "x64") | (os.simpleArch == "aarch64")
+ * @requires (os.simpleArch == "x64") | (os.simpleArch == "aarch64") | (os.simpleArch == "riscv64")
  * @requires vm.compiler2.enabled
  */
 
@@ -118,7 +118,7 @@ public class BasicDoubleOpTest extends VectorizationTestRunner {
 
     // ---------------- Arithmetic ----------------
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.NEG_VD, ">0"})
     public double[] vectorNeg() {
         double[] res = new double[SIZE];
@@ -129,7 +129,7 @@ public class BasicDoubleOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.ABS_VD, ">0"})
     public double[] vectorAbs() {
         double[] res = new double[SIZE];
@@ -140,7 +140,7 @@ public class BasicDoubleOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx", "true", "rvv", "true"},
         counts = {IRNode.SQRT_VD, ">0"})
     public double[] vectorSqrt() {
         double[] res = new double[SIZE];
@@ -151,7 +151,7 @@ public class BasicDoubleOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx", "true", "rvv", "true"},
         counts = {IRNode.ROUND_DOUBLE_MODE_V, ">0"})
     public double[] vectorCeil() {
         double[] res = new double[SIZE];
@@ -162,7 +162,7 @@ public class BasicDoubleOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx", "true", "rvv", "true"},
         counts = {IRNode.ROUND_DOUBLE_MODE_V, ">0"})
     public double[] vectorFloor() {
         double[] res = new double[SIZE];
@@ -173,7 +173,7 @@ public class BasicDoubleOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx", "true", "rvv", "true"},
         counts = {IRNode.ROUND_DOUBLE_MODE_V, ">0"})
     public double[] vectorRint() {
         double[] res = new double[SIZE];
@@ -184,7 +184,7 @@ public class BasicDoubleOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.ADD_VD, ">0"})
     public double[] vectorAdd() {
         double[] res = new double[SIZE];
@@ -195,7 +195,7 @@ public class BasicDoubleOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.SUB_VD, ">0"})
     public double[] vectorSub() {
         double[] res = new double[SIZE];
@@ -206,7 +206,7 @@ public class BasicDoubleOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.MUL_VD, ">0"})
     public double[] vectorMul() {
         double[] res = new double[SIZE];
@@ -217,7 +217,7 @@ public class BasicDoubleOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.DIV_VD, ">0"})
     public double[] vectorDiv() {
         double[] res = new double[SIZE];
@@ -228,7 +228,7 @@ public class BasicDoubleOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx", "true", "rvv", "true"},
         counts = {IRNode.MAX_VD, ">0"})
     public double[] vectorMax() {
         double[] res = new double[SIZE];
@@ -239,7 +239,7 @@ public class BasicDoubleOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx", "true", "rvv", "true"},
         counts = {IRNode.MAX_VD, "0"})
     public double[] vectorMax_8322090() {
         double[] res = new double[SIZE];
@@ -250,7 +250,7 @@ public class BasicDoubleOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx", "true", "rvv", "true"},
         counts = {IRNode.MIN_VD, ">0"})
     public double[] vectorMin() {
         double[] res = new double[SIZE];
@@ -265,6 +265,8 @@ public class BasicDoubleOpTest extends VectorizationTestRunner {
         counts = {IRNode.FMA_VD, ">0", IRNode.VFMLA, ">0"})
     @IR(applyIfCPUFeatureAnd = {"fma", "true", "avx", "true"},
         counts = {IRNode.FMA_VD, ">0"})
+    @IR(applyIfCPUFeature = {"rvv", "true"}, applyIf = {"UseFMA", "true"},
+        counts = {IRNode.FMA_VD, ">0"})
     public double[] vectorMulAdd() {
         double[] res = new double[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -278,6 +280,8 @@ public class BasicDoubleOpTest extends VectorizationTestRunner {
         counts = {IRNode.FMA_VD, ">0", IRNode.VFMLS, ">0"})
     @IR(applyIfCPUFeatureAnd = {"fma", "true", "avx", "true"},
         counts = {IRNode.FMA_VD, ">0"})
+    @IR(applyIfCPUFeature = {"rvv", "true"}, applyIf = {"UseFMA", "true"},
+        counts = {IRNode.FMA_VD, ">0"})
     public double[] vectorMulSub1() {
         double[] res = new double[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -290,6 +294,8 @@ public class BasicDoubleOpTest extends VectorizationTestRunner {
     @IR(applyIfCPUFeature = {"asimd", "true"},
         counts = {IRNode.FMA_VD, ">0", IRNode.VFMLS, ">0"})
     @IR(applyIfCPUFeatureAnd = {"fma", "true", "avx", "true"},
+        counts = {IRNode.FMA_VD, ">0"})
+    @IR(applyIfCPUFeature = {"rvv", "true"}, applyIf = {"UseFMA", "true"},
         counts = {IRNode.FMA_VD, ">0"})
     public double[] vectorMulSub2() {
         double[] res = new double[SIZE];
@@ -306,6 +312,8 @@ public class BasicDoubleOpTest extends VectorizationTestRunner {
         counts = {IRNode.VFNMLA, ">0"})
     @IR(applyIfCPUFeatureAnd = {"fma", "true", "avx", "true"},
         counts = {IRNode.FMA_VD, ">0"})
+    @IR(applyIfCPUFeature = {"rvv", "true"}, applyIf = {"UseFMA", "true"},
+        counts = {IRNode.FMA_VD, ">0"})
     public double[] vectorNegateMulAdd1() {
         double[] res = new double[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -321,6 +329,8 @@ public class BasicDoubleOpTest extends VectorizationTestRunner {
         counts = {IRNode.VFNMLA, ">0"})
     @IR(applyIfCPUFeatureAnd = {"fma", "true", "avx", "true"},
         counts = {IRNode.FMA_VD, ">0"})
+    @IR(applyIfCPUFeature = {"rvv", "true"}, applyIf = {"UseFMA", "true"},
+        counts = {IRNode.FMA_VD, ">0"})
     public double[] vectorNegateMulAdd2() {
         double[] res = new double[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -333,6 +343,8 @@ public class BasicDoubleOpTest extends VectorizationTestRunner {
     @IR(applyIfCPUFeature = {"asimd", "true"},
         counts = {IRNode.FMA_VD, ">0"})
     @IR(applyIfCPUFeatureAnd = {"fma", "true", "avx", "true"},
+        counts = {IRNode.FMA_VD, ">0"})
+    @IR(applyIfCPUFeature = {"rvv", "true"}, applyIf = {"UseFMA", "true"},
         counts = {IRNode.FMA_VD, ">0"})
     public double[] vectorNegateMulSub() {
         double[] res = new double[SIZE];


### PR DESCRIPTION
Hi,
Can you help to review this patch?
Originally, I was going to enable all test cases on riscv in this test file. But seems there was already a try to implement RoundDoubleModeV (which is IRNode.ROUND_DOUBLE_MODE_V) in https://github.com/openjdk/jdk/pull/21164, but failed because of some performance regression.
So I'll just enable part of test cases in this pr.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8356030](https://bugs.openjdk.org/browse/JDK-8356030): RISC-V: enable (part of) BasicDoubleOpTest.java (**Enhancement** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Ludovic Henry](https://openjdk.org/census#luhenry) (@luhenry - Committer)

### Reviewers without OpenJDK IDs
 * @mhaessig (no known openjdk.org user name / role)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24983/head:pull/24983` \
`$ git checkout pull/24983`

Update a local copy of the PR: \
`$ git checkout pull/24983` \
`$ git pull https://git.openjdk.org/jdk.git pull/24983/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24983`

View PR using the GUI difftool: \
`$ git pr show -t 24983`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24983.diff">https://git.openjdk.org/jdk/pull/24983.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24983#issuecomment-2844686119)
</details>
