### PR TITLE
8357193: [VS 2022 17.14] Warning C5287 in debugInit.c: enum type mismatch during build

### DIFF
--- a/make/modules/jdk.jdwp.agent/Lib.gmk
+++ b/make/modules/jdk.jdwp.agent/Lib.gmk
@@ -68,6 +68,7 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBJDWP, \
     DISABLED_WARNINGS_clang_threadControl.c := unused-but-set-variable \
         unused-variable, \
     DISABLED_WARNINGS_clang_utf_util.c := unused-but-set-variable, \
+    DISABLED_WARNINGS_microsoft_debugInit.c := 5287, \
     LDFLAGS := $(ICONV_LDFLAGS), \
     EXTRA_HEADER_DIRS := \
         include \


### PR DESCRIPTION
This patch suppresses compiler warning C5287 triggered in debugInit.c when building with Visual Studio 2022 version 17.14 (released a few days ago).

I’m simply disabling the warning to unblock the broken build. This change is intended to be backported to update releases.

A proper fix (e.g., explicit type cast) may be introduced later if necessary.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8357193](https://bugs.openjdk.org/browse/JDK-8357193): [VS 2022 17.14] Warning C5287 in debugInit.c: enum type mismatch during build (**Bug** - P3)


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25293/head:pull/25293` \
`$ git checkout pull/25293`

Update a local copy of the PR: \
`$ git checkout pull/25293` \
`$ git pull https://git.openjdk.org/jdk.git pull/25293/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25293`

View PR using the GUI difftool: \
`$ git pr show -t 25293`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25293.diff">https://git.openjdk.org/jdk/pull/25293.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25293#issuecomment-2889433450)
</details>
