### PR TITLE
8356224: JFR: Default value of @Registered is ignored

### DIFF
--- a/test/jdk/jdk/jfr/api/metadata/annotations/TestOverrideWithDefaultValue.java
+++ b/test/jdk/jdk/jfr/api/metadata/annotations/TestOverrideWithDefaultValue.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.jfr.api.metadata.annotations;
+
+import java.io.IOException;
+import java.util.List;
+
+import jdk.jfr.Enabled;
+import jdk.jfr.Event;
+import jdk.jfr.Recording;
+import jdk.jfr.Registered;
+import jdk.jfr.consumer.RecordedEvent;
+import jdk.test.lib.jfr.Events;
+
+/**
+ * @test
+ * @summary Tests that annotations can be overridden with the default value.
+ * @requires vm.flagless
+ * @requires vm.hasJFR
+ * @library /test/lib
+ * @run main/othervm jdk.jfr.api.metadata.annotations.TestOverrideWithDefaultValue
+ */
+public class TestOverrideWithDefaultValue {
+
+    @Enabled(false)
+    static class Mammal extends Event {
+    }
+
+    @Enabled
+    static class Cat extends Mammal {
+    }
+
+    @Registered(false)
+    static class Animal extends Event {
+    }
+
+    @Registered
+    static class Dog extends Animal {
+    }
+
+    public static void main(String[] args) throws IOException {
+        testEnabled();
+        testRegistered();
+    }
+
+    private static void testEnabled() throws IOException {
+        try (Recording r = new Recording()) {
+            r.start();
+            Cat cat = new Cat();
+            cat.commit();
+            List<RecordedEvent> events = Events.fromRecording(r);
+            Events.hasEvents(events);
+        }
+    }
+
+    private static void testRegistered() throws IOException {
+        try (Recording r = new Recording()) {
+            r.start();
+            Dog dog = new Dog();
+            dog.commit();
+            List<RecordedEvent> events = Events.fromRecording(r);
+            Events.hasEvents(events);
+        }
+    }
+}


### PR DESCRIPTION
Could I have a review of a change that fixes an issue with the Registered annotation. For details, see bug.

Testing: tier1 + jdk/jdk/jfr

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8356249](https://bugs.openjdk.org/browse/JDK-8356249) to be approved

### Issues
 * [JDK-8356224](https://bugs.openjdk.org/browse/JDK-8356224): JFR: Default value of @<!---->Registered is ignored (**Bug** - P3)
 * [JDK-8356249](https://bugs.openjdk.org/browse/JDK-8356249): JFR: Default value of @<!---->Registered is ignored (**CSR**)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25063/head:pull/25063` \
`$ git checkout pull/25063`

Update a local copy of the PR: \
`$ git checkout pull/25063` \
`$ git pull https://git.openjdk.org/jdk.git pull/25063/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25063`

View PR using the GUI difftool: \
`$ git pr show -t 25063`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25063.diff">https://git.openjdk.org/jdk/pull/25063.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25063#issuecomment-2854286885)
</details>
