### PR TITLE
8355512: Test compiler/vectorization/TestVectorZeroCount.java times out with -XX:TieredStopAtLevel=3

### DIFF
--- a/test/hotspot/jtreg/compiler/vectorization/TestVectorZeroCount.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestVectorZeroCount.java
@@ -23,7 +23,7 @@
 
 /* @test
  * @bug 8349637
- * @requires vm.compiler2.enabled
+ * @requires vm.flavor == "server" & (vm.opt.TieredStopAtLevel == null | vm.opt.TieredStopAtLevel == 4)
  * @summary Ensure that vectorization of numberOfLeadingZeros and numberOfTrailingZeros outputs correct values
  * @library /test/lib /
  * @run main/othervm compiler.vectorization.TestVectorZeroCount

--- a/test/hotspot/jtreg/compiler/vectorization/TestVectorZeroCount.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestVectorZeroCount.java
@@ -23,6 +23,7 @@
 
 /* @test
  * @bug 8349637
+ * @requires vm.compiler2.enabled
  * @summary Ensure that vectorization of numberOfLeadingZeros and numberOfTrailingZeros outputs correct values
  * @library /test/lib /
  * @run main/othervm compiler.vectorization.TestVectorZeroCount


### PR DESCRIPTION
Hi all,
This is a small patch to TestVectorZeroCount to make it only execute when C2 is enabled, to fix a timeout with -XX:TieredStopAtLevel=3. This test takes a long time to finish without C2 because it iterates through all of the integers twice. Since the intention of the test is to stress the C2-specific `numberOfLeadingZeros` and `numberOfTrailingZeros` intrinsics, I think it makes sense to limit it to running with C2 only.

Reviews would be appreciated!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8355512](https://bugs.openjdk.org/browse/JDK-8355512): Test compiler/vectorization/TestVectorZeroCount.java times out with -XX:TieredStopAtLevel=3 (**Bug** - P4)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Emanuel Peter](https://openjdk.org/census#epeter) (@eme64 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25243/head:pull/25243` \
`$ git checkout pull/25243`

Update a local copy of the PR: \
`$ git checkout pull/25243` \
`$ git pull https://git.openjdk.org/jdk.git pull/25243/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25243`

View PR using the GUI difftool: \
`$ git pr show -t 25243`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25243.diff">https://git.openjdk.org/jdk/pull/25243.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25243#issuecomment-2882038800)
</details>
