### PR TITLE
8356276: JavaScript error in script.js after JDK-8348282

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/Head.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/Head.java
@@ -352,7 +352,6 @@ public class Head extends Content {
 
         if (syntaxHighlight) {
             addStylesheet(head, DocPaths.RESOURCE_FILES.resolve(DocPaths.HIGHLIGHT_CSS));
-            addScriptElement(head, DocPaths.HIGHLIGHT_JS);
         }
 
         for (DocPath path : localStylesheets) {
@@ -367,6 +366,9 @@ public class Head extends Content {
     }
 
     private void addScripts(HtmlTree head) {
+        if (syntaxHighlight) {
+            addScriptElement(head, DocPaths.HIGHLIGHT_JS);
+        }
         if (addDefaultScript) {
             addScriptElement(head, DocPaths.SCRIPT_JS);
         }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/script.js.template
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/script.js.template
@@ -21,8 +21,12 @@ var activeTableTab = "active-table-tab";
 const linkIcon = "##REPLACE:doclet.Link_icon##";
 const linkToSection = "##REPLACE:doclet.Link_to_section##";
 
-if (hljs) {
-    hljs.highlightAll();
+if (typeof hljs !== "undefined") {
+    try {
+        hljs.highlightAll();
+    } catch (err) {
+        console.error(err)
+    }
 }
 
 function loadScripts(doc, tag) {


### PR DESCRIPTION
Please review a simple fix to avoid a JavaScript error in API docs when syntax highlighting is not enabled. 

The fix consists in replacing `(hljs)` with `(typeof hljs !== "undefined")` in the `if` statement as the former throws a `TypeError` if `hljs` is undefined.  The `try-catch` wrapper around `hljs.highlightAll()` is just added to be on the safe side, and the change in `Head.java` is just cleanup to preserve the separateion of .css and .js files.

Labeled `noreg-hard` as we do not have a way to test the script in browser. I manually tested the fix in multiple browsers.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8356276](https://bugs.openjdk.org/browse/JDK-8356276): JavaScript error in script.js after JDK-8348282 (**Bug** - P3)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25069/head:pull/25069` \
`$ git checkout pull/25069`

Update a local copy of the PR: \
`$ git checkout pull/25069` \
`$ git pull https://git.openjdk.org/jdk.git pull/25069/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25069`

View PR using the GUI difftool: \
`$ git pr show -t 25069`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25069.diff">https://git.openjdk.org/jdk/pull/25069.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25069#issuecomment-2854904965)
</details>
