### PR TITLE
8356647: Excessively strict assert in PhaseIdealLoop::do_unroll

### DIFF
--- a/src/hotspot/share/opto/loopTransform.cpp
+++ b/src/hotspot/share/opto/loopTransform.cpp
@@ -1900,7 +1900,7 @@ void PhaseIdealLoop::do_unroll(IdealLoopTree *loop, Node_List &old_new, bool adj
     int stride_m    = new_stride_con - (stride_con > 0 ? 1 : -1);
     jlong trip_count = (limit_con - init_con + stride_m)/new_stride_con;
     // New trip count should satisfy next conditions.
-    assert(trip_count > 0 && (julong)trip_count < (julong)max_juint/2, "sanity");
+    assert(trip_count > 0 && (julong)trip_count <= (julong)1 << (sizeof(juint)*BitsPerByte-1), "sanity");
     uint new_trip_count = (uint)trip_count;
     adjust_min_trip = (old_trip_count != new_trip_count*2);
   }


### PR DESCRIPTION
This assert seems a bit too tight. See the JBS issue to check the math: the bound of `trip_count` should be `<= 2^31`, while the current bound is ` < (julong)max_juint/2` = floor((2^32-1)/2) = (2^32-2) / 2 = 2^31-1.
