### PR TITLE
8357287: Unify usage of ICC profile "header size" constants in CMM-related code

### DIFF
--- a/src/java.desktop/share/classes/java/awt/color/ICC_Profile.java
+++ b/src/java.desktop/share/classes/java/awt/color/ICC_Profile.java
@@ -57,6 +57,8 @@ import sun.java2d.cmm.Profile;
 import sun.java2d.cmm.ProfileDataVerifier;
 import sun.java2d.cmm.ProfileDeferralInfo;
 
+import static sun.java2d.cmm.ProfileDataVerifier.HEADER_SIZE;
+
 /**
  * A representation of color profile data for device independent and device
  * dependent color spaces based on the International Color Consortium
@@ -764,8 +766,6 @@ public sealed class ICC_Profile implements Serializable
      */
     public static final int icXYZNumberX = 8;
 
-    private static final int HEADER_SIZE = 128;
-
     /**
      * Constructs an {@code ICC_Profile} object with a given ID.
      */
@@ -913,11 +913,11 @@ public sealed class ICC_Profile implements Serializable
 
     static byte[] getProfileDataFromStream(InputStream s) throws IOException {
         BufferedInputStream bis = new BufferedInputStream(s);
-        bis.mark(128); // 128 is the length of the ICC profile header
+        bis.mark(HEADER_SIZE);
 
-        byte[] header = bis.readNBytes(128);
-        if (header.length < 128 || header[36] != 0x61 || header[37] != 0x63 ||
-            header[38] != 0x73 || header[39] != 0x70) {
+        byte[] header = bis.readNBytes(HEADER_SIZE);
+        if (header.length < HEADER_SIZE || header[36] != 0x61 ||
+            header[37] != 0x63 || header[38] != 0x73 || header[39] != 0x70) {
             return null;   /* not a valid profile */
         }
         int profileSize = intFromBigEndian(header, 0);

--- a/src/java.desktop/share/classes/sun/java2d/cmm/ProfileDataVerifier.java
+++ b/src/java.desktop/share/classes/sun/java2d/cmm/ProfileDataVerifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -106,7 +106,7 @@ public class ProfileDataVerifier {
      */
     private static final int MAX_TAG_COUNT = 100;
 
-    private static final int HEADER_SIZE = 128;
+    public static final int HEADER_SIZE = 128;
     private static final int TOC_OFFSET = HEADER_SIZE + 4;
     private static final int TOC_RECORD_SIZE = 12;
 


### PR DESCRIPTION
Small unification of "header size" constants, as of now the CMM code uses:
1. sun.java2d.cmm.ProfileDataVerifier.HEADER_SIZE introduced in JDK-8013430
2. java.awt.color.ICC_Profile.HEADER_SIZE introduced in [JDK-8347377](https://bugs.openjdk.org/browse/JDK-8347377)
3. Hardcoded literal 128

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8357287](https://bugs.openjdk.org/browse/JDK-8357287): Unify usage of ICC profile "header size" constants in CMM-related code (**Enhancement** - P5)


### Reviewers
 * [Harshitha Onkar](https://openjdk.org/census#honkar) (@honkar-jdk - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25313/head:pull/25313` \
`$ git checkout pull/25313`

Update a local copy of the PR: \
`$ git checkout pull/25313` \
`$ git pull https://git.openjdk.org/jdk.git pull/25313/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25313`

View PR using the GUI difftool: \
`$ git pr show -t 25313`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25313.diff">https://git.openjdk.org/jdk/pull/25313.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25313#issuecomment-2896423174)
</details>
