### PR TITLE
8355743: G1: Collection set clearing is not recorded as part of "Free Collection Set Time"

### DIFF
--- a/src/hotspot/share/gc/g1/g1YoungGCPostEvacuateTasks.cpp
+++ b/src/hotspot/share/gc/g1/g1YoungGCPostEvacuateTasks.cpp
@@ -881,10 +881,10 @@ public:
     }
     FREE_C_HEAP_ARRAY(FreeCSetStats, _worker_stats);
 
+    _g1h->clear_collection_set();
+
     G1GCPhaseTimes* p = _g1h->phase_times();
     p->record_serial_free_cset_time_ms((Ticks::now() - serial_time).seconds() * 1000.0);
-
-    _g1h->clear_collection_set();
   }
 
   double worker_cost() const override { return G1CollectedHeap::heap()->collection_set()->region_length(); }


### PR DESCRIPTION
Hi all,

  please review this change that moves "clear_collection_set" work correctly under the "Serial Free Collection Set" phase.

There is probably no particular impact on timings, but just for correctness.

Testing: gha, gc/g1 tests

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8355743](https://bugs.openjdk.org/browse/JDK-8355743): G1: Collection set clearing is not recorded as part of "Free Collection Set Time" (**Bug** - P4)


### Reviewers
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25222/head:pull/25222` \
`$ git checkout pull/25222`

Update a local copy of the PR: \
`$ git checkout pull/25222` \
`$ git pull https://git.openjdk.org/jdk.git pull/25222/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25222`

View PR using the GUI difftool: \
`$ git pr show -t 25222`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25222.diff">https://git.openjdk.org/jdk/pull/25222.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25222#issuecomment-2879256044)
</details>
