### PR TITLE
8356226: JCov Grabber server didn't respond

### DIFF
--- a/make/RunTests.gmk
+++ b/make/RunTests.gmk
@@ -1348,7 +1348,9 @@ ifeq ($(TEST_OPTS_JCOV), true)
 	if $(JAVA) -jar $(JCOV_HOME)/lib/jcov.jar GrabberManager -status 1>/dev/null 2>&1 ; then \
 	  $(JAVA) -jar $(JCOV_HOME)/lib/jcov.jar GrabberManager -stop -stoptimeout 3600 ; \
 	fi
-	$(JAVA) -Xmx4g -jar $(JCOV_HOME)/lib/jcov.jar Grabber -v -t \
+	$(JAVA) -Xmx4g \
+            -Djdk.xml.totalEntitySizeLimit=1000000 -Djdk.xml.maxGeneralEntitySizeLimit=1000000 \
+            -jar $(JCOV_HOME)/lib/jcov.jar Grabber -v -t \
 	    $(JCOV_IMAGE_DIR)/template.xml -o $(JCOV_RESULT_FILE) \
 	    1>$(JCOV_GRABBER_LOG) 2>&1 &
 

--- a/make/RunTests.gmk
+++ b/make/RunTests.gmk
@@ -1370,7 +1370,9 @@ ifeq ($(TEST_OPTS_JCOV), true)
 
   jcov-gen-report: jcov-stop-grabber
 	$(call LogWarn, Generating JCov report ...)
-	$(JAVA) -Xmx4g -jar $(JCOV_HOME)/lib/jcov.jar RepGen -sourcepath \
+	$(JAVA) -Xmx4g \
+            -Djdk.xml.totalEntitySizeLimit=1000000 -Djdk.xml.maxGeneralEntitySizeLimit=1000000 \
+            -jar $(JCOV_HOME)/lib/jcov.jar RepGen -sourcepath \
 	    `$(ECHO) $(TOPDIR)/src/*/share/classes/ | $(TR) ' ' ':'` -fmt html \
 	    $(JCOV_FILTERS) \
 	    -mainReportTitle "$(JCOV_REPORT_TITLE)" \
@@ -1394,10 +1396,12 @@ ifeq ($(TEST_OPTS_JCOV), true)
     jcov-gen-diffcoverage: jcov-stop-grabber
 	$(call LogWarn, Generating diff coverage with changeset $(TEST_OPTS_JCOV_DIFF_CHANGESET) ... )
 	$(DIFF_COMMAND)
-	$(JAVA) -Xmx4g -jar $(JCOV_HOME)/lib/jcov.jar \
-	  DiffCoverage -replaceDiff "src/.*/classes/:" -all \
-	    $(JCOV_RESULT_FILE) $(JCOV_SOURCE_DIFF) > \
-	    $(JCOV_DIFF_COVERAGE_REPORT)
+	$(JAVA) -Xmx4g \
+            -Djdk.xml.totalEntitySizeLimit=1000000 -Djdk.xml.maxGeneralEntitySizeLimit=1000000 \
+            -jar $(JCOV_HOME)/lib/jcov.jar \
+            DiffCoverage -replaceDiff "src/.*/classes/:" -all \
+            $(JCOV_RESULT_FILE) $(JCOV_SOURCE_DIFF) > \
+            $(JCOV_DIFF_COVERAGE_REPORT)
 
     TARGETS += jcov-gen-diffcoverage
 

--- a/make/RunTests.gmk
+++ b/make/RunTests.gmk
@@ -1395,9 +1395,9 @@ ifeq ($(TEST_OPTS_JCOV), true)
 	$(call LogWarn, Generating diff coverage with changeset $(TEST_OPTS_JCOV_DIFF_CHANGESET) ... )
 	$(DIFF_COMMAND)
 	$(JAVA) $(JCOV_VM_OPTS) -jar $(JCOV_HOME)/lib/jcov.jar \
-            DiffCoverage -replaceDiff "src/.*/classes/:" -all \
-            $(JCOV_RESULT_FILE) $(JCOV_SOURCE_DIFF) > \
-            $(JCOV_DIFF_COVERAGE_REPORT)
+	  DiffCoverage -replaceDiff "src/.*/classes/:" -all \
+	    $(JCOV_RESULT_FILE) $(JCOV_SOURCE_DIFF) > \
+	    $(JCOV_DIFF_COVERAGE_REPORT)
 
     TARGETS += jcov-gen-diffcoverage
 

--- a/make/RunTests.gmk
+++ b/make/RunTests.gmk
@@ -1343,14 +1343,14 @@ TARGETS += run-all-tests pre-run-test post-run-test run-test-report run-test
 
 ifeq ($(TEST_OPTS_JCOV), true)
 
+  JCOV_VM_OPTS := -Xmx4g -Djdk.xml.totalEntitySizeLimit=0 -Djdk.xml.maxGeneralEntitySizeLimit=0
+
   jcov-do-start-grabber:
 	$(call MakeDir, $(JCOV_OUTPUT_DIR))
 	if $(JAVA) -jar $(JCOV_HOME)/lib/jcov.jar GrabberManager -status 1>/dev/null 2>&1 ; then \
 	  $(JAVA) -jar $(JCOV_HOME)/lib/jcov.jar GrabberManager -stop -stoptimeout 3600 ; \
 	fi
-	$(JAVA) -Xmx4g \
-            -Djdk.xml.totalEntitySizeLimit=1000000 -Djdk.xml.maxGeneralEntitySizeLimit=1000000 \
-            -jar $(JCOV_HOME)/lib/jcov.jar Grabber -v -t \
+	$(JAVA) $(JCOV_VM_OPTS) -jar $(JCOV_HOME)/lib/jcov.jar Grabber -v -t \
 	    $(JCOV_IMAGE_DIR)/template.xml -o $(JCOV_RESULT_FILE) \
 	    1>$(JCOV_GRABBER_LOG) 2>&1 &
 
@@ -1370,9 +1370,7 @@ ifeq ($(TEST_OPTS_JCOV), true)
 
   jcov-gen-report: jcov-stop-grabber
 	$(call LogWarn, Generating JCov report ...)
-	$(JAVA) -Xmx4g \
-            -Djdk.xml.totalEntitySizeLimit=1000000 -Djdk.xml.maxGeneralEntitySizeLimit=1000000 \
-            -jar $(JCOV_HOME)/lib/jcov.jar RepGen -sourcepath \
+	$(JAVA) $(JCOV_VM_OPTS) -jar $(JCOV_HOME)/lib/jcov.jar RepGen -sourcepath \
 	    `$(ECHO) $(TOPDIR)/src/*/share/classes/ | $(TR) ' ' ':'` -fmt html \
 	    $(JCOV_FILTERS) \
 	    -mainReportTitle "$(JCOV_REPORT_TITLE)" \
@@ -1396,9 +1394,7 @@ ifeq ($(TEST_OPTS_JCOV), true)
     jcov-gen-diffcoverage: jcov-stop-grabber
 	$(call LogWarn, Generating diff coverage with changeset $(TEST_OPTS_JCOV_DIFF_CHANGESET) ... )
 	$(DIFF_COMMAND)
-	$(JAVA) -Xmx4g \
-            -Djdk.xml.totalEntitySizeLimit=1000000 -Djdk.xml.maxGeneralEntitySizeLimit=1000000 \
-            -jar $(JCOV_HOME)/lib/jcov.jar \
+	$(JAVA) $(JCOV_VM_OPTS) -jar $(JCOV_HOME)/lib/jcov.jar \
             DiffCoverage -replaceDiff "src/.*/classes/:" -all \
             $(JCOV_RESULT_FILE) $(JCOV_SOURCE_DIFF) > \
             $(JCOV_DIFF_COVERAGE_REPORT)


### PR DESCRIPTION
Fix is to allow bigger XML files.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8356226](https://bugs.openjdk.org/browse/JDK-8356226): JCov Grabber server didn't respond (**Bug** - P3)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25056/head:pull/25056` \
`$ git checkout pull/25056`

Update a local copy of the PR: \
`$ git checkout pull/25056` \
`$ git pull https://git.openjdk.org/jdk.git pull/25056/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25056`

View PR using the GUI difftool: \
`$ git pr show -t 25056`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25056.diff">https://git.openjdk.org/jdk/pull/25056.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25056#issuecomment-2853172495)
</details>
