### PR TITLE
8356869: RISC-V: Improve tail handling of array fill stub

### DIFF
--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -2122,32 +2122,32 @@ class StubGenerator: public StubCodeGenerator {
     }
 
     // Remaining count is less than 8 bytes and address is heapword aligned.
-    Label L_fill_2, L_fill_4, L_exit1;
+    Label L_fill_1, L_fill_2, L_exit1;
     switch (t) {
       case T_BYTE:
-        __ test_bit(t0, count, 0);
+        __ test_bit(t0, count, 2);
         __ beqz(t0, L_fill_2);
-        __ sb(value, Address(to, 0));
-        __ addi(to, to, 1);
+        __ sw(value, Address(to, 0));
+        __ addi(to, to, 4);
         __ bind(L_fill_2);
         __ test_bit(t0, count, 1);
-        __ beqz(t0, L_fill_4);
+        __ beqz(t0, L_fill_1);
         __ sh(value, Address(to, 0));
         __ addi(to, to, 2);
-        __ bind(L_fill_4);
-        __ test_bit(t0, count, 2);
+        __ bind(L_fill_1);
+        __ test_bit(t0, count, 0);
         __ beqz(t0, L_exit1);
-        __ sw(value, Address(to, 0));
+        __ sb(value, Address(to, 0));
         break;
       case T_SHORT:
-        __ test_bit(t0, count, 0);
-        __ beqz(t0, L_fill_4);
-        __ sh(value, Address(to, 0));
-        __ addi(to, to, 2);
-        __ bind(L_fill_4);
         __ test_bit(t0, count, 1);
-        __ beqz(t0, L_exit1);
+        __ beqz(t0, L_fill_2);
         __ sw(value, Address(to, 0));
+        __ addi(to, to, 4);
+        __ bind(L_fill_2);
+        __ test_bit(t0, count, 0);
+        __ beqz(t0, L_exit1);
+        __ sh(value, Address(to, 0));
         break;
       case T_INT:
         __ beqz(count, L_exit1);

--- a/test/micro/org/openjdk/bench/vm/compiler/ArrayFill.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/ArrayFill.java
@@ -46,7 +46,7 @@ import java.util.Arrays;
 @Measurement(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
 @Fork(value = 3)
 public class ArrayFill {
-    @Param("65536") private int size;
+    @Param("7", "15", "65536") private int size;
 
     private byte[] ba;
     private short[] sa;

--- a/test/micro/org/openjdk/bench/vm/compiler/ArrayFill.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/ArrayFill.java
@@ -46,7 +46,7 @@ import java.util.Arrays;
 @Measurement(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
 @Fork(value = 3)
 public class ArrayFill {
-    @Param("7", "15", "65536") private int size;
+    @Param({"7", "15", "65536"}) private int size;
 
     private byte[] ba;
     private short[] sa;


### PR DESCRIPTION
The tail handling after bulk copy in array fill stub may trigger misaligned memory accesses.
The address is 8-byte aligned after bulk copy and the tail handling copies BYTE, SHORT, and
INT granules in order. This could trigger misaligned accesses. We should copy the remainings
in this order: INT, SHORT, and BYTE to avoid such an issue.

JMH data on P550 SBC for reference (@Param("15") private int size):
```
Before:
Benchmark                 (size)  Mode  Cnt    Score   Error  Units
ArrayFill.fillByteArray       15  avgt   12  961.604 ± 1.497  ns/op
ArrayFill.fillIntArray        15  avgt   12   29.355 ± 0.024  ns/op
ArrayFill.fillShortArray      15  avgt   12  569.499 ± 0.662  ns/op
ArrayFill.zeroByteArray       15  avgt   12  957.080 ± 5.358  ns/op
ArrayFill.zeroIntArray        15  avgt   12   29.344 ± 0.006  ns/op
ArrayFill.zeroShortArray      15  avgt   12  569.730 ± 0.441  ns/op

After:
Benchmark                 (size)  Mode  Cnt   Score   Error  Units
ArrayFill.fillByteArray       15  avgt   12  32.206 ± 0.005  ns/op
ArrayFill.fillIntArray        15  avgt   12  29.347 ± 0.007  ns/op
ArrayFill.fillShortArray      15  avgt   12  31.732 ± 0.451  ns/op
ArrayFill.zeroByteArray       15  avgt   12  32.208 ± 0.007  ns/op
ArrayFill.zeroIntArray        15  avgt   12  29.346 ± 0.007  ns/op
ArrayFill.zeroShortArray      15  avgt   12  31.492 ± 0.006  ns/op
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8356869](https://bugs.openjdk.org/browse/JDK-8356869): RISC-V: Improve tail handling of array fill stub (**Enhancement** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Feilong Jiang](https://openjdk.org/census#fjiang) (@feilongjiang - Committer)
 * [Hamlin Li](https://openjdk.org/census#mli) (@Hamlin-Li - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25210/head:pull/25210` \
`$ git checkout pull/25210`

Update a local copy of the PR: \
`$ git checkout pull/25210` \
`$ git pull https://git.openjdk.org/jdk.git pull/25210/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25210`

View PR using the GUI difftool: \
`$ git pr show -t 25210`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25210.diff">https://git.openjdk.org/jdk/pull/25210.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25210#issuecomment-2876441882)
</details>
