### PR TITLE
8355674: C2: Partial Peeling should not introduce Phi nodes above OpaqueInitializedAssertionPredicate nodes

### DIFF
--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -3391,7 +3391,7 @@ void PhaseIdealLoop::clone_for_special_use_inside_loop( IdealLoopTree *loop, Nod
   for (DUIterator_Fast jmax, j = n->fast_outs(jmax); j < jmax; j++) {
     Node* use = n->fast_out(j);
     if ( not_peel.test(use->_idx) &&
-         (use->is_If() || use->is_CMove() || use->is_Bool()) &&
+         (use->is_If() || use->is_CMove() || use->is_Bool() || use->is_OpaqueInitializedAssertionPredicate()) &&
          use->in(1) == n)  {
       worklist.push(use);
     }

--- a/test/hotspot/jtreg/compiler/predicates/assertion/TestPhiAboveOpaqueInitializedAssertionPredicate.java
+++ b/test/hotspot/jtreg/compiler/predicates/assertion/TestPhiAboveOpaqueInitializedAssertionPredicate.java
@@ -27,13 +27,16 @@
  * @summary Check that we do not introduce a Phi above a OpaqueInitializedAssertionPredicateNode during Partial Peeling.
  * @run main/othervm -Xcomp -XX:CompileOnly=compiler.predicates.assertion.TestPhiAboveOpaqueInitializedAssertionPredicate::test
  *                   compiler.predicates.assertion.TestPhiAboveOpaqueInitializedAssertionPredicate
+ * @run main         compiler.predicates.assertion.TestPhiAboveOpaqueInitializedAssertionPredicate
  */
 
 package compiler.predicates.assertion;
 
 public class TestPhiAboveOpaqueInitializedAssertionPredicate {
-     public static void main(String[] o) {
-        test();
+    public static void main(String[] o) {
+        for (int i = 0; i < 1000; i++) {
+            test();
+        }
     }
 
     static void test() {

--- a/test/hotspot/jtreg/compiler/predicates/assertion/TestPhiAboveOpaqueInitializedAssertionPredicate.java
+++ b/test/hotspot/jtreg/compiler/predicates/assertion/TestPhiAboveOpaqueInitializedAssertionPredicate.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8355674
+ * @summary Check that we do not introduce a Phi above a OpaqueInitializedAssertionPredicateNode during Partial Peeling.
+ * @run main/othervm -Xcomp -XX:CompileOnly=compiler.predicates.assertion.TestPhiAboveOpaqueInitializedAssertionPredicate::test
+ *                   compiler.predicates.assertion.TestPhiAboveOpaqueInitializedAssertionPredicate
+ */
+
+package compiler.predicates.assertion;
+
+public class TestPhiAboveOpaqueInitializedAssertionPredicate {
+     public static void main(String[] o) {
+        test();
+    }
+
+    static void test() {
+        int e;
+        int h = 8;
+        int[][] iArr = new int[100][100];
+        for (float j = 8; j < 100 ; ++j) {
+            for (int f = 5; f > 1; f -= 2) {
+                for (int g = 1; 3 > g; ++g) {
+                    try {
+                        e = iArr[(int) j][g] / h;
+                    } catch (ArithmeticException k) {
+                    }
+                    h += g;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
In the test case, we have two Initialized Assertion Predicate that share the same `Bool` which is perfectly fine:

![image](https://github.com/user-attachments/assets/a7a1673f-b5df-49e8-8a22-c35aa0ee1693)

These Initialized Assertion Predicates were created for loops that have been folded away. They then end up in a new inner most loop which is partial peeled. Partial Peeling finds that we need to do the cut between `580 IfTrue` and `581 If`. This means, that the Initialized Assertion Predicate `569 RangeCheck` with its `535 OpaqueInitializedAssertionPredicate` is in the peel set and the second Initialized Assertion Predicate `504 RangeCheck` with its `503 OpaqueInitializedAssertionPredicate` is in the not peel set. As a result of that, we are introducing a `Phi` node between an `OpaqueInitializedAssertionPredicate` and a `Bool` node:

![image](https://github.com/user-attachments/assets/3bbc2b88-300a-4c40-99ac-056cbeab822a)

We eventually remove the `OpaqueInitializedAssertionPredicate` and are left with the following graph shape

![image](https://github.com/user-attachments/assets/e839366f-119b-4411-b422-84639c68aa80)

which cannot be handled by the backend.

The fix I propose is to prohibit Partial Peeling from inserting such a `Phi` node by updating `clone_for_special_use_inside_loop()` which takes care of not inserting phis for an `If/Bool`. We need to also special case `OpaqueInitializedAssertionPredicate`.

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8355674](https://bugs.openjdk.org/browse/JDK-8355674): C2: Partial Peeling should not introduce Phi nodes above OpaqueInitializedAssertionPredicate nodes (**Bug** - P3)


### Reviewers
 * [Emanuel Peter](https://openjdk.org/census#epeter) (@eme64 - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25006/head:pull/25006` \
`$ git checkout pull/25006`

Update a local copy of the PR: \
`$ git checkout pull/25006` \
`$ git pull https://git.openjdk.org/jdk.git pull/25006/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25006`

View PR using the GUI difftool: \
`$ git pr show -t 25006`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25006.diff">https://git.openjdk.org/jdk/pull/25006.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25006#issuecomment-2847258265)
</details>
