### PR TITLE
7046003: Default value of Authenticator.getRequestingURL() is not specified

### DIFF
--- a/src/java.base/share/classes/java/net/Authenticator.java
+++ b/src/java.base/share/classes/java/net/Authenticator.java
@@ -426,12 +426,12 @@ class Authenticator {
     }
 
     /**
-     * Returns the URL that resulted in this
-     * request for authentication.
+     * Returns the URL that resulted in this request for authentication.
+     * If the corresponding request does not specify a URL, this method returns null.
      *
      * @since 1.5
      *
-     * @return the requesting URL
+     * @return the requesting URL, or null if not available.
      *
      */
     protected URL getRequestingURL () {

--- a/src/java.base/share/classes/java/net/InterfaceAddress.java
+++ b/src/java.base/share/classes/java/net/InterfaceAddress.java
@@ -62,6 +62,9 @@ public final class InterfaceAddress {
      * <p>
      * Only IPv4 networks have broadcast address therefore, in the case
      * of an IPv6 network, {@code null} will be returned.
+     * <p>
+     * Certain IPv4 addresses, such as the loopback address, do not support
+     * broadcasting and will also result in {@code null} being returned.
      *
      * @return the {@code InetAddress} representing the broadcast
      *         address or {@code null} if there is no broadcast address.

--- a/src/java.base/share/classes/java/net/InterfaceAddress.java
+++ b/src/java.base/share/classes/java/net/InterfaceAddress.java
@@ -62,9 +62,6 @@ public final class InterfaceAddress {
      * <p>
      * Only IPv4 networks have broadcast address therefore, in the case
      * of an IPv6 network, {@code null} will be returned.
-     * <p>
-     * Certain IPv4 addresses, such as the loopback address, do not support
-     * broadcasting and will also result in {@code null} being returned.
      *
      * @return the {@code InetAddress} representing the broadcast
      *         address or {@code null} if there is no broadcast address.


### PR DESCRIPTION
Clarificatiion of spec to outline that Authenticator.getRequestingURL() returns null in the event that the corresponding request does not specify a URL.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8356410](https://bugs.openjdk.org/browse/JDK-8356410) to be approved

### Issues
 * [JDK-7046003](https://bugs.openjdk.org/browse/JDK-7046003): Default value of Authenticator.getRequestingURL() is not specified (**Bug** - P4)
 * [JDK-8356410](https://bugs.openjdk.org/browse/JDK-8356410): Default value of Authenticator.getRequestingURL() is not specified (**CSR**)


### Reviewers
 * [Michael McMahon](https://openjdk.org/census#michaelm) (@Michael-Mc-Mahon - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25097/head:pull/25097` \
`$ git checkout pull/25097`

Update a local copy of the PR: \
`$ git checkout pull/25097` \
`$ git pull https://git.openjdk.org/jdk.git pull/25097/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25097`

View PR using the GUI difftool: \
`$ git pr show -t 25097`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25097.diff">https://git.openjdk.org/jdk/pull/25097.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25097#issuecomment-2858840394)
</details>
