### PR TITLE
8356329: Report compact object headers in hs_err

### DIFF
--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -531,6 +531,7 @@ static void report_vm_version(outputStream* st, char* buf, int buflen) {
 #endif
                  UseCompressedOops ? ", compressed oops" : "",
                  UseCompressedClassPointers ? ", compressed class ptrs" : "",
+                 UseCompactObjectHeaders ? ", compact obj headers" : "",
                  GCConfig::hs_err_name(),
                  VM_Version::vm_platform_string()
                );


### PR DESCRIPTION
We should report when UseCompactObjectHeaders is enabled in the hs_err file, just like we do for UseCompressedOops or UseCompressedClassPointers, for improved diagnostics.