### PR TITLE
8355515: Clarify the purpose of forcePass() and forceFail() methods

### DIFF
--- a/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
+++ b/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
@@ -149,15 +149,17 @@ import static javax.swing.SwingUtilities.isEventDispatchThread;
  * <p>
  * Before returning from {@code awaitAndCheck}, the framework disposes of
  * all the windows and frames.
+ *
  * <p id="forcePassAndFail">
- * There are two other static methods available,
- * {@link #forcePass() forcePass} and {@link #forceFail() forceFail}, which can
- * be used in semi-automated tests to indicate that the test can be forcefully
- * Passed/Failed. These methods are not immediately evaluated, but it decrements
- * a counter and return. The evaluation happens in {@code awaitAndCheck} and
- * the test will be forcefully Passed/Failed accordingly.
- * Code examples are given in the corresponding method javadoc.
+ * For semi-automatic tests, use {@code forcePass} or
+ * {@code forceFail} methods to forcefully pass or fail the test
+ * when it's determined that the required conditions are already met
+ * or cannot be met correspondingly.
+ * These methods release {@code awaitAndCheck}, and
+ * the test will complete successfully or fail.
  * <p>
+ * Refer to examples of using these methods in the description of the
+ * {@link #forcePass() forcePass} and {@link #forceFail() forceFail} methods.
  *
  * <h2 id="sampleManualTest">Sample Manual Test</h2>
  * A simple test would look like this:
@@ -1302,7 +1304,7 @@ public final class PassFailJFrame {
 
 
     /**
-     * Forcibly pass the test.
+     * Forcefully pass the test.
      * <p>
      * Use this method in semi-automatic tests when
      * the test determines that all the conditions for passing the test are met.
@@ -1319,10 +1321,10 @@ public final class PassFailJFrame {
     }
 
     /**
-     * Forcibly fail the test.
+     * Forcefully fail the test.
      * <p>
      * Use this method in semi-automatic tests when
-     * the test determines that all/any of the conditions for passing the test are not met.
+     * it is determined that the conditions for passing the test cannot be met.
      * <p>
      * <strong>Do not use</strong> this method in cases where a resource is unavailable or a
      * feature isn't supported, throw {@code jtreg.SkippedException} instead.
@@ -1336,10 +1338,10 @@ public final class PassFailJFrame {
     }
 
     /**
-     * Forcibly fail the test and provide a reason.
+     * Forcefully fail the test and provide a reason.
      * <p>
      * Use this method in semi-automatic tests when
-     * the test determines that all/any of the conditions for passing the test are not met.
+     * it is determined that the conditions for passing the test cannot be met.
      * <p>
      * <strong>Do not use</strong> this method in cases where a resource is unavailable or a
      * feature isn't supported, throw {@code jtreg.SkippedException} instead.

--- a/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
+++ b/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
@@ -149,6 +149,15 @@ import static javax.swing.SwingUtilities.isEventDispatchThread;
  * <p>
  * Before returning from {@code awaitAndCheck}, the framework disposes of
  * all the windows and frames.
+ * <p id="forcePassAndFail">
+ * There are two other static methods available,
+ * {@link #forcePass() forcePass} and {@link #forceFail() forceFail}, which can
+ * be used in semi-automated tests to indicate that the test can be forcefully
+ * Passed/Failed. These methods are not immediately evaluated, but it decrements
+ * a counter and return. The evaluation happens in {@code awaitAndCheck} and
+ * the test will be forcefully Passed/Failed accordingly.
+ * Code examples are given in the corresponding method javadoc.
+ * <p>
  *
  * <h2 id="sampleManualTest">Sample Manual Test</h2>
  * A simple test would look like this:
@@ -1310,14 +1319,34 @@ public final class PassFailJFrame {
     }
 
     /**
-     *  Forcibly fail the test.
+     * Forcibly fail the test.
+     * <p>
+     * Use this method in semi-automatic tests when
+     * the test determines that all/any of the conditions for passing the test are not met.
+     * <p>
+     * <strong>Do not use</strong> this method in cases where a resource is unavailable or a
+     * feature isn't supported, throw {@code jtreg.SkippedException} instead.
+     *
+     * <p>A sample usage can be found in
+     * <a href="https://github.com/openjdk/jdk/blob/0844745e7bd954a96441365f8010741ec1c29dbf/test/jdk/javax/swing/JScrollPane/AcceleratedWheelScrolling/HorizScrollers.java#L180">{@code
+     * HorizScrollers.java}</a>
      */
     public static void forceFail() {
         forceFail("forceFail called");
     }
 
     /**
-     *  Forcibly fail the test and provide a reason.
+     * Forcibly fail the test and provide a reason.
+     * <p>
+     * Use this method in semi-automatic tests when
+     * the test determines that all/any of the conditions for passing the test are not met.
+     * <p>
+     * <strong>Do not use</strong> this method in cases where a resource is unavailable or a
+     * feature isn't supported, throw {@code jtreg.SkippedException} instead.
+     *
+     * <p>A sample usage can be found in
+     * <a href="https://github.com/openjdk/jdk/blob/7283c8b075aa289dbb9cb80f6937b3349c8d4769/test/jdk/java/awt/FileDialog/SaveFileNameOverrideTest.java#L86">{@code
+     * SaveFileNameOverrideTest.java}</a>
      *
      * @param reason the reason why the test is failed
      */

--- a/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
+++ b/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
@@ -152,7 +152,7 @@ import static javax.swing.SwingUtilities.isEventDispatchThread;
  *
  * <p id="forcePassAndFail">
  * For semi-automatic tests, use {@code forcePass} or
- * {@code forceFail} methods to forcefully pass or fail the test
+ * {@code forceFail} methods to forcibly pass or fail the test
  * when it's determined that the required conditions are already met
  * or cannot be met correspondingly.
  * These methods release {@code awaitAndCheck}, and
@@ -1304,7 +1304,7 @@ public final class PassFailJFrame {
 
 
     /**
-     * Forcefully pass the test.
+     * Forcibly pass the test.
      * <p>
      * Use this method in semi-automatic tests when
      * the test determines that all the conditions for passing the test are met.
@@ -1321,7 +1321,7 @@ public final class PassFailJFrame {
     }
 
     /**
-     * Forcefully fail the test.
+     * Forcibly fail the test.
      * <p>
      * Use this method in semi-automatic tests when
      * it is determined that the conditions for passing the test cannot be met.
@@ -1338,7 +1338,7 @@ public final class PassFailJFrame {
     }
 
     /**
-     * Forcefully fail the test and provide a reason.
+     * Forcibly fail the test and provide a reason.
      * <p>
      * Use this method in semi-automatic tests when
      * it is determined that the conditions for passing the test cannot be met.


### PR DESCRIPTION
Clarified the purpose of forcePass() and forceFail() methods and recommended usage of these methods.

forcePass() contained an incorrect sample; it's addressed by [JDK-8355441](https://bugs.openjdk.org/browse/JDK-8355441).

The description of forceFail() has been expanded, too.


A new section in the description of the PassFailJFrame added to describe forcePass() and forceFail().

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8355515](https://bugs.openjdk.org/browse/JDK-8355515): Clarify the purpose of forcePass() and forceFail() methods (**Sub-task** - P4)


### Reviewers
 * [Alexander Zuev](https://openjdk.org/census#kizune) (@azuev-java - **Reviewer**) Review applies to [68f72e46](https://git.openjdk.org/jdk/pull/25091/files/68f72e4684b703c79853739c43009db225e8173e)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25091/head:pull/25091` \
`$ git checkout pull/25091`

Update a local copy of the PR: \
`$ git checkout pull/25091` \
`$ git pull https://git.openjdk.org/jdk.git pull/25091/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25091`

View PR using the GUI difftool: \
`$ git pr show -t 25091`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25091.diff">https://git.openjdk.org/jdk/pull/25091.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25091#issuecomment-2858408141)
</details>
