### PR TITLE
8356335: Remove linux-x86 from jib profiles

### DIFF
--- a/make/conf/jib-profiles.js
+++ b/make/conf/jib-profiles.js
@@ -241,10 +241,10 @@ var getJibProfilesCommon = function (input, data) {
 
     // List of the main profile names used for iteration
     common.main_profile_names = [
-        "linux-x64", "linux-x86", "macosx-x64", "macosx-aarch64",
+        "macosx-x64", "macosx-aarch64",
         "windows-x64", "windows-aarch64",
-        "linux-aarch64", "linux-arm32", "linux-ppc64le", "linux-s390x",
-        "linux-riscv64"
+        "linux-x64", "linux-aarch64",
+        "linux-arm32", "linux-ppc64le", "linux-s390x", "linux-riscv64"
     ];
 
     // These are the base settings for all the main build profiles.
@@ -282,9 +282,6 @@ var getJibProfilesCommon = function (input, data) {
         configure_args: ["--enable-openjdk-only"],
         labels: "open"
     };
-
-    common.configure_args_64bit = ["--with-target-bits=64"];
-    common.configure_args_32bit = ["--with-target-bits=32"];
 
     /**
      * Define common artifacts template for all main profiles
@@ -412,58 +409,34 @@ var getJibProfilesProfiles = function (input, common, data) {
 
     // Main SE profiles
     var profiles = {
-
-        "linux-x64": {
-            target_os: "linux",
-            target_cpu: "x64",
-            dependencies: ["devkit", "gtest", "build_devkit", "graphviz", "pandoc", "tidy"],
-            configure_args: concat(
-                (input.build_cpu == "x64" ? common.configure_args_64bit
-                 : "--openjdk-target=x86_64-linux-gnu"),
-                "--with-zlib=system", "--disable-dtrace",
-                (isWsl(input) ? [ "--host=x86_64-unknown-linux-gnu",
-                    "--build=x86_64-unknown-linux-gnu" ] : [])),
-        },
-
-        "linux-x86": {
-            target_os: "linux",
-            target_cpu: "x86",
-            build_cpu: "x64",
-            dependencies: ["devkit", "gtest", "libffi"],
-            configure_args: concat(common.configure_args_32bit, [
-                "--with-jvm-variants=minimal,server",
-                "--with-zlib=system",
-                "--with-libffi=" + input.get("libffi", "home_path"),
-                "--enable-libffi-bundling",
-                "--enable-fallback-linker"
-            ])
-        },
-
         "macosx-x64": {
             target_os: "macosx",
             target_cpu: "x64",
             dependencies: ["devkit", "gtest", "graphviz", "pandoc", "tidy"],
-            configure_args: concat(common.configure_args_64bit, "--with-zlib=system",
+            configure_args: [
+                "--with-zlib=system",
                 "--with-macosx-version-max=11.00.00",
                 "--enable-compatible-cds-alignment",
                 // Use system SetFile instead of the one in the devkit as the
                 // devkit one may not work on Catalina.
-                "SETFILE=/usr/bin/SetFile"),
+                "SETFILE=/usr/bin/SetFile"
+            ],
         },
 
         "macosx-aarch64": {
             target_os: "macosx",
             target_cpu: "aarch64",
             dependencies: ["devkit", "gtest", "graphviz", "pandoc", "tidy"],
-            configure_args: concat(common.configure_args_64bit,
-                "--with-macosx-version-max=11.00.00"),
+            configure_args: [
+                "--with-macosx-version-max=11.00.00"
+            ],
         },
 
         "windows-x64": {
             target_os: "windows",
             target_cpu: "x64",
             dependencies: ["devkit", "gtest", "pandoc"],
-            configure_args: concat(common.configure_args_64bit),
+            configure_args: [],
         },
 
         "windows-aarch64": {
@@ -475,7 +448,19 @@ var getJibProfilesProfiles = function (input, common, data) {
             ],
         },
 
-        "linux-aarch64": {
+        "linux-x64": {
+          target_os: "linux",
+          target_cpu: "x64",
+          dependencies: ["devkit", "gtest", "build_devkit", "graphviz", "pandoc", "tidy"],
+          configure_args: concat(
+              "--with-zlib=system",
+              "--disable-dtrace",
+              (cross_compiling ? [ "--openjdk-target=x86_64-linux-gnu" ] : []),
+              (isWsl(input) ? [ "--host=x86_64-unknown-linux-gnu",
+                  "--build=x86_64-unknown-linux-gnu" ] : [])),
+        },
+
+       "linux-aarch64": {
             target_os: "linux",
             target_cpu: "aarch64",
             dependencies: ["devkit", "gtest", "build_devkit", "graphviz", "pandoc", "tidy"],
@@ -492,8 +477,10 @@ var getJibProfilesProfiles = function (input, common, data) {
             build_cpu: "x64",
             dependencies: ["devkit", "gtest", "build_devkit"],
             configure_args: [
-                "--openjdk-target=arm-linux-gnueabihf", "--with-freetype=bundled",
-                "--with-abi-profile=arm-vfp-hflt", "--disable-warnings-as-errors"
+                "--openjdk-target=arm-linux-gnueabihf",
+                "--with-freetype=bundled",
+                "--with-abi-profile=arm-vfp-hflt",
+                "--disable-warnings-as-errors"
             ],
         },
 
@@ -503,7 +490,8 @@ var getJibProfilesProfiles = function (input, common, data) {
             build_cpu: "x64",
             dependencies: ["devkit", "gtest", "build_devkit"],
             configure_args: [
-                "--openjdk-target=ppc64le-linux-gnu", "--with-freetype=bundled",
+                "--openjdk-target=ppc64le-linux-gnu",
+                "--with-freetype=bundled",
                 "--disable-warnings-as-errors"
             ],
         },
@@ -514,7 +502,8 @@ var getJibProfilesProfiles = function (input, common, data) {
             build_cpu: "x64",
             dependencies: ["devkit", "gtest", "build_devkit"],
             configure_args: [
-                "--openjdk-target=s390x-linux-gnu", "--with-freetype=bundled",
+                "--openjdk-target=s390x-linux-gnu",
+                "--with-freetype=bundled",
                 "--disable-warnings-as-errors"
             ],
         },
@@ -525,7 +514,8 @@ var getJibProfilesProfiles = function (input, common, data) {
             build_cpu: "x64",
             dependencies: ["devkit", "gtest", "build_devkit"],
             configure_args: [
-                "--openjdk-target=riscv64-linux-gnu", "--with-freetype=bundled",
+                "--openjdk-target=riscv64-linux-gnu",
+                "--with-freetype=bundled",
                 "--disable-warnings-as-errors"
             ],
         },
@@ -586,24 +576,24 @@ var getJibProfilesProfiles = function (input, common, data) {
             target_os: "linux",
             target_cpu: "x64",
             dependencies: ["devkit", "gtest", "libffi"],
-            configure_args: concat(common.configure_args_64bit, [
+            configure_args: [
                 "--with-zlib=system",
                 "--with-jvm-variants=zero",
                 "--with-libffi=" + input.get("libffi", "home_path"),
                 "--enable-libffi-bundling",
-            ])
+            ]
         },
 
         "linux-aarch64-zero": {
             target_os: "linux",
             target_cpu: "aarch64",
             dependencies: ["devkit", "gtest", "libffi"],
-            configure_args: concat(common.configure_args_64bit, [
+            configure_args: [
                 "--with-zlib=system",
                 "--with-jvm-variants=zero",
                 "--with-libffi=" + input.get("libffi", "home_path"),
                 "--enable-libffi-bundling"
-            ])
+            ]
         },
 
         "linux-x86-zero": {
@@ -611,12 +601,13 @@ var getJibProfilesProfiles = function (input, common, data) {
             target_cpu: "x86",
             build_cpu: "x64",
             dependencies: ["devkit", "gtest", "libffi"],
-            configure_args:  concat(common.configure_args_32bit, [
+            configure_args: [
+                "--with-target-bits=32",
                 "--with-zlib=system",
                 "--with-jvm-variants=zero",
                 "--with-libffi=" + input.get("libffi", "home_path"),
                 "--enable-libffi-bundling"
-            ])
+            ]
         }
     }
     profiles = concatObjects(profiles, zeroProfiles);
@@ -635,8 +626,10 @@ var getJibProfilesProfiles = function (input, common, data) {
             target_os: "linux",
             target_cpu: "x64",
             dependencies: ["devkit", "gtest"],
-            configure_args: concat(common.configure_args_64bit,
-                "--with-zlib=system", "--disable-precompiled-headers"),
+            configure_args: [
+                "--with-zlib=system",
+                "--disable-precompiled-headers"
+            ],
         },
     };
     profiles = concatObjects(profiles, noPchProfiles);
@@ -692,9 +685,6 @@ var getJibProfilesProfiles = function (input, common, data) {
     var artifactData = {
         "linux-x64": {
             platform: "linux-x64",
-        },
-        "linux-x86": {
-            platform: "linux-x86",
         },
         "macosx-x64": {
             platform: "macos-x64",


### PR DESCRIPTION
After [JEP 503](https://openjdk.org/jeps/503), we cannot build linux-x86 so it should not be included in the jib profiles. 

I also took the opportunity to remove the superfluous `--with-target-bits=64` option, clean up some `configure_args` constructs, and to reorder the profiles to group all linux profiles together.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8356335](https://bugs.openjdk.org/browse/JDK-8356335): Remove linux-x86 from jib profiles (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25083/head:pull/25083` \
`$ git checkout pull/25083`

Update a local copy of the PR: \
`$ git checkout pull/25083` \
`$ git pull https://git.openjdk.org/jdk.git pull/25083/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25083`

View PR using the GUI difftool: \
`$ git pr show -t 25083`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25083.diff">https://git.openjdk.org/jdk/pull/25083.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25083#issuecomment-2857490734)
</details>
