### PR TITLE
8356774: AArch64: StubGen final stubs buffer too small for ZGC on Cavium CPU

### DIFF
--- a/src/hotspot/cpu/aarch64/stubDeclarations_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/stubDeclarations_aarch64.hpp
@@ -109,7 +109,7 @@
                                     do_arch_blob,                       \
                                     do_arch_entry,                      \
                                     do_arch_entry_init)                 \
-  do_arch_blob(final, 20000 ZGC_ONLY(+60000))                           \
+  do_arch_blob(final, 20000 ZGC_ONLY(+85000))                           \
   do_stub(final, copy_byte_f)                                           \
   do_arch_entry(aarch64, final, copy_byte_f, copy_byte_f,               \
                 copy_byte_f)                                            \


### PR DESCRIPTION
Increased final stubs buffer size to allow extra space when running with ZGC enabled on Cavium ThunderX. Cavium is special because it generates stub code to handle unaligned copies. With ZGC enabled this implies a lot more injected barrier code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8356774](https://bugs.openjdk.org/browse/JDK-8356774): AArch64: StubGen final stubs buffer too small for ZGC on Cavium CPU (**Bug** - P3)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25203/head:pull/25203` \
`$ git checkout pull/25203`

Update a local copy of the PR: \
`$ git checkout pull/25203` \
`$ git pull https://git.openjdk.org/jdk.git pull/25203/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25203`

View PR using the GUI difftool: \
`$ git pr show -t 25203`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25203.diff">https://git.openjdk.org/jdk/pull/25203.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25203#issuecomment-2875628995)
</details>
