### PR TITLE
8354083: Support --add-reads with -XX:+AOTClassLinking

### DIFF
--- a/src/hotspot/share/classfile/modules.cpp
+++ b/src/hotspot/share/classfile/modules.cpp
@@ -584,6 +584,7 @@ Modules::ArchivedProperty Modules::_archived_props[] = {
   {"jdk.module.addmods", true},                // --add-modules
   {"jdk.module.enable.native.access", true},   // --enable-native-access
   {"jdk.module.addopens", true},               // --add-opens
+  {"jdk.module.addreads", true},               // --add-reads
 };
 
 constexpr size_t Modules::num_archived_props() {

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -331,8 +331,7 @@ bool Arguments::is_incompatible_cds_internal_module_property(const char* propert
 bool Arguments::internal_module_property_helper(const char* property, bool check_for_cds) {
   if (strncmp(property, MODULE_PROPERTY_PREFIX, MODULE_PROPERTY_PREFIX_LEN) == 0) {
     const char* property_suffix = property + MODULE_PROPERTY_PREFIX_LEN;
-    if (matches_property_suffix(property_suffix, ADDREADS, ADDREADS_LEN) ||
-        matches_property_suffix(property_suffix, PATCH, PATCH_LEN) ||
+    if (matches_property_suffix(property_suffix, PATCH, PATCH_LEN) ||
         matches_property_suffix(property_suffix, LIMITMODS, LIMITMODS_LEN) ||
         matches_property_suffix(property_suffix, UPGRADE_PATH, UPGRADE_PATH_LEN) ||
         matches_property_suffix(property_suffix, ILLEGAL_NATIVE_ACCESS, ILLEGAL_NATIVE_ACCESS_LEN)) {
@@ -343,6 +342,7 @@ bool Arguments::internal_module_property_helper(const char* property, bool check
       // CDS notes: these properties are supported by CDS archived full module graph.
       if (matches_property_suffix(property_suffix, ADDEXPORTS, ADDEXPORTS_LEN) ||
           matches_property_suffix(property_suffix, ADDOPENS, ADDOPENS_LEN) ||
+          matches_property_suffix(property_suffix, ADDREADS, ADDREADS_LEN) ||
           matches_property_suffix(property_suffix, PATH, PATH_LEN) ||
           matches_property_suffix(property_suffix, ADDMODS, ADDMODS_LEN) ||
           matches_property_suffix(property_suffix, ENABLE_NATIVE_ACCESS, ENABLE_NATIVE_ACCESS_LEN)) {

--- a/src/java.base/share/classes/jdk/internal/module/ModuleBootstrap.java
+++ b/src/java.base/share/classes/jdk/internal/module/ModuleBootstrap.java
@@ -141,8 +141,7 @@ public final class ModuleBootstrap {
     private static boolean canUseArchivedBootLayer() {
         return getProperty("jdk.module.upgrade.path") == null &&
                getProperty("jdk.module.patch.0") == null &&       // --patch-module
-               getProperty("jdk.module.limitmods") == null &&     // --limit-modules
-               getProperty("jdk.module.addreads.0") == null;      // --add-reads
+               getProperty("jdk.module.limitmods") == null;       // --limit-modules
     }
 
     /**


### PR DESCRIPTION
This fix adds the `--add-reads` support for CDS and AOTClassLinking.
Before the fix, if the `--add-reads` is specified during CDS archive dumping, the user will see the following log if `-Xlog:cds=info` is enabled:
`[0.000s][info][cds] optimized module handling: disabled due to incompatible property: jdk.module.addreads=com.norequires=org.astro`
During runtime, the archived full module graph will be disabled:
`[0.021s][info][cds       ] full module graph: disabled`

With the fix, the optimized module handling won't be disabled during dump time and the full module graph will be enabled during runtime provided the same --add-reads option is specified during dump time and runtime.

Testing: tiers 1 - 4.
