### PR TITLE
8356892: runtime/jni/CalleeSavedRegisters/FPRegs.java fails on static-jdk

### DIFF
--- a/test/hotspot/jtreg/runtime/jni/CalleeSavedRegisters/FPRegs.java
+++ b/test/hotspot/jtreg/runtime/jni/CalleeSavedRegisters/FPRegs.java
@@ -26,6 +26,7 @@
  * @test
  * @bug 8067744
  * @requires vm.flagless
+ * @requires !jdk.static
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  * @run main/native FPRegs


### PR DESCRIPTION
Please review this PR for skipping runtime/jni/CalleeSavedRegisters/FPRegs.java on static-jdk.

FPRegs.java uses a native test launcher executable (`exeFPRegs`) and has a similar situation as the tests described in [JDK-8352276](https://bugs.openjdk.org/browse/JDK-8352276) and [JDK-8356904](https://bugs.openjdk.org/browse/JDK-8356904), although `exeFPRegs` doesn't have an explicit build-time created dependency on libjvm.so (i.e. linking against libjvm explicitly). FPRegs.java at runtime needs to find libjvm.so and pass it to the native launcher executable for creating the VM. Please see discussions on supporting custom launcher on static JDK in https://github.com/openjdk/jdk/pull/24103 review comments. [JDK-8352305](https://bugs.openjdk.org/browse/JDK-8352305) will add tests using custom launcher executable on static JDK.

