### PR TITLE
8356629: Incorrect use of {@linkplain} in java.sql

### DIFF
--- a/src/java.sql/share/classes/java/sql/DriverManager.java
+++ b/src/java.sql/share/classes/java/sql/DriverManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -59,7 +59,7 @@ import jdk.internal.reflect.Reflection;
  * </ul>
  *
  * <li>Service providers of the {@code java.sql.Driver} class, that are loaded
- * via the {@linkplain ServiceLoader#load service-provider loading} mechanism.
+ * via the {@linkplain ServiceLoader#load(Class) service-provider loading} mechanism.
  *</ul>
  *
  * @implNote


### PR DESCRIPTION
Please review this trivial patch to fix a javadoc bug.

TIA