### PR TITLE
8354323: Safeguard SwitchBootstraps.typeSwitch when used outside the compiler

### DIFF
--- a/src/java.base/share/classes/java/lang/runtime/SwitchBootstraps.java
+++ b/src/java.base/share/classes/java/lang/runtime/SwitchBootstraps.java
@@ -779,11 +779,10 @@ public final class SwitchBootstraps {
         }
         else if (selectorType.equals(targetType) ||
                 (targetType.isPrimitive() && selectorType.isPrimitive() &&
-                    ((selectorType.equals(byte.class) && !targetType.equals(char.class)) ||
-                     (selectorType.equals(short.class) && (selectorWrapper.isStrictSubRangeOf(targetWrapper))) ||
-                     (selectorType.equals(char.class)  && (selectorWrapper.isStrictSubRangeOf(targetWrapper)))  ||
-                     (selectorType.equals(int.class)   && (targetType.equals(double.class) || targetType.equals(long.class))) ||
-                     (selectorType.equals(float.class) && (selectorWrapper.isStrictSubRangeOf(targetWrapper)))))) return true;
+                    (selectorWrapper.isStrictSubRangeOf(targetWrapper) &&
+                            !((selectorType.equals(byte.class) && targetType.equals(char.class)) ||
+                              (selectorType.equals(int.class)  && targetType.equals(float.class)) ||
+                              (selectorType.equals(long.class) && (targetType.equals(double.class) || targetType.equals(float.class))))))) return true;
         return false;
     }
 

--- a/src/java.base/share/classes/java/lang/runtime/SwitchBootstraps.java
+++ b/src/java.base/share/classes/java/lang/runtime/SwitchBootstraps.java
@@ -546,7 +546,11 @@ public final class SwitchBootstraps {
                 Object caseLabel = caseLabels[idx];
                 cb.labelBinding(caseTargets[idx]);
                 if (caseLabel instanceof Class<?> classLabel) {
-                    if (unconditionalExactnessCheck(selectorType, classLabel)) {
+                    if (isNotValidPair(selectorType, caseLabel)){
+                        cb.goto_(next);
+                        continue;
+                    }
+                    else if (unconditionalExactnessCheck(selectorType, classLabel)) {
                         //nothing - unconditionally use this case
                     } else if (classLabel.isPrimitive()) {
                         if (!selectorType.isPrimitive() && !Wrapper.isWrapperNumericOrBooleanType(selectorType)) {
@@ -717,6 +721,11 @@ public final class SwitchBootstraps {
         };
     }
 
+    private static boolean isNotValidPair(Class<?> selectorType, Object caseLabel) {
+        return (selectorType == boolean.class && caseLabel != boolean.class && caseLabel != Boolean.class) ||
+               (selectorType != boolean.class && selectorType.isPrimitive() && (caseLabel == boolean.class || caseLabel == Boolean.class));
+    }
+
     /*
      * Construct the method handle that represents the method int typeSwitch(Object, int, BiPredicate, List)
      */
@@ -769,11 +778,12 @@ public final class SwitchBootstraps {
             return true;
         }
         else if (selectorType.equals(targetType) ||
-                ((selectorType.equals(byte.class) && !targetType.equals(char.class)) ||
-                 (selectorType.equals(short.class) && (selectorWrapper.isStrictSubRangeOf(targetWrapper))) ||
-                 (selectorType.equals(char.class)  && (selectorWrapper.isStrictSubRangeOf(targetWrapper)))  ||
-                 (selectorType.equals(int.class)   && (targetType.equals(double.class) || targetType.equals(long.class))) ||
-                 (selectorType.equals(float.class) && (selectorWrapper.isStrictSubRangeOf(targetWrapper))))) return true;
+                (targetType.isPrimitive() && selectorType.isPrimitive() &&
+                    ((selectorType.equals(byte.class) && !targetType.equals(char.class)) ||
+                     (selectorType.equals(short.class) && (selectorWrapper.isStrictSubRangeOf(targetWrapper))) ||
+                     (selectorType.equals(char.class)  && (selectorWrapper.isStrictSubRangeOf(targetWrapper)))  ||
+                     (selectorType.equals(int.class)   && (targetType.equals(double.class) || targetType.equals(long.class))) ||
+                     (selectorType.equals(float.class) && (selectorWrapper.isStrictSubRangeOf(targetWrapper)))))) return true;
         return false;
     }
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
@@ -5085,16 +5085,12 @@ public class Types {
      *  @param targetType       Target type
      */
     public boolean isUnconditionallyExactPrimitives(Type selectorType, Type targetType) {
-        if (isSameType(selectorType, targetType)) {
-            return true;
-        }
-
-        return (selectorType.isPrimitive() && targetType.isPrimitive()) &&
-                ((selectorType.hasTag(BYTE) && !targetType.hasTag(CHAR)) ||
-                 (selectorType.hasTag(SHORT) && (selectorType.getTag().isStrictSubRangeOf(targetType.getTag()))) ||
-                 (selectorType.hasTag(CHAR)  && (selectorType.getTag().isStrictSubRangeOf(targetType.getTag())))  ||
-                 (selectorType.hasTag(INT)   && (targetType.hasTag(DOUBLE) || targetType.hasTag(LONG))) ||
-                 (selectorType.hasTag(FLOAT) && (selectorType.getTag().isStrictSubRangeOf(targetType.getTag()))));
+        return isSameType(selectorType, targetType) ||
+                (selectorType.isPrimitive() && targetType.isPrimitive()) &&
+                ((selectorType.getTag().isStrictSubRangeOf(targetType.getTag())) &&
+                        !((selectorType.hasTag(BYTE) && targetType.hasTag(CHAR)) ||
+                          (selectorType.hasTag(INT)  && targetType.hasTag(FLOAT)) ||
+                          (selectorType.hasTag(LONG) && (targetType.hasTag(DOUBLE) || targetType.hasTag(FLOAT)))));
     }
     // </editor-fold>
 

--- a/test/jdk/java/lang/runtime/SwitchBootstrapsTest.java
+++ b/test/jdk/java/lang/runtime/SwitchBootstrapsTest.java
@@ -147,6 +147,7 @@ public class SwitchBootstrapsTest {
         testPrimitiveType(true, boolean.class,0, 1, false);
         testPrimitiveType((byte) 1, byte.class,0, 1, boolean.class, byte.class);
         testPrimitiveType((byte) 1, byte.class,0, 1, Boolean.class, byte.class);
+        testPrimitiveType(true, boolean.class,0, 1, String.class, boolean.class);
     }
 
     public void testEnums() throws Throwable {

--- a/test/jdk/java/lang/runtime/SwitchBootstrapsTest.java
+++ b/test/jdk/java/lang/runtime/SwitchBootstrapsTest.java
@@ -74,6 +74,12 @@ public class SwitchBootstrapsTest {
         assertEquals(-1, (int) indy.invoke(null, start));
     }
 
+    private void testPrimitiveType(Object target, Class<?> targetType, int start, int result, Object... labels) throws Throwable {
+        MethodType switchType = MethodType.methodType(int.class, targetType, int.class);
+        MethodHandle indy = ((CallSite) BSM_TYPE_SWITCH.invoke(MethodHandles.lookup(), "", switchType, labels)).dynamicInvoker();
+        assertEquals((int) indy.invoke(target, start), result);
+    }
+
     private void testEnum(Enum<?> target, int start, int result, Object... labels) throws Throwable {
         testEnum(target.getClass(), target, start, result, labels);
     }
@@ -130,6 +136,17 @@ public class SwitchBootstrapsTest {
                 return super.equals(obj);
             }
         }, 0, 1, 1L);
+    }
+
+    public void testPrimitiveTypes() throws Throwable {
+        testPrimitiveType((short) 1, short.class, 0, 1, String.class);
+        testPrimitiveType((byte) 1, byte.class,0, 1, String.class, byte.class);
+        testPrimitiveType(true, boolean.class,0, 1, false, boolean.class);
+        testPrimitiveType(1, int.class,0, 1, String.class);
+        testPrimitiveType(1, int.class,0, 1, true);
+        testPrimitiveType(true, boolean.class,0, 1, false);
+        testPrimitiveType((byte) 1, byte.class,0, 1, boolean.class, byte.class);
+        testPrimitiveType((byte) 1, byte.class,0, 1, Boolean.class, byte.class);
     }
 
     public void testEnums() throws Throwable {


### PR DESCRIPTION
While the compiler does not allow invalid queries to flow into `SwitchBootstraps:typeSwitch`, a library user could do that and `typeSwitch` does not prevent such usage pattern errors resulting in erroneous evaluation.

For example this is not valid Java (and protected) by javac:

```java
byte b = 1;
switch (b) {
    case String s -> System.out.println("How did we get here? byte is " + s.getClass());
}
```

but this is a valid call (and not protected):

```java
CallSite shortSwitch = SwitchBootstraps.typeSwitch(
    MethodHandles.lookup(), 
    "", 
    MethodType.methodType(int.class, short.class, int.class),  // models (short, int) -> int
    String.class);
```

The `SwitchBootstraps.typeSwitch` returns wrong result since the code was reasoning erroneously that this pair was unconditionally exact. 

This PR proposes to add the safety check in unconditional exactness which will return false in erroneous pairs and then the actual check will be delegated to `instanceof`. For the case of erroneous pairs with primitive `boolean`s there is a check in the beginning of the type switch skeleton.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8354323](https://bugs.openjdk.org/browse/JDK-8354323): Safeguard SwitchBootstraps.typeSwitch when used outside the compiler (**Bug** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**) Review applies to [835fb6ab](https://git.openjdk.org/jdk/pull/25090/files/835fb6abe4f740060a2ab0773a6204b520aa656d)
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25090/head:pull/25090` \
`$ git checkout pull/25090`

Update a local copy of the PR: \
`$ git checkout pull/25090` \
`$ git pull https://git.openjdk.org/jdk.git pull/25090/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25090`

View PR using the GUI difftool: \
`$ git pr show -t 25090`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25090.diff">https://git.openjdk.org/jdk/pull/25090.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25090#issuecomment-2858316325)
</details>
