### PR TITLE
8354872: Clarify java.lang.Process resource cleanup

### DIFF
--- a/src/java.base/share/classes/java/lang/Process.java
+++ b/src/java.base/share/classes/java/lang/Process.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
Recommend closing streams when no longer in use.
Describe the implementation closing streams when no longer referenced. 
Clarify the interactions between inputStream and inputReader and errorStream and errorReader.