### PR TITLE
JDK-8357082 : Stabilize and add debug logs to CopyAreaOOB.java

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -489,7 +489,6 @@ java/awt/MenuBar/TestNoScreenMenuBar.java 8265987 macosx-all
 
 java/awt/Graphics2D/DrawString/DrawRotatedStringUsingRotatedFont.java 8266283 generic-all
 java/awt/Graphics2D/DrawString/RotTransText.java 8316878 linux-all
-java/awt/Graphics2D/CopyAreaOOB.java 8343106 macosx-aarch64
 java/awt/KeyboardFocusmanager/TypeAhead/ButtonActionKeyTest/ButtonActionKeyTest.java 8257529 windows-x64
 java/awt/KeyboardFocusmanager/ConsumeNextMnemonicKeyTypedTest/ConsumeForModalDialogTest/ConsumeForModalDialogTest.java 8302787 windows-all
 java/awt/KeyboardFocusmanager/TypeAhead/MenuItemActivatedTest/MenuItemActivatedTest.java 8302787 windows-all

--- a/test/jdk/java/awt/Graphics2D/CopyAreaOOB.java
+++ b/test/jdk/java/awt/Graphics2D/CopyAreaOOB.java
@@ -26,17 +26,73 @@
  * @key headful
  * @bug 6430601 8198613
  * @summary Verifies that copyArea() works properly when the
- * destination parameters are outside the destination bounds.
+ *          destination parameters are outside the destination bounds.
  * @run main/othervm CopyAreaOOB
- * @author campbelc
  */
 
-import java.awt.*;
-import java.awt.image.*;
+import java.awt.Canvas;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.GraphicsConfiguration;
+import java.awt.GraphicsEnvironment;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.Robot;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.IOException;
+
+import javax.imageio.ImageIO;
 
 public class CopyAreaOOB extends Canvas {
+    private static Frame frame;
+    private static Robot robot;
+    private static BufferedImage captureImg;
+    private static StringBuffer errorLog = new StringBuffer();
 
-    private static Robot robot = null;
+    public static void main(String[] args) throws Exception {
+        try {
+            robot = new Robot();
+            EventQueue.invokeAndWait(CopyAreaOOB::createTestUI);
+            robot.waitForIdle();
+            robot.delay(1000);
+
+            EventQueue.invokeAndWait(() -> {
+                Point pt1 = frame.getLocationOnScreen();
+                Rectangle rect = new Rectangle(pt1.x, pt1.y, 400, 400);
+                captureImg = robot.createScreenCapture(rect);
+            });
+
+            // Test pixels
+            testRegion("green", 0, 0, 400, 10, 0xff00ff00);
+            testRegion("original-red", 0, 10, 50, 400, 0xffff0000);
+            testRegion("background", 50, 10, 60, 400, 0xff000000);
+            testRegion("in-between", 60, 10, 110, 20, 0xff000000);
+            testRegion("copied-red", 60, 20, 110, 400, 0xffff0000);
+            testRegion("background", 110, 10, 400, 400, 0xff000000);
+
+            if (!errorLog.isEmpty()) {
+                saveImages();
+                throw new RuntimeException("Test failed: \n" + errorLog.toString());
+            }
+        } finally {
+            EventQueue.invokeAndWait(frame::dispose);
+        }
+    }
+
+    private static void createTestUI() {
+        frame = new Frame();
+        CopyAreaOOB test = new CopyAreaOOB();
+        frame.add(test);
+        frame.setUndecorated(true);
+        frame.pack();
+        frame.setLocationRelativeTo(null);
+        frame.setVisible(true);
+    }
 
     public void paint(Graphics g) {
         int w = getWidth();
@@ -50,73 +106,50 @@ public class CopyAreaOOB extends Canvas {
         g2d.fillRect(0, 0, w, 10);
 
         g2d.setColor(Color.red);
-        g2d.fillRect(0, 10, 50, h-10);
+        g2d.fillRect(0, 10, 50, h - 10);
 
         // copy the region such that part of it goes below the bottom of the
         // destination surface
-        g2d.copyArea(0, 10, 50, h-10, 60, 10);
-
-        Toolkit.getDefaultToolkit().sync();
-
-        BufferedImage capture = null;
-        try {
-            Thread.sleep(500);
-            if (robot == null) robot = new Robot();
-            Point pt1 = getLocationOnScreen();
-            Rectangle rect = new Rectangle(pt1.x, pt1.y, 400, 400);
-            capture = robot.createScreenCapture(rect);
-        } catch (Exception e) {
-            throw new RuntimeException("Problems handling Robot");
-        }
-        // Test pixels
-        testRegion(capture, "green",          0,   0, 400,  10, 0xff00ff00);
-        testRegion(capture, "original red",   0,  10,  50, 400, 0xffff0000);
-        testRegion(capture, "background",    50,  10,  60, 400, 0xff000000);
-        testRegion(capture, "in-between",    60,  10, 110,  20, 0xff000000);
-        testRegion(capture, "copied red",    60,  20, 110, 400, 0xffff0000);
-        testRegion(capture, "background",   110,  10, 400, 400, 0xff000000);
+        g2d.copyArea(0, 10, 50, h - 10, 60, 10);
+        g2d.dispose();
     }
 
     public Dimension getPreferredSize() {
         return new Dimension(400, 400);
     }
 
-    private static void testRegion(BufferedImage bi, String name,
+    private static void testRegion(String region,
                                    int x1, int y1, int x2, int y2,
-                                   int expected)
-    {
+                                   int expected) {
+        System.out.print("Testing region: " + region);
         for (int y = y1; y < y2; y++) {
             for (int x = x1; x < x2; x++) {
-                int actual = bi.getRGB(x, y);
+                int actual = captureImg.getRGB(x, y);
                 if (actual != expected) {
-                    throw new RuntimeException("Test failed for " + name +
-                                                       " region at x="+x+" y="+y+
-                                                       " (expected="+
-                                                       Integer.toHexString(expected) +
-                                                       " actual="+
-                                                       Integer.toHexString(actual) +
-                                                       ")");
+                    System.out.print(" Status: FAILED\n");
+                    errorLog.append("Test failed for " + region
+                                               + " region at x: " + x + " y: " + y
+                                               + " (expected: "
+                                               + Integer.toHexString(expected)
+                                               + " actual: "
+                                               + Integer.toHexString(actual) + ")\n");
+                    return;
                 }
             }
         }
+        System.out.print(" Status: PASSED\n");
     }
 
-    public static void main(String[] args) {
-        boolean show = (args.length == 1) && ("-show".equals(args[0]));
-
-        CopyAreaOOB test = new CopyAreaOOB();
-        Frame frame = new Frame();
-        frame.setUndecorated(true);
-        frame.add(test);
-        frame.pack();
-        frame.setLocationRelativeTo(null);
-        frame.setVisible(true);
-
+    private static void saveImages() {
+        GraphicsConfiguration ge = GraphicsEnvironment
+                .getLocalGraphicsEnvironment().getDefaultScreenDevice()
+                .getDefaultConfiguration();
+        BufferedImage screenCapture = robot.createScreenCapture(ge.getBounds());
         try {
-            Thread.sleep(3000);
-        } catch (InterruptedException ex) {}
-        if (!show) {
-            frame.dispose();
+            ImageIO.write(screenCapture, "png", new File("fullscreen.png"));
+            ImageIO.write(captureImg, "png", new File("frame.png"));
+        } catch (IOException e) {
+            System.err.println("Can't write image " + e);
         }
     }
 }

--- a/test/jdk/java/awt/Graphics2D/CopyAreaOOB.java
+++ b/test/jdk/java/awt/Graphics2D/CopyAreaOOB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/awt/Graphics2D/CopyAreaOOB.java
+++ b/test/jdk/java/awt/Graphics2D/CopyAreaOOB.java
@@ -33,7 +33,6 @@
 import java.awt.Canvas;
 import java.awt.Color;
 import java.awt.Dimension;
-import java.awt.EventQueue;
 import java.awt.Frame;
 import java.awt.Graphics;
 import java.awt.Graphics2D;

--- a/test/jdk/java/awt/Graphics2D/CopyAreaOOB.java
+++ b/test/jdk/java/awt/Graphics2D/CopyAreaOOB.java
@@ -71,17 +71,17 @@ public class CopyAreaOOB extends Canvas {
             robot.waitForIdle();
             robot.delay(1000);
 
-            EventQueue.invokeAndWait(() -> {
-                Point pt1 = canvas.getLocationOnScreen();
-                Rectangle rect = new Rectangle(pt1.x, pt1.y, SIZE, SIZE);
-                captureImg = robot.createScreenCapture(rect);
-            });
-
             // added to move mouse pointer away from test UI
             // so that it is not captured in the screenshot
             robot.mouseMove(OFF_FRAME_LOC.x, OFF_FRAME_LOC.y);
             robot.waitForIdle();
             robot.delay(100);
+
+            EventQueue.invokeAndWait(() -> {
+                Point pt1 = canvas.getLocationOnScreen();
+                Rectangle rect = new Rectangle(pt1.x, pt1.y, SIZE, SIZE);
+                captureImg = robot.createScreenCapture(rect);
+            });
 
             // Test pixels
             testRegion("green", 0, 0, 400, 10, 0xff00ff00);

--- a/test/jdk/java/awt/Graphics2D/CopyAreaOOB.java
+++ b/test/jdk/java/awt/Graphics2D/CopyAreaOOB.java
@@ -81,7 +81,9 @@ public class CopyAreaOOB extends Canvas {
                 throw new RuntimeException("Test failed: \n" + errorLog.toString());
             }
         } finally {
-            EventQueue.invokeAndWait(frame::dispose);
+            if (frame != null) {
+                frame.dispose();
+            }
         }
     }
 

--- a/test/jdk/java/awt/Graphics2D/CopyAreaOOB.java
+++ b/test/jdk/java/awt/Graphics2D/CopyAreaOOB.java
@@ -76,14 +76,6 @@ public class CopyAreaOOB extends Canvas {
             createTestUI();
             robot.delay(1000);
 
-            // Test pixels
-            testRegion("green", 0, 0, 400, 10, 0xff00ff00);
-            testRegion("original-red", 0, 10, 50, 400, 0xffff0000);
-            testRegion("background", 50, 10, 60, 400, 0xff000000);
-            testRegion("in-between", 60, 10, 110, 20, 0xff000000);
-            testRegion("copied-red", 60, 20, 110, 400, 0xffff0000);
-            testRegion("background", 110, 10, 400, 400, 0xff000000);
-
             if (!errorLog.isEmpty()) {
                 saveImages();
                 throw new RuntimeException("Test failed: \n" + errorLog.toString());
@@ -128,6 +120,14 @@ public class CopyAreaOOB extends Canvas {
         Point pt1 = this.getLocationOnScreen();
         Rectangle rect = new Rectangle(pt1.x, pt1.y, SIZE, SIZE);
         captureImg = robot.createScreenCapture(rect);
+
+        // Test pixels
+        testRegion("green", 0, 0, 400, 10, 0xff00ff00);
+        testRegion("original-red", 0, 10, 50, 400, 0xffff0000);
+        testRegion("background", 50, 10, 60, 400, 0xff000000);
+        testRegion("in-between", 60, 10, 110, 20, 0xff000000);
+        testRegion("copied-red", 60, 20, 110, 400, 0xffff0000);
+        testRegion("background", 110, 10, 400, 400, 0xff000000);
     }
 
     public Dimension getPreferredSize() {

--- a/test/jdk/java/awt/Graphics2D/CopyAreaOOB.java
+++ b/test/jdk/java/awt/Graphics2D/CopyAreaOOB.java
@@ -43,6 +43,7 @@ import java.awt.Image;
 import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.Robot;
+import java.awt.Toolkit;
 import java.awt.image.BufferedImage;
 import java.awt.image.MultiResolutionImage;
 import java.awt.image.RenderedImage;
@@ -56,7 +57,6 @@ public class CopyAreaOOB extends Canvas {
     private static Frame frame;
     private static Robot robot;
     private static BufferedImage captureImg;
-    private static Canvas canvas;
 
     private static StringBuffer errorLog = new StringBuffer();
 
@@ -67,21 +67,14 @@ public class CopyAreaOOB extends Canvas {
         try {
             robot = new Robot();
 
-            createTestUI();
-            robot.waitForIdle();
-            robot.delay(1000);
-
             // added to move mouse pointer away from test UI
             // so that it is not captured in the screenshot
             robot.mouseMove(OFF_FRAME_LOC.x, OFF_FRAME_LOC.y);
             robot.waitForIdle();
             robot.delay(100);
 
-            EventQueue.invokeAndWait(() -> {
-                Point pt1 = canvas.getLocationOnScreen();
-                Rectangle rect = new Rectangle(pt1.x, pt1.y, SIZE, SIZE);
-                captureImg = robot.createScreenCapture(rect);
-            });
+            createTestUI();
+            robot.delay(1000);
 
             // Test pixels
             testRegion("green", 0, 0, 400, 10, 0xff00ff00);
@@ -101,10 +94,10 @@ public class CopyAreaOOB extends Canvas {
     }
 
     private static void createTestUI() {
+        CopyAreaOOB canvas = new CopyAreaOOB();
         frame = new Frame();
-        canvas = new CopyAreaOOB();
-        frame.add(canvas);
         frame.setUndecorated(true);
+        frame.add(canvas);
         frame.pack();
         frame.setLocationRelativeTo(null);
         frame.setVisible(true);
@@ -127,10 +120,18 @@ public class CopyAreaOOB extends Canvas {
         // copy the region such that part of it goes below the bottom of the
         // destination surface
         g2d.copyArea(0, 10, 50, h - 10, 60, 10);
+
+        Toolkit.getDefaultToolkit().sync();
+
+        robot.delay(500);
+
+        Point pt1 = this.getLocationOnScreen();
+        Rectangle rect = new Rectangle(pt1.x, pt1.y, SIZE, SIZE);
+        captureImg = robot.createScreenCapture(rect);
     }
 
     public Dimension getPreferredSize() {
-        return new Dimension(400, 400);
+        return new Dimension(SIZE, SIZE);
     }
 
     private static void testRegion(String region,
@@ -143,11 +144,11 @@ public class CopyAreaOOB extends Canvas {
                 if (actual != expected) {
                     System.out.print(" Status: FAILED\n");
                     errorLog.append("Test failed for " + region
-                                               + " region at x: " + x + " y: " + y
-                                               + " (expected: "
-                                               + Integer.toHexString(expected)
-                                               + " actual: "
-                                               + Integer.toHexString(actual) + ")\n");
+                                                + " region at x: " + x + " y: " + y
+                                                + " (expected: "
+                                                + Integer.toHexString(expected)
+                                                + " actual: "
+                                                + Integer.toHexString(actual) + ")\n");
                     return;
                 }
             }


### PR DESCRIPTION
CopyAreaOOB.java was failing intermittently on some platforms on CI but recently it started to fail more frequently on macos-aarch64 when the entire test suite runs.

Test failure is not reproducible when the test is run individually (multiple times) on CI.

Rewritten the test and added debug logs that will be helpful to figure out the issue. 

- Added code to capture screenshot (entire screen as well as the frame) in case of failure.
- Since it tests multiple regions added a StringBuffer to consolidate the error logs before throwing RuntimeException.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8357082](https://bugs.openjdk.org/browse/JDK-8357082): Stabilize and add debug logs to CopyAreaOOB.java (**Sub-task** - P4)


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25279/head:pull/25279` \
`$ git checkout pull/25279`

Update a local copy of the PR: \
`$ git checkout pull/25279` \
`$ git pull https://git.openjdk.org/jdk.git pull/25279/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25279`

View PR using the GUI difftool: \
`$ git pr show -t 25279`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25279.diff">https://git.openjdk.org/jdk/pull/25279.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25279#issuecomment-2887870537)
</details>
