### PR TITLE
8356328: Some C2 IR nodes miss size_of() function

### DIFF
--- a/src/hotspot/share/opto/intrinsicnode.hpp
+++ b/src/hotspot/share/opto/intrinsicnode.hpp
@@ -199,6 +199,10 @@ class EncodeISOArrayNode: public Node {
   virtual Node* Ideal(PhaseGVN* phase, bool can_reshape);
   virtual const Type* Value(PhaseGVN* phase) const;
   virtual uint size_of() const { return sizeof(EncodeISOArrayNode); }
+  virtual uint hash() const { return Node::hash() + ascii; }
+  virtual bool cmp(const Node& n) const {
+    return Node::cmp(n) && ascii == ((EncodeISOArrayNode&)n).is_ascii();
+  }
 };
 
 //-------------------------------DigitNode----------------------------------------

--- a/src/hotspot/share/opto/intrinsicnode.hpp
+++ b/src/hotspot/share/opto/intrinsicnode.hpp
@@ -198,6 +198,7 @@ class EncodeISOArrayNode: public Node {
   virtual uint ideal_reg() const { return Op_RegI; }
   virtual Node* Ideal(PhaseGVN* phase, bool can_reshape);
   virtual const Type* Value(PhaseGVN* phase) const;
+  virtual uint size_of() const { return sizeof(EncodeISOArrayNode); }
 };
 
 //-------------------------------DigitNode----------------------------------------

--- a/src/hotspot/share/opto/intrinsicnode.hpp
+++ b/src/hotspot/share/opto/intrinsicnode.hpp
@@ -184,12 +184,12 @@ class VectorizedHashCodeNode: public Node {
 //------------------------------EncodeISOArray--------------------------------
 // encode char[] to byte[] in ISO_8859_1 or ASCII
 class EncodeISOArrayNode: public Node {
-  bool ascii;
+  bool _ascii;
  public:
   EncodeISOArrayNode(Node* control, Node* arymem, Node* s1, Node* s2, Node* c, bool ascii)
-    : Node(control, arymem, s1, s2, c), ascii(ascii) {}
+    : Node(control, arymem, s1, s2, c), _ascii(ascii) {}
 
-  bool is_ascii() { return ascii; }
+  bool is_ascii() { return _ascii; }
   virtual int Opcode() const;
   virtual bool depends_only_on_test() const { return false; }
   virtual const Type* bottom_type() const { return TypeInt::INT; }
@@ -199,9 +199,9 @@ class EncodeISOArrayNode: public Node {
   virtual Node* Ideal(PhaseGVN* phase, bool can_reshape);
   virtual const Type* Value(PhaseGVN* phase) const;
   virtual uint size_of() const { return sizeof(EncodeISOArrayNode); }
-  virtual uint hash() const { return Node::hash() + ascii; }
+  virtual uint hash() const { return Node::hash() + _ascii; }
   virtual bool cmp(const Node& n) const {
-    return Node::cmp(n) && ascii == ((EncodeISOArrayNode&)n).is_ascii();
+    return Node::cmp(n) && _ascii == ((EncodeISOArrayNode&)n).is_ascii();
   }
 };
 

--- a/src/hotspot/share/opto/machnode.hpp
+++ b/src/hotspot/share/opto/machnode.hpp
@@ -499,6 +499,7 @@ public:
   int  constant_offset() const { return ((MachConstantNode*) this)->constant_offset(); }
   // Unchecked version to avoid assertions in debug output.
   int  constant_offset_unchecked() const;
+  virtual uint size_of() const { return sizeof(MachConstantNode); }
 };
 
 //------------------------------MachUEPNode-----------------------------------
@@ -539,6 +540,7 @@ public:
   virtual uint size(PhaseRegAlloc *ra_) const;
   virtual int reloc() const;
   virtual const Pipeline *pipeline() const;
+  virtual uint size_of() const { return sizeof(MachEpilogNode); }
 
 private:
   bool _do_polling;
@@ -567,6 +569,7 @@ public:
 
   virtual int ideal_Opcode() const { return Op_Con; } // bogus; see output.cpp
   virtual const Pipeline *pipeline() const;
+  virtual uint size_of() const { return sizeof(MachNopNode); }
 #ifndef PRODUCT
   virtual const char *Name() const { return "Nop"; }
   virtual void format( PhaseRegAlloc *, outputStream *st ) const;
@@ -794,6 +797,7 @@ public:
   MachJumpNode() : MachConstantNode() {
     init_class_id(Class_MachJump);
   }
+  virtual uint size_of() const { return sizeof(MachJumpNode); }
 };
 
 //------------------------------MachGotoNode-----------------------------------
@@ -892,6 +896,7 @@ public:
     assert(verify_jvms(jvms), "jvms must match");
     set_req(_jvmadj + jvms->monoff() + idx, c);
   }
+  virtual uint size_of() const { return sizeof(MachSafePointNode); }
 };
 
 //------------------------------MachCallNode----------------------------------
@@ -1006,6 +1011,7 @@ public:
 #ifndef PRODUCT
   virtual void dump_spec(outputStream *st) const;
 #endif
+  virtual uint size_of() const { return sizeof(MachCallDynamicJavaNode); }
 };
 
 //------------------------------MachCallRuntimeNode----------------------------
@@ -1039,6 +1045,7 @@ public:
   bool _reachable;
   const char* _halt_reason;
   virtual JVMState* jvms() const;
+  virtual uint size_of() const { return sizeof(MachHaltNode); }
   bool is_reachable() const {
     return _reachable;
   }

--- a/src/hotspot/share/opto/machnode.hpp
+++ b/src/hotspot/share/opto/machnode.hpp
@@ -534,6 +534,8 @@ public:
 //------------------------------MachEpilogNode--------------------------------
 // Machine function Epilog Node
 class MachEpilogNode : public MachIdealNode {
+private:
+  bool _do_polling;
 public:
   MachEpilogNode(bool do_poll = false) : _do_polling(do_poll) {}
   virtual void emit(C2_MacroAssembler *masm, PhaseRegAlloc *ra_) const;
@@ -541,11 +543,6 @@ public:
   virtual int reloc() const;
   virtual const Pipeline *pipeline() const;
   virtual uint size_of() const { return sizeof(MachEpilogNode); }
-
-private:
-  bool _do_polling;
-
-public:
   bool do_polling() const { return _do_polling; }
 
 #ifndef PRODUCT

--- a/src/hotspot/share/opto/memnode.hpp
+++ b/src/hotspot/share/opto/memnode.hpp
@@ -1089,6 +1089,7 @@ public:
   virtual Node *Ideal(PhaseGVN *phase, bool can_reshape);
   virtual uint match_edge(uint idx) const;
   bool is_large() const { return _is_large; }
+  virtual uint size_of() const { return sizeof(ClearArrayNode); }
 
   // Clear the given area of an object or array.
   // The start offset must always be aligned mod BytesPerInt.

--- a/src/hotspot/share/opto/memnode.hpp
+++ b/src/hotspot/share/opto/memnode.hpp
@@ -1090,6 +1090,10 @@ public:
   virtual uint match_edge(uint idx) const;
   bool is_large() const { return _is_large; }
   virtual uint size_of() const { return sizeof(ClearArrayNode); }
+  virtual uint hash() const { return Node::hash() + _is_large; }
+  virtual bool cmp(const Node& n) const {
+    return Node::cmp(n) && _is_large == ((ClearArrayNode&)n).is_large();
+  }
 
   // Clear the given area of an object or array.
   // The start offset must always be aligned mod BytesPerInt.

--- a/src/hotspot/share/opto/opaquenode.hpp
+++ b/src/hotspot/share/opto/opaquenode.hpp
@@ -124,6 +124,7 @@ public:
 
   void mark_useless(PhaseIterGVN& igvn);
   NOT_PRODUCT(virtual void dump_spec(outputStream* st) const;)
+  virtual uint size_of() const { return sizeof(OpaqueMultiversioningNode); }
 };
 
 // This node is used in the context of intrinsics. We sometimes implicitly know that an object is non-null even though
@@ -267,6 +268,7 @@ class ProfileBooleanNode : public Node {
   virtual Node *Ideal(PhaseGVN *phase, bool can_reshape);
   virtual Node* Identity(PhaseGVN* phase);
   virtual const Type *bottom_type() const { return TypeInt::BOOL; }
+  virtual uint size_of() const { return sizeof(ProfileBooleanNode); }
 };
 
 #endif // SHARE_OPTO_OPAQUENODE_HPP

--- a/src/hotspot/share/opto/opaquenode.hpp
+++ b/src/hotspot/share/opto/opaquenode.hpp
@@ -125,12 +125,6 @@ public:
   void mark_useless(PhaseIterGVN& igvn);
   NOT_PRODUCT(virtual void dump_spec(outputStream* st) const;)
   virtual uint size_of() const { return sizeof(OpaqueMultiversioningNode); }
-  virtual uint hash() const { return Node::hash() + _is_delayed_slow_loop + _useless; }
-  virtual bool cmp(const Node& n) const {
-    return Node::cmp(n)
-           && _is_delayed_slow_loop == ((OpaqueMultiversioningNode&)n).is_delayed_slow_loop()
-           DEBUG_ONLY(&& _useless == ((OpaqueMultiversioningNode&)n).is_useless());
-  }
 };
 
 // This node is used in the context of intrinsics. We sometimes implicitly know that an object is non-null even though

--- a/src/hotspot/share/opto/opaquenode.hpp
+++ b/src/hotspot/share/opto/opaquenode.hpp
@@ -125,6 +125,12 @@ public:
   void mark_useless(PhaseIterGVN& igvn);
   NOT_PRODUCT(virtual void dump_spec(outputStream* st) const;)
   virtual uint size_of() const { return sizeof(OpaqueMultiversioningNode); }
+  virtual uint hash() const { return Node::hash() + _is_delayed_slow_loop + _useless; }
+  virtual bool cmp(const Node& n) const {
+    return Node::cmp(n)
+           && _is_delayed_slow_loop == ((OpaqueMultiversioningNode&)n).is_delayed_slow_loop()
+           DEBUG_ONLY(&& _useless == ((OpaqueMultiversioningNode&)n).is_useless());
+  }
 };
 
 // This node is used in the context of intrinsics. We sometimes implicitly know that an object is non-null even though


### PR DESCRIPTION
I wrote a test to check if every C2 IR node has correct size_of() function. And I found some of them are missed. They added new fields and not add size_of() to reflect new size. In linux, it does not cause issue so far, because gcc allocate more space for alignment and can keep these additional `bool` flags. But it will report failure on windows. And if anyone modified base class, it will cause problem.

PS, My test is in https://github.com/openjdk/jdk/compare/master...kuaiwei:jdk:test/check_node_size , but it has many hack on IR nodes to make test to run.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8356328](https://bugs.openjdk.org/browse/JDK-8356328): Some C2 IR nodes miss size_of() function (**Bug** - P4)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**) Review applies to [03f84eb7](https://git.openjdk.org/jdk/pull/25081/files/03f84eb7340889776dba3afd7330740752abd9d3)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25081/head:pull/25081` \
`$ git checkout pull/25081`

Update a local copy of the PR: \
`$ git checkout pull/25081` \
`$ git pull https://git.openjdk.org/jdk.git pull/25081/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25081`

View PR using the GUI difftool: \
`$ git pr show -t 25081`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25081.diff">https://git.openjdk.org/jdk/pull/25081.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25081#issuecomment-2857370920)
</details>
