### PR TITLE
8357053: ZGC: Improved utility for ZPageAge

### DIFF
--- a/src/hotspot/share/gc/z/zAllocator.cpp
+++ b/src/hotspot/share/gc/z/zAllocator.cpp
@@ -23,6 +23,7 @@
 
 #include "gc/z/zAllocator.hpp"
 #include "gc/z/zObjectAllocator.hpp"
+#include "gc/z/zPageAge.inline.hpp"
 
 ZAllocatorEden*          ZAllocator::_eden;
 ZAllocatorForRelocation* ZAllocator::_relocation[ZAllocator::_relocation_allocators];
@@ -47,7 +48,7 @@ ZPageAge ZAllocatorForRelocation::install() {
   for (uint i = 0; i < ZAllocator::_relocation_allocators; ++i) {
     if (_relocation[i] == nullptr) {
       _relocation[i] = this;
-      return static_cast<ZPageAge>(i + 1);
+      return to_zpageage(i + 1);
     }
   }
 

--- a/src/hotspot/share/gc/z/zAllocator.hpp
+++ b/src/hotspot/share/gc/z/zAllocator.hpp
@@ -35,7 +35,7 @@ class ZPage;
 
 class ZAllocator {
 public:
-  static constexpr uint _relocation_allocators = static_cast<uint>(ZPageAge::old);
+  static constexpr uint _relocation_allocators = ZPageAgeCount - 1;
 
 protected:
   ZObjectAllocator _object_allocator;

--- a/src/hotspot/share/gc/z/zAllocator.inline.hpp
+++ b/src/hotspot/share/gc/z/zAllocator.inline.hpp
@@ -27,6 +27,7 @@
 #include "gc/z/zAllocator.hpp"
 
 #include "gc/z/zAddress.inline.hpp"
+#include "gc/z/zPageAge.inline.hpp"
 #include "gc/z/zHeap.hpp"
 
 inline ZAllocatorEden* ZAllocator::eden() {
@@ -34,7 +35,7 @@ inline ZAllocatorEden* ZAllocator::eden() {
 }
 
 inline ZAllocatorForRelocation* ZAllocator::relocation(ZPageAge page_age) {
-  return _relocation[static_cast<uint>(page_age) - 1];
+  return _relocation[untype(page_age) - 1];
 }
 
 inline ZAllocatorForRelocation* ZAllocator::old() {

--- a/src/hotspot/share/gc/z/zPageAge.hpp
+++ b/src/hotspot/share/gc/z/zPageAge.hpp
@@ -24,6 +24,7 @@
 #ifndef SHARE_GC_Z_ZPAGEAGE_HPP
 #define SHARE_GC_Z_ZPAGEAGE_HPP
 
+#include "utilities/enumIterator.hpp"
 #include "utilities/globalDefinitions.hpp"
 
 enum class ZPageAge : uint8_t {
@@ -45,6 +46,19 @@ enum class ZPageAge : uint8_t {
   old
 };
 
-constexpr uint ZPageAgeMax = static_cast<uint>(ZPageAge::old);
+constexpr uint ZPageAgeCount = static_cast<uint>(ZPageAge::old) + 1;
+constexpr ZPageAge ZPageAgeLastPlusOne = static_cast<ZPageAge>(ZPageAgeCount);
+
+ENUMERATOR_VALUE_RANGE(ZPageAge,
+                       static_cast<uint>(ZPageAge::eden),
+                       ZPageAgeCount);
+
+using ZPageAgeRange = EnumRange<ZPageAge>;
+
+constexpr ZPageAgeRange ZPageAgeRangeEden = ZPageAgeRange::create<ZPageAge::eden, ZPageAge::survivor1>();
+constexpr ZPageAgeRange ZPageAgeRangeYoung = ZPageAgeRange::create<ZPageAge::eden, ZPageAge::old>();
+constexpr ZPageAgeRange ZPageAgeRangeSurvivor = ZPageAgeRange::create<ZPageAge::survivor1, ZPageAge::old>();
+constexpr ZPageAgeRange ZPageAgeRangeRelocation = ZPageAgeRange::create<ZPageAge::survivor1, ZPageAgeLastPlusOne>();
+constexpr ZPageAgeRange ZPageAgeRangeOld = ZPageAgeRange::create<ZPageAge::old, ZPageAgeLastPlusOne>();
 
 #endif // SHARE_GC_Z_ZPAGEAGE_HPP

--- a/src/hotspot/share/gc/z/zPageAge.inline.hpp
+++ b/src/hotspot/share/gc/z/zPageAge.inline.hpp
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#ifndef SHARE_GC_Z_ZPAGEAGE_INLINE_HPP
+#define SHARE_GC_Z_ZPAGEAGE_INLINE_HPP
+
+#include "gc/z/zPageAge.hpp"
+
+inline uint untype(ZPageAge age) {
+  const uint value = static_cast<uint>(age);
+  return value;
+}
+
+inline ZPageAge to_zpageage(uint age) {
+  assert(age < ZPageAgeCount, "Invalid age");
+  return static_cast<ZPageAge>(age);
+}
+
+#endif // SHARE_GC_Z_ZPAGEAGE_INLINE_HPP

--- a/src/hotspot/share/gc/z/zRelocate.cpp
+++ b/src/hotspot/share/gc/z/zRelocate.cpp
@@ -488,11 +488,11 @@ public:
   }
 
   ZPage* shared(ZPageAge age) {
-    return _shared[static_cast<uint>(age) - 1];
+    return _shared[untype(age) - 1];
   }
 
   void set_shared(ZPageAge age, ZPage* page) {
-    _shared[static_cast<uint>(age) - 1] = page;
+    _shared[untype(age) - 1] = page;
   }
 
   ZPage* alloc_and_retire_target_page(ZForwarding* forwarding, ZPage* target) {
@@ -570,11 +570,11 @@ private:
 
 
   ZPage* target(ZPageAge age) {
-    return _target[static_cast<uint>(age) - 1];
+    return _target[untype(age) - 1];
   }
 
   void set_target(ZPageAge age, ZPage* page) {
-    _target[static_cast<uint>(age) - 1] = page;
+    _target[untype(age) - 1] = page;
   }
 
   size_t object_alignment() const {
@@ -1232,12 +1232,12 @@ ZPageAge ZRelocate::compute_to_age(ZPageAge from_age) {
     return ZPageAge::old;
   }
 
-  const uint age = static_cast<uint>(from_age);
+  const uint age = untype(from_age);
   if (age >= ZGeneration::young()->tenuring_threshold()) {
     return ZPageAge::old;
   }
 
-  return static_cast<ZPageAge>(age + 1);
+  return to_zpageage(age + 1);
 }
 
 class ZFlipAgePagesTask : public ZTask {

--- a/src/hotspot/share/gc/z/zRelocationSetSelector.hpp
+++ b/src/hotspot/share/gc/z/zRelocationSetSelector.hpp
@@ -62,9 +62,9 @@ class ZRelocationSetSelectorStats {
   friend class ZRelocationSetSelector;
 
 private:
-  ZRelocationSetSelectorGroupStats _small[ZPageAgeMax + 1];
-  ZRelocationSetSelectorGroupStats _medium[ZPageAgeMax + 1];
-  ZRelocationSetSelectorGroupStats _large[ZPageAgeMax + 1];
+  ZRelocationSetSelectorGroupStats _small[ZPageAgeCount];
+  ZRelocationSetSelectorGroupStats _medium[ZPageAgeCount];
+  ZRelocationSetSelectorGroupStats _large[ZPageAgeCount];
 
   size_t _has_relocatable_pages;
 
@@ -87,7 +87,7 @@ private:
   ZArray<ZPage*>                   _live_pages;
   ZArray<ZPage*>                   _not_selected_pages;
   size_t                           _forwarding_entries;
-  ZRelocationSetSelectorGroupStats _stats[ZPageAgeMax + 1];
+  ZRelocationSetSelectorGroupStats _stats[ZPageAgeCount];
 
   bool is_disabled();
   bool is_selectable();

--- a/src/hotspot/share/gc/z/zRelocationSetSelector.inline.hpp
+++ b/src/hotspot/share/gc/z/zRelocationSetSelector.inline.hpp
@@ -28,6 +28,7 @@
 
 #include "gc/z/zArray.inline.hpp"
 #include "gc/z/zPage.inline.hpp"
+#include "gc/z/zPageAge.inline.hpp"
 
 inline size_t ZRelocationSetSelectorGroupStats::npages_candidates() const {
   return _npages_candidates;
@@ -58,15 +59,15 @@ inline bool ZRelocationSetSelectorStats::has_relocatable_pages() const {
 }
 
 inline const ZRelocationSetSelectorGroupStats& ZRelocationSetSelectorStats::small(ZPageAge age) const {
-  return _small[static_cast<uint>(age)];
+  return _small[untype(age)];
 }
 
 inline const ZRelocationSetSelectorGroupStats& ZRelocationSetSelectorStats::medium(ZPageAge age) const {
-  return _medium[static_cast<uint>(age)];
+  return _medium[untype(age)];
 }
 
 inline const ZRelocationSetSelectorGroupStats& ZRelocationSetSelectorStats::large(ZPageAge age) const {
-  return _large[static_cast<uint>(age)];
+  return _large[untype(age)];
 }
 
 inline void ZRelocationSetSelectorGroup::register_live_page(ZPage* page) {
@@ -81,7 +82,7 @@ inline void ZRelocationSetSelectorGroup::register_live_page(ZPage* page) {
     _not_selected_pages.append(page);
   }
 
-  const uint age = static_cast<uint>(page->age());
+  const uint age = untype(page->age());
   _stats[age]._npages_candidates++;
   _stats[age]._total += size;
   _stats[age]._live += live;
@@ -90,7 +91,7 @@ inline void ZRelocationSetSelectorGroup::register_live_page(ZPage* page) {
 inline void ZRelocationSetSelectorGroup::register_empty_page(ZPage* page) {
   const size_t size = page->size();
 
-  const uint age = static_cast<uint>(page->age());
+  const uint age = untype(page->age());
   _stats[age]._npages_candidates++;
   _stats[age]._total += size;
   _stats[age]._empty += size;
@@ -109,7 +110,7 @@ inline size_t ZRelocationSetSelectorGroup::forwarding_entries() const {
 }
 
 inline const ZRelocationSetSelectorGroupStats& ZRelocationSetSelectorGroup::stats(ZPageAge age) const {
-  return _stats[static_cast<uint>(age)];
+  return _stats[untype(age)];
 }
 
 inline void ZRelocationSetSelector::register_live_page(ZPage* page) {
@@ -156,8 +157,7 @@ inline void ZRelocationSetSelector::clear_empty_pages() {
 
 inline size_t ZRelocationSetSelector::total() const {
   size_t sum = 0;
-  for (uint i = 0; i <= ZPageAgeMax; ++i) {
-    const ZPageAge age = static_cast<ZPageAge>(i);
+  for (ZPageAge age : ZPageAgeRange()) {
     sum += _small.stats(age).total() + _medium.stats(age).total() + _large.stats(age).total();
   }
   return sum;
@@ -165,8 +165,7 @@ inline size_t ZRelocationSetSelector::total() const {
 
 inline size_t ZRelocationSetSelector::empty() const {
   size_t sum = 0;
-  for (uint i = 0; i <= ZPageAgeMax; ++i) {
-    const ZPageAge age = static_cast<ZPageAge>(i);
+  for (ZPageAge age : ZPageAgeRange()) {
     sum += _small.stats(age).empty() + _medium.stats(age).empty() + _large.stats(age).empty();
   }
   return sum;
@@ -174,8 +173,7 @@ inline size_t ZRelocationSetSelector::empty() const {
 
 inline size_t ZRelocationSetSelector::relocate() const {
   size_t sum = 0;
-  for (uint i = 0; i <= ZPageAgeMax; ++i) {
-    const ZPageAge age = static_cast<ZPageAge>(i);
+  for (ZPageAge age : ZPageAgeRange()) {
     sum += _small.stats(age).relocate() + _medium.stats(age).relocate() + _large.stats(age).relocate();
   }
   return sum;

--- a/src/hotspot/share/gc/z/zStat.cpp
+++ b/src/hotspot/share/gc/z/zStat.cpp
@@ -30,6 +30,7 @@
 #include "gc/z/zGeneration.inline.hpp"
 #include "gc/z/zGlobals.hpp"
 #include "gc/z/zNMethodTable.hpp"
+#include "gc/z/zPageAge.inline.hpp"
 #include "gc/z/zPageAllocator.inline.hpp"
 #include "gc/z/zRelocationSetSelector.inline.hpp"
 #include "gc/z/zStat.hpp"
@@ -1499,9 +1500,7 @@ void ZStatRelocation::print_page_summary() {
     summary.relocate += stats.relocate();
   };
 
-  for (uint i = 0; i <= ZPageAgeMax; ++i) {
-    const ZPageAge age = static_cast<ZPageAge>(i);
-
+  for (ZPageAge age : ZPageAgeRange()) {
     account_page_size(small_summary, _selector_stats.small(age));
     account_page_size(medium_summary, _selector_stats.medium(age));
     account_page_size(large_summary, _selector_stats.large(age));
@@ -1557,13 +1556,13 @@ void ZStatRelocation::print_age_table() {
            .center("Large")
            .end());
 
-  size_t live[ZPageAgeMax + 1] = {};
-  size_t total[ZPageAgeMax + 1] = {};
+  size_t live[ZPageAgeCount] = {};
+  size_t total[ZPageAgeCount] = {};
 
   uint oldest_none_empty_age = 0;
 
-  for (uint i = 0; i <= ZPageAgeMax; ++i) {
-    ZPageAge age = static_cast<ZPageAge>(i);
+  for (ZPageAge age : ZPageAgeRange()) {
+    uint i = untype(age);
     auto summarize_pages = [&](const ZRelocationSetSelectorGroupStats& stats) {
       live[i] += stats.live();
       total[i] += stats.total();
@@ -1579,7 +1578,7 @@ void ZStatRelocation::print_age_table() {
   }
 
   for (uint i = 0; i <= oldest_none_empty_age; ++i) {
-    ZPageAge age = static_cast<ZPageAge>(i);
+    ZPageAge age = to_zpageage(i);
 
     FormatBuffer<> age_str("");
     if (age == ZPageAge::eden) {
@@ -1791,8 +1790,7 @@ void ZStatHeap::at_select_relocation_set(const ZRelocationSetSelectorStats& stat
   ZLocker<ZLock> locker(&_stat_lock);
 
   size_t live = 0;
-  for (uint i = 0; i <= ZPageAgeMax; ++i) {
-    const ZPageAge age = static_cast<ZPageAge>(i);
+  for (ZPageAge age : ZPageAgeRange()) {
     live += stats.small(age).live() + stats.medium(age).live() + stats.large(age).live();
   }
   _at_mark_end.live = live;

--- a/src/hotspot/share/gc/z/z_globals.hpp
+++ b/src/hotspot/share/gc/z/z_globals.hpp
@@ -106,7 +106,7 @@
                                                                             \
   product(int, ZTenuringThreshold, -1, DIAGNOSTIC,                          \
           "Young generation tenuring threshold, -1 for dynamic computation")\
-          range(-1, static_cast<int>(ZPageAgeMax))                          \
+          range(-1, static_cast<int>(ZPageAgeCount) - 1)                    \
                                                                             \
   develop(bool, ZVerifyOops, false,                                         \
           "Verify accessed oops")                                           \

--- a/src/hotspot/share/utilities/enumIterator.hpp
+++ b/src/hotspot/share/utilities/enumIterator.hpp
@@ -147,6 +147,12 @@ public:
     assert(value <= end, "out of range");
   }
 
+  template <T Value>
+  static constexpr void assert_in_range() {
+    static_assert(_start <= static_cast<Underlying>(Value), "out of range");
+    static_assert(static_cast<Underlying>(Value) <= _end, "out of range");
+  }
+
   // Convert an enumerator value to the corresponding underlying type.
   static constexpr Underlying underlying_value(T value) {
     return static_cast<Underlying>(value);
@@ -229,6 +235,14 @@ class EnumRange {
     assert(size() > 0, "empty range");
   }
 
+private:
+
+  struct ConstExprConstructTag {};
+
+  constexpr EnumRange(T start, T end, ConstExprConstructTag) :
+    _start(Traits::underlying_value(start)),
+    _end(Traits::underlying_value(end)) {}
+
 public:
   using EnumType = T;
   using Iterator = EnumIterator<T>;
@@ -250,6 +264,14 @@ public:
     Traits::assert_in_range(start);
     Traits::assert_in_range(end);
     assert(start <= end, "invalid range");
+  }
+
+  template <EnumType Start, EnumType End>
+  static constexpr EnumRange<T> create() {
+    Traits::template assert_in_range<Start>();
+    Traits::template assert_in_range<End>();
+    static_assert(Start <= End, "invalid range");
+    return EnumRange(Start, End, ConstExprConstructTag{});
   }
 
   // Return an iterator for the start of the range.


### PR DESCRIPTION
Hello,

This RFE improves utility for converting to/from, iterating over and defining structures that are indexed using the `ZPageAge` type.

Converting to/from ZPageAge and its underlying type (uint8_t, often just uint) is currently done via using static_cast. This works fine because sane values are converted in all use cases. However, to make conversion safer (and also more readable), I propose we add a `to_zpageage` and a corresponding `untype` that checks that the conversion is valid. Such conversion methods should be used instead of calling `static_cast<uint/ZPageAge>`.

We currently define a value called `ZPageAgeMax`, which is defined as `static_cast<uint>(ZPageAge::old)`. The majority of places that use this value actualy use `ZPageAgeMax + 1`, which is equivalent to the number of ages. Instead, I propose we define and use a value that represents the number of possible ages, called `ZPageAgeCount`.

Lastly, to make iterating over ages more accessible, I propose we create an intreface of enum iterators of ZPageAge. This will also create a foundation for generating values that require a ZPageAge in the future. Since the end of the enum iterators are exclusive, I've opted to use the following value as end for the iterators:
```
constexpr ZPageAge ZPageAgeLastPlusOne = static_cast<ZPageAge>(ZPageAgeCount);
```

I see us using either this or a sentinel/dummy value at the end of the enum class, but I prefer having a value similar to `ZPageAgeLastPlusOne` over a dummy value.

Testing:
* Currently running through Oracle's tier 1-4
* GHA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8357053](https://bugs.openjdk.org/browse/JDK-8357053): ZGC: Improved utility for ZPageAge (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25251/head:pull/25251` \
`$ git checkout pull/25251`

Update a local copy of the PR: \
`$ git checkout pull/25251` \
`$ git pull https://git.openjdk.org/jdk.git pull/25251/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25251`

View PR using the GUI difftool: \
`$ git pr show -t 25251`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25251.diff">https://git.openjdk.org/jdk/pull/25251.diff</a>

</details>
