### PR TITLE
8355962: RISCV64 cross build fails after 8354996

### DIFF
--- a/make/GenerateLinkOptData.gmk
+++ b/make/GenerateLinkOptData.gmk
@@ -66,7 +66,7 @@ endif
 #   default classlist is minimal, let's filter out the '@cp' lines until we can
 #   find a proper solution.
 CLASSLIST_FILE_VM_OPTS = \
-    -Duser.language=en -Duser.country=US --enable-native-access=ALL-UNNAMED
+    -Duser.language=en -Duser.country=US
 
 # Save the stderr output of the command and print it along with stdout in case
 # something goes wrong.

--- a/make/jdk/src/classes/build/tools/classlist/HelloClasslist.java
+++ b/make/jdk/src/classes/build/tools/classlist/HelloClasslist.java
@@ -31,8 +31,6 @@
  */
 package build.tools.classlist;
 
-import java.lang.foreign.FunctionDescriptor;
-import java.lang.foreign.Linker;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
@@ -174,10 +172,6 @@ public class HelloClasslist {
         // an inconsistency in the classlist between builds (see JDK-8295951).
         // To avoid the problem, load the class explicitly.
         Class<?> striped64Class = Class.forName("java.util.concurrent.atomic.Striped64$Cell");
-
-        // Initialize FFM linkers
-        var signature = FunctionDescriptor.ofVoid();
-        Linker.nativeLinker().downcallHandle(signature);
     }
 
     public HelloClasslist() {}


### PR DESCRIPTION
Roll back the HelloClasslist downcall generation that caused cross build failures for riscv64 and aarch64 from x86-64.

Testing: riscv64 cross build

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8355962](https://bugs.openjdk.org/browse/JDK-8355962): RISCV64 cross build fails after 8354996 (**Bug** - P3)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Man Cao](https://openjdk.org/census#manc) (@caoman - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25013/head:pull/25013` \
`$ git checkout pull/25013`

Update a local copy of the PR: \
`$ git checkout pull/25013` \
`$ git pull https://git.openjdk.org/jdk.git pull/25013/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25013`

View PR using the GUI difftool: \
`$ git pr show -t 25013`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25013.diff">https://git.openjdk.org/jdk/pull/25013.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25013#issuecomment-2847930515)
</details>
