### PR TITLE
8308854: G1 archive region allocation may expand/shrink the heap above/below -Xms

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -547,7 +547,6 @@ void G1CollectedHeap::dealloc_archive_regions(MemRegion range) {
   assert(!is_init_completed(), "Expect to be called at JVM init time");
   MemRegion reserved = _hrm.reserved();
   size_t size_used = 0;
-  uint shrink_count = 0;
 
   // Free the G1 regions that are within the specified range.
   MutexLocker x(Heap_lock);
@@ -559,21 +558,32 @@ void G1CollectedHeap::dealloc_archive_regions(MemRegion range) {
          p2i(start_address), p2i(last_address));
   size_used += range.byte_size();
 
+  uint max_shrink_count = 0;
+  if (capacity() > MinHeapSize) {
+    size_t max_shrink_bytes = capacity() - MinHeapSize;
+    max_shrink_count = (uint)(max_shrink_bytes / G1HeapRegion::GrainBytes);
+  }
+
+  uint shrink_count = 0;
   // Free, empty and uncommit regions with CDS archive content.
   auto dealloc_archive_region = [&] (G1HeapRegion* r, bool is_last) {
     guarantee(r->is_old(), "Expected old region at index %u", r->hrm_index());
     _old_set.remove(r);
     r->set_free();
     r->set_top(r->bottom());
-    _hrm.shrink_at(r->hrm_index(), 1);
-    shrink_count++;
+    if (shrink_count < max_shrink_count) {
+      _hrm.shrink_at(r->hrm_index(), 1);
+      shrink_count++;
+    } else {
+      _hrm.insert_into_free_list(r);
+    }
   };
 
   iterate_regions_in_range(range, dealloc_archive_region);
 
   if (shrink_count != 0) {
-    log_debug(gc, ergo, heap)("Attempt heap shrinking (CDS archive regions). Total size: %zuB",
-                              G1HeapRegion::GrainWords * HeapWordSize * shrink_count);
+    log_debug(gc, ergo, heap)("Attempt heap shrinking (CDS archive regions). Total size: %zuB (%u Regions)",
+                              G1HeapRegion::GrainWords * HeapWordSize * shrink_count, shrink_count);
     // Explicit uncommit.
     uncommit_regions(shrink_count);
   }


### PR DESCRIPTION
Hi,

Please review this change to prevent G1 from shrinking the heap below -Xms when deallocating CDS archive regions. This issue is particularly noticeable when -Xms==-Xmx, G1 still uncommits the archive regions thus shrinking the heap below -Xms. In this change, G1 does not uncommit the archive regions in cases where doing so would shrink the heap below the configured -Xms.

This is a temporary fix, we expect a more complete solution to be delivered under [JDK-8326035](https://bugs.openjdk.org/browse/JDK-8326035).

Testing: gha, manual testing as below:

Mainline:

```
[3.740s][info ][gc,init     ] Heap Min Capacity: 150G
[3.740s][info ][gc,init     ] Heap Initial Capacity: 150G
[3.740s][info ][gc,init     ] Heap Max Capacity: 150G
.
.
[3.749s][debug][gc,ergo,heap] Attempt heap shrinking (CDS archive regions). Total size: 33554432B
.
.
[9.000s][info ][gc          ] GC(0) Pause Full (System.gc()) 10728M->140M(153568M) 119.887ms
```
With patch (No shrinking when -Xms == -Xms):

```
[3.753s][info ][gc,init     ] Heap Min Capacity: 150G
[3.753s][info ][gc,init     ] Heap Initial Capacity: 150G
[3.753s][info ][gc,init     ] Heap Max Capacity: 150G
.
.
[8.773s][info ][gc          ] GC(0) Pause Full (System.gc()) 10687M->140M(153600M) 117.901ms
```
With patch (Shrinking when -Xms != -Xms):

```
[3.755s][info ][gc,init     ] Heap Min Capacity: 153568M
[3.755s][info ][gc,init     ] Heap Initial Capacity: 153568M
[3.755s][info ][gc,init     ] Heap Max Capacity: 150G
.
.
[3.764s][debug][gc,ergo,heap] Attempt heap shrinking (CDS archive regions). Total size: 33554432B (1 Regions)
.
.
[8.919s][info ][gc          ] GC(0) Pause Full (System.gc()) 10692M->140M(153568M) 125.810ms
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308854](https://bugs.openjdk.org/browse/JDK-8308854): G1 archive region allocation may expand/shrink the heap above/below -Xms (**Bug** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25036/head:pull/25036` \
`$ git checkout pull/25036`

Update a local copy of the PR: \
`$ git checkout pull/25036` \
`$ git pull https://git.openjdk.org/jdk.git pull/25036/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25036`

View PR using the GUI difftool: \
`$ git pr show -t 25036`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25036.diff">https://git.openjdk.org/jdk/pull/25036.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25036#issuecomment-2851116817)
</details>
