### PR TITLE
8356695: java/lang/StringBuilder/HugeCapacity.java failing with OOME

### DIFF
--- a/test/jdk/java/lang/StringBuilder/HugeCapacity.java
+++ b/test/jdk/java/lang/StringBuilder/HugeCapacity.java
@@ -32,8 +32,8 @@ import java.util.Arrays;
  *          necessary
  * @modules java.base/jdk.internal.util
  * @requires (sun.arch.data.model == "64" & os.maxMemory >= 8G)
- * @run main/othervm -Xms6G -Xmx6G -XX:+CompactStrings HugeCapacity true
- * @run main/othervm -Xms6G -Xmx6G -XX:-CompactStrings HugeCapacity false
+ * @run main/othervm -Xms8G -Xmx8G -XX:-CompactStrings -Xlog:gc HugeCapacity false
+ * @run main/othervm -Xms8G -Xmx8G -XX:+CompactStrings -Xlog:gc HugeCapacity true
  */
 
 public class HugeCapacity {


### PR DESCRIPTION
The failure of the new StringBuilder HugeCapacity test testHugePlus is intermittent with some GC's.
It could be reliably reproduced with the serialGC and parallelGC's.

Raise the memory limit from 6G to 8G to accommodate the new test with all GCs.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8356695](https://bugs.openjdk.org/browse/JDK-8356695): java/lang/StringBuilder/HugeCapacity.java failing with OOME (**Bug** - P3)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Raffaello Giulietti](https://openjdk.org/census#rgiulietti) (@rgiulietti - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25186/head:pull/25186` \
`$ git checkout pull/25186`

Update a local copy of the PR: \
`$ git checkout pull/25186` \
`$ git pull https://git.openjdk.org/jdk.git pull/25186/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25186`

View PR using the GUI difftool: \
`$ git pr show -t 25186`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25186.diff">https://git.openjdk.org/jdk/pull/25186.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25186#issuecomment-2873133931)
</details>
