### PR TITLE
8310003: Improve logging when default truststore is inaccessible

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/TrustStoreManager.java
+++ b/src/java.base/share/classes/sun/security/ssl/TrustStoreManager.java
@@ -112,7 +112,7 @@ final class TrustStoreManager {
                 SSLLogger.fine(
                     "trustStore is: " + storeName + "\n" +
                     "trustStore type is: " + storeType + "\n" +
-                    "trustStore provider is: " + ((storeProvider == null || storeProvider.isEmpty()) ? "unspecified" : storeProvider) + "\n" +
+                    "trustStore provider is: " + (storeProvider.isEmpty() ? "unspecified" : storeProvider) + "\n" +
                     "the last modified time is: " + (new Date(lastModified)));
             }
         }

--- a/src/java.base/share/classes/sun/security/ssl/TrustStoreManager.java
+++ b/src/java.base/share/classes/sun/security/ssl/TrustStoreManager.java
@@ -130,7 +130,7 @@ final class TrustStoreManager {
                     "javax.net.ssl.trustStoreType",
                     KeyStore.getDefaultType());
             String storePropProvider = System.getProperty(
-                    "javax.net.ssl.trustStoreProvider", "");
+                    "javax.net.ssl.trustStoreProvider", "unspecified");
             String storePropPassword = System.getProperty(
                     "javax.net.ssl.trustStorePassword", "");
 

--- a/src/java.base/share/classes/sun/security/ssl/TrustStoreManager.java
+++ b/src/java.base/share/classes/sun/security/ssl/TrustStoreManager.java
@@ -112,7 +112,7 @@ final class TrustStoreManager {
                 SSLLogger.fine(
                     "trustStore is: " + storeName + "\n" +
                     "trustStore type is: " + storeType + "\n" +
-                    "trustStore provider is: " + storeProvider + "\n" +
+                    "trustStore provider is: " + (storeProvider == null ? "unspecified" : storeProvider) + "\n" +
                     "the last modified time is: " + (new Date(lastModified)));
             }
         }
@@ -130,7 +130,7 @@ final class TrustStoreManager {
                     "javax.net.ssl.trustStoreType",
                     KeyStore.getDefaultType());
             String storePropProvider = System.getProperty(
-                    "javax.net.ssl.trustStoreProvider", "unspecified");
+                    "javax.net.ssl.trustStoreProvider", "");
             String storePropPassword = System.getProperty(
                     "javax.net.ssl.trustStorePassword", "");
 

--- a/src/java.base/share/classes/sun/security/ssl/TrustStoreManager.java
+++ b/src/java.base/share/classes/sun/security/ssl/TrustStoreManager.java
@@ -112,7 +112,7 @@ final class TrustStoreManager {
                 SSLLogger.fine(
                     "trustStore is: " + storeName + "\n" +
                     "trustStore type is: " + storeType + "\n" +
-                    "trustStore provider is: " + (storeProvider == null ? "unspecified" : storeProvider) + "\n" +
+                    "trustStore provider is: " + ((storeProvider == null || storeProvider.isEmpty()) ? "unspecified" : storeProvider) + "\n" +
                     "the last modified time is: " + (new Date(lastModified)));
             }
         }


### PR DESCRIPTION
If the truststore is unavailable, JDK does not log information for 'trustStore provider is:'. We are now adding 'unspecified' instead of keeping empty.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310003](https://bugs.openjdk.org/browse/JDK-8310003): Improve logging when default truststore is inaccessible (**Enhancement** - P4)


### Reviewers
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25077/head:pull/25077` \
`$ git checkout pull/25077`

Update a local copy of the PR: \
`$ git checkout pull/25077` \
`$ git pull https://git.openjdk.org/jdk.git pull/25077/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25077`

View PR using the GUI difftool: \
`$ git pr show -t 25077`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25077.diff">https://git.openjdk.org/jdk/pull/25077.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25077#issuecomment-2856942453)
</details>
