### PR TITLE
8356085: AArch64: compiler stub buffer size wrongly depends on ZGC

### DIFF
--- a/src/hotspot/cpu/aarch64/stubDeclarations_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/stubDeclarations_aarch64.hpp
@@ -44,7 +44,7 @@
                                        do_arch_blob,                    \
                                        do_arch_entry,                   \
                                        do_arch_entry_init)              \
-  do_arch_blob(compiler, 65000 ZGC_ONLY(+5000))                         \
+  do_arch_blob(compiler, 70000)                                         \
   do_stub(compiler, vector_iota_indices)                                \
   do_arch_entry(aarch64, compiler, vector_iota_indices,                 \
                 vector_iota_indices, vector_iota_indices)               \


### PR DESCRIPTION
This patch merges the ZGC-specific component of the compiler stubs buffer size configuration into the default size. The stubs are actually independent of ZGC but the extra space is depended on by normal builds that include ZGC which means that cross-compile builds which exclude ZGC are failing. Now the space is the same in either case.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8356085](https://bugs.openjdk.org/browse/JDK-8356085): AArch64: compiler stub buffer size wrongly depends on ZGC (**Bug** - P3)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25094/head:pull/25094` \
`$ git checkout pull/25094`

Update a local copy of the PR: \
`$ git checkout pull/25094` \
`$ git pull https://git.openjdk.org/jdk.git pull/25094/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25094`

View PR using the GUI difftool: \
`$ git pr show -t 25094`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25094.diff">https://git.openjdk.org/jdk/pull/25094.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25094#issuecomment-2858651222)
</details>
