### PR TITLE
8356114: java/foreign/TestBufferStackStress2.java failed with junit action timed out

### DIFF
--- a/test/jdk/java/foreign/TestBufferStackStress2.java
+++ b/test/jdk/java/foreign/TestBufferStackStress2.java
@@ -29,6 +29,7 @@
  */
 
 import jdk.internal.foreign.BufferStack;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 
 import java.io.FileDescriptor;
@@ -67,10 +68,8 @@ final class TestBufferStackStress2 {
         // this stress test will not work as the main thread is always alive causing
         // us to wait forever for contraction.
         // Hence, we will skip this test if the main thread is virtual.
-        Assumptions.assumeFalse(Thread.currentThread().isVirtual(), "Skipped because the main thread is a virtual thread");
-            System.out.println("Skipped because the main thread is a virtual thread");
-            return;
-        }
+        Assumptions.assumeFalse(Thread.currentThread().isVirtual(),
+                "Skipped because the main thread is a virtual thread");
 
         final long begin = System.nanoTime();
         var pool = BufferStack.of(POOL_SIZE, 1);

--- a/test/jdk/java/foreign/TestBufferStackStress2.java
+++ b/test/jdk/java/foreign/TestBufferStackStress2.java
@@ -67,7 +67,7 @@ final class TestBufferStackStress2 {
         // this stress test will not work as the main thread is always alive causing
         // us to wait forever for contraction.
         // Hence, we will skip this test if the main thread is virtual.
-        if (Thread.currentThread().isVirtual()) {
+        Assumptions.assumeFalse(Thread.currentThread().isVirtual(), "Skipped because the main thread is a virtual thread");
             System.out.println("Skipped because the main thread is a virtual thread");
             return;
         }

--- a/test/jdk/java/foreign/TestBufferStackStress2.java
+++ b/test/jdk/java/foreign/TestBufferStackStress2.java
@@ -62,6 +62,16 @@ final class TestBufferStackStress2 {
      */
     @Test
     void movingVirtualThreadWithGc() throws InterruptedException {
+
+        // If the VM is configured such that the main thread is virtual,
+        // this stress test will not work as the main thread is always alive causing
+        // us to wait forever for contraction.
+        // Hence, we will skipp this test if the main thread is virtual.
+        if (Thread.currentThread().isVirtual()) {
+            System.out.println("Skipped because the main thread is a virtual thread");
+            return;
+        }
+
         final long begin = System.nanoTime();
         var pool = BufferStack.of(POOL_SIZE, 1);
 

--- a/test/jdk/java/foreign/TestBufferStackStress2.java
+++ b/test/jdk/java/foreign/TestBufferStackStress2.java
@@ -66,7 +66,7 @@ final class TestBufferStackStress2 {
         // If the VM is configured such that the main thread is virtual,
         // this stress test will not work as the main thread is always alive causing
         // us to wait forever for contraction.
-        // Hence, we will skipp this test if the main thread is virtual.
+        // Hence, we will skip this test if the main thread is virtual.
         if (Thread.currentThread().isVirtual()) {
             System.out.println("Skipped because the main thread is a virtual thread");
             return;


### PR DESCRIPTION
This PR proposes to skip a stress test if the `main` thread is a virtual thread.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8356114](https://bugs.openjdk.org/browse/JDK-8356114): java/foreign/TestBufferStackStress2.java failed with junit action timed out (**Bug** - P4)


### Reviewers
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25084/head:pull/25084` \
`$ git checkout pull/25084`

Update a local copy of the PR: \
`$ git checkout pull/25084` \
`$ git pull https://git.openjdk.org/jdk.git pull/25084/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25084`

View PR using the GUI difftool: \
`$ git pr show -t 25084`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25084.diff">https://git.openjdk.org/jdk/pull/25084.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25084#issuecomment-2857490540)
</details>
