### PR TITLE
8356968: JFR: Compilation event should be enabled for all compilations by default

### DIFF
--- a/src/jdk.jfr/share/conf/jfr/default.jfc
+++ b/src/jdk.jfr/share/conf/jfr/default.jfc
@@ -564,7 +564,7 @@
 
     <event name="jdk.Compilation">
       <setting name="enabled" control="compiler-enabled">true</setting>
-      <setting name="threshold" control="compiler-compilation-threshold">1000 ms</setting>
+      <setting name="threshold">0 ms</setting>
     </event>
 
     <event name="jdk.CompilerPhase">
@@ -1028,18 +1028,6 @@
       </condition>
 
       <condition name="compiler-sweeper-threshold" true="0 ms" false="100 ms">
-        <test name="compiler" operator="equal" value="all"/>
-      </condition>
-
-      <condition name="compiler-compilation-threshold" true="1000 ms">
-        <test name="compiler" operator="equal" value="normal"/>
-      </condition>
-
-      <condition name="compiler-compilation-threshold" true="100 ms">
-        <test name="compiler" operator="equal" value="detailed"/>
-      </condition>
-
-      <condition name="compiler-compilation-threshold" true="0 ms">
         <test name="compiler" operator="equal" value="all"/>
       </condition>
 


### PR DESCRIPTION
In the field, we are using -XX:+PrintCompilation to track compiler performance. Alternatively, -Xlog:jit* prints the same. JFR has a the related jdk.Compilation event that gives us even richer diagnostics. Yet, that event is set at a very high threshold (1000ms), which skips almost all compilations! This threshold is set to such a high value from the beginning. 

It is fairly normal to have lots of compilations in 100+ ms range individually, and their sum impact is what we are after. Also, the compilations are normally quite rare, and there are a couple of thousands of compiles in most workloads, and they only happen sporadically. This means, the event count without any threshold is not high.

Therefore, it would be convenient to make sure that basic Compilation event is enabled unconditionally, e.g. by dropping the default threshold to 0.

See more logs in the bug itself.

Additional testing:
 - [x] Ad-hoc tests with printing compilation events
 - [x] Linux x86_64 server fastdebug, `jdk_jfr`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8356968](https://bugs.openjdk.org/browse/JDK-8356968): JFR: Compilation event should be enabled for all compilations by default (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25247/head:pull/25247` \
`$ git checkout pull/25247`

Update a local copy of the PR: \
`$ git checkout pull/25247` \
`$ git pull https://git.openjdk.org/jdk.git pull/25247/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25247`

View PR using the GUI difftool: \
`$ git pr show -t 25247`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25247.diff">https://git.openjdk.org/jdk/pull/25247.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25247#issuecomment-2883072607)
</details>
