### PR TITLE
8356153: Shenandoah stubs are missing in AOT Code Cache addresses table

### DIFF
--- a/src/hotspot/share/code/aotCodeCache.cpp
+++ b/src/hotspot/share/code/aotCodeCache.cpp
@@ -46,6 +46,9 @@
 #if INCLUDE_G1GC
 #include "gc/g1/g1BarrierSetRuntime.hpp"
 #endif
+#if INCLUDE_SHENANDOAHGC
+#include "gc/shenandoah/shenandoahRuntime.hpp"
+#endif
 #if INCLUDE_ZGC
 #include "gc/z/zBarrierSetRuntime.hpp"
 #endif
@@ -974,9 +977,9 @@ ImmutableOopMapSet* AOTCodeReader::read_oop_map_set() {
 //      [_blobs_base, _blobs_base + _blobs_max -1],
 //      ...
 //      [_c_str_base, _c_str_base + _c_str_max -1],
-#define _extrs_max 10
+#define _extrs_max 13
 #define _blobs_max 10
-#define _all_max   20
+#define _all_max   23
 
 #define _extrs_base 0
 #define _blobs_base (_extrs_base + _extrs_max)
@@ -1009,6 +1012,11 @@ void AOTCodeAddressTable::init_extrs() {
 #if INCLUDE_G1GC
   SET_ADDRESS(_extrs, G1BarrierSetRuntime::write_ref_field_post_entry);
   SET_ADDRESS(_extrs, G1BarrierSetRuntime::write_ref_field_pre_entry);
+#endif
+#if INCLUDE_SHENANDOAHGC
+  SET_ADDRESS(_extrs, ShenandoahRuntime::write_ref_field_pre);
+  SET_ADDRESS(_extrs, ShenandoahRuntime::load_reference_barrier_phantom);
+  SET_ADDRESS(_extrs, ShenandoahRuntime::load_reference_barrier_phantom_narrow);
 #endif
 #if INCLUDE_ZGC
   SET_ADDRESS(_extrs, ZBarrierSetRuntime::load_barrier_on_phantom_oop_field_preloaded_addr());


### PR DESCRIPTION
See the bug for reproducer. We actually have similar Shenandoah hunks down in Leyden repository, but we have apparently missed them when upstreaming [JDK-8350209](https://bugs.openjdk.org/browse/JDK-8350209). We only need a small subset of stubs that adapters use: pre-barriers and phantom load-barriers. This matches what we do for G1 and Z as well.

Additional testing:
 - [x] Linux x86_64 server fastdebug, `runtime/cds`
 - [x] Linux x86_64 server fastdebug, `runtime/cds` with `-XX:+UseShenandoahGC`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8356153](https://bugs.openjdk.org/browse/JDK-8356153): Shenandoah stubs are missing in AOT Code Cache addresses table (**Bug** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25028/head:pull/25028` \
`$ git checkout pull/25028`

Update a local copy of the PR: \
`$ git checkout pull/25028` \
`$ git pull https://git.openjdk.org/jdk.git pull/25028/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25028`

View PR using the GUI difftool: \
`$ git pr show -t 25028`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25028.diff">https://git.openjdk.org/jdk/pull/25028.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25028#issuecomment-2850417148)
</details>
