### PR TITLE
8356089: java/lang/IO/IO.java fails with -XX:+AOTClassLinking

### DIFF
--- a/test/jdk/ProblemList-AotJdk.txt
+++ b/test/jdk/ProblemList-AotJdk.txt
@@ -1,3 +1,32 @@
+#
+# Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+#
+
+#############################################################################
+#
+# List of quarantined tests for testing in AOT_JDK mode.
+#
+#############################################################################
+
 java/math/BigInteger/largeMemory/DivisionOverflow.java          0000000 generic-all
 java/math/BigInteger/largeMemory/StringConstructorOverflow.java 0000000 generic-all
 
@@ -9,3 +38,8 @@ java/lang/module/ModuleDescriptorHashCodeTest.java              0000000 generic-
 # The test case is incorrect. There's no guarantee that running a JVM with the following
 # parameters will always cause the class java/lang/invoke/MethodHandleStatics to be initialized
 java/lang/invoke/DumpMethodHandleInternals.java                 0000000 generic-all
+
+# The test uses "--add-modules jdk.internal.le" during production.
+# So the test is incompatible with AOT_JDK testing because because all runs must have consistent module options on the command line.
+open/test/jdk/java/lang/IO/IO.java				0000000 generic-all
+

--- a/test/jdk/ProblemList-AotJdk.txt
+++ b/test/jdk/ProblemList-AotJdk.txt
@@ -42,4 +42,3 @@ java/lang/invoke/DumpMethodHandleInternals.java                 0000000 generic-
 # The test uses "--add-modules jdk.internal.le" during production.
 # So the test is incompatible with AOT_JDK testing because because all runs must have consistent module options on the command line.
 open/test/jdk/java/lang/IO/IO.java				0000000 generic-all
-


### PR DESCRIPTION
The failing test is excluded. 
No plan to fix, so no bugid is used. 