### PR TITLE
8351347: HttpClient Improve logging of response headers

### DIFF
--- a/src/java.net.http/share/classes/jdk/internal/net/http/Http1Request.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Http1Request.java
@@ -88,9 +88,7 @@ class Http1Request {
                 // First line contains `GET /foo HTTP/1.1`.
                 // Convert it to look like other `Log.logHeaders()` outputs.
                 if (firstLine[0]) {
-                    int protocolFieldPrefixIndex = line.lastIndexOf(' ');
-                    assert protocolFieldPrefixIndex > 0;
-                    sb.append("  ").append(line, 0, protocolFieldPrefixIndex).append('\n');
+                    sb.append("  ").append(line).append('\n');
                     firstLine[0] = false;
                 } else if (!line.isBlank()) {
                     sb.append("    ").append(line).append('\n');

--- a/src/java.net.http/share/classes/jdk/internal/net/http/Http1Request.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Http1Request.java
@@ -81,15 +81,22 @@ class Http1Request {
 
     private void logHeaders(String completeHeaders) {
         if (Log.headers()) {
-            //StringBuilder sb = new StringBuilder(256);
-            //sb.append("REQUEST HEADERS:\n");
-            //Log.dumpHeaders(sb, "    ", systemHeaders);
-            //Log.dumpHeaders(sb, "    ", userHeaders);
-            //Log.logHeaders(sb.toString());
-
-            String s = completeHeaders.replaceAll("\r\n", "\n");
-            if (s.endsWith("\n\n")) s = s.substring(0, s.length() - 2);
-            Log.logHeaders("REQUEST HEADERS:\n{0}\n", s);
+            StringBuilder sb = new StringBuilder(completeHeaders.length());
+            sb.append("REQUEST HEADERS:\n");
+            boolean[] firstLine = {true};
+            completeHeaders.lines().forEach(line -> {
+                // First line contains `GET /foo HTTP/1.1`.
+                // Convert it to look like other `Log.logHeaders()` outputs.
+                if (firstLine[0]) {
+                    int protocolFieldPrefixIndex = line.lastIndexOf(' ');
+                    assert protocolFieldPrefixIndex > 0;
+                    sb.append("  ").append(line, 0, protocolFieldPrefixIndex).append('\n');
+                    firstLine[0] = false;
+                } else if (!line.isBlank()) {
+                    sb.append("    ").append(line).append('\n');
+                }
+            });
+            Log.logHeaders(sb.toString());
         }
     }
 

--- a/src/java.net.http/share/classes/jdk/internal/net/http/Http1Response.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Http1Response.java
@@ -223,7 +223,13 @@ class Http1Response<T> {
                                         HTTP_1_1);
 
                 if (Log.headers()) {
-                    StringBuilder sb = new StringBuilder("RESPONSE HEADERS:\n");
+                    StringBuilder sb = new StringBuilder("RESPONSE HEADERS:\n  ")
+                            .append(request.method())
+                            .append(' ')
+                            .append(request.uri())
+                            .append(' ')
+                            .append(responseCode)
+                            .append('\n');
                     Log.dumpHeaders(sb, "    ", headers);
                     Log.logHeaders(sb.toString());
                 }

--- a/src/java.net.http/share/classes/jdk/internal/net/http/Http1Response.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Http1Response.java
@@ -224,7 +224,7 @@ class Http1Response<T> {
 
                 if (Log.headers()) {
                     StringBuilder sb = new StringBuilder("RESPONSE HEADERS:\n");
-                    sb.append("  %s %s %d\n".formatted(request.method(), request.uri(), responseCode));
+                    sb.append("  %s %s %s\n".formatted(request.method(), request.uri(), responseCode));
                     Log.dumpHeaders(sb, "    ", headers);
                     Log.logHeaders(sb.toString());
                 }

--- a/src/java.net.http/share/classes/jdk/internal/net/http/Http1Response.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Http1Response.java
@@ -223,13 +223,8 @@ class Http1Response<T> {
                                         HTTP_1_1);
 
                 if (Log.headers()) {
-                    StringBuilder sb = new StringBuilder("RESPONSE HEADERS:\n  ")
-                            .append(request.method())
-                            .append(' ')
-                            .append(request.uri())
-                            .append(' ')
-                            .append(responseCode)
-                            .append('\n');
+                    StringBuilder sb = new StringBuilder("RESPONSE HEADERS:\n");
+                    sb.append("  %s %s %d\n".formatted(request.method(), request.uri(), responseCode));
                     Log.dumpHeaders(sb, "    ", headers);
                     Log.logHeaders(sb.toString());
                 }

--- a/src/java.net.http/share/classes/jdk/internal/net/http/Http2Connection.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Http2Connection.java
@@ -1685,7 +1685,7 @@ class Http2Connection  {
     private List<ByteBuffer> encodeHeaders(OutgoingHeaders<Stream<?>> oh, Stream<?> stream) {
         oh.streamid(stream.streamid);
         if (Log.headers()) {
-            StringBuilder sb = new StringBuilder("HEADERS FRAME (streamid=%d):\n".formatted(stream.streamid));
+            StringBuilder sb = new StringBuilder("HEADERS FRAME (streamid=%s):\n".formatted(stream.streamid));
             sb.append("  %s %s\n".formatted(stream.request.method(), stream.request.uri()));
             Log.dumpHeaders(sb, "    ", oh.getAttachment().getRequestPseudoHeaders());
             Log.dumpHeaders(sb, "    ", oh.getSystemHeaders());

--- a/src/java.net.http/share/classes/jdk/internal/net/http/Http2Connection.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Http2Connection.java
@@ -1685,8 +1685,13 @@ class Http2Connection  {
     private List<ByteBuffer> encodeHeaders(OutgoingHeaders<Stream<?>> oh, Stream<?> stream) {
         oh.streamid(stream.streamid);
         if (Log.headers()) {
-            StringBuilder sb = new StringBuilder("HEADERS FRAME (stream=");
-            sb.append(stream.streamid).append(")\n");
+            StringBuilder sb = new StringBuilder("HEADERS FRAME (streamid=")
+                        .append(stream.streamid)
+                        .append("):\n  ")
+                        .append(stream.request.method())
+                        .append(' ')
+                        .append(stream.request.uri())
+                        .append('\n');
             Log.dumpHeaders(sb, "    ", oh.getAttachment().getRequestPseudoHeaders());
             Log.dumpHeaders(sb, "    ", oh.getSystemHeaders());
             Log.dumpHeaders(sb, "    ", oh.getUserHeaders());

--- a/src/java.net.http/share/classes/jdk/internal/net/http/Http2Connection.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Http2Connection.java
@@ -1685,13 +1685,8 @@ class Http2Connection  {
     private List<ByteBuffer> encodeHeaders(OutgoingHeaders<Stream<?>> oh, Stream<?> stream) {
         oh.streamid(stream.streamid);
         if (Log.headers()) {
-            StringBuilder sb = new StringBuilder("HEADERS FRAME (streamid=")
-                        .append(stream.streamid)
-                        .append("):\n  ")
-                        .append(stream.request.method())
-                        .append(' ')
-                        .append(stream.request.uri())
-                        .append('\n');
+            StringBuilder sb = new StringBuilder("HEADERS FRAME (streamid=%d):\n".formatted(stream.streamid));
+            sb.append("  %s %s\n".formatted(stream.request.method(), stream.request.uri()));
             Log.dumpHeaders(sb, "    ", oh.getAttachment().getRequestPseudoHeaders());
             Log.dumpHeaders(sb, "    ", oh.getSystemHeaders());
             Log.dumpHeaders(sb, "    ", oh.getUserHeaders());

--- a/src/java.net.http/share/classes/jdk/internal/net/http/Stream.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Stream.java
@@ -663,7 +663,7 @@ class Stream<T> extends ExchangeImpl<T> {
 
             if (Log.headers()) {
                 StringBuilder sb = new StringBuilder("RESPONSE HEADERS (streamid=%d):\n".formatted(streamid));
-                sb.append("  %s %s %d\n".formatted(request.method(), request.uri(), responseCode));
+                sb.append("  %s %s %s\n".formatted(request.method(), request.uri(), responseCode));
                 Log.dumpHeaders(sb, "    ", responseHeaders);
                 Log.logHeaders(sb.toString());
             }
@@ -674,8 +674,7 @@ class Stream<T> extends ExchangeImpl<T> {
             completeResponse(response);
         } else {
             if (Log.headers()) {
-                StringBuilder sb = new StringBuilder("TRAILING HEADERS (streamid=%d):\n".formatted(streamid));
-                sb.append("  %s %s %d\n".formatted(request.method(), request.uri(), responseCode));
+                StringBuilder sb = new StringBuilder("TRAILING HEADERS (streamid=%s):\n".formatted(streamid));
                 Log.dumpHeaders(sb, "    ", responseHeaders);
                 Log.logHeaders(sb.toString());
             }
@@ -1772,8 +1771,8 @@ class Stream<T> extends ExchangeImpl<T> {
                 responseHeaders.firstValueAsLong("content-length");
 
                 if (Log.headers()) {
-                    StringBuilder sb = new StringBuilder("RESPONSE HEADERS (streamid=%d):\n".formatted(streamid));
-                    sb.append("  %s %s %d\n".formatted(request.method(), request.uri(), responseCode));
+                    StringBuilder sb = new StringBuilder("RESPONSE HEADERS (streamid=%s):\n".formatted(streamid));
+                    sb.append("  %s %s %s\n".formatted(request.method(), request.uri(), responseCode));
                     Log.dumpHeaders(sb, "    ", responseHeaders);
                     Log.logHeaders(sb.toString());
                 }
@@ -1784,8 +1783,8 @@ class Stream<T> extends ExchangeImpl<T> {
                 completeResponse(response);
             } else {
                 if (Log.headers()) {
-                    StringBuilder sb = new StringBuilder("TRAILING HEADERS (streamid=%d):\n".formatted(streamid));
-                    sb.append("  %s %s %d\n".formatted(request.method(), request.uri(), responseCode));
+                    StringBuilder sb = new StringBuilder("TRAILING HEADERS (streamid=%s):\n".formatted(streamid));
+                    sb.append("  %s %s %s\n".formatted(request.method(), request.uri(), responseCode));
                     Log.dumpHeaders(sb, "    ", responseHeaders);
                     Log.logHeaders(sb.toString());
                 }

--- a/src/java.net.http/share/classes/jdk/internal/net/http/Stream.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Stream.java
@@ -662,7 +662,7 @@ class Stream<T> extends ExchangeImpl<T> {
             responseHeaders.firstValueAsLong("content-length");
 
             if (Log.headers()) {
-                StringBuilder sb = new StringBuilder("RESPONSE HEADERS (streamid=%d):\n".formatted(streamid));
+                StringBuilder sb = new StringBuilder("RESPONSE HEADERS (streamid=%s):\n".formatted(streamid));
                 sb.append("  %s %s %s\n".formatted(request.method(), request.uri(), responseCode));
                 Log.dumpHeaders(sb, "    ", responseHeaders);
                 Log.logHeaders(sb.toString());

--- a/src/java.net.http/share/classes/jdk/internal/net/http/Stream.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Stream.java
@@ -662,15 +662,8 @@ class Stream<T> extends ExchangeImpl<T> {
             responseHeaders.firstValueAsLong("content-length");
 
             if (Log.headers()) {
-                StringBuilder sb = new StringBuilder("RESPONSE HEADERS (streamid=")
-                        .append(streamid)
-                        .append("):\n  ")
-                        .append(request.method())
-                        .append(' ')
-                        .append(request.uri())
-                        .append(' ')
-                        .append(responseCode)
-                        .append('\n');
+                StringBuilder sb = new StringBuilder("RESPONSE HEADERS (streamid=%d):\n".formatted(streamid));
+                sb.append("  %s %s %d\n".formatted(request.method(), request.uri(), responseCode));
                 Log.dumpHeaders(sb, "    ", responseHeaders);
                 Log.logHeaders(sb.toString());
             }
@@ -681,15 +674,8 @@ class Stream<T> extends ExchangeImpl<T> {
             completeResponse(response);
         } else {
             if (Log.headers()) {
-                StringBuilder sb = new StringBuilder("TRAILING HEADERS (streamid=")
-                        .append(streamid)
-                        .append("):\n  ")
-                        .append(request.method())
-                        .append(' ')
-                        .append(request.uri())
-                        .append(' ')
-                        .append(responseCode)
-                        .append('\n');
+                StringBuilder sb = new StringBuilder("TRAILING HEADERS (streamid=%d):\n".formatted(streamid));
+                sb.append("  %s %s %d\n".formatted(request.method(), request.uri(), responseCode));
                 Log.dumpHeaders(sb, "    ", responseHeaders);
                 Log.logHeaders(sb.toString());
             }
@@ -1786,15 +1772,8 @@ class Stream<T> extends ExchangeImpl<T> {
                 responseHeaders.firstValueAsLong("content-length");
 
                 if (Log.headers()) {
-                    StringBuilder sb = new StringBuilder("RESPONSE HEADERS (streamid=")
-                        .append(streamid)
-                        .append("):\n  ")
-                        .append(request.method())
-                        .append(' ')
-                        .append(request.uri())
-                        .append(' ')
-                        .append(responseCode)
-                        .append('\n');
+                    StringBuilder sb = new StringBuilder("RESPONSE HEADERS (streamid=%d):\n".formatted(streamid));
+                    sb.append("  %s %s %d\n".formatted(request.method(), request.uri(), responseCode));
                     Log.dumpHeaders(sb, "    ", responseHeaders);
                     Log.logHeaders(sb.toString());
                 }
@@ -1805,15 +1784,8 @@ class Stream<T> extends ExchangeImpl<T> {
                 completeResponse(response);
             } else {
                 if (Log.headers()) {
-                    StringBuilder sb = new StringBuilder("TRAILING HEADERS (streamid=")
-                        .append(streamid)
-                        .append("):\n  ")
-                        .append(request.method())
-                        .append(' ')
-                        .append(request.uri())
-                        .append(' ')
-                        .append(responseCode)
-                        .append('\n');
+                    StringBuilder sb = new StringBuilder("TRAILING HEADERS (streamid=%d):\n".formatted(streamid));
+                    sb.append("  %s %s %d\n".formatted(request.method(), request.uri(), responseCode));
                     Log.dumpHeaders(sb, "    ", responseHeaders);
                     Log.logHeaders(sb.toString());
                 }

--- a/src/java.net.http/share/classes/jdk/internal/net/http/Stream.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Stream.java
@@ -681,7 +681,15 @@ class Stream<T> extends ExchangeImpl<T> {
             completeResponse(response);
         } else {
             if (Log.headers()) {
-                StringBuilder sb = new StringBuilder("TRAILING HEADERS:\n");
+                StringBuilder sb = new StringBuilder("TRAILING HEADERS (streamid=")
+                        .append(streamid)
+                        .append("):\n  ")
+                        .append(request.method())
+                        .append(' ')
+                        .append(request.uri())
+                        .append(' ')
+                        .append(responseCode)
+                        .append('\n');
                 Log.dumpHeaders(sb, "    ", responseHeaders);
                 Log.logHeaders(sb.toString());
             }
@@ -1778,8 +1786,15 @@ class Stream<T> extends ExchangeImpl<T> {
                 responseHeaders.firstValueAsLong("content-length");
 
                 if (Log.headers()) {
-                    StringBuilder sb = new StringBuilder("RESPONSE HEADERS");
-                    sb.append(" (streamid=").append(streamid).append("):\n");
+                    StringBuilder sb = new StringBuilder("RESPONSE HEADERS (streamid=")
+                        .append(streamid)
+                        .append("):\n  ")
+                        .append(request.method())
+                        .append(' ')
+                        .append(request.uri())
+                        .append(' ')
+                        .append(responseCode)
+                        .append('\n');
                     Log.dumpHeaders(sb, "    ", responseHeaders);
                     Log.logHeaders(sb.toString());
                 }
@@ -1790,8 +1805,15 @@ class Stream<T> extends ExchangeImpl<T> {
                 completeResponse(response);
             } else {
                 if (Log.headers()) {
-                    StringBuilder sb = new StringBuilder("TRAILING HEADERS");
-                    sb.append(" (streamid=").append(streamid).append("):\n");
+                    StringBuilder sb = new StringBuilder("TRAILING HEADERS (streamid=")
+                        .append(streamid)
+                        .append("):\n  ")
+                        .append(request.method())
+                        .append(' ')
+                        .append(request.uri())
+                        .append(' ')
+                        .append(responseCode)
+                        .append('\n');
                     Log.dumpHeaders(sb, "    ", responseHeaders);
                     Log.logHeaders(sb.toString());
                 }

--- a/src/java.net.http/share/classes/jdk/internal/net/http/Stream.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Stream.java
@@ -662,7 +662,15 @@ class Stream<T> extends ExchangeImpl<T> {
             responseHeaders.firstValueAsLong("content-length");
 
             if (Log.headers()) {
-                StringBuilder sb = new StringBuilder("RESPONSE HEADERS:\n");
+                StringBuilder sb = new StringBuilder("RESPONSE HEADERS (streamid=")
+                        .append(streamid)
+                        .append("):\n  ")
+                        .append(request.method())
+                        .append(' ')
+                        .append(request.uri())
+                        .append(' ')
+                        .append(responseCode)
+                        .append('\n');
                 Log.dumpHeaders(sb, "    ", responseHeaders);
                 Log.logHeaders(sb.toString());
             }


### PR DESCRIPTION
Includes request method, request URI, response status code, and HTTP/2 stream ID while logging response headers in the HTTP Client.

### Demonstration

Snippets from running JTreg against `test/jdk/java/net/httpclient/HeadTest.java`:

**Before:**
```
INFO: HEADERS: REQUEST HEADERS:
HEAD /transfer/ HTTP/1.1
Content-Length: 0
Host: 127.0.0.1:43647
...
INFO: HEADERS: RESPONSE HEADERS:
    connection: Upgrade
    upgrade: h2c
...
INFO: HEADERS: RESPONSE HEADERS:
    :status: 304
    content-length: 300
...
INFO: HEADERS: HEADERS FRAME (streamid=1):
    :authority: 127.0.0.1:50611
    :method: GET
    :path: /
```

**After:** 
```
INFO: HEADERS: REQUEST HEADERS:
  HEAD /transfer/ HTTP/1.1
    Content-Length: 0
    Host: 127.0.0.1:43647
...
INFO: HEADERS: RESPONSE HEADERS:
  GET http://127.0.0.1:48497/ 101
    connection: Upgrade
    upgrade: h2c
...
INFO: HEADERS: RESPONSE HEADERS (streamid=1):
  GET http://127.0.0.1:48497/ 304
    :status: 304
    content-length: 300
...
INFO: HEADERS: HEADERS FRAME (streamid=1):
  GET https://127.0.0.1:50611/
    :authority: 127.0.0.1:50611
    :method: GET
    :path: /
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8351347](https://bugs.openjdk.org/browse/JDK-8351347): HttpClient Improve logging of response headers (**Bug** - P4)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)
 * [Michael McMahon](https://openjdk.org/census#michaelm) (@Michael-Mc-Mahon - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25201/head:pull/25201` \
`$ git checkout pull/25201`

Update a local copy of the PR: \
`$ git checkout pull/25201` \
`$ git pull https://git.openjdk.org/jdk.git pull/25201/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25201`

View PR using the GUI difftool: \
`$ git pr show -t 25201`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25201.diff">https://git.openjdk.org/jdk/pull/25201.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25201#issuecomment-2875505694)
</details>
