### PR TITLE
8356551: Javac rejects receiver parameter in constructor of local class in early construction context

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -4540,7 +4540,7 @@ public class Attr extends JCTree.Visitor {
                     return rs.resolveQualifiedMethod(
                         pos, env, location, site, name, resultInfo.pt.getParameterTypes(), resultInfo.pt.getTypeArguments());
                 } else if (name == names._this || name == names._super) {
-                    return rs.resolveSelf(pos, env, site.tsym, name);
+                    return rs.resolveSelf(pos, env, site.tsym, tree);
                 } else if (name == names._class) {
                     // In this case, we have already made sure in
                     // visitSelect that qualifier expression is a type.

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Resolve.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Resolve.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Resolve.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Resolve.java
@@ -3855,13 +3855,14 @@ public class Resolve {
      * Resolve `c.name' where name == this or name == super.
      * @param pos           The position to use for error reporting.
      * @param env           The environment current at the expression.
-     * @param c             The qualifier.
-     * @param name          The identifier's name.
+     * @param c             The type of the selected expression
+     * @param tree          The expression
      */
     Symbol resolveSelf(DiagnosticPosition pos,
                        Env<AttrContext> env,
                        TypeSymbol c,
-                       Name name) {
+                       JCFieldAccess tree) {
+        Name name = tree.name;
         Assert.check(name == names._this || name == names._super);
         Env<AttrContext> env1 = env;
         boolean staticOnly = false;
@@ -3872,7 +3873,9 @@ public class Resolve {
                 if (sym != null) {
                     if (staticOnly)
                         sym = new StaticError(sym);
-                    else if (env1.info.ctorPrologue && !isAllowedEarlyReference(pos, env1, (VarSymbol)sym))
+                    else if (env1.info.ctorPrologue &&
+                            !isReceiverParameter(env, tree) &&
+                            !isAllowedEarlyReference(pos, env1, (VarSymbol)sym))
                         sym = new RefBeforeCtorCalledError(sym);
                     return accessBase(sym, pos, env.enclClass.sym.type,
                             name, true);
@@ -3923,6 +3926,12 @@ public class Resolve {
             }
         }
         return result.toList();
+    }
+    private boolean isReceiverParameter(Env<AttrContext> env, JCFieldAccess tree) {
+        if (env.tree.getTag() != METHODDEF)
+            return false;
+        JCMethodDecl method = (JCMethodDecl)env.tree;
+        return method.recvparam != null && tree == method.recvparam.nameexpr;
     }
 
     /**

--- a/test/langtools/tools/javac/SuperInit/SuperInitGood.java
+++ b/test/langtools/tools/javac/SuperInit/SuperInitGood.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/langtools/tools/javac/SuperInit/SuperInitGood.java
+++ b/test/langtools/tools/javac/SuperInit/SuperInitGood.java
@@ -22,7 +22,7 @@
  */
 /*
  * @test
- * @bug 8194743
+ * @bug 8194743 8345438 8356551
  * @summary Test valid placements of super()/this() in constructors
  * @enablePreview
  */
@@ -454,7 +454,7 @@ public class SuperInitGood {
         }
     }
 
-    // Lambdas within constructors
+    // Lambdas within constructors (JDK-8345438)
     public static class Test22 {
         public Test22() {
             Runnable r = () -> System.out.println();
@@ -487,6 +487,18 @@ public class SuperInitGood {
             };
             r.run();
             super();
+        }
+    }
+
+    // Receiver parameter syntax (JDK-8356551)
+    public static class Test23 {
+        public Test23() {
+            class Local {
+                Local(Test23 Test23.this) {
+                }
+            }
+            super();
+            new Local();
         }
     }
 
@@ -535,5 +547,6 @@ public class SuperInitGood {
         new Test21((int)123);
         new Test21((float)123);
         new Test22('x');
+        new Test23();
     }
 }


### PR DESCRIPTION
Consider a class like this:
```java
class Outer {
  Outer() {
    class Local {
      Local(Outer Outer.this) {  // "receiver parameter"
      }
    }
    super();
  }
}
```
Normally, a reference to `Outer.this` appearing anywhere in `Local` would generate an error because `Local` is defined in an early construction context of `Outer`. But in the above example, `Outer.this` is a "receiver parameter", which is the relatively obscure mechanism by which type annotations can be added to the outer instance (JLS §8.4).

This is allowed, even though the outer instance is otherwise inaccessible here. However, the compiler was reporting an error. This PR adds an exception for receiver parameters to the illegal early access check. It also adds a missing bug ID to the regression test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8356551](https://bugs.openjdk.org/browse/JDK-8356551): Javac rejects receiver parameter in constructor of local class in early construction context (**Bug** - P4)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25153/head:pull/25153` \
`$ git checkout pull/25153`

Update a local copy of the PR: \
`$ git checkout pull/25153` \
`$ git pull https://git.openjdk.org/jdk.git pull/25153/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25153`

View PR using the GUI difftool: \
`$ git pr show -t 25153`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25153.diff">https://git.openjdk.org/jdk/pull/25153.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25153#issuecomment-2867341095)
</details>
