### PR TITLE
8356044: Use Double::hashCode and Long::hashCode in java.vm.ci.meta

### DIFF
--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/meta/AbstractProfiledItem.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/meta/AbstractProfiledItem.java
@@ -63,13 +63,8 @@ public abstract class AbstractProfiledItem<T> implements Comparable<AbstractProf
 
     @Override
     public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        long temp;
-        temp = Double.doubleToLongBits(probability);
-        result = prime * result + (int) (temp ^ (temp >>> 32));
-        result = prime * result + item.hashCode();
-        return result;
+        int result = 31 + Double.hashCode(probability);
+        return 31 * result + item.hashCode();
     }
 
     @Override

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/meta/PrimitiveConstant.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/meta/PrimitiveConstant.java
@@ -160,7 +160,7 @@ public class PrimitiveConstant implements JavaConstant, SerializableConstant {
 
     @Override
     public int hashCode() {
-        return (int) (primitive ^ (primitive >>> 32)) * (getJavaKind().ordinal() + 31);
+        return Long.hashCode(primitive) * (getJavaKind().ordinal() + 31);
     }
 
     @Override


### PR DESCRIPTION
Similar to #24959 and #24971 and #24987, AbstractProfiledItem/PrimitiveConstant in java.vm.ci.meta can also be simplified similarly.

Replace manual bitwise operations in hashCode implementations of java.vm.ci.meta.AbstractProfiledItem/java.vm.ci.meta.PrimitiveConstant with Long::hashCode/Double.hashCode.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8356044](https://bugs.openjdk.org/browse/JDK-8356044): Use Double::hashCode and Long::hashCode in java.vm.ci.meta (**Enhancement** - P5)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24988/head:pull/24988` \
`$ git checkout pull/24988`

Update a local copy of the PR: \
`$ git checkout pull/24988` \
`$ git pull https://git.openjdk.org/jdk.git pull/24988/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24988`

View PR using the GUI difftool: \
`$ git pr show -t 24988`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24988.diff">https://git.openjdk.org/jdk/pull/24988.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24988#issuecomment-2845329498)
</details>
