### PR TITLE
8350329: C2: Div looses dependency on condition that guarantees divisor not zero in counted loop after peeling

### DIFF
--- a/src/hotspot/share/opto/loopTransform.cpp
+++ b/src/hotspot/share/opto/loopTransform.cpp
@@ -813,9 +813,13 @@ void PhaseIdealLoop::do_peeling(IdealLoopTree *loop, Node_List &old_new) {
 
   // Step 5: Assertion Predicates initialization
   if (counted_loop) {
-    initialize_assertion_predicates_for_peeled_loop(new_head->as_CountedLoop(), head->as_CountedLoop(),
+    CountedLoopNode* cl = head->as_CountedLoop();
+    Node* init = cl->init_trip();
+    Node* init_ctrl = cl->skip_strip_mined()->in(LoopNode::EntryControl);
+    initialize_assertion_predicates_for_peeled_loop(new_head->as_CountedLoop(), cl,
                                                     first_node_index_in_post_loop_body, old_new);
- }
+    cast_incr_before_loop(init, init_ctrl, cl);
+  }
 
   // Now force out all loop-invariant dominating tests.  The optimizer
   // finds some, but we _know_ they are all useless.

--- a/test/hotspot/jtreg/compiler/controldependency/TestPeeledLoopNoBackedgeFloatingDiv.java
+++ b/test/hotspot/jtreg/compiler/controldependency/TestPeeledLoopNoBackedgeFloatingDiv.java
@@ -25,8 +25,10 @@
  * @test
  * @bug 8350329
  * @summary C2: Div looses dependency on condition that guarantees divisor not zero in counted loop after peeling
- * @run main/othervm -XX:-TieredCompilation -XX:-BackgroundCompilation -XX:-UseLoopPredicate -XX:+StressGCM -XX:StressSeed=31780379 TestPeeledLoopNoBackedgeFloatingDiv
- * @run main/othervm -XX:-TieredCompilation -XX:-BackgroundCompilation -XX:-UseLoopPredicate -XX:+StressGCM TestPeeledLoopNoBackedgeFloatingDiv
+ * @run main/othervm -XX:-TieredCompilation -XX:-BackgroundCompilation -XX:+IgnoreUnrecognizedVMOptions -XX:-UseLoopPredicate
+ *                   -XX:+UnlockDiagnosticVMOptions -XX:+StressGCM -XX:StressSeed=31780379 TestPeeledLoopNoBackedgeFloatingDiv
+ * @run main/othervm -XX:-TieredCompilation -XX:-BackgroundCompilation -XX:+IgnoreUnrecognizedVMOptions -XX:-UseLoopPredicate
+ *                   -XX:+UnlockDiagnosticVMOptions -XX:+StressGCM TestPeeledLoopNoBackedgeFloatingDiv
  * @run main/othervm TestPeeledLoopNoBackedgeFloatingDiv
  */
 

--- a/test/hotspot/jtreg/compiler/controldependency/TestPeeledLoopNoBackedgeFloatingDiv.java
+++ b/test/hotspot/jtreg/compiler/controldependency/TestPeeledLoopNoBackedgeFloatingDiv.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2025, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8350329
+ * @summary C2: Div looses dependency on condition that guarantees divisor not zero in counted loop after peeling
+ * @run main/othervm -XX:-TieredCompilation -XX:-BackgroundCompilation -XX:-UseLoopPredicate -XX:+StressGCM -XX:StressSeed=31780379 TestPeeledLoopNoBackedgeFloatingDiv
+ * @run main/othervm -XX:-TieredCompilation -XX:-BackgroundCompilation -XX:-UseLoopPredicate -XX:+StressGCM TestPeeledLoopNoBackedgeFloatingDiv
+ * @run main/othervm TestPeeledLoopNoBackedgeFloatingDiv
+ */
+
+public class TestPeeledLoopNoBackedgeFloatingDiv {
+    public static void main(String[] args) {
+        for (int i = 0; i < 20_000; i++) {
+            test1(1000, 0, false, false);
+        }
+        test1(1, 0, false, false);
+    }
+
+    private static int test1(int stop, int res, boolean alwaysTrueInPeeled, boolean alwaysFalse) {
+        stop = Integer.max(stop, 1);
+        for (int i = stop; i >= 1; i--) {
+            res = res / i;
+            if (alwaysFalse) {
+
+            }
+            if (alwaysTrueInPeeled) {
+                break;
+            }
+            alwaysTrueInPeeled = true;
+        }
+        return res;
+    }
+
+}


### PR DESCRIPTION
This is an issue similar to 8349139: the type of the iv phi of a
counted loop is narrowed down so a `Div` node doesn't need a control
input. The loop is then peeled. The `Div` in the loop body is
guaranteed to be non zero only if it is actually executed so the `Div`
is implicitly dependent on the zero trip guard. Then the loop looses
its backedge and the `Div` freely floats. The `Div` instruction is
scheduled above the zero trip guard and faults. Had the `Div` been
control dependent on the zero trip guard, it wouldn't have
executed. The fix, similar to 8349139 is to add a `CastII` on peeling
to make the dependency between what's in the loop body and relies on
the narrowed down type of the iv phi and the zero trip guard explicit.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350329](https://bugs.openjdk.org/browse/JDK-8350329): C2: Div looses dependency on condition that guarantees divisor not zero in counted loop after peeling (**Bug** - P3)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**) Review applies to [eb3a13b3](https://git.openjdk.org/jdk/pull/25262/files/eb3a13b3c53d422313dd0f379051a2cfbfcda147)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25262/head:pull/25262` \
`$ git checkout pull/25262`

Update a local copy of the PR: \
`$ git checkout pull/25262` \
`$ git pull https://git.openjdk.org/jdk.git pull/25262/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25262`

View PR using the GUI difftool: \
`$ git pr show -t 25262`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25262.diff">https://git.openjdk.org/jdk/pull/25262.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25262#issuecomment-2886030462)
</details>
