### PR TITLE
8347530: Improve error message with invalid permits clauses

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -5471,15 +5471,9 @@ public class Attr extends JCTree.Visitor {
                                                         .stream()
                                                         .anyMatch(d -> d.tsym == c);
                             if (!thisIsASuper) {
-                                KindName subtypingLeftKind;
-                                if (subType.tsym.isEnum()) subtypingLeftKind = KindName.ENUM;
-                                else if (subType.isInterface()) subtypingLeftKind = KindName.INTERFACE;
-                                else if (subType.tsym.enclClass().isRecord()) subtypingLeftKind = KindName.RECORD;
-                                else subtypingLeftKind = KindName.CLASS;
-
                                 if(c.isInterface()) {
                                     log.error(TreeInfo.diagnosticPositionFor(subType.tsym, env.tree),
-                                            Errors.InvalidPermitsClause(Fragments.DoesntImplementSealed(subtypingLeftKind, subType)));
+                                            Errors.InvalidPermitsClause(Fragments.DoesntImplementSealed(kindName(subType.tsym), subType)));
                                 } else {
                                     log.error(TreeInfo.diagnosticPositionFor(subType.tsym, env.tree),
                                             Errors.InvalidPermitsClause(Fragments.DoesntExtendSealed(subType)));

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -5471,8 +5471,19 @@ public class Attr extends JCTree.Visitor {
                                                         .stream()
                                                         .anyMatch(d -> d.tsym == c);
                             if (!thisIsASuper) {
-                                log.error(TreeInfo.diagnosticPositionFor(subType.tsym, env.tree),
-                                        Errors.InvalidPermitsClause(Fragments.DoesntExtendSealed(subType)));
+                                KindName subtypingLeftKind;
+                                if (subType.tsym.isEnum()) subtypingLeftKind = KindName.ENUM;
+                                else if (subType.isInterface()) subtypingLeftKind = KindName.INTERFACE;
+                                else if (subType.tsym.enclClass().isRecord()) subtypingLeftKind = KindName.RECORD;
+                                else subtypingLeftKind = KindName.CLASS;
+
+                                if(c.isInterface()) {
+                                    log.error(TreeInfo.diagnosticPositionFor(subType.tsym, env.tree),
+                                            Errors.InvalidPermitsClause(Fragments.DoesntImplementSealed(subtypingLeftKind, subType)));
+                                } else {
+                                    log.error(TreeInfo.diagnosticPositionFor(subType.tsym, env.tree),
+                                            Errors.InvalidPermitsClause(Fragments.DoesntExtendSealed(subType)));
+                                }
                             }
                         }
                     }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
@@ -3957,7 +3957,11 @@ compiler.misc.is.duplicated=\
 
 # 0: type
 compiler.misc.doesnt.extend.sealed=\
-    subclass {0} must extend sealed class
+    class {0} must extend sealed class
+
+# 0: kind name, 1: type
+compiler.misc.doesnt.implement.sealed=\
+    {0} {1} must extend sealed interface
 
 compiler.misc.must.not.be.same.class=\
     illegal self-reference in permits clause

--- a/test/langtools/tools/javac/T8347530.java
+++ b/test/langtools/tools/javac/T8347530.java
@@ -1,0 +1,29 @@
+/*
+ * @test /nodynamiccopyright/
+ * @bug 8347530
+ * @summary Improve error message with invalid permits clauses
+ * @compile/fail/ref=T8347530.out -XDrawDiagnostics T8347530.java
+ */
+
+class T8347530 {
+    // sealed interfaces
+    sealed interface A0 permits B0 {}
+    class B0 {}     // class {0} must implement sealed interface
+
+    sealed interface A1 permits B1 {}
+    record B1() {}  // record {0} must implement sealed interface
+
+    sealed interface A2 permits B2 {}
+    enum B2 {}      // enum {0} must implement sealed interface
+
+    sealed interface A3 permits B3 {}
+    interface B3 {} // interface {0} must implement sealed interface
+
+    // sealed classes
+    sealed class C0 permits S0 {}
+    class S0 {}     // class {0} must extend sealed class
+
+    // record cannot extend other classes in general
+    // enums cannot extend other classes in general
+    // interfaces cannot extend other classes in general
+}

--- a/test/langtools/tools/javac/T8347530.out
+++ b/test/langtools/tools/javac/T8347530.out
@@ -1,0 +1,6 @@
+T8347530.java:10:33: compiler.err.invalid.permits.clause: (compiler.misc.doesnt.implement.sealed: kindname.class, T8347530.B0)
+T8347530.java:13:33: compiler.err.invalid.permits.clause: (compiler.misc.doesnt.implement.sealed: kindname.record, T8347530.B1)
+T8347530.java:16:33: compiler.err.invalid.permits.clause: (compiler.misc.doesnt.implement.sealed: kindname.enum, T8347530.B2)
+T8347530.java:19:33: compiler.err.invalid.permits.clause: (compiler.misc.doesnt.implement.sealed: kindname.interface, T8347530.B3)
+T8347530.java:23:29: compiler.err.invalid.permits.clause: (compiler.misc.doesnt.extend.sealed: T8347530.S0)
+5 errors

--- a/test/langtools/tools/javac/diags/examples/SubtypeDoesntImplementSealed.java
+++ b/test/langtools/tools/javac/diags/examples/SubtypeDoesntImplementSealed.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+// key: compiler.err.invalid.permits.clause
+// key: compiler.misc.doesnt.implement.sealed
+
+sealed interface A3 permits B3 {}
+interface B3 {}
+

--- a/test/langtools/tools/javac/sealed/SealedDiffConfigurationsTest.java
+++ b/test/langtools/tools/javac/sealed/SealedDiffConfigurationsTest.java
@@ -556,7 +556,7 @@ public class SealedDiffConfigurationsTest extends TestRunner {
                 .getOutputLines(OutputKind.DIRECT);
 
         List<String> expected = List.of(
-                "Sealed.java:1:66: compiler.err.invalid.permits.clause: (compiler.misc.doesnt.extend.sealed: pkg.Sub2)",
+                "Sealed.java:1:66: compiler.err.invalid.permits.clause: (compiler.misc.doesnt.implement.sealed: kindname.class, pkg.Sub2)",
                 "1 error");
         if (!error.containsAll(expected)) {
             throw new AssertionError("Expected output not found. Found: " + error);

--- a/test/langtools/tools/javac/sealed/erroneous_hierarchy/CyclicHierarchyTest.out
+++ b/test/langtools/tools/javac/sealed/erroneous_hierarchy/CyclicHierarchyTest.out
@@ -1,3 +1,3 @@
-CyclicHierarchyTest.java:9:37: compiler.err.invalid.permits.clause: (compiler.misc.doesnt.extend.sealed: CyclicHierarchyTest.Add)
+CyclicHierarchyTest.java:9:37: compiler.err.invalid.permits.clause: (compiler.misc.doesnt.implement.sealed: kindname.class, CyclicHierarchyTest.Add)
 CyclicHierarchyTest.java:11:55: compiler.err.invalid.permits.clause: (compiler.misc.must.not.be.same.class)
 2 errors


### PR DESCRIPTION
Currently we report one kind of error message (`subclass {0} must extend sealed class`) when there is a compile-type error in cases like the following:

```
sealed class C0 permits S0 {}
class S0 {}  
```

This PR proposes to improve error reporting since there are other kinds of declarations that can also participate in sealed hierarchies like records, enums and interfaces.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347530](https://bugs.openjdk.org/browse/JDK-8347530): Improve error message with invalid permits clauses (**Bug** - P4)


### Reviewers
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25255/head:pull/25255` \
`$ git checkout pull/25255`

Update a local copy of the PR: \
`$ git checkout pull/25255` \
`$ git pull https://git.openjdk.org/jdk.git pull/25255/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25255`

View PR using the GUI difftool: \
`$ git pr show -t 25255`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25255.diff">https://git.openjdk.org/jdk/pull/25255.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25255#issuecomment-2884494560)
</details>
