### PR TITLE
8356173: NMT chunk pool delete should use a  Mutex

### DIFF
--- a/src/hotspot/share/memory/arena.cpp
+++ b/src/hotspot/share/memory/arena.cpp
@@ -84,8 +84,9 @@ class ChunkPool {
 
   // Clear this pool of all contained chunks
   void prune() {
-    // Free all chunks while in ThreadCritical lock
+    // Free all chunks with ThreadCritical and nmt lock
     // so NMT adjustment is stable.
+    MutexLocker nal(NMTArena_lock, Mutex::_no_safepoint_check_flag);
     ThreadCritical tc;
     Chunk* cur = _first;
     Chunk* next = nullptr;
@@ -198,7 +199,8 @@ void ChunkPool::deallocate_chunk(Chunk* c) {
   if (pool != nullptr) {
     pool->return_to_pool(c);
   } else {
-    ThreadCritical tc;  // Free chunks under TC lock so that NMT adjustment is stable.
+    // Free chunks under NMT lock so that NMT adjustment is stable.
+    MutexLocker nal(NMTArena_lock, Mutex::_no_safepoint_check_flag);
     os::free(c);
   }
 }

--- a/src/hotspot/share/nmt/mallocTracker.cpp
+++ b/src/hotspot/share/nmt/mallocTracker.cpp
@@ -61,10 +61,10 @@ void MemoryCounter::update_peak(size_t size, size_t cnt) {
 }
 
 void MallocMemorySnapshot::copy_to(MallocMemorySnapshot* s) {
-  // Use ThreadCritical to make sure that mtChunks don't get deallocated while the
+  // Use lock to make sure that mtChunks don't get deallocated while the
   // copy is going on, because their size is adjusted using this
   // buffer in make_adjustment().
-  ThreadCritical tc;
+  MutexLocker nal(NMTArena_lock, Mutex::_no_safepoint_check_flag);
   s->_all_mallocs = _all_mallocs;
   size_t total_size = 0;
   size_t total_count = 0;

--- a/src/hotspot/share/nmt/memMapPrinter.cpp
+++ b/src/hotspot/share/nmt/memMapPrinter.cpp
@@ -111,7 +111,7 @@ public:
     if (_count == _capacity) {
       // Enlarge if needed
       const size_t new_capacity = MAX2((size_t)4096, 2 * _capacity);
-      // Unfortunately, we need to allocate manually, raw, since we must prevent NMT deadlocks (ThreadCritical).
+      // Unfortunately, we need to allocate manually, raw, since we must prevent NMT deadlocks.
       _ranges = (Range*)permit_forbidden_function::realloc(_ranges, new_capacity * sizeof(Range));
       _mem_tags = (MemTag*)permit_forbidden_function::realloc(_mem_tags, new_capacity * sizeof(MemTag));
       if (_ranges == nullptr || _mem_tags == nullptr) {

--- a/src/hotspot/share/nmt/nmtUsage.cpp
+++ b/src/hotspot/share/nmt/nmtUsage.cpp
@@ -52,9 +52,9 @@ void NMTUsage::walk_thread_stacks() {
 }
 
 void NMTUsage::update_malloc_usage() {
-  // Thread critical needed keep values in sync, total area size
+  // Lock needed keep values in sync, total area size
   // is deducted from mtChunk in the end to give correct values.
-  ThreadCritical tc;
+  MutexLocker nal(NMTArena_lock, Mutex::_no_safepoint_check_flag);
   const MallocMemorySnapshot* ms = MallocMemorySummary::as_snapshot();
 
   size_t total_arena_size = 0;

--- a/src/hotspot/share/runtime/mutexLocker.cpp
+++ b/src/hotspot/share/runtime/mutexLocker.cpp
@@ -134,7 +134,8 @@ Mutex*   SharedDecoder_lock           = nullptr;
 Mutex*   DCmdFactory_lock             = nullptr;
 Mutex*   NMTQuery_lock                = nullptr;
 Mutex*   NMTCompilationCostHistory_lock = nullptr;
-Mutex*   NmtVirtualMemory_lock          = nullptr;
+Mutex*   NmtVirtualMemory_lock        = nullptr;
+Mutex*   NMTArena_lock                = nullptr;
 
 #if INCLUDE_CDS
 #if INCLUDE_JVMTI
@@ -348,6 +349,7 @@ void mutex_init() {
 #endif
   MUTEX_DEFL(JvmtiThreadState_lock          , PaddedMutex  , JvmtiVTMSTransition_lock);   // Used by JvmtiThreadState/JvmtiEventController
   MUTEX_DEFL(SharedDecoder_lock             , PaddedMutex  , NmtVirtualMemory_lock); // Must be lower than NmtVirtualMemory_lock due to MemTracker::print_containing_region
+  MUTEX_DEFL(NMTArena_lock                  , PaddedMutex  , ExternalsRecorder_lock);
 
   // Allocate RecursiveMutex
   MultiArray_lock = new RecursiveMutex();

--- a/src/hotspot/share/runtime/mutexLocker.hpp
+++ b/src/hotspot/share/runtime/mutexLocker.hpp
@@ -118,6 +118,7 @@ extern Mutex*   DCmdFactory_lock;                // serialize access to DCmdFact
 extern Mutex*   NMTQuery_lock;                   // serialize NMT Dcmd queries
 extern Mutex*   NMTCompilationCostHistory_lock;  // guards NMT compilation cost history
 extern Mutex*   NmtVirtualMemory_lock;           // guards NMT virtual memory updates
+extern Mutex*   NMTArena_lock;                   // guards NMT arena chunk deletion while accounting and printing
 #if INCLUDE_CDS
 #if INCLUDE_JVMTI
 extern Mutex*   CDSClassFileStream_lock;         // FileMapInfo::open_stream_for_jvmti


### PR DESCRIPTION
I added a NMTArena_lock to protect NMT accounting for chunk pool chunks.  We could possibly use another NMT lock.  Feedback welcome.
Tested with tier1-4.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8356173](https://bugs.openjdk.org/browse/JDK-8356173): NMT chunk pool delete should use a  Mutex (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25037/head:pull/25037` \
`$ git checkout pull/25037`

Update a local copy of the PR: \
`$ git checkout pull/25037` \
`$ git pull https://git.openjdk.org/jdk.git pull/25037/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25037`

View PR using the GUI difftool: \
`$ git pr show -t 25037`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25037.diff">https://git.openjdk.org/jdk/pull/25037.diff</a>

</details>
