### PR TITLE
8356266: Fix non-Shenandoah build after JDK-8356075

### DIFF
--- a/src/hotspot/share/jvmci/jvmciCompilerToVMInit.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVMInit.cpp
@@ -236,9 +236,11 @@ void CompilerToVM::Data::initialize(JVMCI_TRAPS) {
     assert(base != nullptr, "unexpected byte_map_base");
     cardtable_start_address = base;
     cardtable_shift = CardTable::card_shift();
+#if INCLUDE_SHENANDOAHGC
   } else if (bs->is_a(BarrierSet::ShenandoahBarrierSet)) {
     cardtable_start_address = nullptr;
     cardtable_shift = CardTable::card_shift();
+#endif
   } else {
     // No card mark barriers
     cardtable_start_address = nullptr;


### PR DESCRIPTION
[JDK-8356075](https://bugs.openjdk.org/browse/JDK-8356075) (see PR #25001) causes builds without Shenandoah GC to fail. It's missing an `#if INCLUDE_SHENANDOAHGC`.

Testing:
 - [x] Build without Shenandoah GC