### PR TITLE
8356949: AArch64: Tighten up template interpreter method entry code

### DIFF
--- a/src/hotspot/cpu/aarch64/templateInterpreterGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/templateInterpreterGenerator_aarch64.cpp
@@ -867,7 +867,6 @@ void TemplateInterpreterGenerator::lock_method() {
 void TemplateInterpreterGenerator::generate_fixed_frame(bool native_call) {
   // Save ConstMethod* in r5_const_method for later use to avoid loading multiple times
   Register r5_const_method = r5;
-  const Register r5 = noreg;
   __ ldr(r5_const_method, Address(rmethod, Method::const_offset()));
 
   // initialize fixed part of activation frame
@@ -902,7 +901,6 @@ void TemplateInterpreterGenerator::generate_fixed_frame(bool native_call) {
 
   // Save ConstantPool* in r11_constants for later use to avoid loading multiple times
   Register r11_constants = r11;
-  const Register r11 = noreg;
   __ ldr(r11_constants, Address(r5_const_method, ConstMethod::constants_offset()));
   __ ldr(rcpool, Address(r11_constants, ConstantPool::cache_offset()));
   __ sub(rscratch1, rlocals, rfp);


### PR DESCRIPTION
[JDK-8356949](https://bugs.openjdk.org/browse/JDK-8356949)

This change is the aarch64 version of [JDK-8352415](https://bugs.openjdk.org/browse/JDK-8352415). 

To improve interpreter performance, which is important for faster startup, the method entry code was refactored to reuse some memory accesses and also spread them out to allow more latency-hiding hardware mechanisms to kick in.

Additional testing:

- [x] Ad-hoc -Xint benchmarks
- [x] Linux aarch64 server fastdebug, tier 1/2/3/4

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8356949](https://bugs.openjdk.org/browse/JDK-8356949): AArch64: Tighten up template interpreter method entry code (**Enhancement** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**) Review applies to [26689b30](https://git.openjdk.org/jdk/pull/25312/files/26689b304d5a33f0c5d16dfb45ab9e6d3d1b688e)
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25312/head:pull/25312` \
`$ git checkout pull/25312`

Update a local copy of the PR: \
`$ git checkout pull/25312` \
`$ git pull https://git.openjdk.org/jdk.git pull/25312/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25312`

View PR using the GUI difftool: \
`$ git pr show -t 25312`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25312.diff">https://git.openjdk.org/jdk/pull/25312.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25312#issuecomment-2895891356)
</details>
