### PR TITLE
8357244: Move class declarations from attachListener_posix.cpp to header files

### DIFF
--- a/src/hotspot/os/posix/attachListener_posix.hpp
+++ b/src/hotspot/os/posix/attachListener_posix.hpp
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef OS_POSIX_ATTACHLISTENER_POSIX_HPP
+#define OS_POSIX_ATTACHLISTENER_POSIX_HPP
+
+#include "posixAttachOperation.hpp"
+
+#include <sys/un.h>
+
+#if INCLUDE_SERVICES
+#ifndef AIX
+
+// forward reference
+class PosixAttachOperation;
+
+#ifndef UNIX_PATH_MAX
+#define UNIX_PATH_MAX   sizeof(sockaddr_un::sun_path)
+#endif
+
+class PosixAttachListener: AllStatic {
+ private:
+  // the path to which we bind the UNIX domain socket
+  static char _path[UNIX_PATH_MAX];
+  static bool _has_path;
+
+  // the file descriptor for the listening socket
+  static volatile int _listener;
+
+  static bool _atexit_registered;
+
+ public:
+  static void set_path(char* path) {
+    if (path == nullptr) {
+      _path[0] = '\0';
+      _has_path = false;
+    } else {
+      strncpy(_path, path, UNIX_PATH_MAX);
+      _path[UNIX_PATH_MAX-1] = '\0';
+      _has_path = true;
+    }
+  }
+
+  static void set_listener(int s)               { _listener = s; }
+
+  // initialize the listener, returns 0 if okay
+  static int init();
+
+  static char* path()                   { return _path; }
+  static bool has_path()                { return _has_path; }
+  static int listener()                 { return _listener; }
+
+  static PosixAttachOperation* dequeue();
+};
+
+#endif // !AIX
+
+#endif // INCLUDE_SERVICES
+
+#endif // OS_POSIX_ATTACHLISTENER_POSIX_HPP

--- a/src/hotspot/os/posix/posixAttachOperation.hpp
+++ b/src/hotspot/os/posix/posixAttachOperation.hpp
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef OS_POSIX_POSIXATTACHOPERATION_HPP
+#define OS_POSIX_POSIXATTACHOPERATION_HPP
+
+#include "os_posix.hpp"
+#include "services/attachListener.hpp"
+
+#if INCLUDE_SERVICES
+#ifndef AIX
+
+class SocketChannel : public AttachOperation::RequestReader, public AttachOperation::ReplyWriter {
+private:
+  int _socket;
+public:
+  SocketChannel(int socket) : _socket(socket) {}
+  ~SocketChannel() {
+    close();
+  }
+
+  bool opened() const {
+    return _socket != -1;
+  }
+
+  void close() {
+    if (opened()) {
+      ::shutdown(_socket, SHUT_RDWR);
+      ::close(_socket);
+      _socket = -1;
+    }
+  }
+
+  // RequestReader
+  int read(void* buffer, int size) override {
+    ssize_t n;
+    RESTARTABLE(::read(_socket, buffer, (size_t)size), n);
+    return checked_cast<int>(n);
+  }
+
+  // ReplyWriter
+  int write(const void* buffer, int size) override {
+    ssize_t n;
+    RESTARTABLE(::write(_socket, buffer, size), n);
+    return checked_cast<int>(n);
+  }
+
+  void flush() override {
+  }
+};
+
+class PosixAttachOperation: public AttachOperation {
+ private:
+  // the connection to the client
+  SocketChannel _socket_channel;
+
+ public:
+  PosixAttachOperation(int socket) : AttachOperation(), _socket_channel(socket) {}
+
+  void complete(jint res, bufferedStream* st) override;
+
+  ReplyWriter* get_reply_writer() override {
+    return &_socket_channel;
+  }
+
+  bool read_request() {
+    return _socket_channel.read_request(this, &_socket_channel);
+  }
+};
+
+#endif // !AIX
+
+#endif // INCLUDE_SERVICES
+
+#endif // OS_POSIX_POSIXATTACHOPERATION_HPP


### PR DESCRIPTION
The patch suggests moving class declarations from `attachListener_posix.cpp` to header files

It's moved in `openjdk/crac` project ahead of upstream and this causes merge conflicts every time attachListener code changes (e.g. https://github.com/openjdk/crac/pull/224). It's therefore suggested that the changes are included in upstream.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8357244](https://bugs.openjdk.org/browse/JDK-8357244): Move class declarations from attachListener_posix.cpp to header files (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25300/head:pull/25300` \
`$ git checkout pull/25300`

Update a local copy of the PR: \
`$ git checkout pull/25300` \
`$ git pull https://git.openjdk.org/jdk.git pull/25300/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25300`

View PR using the GUI difftool: \
`$ git pr show -t 25300`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25300.diff">https://git.openjdk.org/jdk/pull/25300.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25300#issuecomment-2890626653)
</details>
