### PR TITLE
8355360: -d option of jwebserver command should accept relative paths

### DIFF
--- a/src/jdk.httpserver/share/classes/sun/net/httpserver/simpleserver/FileServerHandler.java
+++ b/src/jdk.httpserver/share/classes/sun/net/httpserver/simpleserver/FileServerHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,12 +45,11 @@ import com.sun.net.httpserver.HttpHandlers;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
- * A basic {@linkplain HttpHandler HTTP handler} for static content.
- * <p>
- * Only {@code HEAD} and {@code GET} requests are supported.
- * Directory listings and files can be served.
- * Content types are supported on a best-guess basis.
- * </p>
+ * A basic HTTP file server handler for static content.
+ *
+ * <p> Must be given an absolute pathname to the directory to be served.
+ * Supports only HEAD and GET requests. Directory listings and files can be
+ * served, content types are supported on a best-guess basis.
  */
 public final class FileServerHandler implements HttpHandler {
 
@@ -66,32 +65,18 @@ public final class FileServerHandler implements HttpHandler {
     private final Logger logger;
 
     private FileServerHandler(Path root, UnaryOperator<String> mimeTable) {
-        this.root = readRoot(root);
+        root = root.normalize();
+        if (!Files.exists(root))
+            throw new IllegalArgumentException("Path does not exist: " + root);
+        if (!root.isAbsolute())
+            throw new IllegalArgumentException("Path is not absolute: " + root);
+        if (!Files.isDirectory(root))
+            throw new IllegalArgumentException("Path is not a directory: " + root);
+        if (!Files.isReadable(root))
+            throw new IllegalArgumentException("Path is not readable: " + root);
+        this.root = root;
         this.mimeTable = mimeTable;
         this.logger = System.getLogger("com.sun.net.httpserver");
-    }
-
-    private static Path readRoot(Path root) {
-        // `toRealPath()` invocation below already checks if file exists, though
-        // there is no way to figure out if it fails due to a non-existent file.
-        // Hence, checking the existence here first to deliver the user a more
-        // descriptive message.
-        if (!Files.exists(root)) {
-            throw new IllegalArgumentException("Path does not exist: " + root);
-        }
-        Path realRoot;
-        try {
-            realRoot = root.toRealPath();
-        } catch (IOException exception) {
-            throw new IllegalArgumentException("Path is invalid: " + root, exception);
-        }
-        if (!Files.isDirectory(realRoot)) {
-            throw new IllegalArgumentException("Path is not a directory: " + realRoot);
-        }
-        if (!Files.isReadable(realRoot)) {
-            throw new IllegalArgumentException("Path is not readable: " + realRoot);
-        }
-        return realRoot;
     }
 
     private static final HttpHandler NOT_IMPLEMENTED_HANDLER =
@@ -226,6 +211,7 @@ public final class FileServerHandler implements HttpHandler {
 
     private Path mapToPath(HttpExchange exchange, Path root) {
         try {
+            assert root.isAbsolute() && Files.isDirectory(root);  // checked during creation
             String uriPath = relativeRequestPath(exchange);
             String[] pathSegment = uriPath.split("/");
 

--- a/src/jdk.httpserver/share/classes/sun/net/httpserver/simpleserver/SimpleFileServerImpl.java
+++ b/src/jdk.httpserver/share/classes/sun/net/httpserver/simpleserver/SimpleFileServerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,11 +29,13 @@ import com.sun.net.httpserver.HttpServer;
 import com.sun.net.httpserver.SimpleFileServer;
 import com.sun.net.httpserver.SimpleFileServer.OutputLevel;
 
+import java.io.IOException;
 import java.io.PrintWriter;
 import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Iterator;
@@ -139,6 +141,7 @@ final class SimpleFileServerImpl {
 
         // configure and start server
         try {
+            root = realPath(root);
             var socketAddr = new InetSocketAddress(addr, port);
             var server = SimpleFileServer.createFileServer(socketAddr, root, outputLevel);
             server.start();
@@ -150,6 +153,25 @@ final class SimpleFileServerImpl {
             out.flush();
         }
         return Startup.OK.statusCode;
+    }
+
+    private static Path realPath(Path root) {
+
+        // `toRealPath()` invocation below already checks if file exists, though
+        // there is no way to figure out if it fails due to a non-existent file.
+        // Hence, checking the existence here first to deliver the user a more
+        // descriptive message.
+        if (!Files.exists(root)) {
+            throw new IllegalArgumentException("Path does not exist: " + root);
+        }
+
+        // Obtain the real path
+        try {
+            return root.toRealPath();
+        } catch (IOException exception) {
+            throw new IllegalArgumentException("Path is invalid: " + root, exception);
+        }
+
     }
 
     private static final class Out {

--- a/src/jdk.httpserver/share/classes/sun/net/httpserver/simpleserver/SimpleFileServerImpl.java
+++ b/src/jdk.httpserver/share/classes/sun/net/httpserver/simpleserver/SimpleFileServerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -112,7 +112,7 @@ final class SimpleFileServerImpl {
                         addrSpecified = true;
                     }
                     case "-d", "--directory" ->
-                        root = Path.of(optionArg = options.next());
+                        root = Path.of(optionArg = options.next()).normalize().toAbsolutePath();
                     case "-o", "--output" ->
                         outputLevel = Enum.valueOf(OutputLevel.class,
                                 (optionArg = options.next()).toUpperCase(Locale.ROOT));

--- a/src/jdk.httpserver/share/classes/sun/net/httpserver/simpleserver/SimpleFileServerImpl.java
+++ b/src/jdk.httpserver/share/classes/sun/net/httpserver/simpleserver/SimpleFileServerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -112,7 +112,7 @@ final class SimpleFileServerImpl {
                         addrSpecified = true;
                     }
                     case "-d", "--directory" ->
-                        root = Path.of(optionArg = options.next()).toRealPath();
+                        root = Path.of(optionArg = options.next());
                     case "-o", "--output" ->
                         outputLevel = Enum.valueOf(OutputLevel.class,
                                 (optionArg = options.next()).toUpperCase(Locale.ROOT));

--- a/src/jdk.httpserver/share/classes/sun/net/httpserver/simpleserver/SimpleFileServerImpl.java
+++ b/src/jdk.httpserver/share/classes/sun/net/httpserver/simpleserver/SimpleFileServerImpl.java
@@ -112,7 +112,7 @@ final class SimpleFileServerImpl {
                         addrSpecified = true;
                     }
                     case "-d", "--directory" ->
-                        root = Path.of(optionArg = options.next()).normalize().toAbsolutePath();
+                        root = Path.of(optionArg = options.next()).toRealPath();
                     case "-o", "--output" ->
                         outputLevel = Enum.valueOf(OutputLevel.class,
                                 (optionArg = options.next()).toUpperCase(Locale.ROOT));

--- a/test/jdk/com/sun/net/httpserver/simpleserver/CommandLineNegativeTest.java
+++ b/test/jdk/com/sun/net/httpserver/simpleserver/CommandLineNegativeTest.java
@@ -169,16 +169,6 @@ public class CommandLineNegativeTest {
     public Object[][] directoryOptions() { return new Object[][] {{"-d"}, {"--directory"}}; }
 
     @Test(dataProvider = "directoryOptions")
-    public void testRootNotAbsolute(String opt) throws Throwable {
-        out.println("\n--- testRootNotAbsolute, opt=\"%s\" ".formatted(opt));
-        var root = Path.of(".");
-        assertFalse(root.isAbsolute());
-        simpleserver(JAVA, LOCALE_OPT, "-m", "jdk.httpserver", opt, root.toString())
-                .shouldNotHaveExitValue(0)
-                .shouldContain("Error: server config failed: " + "Path is not absolute:");
-    }
-
-    @Test(dataProvider = "directoryOptions")
     public void testRootNotADirectory(String opt) throws Throwable {
         out.println("\n--- testRootNotADirectory, opt=\"%s\" ".formatted(opt));
         var file = TEST_FILE.toString();

--- a/test/jdk/com/sun/net/httpserver/simpleserver/CommandLinePositiveTest.java
+++ b/test/jdk/com/sun/net/httpserver/simpleserver/CommandLinePositiveTest.java
@@ -125,7 +125,7 @@ public class CommandLinePositiveTest {
         simpleserver(JAVA, LOCALE_OPT, "-m", "jdk.httpserver", "-p", "0", opt, rootDir)
                 .shouldHaveExitValue(NORMAL_EXIT_CODE)
                 .shouldContain("Binding to loopback by default. For all interfaces use \"-b 0.0.0.0\" or \"-b ::\".")
-                .shouldContain("Serving " + ROOT_DIR_STR + " and subdirectories on " + LOOPBACK_ADDR + " port")
+                .shouldContain("Serving " + rootDir + " and subdirectories on " + LOOPBACK_ADDR + " port")
                 .shouldContain("URL http://" + LOOPBACK_ADDR);
     }
 

--- a/test/jdk/com/sun/net/httpserver/simpleserver/CommandLinePositiveTest.java
+++ b/test/jdk/com/sun/net/httpserver/simpleserver/CommandLinePositiveTest.java
@@ -31,6 +31,7 @@
  */
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.net.InetAddress;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -54,23 +55,30 @@ public class CommandLinePositiveTest {
     static final String JAVA = getJava(JAVA_HOME);
 
     /**
-     * The <b>normalized absolute</b> path to the current working directory
-     * where
+     * The <b>real path</b> to the current working directory where
      * <ol>
      * <li>the web server process will be started in,</li>
      * <li>and hence, unless given an explicit content root directory, the web
      * server will be serving from.</li>
      * </ol>
      */
-    private static final Path CWD = Path.of(".").normalize().toAbsolutePath();
+    private static final Path CWD;
+
+    static {
+        try {
+            CWD = Path.of(".").toRealPath();
+        } catch (IOException exception) {
+            throw new UncheckedIOException(exception);
+        }
+    }
 
     private static final String CWD_STR = CWD.toString();
 
     /**
-     * The <b>normalized absolute</b> path to the web server content root
-     * directory, if one needs to be provided explicitly.
+     * The <b>real path</b> to the web server content root directory, if one
+     * needs to be provided explicitly.
      */
-    private static final Path ROOT_DIR = Path.of("www").normalize().toAbsolutePath();
+    private static final Path ROOT_DIR = CWD.resolve("www");
 
     private static final String ROOT_DIR_STR = ROOT_DIR.toString();
 

--- a/test/jdk/com/sun/net/httpserver/simpleserver/CommandLinePositiveTest.java
+++ b/test/jdk/com/sun/net/httpserver/simpleserver/CommandLinePositiveTest.java
@@ -125,7 +125,7 @@ public class CommandLinePositiveTest {
         simpleserver(JAVA, LOCALE_OPT, "-m", "jdk.httpserver", "-p", "0", opt, rootDir)
                 .shouldHaveExitValue(NORMAL_EXIT_CODE)
                 .shouldContain("Binding to loopback by default. For all interfaces use \"-b 0.0.0.0\" or \"-b ::\".")
-                .shouldContain("Serving " + rootDir + " and subdirectories on " + LOOPBACK_ADDR + " port")
+                .shouldContain("Serving " + ROOT_DIR_STR + " and subdirectories on " + LOOPBACK_ADDR + " port")
                 .shouldContain("URL http://" + LOOPBACK_ADDR);
     }
 

--- a/test/jdk/com/sun/net/httpserver/simpleserver/CommandLinePositiveTest.java
+++ b/test/jdk/com/sun/net/httpserver/simpleserver/CommandLinePositiveTest.java
@@ -52,19 +52,37 @@ public class CommandLinePositiveTest {
     static final Path JAVA_HOME = Path.of(System.getProperty("java.home"));
     static final String LOCALE_OPT = "-Duser.language=en -Duser.country=US";
     static final String JAVA = getJava(JAVA_HOME);
-    static final Path CWD = Path.of(".").toAbsolutePath().normalize();
-    static final Path TEST_DIR = CWD.resolve("CommandLinePositiveTest");
-    static final Path TEST_FILE = TEST_DIR.resolve("file.txt");
-    static final String TEST_DIR_STR = TEST_DIR.toString();
+
+    /**
+     * The <b>normalized absolute</b> path to the current working directory
+     * where
+     * <ol>
+     * <li>the web server process will be started in,</li>
+     * <li>and hence, unless given an explicit content root directory, the web
+     * server will be serving from.</li>
+     * </ol>
+     */
+    private static final Path CWD = Path.of(".").normalize().toAbsolutePath();
+
+    private static final String CWD_STR = CWD.toString();
+
+    /**
+     * The <b>normalized absolute</b> path to the web server content root
+     * directory, if one needs to be provided explicitly.
+     */
+    private static final Path ROOT_DIR = Path.of("www").normalize().toAbsolutePath();
+
+    private static final String ROOT_DIR_STR = ROOT_DIR.toString();
+
     static final String LOOPBACK_ADDR = InetAddress.getLoopbackAddress().getHostAddress();
 
     @BeforeTest
     public void setup() throws IOException {
-        if (Files.exists(TEST_DIR)) {
-            FileUtils.deleteFileTreeWithRetry(TEST_DIR);
+        if (Files.exists(ROOT_DIR)) {
+            FileUtils.deleteFileTreeWithRetry(ROOT_DIR);
         }
-        Files.createDirectories(TEST_DIR);
-        Files.createFile(TEST_FILE);
+        Files.createDirectories(ROOT_DIR);
+        Files.createFile(ROOT_DIR.resolve("file.txt"));
     }
 
     static final int SIGTERM = 15;
@@ -83,12 +101,23 @@ public class CommandLinePositiveTest {
     public Object[][] directoryOptions() { return new Object[][] {{"-d"}, {"--directory"}}; }
 
     @Test(dataProvider = "directoryOptions")
-    public void testDirectory(String opt) throws Throwable {
-        out.println("\n--- testDirectory, opt=\"%s\" ".formatted(opt));
-        simpleserver(JAVA, LOCALE_OPT, "-m", "jdk.httpserver", "-p", "0", opt, TEST_DIR_STR)
+    public void testAbsDirectory(String opt) throws Throwable {
+        out.printf("\n--- testAbsDirectory, opt=\"%s\"%n", opt);
+        testDirectory(opt, ROOT_DIR_STR);
+    }
+
+    @Test(dataProvider = "directoryOptions")
+    public void testRelDirectory(String opt) throws Throwable {
+        out.printf("\n--- testRelDirectory, opt=\"%s\"%n", opt);
+        Path rootRelDir = CWD.relativize(ROOT_DIR);
+        testDirectory(opt, rootRelDir.toString());
+    }
+
+    private static void testDirectory(String opt, String rootDir) throws Throwable {
+        simpleserver(JAVA, LOCALE_OPT, "-m", "jdk.httpserver", "-p", "0", opt, rootDir)
                 .shouldHaveExitValue(NORMAL_EXIT_CODE)
                 .shouldContain("Binding to loopback by default. For all interfaces use \"-b 0.0.0.0\" or \"-b ::\".")
-                .shouldContain("Serving " + TEST_DIR_STR + " and subdirectories on " + LOOPBACK_ADDR + " port")
+                .shouldContain("Serving " + ROOT_DIR_STR + " and subdirectories on " + LOOPBACK_ADDR + " port")
                 .shouldContain("URL http://" + LOOPBACK_ADDR);
     }
 
@@ -101,7 +130,7 @@ public class CommandLinePositiveTest {
         simpleserver(JAVA, LOCALE_OPT, "-m", "jdk.httpserver", opt, "0")
                 .shouldHaveExitValue(NORMAL_EXIT_CODE)
                 .shouldContain("Binding to loopback by default. For all interfaces use \"-b 0.0.0.0\" or \"-b ::\".")
-                .shouldContain("Serving " + TEST_DIR_STR + " and subdirectories on " + LOOPBACK_ADDR + " port")
+                .shouldContain("Serving " + CWD_STR + " and subdirectories on " + LOOPBACK_ADDR + " port")
                 .shouldContain("URL http://" + LOOPBACK_ADDR);
     }
 
@@ -155,12 +184,12 @@ public class CommandLinePositiveTest {
         out.println("\n--- testBindAllInterfaces, opt=\"%s\" ".formatted(opt));
         simpleserver(JAVA, LOCALE_OPT, "-m", "jdk.httpserver", "-p", "0", opt, "0.0.0.0")
                 .shouldHaveExitValue(NORMAL_EXIT_CODE)
-                .shouldContain("Serving " + TEST_DIR_STR + " and subdirectories on 0.0.0.0 (all interfaces) port")
+                .shouldContain("Serving " + CWD_STR + " and subdirectories on 0.0.0.0 (all interfaces) port")
                 .shouldContain("URL http://" + InetAddress.getLocalHost().getHostAddress());
         if (IPSupport.hasIPv6()) {
             simpleserver(JAVA, LOCALE_OPT, "-m", "jdk.httpserver", opt, "::0")
                     .shouldHaveExitValue(NORMAL_EXIT_CODE)
-                    .shouldContain("Serving " + TEST_DIR_STR + " and subdirectories on 0.0.0.0 (all interfaces) port")
+                    .shouldContain("Serving " + CWD_STR + " and subdirectories on 0.0.0.0 (all interfaces) port")
                     .shouldContain("URL http://" + InetAddress.getLocalHost().getHostAddress());
         }
     }
@@ -170,7 +199,7 @@ public class CommandLinePositiveTest {
         out.println("\n--- testLastOneWinsBindAddress, opt=\"%s\" ".formatted(opt));
         simpleserver(JAVA, LOCALE_OPT, "-m", "jdk.httpserver", "-p", "0", opt, "123.4.5.6", opt, LOOPBACK_ADDR)
                 .shouldHaveExitValue(NORMAL_EXIT_CODE)
-                .shouldContain("Serving " + TEST_DIR_STR + " and subdirectories on " + LOOPBACK_ADDR + " port")
+                .shouldContain("Serving " + CWD_STR + " and subdirectories on " + LOOPBACK_ADDR + " port")
                 .shouldContain("URL http://" + LOOPBACK_ADDR);
 
     }
@@ -178,10 +207,10 @@ public class CommandLinePositiveTest {
     @Test(dataProvider = "directoryOptions")
     public void testLastOneWinsDirectory(String opt) throws Throwable {
         out.println("\n--- testLastOneWinsDirectory, opt=\"%s\" ".formatted(opt));
-        simpleserver(JAVA, LOCALE_OPT, "-m", "jdk.httpserver", "-p", "0", opt, TEST_DIR_STR, opt, TEST_DIR_STR)
+        simpleserver(JAVA, LOCALE_OPT, "-m", "jdk.httpserver", "-p", "0", opt, ROOT_DIR_STR, opt, ROOT_DIR_STR)
                 .shouldHaveExitValue(NORMAL_EXIT_CODE)
                 .shouldContain("Binding to loopback by default. For all interfaces use \"-b 0.0.0.0\" or \"-b ::\".")
-                .shouldContain("Serving " + TEST_DIR_STR + " and subdirectories on " + LOOPBACK_ADDR + " port")
+                .shouldContain("Serving " + ROOT_DIR_STR + " and subdirectories on " + LOOPBACK_ADDR + " port")
                 .shouldContain("URL http://" + LOOPBACK_ADDR);
     }
 
@@ -194,7 +223,7 @@ public class CommandLinePositiveTest {
         simpleserver(JAVA, LOCALE_OPT, "-m", "jdk.httpserver", "-p", "0", opt, "none", opt, "verbose")
                 .shouldHaveExitValue(NORMAL_EXIT_CODE)
                 .shouldContain("Binding to loopback by default. For all interfaces use \"-b 0.0.0.0\" or \"-b ::\".")
-                .shouldContain("Serving " + TEST_DIR_STR + " and subdirectories on " + LOOPBACK_ADDR + " port")
+                .shouldContain("Serving " + CWD_STR + " and subdirectories on " + LOOPBACK_ADDR + " port")
                 .shouldContain("URL http://" + LOOPBACK_ADDR);
     }
 
@@ -204,14 +233,14 @@ public class CommandLinePositiveTest {
         simpleserver(JAVA, LOCALE_OPT, "-m", "jdk.httpserver", opt, "-999", opt, "0")
                 .shouldHaveExitValue(NORMAL_EXIT_CODE)
                 .shouldContain("Binding to loopback by default. For all interfaces use \"-b 0.0.0.0\" or \"-b ::\".")
-                .shouldContain("Serving " + TEST_DIR_STR + " and subdirectories on " + LOOPBACK_ADDR + " port")
+                .shouldContain("Serving " + CWD_STR + " and subdirectories on " + LOOPBACK_ADDR + " port")
                 .shouldContain("URL http://" + LOOPBACK_ADDR);
     }
 
     @AfterTest
     public void teardown() throws IOException {
-        if (Files.exists(TEST_DIR)) {
-            FileUtils.deleteFileTreeWithRetry(TEST_DIR);
+        if (Files.exists(ROOT_DIR)) {
+            FileUtils.deleteFileTreeWithRetry(ROOT_DIR);
         }
     }
 
@@ -247,7 +276,7 @@ public class CommandLinePositiveTest {
         StringBuffer sb = new StringBuffer();  // stdout & stderr
         // start the process and await the waitForLine before returning
         var p = ProcessTools.startProcess("simpleserver",
-                new ProcessBuilder(args).directory(TEST_DIR.toFile()),
+                new ProcessBuilder(args),
                 line -> sb.append(line + "\n"),
                 line -> line.startsWith(waitForLine.value),
                 30,  // suitably high default timeout, not expected to timeout

--- a/test/jdk/com/sun/net/httpserver/simpleserver/SimpleFileServerTest.java
+++ b/test/jdk/com/sun/net/httpserver/simpleserver/SimpleFileServerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/com/sun/net/httpserver/simpleserver/SimpleFileServerTest.java
+++ b/test/jdk/com/sun/net/httpserver/simpleserver/SimpleFileServerTest.java
@@ -668,14 +668,6 @@ public class SimpleFileServerTest {
     @Test
     public void testIllegalPath() throws Exception {
         var addr = LOOPBACK_ADDR;
-        {   // not absolute
-            Path p = Path.of(".");
-            assert Files.isDirectory(p);
-            assert Files.exists(p);
-            assert !p.isAbsolute();
-            var iae = expectThrows(IAE, () -> SimpleFileServer.createFileServer(addr, p, OutputLevel.INFO));
-            assertTrue(iae.getMessage().contains("is not absolute"));
-        }
         {   // not a directory
             Path p = Files.createFile(TEST_DIR.resolve("aFile"));
             assert !Files.isDirectory(p);

--- a/test/jdk/com/sun/net/httpserver/simpleserver/jwebserver/CommandLineNegativeTest.java
+++ b/test/jdk/com/sun/net/httpserver/simpleserver/jwebserver/CommandLineNegativeTest.java
@@ -169,16 +169,6 @@ public class CommandLineNegativeTest {
     public Object[][] directoryOptions() { return new Object[][] {{"-d"}, {"--directory"}}; }
 
     @Test(dataProvider = "directoryOptions")
-    public void testRootNotAbsolute(String opt) throws Throwable {
-        out.println("\n--- testRootNotAbsolute, opt=\"%s\" ".formatted(opt));
-        var root = Path.of(".");
-        assertFalse(root.isAbsolute());
-        simpleserver(JWEBSERVER, LOCALE_OPT, opt, root.toString())
-                .shouldNotHaveExitValue(0)
-                .shouldContain("Error: server config failed: " + "Path is not absolute:");
-    }
-
-    @Test(dataProvider = "directoryOptions")
     public void testRootNotADirectory(String opt) throws Throwable {
         out.println("\n--- testRootNotADirectory, opt=\"%s\" ".formatted(opt));
         var file = TEST_FILE.toString();

--- a/test/jdk/com/sun/net/httpserver/simpleserver/jwebserver/CommandLinePositiveTest.java
+++ b/test/jdk/com/sun/net/httpserver/simpleserver/jwebserver/CommandLinePositiveTest.java
@@ -31,6 +31,7 @@
  */
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.net.InetAddress;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -54,23 +55,30 @@ public class CommandLinePositiveTest {
     static final String JWEBSERVER = getJwebserver(JAVA_HOME);
 
     /**
-     * The <b>normalized absolute</b> path to the current working directory
-     * where
+     * The <b>real path</b> to the current working directory where
      * <ol>
      * <li>the web server process will be started in,</li>
      * <li>and hence, unless given an explicit content root directory, the web
      * server will be serving from.</li>
      * </ol>
      */
-    private static final Path CWD = Path.of(".").normalize().toAbsolutePath();
+    private static final Path CWD;
+
+    static {
+        try {
+            CWD = Path.of(".").toRealPath();
+        } catch (IOException exception) {
+            throw new UncheckedIOException(exception);
+        }
+    }
 
     private static final String CWD_STR = CWD.toString();
 
     /**
-     * The <b>normalized absolute</b> path to the web server content root
-     * directory, if one needs to be provided explicitly.
+     * The <b>real path</b> to the web server content root directory, if one
+     * needs to be provided explicitly.
      */
-    private static final Path ROOT_DIR = Path.of("www").normalize().toAbsolutePath();
+    private static final Path ROOT_DIR = CWD.resolve("www");
 
     private static final String ROOT_DIR_STR = ROOT_DIR.toString();
 

--- a/test/jdk/com/sun/net/httpserver/simpleserver/jwebserver/CommandLinePositiveTest.java
+++ b/test/jdk/com/sun/net/httpserver/simpleserver/jwebserver/CommandLinePositiveTest.java
@@ -125,7 +125,7 @@ public class CommandLinePositiveTest {
         simpleserver(JWEBSERVER, LOCALE_OPT, "-p", "0", opt, rootDir)
                 .shouldHaveExitValue(NORMAL_EXIT_CODE)
                 .shouldContain("Binding to loopback by default. For all interfaces use \"-b 0.0.0.0\" or \"-b ::\".")
-                .shouldContain("Serving " + ROOT_DIR_STR + " and subdirectories on " + LOOPBACK_ADDR + " port")
+                .shouldContain("Serving " + rootDir + " and subdirectories on " + LOOPBACK_ADDR + " port")
                 .shouldContain("URL http://" + LOOPBACK_ADDR);
     }
 

--- a/test/jdk/com/sun/net/httpserver/simpleserver/jwebserver/CommandLinePositiveTest.java
+++ b/test/jdk/com/sun/net/httpserver/simpleserver/jwebserver/CommandLinePositiveTest.java
@@ -125,7 +125,7 @@ public class CommandLinePositiveTest {
         simpleserver(JWEBSERVER, LOCALE_OPT, "-p", "0", opt, rootDir)
                 .shouldHaveExitValue(NORMAL_EXIT_CODE)
                 .shouldContain("Binding to loopback by default. For all interfaces use \"-b 0.0.0.0\" or \"-b ::\".")
-                .shouldContain("Serving " + rootDir + " and subdirectories on " + LOOPBACK_ADDR + " port")
+                .shouldContain("Serving " + ROOT_DIR_STR + " and subdirectories on " + LOOPBACK_ADDR + " port")
                 .shouldContain("URL http://" + LOOPBACK_ADDR);
     }
 


### PR DESCRIPTION
Allows relative paths in the content root directory passed to the `jwebserver`. Changes effect both the `jwebserver` executable and the `java -m jdk.httpserver` execution.

### Implementation notes

Received `Path` is read using `toRealPath()`, and then employed in `s.n.h.s.FileServerHandler`, which is the only place in the web server code where an absolute path requirement is present.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8355360](https://bugs.openjdk.org/browse/JDK-8355360): -d option of jwebserver command should accept relative paths (**Bug** - P4)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)
 * [Michael McMahon](https://openjdk.org/census#michaelm) (@Michael-Mc-Mahon - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25113/head:pull/25113` \
`$ git checkout pull/25113`

Update a local copy of the PR: \
`$ git checkout pull/25113` \
`$ git pull https://git.openjdk.org/jdk.git pull/25113/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25113`

View PR using the GUI difftool: \
`$ git pr show -t 25113`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25113.diff">https://git.openjdk.org/jdk/pull/25113.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25113#issuecomment-2862318832)
</details>
