### PR TITLE
8356095: AArch64: Obsolete -XX:+NearCPool option

### DIFF
--- a/src/hotspot/cpu/aarch64/globals_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/globals_aarch64.hpp
@@ -83,8 +83,6 @@ define_pd_global(intx, InlineSmallCode,          1000);
                    range,                                               \
                    constraint)                                          \
                                                                         \
-  product(bool, NearCpool, true,                                        \
-         "constant pool is close to instructions")                      \
   product(bool, UseCRC32, false,                                        \
           "Use CRC32 instructions for CRC32 computation")               \
   product(bool, UseCryptoPmullForCRC32, false,                          \

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -535,6 +535,9 @@ static SpecialFlag const special_jvm_flags[] = {
   { "MetaspaceReclaimPolicy",       JDK_Version::undefined(), JDK_Version::jdk(21), JDK_Version::undefined() },
   { "ZGenerational",                JDK_Version::jdk(23), JDK_Version::jdk(24), JDK_Version::undefined() },
   { "ZMarkStackSpaceLimit",         JDK_Version::undefined(), JDK_Version::jdk(25), JDK_Version::undefined() },
+#if defined(AARCH64)
+  { "NearCpool",                    JDK_Version::undefined(), JDK_Version::jdk(25), JDK_Version::undefined() },
+#endif
 
 #ifdef ASSERT
   { "DummyObsoleteTestFlag",        JDK_Version::undefined(), JDK_Version::jdk(18), JDK_Version::undefined() },


### PR DESCRIPTION
The NearCPool option has no effect since #24883. This patch marks NearCpool as obsolete in arguments.cpp, and removes its declaration from globals_aarch64.hpp.

JBS: https://bugs.openjdk.org/browse/JDK-8356095
CSR: https://bugs.openjdk.org/browse/JDK-8356097

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8356097](https://bugs.openjdk.org/browse/JDK-8356097) to be approved

### Issues
 * [JDK-8356095](https://bugs.openjdk.org/browse/JDK-8356095): AArch64: Obsolete -XX:+NearCPool option (**Enhancement** - P4)
 * [JDK-8356097](https://bugs.openjdk.org/browse/JDK-8356097): AArch64: Obsolete -XX:+NearCPool option (**CSR**)


### Reviewers
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25010/head:pull/25010` \
`$ git checkout pull/25010`

Update a local copy of the PR: \
`$ git checkout pull/25010` \
`$ git pull https://git.openjdk.org/jdk.git pull/25010/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25010`

View PR using the GUI difftool: \
`$ git pr show -t 25010`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25010.diff">https://git.openjdk.org/jdk/pull/25010.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25010#issuecomment-2877739117)
</details>
