### PR TITLE
8356036: (fs) FileKey.hashCode and UnixFileStore.hashCode implementations can use Long.hashCode

### DIFF
--- a/src/java.base/unix/classes/sun/nio/ch/FileKey.java
+++ b/src/java.base/unix/classes/sun/nio/ch/FileKey.java
@@ -49,8 +49,7 @@ public class FileKey {
 
     @Override
     public int hashCode() {
-        return (int)(st_dev ^ (st_dev >>> 32)) +
-               (int)(st_ino ^ (st_ino >>> 32));
+        return Long.hashCode(st_dev) + Long.hashCode(st_ino);
     }
 
     @Override

--- a/src/java.base/unix/classes/sun/nio/fs/UnixFileKey.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixFileKey.java
@@ -40,8 +40,7 @@ class UnixFileKey {
 
     @Override
     public int hashCode() {
-        return (int)(st_dev ^ (st_dev >>> 32)) +
-               (int)(st_ino ^ (st_ino >>> 32));
+        return Long.hashCode(st_dev) + Long.hashCode(st_ino);
     }
 
     @Override

--- a/src/java.base/unix/classes/sun/nio/fs/UnixFileStore.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixFileStore.java
@@ -241,7 +241,7 @@ abstract class UnixFileStore
 
     @Override
     public int hashCode() {
-        return (int)(dev ^ (dev >>> 32)) ^ Arrays.hashCode(entry.dir());
+        return Long.hashCode(dev) ^ Arrays.hashCode(entry.dir());
     }
 
     @Override


### PR DESCRIPTION
Similar to #24959 and #24971, sun.nio.ch.FileKey/sun.nio.fs.UnixFileKey/sun.nio.fs.UnixFileStore in java.base can also be simplified similarly.

Replace manual bitwise operations in hashCode implementations of sun.nio.ch.FileKey/sun.nio.fs.UnixFileKey/sun.nio.fs.UnixFileStore with Long::hashCode.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 2 [Reviewers](https://openjdk.org/bylaws#reviewer))

### Issue
 * [JDK-8356036](https://bugs.openjdk.org/browse/JDK-8356036): (fs) FileKey.hashCode and UnixFileStore.hashCode implementations can use Long.hashCode (**Enhancement** - P5)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24987/head:pull/24987` \
`$ git checkout pull/24987`

Update a local copy of the PR: \
`$ git checkout pull/24987` \
`$ git pull https://git.openjdk.org/jdk.git pull/24987/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24987`

View PR using the GUI difftool: \
`$ git pr show -t 24987`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24987.diff">https://git.openjdk.org/jdk/pull/24987.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24987#issuecomment-2845087913)
</details>
