### PR TITLE
8356177: Regression after JDK-8352180

### DIFF
--- a/test/hotspot/jtreg/serviceability/attach/FailedDequeueTest.java
+++ b/test/hotspot/jtreg/serviceability/attach/FailedDequeueTest.java
@@ -59,6 +59,8 @@ public class FailedDequeueTest {
         try {
             // Should throw IOException and don't crash
             vm.setFlag(flagName, flagValue);
+
+            throw new RuntimeException("expected IOException is not thrown");
         } catch (IOException ex) {
             System.out.println("OK: setFlag thrown expected exception:");
             ex.printStackTrace(System.out);

--- a/test/hotspot/jtreg/serviceability/attach/FailedDequeueTest.java
+++ b/test/hotspot/jtreg/serviceability/attach/FailedDequeueTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @summary verifies that failure in AttachListener::dequeue does not crash the VM
+ * @bug 8356177
+ * @library /test/lib
+ * @modules jdk.attach/sun.tools.attach
+ *
+ * @run driver FailedDequeueTest
+ */
+
+import java.io.IOException;
+
+import com.sun.tools.attach.VirtualMachine;
+import sun.tools.attach.HotSpotVirtualMachine;
+
+import jdk.test.lib.apps.LingeredApp;
+
+public class FailedDequeueTest {
+
+    public static void main(String[] args) throws Exception {
+        LingeredApp app = null;
+        try {
+            app = LingeredApp.startApp("-Xlog:attach=trace");
+            test(app);
+        } finally {
+            LingeredApp.stopApp(app);
+        }
+    }
+
+    // The test uses HotSpotVirtualMachine.setFlag method with long flag value (longer than 256K).
+    private static String flagName = "HeapDumpPath";
+    private static String flagValue = "X" + "A".repeat(256 * 1024) + "X";
+
+    private static void test(LingeredApp app) throws Exception {
+        HotSpotVirtualMachine vm = (HotSpotVirtualMachine)VirtualMachine.attach(String.valueOf(app.getPid()));
+        try {
+            // Should throw IOException and don't crash
+            vm.setFlag(flagName, flagValue);
+        } catch (IOException ex) {
+            System.out.println("OK: setFlag thrown expected exception:");
+            ex.printStackTrace(System.out);
+        } finally {
+            vm.detach();
+        }
+    }
+}


### PR DESCRIPTION
The fix handles a special case when `AttachListener::dequeue()` fails to read/parse attach command request and 'PipeChannel' destructor is called when the current thread is `blocked`.

Testing: tier1..4,hs-tier5-svc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8356177](https://bugs.openjdk.org/browse/JDK-8356177): Regression after JDK-8352180 (**Bug** - P4)


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25219/head:pull/25219` \
`$ git checkout pull/25219`

Update a local copy of the PR: \
`$ git checkout pull/25219` \
`$ git pull https://git.openjdk.org/jdk.git pull/25219/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25219`

View PR using the GUI difftool: \
`$ git pr show -t 25219`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25219.diff">https://git.openjdk.org/jdk/pull/25219.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25219#issuecomment-2877918660)
</details>
