### PR TITLE
8356819: [macos] MacSign should use "openssl" and "faketime" from Homebrew by default

### DIFF
--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/MacSign.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/MacSign.java
@@ -1280,9 +1280,9 @@ public final class MacSign {
     // However, jtreg will alter the value of the PATH env variable and
     // /usr/bin/openssl will preempt /usr/local/bin/openssl.
     // To workaround this jtreg behavior support specifying path to openssl command.
-    private static final Path OPENSSL = Path.of(Optional.ofNullable(TKit.getConfigProperty("openssl")).orElse("openssl"));
+    private static final Path OPENSSL = Path.of(Optional.ofNullable(TKit.getConfigProperty("openssl")).orElse("/usr/local/bin/openssl"));
 
     // faketime is not a standard macOS command.
     // One way to get it is with Homebrew.
-    private static final Path FAKETIME = Path.of(Optional.ofNullable(TKit.getConfigProperty("faketime")).orElse("faketime"));
+    private static final Path FAKETIME = Path.of(Optional.ofNullable(TKit.getConfigProperty("faketime")).orElse("/usr/local/bin/faketime"));
 }


### PR DESCRIPTION
`openssl` from macOS will ignore `faketime` and as result expired certificates will not be generated correctly. By default we should use these tools from Homebrew.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8356819](https://bugs.openjdk.org/browse/JDK-8356819): [macos] MacSign should use "openssl" and "faketime" from Homebrew by default (**Bug** - P4)


### Reviewers
 * [Alexey Semenyuk](https://openjdk.org/census#asemenyuk) (@alexeysemenyukoracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25196/head:pull/25196` \
`$ git checkout pull/25196`

Update a local copy of the PR: \
`$ git checkout pull/25196` \
`$ git pull https://git.openjdk.org/jdk.git pull/25196/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25196`

View PR using the GUI difftool: \
`$ git pr show -t 25196`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25196.diff">https://git.openjdk.org/jdk/pull/25196.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25196#issuecomment-2874663135)
</details>
