### PR TITLE
8356201: Some gtests fail on static-jdk

### DIFF
--- a/test/hotspot/jtreg/ProblemList-StaticJdk.txt
+++ b/test/hotspot/jtreg/ProblemList-StaticJdk.txt
@@ -32,3 +32,14 @@ serviceability/sa/ClhsdbFindPC.java#no-xcomp-core       8346719 generic-all
 serviceability/sa/ClhsdbFindPC.java#xcomp-core          8346719 generic-all
 serviceability/sa/ClhsdbPmap.java#core                  8346719 generic-all
 serviceability/sa/ClhsdbPstack.java#core                8346719 generic-all
+
+# Dynamically link with JDK/VM native libraries
+gtest/GTestWrapper.java                                 8356201 generic-all
+gtest/LargePageGtests.java#use-large-pages              8356201 generic-all
+gtest/LargePageGtests.java#use-large-pages-1G           8356201 generic-all
+gtest/LockStackGtests.java                              8356201 generic-all
+gtest/MetaspaceGtests.java#no-ccs                       8356201 generic-all
+gtest/NMTGtests.java#nmt-detail                         8356201 generic-all
+gtest/NMTGtests.java#nmt-off                            8356201 generic-all
+gtest/NMTGtests.java#nmt-summary                        8356201 generic-all
+


### PR DESCRIPTION
Please review this PR that problemlist's following gtests on static-jdk. These test binaries dynamically link with JDK/VM native libraries and fail on static-jdk as the runtime cannot find the required shared libraries.

gtest/GTestWrapper
gtest/LargePageGtests#use-large-pages
gtest/LargePageGtests#use-large-pages-1G
gtest/LockStackGtests
gtest/MetaspaceGtests#no-ccs
gtest/NMTGtests#nmt-detail
gtest/NMTGtests#nmt-off
gtest/NMTGtests#nmt-summary