### PR TITLE
8356027: Print enhanced compilation timings

### DIFF
--- a/src/hotspot/share/compiler/compileTask.hpp
+++ b/src/hotspot/share/compiler/compileTask.hpp
@@ -104,8 +104,10 @@ class CompileTask : public CHeapObj<mtCompiler> {
   CompileTask*         _next, *_prev;
   bool                 _is_free;
   // Fields used for logging why the compilation was initiated:
-  jlong                _time_queued;  // time when task was enqueued
-  jlong                _time_started; // time when compilation started
+  jlong                _time_created;  // time when task was enqueued
+  jlong                _time_queued;   // time when task was enqueued
+  jlong                _time_started;  // time when compilation started
+  jlong                _time_finished; // time when compilation finished
   Method*              _hot_method;   // which method actually triggered this task
   jobject              _hot_method_holder;
   int                  _hot_count;    // information about its invocation counter
@@ -194,7 +196,9 @@ class CompileTask : public CHeapObj<mtCompiler> {
 
   void         mark_complete()                   { _is_complete = true; }
   void         mark_success()                    { _is_success = true; }
+  void         mark_queued(jlong time)           { _time_queued = time; }
   void         mark_started(jlong time)          { _time_started = time; }
+  void         mark_finished(jlong time)         { _time_finished = time; }
 
   int          comp_level()                      { return _comp_level;}
   void         set_comp_level(int comp_level)    { _comp_level = comp_level;}
@@ -226,7 +230,7 @@ private:
   static void  print_impl(outputStream* st, Method* method, int compile_id, int comp_level,
                                       bool is_osr_method = false, int osr_bci = -1, bool is_blocking = false,
                                       const char* msg = nullptr, bool short_form = false, bool cr = true,
-                                      jlong time_queued = 0, jlong time_started = 0);
+                                      jlong time_created = 0, jlong time_queued = 0, jlong time_started = 0, jlong time_finished = 0);
 
 public:
   void         print(outputStream* st = tty, const char* msg = nullptr, bool short_form = false, bool cr = true);

--- a/src/hotspot/share/runtime/timer.cpp
+++ b/src/hotspot/share/runtime/timer.cpp
@@ -37,6 +37,10 @@ double TimeHelper::counter_to_millis(jlong counter) {
   return counter_to_seconds(counter) * 1000.0;
 }
 
+double TimeHelper::counter_to_micros(jlong counter) {
+  return counter_to_seconds(counter) * 1000000.0;
+}
+
 jlong TimeHelper::millis_to_counter(jlong millis) {
   jlong freq = os::elapsed_frequency() / MILLIUNITS;
   return millis * freq;

--- a/src/hotspot/share/runtime/timer.hpp
+++ b/src/hotspot/share/runtime/timer.hpp
@@ -75,6 +75,7 @@ class TimeHelper {
  public:
   static double counter_to_seconds(jlong counter);
   static double counter_to_millis(jlong counter);
+  static double counter_to_micros(jlong counter);
   static jlong millis_to_counter(jlong millis);
   static jlong micros_to_counter(jlong micros);
 };


### PR DESCRIPTION
In Leyden, we have the extended compilation timings printouts with -XX:+PrintCompilation / UL, that are very useful to study compiler dynamics. These timings include:
 - time the task spent before queuing, shows the queue bottlenecks
 - time the task spent in the queue, shows compiler load delays
 - time the task spent actually compiling, shows the per-method compilation costs

We should consider the same kind of printout for mainline.

This would also require us to print the compilation task _after_ the compilation, not only before it. This improvement would also obviate any need for PrintCompilation2 flag, [JDK-8356028](https://bugs.openjdk.org/browse/JDK-8356028).