### PR TITLE
8356866: Cleanup hotspot/jtreg/ProblemList.txt

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -47,7 +47,8 @@ compiler/compilercontrol/jcmd/ClearDirectivesFileStackTest.java 8225370 generic-
 
 compiler/cpuflags/TestAESIntrinsicsOnSupportedConfig.java 8190680 generic-all
 
-compiler/runtime/Test8168712.java 8211769,8211771 generic-ppc64,generic-ppc64le,linux-s390x
+compiler/runtime/Test8168712.java#with-dtrace 8211769,8211771 generic-ppc64,generic-ppc64le,linux-s390x
+compiler/runtime/Test8168712.java#without-dtrace 8211769,8211771 generic-ppc64,generic-ppc64le,linux-s390x
 compiler/loopopts/TestUnreachableInnerLoop.java 8288981 linux-s390x
 
 compiler/c2/Test8004741.java 8235801 generic-all
@@ -88,7 +89,6 @@ gc/g1/logging/TestG1LoggingFailure.java 8169634 generic-all
 gc/g1/humongousObjects/TestHeapCounters.java 8178918 generic-all
 gc/TestAllocHumongousFragment.java#adaptive 8298781 generic-all
 gc/TestAllocHumongousFragment.java#aggressive 8298781 generic-all
-gc/TestAllocHumongousFragment.java#iu-aggressive 8298781 generic-all
 gc/TestAllocHumongousFragment.java#g1 8298781 generic-all
 gc/TestAllocHumongousFragment.java#static 8298781 generic-all
 gc/TestAlwaysPreTouchBehavior.java#ParallelCollector 8334513 generic-all


### PR DESCRIPTION
After running: `make run-test TEST="${test}" VERBOSE JTREG="RETAIN=all;VERBOSE=all;OPTIONS=--verify-exclude"`

```
Testsuite: test/hotspot/jtreg
test/hotspot/jtreg/ProblemList.txt line 50 is invalid. Reason:
The fully qualified test must exist.
Line contents:
--------------
compiler/runtime/Test8168712.java 8211769,8211771 generic-ppc64,generic-ppc64le,linux-s390x
--------------
test/hotspot/jtreg/ProblemList.txt line 91 is invalid. Reason:
The fully qualified test must exist.
Line contents:
--------------
gc/TestAllocHumongousFragment.java#iu-aggressive 8298781 generic-all
--------------
Error: Cannot run because an exclude list had errors, printed above. Either resolve them or remove the exclude list. 
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8356866](https://bugs.openjdk.org/browse/JDK-8356866): Cleanup hotspot/jtreg/ProblemList.txt (**Bug** - P4)


### Reviewers
 * [SendaoYan](https://openjdk.org/census#syan) (@sendaoYan - Committer)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25208/head:pull/25208` \
`$ git checkout pull/25208`

Update a local copy of the PR: \
`$ git checkout pull/25208` \
`$ git pull https://git.openjdk.org/jdk.git pull/25208/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25208`

View PR using the GUI difftool: \
`$ git pr show -t 25208`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25208.diff">https://git.openjdk.org/jdk/pull/25208.diff</a>

</details>
