### PR TITLE
JDK-8357089: Remove VFORK launch mechanism from Process implementation (linux)

### DIFF
--- a/src/java.base/unix/classes/java/lang/ProcessImpl.java
+++ b/src/java.base/unix/classes/java/lang/ProcessImpl.java
@@ -82,8 +82,7 @@ final class ProcessImpl extends Process {
     private static enum LaunchMechanism {
         // order IS important!
         FORK,
-        POSIX_SPAWN,
-        VFORK
+        POSIX_SPAWN
     }
 
     /**
@@ -101,13 +100,9 @@ final class ProcessImpl extends Process {
             LaunchMechanism lm = LaunchMechanism.valueOf(s.toUpperCase(Locale.ROOT));
             switch (OperatingSystem.current()) {
                 case LINUX:
-                    return lm;      // All options are valid for Linux
                 case AIX:
                 case MACOS:
-                    if (lm != LaunchMechanism.VFORK) {
-                        return lm; // All but VFORK are valid
-                    }
-                    break;
+                    return lm;
                 case WINDOWS:
                     // fall through to throw to Error
             }
@@ -256,7 +251,6 @@ final class ProcessImpl extends Process {
      * <pre>
      *   1 - fork(2) and exec(2)
      *   2 - posix_spawn(3P)
-     *   3 - vfork(2) and exec(2)
      * </pre>
      * @param fds an array of three file descriptors.
      *        Indexes 0, 1, and 2 correspond to standard input,

--- a/src/java.base/unix/native/libjava/childproc.h
+++ b/src/java.base/unix/native/libjava/childproc.h
@@ -77,7 +77,6 @@ extern char **environ;
  */
 #define MODE_FORK 1
 #define MODE_POSIX_SPAWN 2
-#define MODE_VFORK 3
 
 typedef struct _ChildStuff
 {


### PR DESCRIPTION
See ratio for this in the companion CSR: https://bugs.openjdk.org/browse/JDK-8357090