### PR TITLE
8354460: Streaming output for attach API should be turned on by default

### DIFF
--- a/src/hotspot/share/services/attachListener.cpp
+++ b/src/hotspot/share/services/attachListener.cpp
@@ -172,8 +172,8 @@ volatile AttachListenerState AttachListener::_state = AL_NOT_INITIALIZED;
 
 AttachAPIVersion AttachListener::_supported_version = ATTACH_API_V1;
 
-// Default is false (if jdk.attach.vm.streaming property is not set).
-bool AttachListener::_default_streaming_output = false;
+// Default is true (if jdk.attach.vm.streaming property is not set).
+bool AttachListener::_default_streaming_output = true;
 
 static bool get_bool_sys_prop(const char* name, bool default_value, TRAPS) {
   ResourceMark rm(THREAD);

--- a/src/jdk.attach/share/classes/sun/tools/attach/HotSpotVirtualMachine.java
+++ b/src/jdk.attach/share/classes/sun/tools/attach/HotSpotVirtualMachine.java
@@ -65,7 +65,7 @@ public abstract class HotSpotVirtualMachine extends VirtualMachine {
         ALLOW_ATTACH_SELF = "".equals(s) || Boolean.parseBoolean(s);
         // For now the default is false.
         String s2 = VM.getSavedProperty("jdk.attach.allowStreamingOutput");
-        ALLOW_STREAMING_OUTPUT = "".equals(s2) || Boolean.parseBoolean(s2);
+        ALLOW_STREAMING_OUTPUT = !("false".equals(s2));
     }
 
     private final boolean selfAttach;


### PR DESCRIPTION
The fix turns on streaming output for attach operations.
Change in HotSpotVirtualMachine.java sets attach client property.
Change in attachListener.cpp sets server property (used when client does not specify the property in the request - this is the case when attach tool from older release connects to new VM).

Testing: tier1..tier8