### PR TITLE
8357145: CRC/Inflater/Deflater/Adler32 methods that take a ByteBuffer throw UOE if backed by shared memory segment

### DIFF
--- a/src/java.base/share/classes/java/util/zip/Adler32.java
+++ b/src/java.base/share/classes/java/util/zip/Adler32.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,8 @@ package java.util.zip;
 
 import java.nio.ByteBuffer;
 
+import jdk.internal.access.JavaNioAccess;
+import jdk.internal.access.SharedSecrets;
 import jdk.internal.util.Preconditions;
 import jdk.internal.vm.annotation.IntrinsicCandidate;
 import sun.nio.ch.DirectBuffer;
@@ -45,6 +47,8 @@ import static java.util.zip.ZipUtils.NIO_ACCESS;
  * @since 1.1
  */
 public class Adler32 implements Checksum {
+
+    private static final JavaNioAccess JAVA_NIO_ACCESS = SharedSecrets.getJavaNioAccess();
 
     private int adler = 1;
 
@@ -100,7 +104,7 @@ public class Adler32 implements Checksum {
         if (buffer.isDirect()) {
             NIO_ACCESS.acquireSession(buffer);
             try {
-                adler = updateByteBuffer(adler, ((DirectBuffer)buffer).address(), pos, rem);
+                adler = updateByteBuffer(adler, JAVA_NIO_ACCESS.getBufferAddress(buffer), pos, rem);
             } finally {
                 NIO_ACCESS.releaseSession(buffer);
             }

--- a/src/java.base/share/classes/java/util/zip/Adler32.java
+++ b/src/java.base/share/classes/java/util/zip/Adler32.java
@@ -27,11 +27,8 @@ package java.util.zip;
 
 import java.nio.ByteBuffer;
 
-import jdk.internal.access.JavaNioAccess;
-import jdk.internal.access.SharedSecrets;
 import jdk.internal.util.Preconditions;
 import jdk.internal.vm.annotation.IntrinsicCandidate;
-import sun.nio.ch.DirectBuffer;
 
 import static java.util.zip.ZipUtils.NIO_ACCESS;
 
@@ -47,8 +44,6 @@ import static java.util.zip.ZipUtils.NIO_ACCESS;
  * @since 1.1
  */
 public class Adler32 implements Checksum {
-
-    private static final JavaNioAccess JAVA_NIO_ACCESS = SharedSecrets.getJavaNioAccess();
 
     private int adler = 1;
 
@@ -104,7 +99,7 @@ public class Adler32 implements Checksum {
         if (buffer.isDirect()) {
             NIO_ACCESS.acquireSession(buffer);
             try {
-                adler = updateByteBuffer(adler, JAVA_NIO_ACCESS.getBufferAddress(buffer), pos, rem);
+                adler = updateByteBuffer(adler, NIO_ACCESS.getBufferAddress(buffer), pos, rem);
             } finally {
                 NIO_ACCESS.releaseSession(buffer);
             }

--- a/src/java.base/share/classes/java/util/zip/CRC32.java
+++ b/src/java.base/share/classes/java/util/zip/CRC32.java
@@ -43,7 +43,6 @@ import static java.util.zip.ZipUtils.NIO_ACCESS;
  * @since 1.1
  */
 public class CRC32 implements Checksum {
-
     private int crc;
 
     /**

--- a/src/java.base/share/classes/java/util/zip/CRC32.java
+++ b/src/java.base/share/classes/java/util/zip/CRC32.java
@@ -28,9 +28,6 @@ package java.util.zip;
 import java.nio.ByteBuffer;
 import java.util.Objects;
 
-import jdk.internal.access.JavaNioAccess;
-import jdk.internal.access.SharedSecrets;
-import sun.nio.ch.DirectBuffer;
 import jdk.internal.util.Preconditions;
 import jdk.internal.vm.annotation.IntrinsicCandidate;
 
@@ -46,8 +43,6 @@ import static java.util.zip.ZipUtils.NIO_ACCESS;
  * @since 1.1
  */
 public class CRC32 implements Checksum {
-
-    private static final JavaNioAccess JAVA_NIO_ACCESS = SharedSecrets.getJavaNioAccess();
 
     private int crc;
 
@@ -104,7 +99,7 @@ public class CRC32 implements Checksum {
         if (buffer.isDirect()) {
             NIO_ACCESS.acquireSession(buffer);
             try {
-                crc = updateByteBuffer(crc, JAVA_NIO_ACCESS.getBufferAddress(buffer), pos, rem);
+                crc = updateByteBuffer(crc, NIO_ACCESS.getBufferAddress(buffer), pos, rem);
             } finally {
                 NIO_ACCESS.releaseSession(buffer);
             }

--- a/src/java.base/share/classes/java/util/zip/CRC32.java
+++ b/src/java.base/share/classes/java/util/zip/CRC32.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,8 @@ package java.util.zip;
 import java.nio.ByteBuffer;
 import java.util.Objects;
 
+import jdk.internal.access.JavaNioAccess;
+import jdk.internal.access.SharedSecrets;
 import sun.nio.ch.DirectBuffer;
 import jdk.internal.util.Preconditions;
 import jdk.internal.vm.annotation.IntrinsicCandidate;
@@ -44,6 +46,9 @@ import static java.util.zip.ZipUtils.NIO_ACCESS;
  * @since 1.1
  */
 public class CRC32 implements Checksum {
+
+    private static final JavaNioAccess JAVA_NIO_ACCESS = SharedSecrets.getJavaNioAccess();
+
     private int crc;
 
     /**
@@ -99,7 +104,7 @@ public class CRC32 implements Checksum {
         if (buffer.isDirect()) {
             NIO_ACCESS.acquireSession(buffer);
             try {
-                crc = updateByteBuffer(crc, ((DirectBuffer)buffer).address(), pos, rem);
+                crc = updateByteBuffer(crc, JAVA_NIO_ACCESS.getBufferAddress(buffer), pos, rem);
             } finally {
                 NIO_ACCESS.releaseSession(buffer);
             }

--- a/src/java.base/share/classes/java/util/zip/CRC32C.java
+++ b/src/java.base/share/classes/java/util/zip/CRC32C.java
@@ -22,11 +22,14 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package java.util.zip;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
+import jdk.internal.access.JavaNioAccess;
+import jdk.internal.access.SharedSecrets;
 import jdk.internal.misc.Unsafe;
 import jdk.internal.util.Preconditions;
 import jdk.internal.vm.annotation.IntrinsicCandidate;
@@ -52,6 +55,8 @@ import static java.util.zip.ZipUtils.NIO_ACCESS;
  * @since 9
  */
 public final class CRC32C implements Checksum {
+
+    private static final JavaNioAccess JAVA_NIO_ACCESS = SharedSecrets.getJavaNioAccess();
 
     /*
      * This CRC-32C implementation uses the 'slicing-by-8' algorithm described
@@ -176,7 +181,7 @@ public final class CRC32C implements Checksum {
         if (buffer.isDirect()) {
             NIO_ACCESS.acquireSession(buffer);
             try {
-                crc = updateDirectByteBuffer(crc, ((DirectBuffer)buffer).address(),
+                crc = updateDirectByteBuffer(crc, JAVA_NIO_ACCESS.getBufferAddress(buffer),
                         pos, limit);
             } finally {
                 NIO_ACCESS.releaseSession(buffer);

--- a/src/java.base/share/classes/java/util/zip/CRC32C.java
+++ b/src/java.base/share/classes/java/util/zip/CRC32C.java
@@ -28,12 +28,9 @@ package java.util.zip;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
-import jdk.internal.access.JavaNioAccess;
-import jdk.internal.access.SharedSecrets;
 import jdk.internal.misc.Unsafe;
 import jdk.internal.util.Preconditions;
 import jdk.internal.vm.annotation.IntrinsicCandidate;
-import sun.nio.ch.DirectBuffer;
 
 import static java.util.zip.ZipUtils.NIO_ACCESS;
 
@@ -55,8 +52,6 @@ import static java.util.zip.ZipUtils.NIO_ACCESS;
  * @since 9
  */
 public final class CRC32C implements Checksum {
-
-    private static final JavaNioAccess JAVA_NIO_ACCESS = SharedSecrets.getJavaNioAccess();
 
     /*
      * This CRC-32C implementation uses the 'slicing-by-8' algorithm described
@@ -181,7 +176,7 @@ public final class CRC32C implements Checksum {
         if (buffer.isDirect()) {
             NIO_ACCESS.acquireSession(buffer);
             try {
-                crc = updateDirectByteBuffer(crc, JAVA_NIO_ACCESS.getBufferAddress(buffer),
+                crc = updateDirectByteBuffer(crc, NIO_ACCESS.getBufferAddress(buffer),
                         pos, limit);
             } finally {
                 NIO_ACCESS.releaseSession(buffer);

--- a/src/java.base/share/classes/java/util/zip/Deflater.java
+++ b/src/java.base/share/classes/java/util/zip/Deflater.java
@@ -30,6 +30,8 @@ import java.nio.ByteBuffer;
 import java.nio.ReadOnlyBufferException;
 import java.util.Objects;
 
+import jdk.internal.access.JavaNioAccess;
+import jdk.internal.access.SharedSecrets;
 import jdk.internal.ref.CleanerFactory;
 import jdk.internal.util.Preconditions;
 import sun.nio.ch.DirectBuffer;
@@ -73,6 +75,8 @@ import static java.util.zip.ZipUtils.NIO_ACCESS;
  */
 
 public class Deflater implements AutoCloseable {
+
+    private static final JavaNioAccess JAVA_NIO_ACCESS = SharedSecrets.getJavaNioAccess();
 
     private final DeflaterZStreamRef zsRef;
     private ByteBuffer input = ZipUtils.defaultBuf;
@@ -322,7 +326,7 @@ public class Deflater implements AutoCloseable {
             if (dictionary.isDirect()) {
                 NIO_ACCESS.acquireSession(dictionary);
                 try {
-                    long address = ((DirectBuffer) dictionary).address();
+                    long address = JAVA_NIO_ACCESS.getBufferAddress(dictionary);
                     setDictionaryBuffer(zsRef.address(), address + position, remaining);
                 } finally {
                     NIO_ACCESS.releaseSession(dictionary);
@@ -577,7 +581,7 @@ public class Deflater implements AutoCloseable {
                 if (input.isDirect()) {
                     NIO_ACCESS.acquireSession(input);
                     try {
-                        long inputAddress = ((DirectBuffer) input).address();
+                        long inputAddress = JAVA_NIO_ACCESS.getBufferAddress(input);
                         result = deflateBufferBytes(zsRef.address(),
                             inputAddress + inputPos, inputRem,
                             output, off, len,
@@ -701,7 +705,7 @@ public class Deflater implements AutoCloseable {
                 if (output.isDirect()) {
                     NIO_ACCESS.acquireSession(output);
                     try {
-                        long outputAddress = ((DirectBuffer) output).address();
+                        long outputAddress = JAVA_NIO_ACCESS.getBufferAddress(output);
                         result = deflateBytesBuffer(zsRef.address(),
                             inputArray, inputPos, inputLim - inputPos,
                             outputAddress + outputPos, outputRem,
@@ -723,11 +727,11 @@ public class Deflater implements AutoCloseable {
                 if (input.isDirect()) {
                     NIO_ACCESS.acquireSession(input);
                     try {
-                        long inputAddress = ((DirectBuffer) input).address();
+                        long inputAddress = JAVA_NIO_ACCESS.getBufferAddress(input);
                         if (output.isDirect()) {
                             NIO_ACCESS.acquireSession(output);
                             try {
-                                long outputAddress = outputPos + ((DirectBuffer) output).address();
+                                long outputAddress = outputPos + JAVA_NIO_ACCESS.getBufferAddress(output);
                                 result = deflateBufferBuffer(zsRef.address(),
                                     inputAddress + inputPos, inputRem,
                                     outputAddress, outputRem,
@@ -752,7 +756,7 @@ public class Deflater implements AutoCloseable {
                     if (output.isDirect()) {
                         NIO_ACCESS.acquireSession(output);
                         try {
-                            long outputAddress = ((DirectBuffer) output).address();
+                            long outputAddress = JAVA_NIO_ACCESS.getBufferAddress(output);
                             result = deflateBytesBuffer(zsRef.address(),
                                 inputArray, inputOffset + inputPos, inputRem,
                                 outputAddress + outputPos, outputRem,

--- a/src/java.base/share/classes/java/util/zip/Deflater.java
+++ b/src/java.base/share/classes/java/util/zip/Deflater.java
@@ -30,11 +30,8 @@ import java.nio.ByteBuffer;
 import java.nio.ReadOnlyBufferException;
 import java.util.Objects;
 
-import jdk.internal.access.JavaNioAccess;
-import jdk.internal.access.SharedSecrets;
 import jdk.internal.ref.CleanerFactory;
 import jdk.internal.util.Preconditions;
-import sun.nio.ch.DirectBuffer;
 
 import static java.util.zip.ZipUtils.NIO_ACCESS;
 
@@ -75,8 +72,6 @@ import static java.util.zip.ZipUtils.NIO_ACCESS;
  */
 
 public class Deflater implements AutoCloseable {
-
-    private static final JavaNioAccess JAVA_NIO_ACCESS = SharedSecrets.getJavaNioAccess();
 
     private final DeflaterZStreamRef zsRef;
     private ByteBuffer input = ZipUtils.defaultBuf;
@@ -326,7 +321,7 @@ public class Deflater implements AutoCloseable {
             if (dictionary.isDirect()) {
                 NIO_ACCESS.acquireSession(dictionary);
                 try {
-                    long address = JAVA_NIO_ACCESS.getBufferAddress(dictionary);
+                    long address = NIO_ACCESS.getBufferAddress(dictionary);
                     setDictionaryBuffer(zsRef.address(), address + position, remaining);
                 } finally {
                     NIO_ACCESS.releaseSession(dictionary);
@@ -581,7 +576,7 @@ public class Deflater implements AutoCloseable {
                 if (input.isDirect()) {
                     NIO_ACCESS.acquireSession(input);
                     try {
-                        long inputAddress = JAVA_NIO_ACCESS.getBufferAddress(input);
+                        long inputAddress = NIO_ACCESS.getBufferAddress(input);
                         result = deflateBufferBytes(zsRef.address(),
                             inputAddress + inputPos, inputRem,
                             output, off, len,
@@ -705,7 +700,7 @@ public class Deflater implements AutoCloseable {
                 if (output.isDirect()) {
                     NIO_ACCESS.acquireSession(output);
                     try {
-                        long outputAddress = JAVA_NIO_ACCESS.getBufferAddress(output);
+                        long outputAddress = NIO_ACCESS.getBufferAddress(output);
                         result = deflateBytesBuffer(zsRef.address(),
                             inputArray, inputPos, inputLim - inputPos,
                             outputAddress + outputPos, outputRem,
@@ -727,11 +722,11 @@ public class Deflater implements AutoCloseable {
                 if (input.isDirect()) {
                     NIO_ACCESS.acquireSession(input);
                     try {
-                        long inputAddress = JAVA_NIO_ACCESS.getBufferAddress(input);
+                        long inputAddress = NIO_ACCESS.getBufferAddress(input);
                         if (output.isDirect()) {
                             NIO_ACCESS.acquireSession(output);
                             try {
-                                long outputAddress = outputPos + JAVA_NIO_ACCESS.getBufferAddress(output);
+                                long outputAddress = outputPos + NIO_ACCESS.getBufferAddress(output);
                                 result = deflateBufferBuffer(zsRef.address(),
                                     inputAddress + inputPos, inputRem,
                                     outputAddress, outputRem,
@@ -756,7 +751,7 @@ public class Deflater implements AutoCloseable {
                     if (output.isDirect()) {
                         NIO_ACCESS.acquireSession(output);
                         try {
-                            long outputAddress = JAVA_NIO_ACCESS.getBufferAddress(output);
+                            long outputAddress = NIO_ACCESS.getBufferAddress(output);
                             result = deflateBytesBuffer(zsRef.address(),
                                 inputArray, inputOffset + inputPos, inputRem,
                                 outputAddress + outputPos, outputRem,

--- a/src/java.base/share/classes/java/util/zip/Inflater.java
+++ b/src/java.base/share/classes/java/util/zip/Inflater.java
@@ -30,11 +30,8 @@ import java.nio.ByteBuffer;
 import java.nio.ReadOnlyBufferException;
 import java.util.Objects;
 
-import jdk.internal.access.JavaNioAccess;
-import jdk.internal.access.SharedSecrets;
 import jdk.internal.ref.CleanerFactory;
 import jdk.internal.util.Preconditions;
-import sun.nio.ch.DirectBuffer;
 
 import static java.util.zip.ZipUtils.NIO_ACCESS;
 
@@ -75,8 +72,6 @@ import static java.util.zip.ZipUtils.NIO_ACCESS;
  */
 
 public class Inflater implements AutoCloseable {
-
-    private static final JavaNioAccess JAVA_NIO_ACCESS = SharedSecrets.getJavaNioAccess();
 
     private final InflaterZStreamRef zsRef;
     private ByteBuffer input = ZipUtils.defaultBuf;
@@ -247,7 +242,7 @@ public class Inflater implements AutoCloseable {
             if (dictionary.isDirect()) {
                 NIO_ACCESS.acquireSession(dictionary);
                 try {
-                    long address = JAVA_NIO_ACCESS.getBufferAddress(dictionary);
+                    long address = NIO_ACCESS.getBufferAddress(dictionary);
                     setDictionaryBuffer(zsRef.address(), address + position, remaining);
                 } finally {
                     NIO_ACCESS.releaseSession(dictionary);
@@ -370,7 +365,7 @@ public class Inflater implements AutoCloseable {
                         if (input.isDirect()) {
                             NIO_ACCESS.acquireSession(input);
                             try {
-                                long inputAddress = JAVA_NIO_ACCESS.getBufferAddress(input);
+                                long inputAddress = NIO_ACCESS.getBufferAddress(input);
                                 result = inflateBufferBytes(zsRef.address(),
                                     inputAddress + inputPos, inputRem,
                                     output, off, len);
@@ -507,7 +502,7 @@ public class Inflater implements AutoCloseable {
                         if (output.isDirect()) {
                             NIO_ACCESS.acquireSession(output);
                             try {
-                                long outputAddress = JAVA_NIO_ACCESS.getBufferAddress(output);
+                                long outputAddress = NIO_ACCESS.getBufferAddress(output);
                                 result = inflateBytesBuffer(zsRef.address(),
                                     inputArray, inputPos, inputLim - inputPos,
                                     outputAddress + outputPos, outputRem);
@@ -532,11 +527,11 @@ public class Inflater implements AutoCloseable {
                         if (input.isDirect()) {
                             NIO_ACCESS.acquireSession(input);
                             try {
-                                long inputAddress = JAVA_NIO_ACCESS.getBufferAddress(input);
+                                long inputAddress = NIO_ACCESS.getBufferAddress(input);
                                 if (output.isDirect()) {
                                     NIO_ACCESS.acquireSession(output);
                                     try {
-                                        long outputAddress = JAVA_NIO_ACCESS.getBufferAddress(output);
+                                        long outputAddress = NIO_ACCESS.getBufferAddress(output);
                                         result = inflateBufferBuffer(zsRef.address(),
                                             inputAddress + inputPos, inputRem,
                                             outputAddress + outputPos, outputRem);
@@ -559,7 +554,7 @@ public class Inflater implements AutoCloseable {
                             if (output.isDirect()) {
                                 NIO_ACCESS.acquireSession(output);
                                 try {
-                                    long outputAddress = JAVA_NIO_ACCESS.getBufferAddress(output);
+                                    long outputAddress = NIO_ACCESS.getBufferAddress(output);
                                     result = inflateBytesBuffer(zsRef.address(),
                                         inputArray, inputOffset + inputPos, inputRem,
                                         outputAddress + outputPos, outputRem);

--- a/src/java.base/share/classes/java/util/zip/Inflater.java
+++ b/src/java.base/share/classes/java/util/zip/Inflater.java
@@ -30,6 +30,8 @@ import java.nio.ByteBuffer;
 import java.nio.ReadOnlyBufferException;
 import java.util.Objects;
 
+import jdk.internal.access.JavaNioAccess;
+import jdk.internal.access.SharedSecrets;
 import jdk.internal.ref.CleanerFactory;
 import jdk.internal.util.Preconditions;
 import sun.nio.ch.DirectBuffer;
@@ -73,6 +75,8 @@ import static java.util.zip.ZipUtils.NIO_ACCESS;
  */
 
 public class Inflater implements AutoCloseable {
+
+    private static final JavaNioAccess JAVA_NIO_ACCESS = SharedSecrets.getJavaNioAccess();
 
     private final InflaterZStreamRef zsRef;
     private ByteBuffer input = ZipUtils.defaultBuf;
@@ -243,7 +247,7 @@ public class Inflater implements AutoCloseable {
             if (dictionary.isDirect()) {
                 NIO_ACCESS.acquireSession(dictionary);
                 try {
-                    long address = ((DirectBuffer) dictionary).address();
+                    long address = JAVA_NIO_ACCESS.getBufferAddress(dictionary);
                     setDictionaryBuffer(zsRef.address(), address + position, remaining);
                 } finally {
                     NIO_ACCESS.releaseSession(dictionary);
@@ -366,7 +370,7 @@ public class Inflater implements AutoCloseable {
                         if (input.isDirect()) {
                             NIO_ACCESS.acquireSession(input);
                             try {
-                                long inputAddress = ((DirectBuffer) input).address();
+                                long inputAddress = JAVA_NIO_ACCESS.getBufferAddress(input);
                                 result = inflateBufferBytes(zsRef.address(),
                                     inputAddress + inputPos, inputRem,
                                     output, off, len);
@@ -503,7 +507,7 @@ public class Inflater implements AutoCloseable {
                         if (output.isDirect()) {
                             NIO_ACCESS.acquireSession(output);
                             try {
-                                long outputAddress = ((DirectBuffer) output).address();
+                                long outputAddress = JAVA_NIO_ACCESS.getBufferAddress(output);
                                 result = inflateBytesBuffer(zsRef.address(),
                                     inputArray, inputPos, inputLim - inputPos,
                                     outputAddress + outputPos, outputRem);
@@ -528,11 +532,11 @@ public class Inflater implements AutoCloseable {
                         if (input.isDirect()) {
                             NIO_ACCESS.acquireSession(input);
                             try {
-                                long inputAddress = ((DirectBuffer) input).address();
+                                long inputAddress = JAVA_NIO_ACCESS.getBufferAddress(input);
                                 if (output.isDirect()) {
                                     NIO_ACCESS.acquireSession(output);
                                     try {
-                                        long outputAddress = ((DirectBuffer) output).address();
+                                        long outputAddress = JAVA_NIO_ACCESS.getBufferAddress(output);
                                         result = inflateBufferBuffer(zsRef.address(),
                                             inputAddress + inputPos, inputRem,
                                             outputAddress + outputPos, outputRem);
@@ -555,7 +559,7 @@ public class Inflater implements AutoCloseable {
                             if (output.isDirect()) {
                                 NIO_ACCESS.acquireSession(output);
                                 try {
-                                    long outputAddress = ((DirectBuffer) output).address();
+                                    long outputAddress = JAVA_NIO_ACCESS.getBufferAddress(output);
                                     result = inflateBytesBuffer(zsRef.address(),
                                         inputArray, inputOffset + inputPos, inputRem,
                                         outputAddress + outputPos, outputRem);

--- a/test/jdk/java/util/zip/ChecksumBase.java
+++ b/test/jdk/java/util/zip/ChecksumBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,14 +21,15 @@
  * questions.
  */
 
-/**
- * Base class for Checksum tests
- */
+import java.lang.foreign.MemorySegment;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
 import java.util.zip.Checksum;
 
+/**
+ * Base class for Checksum tests
+ */
 public class ChecksumBase {
 
     private static final byte[] BYTES_123456789 = "123456789".getBytes(StandardCharsets.US_ASCII);
@@ -36,6 +37,7 @@ public class ChecksumBase {
     public static void testAll(Checksum checksum, long expected) {
         testBytes(checksum, expected);
         testByteArray(checksum, expected);
+        testWrappedMemorySegment(checksum, expected);
         testWrappedByteBuffer(checksum, expected);
         testReadonlyByteBuffer(checksum, expected);
         testDirectByteBuffer(checksum, expected);
@@ -65,6 +67,13 @@ public class ChecksumBase {
     private static void testWrappedByteBuffer(Checksum checksum, long expected) {
         checksum.reset();
         ByteBuffer bb = ByteBuffer.wrap(BYTES_123456789);
+        checksum.update(bb);
+        checkChecksum(checksum, expected);
+    }
+
+    private static void testWrappedMemorySegment(Checksum checksum, long expected) {
+        checksum.reset();
+        ByteBuffer bb = MemorySegment.ofArray(BYTES_123456789).asByteBuffer();
         checksum.update(bb);
         checkChecksum(checksum, expected);
     }

--- a/test/jdk/java/util/zip/DeInflate.java
+++ b/test/jdk/java/util/zip/DeInflate.java
@@ -21,14 +21,15 @@
  * questions.
  */
 
-/**
+/*
  * @test
- * @bug 7110149 8184306 6341887
+ * @bug 7110149 8184306 6341887 8357145
  * @summary Test basic deflater & inflater functionality
  * @key randomness
  */
 
 import java.io.*;
+import java.lang.foreign.Arena;
 import java.nio.*;
 import java.util.*;
 import java.util.zip.*;
@@ -203,6 +204,16 @@ public class DeInflate {
         bbOut2 = ByteBuffer.allocateDirect(out2.length);
         checkByteBuffer(def, inf, bbIn, bbOut1, bbOut2, in, len, out2, false);
         checkByteBufferReadonly(def, inf, bbIn, bbOut1, bbOut2);
+
+        // segment
+        try (var arena = Arena.ofConfined()) {
+            bbIn = arena.allocate(in.length).asByteBuffer();
+            bbIn.put(in, 0, n).flip();
+            bbOut1 = arena.allocate(out1.length).asByteBuffer();
+            bbOut2 = arena.allocate(out2.length).asByteBuffer();
+            checkByteBuffer(def, inf, bbIn, bbOut1, bbOut2, in, len, out2, false);
+            checkByteBufferReadonly(def, inf, bbIn, bbOut1, bbOut2);
+        }
     }
 
     static void checkDict(Deflater def, Inflater inf, byte[] src,


### PR DESCRIPTION
This PR proposes to use ` JavaNioAccess::getBufferAdress` rather than `DirectBuffer::address` in the package `java.util.zip` so that `Buffer` instances backed by `MemorySegment` instances can be used.

This PR passes tier1, tier2, and tier3 tests on multiple platforms and configurations.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8357145](https://bugs.openjdk.org/browse/JDK-8357145): CRC/Inflater/Deflater/Adler32 methods that take a ByteBuffer throw UOE if backed by shared memory segment (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25321/head:pull/25321` \
`$ git checkout pull/25321`

Update a local copy of the PR: \
`$ git checkout pull/25321` \
`$ git pull https://git.openjdk.org/jdk.git pull/25321/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25321`

View PR using the GUI difftool: \
`$ git pr show -t 25321`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25321.diff">https://git.openjdk.org/jdk/pull/25321.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25321#issuecomment-2893549043)
</details>
