### PR TITLE
8356885: Don't emit C1 profiling for casts if TypeProfileCasts is off

### DIFF
--- a/src/hotspot/share/c1/c1_LIR.cpp
+++ b/src/hotspot/share/c1/c1_LIR.cpp
@@ -1444,7 +1444,7 @@ void LIR_List::checkcast (LIR_Opr result, LIR_Opr object, ciKlass* klass,
                           ciMethod* profiled_method, int profiled_bci) {
   LIR_OpTypeCheck* c = new LIR_OpTypeCheck(lir_checkcast, result, object, klass,
                                            tmp1, tmp2, tmp3, fast_check, info_for_exception, info_for_patch, stub);
-  if (profiled_method != nullptr) {
+  if (profiled_method != nullptr && TypeProfileCasts) {
     c->set_profiled_method(profiled_method);
     c->set_profiled_bci(profiled_bci);
     c->set_should_profile(true);
@@ -1454,7 +1454,7 @@ void LIR_List::checkcast (LIR_Opr result, LIR_Opr object, ciKlass* klass,
 
 void LIR_List::instanceof(LIR_Opr result, LIR_Opr object, ciKlass* klass, LIR_Opr tmp1, LIR_Opr tmp2, LIR_Opr tmp3, bool fast_check, CodeEmitInfo* info_for_patch, ciMethod* profiled_method, int profiled_bci) {
   LIR_OpTypeCheck* c = new LIR_OpTypeCheck(lir_instanceof, result, object, klass, tmp1, tmp2, tmp3, fast_check, nullptr, info_for_patch, nullptr);
-  if (profiled_method != nullptr) {
+  if (profiled_method != nullptr && TypeProfileCasts) {
     c->set_profiled_method(profiled_method);
     c->set_profiled_bci(profiled_bci);
     c->set_should_profile(true);
@@ -1466,7 +1466,7 @@ void LIR_List::instanceof(LIR_Opr result, LIR_Opr object, ciKlass* klass, LIR_Op
 void LIR_List::store_check(LIR_Opr object, LIR_Opr array, LIR_Opr tmp1, LIR_Opr tmp2, LIR_Opr tmp3,
                            CodeEmitInfo* info_for_exception, ciMethod* profiled_method, int profiled_bci) {
   LIR_OpTypeCheck* c = new LIR_OpTypeCheck(lir_store_check, object, array, tmp1, tmp2, tmp3, info_for_exception);
-  if (profiled_method != nullptr) {
+  if (profiled_method != nullptr && TypeProfileCasts) {
     c->set_profiled_method(profiled_method);
     c->set_profiled_bci(profiled_bci);
     c->set_should_profile(true);

--- a/test/hotspot/jtreg/compiler/tiered/TypeProfileCasts.java
+++ b/test/hotspot/jtreg/compiler/tiered/TypeProfileCasts.java
@@ -64,6 +64,8 @@ public class TypeProfileCasts {
     private static void test_checkcast(Object o) {
       // checkcast
       Foo f = (Foo) o;
+
+      sideEffect++;
     }
 
     private static void test_array_store(Object o) {

--- a/test/hotspot/jtreg/compiler/tiered/TypeProfileCasts.java
+++ b/test/hotspot/jtreg/compiler/tiered/TypeProfileCasts.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test TypeProfileCasts
+ * @summary Check that turning of TypeProfileCasts is tolerated
+ * @requires vm.debug == true
+ * @modules java.base/jdk.internal.misc
+ *          java.management
+ *
+ * @run main/othervm -XX:+TieredCompilation -XX:-BackgroundCompilation -XX:-TypeProfileCasts
+ *                   -XX:CompileCommand=compileonly,compiler.tiered.TypeProfileCasts::test_instanceof
+ *                   compiler.tiered.TypeProfileCasts
+ * @run main/othervm -XX:+TieredCompilation -XX:-BackgroundCompilation -XX:+TypeProfileCasts
+ *                   -XX:CompileCommand=compileonly,compiler.tiered.TypeProfileCasts::test_instanceof
+ *                   compiler.tiered.TypeProfileCasts
+ * @run main/othervm -XX:+TieredCompilation -XX:-BackgroundCompilation -XX:-TypeProfileCasts
+ *                   -XX:CompileCommand=compileonly,compiler.tiered.TypeProfileCasts::test_checkcast
+ *                   compiler.tiered.TypeProfileCasts
+ * @run main/othervm -XX:+TieredCompilation -XX:-BackgroundCompilation -XX:+TypeProfileCasts
+ *                   -XX:CompileCommand=compileonly,compiler.tiered.TypeProfileCasts::test_checkcast
+ *                   compiler.tiered.TypeProfileCasts
+ * @run main/othervm -XX:+TieredCompilation -XX:-BackgroundCompilation -XX:-TypeProfileCasts
+ *                   -XX:CompileCommand=compileonly,compiler.tiered.TypeProfileCasts::test_array_store
+ *                   compiler.tiered.TypeProfileCasts
+ * @run main/othervm -XX:+TieredCompilation -XX:-BackgroundCompilation -XX:+TypeProfileCasts
+ *                   -XX:CompileCommand=compileonly,compiler.tiered.TypeProfileCasts::test_array_store
+ *                   compiler.tiered.TypeProfileCasts
+ */
+
+package compiler.tiered;
+
+public class TypeProfileCasts {
+    static class Foo { }
+    public static int sideEffect = 0;
+
+    private static void test_instanceof(Object o) {
+      // instanceof
+      if (o instanceof Foo) {
+        sideEffect++;
+      }
+    }
+
+    private static void test_checkcast(Object o) {
+      // checkcast
+      Foo f = (Foo) o;
+    }
+
+    private static void test_array_store(Object o) {
+      // array store type check
+      Foo[] fs = new Foo[1];
+      Object[] os = fs;
+      os[0] = o;
+
+      sideEffect++;
+    }
+
+    public static void main(String... args) {
+      for (int i = 0; i < 100_000; i++) {
+        test_instanceof(new Foo());
+        test_checkcast(new Foo());
+        test_array_store(new Foo());
+      }
+    }
+}


### PR DESCRIPTION
Make sure we don't try to emit cast type profiling if TypeProfileCast == false

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8356885](https://bugs.openjdk.org/browse/JDK-8356885): Don't emit C1 profiling for casts if TypeProfileCasts is off (**Bug** - P4)


### Reviewers
 * [Vladimir Ivanov](https://openjdk.org/census#vlivanov) (@iwanowww - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25218/head:pull/25218` \
`$ git checkout pull/25218`

Update a local copy of the PR: \
`$ git checkout pull/25218` \
`$ git pull https://git.openjdk.org/jdk.git pull/25218/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25218`

View PR using the GUI difftool: \
`$ git pr show -t 25218`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25218.diff">https://git.openjdk.org/jdk/pull/25218.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25218#issuecomment-2877892328)
</details>
