### PR TITLE
8357013: HttpURLConnection#getResponseCode can avoid substring call when parsing to int

### DIFF
--- a/src/java.base/share/classes/java/net/HttpURLConnection.java
+++ b/src/java.base/share/classes/java/net/HttpURLConnection.java
@@ -534,7 +534,7 @@ public abstract class HttpURLConnection extends URLConnection {
 
                 try {
                     responseCode = Integer.parseInt
-                            (statusLine.substring(codePos+1, phrasePos));
+                            (statusLine, codePos+1, phrasePos, 10);
                     return responseCode;
                 } catch (NumberFormatException e) { }
             }


### PR DESCRIPTION
Avoid allocating a substring to parse the response code in HttpURLConnection#getResponseCode, but instead use the Integer.parseInt overload that accepts String indices.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8357013](https://bugs.openjdk.org/browse/JDK-8357013): HttpURLConnection#getResponseCode can avoid substring call when parsing to int (**Enhancement** - P4)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25245/head:pull/25245` \
`$ git checkout pull/25245`

Update a local copy of the PR: \
`$ git checkout pull/25245` \
`$ git pull https://git.openjdk.org/jdk.git pull/25245/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25245`

View PR using the GUI difftool: \
`$ git pr show -t 25245`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25245.diff">https://git.openjdk.org/jdk/pull/25245.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25245#issuecomment-2882452933)
</details>
