### PR TITLE
8356633: Incorrect use of {@link} in jdk.jshell

### DIFF
--- a/src/jdk.jshell/share/classes/jdk/jshell/Snippet.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/Snippet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.jshell/share/classes/jdk/jshell/Snippet.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/Snippet.java
@@ -524,7 +524,7 @@ public abstract class Snippet {
 
         /**
          * The snippet is inactive because it does not yet exist.
-         * Used only in {@link SnippetEvent#previousStatus} for new
+         * Used only in {@link SnippetEvent#previousStatus()} for new
          * snippets.
          * {@link jdk.jshell.JShell#status(jdk.jshell.Snippet) JShell.status(Snippet)}
          * will never return this {@code Status}.

--- a/src/jdk.jshell/share/classes/jdk/jshell/SourceCodeAnalysis.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/SourceCodeAnalysis.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.jshell/share/classes/jdk/jshell/SourceCodeAnalysis.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/SourceCodeAnalysis.java
@@ -150,7 +150,7 @@ public abstract class SourceCodeAnalysis {
      * They will not appear in queries for snippets --
      * for example, {@link JShell#snippets() }.
      * <p>
-     * Restrictions on the input are as in {@link JShell#eval}.
+     * Restrictions on the input are as in {@link JShell#eval(String)}.
      * <p>
      * Only preliminary compilation is performed, sufficient to build the
      * {@code Snippet}.  Snippets known to be erroneous, are returned as


### PR DESCRIPTION
Please review this patch to fix some javadoc bugs.

TIA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8356633](https://bugs.openjdk.org/browse/JDK-8356633): Incorrect use of {@<!---->link} in jdk.jshell (**Sub-task** - P4)


### Reviewers
 * [Raffaello Giulietti](https://openjdk.org/census#rgiulietti) (@rgiulietti - **Reviewer**)
 * [Volkan Yazici](https://openjdk.org/census#vyazici) (@vy - Author)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25285/head:pull/25285` \
`$ git checkout pull/25285`

Update a local copy of the PR: \
`$ git checkout pull/25285` \
`$ git pull https://git.openjdk.org/jdk.git pull/25285/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25285`

View PR using the GUI difftool: \
`$ git pr show -t 25285`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25285.diff">https://git.openjdk.org/jdk/pull/25285.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25285#issuecomment-2890677023)
</details>
