### PR TITLE
8354347: Increase the default padding size for aarch64 in JDK code.

### DIFF
--- a/src/hotspot/cpu/aarch64/globalDefinitions_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/globalDefinitions_aarch64.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2014, 2015, Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/src/hotspot/cpu/aarch64/globalDefinitions_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/globalDefinitions_aarch64.hpp
@@ -46,7 +46,7 @@ const bool CCallingConventionRequiresIntsAsLongs = false;
 #define DEFAULT_CACHE_LINE_SIZE 64
 
 // The default padding size for data structures to avoid false sharing.
-#define DEFAULT_PADDING_SIZE DEFAULT_CACHE_LINE_SIZE
+#define DEFAULT_PADDING_SIZE (2*DEFAULT_CACHE_LINE_SIZE)
 
 // According to the ARMv8 ARM, "Concurrent modification and execution
 // of instructions can lead to the resulting instruction performing


### PR DESCRIPTION
Increase the default padding for C++ fields to avoid false sharing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found trailing period in issue title for `8354347: Increase the default padding size for aarch64 in JDK code.`

### Issue
 * [JDK-8354347](https://bugs.openjdk.org/browse/JDK-8354347): Increase the default padding size for aarch64 in JDK code. (**Enhancement** - P4)


### Reviewers
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)
 * [Eric Caspole](https://openjdk.org/census#ecaspole) (@ericcaspole - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24994/head:pull/24994` \
`$ git checkout pull/24994`

Update a local copy of the PR: \
`$ git checkout pull/24994` \
`$ git pull https://git.openjdk.org/jdk.git pull/24994/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24994`

View PR using the GUI difftool: \
`$ git pr show -t 24994`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24994.diff">https://git.openjdk.org/jdk/pull/24994.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24994#issuecomment-2846080523)
</details>
