### PR TITLE
8356632: Fix remaining {@link/@linkplain} tags with refer to private/protected types in java.base

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -2821,10 +2821,10 @@ assertEquals("[x, y, z]", pb.command().toString());
          * if and only if one of the following is true:
          * <ul>
          * <li>{@code targetClass} is in {@code M0} and {@code M1}
-         *     {@linkplain Module#reads reads} {@code M0} and the type is
+         *     {@linkplain Module#canRead(Module)}  reads} {@code M0} and the type is
          *     in a package that is exported to at least {@code M1}.
          * <li>{@code targetClass} is in {@code M1} and {@code M0}
-         *     {@linkplain Module#reads reads} {@code M1} and the type is
+         *     {@linkplain Module#canRead(Module)}  reads} {@code M1} and the type is
          *     in a package that is exported to at least {@code M0}.
          * <li>{@code targetClass} is in a third module {@code M2} and both {@code M0}
          *     and {@code M1} reads {@code M2} and the type is in a package
@@ -4890,7 +4890,7 @@ assert((int)twice.invokeExact(21) == 42);
      * @param type the type of the desired method handle
      * @return a constant method handle of the given type, which returns a default value of the given return type
      * @throws NullPointerException if the argument is null
-     * @see MethodHandles#primitiveZero
+     * @see <code>primitiveZero(Wrapper)</code>
      * @see MethodHandles#constant
      * @since 9
      */

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -4890,7 +4890,7 @@ assert((int)twice.invokeExact(21) == 42);
      * @param type the type of the desired method handle
      * @return a constant method handle of the given type, which returns a default value of the given return type
      * @throws NullPointerException if the argument is null
-     * @see <code>primitiveZero(Wrapper)</code>
+     * @see MethodHandles#zero(Class)
      * @see MethodHandles#constant
      * @since 9
      */

--- a/src/java.base/share/classes/java/lang/invoke/MethodType.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodType.java
@@ -1332,13 +1332,13 @@ s.writeObject(this.parameterArray());
      * deserialize it).
      * This instance is a scratch object with bogus final fields.
      * It provides the parameters to the factory method called by
-     * {@code readResolve}.
+     * {@link #readResolve readResolve}.
      * After that call it is discarded.
      * @param s the stream to read the object from
      * @throws java.io.IOException if there is a problem reading the object
      * @throws ClassNotFoundException if one of the component classes cannot be resolved
-     * @see <code>MethodType.readResolve()</code>
-     * @see <code>MethodType.writeObject(ObjectOutputStream s)</code>
+     * @see #readResolve
+     * @see #writeObject
      */
     @java.io.Serial
     private void readObject(java.io.ObjectInputStream s) throws java.io.IOException, ClassNotFoundException {

--- a/src/java.base/share/classes/java/lang/invoke/MethodType.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodType.java
@@ -1332,13 +1332,13 @@ s.writeObject(this.parameterArray());
      * deserialize it).
      * This instance is a scratch object with bogus final fields.
      * It provides the parameters to the factory method called by
-     * {@link #readResolve readResolve}.
+     * {@code readResolve}.
      * After that call it is discarded.
      * @param s the stream to read the object from
      * @throws java.io.IOException if there is a problem reading the object
      * @throws ClassNotFoundException if one of the component classes cannot be resolved
-     * @see #readResolve
-     * @see #writeObject
+     * @see <code>MethodType.readResolve()</code>
+     * @see <code>MethodType.writeObject(ObjectOutputStream s)</code>
      */
     @java.io.Serial
     private void readObject(java.io.ObjectInputStream s) throws java.io.IOException, ClassNotFoundException {

--- a/src/java.base/share/classes/java/lang/module/ModuleDescriptor.java
+++ b/src/java.base/share/classes/java/lang/module/ModuleDescriptor.java
@@ -2020,7 +2020,7 @@ public final class ModuleDescriptor
 
         /**
          * Provides a service with one or more implementations. The package for
-         * each {@link Provides#providers provider} (or provider factory) is
+         * each {@link Provides#providers() provider} (or provider factory) is
          * added to the module if not already added.
          *
          * @param  p

--- a/src/java.base/share/classes/java/net/Socket.java
+++ b/src/java.base/share/classes/java/net/Socket.java
@@ -679,7 +679,7 @@ public class Socket implements java.io.Closeable {
      *          SocketAddress subclass not supported by this socket
      *
      * @since   1.4
-     * @see #isBound
+     * @see #isBound()
      */
     public void bind(SocketAddress bindpoint) throws IOException {
         int s = state;
@@ -1612,7 +1612,7 @@ public class Socket implements java.io.Closeable {
      * as well.
      *
      * @throws     IOException  if an I/O error occurs when closing this socket.
-     * @see #isClosed
+     * @see #isClosed()
      */
     public void close() throws IOException {
         synchronized (socketLock) {
@@ -1642,7 +1642,7 @@ public class Socket implements java.io.Closeable {
      * @see java.net.Socket#shutdownOutput()
      * @see java.net.Socket#close()
      * @see java.net.Socket#setSoLinger(boolean, int)
-     * @see #isInputShutdown
+     * @see #isInputShutdown()
      */
     public void shutdownInput() throws IOException {
         int s = state;
@@ -1672,7 +1672,7 @@ public class Socket implements java.io.Closeable {
      * @see java.net.Socket#shutdownInput()
      * @see java.net.Socket#close()
      * @see java.net.Socket#setSoLinger(boolean, int)
-     * @see #isOutputShutdown
+     * @see #isOutputShutdown()
      */
     public void shutdownOutput() throws IOException {
         int s = state;

--- a/src/java.base/share/classes/java/util/concurrent/ForkJoinTask.java
+++ b/src/java.base/share/classes/java/util/concurrent/ForkJoinTask.java
@@ -131,11 +131,11 @@ import jdk.internal.misc.Unsafe;
  * (including the case where a task was cancelled without executing);
  * {@link #isCompletedNormally} is true if a task completed without
  * cancellation or encountering an exception; {@link #isCancelled} is
- * true if the task was cancelled (in which case {@link #getException}
+ * true if the task was cancelled (in which case {@link #getException()}
  * returns a {@link CancellationException}); and
  * {@link #isCompletedAbnormally} is true if a task was either
  * cancelled or encountered an exception, in which case {@link
- * #getException} will return either the encountered exception or
+ * #getException()} will return either the encountered exception or
  * {@link CancellationException}.
  *
  * <p>The ForkJoinTask class is not usually directly subclassed.

--- a/src/java.base/share/classes/javax/crypto/KEM.java
+++ b/src/java.base/share/classes/javax/crypto/KEM.java
@@ -708,7 +708,7 @@ public final class KEM {
      * If any extra information inside this object needs to be transmitted along
      * with the key encapsulation message so that the receiver is able to create
      * a matching decapsulator, it will be included as a byte array in the
-     * {@link Encapsulated#params} field inside the encapsulation output.
+     * {@link Encapsulated#params()} field inside the encapsulation output.
      * In this case, the security provider should provide an
      * {@code AlgorithmParameters} implementation using the same algorithm name
      * as the KEM. The receiver can initiate such an {@code AlgorithmParameters}

--- a/src/java.base/share/classes/javax/crypto/KEM.java
+++ b/src/java.base/share/classes/javax/crypto/KEM.java
@@ -707,8 +707,8 @@ public final class KEM {
      * the same key can be used to derive shared secrets in different ways.
      * If any extra information inside this object needs to be transmitted along
      * with the key encapsulation message so that the receiver is able to create
-     * a matching decapsulator, it will be included as a byte array in the
-     * {@link Encapsulated#params()} field inside the encapsulation output.
+     * a matching decapsulator, it will be included as a byte array returned by the
+     * {@link Encapsulated#params()} method within the encapsulation output.
      * In this case, the security provider should provide an
      * {@code AlgorithmParameters} implementation using the same algorithm name
      * as the KEM. The receiver can initiate such an {@code AlgorithmParameters}


### PR DESCRIPTION
Please review this patch to fix some `javadoc` bugs in `java.base`.
Certain `@link` tags used to refer to private fields instead of public APIs.

A couple of `@see` tags in the [serialization page](https://download.java.net/java/early_access/jdk25/docs/api/serialized-form.html#java.lang.invoke.MethodType) referred to private methods, I updated the javadoc in a way to not change the way it is displayed to users but also remove `@link` tags to non-included types.

TIA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8356632](https://bugs.openjdk.org/browse/JDK-8356632): Fix remaining {@<!---->link/@<!---->linkplain} tags with refer to private/protected types in java.base (**Sub-task** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**) Review applies to [0653af94](https://git.openjdk.org/jdk/pull/25287/files/0653af94b02339830c0b226ae61d55dc3c470eac)
 * [Weijun Wang](https://openjdk.org/census#weijun) (@wangweij - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25287/head:pull/25287` \
`$ git checkout pull/25287`

Update a local copy of the PR: \
`$ git checkout pull/25287` \
`$ git pull https://git.openjdk.org/jdk.git pull/25287/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25287`

View PR using the GUI difftool: \
`$ git pr show -t 25287`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25287.diff">https://git.openjdk.org/jdk/pull/25287.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25287#issuecomment-2891565206)
</details>
