### PR TITLE
8356310: compiler/print/TestPrintAssemblyDeoptRace.java fails with Improperly specified VM option 'DeoptimizeALot'

### DIFF
--- a/test/hotspot/jtreg/compiler/print/TestPrintAssemblyDeoptRace.java
+++ b/test/hotspot/jtreg/compiler/print/TestPrintAssemblyDeoptRace.java
@@ -25,7 +25,7 @@
  * @test
  * @bug 8258229
  * @summary If a method is made not entrant while printing the assembly, hotspot crashes due to mismatched relocation information.
- * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+IgnoreUnrecognizedVMOptions -XX:-TieredCompilation -XX:+DeoptimizeALot
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:-TieredCompilation -XX:+DeoptimizeALot
  *                   -XX:CompileCommand=print,java/math/BitSieve.bit compiler.print.TestPrintAssemblyDeoptRace
  */
 

--- a/test/hotspot/jtreg/compiler/print/TestPrintAssemblyDeoptRace.java
+++ b/test/hotspot/jtreg/compiler/print/TestPrintAssemblyDeoptRace.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8258229 8356310
+ * @bug 8258229
  * @summary If a method is made not entrant while printing the assembly, hotspot crashes due to mismatched relocation information.
  * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+IgnoreUnrecognizedVMOptions -XX:-TieredCompilation -XX:+DeoptimizeALot
  *                   -XX:CompileCommand=print,java/math/BitSieve.bit compiler.print.TestPrintAssemblyDeoptRace

--- a/test/hotspot/jtreg/compiler/print/TestPrintAssemblyDeoptRace.java
+++ b/test/hotspot/jtreg/compiler/print/TestPrintAssemblyDeoptRace.java
@@ -23,10 +23,10 @@
 
 /*
  * @test
- * @bug 8258229
+ * @bug 8258229 8356310
  * @summary If a method is made not entrant while printing the assembly, hotspot crashes due to mismatched relocation information.
- * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:-TieredCompilation -XX:+DeoptimizeALot -XX:CompileCommand=print,java/math/BitSieve.bit
- *                   compiler.print.TestPrintAssemblyDeoptRace
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+IgnoreUnrecognizedVMOptions -XX:-TieredCompilation -XX:+DeoptimizeALot
+ *                   -XX:CompileCommand=print,java/math/BitSieve.bit compiler.print.TestPrintAssemblyDeoptRace
  */
 
 package compiler.print;


### PR DESCRIPTION
This PR adds `-XX:+IgnoreUnrecoginzedVMOptions` to fix `compiler/print/TestPrintAssemblyDeoptRace.java` on product builds.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8356310](https://bugs.openjdk.org/browse/JDK-8356310): compiler/print/TestPrintAssemblyDeoptRace.java fails with Improperly specified VM option 'DeoptimizeALot' (**Bug** - P3)


### Reviewers
 * [Marc Chevalier](https://openjdk.org/census#mchevalier) (@marc-chevalier - Author) Review applies to [4e42cb6a](https://git.openjdk.org/jdk/pull/25082/files/4e42cb6a4ce4cfe128710c5c547f65c9085811b8)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**) Review applies to [af03557b](https://git.openjdk.org/jdk/pull/25082/files/af03557b51a6cb7aa66b36968ecd522a25811e28)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**) Review applies to [af03557b](https://git.openjdk.org/jdk/pull/25082/files/af03557b51a6cb7aa66b36968ecd522a25811e28)
 * [Roberto Castañeda Lozano](https://openjdk.org/census#rcastanedalo) (@robcasloz - **Reviewer**) Review applies to [af03557b](https://git.openjdk.org/jdk/pull/25082/files/af03557b51a6cb7aa66b36968ecd522a25811e28)
 * [Emanuel Peter](https://openjdk.org/census#epeter) (@eme64 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25082/head:pull/25082` \
`$ git checkout pull/25082`

Update a local copy of the PR: \
`$ git checkout pull/25082` \
`$ git pull https://git.openjdk.org/jdk.git pull/25082/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25082`

View PR using the GUI difftool: \
`$ git pr show -t 25082`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25082.diff">https://git.openjdk.org/jdk/pull/25082.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25082#issuecomment-2857446680)
</details>
