### PR TITLE
8357187: JFR: User-defined defaults should be respected when an incorrect setting is set

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/EventControl.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/EventControl.java
@@ -301,7 +301,7 @@ public final class EventControl {
     private static Control defineThreshold(PlatformEventType type) {
         String def = type.getAnnotationValue(Threshold.class, ThresholdSetting.DEFAULT_VALUE);
         type.add(PrivateAccess.getInstance().newSettingDescriptor(TYPE_THRESHOLD, Threshold.NAME, def, Collections.emptyList()));
-        return new Control(new ThresholdSetting(type), def);
+        return new Control(new ThresholdSetting(type, def), def);
     }
 
     private static Control defineStackTrace(PlatformEventType type) {
@@ -313,13 +313,13 @@ public final class EventControl {
     private static Control defineCutoff(PlatformEventType type) {
         String def = type.getAnnotationValue(Cutoff.class, CutoffSetting.DEFAULT_VALUE);
         type.add(PrivateAccess.getInstance().newSettingDescriptor(TYPE_CUTOFF, Cutoff.NAME, def, Collections.emptyList()));
-        return new Control(new CutoffSetting(type), def);
+        return new Control(new CutoffSetting(type, def), def);
     }
 
     private static Control defineThrottle(PlatformEventType type) {
         String def = type.getAnnotationValue(Throttle.class, ThrottleSetting.DEFAULT_VALUE);
         type.add(PrivateAccess.getInstance().newSettingDescriptor(TYPE_THROTTLE, Throttle.NAME, def, Collections.emptyList()));
-        return new Control(new ThrottleSetting(type), def);
+        return new Control(new ThrottleSetting(type, def), def);
     }
 
     private static Control defineLevel(PlatformEventType type) {
@@ -332,7 +332,7 @@ public final class EventControl {
     private static Control definePeriod(PlatformEventType type) {
         String def = type.getAnnotationValue(Period.class, PeriodSetting.DEFAULT_VALUE);
         type.add(PrivateAccess.getInstance().newSettingDescriptor(TYPE_PERIOD, PeriodSetting.NAME, def, Collections.emptyList()));
-        return new Control(new PeriodSetting(type), def);
+        return new Control(new PeriodSetting(type, def), def);
     }
 
     void disable() {

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/settings/CutoffSetting.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/settings/CutoffSetting.java
@@ -39,6 +39,7 @@ import jdk.jfr.Timespan;
 import jdk.jfr.internal.PlatformEventType;
 import jdk.jfr.internal.Type;
 import jdk.jfr.internal.util.ValueParser;
+import jdk.jfr.internal.util.Utils;
 
 @MetadataDefinition
 @Label("Cutoff")
@@ -47,11 +48,14 @@ import jdk.jfr.internal.util.ValueParser;
 @Timespan
 public final class CutoffSetting extends SettingControl {
     public static final String DEFAULT_VALUE = ValueParser.INFINITY;
-    private String value = DEFAULT_VALUE;
     private final PlatformEventType eventType;
+    private final String defaultValue;
+    private String value;
 
-    public CutoffSetting(PlatformEventType eventType) {
-       this.eventType = Objects.requireNonNull(eventType);
+    public CutoffSetting(PlatformEventType eventType, String defaultValue) {
+        this.eventType = Objects.requireNonNull(eventType);
+        this.defaultValue = Utils.validTimespanInfinity(eventType, "Cutoff", defaultValue, DEFAULT_VALUE);
+        this.value = defaultValue;
     }
 
     @Override
@@ -65,7 +69,7 @@ public final class CutoffSetting extends SettingControl {
                 max = nanos;
             }
         }
-        return Objects.requireNonNullElse(text, DEFAULT_VALUE);
+        return Objects.requireNonNullElse(text, defaultValue);
     }
 
     @Override

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/settings/PeriodSetting.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/settings/PeriodSetting.java
@@ -36,6 +36,8 @@ import jdk.jfr.SettingControl;
 import jdk.jfr.internal.PlatformEventType;
 import jdk.jfr.internal.Type;
 import jdk.jfr.internal.util.ValueParser;
+import jdk.jfr.internal.util.Utils;
+
 import static jdk.jfr.internal.util.ValueParser.MISSING;
 
 @MetadataDefinition
@@ -44,17 +46,27 @@ import static jdk.jfr.internal.util.ValueParser.MISSING;
 @Name(Type.SETTINGS_PREFIX + "Period")
 public final class PeriodSetting extends SettingControl {
     private static final long typeId = Type.getTypeId(PeriodSetting.class);
-
     public static final String EVERY_CHUNK = "everyChunk";
     public static final String BEGIN_CHUNK = "beginChunk";
     public static final String END_CHUNK = "endChunk";
     public static final String DEFAULT_VALUE = EVERY_CHUNK;
     public static final String NAME = "period";
     private final PlatformEventType eventType;
-    private String value = EVERY_CHUNK;
+    private final String defaultValue;
+    private String value;
 
-    public PeriodSetting(PlatformEventType eventType) {
+    public PeriodSetting(PlatformEventType eventType, String defaultValue) {
         this.eventType = Objects.requireNonNull(eventType);
+        this.defaultValue = validPeriod(defaultValue);
+        this.value = defaultValue;
+    }
+
+    private String validPeriod(String userDefault) {
+        return switch (userDefault) {
+            case BEGIN_CHUNK -> BEGIN_CHUNK;
+            case END_CHUNK -> END_CHUNK;
+            default -> Utils.validTimespanInfinity(eventType, "Period", userDefault, DEFAULT_VALUE);
+        };
     }
 
     @Override
@@ -95,7 +107,7 @@ public final class PeriodSetting extends SettingControl {
         if (!beginChunk && endChunk) {
             return END_CHUNK;
         }
-        return DEFAULT_VALUE; // "everyChunk" is default
+        return defaultValue;
     }
 
     @Override

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/settings/ThresholdSetting.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/settings/ThresholdSetting.java
@@ -38,6 +38,7 @@ import jdk.jfr.SettingControl;
 import jdk.jfr.Timespan;
 import jdk.jfr.internal.PlatformEventType;
 import jdk.jfr.internal.Type;
+import jdk.jfr.internal.util.Utils;
 import jdk.jfr.internal.util.ValueParser;
 
 @MetadataDefinition
@@ -48,11 +49,14 @@ import jdk.jfr.internal.util.ValueParser;
 public final class ThresholdSetting extends SettingControl {
     public static final String DEFAULT_VALUE = "0 ns";
     private static final long typeId = Type.getTypeId(ThresholdSetting.class);
-    private String value = DEFAULT_VALUE;
     private final PlatformEventType eventType;
+    private final String defaultValue;
+    private String value;
 
-    public ThresholdSetting(PlatformEventType eventType) {
+    public ThresholdSetting(PlatformEventType eventType, String defaultValue) {
        this.eventType = Objects.requireNonNull(eventType);
+       this.defaultValue = Utils.validTimespanInfinity(eventType, "Threshold", defaultValue, DEFAULT_VALUE);
+       this.value = defaultValue;
     }
 
     @Override
@@ -68,7 +72,7 @@ public final class ThresholdSetting extends SettingControl {
                 }
             }
         }
-        return Objects.requireNonNullElse(text, DEFAULT_VALUE);
+        return Objects.requireNonNullElse(text, defaultValue);
     }
 
     @Override

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/settings/ThrottleSetting.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/settings/ThrottleSetting.java
@@ -56,17 +56,19 @@ public final class ThrottleSetting extends SettingControl {
 
     public ThrottleSetting(PlatformEventType eventType, String defaultValue) {
         this.eventType = Objects.requireNonNull(eventType);
-        if (DEFAULT_VALUE.equals(defaultValue)) {
-            this.defaultValue = DEFAULT_VALUE; // Fast path to avoid parsing
-        } else {
-            if (Rate.of(defaultValue) == null) {
-                Utils.warnInvalidAnnotation(eventType, "Throttle", defaultValue, DEFAULT_VALUE);
-                this.defaultValue = DEFAULT_VALUE;
-            } else {
-                this.defaultValue = defaultValue;
-            }
-        }
+        this.defaultValue = validRate(defaultValue);
         this.value = defaultValue;
+    }
+
+    private String validRate(String defaultValue) {
+        if (DEFAULT_VALUE.equals(defaultValue)) {
+            return DEFAULT_VALUE; // Fast path to avoid parsing
+        }
+        if (Rate.of(defaultValue) == null) {
+            Utils.warnInvalidAnnotation(eventType, "Throttle", defaultValue, DEFAULT_VALUE);
+            return DEFAULT_VALUE;
+        }
+        return defaultValue;
     }
 
     @Override

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/settings/ThrottleSetting.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/settings/ThrottleSetting.java
@@ -51,10 +51,22 @@ import jdk.jfr.internal.util.Utils;
 public final class ThrottleSetting extends SettingControl {
     public static final String DEFAULT_VALUE = Throttle.DEFAULT;
     private final PlatformEventType eventType;
-    private String value = DEFAULT_VALUE;
+    private final String defaultValue;
+    private String value;
 
-    public ThrottleSetting(PlatformEventType eventType) {
-       this.eventType = Objects.requireNonNull(eventType);
+    public ThrottleSetting(PlatformEventType eventType, String defaultValue) {
+        this.eventType = Objects.requireNonNull(eventType);
+        if (DEFAULT_VALUE.equals(defaultValue)) {
+            this.defaultValue = DEFAULT_VALUE; // Fast path to avoid parsing
+        } else {
+            if (Rate.of(defaultValue) == null) {
+                Utils.warnInvalidAnnotation(eventType, "Throttle", defaultValue, DEFAULT_VALUE);
+                this.defaultValue = DEFAULT_VALUE;
+            } else {
+                this.defaultValue = defaultValue;
+            }
+        }
+        this.value = defaultValue;
     }
 
     @Override
@@ -71,7 +83,7 @@ public final class ThrottleSetting extends SettingControl {
             }
         }
         // "off" is default
-        return Objects.requireNonNullElse(text, DEFAULT_VALUE);
+        return Objects.requireNonNullElse(text, defaultValue);
     }
 
     @Override

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/settings/ThrottleSetting.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/settings/ThrottleSetting.java
@@ -82,7 +82,6 @@ public final class ThrottleSetting extends SettingControl {
                 }
             }
         }
-        // "off" is default
         return Objects.requireNonNullElse(text, defaultValue);
     }
 

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/util/Utils.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/util/Utils.java
@@ -482,9 +482,9 @@ public final class Utils {
         sb.append(", using ");
         sb.append("@").append(annotation).append("(\"").append(systemDefault).append("\")");
         sb.append( " instead.");
-        //if (type.isSystem()) {
+        if (type.isSystem()) {
             throw new InternalError(sb.toString()); // Fail fast for JDK and JVM events
-        //}
-        // Logger.log(LogTag.JFR_SETTING, LogLevel.WARN, sb.toString());
+        }
+        Logger.log(LogTag.JFR_SETTING, LogLevel.WARN, sb.toString());
     }
 }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/util/Utils.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/util/Utils.java
@@ -55,6 +55,7 @@ import jdk.jfr.internal.LogLevel;
 import jdk.jfr.internal.LogTag;
 import jdk.jfr.internal.Logger;
 import jdk.jfr.internal.MirrorEvent;
+import jdk.jfr.internal.PlatformEventType;
 import jdk.jfr.internal.SecuritySupport;
 import jdk.jfr.internal.Type;
 import jdk.jfr.internal.management.HiddenWait;
@@ -458,5 +459,32 @@ public final class Utils {
         }
         File file = subPath == null ? new File(path) : new File(path, subPath);
         return file.toPath().toAbsolutePath();
+    }
+
+
+    public static String validTimespanInfinity(PlatformEventType type, String annotation, String userDefault, String systemDefault) {
+        if (systemDefault.equals(userDefault)) {
+            return systemDefault; // Fast path to avoid parsing
+        }
+        if (ValueParser.parseTimespanWithInfinity(userDefault, ValueParser.MISSING) != ValueParser.MISSING) {
+            return userDefault;
+        }
+        warnInvalidAnnotation(type, annotation, userDefault, systemDefault);
+        return systemDefault;
+    }
+
+    public static void warnInvalidAnnotation(PlatformEventType type, String annotation, String userDefault, String systemDefault) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Programming error. Event setting ");
+        sb.append("@").append(annotation).append("(\"").append(userDefault).append("\")");
+        sb.append(" is invalid on event ");
+        sb.append(type.getName());
+        sb.append(", using ");
+        sb.append("@").append(annotation).append("(\"").append(systemDefault).append("\")");
+        sb.append( " instead.");
+        //if (type.isSystem()) {
+            throw new InternalError(sb.toString()); // Fail fast for JDK and JVM events
+        //}
+        // Logger.log(LogTag.JFR_SETTING, LogLevel.WARN, sb.toString());
     }
 }


### PR DESCRIPTION
Could I have a review of PR that fixes user-defined default values for event settings?

Testing: jdk/jdk/jfr

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8357187](https://bugs.openjdk.org/browse/JDK-8357187): JFR: User-defined defaults should be respected when an incorrect setting is set (**Enhancement** - P3)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25291/head:pull/25291` \
`$ git checkout pull/25291`

Update a local copy of the PR: \
`$ git checkout pull/25291` \
`$ git pull https://git.openjdk.org/jdk.git pull/25291/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25291`

View PR using the GUI difftool: \
`$ git pr show -t 25291`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25291.diff">https://git.openjdk.org/jdk/pull/25291.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25291#issuecomment-2889000366)
</details>
