### PR TITLE
8351359: OperatingSystemMXBean: values from getCpuLoad and getProcessCpuLoad are stale after 24.8 days (Windows) 

### DIFF
--- a/src/jdk.management/windows/native/libmanagement_ext/OperatingSystemImpl.c
+++ b/src/jdk.management/windows/native/libmanagement_ext/OperatingSystemImpl.c
@@ -50,8 +50,7 @@
 #include <process.h>
 #pragma warning(pop)
 
-#include <sys/types.h>
-#include <sys/timeb.h>
+#include <sysinfoapi.h>
 
 typedef unsigned __int32 juint;
 typedef unsigned __int64 julong;
@@ -994,9 +993,7 @@ bindPdhFunctionPointers(HMODULE h) {
  */
 static int
 getPerformanceData(UpdateQueryP query, HCOUNTER c, PDH_FMT_COUNTERVALUE* value, DWORD format) {
-    struct _timeb t;
-    _ftime_s(&t);
-    uint64_t now = (t.time * 1000) + t.millitm;
+    uint64_t now = GetTickCount64();
 
     /*
      * Need to limit how often we update the query

--- a/src/jdk.management/windows/native/libmanagement_ext/OperatingSystemImpl.c
+++ b/src/jdk.management/windows/native/libmanagement_ext/OperatingSystemImpl.c
@@ -50,6 +50,9 @@
 #include <process.h>
 #pragma warning(pop)
 
+#include <sys/types.h>
+#include <sys/timeb.h>
+
 typedef unsigned __int32 juint;
 typedef unsigned __int64 julong;
 
@@ -215,10 +218,10 @@ static PdhLookupPerfNameByIndexFunc PdhLookupPerfNameByIndex_i;
  */
 typedef struct {
     HQUERY      query;
-    uint64_t    lastUpdate; // Last time query was updated (ticks)
+    uint64_t    lastUpdate; // Last time query was updated (millis)
 } UpdateQueryS, *UpdateQueryP;
 
-// Min time between query updates (ticks)
+// Min time between query updates (millis)
 static const int MIN_UPDATE_INTERVAL = 500;
 
 /*
@@ -991,7 +994,9 @@ bindPdhFunctionPointers(HMODULE h) {
  */
 static int
 getPerformanceData(UpdateQueryP query, HCOUNTER c, PDH_FMT_COUNTERVALUE* value, DWORD format) {
-    clock_t now = clock();
+    struct _timeb t;
+    _ftime_s(&t);
+    uint64_t now = (t.time * 1000) + t.millitm;
 
     /*
      * Need to limit how often we update the query


### PR DESCRIPTION
OperatingSystemImpl.c on Windows is limited by its use of clock(), which hits its limit with longer process uptimes.

https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/clock?view=msvc-170
"maximum clock function return value of 2147483.647 seconds, or about 24.8 days"

The linked alternative, time(), gives 64-bit time but only seconds.  In the example code for time(), there is use of _ftime() to retrieve milliseconds.

Update: GetTickCount64() is a better alternative.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8351359](https://bugs.openjdk.org/browse/JDK-8351359): OperatingSystemMXBean: values from getCpuLoad and getProcessCpuLoad are stale after 24.8 days (Windows) (**Bug** - P4)


### Reviewers
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25062/head:pull/25062` \
`$ git checkout pull/25062`

Update a local copy of the PR: \
`$ git checkout pull/25062` \
`$ git pull https://git.openjdk.org/jdk.git pull/25062/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25062`

View PR using the GUI difftool: \
`$ git pr show -t 25062`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25062.diff">https://git.openjdk.org/jdk/pull/25062.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25062#issuecomment-2854182128)
</details>
