### PR TITLE
8350960: RISC-V: Add riscv backend for Float16 operations - vectorization

### DIFF
--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -1933,8 +1933,8 @@ bool Matcher::match_rule_supported(int opcode) {
     case Op_MaxHF:
     case Op_MinHF:
     case Op_MulHF:
-    case Op_SubHF:
     case Op_SqrtHF:
+    case Op_SubHF:
       return UseZfh;
 
     case Op_CMoveF:

--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -113,6 +113,16 @@ source %{
         if (vlen < 4) {
           return false;
         }
+      case Op_AddVHF:
+      case Op_DivVHF:
+      case Op_MaxVHF:
+      case Op_MinVHF:
+      case Op_MulVHF:
+      case Op_SqrtVHF:
+      case Op_SubVHF:
+        return UseZvfh;
+      case Op_FmaVHF:
+        return UseZvfh && UseFMA;
       default:
         break;
     }
@@ -363,6 +373,21 @@ instruct vadd(vReg dst, vReg src1, vReg src2) %{
   ins_pipe(pipe_slow);
 %}
 
+instruct vadd_hfp(vReg dst, vReg src1, vReg src2) %{
+  match(Set dst (AddVHF src1 src2));
+  ins_cost(VEC_COST);
+  format %{ "vadd_hfp $dst, $src1, $src2" %}
+  ins_encode %{
+    assert(UseZvfh, "must");
+    BasicType bt = Matcher::vector_element_basic_type(this);
+    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vfadd_vv(as_VectorRegister($dst$$reg),
+                as_VectorRegister($src1$$reg),
+                as_VectorRegister($src2$$reg));
+  %}
+  ins_pipe(pipe_slow);
+%}
+
 instruct vadd_fp(vReg dst, vReg src1, vReg src2) %{
   match(Set dst (AddVF src1 src2));
   match(Set dst (AddVD src1 src2));
@@ -542,6 +567,20 @@ instruct vsub(vReg dst, vReg src1, vReg src2) %{
     __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vsub_vv(as_VectorRegister($dst$$reg), as_VectorRegister($src1$$reg),
                as_VectorRegister($src2$$reg));
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+instruct vsub_hfp(vReg dst, vReg src1, vReg src2) %{
+  match(Set dst (SubVHF src1 src2));
+  ins_cost(VEC_COST);
+  format %{ "vsub_hfp $dst, $src1, $src2" %}
+  ins_encode %{
+    assert(UseZvfh, "must");
+    BasicType bt = Matcher::vector_element_basic_type(this);
+    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vfsub_vv(as_VectorRegister($dst$$reg), as_VectorRegister($src1$$reg),
+                as_VectorRegister($src2$$reg));
   %}
   ins_pipe(pipe_slow);
 %}
@@ -1542,6 +1581,21 @@ instruct vnotL_masked(vReg dst_src, immI_M1 m1, vRegMask_V0 v0) %{
 
 // vector float div
 
+instruct vdiv_hfp(vReg dst, vReg src1, vReg src2) %{
+  match(Set dst (DivVHF src1 src2));
+  ins_cost(VEC_COST);
+  format %{ "vdiv_hfp $dst, $src1, $src2" %}
+  ins_encode %{
+    assert(UseZvfh, "must");
+    BasicType bt = Matcher::vector_element_basic_type(this);
+    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vfdiv_vv(as_VectorRegister($dst$$reg),
+                as_VectorRegister($src1$$reg),
+                as_VectorRegister($src2$$reg));
+  %}
+  ins_pipe(pipe_slow);
+%}
+
 instruct vdiv_fp(vReg dst, vReg src1, vReg src2) %{
   match(Set dst (DivVF src1 src2));
   match(Set dst (DivVD src1 src2));
@@ -1698,6 +1752,38 @@ instruct vminu_masked(vReg dst_src1, vReg src2, vRegMask_V0 v0) %{
   ins_pipe(pipe_slow);
 %}
 
+// vector float-point max/min (half precision)
+
+instruct vmax_hfp(vReg dst, vReg src1, vReg src2, vRegMask_V0 v0) %{
+  match(Set dst (MaxVHF src1 src2));
+  effect(TEMP_DEF dst, TEMP v0);
+  ins_cost(VEC_COST);
+  format %{ "vmax_hfp $dst, $src1, $src2" %}
+  ins_encode %{
+    assert(UseZvfh, "must");
+    BasicType bt = Matcher::vector_element_basic_type(this);
+    __ minmax_fp_v(as_VectorRegister($dst$$reg),
+                   as_VectorRegister($src1$$reg), as_VectorRegister($src2$$reg),
+                   bt, false /* is_min */, Matcher::vector_length(this));
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+instruct vmin_hfp(vReg dst, vReg src1, vReg src2, vRegMask_V0 v0) %{
+  match(Set dst (MinVHF src1 src2));
+  effect(TEMP_DEF dst, TEMP v0);
+  ins_cost(VEC_COST);
+  format %{ "vmin_hfp $dst, $src1, $src2" %}
+  ins_encode %{
+    assert(UseZvfh, "must");
+    BasicType bt = Matcher::vector_element_basic_type(this);
+    __ minmax_fp_v(as_VectorRegister($dst$$reg),
+                   as_VectorRegister($src1$$reg), as_VectorRegister($src2$$reg),
+                   bt, true /* is_min */, Matcher::vector_length(this));
+  %}
+  ins_pipe(pipe_slow);
+%}
+
 // vector float-point max/min
 
 instruct vmax_fp(vReg dst, vReg src1, vReg src2, vRegMask_V0 v0) %{
@@ -1769,6 +1855,22 @@ instruct vmin_fp_masked(vReg dst_src1, vReg src2, vRegMask vmask, vReg tmp1, vRe
 %}
 
 // vector fmla
+
+// dst_src1 = src2 * src3 + dst_src1 (half precision)
+instruct vhfmla(vReg dst_src1, vReg src2, vReg src3) %{
+  match(Set dst_src1 (FmaVHF dst_src1 (Binary src2 src3)));
+  ins_cost(VEC_COST);
+  format %{ "vhfmla $dst_src1, $dst_src1, $src2, $src3" %}
+  ins_encode %{
+    assert(UseFMA, "Needs FMA instructions support.");
+    assert(UseZvfh, "must");
+    BasicType bt = Matcher::vector_element_basic_type(this);
+    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vfmacc_vv(as_VectorRegister($dst_src1$$reg),
+                 as_VectorRegister($src2$$reg), as_VectorRegister($src3$$reg));
+  %}
+  ins_pipe(pipe_slow);
+%}
 
 // dst_src1 = src2 * src3 + dst_src1
 instruct vfmla(vReg dst_src1, vReg src2, vReg src3) %{
@@ -2034,6 +2136,20 @@ instruct vmul(vReg dst, vReg src1, vReg src2) %{
     __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vmul_vv(as_VectorRegister($dst$$reg), as_VectorRegister($src1$$reg),
                as_VectorRegister($src2$$reg));
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+instruct vmul_hfp(vReg dst, vReg src1, vReg src2) %{
+  match(Set dst (MulVHF src1 src2));
+  ins_cost(VEC_COST);
+  format %{ "vmul_hfp $dst, $src1, $src2" %}
+  ins_encode %{
+    assert(UseZvfh, "must");
+    BasicType bt = Matcher::vector_element_basic_type(this);
+    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vfmul_vv(as_VectorRegister($dst$$reg), as_VectorRegister($src1$$reg),
+                as_VectorRegister($src2$$reg));
   %}
   ins_pipe(pipe_slow);
 %}
@@ -2967,6 +3083,18 @@ instruct replicateL_imm5(vReg dst, immL5 con) %{
   ins_encode %{
     __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
     __ vmv_v_i(as_VectorRegister($dst$$reg), $con$$constant);
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+instruct replicateHF(vReg dst, fRegF src) %{
+  match(Set dst (Replicate src));
+  ins_cost(VEC_COST);
+  format %{ "replicateHF $dst, $src" %}
+  ins_encode %{
+    assert(UseZvfh, "must");
+    __ vsetvli_helper(T_SHORT, Matcher::vector_length(this));
+    __ vfmv_v_f(as_VectorRegister($dst$$reg), $src$$FloatRegister);
   %}
   ins_pipe(pipe_slow);
 %}
@@ -4013,6 +4141,18 @@ instruct vrotate_left_vi_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
 %}
 
 // vector sqrt
+
+instruct vsqrt_hfp(vReg dst, vReg src) %{
+  match(Set dst (SqrtVHF src));
+  ins_cost(VEC_COST);
+  format %{ "vsqrt_hfp $dst, $src" %}
+  ins_encode %{
+    BasicType bt = Matcher::vector_element_basic_type(this);
+    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vfsqrt_v(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg));
+  %}
+  ins_pipe(pipe_slow);
+%}
 
 instruct vsqrt_fp(vReg dst, vReg src) %{
   match(Set dst (SqrtVF src));

--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -95,9 +95,6 @@ source %{
           return false;
         }
         break;
-      case Op_VectorCastHF2F:
-      case Op_VectorCastF2HF:
-        return UseZvfh;
       case Op_VectorLoadShuffle:
       case Op_VectorRearrange:
         // vlen >= 4 is required, because min vector size for byte is 4 on riscv,
@@ -113,6 +110,8 @@ source %{
         if (vlen < 4) {
           return false;
         }
+      case Op_VectorCastHF2F:
+      case Op_VectorCastF2HF:
       case Op_AddVHF:
       case Op_DivVHF:
       case Op_MaxVHF:
@@ -380,6 +379,7 @@ instruct vadd_hfp(vReg dst, vReg src1, vReg src2) %{
   ins_encode %{
     assert(UseZvfh, "must");
     BasicType bt = Matcher::vector_element_basic_type(this);
+    assert(bt == T_SHORT, "must");
     __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vfadd_vv(as_VectorRegister($dst$$reg),
                 as_VectorRegister($src1$$reg),
@@ -578,6 +578,7 @@ instruct vsub_hfp(vReg dst, vReg src1, vReg src2) %{
   ins_encode %{
     assert(UseZvfh, "must");
     BasicType bt = Matcher::vector_element_basic_type(this);
+    assert(bt == T_SHORT, "must");
     __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vfsub_vv(as_VectorRegister($dst$$reg), as_VectorRegister($src1$$reg),
                 as_VectorRegister($src2$$reg));
@@ -1588,6 +1589,7 @@ instruct vdiv_hfp(vReg dst, vReg src1, vReg src2) %{
   ins_encode %{
     assert(UseZvfh, "must");
     BasicType bt = Matcher::vector_element_basic_type(this);
+    assert(bt == T_SHORT, "must");
     __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vfdiv_vv(as_VectorRegister($dst$$reg),
                 as_VectorRegister($src1$$reg),
@@ -1762,6 +1764,7 @@ instruct vmax_hfp(vReg dst, vReg src1, vReg src2, vRegMask_V0 v0) %{
   ins_encode %{
     assert(UseZvfh, "must");
     BasicType bt = Matcher::vector_element_basic_type(this);
+    assert(bt == T_SHORT, "must");
     __ minmax_fp_v(as_VectorRegister($dst$$reg),
                    as_VectorRegister($src1$$reg), as_VectorRegister($src2$$reg),
                    bt, false /* is_min */, Matcher::vector_length(this));
@@ -1777,6 +1780,7 @@ instruct vmin_hfp(vReg dst, vReg src1, vReg src2, vRegMask_V0 v0) %{
   ins_encode %{
     assert(UseZvfh, "must");
     BasicType bt = Matcher::vector_element_basic_type(this);
+    assert(bt == T_SHORT, "must");
     __ minmax_fp_v(as_VectorRegister($dst$$reg),
                    as_VectorRegister($src1$$reg), as_VectorRegister($src2$$reg),
                    bt, true /* is_min */, Matcher::vector_length(this));
@@ -1865,6 +1869,7 @@ instruct vhfmla(vReg dst_src1, vReg src2, vReg src3) %{
     assert(UseFMA, "Needs FMA instructions support.");
     assert(UseZvfh, "must");
     BasicType bt = Matcher::vector_element_basic_type(this);
+    assert(bt == T_SHORT, "must");
     __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vfmacc_vv(as_VectorRegister($dst_src1$$reg),
                  as_VectorRegister($src2$$reg), as_VectorRegister($src3$$reg));
@@ -2147,6 +2152,7 @@ instruct vmul_hfp(vReg dst, vReg src1, vReg src2) %{
   ins_encode %{
     assert(UseZvfh, "must");
     BasicType bt = Matcher::vector_element_basic_type(this);
+    assert(bt == T_SHORT, "must");
     __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vfmul_vv(as_VectorRegister($dst$$reg), as_VectorRegister($src1$$reg),
                 as_VectorRegister($src2$$reg));
@@ -3088,6 +3094,7 @@ instruct replicateL_imm5(vReg dst, immL5 con) %{
 %}
 
 instruct replicateHF(vReg dst, fRegF src) %{
+  predicate(Matcher::vector_element_basic_type(n) == T_SHORT);
   match(Set dst (Replicate src));
   ins_cost(VEC_COST);
   format %{ "replicateHF $dst, $src" %}
@@ -4149,6 +4156,7 @@ instruct vsqrt_hfp(vReg dst, vReg src) %{
   ins_encode %{
     assert(UseZvfh, "must");
     BasicType bt = Matcher::vector_element_basic_type(this);
+    assert(bt == T_SHORT, "must");
     __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vfsqrt_v(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg));
   %}

--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -378,9 +378,8 @@ instruct vadd_hfp(vReg dst, vReg src1, vReg src2) %{
   format %{ "vadd_hfp $dst, $src1, $src2" %}
   ins_encode %{
     assert(UseZvfh, "must");
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    assert(bt == T_SHORT, "must");
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    assert(Matcher::vector_element_basic_type(this) == T_SHORT, "must");
+    __ vsetvli_helper(T_SHORT, Matcher::vector_length(this));
     __ vfadd_vv(as_VectorRegister($dst$$reg),
                 as_VectorRegister($src1$$reg),
                 as_VectorRegister($src2$$reg));
@@ -577,9 +576,8 @@ instruct vsub_hfp(vReg dst, vReg src1, vReg src2) %{
   format %{ "vsub_hfp $dst, $src1, $src2" %}
   ins_encode %{
     assert(UseZvfh, "must");
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    assert(bt == T_SHORT, "must");
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    assert(Matcher::vector_element_basic_type(this) == T_SHORT, "must");
+    __ vsetvli_helper(T_SHORT, Matcher::vector_length(this));
     __ vfsub_vv(as_VectorRegister($dst$$reg), as_VectorRegister($src1$$reg),
                 as_VectorRegister($src2$$reg));
   %}
@@ -1588,9 +1586,8 @@ instruct vdiv_hfp(vReg dst, vReg src1, vReg src2) %{
   format %{ "vdiv_hfp $dst, $src1, $src2" %}
   ins_encode %{
     assert(UseZvfh, "must");
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    assert(bt == T_SHORT, "must");
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    assert(Matcher::vector_element_basic_type(this) == T_SHORT, "must");
+    __ vsetvli_helper(T_SHORT, Matcher::vector_length(this));
     __ vfdiv_vv(as_VectorRegister($dst$$reg),
                 as_VectorRegister($src1$$reg),
                 as_VectorRegister($src2$$reg));
@@ -1763,11 +1760,10 @@ instruct vmax_hfp(vReg dst, vReg src1, vReg src2, vRegMask_V0 v0) %{
   format %{ "vmax_hfp $dst, $src1, $src2" %}
   ins_encode %{
     assert(UseZvfh, "must");
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    assert(bt == T_SHORT, "must");
+    assert(Matcher::vector_element_basic_type(this) == T_SHORT, "must");
     __ minmax_fp_v(as_VectorRegister($dst$$reg),
                    as_VectorRegister($src1$$reg), as_VectorRegister($src2$$reg),
-                   bt, false /* is_min */, Matcher::vector_length(this));
+                   T_SHORT, false /* is_min */, Matcher::vector_length(this));
   %}
   ins_pipe(pipe_slow);
 %}
@@ -1779,11 +1775,10 @@ instruct vmin_hfp(vReg dst, vReg src1, vReg src2, vRegMask_V0 v0) %{
   format %{ "vmin_hfp $dst, $src1, $src2" %}
   ins_encode %{
     assert(UseZvfh, "must");
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    assert(bt == T_SHORT, "must");
+    assert(Matcher::vector_element_basic_type(this) == T_SHORT, "must");
     __ minmax_fp_v(as_VectorRegister($dst$$reg),
                    as_VectorRegister($src1$$reg), as_VectorRegister($src2$$reg),
-                   bt, true /* is_min */, Matcher::vector_length(this));
+                   T_SHORT, true /* is_min */, Matcher::vector_length(this));
   %}
   ins_pipe(pipe_slow);
 %}
@@ -1868,9 +1863,8 @@ instruct vhfmla(vReg dst_src1, vReg src2, vReg src3) %{
   ins_encode %{
     assert(UseFMA, "Needs FMA instructions support.");
     assert(UseZvfh, "must");
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    assert(bt == T_SHORT, "must");
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    assert(Matcher::vector_element_basic_type(this) == T_SHORT, "must");
+    __ vsetvli_helper(T_SHORT, Matcher::vector_length(this));
     __ vfmacc_vv(as_VectorRegister($dst_src1$$reg),
                  as_VectorRegister($src2$$reg), as_VectorRegister($src3$$reg));
   %}
@@ -2151,9 +2145,8 @@ instruct vmul_hfp(vReg dst, vReg src1, vReg src2) %{
   format %{ "vmul_hfp $dst, $src1, $src2" %}
   ins_encode %{
     assert(UseZvfh, "must");
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    assert(bt == T_SHORT, "must");
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    assert(Matcher::vector_element_basic_type(this) == T_SHORT, "must");
+    __ vsetvli_helper(T_SHORT, Matcher::vector_length(this));
     __ vfmul_vv(as_VectorRegister($dst$$reg), as_VectorRegister($src1$$reg),
                 as_VectorRegister($src2$$reg));
   %}
@@ -4155,9 +4148,8 @@ instruct vsqrt_hfp(vReg dst, vReg src) %{
   format %{ "vsqrt_hfp $dst, $src" %}
   ins_encode %{
     assert(UseZvfh, "must");
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    assert(bt == T_SHORT, "must");
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    assert(Matcher::vector_element_basic_type(this) == T_SHORT, "must");
+    __ vsetvli_helper(T_SHORT, Matcher::vector_length(this));
     __ vfsqrt_v(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg));
   %}
   ins_pipe(pipe_slow);

--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -4147,6 +4147,7 @@ instruct vsqrt_hfp(vReg dst, vReg src) %{
   ins_cost(VEC_COST);
   format %{ "vsqrt_hfp $dst, $src" %}
   ins_encode %{
+    assert(UseZvfh, "must");
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vfsqrt_v(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg));

--- a/test/hotspot/jtreg/compiler/vectorization/TestFloat16VectorOperations.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestFloat16VectorOperations.java
@@ -78,7 +78,7 @@ public class TestFloat16VectorOperations {
     @Test
     @Warmup(10000)
     @IR(counts = {IRNode.ADD_VHF, ">= 1"},
-        applyIfCPUFeature = {"avx512_fp16", "true"})
+        applyIfCPUFeatureOr = {"avx512_fp16", "true", "zvfh", "true"})
     public void vectorAddFloat16() {
         for (int i = 0; i < LEN; ++i) {
             output[i] = float16ToRawShortBits(add(shortBitsToFloat16(input1[i]), shortBitsToFloat16(input2[i])));
@@ -99,7 +99,7 @@ public class TestFloat16VectorOperations {
     @Test
     @Warmup(10000)
     @IR(counts = {IRNode.SUB_VHF, ">= 1"},
-        applyIfCPUFeature = {"avx512_fp16", "true"})
+        applyIfCPUFeatureOr = {"avx512_fp16", "true", "zvfh", "true"})
     public void vectorSubFloat16() {
         for (int i = 0; i < LEN; ++i) {
             output[i] = float16ToRawShortBits(subtract(shortBitsToFloat16(input1[i]), shortBitsToFloat16(input2[i])));
@@ -120,7 +120,7 @@ public class TestFloat16VectorOperations {
     @Test
     @Warmup(10000)
     @IR(counts = {IRNode.MUL_VHF, ">= 1"},
-        applyIfCPUFeature = {"avx512_fp16", "true"})
+        applyIfCPUFeatureOr = {"avx512_fp16", "true", "zvfh", "true"})
     public void vectorMulFloat16() {
         for (int i = 0; i < LEN; ++i) {
             output[i] = float16ToRawShortBits(multiply(shortBitsToFloat16(input1[i]), shortBitsToFloat16(input2[i])));
@@ -141,7 +141,7 @@ public class TestFloat16VectorOperations {
     @Test
     @Warmup(10000)
     @IR(counts = {IRNode.DIV_VHF, ">= 1"},
-        applyIfCPUFeature = {"avx512_fp16", "true"})
+        applyIfCPUFeatureOr = {"avx512_fp16", "true", "zvfh", "true"})
     public void vectorDivFloat16() {
         for (int i = 0; i < LEN; ++i) {
             output[i] = float16ToRawShortBits(divide(shortBitsToFloat16(input1[i]), shortBitsToFloat16(input2[i])));
@@ -162,7 +162,7 @@ public class TestFloat16VectorOperations {
     @Test
     @Warmup(10000)
     @IR(counts = {IRNode.MIN_VHF, ">= 1"},
-        applyIfCPUFeature = {"avx512_fp16", "true"})
+        applyIfCPUFeatureOr = {"avx512_fp16", "true", "zvfh", "true"})
     public void vectorMinFloat16() {
         for (int i = 0; i < LEN; ++i) {
             output[i] = float16ToRawShortBits(min(shortBitsToFloat16(input1[i]), shortBitsToFloat16(input2[i])));
@@ -183,7 +183,7 @@ public class TestFloat16VectorOperations {
     @Test
     @Warmup(10000)
     @IR(counts = {IRNode.MAX_VHF, ">= 1"},
-        applyIfCPUFeature = {"avx512_fp16", "true"})
+        applyIfCPUFeatureOr = {"avx512_fp16", "true", "zvfh", "true"})
     public void vectorMaxFloat16() {
         for (int i = 0; i < LEN; ++i) {
             output[i] = float16ToRawShortBits(max(shortBitsToFloat16(input1[i]), shortBitsToFloat16(input2[i])));
@@ -204,7 +204,7 @@ public class TestFloat16VectorOperations {
     @Test
     @Warmup(10000)
     @IR(counts = {IRNode.SQRT_VHF, ">= 1"},
-        applyIfCPUFeature = {"avx512_fp16", "true"})
+        applyIfCPUFeatureOr = {"avx512_fp16", "true", "zvfh", "true"})
     public void vectorSqrtFloat16() {
         for (int i = 0; i < LEN; ++i) {
             output[i] = float16ToRawShortBits(sqrt(shortBitsToFloat16(input1[i])));
@@ -225,7 +225,7 @@ public class TestFloat16VectorOperations {
     @Test
     @Warmup(10000)
     @IR(counts = {IRNode.FMA_VHF, ">= 1"},
-        applyIfCPUFeature = {"avx512_fp16", "true"})
+        applyIfCPUFeatureOr = {"avx512_fp16", "true", "zvfh", "true"})
     public void vectorFmaFloat16() {
         for (int i = 0; i < LEN; ++i) {
             output[i] = float16ToRawShortBits(fma(shortBitsToFloat16(input1[i]), shortBitsToFloat16(input2[i]),
@@ -248,7 +248,7 @@ public class TestFloat16VectorOperations {
     @Test
     @Warmup(10000)
     @IR(counts = {IRNode.FMA_VHF, " >= 1"},
-        applyIfCPUFeature = {"avx512_fp16", "true"})
+        applyIfCPUFeatureOr = {"avx512_fp16", "true", "zvfh", "true"})
     public void vectorFmaFloat16ScalarMixedConstants() {
         for (int i = 0; i < LEN; ++i) {
             output[i] = float16ToRawShortBits(fma(shortBitsToFloat16(input1[i]), shortBitsToFloat16(SCALAR_FP16),
@@ -272,7 +272,7 @@ public class TestFloat16VectorOperations {
     @Test
     @Warmup(10000)
     @IR(counts = {IRNode.FMA_VHF, " >= 1"},
-        applyIfCPUFeature = {"avx512_fp16", "true"})
+        applyIfCPUFeatureOr = {"avx512_fp16", "true", "zvfh", "true"})
     public void vectorFmaFloat16MixedConstants() {
         short input3 = floatToFloat16(3.0f);
         for (int i = 0; i < LEN; ++i) {
@@ -295,7 +295,7 @@ public class TestFloat16VectorOperations {
     @Test
     @Warmup(10000)
     @IR(counts = {IRNode.FMA_VHF, " 0 "},
-        applyIfCPUFeature = {"avx512_fp16", "true"})
+        applyIfCPUFeatureOr = {"avx512_fp16", "true", "zvfh", "true"})
     public void vectorFmaFloat16AllConstants() {
         short input1 = floatToFloat16(1.0f);
         short input2 = floatToFloat16(2.0f);


### PR DESCRIPTION
Hi,
Can you help to review this patch?
It's a follow-up of https://github.com/openjdk/jdk/commit/9a3f9997b68a1f64e53b9711b878fb073c3c9b90.
Thanks!

## Test

Performance data
<google-sheets-html-origin style="caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0); font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none;">
Benchmark | (vectorDim) | Mode | Cnt | Score - patch | Score - master | Improvement (master/patch) | Error | Units
-- | -- | -- | -- | -- | -- | -- | -- | --
Float16OperationsBenchmark.addBenchmark | 256 | avgt | 10 | 382.123 | 2595.718 | 6.793 | 0.631 | ns/op
Float16OperationsBenchmark.addBenchmark | 512 | avgt | 10 | 563.726 | 5167.687 | 9.167 | 0.063 | ns/op
Float16OperationsBenchmark.addBenchmark | 1024 | avgt | 10 | 888.455 | 9468.714 | 10.658 | 0.147 | ns/op
Float16OperationsBenchmark.addBenchmark | 2048 | avgt | 10 | 1540.255 | 18879.796 | 12.258 | 0.396 | ns/op
Float16OperationsBenchmark.divBenchmark | 256 | avgt | 10 | 579.959 | 4028.335 | 6.946 | 0.008 | ns/op
Float16OperationsBenchmark.divBenchmark | 512 | avgt | 10 | 914.634 | 8034.234 | 8.784 | 0.027 | ns/op
Float16OperationsBenchmark.divBenchmark | 1024 | avgt | 10 | 1494.017 | 15125.924 | 10.124 | 0.292 | ns/op
Float16OperationsBenchmark.divBenchmark | 2048 | avgt | 10 | 2728.517 | 30197.97 | 11.068 | 32.869 | ns/op
Float16OperationsBenchmark.fmaBenchmark | 256 | avgt | 10 | 476.764 | 2817.035 | 5.909 | 0.012 | ns/op
Float16OperationsBenchmark.fmaBenchmark | 512 | avgt | 10 | 707.035 | 5239.438 | 7.41 | 0.129 | ns/op
Float16OperationsBenchmark.fmaBenchmark | 1024 | avgt | 10 | 1114.29 | 7361.105 | 6.606 | 0.024 | ns/op
Float16OperationsBenchmark.fmaBenchmark | 2048 | avgt | 10 | 1931.713 | 14465.602 | 7.488 | 1.852 | ns/op
Float16OperationsBenchmark.maxBenchmark | 256 | avgt | 10 | 501.892 | 3754.563 | 7.481 | 0.408 | ns/op
Float16OperationsBenchmark.maxBenchmark | 512 | avgt | 10 | 738.148 | 7450.666 | 10.094 | 1.206 | ns/op
Float16OperationsBenchmark.maxBenchmark | 1024 | avgt | 10 | 1195.262 | 15463.892 | 12.938 | 8.889 | ns/op
Float16OperationsBenchmark.maxBenchmark | 2048 | avgt | 10 | 2253.656 | 30649.239 | 13.6 | 6.154 | ns/op
Float16OperationsBenchmark.minBenchmark | 256 | avgt | 10 | 501.873 | 3753.9 | 7.48 | 0.298 | ns/op
Float16OperationsBenchmark.minBenchmark | 512 | avgt | 10 | 732.16 | 7445.395 | 10.169 | 0.779 | ns/op
Float16OperationsBenchmark.minBenchmark | 1024 | avgt | 10 | 1186.985 | 15349.186 | 12.931 | 1.829 | ns/op
Float16OperationsBenchmark.minBenchmark | 2048 | avgt | 10 | 2264.592 | 30638.19 | 13.529 | 2.077 | ns/op
Float16OperationsBenchmark.mulBenchmark | 256 | avgt | 10 | 382.06 | 2595.757 | 6.794 | 0.228 | ns/op
Float16OperationsBenchmark.mulBenchmark | 512 | avgt | 10 | 565.259 | 5168.078 | 9.143 | 0.516 | ns/op
Float16OperationsBenchmark.mulBenchmark | 1024 | avgt | 10 | 889.168 | 9468.645 | 10.649 | 0.159 | ns/op
Float16OperationsBenchmark.mulBenchmark | 2048 | avgt | 10 | 1542.165 | 18881.248 | 12.243 | 1.791 | ns/op
Float16OperationsBenchmark.sqrtBenchmark | 256 | avgt | 10 | 508.016 | 3908.87 | 7.694 | 0.01 | ns/op
Float16OperationsBenchmark.sqrtBenchmark | 512 | avgt | 10 | 827.056 | 7775.415 | 9.401 | 0.045 | ns/op
Float16OperationsBenchmark.sqrtBenchmark | 1024 | avgt | 10 | 1395.414 | 15508.686 | 11.114 | 0.208 | ns/op
Float16OperationsBenchmark.sqrtBenchmark | 2048 | avgt | 10 | 2531.666 | 31002.463 | 12.246 | 3.48 | ns/op
Float16OperationsBenchmark.subBenchmark | 256 | avgt | 10 | 380.344 | 2617.333 | 6.881 | 0.926 | ns/op
Float16OperationsBenchmark.subBenchmark | 512 | avgt | 10 | 564.335 | 5170.905 | 9.163 | 0.937 | ns/op
Float16OperationsBenchmark.subBenchmark | 1024 | avgt | 10 | 889.011 | 9469.324 | 10.652 | 0.144 | ns/op
Float16OperationsBenchmark.subBenchmark | 2048 | avgt | 10 | 1540.936 | 18881.797 | 12.253 | 0.824 | ns/op

</google-sheets-html-origin>

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350960](https://bugs.openjdk.org/browse/JDK-8350960): RISC-V: Add riscv backend for Float16 operations - vectorization (**Enhancement** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Dingli Zhang](https://openjdk.org/census#dzhang) (@DingliZhang - Author)
 * [Ludovic Henry](https://openjdk.org/census#luhenry) (@luhenry - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25181/head:pull/25181` \
`$ git checkout pull/25181`

Update a local copy of the PR: \
`$ git checkout pull/25181` \
`$ git pull https://git.openjdk.org/jdk.git pull/25181/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25181`

View PR using the GUI difftool: \
`$ git pr show -t 25181`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25181.diff">https://git.openjdk.org/jdk/pull/25181.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25181#issuecomment-2872232950)
</details>
