### PR TITLE
8356971: [JVMCI] Export VM_Version::supports_avx512_simd_sort to JVMCI compiler

### DIFF
--- a/src/hotspot/share/jvmci/jvmciCompilerToVM.hpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVM.hpp
@@ -118,6 +118,7 @@ class CompilerToVM {
 
 #ifdef X86
     static int L1_line_size;
+    static bool supports_avx512_simd_sort;
 #endif
 
     static address dsin;

--- a/src/hotspot/share/jvmci/jvmciCompilerToVMInit.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVMInit.cpp
@@ -125,6 +125,7 @@ int CompilerToVM::Data::cardtable_shift;
 
 #ifdef X86
 int CompilerToVM::Data::L1_line_size;
+bool CompilerToVM::Data::supports_avx512_simd_sort;
 #endif
 
 size_t CompilerToVM::Data::vm_page_size;
@@ -256,6 +257,7 @@ void CompilerToVM::Data::initialize(JVMCI_TRAPS) {
 
 #ifdef X86
   L1_line_size = VM_Version::L1_line_size();
+  supports_avx512_simd_sort = VM_Version::supports_avx512_simd_sort();
 #endif
 
   vm_page_size = os::vm_page_size();

--- a/src/hotspot/share/jvmci/vmStructs_jvmci.cpp
+++ b/src/hotspot/share/jvmci/vmStructs_jvmci.cpp
@@ -122,6 +122,7 @@
   static_field(CompilerToVM::Data,             cardtable_shift,                        int)                                          \
                                                                                                                                      \
   X86_ONLY(static_field(CompilerToVM::Data,    L1_line_size,                           int))                                         \
+  X86_ONLY(static_field(CompilerToVM::Data,    supports_avx512_simd_sort,              bool))                                        \
                                                                                                                                      \
   static_field(CompilerToVM::Data,             vm_page_size,                           size_t)                                       \
                                                                                                                                      \


### PR DESCRIPTION
HotSpot selects between AVX512 and AVX2 implementations of array sort/partition stubs based on the return value of VM_Version::supports_avx512_simd_sort. The AVX2 version supports fewer element types than the AVX512 version and may fail at runtime if unsupported types are encountered. This capability information should be exposed to the JVMCI compiler to properly guard against incorrect intrinsification. This is especially important because VM_Version::supports_avx512_simd_sort includes a special exclusion rule for AMD Zen4, due to performance considerations.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8356971](https://bugs.openjdk.org/browse/JDK-8356971): [JVMCI] Export VM_Version::supports_avx512_simd_sort to JVMCI compiler (**Bug** - P4)


### Reviewers
 * [Doug Simon](https://openjdk.org/census#dnsimon) (@dougxc - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25225/head:pull/25225` \
`$ git checkout pull/25225`

Update a local copy of the PR: \
`$ git checkout pull/25225` \
`$ git pull https://git.openjdk.org/jdk.git pull/25225/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25225`

View PR using the GUI difftool: \
`$ git pr show -t 25225`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25225.diff">https://git.openjdk.org/jdk/pull/25225.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25225#issuecomment-2880236506)
</details>
