### PR TITLE
8357179: Deprecate VFORK launch mechanism from Process implementation (linux)

### DIFF
--- a/src/java.base/unix/classes/java/lang/ProcessImpl.java
+++ b/src/java.base/unix/classes/java/lang/ProcessImpl.java
@@ -100,16 +100,24 @@ final class ProcessImpl extends Process {
             // Should be value of a LaunchMechanism enum
             LaunchMechanism lm = LaunchMechanism.valueOf(s.toUpperCase(Locale.ROOT));
             switch (OperatingSystem.current()) {
-                case LINUX:
-                    return lm;      // All options are valid for Linux
+                case LINUX: {
+                    // All options are valid for Linux, but VFORK is deprecated and results
+                    // in a warning
+                    if (lm == LaunchMechanism.VFORK) {
+                        System.err.println("VFORK MODE DEPRECATED");
+                        System.err.println("The VFORK launch mechanism has been deprecated for being dangerous.\n" +
+                                           "It will be removed in a future java version. Either remove the\n" +
+                                           "jdk.lang.Process.launchMechanism property (preferred) or use FORK mode\n" +
+                                           "instead (-Djdk.lang.Process.launchMechanism=FORK).");
+                    }
+                    return lm;
+                }
                 case AIX:
                 case MACOS:
                     if (lm != LaunchMechanism.VFORK) {
                         return lm; // All but VFORK are valid
                     }
                     break;
-                case WINDOWS:
-                    // fall through to throw to Error
             }
         } catch (IllegalArgumentException e) {
         }

--- a/src/java.base/unix/classes/java/lang/ProcessImpl.java
+++ b/src/java.base/unix/classes/java/lang/ProcessImpl.java
@@ -105,10 +105,12 @@ final class ProcessImpl extends Process {
                     // in a warning
                     if (lm == LaunchMechanism.VFORK) {
                         System.err.println("VFORK MODE DEPRECATED");
-                        System.err.println("The VFORK launch mechanism has been deprecated for being dangerous.\n" +
-                                           "It will be removed in a future java version. Either remove the\n" +
-                                           "jdk.lang.Process.launchMechanism property (preferred) or use FORK mode\n" +
-                                           "instead (-Djdk.lang.Process.launchMechanism=FORK).");
+                        System.err.println("""
+                                          The VFORK launch mechanism has been deprecated for being dangerous.
+                                          It will be removed in a future java version. Either remove the
+                                          jdk.lang.Process.launchMechanism property (preferred) or use FORK mode
+                                          instead (-Djdk.lang.Process.launchMechanism=FORK).
+                                          """);
                     }
                     return lm;
                 }


### PR DESCRIPTION
For the ratio behind this please see the companion CSR: https://bugs.openjdk.org/browse/JDK-8357180.

We plan to deprecate this in JDK 25 and to remove it in JDK 26.

This patch just writes a deprecation message to stderr:

```
08:46:38 thomas@starfish java -Djdk.lang.Process.launchMechanism=VFORK SimpleSpawn ls
VFORK MODE DEPRECATED
The VFORK launch mechanism has been deprecated for being dangerous.
It will be removed in a future java version. Either remove the
jdk.lang.Process.launchMechanism property (preferred) or use FORK mode
instead (-Djdk.lang.Process.launchMechanism=FORK).
...
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8357180](https://bugs.openjdk.org/browse/JDK-8357180) to be approved

### Issues
 * [JDK-8357179](https://bugs.openjdk.org/browse/JDK-8357179): Deprecate VFORK launch mechanism from Process implementation (linux) (**Enhancement** - P3)
 * [JDK-8357180](https://bugs.openjdk.org/browse/JDK-8357180): Deprecate VFORK launch mechanism from Process implementation (linux) (**CSR**)


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25282/head:pull/25282` \
`$ git checkout pull/25282`

Update a local copy of the PR: \
`$ git checkout pull/25282` \
`$ git pull https://git.openjdk.org/jdk.git pull/25282/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25282`

View PR using the GUI difftool: \
`$ git pr show -t 25282`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25282.diff">https://git.openjdk.org/jdk/pull/25282.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25282#issuecomment-2888153118)
</details>
