### PR TITLE
8356122: Client build fails after JDK-8350209

### DIFF
--- a/src/hotspot/share/code/aotCodeCache.cpp
+++ b/src/hotspot/share/code/aotCodeCache.cpp
@@ -22,6 +22,7 @@
  *
  */
 
+#include "asm/macroAssembler.hpp"
 #include "cds/aotCacheAccess.hpp"
 #include "cds/cds_globals.hpp"
 #include "cds/cdsConfig.hpp"
@@ -40,6 +41,7 @@
 #include "runtime/os.inline.hpp"
 #include "runtime/sharedRuntime.hpp"
 #include "runtime/stubRoutines.hpp"
+#include "utilities/copy.hpp"
 #ifdef COMPILER2
 #include "opto/runtime.hpp"
 #endif


### PR DESCRIPTION
See bug for samples of build failures. I reproduced and fixed both with this PR.

Additional testing:
 - [x] Linux x86_64 client release build
 - [x] Linux x86_64 client fastdebug build

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8356122](https://bugs.openjdk.org/browse/JDK-8356122): Client build fails after JDK-8350209 (**Bug** - P2)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25030/head:pull/25030` \
`$ git checkout pull/25030`

Update a local copy of the PR: \
`$ git checkout pull/25030` \
`$ git pull https://git.openjdk.org/jdk.git pull/25030/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25030`

View PR using the GUI difftool: \
`$ git pr show -t 25030`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25030.diff">https://git.openjdk.org/jdk/pull/25030.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25030#issuecomment-2850490627)
</details>
