### PR TITLE
8357149: Test runtime/cds/appcds/aotCode/AOTCodeFlags.java is broken after JDK-8354887

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/aotCode/AOTCodeFlags.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotCode/AOTCodeFlags.java
@@ -78,6 +78,7 @@ public class AOTCodeFlags {
 
         public List<String> getVMArgsForTestMode() {
             List<String> list = new ArrayList<String>();
+            list.add("-XX:+UnlockDiagnosticVMOptions");
             list.add(isAdapterCachingOn() ? "-XX:+AOTAdapterCaching" : "-XX:-AOTAdapterCaching");
             list.add(isStubCachingOn() ? "-XX:+AOTStubCaching" : "-XX:-AOTStubCaching");
             return list;
@@ -94,8 +95,7 @@ public class AOTCodeFlags {
             case RunMode.ASSEMBLY:
             case RunMode.PRODUCTION: {
                     List<String> args = getVMArgsForTestMode();
-                    args.addAll(List.of("-XX:+UnlockDiagnosticVMOptions",
-                                        "-Xlog:aot+codecache+init=debug",
+                    args.addAll(List.of("-Xlog:aot+codecache+init=debug",
                                         "-Xlog:aot+codecache+exit=debug"));
                     return args.toArray(new String[0]);
                 }


### PR DESCRIPTION
Simple test fix to ensure the `-XX:+UnlockDiagnosticVMOptions` flag is specified before a diagnostic flag such as `-XX:+AOTAdapterCaching`.

Tested with the following JDK builds on linux-x64:
OpenJDK non-debug, OpenJDK debug, Oracle JDK non-debug, Oracle JDK debug.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8357149](https://bugs.openjdk.org/browse/JDK-8357149): Test runtime/cds/appcds/aotCode/AOTCodeFlags.java is broken after JDK-8354887 (**Bug** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25275/head:pull/25275` \
`$ git checkout pull/25275`

Update a local copy of the PR: \
`$ git checkout pull/25275` \
`$ git pull https://git.openjdk.org/jdk.git pull/25275/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25275`

View PR using the GUI difftool: \
`$ git pr show -t 25275`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25275.diff">https://git.openjdk.org/jdk/pull/25275.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25275#issuecomment-2887737462)
</details>
