### PR TITLE
8351313: VM crashes when AOTMode/AOTCache/AOTConfiguration are empty

### DIFF
--- a/src/hotspot/share/cds/cds_globals.hpp
+++ b/src/hotspot/share/cds/cds_globals.hpp
@@ -112,9 +112,11 @@
           "The configuration file written by -XX:AOTMode=record, and "      \
           "loaded by -XX:AOTMode=create. This file contains profiling data "\
           "for deciding what contents should be added to AOTCache. ")       \
+          constraint(AOTConfigurationConstraintFunc, AtParse)               \
                                                                             \
   product(ccstr, AOTCache, nullptr,                                         \
           "Cache for improving start up and warm up")                       \
+          constraint(AOTCacheConstraintFunc, AtParse)                       \
                                                                             \
   product(bool, AOTInvokeDynamicLinking, false, DIAGNOSTIC,                 \
           "AOT-link JVM_CONSTANT_InvokeDynamic entries in cached "          \

--- a/src/hotspot/share/runtime/flags/jvmFlagConstraintsRuntime.cpp
+++ b/src/hotspot/share/runtime/flags/jvmFlagConstraintsRuntime.cpp
@@ -31,7 +31,27 @@
 #include "runtime/task.hpp"
 #include "utilities/powerOfTwo.hpp"
 
+JVMFlag::Error AOTCacheConstraintFunc(ccstr value, bool verbose) {
+  if (value == nullptr) {
+    JVMFlag::printError(verbose, "AOTCache cannot be empty\n");
+    return JVMFlag::VIOLATES_CONSTRAINT;
+  }
+  return JVMFlag::SUCCESS;
+}
+
+JVMFlag::Error AOTConfigurationConstraintFunc(ccstr value, bool verbose) {
+  if (value == nullptr) {
+    JVMFlag::printError(verbose, "AOTConfiguration cannot be empty\n");
+    return JVMFlag::VIOLATES_CONSTRAINT;
+  }
+  return JVMFlag::SUCCESS;
+}
+
 JVMFlag::Error AOTModeConstraintFunc(ccstr value, bool verbose) {
+  if (value == nullptr) {
+    JVMFlag::printError(verbose, "AOTMode cannot be empty\n");
+    return JVMFlag::VIOLATES_CONSTRAINT;
+  }
   if (strcmp(value, "off") != 0 &&
       strcmp(value, "record") != 0 &&
       strcmp(value, "create") != 0 &&
@@ -43,9 +63,9 @@ JVMFlag::Error AOTModeConstraintFunc(ccstr value, bool verbose) {
                         value);
     return JVMFlag::VIOLATES_CONSTRAINT;
   }
-
   return JVMFlag::SUCCESS;
 }
+
 JVMFlag::Error ObjectAlignmentInBytesConstraintFunc(int value, bool verbose) {
   if (!is_power_of_2(value)) {
     JVMFlag::printError(verbose,

--- a/src/hotspot/share/runtime/flags/jvmFlagConstraintsRuntime.hpp
+++ b/src/hotspot/share/runtime/flags/jvmFlagConstraintsRuntime.hpp
@@ -34,6 +34,8 @@
  */
 
 #define RUNTIME_CONSTRAINTS(f)                        \
+  f(ccstr,  AOTCacheConstraintFunc)                   \
+  f(ccstr,  AOTConfigurationConstraintFunc)           \
   f(ccstr,  AOTModeConstraintFunc)                    \
   f(int,    ObjectAlignmentInBytesConstraintFunc)     \
   f(int,    ContendedPaddingWidthConstraintFunc)      \

--- a/test/hotspot/jtreg/runtime/cds/appcds/AOTFlags.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/AOTFlags.java
@@ -354,6 +354,20 @@ public class AOTFlags {
         out.shouldContain("Unable to use AOT cache.");
         out.shouldContain("Not a valid AOT cache (dynamic.jsa)");
         out.shouldHaveExitValue(1);
+
+        //----------------------------------------------------------------------
+        testEmptyValue("AOTCache");
+        testEmptyValue("AOTConfiguration");
+        testEmptyValue("AOTMode");
+    }
+
+    static void testEmptyValue(String option) throws Exception {
+        printTestCase("Empty values for " + option);
+        ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(
+            "-XX:" + option + "=", "--version");
+        OutputAnalyzer out = CDSTestUtils.executeAndLog(pb, "neg");
+        out.shouldContain("Improperly specified VM option '" + option + "='");
+        out.shouldHaveExitValue(1);
     }
 
     static int testNum = 0;


### PR DESCRIPTION
Please review this trivial patch. When `-XX:AOTMode=`, etc, is given on the command line, the global takes on the problematic value `nullptr`. I added constraint functions to forbid such cases.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8351313](https://bugs.openjdk.org/browse/JDK-8351313): VM crashes when AOTMode/AOTCache/AOTConfiguration are empty (**Bug** - P2)


### Reviewers
 * [Calvin Cheung](https://openjdk.org/census#ccheung) (@calvinccheung - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25078/head:pull/25078` \
`$ git checkout pull/25078`

Update a local copy of the PR: \
`$ git checkout pull/25078` \
`$ git pull https://git.openjdk.org/jdk.git pull/25078/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25078`

View PR using the GUI difftool: \
`$ git pr show -t 25078`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25078.diff">https://git.openjdk.org/jdk/pull/25078.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25078#issuecomment-2856967226)
</details>
