### PR TITLE
8356441: IllegalStateException in RichDiagnosticFormatter after JDK-8355065

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/RichDiagnosticFormatter.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/RichDiagnosticFormatter.java
@@ -32,7 +32,6 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Locale;
 import java.util.Map;
-import java.util.WeakHashMap;
 import java.util.function.Supplier;
 
 import com.sun.tools.javac.code.Printer;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/RichDiagnosticFormatter.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/RichDiagnosticFormatter.java
@@ -32,6 +32,8 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Locale;
 import java.util.Map;
+import java.util.WeakHashMap;
+import java.util.function.Supplier;
 
 import com.sun.tools.javac.code.Printer;
 import com.sun.tools.javac.code.Symbol;
@@ -102,17 +104,17 @@ public class RichDiagnosticFormatter extends
     /* map for keeping track of a where clause associated to a given type */
     WhereClauses whereClauses;
 
-    private void enter() {
-        if (nameSimplifier != null || whereClauses != null) {
-            throw new IllegalStateException();
+    private String enter(Supplier<String> r) {
+        ClassNameSimplifier nameSimplifier = this.nameSimplifier;
+        WhereClauses whereClauses = this.whereClauses;
+        try {
+            this.nameSimplifier = new ClassNameSimplifier();
+            this.whereClauses = new WhereClauses();
+            return r.get();
+        } finally {
+            this.nameSimplifier = nameSimplifier;
+            this.whereClauses = whereClauses;
         }
-        nameSimplifier = new ClassNameSimplifier();
-        whereClauses = new WhereClauses();
-    }
-
-    private void exit() {
-        nameSimplifier = null;
-        whereClauses = null;
     }
 
     /** Get the DiagnosticFormatter instance for this context. */
@@ -136,8 +138,7 @@ public class RichDiagnosticFormatter extends
 
     @Override
     public String format(JCDiagnostic diag, Locale l) {
-        enter();
-        try {
+        return enter(() -> {
             StringBuilder sb = new StringBuilder();
             preprocessDiagnostic(diag);
             sb.append(formatter.format(diag, l));
@@ -153,20 +154,15 @@ public class RichDiagnosticFormatter extends
                 }
             }
             return sb.toString();
-        } finally {
-            exit();
-        }
+        });
     }
 
     @Override
     public String formatMessage(JCDiagnostic diag, Locale l) {
-        enter();
-        try {
+        return enter(() -> {
             preprocessDiagnostic(diag);
             return super.formatMessage(diag, l);
-        } finally {
-            exit();
-        }
+        });
     }
 
     /**

--- a/test/langtools/tools/javac/annotations/typeAnnotations/RichFormatterWithTypeAnnotationsReentrantTest.java
+++ b/test/langtools/tools/javac/annotations/typeAnnotations/RichFormatterWithTypeAnnotationsReentrantTest.java
@@ -23,7 +23,7 @@
 
 /**
  * @test
- * @bug 8355065
+ * @bug 8356441
  * @summary Recursive formatting in RichDiagnosticFormatter
  * @library /tools/lib
  * @modules jdk.compiler/com.sun.tools.javac.main jdk.compiler/com.sun.tools.javac.api

--- a/test/langtools/tools/javac/annotations/typeAnnotations/RichFormatterWithTypeAnnotationsReentrantTest.java
+++ b/test/langtools/tools/javac/annotations/typeAnnotations/RichFormatterWithTypeAnnotationsReentrantTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2025, Google LLC. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8355065
+ * @summary Recursive formatting in RichDiagnosticFormatter
+ * @library /tools/lib
+ * @modules jdk.compiler/com.sun.tools.javac.main jdk.compiler/com.sun.tools.javac.api
+ * @build toolbox.ToolBox toolbox.JavacTask
+ * @run main RichFormatterWithTypeAnnotationsReentrantTest
+ */
+import toolbox.JavacTask;
+import toolbox.Task;
+import toolbox.TestRunner;
+import toolbox.ToolBox;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
+
+public class RichFormatterWithTypeAnnotationsReentrantTest extends TestRunner {
+    ToolBox tb;
+
+    public RichFormatterWithTypeAnnotationsReentrantTest() {
+        super(System.err);
+        tb = new ToolBox();
+    }
+
+    public static void main(String[] args) throws Exception {
+        new RichFormatterWithTypeAnnotationsReentrantTest()
+                .runTests(m -> new Object[] {Paths.get(m.getName())});
+    }
+
+    @Test
+    public void test(Path base) throws Exception {
+        Path libClasses = base.resolve("libclasses");
+        Files.createDirectories(libClasses);
+        new JavacTask(tb)
+                .outdir(libClasses)
+                .sources(
+                        """
+                        package lib;
+                        enum Bar {
+                          BAZ
+                        }
+                        """,
+                        """
+                        package lib;
+                        import java.lang.annotation.ElementType;
+                        import java.lang.annotation.Retention;
+                        import java.lang.annotation.RetentionPolicy;
+                        import java.lang.annotation.Target;
+
+                        @Retention(RetentionPolicy.RUNTIME)
+                        @interface Foo {
+                          Bar value();
+                        }
+                        """,
+                        """
+                        package lib;
+                        import java.lang.annotation.ElementType;
+                        import java.lang.annotation.Retention;
+                        import java.lang.annotation.RetentionPolicy;
+                        import java.lang.annotation.Target;
+
+                        @Retention(RetentionPolicy.RUNTIME)
+                        @Target({ElementType.TYPE_USE, ElementType.PARAMETER})
+                        @Foo(Bar.BAZ)
+                        @interface A {}
+                        """,
+                        """
+                        package lib;
+                        public interface M {
+                          String f(@A String k, @A String v);
+                        }
+                        """)
+                .run()
+                .writeAll();
+        Files.delete(libClasses.resolve("lib").resolve("Bar.class"));
+        String code =
+                """
+                import lib.M;
+                class T implements M {
+                }
+                """;
+        List<String> output =
+                new JavacTask(tb)
+                        .classpath(libClasses)
+                        .sources(code)
+                        .run(Task.Expect.FAIL)
+                        .writeAll()
+                        .getOutputLines(Task.OutputKind.DIRECT);
+        // The crash this is a regression test for doesn't reproduce with -XDrawDiagnostics
+        List<String> expected =
+                Arrays.asList(
+                        "warning: unknown enum constant Bar.BAZ",
+                        "  reason: class file for lib.Bar not found",
+                        "T.java:2: error: T is not abstract and does not override abstract method"
+                            + " f(@lib.A String,@lib.A String) in M",
+                        "class T implements M {",
+                        "^",
+                        "1 error",
+                        "1 warning");
+        tb.checkEqual(expected, output);
+    }
+}

--- a/test/langtools/tools/javac/annotations/typeAnnotations/RichFormatterWithTypeAnnotationsReentrantTest.java
+++ b/test/langtools/tools/javac/annotations/typeAnnotations/RichFormatterWithTypeAnnotationsReentrantTest.java
@@ -106,24 +106,10 @@ public class RichFormatterWithTypeAnnotationsReentrantTest extends TestRunner {
                 class T implements M {
                 }
                 """;
-        List<String> output =
-                new JavacTask(tb)
-                        .classpath(libClasses)
-                        .sources(code)
-                        .run(Task.Expect.FAIL)
-                        .writeAll()
-                        .getOutputLines(Task.OutputKind.DIRECT);
-        // The crash this is a regression test for doesn't reproduce with -XDrawDiagnostics
-        List<String> expected =
-                Arrays.asList(
-                        "warning: unknown enum constant Bar.BAZ",
-                        "  reason: class file for lib.Bar not found",
-                        "T.java:2: error: T is not abstract and does not override abstract method"
-                            + " f(@lib.A String,@lib.A String) in M",
-                        "class T implements M {",
-                        "^",
-                        "1 error",
-                        "1 warning");
-        tb.checkEqual(expected, output);
+        // verify that the compilation fails wtih an error, and does not crash
+        new JavacTask(tb)
+                .classpath(libClasses)
+                .sources(code)
+                .run(Task.Expect.FAIL);
     }
 }


### PR DESCRIPTION
[JDK-8355065](https://bugs.openjdk.org/browse/JDK-8355065) fixed an issue where if RichDiagnosticFormatter was used recursively, it would overwrite instance state. That fix added guards to prevent the logic from being used recursively. As reported in [JDK-8356441](https://bugs.openjdk.org/browse/JDK-8356441) there are other situations where RichDiagnosticFormatter is used recursively. This fixes updates it to support being used recursively, by saving and restoring instance state on recursive calls.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8356441](https://bugs.openjdk.org/browse/JDK-8356441): IllegalStateException in RichDiagnosticFormatter after JDK-8355065 (**Bug** - P2)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25105/head:pull/25105` \
`$ git checkout pull/25105`

Update a local copy of the PR: \
`$ git checkout pull/25105` \
`$ git pull https://git.openjdk.org/jdk.git pull/25105/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25105`

View PR using the GUI difftool: \
`$ git pr show -t 25105`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25105.diff">https://git.openjdk.org/jdk/pull/25105.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25105#issuecomment-2860504206)
</details>
