### PR TITLE
8347004: vmTestbase/metaspace/shrink_grow/ShrinkGrowTest/ShrinkGrowTest.java fails with CDS disabled

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/metaspace/shrink_grow/ShrinkGrowTest/ShrinkGrowTest.java
+++ b/test/hotspot/jtreg/vmTestbase/metaspace/shrink_grow/ShrinkGrowTest/ShrinkGrowTest.java
@@ -31,8 +31,8 @@
  * @requires vm.opt.final.ClassUnloading
  * @library /vmTestbase /test/lib
  * @run main/othervm
- *      -XX:MetaspaceSize=10m
- *      -XX:MaxMetaspaceSize=10m
+ *      -XX:MetaspaceSize=20m
+ *      -XX:MaxMetaspaceSize=20m
  *      -Xlog:gc*:gc.log
  *      metaspace.shrink_grow.ShrinkGrowTest.ShrinkGrowTest
  */


### PR DESCRIPTION
Test fails with OOME if CDS is disabled. It is not a regression,  it just  rarely executed in this mode.
The fix is just to slightly increase Metaspace. 
Verified that test now pass with CDS disabled + Xcomp. (It fails with Xcomp only)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347004](https://bugs.openjdk.org/browse/JDK-8347004): vmTestbase/metaspace/shrink_grow/ShrinkGrowTest/ShrinkGrowTest.java fails with CDS disabled (**Bug** - P4)


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25046/head:pull/25046` \
`$ git checkout pull/25046`

Update a local copy of the PR: \
`$ git checkout pull/25046` \
`$ git pull https://git.openjdk.org/jdk.git pull/25046/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25046`

View PR using the GUI difftool: \
`$ git pr show -t 25046`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25046.diff">https://git.openjdk.org/jdk/pull/25046.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25046#issuecomment-2851863534)
</details>
