### PR TITLE
8354260: Launcher help text is wrong for -Xms

### DIFF
--- a/src/java.base/share/classes/sun/launcher/resources/launcher.properties
+++ b/src/java.base/share/classes/sun/launcher/resources/launcher.properties
@@ -154,7 +154,7 @@ java.launcher.X.usage=\n\
 \    -Xmixed           mixed mode execution (default)\n\
 \    -Xmn<size>        sets the initial and maximum size (in bytes) of the heap\n\
 \                      for the young generation (nursery)\n\
-\    -Xms<size>        set initial Java heap size\n\
+\    -Xms<size>        set minimum and initial Java heap size\n\
 \    -Xmx<size>        set maximum Java heap size\n\
 \    -Xnoclassgc       disable class garbage collection\n\
 \    -Xrs              reduce use of OS signals by Java/VM (see documentation)\n\


### PR DESCRIPTION
Please review this update to synchronize the extra help text for `-Xms` with the description given in the manpage.

Copied from the issue:
> The launcher help text for -Xms is wrong and should be updated to match the manpage description. The actual meaning of -Xms is that it sets both the initial and minimum Java heap size, not just the initial Java heap size.
>
> ````
> $ java -X
> ...
> -Xms<size> set initial Java heap size
> ````
>
> From the manpage:
> ````
> `-Xms` *size*
> : Sets the minimum and the initial size (in bytes) of the heap. This value
>     must be a multiple of 1024 and greater than 1 MB. Append the letter `k` or
>     `K` to indicate kilobytes, `m` or `M` to indicate megabytes, or `g` or `G`
>     to indicate gigabytes. The following examples show how to set the size of
>     allocated memory to 6 MB using various units:
> ````

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8354260](https://bugs.openjdk.org/browse/JDK-8354260): Launcher help text is wrong for -Xms (**Bug** - P4)


### Reviewers
 * [Joel Sikström](https://openjdk.org/census#jsikstro) (@jsikstro - Committer)
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25058/head:pull/25058` \
`$ git checkout pull/25058`

Update a local copy of the PR: \
`$ git checkout pull/25058` \
`$ git pull https://git.openjdk.org/jdk.git pull/25058/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25058`

View PR using the GUI difftool: \
`$ git pr show -t 25058`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25058.diff">https://git.openjdk.org/jdk/pull/25058.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25058#issuecomment-2853641943)
</details>
