### PR TITLE
8356756: Cleanup: Make ClassLoaderData::_deallocate_list an object

### DIFF
--- a/src/hotspot/share/classfile/classLoaderData.hpp
+++ b/src/hotspot/share/classfile/classLoaderData.hpp
@@ -150,7 +150,7 @@ class ClassLoaderData : public CHeapObj<mtClass> {
 
   // Metadata to be deallocated when it's safe at class unloading, when
   // this class loader isn't unloaded itself.
-  GrowableArray<Metadata*>*      _deallocate_list;
+  GrowableArray<Metadata*>      _deallocate_list;
 
   // Support for walking class loader data objects
   //


### PR DESCRIPTION
A small cleanup in order to get rid of some branches checking for null.

Testing: GHA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8356756](https://bugs.openjdk.org/browse/JDK-8356756): Cleanup: Make ClassLoaderData::_deallocate_list an object (**Enhancement** - P4) ⚠️ Issue is not open.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25117/head:pull/25117` \
`$ git checkout pull/25117`

Update a local copy of the PR: \
`$ git checkout pull/25117` \
`$ git pull https://git.openjdk.org/jdk.git pull/25117/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25117`

View PR using the GUI difftool: \
`$ git pr show -t 25117`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25117.diff">https://git.openjdk.org/jdk/pull/25117.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25117#issuecomment-2871476853)
</details>
