### PR TITLE
8356642: RISC-V: enable hotspot/jtreg/compiler/vectorapi/VectorFusedMultiplyAddSubTest.java

### DIFF
--- a/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
@@ -2466,9 +2466,19 @@ public class IRNode {
         machOnlyNameRegex(VFMSB_MASKED, "vfmsb_masked");
     }
 
+    public static final String RISCV_VFNMSUB_MASKED = PREFIX + "RISCV_VFNMSUB_MASKED" + POSTFIX;
+    static {
+        machOnlyNameRegex(RISCV_VFNMSUB_MASKED, "vfnmsub_masked");
+    }
+
     public static final String VFNMAD_MASKED = PREFIX + "VFNMAD_MASKED" + POSTFIX;
     static {
         machOnlyNameRegex(VFNMAD_MASKED, "vfnmad_masked");
+    }
+
+    public static final String RISCV_VFNMADD_MASKED = PREFIX + "RISCV_VFNMADD_MASKED" + POSTFIX;
+    static {
+        machOnlyNameRegex(RISCV_VFNMADD_MASKED, "vfnmadd_masked");
     }
 
     public static final String VFNMSB_MASKED = PREFIX + "VFNMSB_MASKED" + POSTFIX;
@@ -2476,9 +2486,19 @@ public class IRNode {
         machOnlyNameRegex(VFNMSB_MASKED, "vfnmsb_masked");
     }
 
+    public static final String RISCV_VFMSUB_MASKED = PREFIX + "RISCV_VFMSUB_MASKED" + POSTFIX;
+    static {
+        machOnlyNameRegex(RISCV_VFMSUB_MASKED, "vfmsub_masked");
+    }
+
     public static final String VFMAD_MASKED = PREFIX + "VFMAD_MASKED" + POSTFIX;
     static {
         machOnlyNameRegex(VFMAD_MASKED, "vfmad_masked");
+    }
+
+    public static final String RISCV_VFMADD_MASKED = PREFIX + "RISCV_VFMADD_MASKED" + POSTFIX;
+    static {
+        machOnlyNameRegex(RISCV_VFMADD_MASKED, "vfmadd_masked");
     }
 
     public static final String VMASK_AND_NOT_L = PREFIX + "VMASK_AND_NOT_L" + POSTFIX;

--- a/test/hotspot/jtreg/compiler/vectorapi/VectorFusedMultiplyAddSubTest.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/VectorFusedMultiplyAddSubTest.java
@@ -48,7 +48,7 @@ import jdk.test.lib.Utils;
  * @key randomness
  * @library /test/lib /
  * @requires vm.cpu.features ~= ".*sve.*" | vm.cpu.features ~= ".*rvv.*"
- * @summary AArch64: Add optimized rules for masked vector multiply-add/sub for SVE
+ * @summary Add optimized rules for masked vector multiply-add/sub for SVE and RVV
  * @modules jdk.incubator.vector
  *
  * @run driver compiler.vectorapi.VectorFusedMultiplyAddSubTest

--- a/test/hotspot/jtreg/compiler/vectorapi/VectorFusedMultiplyAddSubTest.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/VectorFusedMultiplyAddSubTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022, 2023, Arm Limited. All rights reserved.
+ * Copyright (c) 2025, Rivos Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,6 +39,7 @@ import jdk.incubator.vector.VectorOperators;
 import jdk.incubator.vector.VectorSpecies;
 
 import jdk.test.lib.Asserts;
+import jdk.test.lib.Platform;
 import jdk.test.lib.Utils;
 
 /**
@@ -45,7 +47,7 @@ import jdk.test.lib.Utils;
  * @bug 8282431
  * @key randomness
  * @library /test/lib /
- * @requires vm.cpu.features ~= ".*sve.*"
+ * @requires vm.cpu.features ~= ".*sve.*" | vm.cpu.features ~= ".*rvv.*"
  * @summary AArch64: Add optimized rules for masked vector multiply-add/sub for SVE
  * @modules jdk.incubator.vector
  *
@@ -244,7 +246,7 @@ public class VectorFusedMultiplyAddSubTest {
     }
 
     @Test
-    @IR(counts = { IRNode.VMLA_MASKED, ">= 1" })
+    @IR(applyIfPlatformOr = {"aarch64", "true", "riscv64", "true"}, counts = { IRNode.VMLA_MASKED, ">= 1" })
     public static void testByteMultiplyAddMasked() {
         VectorMask<Byte> mask = VectorMask.fromArray(B_SPECIES, m, 0);
         for (int i = 0; i < LENGTH; i += B_SPECIES.length()) {
@@ -257,7 +259,7 @@ public class VectorFusedMultiplyAddSubTest {
     }
 
     @Test
-    @IR(counts = { IRNode.VMLS_MASKED, ">= 1" })
+    @IR(applyIfPlatformOr = {"aarch64", "true", "riscv64", "true"}, counts = { IRNode.VMLS_MASKED, ">= 1" })
     public static void testByteMultiplySubMasked() {
         VectorMask<Byte> mask = VectorMask.fromArray(B_SPECIES, m, 0);
         for (int i = 0; i < LENGTH; i += B_SPECIES.length()) {
@@ -270,7 +272,7 @@ public class VectorFusedMultiplyAddSubTest {
     }
 
     @Test
-    @IR(counts = { IRNode.VMLA_MASKED, ">= 1" })
+    @IR(applyIfPlatformOr = {"aarch64", "true", "riscv64", "true"}, counts = { IRNode.VMLA_MASKED, ">= 1" })
     public static void testShortMultiplyAddMasked() {
         VectorMask<Short> mask = VectorMask.fromArray(S_SPECIES, m, 0);
         for (int i = 0; i < LENGTH; i += S_SPECIES.length()) {
@@ -283,7 +285,7 @@ public class VectorFusedMultiplyAddSubTest {
     }
 
     @Test
-    @IR(counts = { IRNode.VMLS_MASKED, ">= 1" })
+    @IR(applyIfPlatformOr = {"aarch64", "true", "riscv64", "true"}, counts = { IRNode.VMLS_MASKED, ">= 1" })
     public static void testShortMultiplySubMasked() {
         VectorMask<Short> mask = VectorMask.fromArray(S_SPECIES, m, 0);
         for (int i = 0; i < LENGTH; i += S_SPECIES.length()) {
@@ -296,7 +298,7 @@ public class VectorFusedMultiplyAddSubTest {
     }
 
     @Test
-    @IR(counts = { IRNode.VMLA_MASKED, ">= 1" })
+    @IR(applyIfPlatformOr = {"aarch64", "true", "riscv64", "true"}, counts = { IRNode.VMLA_MASKED, ">= 1" })
     public static void testIntMultiplyAddMasked() {
         VectorMask<Integer> mask = VectorMask.fromArray(I_SPECIES, m, 0);
         for (int i = 0; i < LENGTH; i += I_SPECIES.length()) {
@@ -309,7 +311,7 @@ public class VectorFusedMultiplyAddSubTest {
     }
 
     @Test
-    @IR(counts = { IRNode.VMLS_MASKED, ">= 1" })
+    @IR(applyIfPlatformOr = {"aarch64", "true", "riscv64", "true"}, counts = { IRNode.VMLS_MASKED, ">= 1" })
     public static void testIntMultiplySubMasked() {
         VectorMask<Integer> mask = VectorMask.fromArray(I_SPECIES, m, 0);
         for (int i = 0; i < LENGTH; i += I_SPECIES.length()) {
@@ -322,7 +324,7 @@ public class VectorFusedMultiplyAddSubTest {
     }
 
     @Test
-    @IR(counts = { IRNode.VMLA_MASKED, ">= 1" })
+    @IR(applyIfPlatformOr = {"aarch64", "true", "riscv64", "true"}, counts = { IRNode.VMLA_MASKED, ">= 1" })
     public static void testLongMultiplyAddMasked() {
         VectorMask<Long> mask = VectorMask.fromArray(L_SPECIES, m, 0);
         for (int i = 0; i < LENGTH; i += L_SPECIES.length()) {
@@ -335,7 +337,7 @@ public class VectorFusedMultiplyAddSubTest {
     }
 
     @Test
-    @IR(counts = { IRNode.VMLS_MASKED, ">= 1" })
+    @IR(applyIfPlatformOr = {"aarch64", "true", "riscv64", "true"}, counts = { IRNode.VMLS_MASKED, ">= 1" })
     public static void testLongMultiplySubMasked() {
         VectorMask<Long> mask = VectorMask.fromArray(L_SPECIES, m, 0);
         for (int i = 0; i < LENGTH; i += L_SPECIES.length()) {
@@ -348,7 +350,8 @@ public class VectorFusedMultiplyAddSubTest {
     }
 
     @Test
-    @IR(counts = { IRNode.VFMSB_MASKED, ">= 1" })
+    @IR(applyIfPlatform = {"aarch64", "true"}, counts = { IRNode.VFMSB_MASKED, ">= 1" })
+    @IR(applyIfPlatform = {"riscv64", "true"}, counts = { IRNode.RISCV_VFNMSUB_MASKED, ">= 1" })
     public static void testFloatMultiplySubMasked() {
         VectorMask<Float> mask = VectorMask.fromArray(F_SPECIES, m, 0);
         for (int i = 0; i < LENGTH; i += F_SPECIES.length()) {
@@ -361,7 +364,8 @@ public class VectorFusedMultiplyAddSubTest {
     }
 
     @Test
-    @IR(counts = { IRNode.VFMAD_MASKED, ">= 1" })
+    @IR(applyIfPlatform = {"aarch64", "true"}, counts = { IRNode.VFMAD_MASKED, ">= 1" })
+    @IR(applyIfPlatform = {"riscv64", "true"}, counts = { IRNode.RISCV_VFMADD_MASKED, ">= 1" })
     public static void testFloatMultiplyNegAMasked() {
         VectorMask<Float> mask = VectorMask.fromArray(F_SPECIES, m, 0);
         for (int i = 0; i < LENGTH; i += F_SPECIES.length()) {
@@ -374,7 +378,8 @@ public class VectorFusedMultiplyAddSubTest {
     }
 
     @Test
-    @IR(counts = { IRNode.VFNMAD_MASKED, ">= 1" })
+    @IR(applyIfPlatform = {"aarch64", "true"}, counts = { IRNode.VFNMAD_MASKED, ">= 1" })
+    @IR(applyIfPlatform = {"riscv64", "true"}, counts = { IRNode.RISCV_VFNMADD_MASKED, ">= 1" })
     public static void testFloatNegatedMultiplyAddMasked() {
         VectorMask<Float> mask = VectorMask.fromArray(F_SPECIES, m, 0);
         for (int i = 0; i < LENGTH; i += F_SPECIES.length()) {
@@ -387,7 +392,8 @@ public class VectorFusedMultiplyAddSubTest {
     }
 
     @Test
-    @IR(counts = { IRNode.VFNMSB_MASKED, ">= 1" })
+    @IR(applyIfPlatform = {"aarch64", "true"}, counts = { IRNode.VFNMSB_MASKED, ">= 1" })
+    @IR(applyIfPlatform = {"riscv64", "true"}, counts = { IRNode.RISCV_VFMSUB_MASKED, ">= 1" })
     public static void testFloatNegatedMultiplyNegAMasked() {
         VectorMask<Float> mask = VectorMask.fromArray(F_SPECIES, m, 0);
         for (int i = 0; i < LENGTH; i += F_SPECIES.length()) {
@@ -400,7 +406,8 @@ public class VectorFusedMultiplyAddSubTest {
     }
 
     @Test
-    @IR(counts = { IRNode.VFNMSB_MASKED, ">= 1" })
+    @IR(applyIfPlatform = {"aarch64", "true"}, counts = { IRNode.VFNMSB_MASKED, ">= 1" })
+    @IR(applyIfPlatform = {"riscv64", "true"}, counts = { IRNode.RISCV_VFMSUB_MASKED, ">= 1" })
     public static void testFloatNegatedMultiplySubMasked() {
         VectorMask<Float> mask = VectorMask.fromArray(F_SPECIES, m, 0);
         for (int i = 0; i < LENGTH; i += F_SPECIES.length()) {
@@ -413,7 +420,8 @@ public class VectorFusedMultiplyAddSubTest {
     }
 
     @Test
-    @IR(counts = { IRNode.VFMSB_MASKED, ">= 1" })
+    @IR(applyIfPlatform = {"aarch64", "true"}, counts = { IRNode.VFMSB_MASKED, ">= 1" })
+    @IR(applyIfPlatform = {"riscv64", "true"}, counts = { IRNode.RISCV_VFNMSUB_MASKED, ">= 1" })
     public static void testDoubleMultiplySubMasked() {
         VectorMask<Double> mask = VectorMask.fromArray(D_SPECIES, m, 0);
         for (int i = 0; i < LENGTH; i += D_SPECIES.length()) {
@@ -426,7 +434,8 @@ public class VectorFusedMultiplyAddSubTest {
     }
 
     @Test
-    @IR(counts = { IRNode.VFMAD_MASKED, ">= 1" })
+    @IR(applyIfPlatform = {"aarch64", "true"}, counts = { IRNode.VFMAD_MASKED, ">= 1" })
+    @IR(applyIfPlatform = {"riscv64", "true"}, counts = { IRNode.RISCV_VFMADD_MASKED, ">= 1" })
     public static void testDoubleMultiplyNegAMasked() {
         VectorMask<Double> mask = VectorMask.fromArray(D_SPECIES, m, 0);
         for (int i = 0; i < LENGTH; i += D_SPECIES.length()) {
@@ -439,7 +448,8 @@ public class VectorFusedMultiplyAddSubTest {
     }
 
     @Test
-    @IR(counts = { IRNode.VFNMAD_MASKED, ">= 1" })
+    @IR(applyIfPlatform = {"aarch64", "true"}, counts = { IRNode.VFNMAD_MASKED, ">= 1" })
+    @IR(applyIfPlatform = {"riscv64", "true"}, counts = { IRNode.RISCV_VFNMADD_MASKED, ">= 1" })
     public static void testDoubleNegatedMultiplyAddMasked() {
         VectorMask<Double> mask = VectorMask.fromArray(D_SPECIES, m, 0);
         for (int i = 0; i < LENGTH; i += D_SPECIES.length()) {
@@ -452,7 +462,8 @@ public class VectorFusedMultiplyAddSubTest {
     }
 
     @Test
-    @IR(counts = { IRNode.VFNMSB_MASKED, ">= 1" })
+    @IR(applyIfPlatform = {"aarch64", "true"}, counts = { IRNode.VFNMSB_MASKED, ">= 1" })
+    @IR(applyIfPlatform = {"riscv64", "true"}, counts = { IRNode.RISCV_VFMSUB_MASKED, ">= 1" })
     public static void testDoubleNegatedMultiplyNegAMasked() {
         VectorMask<Double> mask = VectorMask.fromArray(D_SPECIES, m, 0);
         for (int i = 0; i < LENGTH; i += D_SPECIES.length()) {
@@ -465,7 +476,8 @@ public class VectorFusedMultiplyAddSubTest {
     }
 
     @Test
-    @IR(counts = { IRNode.VFNMSB_MASKED, ">= 1" })
+    @IR(applyIfPlatform = {"aarch64", "true"}, counts = { IRNode.VFNMSB_MASKED, ">= 1" })
+    @IR(applyIfPlatform = {"riscv64", "true"}, counts = { IRNode.RISCV_VFMSUB_MASKED, ">= 1" })
     public static void testDoubleNegatedMultiplySubMasked() {
         VectorMask<Double> mask = VectorMask.fromArray(D_SPECIES, m, 0);
         for (int i = 0; i < LENGTH; i += D_SPECIES.length()) {
@@ -479,8 +491,10 @@ public class VectorFusedMultiplyAddSubTest {
 
     public static void main(String[] args) {
         TestFramework testFramework = new TestFramework();
-        testFramework.setDefaultWarmup(5000)
-                     .addFlags("--add-modules=jdk.incubator.vector", "-XX:UseSVE=1")
-                     .start();
+        testFramework.setDefaultWarmup(5000).addFlags("--add-modules=jdk.incubator.vector");
+        if (Platform.isAArch64()) {
+            testFramework.addFlags("-XX:UseSVE=1");
+        }
+        testFramework.start();
     }
 }


### PR DESCRIPTION
Hi,
Can you help to review this patch?

API comibnation like `av.lanewise(VectorOperators.FMA, bv.neg(), cv, mask).intoArray(fr, i);` should be able to be optimized to some special instruct rather than a bunch of instructs.

We can not verify IR node (via `beforeMatchingNameRegex`) in PrintIdeal phase, as it does not mean that the special instruct are generated in FINAL CODE phase, it could be a combination of multiple different instruct.

As riscv use different instruct names, so I create new ones in IRNode.java. 

Thanks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8356642](https://bugs.openjdk.org/browse/JDK-8356642): RISC-V: enable hotspot/jtreg/compiler/vectorapi/VectorFusedMultiplyAddSubTest.java (**Enhancement** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Feilong Jiang](https://openjdk.org/census#fjiang) (@feilongjiang - Committer)
 * [Manuel Hässig](https://openjdk.org/census#mhaessig) (@mhaessig - Author)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25145/head:pull/25145` \
`$ git checkout pull/25145`

Update a local copy of the PR: \
`$ git checkout pull/25145` \
`$ git pull https://git.openjdk.org/jdk.git pull/25145/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25145`

View PR using the GUI difftool: \
`$ git pr show -t 25145`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25145.diff">https://git.openjdk.org/jdk/pull/25145.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25145#issuecomment-2871485327)
</details>
