### PR TITLE
8357063: Document preconditions for DecimalDigits methods

### DIFF
--- a/src/java.base/share/classes/java/lang/AbstractStringBuilder.java
+++ b/src/java.base/share/classes/java/lang/AbstractStringBuilder.java
@@ -924,9 +924,9 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
         int spaceNeeded = count + DecimalDigits.stringSize(i);
         byte[] value = ensureCapacitySameCoder(this.value, coder, spaceNeeded);
         if (isLatin1(coder)) {
-            DecimalDigits.getCharsLatin1(i, spaceNeeded, value);
+            DecimalDigits.uncheckedGetCharsLatin1(i, spaceNeeded, value);
         } else {
-            DecimalDigits.getCharsUTF16(i, spaceNeeded, value);
+            DecimalDigits.uncheckedGetCharsUTF16(i, spaceNeeded, value);
         }
         this.value = value;
         this.count = spaceNeeded;
@@ -951,9 +951,9 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
         int spaceNeeded = count + DecimalDigits.stringSize(l);
         byte[] value = ensureCapacitySameCoder(this.value, coder, spaceNeeded);
         if (isLatin1(coder)) {
-            DecimalDigits.getCharsLatin1(l, spaceNeeded, value);
+            DecimalDigits.uncheckedGetCharsLatin1(l, spaceNeeded, value);
         } else {
-            DecimalDigits.getCharsUTF16(l, spaceNeeded, value);
+            DecimalDigits.uncheckedGetCharsUTF16(l, spaceNeeded, value);
         }
         this.value = value;
         this.count = spaceNeeded;

--- a/src/java.base/share/classes/java/lang/Integer.java
+++ b/src/java.base/share/classes/java/lang/Integer.java
@@ -432,11 +432,11 @@ public final class Integer extends Number
         int size = DecimalDigits.stringSize(i);
         if (COMPACT_STRINGS) {
             byte[] buf = new byte[size];
-            DecimalDigits.getCharsLatin1(i, size, buf);
+            DecimalDigits.uncheckedGetCharsLatin1(i, size, buf);
             return new String(buf, LATIN1);
         } else {
             byte[] buf = new byte[size * 2];
-            DecimalDigits.getCharsUTF16(i, size, buf);
+            DecimalDigits.uncheckedGetCharsUTF16(i, size, buf);
             return new String(buf, UTF16);
         }
     }

--- a/src/java.base/share/classes/java/lang/Long.java
+++ b/src/java.base/share/classes/java/lang/Long.java
@@ -462,11 +462,11 @@ public final class Long extends Number
         int size = DecimalDigits.stringSize(i);
         if (COMPACT_STRINGS) {
             byte[] buf = new byte[size];
-            DecimalDigits.getCharsLatin1(i, size, buf);
+            DecimalDigits.uncheckedGetCharsLatin1(i, size, buf);
             return new String(buf, LATIN1);
         } else {
             byte[] buf = new byte[size * 2];
-            DecimalDigits.getCharsUTF16(i, size, buf);
+            DecimalDigits.uncheckedGetCharsUTF16(i, size, buf);
             return new String(buf, UTF16);
         }
     }

--- a/src/java.base/share/classes/java/lang/StringConcatHelper.java
+++ b/src/java.base/share/classes/java/lang/StringConcatHelper.java
@@ -315,12 +315,12 @@ final class StringConcatHelper {
     static long prepend(long indexCoder, byte[] buf, int value, String prefix) {
         int index = (int)indexCoder;
         if (indexCoder < UTF16) {
-            index = DecimalDigits.getCharsLatin1(value, index, buf);
+            index = DecimalDigits.uncheckedGetCharsLatin1(value, index, buf);
             index -= prefix.length();
             prefix.getBytes(buf, index, String.LATIN1);
             return index;
         } else {
-            index = DecimalDigits.getCharsUTF16(value, index, buf);
+            index = DecimalDigits.uncheckedGetCharsUTF16(value, index, buf);
             index -= prefix.length();
             prefix.getBytes(buf, index, String.UTF16);
             return index | UTF16;
@@ -341,12 +341,12 @@ final class StringConcatHelper {
     static long prepend(long indexCoder, byte[] buf, long value, String prefix) {
         int index = (int)indexCoder;
         if (indexCoder < UTF16) {
-            index = DecimalDigits.getCharsLatin1(value, index, buf);
+            index = DecimalDigits.uncheckedGetCharsLatin1(value, index, buf);
             index -= prefix.length();
             prefix.getBytes(buf, index, String.LATIN1);
             return index;
         } else {
-            index = DecimalDigits.getCharsUTF16(value, index, buf);
+            index = DecimalDigits.uncheckedGetCharsUTF16(value, index, buf);
             index -= prefix.length();
             prefix.getBytes(buf, index, String.UTF16);
             return index | UTF16;
@@ -713,11 +713,11 @@ final class StringConcatHelper {
      */
     static int prepend(int index, byte coder, byte[] buf, int value, String prefix) {
         if (coder == String.LATIN1) {
-            index = DecimalDigits.getCharsLatin1(value, index, buf);
+            index = DecimalDigits.uncheckedGetCharsLatin1(value, index, buf);
             index -= prefix.length();
             prefix.getBytes(buf, index, String.LATIN1);
         } else {
-            index = DecimalDigits.getCharsUTF16(value, index, buf);
+            index = DecimalDigits.uncheckedGetCharsUTF16(value, index, buf);
             index -= prefix.length();
             prefix.getBytes(buf, index, String.UTF16);
         }
@@ -737,11 +737,11 @@ final class StringConcatHelper {
      */
     static int prepend(int index, byte coder, byte[] buf, long value, String prefix) {
         if (coder == String.LATIN1) {
-            index = DecimalDigits.getCharsLatin1(value, index, buf);
+            index = DecimalDigits.uncheckedGetCharsLatin1(value, index, buf);
             index -= prefix.length();
             prefix.getBytes(buf, index, String.LATIN1);
         } else {
-            index = DecimalDigits.getCharsUTF16(value, index, buf);
+            index = DecimalDigits.uncheckedGetCharsUTF16(value, index, buf);
             index -= prefix.length();
             prefix.getBytes(buf, index, String.UTF16);
         }

--- a/src/java.base/share/classes/java/math/BigDecimal.java
+++ b/src/java.base/share/classes/java/math/BigDecimal.java
@@ -4138,9 +4138,9 @@ public class BigDecimal extends Number implements Comparable<BigDecimal> {
             int highInt = (int)intCompact / 100;
             int highIntSize = DecimalDigits.stringSize(highInt);
             byte[] buf = new byte[highIntSize + 3];
-            DecimalDigits.getCharsLatin1(highInt, highIntSize, buf);
+            DecimalDigits.uncheckedGetCharsLatin1(highInt, highIntSize, buf);
             buf[highIntSize] = '.';
-            DecimalDigits.putPairLatin1(buf, highIntSize + 1, lowInt);
+            DecimalDigits.uncheckedPutPairLatin1(buf, highIntSize + 1, lowInt);
             try {
                 return JLA.newStringNoRepl(buf, StandardCharsets.ISO_8859_1);
             } catch (CharacterCodingException cce) {

--- a/src/java.base/share/classes/jdk/internal/util/DecimalDigits.java
+++ b/src/java.base/share/classes/jdk/internal/util/DecimalDigits.java
@@ -195,7 +195,7 @@ public final class DecimalDigits {
      * (negative to positive) will expose -Long.MIN_VALUE that overflows
      * long.
      * <p>
-     * <b>WARNING: Used by trusted callers.  Assumes all necessary bounds checks have been done by the caller. </b>
+     * <b>WARNING: This method does not perform any bound checks. </b>
      *
      * @param i     value to convert
      * @param index next index, after the least significant digit

--- a/src/java.base/share/classes/jdk/internal/util/DecimalDigits.java
+++ b/src/java.base/share/classes/jdk/internal/util/DecimalDigits.java
@@ -406,7 +406,7 @@ public final class DecimalDigits {
      * Insert the 2-bytes integer into the buf as 2 decimal digit ASCII bytes,
      * only least significant 16 bits of {@code v} are used.
      * <p>
-     * <b>WARNING: Used by trusted callers.  Assumes all necessary bounds checks have been done by the caller. </b>
+     * <b>WARNING: This method does not perform any bound checks.</b>
      *
      * @param buf byte buffer to copy into
      * @param charPos insert point

--- a/src/java.base/share/classes/jdk/internal/util/DecimalDigits.java
+++ b/src/java.base/share/classes/jdk/internal/util/DecimalDigits.java
@@ -439,6 +439,7 @@ public final class DecimalDigits {
      * <b>WARNING: Used by trusted callers.  Assumes all necessary bounds checks have been done by the caller. </b>
      */
     private static void uncheckedPutCharLatin1(byte[] buf, int charPos, int c) {
+        assert charPos >= 0 && charPos < buf.length;
         UNSAFE.putByte(buf, ARRAY_BYTE_BASE_OFFSET + charPos, (byte) c);
     }
 
@@ -447,6 +448,7 @@ public final class DecimalDigits {
      * <b>WARNING: Used by trusted callers.  Assumes all necessary bounds checks have been done by the caller. </b>
      */
     private static void uncheckedPutCharUTF16(byte[] buf, int charPos, int c) {
+        assert charPos >= 0 && charPos < (buf.length >> 1);
         UNSAFE.putCharUnaligned(buf, ARRAY_BYTE_BASE_OFFSET + ((long) charPos << 1), (char) c);
     }
 }

--- a/src/java.base/share/classes/jdk/internal/util/DecimalDigits.java
+++ b/src/java.base/share/classes/jdk/internal/util/DecimalDigits.java
@@ -149,7 +149,7 @@ public final class DecimalDigits {
      * @param buf   target buffer, Latin1-encoded
      * @return index of the most significant digit or minus sign, if present
      */
-    public static int getCharsLatin1(int i, int index, byte[] buf) {
+    public static int uncheckedGetCharsLatin1(int i, int index, byte[] buf) {
         // Used by trusted callers.  Assumes all necessary bounds checks have been done by the caller.
         int q;
         int charPos = index;
@@ -163,20 +163,20 @@ public final class DecimalDigits {
         while (i <= -100) {
             q = i / 100;
             charPos -= 2;
-            putPairLatin1(buf, charPos, (q * 100) - i);
+            uncheckedPutPairLatin1(buf, charPos, (q * 100) - i);
             i = q;
         }
 
         // We know there are at most two digits left at this point.
         if (i <= -10) {
             charPos -= 2;
-            putPairLatin1(buf, charPos, -i);
+            uncheckedPutPairLatin1(buf, charPos, -i);
         } else {
-            putCharLatin1(buf, --charPos, '0' - i);
+            uncheckedPutCharLatin1(buf, --charPos, '0' - i);
         }
 
         if (negative) {
-            putCharLatin1(buf, --charPos, '-');
+            uncheckedPutCharLatin1(buf, --charPos, '-');
         }
         return charPos;
     }
@@ -199,7 +199,7 @@ public final class DecimalDigits {
      * @param buf   target buffer, Latin1-encoded
      * @return index of the most significant digit or minus sign, if present
      */
-    public static int getCharsLatin1(long i, int index, byte[] buf) {
+    public static int uncheckedGetCharsLatin1(long i, int index, byte[] buf) {
         // Used by trusted callers.  Assumes all necessary bounds checks have been done by the caller.
         long q;
         int charPos = index;
@@ -213,7 +213,7 @@ public final class DecimalDigits {
         while (i < Integer.MIN_VALUE) {
             q = i / 100;
             charPos -= 2;
-            putPairLatin1(buf, charPos, (int)((q * 100) - i));
+            uncheckedPutPairLatin1(buf, charPos, (int)((q * 100) - i));
             i = q;
         }
 
@@ -223,27 +223,27 @@ public final class DecimalDigits {
         while (i2 <= -100) {
             q2 = i2 / 100;
             charPos -= 2;
-            putPairLatin1(buf, charPos, (q2 * 100) - i2);
+            uncheckedPutPairLatin1(buf, charPos, (q2 * 100) - i2);
             i2 = q2;
         }
 
         // We know there are at most two digits left at this point.
         if (i2 <= -10) {
             charPos -= 2;
-            putPairLatin1(buf, charPos, -i2);
+            uncheckedPutPairLatin1(buf, charPos, -i2);
         } else {
-            putCharLatin1(buf, --charPos, '0' - i2);
+            uncheckedPutCharLatin1(buf, --charPos, '0' - i2);
         }
 
         if (negative) {
-            putCharLatin1(buf, --charPos, '-');
+            uncheckedPutCharLatin1(buf, --charPos, '-');
         }
         return charPos;
     }
 
 
     /**
-     * This is a variant of {@link DecimalDigits#getCharsLatin1(int, int, byte[])}, but for
+     * This is a variant of {@link DecimalDigits#uncheckedGetCharsLatin1(int, int, byte[])}, but for
      * UTF-16 coder.
      *
      * @param i     value to convert
@@ -251,7 +251,7 @@ public final class DecimalDigits {
      * @param buf   target buffer, UTF16-coded.
      * @return index of the most significant digit or minus sign, if present
      */
-    public static int getCharsUTF16(int i, int index, byte[] buf) {
+    public static int uncheckedGetCharsUTF16(int i, int index, byte[] buf) {
         // Used by trusted callers.  Assumes all necessary bounds checks have been done by the caller.
         int q;
         int charPos = index;
@@ -265,27 +265,27 @@ public final class DecimalDigits {
         while (i <= -100) {
             q = i / 100;
             charPos -= 2;
-            putPairUTF16(buf, charPos, (q * 100) - i);
+            uncheckedPutPairUTF16(buf, charPos, (q * 100) - i);
             i = q;
         }
 
         // We know there are at most two digits left at this point.
         if (i <= -10) {
             charPos -= 2;
-            putPairUTF16(buf, charPos, -i);
+            uncheckedPutPairUTF16(buf, charPos, -i);
         } else {
-            putCharUTF16(buf, --charPos, '0' - i);
+            uncheckedPutCharUTF16(buf, --charPos, '0' - i);
         }
 
         if (negative) {
-            putCharUTF16(buf, --charPos, '-');
+            uncheckedPutCharUTF16(buf, --charPos, '-');
         }
         return charPos;
     }
 
 
     /**
-     * This is a variant of {@link DecimalDigits#getCharsLatin1(long, int, byte[])}, but for
+     * This is a variant of {@link DecimalDigits#uncheckedGetCharsLatin1(long, int, byte[])}, but for
      * UTF-16 coder.
      *
      * @param i     value to convert
@@ -293,7 +293,7 @@ public final class DecimalDigits {
      * @param buf   target buffer, UTF16-coded.
      * @return index of the most significant digit or minus sign, if present
      */
-    public static int getCharsUTF16(long i, int index, byte[] buf) {
+    public static int uncheckedGetCharsUTF16(long i, int index, byte[] buf) {
         // Used by trusted callers.  Assumes all necessary bounds checks have been done by the caller.
         long q;
         int charPos = index;
@@ -307,7 +307,7 @@ public final class DecimalDigits {
         while (i < Integer.MIN_VALUE) {
             q = i / 100;
             charPos -= 2;
-            putPairUTF16(buf, charPos, (int)((q * 100) - i));
+            uncheckedPutPairUTF16(buf, charPos, (int)((q * 100) - i));
             i = q;
         }
 
@@ -317,26 +317,26 @@ public final class DecimalDigits {
         while (i2 <= -100) {
             q2 = i2 / 100;
             charPos -= 2;
-            putPairUTF16(buf, charPos, (q2 * 100) - i2);
+            uncheckedPutPairUTF16(buf, charPos, (q2 * 100) - i2);
             i2 = q2;
         }
 
         // We know there are at most two digits left at this point.
         if (i2 <= -10) {
             charPos -= 2;
-            putPairUTF16(buf, charPos, -i2);
+            uncheckedPutPairUTF16(buf, charPos, -i2);
         } else {
-            putCharUTF16(buf, --charPos, '0' - i2);
+            uncheckedPutCharUTF16(buf, --charPos, '0' - i2);
         }
 
         if (negative) {
-            putCharUTF16(buf, --charPos, '-');
+            uncheckedPutCharUTF16(buf, --charPos, '-');
         }
         return charPos;
     }
 
     /**
-     * This is a variant of {@link DecimalDigits#getCharsUTF16(long, int, byte[])}, but for
+     * This is a variant of {@link DecimalDigits#uncheckedGetCharsUTF16(long, int, byte[])}, but for
      * UTF-16 coder.
      *
      * @param i     value to convert
@@ -406,10 +406,10 @@ public final class DecimalDigits {
      * @param charPos insert point
      * @param v to convert
      */
-    public static void putPairLatin1(byte[] buf, int charPos, int v) {
+    public static void uncheckedPutPairLatin1(byte[] buf, int charPos, int v) {
         int packed = DIGITS[v & 0x7f];
-        putCharLatin1(buf, charPos, packed & 0xFF);
-        putCharLatin1(buf, charPos + 1, packed >> 8);
+        uncheckedPutCharLatin1(buf, charPos, packed & 0xFF);
+        uncheckedPutCharLatin1(buf, charPos + 1, packed >> 8);
     }
 
     /**
@@ -419,17 +419,17 @@ public final class DecimalDigits {
      * @param charPos insert point
      * @param v to convert
      */
-    public static void putPairUTF16(byte[] buf, int charPos, int v) {
+    public static void uncheckedPutPairUTF16(byte[] buf, int charPos, int v) {
         int packed = DIGITS[v & 0x7f];
-        putCharUTF16(buf, charPos, packed & 0xFF);
-        putCharUTF16(buf, charPos + 1, packed >> 8);
+        uncheckedPutCharUTF16(buf, charPos, packed & 0xFF);
+        uncheckedPutCharUTF16(buf, charPos + 1, packed >> 8);
     }
 
-    private static void putCharLatin1(byte[] buf, int charPos, int c) {
+    private static void uncheckedPutCharLatin1(byte[] buf, int charPos, int c) {
         UNSAFE.putByte(buf, ARRAY_BYTE_BASE_OFFSET + charPos, (byte) c);
     }
 
-    private static void putCharUTF16(byte[] buf, int charPos, int c) {
+    private static void uncheckedPutCharUTF16(byte[] buf, int charPos, int c) {
         UNSAFE.putCharUnaligned(buf, ARRAY_BYTE_BASE_OFFSET + ((long) charPos << 1), (char) c);
     }
 }

--- a/src/java.base/share/classes/jdk/internal/util/DecimalDigits.java
+++ b/src/java.base/share/classes/jdk/internal/util/DecimalDigits.java
@@ -144,7 +144,7 @@ public final class DecimalDigits {
      * (negative to positive) will expose -Integer.MIN_VALUE that overflows
      * integer.
      * <p>
-     * <b>WARNING: Used by trusted callers.  Assumes all necessary bounds checks have been done by the caller. </b>
+     * <b>WARNING: This method does not perform any bound checks. </b>
      *
      * @param i     value to convert
      * @param index next index, after the least significant digit

--- a/src/java.base/share/classes/jdk/internal/util/DecimalDigits.java
+++ b/src/java.base/share/classes/jdk/internal/util/DecimalDigits.java
@@ -434,10 +434,6 @@ public final class DecimalDigits {
         uncheckedPutCharUTF16(buf, charPos + 1, packed >> 8);
     }
 
-    /**
-     * <p>
-     * <b>WARNING: Used by trusted callers.  Assumes all necessary bounds checks have been done by the caller. </b>
-     */
     private static void uncheckedPutCharLatin1(byte[] buf, int charPos, int c) {
         assert charPos >= 0 && charPos < buf.length;
         UNSAFE.putByte(buf, ARRAY_BYTE_BASE_OFFSET + charPos, (byte) c);

--- a/src/java.base/share/classes/jdk/internal/util/DecimalDigits.java
+++ b/src/java.base/share/classes/jdk/internal/util/DecimalDigits.java
@@ -143,6 +143,8 @@ public final class DecimalDigits {
      * values, to cover the Integer.MIN_VALUE case. Converting otherwise
      * (negative to positive) will expose -Integer.MIN_VALUE that overflows
      * integer.
+     * <p>
+     * <b>WARNING: Used by trusted callers.  Assumes all necessary bounds checks have been done by the caller. </b>
      *
      * @param i     value to convert
      * @param index next index, after the least significant digit
@@ -150,7 +152,6 @@ public final class DecimalDigits {
      * @return index of the most significant digit or minus sign, if present
      */
     public static int uncheckedGetCharsLatin1(int i, int index, byte[] buf) {
-        // Used by trusted callers.  Assumes all necessary bounds checks have been done by the caller.
         int q;
         int charPos = index;
 
@@ -193,6 +194,8 @@ public final class DecimalDigits {
      * values, to cover the Long.MIN_VALUE case. Converting otherwise
      * (negative to positive) will expose -Long.MIN_VALUE that overflows
      * long.
+     * <p>
+     * <b>WARNING: Used by trusted callers.  Assumes all necessary bounds checks have been done by the caller. </b>
      *
      * @param i     value to convert
      * @param index next index, after the least significant digit
@@ -200,7 +203,6 @@ public final class DecimalDigits {
      * @return index of the most significant digit or minus sign, if present
      */
     public static int uncheckedGetCharsLatin1(long i, int index, byte[] buf) {
-        // Used by trusted callers.  Assumes all necessary bounds checks have been done by the caller.
         long q;
         int charPos = index;
 
@@ -245,6 +247,8 @@ public final class DecimalDigits {
     /**
      * This is a variant of {@link DecimalDigits#uncheckedGetCharsLatin1(int, int, byte[])}, but for
      * UTF-16 coder.
+     * <p>
+     * <b>WARNING: Used by trusted callers.  Assumes all necessary bounds checks have been done by the caller. </b>
      *
      * @param i     value to convert
      * @param index next index, after the least significant digit
@@ -252,7 +256,6 @@ public final class DecimalDigits {
      * @return index of the most significant digit or minus sign, if present
      */
     public static int uncheckedGetCharsUTF16(int i, int index, byte[] buf) {
-        // Used by trusted callers.  Assumes all necessary bounds checks have been done by the caller.
         int q;
         int charPos = index;
 
@@ -287,6 +290,8 @@ public final class DecimalDigits {
     /**
      * This is a variant of {@link DecimalDigits#uncheckedGetCharsLatin1(long, int, byte[])}, but for
      * UTF-16 coder.
+     * <p>
+     * <b>WARNING: Used by trusted callers.  Assumes all necessary bounds checks have been done by the caller. </b>
      *
      * @param i     value to convert
      * @param index next index, after the least significant digit
@@ -294,7 +299,6 @@ public final class DecimalDigits {
      * @return index of the most significant digit or minus sign, if present
      */
     public static int uncheckedGetCharsUTF16(long i, int index, byte[] buf) {
-        // Used by trusted callers.  Assumes all necessary bounds checks have been done by the caller.
         long q;
         int charPos = index;
 
@@ -345,7 +349,6 @@ public final class DecimalDigits {
      * @return index of the most significant digit or minus sign, if present
      */
     public static int getChars(long i, int index, char[] buf) {
-        // Used by trusted callers.  Assumes all necessary bounds checks have been done by the caller.
         long q;
         int charPos = index;
 
@@ -402,6 +405,9 @@ public final class DecimalDigits {
     /**
      * Insert the 2-bytes integer into the buf as 2 decimal digit ASCII bytes,
      * only least significant 16 bits of {@code v} are used.
+     * <p>
+     * <b>WARNING: Used by trusted callers.  Assumes all necessary bounds checks have been done by the caller. </b>
+     *
      * @param buf byte buffer to copy into
      * @param charPos insert point
      * @param v to convert
@@ -415,6 +421,9 @@ public final class DecimalDigits {
     /**
      * Insert the 2-chars integer into the buf as 2 decimal digit UTF16 bytes,
      * only least significant 16 bits of {@code v} are used.
+     * <p>
+     * <b>WARNING: Used by trusted callers.  Assumes all necessary bounds checks have been done by the caller. </b>
+     *
      * @param buf byte buffer to copy into
      * @param charPos insert point
      * @param v to convert
@@ -425,10 +434,18 @@ public final class DecimalDigits {
         uncheckedPutCharUTF16(buf, charPos + 1, packed >> 8);
     }
 
+    /**
+     * <p>
+     * <b>WARNING: Used by trusted callers.  Assumes all necessary bounds checks have been done by the caller. </b>
+     */
     private static void uncheckedPutCharLatin1(byte[] buf, int charPos, int c) {
         UNSAFE.putByte(buf, ARRAY_BYTE_BASE_OFFSET + charPos, (byte) c);
     }
 
+    /**
+     * <p>
+     * <b>WARNING: Used by trusted callers.  Assumes all necessary bounds checks have been done by the caller. </b>
+     */
     private static void uncheckedPutCharUTF16(byte[] buf, int charPos, int c) {
         UNSAFE.putCharUnaligned(buf, ARRAY_BYTE_BASE_OFFSET + ((long) charPos << 1), (char) c);
     }

--- a/src/java.base/share/classes/jdk/internal/util/DecimalDigits.java
+++ b/src/java.base/share/classes/jdk/internal/util/DecimalDigits.java
@@ -248,7 +248,7 @@ public final class DecimalDigits {
      * This is a variant of {@link DecimalDigits#uncheckedGetCharsLatin1(int, int, byte[])}, but for
      * UTF-16 coder.
      * <p>
-     * <b>WARNING: Used by trusted callers.  Assumes all necessary bounds checks have been done by the caller. </b>
+     * <b>WARNING: This method does not perform any bound checks.</b>
      *
      * @param i     value to convert
      * @param index next index, after the least significant digit

--- a/src/java.base/share/classes/jdk/internal/util/DecimalDigits.java
+++ b/src/java.base/share/classes/jdk/internal/util/DecimalDigits.java
@@ -291,7 +291,7 @@ public final class DecimalDigits {
      * This is a variant of {@link DecimalDigits#uncheckedGetCharsLatin1(long, int, byte[])}, but for
      * UTF-16 coder.
      * <p>
-     * <b>WARNING: Used by trusted callers.  Assumes all necessary bounds checks have been done by the caller. </b>
+     * <b>WARNING: This method does not perform any bound checks.</b>
      *
      * @param i     value to convert
      * @param index next index, after the least significant digit

--- a/src/java.base/share/classes/jdk/internal/util/DecimalDigits.java
+++ b/src/java.base/share/classes/jdk/internal/util/DecimalDigits.java
@@ -443,10 +443,6 @@ public final class DecimalDigits {
         UNSAFE.putByte(buf, ARRAY_BYTE_BASE_OFFSET + charPos, (byte) c);
     }
 
-    /**
-     * <p>
-     * <b>WARNING: Used by trusted callers.  Assumes all necessary bounds checks have been done by the caller. </b>
-     */
     private static void uncheckedPutCharUTF16(byte[] buf, int charPos, int c) {
         assert charPos >= 0 && charPos < (buf.length >> 1);
         UNSAFE.putCharUnaligned(buf, ARRAY_BYTE_BASE_OFFSET + ((long) charPos << 1), (char) c);

--- a/src/java.base/share/classes/jdk/internal/util/DecimalDigits.java
+++ b/src/java.base/share/classes/jdk/internal/util/DecimalDigits.java
@@ -422,7 +422,7 @@ public final class DecimalDigits {
      * Insert the 2-chars integer into the buf as 2 decimal digit UTF16 bytes,
      * only least significant 16 bits of {@code v} are used.
      * <p>
-     * <b>WARNING: Used by trusted callers.  Assumes all necessary bounds checks have been done by the caller. </b>
+     * <b>WARNING: This method does not perform any bound checks.</b>
      *
      * @param buf byte buffer to copy into
      * @param charPos insert point

--- a/test/hotspot/jtreg/compiler/patches/java.base/java/lang/Helper.java
+++ b/test/hotspot/jtreg/compiler/patches/java.base/java/lang/Helper.java
@@ -120,14 +120,14 @@ public class Helper {
 
     public static int getChars(int i, int begin, int end, byte[] value) {
         StringUTF16.checkBoundsBeginEnd(begin, end, value);
-        int pos = DecimalDigits.getCharsUTF16(i, end, value);
+        int pos = DecimalDigits.uncheckedGetCharsUTF16(i, end, value);
         assert begin == pos;
         return pos;
     }
 
     public static int getChars(long l, int begin, int end, byte[] value) {
         StringUTF16.checkBoundsBeginEnd(begin, end, value);
-        int pos = DecimalDigits.getCharsUTF16(l, end, value);
+        int pos = DecimalDigits.uncheckedGetCharsUTF16(l, end, value);
         assert begin == pos;
         return pos;
     }


### PR DESCRIPTION
Similar to PR #24982 
Document preconditions on certain DecimalDigits methods that use operations either unsafe and/or without range checks.

<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8357063](https://bugs.openjdk.org/browse/JDK-8357063): Document preconditions for DecimalDigits methods (**Enhancement** - P4)


### Reviewers
 * [Volkan Yazici](https://openjdk.org/census#vyazici) (@vy - Author)
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25246/head:pull/25246` \
`$ git checkout pull/25246`

Update a local copy of the PR: \
`$ git checkout pull/25246` \
`$ git pull https://git.openjdk.org/jdk.git pull/25246/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25246`

View PR using the GUI difftool: \
`$ git pr show -t 25246`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25246.diff">https://git.openjdk.org/jdk/pull/25246.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25246#issuecomment-2884477043)
</details>
