### PR TITLE
8356394: Remove  USE_LIBRARY_BASED_TLS_ONLY macro

### DIFF
--- a/src/hotspot/share/classfile/symbolTable.cpp
+++ b/src/hotspot/share/classfile/symbolTable.cpp
@@ -88,13 +88,9 @@ static volatile bool   _has_items_to_clean = false;
 
 static volatile bool _alt_hash = false;
 
-#ifdef USE_LIBRARY_BASED_TLS_ONLY
-static volatile bool _lookup_shared_first = false;
-#else
 // "_lookup_shared_first" can get highly contended with many cores if multiple threads
-// are updating "lookup success history" in a global shared variable. If built-in TLS is available, use it.
+// are updating "lookup success history" in a global shared variable, so use built-in TLS
 static THREAD_LOCAL bool _lookup_shared_first = false;
-#endif
 
 // Static arena for symbols that are not deallocated
 Arena* SymbolTable::_arena = nullptr;

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -52,10 +52,7 @@
 #include "jfr/jfr.hpp"
 #endif
 
-#ifndef USE_LIBRARY_BASED_TLS_ONLY
-// Current thread is maintained as a thread-local variable
 THREAD_LOCAL Thread* Thread::_thr_current = nullptr;
-#endif
 
 // ======= Thread ========
 // Base class for all threads: VMThread, WatcherThread, ConcurrentMarkSweepThread,
@@ -158,10 +155,8 @@ void Thread::initialize_tlab() {
 }
 
 void Thread::initialize_thread_current() {
-#ifndef USE_LIBRARY_BASED_TLS_ONLY
   assert(_thr_current == nullptr, "Thread::current already initialized");
   _thr_current = this;
-#endif
   assert(ThreadLocalStorage::thread() == nullptr, "ThreadLocalStorage::thread already initialized");
   ThreadLocalStorage::set_thread(this);
   assert(Thread::current() == ThreadLocalStorage::thread(), "TLS mismatch!");
@@ -169,9 +164,7 @@ void Thread::initialize_thread_current() {
 
 void Thread::clear_thread_current() {
   assert(Thread::current() == ThreadLocalStorage::thread(), "TLS mismatch!");
-#ifndef USE_LIBRARY_BASED_TLS_ONLY
   _thr_current = nullptr;
-#endif
   ThreadLocalStorage::set_thread(nullptr);
 }
 

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -113,10 +113,8 @@ class Thread: public ThreadShadow {
   friend class JavaThread;
  private:
 
-#ifndef USE_LIBRARY_BASED_TLS_ONLY
   // Current thread is maintained as a thread-local variable
   static THREAD_LOCAL Thread* _thr_current;
-#endif
 
   // On AArch64, the high order 32 bits are used by a "patching epoch" number
   // which reflects if this thread has executed the required fences, after
@@ -660,14 +658,7 @@ inline Thread* Thread::current() {
 }
 
 inline Thread* Thread::current_or_null() {
-#ifndef USE_LIBRARY_BASED_TLS_ONLY
   return _thr_current;
-#else
-  if (ThreadLocalStorage::is_initialized()) {
-    return ThreadLocalStorage::thread();
-  }
-  return nullptr;
-#endif
 }
 
 inline Thread* Thread::current_or_null_safe() {


### PR DESCRIPTION
The macro USE_LIBRARY_BASED_TLS_ONLY played a role on AIX and some mobile platforms a while ago but currently it seems to be not needed any more, so it can be removed.
See the discussion here
https://mail.openjdk.org/pipermail/mobile-dev/2025-May/000946.html

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8356394](https://bugs.openjdk.org/browse/JDK-8356394): Remove  USE_LIBRARY_BASED_TLS_ONLY macro (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25099/head:pull/25099` \
`$ git checkout pull/25099`

Update a local copy of the PR: \
`$ git checkout pull/25099` \
`$ git pull https://git.openjdk.org/jdk.git pull/25099/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25099`

View PR using the GUI difftool: \
`$ git pr show -t 25099`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25099.diff">https://git.openjdk.org/jdk/pull/25099.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25099#issuecomment-2858925699)
</details>
