### PR TITLE
8357052: java/io/File/GetXSpace.java prints wrong values in exception

### DIFF
--- a/test/jdk/java/io/File/GetXSpace.java
+++ b/test/jdk/java/io/File/GetXSpace.java
@@ -180,7 +180,7 @@ public class GetXSpace {
         if (fs > ts)
             throw new RuntimeException(f + " free space " + fs + " > total space " + ts);
         if (us > fs)
-            throw new RuntimeException(f + " usable space " + fs + " > free space " + ts);
+            throw new RuntimeException(f + " usable space " + us + " > free space " + fs);
 
         out.format("%s (%d):%n", s.name(), s.size());
         String fmt = "  %-4s total = %12d free = %12d usable = %12d%n";


### PR DESCRIPTION
When the test java/io/File/GetXSpace.java fails, because the usable space is greater than the free space, the values in the exception are not the correct ones.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8357052](https://bugs.openjdk.org/browse/JDK-8357052): java/io/File/GetXSpace.java prints wrong values in exception (**Bug** - P4)


### Reviewers
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25250/head:pull/25250` \
`$ git checkout pull/25250`

Update a local copy of the PR: \
`$ git checkout pull/25250` \
`$ git pull https://git.openjdk.org/jdk.git pull/25250/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25250`

View PR using the GUI difftool: \
`$ git pr show -t 25250`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25250.diff">https://git.openjdk.org/jdk/pull/25250.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25250#issuecomment-2886347933)
</details>
