### PR TITLE
8351029: IncludeCustomExtension does not work on cygwin with source code below /home

### DIFF
--- a/make/PreInit.gmk
+++ b/make/PreInit.gmk
@@ -161,19 +161,19 @@ ifneq ($(SKIP_SPEC), true)
 	  ( cd $(TOPDIR) && \
 	  $(foreach spec, $(SPECS), \
 	    $(MAKE) $(MAKE_INIT_ARGS) -j 1 -f $(TOPDIR)/make/Init.gmk \
-	        SPEC=$(spec) $(MAKE_INIT_MAIN_TARGET_ARGS) \
-	        main && \
+	        SPEC=$(spec) TOPDIR_ALT=$(TOPDIR) \
+	        $(MAKE_INIT_MAIN_TARGET_ARGS) main && \
 	    $(if $(and $(COMPARE_BUILD), $(PARALLEL_TARGETS)), \
 	      $(MAKE) $(MAKE_INIT_ARGS) -f $(TOPDIR)/make/Init.gmk \
-	          SPEC=$(spec) \
+	          SPEC=$(spec) TOPDIR_ALT=$(TOPDIR) \
 	          COMPARE_BUILD="$(COMPARE_BUILD)" \
 	          pre-compare-build && \
 	      $(MAKE) $(MAKE_INIT_ARGS) -j 1 -f $(TOPDIR)/make/Init.gmk \
-	          SPEC=$(spec) $(MAKE_INIT_MAIN_TARGET_ARGS) \
+	          SPEC=$(spec) TOPDIR_ALT=$(TOPDIR) \
 	          COMPARE_BUILD="$(COMPARE_BUILD):NODRYRUN=true" \
-	          main && \
+	          $(MAKE_INIT_MAIN_TARGET_ARGS) main && \
 	      $(MAKE) $(MAKE_INIT_ARGS) -f $(TOPDIR)/make/Init.gmk \
-	          SPEC=$(spec) \
+	          SPEC=$(spec) TOPDIR_ALT=$(TOPDIR) \
 	          COMPARE_BUILD="$(COMPARE_BUILD):NODRYRUN=true" \
 	          post-compare-build && \
 	    ) \

--- a/make/PreInitSupport.gmk
+++ b/make/PreInitSupport.gmk
@@ -250,10 +250,7 @@ endef
 # Param 1: FORCE = force generation of main-targets.gmk or LAZY = do not force.
 # Param 2: The SPEC file to use.
 define DefineMainTargets
-
-  # We need to include the given SPEC file to setup TOPDIR properly
   SPEC_FILE := $(strip $2)
-  -include $$(SPEC_FILE)
 
   # We will start by making sure the main-targets.gmk file is removed, if
   # make has not been restarted. By the -include, we will trigger the
@@ -272,10 +269,10 @@ define DefineMainTargets
   $$(main_targets_file):
 	@( cd $$(TOPDIR) && \
 	$$(MAKE) $$(MAKE_LOG_FLAGS) -r -R -f $$(TOPDIR)/make/GenerateFindTests.gmk \
-	    -I $$(TOPDIR)/make/common SPEC=$$(SPEC_FILE) )
+	    -I $$(TOPDIR)/make/common SPEC=$$(SPEC_FILE) TOPDIR_ALT=$$(TOPDIR))
 	@( cd $$(TOPDIR) && \
 	$$(MAKE) $$(MAKE_LOG_FLAGS) -r -R -f $$(TOPDIR)/make/Main.gmk \
-	    -I $$(TOPDIR)/make/common SPEC=$$(SPEC_FILE) NO_RECIPES=true \
+	    -I $$(TOPDIR)/make/common SPEC=$$(SPEC_FILE) TOPDIR_ALT=$$(TOPDIR) NO_RECIPES=true \
 	    $$(MAKE_LOG_VARS) \
 	    create-main-targets-include )
 

--- a/make/PreInitSupport.gmk
+++ b/make/PreInitSupport.gmk
@@ -251,12 +251,16 @@ endef
 # Param 2: The SPEC file to use.
 define DefineMainTargets
 
+  # We need to include the given SPEC file to setup TOPDIR properly
+  SPEC_FILE := $(strip $2)
+  -include $$(SPEC_FILE)
+
   # We will start by making sure the main-targets.gmk file is removed, if
   # make has not been restarted. By the -include, we will trigger the
   # rule for generating the file (which is never there since we removed it),
   # thus generating it fresh, and make will restart, incrementing the restart
   # count.
-  main_targets_file := $$(dir $(strip $2))make-support/main-targets.gmk
+  main_targets_file := $$(dir $$(SPEC_FILE))make-support/main-targets.gmk
 
   ifeq ($$(MAKE_RESTARTS), )
     # Only do this if make has not been restarted, and if we do not force it.
@@ -268,10 +272,10 @@ define DefineMainTargets
   $$(main_targets_file):
 	@( cd $$(TOPDIR) && \
 	$$(MAKE) $$(MAKE_LOG_FLAGS) -r -R -f $$(TOPDIR)/make/GenerateFindTests.gmk \
-	    -I $$(TOPDIR)/make/common SPEC=$(strip $2) )
+	    -I $$(TOPDIR)/make/common SPEC=$$(SPEC_FILE) )
 	@( cd $$(TOPDIR) && \
 	$$(MAKE) $$(MAKE_LOG_FLAGS) -r -R -f $$(TOPDIR)/make/Main.gmk \
-	    -I $$(TOPDIR)/make/common SPEC=$(strip $2) NO_RECIPES=true \
+	    -I $$(TOPDIR)/make/common SPEC=$$(SPEC_FILE) NO_RECIPES=true \
 	    $$(MAKE_LOG_VARS) \
 	    create-main-targets-include )
 

--- a/make/common/MakeFileStart.gmk
+++ b/make/common/MakeFileStart.gmk
@@ -47,7 +47,7 @@ endif
 # We need spec.gmk to get $(TOPDIR)
 include $(SPEC)
 
-THIS_MAKEFILE := $(patsubst make/%,%,$(patsubst $(TOPDIR)/%,%,$(THIS_MAKEFILE_PATH)))
+THIS_MAKEFILE := $(patsubst make/%,%,$(patsubst $(TOPDIR_ALT)/make/%,%,$(patsubst $(TOPDIR)/%,%,$(THIS_MAKEFILE_PATH))))
 
 ifeq ($(LOG_FLOW), true)
   $(info :Enter $(THIS_MAKEFILE))

--- a/make/common/MakeIncludeStart.gmk
+++ b/make/common/MakeIncludeStart.gmk
@@ -29,7 +29,7 @@
 
 # Get the next to last word (by prepending a padding element)
 THIS_INCLUDE_PATH := $(word $(words ${MAKEFILE_LIST}),padding ${MAKEFILE_LIST})
-THIS_INCLUDE := $(patsubst $(TOPDIR)/make/%,%,$(THIS_INCLUDE_PATH))
+THIS_INCLUDE := $(patsubst $(TOPDIR_ALT)/make/%,%,$(patsubst $(TOPDIR)/make/%,%,$(THIS_INCLUDE_PATH)))
 
 # Print an indented message, also counting the top-level makefile as a level
 ifneq ($(INCLUDE_GUARD_$(THIS_INCLUDE)), true)


### PR DESCRIPTION
If you check out your source code in Cygwin, somewhere under /home/... (as opposed to /cygpath/...), IncludeCustomExtension does not work.

The problem is that TOPDIR gets a different lexical value from the spec.gmk file when setup in Makefile, even if this was the same directory. Since THIS_INCLUDE is calculated as a relative path by string substitution of $(TOPDIR), the path failed to relativize correctly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8351029](https://bugs.openjdk.org/browse/JDK-8351029): IncludeCustomExtension does not work on cygwin with source code below /home (**Bug** - P3)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25100/head:pull/25100` \
`$ git checkout pull/25100`

Update a local copy of the PR: \
`$ git checkout pull/25100` \
`$ git pull https://git.openjdk.org/jdk.git pull/25100/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25100`

View PR using the GUI difftool: \
`$ git pr show -t 25100`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25100.diff">https://git.openjdk.org/jdk/pull/25100.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25100#issuecomment-2860274420)
</details>
