### PR TITLE
8348351: Improve lazy initialization of the available currencies set

### DIFF
--- a/src/java.base/share/classes/java/util/Currency.java
+++ b/src/java.base/share/classes/java/util/Currency.java
@@ -143,7 +143,7 @@ public final class Currency implements Serializable {
 
     private static ConcurrentMap<String, Currency> instances = new ConcurrentHashMap<>(7);
     private static final Supplier<HashSet<Currency>> available =
-            StableValue.supplier(Currency::getCurrencies);
+            StableValue.supplier(Currency::computeAllCurrencies);
 
     // Class data: currency data obtained from currency.data file.
     // Purpose:
@@ -468,7 +468,7 @@ public final class Currency implements Serializable {
     }
 
     // Builds and returns the set of available Currencies
-    private static HashSet<Currency> getCurrencies() {
+    private static HashSet<Currency> computeAllCurrencies() {
         var sysTime = System.currentTimeMillis();
         HashSet<Currency> available = HashSet.newHashSet(256);
 

--- a/src/java.base/share/classes/java/util/Currency.java
+++ b/src/java.base/share/classes/java/util/Currency.java
@@ -38,6 +38,7 @@ import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.function.Supplier;
 import java.util.regex.Pattern;
 import java.util.regex.Matcher;
 import java.util.spi.CurrencyNameProvider;
@@ -141,7 +142,8 @@ public final class Currency implements Serializable {
     // class data: instance map
 
     private static ConcurrentMap<String, Currency> instances = new ConcurrentHashMap<>(7);
-    private static HashSet<Currency> available;
+    private static final Supplier<HashSet<Currency>> available =
+            StableValue.supplier(Currency::getCurrencies);
 
     // Class data: currency data obtained from currency.data file.
     // Purpose:
@@ -447,7 +449,7 @@ public final class Currency implements Serializable {
      * @since 1.7
      */
     public static Set<Currency> getAvailableCurrencies() {
-        return new HashSet<>(getCurrencies());
+        return new HashSet<>(available.get());
     }
 
     /**
@@ -462,53 +464,52 @@ public final class Currency implements Serializable {
      * @since 25
      */
     public static Stream<Currency> availableCurrencies() {
-        return getCurrencies().stream();
+        return available.get().stream();
     }
 
-    // Returns the set of available Currencies which are lazily initialized
-    private static synchronized HashSet<Currency> getCurrencies() {
-        if (available == null) {
-            var sysTime = System.currentTimeMillis();
-            available = HashSet.newHashSet(256);
+    // Builds and returns the set of available Currencies
+    private static HashSet<Currency> getCurrencies() {
+        var sysTime = System.currentTimeMillis();
+        HashSet<Currency> available = HashSet.newHashSet(256);
 
-            // Add simple currencies first
-            for (char c1 = 'A'; c1 <= 'Z'; c1 ++) {
-                for (char c2 = 'A'; c2 <= 'Z'; c2 ++) {
-                    int tableEntry = getMainTableEntry(c1, c2);
-                    if ((tableEntry & COUNTRY_TYPE_MASK) == SIMPLE_CASE_COUNTRY_MASK
-                            && tableEntry != INVALID_COUNTRY_ENTRY) {
-                        char finalChar = (char) ((tableEntry & SIMPLE_CASE_COUNTRY_FINAL_CHAR_MASK) + 'A');
-                        int defaultFractionDigits = (tableEntry & SIMPLE_CASE_COUNTRY_DEFAULT_DIGITS_MASK) >> SIMPLE_CASE_COUNTRY_DEFAULT_DIGITS_SHIFT;
-                        int numericCode = (tableEntry & NUMERIC_CODE_MASK) >> NUMERIC_CODE_SHIFT;
-                        StringBuilder sb = new StringBuilder();
-                        sb.append(c1);
-                        sb.append(c2);
-                        sb.append(finalChar);
-                        available.add(getInstance(sb.toString(), defaultFractionDigits, numericCode));
-                    } else if ((tableEntry & COUNTRY_TYPE_MASK) == SPECIAL_CASE_COUNTRY_MASK
-                            && tableEntry != INVALID_COUNTRY_ENTRY
-                            && tableEntry != COUNTRY_WITHOUT_CURRENCY_ENTRY) {
-                        int index = SpecialCaseEntry.toIndex(tableEntry);
-                        SpecialCaseEntry scEntry = specialCasesList.get(index);
+        for (char c1 = 'A'; c1 <= 'Z'; c1 ++) {
+            for (char c2 = 'A'; c2 <= 'Z'; c2 ++) {
+                int tableEntry = getMainTableEntry(c1, c2);
+                if ((tableEntry & COUNTRY_TYPE_MASK) == SIMPLE_CASE_COUNTRY_MASK
+                        && tableEntry != INVALID_COUNTRY_ENTRY) {
+                    // Simple Currencies
+                    char finalChar = (char) ((tableEntry & SIMPLE_CASE_COUNTRY_FINAL_CHAR_MASK) + 'A');
+                    int defaultFractionDigits = (tableEntry & SIMPLE_CASE_COUNTRY_DEFAULT_DIGITS_MASK) >> SIMPLE_CASE_COUNTRY_DEFAULT_DIGITS_SHIFT;
+                    int numericCode = (tableEntry & NUMERIC_CODE_MASK) >> NUMERIC_CODE_SHIFT;
+                    StringBuilder sb = new StringBuilder();
+                    sb.append(c1);
+                    sb.append(c2);
+                    sb.append(finalChar);
+                    available.add(getInstance(sb.toString(), defaultFractionDigits, numericCode));
+                } else if ((tableEntry & COUNTRY_TYPE_MASK) == SPECIAL_CASE_COUNTRY_MASK
+                        && tableEntry != INVALID_COUNTRY_ENTRY
+                        && tableEntry != COUNTRY_WITHOUT_CURRENCY_ENTRY) {
+                    // Special Currencies
+                    int index = SpecialCaseEntry.toIndex(tableEntry);
+                    SpecialCaseEntry scEntry = specialCasesList.get(index);
 
-                        if (scEntry.cutOverTime == Long.MAX_VALUE
-                                || sysTime < scEntry.cutOverTime) {
-                            available.add(getInstance(scEntry.oldCurrency,
-                                    scEntry.oldCurrencyFraction,
-                                    scEntry.oldCurrencyNumericCode));
-                        } else {
-                            available.add(getInstance(scEntry.newCurrency,
-                                    scEntry.newCurrencyFraction,
-                                    scEntry.newCurrencyNumericCode));
-                        }
+                    if (scEntry.cutOverTime == Long.MAX_VALUE
+                            || sysTime < scEntry.cutOverTime) {
+                        available.add(getInstance(scEntry.oldCurrency,
+                                scEntry.oldCurrencyFraction,
+                                scEntry.oldCurrencyNumericCode));
+                    } else {
+                        available.add(getInstance(scEntry.newCurrency,
+                                scEntry.newCurrencyFraction,
+                                scEntry.newCurrencyNumericCode));
                     }
                 }
             }
+        }
 
-            // Now add other currencies
-            for (OtherCurrencyEntry entry : otherCurrenciesList) {
-                available.add(getInstance(entry.currencyCode));
-            }
+        // Other Currencies
+        for (OtherCurrencyEntry entry : otherCurrenciesList) {
+            available.add(getInstance(entry.currencyCode));
         }
         return available;
     }


### PR DESCRIPTION
Please review this PR which stems from discussion in the PR of JDK-8347949.

The set of lazily loaded Currencies is a good fit for stable values. `available` can now be made final as it is a SV supplier.

(This change also includes an unrelated minor edit to comments in `Currency::getCurrencies` to make the distinction for simple vs special Currencies.)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8348351](https://bugs.openjdk.org/browse/JDK-8348351): Improve lazy initialization of the available currencies set (**Bug** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25134/head:pull/25134` \
`$ git checkout pull/25134`

Update a local copy of the PR: \
`$ git checkout pull/25134` \
`$ git pull https://git.openjdk.org/jdk.git pull/25134/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25134`

View PR using the GUI difftool: \
`$ git pr show -t 25134`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25134.diff">https://git.openjdk.org/jdk/pull/25134.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25134#issuecomment-2864636971)
</details>
