### PR TITLE
8356032

### DIFF
--- a/make/devkit/createAutoconfBundle.sh
+++ b/make/devkit/createAutoconfBundle.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -24,9 +24,20 @@
 # questions.
 #
 
-# Create a bundle in the current directory, containing what's needed to run
+# Create a bundle in OpenJDK build folder, containing what's needed to run
 # the 'autoconf' program by the OpenJDK build. To override TARGET_PLATFORM
 # just set the variable before running this script.
+
+# This script fetches sources from network so make sure your proxy is setup appropriately.
+
+# colored print to highlight some of the logs
+function print_log()
+{
+  Color_Cyan='\033[1;36m'   # Cyan
+  Color_Off='\033[0m'       # Reset color
+  printf "${Color_Cyan}> $1${Color_Off}\n"
+}
+
 
 # Autoconf depends on m4, so download and build that first.
 AUTOCONF_VERSION=2.69
@@ -58,11 +69,12 @@ MODULE_NAME=autoconf-$TARGET_PLATFORM-$AUTOCONF_VERSION+$PACKAGE_VERSION
 BUNDLE_NAME=$MODULE_NAME.tar.gz
 
 SCRIPT_DIR="$(cd "$(dirname $0)" > /dev/null && pwd)"
-OUTPUT_ROOT="${SCRIPT_DIR}/../../build/autoconf"
+BASEDIR="$(cd "$SCRIPT_DIR/../.."  > /dev/null && pwd)"
+OUTPUT_ROOT="$BASEDIR/build/autoconf"
 
-cd $OUTPUT_ROOT
 IMAGE_DIR=$OUTPUT_ROOT/$MODULE_NAME
 mkdir -p $IMAGE_DIR/usr
+cd $OUTPUT_ROOT
 
 # Download and build m4
 
@@ -76,7 +88,7 @@ elif test "x$TARGET_PLATFORM" = xcygwin_x86; then
   cp /usr/bin/m4 $IMAGE_DIR/usr/bin
 elif test "x$TARGET_PLATFORM" = xlinux_x64; then
   M4_VERSION=1.4.13-5
-  wget http://yum.oracle.com/repo/OracleLinux/OL6/latest/x86_64/getPackage/m4-$M4_VERSION.el6.x86_64.rpm
+  wget https://yum.oracle.com/repo/OracleLinux/OL6/latest/x86_64/getPackage/m4-$M4_VERSION.el6.x86_64.rpm
   cd $IMAGE_DIR
   rpm2cpio $OUTPUT_ROOT/m4-$M4_VERSION.el6.x86_64.rpm | cpio -d -i
 elif test "x$TARGET_PLATFORM" = xlinux_x86; then
@@ -85,27 +97,38 @@ elif test "x$TARGET_PLATFORM" = xlinux_x86; then
   cd $IMAGE_DIR
   rpm2cpio $OUTPUT_ROOT/m4-$M4_VERSION.el6.i686.rpm | cpio -d -i
 else
+  print_log "m4: download"
   wget https://ftp.gnu.org/gnu/m4/m4-$M4_VERSION.tar.gz
-  tar xzf m4-$M4_VERSION.tar.gz
+  tar -xzf m4-$M4_VERSION.tar.gz
   cd m4-$M4_VERSION
+  print_log "m4: configure"
   ./configure --prefix=$IMAGE_DIR/usr CFLAGS="-w -Wno-everything"
+  print_log "m4: make"
   make
+  print_log "m4: make install"
   make install
   cd ..
 fi
 
 # Download and build autoconf
 
+print_log "autoconf: download"
 wget https://ftp.gnu.org/gnu/autoconf/autoconf-$AUTOCONF_VERSION.tar.gz
-tar xzf autoconf-$AUTOCONF_VERSION.tar.gz
+tar -xzf autoconf-$AUTOCONF_VERSION.tar.gz
 cd autoconf-$AUTOCONF_VERSION
+print_log "autoconf: configure"
 ./configure --prefix=$IMAGE_DIR/usr M4=$IMAGE_DIR/usr/bin/m4
+print_log "autoconf: make"
 make
+print_log "autoconf: make install"
 make install
 cd ..
 
+# The resulting scripts from installation folder use absolute paths to reference other files within installation folder
+print_log "replace absolue paths from installation files with a relative ."
 perl -pi -e "s!$IMAGE_DIR/!./!" $IMAGE_DIR/usr/bin/auto* $IMAGE_DIR/usr/share/autoconf/autom4te.cfg
 
+print_log "creating $IMAGE_DIR/autoconf wrapper script"
 cat > $IMAGE_DIR/autoconf << EOF
 #!/bin/bash
 # Get an absolute path to this script
@@ -123,6 +146,9 @@ PREPEND_INCLUDE="--prepend-include \$this_script_dir/usr/share/autoconf"
 
 exec \$this_script_dir/usr/bin/autoconf \$PREPEND_INCLUDE "\$@"
 EOF
+
 chmod +x $IMAGE_DIR/autoconf
+
+print_log "archiving $IMAGE_DIR directory as $OUTPUT_ROOT/$BUNDLE_NAME"
 cd $IMAGE_DIR
 tar -cvzf $OUTPUT_ROOT/$BUNDLE_NAME *


### PR DESCRIPTION
Fixed a small issue in createAutoconfBundle.sh where we CD to `build/autoconf` folder before it's created.
As result, we end up with `m4` and `autoconf` downloadable and unpacked folders in CWD.

By a chance, I did few other improvements:
* colored logs for easier log reading
* resolved `/../../` in the path to ease log reading.
* `http://yum.oracle.com` was permanently relocated to `https`.