### PR TITLE
8354674: AArch64: Intrinsify Unsafe::setMemory

### DIFF
--- a/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
@@ -2602,6 +2602,23 @@ class StubGenerator: public StubCodeGenerator {
 
     __ dup(v0, __ T16B, value);
 
+    if (AvoidUnalignedAccesses) {
+      __ cmp(count, (u1)16);
+      __ br(__ LS, tail);
+
+      Label aligned;
+
+      __ neg(rscratch1, dest);
+      __ andr(rscratch1, rscratch1, 15);  // Bytes needed to 16-align dest
+      __ cbz(rscratch1, aligned);
+
+      __ strq(v0, Address(dest));
+      __ sub(count, count, rscratch1);
+      __ add(dest, dest, rscratch1);
+
+      __ bind(aligned);
+    }
+
     __ subs(count, count, (u1)64);
     __ br(__ LO, tail);
     {

--- a/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
@@ -2604,14 +2604,13 @@ class StubGenerator: public StubCodeGenerator {
 
     if (AvoidUnalignedAccesses) {
       __ cmp(count, (u1)16);
-      __ br(__ LS, tail);
+      __ br(__ LO, tail);
 
       Label aligned;
 
-      __ neg(rscratch1, dest);
-      __ andr(rscratch1, rscratch1, 15);  // Bytes needed to 16-align dest
-      __ cbz(rscratch1, aligned);
-
+      __ mov(rscratch1, 16);
+      __ andr(rscratch2, dest, 15);
+      __ sub(rscratch1, rscratch1, rscratch2);  // Bytes needed to 16-align dest
       __ strq(v0, Address(dest));
       __ sub(count, count, rscratch1);
       __ add(dest, dest, rscratch1);

--- a/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
@@ -2616,6 +2616,9 @@ class StubGenerator: public StubCodeGenerator {
     }
 
     __ bind(tail);
+    // The count of bytes is off by 64, but we don't need to correct
+    // it because we're only going to use the least-significant few
+    // count bits from here on.
     // __ add(count, count, 64);
 
     {
@@ -2641,9 +2644,8 @@ class StubGenerator: public StubCodeGenerator {
     __ tst(count, 7);
     __ br(__ EQ, finished);
 
-    __ orr(value, value, value, __ LSL, 8);
-    __ orr(value, value, value, __ LSL, 16);
-
+    __ bfi(value, value, 8, 8);
+    __ bfi(value, value, 16, 16);
     {
       Label dont;
       __ tbz(count, exact_log2(4), dont);

--- a/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
@@ -2644,17 +2644,16 @@ class StubGenerator: public StubCodeGenerator {
     __ tst(count, 7);
     __ br(__ EQ, finished);
 
-    __ bfi(value, value, 8, 8);
-    __ bfi(value, value, 16, 16);
     {
       Label dont;
       __ tbz(count, exact_log2(4), dont);
-      __ strw(value, __ post(dest, 4));
+      __ strs(v0, __ post(dest, 4));
       __ bind(dont);
     }
     {
       Label dont;
       __ tbz(count, exact_log2(2), dont);
+      __ bfi(value, value, 8, 8);
       __ strh(value, __ post(dest, 2));
       __ bind(dont);
     }

--- a/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
@@ -2606,16 +2606,12 @@ class StubGenerator: public StubCodeGenerator {
       __ cmp(count, (u1)16);
       __ br(__ LO, tail);
 
-      Label aligned;
-
       __ mov(rscratch1, 16);
       __ andr(rscratch2, dest, 15);
       __ sub(rscratch1, rscratch1, rscratch2);  // Bytes needed to 16-align dest
       __ strq(v0, Address(dest));
       __ sub(count, count, rscratch1);
       __ add(dest, dest, rscratch1);
-
-      __ bind(aligned);
     }
 
     __ subs(count, count, (u1)64);

--- a/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
@@ -79,9 +79,7 @@
 
 #define BIND(label) bind(label); BLOCK_COMMENT(#label ":")
 
-  int ppp;
-
-  // Stub Code definitions
+// Stub Code definitions
 
 class StubGenerator: public StubCodeGenerator {
  private:

--- a/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
@@ -2568,90 +2568,6 @@ class StubGenerator: public StubCodeGenerator {
     return start;
   }
 
-  address generate_unsafecopy_common_error_exit() {
-    address start_pc = __ pc();
-      __ mov(r0, 0);
-      __ ret(lr);
-    return start_pc;
-  }
-
-  // Helper for generate_unsafe_setmemory
-  //
-  // Atomically fill an array of memory using 1-, 2-, 4-, or 8-byte chunks and return.
-  static void do_setmemory_atomic_loop(int elem_size, Register dest, Register size, Register byteVal,
-                                       MacroAssembler *_masm) {
-    __ andr(rscratch1, byteVal, (u1)0xff);
-    if (elem_size > 8) {
-      __ dup(v0, __ T16B, byteVal);
-    } else {
-      if (elem_size > 1)  __ orr(rscratch1, rscratch1, rscratch1, __ LSL, 8);
-      if (elem_size > 2)  __ orr(rscratch1, rscratch1, rscratch1, __ LSL, 16);
-      if (elem_size > 4)  __ orr(rscratch1, rscratch1, rscratch1, __ LSL, 32);
-    }
-
-    Label done, tail;
-
-    int shift = exact_log2(elem_size);
-
-    __ lsr(size, size, shift);
-
-    __ tst(size, -2);
-    __ br(__ EQ, tail);
-
-    {
-      Label again;
-      __ subs(size, size, 2);
-      __ br(__ LO, tail);
-      __ bind(again);
-      switch(elem_size) {
-        case 1:
-        case 2:
-          __ ld_st2(rscratch1, Address(dest,         0), shift, 0);
-          __ ld_st2(rscratch1, Address(dest, elem_size), shift, 0);
-          break;
-        case 4:
-          __ stpw(rscratch1, rscratch1, Address(dest));
-          break;
-        case 8:
-          __ stp(rscratch1, rscratch1, Address(dest));
-          break;
-        case 32:
-          __ stpq(v0, v0, Address(dest));
-          __ stpq(v0, v0, Address(dest, 32));
-          break;
-        default:
-          ShouldNotReachHere();
-      }
-      __ subs(size, size, 2);
-      __ add(dest, dest, elem_size * 2);
-      __ br(__ HS, again);
-    }
-
-    {
-      Label one;
-      __ bind(tail);
-      __ tbnz(size, 0, one);
-      __ b(done);
-
-      __ bind(one);
-      switch(elem_size) {
-        case 1:
-        case 2:
-        case 4:
-        case 8:
-          __ ld_st2(rscratch1, Address(dest,     0), shift, 0);
-          break;
-        case 32:
-          __ stpq(v0, v0, Address(dest));
-          break;
-        default:
-          ShouldNotReachHere();
-      }
-    }
-
-    __ bind(done);
-    __ ret(lr);
-  }
 
   //
   //  Generate 'unsafe' set memory stub
@@ -2667,7 +2583,7 @@ class StubGenerator: public StubCodeGenerator {
   //    c_rarg1   - byte count (size_t)
   //    c_rarg2   - byte value
   //
-  address better_generate_unsafe_setmemory() {
+  address generate_unsafe_setmemory() {
     __ align(CodeEntryAlignment);
     StubCodeMark mark(this, StubGenStubId::unsafe_setmemory_id);
     address start = __ pc();
@@ -2676,11 +2592,6 @@ class StubGenerator: public StubCodeGenerator {
     Label tail;
 
     UnsafeMemoryAccessMark umam(this, true, false);
-
-#ifdef ASSERT
-    __ mov(rscratch1, (uintptr_t)&ppp);
-    __ addmw(Address(rscratch1), 1, rscratch2);
-#endif
 
     __ dup(v0, __ T16B, value);
 
@@ -2751,88 +2662,6 @@ class StubGenerator: public StubCodeGenerator {
     return start;
   }
 
-
-
-  //
-  //  Generate 'unsafe' set memory stub
-  //  Though just as safe as the other stubs, it takes an unscaled
-  //  size_t (# bytes) argument instead of an element count.
-  //
-  //  Input:
-  //    c_rarg0   - destination array address
-  //    c_rarg1   - byte count (size_t)
-  //    c_rarg2   - byte value
-  //
-  address generate_unsafe_setmemory(address unsafe_byte_fill) {
-    __ align(CodeEntryAlignment);
-    StubCodeMark mark(this, StubGenStubId::unsafe_setmemory_id);
-    address start = __ pc();
-
-    // bump this on entry, not on exit:
-    // inc_counter_np(SharedRuntime::_unsafe_set_memory_ctr);
-
-    // Mark remaining code as such which performs Unsafe accesses.
-    UnsafeMemoryAccessMark umam(this, true, false);
-
-    {
-      Label L_fill8Bytes, L_fill4Bytes, L_fillBytes;
-
-      const Register dest = c_rarg0;
-      const Register size = c_rarg1;
-      const Register byteVal = c_rarg2;
-
-      // fill_to_memory_atomic(unsigned char*, unsigned long, unsigned char)
-
-      {
-        Label small;
-        __ cmp(size, (u1)64);
-        __ br(__ LT, small);
-        __ mov(rscratch2, size);
-        __ andr(size, size, 31);
-        do_setmemory_atomic_loop(32, dest, rscratch2, byteVal, _masm);
-        __ bind(small);
-      }
-
-      // Check for pointer & size alignment
-      __ orr(rscratch1, dest, size);
-
-      __ tst(rscratch1, (u1)7);
-      __ br(__ EQ, L_fill8Bytes);
-
-      __ tst(rscratch1, (u1)3);
-      __ br(__ EQ, L_fill4Bytes);
-
-      __ tst(rscratch1, 1);
-      __ br(__ NE, L_fillBytes);
-
-      // At this point, we know the lower bit of size is zero and a
-      // multiple of 2
-      do_setmemory_atomic_loop(2, dest, size, byteVal, _masm);
-      __ ret(lr);
-
-      __ align(32);
-      __ bind(L_fill8Bytes);
-      // At this point, we know the lower 3 bits of size are zero and a
-      // multiple of 8
-      do_setmemory_atomic_loop(8, dest, size, byteVal, _masm);
-      __ ret(lr);
-
-      __ align(32);
-      __ bind(L_fill4Bytes);
-      // At this point, we know the lower 2 bits of size are zero and a
-      // multiple of 4
-      do_setmemory_atomic_loop(4, dest, size, byteVal, _masm);
-      __ ret(lr);
-
-      __ align(32);
-      __ bind(L_fillBytes);
-      do_setmemory_atomic_loop(1, dest, size, byteVal, _masm);
-      __ ret(lr);
-    }
-
-    return start;
-  }
-
   address generate_data_cache_writeback() {
     const Register line        = c_rarg0;  // address of line to write back
 
@@ -2881,9 +2710,6 @@ class StubGenerator: public StubCodeGenerator {
     address entry_oop_arraycopy;
     address entry_jlong_arraycopy;
     address entry_checkcast_arraycopy;
-
-    address ucm_common_error_exit       =  generate_unsafecopy_common_error_exit();
-    UnsafeMemoryAccess::set_common_exit_stub_pc(ucm_common_error_exit);
 
     generate_copy_longs(StubGenStubId::copy_byte_f_id, IN_HEAP | IS_ARRAY, copy_f, r0, r1, r15);
     generate_copy_longs(StubGenStubId::copy_byte_b_id, IN_HEAP | IS_ARRAY, copy_b, r0, r1, r15);
@@ -11523,7 +11349,7 @@ class StubGenerator: public StubCodeGenerator {
     }
 #endif
 
-    StubRoutines::_unsafe_setmemory = better_generate_unsafe_setmemory();
+    StubRoutines::_unsafe_setmemory = generate_unsafe_setmemory();
 
     StubRoutines::aarch64::set_completed(); // Inidicate that arraycopy and zero_blocks stubs are generated
   }

--- a/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
@@ -2566,6 +2566,12 @@ class StubGenerator: public StubCodeGenerator {
     return start;
   }
 
+  address generate_unsafecopy_common_error_exit() {
+    address start_pc = __ pc();
+      __ mov(r0, 0);
+      __ ret(lr);
+    return start_pc;
+  }
 
   //
   //  Generate 'unsafe' set memory stub
@@ -2708,6 +2714,9 @@ class StubGenerator: public StubCodeGenerator {
     address entry_oop_arraycopy;
     address entry_jlong_arraycopy;
     address entry_checkcast_arraycopy;
+
+    address ucm_common_error_exit       =  generate_unsafecopy_common_error_exit();
+    UnsafeMemoryAccess::set_common_exit_stub_pc(ucm_common_error_exit);
 
     generate_copy_longs(StubGenStubId::copy_byte_f_id, IN_HEAP | IS_ARRAY, copy_f, r0, r1, r15);
     generate_copy_longs(StubGenStubId::copy_byte_b_id, IN_HEAP | IS_ARRAY, copy_b, r0, r1, r15);

--- a/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
@@ -2568,6 +2568,7 @@ class StubGenerator: public StubCodeGenerator {
 
   address generate_unsafecopy_common_error_exit() {
     address start_pc = __ pc();
+      __ leave();
       __ mov(r0, 0);
       __ ret(lr);
     return start_pc;
@@ -2597,6 +2598,8 @@ class StubGenerator: public StubCodeGenerator {
 
     UnsafeMemoryAccessMark umam(this, true, false);
 
+    __ enter(); // required for proper stackwalking of RuntimeStub frame
+
     __ dup(v0, __ T16B, value);
 
     __ subs(count, count, (u1)64);
@@ -2613,7 +2616,7 @@ class StubGenerator: public StubCodeGenerator {
     }
 
     __ bind(tail);
-    __ add(count, count, 64);
+    // __ add(count, count, 64);
 
     {
       Label dont;
@@ -2661,6 +2664,7 @@ class StubGenerator: public StubCodeGenerator {
     }
 
     __ bind(finished);
+    __ leave();
     __ ret(lr);
 
     return start;

--- a/src/java.base/share/classes/jdk/internal/foreign/SegmentBulkOperations.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/SegmentBulkOperations.java
@@ -53,7 +53,7 @@ public final class SegmentBulkOperations {
 
     // All the threshold values below MUST be a power of two and should preferably be
     // greater or equal to 2^3.
-    private static final int NATIVE_THRESHOLD_FILL = powerOfPropertyOr("fill", Architecture.isAARCH64() ? 18 : 5);
+    private static final int NATIVE_THRESHOLD_FILL = powerOfPropertyOr("fill", 5);
     private static final int NATIVE_THRESHOLD_MISMATCH = powerOfPropertyOr("mismatch", 6);
     private static final int NATIVE_THRESHOLD_COPY = powerOfPropertyOr("copy", 6);
 

--- a/test/micro/org/openjdk/bench/java/lang/foreign/MemorySegmentFillUnsafe.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/MemorySegmentFillUnsafe.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+ package org.openjdk.bench.java.lang.foreign;
+
+import jdk.internal.misc.Unsafe;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Setup;
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.AverageTime)
+@Warmup(iterations = 5, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@State(org.openjdk.jmh.annotations.Scope.Thread)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(value = 3, jvmArgs = {"--enable-native-access=ALL-UNNAMED", "--add-opens=java.base/jdk.internal.misc=ALL-UNNAMED"})
+public class MemorySegmentFillUnsafe {
+
+    static final Unsafe UNSAFE = Utils.unsafe;
+    long src;
+
+    @Param({"1", "2", "3", "4", "5", "6", "7", "8", "15", "16", "63", "64", "255", "256"})
+    public int size;
+
+    @Param({"true", "false"})
+    public boolean aligned;
+
+    private MemorySegment segment;
+    private long address;
+
+    @Setup
+    public void setup() throws Throwable {
+        Arena arena = Arena.global();
+        long alignment = 1;
+        // this complex logic is to ensure that if in the future we decide to batch writes with different
+        // batches based on alignment, we would spot it here
+        if (size == 2 || size == 3) {
+            alignment = 2;
+        } else if (size >= 4 && size <= 7) {
+            alignment = 4;
+        } else {
+            alignment = 8;
+        }
+        if (aligned) {
+            segment = arena.allocate(size, alignment);
+        } else {
+            // forcibly misaligned in both address AND size, given that would be the worst case
+            segment = arena.allocate(size + 1, alignment).asSlice(1);
+        }
+        address = segment.address();
+    }
+
+    @Benchmark
+    public void panama() {
+        segment.fill((byte) 99);
+    }
+
+    @Benchmark
+    public void unsafe() {
+        UNSAFE.setMemory(address, size, (byte) 99);
+    }
+}

--- a/test/micro/org/openjdk/bench/java/lang/foreign/MemorySegmentFillUnsafe.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/MemorySegmentFillUnsafe.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/micro/org/openjdk/bench/java/lang/foreign/MemorySegmentFillUnsafe.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/MemorySegmentFillUnsafe.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2025 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
This intrinsic is generally faster than the current implementation for Panama segment operations for all writes larger than about 8 bytes in size, increasing to more than 2* the performance on larger memory blocks on Graviton 2, between "panama" (C2 generated, what we use now) and "unsafe" (this intrinsic).

```
Benchmark                       (aligned)  (size)  Mode  Cnt     Score    Error  Units
MemorySegmentFillUnsafe.panama       true  262143  avgt   10  7295.638 ±  0.422  ns/op
MemorySegmentFillUnsafe.panama      false  262143  avgt   10  8345.300 ± 80.161  ns/op
MemorySegmentFillUnsafe.unsafe       true  262143  avgt   10  2930.594 ±  0.180  ns/op
MemorySegmentFillUnsafe.unsafe      false  262143  avgt   10  3136.828 ±  0.232  ns/op
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8354674](https://bugs.openjdk.org/browse/JDK-8354674): AArch64: Intrinsify Unsafe::setMemory (**Enhancement** - P4)


### Reviewers
 * [Andrew Dinn](https://openjdk.org/census#adinn) (@adinn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25147/head:pull/25147` \
`$ git checkout pull/25147`

Update a local copy of the PR: \
`$ git checkout pull/25147` \
`$ git pull https://git.openjdk.org/jdk.git pull/25147/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25147`

View PR using the GUI difftool: \
`$ git pr show -t 25147`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25147.diff">https://git.openjdk.org/jdk/pull/25147.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25147#issuecomment-2866716397)
</details>
