### PR TITLE
8356420: Provide examples on wrapping System.in

### DIFF
--- a/src/java.base/share/classes/java/io/InputStreamReader.java
+++ b/src/java.base/share/classes/java/io/InputStreamReader.java
@@ -47,15 +47,20 @@ import sun.nio.cs.StreamDecoder;
  * BufferedReader.  For example:
  *
  * {@snippet lang=java :
- *     BufferedReader in = new BufferedReader(
- *         new InputStreamReader(System.in, System.getProperty("stdin.encoding")));
+ *     BufferedReader in = new BufferedReader(new InputStreamReader(anInputStream));
  * }
- * This example also demonstrates how to wrap {@link System#in} with {@link
- * System##stdin.encoding stdin.encoding}.
+ *
+ * <P>To read from {@link System#in}, use the system property value
+ * {@link System##stdin.encoding stdin.encoding} as the {@code Charset}:
+ *
+ * {@snippet lang=java :
+ *     new InputStreamReader(System.in, System.getProperty("stdin.encoding"));
+ * }
  *
  * @see BufferedReader
  * @see InputStream
  * @see Charset
+ * @see System##stdin.encoding stdin.encoding
  *
  * @author      Mark Reinhold
  * @since       1.1

--- a/src/java.base/share/classes/java/io/InputStreamReader.java
+++ b/src/java.base/share/classes/java/io/InputStreamReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,8 +47,11 @@ import sun.nio.cs.StreamDecoder;
  * BufferedReader.  For example:
  *
  * {@snippet lang=java :
- *     BufferedReader in = new BufferedReader(new InputStreamReader(anInputStream));
+ *     BufferedReader in = new BufferedReader(
+ *         new InputStreamReader(System.in, System.getProperty("stdin.encoding")));
  * }
+ * This example also demonstrates how to wrap {@link System#in} with {@link
+ * System##stdin.encoding stdin.encoding}.
  *
  * @see BufferedReader
  * @see InputStream

--- a/src/java.base/share/classes/java/lang/System.java
+++ b/src/java.base/share/classes/java/lang/System.java
@@ -124,10 +124,19 @@ public final class System {
      *
      * @apiNote
      * The typical approach to read character data is to wrap {@code System.in}
-     * within an {@link java.io.InputStreamReader InputStreamReader} or other object
-     * that handles character encoding. After this is done, subsequent reading should
-     * use only the wrapper object; operating directly on {@code System.in} results
-     * in unspecified behavior.
+     * within the object that handles character encoding. After this is done,
+     * subsequent reading should use only the wrapper object; operating directly
+     * on {@code System.in} results in unspecified behavior.
+     * <p>
+     * Here are two common examples. Using an {@link java.io.InputStreamReader
+     * InputStreamReader}:
+     * {@snippet lang=java :
+     *     new InputStreamReader(System.in, System.getProperty("stdin.encoding"));
+     * }
+     * Or with a {@link java.util.Scanner Scanner}:
+     * {@snippet lang=java :
+     *     new Scanner(System.in, System.getProperty("stdin.encoding"));
+     * }
      * <p>
      * For handling interactive input, consider using {@link Console}.
      *

--- a/src/java.base/share/classes/java/lang/System.java
+++ b/src/java.base/share/classes/java/lang/System.java
@@ -125,8 +125,8 @@ public final class System {
      * @apiNote
      * The typical approach to read character data is to wrap {@code System.in}
      * within the object that handles character encoding. After this is done,
-     * subsequent reading should use only the wrapper object; operating directly
-     * on {@code System.in} results in unspecified behavior.
+     * subsequent reading should use only the wrapper object; continuing to
+     * operate directly on {@code System.in} results in unspecified behavior.
      * <p>
      * Here are two common examples. Using an {@link java.io.InputStreamReader
      * InputStreamReader}:

--- a/src/java.base/share/classes/java/lang/System.java
+++ b/src/java.base/share/classes/java/lang/System.java
@@ -133,7 +133,7 @@ public final class System {
      * {@snippet lang=java :
      *     new InputStreamReader(System.in, System.getProperty("stdin.encoding"));
      * }
-     * Or with a {@link java.util.Scanner Scanner}:
+     * Or using a {@link java.util.Scanner Scanner}:
      * {@snippet lang=java :
      *     new Scanner(System.in, System.getProperty("stdin.encoding"));
      * }

--- a/src/java.base/share/classes/java/util/Scanner.java
+++ b/src/java.base/share/classes/java/util/Scanner.java
@@ -91,7 +91,7 @@ import sun.util.locale.provider.ResourceBundleBasedAdapter;
  * {@code Scanner} uses the system property value of
  * {@link System##stdin.encoding stdin.encoding} as the {@code Charset}. Specifying
  * the charset explicitly is important when reading from {@code System.in}, as it
- * may differ from the {@link Charset#defaultCharset()} default charset} depending
+ * may differ from the {@link Charset#defaultCharset() default charset} depending
  * on the host environment or user configuration:
  * {@snippet :
  *      Scanner sc = new Scanner(System.in, System.getProperty("stdin.encoding"));

--- a/src/java.base/share/classes/java/util/Scanner.java
+++ b/src/java.base/share/classes/java/util/Scanner.java
@@ -78,22 +78,25 @@ import sun.util.locale.provider.ResourceBundleBasedAdapter;
  *     }
  * }
  *
- * <p>This code uses a {@code Scanner} to read lines from {@link System#in}. The
- * {@code Scanner} uses the system property value of
- * {@link System##stdin.encoding stdin.encoding} as the {@code Charset}:
- * {@snippet :
- *      Scanner sc = new Scanner(System.in, System.getProperty("stdin.encoding"));
- *      while (sc.hasNextLine()) {
- *          String aLine = sc.nextLine();
- *      }
- * }
- *
  * <p>This code allows {@code long} types to be
  * assigned from entries in a file {@code myNumbers}:
  * {@snippet :
  *      Scanner sc = new Scanner(new File("myNumbers"));
  *      while (sc.hasNextLong()) {
  *          long aLong = sc.nextLong();
+ *      }
+ * }
+ *
+ * <p>This code uses a {@code Scanner} to read lines from {@link System#in}. The
+ * {@code Scanner} uses the system property value of
+ * {@link System##stdin.encoding stdin.encoding} as the {@code Charset}. Specifying
+ * the charset explicitly is important when reading from {@code System.in}, as it
+ * may differ from the {@link Charset#defaultCharset()} default charset} depending
+ * on the host environment or user configuration:
+ * {@snippet :
+ *      Scanner sc = new Scanner(System.in, System.getProperty("stdin.encoding"));
+ *      while (sc.hasNextLine()) {
+ *          String aLine = sc.nextLine();
  *      }
  * }
  *

--- a/src/java.base/share/classes/java/util/Scanner.java
+++ b/src/java.base/share/classes/java/util/Scanner.java
@@ -78,8 +78,8 @@ import sun.util.locale.provider.ResourceBundleBasedAdapter;
  *     }
  * }
  *
- * <p>To read lines from {@link System#in} with {@link System##stdin.encoding
- * stdin.encoding}:
+ * <p>This code reads lines from {@link System#in} with {@link
+ * System##stdin.encoding stdin.encoding}:
  * {@snippet :
  *      Scanner sc = new Scanner(System.in, System.getProperty("stdin.encoding"));
  *      while (sc.hasNextLine()) {

--- a/src/java.base/share/classes/java/util/Scanner.java
+++ b/src/java.base/share/classes/java/util/Scanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -78,7 +78,16 @@ import sun.util.locale.provider.ResourceBundleBasedAdapter;
  *     }
  * }
  *
- * <p>As another example, this code allows {@code long} types to be
+ * <p>To read lines from {@link System#in} with {@link System##stdin.encoding
+ * stdin.encoding}:
+ * {@snippet :
+ *      Scanner sc = new Scanner(System.in, System.getProperty("stdin.encoding"));
+ *      while (sc.hasNextLine()) {
+ *          String aLine = sc.nextLine();
+ *      }
+ * }
+ *
+ * <p>This code allows {@code long} types to be
  * assigned from entries in a file {@code myNumbers}:
  * {@snippet :
  *      Scanner sc = new Scanner(new File("myNumbers"));

--- a/src/java.base/share/classes/java/util/Scanner.java
+++ b/src/java.base/share/classes/java/util/Scanner.java
@@ -78,8 +78,9 @@ import sun.util.locale.provider.ResourceBundleBasedAdapter;
  *     }
  * }
  *
- * <p>This code reads lines from {@link System#in} with {@link
- * System##stdin.encoding stdin.encoding}:
+ * <p>This code uses a {@code Scanner} to read lines from {@link System#in}. The
+ * {@code Scanner} uses the system property value of
+ * {@link System##stdin.encoding stdin.encoding} as the {@code Charset}:
  * {@snippet :
  *      Scanner sc = new Scanner(System.in, System.getProperty("stdin.encoding"));
  *      while (sc.hasNextLine()) {

--- a/src/java.base/share/classes/javax/security/auth/callback/CallbackHandler.java
+++ b/src/java.base/share/classes/javax/security/auth/callback/CallbackHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -113,7 +113,7 @@ public interface CallbackHandler {
      *          System.err.print(nc.getPrompt());
      *          System.err.flush();
      *          nc.setName((new BufferedReader
-     *                  (new InputStreamReader(System.in))).readLine());
+     *                  (new InputStreamReader(System.in, "stdin.encoding"))).readLine());
      *
      *      } else if (callbacks[i] instanceof PasswordCallback) {
      *

--- a/src/java.base/share/classes/javax/security/auth/callback/CallbackHandler.java
+++ b/src/java.base/share/classes/javax/security/auth/callback/CallbackHandler.java
@@ -113,7 +113,9 @@ public interface CallbackHandler {
      *          System.err.print(nc.getPrompt());
      *          System.err.flush();
      *          nc.setName((new BufferedReader
-     *                  (new InputStreamReader(System.in, "stdin.encoding"))).readLine());
+     *                  (new InputStreamReader(
+     *                          System.in,
+     *                          System.getProperty("stdin.encoding")))).readLine());
      *
      *      } else if (callbacks[i] instanceof PasswordCallback) {
      *


### PR DESCRIPTION
With the introduction of `stdin.encoding` ([JDK-8350703](https://bugs.openjdk.org/browse/JDK-8350703)), some guidance for users to decode `System.in` would be desirable. Adding examples in the field description would help.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8356420](https://bugs.openjdk.org/browse/JDK-8356420): Provide examples on wrapping System.in (**Bug** - P4)


### Reviewers
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**) Review applies to [496dd39d](https://git.openjdk.org/jdk/pull/25155/files/496dd39dc49cd834c09864585901b6d6dcfcf1af)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**) Review applies to [496dd39d](https://git.openjdk.org/jdk/pull/25155/files/496dd39dc49cd834c09864585901b6d6dcfcf1af)
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)
 * [Stuart Marks](https://openjdk.org/census#smarks) (@stuart-marks - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25155/head:pull/25155` \
`$ git checkout pull/25155`

Update a local copy of the PR: \
`$ git checkout pull/25155` \
`$ git pull https://git.openjdk.org/jdk.git pull/25155/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25155`

View PR using the GUI difftool: \
`$ git pr show -t 25155`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25155.diff">https://git.openjdk.org/jdk/pull/25155.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25155#issuecomment-2867755692)
</details>
