### PR TITLE
8350596: [Linux] Increase default MaxRAMPercentage for containerized workloads

### DIFF
--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -4432,6 +4432,18 @@ void os::pd_init_container_support() {
   OSContainer::init();
 }
 
+// Called before ergonomic flags processing
+void os::initialize_max_ram_percentage() {
+  if (OSContainer::is_containerized()) {
+    // Increase the default MaxRAMPercentage for
+    // containerized work-loads to 75%. The expectation
+    // is for them to limit resources on the container
+    // level and the default scenario is to deploy a single
+    // application per container.
+    FLAG_SET_ERGO_IF_DEFAULT(MaxRAMPercentage, 75.0);
+  }
+}
+
 void os::Linux::numa_init() {
 
   // Java can be invoked as

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -484,6 +484,7 @@ void os::init_before_ergo() {
   // VM version initialization identifies some characteristics of the
   // platform that are used during ergonomic decisions.
   VM_Version::init_before_ergo();
+  LINUX_ONLY(initialize_max_ram_percentage();)
 }
 
 void os::initialize_jdk_signal_support(TRAPS) {

--- a/src/hotspot/share/runtime/os.hpp
+++ b/src/hotspot/share/runtime/os.hpp
@@ -256,6 +256,7 @@ class os: AllStatic {
   static void initialize_initial_active_processor_count();
 
   LINUX_ONLY(static void pd_init_container_support();)
+  LINUX_ONLY(static void initialize_max_ram_percentage();)
 
  public:
   static void init(void);                      // Called before command line parsing

--- a/test/hotspot/jtreg/containers/cgroup/MaxRAMPercentage.java
+++ b/test/hotspot/jtreg/containers/cgroup/MaxRAMPercentage.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2025 Red Hat, Inc.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8350596
+ * @key cgroups
+ * @requires os.family == "linux"
+ * @requires vm.flagless
+ * @library /testlibrary /test/lib
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI MaxRAMPercentage
+ */
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import jdk.test.whitebox.WhiteBox;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+public class MaxRAMPercentage {
+
+    public static void main(String[] args) throws Exception {
+        WhiteBox wb = WhiteBox.getWhiteBox();
+        if (wb.isContainerized()) {
+            throw new RuntimeException("Test failed! Expected not containerized on plain Linux.");
+        }
+        ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder("-XX:+PrintFlagsFinal", "-version");
+        OutputAnalyzer out = new OutputAnalyzer(pb.start());
+        out.shouldHaveExitValue(0);
+
+        String maxRamPercentage = getFlagValue("MaxRAMPercentage", out.getStdout());
+        // expect a default of 25%
+        if (!maxRamPercentage.startsWith("25")) {
+            throw new RuntimeException("Test failed! Expected MaxRAMPercentage to be 25% but got: " + maxRamPercentage);
+        }
+        System.out.println("PASS. Got expected MaxRAMPercentage=" + maxRamPercentage);
+    }
+
+    private static String getFlagValue(String flag, String where) {
+        Matcher m = Pattern.compile(flag + "\\s+:?= (\\d+\\.\\d+)").matcher(where);
+        if (!m.find()) {
+            throw new RuntimeException("Could not find value for flag " + flag + " in output string");
+        }
+        return m.group(1);
+    }
+
+}

--- a/test/hotspot/jtreg/containers/docker/MaxRAMPercentage.java
+++ b/test/hotspot/jtreg/containers/docker/MaxRAMPercentage.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2025 Red Hat, Inc.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @summary Verify MaxRAMPercentage setting in a containerized system
+ * @bug 8350596
+ * @key cgroups
+ * @requires os.family == "linux"
+ * @requires vm.flagless
+ * @library /testlibrary /test/lib
+ * @run driver MaxRAMPercentage
+ */
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import jdk.test.lib.containers.docker.Common;
+import jdk.test.lib.containers.docker.DockerRunOptions;
+import jdk.test.lib.containers.docker.DockerTestUtils;
+import jdk.test.lib.process.OutputAnalyzer;
+
+public class MaxRAMPercentage {
+    private static final String imageName = Common.imageName("ram-percentage");
+
+    public static void main(String[] args) throws Exception {
+        if (!DockerTestUtils.canTestDocker()) {
+            return;
+        }
+
+        DockerTestUtils.buildJdkContainerImage(imageName);
+
+        try {
+            testMaxRAMPercentage();
+        } finally {
+            DockerTestUtils.removeDockerImage(imageName);
+        }
+    }
+
+    private static String getFlagValue(String flag, String where) {
+        Matcher m = Pattern.compile(flag + "\\s+:?= (\\d+\\.\\d+)").matcher(where);
+        if (!m.find()) {
+            throw new RuntimeException("Could not find value for flag " + flag + " in output string");
+        }
+        return m.group(1);
+    }
+
+    private static void testMaxRAMPercentage() throws Exception {
+        Common.logNewTestCase("Test MaxRAMPercentage");
+        DockerRunOptions opts =
+                new DockerRunOptions(imageName, "/jdk/bin/java", "-version");
+        opts.addJavaOpts("-XX:+PrintFlagsFinal");
+
+        // We are interested in the default option when run in a container, so
+        // don't append test java options
+        opts.appendTestJavaOptions = false;
+        OutputAnalyzer out = DockerTestUtils.dockerRunJava(opts);
+        out.shouldHaveExitValue(0);
+
+        String maxRamPercentage = getFlagValue("MaxRAMPercentage", out.getStdout());
+        // expect a default of 75%
+        if (!maxRamPercentage.startsWith("75")) {
+            throw new RuntimeException("Test failed! Expected MaxRAMPercentage to be 75% but got: " + maxRamPercentage);
+        }
+        System.out.println("PASS. Got expected MaxRAMPercentage=" + maxRamPercentage);
+    }
+
+}


### PR DESCRIPTION
Please take a look at this proposal to fix the "Java needs so much memory" perception in containers. The idea would be to bump the default `MaxRAMPercentage` to a higher value. The patch proposes 75%, but we could just as well use 50% if people feel more comfortable about it. Right now the default deployment in containers with resource limits in place (common for Kubernetes deployments) where a single process runs in the container isn't well catered for today for an application that just uses the default configuration. Only 25% of the container memory will be used for the Java heap, arguably wasting much of the remaining memory that has been granted to the container by a memory limit (that the JVM would detect and use as physical memory).

I've filed a CSR for this as well for which I'm looking for reviewers too and intend to write a release note as well about this change as it has some risk associated with it, although the escape hatch is pretty simple: set `-XX:MaxRAMPercentage=25.0` to go back to the old behavour.

Testing:
- [x] GHA - tier 1 (windows failures seem infra related)
- [x] hotspot and jdk container tests on cg v2 and cg v1 including the two new tests.

Thoughts? Opinions?