### PR TITLE
8356686: doc/building.html is not up to date after JDK-8301971

### DIFF
--- a/doc/building.html
+++ b/doc/building.html
@@ -282,6 +282,11 @@ possible, use an SSD. The build process is very disk intensive, and
 having slow disk access will significantly increase build times. If you
 need to use a network share for the source code, see below for
 suggestions on how to keep the build artifacts on a local disk.</p></li>
+<li><p>UTF-8 support is needed to compile the JDK. On Unix systems, this
+typically means that the <code>C.UTF-8</code> or
+<code>en_US.UTF-8</code> locale needs to be available. For Windows
+users, please see the section on <a href="#locale-requirements">Locale
+Requirements</a> below.</p></li>
 <li><p>On Windows, extra care must be taken to have a smooth building
 experience:</p>
 <ul>
@@ -305,14 +310,6 @@ using
 <li><p>If using <a href="#cygwin">Cygwin</a>, you must make sure the
 file permissions and attributes between Windows and Cygwin are
 consistent. It is recommended that you follow this procedure:</p>
-<li><p>UTF-8 support is needed to compile the JDK. On Unix systems, this
-typically means that the <code>C.UTF-8</code> or
-<code>en_US.UTF-8</code> locale needs to be available. For Windows
-users, please see the section on <a href="#locale-requirements">Locale
-Requirements</a> below.</p></li>
-<li><p>On Windows, if using <a href="#cygwin">Cygwin</a>, extra care
-must be taken to make sure the environment is consistent. It is
-recommended that you follow this procedure:</p>
 <ul>
 <li><p>Create the directory that is going to contain the top directory
 of the JDK clone by using the <code>mkdir</code> command in the Cygwin


### PR DESCRIPTION
Please review this change to doc/building.html.  The change is the result of
using `make update-build-docs` to regenerate it from the current building.md
file.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8356686](https://bugs.openjdk.org/browse/JDK-8356686): doc/building.html is not up to date after JDK-8301971 (**Bug** - P4)


### Reviewers
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25168/head:pull/25168` \
`$ git checkout pull/25168`

Update a local copy of the PR: \
`$ git checkout pull/25168` \
`$ git pull https://git.openjdk.org/jdk.git pull/25168/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25168`

View PR using the GUI difftool: \
`$ git pr show -t 25168`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25168.diff">https://git.openjdk.org/jdk/pull/25168.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25168#issuecomment-2869186158)
</details>
