### PR TITLE
8356560: GHA: Add macOS Windows ARM64 testing

### DIFF
--- a/.github/actions/get-msys2/action.yml
+++ b/.github/actions/get-msys2/action.yml
@@ -30,7 +30,7 @@ runs:
   using: composite
   steps:
     - name: 'Install MSYS2'
-      uses: msys2/setup-msys2@v2.22.0
+      uses: msys2/setup-msys2@v2.25.0
       with:
         install: 'autoconf tar unzip zip make'
         path-type: minimal

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -382,3 +382,14 @@ jobs:
       platform: windows-x64
       bootjdk-platform: windows-x64
       runs-on: windows-2019
+
+  test-windows-aarch64:
+    name: windows-aarch64
+    needs:
+      - build-windows-aarch64
+    uses: ./.github/workflows/test.yml
+    with:
+      platform: windows-aarch64
+      bootjdk-platform: windows-aarch64
+      runs-on: windows-11-arm
+

--- a/make/conf/github-actions.conf
+++ b/make/conf/github-actions.conf
@@ -47,3 +47,7 @@ MACOS_X64_BOOT_JDK_SHA256=6bbfb1d01741cbe55ab90299cb91464b695de9a3ace85c15131aa2
 WINDOWS_X64_BOOT_JDK_EXT=zip
 WINDOWS_X64_BOOT_JDK_URL=https://download.java.net/java/GA/jdk24/1f9ff9062db4449d8ca828c504ffae90/36/GPL/openjdk-24_windows-x64_bin.zip
 WINDOWS_X64_BOOT_JDK_SHA256=11d1d9f6ac272d5361c8a0bef01894364081c7fb1a6914c2ad2fc312ae83d63b
+
+WINDOWS_AARCH64_BOOT_JDK_EXT=zip
+WINDOWS_AARCH64_BOOT_JDK_URL=https://github.com/adoptium/temurin24-binaries/releases/download/jdk-24%2B35-ea-beta/OpenJDK24U-jdk_aarch64_windows_hotspot_24_35-ea.zip
+WINDOWS_AARCH64_BOOT_JDK_SHA256=bf02f568a28ad8e615e9a05b69a02893a4cffa369dfe2ce916d5a7b75fcf384c


### PR DESCRIPTION
Now that Windows ARM64 executors are available in GitHub actions it makes sense to enable testing on the platform.
 
Information:
- https://github.blog/changelog/2025-04-14-windows-arm64-hosted-runners-now-available-in-public-preview/
- https://github.com/msys2/setup-msys2/issues/358 - Reason why we had to bump MSYS 