### PR TITLE
8356395: Spec needs to be clarified for InterfaceAddress class level API documentation and getBroadcast() method

### DIFF
--- a/src/java.base/share/classes/java/net/InterfaceAddress.java
+++ b/src/java.base/share/classes/java/net/InterfaceAddress.java
@@ -28,10 +28,10 @@ package java.net;
 import java.util.Objects;
 
 /**
- * This class represents a Network Interface address. In short it's an
- * IP address, a subnet mask and a broadcast address when the address is
- * an IPv4 one. An IP address and a network prefix length in the case
- * of IPv6 address.
+ * This class represents a Network Interface address. In the case of
+ * IPv4, this comprises the IP address, a subnet mask, and a broadcast
+ * address if the interface supports broadcast. In the case of IPv6,
+ * it comprises the IP address and a network prefix length.
  *
  * @see java.net.NetworkInterface
  * @since 1.6

--- a/src/java.base/share/classes/java/net/InterfaceAddress.java
+++ b/src/java.base/share/classes/java/net/InterfaceAddress.java
@@ -63,8 +63,8 @@ public final class InterfaceAddress {
      * Only IPv4 networks have broadcast address therefore, in the case
      * of an IPv6 network, {@code null} will be returned.
      * <p>
-     * Certain IPv4 addresses, such as the loopback address, do not support
-     * broadcasting and will also result in {@code null} being returned.
+     * Certain network interfaces, such as the loopback interface, do not support
+     * broadcasting and will also return {@code null}.
      *
      * @return the {@code InetAddress} representing the broadcast
      *         address or {@code null} if there is no broadcast address.

--- a/src/java.base/share/classes/java/net/InterfaceAddress.java
+++ b/src/java.base/share/classes/java/net/InterfaceAddress.java
@@ -62,6 +62,9 @@ public final class InterfaceAddress {
      * <p>
      * Only IPv4 networks have broadcast address therefore, in the case
      * of an IPv6 network, {@code null} will be returned.
+     * <p>
+     * Certain IPv4 addresses, such as the loopback address, do not support
+     * broadcasting and will also result in {@code null} being returned.
      *
      * @return the {@code InetAddress} representing the broadcast
      *         address or {@code null} if there is no broadcast address.


### PR DESCRIPTION
Spec currently suggests that only IPv6 addresses can return null for InterfaceAddress.getBroadcast(). Clarifying spec to state that certain IPv4 address such as the loopback address do not support broadcasting and can therefore also return null.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8356002](https://bugs.openjdk.org/browse/JDK-8356002) to be approved

### Issues
 * [JDK-8356395](https://bugs.openjdk.org/browse/JDK-8356395): Spec needs to be clarified for InterfaceAddress class level API documentation and getBroadcast() method (**Bug** - P4)
 * [JDK-8356002](https://bugs.openjdk.org/browse/JDK-8356002): Spec needs to be clarified for InterfaceAddress class level API documentation and getBroadcast() method (**CSR**)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25095/head:pull/25095` \
`$ git checkout pull/25095`

Update a local copy of the PR: \
`$ git checkout pull/25095` \
`$ git pull https://git.openjdk.org/jdk.git pull/25095/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25095`

View PR using the GUI difftool: \
`$ git pr show -t 25095`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25095.diff">https://git.openjdk.org/jdk/pull/25095.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25095#issuecomment-2858744650)
</details>
