### PR TITLE
8356974: tools/launcher/ToolsOpts.java fails if the build id contains "-J"

### DIFF
--- a/test/jdk/tools/launcher/ToolsOpts.java
+++ b/test/jdk/tools/launcher/ToolsOpts.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/tools/launcher/ToolsOpts.java
+++ b/test/jdk/tools/launcher/ToolsOpts.java
@@ -129,6 +129,7 @@ public class ToolsOpts extends TestHelper {
         for (String pat : opts) {
             jopts = jopts.concat(pat + " ");
             if (tr.contains(" -J-")) {
+                System.err.println(tr);
                 throw new RuntimeException(
                         "failed: output should not contain option " + pat);
             }

--- a/test/jdk/tools/launcher/ToolsOpts.java
+++ b/test/jdk/tools/launcher/ToolsOpts.java
@@ -128,7 +128,7 @@ public class ToolsOpts extends TestHelper {
         String jopts = "";
         for (String pat : opts) {
             jopts = jopts.concat(pat + " ");
-            if (tr.contains("-J")) {
+            if (tr.contains(" -J-")) {
                 throw new RuntimeException(
                         "failed: output should not contain option " + pat);
             }


### PR DESCRIPTION
When passing `-J-version` to the patched javac, `tools/launcher/ToolsOpts.java` wants to verify that the output corresponds to the expected version output. However, if the build id of the JDK running this test contains the substring "-J", then the test fails incorrectly at:

https://github.com/openjdk/jdk/blob/97b0dd2167530b3d237e748cd5da0130e38e8af2/test/jdk/tools/launcher/ToolsOpts.java#L131-L134

This PR addresses this false positive by looking for the substring `" -J-"` instead. The preceding space to ensure that `-J` occurs at the beginning of a word as an argument would and a `-` suffix since `-J` options are always followed by a dash. Further, this PR adds a print of the output of the test result in case this condition fails, to be able to inspect what triggered the failure.

Testing:
 - [x] [Github Actions](https://github.com/mhaessig/jdk/actions/runs/15023438332)
 - [x] tier1 and tier2 for Oracle supported platforms and OSs plus Oracle internal testing

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8356974](https://bugs.openjdk.org/browse/JDK-8356974): tools/launcher/ToolsOpts.java fails if the build id contains "-J" (**Bug** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**) Review applies to [a11ff5e5](https://git.openjdk.org/jdk/pull/25230/files/a11ff5e5ee44187d52703c16f96a9e2124f8e809)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25230/head:pull/25230` \
`$ git checkout pull/25230`

Update a local copy of the PR: \
`$ git checkout pull/25230` \
`$ git pull https://git.openjdk.org/jdk.git pull/25230/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25230`

View PR using the GUI difftool: \
`$ git pr show -t 25230`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25230.diff">https://git.openjdk.org/jdk/pull/25230.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25230#issuecomment-2880520479)
</details>
