### PR TITLE
8354078: Implement JEP 521: Generational Shenandoah

### DIFF
--- a/src/hotspot/share/gc/shenandoah/mode/shenandoahGenerationalMode.hpp
+++ b/src/hotspot/share/gc/shenandoah/mode/shenandoahGenerationalMode.hpp
@@ -32,7 +32,7 @@ public:
   virtual void initialize_flags() const;
   virtual const char* name()     { return "Generational"; }
   virtual bool is_diagnostic()   { return false; }
-  virtual bool is_experimental() { return true; }
+  virtual bool is_experimental() { return false; }
   virtual bool is_generational() { return true; }
 };
 

--- a/test/hotspot/jtreg/gc/shenandoah/options/TestModeUnlock.java
+++ b/test/hotspot/jtreg/gc/shenandoah/options/TestModeUnlock.java
@@ -47,7 +47,7 @@ public class TestModeUnlock {
     public static void main(String[] args) throws Exception {
         testWith("-XX:ShenandoahGCMode=satb",         Mode.PRODUCT);
         testWith("-XX:ShenandoahGCMode=passive",      Mode.DIAGNOSTIC);
-        testWith("-XX:ShenandoahGCMode=generational", Mode.EXPERIMENTAL);
+        testWith("-XX:ShenandoahGCMode=generational", Mode.PRODUCT);
     }
 
     private static void testWith(String h, Mode mode) throws Exception {


### PR DESCRIPTION
Testing:
```
% ./build/linux-x86_64-server-fastdebug/jdk/bin/java -XX:+UseShenandoahGC -XX:ShenandoahGCMode=generational --version
openjdk 25 2025-09-16
OpenJDK Runtime Environment (fastdebug build 25-make-genshen-non-experimental)
OpenJDK 64-Bit Server VM (fastdebug build 25-make-genshen-non-experimental, mixed mode)
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Change requires CSR request [JDK-8354079](https://bugs.openjdk.org/browse/JDK-8354079) to be approved
- [x] Commit message must refer to an issue
- [x] Change requires a JEP request to be targeted

### Issues
 * [JDK-8354078](https://bugs.openjdk.org/browse/JDK-8354078): Implement JEP 521: Generational Shenandoah (**Enhancement** - P4)
 * [JDK-8356990](https://bugs.openjdk.org/browse/JDK-8356990): JEP 521: Generational Shenandoah (**JEP**)
 * [JDK-8354079](https://bugs.openjdk.org/browse/JDK-8354079): JEP 521: Shenandoah: Make the generational mode be non-experimental (**CSR**)


### Reviewers
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25270/head:pull/25270` \
`$ git checkout pull/25270`

Update a local copy of the PR: \
`$ git checkout pull/25270` \
`$ git pull https://git.openjdk.org/jdk.git pull/25270/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25270`

View PR using the GUI difftool: \
`$ git pr show -t 25270`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25270.diff">https://git.openjdk.org/jdk/pull/25270.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25270#issuecomment-2887314467)
</details>
