### PR TITLE
8356631: OopHandle replacement methods should not be called on empty handles

### DIFF
--- a/src/hotspot/share/oops/oopHandle.inline.hpp
+++ b/src/hotspot/share/oops/oopHandle.inline.hpp
@@ -70,13 +70,13 @@ inline void OopHandle::release(OopStorage* storage) {
 }
 
 inline void OopHandle::replace(oop obj) {
-  assert(!is_empty(), "Cannot use replace on empty handle");
+  assert(!is_empty(), "Must not use replace on empty handle");
   assert(oopDesc::is_oop_or_null(obj), "Should be oop: " PTR_FORMAT, p2i(obj));
   NativeAccess<>::oop_store(_obj, obj);
 }
 
 inline oop OopHandle::xchg(oop new_value) {
-  assert(!is_empty(), "Cannot use xchg on empty handle");
+  assert(!is_empty(), "Must not use xchg on empty handle");
   assert(oopDesc::is_oop_or_null(new_value), "Should be oop: " PTR_FORMAT, p2i(new_value));
   oop obj = NativeAccess<MO_SEQ_CST>::oop_atomic_xchg(_obj, new_value);
   assert(oopDesc::is_oop_or_null(obj), "Should be oop: " PTR_FORMAT, p2i(obj));
@@ -84,7 +84,7 @@ inline oop OopHandle::xchg(oop new_value) {
 }
 
 inline oop OopHandle::cmpxchg(oop old_value, oop new_value) {
-  assert(!is_empty(), "Cannot use cmpxchg on empty handle");
+  assert(!is_empty(), "Must not use cmpxchg on empty handle");
   assert(oopDesc::is_oop_or_null(new_value), "Should be oop: " PTR_FORMAT, p2i(new_value));
   oop obj = NativeAccess<MO_SEQ_CST>::oop_atomic_cmpxchg(_obj, old_value, new_value);
   assert(oopDesc::is_oop_or_null(obj), "Should be oop: " PTR_FORMAT, p2i(obj));

--- a/src/hotspot/share/oops/oopHandle.inline.hpp
+++ b/src/hotspot/share/oops/oopHandle.inline.hpp
@@ -70,12 +70,13 @@ inline void OopHandle::release(OopStorage* storage) {
 }
 
 inline void OopHandle::replace(oop obj) {
-  assert(!is_empty(), "should not use replace");
+  assert(!is_empty(), "Cannot use replace on empty handle");
   assert(oopDesc::is_oop_or_null(obj), "Should be oop: " PTR_FORMAT, p2i(obj));
   NativeAccess<>::oop_store(_obj, obj);
 }
 
 inline oop OopHandle::xchg(oop new_value) {
+  assert(!is_empty(), "Cannot use xchg on empty handle");
   assert(oopDesc::is_oop_or_null(new_value), "Should be oop: " PTR_FORMAT, p2i(new_value));
   oop obj = NativeAccess<MO_SEQ_CST>::oop_atomic_xchg(_obj, new_value);
   assert(oopDesc::is_oop_or_null(obj), "Should be oop: " PTR_FORMAT, p2i(obj));
@@ -83,6 +84,7 @@ inline oop OopHandle::xchg(oop new_value) {
 }
 
 inline oop OopHandle::cmpxchg(oop old_value, oop new_value) {
+  assert(!is_empty(), "Cannot use cmpxchg on empty handle");
   assert(oopDesc::is_oop_or_null(new_value), "Should be oop: " PTR_FORMAT, p2i(new_value));
   oop obj = NativeAccess<MO_SEQ_CST>::oop_atomic_cmpxchg(_obj, old_value, new_value);
   assert(oopDesc::is_oop_or_null(obj), "Should be oop: " PTR_FORMAT, p2i(obj));

--- a/src/hotspot/share/oops/weakHandle.inline.hpp
+++ b/src/hotspot/share/oops/weakHandle.inline.hpp
@@ -40,7 +40,7 @@ inline oop WeakHandle::peek() const {
 }
 
 inline void WeakHandle::replace(oop with_obj) {
-  assert(!is_null(), "Cannot use replace on empty handle");
+  assert(!is_empty(), "Must not use replace on empty handle");
   NativeAccess<ON_PHANTOM_OOP_REF>::oop_store(_obj, with_obj);
 }
 

--- a/src/hotspot/share/oops/weakHandle.inline.hpp
+++ b/src/hotspot/share/oops/weakHandle.inline.hpp
@@ -40,6 +40,7 @@ inline oop WeakHandle::peek() const {
 }
 
 inline void WeakHandle::replace(oop with_obj) {
+  assert(!is_null(), "Cannot use replace on empty handle");
   NativeAccess<ON_PHANTOM_OOP_REF>::oop_store(_obj, with_obj);
 }
 


### PR DESCRIPTION
I noticed that in OopHandle/WeakHandle we have {replace,xchg,cmpxchg} methods that overwrite the handle. This is only safe to do when the handle is not empty -- i.e. when there is a storage allocated for it in relevant OopStorage. Otherwise we attempt the store to nullptr, and get a SEGV.

Only OopHandle::replace does the assertion for this. We need to add these asserts everywhere else.

Additional testing:
 - [x] Linux x86_64 server fastdebug, `all`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8356631](https://bugs.openjdk.org/browse/JDK-8356631): OopHandle replacement methods should not be called on empty handles (**Enhancement** - P4)


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25139/head:pull/25139` \
`$ git checkout pull/25139`

Update a local copy of the PR: \
`$ git checkout pull/25139` \
`$ git pull https://git.openjdk.org/jdk.git pull/25139/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25139`

View PR using the GUI difftool: \
`$ git pr show -t 25139`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25139.diff">https://git.openjdk.org/jdk/pull/25139.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25139#issuecomment-2866157909)
</details>
