### PR TITLE
8356192: Enable AOT code caching only on supported platforms

### DIFF
--- a/src/hotspot/share/code/aotCodeCache.cpp
+++ b/src/hotspot/share/code/aotCodeCache.cpp
@@ -89,6 +89,10 @@ uint AOTCodeCache::max_aot_code_size() {
 }
 
 void AOTCodeCache::initialize() {
+#if !(defined(AMD64) || defined(AARCH64))
+  log_info(aot, codecache, init)("AOT Code Cache is not supported on this platform.");
+  return;
+#endif
   if (FLAG_IS_DEFAULT(AOTCache)) {
     log_info(aot, codecache, init)("AOT Code Cache is not used: AOTCache is not specified.");
     return; // AOTCache must be specified to dump and use AOT code


### PR DESCRIPTION
@mdoerr report appcds test failures on PPC64 after [JDK-8350209](https://bugs.openjdk.org/browse/JDK-8350209) changes which added AOT adapters caching.

In those changes I forgot to limit the feature to only 2 platforms which we currently support for AOT code caching: X64 and AARCH64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8356192](https://bugs.openjdk.org/browse/JDK-8356192): Enable AOT code caching only on supported platforms (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25157/head:pull/25157` \
`$ git checkout pull/25157`

Update a local copy of the PR: \
`$ git checkout pull/25157` \
`$ git pull https://git.openjdk.org/jdk.git pull/25157/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25157`

View PR using the GUI difftool: \
`$ git pr show -t 25157`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25157.diff">https://git.openjdk.org/jdk/pull/25157.diff</a>

</details>
