### PR TITLE
8357016: Candidate main methods not computed properly

### DIFF
--- a/src/java.base/share/classes/jdk/internal/misc/MethodFinder.java
+++ b/src/java.base/share/classes/jdk/internal/misc/MethodFinder.java
@@ -51,7 +51,6 @@ public class MethodFinder {
      * <li>have a single argument of type {@code String[]}, {@code String...} or no argument</li>
      * <li>have the return type of void</li>
      * <li>be public, protected or package private</li>
-     * <li>not be abstract</li>
      *</ul>
      *
      * The method returned would be used by a launcher to initiate the execution of an
@@ -89,23 +88,21 @@ public class MethodFinder {
             mainMethod = JLA.findMethod(cls, false, "main", String[].class);
         }
 
-        if (mainMethod == null) {
+        if (mainMethod == null || !isValidMainMethod(mainMethod)) {
             mainMethod = JLA.findMethod(cls, false, "main");
         }
 
-        if (mainMethod == null) {
-            return null;
-        }
-
-        int mods = mainMethod.getModifiers();
-
-        if (Modifier.isAbstract(mods) ||
-                mainMethod.getReturnType() != void.class ||
-                Modifier.isPrivate(mods)) {
+        if (mainMethod == null || !isValidMainMethod(mainMethod)) {
             return null;
         }
 
         return mainMethod;
+    }
+
+    private static boolean isValidMainMethod(Method mainMethodCandidate) {
+        return mainMethodCandidate.getReturnType() == void.class &&
+               !Modifier.isPrivate(mainMethodCandidate.getModifiers());
+
     }
 
 }

--- a/src/java.base/share/classes/sun/launcher/LauncherHelper.java
+++ b/src/java.base/share/classes/sun/launcher/LauncherHelper.java
@@ -948,6 +948,9 @@ public final class LauncherHelper {
 
         if (!isStaticMain) {
             String className = mainMethod.getDeclaringClass().getName();
+            if (Modifier.isAbstract(mainClass.getModifiers())) {
+                abort(null, "java.launcher.cls.error8", className);
+            }
             if (mainClass.isMemberClass() && !Modifier.isStatic(mainClass.getModifiers())) {
                 abort(null, "java.launcher.cls.error7", className);
             }

--- a/src/java.base/share/classes/sun/launcher/resources/launcher.properties
+++ b/src/java.base/share/classes/sun/launcher/resources/launcher.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2007, 2025, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -279,6 +279,9 @@ java.launcher.cls.error6=\
 java.launcher.cls.error7=\
     Error: non-static inner class {0} constructor can not be invoked \n\
     make inner class static or move inner class out to separate source file
+java.launcher.cls.error8=\
+    Error: abstract class {0} can not instantiated\n\
+    please use a concrete class
 java.launcher.jar.error1=\
     Error: An unexpected error occurred while trying to open file {0}
 java.launcher.jar.error2=manifest not found in {0}

--- a/src/java.base/share/classes/sun/launcher/resources/launcher.properties
+++ b/src/java.base/share/classes/sun/launcher/resources/launcher.properties
@@ -280,7 +280,7 @@ java.launcher.cls.error7=\
     Error: non-static inner class {0} constructor can not be invoked \n\
     make inner class static or move inner class out to separate source file
 java.launcher.cls.error8=\
-    Error: abstract class {0} can not instantiated\n\
+    Error: abstract class {0} can not be instantiated\n\
     please use a concrete class
 java.launcher.jar.error1=\
     Error: An unexpected error occurred while trying to open file {0}

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/launcher/SourceLauncher.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/launcher/SourceLauncher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -227,6 +227,10 @@ public final class SourceLauncher {
         Object instance = null;
 
         if (!isStatic) {
+            if (Modifier.isAbstract(mainClass.getModifiers())) {
+                throw new Fault(Errors.CantInstantiate(mainClassName));
+            }
+
             Constructor<?> constructor;
             try {
                 constructor = mainClass.getDeclaredConstructor();

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/launcher.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/launcher.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -110,7 +110,11 @@ launcher.err.cant.find.class=\
 
 # 0: string
 launcher.err.cant.find.main.method=\
-    can''t find main(String[]) method in class: {0}
+    can''t find main(String[]) or main() method in class: {0}
+
+# 0: string
+launcher.err.cant.instantiate=\
+    abstract class: {0} cannot be instantiated
 
 # 0: string
 launcher.err.cant.access.main.method=\

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/launcher.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/launcher.properties
@@ -114,7 +114,7 @@ launcher.err.cant.find.main.method=\
 
 # 0: string
 launcher.err.cant.instantiate=\
-    abstract class: {0} cannot be instantiated
+    abstract class: {0} can not be instantiated
 
 # 0: string
 launcher.err.cant.access.main.method=\

--- a/test/jdk/tools/launcher/Arrrghs.java
+++ b/test/jdk/tools/launcher/Arrrghs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -599,6 +599,38 @@ public class Arrrghs extends TestHelper {
                 "public static void main(String... args){}");
         tr = doExec(javaCmd, "-jar", "some.jar");
         tr.checkPositive();
+        if (!tr.testStatus)
+            System.out.println(tr);
+
+        //private method with parameter, usable method without parameter:
+        createJar(new File("some.jar"), new File("Foo"),
+            "private static void main(String[] args){}",
+            "void main() {System.out.println(\"THE_CHOSEN_ONE\");}");
+        tr = doExec(javaCmd, "-jar", "some.jar");
+        tr.contains("THE_CHOSEN_ONE");
+        if (!tr.testStatus)
+            System.out.println(tr);
+
+        //method with a wrong return type with parameter, usable method without parameter:
+        createJar(new File("some.jar"), new File("Foo"),
+            "public static int main(String[] args){ return -1; }",
+            "void main() {System.out.println(\"THE_CHOSEN_ONE\");}");
+        tr = doExec(javaCmd, "-jar", "some.jar");
+        tr.contains("THE_CHOSEN_ONE");
+        if (!tr.testStatus)
+            System.out.println(tr);
+
+        // instance method abstract class:
+        createJarForSource(null, new File("some.jar"), new File("Foo"),
+                """
+                public abstract class Foo {
+                    void main() {
+                        System.out.println("Cannot be called.");
+                    }
+                }
+                """);
+        tr = doExec(javaCmd, "-jar", "some.jar");
+        tr.contains("Error: abstract class Foo can not instantiated");
         if (!tr.testStatus)
             System.out.println(tr);
     }

--- a/test/jdk/tools/launcher/Arrrghs.java
+++ b/test/jdk/tools/launcher/Arrrghs.java
@@ -611,9 +611,25 @@ public class Arrrghs extends TestHelper {
         if (!tr.testStatus)
             System.out.println(tr);
 
+        createJar(new File("some.jar"), new File("Foo"),
+            "private void main(String[] args){}",
+            "void main() {System.out.println(\"THE_CHOSEN_ONE\");}");
+        tr = doExec(javaCmd, "-jar", "some.jar");
+        tr.contains("THE_CHOSEN_ONE");
+        if (!tr.testStatus)
+            System.out.println(tr);
+
         //method with a wrong return type with parameter, usable method without parameter:
         createJar(new File("some.jar"), new File("Foo"),
             "public static int main(String[] args){ return -1; }",
+            "void main() {System.out.println(\"THE_CHOSEN_ONE\");}");
+        tr = doExec(javaCmd, "-jar", "some.jar");
+        tr.contains("THE_CHOSEN_ONE");
+        if (!tr.testStatus)
+            System.out.println(tr);
+
+        createJar(new File("some.jar"), new File("Foo"),
+            "public int main(String[] args){ return -1; }",
             "void main() {System.out.println(\"THE_CHOSEN_ONE\");}");
         tr = doExec(javaCmd, "-jar", "some.jar");
         tr.contains("THE_CHOSEN_ONE");

--- a/test/jdk/tools/launcher/Arrrghs.java
+++ b/test/jdk/tools/launcher/Arrrghs.java
@@ -646,7 +646,7 @@ public class Arrrghs extends TestHelper {
                 }
                 """);
         tr = doExec(javaCmd, "-jar", "some.jar");
-        tr.contains("Error: abstract class Foo can not instantiated");
+        tr.contains("Error: abstract class Foo can not be instantiated");
         if (!tr.testStatus)
             System.out.println(tr);
     }

--- a/test/jdk/tools/launcher/TestHelper.java
+++ b/test/jdk/tools/launcher/TestHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,6 +52,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Arrays;
 import java.util.spi.ToolProvider;
+import java.util.stream.Collectors;
 
 import static java.nio.file.StandardCopyOption.*;
 import static java.nio.file.StandardOpenOption.*;
@@ -64,6 +65,7 @@ public class TestHelper {
     static final File TEST_CLASSES_DIR;
     static final File TEST_SOURCES_DIR;
 
+    static final String NL = System.getProperty("line.separator");
     static final String JAVAHOME = System.getProperty("java.home");
     static final String JAVA_BIN;
     static final String JAVA_LIB;
@@ -287,17 +289,21 @@ public class TestHelper {
      */
     static void createJar(String mEntry, File jarName, File mainClass,
             String... mainDefs) throws FileNotFoundException {
+        String source =
+                Arrays.stream(mainDefs != null ? mainDefs : new String[0])
+                      .collect(Collectors.joining(NL,
+                                                  "public class Foo {" + NL,
+                                                  "}" + NL));
+        createJarForSource(mEntry, jarName, mainClass, source);
+    }
+
+    static void createJarForSource(String mEntry, File jarName, File mainClass,
+            String source) throws FileNotFoundException {
         if (jarName.exists()) {
             jarName.delete();
         }
         try (PrintStream ps = new PrintStream(new FileOutputStream(mainClass + ".java"))) {
-            ps.println("public class Foo {");
-            if (mainDefs != null) {
-                for (String x : mainDefs) {
-                    ps.println(x);
-                }
-            }
-            ps.println("}");
+            ps.println(source);
         }
 
         String compileArgs[] = {

--- a/test/langtools/tools/javac/launcher/SourceLauncherTest.java
+++ b/test/langtools/tools/javac/launcher/SourceLauncherTest.java
@@ -783,7 +783,7 @@ public class SourceLauncherTest extends TestRunner {
                           }
                           """);
         testError(base.resolve("AbstractMain.java"), "",
-                "error: abstract class: AbstractMain cannot be instantiated");
+                "error: abstract class: AbstractMain can not be instantiated");
     }
 
     @Test

--- a/test/langtools/tools/javac/launcher/SourceLauncherTest.java
+++ b/test/langtools/tools/javac/launcher/SourceLauncherTest.java
@@ -802,11 +802,43 @@ public class SourceLauncherTest extends TestRunner {
     }
 
     @Test
+    public void testWrongMainPrivateInstance(Path base) throws IOException {
+        tb.writeJavaFiles(base,
+                          """
+                          public class WrongMainPrivate {
+                              private void main(String[] args) {}
+                              void main() {
+                                  System.out.println("correct");
+                              }
+                          }
+                          """);
+        testSuccess(base.resolve("WrongMainPrivate.java"),
+                    "correct\n");
+    }
+
+    @Test
     public void testWrongMainReturnType(Path base) throws IOException {
         tb.writeJavaFiles(base,
                           """
                           public class WrongMainReturnType {
                               public static int main(String[] args) {
+                                  return -1;
+                              }
+                              void main() {
+                                  System.out.println("correct");
+                              }
+                          }
+                          """);
+        testSuccess(base.resolve("WrongMainReturnType.java"),
+                    "correct\n");
+    }
+
+    @Test
+    public void testWrongMainReturnTypeInstance(Path base) throws IOException {
+        tb.writeJavaFiles(base,
+                          """
+                          public class WrongMainReturnType {
+                              public int main(String[] args) {
                                   return -1;
                               }
                               void main() {

--- a/test/langtools/tools/javac/launcher/SourceLauncherTest.java
+++ b/test/langtools/tools/javac/launcher/SourceLauncherTest.java
@@ -601,7 +601,7 @@ public class SourceLauncherTest extends TestRunner {
     public void testNoMain(Path base) throws IOException {
         tb.writeJavaFiles(base, "class NoMain { }");
         testError(base.resolve("NoMain.java"), "",
-                "error: can't find main(String[]) method in class: NoMain");
+                "error: can't find main(String[]) or main() method in class: NoMain");
     }
 
     @Test
@@ -609,7 +609,7 @@ public class SourceLauncherTest extends TestRunner {
         tb.writeJavaFiles(base,
                 "class BadParams { public static void main(int n) { } }");
         testError(base.resolve("BadParams.java"), "",
-                "error: can't find main(String[]) method in class: BadParams");
+                "error: can't find main(String[]) or main() method in class: BadParams");
     }
 
     @Test
@@ -617,7 +617,7 @@ public class SourceLauncherTest extends TestRunner {
         tb.writeJavaFiles(base,
                 "class NotVoid { public static int main(String... args) { return 0; } }");
         testError(base.resolve("NotVoid.java"), "",
-                "error: can't find main(String[]) method in class: NotVoid");
+                "error: can't find main(String[]) or main() method in class: NotVoid");
     }
 
     @Test
@@ -773,6 +773,50 @@ public class SourceLauncherTest extends TestRunner {
                 out.write(newBytes);
             }
         }
+
+    @Test
+    public void testAbstractClassInstanceMain(Path base) throws IOException {
+        tb.writeJavaFiles(base,
+                          """
+                          public abstract class AbstractMain {
+                              void main(String[] args) {}
+                          }
+                          """);
+        testError(base.resolve("AbstractMain.java"), "",
+                "error: abstract class: AbstractMain cannot be instantiated");
+    }
+
+    @Test
+    public void testWrongMainPrivate(Path base) throws IOException {
+        tb.writeJavaFiles(base,
+                          """
+                          public class WrongMainPrivate {
+                              private static void main(String[] args) {}
+                              void main() {
+                                  System.out.println("correct");
+                              }
+                          }
+                          """);
+        testSuccess(base.resolve("WrongMainPrivate.java"),
+                    "correct\n");
+    }
+
+    @Test
+    public void testWrongMainReturnType(Path base) throws IOException {
+        tb.writeJavaFiles(base,
+                          """
+                          public class WrongMainReturnType {
+                              public static int main(String[] args) {
+                                  return -1;
+                              }
+                              void main() {
+                                  System.out.println("correct");
+                              }
+                          }
+                          """);
+        testSuccess(base.resolve("WrongMainReturnType.java"),
+                    "correct\n");
+    }
 
     Result run(Path file, List<String> runtimeArgs, List<String> appArgs) {
         List<String> args = new ArrayList<>();


### PR DESCRIPTION
A consider class like this:

```
public class TwoMains {
    private static void main(String... args) {}
    static void main() {
        System.out.println("Should be called, but is not.");
    }
}
```

The `MethodFinder` will do lookup for the `main(String[])` method, and it finds one, so does not proceed with a lookup for `main()`. But then, it will check the access modifier, and will reject that method, never going back to the `main()` method. This is not what the JLS says about the lookup - the private method is not a candidate, and should be ignored.

Something similar happens if the return type is not `void`.

This PR is fixing that by checking whether the `main(String[])` method is usable early, and falling back to `main()` if it `main(String[])` is not usable.

It also removes the check for the `abstract` method, as that, by itself, is not really backed by JLS, but adds a check for `abstract` class, producing a user-friendly message is trying to invoke an instance `main` method on an `abstract` class (which, obviously, cannot be instantiated).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8357016](https://bugs.openjdk.org/browse/JDK-8357016): Candidate main methods not computed properly (**Bug** - P3)


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**) Review applies to [f63dab37](https://git.openjdk.org/jdk/pull/25256/files/f63dab37a117f7d271aa7f6b8ba5e9f60edae991)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25256/head:pull/25256` \
`$ git checkout pull/25256`

Update a local copy of the PR: \
`$ git checkout pull/25256` \
`$ git pull https://git.openjdk.org/jdk.git pull/25256/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25256`

View PR using the GUI difftool: \
`$ git pr show -t 25256`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25256.diff">https://git.openjdk.org/jdk/pull/25256.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25256#issuecomment-2884470364)
</details>
