### PR TITLE
8356379: Need a proper way to test existence of binary from configure

### DIFF
--- a/make/autoconf/boot-jdk.m4
+++ b/make/autoconf/boot-jdk.m4
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -180,11 +180,13 @@ AC_DEFUN([BOOTJDK_CHECK_JAVA_HOME],
 # Test: Is there a java or javac in the PATH, which is a symlink to the JDK?
 AC_DEFUN([BOOTJDK_CHECK_JAVA_IN_PATH_IS_SYMLINK],
 [
-  UTIL_LOOKUP_PROGS(JAVAC_CHECK, javac, , NOFIXPATH)
-  UTIL_LOOKUP_PROGS(JAVA_CHECK, java, , NOFIXPATH)
-  BINARY="$JAVAC_CHECK"
-  if test "x$JAVAC_CHECK" = x; then
-    BINARY="$JAVA_CHECK"
+  UTIL_LOOKUP_PROGS(JAVAC_CHECK, javac)
+  UTIL_GET_EXECUTABLE(JAVAC_CHECK) # Will setup JAVAC_CHECK_EXECUTABLE
+  UTIL_LOOKUP_PROGS(JAVA_CHECK, java)
+  UTIL_GET_EXECUTABLE(JAVA_CHECK) # Will setup JAVA_CHECK_EXECUTABLE
+  BINARY="$JAVAC_CHECK_EXECUTABLE"
+  if test "x$JAVAC_CHECK_EXECUTABLE" = x; then
+    BINARY="$JAVA_CHECK_EXECUTABLE"
   fi
   if test "x$BINARY" != x; then
     # So there is a java(c) binary, it might be part of a JDK.

--- a/make/autoconf/util_paths.m4
+++ b/make/autoconf/util_paths.m4
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -186,7 +186,6 @@ AC_DEFUN([UTIL_CHECK_WINENV_EXEC_TYPE],
 # it need to be in the PATH.
 # $1: The name of the variable to fix
 # $2: Where to look for the command (replaces $PATH)
-# $3: set to NOFIXPATH to skip prefixing FIXPATH, even if needed on platform
 AC_DEFUN([UTIL_FIXUP_EXECUTABLE],
 [
   input="[$]$1"
@@ -282,10 +281,6 @@ AC_DEFUN([UTIL_FIXUP_EXECUTABLE],
       fi
     fi
 
-    if test "x$3" = xNOFIXPATH; then
-      fixpath_prefix=""
-    fi
-
     # Now join together the path and the arguments once again
     new_complete="$fixpath_prefix$new_path$arguments"
     $1="$new_complete"
@@ -379,7 +374,6 @@ AC_DEFUN([UTIL_SETUP_TOOL],
 # $1: variable to set
 # $2: executable name (or list of names) to look for
 # $3: [path]
-# $4: set to NOFIXPATH to skip prefixing FIXPATH, even if needed on platform
 AC_DEFUN([UTIL_LOOKUP_PROGS],
 [
   UTIL_SETUP_TOOL($1, [
@@ -421,10 +415,8 @@ AC_DEFUN([UTIL_LOOKUP_PROGS],
 
             # If we have FIXPATH enabled, strip all instances of it and prepend
             # a single one, to avoid double fixpath prefixing.
-            if test "x$4" != xNOFIXPATH; then
-              [ if [[ $FIXPATH != "" && $result =~ ^"$FIXPATH " ]]; then ]
-                result="\$FIXPATH ${result#"$FIXPATH "}"
-              fi
+            [ if [[ $FIXPATH != "" && $result =~ ^"$FIXPATH " ]]; then ]
+              result="\$FIXPATH ${result#"$FIXPATH "}"
             fi
             AC_MSG_RESULT([$result])
             break 2;
@@ -513,6 +505,24 @@ AC_DEFUN([UTIL_ADD_FIXPATH],
   if test "x$FIXPATH" != x; then
     $1="$FIXPATH [$]$1"
   fi
+])
+
+################################################################################
+# Return a path to the executable binary from a command line, stripping away
+# any FIXPATH prefix or arguments. The resulting value can be checked for
+# existence using "test -e". The result is returned in a variable named
+# "$1_EXECUTABLE".
+#
+# $1: variable describing the command to get the binary for
+AC_DEFUN([UTIL_GET_EXECUTABLE],
+[
+  # Strip the FIXPATH prefix, if any
+  fixpath_stripped="[$]$1"
+  [ if [[ $FIXPATH != "" && $fixpath_stripped =~ ^"$FIXPATH " ]]; then ]
+      fixpath_stripped="${fixpath_stripped#"$FIXPATH "}"
+  fi
+  # Remove any arguments following the binary
+  $1_EXECUTABLE="${fixpath_stripped%% *}"
 ])
 
 ################################################################################


### PR DESCRIPTION
When we setup a command to run, e.g. $FOO we typically set this to just a path to a binary, e.g. /usr/bin/foo. However, this is not necessarily true. On Windows, this can be prefixed by the $FIXPATH prefix, and on all platforms we are allowed to pass arguments to the executable.

If we want to test if this binary actually exists, we need to extract the binary name from this command line. We have a NOFIXPATH argument to UTIL_LOOKUP_PROGS, which tried to resolve this, but it is not enough, and it makes it impossible to both lookup a program properly and also check for its existance afterwards.

Instead, I propose to add a UTIL_GET_EXECUTABLE function that extracts just the path to the binary from such a command.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8356379](https://bugs.openjdk.org/browse/JDK-8356379): Need a proper way to test existence of binary from configure (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25087/head:pull/25087` \
`$ git checkout pull/25087`

Update a local copy of the PR: \
`$ git checkout pull/25087` \
`$ git pull https://git.openjdk.org/jdk.git pull/25087/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25087`

View PR using the GUI difftool: \
`$ git pr show -t 25087`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25087.diff">https://git.openjdk.org/jdk/pull/25087.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25087#issuecomment-2858129916)
</details>
