### PR TITLE
8325647: [IR framework] Only prints stdout if exitCode is 134

### DIFF
--- a/test/hotspot/jtreg/compiler/lib/ir_framework/driver/TestVMProcess.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/driver/TestVMProcess.java
@@ -259,7 +259,9 @@ public class TestVMProcess {
         int exitCode = oa.getExitValue();
         String stdErr = oa.getStderr();
         String stdOut = "";
-        if (exitCode == 134) {
+        boolean osIsWindows = System.getProperty("os.name").toLowerCase().contains("windows");
+        boolean JVMHadError = (!osIsWindows && exitCode == 134) || (osIsWindows && exitCode == -1);
+        if (JVMHadError) {
             // Also dump the stdout if we experience a JVM error (e.g. to show hit assertions etc.).
             stdOut = System.lineSeparator() + System.lineSeparator() + "Standard Output" + System.lineSeparator()
                      + "---------------" + System.lineSeparator() + oa.getOutput();

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/driver/TestVMProcess.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/driver/TestVMProcess.java
@@ -259,7 +259,7 @@ public class TestVMProcess {
         int exitCode = oa.getExitValue();
         String stdErr = oa.getStderr();
         String stdOut = "";
-        boolean osIsWindows = System.getProperty("os.name").toLowerCase().contains("windows");
+        boolean osIsWindows = Platform.isWindows();
         boolean JVMHadError = (!osIsWindows && exitCode == 134) || (osIsWindows && exitCode == -1);
         if (JVMHadError) {
             // Also dump the stdout if we experience a JVM error (e.g. to show hit assertions etc.).


### PR DESCRIPTION
On Linux, `assert` and such eventually use `abort` which give the return code 134 (128 + 6 (code of SIGABRT/SIGIOT)). On Windows, dying returns `-1` (exit code are more-or-less-signed int on Windows):

https://github.com/openjdk/jdk/blob/2b3254160933e8b11527f801507a9c01b90d22b0/src/hotspot/os/windows/os_windows.cpp#L1382-L1384

So let's make the IR framework aware of this: we consider there was a JVM error if the OS is windows and the return code -1, or if it's 134 otherwise. I'm not sure what's the most idiomatic/robust way to check whether we are on Windows or not, but it's not customer code: it just needs to work for testing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325647](https://bugs.openjdk.org/browse/JDK-8325647): [IR framework] Only prints stdout if exitCode is 134 (**Bug** - P4)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25200/head:pull/25200` \
`$ git checkout pull/25200`

Update a local copy of the PR: \
`$ git checkout pull/25200` \
`$ git pull https://git.openjdk.org/jdk.git pull/25200/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25200`

View PR using the GUI difftool: \
`$ git pr show -t 25200`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25200.diff">https://git.openjdk.org/jdk/pull/25200.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25200#issuecomment-2876132206)
</details>
