### PR TITLE
8354278: Revert use of non-POSIX echo -n introduced in JDK-8301197

### DIFF
--- a/make/Docs.gmk
+++ b/make/Docs.gmk
@@ -262,7 +262,7 @@ define create_overview_file
   $$($1_OVERVIEW): $$($1_OVERVIEW_VARDEPS_FILE)
 	$$(call LogInfo, Creating overview.html for $1)
 	$$(call MakeDir, $$(@D))
-	$$(ECHO) -n '$$($1_OVERVIEW_TEXT)' > $$@
+	$$(PRINTF) "%s" '$$($1_OVERVIEW_TEXT)' > $$@
 endef
 
 ################################################################################

--- a/make/MainSupport.gmk
+++ b/make/MainSupport.gmk
@@ -57,7 +57,7 @@ define SetupTargetBody
 endef
 
 define CleanDocs
-	@$(ECHO) -n "Cleaning docs ..."
+	@$(PRINTF) "Cleaning docs ..."
 	@$(ECHO) "" $(LOG_DEBUG)
 	$(RM) -r $(SUPPORT_OUTPUTDIR)/docs
 	$(RM) -r $(SUPPORT_OUTPUTDIR)/javadoc
@@ -67,28 +67,28 @@ endef
 
 # Cleans the dir given as $1
 define CleanDir
-	@$(ECHO) -n "Cleaning $(strip $1) build artifacts ..."
+	@$(PRINTF) "Cleaning %s build artifacts ..." "$(strip $1)"
 	@$(ECHO) "" $(LOG_DEBUG)
 	($(CD) $(OUTPUTDIR) && $(RM) -r $1)
 	@$(ECHO) " done"
 endef
 
 define CleanSupportDir
-	@$(ECHO) -n "Cleaning$(strip $1) build artifacts ..."
+	@$(PRINTF) "Cleaning %s build artifacts ..." "$(strip $1)"
 	@$(ECHO) "" $(LOG_DEBUG)
 	$(RM) -r $(SUPPORT_OUTPUTDIR)/$(strip $1)
 	@$(ECHO) " done"
 endef
 
 define CleanMakeSupportDir
-	@$(ECHO) -n "Cleaning $(strip $1) make support artifacts ..."
+	@$(PRINTF) "Cleaning %s make support artifacts ..." "$(strip $1)"
 	@$(ECHO) "" $(LOG_DEBUG)
 	$(RM) -r $(MAKESUPPORT_OUTPUTDIR)/$(strip $1)
 	@$(ECHO) " done"
 endef
 
 define CleanTest
-	@$(ECHO) -n "Cleaning test $(strip $1) ..."
+	@$(PRINTF) "Cleaning test %s ..." "$(strip $1)"
 	@$(ECHO) "" $(LOG_DEBUG)
 	$(RM) -r $(SUPPORT_OUTPUTDIR)/test/$(strip $(subst -,/,$1))
         # Remove as much of the test directory structure as is empty
@@ -97,25 +97,25 @@ define CleanTest
 endef
 
 define Clean-gensrc
-	@$(ECHO) -n "Cleaning gensrc $(if $1,for $(strip $1) )..."
+	@$(PRINTF) "Cleaning gensrc %s..." "$(if $1,for $(strip $1) )"
 	@$(ECHO) "" $(LOG_DEBUG)
 	$(RM) -r $(SUPPORT_OUTPUTDIR)/gensrc/$(strip $1)
 	@$(ECHO) " done"
 endef
 
 define Clean-java
-	@$(ECHO) -n "Cleaning java $(if $1,for $(strip $1) )..."
+	@$(PRINTF) "Cleaning java %s..." "$(if $1,for $(strip $1) )"
 	@$(ECHO) "" $(LOG_DEBUG)
 	$(RM) -r $(JDK_OUTPUTDIR)/modules/$(strip $1)
 	$(RM) -r $(SUPPORT_OUTPUTDIR)/special_classes/$(strip $1)
 	$(ECHO) " done"
-	$(ECHO) -n "Cleaning headers $(if $1,for $(strip $1) )..."
+	$(PRINTF) "Cleaning headers %s..." "$(if $1,for $(strip $1) )"
 	$(RM) -r $(SUPPORT_OUTPUTDIR)/headers/$(strip $1)
 	@$(ECHO) " done"
 endef
 
 define Clean-native
-	@$(ECHO) -n "Cleaning native $(if $1,for $(strip $1) )..."
+	@$(PRINTF) "Cleaning native %s..." "$(if $1,for $(strip $1) )"
 	@$(ECHO) "" $(LOG_DEBUG)
 	$(RM) -r $(SUPPORT_OUTPUTDIR)/native/$(strip $1)
 	$(RM) -r $(SUPPORT_OUTPUTDIR)/modules_libs/$(strip $1)
@@ -124,7 +124,7 @@ define Clean-native
 endef
 
 define Clean-include
-	@$(ECHO) -n "Cleaning include $(if $1,for $(strip $1) )..."
+	@$(PRINTF) "Cleaning include %s..." "$(if $1,for $(strip $1) )"
 	@$(ECHO) "" $(LOG_DEBUG)
 	$(RM) -r $(SUPPORT_OUTPUTDIR)/modules_include/$(strip $1)
 	@$(ECHO) " done"

--- a/make/autoconf/help.m4
+++ b/make/autoconf/help.m4
@@ -292,12 +292,12 @@ AC_DEFUN_ONCE([HELP_PRINT_SUMMARY_AND_WARNINGS],
   $ECHO "* Debug level:    $DEBUG_LEVEL"
   $ECHO "* HS debug level: $HOTSPOT_DEBUG_LEVEL"
   $ECHO "* JVM variants:   $JVM_VARIANTS"
-  $ECHO -n "* JVM features:   "
+  $PRINTF "* JVM features:   "
 
   for variant in $JVM_VARIANTS; do
     features_var_name=JVM_FEATURES_$variant
     JVM_FEATURES_FOR_VARIANT=${!features_var_name}
-    $ECHO -n "$variant: '$JVM_FEATURES_FOR_VARIANT' "
+    $PRINTF "%s: \'%s\' " "$variant" "$JVM_FEATURES_FOR_VARIANT"
   done
   $ECHO ""
 

--- a/make/common/FindTests.gmk
+++ b/make/common/FindTests.gmk
@@ -59,14 +59,14 @@ ifeq ($(GENERATE_FIND_TESTS_FILE), true)
 	$(call MakeTargetDir)
 	( $(foreach root, $(JTREG_TESTROOTS), \
 	    $(ECHO) ""; \
-	    $(ECHO) -n "$(root)_JTREG_TEST_GROUPS := "; \
+	    $(PRINTF) "\n%s_JTREG_TEST_GROUPS := " "$(root)"; \
 	    $(SED) -n -e 's/^\#.*//g' -e 's/\([^ ]*\)\w*=.*/\1/gp' \
 	      $($(root)_JTREG_GROUP_FILES) \
 	      | $(SORT) -u | $(TR) '\n' ' ' ; \
 	  ) \
 	) > $@
 	$(ECHO) "" >> $@
-	$(ECHO) -n "MAKE_TEST_TARGETS := " >> $@
+	$(PRINTF) "MAKE_TEST_TARGETS := " >> $@
 	$(MAKE) -s --no-print-directory $(MAKE_ARGS) \
 	    SPEC=$(SPEC) -f $(TOPDIR)/test/make/TestMake.gmk print-targets \
 	    TARGETS_FILE=$@

--- a/make/common/Modules.gmk
+++ b/make/common/Modules.gmk
@@ -180,7 +180,7 @@ ifeq ($(GENERATE_MODULE_DEPS_FILE), true)
 	$(call MakeTargetDir)
 	$(RM) $@
 	$(foreach m, $(MODULE_INFOS), \
-	    ( $(ECHO) -n "DEPS_$(call GetModuleNameFromModuleInfo, $m) := " && \
+	    ( $(PRINTF) "DEPS_%s := " "$(call GetModuleNameFromModuleInfo, $m)" && \
 	      $(AWK) -v MODULE=$(call GetModuleNameFromModuleInfo, $m) ' \
 	          BEGIN      { if (MODULE != "java.base") printf(" java.base"); } \
 	          /^ *requires/ { sub(/;/, ""); \
@@ -194,7 +194,7 @@ ifeq ($(GENERATE_MODULE_DEPS_FILE), true)
 	                          gsub(/\r/, ""); \
 	                          printf(" %s", $$0) } \
 	          END           { printf("\n") }' $m && \
-	      $(ECHO) -n "TRANSITIVE_MODULES_$(call GetModuleNameFromModuleInfo, $m) := " && \
+	      $(PRINTF) "TRANSITIVE_MODULES_%s := " "$(call GetModuleNameFromModuleInfo, $m)" && \
 	      $(AWK) -v MODULE=$(call GetModuleNameFromModuleInfo, $m) ' \
 	          BEGIN      { if (MODULE != "java.base") printf(" java.base"); } \
 	          /^ *requires  *transitive/ { \


### PR DESCRIPTION
`echo -n` is not part of the required POSIX standard, and built in shell versions of echo might not support it. Restore the previous use of `printf` instead.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8354278](https://bugs.openjdk.org/browse/JDK-8354278): Revert use of non-POSIX echo -n introduced in JDK-8301197 (**Bug** - P3)


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25106/head:pull/25106` \
`$ git checkout pull/25106`

Update a local copy of the PR: \
`$ git checkout pull/25106` \
`$ git pull https://git.openjdk.org/jdk.git pull/25106/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25106`

View PR using the GUI difftool: \
`$ git pr show -t 25106`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25106.diff">https://git.openjdk.org/jdk/pull/25106.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25106#issuecomment-2860437383)
</details>
