### PR TITLE
8356192: [PPC64] AOTAdapterCaching: SIGSEGV after 8350209

### DIFF
--- a/src/hotspot/cpu/ppc/interp_masm_ppc_64.cpp
+++ b/src/hotspot/cpu/ppc/interp_masm_ppc_64.cpp
@@ -206,7 +206,7 @@ void InterpreterMacroAssembler::load_earlyret_value(TosState state, Register Rsc
 // Dispatch value in Lbyte_code and increment Lbcp.
 
 void InterpreterMacroAssembler::load_dispatch_table(Register dst, address* table) {
-  address table_base = (address)Interpreter::dispatch_table((TosState)0);
+  address table_base = (address)Interpreter::dispatch_table();
   intptr_t table_offs = (intptr_t)table - (intptr_t)table_base;
   if (is_simm16(table_offs)) {
     addi(dst, R25_templateTableBase, (int)table_offs);

--- a/src/hotspot/cpu/ppc/macroAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/macroAssembler_ppc.cpp
@@ -1072,8 +1072,18 @@ address MacroAssembler::call_c_and_return_to_caller(Register r_function_entry) {
 }
 
 address MacroAssembler::call_c(address function_entry, relocInfo::relocType rt) {
+  if (rt != relocInfo::none) {
+    relocate(rt);
+  }
   load_const(R12, function_entry, R0);
-  return branch_to(R12,  /*and_link=*/true);
+  return branch_to(R12, /*and_link=*/true);
+}
+
+bool MacroAssembler::is_simple_call_c_at(address a) {
+  uint32_t* instruction = (uint32_t*)a;
+  return is_load_const_at(a) &&
+         is_mtctr(instruction[5]) &&
+         is_bctrl(instruction[6]);
 }
 
 #else

--- a/src/hotspot/cpu/ppc/macroAssembler_ppc.hpp
+++ b/src/hotspot/cpu/ppc/macroAssembler_ppc.hpp
@@ -372,6 +372,7 @@ class MacroAssembler: public Assembler {
   // For tail calls: only branch, don't link, so callee returns to caller of this function.
   address call_c_and_return_to_caller(Register function_entry);
   address call_c(address function_entry, relocInfo::relocType rt = relocInfo::none);
+  static bool is_simple_call_c_at(address a);
 #else
   // Call a C function via a function descriptor and use full C
   // calling conventions. Updates and returns _last_calls_return_pc.
@@ -382,6 +383,7 @@ class MacroAssembler: public Assembler {
   address call_c(address function_entry, relocInfo::relocType rt = relocInfo::none) {
     return call_c((const FunctionDescriptor*)function_entry, rt);
   }
+  static bool is_simple_call_c_at(address a) { return false; }
   address call_c_using_toc(const FunctionDescriptor* function_descriptor, relocInfo::relocType rt,
                            Register toc);
 #endif

--- a/src/hotspot/cpu/ppc/relocInfo_ppc.cpp
+++ b/src/hotspot/cpu/ppc/relocInfo_ppc.cpp
@@ -23,7 +23,7 @@
  *
  */
 
-#include "asm/assembler.inline.hpp"
+#include "asm/macroAssembler.inline.hpp"
 #include "code/relocInfo.hpp"
 #include "nativeInst_ppc.hpp"
 #include "oops/compressedOops.inline.hpp"
@@ -63,6 +63,8 @@ address Relocation::pd_call_destination(address orig_addr) {
   } else if (NativeConditionalFarBranch::is_conditional_far_branch_at(inst_loc)) {
     NativeConditionalFarBranch* branch = NativeConditionalFarBranch_at(inst_loc);
     return branch->branch_destination();
+  } else if (MacroAssembler::is_simple_call_c_at(inst_loc)) {
+    return (address)MacroAssembler::get_const(inst_loc);
   } else {
     orig_addr = nativeCall_at(inst_loc)->get_trampoline();
     if (orig_addr == nullptr) {
@@ -85,6 +87,8 @@ void Relocation::pd_set_call_destination(address x) {
   } else if (NativeConditionalFarBranch::is_conditional_far_branch_at(inst_loc)) {
     NativeConditionalFarBranch* branch = NativeConditionalFarBranch_at(inst_loc);
     branch->set_branch_destination(x);
+  } else if (MacroAssembler::is_simple_call_c_at(inst_loc)) {
+    MacroAssembler::patch_const(inst_loc, (uintptr_t)x);
   } else {
     NativeCall* call = nativeCall_at(inst_loc);
     call->set_destination_mt_safe(x, false);

--- a/src/hotspot/cpu/ppc/stubGenerator_ppc.cpp
+++ b/src/hotspot/cpu/ppc/stubGenerator_ppc.cpp
@@ -262,7 +262,7 @@ class StubGenerator: public StubCodeGenerator {
       assert(tos != r_arg_thread && R19_method != r_arg_thread, "trashed r_arg_thread");
 
       // Set R15_prev_state to 0 for simplifying checks in callee.
-      __ load_const_optimized(R25_templateTableBase, (address)Interpreter::dispatch_table((TosState)0), R11_scratch1);
+      __ load_const_optimized(R25_templateTableBase, (address)Interpreter::dispatch_table(), R11_scratch1);
       // Stack on entry to frame manager / native entry:
       //
       //      F0      [TOP_IJAVA_FRAME_ABI]

--- a/src/hotspot/cpu/ppc/templateInterpreterGenerator_ppc.cpp
+++ b/src/hotspot/cpu/ppc/templateInterpreterGenerator_ppc.cpp
@@ -621,7 +621,7 @@ address TemplateInterpreterGenerator::generate_return_entry_for(TosState state, 
   __ restore_interpreter_state(R11_scratch1, false /*bcp_and_mdx_only*/, true /*restore_top_frame_sp*/);
 
   // Compiled code destroys templateTableBase, reload.
-  __ load_const_optimized(R25_templateTableBase, (address)Interpreter::dispatch_table((TosState)0), R12_scratch2);
+  __ load_const_optimized(R25_templateTableBase, (address)Interpreter::dispatch_table(), R12_scratch2);
 
   if (state == atos) {
     __ profile_return_type(R3_RET, R11_scratch1, R12_scratch2);
@@ -699,7 +699,7 @@ address TemplateInterpreterGenerator::generate_cont_resume_interpreter_adapter()
   if (!Continuations::enabled()) return nullptr;
   address start = __ pc();
 
-  __ load_const_optimized(R25_templateTableBase, (address)Interpreter::dispatch_table((TosState)0), R12_scratch2);
+  __ load_const_optimized(R25_templateTableBase, (address)Interpreter::dispatch_table(), R12_scratch2);
   __ restore_interpreter_state(R11_scratch1, false, true /*restore_top_frame_sp*/);
   __ blr();
 
@@ -2023,7 +2023,7 @@ void TemplateInterpreterGenerator::generate_throw_exception() {
     __ restore_interpreter_state(R11_scratch1, false /*bcp_and_mdx_only*/, true /*restore_top_frame_sp*/);
 
     // Compiled code destroys templateTableBase, reload.
-    __ load_const_optimized(R25_templateTableBase, (address)Interpreter::dispatch_table((TosState)0), R11_scratch1);
+    __ load_const_optimized(R25_templateTableBase, (address)Interpreter::dispatch_table(), R11_scratch1);
   }
 
   // Entry point if a interpreted method throws an exception (throw).

--- a/src/hotspot/share/code/aotCodeCache.cpp
+++ b/src/hotspot/share/code/aotCodeCache.cpp
@@ -54,7 +54,6 @@
 #endif
 #if INCLUDE_ZGC
 #include "gc/z/zBarrierSetRuntime.hpp"
-
 #endif
 
 #include <sys/stat.h>

--- a/src/hotspot/share/code/aotCodeCache.cpp
+++ b/src/hotspot/share/code/aotCodeCache.cpp
@@ -32,6 +32,7 @@
 #include "code/aotCodeCache.hpp"
 #include "code/codeCache.hpp"
 #include "gc/shared/gcConfig.hpp"
+#include "interpreter/interpreter.hpp"
 #include "logging/logStream.hpp"
 #include "memory/memoryReserver.hpp"
 #include "runtime/flags/flagSetting.hpp"
@@ -53,6 +54,7 @@
 #endif
 #if INCLUDE_ZGC
 #include "gc/z/zBarrierSetRuntime.hpp"
+
 #endif
 
 #include <sys/stat.h>
@@ -1032,6 +1034,9 @@ void AOTCodeAddressTable::init_extrs() {
 #ifndef ZERO
 #if defined(AMD64) || defined(AARCH64) || defined(RISCV64)
   SET_ADDRESS(_extrs, MacroAssembler::debug64);
+#endif
+#if defined (PPC64)
+  SET_ADDRESS(_extrs, Interpreter::dispatch_table());
 #endif
 #endif // ZERO
 

--- a/src/hotspot/share/code/aotCodeCache.cpp
+++ b/src/hotspot/share/code/aotCodeCache.cpp
@@ -1034,7 +1034,7 @@ void AOTCodeAddressTable::init_extrs() {
 #if defined(AMD64) || defined(AARCH64) || defined(RISCV64)
   SET_ADDRESS(_extrs, MacroAssembler::debug64);
 #endif
-#if defined (PPC64)
+#if defined(PPC64)
   SET_ADDRESS(_extrs, Interpreter::dispatch_table());
 #endif
 #endif // ZERO


### PR DESCRIPTION
Incomplete fix for [JDK-8356192](https://bugs.openjdk.org/browse/JDK-8356192) (`AOTAdapterCaching `). Some more relocations may be missing. This feature may be less important for PPC64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8356192](https://bugs.openjdk.org/browse/JDK-8356192)

### Issue
 * [JDK-8356192](https://bugs.openjdk.org/browse/JDK-8356192): Enable AOT code caching only on supported platforms (**Bug** - P3) ⚠️ Title mismatch between PR and JBS.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25143/head:pull/25143` \
`$ git checkout pull/25143`

Update a local copy of the PR: \
`$ git checkout pull/25143` \
`$ git pull https://git.openjdk.org/jdk.git pull/25143/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25143`

View PR using the GUI difftool: \
`$ git pr show -t 25143`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25143.diff">https://git.openjdk.org/jdk/pull/25143.diff</a>

</details>
