### PR TITLE
8355230: Crash in fuzzer tests: assert(n != nullptr) failed: must not be null

### DIFF
--- a/src/hotspot/share/opto/node.cpp
+++ b/src/hotspot/share/opto/node.cpp
@@ -3120,7 +3120,7 @@ void TypeNode::make_paths_from_here_dead(PhaseIterGVN* igvn, PhaseIdealLoop* loo
         assert(r->is_Region() || r->is_top(), "unexpected Phi's control");
         if (r->is_Region()) {
           for (uint j = 1; j < u->req(); ++j) {
-            if (u->in(j) == n) {
+            if (u->in(j) == n && r->in(j) != nullptr) {
               make_path_dead(igvn, loop, r, j, phase_str);
             }
           }

--- a/test/hotspot/jtreg/compiler/c2/TestNullRegionInputAtPhiMakePathDead.java
+++ b/test/hotspot/jtreg/compiler/c2/TestNullRegionInputAtPhiMakePathDead.java
@@ -60,6 +60,9 @@ public class TestNullRegionInputAtPhiMakePathDead {
             for (i21 = i19; i21 < 90; i21++) {
                 if (b2) {
                 } else {
+                    // CastII of b2 to false added here becomes top during igvn. It's used by a Phi
+                    // at a Region that merges paths from the switch and if. Some of those paths are
+                    // found unreachable at parse time but added to the Region anyway.
                     switch ((((i21 >>> 1) % 4) * 5) + 115) {
                     case 129:
                         break;

--- a/test/hotspot/jtreg/compiler/c2/TestNullRegionInputAtPhiMakePathDead.java
+++ b/test/hotspot/jtreg/compiler/c2/TestNullRegionInputAtPhiMakePathDead.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2025, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8355230
+ * @summary Crash in fuzzer tests: assert(n != nullptr) failed: must not be null
+ * @run main/othervm -XX:CompileCommand=compileonly,TestNullRegionInputAtPhiMakePathDead::* -Xcomp TestNullRegionInputAtPhiMakePathDead
+ */
+
+public class TestNullRegionInputAtPhiMakePathDead {
+
+    public static long instanceCount=-37082278491330812L;
+    public static float fFld=1.509F;
+    public static int iFld=89;
+
+    public static long vMeth_check_sum = 0;
+
+    public static void vMeth1(int i1) {
+        double d=-42.69476;
+        int i3=-119;
+
+        for (d = 5; d < 131; ++d) {
+            i3 = 12;
+            while (--i3 > 0) {
+                TestNullRegionInputAtPhiMakePathDead.fFld *= -31237;
+            }
+        }
+    }
+
+    public static double dMeth(long l) {
+        int i7=-76;
+
+        vMeth1(i7);
+        TestNullRegionInputAtPhiMakePathDead.fFld %= 16334;
+        return 0;
+    }
+
+    public static void vMeth() {
+        TestNullRegionInputAtPhiMakePathDead.instanceCount = (long)dMeth(TestNullRegionInputAtPhiMakePathDead.instanceCount);
+    }
+
+    public void mainTest(String[] strArr1) {
+
+        int i19=-9, i20=13736, i21=0, i24=5;
+        boolean b2=true;
+
+        vMeth();
+        for (i19 = 2; i19 < 281; i19++) {
+            try {
+                TestNullRegionInputAtPhiMakePathDead.iFld = (57 % i20);
+            } catch (ArithmeticException a_e) {}
+            i20 += (((i19 * TestNullRegionInputAtPhiMakePathDead.fFld) + TestNullRegionInputAtPhiMakePathDead.instanceCount) - i19);
+            if (b2) {
+                if (true) {
+                    for (i21 = i19; i21 < 90; i21++) {
+                        if (b2) {
+                        } else if (true) {
+                            switch ((((i21 >>> 1) % 4) * 5) + 115) {
+                            case 129:
+                                if (b2) break;
+                                break;
+                            case 135:
+                                i24 |= i24;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        System.out.println("vMeth_check_sum: " + vMeth_check_sum);
+    }
+    public static void main(String[] strArr) {
+        try {
+            TestNullRegionInputAtPhiMakePathDead _instance = new TestNullRegionInputAtPhiMakePathDead();
+            for (int i = 0; i < 10; i++ ) {
+                _instance.mainTest(strArr);
+            }
+         } catch (Exception ex) {
+         }
+    }
+}

--- a/test/hotspot/jtreg/compiler/c2/TestNullRegionInputAtPhiMakePathDead.java
+++ b/test/hotspot/jtreg/compiler/c2/TestNullRegionInputAtPhiMakePathDead.java
@@ -36,9 +36,13 @@ public class TestNullRegionInputAtPhiMakePathDead {
 
     public static long vMeth_check_sum = 0;
 
-    public static void vMeth1(int i1) {
-        double d=-42.69476;
-        int i3=-119;
+    public void mainTest() {
+
+        int i19, i20=13736, i21, i24=5;
+        boolean b2=true;
+
+        double d;
+        int i3;
 
         for (d = 5; d < 131; ++d) {
             i3 = 12;
@@ -46,44 +50,21 @@ public class TestNullRegionInputAtPhiMakePathDead {
                 TestNullRegionInputAtPhiMakePathDead.fFld *= -31237;
             }
         }
-    }
-
-    public static double dMeth(long l) {
-        int i7=-76;
-
-        vMeth1(i7);
         TestNullRegionInputAtPhiMakePathDead.fFld %= 16334;
-        return 0;
-    }
-
-    public static void vMeth() {
-        TestNullRegionInputAtPhiMakePathDead.instanceCount = (long)dMeth(TestNullRegionInputAtPhiMakePathDead.instanceCount);
-    }
-
-    public void mainTest(String[] strArr1) {
-
-        int i19=-9, i20=13736, i21=0, i24=5;
-        boolean b2=true;
-
-        vMeth();
+        TestNullRegionInputAtPhiMakePathDead.instanceCount = 0;
         for (i19 = 2; i19 < 281; i19++) {
             try {
                 TestNullRegionInputAtPhiMakePathDead.iFld = (57 % i20);
             } catch (ArithmeticException a_e) {}
             i20 += (((i19 * TestNullRegionInputAtPhiMakePathDead.fFld) + TestNullRegionInputAtPhiMakePathDead.instanceCount) - i19);
-            if (b2) {
-                if (true) {
-                    for (i21 = i19; i21 < 90; i21++) {
-                        if (b2) {
-                        } else if (true) {
-                            switch ((((i21 >>> 1) % 4) * 5) + 115) {
-                            case 129:
-                                if (b2) break;
-                                break;
-                            case 135:
-                                i24 |= i24;
-                            }
-                        }
+            for (i21 = i19; i21 < 90; i21++) {
+                if (b2) {
+                } else {
+                    switch ((((i21 >>> 1) % 4) * 5) + 115) {
+                    case 129:
+                        break;
+                    case 135:
+                        i24 |= i24;
                     }
                 }
             }
@@ -95,7 +76,7 @@ public class TestNullRegionInputAtPhiMakePathDead {
         try {
             TestNullRegionInputAtPhiMakePathDead _instance = new TestNullRegionInputAtPhiMakePathDead();
             for (int i = 0; i < 10; i++ ) {
-                _instance.mainTest(strArr);
+                _instance.mainTest();
             }
          } catch (Exception ex) {
          }


### PR DESCRIPTION
During IGVN, `TypeNode::make_paths_from_here_dead()` follows data
nodes until a `Phi`. The `Region` input for the input that that logic
goes through to reach the `Phi` is `null` causing the crash. I propose
simply adding an extra check for that corner case.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8355230](https://bugs.openjdk.org/browse/JDK-8355230): Crash in fuzzer tests: assert(n != nullptr) failed: must not be null (**Bug** - P3)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Emanuel Peter](https://openjdk.org/census#epeter) (@eme64 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25268/head:pull/25268` \
`$ git checkout pull/25268`

Update a local copy of the PR: \
`$ git checkout pull/25268` \
`$ git pull https://git.openjdk.org/jdk.git pull/25268/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25268`

View PR using the GUI difftool: \
`$ git pr show -t 25268`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25268.diff">https://git.openjdk.org/jdk/pull/25268.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25268#issuecomment-2886866063)
</details>
