### PR TITLE
8356995: Provide default methods min(T, T) and max(T, T) in Comparator interface

### DIFF
--- a/src/java.base/share/classes/java/util/Comparator.java
+++ b/src/java.base/share/classes/java/util/Comparator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,6 @@ import java.util.function.Function;
 import java.util.function.ToIntFunction;
 import java.util.function.ToLongFunction;
 import java.util.function.ToDoubleFunction;
-import java.util.Comparators;
 
 /**
  * A comparison function, which imposes a <i>total ordering</i> on
@@ -187,6 +186,42 @@ public interface Comparator<T> {
      */
     default Comparator<T> reversed() {
         return Collections.reverseOrder(this);
+    }
+
+    /**
+     * Returns the greater of two values according to this comparator.
+     * If the arguments are equal with respect to this comparator,
+     * the {@code b} argument is returned.
+     *
+     * @param   a   an argument.
+     * @param   b   another argument.
+     * @return  the larger of {@code a} and {@code b} according to this comparator.
+     * @throws  ClassCastException if the collection contains elements that are
+     *          not <i>mutually comparable</i> (for example, strings and
+     *          integers).
+     *
+     * @since 25
+     */
+    default T max(T a, T b) {
+        return compare(a, b) > 0 ? a : b;
+    }
+
+    /**
+     * Returns the smaller of two values according to this comparator.
+     * If the arguments are equal with respect to this comparator,
+     * the {@code a} argument is returned.
+     *
+     * @param   a   an argument.
+     * @param   b   another argument.
+     * @return  the smaller of {@code a} and {@code b} according to this comparator.
+     * @throws  ClassCastException if the collection contains elements that are
+     *          not <i>mutually comparable</i> (for example, strings and
+     *          integers).
+     *
+     * @since 25
+     */
+    default T min(T a, T b) {
+        return compare(a, b) > 0 ? b : a;
     }
 
     /**

--- a/test/jdk/java/util/Comparator/MinMaxTest.java
+++ b/test/jdk/java/util/Comparator/MinMaxTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8356995
+ * @summary Comparator min/max method tests
+ * @run testng MinMaxTest
+ */
+
+import org.testng.annotations.Test;
+
+import java.util.Comparator;
+import static org.testng.Assert.*;
+
+@Test(groups = "unit")
+public class MinMaxTest {
+  public void testMin() {
+    Comparator<String> c = Comparator.naturalOrder();
+    assertEquals(c.min("a", "b"), "a");
+    assertEquals(c.min("b", "a"), "a");
+  }
+
+  public void testMax() {
+    Comparator<String> c = Comparator.naturalOrder();
+    assertEquals(c.max("a", "b"), "b");
+    assertEquals(c.max("b", "a"), "b");
+  }
+
+  public void testThrowsNPE() {
+    Comparator<String> c = Comparator.naturalOrder();
+    assertThrows(NullPointerException.class, () -> c.min(null, "a"));
+    assertThrows(NullPointerException.class, () -> c.min("a", null));
+    assertThrows(NullPointerException.class, () -> c.max(null, "a"));
+    assertThrows(NullPointerException.class, () -> c.max("a", null));
+  }
+
+  public void testThrowsCCE() {
+    @SuppressWarnings("unchecked")
+    Comparator<Object> c = (Comparator<Object>) (Comparator<?>)Comparator.naturalOrder();
+    assertThrows(ClassCastException.class, () -> c.min(1, "a"));
+    assertThrows(ClassCastException.class, () -> c.min("a", 1));
+    assertThrows(ClassCastException.class, () -> c.max(1, "a"));
+    assertThrows(ClassCastException.class, () -> c.max("a", 1));
+  }
+
+  public void testEqualReturnFirstOrLast() {
+    Comparator<Object> allEqual = (_, _) -> 0;
+    Object o1 = new Object();
+    Object o2 = new Object();
+    assertSame(allEqual.min(o1, o2), o1);
+    assertSame(allEqual.max(o1, o2), o2);
+  }
+}


### PR DESCRIPTION
Implementation of Comparator.min and Comparator.max methods. Preliminary discussion is in this thread:
https://mail.openjdk.org/pipermail/core-libs-dev/2025-May/145638.html
The specification is mostly composed of Math.min/max and Collections.min/max specifications. 

The methods are quite trivial, so I don't think we need more extensive testing (e.g., using different comparators). But if you have ideas of new useful tests, I'll gladly add them.

I'm not sure whether we should specify exactly the behavior in case if the comparator returns 0. I feel that it could be a useful invariant that `Comparator.min(a, b)` and `Comparator.max(a, b)` always return different argument, partitioning the set of {a, b} objects (even if they are equal). But I'm open to suggestions here.