### PR TITLE
8356212: runtime/cds/appcds/LotsOfSyntheticClasses.java timed out with -XX:+AOTClassLinking

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/LotsOfSyntheticClasses.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/LotsOfSyntheticClasses.java
@@ -37,7 +37,7 @@ import jdk.test.lib.process.OutputAnalyzer;
  * @summary Try to archive lots and lots of classes.
  * @requires vm.cds
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds
- * @run driver/timeout=500 LotsOfSyntheticClasses
+ * @run driver/timeout=800 LotsOfSyntheticClasses
  */
 
 public class LotsOfSyntheticClasses {

--- a/test/hotspot/jtreg/runtime/cds/appcds/LotsOfSyntheticClasses.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/LotsOfSyntheticClasses.java
@@ -37,14 +37,17 @@ import jdk.test.lib.process.OutputAnalyzer;
  * @summary Try to archive lots and lots of classes.
  * @requires vm.cds
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds
- * @run driver/timeout=800 LotsOfSyntheticClasses
+ * @run driver/timeout=500 LotsOfSyntheticClasses
  */
 
 public class LotsOfSyntheticClasses {
 
-    // Generate 100 top-level classes, each containing 1000 nested classes.
-    // 100K total classes are more than enough to push the CDS limits.
-    private static final int NUM_CLASSES = 100;
+    // Generate 70 top-level classes, each containing 1000 nested classes.
+    // 70K total classes is enough to push the CDS limits. Any archived
+    // collection that holds Classes should not have backing storage larger
+    // than CDS archival limit (256KB). This means we want at least 64K classes
+    // to probe that limit.
+    private static final int NUM_CLASSES = 70;
     private static final int NUM_NESTED_CLASSES = 1000;
 
     private static final Path USER_DIR = Paths.get(CDSTestUtils.getOutputDir());
@@ -117,7 +120,11 @@ public class LotsOfSyntheticClasses {
             OutputAnalyzer output = TestCommon.createArchive(
                 APP_JAR.toString(),
                 listAppClasses(),
-                MAIN_CLASS_NAME
+                MAIN_CLASS_NAME,
+                // Verification for lots of classes slows down the test.
+                "-XX:+IgnoreUnrecognizedVMOptions",
+                "-XX:-VerifyDependencies",
+                "-XX:-VerifyBeforeExit"
             );
             TestCommon.checkDump(output);
         }
@@ -125,9 +132,10 @@ public class LotsOfSyntheticClasses {
         // Step 3. Try to run, touching every class.
         {
             TestCommon.run(
-                // Verifying dependencies for lots of classes slows down the test.
-                "-XX:+IgnoreUnrecognizedVMOptions", "-XX:-VerifyDependencies",
-                "-Xlog:cds",
+                // Verification for lots of classes slows down the test.
+                "-XX:+IgnoreUnrecognizedVMOptions",
+                "-XX:-VerifyDependencies",
+                "-XX:-VerifyBeforeExit",
                 "-cp", APP_JAR.toString(),
                 MAIN_CLASS_NAME).
                     assertNormalExit("Success");


### PR DESCRIPTION
The LotsOfSyntheticClasses.java test times out intermittently when the `open/test/hotspot/jtreg:hotspot_aot_classlinking` test group is run with the` -XX:+AOTClassLinking` option on macosx-aarch64 platform.
Increasing the timeout value from 500 to 800 seems to have addressed the issue.
With the change, there's no timeout when the test group is run 40 times on macosx-aarch64 with the same option.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8356212](https://bugs.openjdk.org/browse/JDK-8356212): runtime/cds/appcds/LotsOfSyntheticClasses.java timed out with -XX:+AOTClassLinking (**Bug** - P3)


### Reviewers
 * [SendaoYan](https://openjdk.org/census#syan) (@sendaoYan - Committer) Review applies to [65d369dc](https://git.openjdk.org/jdk/pull/25111/files/65d369dc162cf567e3aef1b7be66997e913b1751)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25111/head:pull/25111` \
`$ git checkout pull/25111`

Update a local copy of the PR: \
`$ git checkout pull/25111` \
`$ git pull https://git.openjdk.org/jdk.git pull/25111/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25111`

View PR using the GUI difftool: \
`$ git pr show -t 25111`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25111.diff">https://git.openjdk.org/jdk/pull/25111.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25111#issuecomment-2861792793)
</details>
