### PR TITLE
8357268: Use JavaNioAccess.getBufferAddress rather than DirectBuffer.address()

### DIFF
--- a/src/java.base/share/classes/com/sun/crypto/provider/GaloisCounterMode.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/GaloisCounterMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,7 @@ package com.sun.crypto.provider;
 
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.security.*;
@@ -910,26 +911,26 @@ abstract class GaloisCounterMode extends CipherSpi {
          */
         ByteBuffer overlapDetection(ByteBuffer src, ByteBuffer dst) {
             if (src.isDirect() && dst.isDirect()) {
-                // The use of DirectBuffer::address below need not be guarded as
+                // The use of addresses below need not be guarded as
                 // no access is made to actual memory.
                 DirectBuffer dsrc = (DirectBuffer) src;
                 DirectBuffer ddst = (DirectBuffer) dst;
 
                 // Get the current memory address for the given ByteBuffers
-                long srcaddr = dsrc.address();
-                long dstaddr = ddst.address();
+                long srcaddr = NIO_ACCESS.getBufferAddress(src);
+                long dstaddr = NIO_ACCESS.getBufferAddress(dst);
 
                 // Find the lowest attachment that is the base memory address
                 // of the shared memory for the src object
                 while (dsrc.attachment() != null) {
-                    srcaddr = ((DirectBuffer) dsrc.attachment()).address();
+                    srcaddr = NIO_ACCESS.getBufferAddress((Buffer) dsrc.attachment());
                     dsrc = (DirectBuffer) dsrc.attachment();
                 }
 
                 // Find the lowest attachment that is the base memory address
                 // of the shared memory for the dst object
                 while (ddst.attachment() != null) {
-                    dstaddr = ((DirectBuffer) ddst.attachment()).address();
+                    dstaddr = NIO_ACCESS.getBufferAddress((Buffer) ddst.attachment());
                     ddst = (DirectBuffer) ddst.attachment();
                 }
 
@@ -947,8 +948,8 @@ abstract class GaloisCounterMode extends CipherSpi {
                 // side, we are not in overlap.
                 // NOTE: inPlaceArray does not apply here as direct buffers run
                 // through a byte[] to get to the combined intrinsic
-                if (((DirectBuffer) src).address() - srcaddr + src.position() >=
-                    ((DirectBuffer) dst).address() - dstaddr + dst.position()) {
+                if (NIO_ACCESS.getBufferAddress(src) - srcaddr + src.position() >=
+                        NIO_ACCESS.getBufferAddress(dst) - dstaddr + dst.position()) {
                     return dst;
                 }
 
@@ -1602,7 +1603,7 @@ abstract class GaloisCounterMode extends CipherSpi {
                         NIO_ACCESS.acquireSession(dst);
                         try {
                             Unsafe.getUnsafe().setMemory(
-                                ((DirectBuffer)dst).address(),
+                                    NIO_ACCESS.getBufferAddress(dst),
                                 len + dst.position(), (byte) 0);
                         } finally {
                             NIO_ACCESS.releaseSession(dst);

--- a/src/java.base/share/classes/sun/nio/ch/SocketChannelImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/SocketChannelImpl.java
@@ -58,6 +58,7 @@ import java.util.concurrent.locks.ReentrantLock;
 import static java.net.StandardProtocolFamily.INET;
 import static java.net.StandardProtocolFamily.INET6;
 import static java.net.StandardProtocolFamily.UNIX;
+import static sun.nio.ch.Util.NIO_ACCESS;
 
 import jdk.internal.event.SocketReadEvent;
 import jdk.internal.event.SocketWriteEvent;
@@ -1323,13 +1324,15 @@ class SocketChannelImpl
     private int tryRead(byte[] b, int off, int len) throws IOException {
         ByteBuffer dst = Util.getTemporaryDirectBuffer(len);
         assert dst.position() == 0;
+        NIO_ACCESS.acquireSession(dst);
         try {
-            int n = nd.read(fd, ((DirectBuffer)dst).address(), len);
+            int n = nd.read(fd, NIO_ACCESS.getBufferAddress(dst), len);
             if (n > 0) {
                 dst.get(b, off, n);
             }
             return n;
         } finally{
+            NIO_ACCESS.releaseSession(dst);
             Util.offerFirstTemporaryDirectBuffer(dst);
         }
     }
@@ -1427,10 +1430,12 @@ class SocketChannelImpl
     private int tryWrite(byte[] b, int off, int len) throws IOException {
         ByteBuffer src = Util.getTemporaryDirectBuffer(len);
         assert src.position() == 0;
+        NIO_ACCESS.acquireSession(src);
         try {
             src.put(b, off, len);
-            return nd.write(fd, ((DirectBuffer)src).address(), len);
+            return nd.write(fd, NIO_ACCESS.getBufferAddress(src), len);
         } finally {
+            NIO_ACCESS.releaseSession(src);
             Util.offerFirstTemporaryDirectBuffer(src);
         }
     }

--- a/src/java.base/share/classes/sun/nio/ch/Util.java
+++ b/src/java.base/share/classes/sun/nio/ch/Util.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,7 +43,7 @@ import jdk.internal.misc.Unsafe;
 
 public class Util {
 
-    private static final JavaNioAccess NIO_ACCESS = SharedSecrets.getJavaNioAccess();
+    static final JavaNioAccess NIO_ACCESS = SharedSecrets.getJavaNioAccess();
 
     // -- Caches --
 
@@ -340,7 +340,7 @@ public class Util {
      * Frees the memory for the given direct buffer
      */
     private static void free(ByteBuffer buf) {
-        unsafe.freeMemory(((DirectBuffer)buf).address());
+        unsafe.freeMemory(NIO_ACCESS.getBufferAddress(buf));
     }
 
 
@@ -405,7 +405,7 @@ public class Util {
     }
 
     static void erase(ByteBuffer bb) {
-        unsafe.setMemory(((DirectBuffer)bb).address(), bb.capacity(), (byte)0);
+        unsafe.setMemory(NIO_ACCESS.getBufferAddress(bb), bb.capacity(), (byte)0);
     }
 
     static Unsafe unsafe() {

--- a/src/java.base/unix/classes/sun/nio/fs/UnixUserDefinedFileAttributeView.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixUserDefinedFileAttributeView.java
@@ -166,10 +166,10 @@ abstract class UnixUserDefinedFileAttributeView
         assert (pos <= lim);
         int rem = (pos <= lim ? lim - pos : 0);
 
-        if (dst instanceof sun.nio.ch.DirectBuffer ddst) {
+        if (dst instanceof sun.nio.ch.DirectBuffer) {
             NIO_ACCESS.acquireSession(dst);
             try {
-                long address = ddst.address() + pos;
+                long address = NIO_ACCESS.getBufferAddress(dst) + pos;
                 int n = read(name, address, rem);
                 dst.position(pos + n);
                 return n;
@@ -225,10 +225,10 @@ abstract class UnixUserDefinedFileAttributeView
         assert (pos <= lim);
         int rem = (pos <= lim ? lim - pos : 0);
 
-        if (src instanceof sun.nio.ch.DirectBuffer buf) {
+        if (src instanceof sun.nio.ch.DirectBuffer) {
             NIO_ACCESS.acquireSession(src);
             try {
-                long address = buf.address() + pos;
+                long address = NIO_ACCESS.getBufferAddress(src) + pos;
                 write(name, address, rem);
                 src.position(pos + rem);
                 return rem;

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11AEADCipher.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11AEADCipher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,6 +22,7 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package sun.security.pkcs11;
 
 import java.io.ByteArrayOutputStream;
@@ -743,8 +744,8 @@ final class P11AEADCipher extends CipherSpi {
                         inOfs = 0;
                         inLen = in.length;
                     } else {
-                        if (inBuffer instanceof DirectBuffer dInBuffer) {
-                            inAddr = dInBuffer.address();
+                        if (inBuffer instanceof DirectBuffer) {
+                            inAddr = NIO_ACCESS.getBufferAddress(inBuffer);
                             inOfs = inBuffer.position();
                         } else {
                             if (inBuffer.hasArray()) {
@@ -759,8 +760,8 @@ final class P11AEADCipher extends CipherSpi {
                     long outAddr = 0;
                     byte[] outArray = null;
                     int outOfs = 0;
-                    if (outBuffer instanceof DirectBuffer dOutBuffer) {
-                        outAddr = dOutBuffer.address();
+                    if (outBuffer instanceof DirectBuffer) {
+                        outAddr = NIO_ACCESS.getBufferAddress(outBuffer);
                         outOfs = outBuffer.position();
                     } else {
                         if (outBuffer.hasArray()) {

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Cipher.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Cipher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,6 +22,7 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package sun.security.pkcs11;
 
 import java.nio.ByteBuffer;
@@ -742,8 +743,8 @@ final class P11Cipher extends CipherSpi {
                 int inOfs = 0;
                 byte[] inArray = null;
 
-                if (inBuffer instanceof DirectBuffer dInBuffer) {
-                    inAddr = dInBuffer.address();
+                if (inBuffer instanceof DirectBuffer) {
+                    inAddr = NIO_ACCESS.getBufferAddress(inBuffer);
                     inOfs = origPos;
                 } else if (inBuffer.hasArray()) {
                     inArray = inBuffer.array();
@@ -753,8 +754,8 @@ final class P11Cipher extends CipherSpi {
                 long outAddr = 0;
                 int outOfs = 0;
                 byte[] outArray = null;
-                if (outBuffer instanceof DirectBuffer dOutBuffer) {
-                    outAddr = dOutBuffer.address();
+                if (outBuffer instanceof DirectBuffer) {
+                    outAddr = NIO_ACCESS.getBufferAddress(outBuffer);
                     outOfs = outBuffer.position();
                 } else {
                     if (outBuffer.hasArray()) {
@@ -1012,8 +1013,8 @@ final class P11Cipher extends CipherSpi {
                 long outAddr = 0;
                 byte[] outArray = null;
                 int outOfs = 0;
-                if (outBuffer instanceof DirectBuffer dOutBuffer) {
-                    outAddr = dOutBuffer.address();
+                if (outBuffer instanceof DirectBuffer) {
+                    outAddr = NIO_ACCESS.getBufferAddress(outBuffer);
                     outOfs = outBuffer.position();
                 } else {
                     if (outBuffer.hasArray()) {

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Digest.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Digest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -271,7 +271,7 @@ final class P11Digest extends MessageDigestSpi implements Cloneable,
             return;
         }
 
-        if (!(byteBuffer instanceof DirectBuffer dByteBuffer)) {
+        if (!(byteBuffer instanceof DirectBuffer)) {
             super.engineUpdate(byteBuffer);
             return;
         }
@@ -289,7 +289,7 @@ final class P11Digest extends MessageDigestSpi implements Cloneable,
             }
             NIO_ACCESS.acquireSession(byteBuffer);
             try {
-                token.p11.C_DigestUpdate(session.id(), dByteBuffer.address() + ofs, null, 0, len);
+                token.p11.C_DigestUpdate(session.id(), NIO_ACCESS.getBufferAddress(byteBuffer) + ofs, null, 0, len);
             } finally {
                 NIO_ACCESS.releaseSession(byteBuffer);
             }

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11KeyWrapCipher.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11KeyWrapCipher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,6 +22,7 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package sun.security.pkcs11;
 
 import java.io.ByteArrayOutputStream;
@@ -577,8 +578,8 @@ final class P11KeyWrapCipher extends CipherSpi {
                         inOfs = 0;
                         inLen = in.length;
                     } else {
-                        if (inBuffer instanceof DirectBuffer dInBuffer) {
-                            inAddr = dInBuffer.address();
+                        if (inBuffer instanceof DirectBuffer) {
+                            inAddr = NIO_ACCESS.getBufferAddress(inBuffer);
                             inOfs = inBuffer.position();
                         } else {
                             if (inBuffer.hasArray()) {
@@ -593,8 +594,8 @@ final class P11KeyWrapCipher extends CipherSpi {
                     long outAddr = 0;
                     byte[] outArray = null;
                     int outOfs = 0;
-                    if (outBuffer instanceof DirectBuffer dOutBuffer) {
-                        outAddr = dOutBuffer.address();
+                    if (outBuffer instanceof DirectBuffer) {
+                        outAddr = NIO_ACCESS.getBufferAddress(outBuffer);
                         outOfs = outBuffer.position();
                     } else {
                         if (outBuffer.hasArray()) {

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Mac.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Mac.java
@@ -279,14 +279,14 @@ final class P11Mac extends MacSpi {
             if (len <= 0) {
                 return;
             }
-            if (!(byteBuffer instanceof DirectBuffer dByteBuffer)) {
+            if (!(byteBuffer instanceof DirectBuffer)) {
                 super.engineUpdate(byteBuffer);
                 return;
             }
             int ofs = byteBuffer.position();
             NIO_ACCESS.acquireSession(byteBuffer);
             try  {
-                token.p11.C_SignUpdate(session.id(), dByteBuffer.address() + ofs, null, 0, len);
+                token.p11.C_SignUpdate(session.id(), NIO_ACCESS.getBufferAddress(byteBuffer) + ofs, null, 0, len);
             } finally {
                 NIO_ACCESS.releaseSession(byteBuffer);
             }

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11PSSSignature.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11PSSSignature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -614,7 +614,7 @@ final class P11PSSSignature extends SignatureSpi {
         isActive = true;
         switch (type) {
             case T_UPDATE -> {
-                if (!(byteBuffer instanceof DirectBuffer dByteBuffer)) {
+                if (!(byteBuffer instanceof DirectBuffer)) {
                     // cannot do better than default impl
                     super.engineUpdate(byteBuffer);
                     return;
@@ -622,7 +622,7 @@ final class P11PSSSignature extends SignatureSpi {
                 int ofs = byteBuffer.position();
                 NIO_ACCESS.acquireSession(byteBuffer);
                 try {
-                    long addr = dByteBuffer.address();
+                    long addr = NIO_ACCESS.getBufferAddress(byteBuffer);
                     if (mode == M_SIGN) {
                         if (DEBUG) System.out.println(this + ": Calling C_SignUpdate");
                         token.p11.C_SignUpdate

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Signature.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Signature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -579,7 +579,7 @@ final class P11Signature extends SignatureSpi {
         }
         switch (type) {
             case T_UPDATE -> {
-                if (!(byteBuffer instanceof DirectBuffer dByteBuffer)) {
+                if (!(byteBuffer instanceof DirectBuffer)) {
                     // cannot do better than default impl
                     super.engineUpdate(byteBuffer);
                     return;
@@ -587,7 +587,7 @@ final class P11Signature extends SignatureSpi {
                 int ofs = byteBuffer.position();
                 NIO_ACCESS.acquireSession(byteBuffer);
                 try {
-                    long addr = dByteBuffer.address();
+                    long addr = NIO_ACCESS.getBufferAddress(byteBuffer);
                     if (mode == M_SIGN) {
                         token.p11.C_SignUpdate
                                 (session.id(), addr + ofs, null, 0, len);

--- a/src/jdk.sctp/unix/classes/sun/nio/ch/sctp/SctpChannelImpl.java
+++ b/src/jdk.sctp/unix/classes/sun/nio/ch/sctp/SctpChannelImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,6 +22,7 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package sun.nio.ch.sctp;
 
 import java.net.InetAddress;
@@ -65,6 +66,7 @@ import sun.nio.ch.SelChImpl;
 import sun.nio.ch.SelectionKeyImpl;
 import sun.nio.ch.Util;
 import static com.sun.nio.sctp.SctpStandardSocketOptions.*;
+import static sun.nio.ch.Util.NIO_ACCESS;
 import static sun.nio.ch.sctp.ResultContainer.SEND_FAILED;
 import static sun.nio.ch.sctp.ResultContainer.ASSOCIATION_CHANGED;
 import static sun.nio.ch.sctp.ResultContainer.PEER_ADDRESS_CHANGED;
@@ -829,7 +831,7 @@ public class SctpChannelImpl extends SctpChannel
     {
         NIO_ACCESS.acquireSession(bb);
         try {
-            int n = receive0(fd, resultContainer, ((DirectBuffer)bb).address() + pos, rem, peek);
+            int n = receive0(fd, resultContainer, NIO_ACCESS.getBufferAddress(bb) + pos, rem, peek);
 
             if (n > 0)
                 bb.position(pos + n);
@@ -1012,7 +1014,7 @@ public class SctpChannelImpl extends SctpChannel
 
         NIO_ACCESS.acquireSession(bb);
         try {
-            int written = send0(fd, ((DirectBuffer)bb).address() + pos, rem, addr,
+            int written = send0(fd, NIO_ACCESS.getBufferAddress(bb) + pos, rem, addr,
                     port, -1 /*121*/, streamNumber, unordered, ppid);
             if (written > 0)
                 bb.position(pos + written);

--- a/src/jdk.sctp/unix/classes/sun/nio/ch/sctp/SctpMultiChannelImpl.java
+++ b/src/jdk.sctp/unix/classes/sun/nio/ch/sctp/SctpMultiChannelImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,6 +22,7 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package sun.nio.ch.sctp;
 
 import java.net.InetAddress;
@@ -561,7 +562,7 @@ public class SctpMultiChannelImpl extends SctpMultiChannel
             throws IOException {
         NIO_ACCESS.acquireSession(bb);
         try {
-            int n = receive0(fd, resultContainer, ((DirectBuffer)bb).address() + pos, rem);
+            int n = receive0(fd, resultContainer, NIO_ACCESS.getBufferAddress(bb) + pos, rem);
             if (n > 0)
                 bb.position(pos + n);
             return n;
@@ -870,7 +871,7 @@ public class SctpMultiChannelImpl extends SctpMultiChannel
 
         NIO_ACCESS.acquireSession(bb);
         try {
-            int written = send0(fd, ((DirectBuffer)bb).address() + pos, rem, addr,
+            int written = send0(fd, NIO_ACCESS.getBufferAddress(bb) + pos, rem, addr,
                     port, assocId, streamNumber, unordered, ppid);
             if (written > 0)
                 bb.position(pos + written);


### PR DESCRIPTION
This PR proposes to use  JavaNioAccess::getBufferAdress rather than DirectBuffer::address so that Buffer instances backed by MemorySegment instances can be used in classes that were not covered by https://github.com/openjdk/jdk/pull/25321

This PR passes tier1, tier2, and tier3 tests on multiple platforms and configurations.