### PR TITLE
8356221: Clarify Console.charset() method description

### DIFF
--- a/src/java.base/share/classes/java/io/Console.java
+++ b/src/java.base/share/classes/java/io/Console.java
@@ -512,7 +512,7 @@ public sealed class Console implements Flushable permits ProxyingConsole {
      * Returns the {@link java.nio.charset.Charset Charset} object used for
      * the {@code Console}.
      * <p>
-     * The returned charset corresponds to the input and output source
+     * The returned charset is used for interpreting the input and output source
      * (e.g., keyboard and/or display) specified by the host environment or user,
      * which defaults to the one based on {@link System##stdout.encoding stdout.encoding}.
      * It may not necessarily be the same as the default charset returned from


### PR DESCRIPTION
Simple clarification of the `Console.charset()` method description, making explicit how the charset is applied.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8356221](https://bugs.openjdk.org/browse/JDK-8356221): Clarify Console.charset() method description (**Bug** - P4)


### Reviewers
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25103/head:pull/25103` \
`$ git checkout pull/25103`

Update a local copy of the PR: \
`$ git checkout pull/25103` \
`$ git pull https://git.openjdk.org/jdk.git pull/25103/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25103`

View PR using the GUI difftool: \
`$ git pr show -t 25103`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25103.diff">https://git.openjdk.org/jdk/pull/25103.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25103#issuecomment-2859385542)
</details>
