### PR TITLE
8356020: Failed assert in virtualMemoryTracker.cpp

### DIFF
--- a/src/hotspot/share/cds/archiveBuilder.cpp
+++ b/src/hotspot/share/cds/archiveBuilder.cpp
@@ -313,7 +313,7 @@ address ArchiveBuilder::reserve_buffer() {
   ReservedSpace rs = MemoryReserver::reserve(buffer_size,
                                              MetaspaceShared::core_region_alignment(),
                                              os::vm_page_size(),
-                                             mtClassShared);
+                                             mtNone);
   if (!rs.is_reserved()) {
     log_error(cds)("Failed to reserve %zu bytes of output buffer.", buffer_size);
     MetaspaceShared::unrecoverable_writing_error();


### PR DESCRIPTION
This is a temporary fix. The real fix needs more investigation in the NMT area. The change is just to pass `mtNone` as the `mem_tag` when calling `MemoryReserver::reserve()`.

Testing:

- Ran the test group `open/test/hotspot/jtreg:hotspot_aot_classlinking` 40 times on linux-aarch64 with the options: `-XX:+AOTClassLinking -XX:MaxRAMPercentage=6.25`
- tier1
- tiers 2 - 3 (in progress)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8356020](https://bugs.openjdk.org/browse/JDK-8356020): Failed assert in virtualMemoryTracker.cpp (**Bug** - P2)


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)
 * [Gerard Ziemski](https://openjdk.org/census#gziemski) (@gerard-ziemski - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25054/head:pull/25054` \
`$ git checkout pull/25054`

Update a local copy of the PR: \
`$ git checkout pull/25054` \
`$ git pull https://git.openjdk.org/jdk.git pull/25054/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25054`

View PR using the GUI difftool: \
`$ git pr show -t 25054`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25054.diff">https://git.openjdk.org/jdk/pull/25054.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25054#issuecomment-2852832527)
</details>
