### PR TITLE
8355353: File Leak in os::read_image_release_file of os.cpp:1552

### DIFF
--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -1551,6 +1551,7 @@ void os::read_image_release_file() {
   fseek(file, 0, SEEK_END);
   long sz = ftell(file);
   if (sz == -1) {
+    fclose(file);
     return;
   }
   fseek(file, 0, SEEK_SET);


### PR DESCRIPTION
Simple change to close an opened file. 
Tested with tier1-4.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8355353](https://bugs.openjdk.org/browse/JDK-8355353): File Leak in os::read_image_release_file of os.cpp:1552 (**Bug** - P3)


### Reviewers
 * [Zhengyu Gu](https://openjdk.org/census#zgu) (@zhengyu123 - **Reviewer**)
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@jdksjolen - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25012/head:pull/25012` \
`$ git checkout pull/25012`

Update a local copy of the PR: \
`$ git checkout pull/25012` \
`$ git pull https://git.openjdk.org/jdk.git pull/25012/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25012`

View PR using the GUI difftool: \
`$ git pr show -t 25012`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25012.diff">https://git.openjdk.org/jdk/pull/25012.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25012#issuecomment-2847882175)
</details>
