### PR TITLE
8346255: java/lang/management/ThreadMXBean/VirtualThreadDeadlocks.java finds no deadlock

### DIFF
--- a/test/jdk/java/lang/management/ThreadMXBean/VirtualThreadDeadlocks.java
+++ b/test/jdk/java/lang/management/ThreadMXBean/VirtualThreadDeadlocks.java
@@ -95,8 +95,8 @@ public class VirtualThreadDeadlocks {
         System.out.println("thread2 => " + thread2);
 
         System.out.println("Waiting for thread1 and thread2 to deadlock ...");
-        awaitBlocked(thread1, reached1);
-        awaitBlocked(thread2, reached2);
+        awaitTrueAndBlocked(thread1, reached1);
+        awaitTrueAndBlocked(thread2, reached2);
 
         ThreadMXBean bean = ManagementFactory.getPlatformMXBean(ThreadMXBean.class);
         long[] deadlockedThreads = sorted(bean.findMonitorDeadlockedThreads());
@@ -113,7 +113,7 @@ public class VirtualThreadDeadlocks {
             throw new RuntimeException("Unexpected result");
     }
 
-    private static void awaitBlocked(Thread thread, AtomicBoolean flag) throws InterruptedException {
+    private static void awaitTrueAndBlocked(Thread thread, AtomicBoolean flag) throws InterruptedException {
         while (!flag.get() || thread.getState() != Thread.State.BLOCKED) {
             Thread.sleep(10);
             if (!thread.isAlive()) {

--- a/test/jdk/java/lang/management/ThreadMXBean/VirtualThreadDeadlocks.java
+++ b/test/jdk/java/lang/management/ThreadMXBean/VirtualThreadDeadlocks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,6 +47,7 @@ import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadMXBean;
 import java.util.Arrays;
 import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Stream;
 import jdk.test.lib.thread.VThreadRunner;   // ensureParallelism requires jdk.management
 
@@ -55,6 +56,8 @@ public class VirtualThreadDeadlocks {
     private static final Object LOCK2 = new Object();
 
     private static final CyclicBarrier barrier = new CyclicBarrier(2);
+    private static final AtomicBoolean reached1 = new AtomicBoolean();
+    private static final AtomicBoolean reached2 = new AtomicBoolean();
 
     /**
      * PP = test deadlock with two platform threads
@@ -72,6 +75,7 @@ public class VirtualThreadDeadlocks {
         Thread thread1 = builder1.start(() -> {
             synchronized (LOCK1) {
                 try { barrier.await(); } catch (Exception ie) {}
+                reached1.set(true);
                 synchronized (LOCK2) { }
             }
         });
@@ -84,14 +88,15 @@ public class VirtualThreadDeadlocks {
         Thread thread2 = builder2.start(() -> {
             synchronized (LOCK2) {
                 try { barrier.await(); } catch (Exception ie) {}
+                reached2.set(true);
                 synchronized (LOCK1) { }
             }
         });
         System.out.println("thread2 => " + thread2);
 
         System.out.println("Waiting for thread1 and thread2 to deadlock ...");
-        awaitBlocked(thread1);
-        awaitBlocked(thread2);
+        awaitBlocked(thread1, reached1);
+        awaitBlocked(thread2, reached2);
 
         ThreadMXBean bean = ManagementFactory.getPlatformMXBean(ThreadMXBean.class);
         long[] deadlockedThreads = sorted(bean.findMonitorDeadlockedThreads());
@@ -108,8 +113,8 @@ public class VirtualThreadDeadlocks {
             throw new RuntimeException("Unexpected result");
     }
 
-    private static void awaitBlocked(Thread thread) throws InterruptedException {
-        while (thread.getState() != Thread.State.BLOCKED) {
+    private static void awaitBlocked(Thread thread, AtomicBoolean flag) throws InterruptedException {
+        while (!flag.get() || thread.getState() != Thread.State.BLOCKED) {
             Thread.sleep(10);
             if (!thread.isAlive()) {
                 throw new RuntimeException("Thread " + thread + " is terminated.");


### PR DESCRIPTION
Please review this small test fix. We need to make sure the two threads are blocked on the expected locks before invoking findMonitorDeadlockedThreads. In the failing cases, one of the threads is seen as blocked while waiting for a class to be initialized by the other thread (I've added the stack traces showing where this occurs in the bug comments).

I should point out that there is an inconsistency in the VM here though. We are changing the state to Thread.State.BLOCKED while using ObjectLocker internally when there is contention to enter the monitor, but we don’t change the state to Thread.State.WAITING when using ObjectLocker and calling wait_uninterruptibly(). I still think the test should be improved to avoid having to think if there is some other synchronize statement executed along the way (CyclicBarrier implementation for instance, or code run by a vthread during startup).

I was able to reproduce the failure and verified it doesn’t reproduce anymore with the fix.

Thanks,
Patricio

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346255](https://bugs.openjdk.org/browse/JDK-8346255): java/lang/management/ThreadMXBean/VirtualThreadDeadlocks.java finds no deadlock (**Bug** - P4)


### Reviewers
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25119/head:pull/25119` \
`$ git checkout pull/25119`

Update a local copy of the PR: \
`$ git checkout pull/25119` \
`$ git pull https://git.openjdk.org/jdk.git pull/25119/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25119`

View PR using the GUI difftool: \
`$ git pr show -t 25119`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25119.diff">https://git.openjdk.org/jdk/pull/25119.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25119#issuecomment-2863548996)
</details>
