### PR TITLE
8356820: fixpath should allow + in paths on Windows

### DIFF
--- a/make/scripts/fixpath.sh
+++ b/make/scripts/fixpath.sh
@@ -157,12 +157,12 @@ function import_path() {
     if [[ $? -eq 0 && -e "$unixpath" ]]; then
       if [[ ! "$winpath" =~ ^"$ENVROOT"\\.*$ ]] ; then
         # If it is not in envroot, it's a generic windows path
-        if [[ ! $winpath =~ ^[-_.:~\\a-zA-Z0-9]*$ ]] ; then
+        if [[ ! $winpath =~ ^[-_.:~+\\a-zA-Z0-9]*$ ]] ; then
           # Path has forbidden characters, rewrite as short name
           # This monster of a command uses the %~s support from cmd.exe to
           # reliably convert to short paths on all winenvs.
           shortpath="$($CMD /q /c for %I in \( "$winpath" \) do echo %~sI 2>/dev/null | tr -d \\n\\r)"
-          if [[ ! $shortpath =~ ^[-_.:~\\a-zA-Z0-9]*$ ]] ; then
+          if [[ ! $shortpath =~ ^[-_.:~+\\a-zA-Z0-9]*$ ]] ; then
             if [[ $QUIET != true ]]; then
               echo fixpath: failure: Path "'"$path"'" could not be converted to short path >&2
             fi


### PR DESCRIPTION
When we run configure on Windows, fixpath is used, but this causes an error if the path contains +.

For example, when we unzip Temurin 24, the directory name created is jdk-24+36. When we specify this as the boot JDK, the following error is output and configure fails

```
configure: The path of BOOT_JDK_ARG, which is given as “/mnt/d/opt/jdks/temurin-24+36”, cannot be properly resolved.
configure: Please see the section “Special Considerations” in building.md.
configure: This is the error message given by fixpath:
fixpath: failure: Path '/mnt/d/opt/jdks/temurin-24+36' could not be converted to short path
configure: error: Cannot continue
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8356820: fixpath should allow + in paths on Windows`

### Issue
 * [JDK-8356820](https://bugs.openjdk.org/browse/JDK-8356820): fixpath should allow + in paths on Windows (**Enhancement** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25197/head:pull/25197` \
`$ git checkout pull/25197`

Update a local copy of the PR: \
`$ git checkout pull/25197` \
`$ git pull https://git.openjdk.org/jdk.git pull/25197/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25197`

View PR using the GUI difftool: \
`$ git pr show -t 25197`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25197.diff">https://git.openjdk.org/jdk/pull/25197.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25197#issuecomment-2874734650)
</details>
