### PR TITLE
8356778: Compiler add event logging in case of failures

### DIFF
--- a/src/hotspot/share/c1/c1_Compilation.cpp
+++ b/src/hotspot/share/c1/c1_Compilation.cpp
@@ -648,12 +648,10 @@ void Compilation::notice_inlined_method(ciMethod* method) {
 void Compilation::bailout(const char* msg) {
   assert(msg != nullptr, "bailout message must exist");
   // record the bailout for hserr envlog
-  if (msg != nullptr) {
-    if (CompilationLog::log() != nullptr) {
-      CompilerThread* thread = CompilerThread::current();
-      CompileTask* task = thread->task();
-      CompilationLog::log()->log_failure(thread, task, msg, nullptr);
-    }
+  if (CompilationLog::log() != nullptr) {
+    CompilerThread* thread = CompilerThread::current();
+    CompileTask* task = thread->task();
+    CompilationLog::log()->log_failure(thread, task, msg, nullptr);
   }
 
   if (!bailed_out()) {

--- a/src/hotspot/share/c1/c1_Compilation.cpp
+++ b/src/hotspot/share/c1/c1_Compilation.cpp
@@ -33,6 +33,7 @@
 #include "c1/c1_ValueStack.hpp"
 #include "code/debugInfoRec.hpp"
 #include "compiler/compilationFailureInfo.hpp"
+#include "compiler/compilationLog.hpp"
 #include "compiler/compilationMemoryStatistic.hpp"
 #include "compiler/compileLog.hpp"
 #include "compiler/compiler_globals.hpp"
@@ -646,6 +647,15 @@ void Compilation::notice_inlined_method(ciMethod* method) {
 
 void Compilation::bailout(const char* msg) {
   assert(msg != nullptr, "bailout message must exist");
+  // record the bailout for hserr envlog
+  if (msg != nullptr) {
+    if (CompilationLog::log() != nullptr) {
+      CompilerThread* thread = CompilerThread::current();
+      CompileTask* task = thread->task();
+      CompilationLog::log()->log_failure(thread, task, msg, nullptr);
+    }
+  }
+
   if (!bailed_out()) {
     // keep first bailout message
     if (PrintCompilation || PrintBailouts) tty->print_cr("compilation bailout: %s", msg);

--- a/src/hotspot/share/ci/ciEnv.cpp
+++ b/src/hotspot/share/ci/ciEnv.cpp
@@ -1170,6 +1170,15 @@ int ciEnv::num_inlined_bytecodes() const {
 // ------------------------------------------------------------------
 // ciEnv::record_failure()
 void ciEnv::record_failure(const char* reason) {
+  // record the bailout for hserr envlog
+  if (reason != nullptr) {
+    if (CompilationLog::log() != nullptr) {
+      CompilerThread* thread = CompilerThread::current();
+      CompileTask* task = thread->task();
+      CompilationLog::log()->log_failure(thread, task, reason, nullptr);
+    }
+  }
+
   if (_failure_reason.get() == nullptr) {
     // Record the first failure reason.
     _failure_reason.set(reason);

--- a/src/hotspot/share/compiler/compilationLog.cpp
+++ b/src/hotspot/share/compiler/compilationLog.cpp
@@ -51,7 +51,11 @@ void CompilationLog::log_nmethod(JavaThread* thread, nmethod* nm) {
 
 void CompilationLog::log_failure(JavaThread* thread, CompileTask* task, const char* reason, const char* retry_message) {
   StringLogMessage lm;
-  lm.print("%4d   COMPILE SKIPPED: %s", task->compile_id(), reason);
+  if (task == nullptr) {
+    lm.print("Id not known, task was 0;  COMPILE SKIPPED: %s", reason);
+  } else {
+    lm.print("%4d   COMPILE SKIPPED: %s", task->compile_id(), reason);
+  }
   if (retry_message != nullptr) {
     lm.append(" (%s)", retry_message);
   }


### PR DESCRIPTION
We should add event logging to some related hotspot methods. While testing this functionality it turned out that sometimes the CompileTask pointer is 0, so this needs to be check to avoid crashes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8356778](https://bugs.openjdk.org/browse/JDK-8356778): Compiler add event logging in case of failures (**Enhancement** - P4)


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25188/head:pull/25188` \
`$ git checkout pull/25188`

Update a local copy of the PR: \
`$ git checkout pull/25188` \
`$ git pull https://git.openjdk.org/jdk.git pull/25188/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25188`

View PR using the GUI difftool: \
`$ git pr show -t 25188`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25188.diff">https://git.openjdk.org/jdk/pull/25188.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25188#issuecomment-2873490855)
</details>
