### PR TITLE
8354878: File Leak in CgroupSubsystemFactory::determine_type of cgroupSubsystem_linux.cpp:300

### DIFF
--- a/src/hotspot/os/linux/cgroupSubsystem_linux.cpp
+++ b/src/hotspot/os/linux/cgroupSubsystem_linux.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/os/linux/cgroupSubsystem_linux.cpp
+++ b/src/hotspot/os/linux/cgroupSubsystem_linux.cpp
@@ -297,6 +297,7 @@ bool CgroupSubsystemFactory::determine_type(CgroupInfo* cg_infos,
     } else {
       log_debug(os, container)("Can't read %s, %s", controllers_file, os::strerror(errno));
       *flags = INVALID_CGROUPS_V2;
+      fclose(controllers);
       return false;
     }
     for (int i = 0; i < CG_INFO_LENGTH; i++) {


### PR DESCRIPTION
Hi,

There's a file descriptor in `cgroupSubsystem_linux.cpp` that isn't closed if we successfully open it but can't read from it. In that case, the open descriptor should still be closed before returning.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8354878](https://bugs.openjdk.org/browse/JDK-8354878): File Leak in CgroupSubsystemFactory::determine_type of cgroupSubsystem_linux.cpp:300 (**Bug** - P3)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) Review applies to [a5180f6d](https://git.openjdk.org/jdk/pull/25093/files/a5180f6d385da2b7b5afd6ff73eed2cecb887e7b)
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@jdksjolen - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25093/head:pull/25093` \
`$ git checkout pull/25093`

Update a local copy of the PR: \
`$ git checkout pull/25093` \
`$ git pull https://git.openjdk.org/jdk.git pull/25093/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25093`

View PR using the GUI difftool: \
`$ git pr show -t 25093`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25093.diff">https://git.openjdk.org/jdk/pull/25093.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25093#issuecomment-2858536562)
</details>
