### PR TITLE
8355708: Two Float16 IR tests fail after JDK-8345125

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -78,9 +78,6 @@ compiler/ciReplay/TestIncrementalInlining.java 8349191 generic-all
 
 compiler/c2/TestVerifyConstraintCasts.java 8355574 generic-all
 
-compiler/c2/irTests/TestFloat16ScalarOperations.java 8355708 linux-aarch64
-compiler/c2/irTests/MulHFNodeIdealizationTests.java 8355708 linux-aarch64
-
 #############################################################################
 
 # :hotspot_gc

--- a/test/hotspot/jtreg/compiler/c2/irTests/MulHFNodeIdealizationTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/MulHFNodeIdealizationTests.java
@@ -53,6 +53,7 @@ public class MulHFNodeIdealizationTests {
     }
 
     @Test
+    @Warmup(value = 10000)
     @IR(counts = {IRNode.ADD_HF, "1"},
         applyIfCPUFeatureOr = {"avx512_fp16", "true", "zfh", "true"},
         failOn = {IRNode.MUL_HF})

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestFloat16ScalarOperations.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestFloat16ScalarOperations.java
@@ -608,6 +608,7 @@ public class TestFloat16ScalarOperations {
     }
 
     @Test
+    @Warmup(value = 10000)
     @IR(counts = {IRNode.ADD_HF, " >0 ", IRNode.SUB_HF, " >0 ", IRNode.MUL_HF, " >0 ",
                   IRNode.DIV_HF, " >0 ", IRNode.SQRT_HF, " >0 ", IRNode.FMA_HF, " >0 "},
         applyIfCPUFeatureOr = {"avx512_fp16", "true", "zfh", "true"})


### PR DESCRIPTION
Two FP16 tests fail due to IR verification failure in JTREG. Increased the warmup time to 10000 to make sure it is being compiled by c2 and the expected IR is being generated.

Testing:
Tested both the testcases with and without these options - `"-ea -esa -XX:CompileThreshold=100 -XX:+UnlockExperimentalVMOptions -server -XX:-TieredCompilation"` and they pass successfully on aarch64.