### PR TITLE
8356875: RISC-V: extension flag UseZvfh should depends on UseZfh

### DIFF
--- a/src/hotspot/cpu/riscv/vm_version_riscv.cpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.cpp
@@ -240,9 +240,15 @@ void VM_Version::common_initialize() {
   }
 
   // UseZvfh (depends on RVV)
-  if (UseZvfh && !UseRVV) {
-    warning("Cannot enable UseZvfh on cpu without RVV support.");
-    FLAG_SET_DEFAULT(UseZvfh, false);
+  if (UseZvfh) {
+    if (!UseRVV) {
+      warning("Cannot enable UseZvfh on cpu without RVV support.");
+      FLAG_SET_DEFAULT(UseZvfh, false);
+    }
+    if (!UseZfh) {
+      warning("Cannot enable UseZvfh on cpu without Zfh support.");
+      FLAG_SET_DEFAULT(UseZvfh, false);
+    }
   }
 }
 


### PR DESCRIPTION
Hi,
Can you help to review this simple patch?
If we don't enable such dependency, then there will be situation that when Zvfh is enabled but Zfh is disabled, and optimizations depending on Zvfh will be disabled (e.g. in C2) because Zfh related IR node are considered not supported.

Thanks!

By [rvv spec](https://github.com/riscvarchive/riscv-v-spec/blob/master/v-spec.adoc#185-zvfh-vector-extension-for-half-precision-floating-point), `The Zvfh extension depends on the Zve32f and Zfhmin extensions.`
But I think in logic and JVM code, we should let `Zvfh` depends on `Zfh`.