### PR TITLE
8356594: JSplitPane loses divider location when reopened via JOptionPane.createDialog()

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/JSplitPane.java
+++ b/src/java.desktop/share/classes/javax/swing/JSplitPane.java
@@ -369,23 +369,24 @@ public class JSplitPane extends JComponent implements Accessible
      */
     @Override
     public void setComponentOrientation(ComponentOrientation orientation) {
-        super.setComponentOrientation(orientation);
-        Component leftComponent = this.getLeftComponent();
-        Component rightComponent = this.getRightComponent();
-        this.setDividerLocation(this.getDividerLocation());
-        if (!this.getComponentOrientation().isLeftToRight()) {
-            if (rightComponent != null) {
-                setLeftComponent(rightComponent);
-            }
-            if (leftComponent != null) {
-                setRightComponent(leftComponent);
-            }
-        } else {
-            if (leftComponent != null) {
-                setLeftComponent(leftComponent);
-            }
-            if (rightComponent != null) {
-                setRightComponent(rightComponent);
+        if (!orientation.equals(this.getComponentOrientation())) {
+            super.setComponentOrientation(orientation);
+            Component leftComponent = this.getLeftComponent();
+            Component rightComponent = this.getRightComponent();
+            if (!this.getComponentOrientation().isLeftToRight()) {
+                if (rightComponent != null) {
+                    setLeftComponent(rightComponent);
+                }
+                if (leftComponent != null) {
+                    setRightComponent(leftComponent);
+                }
+            } else {
+                if (leftComponent != null) {
+                    setLeftComponent(leftComponent);
+                }
+                if (rightComponent != null) {
+                    setRightComponent(rightComponent);
+                }
             }
         }
     }

--- a/src/java.desktop/share/classes/javax/swing/JSplitPane.java
+++ b/src/java.desktop/share/classes/javax/swing/JSplitPane.java
@@ -369,8 +369,9 @@ public class JSplitPane extends JComponent implements Accessible
      */
     @Override
     public void setComponentOrientation(ComponentOrientation orientation) {
-        if (!orientation.equals(this.getComponentOrientation())) {
-            super.setComponentOrientation(orientation);
+        ComponentOrientation curOrn = this.getComponentOrientation();
+        super.setComponentOrientation(orientation);
+        if (!orientation.equals(curOrn)) {
             Component leftComponent = this.getLeftComponent();
             Component rightComponent = this.getRightComponent();
             if (!this.getComponentOrientation().isLeftToRight()) {

--- a/src/java.desktop/share/classes/javax/swing/JSplitPane.java
+++ b/src/java.desktop/share/classes/javax/swing/JSplitPane.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -372,6 +372,7 @@ public class JSplitPane extends JComponent implements Accessible
         super.setComponentOrientation(orientation);
         Component leftComponent = this.getLeftComponent();
         Component rightComponent = this.getRightComponent();
+        this.setDividerLocation(this.getDividerLocation());
         if (!this.getComponentOrientation().isLeftToRight()) {
             if (rightComponent != null) {
                 setLeftComponent(rightComponent);

--- a/test/jdk/javax/swing/JSplitPane/TestSplitPaneResetDividerLoc.java
+++ b/test/jdk/javax/swing/JSplitPane/TestSplitPaneResetDividerLoc.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8356594
+ * @summary Verifies if JSplitPane loses divider location when
+ *          reopened via JOptionPane.createDialog()
+ * @run main TestSplitPaneResetDividerLoc
+ */
+
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.event.ActionEvent;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
+
+import javax.swing.AbstractAction;
+import javax.swing.JButton;
+import javax.swing.JDialog;
+import javax.swing.JFrame;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JSplitPane;
+import javax.swing.SwingUtilities;
+
+public class TestSplitPaneResetDividerLoc {
+
+    private static JPanel lazyPanel;
+    private static JSplitPane splitPane;
+    private static JButton openDialogButton;
+    private static JDialog dialog;
+    private static JFrame frame;
+    private static volatile Point point;
+    private static volatile int setLoc;
+    private static volatile int curLoc;
+
+    public static void main(String[] args) throws Exception {
+        try {
+            SwingUtilities.invokeAndWait(TestSplitPaneResetDividerLoc::createAndShowUI);
+
+            Robot robot = new Robot();
+            robot.waitForIdle();
+            robot.delay(1000);
+            SwingUtilities.invokeAndWait(() -> {
+                point = openDialogButton.getLocationOnScreen();
+            });
+            robot.mouseMove(point.x, point.y);
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+            robot.waitForIdle();
+            robot.delay(1000);
+
+            SwingUtilities.invokeAndWait(() -> {
+                int divLoc = splitPane.getDividerLocation();
+                splitPane.setDividerLocation(divLoc + 200);
+            });
+            robot.waitForIdle();
+            robot.delay(1000);
+            robot.keyPress(KeyEvent.VK_ESCAPE);
+            robot.keyRelease(KeyEvent.VK_ESCAPE);
+
+            SwingUtilities.invokeAndWait(() -> {
+                setLoc = splitPane.getDividerLocation();
+                System.out.println(setLoc);
+            });
+
+            robot.waitForIdle();
+            robot.delay(1000);
+            robot.mouseMove(point.x, point.y);
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+            robot.waitForIdle();
+            robot.delay(1000);
+
+            SwingUtilities.invokeAndWait(() -> {
+                curLoc = splitPane.getDividerLocation();
+                System.out.println(curLoc);
+            });
+
+            robot.keyPress(KeyEvent.VK_ESCAPE);
+            robot.keyRelease(KeyEvent.VK_ESCAPE);
+
+            if (curLoc != setLoc) {
+                throw new RuntimeException("Divider location is preserved");
+            }
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+    }
+
+    private static void createAndShowUI() {
+        frame = new JFrame("JSplitPane Divider Location");
+        frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+
+         openDialogButton = new JButton(new AbstractAction("Open Dialog") {
+            public void actionPerformed(ActionEvent e) {
+                openDialogFromOptionPane(frame);
+            }
+        });
+
+        frame.getContentPane().add(openDialogButton, BorderLayout.CENTER);
+        frame.setSize(400, 100);
+        frame.setLocationRelativeTo(null);
+        frame.setVisible(true);
+    }
+
+    private static void openDialogFromOptionPane(JFrame parent) {
+        if (lazyPanel == null) {
+            System.out.println("Creating lazy panel...");
+            lazyPanel = new JPanel(new BorderLayout());
+
+            JPanel left = new JPanel();
+            left.setBackground(Color.ORANGE);
+            JPanel right = new JPanel();
+            right.setBackground(Color.LIGHT_GRAY);
+
+            splitPane = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, left, right);
+            splitPane.setPreferredSize(new Dimension(400, 200));
+
+            // Set initial divider location — not preserved across dialog openings in OpenJDK 24
+            splitPane.setDividerLocation(120);
+
+            lazyPanel.add(splitPane, BorderLayout.CENTER);
+        }
+
+        JOptionPane optionPane = new JOptionPane(lazyPanel, JOptionPane.PLAIN_MESSAGE, JOptionPane.DEFAULT_OPTION);
+        dialog = optionPane.createDialog(parent, "SplitPane Dialog (JOptionPane)");
+        dialog.setModal(false);
+        dialog.setVisible(true);
+    }
+} 

--- a/test/jdk/javax/swing/JSplitPane/TestSplitPaneResetDividerLoc.java
+++ b/test/jdk/javax/swing/JSplitPane/TestSplitPaneResetDividerLoc.java
@@ -156,4 +156,4 @@ public class TestSplitPaneResetDividerLoc {
         dialog.setModal(false);
         dialog.setVisible(true);
     }
-} 
+}

--- a/test/jdk/javax/swing/JSplitPane/TestSplitPaneResetDividerLoc.java
+++ b/test/jdk/javax/swing/JSplitPane/TestSplitPaneResetDividerLoc.java
@@ -62,11 +62,13 @@ public class TestSplitPaneResetDividerLoc {
     private static volatile int setLoc;
     private static volatile int curLoc;
 
-     private static void setLookAndFeel(UIManager.LookAndFeelInfo laf) {
+    private static boolean setLookAndFeel(UIManager.LookAndFeelInfo laf) {
         try {
             UIManager.setLookAndFeel(laf.getClassName());
+            return true;
         } catch (UnsupportedLookAndFeelException ignored) {
             System.out.println("Unsupported LAF: " + laf.getClassName());
+            return false;
         } catch (ClassNotFoundException | InstantiationException
                  | IllegalAccessException e) {
             throw new RuntimeException(e);
@@ -77,7 +79,9 @@ public class TestSplitPaneResetDividerLoc {
         for (UIManager.LookAndFeelInfo laf : UIManager.getInstalledLookAndFeels()) {
             System.out.println("Testing LAF : " + laf.getClassName());
             try {
-                setLookAndFeel(laf);
+                if (!setLookAndFeel(laf)) {
+                    continue;
+                }
                 SwingUtilities.invokeAndWait(TestSplitPaneResetDividerLoc::createAndShowUI);
 
                 Robot robot = new Robot();

--- a/test/jdk/javax/swing/JSplitPane/TestSplitPaneResetDividerLoc.java
+++ b/test/jdk/javax/swing/JSplitPane/TestSplitPaneResetDividerLoc.java
@@ -24,6 +24,7 @@
 /*
  * @test
  * @bug 8356594
+ * @key headful
  * @summary Verifies if JSplitPane loses divider location when
  *          reopened via JOptionPane.createDialog()
  * @run main TestSplitPaneResetDividerLoc


### PR DESCRIPTION
The issue is when a JSplitPane is embedded inside a lazily-initialized panel, and this panel is displayed using a dialog created via JOptionPane.createDialog(), the divider location is not preserved when reopening the dialog. 
This is because when we added support for ComponentOrientation for JSplitPane, even though the left and right compoent is drawn the divider location is not set and was set to initial value and not to the value set by user.
Fixed by setting the divider location before rendering the left and right components..

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8356594](https://bugs.openjdk.org/browse/JDK-8356594): JSplitPane loses divider location when reopened via JOptionPane.createDialog() (**Bug** - P4)


### Reviewers
 * [Alexander Zuev](https://openjdk.org/census#kizune) (@azuev-java - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25294/head:pull/25294` \
`$ git checkout pull/25294`

Update a local copy of the PR: \
`$ git checkout pull/25294` \
`$ git pull https://git.openjdk.org/jdk.git pull/25294/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25294`

View PR using the GUI difftool: \
`$ git pr show -t 25294`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25294.diff">https://git.openjdk.org/jdk/pull/25294.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25294#issuecomment-2889743631)
</details>
