### PR TITLE
8351958: Some compile commands should be made diagnostic

### DIFF
--- a/test/hotspot/jtreg/compiler/compilercontrol/commands/OptionTest.java
+++ b/test/hotspot/jtreg/compiler/compilercontrol/commands/OptionTest.java
@@ -37,13 +37,13 @@ import jdk.test.lib.process.ProcessTools;
 
 public class OptionTest {
     public static void main(String[] args) throws Exception {
-        ProcessTools.executeTestJava("-XX:CompileCommand=option,package/class,ccstrlist,ControlIntrinsic,+_getClass", "-version")
+        ProcessTools.executeTestJava("-XX:+UnlockDiagnosticVMOptions", "-XX:CompileCommand=option,package/class,ccstrlist,ControlIntrinsic,+_getClass", "-version")
                     .shouldHaveExitValue(1)
                     .shouldContain("CompileCommand: An error occurred during parsing")
                     .shouldContain("Error: Did not specify any method name")
                     .shouldNotContain("# A fatal error has been detected by the Java Runtime Environment");
 
-        ProcessTools.executeTestJava("-XX:CompileCommand=option,*,ccstrlist,ControlIntrinsic,+_getClass", "-version")
+        ProcessTools.executeTestJava("-XX:+UnlockDiagnosticVMOptions", "-XX:CompileCommand=option,*,ccstrlist,ControlIntrinsic,+_getClass", "-version")
                     .shouldHaveExitValue(1)
                     .shouldContain("CompileCommand: An error occurred during parsing")
                     .shouldContain("Error: Did not specify any method name")
@@ -51,24 +51,24 @@ public class OptionTest {
 
         // corner case:
         // ccstrlist could be a valid method name, so it is accepted in the well-formed case.
-        ProcessTools.executeTestJava("-XX:CompileCommand=option,*.ccstrlist,ccstrlist,ControlIntrinsic,+_getClass", "-version")
+        ProcessTools.executeTestJava("-XX:+UnlockDiagnosticVMOptions", "-XX:CompileCommand=option,*.ccstrlist,ccstrlist,ControlIntrinsic,+_getClass", "-version")
                     .shouldContain("CompileCommand: ControlIntrinsic *.ccstrlist const char* ControlIntrinsic")
                     .shouldHaveExitValue(0)
                     .shouldNotContain("# A fatal error has been detected by the Java Runtime Environment");
 
 
-        ProcessTools.executeTestJava("-XX:CompileCommand=option,*.*,ccstrlist,ControlIntrinsic,+_getClass", "-version")
+        ProcessTools.executeTestJava("-XX:+UnlockDiagnosticVMOptions", "-XX:CompileCommand=option,*.*,ccstrlist,ControlIntrinsic,+_getClass", "-version")
                     .shouldContain("CompileCommand: ControlIntrinsic *.* const char* ControlIntrinsic")
                     .shouldHaveExitValue(0)
                     .shouldNotContain("# A fatal error has been detected by the Java Runtime Environment");
 
-        ProcessTools.executeTestJava("-XX:CompileCommand=option,class,PrintIntrinsics", "-version")
+        ProcessTools.executeTestJava("-XX:+UnlockDiagnosticVMOptions", "-XX:CompileCommand=option,class,PrintIntrinsics", "-version")
                     .shouldHaveExitValue(0)
                     .shouldNotContain("# A fatal error has been detected by the Java Runtime Environment");
 
         // corner case:
         // PrintIntrinsics could be a valid method name, so it is accepted in the well-formed case.
-        ProcessTools.executeTestJava("-XX:CompileCommand=option,class.PrintIntrinsics,PrintIntrinsics", "-version")
+        ProcessTools.executeTestJava("-XX:+UnlockDiagnosticVMOptions", "-XX:CompileCommand=option,class.PrintIntrinsics,PrintIntrinsics", "-version")
                     .shouldContain("CompileCommand: PrintIntrinsics class.PrintIntrinsics bool PrintIntrinsics = true")
                     .shouldHaveExitValue(0)
                     .shouldNotContain("# A fatal error has been detected by the Java Runtime Environment");

--- a/test/hotspot/jtreg/compiler/intrinsics/bigInteger/TestMultiplyToLen.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/bigInteger/TestMultiplyToLen.java
@@ -29,6 +29,7 @@
  *
  * @library /test/lib
  * @run main/othervm/timeout=600 -XX:-TieredCompilation -Xbatch
+ *      -XX:+UnlockDiagnosticVMOptions
  *      -XX:CompileCommand=exclude,compiler.intrinsics.bigInteger.TestMultiplyToLen::main
  *      -XX:CompileCommand=option,compiler.intrinsics.bigInteger.TestMultiplyToLen::base_multiply,ccstrlist,DisableIntrinsic,_multiplyToLen
  *      -XX:CompileCommand=option,java.math.BigInteger::multiply,ccstrlist,DisableIntrinsic,_multiplyToLen

--- a/test/hotspot/jtreg/compiler/intrinsics/bigInteger/TestShift.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/bigInteger/TestShift.java
@@ -30,6 +30,7 @@
  * @requires vm.compiler2.enabled
  *
  * @run main/othervm/timeout=600 -XX:-TieredCompilation -Xbatch
+ *      -XX:+UnlockDiagnosticVMOptions
  *      -XX:CompileCommand=exclude,compiler.intrinsics.bigInteger.TestShift::main
  *      -XX:CompileCommand=option,compiler.intrinsics.bigInteger.TestShift::base_left_shift,ccstrlist,DisableIntrinsic,_bigIntegerLeftShiftWorker
  *      -XX:CompileCommand=option,compiler.intrinsics.bigInteger.TestShift::base_right_shift,ccstrlist,DisableIntrinsic,_bigIntegerRightShiftWorker
@@ -38,6 +39,7 @@
  *      compiler.intrinsics.bigInteger.TestShift
  *
  * @run main/othervm/timeout=600
+ *      -XX:+UnlockDiagnosticVMOptions
  *      -XX:CompileCommand=exclude,compiler.intrinsics.bigInteger.TestShift::main
  *      -XX:CompileCommand=option,compiler.intrinsics.bigInteger.TestShift::base_left_shift,ccstrlist,DisableIntrinsic,_bigIntegerLeftShiftWorker
  *      -XX:CompileCommand=option,compiler.intrinsics.bigInteger.TestShift::base_right_shift,ccstrlist,DisableIntrinsic,_bigIntegerRightShiftWorker

--- a/test/hotspot/jtreg/compiler/intrinsics/bigInteger/TestSquareToLen.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/bigInteger/TestSquareToLen.java
@@ -29,6 +29,7 @@
  * @library /test/lib
  *
  * @run main/othervm/timeout=600 -XX:-TieredCompilation -Xbatch
+ *      -XX:+UnlockDiagnosticVMOptions
  *      -XX:CompileCommand=exclude,compiler.intrinsics.bigInteger.TestSquareToLen::main
  *      -XX:CompileCommand=option,compiler.intrinsics.bigInteger.TestSquareToLen::base_multiply,ccstrlist,DisableIntrinsic,_squareToLen
  *      -XX:CompileCommand=option,java.math.BigInteger::multiply,ccstrlist,DisableIntrinsic,_squareToLen

--- a/test/hotspot/jtreg/runtime/CommandLine/VMOptionWarning.java
+++ b/test/hotspot/jtreg/runtime/CommandLine/VMOptionWarning.java
@@ -44,6 +44,17 @@
  * @run driver VMOptionWarning Diagnostic
  */
 
+/* @test VMCompileCommandWarningDiagnostic
+ * @bug 8027314
+ * @summary Warn if compile command that is an alias for a diagnostic vm option is used and -XX:+UnlockDiagnosticVMOptions isn't specified.
+ * @requires vm.flagless
+ * @requires ! vm.debug
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ *          java.management
+ * @run driver VMOptionWarning DiagnosticCompileCommand
+ */
+
 /* @test VMOptionWarningDevelop
  * @bug 8027314
  * @summary Warn if develop vm option is used with product version of VM.
@@ -80,6 +91,13 @@ public class VMOptionWarning {
                 output = new OutputAnalyzer(pb.start());
                 output.shouldNotHaveExitValue(0);
                 output.shouldContain("Error: VM option 'PrintInlining' is diagnostic and must be enabled via -XX:+UnlockDiagnosticVMOptions.");
+                break;
+            }
+            case "DiagnosticCompileCommand": {
+                pb = ProcessTools.createLimitedTestJavaProcessBuilder("-XX:CompileCommand=PrintAssembly,*::*", "-version");
+                output = new OutputAnalyzer(pb.start());
+                output.shouldNotHaveExitValue(0);
+                output.shouldContain("Error: VM option 'PrintAssembly' is diagnostic and must be enabled via -XX:+UnlockDiagnosticVMOptions.");
                 break;
             }
             case "Develop": {


### PR DESCRIPTION
Error when using a `CompileCommand` that is an alias for a diagnostic option when `-XX:+UnlockDiagnosticVMOptions` is not provided.

The argument processing works this way:
1. Flags are parsed, setting the value accordingly. For `CompileCommand`, each option is added to a  `\n`-separated string. At this step, if a flag is diagnostic but `-XX:+UnlockDiagnosticVMOptions` is not provided, then an error message is emitted, argument parsing fails and the VM terminates. Yet, the value of `CompileCommand` is still an unparsed list of string.
2. Eventually, `CompileCommand` is parsed. For some of them, the value of regular flag is used as the default value, and as far as I know, it's the only mapping between `CompileCommand` and the equivalent flag. Moreover, at this point, the order of the various command line arguments is lost: it is not possible to know which `CompileCommand` comes before or after the `-XX:+UnlockDiagnosticVMOptions`.

Moreover, `CompileCommand` are parsed in the same way as compiler directives coming from a file. If we complain about diagnostic `CompileCommand`, we should also when coming from a directive file, for consistency. But then, while the relative order of `CompileCommand` and `-XX:+UnlockDiagnosticVMOptions` is lost, it simply makes no sense to compare the ordering of command line arguments and directives from a file.

So, before the difficulty and the relative lack of sense, I defaulted to ignore the ordering requirement. And by using the `CompileCommand` error reporting mechanism, we get an error that is consistent with other `CompileCommand`-parsing related errors, e.g.
```
CompileCommand: An error occurred during parsing
Error: VM option 'PrintAssembly' is diagnostic and must be enabled via -XX:+UnlockDiagnosticVMOptions.
Line: 'PrintAssembly,*::*'

Usage: '-XX:CompileCommand=<option>,<method pattern>' - to set boolean option to true
Usage: '-XX:CompileCommand=<option>,<method pattern>,<value>'
Use:   '-XX:CompileCommand=help' for more information and to list all option.

CompileCommand: compileonly Test.* bool compileonly = true
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.
```

The other problem is how to identify that a `CompileCommand` is an alias for a diagnostic flag. I refrained from hardcoding the list, but there is no nice mapping stating "this is an alias for...", only the default value for some:
https://github.com/openjdk/jdk/blob/9f9e73d5f9fcb5e926a2674c54cbbc92012b75f6/src/hotspot/share/compiler/compilerDirectives.hpp#L37-L60
But I couldn't recycle `compilerdirectives_common_flags` (or similar) to define this mapping because the alias is just the default value. It can also be a literal. While `PrintAssembly` is an alias for `PrintAssembly`, `MemLimit` is not an alias for `0`, it's just the default value. The best I could find is to assume that if there is a flag, it bears the same name. The only thing that looks like an exception is `Log` and `LogCompilation`, but actually, the `CompileCommand` `Log` requires the `LogCompilation` flag (which is diagnostic) to be set. So it is not actually an alias.