### PR TITLE
8139744: Types referred in @link/@linkplain tags are not always hyperlinks

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/standard.properties
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/standard.properties
@@ -110,6 +110,7 @@ doclet.link.no_reference=no reference given
 doclet.link.see.no_label=missing reference label
 doclet.link.see.reference_invalid=invalid reference
 doclet.link.see.reference_not_found=reference not found: {0}
+doclet.link.see.reference_not_visible=the specified link will not be shown because the referenced element has access-level "{0}" (see -{0})
 doclet.link.see.reference_not_accessible=reference not accessible: {0}
 doclet.see.nested_link=Tag {0}: nested link
 doclet.throws.reference_not_found=cannot find exception type by name

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/taglets/LinkTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/taglets/LinkTaglet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -276,6 +276,13 @@ public class LinkTaglet extends BaseTaglet {
                     // The method to actually link.
                     refMem = overriddenMethod;
                 }
+            }
+            if (!utils.isLinkable(containing, refMem)) {
+                String suggestion = utils.isProtected(refMem) ? "protected" : "private";
+                reportWarning.accept(
+                        "doclet.link.see.reference_not_visible",
+                        new Object[]{suggestion}
+                );
             }
 
             return htmlWriter.getDocLink(HtmlLinkInfo.Kind.SHOW_PREVIEW, containing,

--- a/test/langtools/jdk/javadoc/doclet/testNonLinkableTypeWarn/TestNonLinkableLinkWarn.java
+++ b/test/langtools/jdk/javadoc/doclet/testNonLinkableTypeWarn/TestNonLinkableLinkWarn.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8139744 8356549
+ * @summary Verify warning emitted for non-linkable {@link} targets
+ * @library /tools/lib ../../lib
+ * @modules jdk.javadoc/jdk.javadoc.internal.tool
+ * @build toolbox.ToolBox javadoc.tester.*
+ * @run main TestNonLinkableLinkWarn
+ */
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import javadoc.tester.JavadocTester;
+import toolbox.ToolBox;
+
+public class TestNonLinkableLinkWarn extends JavadocTester {
+
+    public static void main(String... args) throws Exception {
+        new TestNonLinkableLinkWarn().runTests();
+    }
+
+    private final ToolBox tb = new ToolBox();
+    private final Path src = Path.of("src");
+
+    public TestNonLinkableLinkWarn() throws IOException {
+        tb.writeJavaFiles(src, """
+            package p;
+            public class A {
+                /**
+                 * This should warn, because {@link #privateField} is private.
+                 * This should warn, because {@link #protectedField} is protected.
+                 */
+                public void foo() { }
+
+                private int privateField;
+                protected int protectedField;
+            }
+        """);
+    }
+
+    @Test
+    public void testWarnPrivateField(Path base) {
+        javadoc(
+                "-d", base.resolve("out").toString(),
+                "-sourcepath", src.toString(),
+                "p"
+        );
+        checkExit(Exit.OK);
+
+        checkOutput(
+                Output.OUT, true, """
+                        warning: the specified link will not be shown because the referenced element has access-level "private" (see -private)
+                                 * This should warn, because {@link #privateField} is private.
+                                                             ^"""
+        );
+    }
+
+    @Test
+    public void testWarnProtectedField(Path base) {
+        javadoc(
+                "-d", base.resolve("out").toString(),
+                "-public",
+                "-sourcepath", src.toString(),
+                "p"
+        );
+        checkExit(Exit.OK);
+
+        checkOutput(
+                Output.OUT,
+                true, """
+                        warning: the specified link will not be shown because the referenced element has access-level "private" (see -private)
+                                 * This should warn, because {@link #privateField} is private.
+                                                             ^""", """
+                        warning: the specified link will not be shown because the referenced element has access-level "protected" (see -protected)
+                                 * This should warn, because {@link #protectedField} is protected.
+                                                             ^"""
+        );
+    }
+}


### PR DESCRIPTION
Please review this patch to emit a new warning if the reference element cannot be linked. This is intended to prevent links to private member in the JDK docs (see https://bugs.openjdk.org/browse/JDK-8310868).

Here is a [clear example](https://download.java.net/java/early_access/jdk25/docs/api/java.base/java/net/Socket.html#shutdownOutput()) of this bug:

<img width="1071" alt="Screenshot 2025-05-12 at 16 55 26" src="https://github.com/user-attachments/assets/9bbca975-7f41-4970-9735-95906b402534" />

We should link to `sInputShutdown()` instead.


Some private fields are [documented](https://download.java.net/java/early_access/jdk25/docs/api/serialized-form.html#java.awt.Frame) on the Serialization page if the class is serializable. After this patch, warnings will be emitted if a there is an incorrect link in their javadoc. 

Similar to the image below where the there is no hypertext and the link is rendered as plain text, because the linked method is private.
<img width="422" alt="Screenshot 2025-05-12 at 16 53 56" src="https://github.com/user-attachments/assets/847a2acc-f289-4048-b239-77baa87a01ea" />

This bug can also creep in later without the author noticing, if they add a new method and javadoc matches it instead.


Note: This PR can only be integrated after all site bugs are fixed in [JDK-8356549.](https://bugs.openjdk.org/browse/JDK-8356549)