### PR TITLE
Optimize BigDecimal.valueOf(double)

### DIFF
--- a/src/java.base/share/classes/java/math/BigDecimal.java
+++ b/src/java.base/share/classes/java/math/BigDecimal.java
@@ -42,6 +42,7 @@ import java.util.Objects;
 
 import jdk.internal.access.JavaLangAccess;
 import jdk.internal.access.SharedSecrets;
+import jdk.internal.math.FormattedFPDecimal;
 import jdk.internal.util.DecimalDigits;
 
 /**
@@ -1393,11 +1394,18 @@ public class BigDecimal extends Number implements Comparable<BigDecimal> {
      * @since  1.5
      */
     public static BigDecimal valueOf(double val) {
-        // Reminder: a zero double returns '0.0', so we cannot fastpath
-        // to use the constant ZERO.  This might be important enough to
-        // justify a factory approach, a cache, or a few private
-        // constants, later.
-        return new BigDecimal(Double.toString(val));
+        if (!Double.isFinite(val)) {
+            throw new NumberFormatException("Infinite or NaN");
+        }
+
+        var fmt = FormattedFPDecimal.valueForDoubleToString(Math.abs(val));
+        long s = fmt.getSignificand();
+        if (val < 0) {
+            // Original s is never negative, so no overflow
+            s = -s;
+        }
+
+        return valueOf(s, fmt.getScale(), fmt.getPrecision());
     }
 
     // Arithmetic Operations

--- a/test/jdk/java/math/BigDecimal/ValueOfDouble.java
+++ b/test/jdk/java/math/BigDecimal/ValueOfDouble.java
@@ -1,0 +1,47 @@
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * @test
+ * @run junit ValueOfDouble
+ */
+
+public class ValueOfDouble {
+    private static final String DIGITS = "12345678991234567899"; // More than enough digits to fill a long
+
+    @Test
+    public void testValueOfDouble() {
+        checkValue(0.0);
+        checkValue(-0.0);
+        checkValue(Math.PI);
+        checkValue(-Math.PI);
+        checkValue(Double.MAX_VALUE);
+        checkValue(Double.MIN_VALUE);
+        checkValue(1e-44); // Lots of digits with lots of 9s
+
+        for (int i = 1; i < DIGITS.length(); i++) {
+            String prefix = DIGITS.substring(0, i);
+            for (int exp = -30; exp < 30; exp++) {
+                double value = Double.parseDouble(prefix + "e" + exp);
+                checkValue(value);
+                checkValue(-value);
+            }
+        }
+    }
+
+    private static void checkValue(double value) {
+        BigDecimal expected = new BigDecimal(Double.toString(value));
+        assertEquals(expected, BigDecimal.valueOf(value));
+    }
+
+    @Test
+    public void testExceptions() {
+        assertThrows(NumberFormatException.class, () -> BigDecimal.valueOf(Double.NaN));
+        assertThrows(NumberFormatException.class, () -> BigDecimal.valueOf(Double.POSITIVE_INFINITY));
+        assertThrows(NumberFormatException.class, () -> BigDecimal.valueOf(Double.NEGATIVE_INFINITY));
+    }
+}

--- a/test/micro/org/openjdk/bench/java/math/BigDecimals.java
+++ b/test/micro/org/openjdk/bench/java/math/BigDecimals.java
@@ -227,4 +227,23 @@ public class BigDecimals {
             bh.consume(c.compareTo(s));
         }
     }
+
+
+    /** Invokes the valueOf(double) of BigDecimal with various different values. */
+    @Benchmark
+    @OperationsPerInvocation(TEST_SIZE)
+    public void testValueOfWithDouble(Blackhole bh) {
+        for (double s : doubleInputs) {
+            bh.consume(BigDecimal.valueOf(s));
+        }
+    }
+
+    /** Create BigDecimal from double with Double.toString on different values. */
+    @Benchmark
+    @OperationsPerInvocation(TEST_SIZE)
+    public void testValueOfWithDoubleString(Blackhole bh) {
+        for (double s : doubleInputs) {
+            bh.consume(new BigDecimal(Double.toString(s)));
+        }
+    }
 }


### PR DESCRIPTION
Optimize `BigDecimal.valueOf(double)` by using `FormattedFPDecimal` instead of converting to decimal string and then parsing it.