### PR TITLE
8356814: LineBreakMeasurer.nextLayout() slower than necessary when no break needed

### DIFF
--- a/src/java.desktop/share/classes/sun/font/ExtendedTextSourceLabel.java
+++ b/src/java.desktop/share/classes/sun/font/ExtendedTextSourceLabel.java
@@ -875,7 +875,14 @@ class ExtendedTextSourceLabel extends ExtendedTextLabel implements Decoration.La
   }
 
   public TextLineComponent getSubset(int start, int limit, int dir) {
-    return new ExtendedTextSourceLabel(source.getSubSource(start, limit-start, dir), decorator);
+    if (start == 0 &&
+        limit == source.getLength() &&
+        (dir == source.getBidiLevel() || dir == TextLineComponent.UNCHANGED)) {
+      return this; // avoid unnecessary object creation and text shaping
+    } else {
+      TextSource subSource = source.getSubSource(start, limit-start, dir);
+      return new ExtendedTextSourceLabel(subSource, decorator);
+    }
   }
 
   public String toString() {


### PR DESCRIPTION
`LineBreakMeasurer.nextLayout()` calls `nextOffset()` internally to calculate the layout limit. When this happens, a `GlyphVector` is created and the layout engine is invoked to shape the text. The `GlyphVector` is cached in the relevant `ExtendedTextSourceLabel` component.

`LineBreakMeasurer.nextLayout()` then calls `TextMeasurer.getLayout()` which eventually asks that same `ExtendedTextSourceLabel` component for a subset component. This triggers the creation of a fresh `ExtendedTextSourceLabel` without the cached `GlyphVector`.

However, this fresh `ExtendedTextSourceLabel` is not necessary if the subset requested perfectly matches the already-existing `ExtendedTextSourceLabel` component. This happens when the text is short enough that no line break is needed.

I think we should change `ExtendedTextSourceLabel.getSubset()` to return `this` if the requested subset is identical to the existing instance. This will allow us to use the existing cached `GlyphVector`, and the call to `LineBreakMeasurer.nextLayout()` will trigger text shaping once, rather than twice.

In local testing, the test program below ran in ~1250 ms before this optimization, and ran in ~960 ms after the change (a 23% reduction in run time).

The following three existing test classes provide good regression test coverage for this change:
- test/jdk/java/awt/font/LineBreakMeasurer/LineBreakWithTrackingAuto
- test/jdk/java/awt/font/LineBreakMeasurer/TestLineBreakWithFontSub
- test/jdk/java/awt/font/LineBreakMeasurer/FRCTest

```
public class LineBreakMeasurerPerfTest {

    public static void main(String[] args) {

        float advance = 0;
        long start = System.currentTimeMillis();
        AttributedString string = new AttributedString("This is a test.");
        FontRenderContext frc = new FontRenderContext(new AffineTransform(), true, true);

        for (int i = 0; i < 100_000; i++) {
            LineBreakMeasurer measurer = new LineBreakMeasurer(string.getIterator(), frc);
            TextLayout layout = measurer.nextLayout(999); // large enough to not require break
            advance = Math.max(advance, layout.getAdvance());
        }

        long end = System.currentTimeMillis();
        System.out.println((end - start) + " ms elapsed (advance: " + advance + ")");
    }

} 
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8356814](https://bugs.openjdk.org/browse/JDK-8356814): LineBreakMeasurer.nextLayout() slower than necessary when no break needed (**Bug** - P4)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)
 * [Damon Nguyen](https://openjdk.org/census#dnguyen) (@DamonGuy - Committer)
 * [Harshitha Onkar](https://openjdk.org/census#honkar) (@honkar-jdk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25193/head:pull/25193` \
`$ git checkout pull/25193`

Update a local copy of the PR: \
`$ git checkout pull/25193` \
`$ git pull https://git.openjdk.org/jdk.git pull/25193/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25193`

View PR using the GUI difftool: \
`$ git pr show -t 25193`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25193.diff">https://git.openjdk.org/jdk/pull/25193.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25193#issuecomment-2873954427)
</details>
