### PR TITLE
8357106: Add missing classpath exception copyright headers

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/CaptureStateUtil.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/CaptureStateUtil.java
@@ -4,7 +4,9 @@
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or


### PR DESCRIPTION
This PR adds missing classpath exception

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8357106](https://bugs.openjdk.org/browse/JDK-8357106): Add missing classpath exception copyright headers (**Bug** - P4)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25261/head:pull/25261` \
`$ git checkout pull/25261`

Update a local copy of the PR: \
`$ git checkout pull/25261` \
`$ git pull https://git.openjdk.org/jdk.git pull/25261/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25261`

View PR using the GUI difftool: \
`$ git pr show -t 25261`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25261.diff">https://git.openjdk.org/jdk/pull/25261.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25261#issuecomment-2885845892)
</details>
