### PR TITLE
8356188: RISC-V: Cleanup effect of vmaskcmp_fp

### DIFF
--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -251,7 +251,6 @@ instruct vmaskcmp_fp(vRegMask dst, vReg src1, vReg src2, immI cond) %{
   predicate(Matcher::vector_element_basic_type(n) == T_FLOAT ||
             Matcher::vector_element_basic_type(n) == T_DOUBLE);
   match(Set dst (VectorMaskCmp (Binary src1 src2) cond));
-  effect(TEMP_DEF dst);
   format %{ "vmaskcmp_fp $dst, $src1, $src2, $cond" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);


### PR DESCRIPTION
Hi all,
Please take a look and review this PR, thanks!

See "The RISC-V Instruction Set Manual" at https://riscv.org/technical/specifications/. In the Vector Floating-Point Compare Instructions section:
```
The destination mask vector register may be the same as the source vector mask register (v0).
```
Also, the integer form of `vmaskcmp` has no effect too, so remove the effect of vmaskcmp_fp.

### Testing
qemu-system 9.1.0 with UseRVV (ubuntu24.10):
* [x]  Run test/jdk/jdk/incubator/vector (fastdebug)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8356188](https://bugs.openjdk.org/browse/JDK-8356188): RISC-V: Cleanup effect of vmaskcmp_fp (**Enhancement** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Gui Cao](https://openjdk.org/census#gcao) (@zifeihan - Author)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25055/head:pull/25055` \
`$ git checkout pull/25055`

Update a local copy of the PR: \
`$ git checkout pull/25055` \
`$ git pull https://git.openjdk.org/jdk.git pull/25055/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25055`

View PR using the GUI difftool: \
`$ git pr show -t 25055`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25055.diff">https://git.openjdk.org/jdk/pull/25055.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25055#issuecomment-2852985021)
</details>
