### PR TITLE
8357178: Simplify Class::componentType

### DIFF
--- a/src/java.base/share/classes/java/lang/Class.java
+++ b/src/java.base/share/classes/java/lang/Class.java
@@ -3982,7 +3982,7 @@ public final class Class<T> implements java.io.Serializable,
      */
     @Override
     public Class<?> componentType() {
-        return componentType;
+        return getComponentType();
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/Class.java
+++ b/src/java.base/share/classes/java/lang/Class.java
@@ -3982,7 +3982,7 @@ public final class Class<T> implements java.io.Serializable,
      */
     @Override
     public Class<?> componentType() {
-        return isArray() ? componentType : null;
+        return componentType;
     }
 
     /**


### PR DESCRIPTION
`isArray` and null return is now redundant when `componentType` is changed to an explicit field.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8357178](https://bugs.openjdk.org/browse/JDK-8357178): Simplify Class::componentType (**Enhancement** - P5)


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25280/head:pull/25280` \
`$ git checkout pull/25280`

Update a local copy of the PR: \
`$ git checkout pull/25280` \
`$ git pull https://git.openjdk.org/jdk.git pull/25280/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25280`

View PR using the GUI difftool: \
`$ git pr show -t 25280`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25280.diff">https://git.openjdk.org/jdk/pull/25280.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25280#issuecomment-2887980337)
</details>
