### PR TITLE
8356102: TestJcmdOutput, JcmdWithNMTDisabled and DumpSharedDictionary hs/tier1 tests fail on static-jdk

### DIFF
--- a/test/hotspot/jtreg/runtime/CommandLine/OptionsValidation/TestJcmdOutput.java
+++ b/test/hotspot/jtreg/runtime/CommandLine/OptionsValidation/TestJcmdOutput.java
@@ -53,6 +53,7 @@ public class TestJcmdOutput {
         System.out.println("Verify jcmd error message and that jcmd does not write errors to the target process output");
         output = new OutputAnalyzer((ProcessTools.createLimitedTestJavaProcessBuilder(
                 "-Dtest.jdk=" + System.getProperty("test.jdk"),
+                "-Dcompile.jdk=" + System.getProperty("compile.jdk"),
                 "-XX:MinHeapFreeRatio=20", "-XX:MaxHeapFreeRatio=80", runJcmd.class.getName())).start());
 
         output.shouldHaveExitValue(0);

--- a/test/hotspot/jtreg/runtime/CommandLine/OptionsValidation/TestJcmdOutput.java
+++ b/test/hotspot/jtreg/runtime/CommandLine/OptionsValidation/TestJcmdOutput.java
@@ -53,7 +53,6 @@ public class TestJcmdOutput {
         System.out.println("Verify jcmd error message and that jcmd does not write errors to the target process output");
         output = new OutputAnalyzer((ProcessTools.createLimitedTestJavaProcessBuilder(
                 "-Dtest.jdk=" + System.getProperty("test.jdk"),
-                "-Dcompile.jdk=" + System.getProperty("compile.jdk"),
                 "-XX:MinHeapFreeRatio=20", "-XX:MaxHeapFreeRatio=80", runJcmd.class.getName())).start());
 
         output.shouldHaveExitValue(0);

--- a/test/hotspot/jtreg/runtime/NMT/JcmdWithNMTDisabled.java
+++ b/test/hotspot/jtreg/runtime/NMT/JcmdWithNMTDisabled.java
@@ -48,16 +48,20 @@ public class JcmdWithNMTDisabled {
       ProcessBuilder pb;
       OutputAnalyzer output;
       String testjdkPath = System.getProperty("test.jdk");
+      String compilejdkPath = System.getProperty("compile.jdk");
 
       // First run without enabling NMT (not in debug, where NMT is by default on)
       if (!Platform.isDebugBuild()) {
-        pb = ProcessTools.createLimitedTestJavaProcessBuilder("-Dtest.jdk=" + testjdkPath, "JcmdWithNMTDisabled");
+        pb = ProcessTools.createLimitedTestJavaProcessBuilder(
+          "-Dtest.jdk=" + testjdkPath, "-Dcompile.jdk=" + compilejdkPath, "JcmdWithNMTDisabled");
         output = new OutputAnalyzer(pb.start());
         output.shouldHaveExitValue(0);
       }
 
       // Then run with explicitly disabling NMT, should not be any difference
-      pb = ProcessTools.createLimitedTestJavaProcessBuilder("-Dtest.jdk=" + testjdkPath, "-XX:NativeMemoryTracking=off", "JcmdWithNMTDisabled");
+      pb = ProcessTools.createLimitedTestJavaProcessBuilder(
+        "-Dtest.jdk=" + testjdkPath, "-Dcompile.jdk=" + compilejdkPath,
+        "-XX:NativeMemoryTracking=off", "JcmdWithNMTDisabled");
       output = new OutputAnalyzer(pb.start());
       output.shouldHaveExitValue(0);
 

--- a/test/hotspot/jtreg/runtime/NMT/JcmdWithNMTDisabled.java
+++ b/test/hotspot/jtreg/runtime/NMT/JcmdWithNMTDisabled.java
@@ -48,20 +48,16 @@ public class JcmdWithNMTDisabled {
       ProcessBuilder pb;
       OutputAnalyzer output;
       String testjdkPath = System.getProperty("test.jdk");
-      String compilejdkPath = System.getProperty("compile.jdk");
 
       // First run without enabling NMT (not in debug, where NMT is by default on)
       if (!Platform.isDebugBuild()) {
-        pb = ProcessTools.createLimitedTestJavaProcessBuilder(
-          "-Dtest.jdk=" + testjdkPath, "-Dcompile.jdk=" + compilejdkPath, "JcmdWithNMTDisabled");
+        pb = ProcessTools.createLimitedTestJavaProcessBuilder("-Dtest.jdk=" + testjdkPath, "JcmdWithNMTDisabled");
         output = new OutputAnalyzer(pb.start());
         output.shouldHaveExitValue(0);
       }
 
       // Then run with explicitly disabling NMT, should not be any difference
-      pb = ProcessTools.createLimitedTestJavaProcessBuilder(
-        "-Dtest.jdk=" + testjdkPath, "-Dcompile.jdk=" + compilejdkPath,
-        "-XX:NativeMemoryTracking=off", "JcmdWithNMTDisabled");
+      pb = ProcessTools.createLimitedTestJavaProcessBuilder("-Dtest.jdk=" + testjdkPath, "-XX:NativeMemoryTracking=off", "JcmdWithNMTDisabled");
       output = new OutputAnalyzer(pb.start());
       output.shouldHaveExitValue(0);
 

--- a/test/hotspot/jtreg/runtime/cds/DumpSharedDictionary.java
+++ b/test/hotspot/jtreg/runtime/cds/DumpSharedDictionary.java
@@ -45,12 +45,11 @@ public class DumpSharedDictionary {
                 .setArchiveName("./DumpSharedDictionary.jsa");
             CDSTestUtils.createArchiveAndCheck(opts);
 
-            String testjdkPath = System.getProperty("test.jdk");
-
             opts = (new CDSOptions())
                 .setUseVersion(false)
                 .addSuffix("-XX:SharedArchiveFile=./DumpSharedDictionary.jsa",
-                           "-Dtest.jdk=" + testjdkPath,
+                           "-Dtest.jdk=" + System.getProperty("test.jdk"),
+                           "-Dcompile.jdk=" + System.getProperty("compile.jdk"),
                            "DumpSharedDictionary", "test");
             CDSTestUtils.run(opts)
                         .assertNormalExit();

--- a/test/hotspot/jtreg/runtime/cds/DumpSharedDictionary.java
+++ b/test/hotspot/jtreg/runtime/cds/DumpSharedDictionary.java
@@ -45,11 +45,12 @@ public class DumpSharedDictionary {
                 .setArchiveName("./DumpSharedDictionary.jsa");
             CDSTestUtils.createArchiveAndCheck(opts);
 
+            String testjdkPath = System.getProperty("test.jdk");
+
             opts = (new CDSOptions())
                 .setUseVersion(false)
                 .addSuffix("-XX:SharedArchiveFile=./DumpSharedDictionary.jsa",
-                           "-Dtest.jdk=" + System.getProperty("test.jdk"),
-                           "-Dcompile.jdk=" + System.getProperty("compile.jdk"),
+                           "-Dtest.jdk=" + testjdkPath,
                            "DumpSharedDictionary", "test");
             CDSTestUtils.run(opts)
                         .assertNormalExit();

--- a/test/lib/jdk/test/lib/process/ProcessTools.java
+++ b/test/lib/jdk/test/lib/process/ProcessTools.java
@@ -458,8 +458,6 @@ public final class ProcessTools {
             args.add(System.getProperty("java.class.path"));
         }
 
-        args.add("-Dcompile.jdk=" + System.getProperty("compile.jdk"));
-
         String testThreadFactoryName = System.getProperty("test.thread.factory");
         if (testThreadFactoryName != null) {
             args.addAll(addTestThreadFactoryArgs(testThreadFactoryName, Arrays.asList(command)));

--- a/test/lib/jdk/test/lib/process/ProcessTools.java
+++ b/test/lib/jdk/test/lib/process/ProcessTools.java
@@ -458,6 +458,8 @@ public final class ProcessTools {
             args.add(System.getProperty("java.class.path"));
         }
 
+        args.add("-Dcompile.jdk=" + System.getProperty("compile.jdk"));
+
         String testThreadFactoryName = System.getProperty("test.thread.factory");
         if (testThreadFactoryName != null) {
             args.addAll(addTestThreadFactoryArgs(testThreadFactoryName, Arrays.asList(command)));


### PR DESCRIPTION
Please review the change to set `-Dcompile.jdk=<jdk>` when launching child processes in TestJcmdOutput, JcmdWithNMTDisabled and DumpSharedDictionary hs/tier1 tests.

These three tests fail on static-jdk as `jdk.test.lib.JDKToolFinder.getJDKTool()` fails to locate the `jcmd` tool. `JDKToolFinder.getJDKTool()` locates the requested tool from the path specified in 'test.jdk' system property first, then using the path specified in 'compile.jdk' system property. Currently when running jtreg tests on static-jdk, jtreg '-compilejdk' is set to a regular JDK binary. Populating the 'compile.jdk' system property from jtreg when creating the child process would allow `JDKToolFinder.getJDKTool()` (executing in the child process) to locate the tool from 'compile.jdk' path.

Tested all three tests on static-jdk. All three tests pass with the fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8356102](https://bugs.openjdk.org/browse/JDK-8356102): TestJcmdOutput, JcmdWithNMTDisabled and DumpSharedDictionary hs/tier1 tests fail on static-jdk (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25018/head:pull/25018` \
`$ git checkout pull/25018`

Update a local copy of the PR: \
`$ git checkout pull/25018` \
`$ git pull https://git.openjdk.org/jdk.git pull/25018/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25018`

View PR using the GUI difftool: \
`$ git pr show -t 25018`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25018.diff">https://git.openjdk.org/jdk/pull/25018.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25018#issuecomment-2848266136)
</details>
