### PR TITLE
8347570: Configure fails on macOS if directory name do not have correct case

### DIFF
--- a/make/autoconf/basic.m4
+++ b/make/autoconf/basic.m4
@@ -416,11 +416,10 @@ AC_DEFUN_ONCE([BASIC_SETUP_OUTPUT_DIR],
 
   # Test from where we are running configure, in or outside of src root.
   if test "x$OPENJDK_BUILD_OS" = xwindows || test "x$OPENJDK_BUILD_OS" = "xmacosx"; then
-    # These systems have case insensitive paths. Use bash variable substitution
-    # to convert paths to all lower case
-    cmp_configure_start_dir="${CONFIGURE_START_DIR,,}"
-    cmp_topdir="${TOPDIR,,}"
-    cmp_custom_root="${CUSTOM_ROOT,,}"
+    # These systems have case insensitive paths, so convert them to lower case.
+    [ cmp_configure_start_dir=`$ECHO $CONFIGURE_START_DIR | $TR '[:upper:]' '[:lower:]'` ]
+    [ cmp_topdir=`$ECHO $TOPDIR | $TR '[:upper:]' '[:lower:]'` ]
+    [ cmp_custom_root=`$ECHO $CUSTOM_ROOT | $TR '[:upper:]' '[:lower:]'` ]
   else
     cmp_configure_start_dir="$CONFIGURE_START_DIR"
     cmp_topdir="$TOPDIR"

--- a/make/autoconf/basic.m4
+++ b/make/autoconf/basic.m4
@@ -415,11 +415,22 @@ AC_DEFUN_ONCE([BASIC_SETUP_OUTPUT_DIR],
       [ CONF_NAME=${with_conf_name} ])
 
   # Test from where we are running configure, in or outside of src root.
+  if test "x$OPENJDK_BUILD_OS" = xwindows || test "x$OPENJDK_BUILD_OS" = "xmacosx"; then
+    # These systems have case insensitive paths. Use bash variable substitution
+    # to convert paths to all lower case
+    cmp_configure_start_dir="${CONFIGURE_START_DIR,,}"
+    cmp_topdir="${TOPDIR,,}"
+    cmp_custom_root="${CUSTOM_ROOT,,}"
+  else
+    cmp_configure_start_dir="$CONFIGURE_START_DIR"
+    cmp_topdir="$TOPDIR"
+    cmp_custom_root="$CUSTOM_ROOT"
+  fi
   AC_MSG_CHECKING([where to store configuration])
-  if test "x$CONFIGURE_START_DIR" = "x$TOPDIR" \
-      || test "x$CONFIGURE_START_DIR" = "x$CUSTOM_ROOT" \
-      || test "x$CONFIGURE_START_DIR" = "x$TOPDIR/make/autoconf" \
-      || test "x$CONFIGURE_START_DIR" = "x$TOPDIR/make" ; then
+  if test "x$cmp_configure_start_dir" = "x$cmp_topdir" \
+      || test "x$cmp_configure_start_dir" = "x$cmp_custom_root" \
+      || test "x$cmp_configure_start_dir" = "x$cmp_topdir/make/autoconf" \
+      || test "x$cmp_configure_start_dir" = "x$cmp_topdir/make" ; then
     # We are running configure from the src root.
     # Create a default ./build/target-variant-debuglevel output root.
     if test "x${CONF_NAME}" = x; then
@@ -440,7 +451,12 @@ AC_DEFUN_ONCE([BASIC_SETUP_OUTPUT_DIR],
     # If configuration is situated in normal build directory, just use the build
     # directory name as configuration name, otherwise use the complete path.
     if test "x${CONF_NAME}" = x; then
-      CONF_NAME=`$ECHO $CONFIGURE_START_DIR | $SED -e "s!^${TOPDIR}/build/!!"`
+      [ if [[ "$cmp_configure_start_dir" =~ ^${cmp_topdir}/build/[^/]+$ ||
+          "$cmp_configure_start_dir" =~ ^${cmp_custom_root}/build/[^/]+$ ]]; then ]
+          CONF_NAME="${CONFIGURE_START_DIR##*/}"
+      else
+          CONF_NAME="$CONFIGURE_START_DIR"
+      fi
     fi
     OUTPUTDIR="$CONFIGURE_START_DIR"
     AC_MSG_RESULT([in current directory])


### PR DESCRIPTION
If you have a directory `OpenJDK` and do `cd openjdk`, this will register the current directory as `openjdk`, not `OpenJDK`. This will later on make the check in configure to see if we are in the root directory (to determine where to put the configuration) will fail, since it does a case-sensitive comparison.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347570](https://bugs.openjdk.org/browse/JDK-8347570): Configure fails on macOS if directory name do not have correct case (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25146/head:pull/25146` \
`$ git checkout pull/25146`

Update a local copy of the PR: \
`$ git checkout pull/25146` \
`$ git pull https://git.openjdk.org/jdk.git pull/25146/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25146`

View PR using the GUI difftool: \
`$ git pr show -t 25146`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25146.diff">https://git.openjdk.org/jdk/pull/25146.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25146#issuecomment-2866695940)
</details>
