### PR TITLE
8356130: Improper Implementation of hasNext method in ArrayList Class

### DIFF
--- a/src/java.base/share/classes/java/util/ArrayList.java
+++ b/src/java.base/share/classes/java/util/ArrayList.java
@@ -1042,7 +1042,7 @@ public class ArrayList<E> extends AbstractList<E>
         Itr() {}
 
         public boolean hasNext() {
-            return cursor != size;
+            return cursor < size;
         }
 
         @SuppressWarnings("unchecked")
@@ -1107,7 +1107,7 @@ public class ArrayList<E> extends AbstractList<E>
         }
 
         public boolean hasPrevious() {
-            return cursor != 0;
+            return cursor > 0;
         }
 
         public int nextIndex() {
@@ -1373,7 +1373,7 @@ public class ArrayList<E> extends AbstractList<E>
                 int expectedModCount = SubList.this.modCount;
 
                 public boolean hasNext() {
-                    return cursor != SubList.this.size;
+                    return cursor < SubList.this.size;
                 }
 
                 @SuppressWarnings("unchecked")
@@ -1390,7 +1390,7 @@ public class ArrayList<E> extends AbstractList<E>
                 }
 
                 public boolean hasPrevious() {
-                    return cursor != 0;
+                    return cursor > 0;
                 }
 
                 @SuppressWarnings("unchecked")


### PR DESCRIPTION
In arrayList, hasNext() method we were checking cursor!=size , After internally increasing cursor more than size of ArrayList will cause method to work improperly. Fixed using <  operators.
Also in hasPrevious() method earlier cursor!=0 after decreasing cursor internally to any negative value this function will not work properly fixed using > operator.

Type: Bug
Component: core-libs
Sub-Component: java.util.collection
Affected version:8,25
Priority: P4

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Issue
 * [JDK-8356130](https://bugs.openjdk.org/browse/JDK-8356130): Improper Implementation of hasNext method in ArrayList Class (**Bug** - P4) ⚠️ Issue is not open.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25027/head:pull/25027` \
`$ git checkout pull/25027`

Update a local copy of the PR: \
`$ git checkout pull/25027` \
`$ git pull https://git.openjdk.org/jdk.git pull/25027/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25027`

View PR using the GUI difftool: \
`$ git pr show -t 25027`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25027.diff">https://git.openjdk.org/jdk/pull/25027.diff</a>

</details>
