### PR TITLE
8356453: C2: assert(!vbox->is_Phi()) during vector box expansion

### DIFF
--- a/src/hotspot/share/opto/vector.cpp
+++ b/src/hotspot/share/opto/vector.cpp
@@ -44,6 +44,10 @@ void PhaseVector::optimize_vector_boxes() {
 
   C->igvn_worklist()->ensure_empty(); // should be done with igvn
 
+  if (StressMacroExpansion) {
+    C->shuffle_macro_nodes();
+  }
+
   expand_vunbox_nodes();
   scalarize_vbox_nodes();
 
@@ -311,7 +315,7 @@ Node* PhaseVector::expand_vbox_node_helper(Node* vbox,
                                            VectorSet &visited) {
   // JDK-8304948 shows an example that there may be a cycle in the graph.
   if (visited.test_set(vbox->_idx)) {
-    assert(vbox->is_Phi(), "should be phi");
+    assert(vbox->is_Phi() || vbox->is_CheckCastPP(), "either phi or expanded");
     return vbox; // already visited
   }
 
@@ -362,7 +366,7 @@ Node* PhaseVector::expand_vbox_node_helper(Node* vbox,
     return C->initial_gvn()->transform(vbox);
   }
 
-  assert(!vbox->is_Phi(), "should be expanded");
+  assert(vbox->is_CheckCastPP(), "should be expanded");
   // TODO: assert that expanded vbox is initialized with the same value (vect).
   return vbox; // already expanded
 }

--- a/test/hotspot/jtreg/compiler/vectorapi/VectorBoxExpandTest.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/VectorBoxExpandTest.java
@@ -41,6 +41,7 @@ public class VectorBoxExpandTest {
 
     private static int[] iarr = new int[ARR_LEN];
     private static IntVector g;
+    private static int acc = 0;
 
     // C2 would generate IR graph like below:
     //
@@ -86,10 +87,14 @@ public class VectorBoxExpandTest {
 
         for (int ic = 0; ic < NUM_ITER; ic++) {
             for (int i = 0; i < iarr.length; i++) {
+                acc += System.identityHashCode(a);
                 a = a.add(a);
+                acc += System.identityHashCode(a);
             }
         }
         g = a;
+        acc += System.identityHashCode(a);
+
     }
 
     public static void main(String[] args) {


### PR DESCRIPTION
Some Vector API tests fail with an assert during `PhaseVector::expand_vbox_node()`. The assert itself is the culprit, since it doesn't cover the case when VBox node is already expanded.

Proposed fix adjusts the assert.

Also, extended `PhaseVector::optimize_vector_boxes()` with `StressMacroExpansion` support.

Testing: hs-tier1 - hs-tier5

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8356453](https://bugs.openjdk.org/browse/JDK-8356453): C2: assert(!vbox-&gt;is_Phi()) during vector box expansion (**Bug** - P3)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25110/head:pull/25110` \
`$ git checkout pull/25110`

Update a local copy of the PR: \
`$ git checkout pull/25110` \
`$ git pull https://git.openjdk.org/jdk.git pull/25110/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25110`

View PR using the GUI difftool: \
`$ git pr show -t 25110`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25110.diff">https://git.openjdk.org/jdk/pull/25110.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25110#issuecomment-2861403559)
</details>
