### PR TITLE
8356087: Problematic KeyInfo check using key algorithm in P11SecretKeyFactory class

### DIFF
--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11SecretKeyFactory.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11SecretKeyFactory.java
@@ -449,7 +449,7 @@ final class P11SecretKeyFactory extends SecretKeyFactorySpi {
         }
         if (key instanceof PBEKey pbeKey) {
             // make sure key info matches key type
-            KeyInfo ki = getKeyInfo(keyAlgo);
+            KeyInfo ki = (keyAlgo == svcAlgo ? si : getKeyInfo(keyAlgo));
             if (ki instanceof PBEKeyInfo pbeKi) {
                 PBEKeySpec keySpec = getPbeKeySpec(pbeKey);
                 try {

--- a/test/jdk/sun/security/pkcs11/Mac/InitMacWithAnyKey.java
+++ b/test/jdk/sun/security/pkcs11/Mac/InitMacWithAnyKey.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8356087
+ * @summary Ensure P11Mac using SHA message digests can be initialized with
+ *     any secret keys
+ * @library /test/lib ..
+ * @modules jdk.crypto.cryptoki
+ * @run main/othervm InitMacWithAnyKey
+ */
+
+import java.security.Provider;
+import java.util.List;
+import javax.crypto.Mac;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+
+public class InitMacWithAnyKey extends PKCS11Test {
+
+    public static void main(String[] args) throws Exception {
+        main(new InitMacWithAnyKey(), args);
+    }
+
+    @Override
+    public void main(Provider p) throws Exception {
+        SecretKey skey = new SecretKeySpec("whatever".getBytes(), "Any");
+        // Test against Hmacs using SHA-1, SHA-2 message digests and skip
+        // PBE-related Hmacs as they need PBEKey
+        List<String> algorithms = getSupportedAlgorithms("Mac", "HmacSHA", p);
+        for (String algo : algorithms) {
+            System.out.println("Testing " + algo);
+            Mac mac = Mac.getInstance(algo, p);
+            try {
+                mac.init(skey);
+            } catch (Exception e) {
+                throw new Exception("Unexpected exception", e);
+            }
+        }
+        System.out.println("Passed");
+    }
+}

--- a/test/jdk/sun/security/pkcs11/Mac/InitMacWithAnyKey.java
+++ b/test/jdk/sun/security/pkcs11/Mac/InitMacWithAnyKey.java
@@ -25,7 +25,7 @@
  * @test
  * @bug 8356087
  * @summary Ensure P11Mac using SHA message digests can be initialized with
- *     any secret keys
+ *     secret keys with unrecognized algorithms
  * @library /test/lib ..
  * @modules jdk.crypto.cryptoki
  * @run main/othervm InitMacWithAnyKey


### PR DESCRIPTION
In the PR for JDK-8348732 "SunJCE and SunPKCS11 have different PBE key encodings", the `P11SecretKeyFactory.convertKey(...)` method is refactored to call `getKeyInfo(keyAlgo)` and check that it's not `null`. However, this leads to problems for the `P11Mac` object when it's initialized with a key whose algorithm is not recognized by SunPKCS11 provider. It fails with an unexpected `InvalidKeyException`. Thus, reverting back to the pre-JDK8348732 code and calls `getKeyInfo(keyAlgo)` only when needed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8356087](https://bugs.openjdk.org/browse/JDK-8356087): Problematic KeyInfo check using key algorithm in P11SecretKeyFactory class (**Bug** - P3)


### Reviewers
 * [Weijun Wang](https://openjdk.org/census#weijun) (@wangweij - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25108/head:pull/25108` \
`$ git checkout pull/25108`

Update a local copy of the PR: \
`$ git checkout pull/25108` \
`$ git pull https://git.openjdk.org/jdk.git pull/25108/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25108`

View PR using the GUI difftool: \
`$ git pr show -t 25108`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25108.diff">https://git.openjdk.org/jdk/pull/25108.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25108#issuecomment-2860592820)
</details>
