### PR TITLE
8353496: SuspendResume1.java and SuspendResume2.java timeout after JDK-8319447

### DIFF
--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/SuspendResume1/SuspendResume1.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/SuspendResume1/SuspendResume1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -164,11 +164,11 @@ class TestedThread extends Thread {
         // run in a loop
         threadReady = true;
         int i = 0;
-        int n = 1000;
+        int n = 100;
         while (!shouldFinish) {
             if (n <= 0) {
-                n = 1000;
-                SuspendResume1.sleep(10);
+                n = 100;
+                SuspendResume1.sleep(50);
             }
             if (i > n) {
                 i = 0;

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/SuspendResume2/SuspendResume2.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/SuspendResume2/SuspendResume2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -158,11 +158,11 @@ class TestedThread extends Thread {
         // run in a loop
         threadReady = true;
         int i = 0;
-        int n = 1000;
+        int n = 100;
         while (!shouldFinish) {
             if (n <= 0) {
-                n = 1000;
-                SuspendResume2.sleep(10);
+                n = 100;
+                SuspendResume2.sleep(50);
             }
             if (i > n) {
                 i = 0;

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/SuspendResumeAll/SuspendResumeAll.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/SuspendResumeAll/SuspendResumeAll.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -155,12 +155,12 @@ class TestedThread extends Thread {
         // run in a loop
         threadReady = true;
         int i = 0;
-        int n = 1000;
+        int n = 100;
         while (!shouldFinish) {
             breakpointCheck();
             if (n <= 0) {
-                n = 1000;
-                SuspendResumeAll.sleep(1);
+                n = 100;
+                SuspendResumeAll.sleep(50);
             }
             if (i > n) {
                 i = 0;


### PR DESCRIPTION
The tests `SuspendResume1`, `SuspendResume2` and `SuspendResumeAll` are intermittently failed with a timeout (deadlock). The tests run with `-Djdk.virtualThreadScheduler.maxPoolSize=1` so there is only one carrier. The short sleep in `TestedThread.run` isn't sufficient to make progress. This will happen if tasks pushed by the delayed scheduler are executing before the tasks for the newly started virtual thread. FJP won't search other submission queues until the queue it keeps going back to is empty or there is contention. These deadlocks can be made better reproducible if the sleep in `TestedThread.run` is made minimal (1 millisecond).
The fix is to increase the sleep to 50 milliseconds and also to decrease the busy part of the busy loop.

Testing:
- Mach5 test runs of the fixed tests

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8353496](https://bugs.openjdk.org/browse/JDK-8353496): SuspendResume1.java and SuspendResume2.java timeout after JDK-8319447 (**Bug** - P3)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25194/head:pull/25194` \
`$ git checkout pull/25194`

Update a local copy of the PR: \
`$ git checkout pull/25194` \
`$ git pull https://git.openjdk.org/jdk.git pull/25194/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25194`

View PR using the GUI difftool: \
`$ git pr show -t 25194`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25194.diff">https://git.openjdk.org/jdk/pull/25194.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25194#issuecomment-2877762880)
</details>
