### PR TITLE
8356588: Some nsk/jdi tests can fetch ThreadReference from static field in the debuggee: part 3

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/BreakpointEvent/_itself_/breakpoint001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/BreakpointEvent/_itself_/breakpoint001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/BreakpointEvent/_itself_/breakpoint001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/BreakpointEvent/_itself_/breakpoint001.java
@@ -117,16 +117,7 @@ public class breakpoint001 {
             checkedClass = (ReferenceType) classes.get(0);
 
             log.display("Getting reference to main thread");
-            Iterator threadIterator = vm.allThreads().iterator();
-            while (threadIterator.hasNext()) {
-                ThreadReference curThread = (ThreadReference) threadIterator.next();
-                if (curThread.name().equals("main")) {
-                     checkedThread = curThread;
-                }
-            }
-            if (checkedThread == null) {
-                throw new Failure("TEST BUG: unable to find reference to main thread");
-            }
+            checkedThread = debuggee.threadByFieldNameOrThrow(checkedClass, "mainThread", "main");
 
             log.display("Getting reference to method <foo>");
             List allMethods  = checkedClass.methodsByName("foo");

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/BreakpointEvent/_itself_/breakpoint001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/BreakpointEvent/_itself_/breakpoint001a.java
@@ -57,7 +57,7 @@ public class breakpoint001a {
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
         mainThread = Thread.currentThread();
- 
+
         // notify debugger about ready to execute
         pipe.println(COMMAND_READY);
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/BreakpointEvent/_itself_/breakpoint001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/BreakpointEvent/_itself_/breakpoint001a.java
@@ -40,10 +40,12 @@ public class breakpoint001a {
     static final String COMMAND_GO    = "go";
     static final String COMMAND_DONE  = "done";
 
-    public static final int breakpointLineNumber = 86;
+    public static final int breakpointLineNumber = 90;
 
     static private int counter = 0;
     static private final int LIMIT = 10;
+
+    static Thread mainThread = null;
 
     public static void main(String args[]) {
         breakpoint001a _breakpoint001a = new breakpoint001a();
@@ -54,6 +56,8 @@ public class breakpoint001a {
         ArgumentHandler argHandler = new ArgumentHandler(args);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
+        mainThread = Thread.currentThread();
+ 
         // notify debugger about ready to execute
         pipe.println(COMMAND_READY);
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/BreakpointEvent/_itself_/breakpoint001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/BreakpointEvent/_itself_/breakpoint001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventRequestManager/createStepRequest/crstepreq001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventRequestManager/createStepRequest/crstepreq001.java
@@ -23,6 +23,7 @@
 
 package nsk.jdi.EventRequestManager.createStepRequest;
 
+import com.sun.jdi.ReferenceType;
 import com.sun.jdi.ThreadReference;
 import com.sun.jdi.VirtualMachine;
 import com.sun.jdi.request.StepRequest;
@@ -104,35 +105,24 @@ public class crstepreq001 {
             return quitDebuggee(FAILED);
         }
 
-        try {
-            threads = vm.allThreads();
-        } catch (Exception e) {
-            log.complain("TEST FAILURE: allThreads: " + e);
-            return quitDebuggee(FAILED);
-        }
-        Iterator iter = threads.iterator();
-        while (iter.hasNext()) {
-            thR = (ThreadReference) iter.next();
-            if (thR.name().equals(DEBUGGEE_THRD)) {
-                log.display("\nCreating StepRequest for the debuggee's thread \""
+        ReferenceType debuggeeClass = debuggee.classByName(DEBUGGEE_CLASS);
+        thR = debuggee.threadByFieldNameOrThrow(debuggeeClass, "debuggeeThread", DEBUGGEE_THRD);
+        log.display("\nCreating StepRequest for the debuggee's thread \""
                     + thR.name() + "\"");
-                try {
-                    StepRequest sReq = erManager.createStepRequest(thR,
-                        RESTRICTIONS[0][0],RESTRICTIONS[0][1]);
-                    sReq.enable();
-                    enabledStepRequests.add(sReq);
-                } catch (DuplicateRequestException e) {
-                    log.complain("TEST FAILURE: createStepRequest: caught " + e);
-                    return quitDebuggee(FAILED);
-                } catch (ObjectCollectedException e) {
-                    log.complain("TEST FAILURE: createStepRequest: caught " + e);
-                    return quitDebuggee(FAILED);
-                } catch (VMMismatchException e) {
-                    log.complain("TEST FAILURE: createStepRequest: caught " + e);
-                    return quitDebuggee(FAILED);
-                }
-                break;
-            }
+        try {
+            StepRequest sReq =
+                erManager.createStepRequest(thR, RESTRICTIONS[0][0],RESTRICTIONS[0][1]);
+            sReq.enable();
+            enabledStepRequests.add(sReq);
+        } catch (DuplicateRequestException e) {
+            log.complain("TEST FAILURE: createStepRequest: caught " + e);
+            return quitDebuggee(FAILED);
+        } catch (ObjectCollectedException e) {
+            log.complain("TEST FAILURE: createStepRequest: caught " + e);
+            return quitDebuggee(FAILED);
+        } catch (VMMismatchException e) {
+            log.complain("TEST FAILURE: createStepRequest: caught " + e);
+            return quitDebuggee(FAILED);
         }
 
 // Check that createStepRequest() throws DuplicateRequestException

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventRequestManager/createStepRequest/crstepreq001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventRequestManager/createStepRequest/crstepreq001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventRequestManager/createStepRequest/crstepreq001t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventRequestManager/createStepRequest/crstepreq001t.java
@@ -32,12 +32,14 @@ import nsk.share.jdi.*;
  * This is a debuggee class.
  */
 public class crstepreq001t {
+    static Thread debuggeeThread = null;
+
     public static void main(String args[]) {
         ArgumentHandler argHandler = new ArgumentHandler(args);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
-        Thread  thr = Thread.currentThread();
+        debuggeeThread = Thread.currentThread();
 
-        thr.setName(crstepreq001.DEBUGGEE_THRD);
+        debuggeeThread.setName(crstepreq001.DEBUGGEE_THRD);
         pipe.println(crstepreq001.COMMAND_READY);
         String cmd = pipe.readln();
         if (!cmd.equals(crstepreq001.COMMAND_QUIT)) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventRequestManager/createStepRequest/crstepreq001t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventRequestManager/createStepRequest/crstepreq001t.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ExceptionEvent/catchLocation/location001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ExceptionEvent/catchLocation/location001.java
@@ -165,16 +165,7 @@ public class location001 {
 
             // get mirror of main thread in debuggee
             log.display("Getting reference to main thread");
-            Iterator threadIterator = vm.allThreads().iterator();
-            while (threadIterator.hasNext()) {
-                ThreadReference curThread = (ThreadReference) threadIterator.next();
-                if (curThread.name().equals("main")) {
-                     checkedThread = curThread;
-                }
-            }
-            if (checkedThread == null) {
-                throw new Failure("TEST BUG: unable to find reference to main thread");
-            }
+            checkedThread = debuggee.threadByFieldNameOrThrow(checkedClass, "mainThread", "main");
 
             // create ExceptionRequest for all throwable classes (initially disabled)
             log.display("Creating ExceptionRequest");

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ExceptionEvent/catchLocation/location001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ExceptionEvent/catchLocation/location001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ExceptionEvent/catchLocation/location001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ExceptionEvent/catchLocation/location001a.java
@@ -47,16 +47,16 @@ class location001a {
     static final String COMMAND_ERROR = "error";
 
     // line numbers where checked exceptions thrown (for user exceptions only)
-    public static final int userExceptionLocation = 98;
-    public static final int userErrorLocation     = 105;
-    public static final int userThrowableLocation = 112;
+    public static final int userExceptionLocation = 101;
+    public static final int userErrorLocation     = 108;
+    public static final int userThrowableLocation = 115;
 
     // line numbers where checked exceptions caught. Numbers were changed due to 4740123
-    public static final int userExceptionCatchLocation = 99;
-    public static final int userErrorCatchLocation     = 106;
-    public static final int userThrowableCatchLocation = 113;
-    public static final int javaExceptionCatchLocation = 120;
-    public static final int javaErrorCatchLocation     = 127;
+    public static final int userExceptionCatchLocation = 102;
+    public static final int userErrorCatchLocation     = 109;
+    public static final int userThrowableCatchLocation = 116;
+    public static final int javaExceptionCatchLocation = 123;
+    public static final int javaErrorCatchLocation     = 130;
 
     // flags marked all actually thrown exceptions
     private static boolean userExceptionThrown = false;
@@ -65,9 +65,12 @@ class location001a {
     private static boolean javaExceptionThrown = false;
     private static boolean javaErrorThrown     = false;
 
+    static Thread mainThread = null;
+
     // run debuggee from command line
     public static void main(String args[]) throws Throwable {
         location001a _location001a = new location001a();
+        mainThread = Thread.currentThread();
         System.exit(JCK_STATUS_BASE + _location001a.runIt(args, System.err));
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ExceptionEvent/catchLocation/location001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ExceptionEvent/catchLocation/location001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ExceptionEvent/exception/exception001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ExceptionEvent/exception/exception001.java
@@ -165,16 +165,7 @@ public class exception001 {
 
             // get mirror of main thread in debuggee
             log.display("Getting reference to main thread");
-            Iterator threadIterator = vm.allThreads().iterator();
-            while (threadIterator.hasNext()) {
-                ThreadReference curThread = (ThreadReference) threadIterator.next();
-                if (curThread.name().equals("main")) {
-                     checkedThread = curThread;
-                }
-            }
-            if (checkedThread == null) {
-                throw new Failure("TEST BUG: unable to find reference to main thread");
-            }
+            checkedThread = debuggee.threadByFieldNameOrThrow(checkedClass, "mainThread", "main");
 
             // create ExceptionRequest for all throwable classes (initially disabled)
             log.display("Creating ExceptionRequest");

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ExceptionEvent/exception/exception001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ExceptionEvent/exception/exception001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ExceptionEvent/exception/exception001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ExceptionEvent/exception/exception001a.java
@@ -65,9 +65,12 @@ class exception001a {
     private static boolean javaExceptionThrown = false;
     private static boolean javaErrorThrown     = false;
 
+    static Thread mainThread = null;
+
     // run debuggee from command line
     public static void main(String args[]) throws Throwable {
         exception001a _exception001a = new exception001a();
+        mainThread = Thread.currentThread();
         System.exit(JCK_STATUS_BASE + _exception001a.runIt(args, System.err));
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ExceptionEvent/exception/exception001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ExceptionEvent/exception/exception001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/LocalVariable/isVisible/isvisible001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/LocalVariable/isVisible/isvisible001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/LocalVariable/isVisible/isvisible001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/LocalVariable/isVisible/isvisible001.java
@@ -173,6 +173,7 @@ public class isvisible001 {
         }
 
         VirtualMachine vm = debuggee.VM();
+        ReferenceType debuggeeClass = debuggee.classByName(debuggeeName);
 
     //------------------------------------------------------  testing section
         log1("      TESTING BEGINS");
@@ -204,8 +205,6 @@ public class isvisible001 {
 
             BreakpointRequest breakpRequest1 = null;
 
-            List            allThreads   = null;
-            ListIterator    listIterator = null;
             List            classes      = null;
 
             StackFrame stackFrame  = null;
@@ -230,7 +229,6 @@ public class isvisible001 {
 
                 log2("getting ThreadReference object");
                 try {
-                    allThreads  = vm.allThreads();
                     classes     = vm.classesByName(testedClassName);
                     testedclass = (ReferenceType) classes.get(0);
                 } catch ( Exception e) {
@@ -239,19 +237,7 @@ public class isvisible001 {
                     break label0;
                 }
 
-                listIterator = allThreads.listIterator();
-                for (;;) {
-                    try {
-                        thread2 = (ThreadReference) listIterator.next();
-                        if (thread2.name().equals(threadName))
-                            break ;
-                    } catch ( NoSuchElementException e ) {
-                        log3("ERROR: NoSuchElementException for listIterator.next()");
-                        log3("ERROR: NO THREAD2 ?????????!!!!!!!");
-                        expresult = returnCode1;
-                        break label0;
-                    }
-                }
+                thread2 = debuggee.threadByFieldNameOrThrow(debuggeeClass, "thread2", threadName);
 
                 log2("setting up breakpoint");
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/LocalVariable/isVisible/isvisible001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/LocalVariable/isVisible/isvisible001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/LocalVariable/isVisible/isvisible001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/LocalVariable/isVisible/isvisible001a.java
@@ -58,6 +58,9 @@ public class isvisible001a {
     }
 
     //====================================================== test program
+
+    static Thread thread2 = null;
+
     //----------------------------------------------------   main method
 
     public static void main (String argv[]) {
@@ -93,7 +96,7 @@ public class isvisible001a {
     //------------------------------------------------------  section tested
 
                 case 0:
-                         Thread thread2 =
+                         thread2 =
                              JDIThreadFactory.newThread(new Threadisvisible001a("Thread2"));
                          log1("       thread2 is created");
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/Locatable/location/location004.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/Locatable/location/location004.java
@@ -162,6 +162,7 @@ public class location004 {
         }
 
         VirtualMachine vm = debuggee.VM();
+        ReferenceType debuggeeClass = debuggee.classByName(debuggeeName);
 
     //------------------------------------------------------  testing section
         log1("      TESTING BEGINS");
@@ -195,8 +196,6 @@ public class location004 {
 
             BreakpointRequest breakpRequest1 = null;
 
-            List            allThreads   = null;
-            ListIterator    listIterator = null;
             List            classes      = null;
 
             StackFrame    stackFrame = null;
@@ -206,7 +205,6 @@ public class location004 {
 
                 log2("getting ThreadReference object");
                 try {
-                    allThreads  = vm.allThreads();
                     classes     = vm.classesByName(testedClassName);
                     testedclass = (ReferenceType) classes.get(0);
                 } catch ( Exception e) {
@@ -215,19 +213,7 @@ public class location004 {
                     break label0;
                 }
 
-                listIterator = allThreads.listIterator();
-                for (;;) {
-                    try {
-                        thread2 = (ThreadReference) listIterator.next();
-                        if (thread2.name().equals(threadName))
-                            break ;
-                    } catch ( NoSuchElementException e ) {
-                        log3("ERROR: NoSuchElementException for listIterator.next()");
-                        log3("ERROR: NO THREAD2 ?????????!!!!!!!");
-                        expresult = returnCode1;
-                        break label0;
-                    }
-                }
+                thread2 = debuggee.threadByFieldNameOrThrow(debuggeeClass, "thread2", threadName);
 
                 log2("setting up breakpoint");
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/Locatable/location/location004.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/Locatable/location/location004.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/Locatable/location/location004a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/Locatable/location/location004a.java
@@ -58,6 +58,9 @@ public class location004a {
     }
 
     //====================================================== test program
+
+    static Thread thread2 = null;
+
     //----------------------------------------------------   main method
 
     public static void main (String argv[]) {
@@ -93,7 +96,7 @@ public class location004a {
     //------------------------------------------------------  section tested
 
                 case 0:
-                         Thread thread2 =
+                         thread2 =
                              JDIThreadFactory.newThread(new Threadlocation004a("Thread2"));
                          log1("       thread2 is created");
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/Locatable/location/location004a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/Locatable/location/location004a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/Locatable/location/location005.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/Locatable/location/location005.java
@@ -162,6 +162,7 @@ public class location005 {
         }
 
         VirtualMachine vm = debuggee.VM();
+        ReferenceType debuggeeClass = debuggee.classByName(debuggeeName);
 
     //------------------------------------------------------  testing section
         log1("      TESTING BEGINS");
@@ -195,8 +196,6 @@ public class location005 {
 
             BreakpointRequest breakpRequest1 = null;
 
-            List            allThreads   = null;
-            ListIterator    listIterator = null;
             List            classes      = null;
 
             StackFrame    stackFrame = null;
@@ -206,7 +205,6 @@ public class location005 {
 
                 log2("getting ThreadReference object");
                 try {
-                    allThreads  = vm.allThreads();
                     classes     = vm.classesByName(testedClassName);
                     testedclass = (ReferenceType) classes.get(0);
                 } catch ( Exception e) {
@@ -215,19 +213,7 @@ public class location005 {
                     break label0;
                 }
 
-                listIterator = allThreads.listIterator();
-                for (;;) {
-                    try {
-                        thread2 = (ThreadReference) listIterator.next();
-                        if (thread2.name().equals(threadName))
-                            break ;
-                    } catch ( NoSuchElementException e ) {
-                        log3("ERROR: NoSuchElementException for listIterator.next()");
-                        log3("ERROR: NO THREAD2 ?????????!!!!!!!");
-                        expresult = returnCode1;
-                        break label0;
-                    }
-                }
+                thread2 = debuggee.threadByFieldNameOrThrow(debuggeeClass, "thread2", threadName);
 
                 log2("setting up breakpoint");
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/Locatable/location/location005.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/Locatable/location/location005.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/Locatable/location/location005a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/Locatable/location/location005a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/Locatable/location/location005a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/Locatable/location/location005a.java
@@ -58,6 +58,9 @@ public class location005a {
     }
 
     //====================================================== test program
+
+    static Thread thread2 = null;
+
     //----------------------------------------------------   main method
 
     public static void main (String argv[]) {
@@ -93,7 +96,7 @@ public class location005a {
     //------------------------------------------------------  section tested
 
                 case 0:
-                         Thread thread2 =
+                         thread2 =
                              JDIThreadFactory.newThread(new Threadlocation005a("Thread2"));
                          log1("       thread2 is created");
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/MethodEntryEvent/method/method001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/MethodEntryEvent/method/method001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/MethodEntryEvent/method/method001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/MethodEntryEvent/method/method001.java
@@ -131,16 +131,7 @@ public class method001 {
             log.display("Getting loaded class in debuggee");
             checkedClass = debuggee.classByName(DEBUGGEE_NAME);
 
-            Iterator threadIterator = vm.allThreads().iterator();
-            while (threadIterator.hasNext()) {
-                ThreadReference curThread = (ThreadReference) threadIterator.next();
-                if (curThread.name().equals("main")) {
-                    checkedThread = curThread;
-                }
-            }
-            if (checkedThread == null) {
-                throw new Failure("TEST BUG: unable to find reference to main thread");
-            }
+            checkedThread = debuggee.threadByFieldNameOrThrow(checkedClass, "mainThread", "main");
 
             log.display("Getting reference to method <foo>");
             checkedMethod = debuggee.methodByName(checkedClass, "foo");

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/MethodEntryEvent/method/method001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/MethodEntryEvent/method/method001a.java
@@ -45,8 +45,8 @@ public class method001a {
     static final String COMMAND_DONE  = "done";
 
     // line numbers for auxilary breakpoints
-    public static final int STARTING_BREAKPOINT_LINE = 86;
-    public static final int ENDING_BREAKPOINT_LINE = 91;
+    public static final int STARTING_BREAKPOINT_LINE = 89;
+    public static final int ENDING_BREAKPOINT_LINE = 94;
 
     // scaffold objects
     static private ArgumentHandler argHandler;
@@ -58,9 +58,12 @@ public class method001a {
     static private int depth;
     static private boolean methodInvoked;
 
+    static Thread mainThread = null;
+
     // start debuggee
     public static void main(String args[]) {
         method001a _method001a = new method001a();
+        mainThread = Thread.currentThread();
         System.exit(JCK_STATUS_BASE + _method001a.run(args, System.err));
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/MethodEntryEvent/method/method001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/MethodEntryEvent/method/method001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod001.java
@@ -213,9 +213,6 @@ public class invokemethod001 {
             //String bpLine2 = "breakpointLineNumber2";
             //String bpLine3 = "breakpointLineNumber3";
 
-
-            List            allThreads   = null;
-            ListIterator    listIterator = null;
             List            classes      = null;
 
             BreakpointRequest breakpRequest1 = null;
@@ -225,7 +222,6 @@ public class invokemethod001 {
 
                 log2("getting ThreadReference object");
                 try {
-                    allThreads  = vm.allThreads();
                     classes     = vm.classesByName(testedClassName);
                     testedclass = (ReferenceType) classes.get(0);
                 } catch ( Exception e) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/owningThread/owningthread001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/owningThread/owningthread001.java
@@ -105,7 +105,6 @@ public class owningthread001 {
     static VirtualMachine      vm  = null;
 
     ReferenceType     testedClass  = null;
-    ThreadReference   thread2      = null;
     ThreadReference   mainThread   = null;
 
     static int  testExitCode = PASSED;
@@ -150,6 +149,7 @@ public class owningthread001 {
         }
 
         vm = debuggee.VM();
+        ReferenceType debuggeeClass = debuggee.classByName(debuggeeName);
 
     //------------------------------------------------------  testing section
         log1("      TESTING BEGINS");
@@ -174,11 +174,7 @@ public class owningthread001 {
 
             int expresult = returnCode0;
 
-            String threadName = "testedThread";
-
-            List            allThreads   = null;
             List            monitors     = null;
-            ListIterator    listIterator = null;
             List            classes      = null;
             ObjectReference objRef       = null;
 
@@ -187,7 +183,6 @@ public class owningthread001 {
 
                 log2("getting ThreadReference object");
                 try {
-                    allThreads  = vm.allThreads();
                     classes     = vm.classesByName(testedClassName);
                     testedClass = (ReferenceType) classes.get(0);
                 } catch ( Exception e) {
@@ -196,19 +191,7 @@ public class owningthread001 {
                     break label0;
                 }
 
-                listIterator = allThreads.listIterator();
-                for (;;) {
-                    try {
-                        mainThread = (ThreadReference) listIterator.next();
-                        if (mainThread.name().equals("main"))
-                            break ;
-                    } catch ( NoSuchElementException e ) {
-                        log3("ERROR: NoSuchElementException for listIterator.next()");
-                        log3("ERROR: NO 'main' thread  ?????????!!!!!!!");
-                        expresult = returnCode1;
-                        break label0;
-                    }
-                }
+                mainThread = debuggee.threadByFieldNameOrThrow(debuggeeClass, "mainThread", "main");
             }
 
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/owningThread/owningthread001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/owningThread/owningthread001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/owningThread/owningthread001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/owningThread/owningthread001a.java
@@ -60,12 +60,15 @@ public class owningthread001a {
     //====================================================== test program
 
     private static Thread thread2 = null;
+    static Thread mainThread = null;
 
     static TestClass  testObj  = new TestClass();
 
     //----------------------------------------------------   main method
 
     public static void main (String argv[]) {
+
+        mainThread = Thread.currentThread();
 
         for (int i=0; i<argv.length; i++) {
             if ( argv[i].equals("-vbs") || argv[i].equals("-verbose") ) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/owningThread/owningthread001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/owningThread/owningthread001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StepEvent/_itself_/stepevent001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StepEvent/_itself_/stepevent001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StepEvent/_itself_/stepevent001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StepEvent/_itself_/stepevent001.java
@@ -121,16 +121,7 @@ public class stepevent001 {
             checkedClass = (ReferenceType) classes.get(0);
 
             log.display("Getting reference to main thread");
-            Iterator threadIterator = vm.allThreads().iterator();
-            while (threadIterator.hasNext()) {
-                ThreadReference curThread = (ThreadReference) threadIterator.next();
-                if (curThread.name().equals("main")) {
-                     checkedThread = curThread;
-                }
-            }
-            if (checkedThread == null) {
-                throw new Failure("TEST BUG: unable to find reference to main thread");
-            }
+            checkedThread = debuggee.threadByFieldNameOrThrow(checkedClass, "mainThread", "main");
 
             log.display("Getting reference to method <foo>");
             List allMethods  = checkedClass.methodsByName("foo");

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StepEvent/_itself_/stepevent001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StepEvent/_itself_/stepevent001a.java
@@ -41,11 +41,13 @@ public class stepevent001a {
     static final String COMMAND_GO    = "go";
     static final String COMMAND_DONE  = "done";
 
-    public static final int stepLineBegin = 90;
-    public static final int stepLineEnd = 100;
+    public static final int stepLineBegin = 94;
+    public static final int stepLineEnd = 104;
 
     static private int counter;
     static private final int LIMIT = 10;
+
+    static Thread mainThread = null;
 
     static private ArgumentHandler argHandler;
     static private IOPipe pipe;
@@ -58,6 +60,8 @@ public class stepevent001a {
     int run( String args[]) {
         argHandler = new ArgumentHandler(args);
         pipe = argHandler.createDebugeeIOPipe();
+
+        mainThread = Thread.currentThread();
 
         // notify debugger about ready to execute
         pipe.println(COMMAND_READY);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StepEvent/_itself_/stepevent001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StepEvent/_itself_/stepevent001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/currentContendedMonitor/currentcm001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/currentContendedMonitor/currentcm001.java
@@ -158,6 +158,7 @@ public class currentcm001 {
         }
 
         vm = debuggee.VM();
+        ReferenceType debuggeeClass = debuggee.classByName(debuggeeName);
 
     //------------------------------------------------------  testing section
 
@@ -196,13 +197,7 @@ public class currentcm001 {
             //String bpLine2 = "breakpointLineNumber2";
             //String bpLine3 = "breakpointLineNumber3";
 
-
-            List            allThreads   = null;
-
             ObjectReference monitor      = null;
-
-            ListIterator    listIterator = null;
-            List            classes      = null;
 
             //BreakpointRequest breakpRequest1 = null;
             //BreakpointRequest breakpRequest2 = null;
@@ -212,29 +207,7 @@ public class currentcm001 {
             label0: {
 
                 log2("getting ThreadReference objects");
-                try {
-                    allThreads  = vm.allThreads();
-//                    classes     = vm.classesByName(testedClassName);
-//                    testedclass = (ReferenceType) classes.get(0);
-                } catch ( Exception e) {
-                    log3("ERROR: Exception at very beginning !? : " + e);
-                    expresult = returnCode1;
-                    break label0;
-                }
-
-                listIterator = allThreads.listIterator();
-                for (;;) {
-                    try {
-                        mainThread = (ThreadReference) listIterator.next();
-                        if (mainThread.name().equals("main"))
-                            break ;
-                    } catch ( NoSuchElementException e ) {
-                        log3("ERROR: NoSuchElementException for listIterator.next()");
-                        log3("ERROR: NO 'main' thread  ?????????!!!!!!!");
-                        expresult = returnCode1;
-                        break label0;
-                    }
-                }
+                mainThread = debuggee.threadByFieldNameOrThrow(debuggeeClass, "mainThread", "main");
             }
 
             label1: {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/currentContendedMonitor/currentcm001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/currentContendedMonitor/currentcm001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/currentContendedMonitor/currentcm001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/currentContendedMonitor/currentcm001a.java
@@ -61,10 +61,13 @@ public class currentcm001a {
     //====================================================== test program
 
 //    private static Threadcurrentcm001a thread2 = null;
+    static Thread mainThread = null;
 
     //----------------------------------------------------   main method
 
     public static void main (String argv[]) {
+
+        mainThread = Thread.currentThread();
 
         for (int i=0; i<argv.length; i++) {
             if ( argv[i].equals("-vbs") || argv[i].equals("-verbose") ) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/currentContendedMonitor/currentcm001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/currentContendedMonitor/currentcm001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/ownedMonitors/ownedmonitors001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/ownedMonitors/ownedmonitors001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/ownedMonitors/ownedmonitors001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/ownedMonitors/ownedmonitors001.java
@@ -141,6 +141,10 @@ public class ownedmonitors001 {
                 break label1;
             }
 
+            log1("Getting ThreadReference for main thread");
+            ThreadReference mainThread =
+                debuggee.threadByFieldNameOrThrow(debuggeeRef, "mainThread", "main");
+
             for (int i2 = 0; ; i2++) {
                 if (!vm.canGetOwnedMonitorInfo()) {
                     log1("TEST ABORTED: vm.canGetOwnedMonitorInfo() returned false.");
@@ -163,11 +167,11 @@ public class ownedmonitors001 {
                 switch (i2) {
 
                     case 0 :
-                        checkMonitors("main", 0);
+                        checkMonitors(mainThread, 0);
                         break;
 
                     case 1 :
-                        checkMonitors("main", monitorCount);
+                        checkMonitors(mainThread, monitorCount);
                         break;
 
                     default:
@@ -210,21 +214,8 @@ public class ownedmonitors001 {
         return testExitCode;
     }
 
-    private void checkMonitors(String threadName, int expSize) {
-        log1("Getting ThreadReference for " + threadName + " thread");
-        ThreadReference checkedThread = null;
-        Iterator itr = vm.allThreads().listIterator();
-        while (itr.hasNext()) {
-             ThreadReference thread = (ThreadReference) itr.next();
-             if (thread.name().equals(threadName)) {
-                  checkedThread = thread;
-             }
-        }
-        if (checkedThread == null) {
-            log3("Cannot find  " + threadName + "thread in the debuggee");
-            testExitCode = FAILED;
-            return;
-        }
+    private void checkMonitors(ThreadReference checkedThread, int expSize) {
+        String threadName = checkedThread.name();
         log1("Checking up throwing an IncompatibleThreadStateException for not suspended thread");
         List monitors;
         try {
@@ -252,7 +243,7 @@ public class ownedmonitors001 {
                 if (expSize > 0) {
                     log1("Checking up items in ownedMonitors() list");
                     getMonitorRefs();
-                    itr = expMonitors.iterator();
+                    Iterator itr = expMonitors.iterator();
                     while (itr.hasNext()) {
                         ObjectReference mon = (ObjectReference) itr.next();
                         if (monitors.contains(mon)) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/ownedMonitors/ownedmonitors001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/ownedMonitors/ownedmonitors001a.java
@@ -69,7 +69,7 @@ public class ownedmonitors001a {
     public static void main (String argv[]) {
 
         mainThread = Thread.currentThread();
- 
+
         for (int i=0; i<argv.length; i++) {
             if ( argv[i].equals("-vbs") || argv[i].equals("-verbose") ) {
                 verbMode = true;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/ownedMonitors/ownedmonitors001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/ownedMonitors/ownedmonitors001a.java
@@ -62,11 +62,14 @@ public class ownedmonitors001a {
 
     public static Object waitnotifyObj = new Object();
     public static Object lockingObject = new Object();
+    static Thread mainThread = null;
 
     //----------------------------------------------------   main method
 
     public static void main (String argv[]) {
 
+        mainThread = Thread.currentThread();
+ 
         for (int i=0; i<argv.length; i++) {
             if ( argv[i].equals("-vbs") || argv[i].equals("-verbose") ) {
                 verbMode = true;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/ownedMonitors/ownedmonitors001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/ownedMonitors/ownedmonitors001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/threadGroup/threadgroup001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/threadGroup/threadgroup001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/threadGroup/threadgroup001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/threadGroup/threadgroup001.java
@@ -213,8 +213,6 @@ public class threadgroup001 {
             ThreadReference thread3 = null;
             ThreadReference thread4 = null;
 
-            String threadNames [] = { "Thread2", "Thread3", "Thread4" };
-
             ReferenceType mainthreadClass = null;
             ReferenceType thread2Class    = null;
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/threadGroup/threadgroup001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/threadGroup/threadgroup001.java
@@ -209,12 +209,6 @@ public class threadgroup001 {
                                       "threadGroup3Obj",
                                       "threadGroup4Obj"  };
 
-            List            threads;
-            ListIterator    iterator;
-            int             flag;
-            String          threadName;
-            ThreadReference thread;
-
             ThreadReference thread2 = null;
             ThreadReference thread3 = null;
             ThreadReference thread4 = null;
@@ -244,24 +238,10 @@ public class threadgroup001 {
                              mainthreadClass.getValue(mainthreadClass.fieldByName(groupNames[i1]));
                 }
 
-                log2("      getting a List of all running threads");
-                threads = vm.allThreads();
-
-
                 log2("      getting Thread 2,3,4 mirror objects");
-
-                iterator = threads.listIterator();
-                for ( int i2 = 0; iterator.hasNext(); i2++ ) {
-                    thread = (ThreadReference) iterator.next();
-                    threadName = thread.name();
-                    if (threadName.equals(threadNames[0]))
-                         thread2 = thread;
-                    else if (threadName.equals(threadNames[1]))
-                         thread3 = thread;
-                    else if (threadName.equals(threadNames[2]))
-                         thread4 = thread;
-                }
-
+                thread2 = debuggee.threadByFieldNameOrThrow(mainthreadClass, "thread2", "Thread2");
+                thread3 = debuggee.threadByFieldNameOrThrow(mainthreadClass, "thread3", "Thread3");
+                thread4 = debuggee.threadByFieldNameOrThrow(mainthreadClass, "thread4", "Thread4");
 
                 log2("......checking up Thread2's group");
                 if (!thread2.threadGroup().equals(groups[1])) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/Value/_itself_/value001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/Value/_itself_/value001.java
@@ -342,9 +342,6 @@ public class value001 {
 
             StackFrame      stackFrame   = null;
 
-            List            allThreads   = null;
-            ListIterator    listIterator = null;
-
 
             int expresult = returnCode0;
 
@@ -353,7 +350,6 @@ public class value001 {
                 log2("getting ThreadReference object");
 
                 try {
-                    allThreads  = vm.allThreads();
                     classes     = vm.classesByName(testedClassName);
                     testedclass = (ReferenceType) classes.get(0);
                 } catch ( Exception e) {
@@ -362,19 +358,7 @@ public class value001 {
                     break label0;
                 }
 
-                listIterator = allThreads.listIterator();
-                for (;;) {
-                    try {
-                        thread2 = (ThreadReference) listIterator.next();
-                        if (thread2.name().equals(threadName))
-                            break ;
-                    } catch ( NoSuchElementException e ) {
-                        log3("ERROR: NoSuchElementException for listIterator.next()");
-                        log3("ERROR: NO THREAD2 ?????????!!!!!!!");
-                        expresult = returnCode1;
-                        break label0;
-                    }
-                }
+                thread2 = debuggee.threadByFieldNameOrThrow(debuggeeClass, "thread2", threadName);
 
                 log2("setting up a breakpoint");
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/Value/_itself_/value001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/Value/_itself_/value001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/Value/type/type002/type002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/Value/type/type002/type002.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/Value/type/type002/type002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/Value/type/type002/type002.java
@@ -209,6 +209,7 @@ public class type002 {
         }
 
         VirtualMachine vm = debuggee.VM();
+        ReferenceType debuggeeClass = debuggee.classByName(debuggeeName);
 
     //------------------------------------------------------  testing section
         log1("      TESTING BEGINS");
@@ -235,8 +236,6 @@ public class type002 {
             eventRManager = vm.eventRequestManager();
             eventQueue    = vm.eventQueue();
 
-            List            allThreads   = null;
-            ListIterator    listIterator = null;
             List            classes      = null;
 
             String threadName = "Thread2";
@@ -251,7 +250,6 @@ public class type002 {
 
                 log2("getting ThreadReference object");
                 try {
-                    allThreads  = vm.allThreads();
                     classes     = vm.classesByName(testedClassName);
                     testedclass = (ReferenceType) classes.get(0);
                 } catch ( Exception e) {
@@ -260,19 +258,7 @@ public class type002 {
                     break label0;
                 }
 
-                listIterator = allThreads.listIterator();
-                for (;;) {
-                    try {
-                        thread2 = (ThreadReference) listIterator.next();
-                        if (thread2.name().equals(threadName))
-                            break ;
-                    } catch ( NoSuchElementException e ) {
-                        log3("ERROR: NoSuchElementException for listIterator.next()");
-                        log3("ERROR: NO THREAD2 ?????????!!!!!!!");
-                        expresult = returnCode1;
-                        break label0;
-                    }
-                }
+                thread2 = debuggee.threadByFieldNameOrThrow(debuggeeClass, "thread2", threadName);
 
                 log2("setting up breakpoint");
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/Value/type/type002/type002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/Value/type/type002/type002a.java
@@ -59,6 +59,9 @@ public class type002a {
     }
 
     //====================================================== test program
+
+    static Threadtype002a thread2 = null;
+
     //----------------------------------------------------   main method
 
     public static void main (String argv[]) {
@@ -94,8 +97,7 @@ public class type002a {
     //------------------------------------------------------  section tested
 
                 case 0:
-                         Threadtype002a thread2 =
-                             new Threadtype002a("Thread2");
+                         thread2 = new Threadtype002a("Thread2");
                          log1("       thread2 is created");
 
                          label:

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/Value/type/type002/type002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/Value/type/type002/type002a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/VoidValue/equals/equals001/equals001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/VoidValue/equals/equals001/equals001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/VoidValue/equals/equals001/equals001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/VoidValue/equals/equals001/equals001.java
@@ -217,6 +217,7 @@ public class equals001 {
         }
 
         VirtualMachine vm = debuggee.VM();
+        ReferenceType debuggeeClass = debuggee.classByName(debuggeeName);
 
     //------------------------------------------------------  testing section
         log1("      TESTING BEGINS");
@@ -243,8 +244,6 @@ public class equals001 {
             eventRManager = vm.eventRequestManager();
             eventQueue    = vm.eventQueue();
 
-            List            allThreads   = null;
-            ListIterator    listIterator = null;
             List            classes      = null;
 
             String threadName = "Thread2";
@@ -259,7 +258,6 @@ public class equals001 {
 
                 log2("getting ThreadReference object");
                 try {
-                    allThreads  = vm.allThreads();
                     classes     = vm.classesByName(testedClassName);
                     testedclass = (ReferenceType) classes.get(0);
                 } catch ( Exception e) {
@@ -268,19 +266,7 @@ public class equals001 {
                     break label0;
                 }
 
-                listIterator = allThreads.listIterator();
-                for (;;) {
-                    try {
-                        thread2 = (ThreadReference) listIterator.next();
-                        if (thread2.name().equals(threadName))
-                            break ;
-                    } catch ( NoSuchElementException e ) {
-                        log3("ERROR: NoSuchElementException for listIterator.next()");
-                        log3("ERROR: NO THREAD2 ?????????!!!!!!!");
-                        expresult = returnCode1;
-                        break label0;
-                    }
-                }
+                thread2 = debuggee.threadByFieldNameOrThrow(debuggeeClass, "thread2", threadName);
 
                 log2("setting up breakpoint");
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/VoidValue/equals/equals001/equals001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/VoidValue/equals/equals001/equals001a.java
@@ -59,6 +59,9 @@ public class equals001a {
     }
 
     //====================================================== test program
+
+    static Threadequals001a thread2 = null;
+
     //----------------------------------------------------   main method
 
     public static void main (String argv[]) {
@@ -94,8 +97,7 @@ public class equals001a {
     //------------------------------------------------------  section tested
 
                 case 0:
-                         Threadequals001a thread2 =
-                             new Threadequals001a("Thread2");
+                         thread2 = new Threadequals001a("Thread2");
                          log1("       thread2 is created");
 
                          label:

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/VoidValue/equals/equals001/equals001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/VoidValue/equals/equals001/equals001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/VoidValue/hashCode/hashcode001/hashcode001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/VoidValue/hashCode/hashcode001/hashcode001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/VoidValue/hashCode/hashcode001/hashcode001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/VoidValue/hashCode/hashcode001/hashcode001.java
@@ -217,6 +217,7 @@ public class hashcode001 {
         }
 
         VirtualMachine vm = debuggee.VM();
+        ReferenceType debuggeeClass = debuggee.classByName(debuggeeName);
 
     //------------------------------------------------------  testing section
         log1("      TESTING BEGINS");
@@ -243,8 +244,6 @@ public class hashcode001 {
             eventRManager = vm.eventRequestManager();
             eventQueue    = vm.eventQueue();
 
-            List            allThreads   = null;
-            ListIterator    listIterator = null;
             List            classes      = null;
 
             String threadName = "Thread2";
@@ -259,7 +258,6 @@ public class hashcode001 {
 
                 log2("getting ThreadReference object");
                 try {
-                    allThreads  = vm.allThreads();
                     classes     = vm.classesByName(testedClassName);
                     testedclass = (ReferenceType) classes.get(0);
                 } catch ( Exception e) {
@@ -268,19 +266,7 @@ public class hashcode001 {
                     break label0;
                 }
 
-                listIterator = allThreads.listIterator();
-                for (;;) {
-                    try {
-                        thread2 = (ThreadReference) listIterator.next();
-                        if (thread2.name().equals(threadName))
-                            break ;
-                    } catch ( NoSuchElementException e ) {
-                        log3("ERROR: NoSuchElementException for listIterator.next()");
-                        log3("ERROR: NO THREAD2 ?????????!!!!!!!");
-                        expresult = returnCode1;
-                        break label0;
-                    }
-                }
+                thread2 = debuggee.threadByFieldNameOrThrow(debuggeeClass, "thread2", threadName);
 
                 log2("setting up breakpoint");
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/VoidValue/hashCode/hashcode001/hashcode001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/VoidValue/hashCode/hashcode001/hashcode001a.java
@@ -59,6 +59,9 @@ public class hashcode001a {
     }
 
     //====================================================== test program
+
+    static Threadhashcode001a thread2 = null;
+
     //----------------------------------------------------   main method
 
     public static void main (String argv[]) {
@@ -94,8 +97,7 @@ public class hashcode001a {
     //------------------------------------------------------  section tested
 
                  case 0:
-                         Threadhashcode001a thread2 =
-                             new Threadhashcode001a("Thread2");
+                         thread2 = new Threadhashcode001a("Thread2");
                          log1("       thread2 is created");
 
                          label:

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/VoidValue/hashCode/hashcode001/hashcode001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/VoidValue/hashCode/hashcode001/hashcode001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/WatchpointEvent/object/object001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/WatchpointEvent/object/object001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/WatchpointEvent/object/object001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/WatchpointEvent/object/object001.java
@@ -147,16 +147,7 @@ public class object001 {
             }
 
             log.display("Getting reference to <main> thread");
-            Iterator threadIterator = vm.allThreads().iterator();
-            while (threadIterator.hasNext()) {
-                ThreadReference curThread = (ThreadReference) threadIterator.next();
-                if (curThread.name().equals("main")) {
-                     checkedThread = curThread;
-                }
-            }
-            if (checkedThread == null) {
-                throw new Failure("TEST BUG: unable to find reference to <main> thread");
-            }
+            checkedThread = debuggee.threadByFieldNameOrThrow(debuggeeClass, "mainThread", "main");
 
             // get object of checked class
             log.display("Getting object of checked class");

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/WatchpointEvent/object/object001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/WatchpointEvent/object/object001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/WatchpointEvent/object/object001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/WatchpointEvent/object/object001a.java
@@ -48,6 +48,8 @@ class object001a {
 
     public static CheckedClass foo;
 
+    static Thread mainThread = null;
+
     public static void main(String args[]) {
 //        object001a _object001a = new object001a();
         System.exit(JCK_STATUS_BASE + run(args));
@@ -56,6 +58,7 @@ class object001a {
     static int run( String args[]) {
         ArgumentHandler argHandler = new ArgumentHandler(args);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
+        mainThread = Thread.currentThread();
 
         // create instance of checked class
         foo = new CheckedClass();


### PR DESCRIPTION
There were a small number of tests that were missed with [JDK-8356023](https://bugs.openjdk.org/browse/JDK-8356023) (part 2). Most of these tests are ones that were calling vm.allThreads() directly to search for the needed thread rather than relying on findThreadByNameOrThrow().

Tested with CI tier5, which is where all the nsk/jdi testing is done. Also ran locally on linux-x64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8356588](https://bugs.openjdk.org/browse/JDK-8356588): Some nsk/jdi tests can fetch ThreadReference from static field in the debuggee: part 3 (**Enhancement** - P4)


### Reviewers
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25132/head:pull/25132` \
`$ git checkout pull/25132`

Update a local copy of the PR: \
`$ git checkout pull/25132` \
`$ git pull https://git.openjdk.org/jdk.git pull/25132/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25132`

View PR using the GUI difftool: \
`$ git pr show -t 25132`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25132.diff">https://git.openjdk.org/jdk/pull/25132.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25132#issuecomment-2864555436)
</details>
