### PR TITLE
8356251: Need minor cleanup for interp_only_mode

### DIFF
--- a/src/hotspot/share/prims/jvmtiThreadState.cpp
+++ b/src/hotspot/share/prims/jvmtiThreadState.cpp
@@ -123,7 +123,7 @@ JvmtiThreadState::JvmtiThreadState(JavaThread* thread, oop thread_oop)
       // Set this only if thread_oop is current thread->jvmti_vthread().
       thread->set_jvmti_thread_state(this);
     }
-    thread->set_interp_only_mode(0);
+    thread->set_interp_only_mode(false);
   }
 }
 
@@ -778,7 +778,7 @@ void JvmtiThreadState::enter_interp_only_mode() {
   assert(_thread != nullptr, "sanity check");
   assert(!is_interp_only_mode(), "entering interp only when in interp only mode");
   _seen_interp_only_mode = true;
-  _thread->set_interp_only_mode();
+  _thread->set_interp_only_mode(true);
   invalidate_cur_stack_depth();
 }
 
@@ -788,7 +788,7 @@ void JvmtiThreadState::leave_interp_only_mode() {
     // Unmounted virtual thread updates the saved value.
     _saved_interp_only_mode = 0;
   } else {
-    _thread->clear_interp_only_mode();
+    _thread->set_interp_only_mode(false);
   }
 }
 

--- a/src/hotspot/share/prims/jvmtiThreadState.cpp
+++ b/src/hotspot/share/prims/jvmtiThreadState.cpp
@@ -776,8 +776,9 @@ void JvmtiThreadState::add_env(JvmtiEnvBase *env) {
 
 void JvmtiThreadState::enter_interp_only_mode() {
   assert(_thread != nullptr, "sanity check");
+  assert(!is_interp_only_mode(), "entering interp only when in interp only mode");
   _seen_interp_only_mode = true;
-  _thread->increment_interp_only_mode();
+  _thread->set_interp_only_mode();
   invalidate_cur_stack_depth();
 }
 
@@ -785,9 +786,9 @@ void JvmtiThreadState::leave_interp_only_mode() {
   assert(is_interp_only_mode(), "leaving interp only when not in interp only mode");
   if (_thread == nullptr) {
     // Unmounted virtual thread updates the saved value.
-    --_saved_interp_only_mode;
+    _saved_interp_only_mode = 0;
   } else {
-    _thread->decrement_interp_only_mode();
+    _thread->clear_interp_only_mode();
   }
 }
 

--- a/src/hotspot/share/prims/jvmtiThreadState.hpp
+++ b/src/hotspot/share/prims/jvmtiThreadState.hpp
@@ -191,6 +191,7 @@ class JvmtiThreadState : public CHeapObj<mtInternal> {
   bool              _pending_step_for_popframe;
   bool              _pending_step_for_earlyret;
   bool              _top_frame_is_exiting;
+  bool              _saved_interp_only_mode;
   int               _hide_level;
 
  public:
@@ -211,7 +212,6 @@ class JvmtiThreadState : public CHeapObj<mtInternal> {
 
   // This is only valid when is_interp_only_mode() returns true
   int               _cur_stack_depth;
-  int               _saved_interp_only_mode;
 
   JvmtiThreadEventEnable _thread_event_enable;
 
@@ -273,7 +273,7 @@ class JvmtiThreadState : public CHeapObj<mtInternal> {
 
   // Used by the interpreter for fullspeed debugging support
   bool is_interp_only_mode()                {
-    return _thread == nullptr ?  _saved_interp_only_mode != 0 : _thread->is_interp_only_mode();
+    return _thread == nullptr ? _saved_interp_only_mode : _thread->is_interp_only_mode();
   }
   void enter_interp_only_mode();
   void leave_interp_only_mode();

--- a/src/hotspot/share/prims/jvmtiThreadState.inline.hpp
+++ b/src/hotspot/share/prims/jvmtiThreadState.inline.hpp
@@ -144,13 +144,13 @@ inline void JvmtiThreadState::unbind_from(JvmtiThreadState* state, JavaThread* t
     return;
   }
   // Save thread's interp_only_mode.
-  state->_saved_interp_only_mode = thread->get_interp_only_mode();
+  state->_saved_interp_only_mode = thread->is_interp_only_mode();
   state->set_thread(nullptr);  // Make sure stale _thread value is never used.
 }
 
 inline void JvmtiThreadState::bind_to(JvmtiThreadState* state, JavaThread* thread) {
   // Restore thread's interp_only_mode.
-  thread->set_interp_only_mode(state == nullptr ? 0 : state->_saved_interp_only_mode);
+  thread->set_interp_only_mode(state != nullptr && state->_saved_interp_only_mode);
 
   // Make continuation notice the interp_only_mode change.
   Continuation::set_cont_fastpath_thread_state(thread);

--- a/src/hotspot/share/prims/jvmtiThreadState.inline.hpp
+++ b/src/hotspot/share/prims/jvmtiThreadState.inline.hpp
@@ -168,11 +168,7 @@ inline void JvmtiThreadState::process_pending_interp_only(JavaThread* current) {
   JvmtiThreadState* state = current->jvmti_thread_state();
 
   if (state != nullptr && state->is_pending_interp_only_mode()) {
-    MutexLocker mu(JvmtiThreadState_lock);
-    state = current->jvmti_thread_state();
-    if (state != nullptr && state->is_pending_interp_only_mode()) {
-      JvmtiEventController::enter_interp_only_mode(state);
-    }
+    JvmtiEventController::enter_interp_only_mode(state);
   }
 }
 #endif // SHARE_PRIMS_JVMTITHREADSTATE_INLINE_HPP

--- a/src/hotspot/share/runtime/javaThread.hpp
+++ b/src/hotspot/share/runtime/javaThread.hpp
@@ -1167,6 +1167,7 @@ private:
   // It can be set to zero asynchronously to this threads execution (i.e., without
   // safepoint/handshake or a lock) so we have to be very careful.
   // Accesses by other threads are synchronized using JvmtiThreadState_lock though.
+  // This field is checked by the interpreter which expects it to be an integer.
   int               _interp_only_mode;
 
  public:

--- a/src/hotspot/share/runtime/javaThread.hpp
+++ b/src/hotspot/share/runtime/javaThread.hpp
@@ -1173,10 +1173,7 @@ private:
   // used by the interpreter for fullspeed debugging support (see above)
   static ByteSize interp_only_mode_offset() { return byte_offset_of(JavaThread, _interp_only_mode); }
   bool is_interp_only_mode()                { return (_interp_only_mode != 0); }
-  int get_interp_only_mode()                { return _interp_only_mode; }
-  int set_interp_only_mode(int val)         { return _interp_only_mode = val; }
-  void set_interp_only_mode()               { _interp_only_mode = 1; }
-  void clear_interp_only_mode()             { _interp_only_mode = 0; }
+  void set_interp_only_mode(bool val)       { _interp_only_mode = val ? 1 : 0; }
 
   // support for cached flag that indicates whether exceptions need to be posted for this thread
   // if this is false, we can avoid deoptimizing when events are thrown

--- a/src/hotspot/share/runtime/javaThread.hpp
+++ b/src/hotspot/share/runtime/javaThread.hpp
@@ -1175,8 +1175,8 @@ private:
   bool is_interp_only_mode()                { return (_interp_only_mode != 0); }
   int get_interp_only_mode()                { return _interp_only_mode; }
   int set_interp_only_mode(int val)         { return _interp_only_mode = val; }
-  void increment_interp_only_mode()         { ++_interp_only_mode; }
-  void decrement_interp_only_mode()         { --_interp_only_mode; }
+  void set_interp_only_mode()               { _interp_only_mode = 1; }
+  void clear_interp_only_mode()             { _interp_only_mode = 0; }
 
   // support for cached flag that indicates whether exceptions need to be posted for this thread
   // if this is false, we can avoid deoptimizing when events are thrown


### PR DESCRIPTION
This is a minor cleanup for the JVMTI `interp_only_mode` implementation which includes the following changes:
 - The `interp_only_mode` in `JavaThread` is represented with a counter which is incremented and decremented. This is confusing because this value should only take values `0` or `1`. Asserts are placed to make sure it is never going out of bounds. The `interp_only_mode` in a `JavaThread` is checked by the interpreter chunks which expect it to be an `integer`. This cleanup has no intention to make it a boolean.
 - The function `JvmtiThreadState::process_pending_interp_only()` does a sync on the `JvmtiThreadState_lock` which is not really needed and is being removed. It is called in a `VTMS` transition and so, can not clash with the `SetEventNotificationMode` because it sets a `JvmtiVTMSTransitionDisabler`.
 
 Testing:
  - TBD: Mach5 tiers 1-6

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8356251](https://bugs.openjdk.org/browse/JDK-8356251): Need minor cleanup for interp_only_mode (**Enhancement** - P4)


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25060/head:pull/25060` \
`$ git checkout pull/25060`

Update a local copy of the PR: \
`$ git checkout pull/25060` \
`$ git pull https://git.openjdk.org/jdk.git pull/25060/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25060`

View PR using the GUI difftool: \
`$ git pr show -t 25060`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25060.diff">https://git.openjdk.org/jdk/pull/25060.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25060#issuecomment-2853718439)
</details>
