### PR TITLE
8356593: RISC-V: Small improvement to array fill stub

### DIFF
--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -2042,13 +2042,11 @@ class StubGenerator: public StubCodeGenerator {
         // Zero extend value
         // 8 bit -> 16 bit
         __ zext(value, value, 8);
-        __ mv(tmp_reg, value);
-        __ slli(tmp_reg, tmp_reg, 8);
+        __ slli(tmp_reg, value, 8);
         __ orr(value, value, tmp_reg);
 
         // 16 bit -> 32 bit
-        __ mv(tmp_reg, value);
-        __ slli(tmp_reg, tmp_reg, 16);
+        __ slli(tmp_reg, value, 16);
         __ orr(value, value, tmp_reg);
         break;
       case T_SHORT:
@@ -2060,8 +2058,7 @@ class StubGenerator: public StubCodeGenerator {
         // Zero extend value
         // 16 bit -> 32 bit
         __ zext(value, value, 16);
-        __ mv(tmp_reg, value);
-        __ slli(tmp_reg, tmp_reg, 16);
+        __ slli(tmp_reg, value, 16);
         __ orr(value, value, tmp_reg);
         break;
       case T_INT:

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -2029,12 +2029,15 @@ class StubGenerator: public StubCodeGenerator {
 
     __ enter();
 
-    Label L_fill_elements, L_exit1;
+    Label L_fill_elements;
 
     int shift = -1;
     switch (t) {
       case T_BYTE:
         shift = 0;
+        // Short arrays (< 8 bytes) fill by element
+        __ mv(tmp_reg, 8 >> shift);
+        __ bltu(count, tmp_reg, L_fill_elements);
 
         // Zero extend value
         // 8 bit -> 16 bit
@@ -2047,26 +2050,22 @@ class StubGenerator: public StubCodeGenerator {
         __ mv(tmp_reg, value);
         __ slli(tmp_reg, tmp_reg, 16);
         __ orr(value, value, tmp_reg);
-
-        __ mv(tmp_reg, 8 >> shift); // Short arrays (< 8 bytes) fill by element
-        __ bltu(count, tmp_reg, L_fill_elements);
         break;
       case T_SHORT:
         shift = 1;
+        // Short arrays (< 8 bytes) fill by element
+        __ mv(tmp_reg, 8 >> shift);
+        __ bltu(count, tmp_reg, L_fill_elements);
+
         // Zero extend value
         // 16 bit -> 32 bit
         __ zext(value, value, 16);
         __ mv(tmp_reg, value);
         __ slli(tmp_reg, tmp_reg, 16);
         __ orr(value, value, tmp_reg);
-
-        // Short arrays (< 8 bytes) fill by element
-        __ mv(tmp_reg, 8 >> shift);
-        __ bltu(count, tmp_reg, L_fill_elements);
         break;
       case T_INT:
         shift = 2;
-
         // Short arrays (< 8 bytes) fill by element
         __ mv(tmp_reg, 8 >> shift);
         __ bltu(count, tmp_reg, L_fill_elements);
@@ -2125,20 +2124,8 @@ class StubGenerator: public StubCodeGenerator {
       __ fill_words(to, cnt_words, value);
     }
 
-    // Remaining count is less than 8 bytes. Fill it by a single store.
-    // Note that the total length is no less than 8 bytes.
-    if (!AvoidUnalignedAccesses && (t == T_BYTE || t == T_SHORT)) {
-      __ beqz(count, L_exit1);
-      __ shadd(to, count, to, tmp_reg, shift); // points to the end
-      __ sd(value, Address(to, -8)); // overwrite some elements
-      __ bind(L_exit1);
-      __ leave();
-      __ ret();
-    }
-
-    // Handle copies less than 8 bytes.
-    Label L_fill_2, L_fill_4, L_exit2;
-    __ bind(L_fill_elements);
+    // Remaining count is less than 8 bytes and address is heapword aligned.
+    Label L_fill_2, L_fill_4, L_exit1;
     switch (t) {
       case T_BYTE:
         __ test_bit(t0, count, 0);
@@ -2152,7 +2139,7 @@ class StubGenerator: public StubCodeGenerator {
         __ addi(to, to, 2);
         __ bind(L_fill_4);
         __ test_bit(t0, count, 2);
-        __ beqz(t0, L_exit2);
+        __ beqz(t0, L_exit1);
         __ sw(value, Address(to, 0));
         break;
       case T_SHORT:
@@ -2162,11 +2149,39 @@ class StubGenerator: public StubCodeGenerator {
         __ addi(to, to, 2);
         __ bind(L_fill_4);
         __ test_bit(t0, count, 1);
-        __ beqz(t0, L_exit2);
+        __ beqz(t0, L_exit1);
         __ sw(value, Address(to, 0));
         break;
       case T_INT:
-        __ beqz(count, L_exit2);
+        __ beqz(count, L_exit1);
+        __ sw(value, Address(to, 0));
+        break;
+      default: ShouldNotReachHere();
+    }
+    __ bind(L_exit1);
+    __ leave();
+    __ ret();
+
+    // Handle copies less than 8 bytes.
+    Label L_loop1, L_loop2, L_exit2;
+    __ bind(L_fill_elements);
+    __ beqz(count, L_exit2);
+    switch (t) {
+      case T_BYTE:
+        __ bind(L_loop1);
+        __ sb(value, Address(to, 0));
+        __ addi(to, to, 1);
+        __ subiw(count, count, 1);
+        __ bnez(count, L_loop1);
+        break;
+      case T_SHORT:
+        __ bind(L_loop2);
+        __ sh(value, Address(to, 0));
+        __ addi(to, to, 2);
+        __ subiw(count, count, 2 >> shift);
+        __ bnez(count, L_loop2);
+        break;
+      case T_INT:
         __ sw(value, Address(to, 0));
         break;
       default: ShouldNotReachHere();
@@ -2174,6 +2189,7 @@ class StubGenerator: public StubCodeGenerator {
     __ bind(L_exit2);
     __ leave();
     __ ret();
+
     return start;
   }
 


### PR DESCRIPTION
When working on [JDK-8351140](https://bugs.openjdk.org/browse/JDK-8351140), I witnessed possible misaligned memory access in array fill stub.
We fill by element for short arrays (< 8 bytes), which assumes a heapword alignment[1]. But that is not guaranteed. This issue could be reproduced by running: `make test TEST="micro:vm.compiler.ArrayFill"`
with `@Param("5") private int size;` on riscv platforms with slow misalgned memory accesses.

[1] https://github.com/openjdk/jdk/blob/master/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp#L2141

This fixes this issue by using a small loop to fill the elements for short arrays.
Tier1-2 tested on linux-riscv64 platform. JMH result on P550 SBC for reference:
1. (`@Param("5") private int size;`):
```
Before:
Benchmark                 (size)  Mode  Cnt    Score   Error  Units
ArrayFill.fillByteArray        5  avgt   12  558.781 ± 1.396  ns/op
ArrayFill.fillIntArray         5  avgt   12   29.346 ± 0.003  ns/op
ArrayFill.fillShortArray       5  avgt   12   30.779 ± 0.004  ns/op
ArrayFill.zeroByteArray        5  avgt   12  559.249 ± 1.909  ns/op
ArrayFill.zeroIntArray         5  avgt   12   29.346 ± 0.002  ns/op
ArrayFill.zeroShortArray       5  avgt   12   30.777 ± 0.006  ns/op

After:
Benchmark                 (size)  Mode  Cnt   Score   Error  Units
ArrayFill.fillByteArray        5  avgt   12  23.977 ± 0.004  ns/op
ArrayFill.fillIntArray         5  avgt   12  29.343 ± 0.004  ns/op
ArrayFill.fillShortArray       5  avgt   12  30.776 ± 0.005  ns/op
ArrayFill.zeroByteArray        5  avgt   12  23.977 ± 0.002  ns/op
ArrayFill.zeroIntArray         5  avgt   12  29.345 ± 0.005  ns/op
ArrayFill.zeroShortArray       5  avgt   12  30.776 ± 0.004  ns/op
```
2. (`@Param("3") private int size;`):
```
Before:
Benchmark                 (size)  Mode  Cnt    Score   Error  Units
ArrayFill.fillByteArray        3  avgt   12  428.923 ± 0.409  ns/op
ArrayFill.fillIntArray         3  avgt   12   28.629 ± 0.005  ns/op
ArrayFill.fillShortArray       3  avgt   12  558.872 ± 2.641  ns/op
ArrayFill.zeroByteArray        3  avgt   12  429.744 ± 2.049  ns/op
ArrayFill.zeroIntArray         3  avgt   12   28.628 ± 0.002  ns/op
ArrayFill.zeroShortArray       3  avgt   12  557.682 ± 1.661  ns/op

After:
Benchmark                 (size)  Mode  Cnt   Score   Error  Units
ArrayFill.fillByteArray        3  avgt   12  21.471 ± 0.002  ns/op
ArrayFill.fillIntArray         3  avgt   12  28.631 ± 0.003  ns/op
ArrayFill.fillShortArray       3  avgt   12  20.436 ± 0.288  ns/op
ArrayFill.zeroByteArray        3  avgt   12  21.472 ± 0.002  ns/op
ArrayFill.zeroIntArray         3  avgt   12  28.633 ± 0.003  ns/op
ArrayFill.zeroShortArray       3  avgt   12  20.203 ± 0.137  ns/op
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8356593](https://bugs.openjdk.org/browse/JDK-8356593): RISC-V: Small improvement to array fill stub (**Enhancement** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25135/head:pull/25135` \
`$ git checkout pull/25135`

Update a local copy of the PR: \
`$ git checkout pull/25135` \
`$ git pull https://git.openjdk.org/jdk.git pull/25135/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25135`

View PR using the GUI difftool: \
`$ git pr show -t 25135`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25135.diff">https://git.openjdk.org/jdk/pull/25135.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25135#issuecomment-2865417332)
</details>
