### PR TITLE
NPE: Cannot invoke "getDeclarationAttributes" because "sym" is null

### DIFF
--- a/test/langtools/tools/javac/8351232/Anno.java
+++ b/test/langtools/tools/javac/8351232/Anno.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.lang.annotation.*;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE_USE)
+public @interface Anno {}

--- a/test/langtools/tools/javac/8351232/Cls.java
+++ b/test/langtools/tools/javac/8351232/Cls.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+public class Cls<K, V> {
+
+  public static Cls<Object, Object> newInstance() {
+    return new Cls<>();
+  }
+
+  public <K1 extends K, V1 extends @Anno V> V1 doSomething(Intf1 arg) {
+      throw new UnsupportedOperationException();
+  }
+
+  public <K1 extends K, V1 extends @Anno V> V1 doSomething(Intf2 arg) {
+      throw new UnsupportedOperationException();
+  }
+}

--- a/test/langtools/tools/javac/8351232/Intf1.java
+++ b/test/langtools/tools/javac/8351232/Intf1.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+public interface Intf1 {
+
+    Object foo(Object bar);
+
+}

--- a/test/langtools/tools/javac/8351232/Intf2.java
+++ b/test/langtools/tools/javac/8351232/Intf2.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+public interface Intf2 extends Intf1 {
+}

--- a/test/langtools/tools/javac/8351232/TestClass.java
+++ b/test/langtools/tools/javac/8351232/TestClass.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+public class TestClass {
+  void test() {
+    Cls.newInstance()
+        .<Void, Void>doSomething(
+            image -> {
+              return;
+            });
+  }
+}

--- a/test/langtools/tools/javac/8351232/TypeAnnotationSymNullTest.java
+++ b/test/langtools/tools/javac/8351232/TypeAnnotationSymNullTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8351232
+ * @summary NPE when type annotation missing on classpath
+ * @modules jdk.compiler/com.sun.tools.javac.api
+ */
+
+import java.io.File;
+import com.sun.tools.javac.api.*;
+
+public class TypeAnnotationSymNullTest {
+    public static void main(String[] args) {
+        File testSrc = new File(System.getProperty("test.src", "."));
+
+        File ANNO = new File("ANNO");
+        ANNO.mkdirs();
+
+        // first, compile Anno to the ANNO directory
+        compile(0, "-d", ANNO.getPath(), new File(testSrc, "Anno.java").getPath());
+
+        File CLP = new File("CLP");
+        CLP.mkdirs();
+
+        // second, compile Cls, Intf1 and Intf2 to the CLP directory with ANNO on classpath
+        compile(0, "-cp", ANNO.getPath(), "-d", CLP.getPath(), new File(testSrc, "Cls.java").getPath(),
+                                                            new File(testSrc, "Intf1.java").getPath(),
+                                                            new File(testSrc, "Intf2.java").getPath());
+
+        // now compile TestClass with CLP on classpath (but Anno.class missing)
+        // compilation fails (exit code 1) but should not get NPE from compiler (exit code 4)
+        compile(1, "-cp", CLP.getPath(), "-d", ".", new File(testSrc, "TestClass.java").getPath());
+    }
+
+    private static void compile(int expectedExit, String... args) {
+        int exitCode = JavacTool.create().run(null, null, null, args);
+        if (exitCode != expectedExit) {
+            throw new AssertionError("test compilation failed with exit code: " + exitCode);
+        }
+    }
+}


### PR DESCRIPTION
Javac throws NPE in very specific circumstances described in [JDK-8351232](https://bugs.openjdk.org/browse/JDK-8351232).
The NPE has been fixed as a side effect of "stripMetadata" call in the recent [JDK-8355065](https://bugs.openjdk.org/browse/JDK-8355065) fix.

This PR only adds a test case to avoid regression of the NPE.

Please review.

Thank you,
Adam