### PR TITLE
8356571: Re-enable -Wtype-limits for GCC in LCMS

### DIFF
--- a/make/modules/java.desktop/lib/ClientLibraries.gmk
+++ b/make/modules/java.desktop/lib/ClientLibraries.gmk
@@ -87,7 +87,7 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBLCMS, \
         libawt/java2d \
         java.base:libjvm, \
     HEADERS_FROM_SRC := $(LIBLCMS_HEADERS_FROM_SRC), \
-    DISABLED_WARNINGS_gcc := format-nonliteral stringop-truncation type-limits \
+    DISABLED_WARNINGS_gcc := format-nonliteral stringop-truncation \
         unused-variable, \
     DISABLED_WARNINGS_clang := format-nonliteral, \
     JDK_LIBS := libawt java.base:libjava, \


### PR DESCRIPTION
The -Wtype-limits warning was previously disabled in the OpenJDK build for LCMS 2.14+ due to upstream issues: https://github.com/openjdk/jdk/pull/11217
The issue was reported to the LCMS project: https://github.com/mm2/Little-CMS/issues/458
It has since been fixed in LCMS 2.17 and integrated into OpenJDK as part of [JDK-8348110](https://bugs.openjdk.org/browse/JDK-8348110).

Now that the issue has been resolved, we can re-enable this warning.

The build works fine on the system where the initial [issue](https://github.com/openjdk/jdk/pull/11217) could be reproduced.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8356571](https://bugs.openjdk.org/browse/JDK-8356571): Re-enable -Wtype-limits for GCC in LCMS (**Bug** - P4)


### Reviewers
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25127/head:pull/25127` \
`$ git checkout pull/25127`

Update a local copy of the PR: \
`$ git checkout pull/25127` \
`$ git pull https://git.openjdk.org/jdk.git pull/25127/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25127`

View PR using the GUI difftool: \
`$ git pr show -t 25127`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25127.diff">https://git.openjdk.org/jdk/pull/25127.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25127#issuecomment-2864323053)
</details>
