### PR TITLE
8356108: Update SourceVersion.RELEASE_25 description for JEPs 511 and 512

### DIFF
--- a/src/java.compiler/share/classes/javax/lang/model/SourceVersion.java
+++ b/src/java.compiler/share/classes/javax/lang/model/SourceVersion.java
@@ -81,6 +81,8 @@ public enum SourceVersion {
      *      switch in second preview, module Import Declarations in second
      *      preview, simple source files and instance main in fourth
      *      preview, flexible constructor bodies in third preview)
+     *  25: module import declarations, compact source files and
+     *      instance main methods,
      */
 
     /**
@@ -449,11 +451,18 @@ public enum SourceVersion {
      * The version introduced by the Java Platform, Standard Edition
      * 25.
      *
+     * Additions in this release include module import declarations
+     * and compact source files and instance main methods.
+     *
      * @since 25
      *
      * @see <a
      * href="https://docs.oracle.com/javase/specs/jls/se25/html/index.html">
      * <cite>The Java Language Specification, Java SE 25 Edition</cite></a>
+     * @see <a href="https://openjdk.org/jeps/511">
+     * JEP 511: Module Import Declarations</a>
+     * @see <a href="https://openjdk.org/jeps/512">
+     * JEP 512: Compact Source Files and Instance Main Methods</a>
      */
     RELEASE_25,
     ; // Reduce code churn when appending new constants

--- a/test/langtools/tools/javac/versions/Versions.java
+++ b/test/langtools/tools/javac/versions/Versions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
  * @bug 4981566 5028634 5094412 6304984 7025786 7025789 8001112 8028545
  * 8000961 8030610 8028546 8188870 8173382 8173382 8193290 8205619 8028563
  * 8245147 8245586 8257453 8286035 8306586 8320806 8306586 8319414 8330183
- * 8342982
+ * 8342982 8356108
  * @summary Check interpretation of -target and -source options
  * @modules java.compiler
  *          jdk.compiler
@@ -401,6 +401,14 @@ public class Versions {
                                         default        -> o.toString();
                                         });
                  }
+             }
+             """),
+
+         SOURCE_25(25, "New25.java",
+             // New feature in 25: module import declarations
+             """
+             import module java.base;
+             public class New25 {
              }
              """),
             ; // Reduce code churn when appending new constants


### PR DESCRIPTION
Expected update to keep the description of language evolution accurate.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8356108](https://bugs.openjdk.org/browse/JDK-8356108): Update SourceVersion.RELEASE_25 description for JEPs 511 and 512 (**Bug** - P4)


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25015/head:pull/25015` \
`$ git checkout pull/25015`

Update a local copy of the PR: \
`$ git checkout pull/25015` \
`$ git pull https://git.openjdk.org/jdk.git pull/25015/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25015`

View PR using the GUI difftool: \
`$ git pr show -t 25015`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25015.diff">https://git.openjdk.org/jdk/pull/25015.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25015#issuecomment-2848179527)
</details>
