### PR TITLE
8356993: ArrayDeque should use Arrays.fill() instead of for() loops

### DIFF
--- a/src/java.base/share/classes/java/util/ArrayDeque.java
+++ b/src/java.base/share/classes/java/util/ArrayDeque.java
@@ -151,8 +151,7 @@ public class ArrayDeque<E> extends AbstractCollection<E>
             System.arraycopy(es, head,
                              es, head + newSpace,
                              oldCapacity - head);
-            for (int i = head, to = (head += newSpace); i < to; i++)
-                es[i] = null;
+            Arrays.fill(es, head, head += newSpace, null);
         }
     }
 
@@ -1046,7 +1045,7 @@ public class ArrayDeque<E> extends AbstractCollection<E>
         // assert 0 <= end && end < es.length;
         for (int to = (i <= end) ? end : es.length;
              ; i = 0, to = end) {
-            for (; i < to; i++) es[i] = null;
+            Arrays.fill(es, i, to, null);
             if (to == end) break;
         }
     }

--- a/test/jdk/java/util/ArrayDeque/ClearBenchmarkTestJMH.java
+++ b/test/jdk/java/util/ArrayDeque/ClearBenchmarkTestJMH.java
@@ -35,6 +35,7 @@ import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -55,15 +56,15 @@ public class ClearBenchmarkTestJMH {
         array = new Object[LIST_SIZE];
         for (int i = 0; i < LIST_SIZE; i++)
             array[i] = new Object();
-        //deques = new ArrayList<>();
     }
 
     @Benchmark
     @Measurement(iterations = 10)
     @Warmup(iterations = 3)
-    public void fillAndClear() {
+    public void fillAndClear(Blackhole bh) {
         ArrayDeque<Object> a = new ArrayDeque<>(LIST_SIZE);
         Collections.addAll(a, array);
         a.clear();
+        bh.consume(a);
     }
 }

--- a/test/jdk/java/util/ArrayDeque/ClearBenchmarkTestJMH.java
+++ b/test/jdk/java/util/ArrayDeque/ClearBenchmarkTestJMH.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package org.openjdk.bench.java.util.ArrayDeque;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Thread)
+public class ClearBenchmarkTestJMH {
+
+    private static final int LIST_SIZE = 10_000_000;
+
+    private Object[] array;
+
+    @Setup
+    public void setUp() {
+        array = new Object[LIST_SIZE];
+        for (int i = 0; i < LIST_SIZE; i++)
+            array[i] = new Object();
+        //deques = new ArrayList<>();
+    }
+
+    @Benchmark
+    @Measurement(iterations = 10)
+    @Warmup(iterations = 3)
+    public void fillAndClear() {
+        ArrayDeque<Object> a = new ArrayDeque<>(LIST_SIZE);
+        Collections.addAll(a, array);
+        a.clear();
+    }
+}


### PR DESCRIPTION
Please review this small performance tweak `ArrayDeque`.

`ArrayDeque` has an invariant in which any unused elements in the array must be null. In a couple of places, the code is setting contiguous ranges of elements to null using `for()` loops. This can be both simplified and sped up by using `Arrays.fill()` instead.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8356993](https://bugs.openjdk.org/browse/JDK-8356993): ArrayDeque should use Arrays.fill() instead of for() loops (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25237/head:pull/25237` \
`$ git checkout pull/25237`

Update a local copy of the PR: \
`$ git checkout pull/25237` \
`$ git pull https://git.openjdk.org/jdk.git pull/25237/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25237`

View PR using the GUI difftool: \
`$ git pr show -t 25237`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25237.diff">https://git.openjdk.org/jdk/pull/25237.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25237#issuecomment-2881359655)
</details>
