### PR TITLE
8357143: New test AOTCodeCompressedOopsTest.java fails on platforms without AOT Code Cache support

### DIFF
--- a/test/hotspot/jtreg/TEST.ROOT
+++ b/test/hotspot/jtreg/TEST.ROOT
@@ -81,6 +81,7 @@ requires.properties= \
     vm.cds \
     vm.cds.custom.loaders \
     vm.cds.supports.aot.class.linking \
+    vm.cds.supports.aot.code.caching \
     vm.cds.write.archived.java.heap \
     vm.continuations \
     vm.jvmti \

--- a/test/hotspot/jtreg/runtime/cds/appcds/aotCode/AOTCodeCompressedOopsTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotCode/AOTCodeCompressedOopsTest.java
@@ -25,10 +25,8 @@
 /**
  * @test
  * @summary Sanity test of AOT Code Cache with compressed oops configurations
- * @requires vm.cds
- * @requires vm.cds.supports.aot.class.linking
+ * @requires vm.cds.supports.aot.code.caching
  * @requires vm.flagless
- * @requires !vm.jvmci.enabled
  * @library /test/lib /test/setup_aot
  * @build AOTCodeCompressedOopsTest JavacBenchApp
  * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar app.jar

--- a/test/hotspot/jtreg/runtime/cds/appcds/aotCode/AOTCodeFlags.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotCode/AOTCodeFlags.java
@@ -25,13 +25,7 @@
 /**
  * @test
  * @summary Sanity test of combinations of the AOT Code Caching diagnostic flags
- * @requires vm.cds
- * @requires vm.cds.supports.aot.class.linking
- * @requires vm.flavor != "zero"
- * @requires os.arch=="amd64" | os.arch=="x86_64" | os.arch=="aarch64"
- * @requires vm.flagless
- * @comment work around JDK-8345635
- * @requires !vm.jvmci.enabled
+ * @requires vm.cds.supports.aot.code.caching
  * @library /test/lib /test/setup_aot
  * @build AOTCodeFlags JavacBenchApp
  * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar app.jar

--- a/test/hotspot/jtreg/runtime/cds/appcds/aotCode/AOTCodeFlags.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotCode/AOTCodeFlags.java
@@ -26,6 +26,7 @@
  * @test
  * @summary Sanity test of combinations of the AOT Code Caching diagnostic flags
  * @requires vm.cds.supports.aot.code.caching
+ * @requires vm.flagless
  * @library /test/lib /test/setup_aot
  * @build AOTCodeFlags JavacBenchApp
  * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar app.jar

--- a/test/jtreg-ext/requires/VMProps.java
+++ b/test/jtreg-ext/requires/VMProps.java
@@ -124,6 +124,7 @@ public class VMProps implements Callable<Map<String, String>> {
         map.put("vm.cds", this::vmCDS);
         map.put("vm.cds.custom.loaders", this::vmCDSForCustomLoaders);
         map.put("vm.cds.supports.aot.class.linking", this::vmCDSSupportsAOTClassLinking);
+        map.put("vm.cds.supports.aot.code.caching", this::vmCDSSupportsAOTCodeCaching);
         map.put("vm.cds.write.archived.java.heap", this::vmCDSCanWriteArchivedJavaHeap);
         map.put("vm.continuations", this::vmContinuations);
         // vm.graal.enabled is true if Graal is used as JIT
@@ -470,6 +471,20 @@ public class VMProps implements Callable<Map<String, String>> {
     protected String vmCDSSupportsAOTClassLinking() {
       // Currently, the VM supports AOTClassLinking as long as it's able to write archived java heap.
       return vmCDSCanWriteArchivedJavaHeap();
+    }
+
+    /**
+     * @return true if this VM can support the AOT Code Caching
+     */
+    protected String vmCDSSupportsAOTCodeCaching() {
+      if ("true".equals(vmCDSSupportsAOTClassLinking()) &&
+          !"zero".equals(vmFlavor()) &&
+          "false".equals(vmJvmciEnabled()) &&
+          (Platform.isX64() || Platform.isAArch64())) {
+        return "true";
+      } else {
+        return "false";
+      }
     }
 
     /**


### PR DESCRIPTION
New test missed check for AOT code caching  supported platforms.

Instead of adding missed checks I added new jtreg's VM property `vm.cds.supports.aot.code.caching` to simplify checks in new AOT code caching tests.

Tested tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8357143](https://bugs.openjdk.org/browse/JDK-8357143): New test AOTCodeCompressedOopsTest.java fails on platforms without AOT Code Cache support (**Bug** - P4)


### Reviewers
 * [Ashutosh Mehra](https://openjdk.org/census#asmehra) (@ashu-mehra - Committer)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25272/head:pull/25272` \
`$ git checkout pull/25272`

Update a local copy of the PR: \
`$ git checkout pull/25272` \
`$ git pull https://git.openjdk.org/jdk.git pull/25272/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25272`

View PR using the GUI difftool: \
`$ git pr show -t 25272`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25272.diff">https://git.openjdk.org/jdk/pull/25272.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25272#issuecomment-2887481634)
</details>
