### PR TITLE
8357370: Export supported GCs in JVMCI

### DIFF
--- a/src/hotspot/share/jvmci/vmStructs_jvmci.cpp
+++ b/src/hotspot/share/jvmci/vmStructs_jvmci.cpp
@@ -495,10 +495,10 @@
 #define VM_INT_CONSTANTS(declare_constant, declare_constant_with_value, declare_preprocessor_constant) \
   declare_preprocessor_constant("ASSERT", DEBUG_ONLY(1) NOT_DEBUG(0))     \
                                                                           \
-  declare_preprocessor_constant("INCLUDE_SERIALGC",     INCLUDE_SERIALGC)     \
-  declare_preprocessor_constant("INCLUDE_PARALLELGC",   INCLUDE_PARALLELGC)   \
-  declare_preprocessor_constant("INCLUDE_G1GC",         INCLUDE_G1GC)         \
-  declare_preprocessor_constant("INCLUDE_ZGC",          INCLUDE_ZGC)          \
+  declare_preprocessor_constant("INCLUDE_SERIALGC", INCLUDE_SERIALGC)         \
+  declare_preprocessor_constant("INCLUDE_PARALLELGC", INCLUDE_PARALLELGC)     \
+  declare_preprocessor_constant("INCLUDE_G1GC", INCLUDE_G1GC)                 \
+  declare_preprocessor_constant("INCLUDE_ZGC", INCLUDE_ZGC)                   \
   declare_preprocessor_constant("INCLUDE_SHENANDOAHGC", INCLUDE_SHENANDOAHGC) \
                                                                           \
   declare_constant(CompLevel_none)                                        \

--- a/src/hotspot/share/jvmci/vmStructs_jvmci.cpp
+++ b/src/hotspot/share/jvmci/vmStructs_jvmci.cpp
@@ -495,10 +495,10 @@
 #define VM_INT_CONSTANTS(declare_constant, declare_constant_with_value, declare_preprocessor_constant) \
   declare_preprocessor_constant("ASSERT", DEBUG_ONLY(1) NOT_DEBUG(0))     \
                                                                           \
-  declare_preprocessor_constant("INCLUDE_SERIALGC", INCLUDE_SERIALGC)         \
-  declare_preprocessor_constant("INCLUDE_PARALLELGC", INCLUDE_PARALLELGC)     \
-  declare_preprocessor_constant("INCLUDE_G1GC", INCLUDE_G1GC)                 \
-  declare_preprocessor_constant("INCLUDE_ZGC", INCLUDE_ZGC)                   \
+  declare_preprocessor_constant("INCLUDE_SERIALGC", INCLUDE_SERIALGC)     \
+  declare_preprocessor_constant("INCLUDE_PARALLELGC", INCLUDE_PARALLELGC) \
+  declare_preprocessor_constant("INCLUDE_G1GC", INCLUDE_G1GC)             \
+  declare_preprocessor_constant("INCLUDE_ZGC", INCLUDE_ZGC)               \
   declare_preprocessor_constant("INCLUDE_SHENANDOAHGC", INCLUDE_SHENANDOAHGC) \
                                                                           \
   declare_constant(CompLevel_none)                                        \

--- a/src/hotspot/share/jvmci/vmStructs_jvmci.cpp
+++ b/src/hotspot/share/jvmci/vmStructs_jvmci.cpp
@@ -495,6 +495,12 @@
 #define VM_INT_CONSTANTS(declare_constant, declare_constant_with_value, declare_preprocessor_constant) \
   declare_preprocessor_constant("ASSERT", DEBUG_ONLY(1) NOT_DEBUG(0))     \
                                                                           \
+  declare_preprocessor_constant("INCLUDE_SERIALGC",     INCLUDE_SERIALGC)     \
+  declare_preprocessor_constant("INCLUDE_PARALLELGC",   INCLUDE_PARALLELGC)   \
+  declare_preprocessor_constant("INCLUDE_G1GC",         INCLUDE_G1GC)         \
+  declare_preprocessor_constant("INCLUDE_ZGC",          INCLUDE_ZGC)          \
+  declare_preprocessor_constant("INCLUDE_SHENANDOAHGC", INCLUDE_SHENANDOAHGC) \
+                                                                          \
   declare_constant(CompLevel_none)                                        \
   declare_constant(CompLevel_simple)                                      \
   declare_constant(CompLevel_limited_profile)                             \


### PR DESCRIPTION
I need a way to detect in JVMCI if Shenandoah GC is supported (that is, built-in) by HotSpot. I need it for Shenandoah, because some vendors don't build it, but for cleanliness the relevant preprocessor constants should be exported for all GCs.

Testing:
 - [x] build/test https://github.com/oracle/graal/pull/10904

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8357370](https://bugs.openjdk.org/browse/JDK-8357370): Export supported GCs in JVMCI (**Enhancement** - P4)


### Reviewers
 * [Doug Simon](https://openjdk.org/census#dnsimon) (@dougxc - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25325/head:pull/25325` \
`$ git checkout pull/25325`

Update a local copy of the PR: \
`$ git checkout pull/25325` \
`$ git pull https://git.openjdk.org/jdk.git pull/25325/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25325`

View PR using the GUI difftool: \
`$ git pr show -t 25325`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25325.diff">https://git.openjdk.org/jdk/pull/25325.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25325#issuecomment-2894312329)
</details>
