### PR TITLE
8356945: jdk/jfr/event/os/TestProcessStart failed on Windows Subsystem for Linux

### DIFF
--- a/test/jdk/jdk/jfr/event/os/TestProcessStart.java
+++ b/test/jdk/jdk/jfr/event/os/TestProcessStart.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,11 +51,12 @@ public class TestProcessStart {
             recording.start();
             List<String> commandList = new ArrayList<>();
             if (Platform.isWindows()) {
+                commandList.add("help");
                 commandList.add("dir");
             } else {
                 commandList.add("ls");
+                commandList.add("*.jfr");
             }
-            commandList.add("*.jfr");
             ProcessBuilder pb = new ProcessBuilder(commandList);
             pb.directory(new File(".").getAbsoluteFile());
             Process p = pb.start();


### PR DESCRIPTION
Currently, when this test is run on Windows Subsystem for Linux, dir is executed as an external process.
However, dir is a cmd.exe command, and dir.exe does not exist, so the test fails as shown below.

----------System.out:(0/0)----------
----------System.err:(19/2649)*----------
java.io.IOException: Cannot run program "dir" (in directory "D:\\dev\\jdk\\build\\windows-x86_64-server-release\\test-support\\jtreg_test_jdk_jdk_jfr_event_os_TestProcessStart_java\\scratch\\0\\."): CreateProcess error=2, The system cannot find the file specified

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8356945](https://bugs.openjdk.org/browse/JDK-8356945): jdk/jfr/event/os/TestProcessStart failed on Windows Subsystem for Linux (**Bug** - P4)


### Reviewers
 * [Erik Gahlin](https://openjdk.org/census#egahlin) (@egahlin - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25227/head:pull/25227` \
`$ git checkout pull/25227`

Update a local copy of the PR: \
`$ git checkout pull/25227` \
`$ git pull https://git.openjdk.org/jdk.git pull/25227/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25227`

View PR using the GUI difftool: \
`$ git pr show -t 25227`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25227.diff">https://git.openjdk.org/jdk/pull/25227.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25227#issuecomment-2880343679)
</details>
