### PR TITLE
8356165: System.in in jshell replace supplementary characters with ??

### DIFF
--- a/src/jdk.jshell/share/classes/jdk/internal/jshell/tool/ConsoleIOContext.java
+++ b/src/jdk.jshell/share/classes/jdk/internal/jshell/tool/ConsoleIOContext.java
@@ -980,9 +980,14 @@ class ConsoleIOContext extends IOContext {
             StringBuilder dataToConvert = new StringBuilder();
             dataToConvert.append(userChar);
             if (Character.isHighSurrogate(userChar)) {
-                if (pendingLine.length() > pendingLinePointer &&
-                    Character.isLowSurrogate(pendingLine.charAt(pendingLinePointer))) {
-                    dataToConvert.append(readUserInputChar());
+                //surrogates cannot be converted independently,
+                //read the low surrogate and append it to dataToConvert:
+                char lowSurrogate = readUserInputChar();
+                if (Character.isLowSurrogate(lowSurrogate)) {
+                    dataToConvert.append(lowSurrogate);
+                } else {
+                    //if not the low surrogate, rollback the reading of the character:
+                    pendingLinePointer--;
                 }
             }
             pendingBytes = dataToConvert.toString().getBytes();

--- a/src/jdk.jshell/share/classes/jdk/internal/jshell/tool/ConsoleIOContext.java
+++ b/src/jdk.jshell/share/classes/jdk/internal/jshell/tool/ConsoleIOContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -977,7 +977,15 @@ class ConsoleIOContext extends IOContext {
     public synchronized int readUserInput() throws IOException {
         if (pendingBytes == null || pendingBytes.length <= pendingBytesPointer) {
             char userChar = readUserInputChar();
-            pendingBytes = String.valueOf(userChar).getBytes();
+            StringBuilder dataToConvert = new StringBuilder();
+            dataToConvert.append(userChar);
+            if (Character.isHighSurrogate(userChar)) {
+                if (pendingLine.length() > pendingLinePointer &&
+                    Character.isLowSurrogate(pendingLine.charAt(pendingLinePointer))) {
+                    dataToConvert.append(readUserInputChar());
+                }
+            }
+            pendingBytes = dataToConvert.toString().getBytes();
             pendingBytesPointer = 0;
         }
         return pendingBytes[pendingBytesPointer++];

--- a/test/langtools/jdk/jshell/InputUITest.java
+++ b/test/langtools/jdk/jshell/InputUITest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8356165
+ * @summary Check user input works properly
+ * @modules
+ *     jdk.compiler/com.sun.tools.javac.api
+ *     jdk.compiler/com.sun.tools.javac.main
+ *     jdk.jshell/jdk.internal.jshell.tool:open
+ *     jdk.jshell/jdk.internal.jshell.tool.resources:open
+ *     jdk.jshell/jdk.jshell:open
+ * @library /tools/lib
+ * @build toolbox.ToolBox toolbox.JarTask toolbox.JavacTask
+ * @build Compiler UITesting
+ * @compile InputUITest.java
+ * @run testng InputUITest
+ */
+
+import org.testng.annotations.Test;
+
+@Test
+public class InputUITest extends UITesting {
+
+    public InputUITest() {
+        super(true);
+    }
+
+    public void testUserInputWithSurrogates() throws Exception {
+        doRunTest((inputSink, out) -> {
+            inputSink.write("new String(System.in.readNBytes(4))\n\uD83D\uDE03\n");
+            waitOutput(out, "\"\uD83D\uDE03\"");
+        });
+    }
+
+}

--- a/test/langtools/jdk/jshell/InputUITest.java
+++ b/test/langtools/jdk/jshell/InputUITest.java
@@ -49,8 +49,12 @@ public class InputUITest extends UITesting {
 
     public void testUserInputWithSurrogates() throws Exception {
         doRunTest((inputSink, out) -> {
-            inputSink.write("new String(System.in.readNBytes(4))\n\uD83D\uDE03\n");
-            waitOutput(out, "\"\uD83D\uDE03\"");
+            inputSink.write("new String(System.in.readNBytes(5))\n\uD83D\uDE03\n");
+            waitOutput(out, patternQuote("\"\uD83D\uDE03\\n\""));
+            inputSink.write("new String(System.in.readNBytes(2))\n\uD83D\n");
+            waitOutput(out, patternQuote("\"?\\n\""));
+            inputSink.write("new String(System.in.readNBytes(2))\n\uDE03\n");
+            waitOutput(out, patternQuote("\"?\\n\""));
         }, false);
     }
 

--- a/test/langtools/jdk/jshell/InputUITest.java
+++ b/test/langtools/jdk/jshell/InputUITest.java
@@ -51,7 +51,7 @@ public class InputUITest extends UITesting {
         doRunTest((inputSink, out) -> {
             inputSink.write("new String(System.in.readNBytes(4))\n\uD83D\uDE03\n");
             waitOutput(out, "\"\uD83D\uDE03\"");
-        });
+        }, false);
     }
 
 }

--- a/test/langtools/jdk/jshell/UITesting.java
+++ b/test/langtools/jdk/jshell/UITesting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,7 @@
  * questions.
  */
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -62,6 +63,10 @@ public class UITesting {
     }
 
     protected void doRunTest(Test test) throws Exception {
+        doRunTest(test, true);
+    }
+
+    protected void doRunTest(Test test, boolean setUserInput) throws Exception {
         // turn on logging of launch failures
         Logger.getLogger("jdk.jshell.execution").setLevel(Level.ALL);
 
@@ -87,7 +92,7 @@ public class UITesting {
         Thread runner = new Thread(() -> {
             try {
                 JavaShellToolBuilder.builder()
-                        .in(input, input)
+                        .in(input, setUserInput ? input : null)
                         .out(outS)
                         .err(outS)
                         .promptCapture(true)


### PR DESCRIPTION
When reading from `System.in` in a JShell snippet, JShell first reads the whole line (getting a `String`), and then converts this characters from this `String` to bytes on demand. But, it does not convert multi-surrogate code points correctly, it tries to convert each surrogate separately, which cannot work.

The proposal herein is to, when the current character is a high surrogate, peek at the next character, and if it is a low surrogate, convert both the high and low surrogates to bytes together.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8356165](https://bugs.openjdk.org/browse/JDK-8356165): System.in in jshell replace supplementary characters with ?? (**Bug** - P3)


### Reviewers
 * [Christian Stein](https://openjdk.org/census#cstein) (@sormuras - Committer)
 * [Adam Sotona](https://openjdk.org/census#asotona) (@asotona - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25079/head:pull/25079` \
`$ git checkout pull/25079`

Update a local copy of the PR: \
`$ git checkout pull/25079` \
`$ git pull https://git.openjdk.org/jdk.git pull/25079/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25079`

View PR using the GUI difftool: \
`$ git pr show -t 25079`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25079.diff">https://git.openjdk.org/jdk/pull/25079.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25079#issuecomment-2857319462)
</details>
