### PR TITLE
8356390: Rename ResolvedIndyEntry::set_flags to set_has_appendix

### DIFF
--- a/src/hotspot/share/oops/resolvedIndyEntry.hpp
+++ b/src/hotspot/share/oops/resolvedIndyEntry.hpp
@@ -114,10 +114,8 @@ public:
   }
 
   void set_has_appendix(bool has_appendix) {
-    u1 new_flags = (has_appendix << has_appendix_shift);
-    u1 old_flags = _flags &  ~(1 << has_appendix_shift);
-    // Preserve the unaffected bits
-    _flags = old_flags | new_flags;
+    u1 new_flags = (has_appendix ? 1 : 0) << has_appendix_shift;
+    _flags = _flags | new_flags;
   }
 
 

--- a/src/hotspot/share/oops/resolvedIndyEntry.hpp
+++ b/src/hotspot/share/oops/resolvedIndyEntry.hpp
@@ -69,7 +69,7 @@ public:
 
   // Bit shift to get flags
   enum {
-    resolutin_failed_shift    = 0,
+    resolution_failed_shift    = 0,
     has_appendix_shift        = 1,
   };
 
@@ -117,7 +117,7 @@ public:
     u1 new_flags = (has_appendix ? 1 : 0) << has_appendix_shift;
     u1 old_flags = _flags & ~(1 << has_appendix_shift);
     // Preserve the unaffected bits
-    _flags = _old_flags | new_flags;
+    _flags = old_flags | new_flags;
   }
 
 

--- a/src/hotspot/share/oops/resolvedIndyEntry.hpp
+++ b/src/hotspot/share/oops/resolvedIndyEntry.hpp
@@ -69,8 +69,8 @@ public:
 
   // Bit shift to get flags
   enum {
-    resolution_failed_shift    = 0,
-    has_appendix_shift        = 1,
+    resolution_failed_shift = 0,
+    has_appendix_shift      = 1,
   };
 
   // Getters

--- a/src/hotspot/share/oops/resolvedIndyEntry.hpp
+++ b/src/hotspot/share/oops/resolvedIndyEntry.hpp
@@ -115,7 +115,9 @@ public:
 
   void set_has_appendix(bool has_appendix) {
     u1 new_flags = (has_appendix ? 1 : 0) << has_appendix_shift;
-    _flags = _flags | new_flags;
+    u1 old_flags = _flags & ~(1 << has_appendix_shift);
+    // Preserve the unaffected bits
+    _flags = _old_flags | new_flags;
   }
 
 

--- a/src/hotspot/share/oops/resolvedIndyEntry.hpp
+++ b/src/hotspot/share/oops/resolvedIndyEntry.hpp
@@ -68,9 +68,9 @@ public:
     _flags(0) {}
 
   // Bit shift to get flags
-  // Note: Only two flags exists at the moment but more could be added
   enum {
-      has_appendix_shift        = 1,
+    resolutin_failed_shift    = 0,
+    has_appendix_shift        = 1,
   };
 
   // Getters
@@ -120,7 +120,7 @@ public:
 
 
   void set_resolution_failed() {
-    _flags = _flags | 1;
+    _flags = _flags | (1 << resolution_failed_shift);
   }
 
   void adjust_method_entry(Method* new_method) { _method = new_method; }

--- a/src/hotspot/share/oops/resolvedIndyEntry.hpp
+++ b/src/hotspot/share/oops/resolvedIndyEntry.hpp
@@ -107,19 +107,19 @@ public:
   void fill_in(Method* m, u2 num_params, u1 return_type, bool has_appendix) {
     set_num_parameters(num_params);
     _return_type = return_type;
-    set_flags(has_appendix);
+    set_has_appendix(has_appendix);
     // Set the method last since it is read lock free.
     // Resolution is indicated by whether or not the method is set.
     Atomic::release_store(&_method, m);
   }
 
-  // has_appendix is currently the only other flag besides resolution_failed
-  void set_flags(bool has_appendix) {
+  void set_has_appendix(bool has_appendix) {
     u1 new_flags = (has_appendix << has_appendix_shift);
-    assert((new_flags & 1) == 0, "New flags should not change resolution flag");
-    // Preserve the resolution_failed bit
-    _flags = (_flags & 1) | new_flags;
+    u1 old_flags = _flags &  ~(1 << has_appendix_shift);
+    // Preserve the unaffected bits
+    _flags = old_flags | new_flags;
   }
+
 
   void set_resolution_failed() {
     _flags = _flags | 1;


### PR DESCRIPTION
The `set_flags` function really only sets whether it has an appendix or not, and there's a separate `set_resolution_failed` method just below that also alters the flag. Just rename this to `set_has_appendix`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8356390](https://bugs.openjdk.org/browse/JDK-8356390): Rename ResolvedIndyEntry::set_flags to set_has_appendix (**Enhancement** - P4)


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) Review applies to [56e43e5a](https://git.openjdk.org/jdk/pull/25092/files/56e43e5acad9205e7aafec57c0e49b75a8bd5860)

### Contributors
 * John R Rose `<jrose@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25092/head:pull/25092` \
`$ git checkout pull/25092`

Update a local copy of the PR: \
`$ git checkout pull/25092` \
`$ git pull https://git.openjdk.org/jdk.git pull/25092/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25092`

View PR using the GUI difftool: \
`$ git pr show -t 25092`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25092.diff">https://git.openjdk.org/jdk/pull/25092.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25092#issuecomment-2858690797)
</details>
