### PR TITLE
8357018: Guidance for ParallelRefProcEnabled is wrong in the man pages

### DIFF
--- a/src/java.base/share/man/java.md
+++ b/src/java.base/share/man/java.md
@@ -2701,7 +2701,12 @@ Java HotSpot VM.
     >   `-XX:ParallelGCThreads=2`
 
 `-XX:+ParallelRefProcEnabled`
-:   Enables parallel reference processing. By default, this option is disabled.
+:   Enables parallel reference processing. By default, collectors employing multiple
+    threads perform parallel reference processing if the number of parallel threads
+    to use is larger than one.
+    The option is available only when the throughput or G1 garbage collector is used
+    (`-XX:+UseParallelGC` or `-XX:+UseG1GC`). Other collectors employing multiple
+    threads always perform reference processing in parallel.
 
 `-XX:+PrintAdaptiveSizePolicy`
 :   Enables printing of information about adaptive-generation sizing. By


### PR DESCRIPTION
Hi all,

  please review this small update to the parallel reference processing option in the manpage.

Testing: compilation/manpage building?

Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8357018](https://bugs.openjdk.org/browse/JDK-8357018): Guidance for ParallelRefProcEnabled is wrong in the man pages (**Bug** - P4)


### Reviewers
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25323/head:pull/25323` \
`$ git checkout pull/25323`

Update a local copy of the PR: \
`$ git checkout pull/25323` \
`$ git pull https://git.openjdk.org/jdk.git pull/25323/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25323`

View PR using the GUI difftool: \
`$ git pr show -t 25323`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25323.diff">https://git.openjdk.org/jdk/pull/25323.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25323#issuecomment-2895198291)
</details>
