### PR TITLE
8344270: Update tier1_common and hotspot_misc groups to better organize hotspot non-component tests

### DIFF
--- a/test/hotspot/jtreg/TEST.groups
+++ b/test/hotspot/jtreg/TEST.groups
@@ -156,9 +156,9 @@ serviceability_ttf_virtual = \
   -serviceability/jvmti/negative
 
 # tier1_common shouldn't be executed with VM flags, because
-# non_hotspot and gtest ignore them,
+# non_hotspot and gtest ignore them.
 # hotspot_misc should be used for execution of
-# all non-component tests with VM flags
+# all non-component tests with VM flags.
 tier1_common = \
   sanity \
   native_sanity \

--- a/test/hotspot/jtreg/TEST.groups
+++ b/test/hotspot/jtreg/TEST.groups
@@ -76,7 +76,7 @@ non_hotspot_tests = \
   testlibrary_tests \
   sources
 
-# Gtest unit-test with jtreg wrapper
+# Gtest unit-test with jtreg wrapper, VM flags are set by test
 hotspot_gtest = \
  gtest
 

--- a/test/hotspot/jtreg/TEST.groups
+++ b/test/hotspot/jtreg/TEST.groups
@@ -74,7 +74,8 @@ non_hotspot_tests = \
   testlibrary_tests \
   sources
 
-# Gtest unit-test with jtreg wrapper, VM flags are set by test
+# Gtest unit-test with jtreg wrapper, VM flags are set by test,
+# and so should not be executed with VM flags.
 hotspot_gtest = \
  gtest
 

--- a/test/hotspot/jtreg/TEST.groups
+++ b/test/hotspot/jtreg/TEST.groups
@@ -26,11 +26,19 @@
 all = \
   :hotspot_all
 
+# The resourcehos tests might require a lot of resources  and
+# shouldn't be executed concurrently with ANY other tests
+# So the group shouldn't be part of any other group
+hotspot_resourcehogs = \
+  resourcehogs
+
 hotspot_all = \
+  -:hotspot_resourcehogs \
   /
 
 hotspot_all_no_apps = \
   / \
+  -:hotspot_resourcehogs \
   -applications
 
 # Component test groups
@@ -62,17 +70,27 @@ hotspot_handshake = \
 hotspot_serviceability = \
   serviceability
 
-hotspot_resourcehogs = \
-  resourcehogs
+# The other tests includes all tests that don't
+# test hotspot itself
+non_hotspot_tests = \
+  testlibrary_tests \
+  sources
+
+# Gtest unit-test with jtreg wrapper
+hotspot_gtest = \
+ gtest
 
 hotspot_misc = \
   / \
  -applications \
  -vmTestbase \
+ -:non_hotspot_tests \
  -:hotspot_compiler \
  -:hotspot_gc \
  -:hotspot_runtime \
  -:hotspot_serviceability \
+ -:hotspot_gtest \
+ -:hotspot_resourcehogs \
  -:hotspot_containers
 
 hotspot_native_sanity = \
@@ -138,15 +156,14 @@ serviceability_ttf_virtual = \
   -serviceability/jvmti/events  \
   -serviceability/jvmti/negative
 
+# gtest and non_hotspot tests shouldn't be executed with VM flags
+# hotspot_misc includes sanity testing and might be used
+# for execution non-component tests with VM flags
 tier1_common = \
-  sources \
-  sanity/BasicVMTest.java \
-  gtest/GTestWrapper.java \
-  gtest/LockStackGtests.java \
-  gtest/MetaspaceGtests.java \
-  gtest/LargePageGtests.java \
-  gtest/NMTGtests.java \
-  gtest/WindowsProcessorGroups.java
+  sanity \
+  native_sanity \
+  :non_hotspot_tests \
+  :hotspot_gtest
 
 tier1_compiler = \
   :tier1_compiler_1 \

--- a/test/hotspot/jtreg/TEST.groups
+++ b/test/hotspot/jtreg/TEST.groups
@@ -69,7 +69,7 @@ hotspot_resourcehogs = \
   resourcehogs
 
 # The other tests includes all tests that don't
-# test hotspot itself
+# test hotspot itself.
 non_hotspot_tests = \
   testlibrary_tests \
   sources

--- a/test/hotspot/jtreg/TEST.groups
+++ b/test/hotspot/jtreg/TEST.groups
@@ -62,9 +62,9 @@ hotspot_handshake = \
 hotspot_serviceability = \
   serviceability
 
-# The resourcehogs tests might require a lot of resources  and
-# shouldn't be executed concurrently with ANY other tests
-# So the group shouldn't be part of any other group
+# The resourcehogs tests might require a lot of resources and
+# shouldn't be executed concurrently with ANY other tests.
+# So the group shouldn't be part of any other group.
 hotspot_resourcehogs = \
   resourcehogs
 

--- a/test/hotspot/jtreg/TEST.groups
+++ b/test/hotspot/jtreg/TEST.groups
@@ -26,19 +26,11 @@
 all = \
   :hotspot_all
 
-# The resourcehos tests might require a lot of resources  and
-# shouldn't be executed concurrently with ANY other tests
-# So the group shouldn't be part of any other group
-hotspot_resourcehogs = \
-  resourcehogs
-
 hotspot_all = \
-  -:hotspot_resourcehogs \
   /
 
 hotspot_all_no_apps = \
   / \
-  -:hotspot_resourcehogs \
   -applications
 
 # Component test groups
@@ -69,6 +61,12 @@ hotspot_handshake = \
 
 hotspot_serviceability = \
   serviceability
+
+# The resourcehogs tests might require a lot of resources  and
+# shouldn't be executed concurrently with ANY other tests
+# So the group shouldn't be part of any other group
+hotspot_resourcehogs = \
+  resourcehogs
 
 # The other tests includes all tests that don't
 # test hotspot itself
@@ -158,7 +156,7 @@ serviceability_ttf_virtual = \
 
 # gtest and non_hotspot tests shouldn't be executed with VM flags
 # hotspot_misc includes sanity testing and might be used
-# for execution non-component tests with VM flags
+# for execution of non-component tests with VM flags
 tier1_common = \
   sanity \
   native_sanity \

--- a/test/hotspot/jtreg/TEST.groups
+++ b/test/hotspot/jtreg/TEST.groups
@@ -154,9 +154,10 @@ serviceability_ttf_virtual = \
   -serviceability/jvmti/events  \
   -serviceability/jvmti/negative
 
-# gtest and non_hotspot tests shouldn't be executed with VM flags
-# hotspot_misc includes sanity testing and might be used
-# for execution of non-component tests with VM flags
+# tier1_common shouldn't be executed with VM flags, because
+# non_hotspot and gtest ignore them,
+# hotspot_misc should be used for execution of
+# all non-component tests with VM flags
 tier1_common = \
   sanity \
   native_sanity \


### PR DESCRIPTION
Can you please review following PR that improve test groups.
The bug was originally filed  to eliminate duplication between tier1_common and hotspot_misc test groups.  However while looked on the test content of these groups I realized that there are some other issues. 
1) hotspot_resourcehogs groups should be executed always separately from other tests to don't cause intermittent failures.
2) it makes sense to run all gtest tests in tier1 but don't run in any other tiers (with any VM flags) 
3) testlibrary_tests and  sources should be a separate groups that don't need to be executed with any VM flags, or event with all builds 

So tier1_common includes non-component tests that should be executed in tier1. 
**all** sanity tests
**all** gttest tests (were not all of them)
testlibrary_tests (might be os/cpu specifc, so need to run them with all builds)
source code checking tests (no need to run them an all builds, but it takes only few seconds)

And it doesn't makes any sense to execute  tier1_common with any external VM flags.

While hotspot_misc now includes on 2 sanity tests.  It doesn't looks useful, but main purpose for this group would be to catch all tests that somehow missed from other groups. So let keep it. 

The new test groups were added mostly to add comments explaining their specific.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344270](https://bugs.openjdk.org/browse/JDK-8344270): Update tier1_common and hotspot_misc groups to better organize hotspot non-component tests (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25070/head:pull/25070` \
`$ git checkout pull/25070`

Update a local copy of the PR: \
`$ git checkout pull/25070` \
`$ git pull https://git.openjdk.org/jdk.git pull/25070/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25070`

View PR using the GUI difftool: \
`$ git pr show -t 25070`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25070.diff">https://git.openjdk.org/jdk/pull/25070.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25070#issuecomment-2855436039)
</details>
