### PR TITLE
JDK-8354316 : clang/linux build fails with -Wunused-result warning at XToolkit.c:695:9

### DIFF
--- a/make/modules/java.desktop/lib/AwtLibraries.gmk
+++ b/make/modules/java.desktop/lib/AwtLibraries.gmk
@@ -278,7 +278,6 @@ ifeq ($(call isTargetOs, windows macosx)+$(ENABLE_HEADLESS_ONLY), false+false)
       DISABLED_WARNINGS_gcc_X11TextRenderer_md.c := unused-but-set-variable, \
       DISABLED_WARNINGS_gcc_XlibWrapper.c := type-limits pointer-to-int-cast, \
       DISABLED_WARNINGS_gcc_XRBackendNative.c := maybe-uninitialized, \
-      DISABLED_WARNINGS_gcc_XToolkit.c := unused-result, \
       DISABLED_WARNINGS_gcc_XWindow.c := unused-function, \
       DISABLED_WARNINGS_clang_awt_Taskbar.c := parentheses, \
       DISABLED_WARNINGS_clang_gtk3_interface.c := unused-function parentheses, \

--- a/src/java.desktop/unix/native/libawt_xawt/xawt/XToolkit.c
+++ b/src/java.desktop/unix/native/libawt_xawt/xawt/XToolkit.c
@@ -692,7 +692,12 @@ void awt_output_flush() {
 static void wakeUp() {
     static char wakeUp_char = 'p';
     if (!isMainThread() && awt_pipe_inited) {
-        write ( AWT_WRITEPIPE, &wakeUp_char, 1 );
+        if (write(AWT_WRITEPIPE, &wakeUp_char, 1) < 0) {
+            // if block is left empty to avoid adding unused-result to
+            // AwtLibraries.gmk disabled warning section on linux (gcc & clang)
+            // Additionally, throwing error in this case may introduce
+            // unexpected behavior change
+        }
     }
 }
 

--- a/src/java.desktop/unix/native/libawt_xawt/xawt/XToolkit.c
+++ b/src/java.desktop/unix/native/libawt_xawt/xawt/XToolkit.c
@@ -693,10 +693,7 @@ static void wakeUp() {
     static char wakeUp_char = 'p';
     if (!isMainThread() && awt_pipe_inited) {
         if (write(AWT_WRITEPIPE, &wakeUp_char, 1) < 0) {
-            // if block is left empty to avoid adding unused-result to
-            // AwtLibraries.gmk disabled warning section on linux (gcc & clang)
-            // Additionally, throwing error in this case may introduce
-            // unexpected behavior change
+            DTRACE_PRINTLN("wakeUp(): write to AWT pipe failed");
         }
     }
 }

--- a/src/java.desktop/unix/native/libawt_xawt/xawt/XToolkit.c
+++ b/src/java.desktop/unix/native/libawt_xawt/xawt/XToolkit.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
The following line results in unused-result warning on linux/clang.

```
/java.desktop/unix/native/libawt_xawt/xawt/XToolkit.c:695:9: error: ignoring return value of function
 declared with 'warn_unused_result' attribute [-Werror,-Wunused-result]
 695 | write ( AWT_WRITEPIPE, &wakeUp_char, 1 ); 
```

There are two ways to handle it 

1) Make changes to XToolkit.c such that the warning is no longer thrown. But throwing an error based on the result of `write ( AWT_WRITEPIPE, &wakeUp_char, 1 );` will result in unexpected behavioral changes and the best way to handle it is to have an empty if block with an appropriate comment.


There was a discussion about the same line long ago and the reason the result of `write()` was not handled and it was left unchanged was not to introduce behavioral change - https://mail.openjdk.org/pipermail/awt-dev/2016-July/011626.html


2) Add unused-result to disabled warning section for clang similar to gcc - https://github.com/openjdk/jdk/blob/d1543429ff29ca0d761b8473b3fb8621abcd226d/make/modules/java.desktop/lib/AwtLibraries.gmk#L281. The 1st approach was picked over the 2nd since the usual recommendation is not to add to disabled warning section unless there is no other option.

NOTE: the fix has been tested on linux/gcc , it does need to be tested on linux/clang.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8354316](https://bugs.openjdk.org/browse/JDK-8354316): clang/linux build fails with -Wunused-result warning at XToolkit.c:695:9 (**Bug** - P4)


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**) Review applies to [91f3d409](https://git.openjdk.org/jdk/pull/25217/files/91f3d409151dd7e489c7754e8d856a3ae41827f4)
 * [Alexander Zuev](https://openjdk.org/census#kizune) (@azuev-java - **Reviewer**) Review applies to [91f3d409](https://git.openjdk.org/jdk/pull/25217/files/91f3d409151dd7e489c7754e8d856a3ae41827f4)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [SendaoYan](https://openjdk.org/census#syan) (@sendaoYan - Committer) Review applies to [91f3d409](https://git.openjdk.org/jdk/pull/25217/files/91f3d409151dd7e489c7754e8d856a3ae41827f4)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**) Review applies to [91f3d409](https://git.openjdk.org/jdk/pull/25217/files/91f3d409151dd7e489c7754e8d856a3ae41827f4)
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25217/head:pull/25217` \
`$ git checkout pull/25217`

Update a local copy of the PR: \
`$ git checkout pull/25217` \
`$ git pull https://git.openjdk.org/jdk.git pull/25217/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25217`

View PR using the GUI difftool: \
`$ git pr show -t 25217`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25217.diff">https://git.openjdk.org/jdk/pull/25217.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25217#issuecomment-2877546646)
</details>
