### PR TITLE
8356811: Some nsk/jdi tests can fetch ThreadReference from static field in the debuggee: part 4

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/invokeMethod/invokemethod007.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/invokeMethod/invokemethod007.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/invokeMethod/invokemethod007.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/invokeMethod/invokemethod007.java
@@ -158,7 +158,8 @@ public class invokemethod007 {
 
             thread = brkpEvent.thread();
 
-            suspendedThread = debugee.threadByName(invokemethod007a.testedThread);
+            suspendedThread = debugee.threadByFieldNameOrThrow(testedClass, "thread",
+                                                               invokemethod007a.testedThread);
             switch (i) {
             case 0:
                 suspendedThread.suspend();

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/invokeMethod/invokemethod007a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/invokeMethod/invokemethod007a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/invokeMethod/invokemethod007a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/invokeMethod/invokemethod007a.java
@@ -40,13 +40,13 @@ public class invokemethod007a {
     public static Log log;
     public static long waitTime;
     private static IOPipe pipe;
+    static Thread thread = null;
 
     public static void main (String argv[]) {
         ArgumentHandler argHandler = new ArgumentHandler(argv);
         log = new Log(System.err, argHandler);
         waitTime = argHandler.getWaitTime() * 60000;
         pipe = argHandler.createDebugeeIOPipe(log);
-        Thread thread = null;
         pipe.println(invokemethod007.SGNL_READY);
 
         String instr = pipe.readln();
@@ -54,7 +54,7 @@ public class invokemethod007a {
 
             // create new thread and start it
             if (instr.equals(invokemethod007.SGNL_STRTHRD)) {
-                thread = JDIThreadFactory.newThread(new im007aThread01("im007aThread01"));
+                thread = JDIThreadFactory.newThread(new im007aThread01(testedThread));
                 synchronized(im007aThread01.waitStarting) {
                     thread.start();
                     try {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/invokeMethod/invokemethod009.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/invokeMethod/invokemethod009.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/invokeMethod/invokemethod009.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/invokeMethod/invokemethod009.java
@@ -115,7 +115,7 @@ public class invokemethod009 {
         // debuggee main class
         ReferenceType rType = debuggee.classByName(DEBUGGEE_CLASS);
 
-        thrRef = debuggee.threadByFieldNameOrThrow(rType, "testThread", DEBUGGEE_THRNAME);
+        thrRef = debuggee.threadByFieldName(rType, "testThread", DEBUGGEE_THRNAME);
         if (thrRef == null) {
             log.complain("TEST FAILURE: Method Debugee.threadByName() returned null for debuggee thread "
                 + DEBUGGEE_THRNAME);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/invokeMethod/invokemethod009.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/invokeMethod/invokemethod009.java
@@ -55,7 +55,7 @@ public class invokemethod009 {
     static final String DEBUGGEE_THRNAME = "invokemethod009tThr";
 
     // debuggee source line where it should be stopped
-    static final int DEBUGGEE_STOPATLINE = 57;
+    static final int DEBUGGEE_STOPATLINE = 60;
 
     // tested debuggee methods, fields and reference types
     static final int METH_NUM = 2;
@@ -112,15 +112,16 @@ public class invokemethod009 {
             return quitDebuggee();
         }
 
-        if ((thrRef =
-                debuggee.threadByName(DEBUGGEE_THRNAME)) == null) {
+        // debuggee main class
+        ReferenceType rType = debuggee.classByName(DEBUGGEE_CLASS);
+
+        thrRef = debuggee.threadByFieldNameOrThrow(rType, "testThread", DEBUGGEE_THRNAME);
+        if (thrRef == null) {
             log.complain("TEST FAILURE: Method Debugee.threadByName() returned null for debuggee thread "
                 + DEBUGGEE_THRNAME);
             tot_res = Consts.TEST_FAILED;
             return quitDebuggee();
         }
-        // debuggee main class
-        ReferenceType rType = debuggee.classByName(DEBUGGEE_CLASS);
 
 // Check the tested assersion
         try {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/invokeMethod/invokemethod009.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/invokeMethod/invokemethod009.java
@@ -117,7 +117,7 @@ public class invokemethod009 {
 
         thrRef = debuggee.threadByFieldName(rType, "testThread", DEBUGGEE_THRNAME);
         if (thrRef == null) {
-            log.complain("TEST FAILURE: Method Debugee.threadByName() returned null for debuggee thread "
+            log.complain("TEST FAILURE: Method Debugee.threadByFieldName() returned null for debuggee thread "
                 + DEBUGGEE_THRNAME);
             tot_res = Consts.TEST_FAILED;
             return quitDebuggee();

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/invokeMethod/invokemethod009t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/invokeMethod/invokemethod009t.java
@@ -33,6 +33,8 @@ import nsk.share.jdi.*;
  * This is a debuggee class.
  */
 public class invokemethod009t {
+    static Thread testThread = null;
+
     public static void main(String args[]) {
         System.exit(run(args) + Consts.JCK_STATUS_BASE);
     }
@@ -44,7 +46,8 @@ public class invokemethod009t {
     private int runIt(String args[]) {
         ArgumentHandler argHandler = new ArgumentHandler(args);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
-        Thread.currentThread().setName(invokemethod009.DEBUGGEE_THRNAME);
+        testThread = Thread.currentThread();
+        testThread.setName(invokemethod009.DEBUGGEE_THRNAME);
 
         pipe.println(invokemethod009.COMMAND_READY);
         String cmd = pipe.readln();

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/invokeMethod/invokemethod009t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/invokeMethod/invokemethod009t.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/invokeMethod/invokemethod010.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/invokeMethod/invokemethod010.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/invokeMethod/invokemethod010.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/invokeMethod/invokemethod010.java
@@ -113,7 +113,7 @@ public class invokemethod010 {
 
         // debuggee main class
         ReferenceType rType = debuggee.classByName(DEBUGGEE_CLASS);
-        
+
         thrRef = debuggee.threadByFieldName(rType, "testThread", DEBUGGEE_THRNAME);
         if (thrRef == null) {
             log.complain("TEST FAILURE: method Debugee.threadByName() returned null for debuggee thread "

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/invokeMethod/invokemethod010.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/invokeMethod/invokemethod010.java
@@ -111,8 +111,11 @@ public class invokemethod010 {
             return quitDebuggee();
         }
 
-        if ((thrRef =
-                debuggee.threadByName(DEBUGGEE_THRNAME)) == null) {
+        // debuggee main class
+        ReferenceType rType = debuggee.classByName(DEBUGGEE_CLASS);
+        
+        thrRef = debuggee.threadByFieldNameOrThrow(rType, "testThread", DEBUGGEE_THRNAME);
+        if (thrRef == null) {
             log.complain("TEST FAILURE: method Debugee.threadByName() returned null for debuggee thread "
                 + DEBUGGEE_THRNAME);
             tot_res = Consts.TEST_FAILED;
@@ -139,7 +142,6 @@ public class invokemethod010 {
 
         try {
             // debuggee main class
-            ReferenceType rType = debuggee.classByName(DEBUGGEE_CLASS);
             ClassType clsType = (ClassType) rType;
 
             for (int i=0; i<METH_NUM; i++) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/invokeMethod/invokemethod010.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/invokeMethod/invokemethod010.java
@@ -116,7 +116,7 @@ public class invokemethod010 {
 
         thrRef = debuggee.threadByFieldName(rType, "testThread", DEBUGGEE_THRNAME);
         if (thrRef == null) {
-            log.complain("TEST FAILURE: method Debugee.threadByName() returned null for debuggee thread "
+            log.complain("TEST FAILURE: method Debugee.threadByFieldName() returned null for debuggee thread "
                 + DEBUGGEE_THRNAME);
             tot_res = Consts.TEST_FAILED;
             return quitDebuggee();

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/invokeMethod/invokemethod010.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/invokeMethod/invokemethod010.java
@@ -114,7 +114,7 @@ public class invokemethod010 {
         // debuggee main class
         ReferenceType rType = debuggee.classByName(DEBUGGEE_CLASS);
         
-        thrRef = debuggee.threadByFieldNameOrThrow(rType, "testThread", DEBUGGEE_THRNAME);
+        thrRef = debuggee.threadByFieldName(rType, "testThread", DEBUGGEE_THRNAME);
         if (thrRef == null) {
             log.complain("TEST FAILURE: method Debugee.threadByName() returned null for debuggee thread "
                 + DEBUGGEE_THRNAME);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/invokeMethod/invokemethod010t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/invokeMethod/invokemethod010t.java
@@ -31,6 +31,8 @@ import nsk.share.jdi.*;
  * This is debuggee class.
  */
 public class invokemethod010t {
+    static Thread testThread = null;
+
     public static void main(String args[]) {
         System.exit(run(args) + Consts.JCK_STATUS_BASE);
     }
@@ -42,7 +44,8 @@ public class invokemethod010t {
     private int runIt(String args[]) {
         ArgumentHandler argHandler = new ArgumentHandler(args);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
-        Thread.currentThread().setName(invokemethod010.DEBUGGEE_THRNAME);
+        testThread = Thread.currentThread();
+        testThread.setName(invokemethod010.DEBUGGEE_THRNAME);
 
         pipe.println(invokemethod010.COMMAND_READY);
         String cmd = pipe.readln();

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/invokeMethod/invokemethod010t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/invokeMethod/invokemethod010t.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/invokeMethod/invokemethod014.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/invokeMethod/invokemethod014.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/invokeMethod/invokemethod014.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/invokeMethod/invokemethod014.java
@@ -120,7 +120,7 @@ public class invokemethod014 {
         ThreadReference thrRef =
             debuggee.threadByFieldName(rType, "testThread", DEBUGGEE_THRNAME);
         if (thrRef == null) {
-            log.complain("TEST FAILURE: method Debugee.threadByName() returned null for debuggee thread "
+            log.complain("TEST FAILURE: method Debugee.threadByFieldName() returned null for debuggee thread "
                 + DEBUGGEE_THRNAME);
             tot_res = Consts.TEST_FAILED;
             return quitDebuggee();

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/invokeMethod/invokemethod014.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/invokeMethod/invokemethod014.java
@@ -68,7 +68,7 @@ public class invokemethod014 {
     static final String DEBUGGEE_THRNAME = "invokemethod014tThr";
 
     // debuggee source line where it should be stopped
-    static final int DEBUGGEE_STOPATLINE = 61;
+    static final int DEBUGGEE_STOPATLINE = 63;
 
     static final int TIMEOUT_DELTA = 1000; // in milliseconds
 
@@ -113,9 +113,13 @@ public class invokemethod014 {
             return quitDebuggee();
         }
 
-        ThreadReference thrRef = null;
-        if ((thrRef =
-                debuggee.threadByName(DEBUGGEE_THRNAME)) == null) {
+        // debuggee main class
+        ReferenceType rType = debuggee.classByName(DEBUGGEE_CLASS);
+        ClassType clsType = (ClassType) rType;
+       
+        ThreadReference thrRef =
+            debuggee.threadByFieldNameOrThrow(rType, "testThread", DEBUGGEE_THRNAME);
+        if (thrRef == null) {
             log.complain("TEST FAILURE: method Debugee.threadByName() returned null for debuggee thread "
                 + DEBUGGEE_THRNAME);
             tot_res = Consts.TEST_FAILED;
@@ -123,9 +127,6 @@ public class invokemethod014 {
         }
 
         try {
-            // debuggee main class
-            ReferenceType rType = debuggee.classByName(DEBUGGEE_CLASS);
-            ClassType clsType = (ClassType) rType;
             suspendAtBP(rType, DEBUGGEE_STOPATLINE);
 
             for (int i=0; i<METH_NUM; i++) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/invokeMethod/invokemethod014.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/invokeMethod/invokemethod014.java
@@ -116,7 +116,7 @@ public class invokemethod014 {
         // debuggee main class
         ReferenceType rType = debuggee.classByName(DEBUGGEE_CLASS);
         ClassType clsType = (ClassType) rType;
-       
+
         ThreadReference thrRef =
             debuggee.threadByFieldName(rType, "testThread", DEBUGGEE_THRNAME);
         if (thrRef == null) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/invokeMethod/invokemethod014.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/invokeMethod/invokemethod014.java
@@ -118,7 +118,7 @@ public class invokemethod014 {
         ClassType clsType = (ClassType) rType;
        
         ThreadReference thrRef =
-            debuggee.threadByFieldNameOrThrow(rType, "testThread", DEBUGGEE_THRNAME);
+            debuggee.threadByFieldName(rType, "testThread", DEBUGGEE_THRNAME);
         if (thrRef == null) {
             log.complain("TEST FAILURE: method Debugee.threadByName() returned null for debuggee thread "
                 + DEBUGGEE_THRNAME);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/invokeMethod/invokemethod014t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/invokeMethod/invokemethod014t.java
@@ -34,6 +34,7 @@ import nsk.share.jdi.*;
  */
 public class invokemethod014t {
     static {} // force javac to produce <clinit> method
+    static Thread testThread = null;
 
     invokemethod014t() {} // force javac to produce <init> method
 
@@ -48,7 +49,8 @@ public class invokemethod014t {
     private int runIt(String args[]) {
         ArgumentHandler argHandler = new ArgumentHandler(args);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
-        Thread.currentThread().setName(invokemethod014.DEBUGGEE_THRNAME);
+        testThread = Thread.currentThread();
+        testThread.setName(invokemethod014.DEBUGGEE_THRNAME);
 
         pipe.println(invokemethod014.COMMAND_READY);
         String cmd = pipe.readln();

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/invokeMethod/invokemethod014t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/invokeMethod/invokemethod014t.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/newInstance/newinstance007.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/newInstance/newinstance007.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/newInstance/newinstance007.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/newInstance/newinstance007.java
@@ -157,7 +157,8 @@ public class newinstance007 {
 
             thread = brkpEvent.thread();
 
-            suspendedThread = debugee.threadByName(newinstance007a.testedThread);
+            suspendedThread = debugee.threadByFieldNameOrThrow(testedClass, "thread",
+                                                               newinstance007a.testedThread);
             switch (i) {
             case 0:
                 suspendedThread.suspend();

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/newInstance/newinstance007a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/newInstance/newinstance007a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/newInstance/newinstance007a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/newInstance/newinstance007a.java
@@ -34,19 +34,19 @@ import nsk.share.jdi.*;
 public class newinstance007a {
 
     public final static String brkpMethodName = "main";
-    public final static int brkpLineNumber = 70;
+    public final static int brkpLineNumber = 71;
     public final static String testedThread = "im007aThread01";
 
     public static Log log;
     public static long waitTime;
     private static IOPipe pipe;
+    static Thread thread = null;
 
     public static void main (String argv[]) {
         ArgumentHandler argHandler = new ArgumentHandler(argv);
         log = new Log(System.err, argHandler);
         waitTime = argHandler.getWaitTime() * 60000;
         pipe = argHandler.createDebugeeIOPipe(log);
-        Thread thread = null;
         pipe.println(newinstance007.SGNL_READY);
 
         String instr = pipe.readln();
@@ -54,7 +54,7 @@ public class newinstance007a {
 
             // create new thread and start it
             if (instr.equals(newinstance007.SGNL_STRTHRD)) {
-                thread = JDIThreadFactory.newThread(new im007aThread01("im007aThread01"));
+                thread = JDIThreadFactory.newThread(new im007aThread01(testedThread));
                 synchronized(im007aThread01.waitStarting) {
                     thread.start();
                     try {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/newInstance/newinstance009.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/newInstance/newinstance009.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/newInstance/newinstance009.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/newInstance/newinstance009.java
@@ -95,9 +95,12 @@ public class newinstance009 {
             return quitDebuggee();
         }
 
-        ThreadReference thrRef = null;
-        if ((thrRef =
-                debuggee.threadByName(DEBUGGEE_THRNAME)) == null) {
+        // debuggee main class
+        ReferenceType rType = debuggee.classByName(DEBUGGEE_CLASS);
+        ClassType clsType = (ClassType) rType;
+
+        ThreadReference thrRef = debuggee.threadByFieldNameOrThrow(rType, "thread", DEBUGGEE_THRNAME);
+        if (thrRef == null) {
             log.complain("TEST FAILURE: method Debugee.threadByName() returned null for debuggee thread "
                 + DEBUGGEE_THRNAME);
             tot_res = Consts.TEST_FAILED;
@@ -123,10 +126,6 @@ public class newinstance009 {
         }
 
         try {
-            // debuggee main class
-            ReferenceType rType = debuggee.classByName(DEBUGGEE_CLASS);
-            ClassType clsType = (ClassType) rType;
-
             List methList = rType.methodsByName("<init>");
             if (methList.isEmpty()) {
                 log.complain("TEST FAILURE: the expected constructor "

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/newInstance/newinstance009.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/newInstance/newinstance009.java
@@ -99,7 +99,7 @@ public class newinstance009 {
         ReferenceType rType = debuggee.classByName(DEBUGGEE_CLASS);
         ClassType clsType = (ClassType) rType;
 
-        ThreadReference thrRef = debuggee.threadByFieldNameOrThrow(rType, "thread", DEBUGGEE_THRNAME);
+        ThreadReference thrRef = debuggee.threadByFieldName(rType, "thread", DEBUGGEE_THRNAME);
         if (thrRef == null) {
             log.complain("TEST FAILURE: method Debugee.threadByName() returned null for debuggee thread "
                 + DEBUGGEE_THRNAME);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/newInstance/newinstance009.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/newInstance/newinstance009.java
@@ -101,7 +101,7 @@ public class newinstance009 {
 
         ThreadReference thrRef = debuggee.threadByFieldName(rType, "thread", DEBUGGEE_THRNAME);
         if (thrRef == null) {
-            log.complain("TEST FAILURE: method Debugee.threadByName() returned null for debuggee thread "
+            log.complain("TEST FAILURE: method Debugee.threadByFieldName() returned null for debuggee thread "
                 + DEBUGGEE_THRNAME);
             tot_res = Consts.TEST_FAILED;
             return quitDebuggee();

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/newInstance/newinstance009t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/newInstance/newinstance009t.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/newInstance/newinstance009t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/newInstance/newinstance009t.java
@@ -31,6 +31,8 @@ import nsk.share.jdi.*;
  * This is debuggee class.
  */
 public class newinstance009t {
+    static Thread thread = null;
+
     // constructor used only to check IncompatibleThreadStateException throwing
     // in the debugger
     newinstance009t() {
@@ -48,7 +50,8 @@ public class newinstance009t {
     private int runIt(String args[]) {
         ArgumentHandler argHandler = new ArgumentHandler(args);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
-        Thread.currentThread().setName(newinstance009.DEBUGGEE_THRNAME);
+        thread = Thread.currentThread();
+        thread.setName(newinstance009.DEBUGGEE_THRNAME);
 
         pipe.println(newinstance009.COMMAND_READY);
         String cmd = pipe.readln();

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/Event/equals/equals001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/Event/equals/equals001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/Event/equals/equals001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/Event/equals/equals001.java
@@ -126,7 +126,8 @@ public class equals001 {
             switch (i) {
 
                 case 0:
-                       ThreadReference thread = debuggee.threadByName(threadName);
+                       ThreadReference thread =
+                           debuggee.threadByFieldNameOrThrow(debuggeeClass, threadName);
 
                        display("setting up StepRequest");
                        eventRequest = eventRequestManager.createStepRequest

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/Event/equals/equals001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/Event/equals/equals001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/Event/equals/equals001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/Event/equals/equals001a.java
@@ -64,6 +64,7 @@ public class equals001a {
 
     static Object lock = new Object();
     static Object wait = new Object();
+    static Thread thread1 = null;
 
     //------------------------------------------------------ mutable common method
 
@@ -73,7 +74,7 @@ public class equals001a {
         log = new Log(System.err, argHandler);
         pipe = argHandler.createDebugeeIOPipe(log);
         try {
-            Thread thread1 = JDIThreadFactory.newThread(new equals001aThread("thread1"));
+            thread1 = JDIThreadFactory.newThread(new equals001aThread("thread1"));
 
             synchronized (lock) {
                  synchronized(wait) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/Event/hashCode/hashcode001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/Event/hashCode/hashcode001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/Event/hashCode/hashcode001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/Event/hashCode/hashcode001.java
@@ -64,7 +64,7 @@ public class hashcode001 {
     private final static String threadName = "thread1";
     private final static String methodName = "foo";
     private final static String fieldName = "name";
-    private final static int brkpLineNumber = 145;
+    private final static int brkpLineNumber = 146;
 
     //------------------------------------------------------- immutable common methods
 
@@ -126,7 +126,8 @@ public class hashcode001 {
             switch (i) {
 
                 case 0:
-                       ThreadReference thread = debuggee.threadByName(threadName);
+                       ThreadReference thread =
+                           debuggee.threadByFieldNameOrThrow(debuggeeClass, threadName);
 
                        display(".....setting up StepRequest");
                        eventRequest = eventRequestManager.createStepRequest

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/Event/hashCode/hashcode001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/Event/hashCode/hashcode001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/Event/hashCode/hashcode001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/Event/hashCode/hashcode001a.java
@@ -64,6 +64,7 @@ public class hashcode001a {
 
     static Object lock = new Object();
     static Object wait = new Object();
+    static Thread thread1 = null;
 
     //------------------------------------------------------ mutable common method
 
@@ -73,7 +74,7 @@ public class hashcode001a {
         log = new Log(System.err, argHandler);
         pipe = argHandler.createDebugeeIOPipe(log);
         try {
-            Thread thread1 = JDIThreadFactory.newThread(new hashcode001aThread("thread1"));
+            thread1 = JDIThreadFactory.newThread(new hashcode001aThread("thread1"));
 
             synchronized (lock) {
                  synchronized(wait) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod002.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod002.java
@@ -128,7 +128,7 @@ public class invokemethod002 {
 
         thrRef = debuggee.threadByFieldName(rType[0], "testThread", DEBUGGEE_THRNAME);
         if (thrRef == null) {
-            log.complain("TEST FAILURE: Method Debugee.threadByName() returned null for debuggee thread "
+            log.complain("TEST FAILURE: Method Debugee.threadByFieldName() returned null for debuggee thread "
                 + DEBUGGEE_THRNAME);
             tot_res = Consts.TEST_FAILED;
             return quitDebuggee();

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod002.java
@@ -71,7 +71,7 @@ public class invokemethod002 {
     static final String DEBUGGEE_THRNAME = "invokemethod002tThr";
 
     // debuggee source line where it should be stopped
-    static final int DEBUGGEE_STOPATLINE = 62;
+    static final int DEBUGGEE_STOPATLINE = 64;
 
     // debuggee local var used to find needed stack frame
     static final String DEBUGGEE_LOCALVAR = "invokemethod002tdummyCls";
@@ -124,14 +124,15 @@ public class invokemethod002 {
             return quitDebuggee();
         }
 
-        if ((thrRef =
-                debuggee.threadByName(DEBUGGEE_THRNAME)) == null) {
+        rType[0] = debuggee.classByName(DEBUGGEE_CLASS); // debuggee main class
+
+        thrRef = debuggee.threadByFieldNameOrThrow(rType[0], "testThread", DEBUGGEE_THRNAME);
+        if (thrRef == null) {
             log.complain("TEST FAILURE: Method Debugee.threadByName() returned null for debuggee thread "
                 + DEBUGGEE_THRNAME);
             tot_res = Consts.TEST_FAILED;
             return quitDebuggee();
         }
-        rType[0] = debuggee.classByName(DEBUGGEE_CLASS); // debuggee main class
 
 // Check the tested assersion
         try {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod002.java
@@ -126,7 +126,7 @@ public class invokemethod002 {
 
         rType[0] = debuggee.classByName(DEBUGGEE_CLASS); // debuggee main class
 
-        thrRef = debuggee.threadByFieldNameOrThrow(rType[0], "testThread", DEBUGGEE_THRNAME);
+        thrRef = debuggee.threadByFieldName(rType[0], "testThread", DEBUGGEE_THRNAME);
         if (thrRef == null) {
             log.complain("TEST FAILURE: Method Debugee.threadByName() returned null for debuggee thread "
                 + DEBUGGEE_THRNAME);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod002t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod002t.java
@@ -33,6 +33,7 @@ import nsk.share.jdi.*;
  */
 public class invokemethod002t {
     static {} // force javac to produce <clinit> method
+    static Thread testThread = null;
 
     invokemethod002t() {} // force javac to produce <init> method
 
@@ -49,7 +50,8 @@ public class invokemethod002t {
         IOPipe pipe = argHandler.createDebugeeIOPipe();
         invokemethod002tDummyClass invokemethod002tdummyCls = new invokemethod002tDummyClass();
 
-        Thread.currentThread().setName(invokemethod002.DEBUGGEE_THRNAME);
+        testThread = Thread.currentThread();
+        testThread.setName(invokemethod002.DEBUGGEE_THRNAME);
 
         pipe.println(invokemethod002.COMMAND_READY);
         String cmd = pipe.readln();

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod002t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod002t.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod003.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod003.java
@@ -143,7 +143,7 @@ public class invokemethod003 {
         // debuggee dummy abstract class
         rType[2] = debuggee.classByName(DEBUGGEE_ABSTRACTCLASS);
 
-        thrRef = debuggee.threadByFieldNameOrThrow(rType[0], "testThread", DEBUGGEE_THRNAME);
+        thrRef = debuggee.threadByFieldName(rType[0], "testThread", DEBUGGEE_THRNAME);
         if (thrRef == null) {
             log.complain("TEST FAILURE: Method Debugee.threadByName() returned null for debuggee thread "
                 + DEBUGGEE_THRNAME);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod003.java
@@ -58,7 +58,7 @@ public class invokemethod003 {
     static final String DEBUGGEE_THRNAME = "invokemethod003tThr";
 
     // debuggee source line where it should be stopped
-    static final int DEBUGGEE_STOPATLINE = 59;
+    static final int DEBUGGEE_STOPATLINE = 62;
 
     // debuggee local var used to find needed stack frame
     static final String DEBUGGEE_LOCALVAR =
@@ -135,13 +135,6 @@ public class invokemethod003 {
             return quitDebuggee();
         }
 
-        if ((thrRef =
-                debuggee.threadByName(DEBUGGEE_THRNAME)) == null) {
-            log.complain("TEST FAILURE: Method Debugee.threadByName() returned null for debuggee thread "
-                + DEBUGGEE_THRNAME);
-            tot_res = Consts.TEST_FAILED;
-            return quitDebuggee();
-        }
         ReferenceType[] rType = new ReferenceType[3];
         // debuggee main class
         rType[0] = debuggee.classByName(DEBUGGEE_CLASS);
@@ -149,6 +142,14 @@ public class invokemethod003 {
         rType[1] = debuggee.classByName(DEBUGGEE_INTERFACE);
         // debuggee dummy abstract class
         rType[2] = debuggee.classByName(DEBUGGEE_ABSTRACTCLASS);
+
+        thrRef = debuggee.threadByFieldNameOrThrow(rType[0], "testThread", DEBUGGEE_THRNAME);
+        if (thrRef == null) {
+            log.complain("TEST FAILURE: Method Debugee.threadByName() returned null for debuggee thread "
+                + DEBUGGEE_THRNAME);
+            tot_res = Consts.TEST_FAILED;
+            return quitDebuggee();
+        }
 
 // Check the tested assersion
         try {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod003.java
@@ -145,7 +145,7 @@ public class invokemethod003 {
 
         thrRef = debuggee.threadByFieldName(rType[0], "testThread", DEBUGGEE_THRNAME);
         if (thrRef == null) {
-            log.complain("TEST FAILURE: Method Debugee.threadByName() returned null for debuggee thread "
+            log.complain("TEST FAILURE: Method Debugee.threadByFieldName() returned null for debuggee thread "
                 + DEBUGGEE_THRNAME);
             tot_res = Consts.TEST_FAILED;
             return quitDebuggee();

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod003t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod003t.java
@@ -33,6 +33,8 @@ import nsk.share.jdi.*;
  * This is a debuggee class.
  */
 public class invokemethod003t {
+    static Thread testThread = null;
+
     public static void main(String args[]) {
         System.exit(run(args) + Consts.JCK_STATUS_BASE);
     }
@@ -46,7 +48,8 @@ public class invokemethod003t {
         IOPipe pipe = argHandler.createDebugeeIOPipe();
         invokemethod003tDummyClass invokemethod003tdummyCls = new invokemethod003tDummyClass();
 
-        Thread.currentThread().setName(invokemethod003.DEBUGGEE_THRNAME);
+        testThread = Thread.currentThread();
+        testThread.setName(invokemethod003.DEBUGGEE_THRNAME);
 
         pipe.println(invokemethod003.COMMAND_READY);
         String cmd = pipe.readln();

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod003t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod003t.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod004.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod004.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod004.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod004.java
@@ -113,7 +113,7 @@ public class invokemethod004 {
 
         ReferenceType debuggeeClass = debuggee.classByName(DEBUGGEE_CLASS); // debuggee main class
 
-        thrRef = debuggee.threadByFieldNameOrThrow(debuggeeClass, "testThread", DEBUGGEE_THRNAME);
+        thrRef = debuggee.threadByFieldName(debuggeeClass, "testThread", DEBUGGEE_THRNAME);
         if (thrRef == null) {
             log.complain("TEST FAILURE: method Debugee.threadByName() returned null for debuggee thread "
                 + DEBUGGEE_THRNAME);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod004.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod004.java
@@ -115,7 +115,7 @@ public class invokemethod004 {
 
         thrRef = debuggee.threadByFieldName(debuggeeClass, "testThread", DEBUGGEE_THRNAME);
         if (thrRef == null) {
-            log.complain("TEST FAILURE: method Debugee.threadByName() returned null for debuggee thread "
+            log.complain("TEST FAILURE: method Debugee.threadByFieldName() returned null for debuggee thread "
                 + DEBUGGEE_THRNAME);
             tot_res = Consts.TEST_FAILED;
             return quitDebuggee();

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod004.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod004.java
@@ -111,8 +111,10 @@ public class invokemethod004 {
             return quitDebuggee();
         }
 
-        if ((thrRef =
-                debuggee.threadByName(DEBUGGEE_THRNAME)) == null) {
+        ReferenceType debuggeeClass = debuggee.classByName(DEBUGGEE_CLASS); // debuggee main class
+
+        thrRef = debuggee.threadByFieldNameOrThrow(debuggeeClass, "testThread", DEBUGGEE_THRNAME);
+        if (thrRef == null) {
             log.complain("TEST FAILURE: method Debugee.threadByName() returned null for debuggee thread "
                 + DEBUGGEE_THRNAME);
             tot_res = Consts.TEST_FAILED;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod004t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod004t.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod004t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod004t.java
@@ -31,6 +31,8 @@ import nsk.share.jdi.*;
  * This is a debuggee class.
  */
 public class invokemethod004t {
+    static Thread testThread = null;
+
     public static void main(String args[]) {
         System.exit(run(args) + Consts.JCK_STATUS_BASE);
     }
@@ -43,7 +45,8 @@ public class invokemethod004t {
         ArgumentHandler argHandler = new ArgumentHandler(args);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
         invokemethod004tDummyClass invokemethod004tdummyCls = new invokemethod004tDummyClass();
-        Thread.currentThread().setName(invokemethod004.DEBUGGEE_THRNAME);
+        testThread = Thread.currentThread();
+        testThread.setName(invokemethod004.DEBUGGEE_THRNAME);
 
         pipe.println(invokemethod004.COMMAND_READY);
         String cmd = pipe.readln();

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod005.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod005.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod005.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod005.java
@@ -51,7 +51,7 @@ public class invokemethod005 {
     static final String DEBUGGEE_THRNAME = "invokemethod005tThr";
 
     // debuggee source line where it should be stopped
-    static final int DEBUGGEE_STOPATLINE = 58;
+    static final int DEBUGGEE_STOPATLINE = 61;
 
     // debuggee local var used to find needed stack frame
     static final String DEBUGGEE_LOCALVAR =
@@ -113,16 +113,17 @@ public class invokemethod005 {
             return quitDebuggee();
         }
 
-        if ((thrRef =
-                debuggee.threadByName(DEBUGGEE_THRNAME)) == null) {
+        ReferenceType[] rType = new ReferenceType[2];
+        // debuggee main class
+        rType[0] = debuggee.classByName(DEBUGGEE_CLASS);
+
+        thrRef = debuggee.threadByFieldNameOrThrow(rType[0], "testThread", DEBUGGEE_THRNAME);
+        if (thrRef == null) {
             log.complain("TEST FAILURE: Method Debugee.threadByName() returned null for debuggee thread "
                 + DEBUGGEE_THRNAME);
             tot_res = Consts.TEST_FAILED;
             return quitDebuggee();
         }
-        ReferenceType[] rType = new ReferenceType[2];
-        // debuggee main class
-        rType[0] = debuggee.classByName(DEBUGGEE_CLASS);
 
 // Check the tested assersion
         try {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod005.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod005.java
@@ -117,7 +117,7 @@ public class invokemethod005 {
         // debuggee main class
         rType[0] = debuggee.classByName(DEBUGGEE_CLASS);
 
-        thrRef = debuggee.threadByFieldNameOrThrow(rType[0], "testThread", DEBUGGEE_THRNAME);
+        thrRef = debuggee.threadByFieldName(rType[0], "testThread", DEBUGGEE_THRNAME);
         if (thrRef == null) {
             log.complain("TEST FAILURE: Method Debugee.threadByName() returned null for debuggee thread "
                 + DEBUGGEE_THRNAME);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod005.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod005.java
@@ -119,7 +119,7 @@ public class invokemethod005 {
 
         thrRef = debuggee.threadByFieldName(rType[0], "testThread", DEBUGGEE_THRNAME);
         if (thrRef == null) {
-            log.complain("TEST FAILURE: Method Debugee.threadByName() returned null for debuggee thread "
+            log.complain("TEST FAILURE: Method Debugee.threadByFieldName() returned null for debuggee thread "
                 + DEBUGGEE_THRNAME);
             tot_res = Consts.TEST_FAILED;
             return quitDebuggee();

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod005t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod005t.java
@@ -33,6 +33,8 @@ import nsk.share.jdi.*;
  * This is a debuggee class.
  */
 public class invokemethod005t {
+    static Thread testThread = null;
+
     public static void main(String args[]) {
         System.exit(run(args) + Consts.JCK_STATUS_BASE);
     }
@@ -45,7 +47,8 @@ public class invokemethod005t {
         ArgumentHandler argHandler = new ArgumentHandler(args);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
         invokemethod005tDummyClass invokemethod005tdummyCls = new invokemethod005tDummyClass();
-        Thread.currentThread().setName(invokemethod005.DEBUGGEE_THRNAME);
+        testThread = Thread.currentThread();
+        testThread.setName(invokemethod005.DEBUGGEE_THRNAME);
 
         pipe.println(invokemethod005.COMMAND_READY);
         String cmd = pipe.readln();

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod005t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod005t.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod006.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod006.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod006.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod006.java
@@ -50,7 +50,7 @@ public class invokemethod006 {
     static final String DEBUGGEE_THRNAME = "invokemethod006tThr";
 
     // debuggee source line where it should be stopped
-    static final int DEBUGGEE_STOPATLINE = 58;
+    static final int DEBUGGEE_STOPATLINE = 61;
 
     // debuggee local var used to find needed stack frame
     static final String DEBUGGEE_LOCALVAR =
@@ -111,16 +111,17 @@ public class invokemethod006 {
             return quitDebuggee();
         }
 
-        if ((thrRef =
-                debuggee.threadByName(DEBUGGEE_THRNAME)) == null) {
+        ReferenceType[] rType = new ReferenceType[2];
+        // debuggee main class
+        rType[0] = debuggee.classByName(DEBUGGEE_CLASS);
+
+        thrRef = debuggee.threadByFieldNameOrThrow(rType[0], "testThread", DEBUGGEE_THRNAME);
+        if (thrRef == null) {
             log.complain("TEST FAILURE: Method Debugee.threadByName() returned null for debuggee thread "
                 + DEBUGGEE_THRNAME);
             tot_res = Consts.TEST_FAILED;
             return quitDebuggee();
         }
-        ReferenceType[] rType = new ReferenceType[2];
-        // debuggee main class
-        rType[0] = debuggee.classByName(DEBUGGEE_CLASS);
 
 // Check the tested assersion
         try {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod006.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod006.java
@@ -117,7 +117,7 @@ public class invokemethod006 {
 
         thrRef = debuggee.threadByFieldName(rType[0], "testThread", DEBUGGEE_THRNAME);
         if (thrRef == null) {
-            log.complain("TEST FAILURE: Method Debugee.threadByName() returned null for debuggee thread "
+            log.complain("TEST FAILURE: Method Debugee.threadByFieldName() returned null for debuggee thread "
                 + DEBUGGEE_THRNAME);
             tot_res = Consts.TEST_FAILED;
             return quitDebuggee();

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod006.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod006.java
@@ -115,7 +115,7 @@ public class invokemethod006 {
         // debuggee main class
         rType[0] = debuggee.classByName(DEBUGGEE_CLASS);
 
-        thrRef = debuggee.threadByFieldNameOrThrow(rType[0], "testThread", DEBUGGEE_THRNAME);
+        thrRef = debuggee.threadByFieldName(rType[0], "testThread", DEBUGGEE_THRNAME);
         if (thrRef == null) {
             log.complain("TEST FAILURE: Method Debugee.threadByName() returned null for debuggee thread "
                 + DEBUGGEE_THRNAME);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod006t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod006t.java
@@ -33,6 +33,8 @@ import nsk.share.jdi.*;
  * This is a debuggee class.
  */
 public class invokemethod006t {
+    static Thread testThread = null;
+
     public static void main(String args[]) {
         System.exit(run(args) + Consts.JCK_STATUS_BASE);
     }
@@ -45,7 +47,8 @@ public class invokemethod006t {
         ArgumentHandler argHandler = new ArgumentHandler(args);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
         invokemethod006tDummyClass invokemethod006tdummyCls = new invokemethod006tDummyClass();
-        Thread.currentThread().setName(invokemethod006.DEBUGGEE_THRNAME);
+        testThread = Thread.currentThread();
+        testThread.setName(invokemethod006.DEBUGGEE_THRNAME);
 
         pipe.println(invokemethod006.COMMAND_READY);
         String cmd = pipe.readln();

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod006t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod006t.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod007.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod007.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod007.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod007.java
@@ -51,7 +51,7 @@ public class invokemethod007 {
     static final String DEBUGGEE_THRNAME = "invokemethod007tThr";
 
     // debuggee source line where it should be stopped
-    static final int DEBUGGEE_STOPATLINE = 58;
+    static final int DEBUGGEE_STOPATLINE = 61;
 
     // debuggee local var used to find needed stack frame
     static final String DEBUGGEE_LOCALVAR =
@@ -127,16 +127,17 @@ public class invokemethod007 {
             return quitDebuggee();
         }
 
-        if ((thrRef =
-                debuggee.threadByName(DEBUGGEE_THRNAME)) == null) {
+        ReferenceType[] rType = new ReferenceType[2];
+        // debuggee main class
+        rType[0] = debuggee.classByName(DEBUGGEE_CLASS);
+
+        thrRef = debuggee.threadByFieldNameOrThrow(rType[0], "testThread", DEBUGGEE_THRNAME);
+        if (thrRef == null) {
             log.complain("TEST FAILURE: Method Debugee.threadByName() returned null for debuggee thread "
                 + DEBUGGEE_THRNAME);
             tot_res = Consts.TEST_FAILED;
             return quitDebuggee();
         }
-        ReferenceType[] rType = new ReferenceType[2];
-        // debuggee main class
-        rType[0] = debuggee.classByName(DEBUGGEE_CLASS);
 
 // Check the tested assersion
         try {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod007.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod007.java
@@ -133,7 +133,7 @@ public class invokemethod007 {
 
         thrRef = debuggee.threadByFieldName(rType[0], "testThread", DEBUGGEE_THRNAME);
         if (thrRef == null) {
-            log.complain("TEST FAILURE: Method Debugee.threadByName() returned null for debuggee thread "
+            log.complain("TEST FAILURE: Method Debugee.threadByFieldName() returned null for debuggee thread "
                 + DEBUGGEE_THRNAME);
             tot_res = Consts.TEST_FAILED;
             return quitDebuggee();

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod007.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod007.java
@@ -131,7 +131,7 @@ public class invokemethod007 {
         // debuggee main class
         rType[0] = debuggee.classByName(DEBUGGEE_CLASS);
 
-        thrRef = debuggee.threadByFieldNameOrThrow(rType[0], "testThread", DEBUGGEE_THRNAME);
+        thrRef = debuggee.threadByFieldName(rType[0], "testThread", DEBUGGEE_THRNAME);
         if (thrRef == null) {
             log.complain("TEST FAILURE: Method Debugee.threadByName() returned null for debuggee thread "
                 + DEBUGGEE_THRNAME);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod007t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod007t.java
@@ -33,6 +33,8 @@ import nsk.share.jdi.*;
  * This is a debuggee class.
  */
 public class invokemethod007t {
+    static Thread testThread = null;
+
     public static void main(String args[]) {
         System.exit(run(args) + Consts.JCK_STATUS_BASE);
     }
@@ -45,7 +47,8 @@ public class invokemethod007t {
         ArgumentHandler argHandler = new ArgumentHandler(args);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
         invokemethod007tDummyClass invokemethod007tdummyCls = new invokemethod007tDummyClass();
-        Thread.currentThread().setName(invokemethod007.DEBUGGEE_THRNAME);
+        testThread = Thread.currentThread();
+        testThread.setName(invokemethod007.DEBUGGEE_THRNAME);
 
         pipe.println(invokemethod007.COMMAND_READY);
         String cmd = pipe.readln();

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod007t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod007t.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod008.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod008.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod008.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod008.java
@@ -126,7 +126,7 @@ public class invokemethod008 {
         rType[1] = debuggee.classByName(DEBUGGEE_CLASSES[1]);
         rType[2] = debuggee.classByName(DEBUGGEE_CLASSES[2]);
 
-        thrRef = debuggee.threadByFieldNameOrThrow(rType[0], "testThread", DEBUGGEE_THRNAME);
+        thrRef = debuggee.threadByFieldName(rType[0], "testThread", DEBUGGEE_THRNAME);
         if (thrRef == null) {
             log.complain("TEST FAILURE: Method Debugee.threadByName() returned null for debuggee thread "
                 + DEBUGGEE_THRNAME);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod008.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod008.java
@@ -58,7 +58,7 @@ public class invokemethod008 {
     static final String DEBUGGEE_THRNAME = "invokemethod008tThr";
 
     // debuggee source line where it should be stopped
-    static final int DEBUGGEE_STOPATLINE = 69;
+    static final int DEBUGGEE_STOPATLINE = 71;
 
     // debuggee local var used to find needed stack frame
     static final String DEBUGGEE_LOCALVAR =
@@ -120,18 +120,19 @@ public class invokemethod008 {
             return quitDebuggee();
         }
 
-        if ((thrRef =
-                debuggee.threadByName(DEBUGGEE_THRNAME)) == null) {
-            log.complain("TEST FAILURE: Method Debugee.threadByName() returned null for debuggee thread "
-                + DEBUGGEE_THRNAME);
-            tot_res = Consts.TEST_FAILED;
-            return quitDebuggee();
-        }
         ReferenceType[] rType = new ReferenceType[3];
         // reference types of debuggee main & dummy classes
         rType[0] = debuggee.classByName(DEBUGGEE_CLASSES[0]);
         rType[1] = debuggee.classByName(DEBUGGEE_CLASSES[1]);
         rType[2] = debuggee.classByName(DEBUGGEE_CLASSES[2]);
+
+        thrRef = debuggee.threadByFieldNameOrThrow(rType[0], "testThread", DEBUGGEE_THRNAME);
+        if (thrRef == null) {
+            log.complain("TEST FAILURE: Method Debugee.threadByName() returned null for debuggee thread "
+                + DEBUGGEE_THRNAME);
+            tot_res = Consts.TEST_FAILED;
+            return quitDebuggee();
+        }
 
 // Check the tested assersion
         try {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod008.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod008.java
@@ -128,7 +128,7 @@ public class invokemethod008 {
 
         thrRef = debuggee.threadByFieldName(rType[0], "testThread", DEBUGGEE_THRNAME);
         if (thrRef == null) {
-            log.complain("TEST FAILURE: Method Debugee.threadByName() returned null for debuggee thread "
+            log.complain("TEST FAILURE: Method Debugee.threadByFieldName() returned null for debuggee thread "
                 + DEBUGGEE_THRNAME);
             tot_res = Consts.TEST_FAILED;
             return quitDebuggee();

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod008t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod008t.java
@@ -34,6 +34,7 @@ import nsk.share.jdi.*;
  */
 public class invokemethod008t {
     static Log log;
+    static Thread testThread = null;
 
     public static void main(String args[]) {
         System.exit(run(args) + Consts.JCK_STATUS_BASE);
@@ -56,7 +57,8 @@ public class invokemethod008t {
         invokemethod008tDummySuperSuperClass invokemethod008tdummySSCls =
             new invokemethod008tDummySuperSuperClass();
 
-        Thread.currentThread().setName(invokemethod008.DEBUGGEE_THRNAME);
+        testThread = Thread.currentThread();
+        testThread.setName(invokemethod008.DEBUGGEE_THRNAME);
 
         pipe.println(invokemethod008.COMMAND_READY);
         String cmd = pipe.readln();

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod008t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod008t.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod009.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod009.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod009.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod009.java
@@ -58,7 +58,7 @@ public class invokemethod009 {
     static final String DEBUGGEE_THRNAME = "invokemethod009tThr";
 
     // debuggee source line where it should be stopped
-    static final int DEBUGGEE_STOPATLINE = 69;
+    static final int DEBUGGEE_STOPATLINE = 71;
 
     // debuggee local var used to find needed stack frame
     static final String DEBUGGEE_LOCALVAR =
@@ -120,18 +120,19 @@ public class invokemethod009 {
             return quitDebuggee();
         }
 
-        if ((thrRef =
-                debuggee.threadByName(DEBUGGEE_THRNAME)) == null) {
-            log.complain("TEST FAILURE: Method Debugee.threadByName() returned null for debuggee thread "
-                + DEBUGGEE_THRNAME);
-            tot_res = Consts.TEST_FAILED;
-            return quitDebuggee();
-        }
         ReferenceType[] rType = new ReferenceType[3];
         // reference types of debuggee main & dummy classes
         rType[0] = debuggee.classByName(DEBUGGEE_CLASSES[0]);
         rType[1] = debuggee.classByName(DEBUGGEE_CLASSES[1]);
         rType[2] = debuggee.classByName(DEBUGGEE_CLASSES[2]);
+
+        thrRef = debuggee.threadByFieldNameOrThrow(rType[0], "testThread", DEBUGGEE_THRNAME);
+        if (thrRef == null) {
+            log.complain("TEST FAILURE: Method Debugee.threadByName() returned null for debuggee thread "
+                + DEBUGGEE_THRNAME);
+            tot_res = Consts.TEST_FAILED;
+            return quitDebuggee();
+        }
 
 // Check the tested assersion
         try {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod009.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod009.java
@@ -128,7 +128,7 @@ public class invokemethod009 {
 
         thrRef = debuggee.threadByFieldName(rType[0], "testThread", DEBUGGEE_THRNAME);
         if (thrRef == null) {
-            log.complain("TEST FAILURE: Method Debugee.threadByName() returned null for debuggee thread "
+            log.complain("TEST FAILURE: Method Debugee.threadByFieldName() returned null for debuggee thread "
                 + DEBUGGEE_THRNAME);
             tot_res = Consts.TEST_FAILED;
             return quitDebuggee();

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod009.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod009.java
@@ -126,7 +126,7 @@ public class invokemethod009 {
         rType[1] = debuggee.classByName(DEBUGGEE_CLASSES[1]);
         rType[2] = debuggee.classByName(DEBUGGEE_CLASSES[2]);
 
-        thrRef = debuggee.threadByFieldNameOrThrow(rType[0], "testThread", DEBUGGEE_THRNAME);
+        thrRef = debuggee.threadByFieldName(rType[0], "testThread", DEBUGGEE_THRNAME);
         if (thrRef == null) {
             log.complain("TEST FAILURE: Method Debugee.threadByName() returned null for debuggee thread "
                 + DEBUGGEE_THRNAME);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod009t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod009t.java
@@ -34,6 +34,7 @@ import nsk.share.jdi.*;
  */
 public class invokemethod009t {
     static Log log;
+    static Thread testThread = null;
 
     public static void main(String args[]) {
         System.exit(run(args) + Consts.JCK_STATUS_BASE);
@@ -56,7 +57,8 @@ public class invokemethod009t {
         invokemethod009tDummySuperSuperClass invokemethod009tdummySSCls =
             new invokemethod009tDummySuperSuperClass();
 
-        Thread.currentThread().setName(invokemethod009.DEBUGGEE_THRNAME);
+        testThread = Thread.currentThread();
+        testThread.setName(invokemethod009.DEBUGGEE_THRNAME);
 
         pipe.println(invokemethod009.COMMAND_READY);
         String cmd = pipe.readln();

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod009t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod009t.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod014.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod014.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod014.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod014.java
@@ -55,7 +55,7 @@ public class invokemethod014 {
     static final String DEBUGGEE_THRNAME = "invokemethod014tThr";
 
     // debuggee source line where it should be stopped
-    static final int DEBUGGEE_STOPATLINE = 72;
+    static final int DEBUGGEE_STOPATLINE = 74;
 
     // debuggee local var used to find needed stack frame
     static final String DEBUGGEE_LOCALVAR =
@@ -143,19 +143,20 @@ public class invokemethod014 {
             return quitDebuggee();
         }
 
-        ThreadReference thrRef;
-        if ((thrRef =
-                debuggee.threadByName(DEBUGGEE_THRNAME)) == null) {
-            log.complain("TEST FAILURE: method Debugee.threadByName() returned null for debuggee thread "
-                + DEBUGGEE_THRNAME);
-            tot_res = Consts.TEST_FAILED;
-            return quitDebuggee();
-        }
         ReferenceType[] rType = new ReferenceType[3];
         // debuggee main & dummy classes
         rType[0] = debuggee.classByName(DEBUGGEE_CLASSES[0]);
         rType[1] = debuggee.classByName(DEBUGGEE_CLASSES[1]);
         rType[2] = debuggee.classByName(DEBUGGEE_CLASSES[2]);
+
+        ThreadReference thrRef =
+            debuggee.threadByFieldNameOrThrow(rType[0], "testThread", DEBUGGEE_THRNAME);
+        if (thrRef == null) {
+            log.complain("TEST FAILURE: method Debugee.threadByName() returned null for debuggee thread "
+                + DEBUGGEE_THRNAME);
+            tot_res = Consts.TEST_FAILED;
+            return quitDebuggee();
+        }
 
 // Check the tested assersion
         try {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod014.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod014.java
@@ -150,7 +150,7 @@ public class invokemethod014 {
         rType[2] = debuggee.classByName(DEBUGGEE_CLASSES[2]);
 
         ThreadReference thrRef =
-            debuggee.threadByFieldNameOrThrow(rType[0], "testThread", DEBUGGEE_THRNAME);
+            debuggee.threadByFieldName(rType[0], "testThread", DEBUGGEE_THRNAME);
         if (thrRef == null) {
             log.complain("TEST FAILURE: method Debugee.threadByName() returned null for debuggee thread "
                 + DEBUGGEE_THRNAME);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod014.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod014.java
@@ -152,7 +152,7 @@ public class invokemethod014 {
         ThreadReference thrRef =
             debuggee.threadByFieldName(rType[0], "testThread", DEBUGGEE_THRNAME);
         if (thrRef == null) {
-            log.complain("TEST FAILURE: method Debugee.threadByName() returned null for debuggee thread "
+            log.complain("TEST FAILURE: method Debugee.threadByFieldName() returned null for debuggee thread "
                 + DEBUGGEE_THRNAME);
             tot_res = Consts.TEST_FAILED;
             return quitDebuggee();

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod014t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod014t.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod014t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod014t.java
@@ -34,6 +34,7 @@ import nsk.share.jdi.*;
  */
 public class invokemethod014t {
     public static Log log;
+    static Thread testThread = null;
 
     public static void main(String args[]) {
         System.exit(run(args) + Consts.JCK_STATUS_BASE);
@@ -58,7 +59,8 @@ public class invokemethod014t {
 
         log = argHandler.createDebugeeLog();
 
-        Thread.currentThread().setName(invokemethod014.DEBUGGEE_THRNAME);
+        testThread = Thread.currentThread();
+        testThread.setName(invokemethod014.DEBUGGEE_THRNAME);
 
         // Now the debuggee is ready for testing
         pipe.println(invokemethod014.COMMAND_READY);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/setValue/setvalue002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/setValue/setvalue002.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/setValue/setvalue002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/setValue/setvalue002.java
@@ -109,8 +109,10 @@ public class setvalue002 {
             return quitDebuggee();
         }
 
-        if ((thrRef =
-                debuggee.threadByName(DEBUGGEE_THRNAME)) == null) {
+        ReferenceType debuggeeClass = debuggee.classByName(DEBUGGEE_CLASS); // debuggee main class
+
+        thrRef = debuggee.threadByFieldNameOrThrow(debuggeeClass, "testThread", DEBUGGEE_THRNAME);
+        if (thrRef == null) {
             log.complain("TEST FAILURE: Method Debugee.threadByName() returned null for debuggee's thread "
                 + DEBUGGEE_THRNAME);
             tot_res = Consts.TEST_FAILED;
@@ -208,6 +210,10 @@ public class setvalue002 {
         Iterator iter = fields.iterator();
         while (iter.hasNext()) {
             Field fld = (Field) iter.next();
+            if (fld.name().equals("testThread")) {
+                // skip the static testThread field
+                continue;
+            }
             try {
                 log.display("\nTrying to set value for the field \""
                     + fld.name() + "\"\n\tfrom the debuggee's object reference \""
@@ -229,7 +235,7 @@ public class setvalue002 {
                 log.complain("TEST FAILED: ObjectReference.setValue(): caught unexpected "
                     + e + "\n\tinstead of expected IllegalArgumentException"
                     + "\n\twhen attempted to set value for the field \""
-                    + fld.name() + "\"\n\tfrom the debuggee's object reference \""
+                    + fld.name() + "\"\n\tfrom the de19buggee's object reference \""
                     + objRef
                     + "\n\tusing not valid Field's value from the other object reference \""
                     + fldObjRef + "\"");

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/setValue/setvalue002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/setValue/setvalue002.java
@@ -111,7 +111,7 @@ public class setvalue002 {
 
         ReferenceType debuggeeClass = debuggee.classByName(DEBUGGEE_CLASS); // debuggee main class
 
-        thrRef = debuggee.threadByFieldNameOrThrow(debuggeeClass, "testThread", DEBUGGEE_THRNAME);
+        thrRef = debuggee.threadByFieldName(debuggeeClass, "testThread", DEBUGGEE_THRNAME);
         if (thrRef == null) {
             log.complain("TEST FAILURE: Method Debugee.threadByName() returned null for debuggee's thread "
                 + DEBUGGEE_THRNAME);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/setValue/setvalue002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/setValue/setvalue002.java
@@ -113,7 +113,7 @@ public class setvalue002 {
 
         thrRef = debuggee.threadByFieldName(debuggeeClass, "testThread", DEBUGGEE_THRNAME);
         if (thrRef == null) {
-            log.complain("TEST FAILURE: Method Debugee.threadByName() returned null for debuggee's thread "
+            log.complain("TEST FAILURE: Method Debugee.threadByFieldName() returned null for debuggee's thread "
                 + DEBUGGEE_THRNAME);
             tot_res = Consts.TEST_FAILED;
             return quitDebuggee();

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/setValue/setvalue002t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/setValue/setvalue002t.java
@@ -31,6 +31,8 @@ import nsk.share.jdi.*;
  * This is a debuggee class.
  */
 public class setvalue002t {
+    static Thread testThread = null;
+
     // tested static fields
     static byte    sByteFld = 127;
     static short   sShortFld = -32768;
@@ -53,7 +55,6 @@ public class setvalue002t {
     boolean booleanFld = false;
     String  strFld = "instance field";
 
-
     public static void main(String args[]) {
         System.exit(run(args) + Consts.JCK_STATUS_BASE);
     }
@@ -67,7 +68,8 @@ public class setvalue002t {
         IOPipe pipe = argHandler.createDebugeeIOPipe();
         setvalue002tDummyClass dummyCls = new setvalue002tDummyClass();
 
-        Thread.currentThread().setName(setvalue002.DEBUGGEE_THRNAME);
+        testThread = Thread.currentThread();
+        testThread.setName(setvalue002.DEBUGGEE_THRNAME);
 
         pipe.println(setvalue002.COMMAND_READY);
         String cmd = pipe.readln();

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/setValue/setvalue002t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/setValue/setvalue002t.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/setValue/setvalue003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/setValue/setvalue003.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/setValue/setvalue003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/setValue/setvalue003.java
@@ -146,7 +146,7 @@ public class setvalue003 {
 
         thrRef = debuggee.threadByFieldName(debuggeeClass, "testThread", DEBUGGEE_THRNAME);
         if (thrRef == null) {
-            log.complain("TEST FAILURE: Method Debugee.threadByName() returned null for debuggee's thread "
+            log.complain("TEST FAILURE: Method Debugee.threadByFieldName() returned null for debuggee's thread "
                 + DEBUGGEE_THRNAME);
             tot_res = Consts.TEST_FAILED;
             return quitDebuggee();

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/setValue/setvalue003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/setValue/setvalue003.java
@@ -142,8 +142,10 @@ public class setvalue003 {
             return quitDebuggee();
         }
 
-        if ((thrRef =
-                debuggee.threadByName(DEBUGGEE_THRNAME)) == null) {
+        ReferenceType debuggeeClass = debuggee.classByName(DEBUGGEE_CLASS); // debuggee main class
+
+        thrRef = debuggee.threadByFieldNameOrThrow(debuggeeClass, "testThread", DEBUGGEE_THRNAME);
+        if (thrRef == null) {
             log.complain("TEST FAILURE: Method Debugee.threadByName() returned null for debuggee's thread "
                 + DEBUGGEE_THRNAME);
             tot_res = Consts.TEST_FAILED;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/setValue/setvalue003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/setValue/setvalue003.java
@@ -144,7 +144,7 @@ public class setvalue003 {
 
         ReferenceType debuggeeClass = debuggee.classByName(DEBUGGEE_CLASS); // debuggee main class
 
-        thrRef = debuggee.threadByFieldNameOrThrow(debuggeeClass, "testThread", DEBUGGEE_THRNAME);
+        thrRef = debuggee.threadByFieldName(debuggeeClass, "testThread", DEBUGGEE_THRNAME);
         if (thrRef == null) {
             log.complain("TEST FAILURE: Method Debugee.threadByName() returned null for debuggee's thread "
                 + DEBUGGEE_THRNAME);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/setValue/setvalue003t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/setValue/setvalue003t.java
@@ -31,6 +31,8 @@ import nsk.share.jdi.*;
  * This is a debuggee class.
  */
 public class setvalue003t {
+    static Thread testThread = null;
+
     // tested static fields
     static byte    sByteFld = Byte.MAX_VALUE;
     static short   sShortFld = Short.MAX_VALUE;
@@ -53,7 +55,6 @@ public class setvalue003t {
     boolean booleanFld = false;
     String  strFld = "instance field";
 
-
     public static void main(String args[]) {
         System.exit(run(args) + Consts.JCK_STATUS_BASE);
     }
@@ -66,7 +67,8 @@ public class setvalue003t {
         ArgumentHandler argHandler = new ArgumentHandler(args);
         IOPipe setvalue003tPipe = argHandler.createDebugeeIOPipe();
 
-        Thread.currentThread().setName(setvalue003.DEBUGGEE_THRNAME);
+        testThread = Thread.currentThread();
+        testThread.setName(setvalue003.DEBUGGEE_THRNAME);
 
         setvalue003tPipe.println(setvalue003.COMMAND_READY);
         String cmd = setvalue003tPipe.readln();

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/setValue/setvalue003t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/setValue/setvalue003t.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/setValue/setvalue004.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/setValue/setvalue004.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/setValue/setvalue004.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/setValue/setvalue004.java
@@ -124,7 +124,7 @@ public class setvalue004 {
 
         ReferenceType debuggeeClass = debuggee.classByName(DEBUGGEE_CLASS); // debuggee main class
 
-        thrRef = debuggee.threadByFieldNameOrThrow(debuggeeClass, "testThread", DEBUGGEE_THRNAME);
+        thrRef = debuggee.threadByFieldName(debuggeeClass, "testThread", DEBUGGEE_THRNAME);
         if (thrRef == null) {
             log.complain("TEST FAILURE: Method Debugee.threadByName() returned null for debuggee's thread "
                 + DEBUGGEE_THRNAME);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/setValue/setvalue004.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/setValue/setvalue004.java
@@ -126,7 +126,7 @@ public class setvalue004 {
 
         thrRef = debuggee.threadByFieldName(debuggeeClass, "testThread", DEBUGGEE_THRNAME);
         if (thrRef == null) {
-            log.complain("TEST FAILURE: Method Debugee.threadByName() returned null for debuggee's thread "
+            log.complain("TEST FAILURE: Method Debugee.threadByFieldName() returned null for debuggee's thread "
                 + DEBUGGEE_THRNAME);
             tot_res = Consts.TEST_FAILED;
             return quitDebuggee();

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/setValue/setvalue004.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/setValue/setvalue004.java
@@ -122,8 +122,10 @@ public class setvalue004 {
             return quitDebuggee();
         }
 
-        if ((thrRef =
-                debuggee.threadByName(DEBUGGEE_THRNAME)) == null) {
+        ReferenceType debuggeeClass = debuggee.classByName(DEBUGGEE_CLASS); // debuggee main class
+
+        thrRef = debuggee.threadByFieldNameOrThrow(debuggeeClass, "testThread", DEBUGGEE_THRNAME);
+        if (thrRef == null) {
             log.complain("TEST FAILURE: Method Debugee.threadByName() returned null for debuggee's thread "
                 + DEBUGGEE_THRNAME);
             tot_res = Consts.TEST_FAILED;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/setValue/setvalue004t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/setValue/setvalue004t.java
@@ -31,6 +31,8 @@ import nsk.share.jdi.*;
  * This is a debuggee class.
  */
 public class setvalue004t {
+    static Thread testThread = null;
+
     // tested static final fields
     static final byte    sByteFld = 127;
     static final short   sShortFld = -32768;
@@ -65,7 +67,8 @@ public class setvalue004t {
         ArgumentHandler argHandler = new ArgumentHandler(args);
         IOPipe setvalue004tPipe = argHandler.createDebugeeIOPipe();
 
-        Thread.currentThread().setName(setvalue004.DEBUGGEE_THRNAME);
+        testThread = Thread.currentThread();
+        testThread.setName(setvalue004.DEBUGGEE_THRNAME);
 
         setvalue004tPipe.println(setvalue004.COMMAND_READY);
         String cmd = setvalue004tPipe.readln();

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/setValue/setvalue004t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/setValue/setvalue004t.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/setValue/setvalue005.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/setValue/setvalue005.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/setValue/setvalue005.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/setValue/setvalue005.java
@@ -111,7 +111,7 @@ public class setvalue005 {
 
         ReferenceType debuggeeClass = debuggee.classByName(DEBUGGEE_CLASS); // debuggee main class
 
-        thrRef = debuggee.threadByFieldNameOrThrow(debuggeeClass, "testThread", DEBUGGEE_THRNAME);
+        thrRef = debuggee.threadByFieldName(debuggeeClass, "testThread", DEBUGGEE_THRNAME);
         if (thrRef == null) {
             log.complain("TEST FAILURE: Method Debugee.threadByName() returned null for debuggee thread "
                 + DEBUGGEE_THRNAME);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/setValue/setvalue005.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/setValue/setvalue005.java
@@ -109,8 +109,10 @@ public class setvalue005 {
             return quitDebuggee();
         }
 
-        if ((thrRef =
-                debuggee.threadByName(DEBUGGEE_THRNAME)) == null) {
+        ReferenceType debuggeeClass = debuggee.classByName(DEBUGGEE_CLASS); // debuggee main class
+
+        thrRef = debuggee.threadByFieldNameOrThrow(debuggeeClass, "testThread", DEBUGGEE_THRNAME);
+        if (thrRef == null) {
             log.complain("TEST FAILURE: Method Debugee.threadByName() returned null for debuggee thread "
                 + DEBUGGEE_THRNAME);
             tot_res = Consts.TEST_FAILED;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/setValue/setvalue005.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/setValue/setvalue005.java
@@ -113,7 +113,7 @@ public class setvalue005 {
 
         thrRef = debuggee.threadByFieldName(debuggeeClass, "testThread", DEBUGGEE_THRNAME);
         if (thrRef == null) {
-            log.complain("TEST FAILURE: Method Debugee.threadByName() returned null for debuggee thread "
+            log.complain("TEST FAILURE: Method Debugee.threadByFieldName() returned null for debuggee thread "
                 + DEBUGGEE_THRNAME);
             tot_res = Consts.TEST_FAILED;
             return quitDebuggee();

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/setValue/setvalue005t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/setValue/setvalue005t.java
@@ -31,6 +31,8 @@ import nsk.share.jdi.*;
  * This is a debuggee class.
  */
 public class setvalue005t {
+    static Thread testThread = null;
+
     // dummy instance uninitialized fields of reference types
     setvalue005tDummyType dummyType;
     setvalue005tAbsDummyType absDummyType;
@@ -48,7 +50,8 @@ public class setvalue005t {
         ArgumentHandler argHandler = new ArgumentHandler(args);
         IOPipe setvalue005tPipe = argHandler.createDebugeeIOPipe();
 
-        Thread.currentThread().setName(setvalue005.DEBUGGEE_THRNAME);
+        testThread = Thread.currentThread();
+        testThread.setName(setvalue005.DEBUGGEE_THRNAME);
 
         setvalue005tPipe.println(setvalue005.COMMAND_READY);
         String cmd = setvalue005tPipe.readln();

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/setValue/setvalue005t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/setValue/setvalue005t.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/defaultStratum/defaultStratum003/defaultStratum003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/defaultStratum/defaultStratum003/defaultStratum003.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/defaultStratum/defaultStratum003/defaultStratum003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/defaultStratum/defaultStratum003/defaultStratum003.java
@@ -71,7 +71,9 @@ package nsk.jdi.ReferenceType.defaultStratum.defaultStratum003;
 
 import java.io.*;
 import java.util.*;
+import com.sun.jdi.ReferenceType;
 import com.sun.jdi.request.StepRequest;
+import com.sun.jdi.ThreadReference;
 import nsk.share.Consts;
 import nsk.share.TestBug;
 import nsk.share.jdi.EventHandler;
@@ -166,8 +168,12 @@ public class defaultStratum003 extends SDEDebugger {
         StepEventListener stepEventListener = new StepEventListener();
         eventHandler.addListener(stepEventListener);
 
+        ReferenceType debuggeeClass = debuggee.classByName(SDEDebuggee.class.getName());
+        ThreadReference mainThread =
+            debuggee.threadByFieldNameOrThrow(debuggeeClass, "mainThread",
+                                              SDEDebuggee.mainThreadName);
         StepRequest stepRequest = debuggee.getEventRequestManager().createStepRequest(
-                debuggee.threadByName(SDEDebuggee.mainThreadName),
+                mainThread,
                 StepRequest.STEP_LINE,
                 StepRequest.STEP_INTO);
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/defaultStratum/defaultStratum004/defaultStratum004.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/defaultStratum/defaultStratum004/defaultStratum004.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/defaultStratum/defaultStratum004/defaultStratum004.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/defaultStratum/defaultStratum004/defaultStratum004.java
@@ -61,7 +61,9 @@ package nsk.jdi.ReferenceType.defaultStratum.defaultStratum004;
 
 import java.io.*;
 import java.util.*;
+import com.sun.jdi.ReferenceType;
 import com.sun.jdi.request.StepRequest;
+import com.sun.jdi.ThreadReference;
 import nsk.share.Consts;
 import nsk.share.TestBug;
 import nsk.share.jdi.EventHandler;
@@ -165,11 +167,16 @@ public class defaultStratum004 extends SDEDebugger {
         StepEventListener stepEventListener = new StepEventListener();
         eventHandler.addListener(stepEventListener);
 
+        ReferenceType debuggeeClass = debuggee.classByName(SDEDebuggee.class.getName());
+        ThreadReference mainThread =
+            debuggee.threadByFieldNameOrThrow(debuggeeClass, "mainThread",
+                                              SDEDebuggee.mainThreadName);
+
         // perform step events generation 3 times
         for (int i = 0; i < 3; i++) {
             for (String testedClassName : classLocations.keySet()) {
                 StepRequest stepRequest = debuggee.getEventRequestManager().createStepRequest(
-                        debuggee.threadByName(SDEDebuggee.mainThreadName),
+                        mainThread,
                         StepRequest.STEP_LINE,
                         StepRequest.STEP_INTO);
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/sourceName/sourcename004.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/sourceName/sourcename004.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/sourceName/sourcename004.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/sourceName/sourcename004.java
@@ -140,7 +140,7 @@ public class sourcename004 {
 
             // debuggee main thread
             ThreadReference thrRef =
-                debuggee.threadByFieldNameOrThrow(rType, "testThread", DEBUGGEE_THRNAME);
+                debuggee.threadByFieldName(rType, "testThread", DEBUGGEE_THRNAME);
             if (thrRef == null) {
                 throw new Failure("method Debugee.threadByName() returned null for debuggee thread "
                     + DEBUGGEE_THRNAME);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/sourceName/sourcename004.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/sourceName/sourcename004.java
@@ -60,7 +60,7 @@ public class sourcename004 {
     static final String DEBUGGEE_METHOD = "sourcename004trunIt";
 
     // debuggee source line where it should be stopped
-    static final int DEBUGGEE_STOPATLINE = 57;
+    static final int DEBUGGEE_STOPATLINE = 60;
 
     static final int FLD_NUM = 24;
     // tested fields used to provoke the exception
@@ -135,15 +135,18 @@ public class sourcename004 {
         }
 
         try {
-            // debuggee main thread
-            ThreadReference thrRef = null;
-            if ((thrRef =
-                    debuggee.threadByName(DEBUGGEE_THRNAME)) == null)
-                throw new Failure("method Debugee.threadByName() returned null for debuggee thread "
-                    + DEBUGGEE_THRNAME);
-
             // debuggee main class
             ReferenceType rType = debuggee.classByName(DEBUGGEE_CLASS);
+
+            // debuggee main thread
+            ThreadReference thrRef =
+                debuggee.threadByFieldNameOrThrow(rType, "testThread", DEBUGGEE_THRNAME);
+            if (thrRef == null) {
+                throw new Failure("method Debugee.threadByName() returned null for debuggee thread "
+                    + DEBUGGEE_THRNAME);
+            }
+
+            // debuggee main class
             Method meth = debuggee.methodByName(rType, DEBUGGEE_METHOD);
             suspendAtBP(rType, DEBUGGEE_STOPATLINE);
             ObjectReference objRef = findObjRef(thrRef, meth);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/sourceName/sourcename004.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/sourceName/sourcename004.java
@@ -142,7 +142,7 @@ public class sourcename004 {
             ThreadReference thrRef =
                 debuggee.threadByFieldName(rType, "testThread", DEBUGGEE_THRNAME);
             if (thrRef == null) {
-                throw new Failure("method Debugee.threadByName() returned null for debuggee thread "
+                throw new Failure("method Debugee.threadByFieldName() returned null for debuggee thread "
                     + DEBUGGEE_THRNAME);
             }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/sourceName/sourcename004t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/sourceName/sourcename004t.java
@@ -33,6 +33,8 @@ import nsk.share.jdi.*;
  * This is debuggee class.
  */
 public class sourcename004t {
+    static Thread testThread = null;
+
     public static void main(String args[]) {
         System.exit(run(args) + Consts.JCK_STATUS_BASE);
     }
@@ -44,7 +46,8 @@ public class sourcename004t {
     private int sourcename004trunIt(String args[]) {
         ArgumentHandler argHandler = new ArgumentHandler(args);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
-        Thread.currentThread().setName(sourcename004.DEBUGGEE_THRNAME);
+        testThread = Thread.currentThread();
+        testThread.setName(sourcename004.DEBUGGEE_THRNAME);
 
         pipe.println(sourcename004.COMMAND_READY);
         String cmd = pipe.readln();

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/sourceName/sourcename004t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/sourceName/sourcename004t.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/sourceNames/sourcenames002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/sourceNames/sourcenames002.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/sourceNames/sourcenames002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/sourceNames/sourcenames002.java
@@ -60,7 +60,7 @@ public class sourcenames002 {
     static final String DEBUGGEE_METHOD = "sourcenames002trunIt";
 
     // debuggee source line where it should be stopped
-    static final int DEBUGGEE_STOPATLINE = 57;
+    static final int DEBUGGEE_STOPATLINE = 60;
 
     static final int FLD_NUM = 24;
     // tested fields used to provoke the exception
@@ -135,15 +135,17 @@ public class sourcenames002 {
         }
 
         try {
-            // debuggee main thread
-            ThreadReference thrRef = null;
-            if ((thrRef =
-                    debuggee.threadByName(DEBUGGEE_THRNAME)) == null)
-                throw new Failure("method Debugee.threadByName() returned null for debuggee thread "
-                    + DEBUGGEE_THRNAME);
-
             // debuggee main class
             ReferenceType rType = debuggee.classByName(DEBUGGEE_CLASS);
+
+            // debuggee main thread
+            ThreadReference thrRef =
+                debuggee.threadByFieldNameOrThrow(rType, "testThread", DEBUGGEE_THRNAME);
+            if (thrRef == null) {
+                throw new Failure("method Debugee.threadByName() returned null for debuggee thread "
+                    + DEBUGGEE_THRNAME);
+            }
+
             Method meth = debuggee.methodByName(rType, DEBUGGEE_METHOD);
             suspendAtBP(rType, DEBUGGEE_STOPATLINE);
             ObjectReference objRef = findObjRef(thrRef, meth);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/sourceNames/sourcenames002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/sourceNames/sourcenames002.java
@@ -142,7 +142,7 @@ public class sourcenames002 {
             ThreadReference thrRef =
                 debuggee.threadByFieldName(rType, "testThread", DEBUGGEE_THRNAME);
             if (thrRef == null) {
-                throw new Failure("method Debugee.threadByName() returned null for debuggee thread "
+                throw new Failure("method Debugee.threadByFieldName() returned null for debuggee thread "
                     + DEBUGGEE_THRNAME);
             }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/sourceNames/sourcenames002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/sourceNames/sourcenames002.java
@@ -140,7 +140,7 @@ public class sourcenames002 {
 
             // debuggee main thread
             ThreadReference thrRef =
-                debuggee.threadByFieldNameOrThrow(rType, "testThread", DEBUGGEE_THRNAME);
+                debuggee.threadByFieldName(rType, "testThread", DEBUGGEE_THRNAME);
             if (thrRef == null) {
                 throw new Failure("method Debugee.threadByName() returned null for debuggee thread "
                     + DEBUGGEE_THRNAME);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/sourceNames/sourcenames002t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/sourceNames/sourcenames002t.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/sourceNames/sourcenames002t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/sourceNames/sourcenames002t.java
@@ -33,6 +33,8 @@ import nsk.share.jdi.*;
  * This is debuggee class.
  */
 public class sourcenames002t {
+    static Thread testThread = null;
+
     public static void main(String args[]) {
         System.exit(run(args) + Consts.JCK_STATUS_BASE);
     }
@@ -44,7 +46,8 @@ public class sourcenames002t {
     private int sourcenames002trunIt(String args[]) {
         ArgumentHandler argHandler = new ArgumentHandler(args);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
-        Thread.currentThread().setName(sourcenames002.DEBUGGEE_THRNAME);
+        testThread = Thread.currentThread();
+        testThread.setName(sourcenames002.DEBUGGEE_THRNAME);
 
         pipe.println(sourcenames002.COMMAND_READY);
         String cmd = pipe.readln();

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/getValue/getvalue003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/getValue/getvalue003.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/getValue/getvalue003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/getValue/getvalue003.java
@@ -51,15 +51,14 @@ public class getvalue003 {
         "nsk.jdi.StackFrame.getValue.getvalue003t";
 
     // names of debuggee threads
-    static final String DEBUGGEE_THRDNAMES[] = {
-        "getvalue003tMainThr", "getvalue003tAuxThr"
-    };
+    static final String DEBUGGEE_MAIN_THREAD_NAME = "getvalue003tMainThr";
+    static final String DEBUGGEE_AUX_THREAD_NAME  = "getvalue003tAuxThr";
 
     // debuggee local var used in testing
     static final String DEBUGGEE_LOCALVAR = "getvalue003tFindMe";
 
     // debuggee source line where it should be stopped
-    static final int DEBUGGEE_STOPATLINE = 69;
+    static final int DEBUGGEE_STOPATLINE = 72;
 
     static final int DELAY = 500; // in milliseconds
 
@@ -105,33 +104,30 @@ public class getvalue003 {
             return quitDebuggee();
         }
 
-        ThreadReference thrRef[] = new ThreadReference[2];
-        for (int i=0; i<2; i++)
-            if ((thrRef[i] =
-                    debuggee.threadByName(DEBUGGEE_THRDNAMES[i])) == null) {
-                log.complain("TEST FAILURE: method Debugee.threadByName() returned null for debuggee thread "
-                    + DEBUGGEE_THRDNAMES[i]);
-                tot_res = Consts.TEST_FAILED;
-                return quitDebuggee();
-            }
+        // debuggee main class
+        ReferenceType rType = debuggee.classByName(DEBUGGEE_CLASS);
+
+        ThreadReference mainThread =
+            debuggee.threadByFieldNameOrThrow(rType, "mainThread",
+                                              DEBUGGEE_MAIN_THREAD_NAME);
+        ThreadReference auxThread =
+            debuggee.threadByFieldNameOrThrow(rType, "auxThr",
+                                              DEBUGGEE_AUX_THREAD_NAME);
 
         try {
-            // debuggee main class
-            ReferenceType rType = debuggee.classByName(DEBUGGEE_CLASS);
-
             suspendAtBP(rType, DEBUGGEE_STOPATLINE);
 
             // get a stack frame which belongs to the "getvalue003tMainThr" thread
-            StackFrame stFrame = findFrame(thrRef[0], DEBUGGEE_LOCALVAR, false);
+            StackFrame stFrame = findFrame(mainThread, DEBUGGEE_LOCALVAR, false);
 
             // store a LocalVariable which belongs to the "getvalue003tAuxThr" thread
-            findFrame(thrRef[1], DEBUGGEE_LOCALVAR, true);
+            findFrame(auxThread, DEBUGGEE_LOCALVAR, true);
 
             log.display("\nTrying to get value of local variable \""
                 + wrongLocVar
-                + "\"\n\tgotten from thread \"" + thrRef[1]
+                + "\"\n\tgotten from thread \"" + auxThread
                 + "\"\n\tusing stack frame \"" + stFrame
-                + "\"\n\tbelongs to thread \"" + thrRef[0]
+                + "\"\n\tbelongs to thread \"" + mainThread
                 + "\" ...");
 
 // Check the tested assersion
@@ -140,9 +136,9 @@ public class getvalue003 {
                 log.complain("TEST FAILED: expected IllegalArgumentException was not thrown"
                     + "\n\twhen attempted to get value of local variable \""
                     + wrongLocVar
-                    + "\"\n\tgotten from thread \"" + thrRef[1]
+                    + "\"\n\tgotten from thread \"" + auxThread
                     + "\"\n\tusing stack frame \"" + stFrame
-                    + "\"\n\tbelongs to thread \"" + thrRef[0] + "\"");
+                    + "\"\n\tbelongs to thread \"" + mainThread + "\"");
                 tot_res = Consts.TEST_FAILED;
             } catch(IllegalArgumentException ee) {
                 log.display("CHECK PASSED: caught expected " + ee);
@@ -152,9 +148,9 @@ public class getvalue003 {
                     + ue + "\n\tinstead of IllegalArgumentException"
                     + "\n\twhen attempted to get value of local variable \""
                     + wrongLocVar
-                    + "\"\n\tgotten from thread \"" + thrRef[1]
+                    + "\"\n\tgotten from thread \"" + auxThread
                     + "\"\n\tusing stack frame \"" + stFrame
-                    + "\"\n\tbelongs to thread \"" + thrRef[0] + "\"");
+                    + "\"\n\tbelongs to thread \"" + mainThread + "\"");
                 tot_res = Consts.TEST_FAILED;
             }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/getValue/getvalue003t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/getValue/getvalue003t.java
@@ -34,7 +34,9 @@ import nsk.share.jdi.*;
 public class getvalue003t {
     private Log log;
     private IOPipe pipe;
-    private OtherThr auxThr;
+
+    static Thread mainThread = null;
+    static OtherThr auxThr = null;
 
     public static void main(String args[]) {
         System.exit(run(args) + Consts.JCK_STATUS_BASE);
@@ -50,7 +52,8 @@ public class getvalue003t {
         log = argHandler.createDebugeeLog();
         pipe = argHandler.createDebugeeIOPipe();
 
-        Thread.currentThread().setName(getvalue003.DEBUGGEE_THRDNAMES[0]);
+        mainThread = Thread.currentThread();
+        mainThread.setName(getvalue003.DEBUGGEE_MAIN_THREAD_NAME);
         startThread();
 
         // local var used by debugger to find appropriate stack frame
@@ -81,8 +84,7 @@ public class getvalue003t {
     private void startThread() {
         Object readyObj = new Object();
 
-        auxThr = new OtherThr(readyObj,
-            getvalue003.DEBUGGEE_THRDNAMES[1]);
+        auxThr = new OtherThr(readyObj, getvalue003.DEBUGGEE_AUX_THREAD_NAME);
         auxThr.setDaemon(true);
 
         log.display("Debuggee: starting thread \""

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/getValue/getvalue003t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/getValue/getvalue003t.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/getValues/getvalues003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/getValues/getvalues003.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/getValues/getvalues003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/getValues/getvalues003.java
@@ -52,9 +52,8 @@ public class getvalues003 {
         "nsk.jdi.StackFrame.getValues.getvalues003t";
 
     // names of debuggee threads
-    static final String DEBUGGEE_THRDNAMES[] = {
-        "getvalues003tMainThr", "getvalues003tAuxThr"
-    };
+    static final String DEBUGGEE_MAIN_THREAD_NAME = "getvalues003tMainThr";
+    static final String DEBUGGEE_AUX_THREAD_NAME  = "getvalues003tAuxThr";
 
     // tested debuggee local vars
     static final int VAR_NUM = 9;
@@ -65,7 +64,7 @@ public class getvalues003 {
     };
 
     // debuggee source line where it should be stopped
-    static final int DEBUGGEE_STOPATLINE = 78;
+    static final int DEBUGGEE_STOPATLINE = 81;
 
     static final int DELAY = 500; // in milliseconds
 
@@ -111,27 +110,24 @@ public class getvalues003 {
             return quitDebuggee();
         }
 
-        ThreadReference thrRef[] = new ThreadReference[2];
-        for (int i=0; i<2; i++)
-            if ((thrRef[i] =
-                    debuggee.threadByName(DEBUGGEE_THRDNAMES[i])) == null) {
-                log.complain("TEST FAILURE: method Debugee.threadByName() returned null for debuggee thread "
-                    + DEBUGGEE_THRDNAMES[i]);
-                tot_res = Consts.TEST_FAILED;
-                return quitDebuggee();
-            }
+        // debuggee main class
+        ReferenceType rType = debuggee.classByName(DEBUGGEE_CLASS);
+
+        ThreadReference mainThread =
+            debuggee.threadByFieldNameOrThrow(rType, "mainThread",
+                                              DEBUGGEE_MAIN_THREAD_NAME);
+        ThreadReference auxThread =
+            debuggee.threadByFieldNameOrThrow(rType, "auxThr",
+                                              DEBUGGEE_AUX_THREAD_NAME);
 
         try {
-            // debuggee main class
-            ReferenceType rType = debuggee.classByName(DEBUGGEE_CLASS);
-
             suspendAtBP(rType, DEBUGGEE_STOPATLINE);
 
             // get a stack frame which belongs to the "getvalue003tMainThr" thread
-            StackFrame stFrame = findFrame(thrRef[0], DEBUGGEE_VARS[0], true);
+            StackFrame stFrame = findFrame(mainThread, DEBUGGEE_VARS[0], true);
 
             // store a LocalVariable which belongs to the "getvalue003tAuxThr" thread
-            StackFrame wrongStFrame = findFrame(thrRef[1], DEBUGGEE_VARS[0], false);
+            StackFrame wrongStFrame = findFrame(auxThread, DEBUGGEE_VARS[0], false);
 
             StringBuffer varNames = new StringBuffer();
             Iterator varIter = locVars.iterator();
@@ -153,13 +149,13 @@ public class getvalues003 {
                 log.display("\n" + (i+1)
                     + ") Trying to get values of local variables:"
                     + varNames
-                    + "\n\tgotten from thread \"" + thrRef[0]
+                    + "\n\tgotten from thread \"" + mainThread
                     + "\"\n\tand wrongly, of local variable\n\t\t"
                     + wrongLocVar.typeName() + " " + wrongLocVar.name()
                     + " " + wrongLocVar.signature()
-                    + "\n\tgotten from thread \"" + thrRef[1]
+                    + "\n\tgotten from thread \"" + auxThread
                     + "\"\n\tusing stack frame \"" + stFrame
-                    + "\"\n\tin the thread \"" + thrRef[0]
+                    + "\"\n\tin the thread \"" + mainThread
                     + "\" ...");
 
                 // Check the tested assersion
@@ -168,13 +164,13 @@ public class getvalues003 {
                     log.complain("TEST FAILED: expected IllegalArgumentException was not thrown"
                         + "\n\twhen attempted to get values of local variables:"
                         + varNames
-                        + "\"\n\tgotten from thread \"" + thrRef[0]
+                        + "\"\n\tgotten from thread \"" + mainThread
                         + "\"\n\tand wrongly, of local variable\n\t\t"
                         + wrongLocVar.typeName() + " " + wrongLocVar.name()
                         + " " + wrongLocVar.signature()
-                        + "\n\tgotten from thread \"" + thrRef[1]
+                        + "\n\tgotten from thread \"" + auxThread
                         + "\"\n\tusing stack frame \"" + stFrame
-                        + "\"\n\tin the thread \"" + thrRef[0] + "\"");
+                        + "\"\n\tin the thread \"" + mainThread + "\"");
                     tot_res = Consts.TEST_FAILED;
                 } catch(IllegalArgumentException ee) {
                     log.display("CHECK PASSED: caught expected " + ee);
@@ -184,13 +180,13 @@ public class getvalues003 {
                         + ue + "\n\tinstead of IllegalArgumentException"
                         + "\n\twhen attempted to get values of local variables:"
                         + varNames
-                        + "\"\n\tgotten from thread \"" + thrRef[0]
+                        + "\"\n\tgotten from thread \"" + mainThread
                         + "\"\n\tand wrongly, of local variable\n\t\t"
                         + wrongLocVar.typeName() + " " + wrongLocVar.name()
                         + " " + wrongLocVar.signature()
-                        + "\"\n\tgotten from thread \"" + thrRef[1]
+                        + "\"\n\tgotten from thread \"" + auxThread
                         + "\"\n\tusing stack frame \"" + stFrame
-                        + "\"\n\tin the thread \"" + thrRef[0] + "\"");
+                        + "\"\n\tin the thread \"" + mainThread + "\"");
                     tot_res = Consts.TEST_FAILED;
                 }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/getValues/getvalues003t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/getValues/getvalues003t.java
@@ -35,7 +35,9 @@ import nsk.share.jdi.*;
 public class getvalues003t {
     private Log log;
     private IOPipe pipe;
-    private OtherThr auxThr;
+
+    static Thread mainThread = null;
+    static OtherThr auxThr = null;
 
     public static void main(String args[]) {
         System.exit(run(args) + Consts.JCK_STATUS_BASE);
@@ -51,7 +53,8 @@ public class getvalues003t {
         log = argHandler.createDebugeeLog();
         pipe = argHandler.createDebugeeIOPipe();
 
-        Thread.currentThread().setName(getvalues003.DEBUGGEE_THRDNAMES[0]);
+        mainThread = Thread.currentThread();
+        mainThread.setName(getvalues003.DEBUGGEE_MAIN_THREAD_NAME);
         startThread();
 
         // dummy local vars used by debugger for testing
@@ -90,8 +93,7 @@ public class getvalues003t {
     private void startThread() {
         Object readyObj = new Object();
 
-        auxThr = new OtherThr(readyObj,
-            getvalues003.DEBUGGEE_THRDNAMES[1]);
+        auxThr = new OtherThr(readyObj, getvalues003.DEBUGGEE_AUX_THREAD_NAME);
         auxThr.setDaemon(true);
 
         log.display("Debuggee: starting thread \""

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/getValues/getvalues003t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/getValues/getvalues003t.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/setValue/setvalue005/setvalue005.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/setValue/setvalue005/setvalue005.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/setValue/setvalue005/setvalue005.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/setValue/setvalue005/setvalue005.java
@@ -160,7 +160,7 @@ public class setvalue005 {
         ReferenceType rType = debuggee.classByName(DEBUGGEE_CLASS);
 
         ThreadReference thrRef =
-            debuggee.threadByFieldNameOrThrow(rType, "mainThread", DEBUGGEE_THRDNAME);
+            debuggee.threadByFieldName(rType, "mainThread", DEBUGGEE_THRDNAME);
         if (thrRef == null) {
             log.complain("TEST FAILURE: method Debugee.threadByName() returned null for debuggee thread "
                 + DEBUGGEE_THRDNAME);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/setValue/setvalue005/setvalue005.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/setValue/setvalue005/setvalue005.java
@@ -111,7 +111,7 @@ public class setvalue005 {
     };
 
     // debuggee source line where it should be stopped
-    static final int DEBUGGEE_STOPATLINE = 67;
+    static final int DEBUGGEE_STOPATLINE = 70;
 
     static final int DELAY = 500; // in milliseconds
 
@@ -156,9 +156,12 @@ public class setvalue005 {
             return quitDebuggee();
         }
 
-        ThreadReference thrRef = null;
-        if ((thrRef =
-                debuggee.threadByName(DEBUGGEE_THRDNAME)) == null) {
+        // debuggee main class
+        ReferenceType rType = debuggee.classByName(DEBUGGEE_CLASS);
+
+        ThreadReference thrRef =
+            debuggee.threadByFieldNameOrThrow(rType, "mainThread", DEBUGGEE_THRDNAME);
+        if (thrRef == null) {
             log.complain("TEST FAILURE: method Debugee.threadByName() returned null for debuggee thread "
                 + DEBUGGEE_THRDNAME);
             tot_res = Consts.TEST_FAILED;
@@ -166,9 +169,6 @@ public class setvalue005 {
         }
 
         try {
-            // debuggee main class
-            ReferenceType rType = debuggee.classByName(DEBUGGEE_CLASS);
-
             suspendAtBP(rType, DEBUGGEE_STOPATLINE);
 
             // find a stack frame which belongs to the "setvalue005tMainThr" thread

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/setValue/setvalue005/setvalue005.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/setValue/setvalue005/setvalue005.java
@@ -162,7 +162,7 @@ public class setvalue005 {
         ThreadReference thrRef =
             debuggee.threadByFieldName(rType, "mainThread", DEBUGGEE_THRDNAME);
         if (thrRef == null) {
-            log.complain("TEST FAILURE: method Debugee.threadByName() returned null for debuggee thread "
+            log.complain("TEST FAILURE: method Debugee.threadByFieldName() returned null for debuggee thread "
                 + DEBUGGEE_THRDNAME);
             tot_res = Consts.TEST_FAILED;
             return quitDebuggee();

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/setValue/setvalue005/setvalue005t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/setValue/setvalue005/setvalue005t.java
@@ -33,6 +33,8 @@ import nsk.share.jdi.*;
  * This is a debuggee class.
  */
 public class setvalue005t {
+    static Thread mainThread = null;
+
     public static void main(String args[]) {
         System.exit(run(args) + Consts.JCK_STATUS_BASE);
     }
@@ -46,7 +48,8 @@ public class setvalue005t {
         Log log = argHandler.createDebugeeLog();
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
-        Thread.currentThread().setName(setvalue005.DEBUGGEE_THRDNAME);
+        mainThread = Thread.currentThread();
+        mainThread.setName(setvalue005.DEBUGGEE_THRDNAME);
 
         // dummy local var used by debugger for stack frame searching
         int setvalue005tFindMe = 0;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/setValue/setvalue005/setvalue005t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/setValue/setvalue005/setvalue005t.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/setValue/setvalue006/setvalue006.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/setValue/setvalue006/setvalue006.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/setValue/setvalue006/setvalue006.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/setValue/setvalue006/setvalue006.java
@@ -183,7 +183,7 @@ public class setvalue006 {
         ThreadReference thrRef =
             debuggee.threadByFieldName(rType, "mainThread", DEBUGGEE_THRDNAME);
         if (thrRef == null) {
-            log.complain("TEST FAILURE: method Debugee.threadByName() returned null for debuggee thread "
+            log.complain("TEST FAILURE: method Debugee.threadByFieldName() returned null for debuggee thread "
                 + DEBUGGEE_THRDNAME);
             tot_res = Consts.TEST_FAILED;
             return quitDebuggee();

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/setValue/setvalue006/setvalue006.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/setValue/setvalue006/setvalue006.java
@@ -181,7 +181,7 @@ public class setvalue006 {
         ReferenceType rType = debuggee.classByName(DEBUGGEE_CLASS);
 
         ThreadReference thrRef =
-            debuggee.threadByFieldNameOrThrow(rType, "mainThread", DEBUGGEE_THRDNAME);
+            debuggee.threadByFieldName(rType, "mainThread", DEBUGGEE_THRDNAME);
         if (thrRef == null) {
             log.complain("TEST FAILURE: method Debugee.threadByName() returned null for debuggee thread "
                 + DEBUGGEE_THRDNAME);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/setValue/setvalue006/setvalue006.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/setValue/setvalue006/setvalue006.java
@@ -132,7 +132,7 @@ public class setvalue006 {
     };
 
     // debuggee source line where it should be stopped
-    static final int DEBUGGEE_STOPATLINE = 72;
+    static final int DEBUGGEE_STOPATLINE = 75;
 
     static final int DELAY = 500; // in milliseconds
 
@@ -177,9 +177,12 @@ public class setvalue006 {
             return quitDebuggee();
         }
 
-        ThreadReference thrRef = null;
-        if ((thrRef =
-                debuggee.threadByName(DEBUGGEE_THRDNAME)) == null) {
+        // debuggee main class
+        ReferenceType rType = debuggee.classByName(DEBUGGEE_CLASS);
+
+        ThreadReference thrRef =
+            debuggee.threadByFieldNameOrThrow(rType, "mainThread", DEBUGGEE_THRDNAME);
+        if (thrRef == null) {
             log.complain("TEST FAILURE: method Debugee.threadByName() returned null for debuggee thread "
                 + DEBUGGEE_THRDNAME);
             tot_res = Consts.TEST_FAILED;
@@ -187,9 +190,6 @@ public class setvalue006 {
         }
 
         try {
-            // debuggee main class
-            ReferenceType rType = debuggee.classByName(DEBUGGEE_CLASS);
-
             suspendAtBP(rType, DEBUGGEE_STOPATLINE);
 
             // find a stack frame which belongs to the "setvalue006tMainThr" thread

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/setValue/setvalue006/setvalue006t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/setValue/setvalue006/setvalue006t.java
@@ -33,6 +33,8 @@ import nsk.share.jdi.*;
  * This is a debuggee class.
  */
 public class setvalue006t {
+    static Thread mainThread = null;
+
     public static void main(String args[]) {
         System.exit(run(args) + Consts.JCK_STATUS_BASE);
     }
@@ -46,7 +48,8 @@ public class setvalue006t {
         Log log = argHandler.createDebugeeLog();
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
-        Thread.currentThread().setName(setvalue006.DEBUGGEE_THRDNAME);
+        mainThread = Thread.currentThread();
+        mainThread.setName(setvalue006.DEBUGGEE_THRDNAME);
 
         // dummy local vars used by debugger to provoke InvalidTypeException
         byte    byteVar = Byte.MAX_VALUE;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/setValue/setvalue006/setvalue006t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/setValue/setvalue006/setvalue006t.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StepEvent/_itself_/stepEvent003/stepEvent003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StepEvent/_itself_/stepEvent003/stepEvent003.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StepEvent/_itself_/stepEvent003/stepEvent003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StepEvent/_itself_/stepEvent003/stepEvent003.java
@@ -73,7 +73,9 @@ package nsk.jdi.StepEvent._itself_.stepEvent003;
 
 import java.io.*;
 import java.util.*;
+import com.sun.jdi.ReferenceType;
 import com.sun.jdi.request.StepRequest;
+import com.sun.jdi.ThreadReference;
 import nsk.share.Consts;
 import nsk.share.jdi.EventHandler;
 import nsk.share.jdi.sde.*;
@@ -165,8 +167,12 @@ public class stepEvent003 extends SDEDebugger {
         StepEventListener stepEventListener = new StepEventListener();
         eventHandler.addListener(stepEventListener);
 
+        ReferenceType debuggeeClass = debuggee.classByName(SDEDebuggee.class.getName());
+        ThreadReference mainThread =
+            debuggee.threadByFieldNameOrThrow(debuggeeClass, "mainThread",
+                                              SDEDebuggee.mainThreadName);
         StepRequest stepRequest = debuggee.getEventRequestManager().createStepRequest(
-                debuggee.threadByName(SDEDebuggee.mainThreadName),
+                mainThread,
                 StepRequest.STEP_LINE,
                 StepRequest.STEP_INTO);
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StepEvent/_itself_/stepEvent004/stepEvent004.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StepEvent/_itself_/stepEvent004/stepEvent004.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StepEvent/_itself_/stepEvent004/stepEvent004.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StepEvent/_itself_/stepEvent004/stepEvent004.java
@@ -79,7 +79,9 @@ package nsk.jdi.StepEvent._itself_.stepEvent004;
 
 import java.io.*;
 import java.util.*;
+import com.sun.jdi.ReferenceType;
 import com.sun.jdi.request.StepRequest;
+import com.sun.jdi.ThreadReference;
 import nsk.share.Consts;
 import nsk.share.jdi.EventHandler;
 import nsk.share.jdi.sde.*;
@@ -230,8 +232,12 @@ public class stepEvent004 extends SDEDebugger {
         StepEventListener stepEventListener = new StepEventListener();
         eventHandler.addListener(stepEventListener);
 
+        ReferenceType debuggeeClass = debuggee.classByName(SDEDebuggee.class.getName());
+        ThreadReference mainThread =
+            debuggee.threadByFieldNameOrThrow(debuggeeClass, "mainThread",
+                                              SDEDebuggee.mainThreadName);
         StepRequest stepRequest = debuggee.getEventRequestManager().createStepRequest(
-                debuggee.threadByName(SDEDebuggee.mainThreadName),
+                mainThread,
                 StepRequest.STEP_LINE,
                 StepRequest.STEP_INTO);
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StepRequest/addClassExclusionFilter/filter001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StepRequest/addClassExclusionFilter/filter001.java
@@ -104,7 +104,7 @@ public class filter001 extends TestDebuggerType1 {
             switch (i) {
 
                 case 0:
-                thread1 = debuggee.threadByName(threadName1);
+                thread1 = debuggee.threadByFieldNameOrThrow(debuggeeClass, threadName1);
                 eventRequest1 = setting23StepRequest(thread1, "*" + testedClassName1,
                                          EventRequest.SUSPEND_NONE, property1);
 
@@ -131,7 +131,7 @@ public class filter001 extends TestDebuggerType1 {
                 break;
 
                 case 1:
-                thread2 = debuggee.threadByName(threadName2);
+                thread2 = debuggee.threadByFieldNameOrThrow(debuggeeClass, threadName2);
                 eventRequest2 = setting23StepRequest(thread2, testedClassName2 + "*",
                                          EventRequest.SUSPEND_NONE, property2);
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StepRequest/addClassExclusionFilter/filter001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StepRequest/addClassExclusionFilter/filter001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StepRequest/addClassFilter_rt/filter_rt001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StepRequest/addClassFilter_rt/filter_rt001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StepRequest/addClassFilter_rt/filter_rt001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StepRequest/addClassFilter_rt/filter_rt001.java
@@ -105,7 +105,7 @@ public class filter_rt001 extends TestDebuggerType1 {
 
                 case 0:
                 testClassReference = (ReferenceType)debuggee.classByName(testedClassName);
-                thread1 = debuggee.threadByFieldNameOrThrow(debuggeeClass, threadName1);
+                thread1 = debuggee.threadByFieldName(debuggeeClass, threadName1);
                 if (thread1 == null)
                     throw new Failure("Cannot get ThreadReference for " + threadName1);
                 eventRequest1 = setting21StepRequest(thread1, testClassReference,

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StepRequest/addClassFilter_rt/filter_rt001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StepRequest/addClassFilter_rt/filter_rt001.java
@@ -105,7 +105,7 @@ public class filter_rt001 extends TestDebuggerType1 {
 
                 case 0:
                 testClassReference = (ReferenceType)debuggee.classByName(testedClassName);
-                thread1 = debuggee.threadByName(threadName1);
+                thread1 = debuggee.threadByFieldNameOrThrow(debuggeeClass, threadName1);
                 if (thread1 == null)
                     throw new Failure("Cannot get ThreadReference for " + threadName1);
                 eventRequest1 = setting21StepRequest(thread1, testClassReference,

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StepRequest/addClassFilter_rt/filter_rt003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StepRequest/addClassFilter_rt/filter_rt003.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StepRequest/addClassFilter_rt/filter_rt003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StepRequest/addClassFilter_rt/filter_rt003.java
@@ -124,8 +124,8 @@ public class filter_rt003 extends TestDebuggerType1 {
                 testClassReference11 = (ReferenceType)debuggee.classByName(testedClassName11);
                 testClassReference21 = (ReferenceType)debuggee.classByName(testedClassName21);
 
-                thread1 = debuggee.threadByName(threadName1);
-                thread2 = debuggee.threadByName(threadName2);
+                thread1 = debuggee.threadByFieldNameOrThrow(debuggeeClass, threadName1);
+                thread2 = debuggee.threadByFieldNameOrThrow(debuggeeClass, threadName2);
 
                 eventRequest1 = setting21StepRequest(thread1, testClassReference11,
                                              EventRequest.SUSPEND_ALL, property1);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StepRequest/addClassFilter_s/filter_s001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StepRequest/addClassFilter_s/filter_s001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StepRequest/addClassFilter_s/filter_s001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StepRequest/addClassFilter_s/filter_s001.java
@@ -105,7 +105,7 @@ public class filter_s001 extends TestDebuggerType1 {
             switch (i) {
 
                 case 0:
-                thread1 = debuggee.threadByName(threadName1);
+                thread1 = debuggee.threadByFieldNameOrThrow(debuggeeClass, threadName1);
                 eventRequest1 = setting23StepRequest(thread1, "*" + testedClassName1,
                                                      EventRequest.SUSPEND_ALL, property1);
 
@@ -131,7 +131,7 @@ public class filter_s001 extends TestDebuggerType1 {
                 break;
 
                 case 1:
-                thread2 = debuggee.threadByName(threadName2);
+                thread2 = debuggee.threadByFieldNameOrThrow(debuggeeClass, threadName2);
                 eventRequest2 = setting23StepRequest(thread2, testedClassName2 + "*",
                                                      EventRequest.SUSPEND_ALL, property2);
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/forceEarlyReturn/forceEarlyReturn002/forceEarlyReturn002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/forceEarlyReturn/forceEarlyReturn002/forceEarlyReturn002.java
@@ -118,7 +118,7 @@ public class forceEarlyReturn002 extends ForceEarlyReturnDebugger {
         }
 
         ThreadReference threadReference =
-            debuggee.threadByFieldName(debuggeeClass, "mainThread", forceEarlyReturn002a.mainThreadName);
+            debuggee.threadByFieldNameOrThrow(debuggeeClass, "mainThread", forceEarlyReturn002a.mainThreadName);
 
         try {
             if (testClassIsLoaded) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/forceEarlyReturn/forceEarlyReturn002/forceEarlyReturn002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/forceEarlyReturn/forceEarlyReturn002/forceEarlyReturn002.java
@@ -118,7 +118,7 @@ public class forceEarlyReturn002 extends ForceEarlyReturnDebugger {
         }
 
         ThreadReference threadReference =
-            debuggee.threadByFieldNameOrThrow(debuggeeClass, "mainThread", forceEarlyReturn002a.mainThreadName);
+            debuggee.threadByFieldName(debuggeeClass, "mainThread", forceEarlyReturn002a.mainThreadName);
 
         try {
             if (testClassIsLoaded) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/interrupt/interrupt001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/interrupt/interrupt001.java
@@ -205,7 +205,9 @@ public class interrupt001 {
     }
 
     private void executeCase(int testCase, String threadName2) {
-        ThreadReference thread2 = debuggee.threadByName(threadName2);
+        ReferenceType debuggeeClass = debuggee.classByName(debuggeeName);
+        ThreadReference thread2 =
+            debuggee.threadByFieldNameOrThrow(debuggeeClass, "thread2", threadName2);
         if (thread2 == null) {
             debuggee.quit();
             throw new TestBug("ERROR: Not found ThreadReference for name :" + threadName2);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/interrupt/interrupt001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/interrupt/interrupt001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/interrupt/interrupt001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/interrupt/interrupt001.java
@@ -207,7 +207,7 @@ public class interrupt001 {
     private void executeCase(int testCase, String threadName2) {
         ReferenceType debuggeeClass = debuggee.classByName(debuggeeName);
         ThreadReference thread2 =
-            debuggee.threadByFieldNameOrThrow(debuggeeClass, "thread2", threadName2);
+            debuggee.threadByFieldName(debuggeeClass, "thread2", threadName2);
         if (thread2 == null) {
             debuggee.quit();
             throw new TestBug("ERROR: Not found ThreadReference for name :" + threadName2);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/ownedMonitors/ownedmonitors002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/ownedMonitors/ownedmonitors002.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/ownedMonitors/ownedmonitors002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/ownedMonitors/ownedmonitors002.java
@@ -97,7 +97,7 @@ public class ownedmonitors002 {
         ThreadReference thrRef =
             debuggee.threadByFieldName(rType, "testThread", DEBUGGEE_THRNAME);
         if (thrRef == null) {
-            log.complain("TEST FAILURE: method Debugee.threadByName() returned null for debuggee thread "
+            log.complain("TEST FAILURE: method Debugee.threadByFieldName() returned null for debuggee thread "
                 + DEBUGGEE_THRNAME);
             tot_res = Consts.TEST_FAILED;
             return quitDebuggee();

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/ownedMonitors/ownedmonitors002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/ownedMonitors/ownedmonitors002.java
@@ -91,9 +91,12 @@ public class ownedmonitors002 {
             return quitDebuggee();
         }
 
-        ThreadReference thrRef;
-        if ((thrRef =
-                debuggee.threadByName(DEBUGGEE_THRNAME)) == null) {
+        // debuggee main class
+        ReferenceType rType = debuggee.classByName(DEBUGGEE_CLASS);
+
+        ThreadReference thrRef =
+            debuggee.threadByFieldNameOrThrow(rType, "testThread", DEBUGGEE_THRNAME);
+        if (thrRef == null) {
             log.complain("TEST FAILURE: method Debugee.threadByName() returned null for debuggee thread "
                 + DEBUGGEE_THRNAME);
             tot_res = Consts.TEST_FAILED;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/ownedMonitors/ownedmonitors002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/ownedMonitors/ownedmonitors002.java
@@ -95,7 +95,7 @@ public class ownedmonitors002 {
         ReferenceType rType = debuggee.classByName(DEBUGGEE_CLASS);
 
         ThreadReference thrRef =
-            debuggee.threadByFieldNameOrThrow(rType, "testThread", DEBUGGEE_THRNAME);
+            debuggee.threadByFieldName(rType, "testThread", DEBUGGEE_THRNAME);
         if (thrRef == null) {
             log.complain("TEST FAILURE: method Debugee.threadByName() returned null for debuggee thread "
                 + DEBUGGEE_THRNAME);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/ownedMonitors/ownedmonitors002t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/ownedMonitors/ownedmonitors002t.java
@@ -31,13 +31,16 @@ import nsk.share.jdi.*;
  * This is a debuggee class.
  */
 public class ownedmonitors002t {
+    static Thread testThread = null;
+
     public static void main(String args[]) {
         ArgumentHandler argHandler = new ArgumentHandler(args);
 
         Log log = argHandler.createDebugeeLog();
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
-        Thread.currentThread().setName(ownedmonitors002.DEBUGGEE_THRNAME);
+        testThread = Thread.currentThread();
+        testThread.setName(ownedmonitors002.DEBUGGEE_THRNAME);
 
         // Now the debuggee is ready for testing
         pipe.println(ownedmonitors002.COMMAND_READY);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/ownedMonitors/ownedmonitors002t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/ownedMonitors/ownedmonitors002t.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/popFrames/popframes006.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/popFrames/popframes006.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/popFrames/popframes006.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/popFrames/popframes006.java
@@ -112,7 +112,7 @@ public class popframes006 {
         ThreadReference thrRef =
             debuggee.threadByFieldName(rType, "testThread", DEBUGGEE_THRNAME);
         if (thrRef == null) {
-            log.complain("TEST FAILURE: method Debugee.threadByName() returned null for debuggee thread "
+            log.complain("TEST FAILURE: method Debugee.threadByFieldName() returned null for debuggee thread "
                 + DEBUGGEE_THRNAME);
             tot_res = Consts.TEST_FAILED;
             return quitDebuggee();

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/popFrames/popframes006.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/popFrames/popframes006.java
@@ -59,7 +59,7 @@ public class popframes006 {
     static final String DEBUGGEE_FIELD = "wasPopped";
 
     // debuggee source line where it should be stopped
-    static final int DEBUGGEE_STOPATLINE = 80;
+    static final int DEBUGGEE_STOPATLINE = 83;
 
     static final int ATTEMPTS = 5;
     static final int DELAY = 500; // in milliseconds
@@ -106,9 +106,12 @@ public class popframes006 {
             return quitDebuggee();
         }
 
-        ThreadReference thrRef = null;
-        if ((thrRef =
-                debuggee.threadByName(DEBUGGEE_THRNAME)) == null) {
+        // debuggee main class
+        ReferenceType rType = debuggee.classByName(DEBUGGEE_CLASS);
+
+        ThreadReference thrRef =
+            debuggee.threadByFieldNameOrThrow(rType, "testThread", DEBUGGEE_THRNAME);
+        if (thrRef == null) {
             log.complain("TEST FAILURE: method Debugee.threadByName() returned null for debuggee thread "
                 + DEBUGGEE_THRNAME);
             tot_res = Consts.TEST_FAILED;
@@ -117,9 +120,6 @@ public class popframes006 {
 
         Field doExit = null;
         try {
-            // debuggee main class
-            ReferenceType rType = debuggee.classByName(DEBUGGEE_CLASS);
-
             suspendAtBP(rType, DEBUGGEE_STOPATLINE);
 
             // debuggee field used to indicate that popping has been done

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/popFrames/popframes006.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/popFrames/popframes006.java
@@ -110,7 +110,7 @@ public class popframes006 {
         ReferenceType rType = debuggee.classByName(DEBUGGEE_CLASS);
 
         ThreadReference thrRef =
-            debuggee.threadByFieldNameOrThrow(rType, "testThread", DEBUGGEE_THRNAME);
+            debuggee.threadByFieldName(rType, "testThread", DEBUGGEE_THRNAME);
         if (thrRef == null) {
             log.complain("TEST FAILURE: method Debugee.threadByName() returned null for debuggee thread "
                 + DEBUGGEE_THRNAME);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/popFrames/popframes006t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/popFrames/popframes006t.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/popFrames/popframes006t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/popFrames/popframes006t.java
@@ -33,6 +33,8 @@ import nsk.share.jdi.*;
  * This is a debuggee class.
  */
 public class popframes006t {
+    static Thread testThread = null;
+
     private Log log;
     private IOPipe pipe;
     volatile boolean wasPopped = false;
@@ -51,7 +53,8 @@ public class popframes006t {
         log = argHandler.createDebugeeLog();
         pipe = argHandler.createDebugeeIOPipe();
 
-        Thread.currentThread().setName(popframes006.DEBUGGEE_THRNAME);
+        testThread = Thread.currentThread();
+        testThread.setName(popframes006.DEBUGGEE_THRNAME);
 
         pipe.println(popframes006.COMMAND_READY);
         String cmd = pipe.readln();

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/popFrames/popframes007.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/popFrames/popframes007.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/popFrames/popframes007.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/popFrames/popframes007.java
@@ -110,7 +110,7 @@ public class popframes007 {
         ReferenceType rType = debuggee.classByName(DEBUGGEE_CLASS);
 
         ThreadReference mainThread =
-            debuggee.threadByFieldNameOrThrow(rType, "mainThread", DEBUGGEE_MAIN_THREAD_NAME);
+            debuggee.threadByFieldName(rType, "mainThread", DEBUGGEE_MAIN_THREAD_NAME);
         if (mainThread == null) {
             log.complain("TEST FAILURE: method Debugee.threadByName() returned null for debuggee thread "
                          + DEBUGGEE_MAIN_THREAD_NAME);
@@ -119,7 +119,7 @@ public class popframes007 {
         }
 
         ThreadReference auxThread =
-            debuggee.threadByFieldNameOrThrow(rType, "auxThr", DEBUGGEE_AUX_THREAD_NAME);
+            debuggee.threadByFieldName(rType, "auxThr", DEBUGGEE_AUX_THREAD_NAME);
         if (mainThread == null) {
             log.complain("TEST FAILURE: method Debugee.threadByName() returned null for debuggee thread "
                          + DEBUGGEE_AUX_THREAD_NAME);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/popFrames/popframes007.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/popFrames/popframes007.java
@@ -112,7 +112,7 @@ public class popframes007 {
         ThreadReference mainThread =
             debuggee.threadByFieldName(rType, "mainThread", DEBUGGEE_MAIN_THREAD_NAME);
         if (mainThread == null) {
-            log.complain("TEST FAILURE: method Debugee.threadByName() returned null for debuggee thread "
+            log.complain("TEST FAILURE: method Debugee.threadByFieldName() returned null for debuggee thread "
                          + DEBUGGEE_MAIN_THREAD_NAME);
             tot_res = Consts.TEST_FAILED;
             return quitDebuggee();
@@ -121,7 +121,7 @@ public class popframes007 {
         ThreadReference auxThread =
             debuggee.threadByFieldName(rType, "auxThr", DEBUGGEE_AUX_THREAD_NAME);
         if (auxThread == null) {
-            log.complain("TEST FAILURE: method Debugee.threadByName() returned null for debuggee thread "
+            log.complain("TEST FAILURE: method Debugee.threadByFieldName() returned null for debuggee thread "
                          + DEBUGGEE_AUX_THREAD_NAME);
             tot_res = Consts.TEST_FAILED;
             return quitDebuggee();

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/popFrames/popframes007.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/popFrames/popframes007.java
@@ -50,16 +50,16 @@ public class popframes007 {
         "nsk.jdi.ThreadReference.popFrames.popframes007t";
 
     // names of debuggee threads
-    static final String DEBUGGEE_THRDS[] = {
-        "popframes007tMainThr", "popframes007tAuxThr"
-    };
+    static final String DEBUGGEE_MAIN_THREAD_NAME = "popframes007tMainThr";
+    static final String DEBUGGEE_AUX_THREAD_NAME  = "popframes007tAuxThr";
+
     // debuggee local var used to find needed stack frame
     static final String DEBUGGEE_LOCALVAR = "popframes007tFindMe";
     // debuggee field used to indicate that popping has been done
     static final String DEBUGGEE_FIELD = "leaveMethod";
 
     // debuggee source line where it should be stopped
-    static final int DEBUGGEE_STOPATLINE = 83;
+    static final int DEBUGGEE_STOPATLINE = 86;
 
     static final int ATTEMPTS = 5;
     static final int DELAY = 500; // in milliseconds
@@ -106,44 +106,52 @@ public class popframes007 {
             return quitDebuggee();
         }
 
-        ThreadReference thrRef[] = new ThreadReference[2];
-        for (int i=0; i<2; i++)
-            if ((thrRef[i] =
-                    debuggee.threadByName(DEBUGGEE_THRDS[i])) == null) {
-                log.complain("TEST FAILURE: method Debugee.threadByName() returned null for debuggee thread "
-                    + DEBUGGEE_THRDS[i]);
-                tot_res = Consts.TEST_FAILED;
-                return quitDebuggee();
-            }
+        // debuggee main class
+        ReferenceType rType = debuggee.classByName(DEBUGGEE_CLASS);
+
+        ThreadReference mainThread =
+            debuggee.threadByFieldNameOrThrow(rType, "mainThread", DEBUGGEE_MAIN_THREAD_NAME);
+        if (mainThread == null) {
+            log.complain("TEST FAILURE: method Debugee.threadByName() returned null for debuggee thread "
+                         + DEBUGGEE_MAIN_THREAD_NAME);
+            tot_res = Consts.TEST_FAILED;
+            return quitDebuggee();
+        }
+
+        ThreadReference auxThread =
+            debuggee.threadByFieldNameOrThrow(rType, "auxThr", DEBUGGEE_AUX_THREAD_NAME);
+        if (mainThread == null) {
+            log.complain("TEST FAILURE: method Debugee.threadByName() returned null for debuggee thread "
+                         + DEBUGGEE_AUX_THREAD_NAME);
+            tot_res = Consts.TEST_FAILED;
+            return quitDebuggee();
+        }
 
         Field doExit = null;
         try {
-            // debuggee main class
-            ReferenceType rType = debuggee.classByName(DEBUGGEE_CLASS);
-
             suspendAtBP(rType, DEBUGGEE_STOPATLINE);
 
             // debuggee field used to indicate that popping has been done
             doExit = rType.fieldByName(DEBUGGEE_FIELD);
 
             // debuggee stack frame to be popped which is not on specified thread's call stack
-            StackFrame stFrame = findFrame(thrRef[1], DEBUGGEE_LOCALVAR);
+            StackFrame stFrame = findFrame(auxThread, DEBUGGEE_LOCALVAR);
 
             log.display("\nTrying to pop stack frame \"" + stFrame
                 + "\"\n\tlocation \"" + stFrame.location()
-                + "\"\n\tgot from thread reference \"" + thrRef[1]
+                + "\"\n\tgot from thread reference \"" + auxThread
                 + "\"\n\tand the frame is not on the following thread's call stack: \""
-                + thrRef[0] + "\" ...");
+                + mainThread + "\" ...");
 
 // Check the tested assersion
             try {
-                thrRef[0].popFrames(stFrame);
+                mainThread.popFrames(stFrame);
                 log.complain("TEST FAILED: expected IllegalArgumentException was not thrown"
                     + "\n\twhen attempted to pop stack frame \"" + stFrame
                     + "\"\n\tlocation \"" + stFrame.location()
-                    + "\"\n\tgot from thread reference \"" + thrRef[1]
+                    + "\"\n\tgot from thread reference \"" + auxThread
                     + "\"\n\tand the frame is not on the following thread's call stack: \""
-                    + thrRef[0] + "\"");
+                    + mainThread + "\"");
                 tot_res = Consts.TEST_FAILED;
             } catch(IllegalArgumentException ee) {
                 log.display("CHECK PASSED: caught expected " + ee);
@@ -167,9 +175,9 @@ public class popframes007 {
                     + ue + "\n\tinstead of IllegalArgumentException"
                     + "\n\twhen attempted to pop stack \"" + stFrame
                     + "\"\n\tlocation \"" + stFrame.location()
-                    + "\"\n\tgot from thread reference \"" + thrRef[1]
+                    + "\"\n\tgot from thread reference \"" + auxThread
                     + "\"\n\tand the frame is not on the following thread's call stack: \""
-                    + thrRef[0] + "\"");
+                    + mainThread + "\"");
                 tot_res = Consts.TEST_FAILED;
             }
         } catch (Exception e) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/popFrames/popframes007.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/popFrames/popframes007.java
@@ -120,7 +120,7 @@ public class popframes007 {
 
         ThreadReference auxThread =
             debuggee.threadByFieldName(rType, "auxThr", DEBUGGEE_AUX_THREAD_NAME);
-        if (mainThread == null) {
+        if (auxThread == null) {
             log.complain("TEST FAILURE: method Debugee.threadByName() returned null for debuggee thread "
                          + DEBUGGEE_AUX_THREAD_NAME);
             tot_res = Consts.TEST_FAILED;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/popFrames/popframes007t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/popFrames/popframes007t.java
@@ -33,9 +33,11 @@ import nsk.share.jdi.*;
  * This is a debuggee class.
  */
 public class popframes007t {
+    static Thread mainThread = null;
+    static OtherThr auxThr = null;
+
     private Log log;
     private IOPipe pipe;
-    private OtherThr auxThr;
     volatile boolean leaveMethod = false;
 
     public static void main(String args[]) {
@@ -52,7 +54,8 @@ public class popframes007t {
         log = argHandler.createDebugeeLog();
         pipe = argHandler.createDebugeeIOPipe();
 
-        Thread.currentThread().setName(popframes007.DEBUGGEE_THRDS[0]);
+        mainThread = Thread.currentThread();
+        mainThread.setName(popframes007.DEBUGGEE_MAIN_THREAD_NAME);
         startThread();
 
         // Now the debuggee is ready for testing
@@ -93,7 +96,7 @@ public class popframes007t {
         Object readyObj = new Object();
 
         auxThr = new OtherThr(readyObj,
-            popframes007.DEBUGGEE_THRDS[1], this);
+            popframes007.DEBUGGEE_AUX_THREAD_NAME, this);
         auxThr.setDaemon(true);
 
         log.display("Debuggee: starting thread \""

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/popFrames/popframes007t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/popFrames/popframes007t.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/stop/stop002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/stop/stop002.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/stop/stop002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/stop/stop002.java
@@ -67,7 +67,7 @@ public class stop002 {
     static final String DEBUGGEE_STOP_LOOP2_FIELD = "stopLooping2";
 
     // debuggee source line where it should be stopped
-    static final int DEBUGGEE_STOPATLINE = 88;
+    static final int DEBUGGEE_STOPATLINE = 90;
 
     static final int DELAY = 500; // in milliseconds
 
@@ -115,7 +115,10 @@ public class stop002 {
             return quitDebuggee();
         }
 
-        ThreadReference thrRef = debuggee.threadByName(DEBUGGEE_THRNAME);
+        // debuggee main class
+        mainClass = debuggee.classByName(DEBUGGEE_CLASS);
+
+        ThreadReference thrRef = debuggee.threadByFieldNameOrThrow(mainClass, "testThread", DEBUGGEE_THRNAME);
         if (thrRef == null) {
             log.complain("TEST FAILURE: method Debugee.threadByName() returned null for debuggee thread "
                 + DEBUGGEE_THRNAME);
@@ -128,9 +131,6 @@ public class stop002 {
         ObjectReference objRef = null;
         ObjectReference throwableRef = null;
         try {
-            // debuggee main class
-            mainClass = debuggee.classByName(DEBUGGEE_CLASS);
-
             suspendAtBP(mainClass, DEBUGGEE_STOPATLINE);
             objRef = findObjRef(thrRef, DEBUGGEE_NON_THROWABLE_VAR);
             throwableRef = findObjRef(thrRef, DEBUGGEE_THROWABLE_VAR);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/stop/stop002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/stop/stop002.java
@@ -118,7 +118,7 @@ public class stop002 {
         // debuggee main class
         mainClass = debuggee.classByName(DEBUGGEE_CLASS);
 
-        ThreadReference thrRef = debuggee.threadByFieldNameOrThrow(mainClass, "testThread", DEBUGGEE_THRNAME);
+        ThreadReference thrRef = debuggee.threadByFieldName(mainClass, "testThread", DEBUGGEE_THRNAME);
         if (thrRef == null) {
             log.complain("TEST FAILURE: method Debugee.threadByName() returned null for debuggee thread "
                 + DEBUGGEE_THRNAME);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/stop/stop002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/stop/stop002.java
@@ -120,7 +120,7 @@ public class stop002 {
 
         ThreadReference thrRef = debuggee.threadByFieldName(mainClass, "testThread", DEBUGGEE_THRNAME);
         if (thrRef == null) {
-            log.complain("TEST FAILURE: method Debugee.threadByName() returned null for debuggee thread "
+            log.complain("TEST FAILURE: method Debugee.threadByFieldName() returned null for debuggee thread "
                 + DEBUGGEE_THRNAME);
             tot_res = Consts.TEST_FAILED;
             return quitDebuggee();

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/stop/stop002t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/stop/stop002t.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/stop/stop002t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/stop/stop002t.java
@@ -39,6 +39,7 @@ public class stop002t {
     volatile boolean stopLooping2 = false;
     volatile static int testNumReady = 0;
     static final boolean vthreadMode = "Virtual".equals(System.getProperty("test.thread.factory"));
+    static Thread testThread = null;
 
     public static void main(String args[]) {
         System.exit(run(args) + Consts.JCK_STATUS_BASE);
@@ -54,7 +55,8 @@ public class stop002t {
         log = argHandler.createDebugeeLog();
         pipe = argHandler.createDebugeeIOPipe();
 
-        Thread.currentThread().setName(stop002.DEBUGGEE_THRNAME);
+        testThread = Thread.currentThread();
+        testThread.setName(stop002.DEBUGGEE_THRNAME);
 
         // non-throwable object which will be used by debugger
         // as wrong parameter of JDI method ThreadReference.stop()

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/setDefaultStratum/setDefaultStratum003/setDefaultStratum003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/setDefaultStratum/setDefaultStratum003/setDefaultStratum003.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/setDefaultStratum/setDefaultStratum003/setDefaultStratum003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/setDefaultStratum/setDefaultStratum003/setDefaultStratum003.java
@@ -75,7 +75,9 @@ package nsk.jdi.VirtualMachine.setDefaultStratum.setDefaultStratum003;
 
 import java.io.*;
 import java.util.*;
+import com.sun.jdi.ReferenceType;
 import com.sun.jdi.request.*;
+import com.sun.jdi.ThreadReference;
 import nsk.share.Consts;
 import nsk.share.jdi.EventHandler;
 import nsk.share.jdi.sde.*;
@@ -150,8 +152,12 @@ public class setDefaultStratum003 extends SDEDebugger {
         StepEventListener stepEventListener = new StepEventListener();
         eventHandler.addListener(stepEventListener);
 
+        ReferenceType debuggeeClass = debuggee.classByName(SDEDebuggee.class.getName());
+        ThreadReference mainThread =
+            debuggee.threadByFieldNameOrThrow(debuggeeClass, "mainThread",
+                                              SDEDebuggee.mainThreadName);
         StepRequest stepRequest = debuggee.getEventRequestManager().createStepRequest(
-                debuggee.threadByName(SDEDebuggee.mainThreadName),
+                mainThread,
                 StepRequest.STEP_LINE,
                 StepRequest.STEP_INTO);
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/Debugee.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/Debugee.java
@@ -290,6 +290,24 @@ public class Debugee extends DebugeeProcess {
     /**
      * Return a debuggee thread by fetching it from a static field in the debuggee.
      */
+
+    public ThreadReference threadByFieldName(ReferenceType debuggeeClass,
+                                             String threadFieldName) {
+        return threadByFieldName(debuggeeClass, threadFieldName, threadFieldName);
+    }
+
+    public ThreadReference threadByFieldName(ReferenceType debuggeeClass,
+                                             String threadFieldName,
+                                             String threadName) {
+        try {
+            return threadByFieldNameOrThrow(debuggeeClass, threadFieldName, threadName);
+        } catch (JDITestRuntimeException e) {
+            log.display("** Unexpected exception trying to find thread \"" + threadName + "\"");
+            e.printStackTrace(log.getOutStream());
+            return null;
+        }
+    }
+
     public ThreadReference threadByFieldNameOrThrow(ReferenceType debuggeeClass,
                                                     String threadFieldName)
             throws JDITestRuntimeException {

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/sde/SDEDebuggee.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/sde/SDEDebuggee.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/sde/SDEDebuggee.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/sde/SDEDebuggee.java
@@ -28,6 +28,7 @@ import nsk.share.jdi.*;
 
 public class SDEDebuggee extends AbstractJDIDebuggee {
     public static String mainThreadName = "SDEDebuggee_mainThread";
+    public static Thread mainThread = null;
 
     // command:class_name
     public static String COMMAND_EXECUTE_TEST_METHODS = "executeTestMethods";
@@ -42,7 +43,8 @@ public class SDEDebuggee extends AbstractJDIDebuggee {
         if (classpath == null)
             throw new TestBug("Debuggee requires '-testClassPath' parameter");
 
-        Thread.currentThread().setName(mainThreadName);
+        mainThread = Thread.currentThread();
+        mainThread.setName(mainThreadName);
 
         return args;
     }


### PR DESCRIPTION
This batch of changes mostly concerns the remaining uses of threadByName() and converting them to use threadByFieldNameOrThrow() or the new threadByFieldName(). The latter is used if the caller has code to handle a null result. The former is when an exception is needed to get the test to terminate properly. I did fix a few long standing cases where threadyByName() was being called and not checking the result. These call sites now use threadByFieldNameOrThrow() instead of threadByFieldName().

Note there is a minor semantic change in doing this. threadByName() has some extra code to check that the named thread is only found once, and will throw an exception if it is. I think this was just some extra checking that was being done during test development, and is not needed for proper test execution. I've run all the tests without this check and they still pass. I plan on removing this check at some point. 

Tested by running all tier5 svc tests, which includes the nsk/jdi tests. Also ran tier1 and ran locally.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8356811](https://bugs.openjdk.org/browse/JDK-8356811): Some nsk/jdi tests can fetch ThreadReference from static field in the debuggee: part 4 (**Enhancement** - P4)


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25190/head:pull/25190` \
`$ git checkout pull/25190`

Update a local copy of the PR: \
`$ git checkout pull/25190` \
`$ git pull https://git.openjdk.org/jdk.git pull/25190/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25190`

View PR using the GUI difftool: \
`$ git pr show -t 25190`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25190.diff">https://git.openjdk.org/jdk/pull/25190.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25190#issuecomment-2874077070)
</details>
