### PR TITLE
8356641: Test com/sun/jdi/EarlyThreadGroupChildrenTest.java fails sometimes on macOS

### DIFF
--- a/test/jdk/com/sun/jdi/EarlyThreadGroupChildrenTest.java
+++ b/test/jdk/com/sun/jdi/EarlyThreadGroupChildrenTest.java
@@ -101,6 +101,12 @@ public class EarlyThreadGroupChildrenTest extends TestScaffold {
     protected void runTests() throws Exception {
         connect(new String[]{"EarlyThreadGroupChildrenTestTarg"});
         System.out.println("Connected: ");
+
+        waitForVMStart();
+        System.out.println("VM Started: ");
+
+        // Do not add until after the VMStartEvent has arrived. Otherwise the debuggee
+        // will be resumed after handling the VMStartEvent, and we don't want it resumed.
         addListener(this);
 
         // Create a ThreadStartRequest for the first ThreadStartEvent. When this event is
@@ -109,9 +115,6 @@ public class EarlyThreadGroupChildrenTest extends TestScaffold {
         tsRequest.setSuspendPolicy(EventRequest.SUSPEND_ALL);
         tsRequest.addCountFilter(1);
         tsRequest.enable();
-
-        waitForVMStart();
-        System.out.println("VM Started: ");
 
         resumeToVMDisconnect();
 


### PR DESCRIPTION
We need to wait until after the VMStart event has arrived before adding the listener. Otherwise if the listener is already installed before the VMStart arrives, it will result in resuming the debuggee after processing the VMStart. We want the debuggee to remain suspended after handling the VMStart. More details in the CR.

Tested by running test on all supported platforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8356641](https://bugs.openjdk.org/browse/JDK-8356641): Test com/sun/jdi/EarlyThreadGroupChildrenTest.java fails sometimes on macOS (**Bug** - P4)


### Reviewers
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - **Reviewer**)
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25156/head:pull/25156` \
`$ git checkout pull/25156`

Update a local copy of the PR: \
`$ git checkout pull/25156` \
`$ git pull https://git.openjdk.org/jdk.git pull/25156/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25156`

View PR using the GUI difftool: \
`$ git pr show -t 25156`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25156.diff">https://git.openjdk.org/jdk/pull/25156.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25156#issuecomment-2867875653)
</details>
