### PR TITLE
8356664: [macos] AppContentTest fails after JDK-8352480

### DIFF
--- a/test/jdk/tools/jpackage/share/AppContentTest.java
+++ b/test/jdk/tools/jpackage/share/AppContentTest.java
@@ -162,13 +162,16 @@ public class AppContentTest {
 
         private static Path createAppContentLink(Path appContentPath) throws IOException {
             var appContentArg = TKit.createTempDirectory("app-content");
+            Path dstPath;
             if (copyInResources) {
-                appContentArg = appContentArg.resolve(RESOURCES_DIR).resolve(LINKS_DIR);
-            }   else {
+                appContentArg = appContentArg.resolve(RESOURCES_DIR);
+                dstPath = appContentArg.resolve(LINKS_DIR)
+                                       .resolve(appContentPath.getFileName());
+            } else {
                 appContentArg = appContentArg.resolve(LINKS_DIR);
+                dstPath = appContentArg.resolve(appContentPath.getFileName());
             }
 
-            var dstPath = appContentArg.resolve(appContentPath.getFileName());
             Files.createDirectories(dstPath.getParent());
 
             // Create target file for a link


### PR DESCRIPTION
- Regression from JDK-8352480.
- On macOS we should create `Links` folder under `Resources`. Which means `--app-content` should point to `app-content/Resources` and not to `app-content/Resources/Links`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8356664](https://bugs.openjdk.org/browse/JDK-8356664): [macos] AppContentTest fails after JDK-8352480 (**Bug** - P4)


### Reviewers
 * [Alexey Semenyuk](https://openjdk.org/census#asemenyuk) (@alexeysemenyukoracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25164/head:pull/25164` \
`$ git checkout pull/25164`

Update a local copy of the PR: \
`$ git checkout pull/25164` \
`$ git pull https://git.openjdk.org/jdk.git pull/25164/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25164`

View PR using the GUI difftool: \
`$ git pr show -t 25164`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25164.diff">https://git.openjdk.org/jdk/pull/25164.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25164#issuecomment-2868101077)
</details>
