### PR TITLE
8356152: String.concat can throw StringIndexOutOfBoundsException

### DIFF
--- a/src/java.base/share/classes/java/lang/StringConcatHelper.java
+++ b/src/java.base/share/classes/java/lang/StringConcatHelper.java
@@ -432,7 +432,7 @@ final class StringConcatHelper {
     @ForceInline
     static String doConcat(String s1, String s2) {
         byte coder = (byte) (s1.coder() | s2.coder());
-        int newLength = (s1.length() + s2.length()) << coder;
+        int newLength = checkOverflow(s1.length() + s2.length()) << coder;
         byte[] buf = newArray(newLength);
         s1.getBytes(buf, 0, coder);
         s2.getBytes(buf, s1.length(), coder);

--- a/test/jdk/java/lang/String/concat/HugeConcatTest.java
+++ b/test/jdk/java/lang/String/concat/HugeConcatTest.java
@@ -53,21 +53,25 @@ public class HugeConcatTest {
 
     @Test
     public void testConcat_Latin1_Latin1() {
+        assertThrows(OutOfMemoryError.class, () -> { var s = hugeLatin1 + hugeLatin1; });
         assertThrows(OutOfMemoryError.class, () -> hugeLatin1.concat(hugeLatin1));
     }
 
     @Test
     public void testConcat_Latin1_UTF16() {
+        assertThrows(OutOfMemoryError.class, () -> { var s = hugeLatin1 + hugeUTF16; });
         assertThrows(OutOfMemoryError.class, () -> hugeLatin1.concat(hugeUTF16));
     }
 
     @Test
     public void testConcat_UTF16_Latin1() {
+        assertThrows(OutOfMemoryError.class, () -> { var s = hugeUTF16 + hugeLatin1; });
         assertThrows(OutOfMemoryError.class, () -> hugeUTF16.concat(hugeLatin1));
     }
 
     @Test
     public void testConcat_UTF16_UTF16() {
+        assertThrows(OutOfMemoryError.class, () -> { var s = hugeUTF16 + hugeUTF16; });
         assertThrows(OutOfMemoryError.class, () -> hugeUTF16.concat(hugeUTF16));
     }
 

--- a/test/jdk/java/lang/String/concat/HugeConcatTest.java
+++ b/test/jdk/java/lang/String/concat/HugeConcatTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8356152
+ * @summary Check that huge concatenations throw OutOfMemoryError
+ * @run junit/othervm -Xmx6G -XX:+CompactStrings -Dcompact=true HugeConcatTest
+ * @run junit/othervm -Xmx6G -XX:-CompactStrings -Dcompact=false HugeConcatTest
+ */
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.Assert.assertThrows;
+
+public class HugeConcatTest {
+
+    private static final int HUGE_LENGTH_UTF16 = Integer.MAX_VALUE / 2 - 2;
+    private static int HUGE_LENGTH_LATIN1;
+
+    @BeforeAll
+    public static void setHugeLengthLatin1() {
+        String compact = System.getProperty("compact", "true");
+        HUGE_LENGTH_LATIN1 = Boolean.parseBoolean(compact)
+                ? Integer.MAX_VALUE - 2
+                : HUGE_LENGTH_UTF16;
+    }
+
+    private static String hugeLatin1() {
+        return "a".repeat(HUGE_LENGTH_LATIN1);
+    }
+
+    private static String hugeUTF16() {
+        return "\u20AC".repeat(HUGE_LENGTH_UTF16);
+    }
+
+    @Test
+    public void testConcat_Latin1_Latin1() {
+        String s1 = hugeLatin1();
+        assertThrows(OutOfMemoryError.class, () -> s1.concat(s1));
+    }
+
+    @Test
+    public void testConcat_Latin1_UTF16() {
+        String s1 = hugeLatin1();
+        String s2 = hugeUTF16();
+        assertThrows(OutOfMemoryError.class, () -> s1.concat(s2));
+    }
+
+    @Test
+    public void testConcat_UTF16_Latin1() {
+        String s1 = hugeUTF16();
+        String s2 = hugeLatin1();
+        assertThrows(OutOfMemoryError.class, () -> s1.concat(s2));
+    }
+
+    @Test
+    public void testConcat_UTF16_UTF16() {
+        String s1 = hugeUTF16();
+        assertThrows(OutOfMemoryError.class, () -> s1.concat(s1));
+    }
+
+}

--- a/test/jdk/java/lang/String/concat/HugeConcatTest.java
+++ b/test/jdk/java/lang/String/concat/HugeConcatTest.java
@@ -25,6 +25,7 @@
  * @test
  * @bug 8356152
  * @summary Check that huge concatenations throw OutOfMemoryError
+ * @requires os.maxMemory > 6G
  * @run junit/othervm -Xmx6G -XX:+CompactStrings -Dcompact=true HugeConcatTest
  * @run junit/othervm -Xmx6G -XX:-CompactStrings -Dcompact=false HugeConcatTest
  */

--- a/test/jdk/java/lang/String/concat/HugeConcatTest.java
+++ b/test/jdk/java/lang/String/concat/HugeConcatTest.java
@@ -25,9 +25,9 @@
  * @test
  * @bug 8356152
  * @summary Check that huge concatenations throw OutOfMemoryError
- * @requires os.maxMemory > 6G
- * @run junit/othervm -Xmx6G -XX:+CompactStrings -Dcompact=true HugeConcatTest
- * @run junit/othervm -Xmx6G -XX:-CompactStrings -Dcompact=false HugeConcatTest
+ * @requires os.maxMemory > 8G
+ * @run junit/othervm -Xmx8G -XX:+CompactStrings -Dcompact=true HugeConcatTest
+ * @run junit/othervm -Xmx8G -XX:-CompactStrings -Dcompact=false HugeConcatTest
  */
 
 import org.junit.jupiter.api.BeforeAll;

--- a/test/jdk/java/lang/String/concat/HugeConcatTest.java
+++ b/test/jdk/java/lang/String/concat/HugeConcatTest.java
@@ -37,48 +37,37 @@ import static org.junit.Assert.assertThrows;
 public class HugeConcatTest {
 
     private static final int HUGE_LENGTH_UTF16 = Integer.MAX_VALUE / 2 - 2;
-    private static int HUGE_LENGTH_LATIN1;
+
+    private static String hugeLatin1;
+    private static final String hugeUTF16 = "\u20AC".repeat(HUGE_LENGTH_UTF16);
 
     @BeforeAll
-    public static void setHugeLengthLatin1() {
+    public static void initHugeLatin1() {
         String compact = System.getProperty("compact", "true");
-        HUGE_LENGTH_LATIN1 = Boolean.parseBoolean(compact)
+        int hugeLatin1Length = Boolean.parseBoolean(compact)
                 ? Integer.MAX_VALUE - 2
                 : HUGE_LENGTH_UTF16;
-    }
-
-    private static String hugeLatin1() {
-        return "a".repeat(HUGE_LENGTH_LATIN1);
-    }
-
-    private static String hugeUTF16() {
-        return "\u20AC".repeat(HUGE_LENGTH_UTF16);
+        hugeLatin1 = "a".repeat(hugeLatin1Length);
     }
 
     @Test
     public void testConcat_Latin1_Latin1() {
-        String s1 = hugeLatin1();
-        assertThrows(OutOfMemoryError.class, () -> s1.concat(s1));
+        assertThrows(OutOfMemoryError.class, () -> hugeLatin1.concat(hugeLatin1));
     }
 
     @Test
     public void testConcat_Latin1_UTF16() {
-        String s1 = hugeLatin1();
-        String s2 = hugeUTF16();
-        assertThrows(OutOfMemoryError.class, () -> s1.concat(s2));
+        assertThrows(OutOfMemoryError.class, () -> hugeLatin1.concat(hugeUTF16));
     }
 
     @Test
     public void testConcat_UTF16_Latin1() {
-        String s1 = hugeUTF16();
-        String s2 = hugeLatin1();
-        assertThrows(OutOfMemoryError.class, () -> s1.concat(s2));
+        assertThrows(OutOfMemoryError.class, () -> hugeUTF16.concat(hugeLatin1));
     }
 
     @Test
     public void testConcat_UTF16_UTF16() {
-        String s1 = hugeUTF16();
-        assertThrows(OutOfMemoryError.class, () -> s1.concat(s1));
+        assertThrows(OutOfMemoryError.class, () -> hugeUTF16.concat(hugeUTF16));
     }
 
 }


### PR DESCRIPTION
A fix to throw `OutOfMemoryError`, as done in releases ≤ 23.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8356152](https://bugs.openjdk.org/browse/JDK-8356152): String.concat can throw StringIndexOutOfBoundsException (**Bug** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)
 * [Andrey Turbanov](https://openjdk.org/census#aturbanov) (@turbanoff - Committer)
 * [Claes Redestad](https://openjdk.org/census#redestad) (@cl4es - **Reviewer**)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25038/head:pull/25038` \
`$ git checkout pull/25038`

Update a local copy of the PR: \
`$ git checkout pull/25038` \
`$ git pull https://git.openjdk.org/jdk.git pull/25038/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25038`

View PR using the GUI difftool: \
`$ git pr show -t 25038`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25038.diff">https://git.openjdk.org/jdk/pull/25038.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25038#issuecomment-2850969571)
</details>
