### PR TITLE
8355578: [java.net] Use @requires tag instead of exiting based on "os.name" property value

### DIFF
--- a/test/jdk/java/net/Inet4Address/PingThis.java
+++ b/test/jdk/java/net/Inet4Address/PingThis.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,27 +27,20 @@
 
 /* @test
  * @bug 7163874 8133015
+ * @summary InetAddress.isReachable is returning false for InetAdress 0.0.0.0 and ::0
+ * @requires os.family != "windows"
  * @library /test/lib
- * @summary InetAddress.isReachable is returning false
- *          for InetAdress 0.0.0.0 and ::0
  * @run main PingThis
  * @run main/othervm -Djava.net.preferIPv4Stack=true PingThis
  */
 
-import java.net.Inet6Address;
 import java.net.InetAddress;
-import java.net.NetworkInterface;
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
 import jdk.test.lib.net.IPSupport;
 
 public class PingThis {
     public static void main(String args[]) throws Exception {
-        if (System.getProperty("os.name").startsWith("Windows")) {
-            return;
-        }
         IPSupport.throwSkippedExceptionIfNonOperational();
 
         List<String> addrs = new ArrayList<String>();

--- a/test/jdk/java/net/MulticastSocket/NoLoopbackPackets.java
+++ b/test/jdk/java/net/MulticastSocket/NoLoopbackPackets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,8 +24,9 @@
 /*
  * @test
  * @bug 4742177
- * @library /test/lib
  * @summary Re-test IPv6 (and specifically MulticastSocket) with latest Linux & USAGI code
+ * @requires os.family != "windows"
+ * @library /test/lib
  */
 import java.util.*;
 import java.net.*;
@@ -33,20 +34,10 @@ import jdk.test.lib.NetworkConfiguration;
 import jdk.test.lib.net.IPSupport;
 
 public class NoLoopbackPackets {
-    private static String osname;
-
-    static boolean isWindows() {
-        if (osname == null)
-            osname = System.getProperty("os.name");
-        return osname.contains("Windows");
-    }
 
     private static final String MESSAGE = "hello world (" + System.nanoTime() + ")";
+
     public static void main(String[] args) throws Exception {
-        if (isWindows()) {
-            System.out.println("The test only run on non-Windows OS. Bye.");
-            return;
-        }
 
         MulticastSocket msock = null;
         List<SocketAddress> failedGroups = new ArrayList<SocketAddress>();

--- a/test/jdk/java/net/MulticastSocket/PromiscuousIPv6.java
+++ b/test/jdk/java/net/MulticastSocket/PromiscuousIPv6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug 8215294
- * @requires os.family == "linux"
+ * @requires os.family == "linux" & !(os.version ~= "3\\.10\\.0.*")
  * @library /test/lib
  * @build jdk.test.lib.NetworkConfiguration
  *        PromiscuousIPv6
@@ -148,18 +148,6 @@ public class PromiscuousIPv6 {
     }
 
     public static void main(String args[]) throws IOException {
-        String os = System.getProperty("os.name");
-
-        if (!os.equals("Linux")) {
-            throw new SkippedException("This test should be run only on Linux");
-        } else {
-            String osVersion = System.getProperty("os.version");
-            String prefix = "3.10.0";
-            if (osVersion.startsWith(prefix)) {
-                throw new SkippedException(
-                        String.format("The behavior under test is known NOT to work on '%s' kernels", prefix));
-            }
-        }
 
         NetworkConfiguration.printSystemConfiguration(System.out);
         List<NetworkInterface> nifs = NetworkConfiguration.probe()

--- a/test/jdk/java/net/MulticastSocket/PromiscuousIPv6.java
+++ b/test/jdk/java/net/MulticastSocket/PromiscuousIPv6.java
@@ -25,6 +25,8 @@
  * @test
  * @bug 8215294
  * @requires os.family == "linux" & !(os.version ~= "3\\.10\\.0.*")
+ * @comment This test should only be run on Linux.
+ *          The behavior under test is known NOT to work on Linux 3.10.0* kernels.
  * @library /test/lib
  * @build jdk.test.lib.NetworkConfiguration
  *        PromiscuousIPv6

--- a/test/jdk/java/net/MulticastSocket/SetOutgoingIf.java
+++ b/test/jdk/java/net/MulticastSocket/SetOutgoingIf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,9 +24,10 @@
 /*
  * @test
  * @bug 4742177 8241786
+ * @summary Re-test IPv6 (and specifically MulticastSocket) with latest Linux & USAGI code
+ * @requires os.family != "windows"
  * @library /test/lib
  * @run main/othervm SetOutgoingIf
- * @summary Re-test IPv6 (and specifically MulticastSocket) with latest Linux & USAGI code
  */
 import java.io.IOException;
 import java.net.*;
@@ -36,7 +37,7 @@ import jdk.test.lib.NetworkConfiguration;
 
 
 public class SetOutgoingIf implements AutoCloseable {
-    private static String osname;
+
     private final MulticastSocket SOCKET;
     private final int PORT;
     private final Map<NetIf, MulticastSender> sendersMap = new ConcurrentHashMap<>();
@@ -47,12 +48,6 @@ public class SetOutgoingIf implements AutoCloseable {
         } catch (IOException io) {
             throw new ExceptionInInitializerError(io);
         }
-    }
-
-    static boolean isWindows() {
-        if (osname == null)
-            osname = System.getProperty("os.name");
-        return osname.contains("Windows");
     }
 
     static boolean isMacOS() {
@@ -82,10 +77,6 @@ public class SetOutgoingIf implements AutoCloseable {
     }
 
     public void run() throws Exception {
-        if (isWindows()) {
-            System.out.println("The test only run on non-Windows OS. Bye.");
-            return;
-        }
 
         if (!hasIPv6()) {
             System.out.println("No IPv6 available. Bye.");

--- a/test/jdk/java/net/ServerSocket/AnotherSelectFdsLimit.java
+++ b/test/jdk/java/net/ServerSocket/AnotherSelectFdsLimit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
  * @test
  * @bug 8035897
  * @summary FD_SETSIZE should be set on macosx
+ * @requires os.family == "mac"
  * @run main/othervm AnotherSelectFdsLimit 1023
  * @run main/othervm AnotherSelectFdsLimit 1024
  * @run main/othervm AnotherSelectFdsLimit 1025
@@ -41,10 +42,6 @@ public class AnotherSelectFdsLimit {
     static final int DEFAULT_FDS_TO_USE = 1600;
 
     public static void main(String [] args) throws Exception {
-        if (!System.getProperty("os.name").contains("OS X")) {
-            System.out.println("Test only run on MAC. Exiting.");
-            return;
-        }
 
         int fdsToUse = DEFAULT_FDS_TO_USE;
         if (args.length == 1)

--- a/test/jdk/java/net/ServerSocket/SelectFdsLimit.java
+++ b/test/jdk/java/net/ServerSocket/SelectFdsLimit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,7 @@
  * @summary The total number of file descriptors is limited to
  * 1024(FDSET_SIZE) on MacOSX (the size of fd array passed to select()
  * call in java.net classes is limited to this value).
+ * @requires os.family == "mac"
  * @run main/othervm SelectFdsLimit
  * @author aleksej.efimov@oracle.com
  */
@@ -35,7 +36,6 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.ServerSocket;
 import java.net.SocketTimeoutException;
 
@@ -71,12 +71,6 @@ public class SelectFdsLimit {
     }
 
     public static void main(String [] args) throws IOException, FileNotFoundException {
-
-        //The bug 8021820 is a Mac specific and because of that test will pass on all
-        //other platforms
-        if (!System.getProperty("os.name").contains("OS X")) {
-           return;
-        }
 
         //Create test directory with test files
         prepareTestEnv();


### PR DESCRIPTION
Replaces `os.name` checks in tests with `@requires`. This prevents these tests from being run, and superficial results being generated, on unnecessary platforms.

Note that `os.name` checks are replaced with `os.family` instead.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8355578](https://bugs.openjdk.org/browse/JDK-8355578): [java.net] Use @<!---->requires tag instead of exiting based on "os.name" property value (**Sub-task** - P4) ⚠️ Issue is already resolved. Consider making this a "backport pull request" by setting the PR title to `Backport <hash>` with the hash of the original commit. See [Backports](https://wiki.openjdk.org/display/SKARA/Backports).


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24997/head:pull/24997` \
`$ git checkout pull/24997`

Update a local copy of the PR: \
`$ git checkout pull/24997` \
`$ git pull https://git.openjdk.org/jdk.git pull/24997/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24997`

View PR using the GUI difftool: \
`$ git pr show -t 24997`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24997.diff">https://git.openjdk.org/jdk/pull/24997.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24997#issuecomment-2846664405)
</details>
