### PR TITLE
8356694: Removed unused subclass audits in ObjectInput/OutputStream

### DIFF
--- a/src/java.base/share/classes/java/io/ObjectInputStream.java
+++ b/src/java.base/share/classes/java/io/ObjectInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -255,14 +255,6 @@ public class ObjectInputStream
     private static final Object unsharedMarker = new Object();
 
     private static class Caches {
-        /** cache of subclass security audit results */
-        static final ClassValue<Boolean> subclassAudits =
-            new ClassValue<>() {
-                @Override
-                protected Boolean computeValue(Class<?> type) {
-                    return auditSubclass(type);
-                }
-            };
 
         /**
          * Property to permit setting a filter after objects
@@ -1542,31 +1534,6 @@ public class ObjectInputStream
          *         not serializable or if the field type is incorrect
          */
         public abstract Object get(String name, Object val) throws IOException, ClassNotFoundException;
-    }
-
-    /**
-     * Performs reflective checks on given subclass to verify that it doesn't
-     * override security-sensitive non-final methods.  Returns TRUE if subclass
-     * is "safe", FALSE otherwise.
-     */
-    private static Boolean auditSubclass(Class<?> subcl) {
-        for (Class<?> cl = subcl;
-             cl != ObjectInputStream.class;
-             cl = cl.getSuperclass())
-        {
-            try {
-                cl.getDeclaredMethod(
-                    "readUnshared", (Class[]) null);
-                return Boolean.FALSE;
-            } catch (NoSuchMethodException ex) {
-            }
-            try {
-                cl.getDeclaredMethod("readFields", (Class[]) null);
-                return Boolean.FALSE;
-            } catch (NoSuchMethodException ex) {
-            }
-        }
-        return Boolean.TRUE;
     }
 
     /**

--- a/src/java.base/share/classes/java/io/ObjectOutputStream.java
+++ b/src/java.base/share/classes/java/io/ObjectOutputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2025, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2024, Alibaba Group Holding Limited. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -173,17 +173,6 @@ public class ObjectOutputStream
     extends OutputStream implements ObjectOutput, ObjectStreamConstants
 {
     private static final JavaLangAccess JLA = SharedSecrets.getJavaLangAccess();
-
-    private static class Caches {
-        /** cache of subclass security audit results */
-        static final ClassValue<Boolean> subclassAudits =
-            new ClassValue<>() {
-                @Override
-                protected Boolean computeValue(Class<?> type) {
-                    return auditSubclass(type);
-                }
-            };
-    }
 
     /** filter stream for handling block data conversion */
     private final BlockDataOutputStream bout;
@@ -1001,31 +990,6 @@ public class ObjectOutputStream
         } else {
             writeString(str, false);
         }
-    }
-
-    /**
-     * Performs reflective checks on given subclass to verify that it doesn't
-     * override security-sensitive non-final methods.  Returns TRUE if subclass
-     * is "safe", FALSE otherwise.
-     */
-    private static Boolean auditSubclass(Class<?> subcl) {
-        for (Class<?> cl = subcl;
-             cl != ObjectOutputStream.class;
-             cl = cl.getSuperclass())
-        {
-            try {
-                cl.getDeclaredMethod(
-                    "writeUnshared", new Class<?>[] { Object.class });
-                return Boolean.FALSE;
-            } catch (NoSuchMethodException ex) {
-            }
-            try {
-                cl.getDeclaredMethod("putFields", (Class<?>[]) null);
-                return Boolean.FALSE;
-            } catch (NoSuchMethodException ex) {
-            }
-        }
-        return Boolean.TRUE;
     }
 
     /**


### PR DESCRIPTION
These two subclass audits in ObjectInputStream and ObjectOutputStream were only used when security managers are present, which is no longer the case in releases 24 and newer. Thus, we can remove these two redundant `ClassValue` and the computation methods safely.

Testing: java/io/Serializable and ObjectInput, jdk tier 1-3 in progress

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8356694](https://bugs.openjdk.org/browse/JDK-8356694): Removed unused subclass audits in ObjectInput/OutputStream (**Enhancement** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25174/head:pull/25174` \
`$ git checkout pull/25174`

Update a local copy of the PR: \
`$ git checkout pull/25174` \
`$ git pull https://git.openjdk.org/jdk.git pull/25174/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25174`

View PR using the GUI difftool: \
`$ git pr show -t 25174`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25174.diff">https://git.openjdk.org/jdk/pull/25174.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25174#issuecomment-2870539777)
</details>
