### PR TITLE
MLDSA sign generates 3GB every 6 seconds

### DIFF
--- a/make/test/BuildMicrobenchmark.gmk
+++ b/make/test/BuildMicrobenchmark.gmk
@@ -99,6 +99,7 @@ $(eval $(call SetupJavaCompilation, BUILD_JDK_MICROBENCHMARK, \
         --add-exports java.base/sun.security.util=ALL-UNNAMED \
         --add-exports java.base/sun.security.util.math=ALL-UNNAMED \
         --add-exports java.base/sun.security.util.math.intpoly=ALL-UNNAMED \
+        --add-exports=java.base/sun.security.provider=ALL-UNNAMED \
         --enable-preview \
         -XDsuppressNotes \
         -processor org.openjdk.jmh.generators.BenchmarkProcessor \

--- a/test/micro/org/openjdk/bench/java/security/MLDSA.java
+++ b/test/micro/org/openjdk/bench/java/security/MLDSA.java
@@ -66,10 +66,11 @@ public class MLDSA {
     public static class MyState {
 
         Object mldsa44;
+        Object mldsa44_2;
         Object mldsa65;
         Object mldsa87;
 
-        MethodHandle keygen, siggen, sigver;
+        MethodHandle keygen, siggen, sigver, siggen2;
 
         @Setup(Level.Trial)
         public void setup() throws Throwable, Exception {
@@ -96,6 +97,7 @@ public class MLDSA {
             sigver = lookup.unreflect(m);
 
             mldsa44 = constructor.newInstance(2);
+            mldsa44_2 = constructor.newInstance(2);
             mldsa65 = constructor.newInstance(3);
             mldsa87 = constructor.newInstance(5);
         }
@@ -144,6 +146,23 @@ public class MLDSA {
                         rnd, testCase.sk);
             }
         }
+    }
+
+    @Benchmark
+    public void siggenvp2(MyState myState) throws Throwable {
+        SigGenTestCase testCase = SigGenTestCases44[0];
+        dsa.signInternal(testCase.msg, rnd, testCase.sk);
+    }
+
+    sun.security.provider.ML_DSA dsa = new sun.security.provider.ML_DSA(2);
+    byte[] rnd = new byte[32];
+    sun.security.provider.ML_DSA.ML_DSA_PrivateKey sk = dsa.skDecode(SigGenTestCases44[0].sk);
+    sun.security.provider.SHA3.SHAKE256 hash = new sun.security.provider.SHA3.SHAKE256(0);
+    @Benchmark
+    public void siggenvp3(MyState myState) throws Throwable {
+        SigGenTestCase testCase = SigGenTestCases44[0];
+        dsa.resetSK(testCase.sk, sk);
+        dsa.signInternal(testCase.msg, rnd, sk, hash);
     }
 
     @Benchmark


### PR DESCRIPTION
@ferakocz This is something I wanted to bring to your attention.

I noticed almost 50% of the profile is being spent in GC while doing signatures:
![image](https://github.com/user-attachments/assets/faaa6c86-5fc8-443f-af03-9977522b7152)

![image](https://github.com/user-attachments/assets/4893770f-e6d3-46aa-9287-a81a05da6d2b)

I thought it could be an easy fix, but now believe it might need more drastic reorg of code. I thought it would be just a matter of making some local allocations (in function) part of the class constructor (i.e. allocate then reuse memory). It would also 'bypass/lessen' the issues with https://bugs.openjdk.org/browse/JDK-8308105 (multianewarray is slow).

I have two benchmarks here, one with the original allocations, the other with those allocations moved to class constructor (took some debugging.. Signature modifies PrivateKey!? that really tripped me up)

Despite my efforts, the GC activity remails high, which is really puzzling to me; no idea where it is hiding
![image](https://github.com/user-attachments/assets/d00ff10f-009e-47e6-9f58-93abb3b44e51)

I am not sure if I am explaining this well so feel free to contact me (I also have a lot more data, but above is probably a good start/summary)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Warnings
&nbsp;⚠️ Patch contains a binary file (test/hotspot/jtreg/runtime/ClassFile/JsrRewritingTestCase.jar)
&nbsp;⚠️ Patch contains a binary file (test/hotspot/jtreg/runtime/ClassFile/testcase.jar)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25048/head:pull/25048` \
`$ git checkout pull/25048`

Update a local copy of the PR: \
`$ git checkout pull/25048` \
`$ git pull https://git.openjdk.org/jdk.git pull/25048/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25048`

View PR using the GUI difftool: \
`$ git pr show -t 25048`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25048.diff">https://git.openjdk.org/jdk/pull/25048.diff</a>

</details>
