### PR TITLE
8356966: java/awt/Graphics2D/DrawString/IgnoredWhitespaceTest.java fails on Linux after JDK-8350203

### DIFF
--- a/src/java.desktop/share/classes/sun/font/Type1GlyphMapper.java
+++ b/src/java.desktop/share/classes/sun/font/Type1GlyphMapper.java
@@ -78,7 +78,7 @@ public final class Type1GlyphMapper extends CharToGlyphMapper {
     }
 
     public int charToGlyph(char ch) {
-        if (FontUtilities.isDefaultIgnorable(ch)) {
+        if (FontUtilities.isDefaultIgnorable(ch) || isIgnorableWhitespace(ch)) {
             return INVISIBLE_GLYPH_ID;
         }
         try {
@@ -93,7 +93,7 @@ public final class Type1GlyphMapper extends CharToGlyphMapper {
         if (ch < 0 || ch > 0xffff) {
             return missingGlyph;
         } else {
-            if (FontUtilities.isDefaultIgnorable(ch)) {
+            if (FontUtilities.isDefaultIgnorable(ch) || isIgnorableWhitespace(ch)) {
                 return INVISIBLE_GLYPH_ID;
             }
             try {
@@ -103,6 +103,13 @@ public final class Type1GlyphMapper extends CharToGlyphMapper {
                 return charToGlyph(ch);
             }
         }
+    }
+
+    // Matches behavior in e.g. CMap.getControlCodeGlyph(int, boolean)
+    // and RasterPrinterJob.removeControlChars(String)
+    // and CCharToGlyphMapper.isIgnorableWhitespace(int)
+    private static boolean isIgnorableWhitespace(int code) {
+        return code == 0x0009 || code == 0x000a || code == 0x000d;
     }
 
     public void charsToGlyphs(int count, char[] unicodes, int[] glyphs) {

--- a/test/jdk/java/awt/Graphics2D/DrawString/IgnoredWhitespaceTest.java
+++ b/test/jdk/java/awt/Graphics2D/DrawString/IgnoredWhitespaceTest.java
@@ -93,36 +93,37 @@ public class IgnoredWhitespaceTest {
         g2d.setColor(Color.BLACK);
         g2d.drawString(text, x, y);
         Rectangle actual = findTextBoundingBox(image);
-        assertEqual(expected, actual, text);
+        assertEqual(expected, actual, text, font);
 
         g2d.setColor(Color.WHITE);
         g2d.fillRect(0, 0, w, h);
         g2d.setColor(Color.BLACK);
         g2d.drawString(new AttributedString(text, Map.of(TextAttribute.FONT, font)).getIterator(), x, y);
         actual = findTextBoundingBox(image);
-        assertEqual(expected, actual, text);
+        assertEqual(expected, actual, text, font);
 
         g2d.setColor(Color.WHITE);
         g2d.fillRect(0, 0, w, h);
         g2d.setColor(Color.BLACK);
         g2d.drawChars(text.toCharArray(), 0, text.length(), x, y);
         actual = findTextBoundingBox(image);
-        assertEqual(expected, actual, text);
+        assertEqual(expected, actual, text, font);
 
         g2d.setColor(Color.WHITE);
         g2d.fillRect(0, 0, w, h);
         g2d.setColor(Color.BLACK);
         g2d.drawGlyphVector(font.createGlyphVector(frc, text), x, y);
         actual = findTextBoundingBox(image);
-        assertEqual(expected, actual, text);
+        assertEqual(expected, actual, text, font);
     }
 
-    private static void assertEqual(Rectangle r1, Rectangle r2, String text) {
+    private static void assertEqual(Rectangle r1, Rectangle r2, String text, Font font) {
         if (!r1.equals(r2)) {
             String escaped = text.replace("\r", "\\r")
                                  .replace("\n", "\\n")
                                  .replace("\t", "\\t");
-            String msg = String.format("for text '%s': %s != %s", escaped, r1.toString(), r2.toString());
+            String msg = String.format("for text '%s' with font '%s': %s != %s",
+                escaped, font.getName(), r1.toString(), r2.toString());
             throw new RuntimeException(msg);
         }
     }


### PR DESCRIPTION
If the new test (`IgnoredWhitespaceTest`) runs on a system with Type1 physical fonts, it fails because the Type1 handling of ignorable whitespace characters does not match the behavior of the TrueType and macOS glyph mappers.

This PR updates the Type1 glyph mapper to follow the same rules in this area as the other glyph mappers.

It would probably be a good idea to consolidate all of this into the `CharToGlyphMapper` superclass at some point, so that we're not duplicating this handling across the subclasses, but some users are reporting failing builds and I wanted to keep the PR simple.