### PR TITLE
8357688: Remove unnecessary List.get before remove in PopupFactory

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/PopupFactory.java
+++ b/src/java.desktop/share/classes/javax/swing/PopupFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -433,10 +433,8 @@ public class PopupFactory {
                 } else {
                     return null;
                 }
-                if (cache.size() > 0) {
-                    HeavyWeightPopup r = cache.get(0);
-                    cache.remove(0);
-                    return r;
+                if (!cache.isEmpty()) {
+                    return cache.removeFirst();
                 }
                 return null;
             }
@@ -776,10 +774,8 @@ public class PopupFactory {
         private static LightWeightPopup getRecycledLightWeightPopup() {
             synchronized (LightWeightPopup.class) {
                 List<LightWeightPopup> lightPopupCache = getLightWeightPopupCache();
-                if (lightPopupCache.size() > 0) {
-                    LightWeightPopup r = lightPopupCache.get(0);
-                    lightPopupCache.remove(0);
-                    return r;
+                if (!lightPopupCache.isEmpty()) {
+                    return lightPopupCache.removeFirst();
                 }
                 return null;
             }
@@ -934,10 +930,8 @@ public class PopupFactory {
         private static MediumWeightPopup getRecycledMediumWeightPopup() {
             synchronized (MediumWeightPopup.class) {
                 List<MediumWeightPopup> mediumPopupCache = getMediumWeightPopupCache();
-                if (mediumPopupCache.size() > 0) {
-                    MediumWeightPopup r = mediumPopupCache.get(0);
-                    mediumPopupCache.remove(0);
-                    return r;
+                if (!mediumPopupCache.isEmpty()) {
+                    return mediumPopupCache.removeFirst();
                 }
                 return null;
             }


### PR DESCRIPTION
Instead of separate List.get+List.remove calls we can use single `removeFirst`. It's clearer.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8357688](https://bugs.openjdk.org/browse/JDK-8357688): Remove unnecessary List.get before remove in PopupFactory (**Enhancement** - P5)


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)
 * [Alexander Zuev](https://openjdk.org/census#kizune) (@azuev-java - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25283/head:pull/25283` \
`$ git checkout pull/25283`

Update a local copy of the PR: \
`$ git checkout pull/25283` \
`$ git pull https://git.openjdk.org/jdk.git pull/25283/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25283`

View PR using the GUI difftool: \
`$ git pr show -t 25283`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25283.diff">https://git.openjdk.org/jdk/pull/25283.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25283#issuecomment-2906922633)
</details>
