### PR TITLE
8357218

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -1864,24 +1864,12 @@ bool G1CollectedHeap::try_collect_fullgc(GCCause::Cause cause,
                                          const G1GCCounters& counters_before) {
   assert_heap_not_locked();
 
-  while(true) {
-    VM_G1CollectFull op(counters_before.total_collections(),
-                        counters_before.total_full_collections(),
-                        cause);
-    VMThread::execute(&op);
+  VM_G1CollectFull op(counters_before.total_collections(),
+                      counters_before.total_full_collections(),
+                      cause);
+  VMThread::execute(&op);
 
-    // Request is trivially finished.
-    if (!GCCause::is_explicit_full_gc(cause) || op.gc_succeeded()) {
-      return op.gc_succeeded();
-    }
-
-    {
-      MutexLocker ml(Heap_lock);
-      if (counters_before.total_full_collections() != total_full_collections()) {
-        return true;
-      }
-    }
-  }
+  return true;
 }
 
 bool G1CollectedHeap::try_collect(GCCause::Cause cause,

--- a/src/hotspot/share/gc/g1/g1VMOperations.cpp
+++ b/src/hotspot/share/gc/g1/g1VMOperations.cpp
@@ -50,8 +50,8 @@ bool VM_G1CollectFull::skip_operation() const {
 void VM_G1CollectFull::doit() {
   G1CollectedHeap* g1h = G1CollectedHeap::heap();
   GCCauseSetter x(g1h, _gc_cause);
-  _gc_succeeded = g1h->do_full_collection(false /* clear_all_soft_refs */,
-                                          false /* do_maximal_compaction */);
+  g1h->do_full_collection(false /* clear_all_soft_refs */,
+                          false /* do_maximal_compaction */);
 }
 
 VM_G1TryInitiateConcMark::VM_G1TryInitiateConcMark(uint gc_count_before,

--- a/src/hotspot/share/gc/g1/g1VMOperations.hpp
+++ b/src/hotspot/share/gc/g1/g1VMOperations.hpp
@@ -31,8 +31,6 @@
 // VM_operations for the G1 collector.
 
 class VM_G1CollectFull : public VM_GC_Operation {
-  bool _gc_succeeded;
-
 protected:
   bool skip_operation() const override;
 
@@ -40,11 +38,9 @@ public:
   VM_G1CollectFull(uint gc_count_before,
                    uint full_gc_count_before,
                    GCCause::Cause cause) :
-    VM_GC_Operation(gc_count_before, cause, full_gc_count_before, true),
-    _gc_succeeded(false) { }
+    VM_GC_Operation(gc_count_before, cause, full_gc_count_before, true) { }
   VMOp_Type type() const override { return VMOp_G1CollectFull; }
   void doit() override;
-  bool gc_succeeded() const { return _gc_succeeded; }
 };
 
 class VM_G1TryInitiateConcMark : public VM_GC_Operation {


### PR DESCRIPTION
Simple removing unnecessary loop in "caller" of `VM_G1CollectFull`, because full-gc always run-to-completion.

Test: tier1-3