### PR TITLE
8356275: TestCodeEntryAlignment fails with "Alignment must be <= CodeEntryAlignment"

### DIFF
--- a/src/hotspot/cpu/x86/macroAssembler_x86_sha.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86_sha.cpp
@@ -1511,7 +1511,7 @@ void MacroAssembler::sha512_update_ni_x1(Register arg_hash, Register arg_msg, Re
     //ymm13 = A B E F, ymm14 = C D G H
 
     lea(rax, ExternalAddress(K512_W));
-    align(32);
+    align(CodeEntryAlignment);
     bind(block_loop);
     vmovdqu(xmm11, xmm13);//ABEF
     vmovdqu(xmm12, xmm14);//CDGH


### PR DESCRIPTION
In the [original code](https://github.com/intel/intel-ipsec-mb/blob/9b607277c75dc7994615700a7ebd5d02e74b52a7/lib/avx2_t4/sha512_x1_ni_avx2.asm#L153), we have an `align 32` here.

This alignment is pure optimization: we align the head of the loop to make the CPU happier. But if we set `CodeEntryAlignment` to 16, the 32 alignment makes an assert fail. Let's align to `CodeEntryAlignment` instead. It should be 32 by default, but if someone has a different opinion, it's still fine. Anyway, this alignment doesn't seem useful for correctness, so the consequences of an insufficient alignment are small. On the other hand, if someone wants to set `CodeEntryAlignment` to 64 for instance, it's also ok: 64-bit alignment is also a 32-bit alignment. We just lose a bit of space for no good reason but the user's input stating that we should prefer 64-bit alignment.

It seems questionable to me whether there is any sense in overriding the alignment when using such advanced features, that only exists on modern enough CPUs, so not with a 16-bit alignment, but for consistency, I suppose.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8356275](https://bugs.openjdk.org/browse/JDK-8356275): TestCodeEntryAlignment fails with "Alignment must be &lt;= CodeEntryAlignment" (**Bug** - P3)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25180/head:pull/25180` \
`$ git checkout pull/25180`

Update a local copy of the PR: \
`$ git checkout pull/25180` \
`$ git pull https://git.openjdk.org/jdk.git pull/25180/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25180`

View PR using the GUI difftool: \
`$ git pr show -t 25180`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25180.diff">https://git.openjdk.org/jdk/pull/25180.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25180#issuecomment-2872306123)
</details>
