### PR TITLE
8357135: java.lang.OutOfMemoryError: Error creating or attaching to libjvmci after JDK-8356447

### DIFF
--- a/test/hotspot/jtreg/gc/arguments/TestUseCompressedOopsFlagsWithUlimit.java
+++ b/test/hotspot/jtreg/gc/arguments/TestUseCompressedOopsFlagsWithUlimit.java
@@ -34,6 +34,9 @@ package gc.arguments;
  * @requires os.family == "linux"
  * @requires vm.gc != "Z"
  * @requires vm.opt.UseCompressedOops == null
+ * @comment Not run on libgraal as it needs at least 32GB of addressable
+ *          virtual memory for its managed heap.
+ * @requires !vm.libgraal.jit
  * @run driver gc.arguments.TestUseCompressedOopsFlagsWithUlimit
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/Allocate/alloc001/alloc001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/Allocate/alloc001/alloc001.java
@@ -43,6 +43,9 @@
  *
  * @comment Not run on AIX as it does not support ulimit -v
  * @requires os.family != "aix"
+ * @comment Not run on libgraal as it needs at least 32GB of addressable
+ *          virtual memory for its managed heap.
+ * @requires !vm.libgraal.jit
  * @run main/native nsk.jvmti.Allocate.alloc001.alloc001
  */
 


### PR DESCRIPTION
This PR modified 2 tests that limit virtual memory (with `ulimit -v`) such that they are skipped if libgraal is in use. Initializing a libgraal instance means reserving [at least 32GB](https://github.com/oracle/graal/blob/69f10d3d658a6aeca3d5ce59c64af6a18336f14c/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/AddressRangeCommittedMemoryProvider.java#L150) of virtual address space.

