### PR TITLE
8328848: Inaccuracy in the documentation of the -group option

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/standard.properties
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/standard.properties
@@ -599,7 +599,7 @@ doclet.usage.excludedocfilessubdir.description=\
 doclet.usage.group.parameters=\
     <name> <g1>,<g2>...
 doclet.usage.group.description=\
-    Group specified elements together in overview page.\n\
+    Group specified packages or modules together in overview page.\n\
     ':' can also be used anywhere in the argument as a separator.
 
 doclet.usage.legal-notices.parameters=\

--- a/src/jdk.javadoc/share/man/javadoc.md
+++ b/src/jdk.javadoc/share/man/javadoc.md
@@ -510,8 +510,9 @@ The following options are provided by the standard doclet.
 <span id="option-footer">`-footer` *html-code*</span>
 :   This option is no longer supported and reports a warning.
 
-<span id="option-group">`-group` *name* *p1*`,`*p2...*</span>
-:   Group the specified packages together in the Overview page.
+<span id="option-group">`-group` *name* *g1*`,`*g2...*</span>
+:   Group the specified packages, or modules when documenting modular code,
+    together in the Overview page.
     For historical reasons, `:` can be used as a separator anywhere in the
     argument instead of `,`.
 


### PR DESCRIPTION
Please review a documentation fix in the `javadoc` man page to document that the `-group` option can be used with packages or modules depending on documented code. 

Although the help output of the `javadoc` tool already included this fact I replaced the abstract term "elements" with "packages or modules" to make it a bit more concrete.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8328848](https://bugs.openjdk.org/browse/JDK-8328848): Inaccuracy in the documentation of the -group option (**Bug** - P4)(⚠️ The fixVersion in this issue is [25] but the fixVersion in .jcheck/conf is 26, a new backport will be created when this pr is integrated.)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25212/head:pull/25212` \
`$ git checkout pull/25212`

Update a local copy of the PR: \
`$ git checkout pull/25212` \
`$ git pull https://git.openjdk.org/jdk.git pull/25212/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25212`

View PR using the GUI difftool: \
`$ git pr show -t 25212`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25212.diff">https://git.openjdk.org/jdk/pull/25212.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25212#issuecomment-2876502878)
</details>
