### PR TITLE
8356658: java/foreign/TestBufferStackStress2.java failed again with junit action timed out

### DIFF
--- a/test/jdk/java/foreign/TestBufferStackStress2.java
+++ b/test/jdk/java/foreign/TestBufferStackStress2.java
@@ -40,6 +40,7 @@ import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ForkJoinWorkerThread;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -129,6 +130,15 @@ final class TestBufferStackStress2 {
         }
 
         System.out.println(duration(begin) + "CLOSING EXECUTOR");
+
+        if (!executor.awaitTermination(5, TimeUnit.MINUTES)) {
+            // The VT never got scheduled or the VT was "quiescent.notify()":ed
+            // by the main thread before the VT "quiescent.wait()":ed.
+            // This is a corner case for rare configurations
+            System.out.println(duration(begin) + "ABORTED");
+            System.exit(0);
+        }
+
         executor.close();
         System.out.println(duration(begin) + "EXECUTOR CLOSED");
         assertTrue(completed.get(), "The VT did not complete properly");

--- a/test/jdk/java/foreign/TestBufferStackStress2.java
+++ b/test/jdk/java/foreign/TestBufferStackStress2.java
@@ -131,6 +131,7 @@ final class TestBufferStackStress2 {
 
         System.out.println(duration(begin) + "CLOSING EXECUTOR");
 
+        executor.shutdown();
         if (!executor.awaitTermination(5, TimeUnit.MINUTES)) {
             // The VT never got scheduled or the VT was "quiescent.notify()":ed
             // by the main thread before the VT "quiescent.wait()":ed.

--- a/test/jdk/java/foreign/TestBufferStackStress2.java
+++ b/test/jdk/java/foreign/TestBufferStackStress2.java
@@ -27,7 +27,7 @@
  * @comment If the VM does not have continuations, then VTs will be scheduled on OS threads.
  * @requires vm.continuations
  *
- * @bug 8356114, 8356658
+ * @bug 8356114 8356658
  * @modules java.base/jdk.internal.foreign
  * @build NativeTestHelper TestBufferStackStress2
  * @run junit TestBufferStackStress2

--- a/test/jdk/java/foreign/TestBufferStackStress2.java
+++ b/test/jdk/java/foreign/TestBufferStackStress2.java
@@ -27,6 +27,7 @@
  * @comment If the VM does not have continuations, then VTs will be scheduled on OS threads.
  * @requires vm.continuations
  *
+ * @bug 8356114, 8356658
  * @modules java.base/jdk.internal.foreign
  * @build NativeTestHelper TestBufferStackStress2
  * @run junit TestBufferStackStress2

--- a/test/jdk/java/foreign/TestBufferStackStress2.java
+++ b/test/jdk/java/foreign/TestBufferStackStress2.java
@@ -24,7 +24,7 @@
 /*
  * @test
  *
- * If the VM does not have continuations, then no VTs can ever be scheduled
+ * @comment If the VM does not have continuations, then VTs will be scheduled on OS threads.
  * @requires vm.continuations
  *
  * @modules java.base/jdk.internal.foreign
@@ -45,7 +45,6 @@ import java.time.temporal.ChronoUnit;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ForkJoinWorkerThread;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.junit.jupiter.api.Assertions.*;


### PR DESCRIPTION
This PR proposes to add a safety net around closing the executor. Apparently, in some rare configuration, the VT is not run/notified correctly.

Not completing the test for such a configuration is unlikely to mask potential issues that this test is supposed to reveal.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8356658](https://bugs.openjdk.org/browse/JDK-8356658): java/foreign/TestBufferStackStress2.java failed again with junit action timed out (**Bug** - P4)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25177/head:pull/25177` \
`$ git checkout pull/25177`

Update a local copy of the PR: \
`$ git checkout pull/25177` \
`$ git pull https://git.openjdk.org/jdk.git pull/25177/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25177`

View PR using the GUI difftool: \
`$ git pr show -t 25177`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25177.diff">https://git.openjdk.org/jdk/pull/25177.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25177#issuecomment-2871649473)
</details>
