### PR TITLE
8356187: TestJcmd.java may incorrectly parse podman version

### DIFF
--- a/test/hotspot/jtreg/containers/docker/TestJcmd.java
+++ b/test/hotspot/jtreg/containers/docker/TestJcmd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/containers/docker/TestJcmd.java
+++ b/test/hotspot/jtreg/containers/docker/TestJcmd.java
@@ -37,6 +37,8 @@
  */
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
+import java.util.regex.Matcher;
 import java.util.stream.Collectors;
 import jdk.test.lib.Container;
 import jdk.test.lib.JDKToolFinder;
@@ -264,14 +266,16 @@ public class TestJcmd {
         }
 
         private static PodmanVersion fromVersionString(String version) {
-            try {
-                // Example 'podman version 3.2.1'
-                String versNums = version.split("\\s+", 3)[2];
-                String[] numbers = versNums.split("\\.", 3);
-                return new PodmanVersion(Integer.parseInt(numbers[0]),
-                                         Integer.parseInt(numbers[1]),
-                                         Integer.parseInt(numbers[2]));
-            } catch (Exception e) {
+            // Examples: 'podman version 3.2.1', 'podman version 4.9.4-rhel'
+            final Pattern pattern = Pattern.compile("podman version (\\d+)\\.(\\d+)\\.(\\d+).*");
+            final Matcher matcher = pattern.matcher(version);
+
+            if (matcher.matches()) {
+                return new PodmanVersion(
+                        Integer.parseInt(matcher.group(1)),
+                        Integer.parseInt(matcher.group(2)),
+                        Integer.parseInt(matcher.group(3)));
+            } else {
                 System.out.println("Failed to parse podman version: " + version);
                 return DEFAULT;
             }


### PR DESCRIPTION
fixing an issue with TestJcmd.java test not able to parse podman version string of kind "podman version 4.9.4-rhel".

Tested locally - run test with mocked podman version string.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8356187](https://bugs.openjdk.org/browse/JDK-8356187): TestJcmd.java may incorrectly parse podman version (**Bug** - P4)


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25041/head:pull/25041` \
`$ git checkout pull/25041`

Update a local copy of the PR: \
`$ git checkout pull/25041` \
`$ git pull https://git.openjdk.org/jdk.git pull/25041/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25041`

View PR using the GUI difftool: \
`$ git pr show -t 25041`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25041.diff">https://git.openjdk.org/jdk/pull/25041.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25041#issuecomment-2851241971)
</details>
