### PR TITLE
8355970: C2: Add command line option to print the compile phases

### DIFF
--- a/src/hotspot/share/compiler/compilerDirectives.hpp
+++ b/src/hotspot/share/compiler/compilerDirectives.hpp
@@ -202,7 +202,7 @@ void set_##name(void* value) {                                      \
   void set_ideal_phase_name_set(const BitMap& set) {
     _ideal_phase_name_set.set_from(set);
   };
-  bool should_print_phase(const CompilerPhaseType cpt) const {
+  bool should_print_ideal_phase(const CompilerPhaseType cpt) const {
     return _ideal_phase_name_set.at(cpt);
   };
   void set_trace_auto_vectorization_tags(const CHeapBitMap& tags) {

--- a/src/hotspot/share/compiler/compilerDirectives.hpp
+++ b/src/hotspot/share/compiler/compilerDirectives.hpp
@@ -83,7 +83,8 @@ NOT_PRODUCT(cflags(PrintIdeal,          bool, PrintIdeal, PrintIdeal)) \
     cflags(TraceSpilling,           bool, TraceSpilling, TraceSpilling) \
     cflags(Vectorize,               bool, false, Vectorize) \
     cflags(CloneMapDebug,           bool, false, CloneMapDebug) \
-NOT_PRODUCT(cflags(IGVPrintLevel,       intx, PrintIdealGraphLevel, IGVPrintLevel)) \
+NOT_PRODUCT(cflags(PhasePrintLevel, intx, PrintPhaseLevel, PhasePrintLevel)) \
+NOT_PRODUCT(cflags(IGVPrintLevel,   intx, PrintIdealGraphLevel, IGVPrintLevel)) \
     cflags(IncrementalInlineForceCleanup, bool, IncrementalInlineForceCleanup, IncrementalInlineForceCleanup) \
     cflags(MaxNodeLimit,            intx, MaxNodeLimit, MaxNodeLimit)
 #define compilerdirectives_c2_string_flags(cflags) \

--- a/src/hotspot/share/compiler/compilerOracle.hpp
+++ b/src/hotspot/share/compiler/compilerOracle.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -84,6 +84,7 @@ class methodHandle;
 NOT_PRODUCT(option(TraceEscapeAnalysis, "TraceEscapeAnalysis", Bool)) \
 NOT_PRODUCT(option(PrintIdeal, "PrintIdeal", Bool))  \
 NOT_PRODUCT(option(PrintIdealPhase, "PrintIdealPhase", Ccstrlist)) \
+NOT_PRODUCT(option(PhasePrintLevel, "PhasePrintLevel", Intx)) \
 NOT_PRODUCT(option(IGVPrintLevel, "IGVPrintLevel", Intx)) \
 NOT_PRODUCT(option(TraceAutoVectorization, "TraceAutoVectorization", Ccstrlist)) \
 NOT_PRODUCT(option(TraceMergeStores, "TraceMergeStores", Ccstrlist)) \

--- a/src/hotspot/share/opto/c2_globals.hpp
+++ b/src/hotspot/share/opto/c2_globals.hpp
@@ -386,6 +386,15 @@
           "Limit of ops to make speculative when using CMOVE")              \
           range(0, max_jint)                                                \
                                                                             \
+  develop(intx, PrintPhaseLevel, 0,                                         \
+          "Level of detail of the phase trace print. "                      \
+          "System-wide value, -1=printing is disabled, "                    \
+          "0=print nothing except PhasePrintLevel directives, "             \
+          "6=all details printed. "                                         \
+          "Level of detail of printouts can be set on a per-method level "  \
+          "as well by using CompileCommand=option.")                        \
+          range(-1, 6)                                                      \
+                                                                            \
   develop(bool, PrintIdealGraph, false,                                     \
           "Print ideal graph to XML file / network interface. "             \
           "By default attempts to connect to the visualizer on a socket.")  \

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -5134,7 +5134,7 @@ void Compile::print_method(CompilerPhaseType cpt, int level, Node* n) {
   if (should_print_igv(level)) {
     _igv_printer->print_graph(name);
   }
-  if (should_print_phase(cpt)) {
+  if (should_print_ideal_phase(cpt)) {
     print_ideal_ir(CompilerPhaseTypeHelper::to_name(cpt));
   }
 #endif
@@ -5165,9 +5165,9 @@ void Compile::end_method() {
 #endif
 }
 
-bool Compile::should_print_phase(CompilerPhaseType cpt) {
+bool Compile::should_print_ideal_phase(CompilerPhaseType cpt) {
 #ifndef PRODUCT
-  if (_directive->should_print_phase(cpt)) {
+  if (_directive->should_print_ideal_phase(cpt)) {
     return true;
   }
 #endif

--- a/src/hotspot/share/opto/compile.hpp
+++ b/src/hotspot/share/opto/compile.hpp
@@ -665,7 +665,7 @@ public:
   void begin_method();
   void end_method();
   bool should_print_igv(int level);
-  bool should_print_phase(CompilerPhaseType cpt);
+  bool should_print_ideal_phase(CompilerPhaseType cpt);
 
   void print_method(CompilerPhaseType cpt, int level, Node* n = nullptr);
 

--- a/src/hotspot/share/opto/compile.hpp
+++ b/src/hotspot/share/opto/compile.hpp
@@ -346,6 +346,7 @@ class Compile : public Phase {
   bool                  _print_inlining;        // True if we should print inlining for this compilation
   bool                  _print_intrinsics;      // True if we should print intrinsics for this compilation
 #ifndef PRODUCT
+  uintx                 _phase_counter;         // Counter for the number of already printed phases
   uint                  _igv_idx;               // Counter for IGV node identifiers
   uint                  _igv_phase_iter[PHASE_NUM_TYPES]; // Counters for IGV phase iterations
   bool                  _trace_opto_output;
@@ -640,13 +641,14 @@ public:
   void          set_has_scoped_access(bool v)    { _has_scoped_access = v; }
 
   // check the CompilerOracle for special behaviours for this compile
-  bool          method_has_option(CompileCommandEnum option) {
+  bool          method_has_option(CompileCommandEnum option) const {
     return method() != nullptr && method()->has_option(option);
   }
 
 #ifndef PRODUCT
   uint          next_igv_idx()                  { return _igv_idx++; }
   bool          trace_opto_output() const       { return _trace_opto_output; }
+  void          print_phase(const char* phase_name);
   void          print_ideal_ir(const char* phase_name);
   bool          should_print_ideal() const      { return _directive->PrintIdealOption; }
   bool              parsed_irreducible_loop() const { return _parsed_irreducible_loop; }
@@ -665,6 +667,7 @@ public:
   void begin_method();
   void end_method();
   bool should_print_igv(int level);
+  bool should_print_phase(int level) const;
   bool should_print_ideal_phase(CompilerPhaseType cpt);
 
   void print_method(CompilerPhaseType cpt, int level, Node* n = nullptr);


### PR DESCRIPTION
This PR introduces the flag `-XX:PrintPhaseLevel` that works like the flag `-XX:PrintIdealGraphLevel` and prints the name phases of a C2 compilation (essentially what we have in the left side bar in IGV) to the terminal. This allows redirecting the output to a file and comparing phase decisions between two compilations. Further, it is useful in conjunction with loop opts tracing to immediately see in which phase a certain optimization happened.

<details>
<summary>Output with `-XX:PrintPhaseLevel=2`</summary>

```
> java-fastdebug -Xbatch -XX:CompileCommand=compileonly,TestLoop.test10 -XX:CompileCommand=printcompilation,TestLoop.test\* -XX:PrintPhaseLevel=2 TestLoop.java
CompileCommand: compileonly TestLoop.test10 bool compileonly = true
CompileCommand: PrintCompilation TestLoop.test* bool PrintCompilation = true
3577   98 %  b  3       TestLoop::test10 @ 2 (64 bytes)
3584   99    b  3       TestLoop::test10 (64 bytes)
3648  100 %  b  4       TestLoop::test10 @ 2 (64 bytes)
1.      After Parsing
2.      Iter GVN 1
3.      Incremental Inline
4.      Incremental Boxing Inline
5.      Before Loop Optimizations
6.      PhaseIdealLoop 1
7.      PhaseIdealLoop 2
8.      PhaseIdealLoop 3
9.      Before PhaseCCP 1
10.     PhaseCCP 1
11.     Iter GVN 2
12.     PhaseIdealLoop iterations
13.     After Loop Optimizations
14.     After Macro Expansion
15.     Barrier expand
16.     Optimize finished
17.     Before matching
18.     After matching
19.     Global code motion
20.     Register Allocation
21.     Final Code
3668  103    b  4       TestLoop::test10 (64 bytes)
1.      After Parsing
2.      Iter GVN 1
3.      Incremental Inline
4.      Incremental Boxing Inline
5.      Before Loop Optimizations
6.      PhaseIdealLoop 1
7.      PhaseIdealLoop 2
8.      PhaseIdealLoop 3
9.      Before PhaseCCP 1
10.     PhaseCCP 1
11.     Iter GVN 2
12.     PhaseIdealLoop iterations
13.     PhaseIdealLoop iterations 2
14.     PhaseIdealLoop iterations 3
15.     PhaseIdealLoop iterations 4
16.     PhaseIdealLoop iterations 5
17.     PhaseIdealLoop iterations 6
18.     PhaseIdealLoop iterations 7
19.     PhaseIdealLoop iterations 8
20.     PhaseIdealLoop iterations 9
21.     After Loop Optimizations
22.     After Macro Expansion
23.     Barrier expand
24.     Optimize finished
25.     Before matching
26.     After matching
27.     Global code motion
28.     Register Allocation
29.     Final Code
```
</details>

<details>
<summary>Output with `-XX:PrintPhaseLevel=2` in conjunction with loop opt tracing</summary>

```
> java-fastdebug -Xbatch -XX:CompileCommand=compileonly,TestLoop.test\* -XX:CompileCommand=printcompilation,TestLoop.test\* -XX:+TraceNewVectors -XX:+TraceLoopOpts -XX:PrintPhaseLevel=2 TestLoop.java
CompileCommand: compileonly TestLoop.test* bool compileonly = true
CompileCommand: PrintCompilation TestLoop.test* bool PrintCompilation = true
3016   98 %  b  3       TestLoop::test10 @ 2 (64 bytes)
3040   99    b  3       TestLoop::test10 (64 bytes)
3097  100 %  b  4       TestLoop::test10 @ 2 (64 bytes)
1.      After Parsing
2.      Iter GVN 1
3.      Incremental Inline
4.      Incremental Boxing Inline
5.      Before Loop Optimizations
Loop: N0/N0  has_sfpt
  Loop: N1894/N1845  limit_check profile_predicated predicated sfpts={ 1845 }
Predicate IC   Loop: N1894/N1845  limit_check profile_predicated predicated sfpts={ 1845 }
Predicate IC   Loop: N1894/N1845  limit_check profile_predicated predicated sfpts={ 1845 }
Predicate IC   Loop: N1894/N1845  limit_check profile_predicated predicated sfpts={ 1845 }
Predicate IC   Loop: N1894/N1845  limit_check profile_predicated predicated sfpts={ 1845 }
Predicate IC   Loop: N1894/N1845  limit_check profile_predicated predicated sfpts={ 1845 }
Predicate IC   Loop: N1894/N1845  limit_check profile_predicated predicated sfpts={ 1845 }
Predicate IC   Loop: N1894/N1845  limit_check profile_predicated predicated sfpts={ 1845 }
Predicate IC   Loop: N1894/N1845  limit_check profile_predicated predicated sfpts={ 1845 }
Predicate IC   Loop: N1894/N1845  limit_check profile_predicated predicated sfpts={ 1845 }
Predicate IC   Loop: N1894/N1845  limit_check profile_predicated predicated sfpts={ 1845 }
Predicate IC   Loop: N1894/N1845  limit_check profile_predicated predicated sfpts={ 1845 }
Predicate IC   Loop: N1894/N1845  limit_check profile_predicated predicated sfpts={ 1845 }
Predicate IC   Loop: N1894/N1845  limit_check profile_predicated predicated sfpts={ 1845 }
Predicate IC   Loop: N1894/N1845  limit_check profile_predicated predicated sfpts={ 1845 }
Predicate IC   Loop: N1894/N1845  limit_check profile_predicated predicated sfpts={ 1845 }
Predicate IC   Loop: N1894/N1845  limit_check profile_predicated predicated sfpts={ 1845 }
Predicate IC   Loop: N1894/N1845  limit_check profile_predicated predicated sfpts={ 1845 }
6.      PhaseIdealLoop 1
Loop: N0/N0  has_sfpt
  Loop: N1894/N1845  limit_check profile_predicated predicated sfpts={ 1845 }
7.      PhaseIdealLoop 2
Loop: N0/N0  has_sfpt
  Loop: N1894/N1845  limit_check profile_predicated predicated sfpts={ 1845 }
8.      PhaseIdealLoop 3
9.      Before PhaseCCP 1
10.     PhaseCCP 1
11.     Iter GVN 2
Loop: N0/N0  has_sfpt
  Loop: N1894/N1845  limit_check profile_predicated predicated sfpts={ 1845 }
PredicatesOff
12.     PhaseIdealLoop iterations
Loop: N0/N0  has_sfpt
  Loop: N1894/N1845  profile_predicated predicated sfpts={ 1845 }
13.     After Loop Optimizations
14.     After Macro Expansion
15.     Barrier expand
16.     Optimize finished
17.     Before matching
18.     After matching
19.     Global code motion
20.     Register Allocation
21.     Final Code
3126  103    b  4       TestLoop::test10 (64 bytes)
1.      After Parsing
2.      Iter GVN 1
3.      Incremental Inline
4.      Incremental Boxing Inline
5.      Before Loop Optimizations
Loop: N0/N0  has_sfpt
  Loop: N1912/N1855  limit_check profile_predicated predicated sfpts={ 1777 }
6.      PhaseIdealLoop 1
Counted        Loop: N1924/N1855  limit_check profile_predicated predicated sfpts={ 1777 }
Loop: N0/N0  has_sfpt
  Loop: N1924/N1855  limit_check profile_predicated predicated sfpts={ 1777 }
Predicate IC   Loop: N1924/N1855  limit_check profile_predicated predicated sfpts={ 1777 }
Predicate IC   Loop: N1924/N1855  limit_check profile_predicated predicated sfpts={ 1777 }
Predicate IC   Loop: N1924/N1855  limit_check profile_predicated predicated sfpts={ 1777 }
Predicate IC   Loop: N1924/N1855  limit_check profile_predicated predicated sfpts={ 1777 }
Predicate IC   Loop: N1924/N1855  limit_check profile_predicated predicated sfpts={ 1777 }
Predicate IC   Loop: N1924/N1855  limit_check profile_predicated predicated sfpts={ 1777 }
Predicate IC   Loop: N1924/N1855  limit_check profile_predicated predicated sfpts={ 1777 }
Predicate IC   Loop: N1924/N1855  limit_check profile_predicated predicated sfpts={ 1777 }
Predicate IC   Loop: N1924/N1855  limit_check profile_predicated predicated sfpts={ 1777 }
Predicate IC   Loop: N1924/N1855  limit_check profile_predicated predicated sfpts={ 1777 }
Predicate IC   Loop: N1924/N1855  limit_check profile_predicated predicated sfpts={ 1777 }
Predicate IC   Loop: N1924/N1855  limit_check profile_predicated predicated sfpts={ 1777 }
Predicate IC   Loop: N1924/N1855  limit_check profile_predicated predicated sfpts={ 1777 }
Predicate IC   Loop: N1924/N1855  limit_check profile_predicated predicated sfpts={ 1777 }
Predicate IC   Loop: N1924/N1855  limit_check profile_predicated predicated sfpts={ 1777 }
Predicate IC   Loop: N1924/N1855  limit_check profile_predicated predicated sfpts={ 1777 }
7.      PhaseIdealLoop 2
Loop: N0/N0  has_sfpt
  Loop: N1924/N1855  limit_check profile_predicated predicated sfpts={ 1777 }
Peel             Loop: N2112/N1855  sfpts={ 1777 }
Exceeding node budget: 0 < 141
8.      PhaseIdealLoop 3
9.      Before PhaseCCP 1
10.     PhaseCCP 1
11.     Iter GVN 2
Counted            Loop: N2288/N1855  counted [1,int),+1 (-1 iters) 
Loop: N0/N0  has_sfpt
  Loop: N2088/N2085  limit_check profile_predicated predicated sfpts={ 2168 }
    Loop: N2287/N2286  limit_check profile_predicated predicated
      Loop: N2288/N1855  limit_check profile_predicated predicated counted [1,int),+1 (-1 iters)  has_sfpt strip_mined
Predicate RC       Loop: N2288/N1855  limit_check profile_predicated predicated counted [1,int),+1 (40920 iters)  has_sfpt rce strip_mined
12.     PhaseIdealLoop iterations
Loop: N0/N0  has_sfpt
  Loop: N2088/N2085  limit_check profile_predicated predicated sfpts={ 2168 }
    Loop: N2287/N2286  limit_check profile_predicated predicated sfpts={ 2289 }
      Loop: N2288/N1855  limit_check profile_predicated predicated counted [1,int),+1 (40920 iters)  rc  has_sfpt strip_mined
PreMainPost        Loop: N2288/N1855  limit_check profile_predicated predicated counted [1,int),+1 (40920 iters)  rc  has_sfpt strip_mined
Unroll 2           Loop: N2288/N1855  limit_check counted [int,int),+1 (40920 iters)  main rc  has_sfpt strip_mined
13.     PhaseIdealLoop iterations 2
Loop: N0/N0  has_sfpt
  Loop: N2088/N2085  limit_check profile_predicated predicated sfpts={ 2168 }
    Loop: N2499/N2498  limit_check profile_predicated predicated counted [1,int),+1 (4 iters)  pre rc 
    Loop: N2287/N2286  limit_check sfpts={ 2289 }
      Loop: N2611/N1855  limit_check counted [int,int),+2 (40920 iters)  main rc  has_sfpt strip_mined
    Loop: N2402/N2401  limit_check counted [int,int),+1 (4 iters)  post rc 
Unroll 4           Loop: N2611/N1855  limit_check counted [int,int),+2 (40920 iters)  main rc  has_sfpt rce strip_mined
14.     PhaseIdealLoop iterations 3
Loop: N0/N0  has_sfpt
  Loop: N2088/N2085  limit_check profile_predicated predicated sfpts={ 2168 }
    Loop: N2499/N2498  limit_check profile_predicated predicated counted [1,int),+1 (4 iters)  pre rc 
    Loop: N2287/N2286  limit_check sfpts={ 2289 }
      Loop: N2741/N1855  limit_check counted [int,int),+4 (40920 iters)  main rc  has_sfpt strip_mined
    Loop: N2402/N2401  limit_check counted [int,int),+1 (4 iters)  post rc 
Peel                 Loop: N2875/N1855  has_sfpt rce
Exceeding node budget: 0 < 258
15.     PhaseIdealLoop iterations 4
Counted              Loop: N3236/N1855  counted [4,int),+4 (-1 iters) 
Loop: N0/N0  has_sfpt
  Loop: N2088/N2085  limit_check profile_predicated predicated sfpts={ 2168 }
    Loop: N2499/N2498  limit_check profile_predicated predicated counted [1,int),+1 (4 iters)  pre rc 
    Loop: N2852/N2849  limit_check sfpts={ 3057 }
      Loop: N3235/N3234  limit_check profile_predicated predicated
        Loop: N3236/N1855  limit_check profile_predicated predicated counted [4,int),+4 (-1 iters)  has_sfpt strip_mined
    Loop: N2402/N2401  limit_check counted [int,int),+1 (4 iters)  post rc 
Predicate RC         Loop: N3236/N1855  limit_check profile_predicated predicated counted [4,int),+4 (40920 iters)  has_sfpt rce strip_mined
Predicate RC         Loop: N3236/N1855  limit_check profile_predicated predicated counted [4,int),+4 (40920 iters)  has_sfpt rce strip_mined
Predicate RC         Loop: N3236/N1855  limit_check profile_predicated predicated counted [4,int),+4 (40920 iters)  has_sfpt rce strip_mined
16.     PhaseIdealLoop iterations 5
Loop: N0/N0  has_sfpt
  Loop: N2088/N2085  limit_check profile_predicated predicated sfpts={ 2168 }
    Loop: N2499/N2498  limit_check profile_predicated predicated counted [1,int),+1 (4 iters)  pre rc 
    Loop: N2852/N2849  limit_check sfpts={ 3057 }
      Loop: N3235/N3234  limit_check profile_predicated predicated sfpts={ 3237 }
        Loop: N3236/N1855  limit_check profile_predicated predicated counted [4,int),+4 (40920 iters)  rc  has_sfpt strip_mined
    Loop: N2402/N2401  limit_check counted [int,int),+1 (4 iters)  post rc 
PreMainPost          Loop: N3236/N1855  limit_check profile_predicated predicated counted [4,int),+4 (40920 iters)  rc  has_sfpt strip_mined
Unroll 2             Loop: N3236/N1855  limit_check counted [int,int),+4 (40920 iters)  main rc  has_sfpt strip_mined
Exceeding node budget: 479 < 569
17.     PhaseIdealLoop iterations 6
Loop: N0/N0  has_sfpt
  Loop: N2088/N2085  limit_check profile_predicated predicated sfpts={ 2168 }
    Loop: N2499/N2498  limit_check profile_predicated predicated counted [1,int),+1 (4 iters)  pre rc 
    Loop: N2852/N2849  limit_check sfpts={ 3057 }
      Loop: N3795/N3799  limit_check profile_predicated predicated counted [4,int),+4 (4 iters)  pre rc 
      Loop: N3235/N3234  limit_check sfpts={ 3237 }
        Loop: N4050/N1855  limit_check counted [int,int),+8 (40920 iters)  main rc  has_sfpt strip_mined
      Loop: N3562/N3566  limit_check counted [int,int),+4 (4 iters)  post rc 
    Loop: N2402/N2401  limit_check counted [int,int),+1 (4 iters)  post rc 
Peel                   Loop: N4281/N1855  has_sfpt rce
Exceeding node budget: 0 < 196
18.     PhaseIdealLoop iterations 7
Counted                Loop: N4512/N1855  counted [8,int),+8 (-1 iters) 
Loop: N0/N0  has_sfpt
  Loop: N2088/N2085  limit_check profile_predicated predicated sfpts={ 2168 }
    Loop: N2499/N2498  limit_check profile_predicated predicated counted [1,int),+1 (4 iters)  pre rc 
    Loop: N2852/N2849  limit_check sfpts={ 3057 }
      Loop: N3795/N3799  limit_check profile_predicated predicated counted [4,int),+4 (4 iters)  pre rc 
      Loop: N4258/N4255  limit_check sfpts={ 4402 }
        Loop: N4511/N4510  limit_check profile_predicated predicated
          Loop: N4512/N1855  limit_check profile_predicated predicated counted [8,int),+8 (-1 iters)  has_sfpt strip_mined
      Loop: N3562/N3566  limit_check counted [int,int),+4 (4 iters)  post rc 
    Loop: N2402/N2401  limit_check counted [int,int),+1 (4 iters)  post rc 
PreMainPost            Loop: N4512/N1855  limit_check profile_predicated predicated counted [8,int),+8 (40920 iters)  has_sfpt rce strip_mined
RangeCheck             Loop: N4512/N1855  counted [int,int),+8 (40920 iters)  main has_sfpt rce strip_mined
19.     PhaseIdealLoop iterations 8
Loop: N0/N0  has_sfpt
  Loop: N2088/N2085  limit_check profile_predicated predicated sfpts={ 2168 }
    Loop: N2499/N2498  limit_check profile_predicated predicated counted [1,int),+1 (4 iters)  pre rc 
    Loop: N2852/N2849  limit_check sfpts={ 3057 }
      Loop: N3795/N3799  limit_check profile_predicated predicated counted [4,int),+4 (4 iters)  pre rc 
      Loop: N4258/N4255  limit_check sfpts={ 4402 }
        Loop: N4731/N4737  limit_check profile_predicated predicated counted [8,int),+8 (4 iters)  pre rc 
        Loop: N4511/N4510  limit_check sfpts={ 4513 }
          Loop: N4512/N1855  limit_check counted [int,int),+8 (40920 iters)  main rc  has_sfpt strip_mined
        Loop: N4616/N4622  counted [int,int),+8 (4 iters)  post rc 
      Loop: N3562/N3566  limit_check counted [int,int),+4 (4 iters)  post rc 
    Loop: N2402/N2401  limit_check counted [int,int),+1 (4 iters)  post rc 
PredicatesOff
20.     PhaseIdealLoop iterations 9
Loop: N0/N0  has_sfpt
  Loop: N2088/N2085  predicated sfpts={ 2168 }
    Loop: N2499/N2498  predicated counted [1,int),+1 (4 iters)  pre rc 
    Loop: N2852/N2849  limit_check sfpts={ 3057 }
      Loop: N3795/N3799  predicated counted [4,int),+4 (4 iters)  pre rc 
      Loop: N4258/N4255  limit_check sfpts={ 4402 }
        Loop: N4731/N4737  counted [8,int),+8 (4 iters)  pre rc 
        Loop: N4511/N4510  limit_check sfpts={ 4513 }
          Loop: N4512/N1855  limit_check counted [int,int),+8 (40920 iters)  main rc  has_sfpt strip_mined
        Loop: N4616/N4622  counted [int,int),+8 (4 iters)  post rc 
      Loop: N3562/N3566  limit_check counted [int,int),+4 (4 iters)  post rc 
    Loop: N2402/N2401  limit_check counted [int,int),+1 (4 iters)  post rc 
21.     After Loop Optimizations
22.     After Macro Expansion
23.     Barrier expand
24.     Optimize finished
25.     Before matching
26.     After matching
27.     Global code motion
28.     Register Allocation
29.     Final Code
```
</details>

## Testing

 - [ ] [Github Actions](https://github.com/mhaessig/jdk/actions/runs/14972614510)
 - [ ] tier1 through tier3 on Oracle supported platforms and OSs plus Oracle internal testing
 - [ ] tier1 through tier2 with `-XX:PrintPhaseLevel=4`