### PR TITLE
8356447: Change default for EagerJVMCI to true

### DIFF
--- a/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
@@ -3231,7 +3231,11 @@ C2V_END
 
 C2V_VMENTRY_0(jint, getCompilationActivityMode, (JNIEnv* env, jobject))
   return CompileBroker::get_compilation_activity_mode();
-}
+C2V_END
+
+C2V_VMENTRY_0(jboolean, isCompilerThread, (JNIEnv* env, jobject))
+  return thread->is_Compiler_thread();
+C2V_END
 
 #define CC (char*)  /*cast a literal from (const char*)*/
 #define FN_PTR(f) CAST_FROM_FN_PTR(void*, &(c2v_ ## f))
@@ -3396,6 +3400,7 @@ JNINativeMethod CompilerToVM::methods[] = {
   {CC "getOopMapAt",                                  CC "(" HS_METHOD2 "I[J)V",                                                            FN_PTR(getOopMapAt)},
   {CC "updateCompilerThreadCanCallJava",              CC "(Z)Z",                                                                            FN_PTR(updateCompilerThreadCanCallJava)},
   {CC "getCompilationActivityMode",                   CC "()I",                                                                             FN_PTR(getCompilationActivityMode)},
+  {CC "isCompilerThread",                             CC "()Z",                                                                             FN_PTR(isCompilerThread)},
 };
 
 int CompilerToVM::methods_count() {

--- a/src/hotspot/share/jvmci/jvmci_globals.cpp
+++ b/src/hotspot/share/jvmci/jvmci_globals.cpp
@@ -86,6 +86,9 @@ bool JVMCIGlobals::check_jvmci_flags_are_consistent() {
       return false;
     }
     FLAG_SET_DEFAULT(EnableJVMCI, true);
+    if (FLAG_IS_DEFAULT(EagerJVMCI) && !EagerJVMCI) {
+      FLAG_SET_DEFAULT(EagerJVMCI, true);
+    }
   }
 
   if (EnableJVMCI) {

--- a/src/hotspot/share/jvmci/jvmci_globals.cpp
+++ b/src/hotspot/share/jvmci/jvmci_globals.cpp
@@ -86,9 +86,7 @@ bool JVMCIGlobals::check_jvmci_flags_are_consistent() {
       return false;
     }
     FLAG_SET_DEFAULT(EnableJVMCI, true);
-    if (FLAG_IS_DEFAULT(EagerJVMCI) && !EagerJVMCI) {
-      FLAG_SET_DEFAULT(EagerJVMCI, true);
-    }
+    FLAG_SET_ERGO_IF_DEFAULT(EagerJVMCI, true);
   }
 
   if (EnableJVMCI) {

--- a/src/hotspot/share/jvmci/jvmci_globals.hpp
+++ b/src/hotspot/share/jvmci/jvmci_globals.hpp
@@ -88,7 +88,8 @@ class fileStream;
           "-XX:-TieredCompilation makes JVMCI compile more of itself.")     \
                                                                             \
   product(bool, EagerJVMCI, false, EXPERIMENTAL,                            \
-          "Force eager JVMCI initialization")                               \
+          "Force eager JVMCI initialization. Defaults to true if "          \
+          "UseJVMCICompiler is true.")                                      \
                                                                             \
   product(bool, PrintBootstrap, true, EXPERIMENTAL,                         \
           "Print JVMCI bootstrap progress and summary")                     \

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/CompilerToVM.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/CompilerToVM.java
@@ -1528,4 +1528,9 @@ final class CompilerToVM {
      * {@code stop_compilation = 0}, {@code run_compilation = 1} or {@code shutdown_compilation = 2}
      */
     native int getCompilationActivityMode();
+
+    /**
+     * Returns whether the current thread is a CompilerThread.
+     */
+    native boolean isCompilerThread();
 }

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotJVMCICompilerConfig.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotJVMCICompilerConfig.java
@@ -51,11 +51,21 @@ final class HotSpotJVMCICompilerConfig {
         DummyCompilerFactory(String reason, HotSpotJVMCIRuntime runtime) {
             this.reason = reason;
             this.runtime = runtime;
+            if (runtime.getConfig().getFlag("EagerJVMCI", Boolean.class)) {
+                throw noCompilerError();
+            }
+        }
+
+        /**
+         * Exits the VM due to unavailability of a JVMCI compiler.
+         */
+        Error noCompilerError() {
+            throw runtime.exitHotSpotWithMessage(1, "Cannot use JVMCI compiler: %s%n", reason);
         }
 
         @Override
         public HotSpotCompilationRequestResult compileMethod(CompilationRequest request) {
-            throw runtime.exitHotSpotWithMessage(1, "Cannot use JVMCI compiler: %s%n", reason);
+            throw noCompilerError();
         }
 
         @Override

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotJVMCICompilerConfig.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotJVMCICompilerConfig.java
@@ -52,7 +52,13 @@ final class HotSpotJVMCICompilerConfig {
             this.reason = reason;
             this.runtime = runtime;
             if (runtime.getConfig().getFlag("EagerJVMCI", Boolean.class)) {
-                throw noCompilerError();
+                if (runtime.getCompilerToVM().isCompilerThread()) {
+                    throw noCompilerError();
+                } else {
+                    // This path will be taken when initializing JVMCI on a non-JIT thread.
+                    // Such a usage of JVMCI might never request a compilation so delay the
+                    // noCompilerError until such a request is made.
+                }
             }
         }
 

--- a/test/hotspot/jtreg/compiler/jvmci/TestJVMCIPrintProperties.java
+++ b/test/hotspot/jtreg/compiler/jvmci/TestJVMCIPrintProperties.java
@@ -45,6 +45,7 @@ public class TestJVMCIPrintProperties {
         ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(
             "-XX:+UnlockExperimentalVMOptions",
             enableFlag, "-Djvmci.Compiler=null",
+            "-XX:-EagerJVMCI",
             "-XX:+JVMCIPrintProperties");
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         output.shouldContain("[JVMCI properties]"); // expected message


### PR DESCRIPTION
By default, JVMCI and Graal initialization only occurs on the first top-tier (i.e. tier 4) JIT compilation request. This made sense prior to libgraal where the initialization was interpreted and so noticeably contributed to VM startup. However, with libgraal, the initialization is sufficiently fast to not impact startup.

The motivation for JVMCI and Graal eager initialization by default is to make Graal command line option processing happen in the same VM phase as handling of all other VM command line flags. That is, errors in Graal options should:
1. Happen deterministically, not just for apps that run long enough to trigger a top tier JIT compilation. For example: `java -XX:+UnlockExperimentalVMOptions -XX:+UseGraalJIT --version`. In a JDK build that does not include Graal, this may succeed (and print out the version info) or result in a VM error ("Cannot use JVMCI compiler: No JVMCI compiler found").
2. Stop the VM before any application code can be executed. This is just good hygiene.

This PR makes JVMCI initialization eager by default if `UseJVMCICompiler` is true.
This is done for both libgraal and jargraal so that the behavior is uniform. Since jargraal is now a development configuration, VM startup costs are not critical.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8356447](https://bugs.openjdk.org/browse/JDK-8356447): Change default for EagerJVMCI to true (**Enhancement** - P4)


### Reviewers
 * [Yudi Zheng](https://openjdk.org/census#yzheng) (@mur47x111 - Committer)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tom Rodriguez](https://openjdk.org/census#never) (@tkrodriguez - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25121/head:pull/25121` \
`$ git checkout pull/25121`

Update a local copy of the PR: \
`$ git checkout pull/25121` \
`$ git pull https://git.openjdk.org/jdk.git pull/25121/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25121`

View PR using the GUI difftool: \
`$ git pr show -t 25121`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25121.diff">https://git.openjdk.org/jdk/pull/25121.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25121#issuecomment-2873868758)
</details>
