### PR TITLE
8143850: Add indexed get() and set() methods to ArrayDeque

### DIFF
--- a/src/java.base/share/classes/java/util/ArrayDeque.java
+++ b/src/java.base/share/classes/java/util/ArrayDeque.java
@@ -351,6 +351,50 @@ public class ArrayDeque<E> extends AbstractCollection<E>
         return true;
     }
 
+    // *** Indexed methods ***
+
+    /**
+     * Returns the element at the specified position in this deque.
+     *
+     * @param index index of the element to return
+     * @return the element at the specified position in this deque
+     * @throws IndexOutOfBoundsException if the index is out of range
+     *         ({@code index < 0 || index >= size()})
+     */
+    public E get(int index) {
+        return getset(index, null);
+    }
+
+    /**
+     * Replaces the element at the specified position in this deque
+     * with the specified element.
+     *
+     * @param index index of the element to replace
+     * @param element element to be stored at the specified position
+     * @return the element previously at the specified position
+     * @throws ClassCastException if the class of the specified element
+     *         prevents it from being added to this deque
+     * @throws NullPointerException if the specified element is null
+     * @throws IndexOutOfBoundsException if the index is out of range
+     *         ({@code index < 0 || index >= size()})
+     */
+    public E set(int index, E element) {
+        if (element == null)
+            throw new NullPointerException();
+        return getset(index, element);
+    }
+
+    private E getset(int index, E newValue) {
+        Objects.checkIndex(index, size());
+        index = inc(head, index, elements.length);
+        E oldValue = elementAt(elements, index);
+        if (newValue != null)
+            elements[index] = newValue;
+        return oldValue;
+    }
+
+    // *** Deque methods ***
+
     /**
      * @throws NoSuchElementException {@inheritDoc}
      */

--- a/src/java.base/share/classes/java/util/ArrayDeque.java
+++ b/src/java.base/share/classes/java/util/ArrayDeque.java
@@ -354,10 +354,9 @@ public class ArrayDeque<E> extends AbstractCollection<E>
     // *** Indexed methods ***
 
     /**
-     * Returns the element at the specified position in this deque.
+     * {@return the element at the specified position in this deque}
      *
      * @param index index of the element to return
-     * @return the element at the specified position in this deque
      * @throws IndexOutOfBoundsException if the index is out of range
      *         ({@code index < 0 || index >= size()})
      */

--- a/src/java.base/share/classes/java/util/ArrayDeque.java
+++ b/src/java.base/share/classes/java/util/ArrayDeque.java
@@ -359,6 +359,7 @@ public class ArrayDeque<E> extends AbstractCollection<E>
      * @param index index of the element to return
      * @throws IndexOutOfBoundsException if the index is out of range
      *         ({@code index < 0 || index >= size()})
+     * @since 25
      */
     public E get(int index) {
         return getset(index, null);
@@ -376,6 +377,7 @@ public class ArrayDeque<E> extends AbstractCollection<E>
      * @throws NullPointerException if the specified element is null
      * @throws IndexOutOfBoundsException if the index is out of range
      *         ({@code index < 0 || index >= size()})
+     * @since 25
      */
     public E set(int index, E element) {
         if (element == null)

--- a/test/jdk/java/util/ArrayDeque/IndexedAccess.java
+++ b/test/jdk/java/util/ArrayDeque/IndexedAccess.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.util.ArrayDeque;
+import java.util.Collections;
+
+/**
+ * @test
+ * @bug 8143850
+ * @summary Verify ArrayDeque indexed get() and set()
+ * @run testng IndexedAccess
+ */
+
+import static org.testng.Assert.*;
+import org.testng.annotations.Test;
+
+public class IndexedAccess {
+
+    @Test
+    public void testIndexedAccess() {
+        ArrayDeque<String> a = new ArrayDeque<>();
+        Collections.addAll(a, "aaa", "bbb", "ccc", "ddd", "eee");
+
+        checkSize(a, 5);
+        assertEquals(a.get(0), "aaa");
+        assertEquals(a.get(1), "bbb");
+        assertEquals(a.get(2), "ccc");
+        assertEquals(a.get(3), "ddd");
+        assertEquals(a.get(4), "eee");
+
+        a.removeFirst();
+        checkSize(a, 4);
+        assertEquals(a.get(0), "bbb");
+        assertEquals(a.get(1), "ccc");
+        assertEquals(a.get(2), "ddd");
+        assertEquals(a.get(3), "eee");
+
+        assertEquals(a.set(2, "xxx"), "ddd");
+        checkSize(a, 4);
+        assertEquals(a.get(0), "bbb");
+        assertEquals(a.get(1), "ccc");
+        assertEquals(a.get(2), "xxx");
+        assertEquals(a.get(3), "eee");
+
+        a.addFirst("yyy");
+        checkSize(a, 5);
+        assertEquals(a.set(2, "zzz"), "ccc");
+        assertEquals(a.get(0), "yyy");
+        assertEquals(a.get(1), "bbb");
+        assertEquals(a.get(2), "zzz");
+        assertEquals(a.get(3), "xxx");
+        assertEquals(a.get(4), "eee");
+
+        try {
+            a.set(0, null);
+        } catch (NullPointerException e) {
+            // expected
+        }
+    }
+
+    private void checkSize(ArrayDeque<String> a, int size) {
+        assertEquals(a.size(), size);
+        for (int index = 0; index < size; index++) {
+            a.set(index, a.get(index));
+        }
+        for (int index : new int[] { Integer.MIN_VALUE, -1, size, Integer.MAX_VALUE }) {
+            try {
+                a.get(index);
+                throw new AssertionError();
+            } catch (IndexOutOfBoundsException e) {
+                // expected
+            }
+            try {
+                a.set(index, "sss");
+                throw new AssertionError();
+            } catch (IndexOutOfBoundsException e) {
+                // expected
+            }
+        }
+    }
+}


### PR DESCRIPTION
Because it is backed by an array, the `ArrayDeque` class has the ability to get and replace any element in the list (accessed by index) in constant time. However, this capability is not exposed in the API.

Please review this PR which adds the following two new methods to `ArrayDeque`:
* `public E get(int index)`
* `public E set(int index, E element)`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change requires CSR request [JDK-8356821](https://bugs.openjdk.org/browse/JDK-8356821) to be approved

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8143850](https://bugs.openjdk.org/browse/JDK-8143850)

### Issues
 * [JDK-8143850](https://bugs.openjdk.org/browse/JDK-8143850): Add a List view to ArrayDeque (**Enhancement** - P4) ⚠️ Title mismatch between PR and JBS.
 * [JDK-8356821](https://bugs.openjdk.org/browse/JDK-8356821): Add indexed get() and set() methods to ArrayDeque (**CSR**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25189/head:pull/25189` \
`$ git checkout pull/25189`

Update a local copy of the PR: \
`$ git checkout pull/25189` \
`$ git pull https://git.openjdk.org/jdk.git pull/25189/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25189`

View PR using the GUI difftool: \
`$ git pr show -t 25189`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25189.diff">https://git.openjdk.org/jdk/pull/25189.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25189#issuecomment-2876959620)
</details>
