### PR TITLE
8348906: InstanceOfTree#getType doesn't specify when it returns null

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/source/tree/InstanceOfTree.java
+++ b/src/jdk.compiler/share/classes/com/sun/source/tree/InstanceOfTree.java
@@ -31,6 +31,8 @@ package com.sun.source.tree;
  * For example:
  * <pre>
  *   <em>expression</em> instanceof <em>type</em>
+ *
+ *   <em>expression</em> instanceof <em>pattern</em>
  * </pre>
  *
  * @jls 15.20.2 The instanceof Operator
@@ -48,32 +50,50 @@ public interface InstanceOfTree extends ExpressionTree {
     ExpressionTree getExpression();
 
     /**
-     * Returns the type for which to check, or {@code null} if this instanceof
+     * Returns the type for which to check, or {@code null} if this {@code instanceof}
      * uses a pattern other the {@link BindingPatternTree}.
      *
-     * @return the type or {@code null} if this instanceof uses a pattern other than
+     * <p>For {@code instanceof} without a pattern, i.e. in the following form:
+     * <pre>
+     *   <em>expression</em> instanceof <em>type</em>
+     * </pre>
+     * returns the type.
+     *
+     * <p>For {@code instanceof} with a {@link BindingPatternTree}, i.e. in the following form:
+     * <pre>
+     *   <em>expression</em> instanceof <em>type</em> <em>variable_name</em>
+     * </pre>
+     * returns the type.
+     *
+     * <p>For instanceof with a pattern, i.e. in the following form:
+     * <pre>
+     *   <em>expression</em> instanceof <em>pattern</em>
+     * </pre>
+     * returns {@code null}.
+     *
+     * @return the type or {@code null} if this {@code instanceof} uses a pattern other than
      *         the {@linkplain BindingPatternTree}
      * @see #getPattern()
      */
     Tree getType();
 
     /**
-     * Returns the tested pattern, or null if this instanceof does not use
+     * Returns the tested pattern, or {@code null} if this {@code instanceof} does not use
      * a pattern.
      *
      * <p>For instanceof with a pattern, i.e. in the following form:
      * <pre>
-     *   <em>expression</em> instanceof <em>type</em> <em>variable name</em>
+     *   <em>expression</em> instanceof <em>pattern</em>
      * </pre>
      * returns the pattern.
      *
-     * <p>For instanceof without a pattern, i.e. in the following form:
+     * <p>For {@code instanceof} without a pattern, i.e. in the following form:
      * <pre>
      *   <em>expression</em> instanceof <em>type</em>
      * </pre>
-     * returns null.
+     * returns {@code null}.
      *
-     * @return the tested pattern, or null if this instanceof does not use a pattern
+     * @return the tested pattern, or {@code null} if this {@code instanceof} does not use a pattern
      * @since 16
      */
     PatternTree getPattern();

--- a/src/jdk.compiler/share/classes/com/sun/source/tree/InstanceOfTree.java
+++ b/src/jdk.compiler/share/classes/com/sun/source/tree/InstanceOfTree.java
@@ -48,8 +48,11 @@ public interface InstanceOfTree extends ExpressionTree {
     ExpressionTree getExpression();
 
     /**
-     * Returns the type for which to check.
-     * @return the type
+     * Returns the type for which to check, or {@code null} if this instanceof
+     * uses a pattern other the {@link BindingPatternTree}.
+     *
+     * @return the type or {@code null} if this instanceof uses a pattern other than
+     *         the {@linkplain BindingPatternTree}
      * @see #getPattern()
      */
     Tree getType();

--- a/test/langtools/tools/javac/patterns/InstanceOfModelTest.java
+++ b/test/langtools/tools/javac/patterns/InstanceOfModelTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8348906
+ * @summary Verify the InstanceOfTree model
+ */
+
+import com.sun.source.tree.CompilationUnitTree;
+import com.sun.source.tree.InstanceOfTree;
+import com.sun.source.util.JavacTask;
+import com.sun.source.util.TreeScanner;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import javax.tools.JavaCompiler;
+import javax.tools.JavaFileObject;
+import javax.tools.SimpleJavaFileObject;
+import javax.tools.ToolProvider;
+
+public class InstanceOfModelTest {
+    private final JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+
+    public static void main(String... args) throws Exception {
+        new InstanceOfModelTest().run();
+    }
+
+    private void run() throws Exception {
+        JavaFileObject input =
+                SimpleJavaFileObject.forSource(URI.create("mem://Test.java"),
+                                               """
+                                               public class Test {
+                                                   void test(Object o) {
+                                                       boolean _ = o instanceof R;
+                                                       boolean _ = o instanceof R r;
+                                                       boolean _ = o instanceof R(var v);
+                                                   }
+                                                   record R(int i) {}
+                                               }
+                                               """);
+        JavacTask task =
+                (JavacTask) compiler.getTask(null, null, null, null, null, List.of(input));
+        CompilationUnitTree cut = task.parse().iterator().next();
+
+        task.analyze();
+
+        List<String> instanceOf = new ArrayList<>();
+
+        new TreeScanner<Void, Void>() {
+            @Override
+            public Void visitInstanceOf(InstanceOfTree node, Void p) {
+                instanceOf.add(node.getPattern() + ":" + node.getType());
+                return super.visitInstanceOf(node, p);
+            }
+        }.scan(cut, null);
+
+        List<String> expectedInstanceOf = List.of(
+            "null:R",
+            "R r:R",
+            "R(int v):null"
+        );
+
+        if (!Objects.equals(expectedInstanceOf, instanceOf)) {
+            throw new AssertionError("Expected: " + expectedInstanceOf + ",\n" +
+                                     "got: " + instanceOf);
+        }
+    }
+}


### PR DESCRIPTION
`InstanceOfTree.getType()` returns `null` if the `instanceof` uses a pattern different than the type test pattern. This is not documented, and should be documented. This PR proposes the documentation for this.

Alternatively, we could change `getType()` to return a type for other types of patterns, but the meaning of that is not quite clear even for record patterns, and it gets even less clear with the possible future patterns. I believe it has been mostly a conscious decision to not handle record patterns in this method. Possibly, it was a mistake to handle the type test/binding patterns in `getType()`, but that's not something that we should change, I think.

Please also review the CSR:
https://bugs.openjdk.org/browse/JDK-8356857

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8356857](https://bugs.openjdk.org/browse/JDK-8356857) to be approved

### Issues
 * [JDK-8348906](https://bugs.openjdk.org/browse/JDK-8348906): InstanceOfTree#getType doesn't specify when it returns null (**Enhancement** - P4)
 * [JDK-8356857](https://bugs.openjdk.org/browse/JDK-8356857): InstanceOfTree#getType doesn't specify when it returns null (**CSR**)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25205/head:pull/25205` \
`$ git checkout pull/25205`

Update a local copy of the PR: \
`$ git checkout pull/25205` \
`$ git pull https://git.openjdk.org/jdk.git pull/25205/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25205`

View PR using the GUI difftool: \
`$ git pr show -t 25205`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25205.diff">https://git.openjdk.org/jdk/pull/25205.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25205#issuecomment-2876143107)
</details>
