### PR TITLE
8357280: (bf) Remove @requires tags from java/nio/Buffer/LimitDirectMemory[NegativeTest].java

### DIFF
--- a/test/jdk/java/nio/Buffer/LimitDirectMemory.java
+++ b/test/jdk/java/nio/Buffer/LimitDirectMemory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
  * @test
  * @bug 4627316 6743526
  * @summary Test option to limit direct memory allocation
- * @requires (os.arch == "x86_64") | (os.arch == "amd64") | (os.arch == "aarch64")
  * @library /test/lib
  *
  * @summary Test: memory is properly limited using multiple buffers

--- a/test/jdk/java/nio/Buffer/LimitDirectMemoryNegativeTest.java
+++ b/test/jdk/java/nio/Buffer/LimitDirectMemoryNegativeTest.java
@@ -26,7 +26,6 @@
  * @bug 4627316 6743526
  * @summary Test option to limit direct memory allocation,
  *          various bad values fail to launch the VM
- * @requires (os.arch == "x86_64") | (os.arch == "amd64") | (os.arch == "aarch64")
  * @library /test/lib
  * @build jdk.test.lib.Utils
  *        jdk.test.lib.Asserts

--- a/test/jdk/java/nio/Buffer/LimitDirectMemoryNegativeTest.java
+++ b/test/jdk/java/nio/Buffer/LimitDirectMemoryNegativeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
  * @bug 4627316 6743526
  * @summary Test option to limit direct memory allocation,
  *          various bad values fail to launch the VM
- * @requires (os.arch == "x86_64") | (os.arch == "amd64")
+ * @requires (os.arch == "x86_64") | (os.arch == "amd64") | (os.arch == "aarch64")
  * @library /test/lib
  * @build jdk.test.lib.Utils
  *        jdk.test.lib.Asserts


### PR DESCRIPTION
Remove the `@requires` tag from the affected tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8357280](https://bugs.openjdk.org/browse/JDK-8357280): (bf) Remove @<!---->requires tags from java/nio/Buffer/LimitDirectMemory[NegativeTest].java (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25311/head:pull/25311` \
`$ git checkout pull/25311`

Update a local copy of the PR: \
`$ git checkout pull/25311` \
`$ git pull https://git.openjdk.org/jdk.git pull/25311/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25311`

View PR using the GUI difftool: \
`$ git pr show -t 25311`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25311.diff">https://git.openjdk.org/jdk/pull/25311.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25311#issuecomment-2892398336)
</details>
