### PR TITLE
8354969: Add strdup function for ResourceArea

### DIFF
--- a/src/hotspot/share/memory/arena.hpp
+++ b/src/hotspot/share/memory/arena.hpp
@@ -209,6 +209,13 @@ protected:
   MemTag get_mem_tag() const { return _mem_tag; }
   Tag get_tag() const { return _tag; }
 
+  const char* strdup(const char* s) {
+    const size_t sz = strlen(s) + 1;
+    char* ptr = (char*)Amalloc(sz);
+    memcpy(ptr, s, sz);
+    return ptr;
+  }
+
 private:
   // Reset this Arena to empty, access will trigger grow if necessary
   void reset(void) {

--- a/test/hotspot/gtest/memory/test_arena.cpp
+++ b/test/hotspot/gtest/memory/test_arena.cpp
@@ -381,3 +381,13 @@ TEST_VM(Arena, different_chunk_sizes) {
     Arena ar7(mtTest, Arena::Tag::tag_other, random_arena_chunk_size());
   }
 }
+
+TEST_VM(Arena, string_duplicate)
+{
+  char testString[] = "this is a test string";
+  Arena ar(mtTest);
+  auto copy = ar.strdup(&testString[0]);
+  int result = strcmp(testString, copy);
+  ASSERT_TRUE(0 == result);
+  ASSERT_NE(copy, &testString[0]);
+}


### PR DESCRIPTION
Added a strdup() method, as requested by the bug reporter. The method is added to Arena, but also available in ResourceArea, as requested. A test for the method is provided. 

Testing: tiers 1-3 on multiple platforms. 