### PR TITLE
8356605: JRSUIControl.hashCode and JRSUIState.hashCode can use Long.hashCode

### DIFF
--- a/src/java.desktop/macosx/classes/apple/laf/JRSUIControl.java
+++ b/src/java.desktop/macosx/classes/apple/laf/JRSUIControl.java
@@ -324,7 +324,7 @@ public final class JRSUIControl {
 
     @Override
     public int hashCode() {
-        int bits = (int)(currentEncodedProperties ^ (currentEncodedProperties >>> 32));
+        int bits = Long.hashCode(currentEncodedProperties);
         bits ^= nativeMap.hashCode();
         bits ^= changes.hashCode();
         return bits;

--- a/src/java.desktop/macosx/classes/apple/laf/JRSUIState.java
+++ b/src/java.desktop/macosx/classes/apple/laf/JRSUIState.java
@@ -90,7 +90,7 @@ public class JRSUIState {
 
     @Override
     public int hashCode() {
-        return (int)(encodedState ^ (encodedState >>> 32)) ^ getClass().hashCode();
+        return Long.hashCode(encodedState) ^ getClass().hashCode();
     }
 
     public static class AnimationFrameState extends JRSUIState {
@@ -183,8 +183,7 @@ public class JRSUIState {
 
         @Override
         public int hashCode() {
-            final long bits = Double.doubleToRawLongBits(value);
-            return super.hashCode() ^ (int)bits ^ (int)(bits >>> 32);
+            return super.hashCode() ^ Double.hashCode(value);
         }
     }
 
@@ -258,7 +257,7 @@ public class JRSUIState {
         @Override
         public int hashCode() {
             final long bits = Double.doubleToRawLongBits(thumbProportion) ^ Double.doubleToRawLongBits(thumbStart);
-            return super.hashCode() ^ (int)bits ^ (int)(bits >>> 32);
+            return super.hashCode() ^ Long.hashCode(bits);
         }
     }
 }


### PR DESCRIPTION
Similar to #24959 and #24971 and #24987, apple.laf.JRSUIControl and apple.laf.JRSUIState in java.desktop can also be simplified similarly.

Replace manual bitwise operations in hashCode implementations of JRSUIControl/JRSUIState with Long::hashCode.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8356605](https://bugs.openjdk.org/browse/JDK-8356605): JRSUIControl.hashCode and JRSUIState.hashCode can use Long.hashCode (**Enhancement** - P5)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24989/head:pull/24989` \
`$ git checkout pull/24989`

Update a local copy of the PR: \
`$ git checkout pull/24989` \
`$ git pull https://git.openjdk.org/jdk.git pull/24989/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24989`

View PR using the GUI difftool: \
`$ git pr show -t 24989`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24989.diff">https://git.openjdk.org/jdk/pull/24989.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24989#issuecomment-2865620793)
</details>
