### PR TITLE
8354443: [Graal] crash after deopt in TestG1BarrierGeneration.java

### DIFF
--- a/src/hotspot/share/code/nmethod.inline.hpp
+++ b/src/hotspot/share/code/nmethod.inline.hpp
@@ -33,21 +33,12 @@
 
 inline bool nmethod::is_deopt_pc(address pc) { return is_deopt_entry(pc) || is_deopt_mh_entry(pc); }
 
-// When using JVMCI the address might be off by the size of a call instruction.
 inline bool nmethod::is_deopt_entry(address pc) {
-  return pc == deopt_handler_begin()
-#if INCLUDE_JVMCI
-    || (is_compiled_by_jvmci() && pc == (deopt_handler_begin() + NativeCall::byte_size()))
-#endif
-    ;
+  return pc == deopt_handler_begin();
 }
 
 inline bool nmethod::is_deopt_mh_entry(address pc) {
-  return pc == deopt_mh_handler_begin()
-#if INCLUDE_JVMCI
-    || (is_compiled_by_jvmci() && pc == (deopt_mh_handler_begin() + NativeCall::byte_size()))
-#endif
-    ;
+  return pc == deopt_mh_handler_begin();
 }
 
 // class ExceptionCache methods


### PR DESCRIPTION
Remove special cases in `nmethod::is_deopt_entry` and `nmethod::is_deopt_mh_entry`. Graal used to generate a different code pattern from C2 for deopt handlers. This was changed in https://github.com/oracle/graal/commit/099f57b58edb23ed2184c11badea24edf36f30d2 to align Graal's code generation with C2. The special cases are no longer needed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8354443](https://bugs.openjdk.org/browse/JDK-8354443): [Graal] crash after deopt in TestG1BarrierGeneration.java (**Bug** - P3)


### Reviewers
 * [Doug Simon](https://openjdk.org/census#dnsimon) (@dougxc - **Reviewer**)
 * [Yudi Zheng](https://openjdk.org/census#yzheng) (@mur47x111 - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25088/head:pull/25088` \
`$ git checkout pull/25088`

Update a local copy of the PR: \
`$ git checkout pull/25088` \
`$ git pull https://git.openjdk.org/jdk.git pull/25088/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25088`

View PR using the GUI difftool: \
`$ git pr show -t 25088`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25088.diff">https://git.openjdk.org/jdk/pull/25088.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25088#issuecomment-2858215901)
</details>
