### PR TITLE
8356657: Use stable source-date for cmp-baseline jib profiles

### DIFF
--- a/make/conf/jib-profiles.js
+++ b/make/conf/jib-profiles.js
@@ -862,7 +862,8 @@ var getJibProfilesProfiles = function (input, common, data) {
             profiles[cmpBaselineName].configure_args = concat(
                 profiles[cmpBaselineName].configure_args,
                 "--with-hotspot-build-time=n/a",
-                "--disable-precompiled-headers");
+                "--disable-precompiled-headers",
+                "--with-source-date=version");
             // Do not inherit artifact definitions from base profile
             delete profiles[cmpBaselineName].artifacts;
         });


### PR DESCRIPTION
The cmp-baseline builds expect the source-date to be stable across the two builds (really: invocations of configure). For CI builds the source-date gets set based on information from the job, but for local builds it gets the default "current" value which will not be the same for the two builds.

While it's possible to override this on the command line it would be more user friendly to have jib provide a stable source-date instead.

Testing: tier1,builds-tier[2-5]

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8356657](https://bugs.openjdk.org/browse/JDK-8356657): Use stable source-date for cmp-baseline jib profiles (**Enhancement** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25160/head:pull/25160` \
`$ git checkout pull/25160`

Update a local copy of the PR: \
`$ git checkout pull/25160` \
`$ git pull https://git.openjdk.org/jdk.git pull/25160/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25160`

View PR using the GUI difftool: \
`$ git pr show -t 25160`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25160.diff">https://git.openjdk.org/jdk/pull/25160.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25160#issuecomment-2868005468)
</details>
