### PR TITLE
8356716: ZGC: Cleanup Uncommit Logic

### DIFF
--- a/src/hotspot/share/gc/z/zMappedCache.cpp
+++ b/src/hotspot/share/gc/z/zMappedCache.cpp
@@ -562,7 +562,10 @@ size_t ZMappedCache::reset_uncommit_cycle() {
 }
 
 size_t ZMappedCache::remove_for_uncommit(size_t max_size, ZArray<ZVirtualMemory>* out) {
-  const size_t remove_allowed = MAX2(_min_last_uncommit_cycle, _removed_last_uncommit_cycle) - _removed_last_uncommit_cycle;
+  const size_t remove_allowed =
+      _min_last_uncommit_cycle < _removed_last_uncommit_cycle
+          ? 0
+          : _min_last_uncommit_cycle - _removed_last_uncommit_cycle;
   const size_t size = MIN2(remove_allowed, max_size);
 
   if (size == 0) {

--- a/src/hotspot/share/gc/z/zMappedCache.hpp
+++ b/src/hotspot/share/gc/z/zMappedCache.hpp
@@ -63,7 +63,8 @@ private:
   size_t        _entry_count;
   SizeClassList _size_class_lists[NumSizeClasses];
   size_t        _size;
-  size_t        _min;
+  size_t        _min_last_uncommit_cycle;
+  size_t        _removed_last_uncommit_cycle;
 
   static int size_class_index(size_t size);
   static int guaranteed_size_class_index(size_t size);
@@ -102,8 +103,8 @@ public:
   ZVirtualMemory remove_contiguous(size_t size);
   size_t remove_discontiguous(size_t size, ZArray<ZVirtualMemory>* out);
 
-  size_t reset_min();
-  size_t remove_from_min(size_t max_size, ZArray<ZVirtualMemory>* out);
+  size_t reset_uncommit_cycle();
+  size_t remove_for_uncommit(size_t max_size, ZArray<ZVirtualMemory>* out);
 
   void print_on(outputStream* st) const;
   void print_extended_on(outputStream* st) const;

--- a/src/hotspot/share/gc/z/zPageAllocator.cpp
+++ b/src/hotspot/share/gc/z/zPageAllocator.cpp
@@ -626,7 +626,7 @@ size_t ZPartition::increase_capacity(size_t size) {
     // Update atomically since we have concurrent readers
     Atomic::add(&_capacity, increased);
 
-    _cache.reset_min();
+    _cache.reset_uncommit_cycle();
     _uncommitter.cancel_uncommit_cycle();
   }
 
@@ -760,14 +760,14 @@ size_t ZPartition::uncommit() {
     if (limit == 0) {
       // This may occur if the current max capacity for this partition is 0
 
-      _cache.reset_min();
+      _cache.reset_uncommit_cycle();
       _uncommitter.cancel_uncommit_cycle();
       return 0;
     }
 
     if (!_uncommitter.uncommit_cycle_is_active()) {
       // We are activating a new cycle
-      const size_t to_uncommit = MIN2(_capacity - _min_capacity, _cache.reset_min());
+      const size_t to_uncommit = MIN2(_capacity - _min_capacity, _cache.reset_uncommit_cycle());
       _uncommitter.activate_uncommit_cycle(to_uncommit);
     }
 
@@ -780,16 +780,16 @@ size_t ZPartition::uncommit() {
 
     if (flush == 0) {
       // Nothing to flush
-      _cache.reset_min();
+      _cache.reset_uncommit_cycle();
       _uncommitter.cancel_uncommit_cycle();
       return 0;
     }
 
     // Flush memory from the mapped cache to uncommit
-    flushed = _cache.remove_from_min(flush, &flushed_vmems);
+    flushed = _cache.remove_for_uncommit(flush, &flushed_vmems);
     if (flushed == 0) {
       // Nothing flushed
-      _cache.reset_min();
+      _cache.reset_uncommit_cycle();
       _uncommitter.cancel_uncommit_cycle();
       return 0;
     }

--- a/src/hotspot/share/gc/z/zPageAllocator.cpp
+++ b/src/hotspot/share/gc/z/zPageAllocator.cpp
@@ -778,14 +778,12 @@ size_t ZPartition::uncommit(uint64_t* timeout) {
       // We are in the uncommit phase
       const size_t num_uncommits_left = _to_uncommit / limit;
       const double time_left = double(ZUncommitDelay) - time_since_last_uncommit;
-      if (time_left < *timeout * num_uncommits_left) {
-        // Running out of time, speed up.
-        uint64_t new_timeout = uint64_t(std::floor(time_left / double(num_uncommits_left + 1)));
-        *timeout = new_timeout;
-      }
+
+      // Update timeout for the remaining uncommit
+      *timeout = uint64_t(std::floor(time_left / double(num_uncommits_left + 1)));
     } else {
       // We are about to start uncommitting
-      _to_uncommit = _cache.reset_min();
+      _to_uncommit = MIN2(_capacity - _min_capacity, _cache.reset_min());
       _last_uncommit = now;
 
       const size_t split = _to_uncommit / limit + 1;

--- a/src/hotspot/share/gc/z/zPageAllocator.hpp
+++ b/src/hotspot/share/gc/z/zPageAllocator.hpp
@@ -68,9 +68,6 @@ private:
   volatile size_t       _capacity;
   volatile size_t       _claimed;
   size_t                _used;
-  double                _last_commit;
-  double                _last_uncommit;
-  size_t                _to_uncommit;
   const uint32_t        _numa_id;
 
   const ZVirtualMemoryManager& virtual_memory_manager() const;
@@ -102,7 +99,9 @@ public:
   void claim_from_cache_or_increase_capacity(ZMemoryAllocation* allocation);
   bool claim_capacity(ZMemoryAllocation* allocation);
 
-  size_t uncommit(uint64_t* timeout);
+  template <typename Fn>
+  void evaluate_under_lock(Fn function) const;
+  size_t uncommit();
 
   void sort_segments_physical(const ZVirtualMemory& vmem);
 

--- a/src/hotspot/share/gc/z/zPageAllocator.inline.hpp
+++ b/src/hotspot/share/gc/z/zPageAllocator.inline.hpp
@@ -26,6 +26,12 @@
 
 #include "gc/z/zPageAllocator.hpp"
 
+template <typename Fn>
+void ZPartition::evaluate_under_lock(Fn function) const {
+  ZLocker<ZLock> locker(&_page_allocator->_lock);
+  function();
+}
+
 inline ZPageAllocatorStats::ZPageAllocatorStats(size_t min_capacity,
                                                 size_t max_capacity,
                                                 size_t soft_max_capacity,

--- a/src/hotspot/share/gc/z/zPhysicalMemoryManager.cpp
+++ b/src/hotspot/share/gc/z/zPhysicalMemoryManager.cpp
@@ -113,6 +113,11 @@ void ZPhysicalMemoryManager::try_enable_uncommit(size_t min_capacity, size_t max
     return;
   }
 
+  const size_t max_delay_without_overflow = std::numeric_limits<uint64_t>::max() / MILLIUNITS;
+  if (ZUncommitDelay > max_delay_without_overflow) {
+    FLAG_SET_ERGO(ZUncommitDelay, max_delay_without_overflow);
+  }
+
   log_info_p(gc, init)("Uncommit: Enabled");
   log_info_p(gc, init)("Uncommit Delay: %zus", ZUncommitDelay);
 }

--- a/src/hotspot/share/gc/z/zUncommitter.cpp
+++ b/src/hotspot/share/gc/z/zUncommitter.cpp
@@ -75,6 +75,9 @@ void ZUncommitter::run_thread() {
       }
 
       total_uncommitted += uncommitted;
+
+      // Wait until next uncommit
+      wait(timeout);
     }
 
     if (total_uncommitted > 0) {

--- a/src/hotspot/share/gc/z/zUncommitter.cpp
+++ b/src/hotspot/share/gc/z/zUncommitter.cpp
@@ -22,12 +22,18 @@
  */
 
 #include "gc/shared/gc_globals.hpp"
+#include "gc/z/zGlobals.hpp"
 #include "gc/z/zHeap.inline.hpp"
 #include "gc/z/zLock.inline.hpp"
 #include "gc/z/zStat.hpp"
 #include "gc/z/zUncommitter.hpp"
 #include "jfr/jfrEvents.hpp"
 #include "logging/log.hpp"
+#include "utilities/align.hpp"
+#include "utilities/debug.hpp"
+
+#include <cmath>
+#include <limits>
 
 static const ZStatCounter ZCounterUncommit("Memory", "Uncommit", ZStatUnitBytesPerSecond);
 
@@ -35,7 +41,13 @@ ZUncommitter::ZUncommitter(uint32_t id, ZPartition* partition)
   : _id(id),
     _partition(partition),
     _lock(),
-    _stop(false) {
+    _stop(false),
+    _cancel_time(0.0),
+    _next_cycle_timeout(ZUncommitDelay),
+    _next_uncommit_timeout(0),
+    _cycle_start(0.0),
+    _to_uncommit(0),
+    _uncommitted(0) {
   set_name("ZUncommitter#%u", id);
   create_and_start();
 }
@@ -47,7 +59,12 @@ bool ZUncommitter::wait(uint64_t timeout) const {
   }
 
   if (!_stop && timeout > 0) {
-    log_debug(gc, heap)("Uncommitter (%u) Timeout: " UINT64_FORMAT "s", _id, timeout);
+    if (!uncommit_cycle_is_finished()) {
+      log_debug(gc, heap)("Uncommitter (%u) Timeout: " UINT64_FORMAT "s left to uncommit: "
+                          EXACTFMT, _id, timeout, EXACTFMTARGS(_to_uncommit));
+    } else {
+      log_debug(gc, heap)("Uncommitter (%u) Timeout: " UINT64_FORMAT "s", _id, timeout);
+    }
     _lock.wait(timeout * MILLIUNITS);
   }
 
@@ -60,35 +77,32 @@ bool ZUncommitter::should_continue() const {
 }
 
 void ZUncommitter::run_thread() {
-  uint64_t timeout = 0;
-
-  while (wait(timeout)) {
+  while (wait(_next_cycle_timeout)) {
     EventZUncommit event;
-    size_t total_uncommitted = 0;
 
     while (should_continue()) {
       // Uncommit chunk
-      const size_t uncommitted = _partition->uncommit(&timeout);
-      if (uncommitted == 0) {
+      const size_t uncommitted = _partition->uncommit();
+      if (uncommitted == 0 || uncommit_cycle_is_finished()) {
         // Done
         break;
       }
 
-      total_uncommitted += uncommitted;
-
       // Wait until next uncommit
-      wait(timeout);
+      wait(_next_uncommit_timeout);
     }
 
-    if (total_uncommitted > 0) {
+    if (_uncommitted > 0) {
       // Update statistics
-      ZStatInc(ZCounterUncommit, total_uncommitted);
+      ZStatInc(ZCounterUncommit, _uncommitted);
       log_info(gc, heap)("Uncommitter (%u) Uncommitted: %zuM(%.0f%%)",
-                         _id, total_uncommitted / M, percent_of(total_uncommitted, ZHeap::heap()->max_capacity()));
+                         _id, _uncommitted / M, percent_of(_uncommitted, ZHeap::heap()->max_capacity()));
 
       // Send event
-      event.commit(total_uncommitted);
+      event.commit(_uncommitted);
     }
+
+    deactivate_uncommit_cycle();
   }
 }
 
@@ -96,4 +110,148 @@ void ZUncommitter::terminate() {
   ZLocker<ZConditionLock> locker(&_lock);
   _stop = true;
   _lock.notify_all();
+}
+
+void ZUncommitter::deactivate_uncommit_cycle() {
+  if (!should_continue()) {
+    // We are stopping
+    return;
+  }
+
+  _partition->evaluate_under_lock([&]() {
+    precond(uncommit_cycle_is_active() || uncommit_cycle_is_canceled());
+    precond(uncommit_cycle_is_finished() || uncommit_cycle_is_canceled());
+    // Update the next timeout
+    if (uncommit_cycle_is_canceled()) {
+      update_next_cycle_timeout_on_cancel();
+    } else {
+      update_next_cycle_timeout_on_finish();
+    }
+
+    // Reset the cycle
+    _to_uncommit = 0;
+    _uncommitted = 0;
+    _cycle_start = 0.0;
+    _cancel_time = 0.0;
+    postcond(uncommit_cycle_is_finished());
+    postcond(!uncommit_cycle_is_canceled());
+    postcond(!uncommit_cycle_is_active());
+  });
+}
+
+void ZUncommitter::activate_uncommit_cycle(size_t to_uncommit) {
+  precond(uncommit_cycle_is_finished());
+  precond(!uncommit_cycle_is_active());
+  precond(!uncommit_cycle_is_canceled());
+  precond(is_aligned(to_uncommit, ZGranuleSize));
+  _cycle_start = os::elapsedTime();
+  _to_uncommit = to_uncommit;
+  _uncommitted = 0;
+}
+
+size_t ZUncommitter::to_uncommit() const {
+  return _to_uncommit;
+}
+
+void ZUncommitter::update_next_cycle_timeout_on_cancel() {
+  precond(uncommit_cycle_is_canceled());
+
+  const double now = os::elapsedTime();
+
+  if (now < _cancel_time + double(ZUncommitDelay)) {
+    _next_cycle_timeout = ZUncommitDelay - uint64_t(std::floor(now - _cancel_time));
+  } else {
+    // ZUncommitDelay has already expired
+    _next_cycle_timeout = 0.0;
+  }
+
+  log_debug(gc, heap)("Uncommitter (%u) Cancel Next Cycle Timeout: " UINT64_FORMAT "s",
+                      _id, _next_cycle_timeout);
+}
+
+void ZUncommitter::update_next_cycle_timeout_on_finish() {
+  precond(uncommit_cycle_is_active());
+  precond(uncommit_cycle_is_finished());
+
+  const double now = os::elapsedTime();
+
+  if (now < _cycle_start + double(ZUncommitDelay)) {
+    _next_cycle_timeout = ZUncommitDelay - uint64_t(std::floor(now - _cycle_start));
+  } else {
+    // ZUncommitDelay has already expired
+    _next_cycle_timeout = 0.0;
+  }
+
+  log_debug(gc, heap)("Uncommitter (%u) Finish Next Cycle Timeout: " UINT64_FORMAT "s",
+                      _id, _next_cycle_timeout);
+}
+
+void ZUncommitter::cancel_uncommit_cycle() {
+  _cancel_time = os::elapsedTime();
+}
+
+void ZUncommitter::register_uncommit(size_t size) {
+  precond(uncommit_cycle_is_active());
+  precond(size > 0);
+  precond(size <= _to_uncommit);
+  precond(is_aligned(size, ZGranuleSize));
+
+  _to_uncommit -= size;
+  _uncommitted += size;
+
+  if (uncommit_cycle_is_canceled()) {
+    // Uncommit cycle got canceled while uncommitting.
+    return;
+  }
+
+  if (uncommit_cycle_is_finished()) {
+    // Everything has been uncommitted.
+    return;
+  }
+
+  const double now = os::elapsedTime();
+  const double time_since_start = now - _cycle_start;
+
+  if (time_since_start == 0.0) {
+    // Handle degenerate case where no time has elapsed.
+    _next_uncommit_timeout = 0;
+    return;
+  }
+
+  const double uncommit_rate = double(_uncommitted) / time_since_start;
+  const double time_to_compleat = double(_to_uncommit) / uncommit_rate;
+  const double time_left = double(ZUncommitDelay) - time_since_start;
+
+  if (time_left < time_to_compleat) {
+    // To slow, work as fast as we can.
+    _next_uncommit_timeout = 0;
+    return;
+  }
+
+  const size_t uncommits_remaining_estimate = _to_uncommit / size + 1;
+  const uint64_t time_left_rounded_down = uint64_t(std::floor(time_left));
+
+  if (uncommits_remaining_estimate < time_left_rounded_down) {
+    // We have at least one second per uncommit, spread them out.
+    _next_uncommit_timeout = time_left_rounded_down / uncommits_remaining_estimate;
+    return;
+  }
+
+  // Randomly distribute the extra time, one second at a time.
+  const double extra_time = time_left - time_to_compleat;
+  const double random = double(uint32_t(os::random())) / double(std::numeric_limits<uint32_t>::max());
+
+  _next_uncommit_timeout = random < (extra_time / time_left) ? 1 : 0;
+}
+
+bool ZUncommitter::uncommit_cycle_is_finished() const {
+  return _to_uncommit == 0;
+}
+
+bool ZUncommitter::uncommit_cycle_is_active() const {
+  return _cycle_start != 0.0;
+}
+
+bool ZUncommitter::uncommit_cycle_is_canceled() const {
+  return _cancel_time != 0.0;
 }

--- a/src/hotspot/share/gc/z/zUncommitter.hpp
+++ b/src/hotspot/share/gc/z/zUncommitter.hpp
@@ -46,6 +46,8 @@ private:
   bool wait(uint64_t timeout) const;
   bool should_continue() const;
 
+  uint64_t to_millis(double seconds) const;
+
   void update_next_cycle_timeout(double from_time);
   void update_next_cycle_timeout_on_cancel();
   void update_next_cycle_timeout_on_finish();

--- a/src/hotspot/share/gc/z/zUncommitter.hpp
+++ b/src/hotspot/share/gc/z/zUncommitter.hpp
@@ -35,9 +35,20 @@ private:
   ZPartition* const      _partition;
   mutable ZConditionLock _lock;
   bool                   _stop;
+  double                 _cancel_time;
+  uint64_t               _next_cycle_timeout;
+  uint64_t               _next_uncommit_timeout;
+  double                 _cycle_start;
+  size_t                 _to_uncommit;
+  size_t                 _uncommitted;
 
   bool wait(uint64_t timeout) const;
   bool should_continue() const;
+
+  void update_next_cycle_timeout_on_cancel();
+  void update_next_cycle_timeout_on_finish();
+
+  void deactivate_uncommit_cycle();
 
 protected:
   virtual void run_thread();
@@ -45,6 +56,15 @@ protected:
 
 public:
   ZUncommitter(uint32_t id, ZPartition* partition);
+
+  void activate_uncommit_cycle(size_t to_uncommit);
+  size_t to_uncommit() const;
+  void cancel_uncommit_cycle();
+  void register_uncommit(size_t size);
+
+  bool uncommit_cycle_is_finished() const;
+  bool uncommit_cycle_is_active() const;
+  bool uncommit_cycle_is_canceled() const;
 };
 
 #endif // SHARE_GC_Z_ZUNCOMMITTER_HPP

--- a/src/hotspot/share/gc/z/zUncommitter.hpp
+++ b/src/hotspot/share/gc/z/zUncommitter.hpp
@@ -27,6 +27,7 @@
 #include "gc/z/zLock.hpp"
 #include "gc/z/zThread.hpp"
 
+class ZMappedCache;
 class ZPartition;
 
 class ZUncommitter : public ZThread {
@@ -45,6 +46,7 @@ private:
   bool wait(uint64_t timeout) const;
   bool should_continue() const;
 
+  void update_next_cycle_timeout(double from_time);
   void update_next_cycle_timeout_on_cancel();
   void update_next_cycle_timeout_on_finish();
 
@@ -57,9 +59,9 @@ protected:
 public:
   ZUncommitter(uint32_t id, ZPartition* partition);
 
-  void activate_uncommit_cycle(size_t to_uncommit);
+  void activate_uncommit_cycle(ZMappedCache* cache, size_t uncommit_limit);
   size_t to_uncommit() const;
-  void cancel_uncommit_cycle();
+  void cancel_uncommit_cycle(ZMappedCache* cache);
   void register_uncommit(size_t size);
 
   bool uncommit_cycle_is_finished() const;

--- a/test/hotspot/jtreg/gc/z/TestUncommit.java
+++ b/test/hotspot/jtreg/gc/z/TestUncommit.java
@@ -27,12 +27,10 @@ package gc.z;
  * @test TestUncommit
  * @requires vm.gc.Z
  * @summary Test ZGC uncommit unused memory
- * @library /test/lib
  * @run main/othervm -XX:+UseZGC -Xlog:gc*,gc+heap=debug,gc+stats=off -Xms128M -Xmx512M -XX:ZUncommitDelay=5 gc.z.TestUncommit
  */
 
 import java.util.ArrayList;
-import jdk.test.lib.Utils;
 
 public class TestUncommit {
     private static final int delay = 5 * 1000; // milliseconds
@@ -110,7 +108,7 @@ public class TestUncommit {
             throw new Exception("Uncommitted too fast");
         }
 
-        if (actualDelay > delay * 3 * Utils.TIMEOUT_FACTOR) {
+        if (actualDelay > delay * 3) {
             throw new Exception("Uncommitted too slow");
         }
 

--- a/test/hotspot/jtreg/gc/z/TestUncommit.java
+++ b/test/hotspot/jtreg/gc/z/TestUncommit.java
@@ -110,7 +110,7 @@ public class TestUncommit {
             throw new Exception("Uncommitted too fast");
         }
 
-        if (actualDelay > delay * 2 * Utils.TIMEOUT_FACTOR) {
+        if (actualDelay > delay * 3 * Utils.TIMEOUT_FACTOR) {
             throw new Exception("Uncommitted too slow");
         }
 


### PR DESCRIPTION
[JDK-8350441](https://bugs.openjdk.org/browse/JDK-8350441) required changing the way ZGC handle memory uncommitting (returning physical memory to the OS). Previously ZGC tracked how recently used memory was on a ZPage level. [JDK-8350441](https://bugs.openjdk.org/browse/JDK-8350441) did away with the ZPage abstraction for unused memory. But because of this ZGC does not have a convenient way of tracking the usage of a specific memory range. Instead [JDK-8350441](https://bugs.openjdk.org/browse/JDK-8350441) opted to keep a watermark in the cache unused mapped memory, to keep track of the amount of memory that was not used within the last ZUncommitDelay, and use this when deciding how much to uncommit.

Because this measurement is not as granular as previously, and because uncommitting memory is something we want to do conservatively, as a response to low memory utilization, [JDK-8350441](https://bugs.openjdk.org/browse/JDK-8350441) was written with the intent to spread out the uncommitting over some time interval.

The actual implementation in [JDK-8350441](https://bugs.openjdk.org/browse/JDK-8350441) has a few issues which this RFE tries to address:
  * Missing wait, the uncommitting is not actually spread out, but happens all at once.
  * Reactivity, if the process starts using memory that was below the previous watermark, uncommitting should stop.
  * Structure, the current implementation has a lot of different dependencies and has state spread out over multiple classes. Refactor to keep the logic contained to the ZUncommitter, and provide better named facilitating functions on the ZPartition and ZMappedCache. And make the lifecycle of ZUncommitter more explicit.
  * Events, overhaul the JFR uncommit events to be sent (and track the time for) a chunk of uncommits without any waits.

An alternative discussed has been to do uncommitting based on GC triggers rather than a periodically. So rather than using ZUncommitDelay, we could have our proactive GCs actually trigger and track uncommitting. This might be a future RFE, but it was not attempted here as it would change user facing APIs. [JDK-8329758](https://bugs.openjdk.org/browse/JDK-8329758) will more than likely overhaul the uncommit triggers as well, and the whole concept of ZUncommitDelay and having to tune how to uncommit will go away.