### PR TITLE
8357275: Locale.Builder.setLanguageTag should mention conversions made on language tag

### DIFF
--- a/src/java.base/share/classes/java/util/Locale.java
+++ b/src/java.base/share/classes/java/util/Locale.java
@@ -1826,9 +1826,12 @@ public final class Locale implements Cloneable, Serializable {
      *     loc.getExtension('x'); // returns "urp"
      * }
      *
-     * <li>{@code languageTag} may contain up to three extlang subtags.
-     * For such occurrences, the first extlang subtag is used as the language, and the primary
-     * language subtag and other extlang subtags are ignored:
+     * <li> BCP 47 language tags permit up to three extlang subtags. However,
+     * the second and third extlang subtags are always ignored. As such,
+     * the first extlang subtag in {@code languageTag} is used as the language,
+     * and the primary language subtag and other extlang subtags are ignored.
+     * Language tags that exceed three extlang subtags are considered
+     * ill-formed starting at the offending extlang subtag.
      *
      * {@snippet lang=java :
      *     Locale.forLanguageTag("ar-aao").getLanguage(); // returns "aao"

--- a/src/java.base/share/classes/java/util/Locale.java
+++ b/src/java.base/share/classes/java/util/Locale.java
@@ -1834,7 +1834,8 @@ public final class Locale implements Cloneable, Serializable {
      *     Locale.forLanguageTag("ar-aao").getLanguage(); // returns "aao"
      *     Locale.forLanguageTag("en-abc-def-us").toString(); // returns "abc_US"
      *     Locale.forLanguageTag("zh-yue-gan-cmn-czh-CN").toString();
-     *     // returns "yue"; the rest of the tag is considered ill-formed
+     *     // returns "yue"; "czh" exceeds the extlang limit, and subsequent
+     *     // subtags are considered ill-formed
      * }
      *
      * <li>Case is normalized except for variant tags, which are left

--- a/src/java.base/share/classes/java/util/Locale.java
+++ b/src/java.base/share/classes/java/util/Locale.java
@@ -1826,13 +1826,15 @@ public final class Locale implements Cloneable, Serializable {
      *     loc.getExtension('x'); // returns "urp"
      * }
      *
-     * <li>When the languageTag argument contains an extlang subtag,
-     * the first such subtag is used as the language, and the primary
+     * <li>{@code languageTag} may contain up to three extlang subtags.
+     * For such occurrences, the first extlang subtag is used as the language, and the primary
      * language subtag and other extlang subtags are ignored:
      *
      * {@snippet lang=java :
      *     Locale.forLanguageTag("ar-aao").getLanguage(); // returns "aao"
      *     Locale.forLanguageTag("en-abc-def-us").toString(); // returns "abc_US"
+     *     // returns "yue"; the rest of the tag is discarded
+     *     Locale.forLanguageTag("zh-yue-gan-cmn-czh-CN").toString();
      * }
      *
      * <li>Case is normalized except for variant tags, which are left
@@ -2785,7 +2787,9 @@ public final class Locale implements Cloneable, Serializable {
          * must be well-formed (see {@link Locale}) or an exception is
          * thrown (unlike {@code Locale.forLanguageTag}, which
          * just discards ill-formed and following portions of the
-         * tag).
+         * tag). {@code languageTag} may contain up to three extlang subtags.
+         + For such occurrences, the first extlang subtag is used as the language,
+         * and the primary language subtag and other extlang subtags are ignored.
          *
          * @param languageTag the language tag
          * @return This builder.

--- a/src/java.base/share/classes/java/util/Locale.java
+++ b/src/java.base/share/classes/java/util/Locale.java
@@ -1800,7 +1800,7 @@ public final class Locale implements Cloneable, Serializable {
      * to {@link Locale.Builder#setLanguageTag(String)} which throws an exception
      * in this case.
      *
-     * <p>The following <b>conversions</b> are performed:<ul>
+     * <p>The following <b id="langtag_conversions">conversions</b> are performed:<ul>
      *
      * <li>The language code "und" is mapped to language "".
      *
@@ -1833,8 +1833,8 @@ public final class Locale implements Cloneable, Serializable {
      * {@snippet lang=java :
      *     Locale.forLanguageTag("ar-aao").getLanguage(); // returns "aao"
      *     Locale.forLanguageTag("en-abc-def-us").toString(); // returns "abc_US"
-     *     // returns "yue"; the rest of the tag is discarded
      *     Locale.forLanguageTag("zh-yue-gan-cmn-czh-CN").toString();
+     *     // returns "yue"; the rest of the tag is considered ill-formed
      * }
      *
      * <li>Case is normalized except for variant tags, which are left
@@ -2787,9 +2787,10 @@ public final class Locale implements Cloneable, Serializable {
          * must be well-formed (see {@link Locale}) or an exception is
          * thrown (unlike {@code Locale.forLanguageTag}, which
          * just discards ill-formed and following portions of the
-         * tag). {@code languageTag} may contain up to three extlang subtags.
-         + For such occurrences, the first extlang subtag is used as the language,
-         * and the primary language subtag and other extlang subtags are ignored.
+         * tag).
+         *
+         * <p>See {@link Locale##langtag_conversions converions} for a full list
+         * of conversions that are performed on {@code languageTag}.
          *
          * @param languageTag the language tag
          * @return This builder.


### PR DESCRIPTION
It is not clear that `Locale.Builder.setLanguageTag(String)` accepts _extlang_ subtags in the input as well as what behavior occurs. Additionally, both this method and `Locale.forLanguageTag(String)` should mention their behavior when more than three _extlang_ subtags are provided. This PR clarifies the lack of context in the specification.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8357279](https://bugs.openjdk.org/browse/JDK-8357279) to be approved

### Issues
 * [JDK-8357275](https://bugs.openjdk.org/browse/JDK-8357275): Locale.Builder.setLanguageTag should mention conversions made on language tag (**Bug** - P4)
 * [JDK-8357279](https://bugs.openjdk.org/browse/JDK-8357279): Locale.Builder.setLanguageTag should mention conversions made on language tag (**CSR**)


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25309/head:pull/25309` \
`$ git checkout pull/25309`

Update a local copy of the PR: \
`$ git checkout pull/25309` \
`$ git pull https://git.openjdk.org/jdk.git pull/25309/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25309`

View PR using the GUI difftool: \
`$ git pr show -t 25309`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25309.diff">https://git.openjdk.org/jdk/pull/25309.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25309#issuecomment-2892256902)
</details>
