### PR TITLE
8356904: Skip jdk/test/lib/process/TestNativeProcessBuilder on static-jdk

### DIFF
--- a/test/lib-test/TEST.ROOT
+++ b/test/lib-test/TEST.ROOT
@@ -31,6 +31,23 @@ keys=randomness
 # Minimum jtreg version
 requiredVersion=7.5.1+1
 
+# Allow querying of various System properties in @requires clauses
+requires.extraPropDefns = ../jtreg-ext/requires/VMProps.java
+requires.extraPropDefns.bootlibs = ../lib/jdk/test/whitebox
+requires.extraPropDefns.libs = \
+    ../lib/jdk/test/lib/Platform.java \
+    ../lib/jdk/test/lib/Container.java
+requires.extraPropDefns.javacOpts = \
+    --add-exports java.base/jdk.internal.foreign=ALL-UNNAMED \
+    --add-exports java.base/jdk.internal.misc=ALL-UNNAMED
+requires.extraPropDefns.vmOpts = \
+    -XX:+UnlockDiagnosticVMOptions \
+    -XX:+WhiteBoxAPI \
+    --add-exports java.base/jdk.internal.foreign=ALL-UNNAMED \
+    --add-exports java.base/jdk.internal.misc=ALL-UNNAMED
+requires.properties= \
+    jdk.static
+
 # Path to libraries in the topmost test directory. This is needed so @library
 # does not need ../../ notation to reach them
 external.lib.roots = ../../

--- a/test/lib-test/jdk/test/lib/process/TestNativeProcessBuilder.java
+++ b/test/lib-test/jdk/test/lib/process/TestNativeProcessBuilder.java
@@ -25,6 +25,7 @@
  * @test
  * @summary Test the native process builder API.
  * @library /test/lib
+ * @requires !jdk.static
  * @run main/native TestNativeProcessBuilder
  */
 

--- a/test/lib-test/jdk/test/lib/process/TestNativeProcessBuilder.java
+++ b/test/lib-test/jdk/test/lib/process/TestNativeProcessBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
Please review this PR for skipping jdk/test/lib/process/TestNativeProcessBuilder on static-jdk. Duplicating the context from https://bugs.openjdk.org/browse/JDK-8356904 description:

jdk/test/lib/process/TestNativeProcessBuilder.java (in lib-test/tier1) uses a native test launcher executable, exejvm-test-launcher, which has explicitly dependency on libjvm.so. The test fails on static-jdk. This is the same issue as [JDK-8352276](https://bugs.openjdk.org/browse/JDK-8352276). With [JDK-8352276](https://bugs.openjdk.org/browse/JDK-8352276), we decided to skip the affected hotspot tier1 tests on static-jdk. We should skip jdk/test/lib/process/TestNativeProcessBuilder.java on static-jdk as well. [JDK-8352305](https://bugs.openjdk.org/browse/JDK-8352305) will add tests using custom launcher executable on static JDK.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8356904](https://bugs.openjdk.org/browse/JDK-8356904): Skip jdk/test/lib/process/TestNativeProcessBuilder on static-jdk (**Bug** - P4)


### Reviewers
 * [Henry Jen](https://openjdk.org/census#henryjen) (@slowhog - Committer)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25220/head:pull/25220` \
`$ git checkout pull/25220`

Update a local copy of the PR: \
`$ git checkout pull/25220` \
`$ git pull https://git.openjdk.org/jdk.git pull/25220/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25220`

View PR using the GUI difftool: \
`$ git pr show -t 25220`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25220.diff">https://git.openjdk.org/jdk/pull/25220.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25220#issuecomment-2878004837)
</details>
