### PR TITLE
8356450: NPE in CLDRTimeZoneNameProviderImpl for tzdata downgrades after JDK-8342550

### DIFF
--- a/src/java.base/share/classes/sun/util/cldr/CLDRTimeZoneNameProviderImpl.java
+++ b/src/java.base/share/classes/sun/util/cldr/CLDRTimeZoneNameProviderImpl.java
@@ -93,8 +93,7 @@ public class CLDRTimeZoneNameProviderImpl extends TimeZoneNameProviderImpl {
                 switch (namesSuper[i]) {
                 case "":
                     // Fill in empty elements
-                    deriveFallbackName(namesSuper, i, locale,
-                                       ZoneInfo.getTimeZone(id).toZoneId().getRules().isFixedOffset());
+                    deriveFallbackName(namesSuper, i, locale, isFixedOffset(id));
                     break;
                 case NO_INHERITANCE_MARKER:
                     // CLDR's "no inheritance marker"
@@ -132,7 +131,7 @@ public class CLDRTimeZoneNameProviderImpl extends TimeZoneNameProviderImpl {
 
     // Derive fallback time zone name according to LDML's logic
     private void deriveFallbackNames(String[] names, Locale locale) {
-        boolean noDST = ZoneInfo.getTimeZone(names[0]).toZoneId().getRules().isFixedOffset();
+        boolean noDST = isFixedOffset(names[0]);
 
         for (int i = INDEX_STD_LONG; i <= INDEX_GEN_SHORT; i++) {
             deriveFallbackName(names, i, locale, noDST);
@@ -311,5 +310,12 @@ public class CLDRTimeZoneNameProviderImpl extends TimeZoneNameProviderImpl {
             return MessageFormat.format(gmtFormat,
                     String.format(l, hourFormat, offset / 60, offset % 60));
         }
+    }
+
+    // ZoneInfo.getTimeZone() may return null if the tzdata has been
+    // forcibly downgraded to an older release using TZUpdater
+    private boolean isFixedOffset(String id) {
+        var zi = ZoneInfo.getTimeZone(id);
+        return zi == null || zi.toZoneId().getRules().isFixedOffset();
     }
 }


### PR DESCRIPTION
Fixing the NPE in CLDR time zone name provider. The NPE occurrs if the time zone data was downgraded by the TZUpdater tool in which some time zones are missing. For those missing zones, `ZoneInfo.getTimeZone()` returns null, while `TimeZone.getTimeZone()` falls back to `GMT`, which was the case prior to JDK-8342550. Changed the code in CLDR provider to assume the fixed zone in such a case.
Manually confirmed the fix, and no test case is provided, as it requires tweaking the JDK with TZUpdater.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8356450](https://bugs.openjdk.org/browse/JDK-8356450): NPE in CLDRTimeZoneNameProviderImpl for tzdata downgrades after JDK-8342550 (**Bug** - P4)


### Reviewers
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)
 * [Justin Lu](https://openjdk.org/census#jlu) (@justin-curtis-lu - Committer)
 * [Joe Wang](https://openjdk.org/census#joehw) (@JoeWang-Java - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25130/head:pull/25130` \
`$ git checkout pull/25130`

Update a local copy of the PR: \
`$ git checkout pull/25130` \
`$ git pull https://git.openjdk.org/jdk.git pull/25130/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25130`

View PR using the GUI difftool: \
`$ git pr show -t 25130`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25130.diff">https://git.openjdk.org/jdk/pull/25130.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25130#issuecomment-2864302310)
</details>
