### PR TITLE
8356678: (fs) Files.readAttributes should map ENOTDIR to NoSuchFileException where possible (unix)

### DIFF
--- a/src/java.base/unix/classes/sun/nio/fs/UnixFileAttributeViews.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixFileAttributeViews.java
@@ -48,10 +48,12 @@ class UnixFileAttributeViews {
         @Override
         public BasicFileAttributes readAttributes() throws IOException {
             try {
-                 UnixFileAttributes attrs =
-                     UnixFileAttributes.get(file, followLinks);
+                 UnixFileAttributes attrs = UnixFileAttributes.get(file, followLinks);
                  return attrs.asBasicFileAttributes();
             } catch (UnixException x) {
+                if (x.errno() == ENOTDIR) {
+                    x.setError(ENOENT);
+                }
                 x.rethrowAsIOException(file);
                 return null;    // keep compiler happy
             }
@@ -209,6 +211,9 @@ class UnixFileAttributeViews {
             try {
                  return UnixFileAttributes.get(file, followLinks);
             } catch (UnixException x) {
+                if (x.errno() == ENOTDIR) {
+                    x.setError(ENOENT);
+                }
                 x.rethrowAsIOException(file);
                 return null;    // keep compiler happy
             }

--- a/src/java.base/unix/classes/sun/nio/fs/UnixFileSystem.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixFileSystem.java
@@ -482,6 +482,9 @@ abstract class UnixFileSystem
         } catch (UnixException x) {
             if (x.errno() == EEXIST && flags.replaceExisting)
                 throw new FileSystemException(target.toString());
+            if (x.errno() == ENOTDIR) {
+                x.setError(ENOENT);
+            }
             x.rethrowAsIOException(target);
         }
 
@@ -630,6 +633,9 @@ abstract class UnixFileSystem
             } catch (UnixException x) {
                 if (x.errno() == EEXIST && flags.replaceExisting)
                     throw new FileSystemException(target.toString());
+                if (x.errno() == ENOTDIR) {
+                    x.setError(ENOENT);
+                }
                 x.rethrowAsIOException(target);
             }
 
@@ -819,6 +825,8 @@ abstract class UnixFileSystem
                         source.getPathForExceptionMessage(),
                         target.getPathForExceptionMessage(),
                         x.errorString());
+                } else if (x.errno() == ENOTDIR) {
+                    x.setError(ENOENT);
                 }
                 x.rethrowAsIOException(source, target);
             }
@@ -839,6 +847,9 @@ abstract class UnixFileSystem
                     new UnixException(errno).rethrowAsIOException(source);
             }
         } catch (UnixException x) {
+            if (x.errno() == ENOTDIR) {
+                x.setError(ENOENT);
+            }
             x.rethrowAsIOException(source);
         }
 
@@ -888,6 +899,9 @@ abstract class UnixFileSystem
             return;
         } catch (UnixException x) {
             if (x.errno() != EXDEV && x.errno() != EISDIR) {
+                if (x.errno() == ENOTDIR) {
+                    x.setError(ENOENT);
+                }
                 x.rethrowAsIOException(source, target);
             }
         }

--- a/src/java.base/unix/classes/sun/nio/fs/UnixFileSystem.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixFileSystem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -951,6 +951,9 @@ abstract class UnixFileSystem
         try {
             sourceAttrs = UnixFileAttributes.get(source, flags.followLinks);
         } catch (UnixException x) {
+            if (x.errno() == ENOTDIR) {
+                x.setError(ENOENT);
+            }
             x.rethrowAsIOException(source);
         }
 

--- a/src/java.base/unix/classes/sun/nio/fs/UnixFileSystem.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixFileSystem.java
@@ -482,9 +482,6 @@ abstract class UnixFileSystem
         } catch (UnixException x) {
             if (x.errno() == EEXIST && flags.replaceExisting)
                 throw new FileSystemException(target.toString());
-            if (x.errno() == ENOTDIR) {
-                x.setError(ENOENT);
-            }
             x.rethrowAsIOException(target);
         }
 
@@ -633,9 +630,6 @@ abstract class UnixFileSystem
             } catch (UnixException x) {
                 if (x.errno() == EEXIST && flags.replaceExisting)
                     throw new FileSystemException(target.toString());
-                if (x.errno() == ENOTDIR) {
-                    x.setError(ENOENT);
-                }
                 x.rethrowAsIOException(target);
             }
 
@@ -825,8 +819,6 @@ abstract class UnixFileSystem
                         source.getPathForExceptionMessage(),
                         target.getPathForExceptionMessage(),
                         x.errorString());
-                } else if (x.errno() == ENOTDIR) {
-                    x.setError(ENOENT);
                 }
                 x.rethrowAsIOException(source, target);
             }
@@ -899,9 +891,6 @@ abstract class UnixFileSystem
             return;
         } catch (UnixException x) {
             if (x.errno() != EXDEV && x.errno() != EISDIR) {
-                if (x.errno() == ENOTDIR) {
-                    x.setError(ENOENT);
-                }
                 x.rethrowAsIOException(source, target);
             }
         }

--- a/src/java.base/unix/classes/sun/nio/fs/UnixFileSystemProvider.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixFileSystemProvider.java
@@ -322,8 +322,12 @@ public abstract class UnixFileSystemProvider
             mode |= X_OK;
         }
         int errno = access(file, mode);
-        if (errno != 0)
+        if (errno != 0) {
+            if (errno == ENOTDIR) {
+                errno = ENOENT;
+            }
             new UnixException(errno).rethrowAsIOException(file);
+        }
     }
 
     @Override

--- a/test/jdk/java/nio/file/Files/NotADirectory.java
+++ b/test/jdk/java/nio/file/Files/NotADirectory.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @bug 8356678
+ * @requires (os.family != "windows")
+ * @summary Test behavior of Files methods for regular file "foo/bar"
+ * @run junit NotADirectory
+ */
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.attribute.PosixFileAttributes;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class NotADirectory {
+    private static final String DIR = ".";
+    private static final String PARENT = "foo";
+    private static final String LEAF = "bar";
+
+    private static Path parent;
+    private static Path leaf;
+
+    @BeforeAll
+    public static void init() throws IOException {
+        parent = Path.of(DIR).resolve(PARENT);
+        Files.createFile(parent);
+        leaf = parent.resolve(LEAF);
+    }
+
+    @AfterAll
+    public static void clean() throws IOException {
+        Files.delete(parent);
+    }
+
+    @Test
+    public void copy() throws IOException {
+        try {
+            Files.copy(leaf, Path.of("junk"));
+        } catch (NoSuchFileException expected) {
+        }
+    }
+
+    @Test
+    public void readBasic() throws IOException {
+        try {
+            Files.readAttributes(leaf, BasicFileAttributes.class);
+        } catch (NoSuchFileException expected) {
+        }
+    }
+
+    @Test
+    public void readPosix() throws IOException {
+        try {
+            Files.readAttributes(leaf, PosixFileAttributes.class);
+        } catch (NoSuchFileException expected) {
+        }
+    }
+
+    @Test
+    public void exists() throws IOException {
+        assertFalse(Files.exists(leaf));
+    }
+
+    @Test
+    public void notExists() throws IOException {
+        assertTrue(Files.notExists(leaf));
+    }
+}

--- a/test/jdk/java/nio/file/Files/NotADirectory.java
+++ b/test/jdk/java/nio/file/Files/NotADirectory.java
@@ -24,7 +24,7 @@
 /* @test
  * @bug 8356678
  * @requires (os.family != "windows")
- * @summary Test files operations when a path component is not a regular file
+ * @summary Test Files operations when a path component is not a directory
  * @run junit NotADirectory
  */
 

--- a/test/jdk/java/nio/file/Files/NotADirectory.java
+++ b/test/jdk/java/nio/file/Files/NotADirectory.java
@@ -31,6 +31,7 @@
 import java.io.IOException;
 import java.nio.file.CopyOption;
 import java.nio.file.Files;
+import java.nio.file.FileSystemException;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.attribute.BasicFileAttributes;
@@ -114,7 +115,9 @@ public class NotADirectory {
     @MethodSource("copyParams")
     public void copy(Path src, Path dst, CopyOption[] opts)
         throws IOException {
-        assertThrows(NoSuchFileException.class,
+        Class exceptionClass = dst.equals(BOGUS) ?
+            FileSystemException.class : NoSuchFileException.class;
+        assertThrows(exceptionClass,
                      () -> Files.copy(src, dst, opts));
     }
 
@@ -122,7 +125,9 @@ public class NotADirectory {
     @MethodSource("moveParams")
     public void move(Path src, Path dst, CopyOption[] opts)
         throws IOException {
-        assertThrows(NoSuchFileException.class,
+        Class exceptionClass = src.equals(BOGUS) || dst.equals(BOGUS) ?
+            FileSystemException.class : NoSuchFileException.class;
+        assertThrows(exceptionClass,
                      () -> Files.move(src, dst, opts));
     }
 


### PR DESCRIPTION
Treat `ENOTDIR` as causing a `NoSuchFileException` instead of a `FileSystemExcception` in some places in order to handle cases such as a regular file named, for example, `foo/bar`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8356678](https://bugs.openjdk.org/browse/JDK-8356678): (fs) Files.readAttributes should map ENOTDIR to NoSuchFileException where possible (unix) (**Enhancement** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Christian Stein](https://openjdk.org/census#cstein) (@sormuras - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25191/head:pull/25191` \
`$ git checkout pull/25191`

Update a local copy of the PR: \
`$ git checkout pull/25191` \
`$ git pull https://git.openjdk.org/jdk.git pull/25191/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25191`

View PR using the GUI difftool: \
`$ git pr show -t 25191`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25191.diff">https://git.openjdk.org/jdk/pull/25191.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25191#issuecomment-2873782589)
</details>
