### PR TITLE
8347050: Console.readLine() drops '\' when reading through JLine

### DIFF
--- a/src/jdk.internal.le/share/classes/jdk/internal/org/jline/JdkConsoleProviderImpl.java
+++ b/src/jdk.internal.le/share/classes/jdk/internal/org/jline/JdkConsoleProviderImpl.java
@@ -273,7 +273,10 @@ public class JdkConsoleProviderImpl implements JdkConsoleProvider {
                 synchronized (this) {
                     jline = this.jline;
                     if (jline == null) {
-                        jline = LineReaderBuilder.builder().terminal(terminal).build();
+                        jline = LineReaderBuilder.builder()
+                                                 .option(LineReader.Option.DISABLE_EVENT_EXPANSION, true)
+                                                 .terminal(terminal)
+                                                 .build();
                         this.jline = jline;
                     }
                 }

--- a/test/jdk/jdk/internal/jline/JLineConsoleProviderTest.java
+++ b/test/jdk/jdk/internal/jline/JLineConsoleProviderTest.java
@@ -23,7 +23,7 @@
 
 /**
  * @test
- * @bug 8331535 8351435
+ * @bug 8331535 8351435 8347050
  * @summary Verify the jdk.internal.le's console provider works properly.
  * @modules jdk.internal.le
  * @library /test/lib

--- a/test/jdk/jdk/internal/jline/JLineConsoleProviderTest.java
+++ b/test/jdk/jdk/internal/jline/JLineConsoleProviderTest.java
@@ -38,6 +38,8 @@ import jdk.test.lib.process.ProcessTools;
 
 public class JLineConsoleProviderTest {
 
+    private static final String NL = System.getProperty("line.separator");
+
     public static void main(String... args) throws Throwable {
         for (Method m : JLineConsoleProviderTest.class.getDeclaredMethods()) {
             if (m.getName().startsWith("test")) {
@@ -55,8 +57,9 @@ public class JLineConsoleProviderTest {
     }
 
     void testEvenExpansionDisabled() throws Exception {
-        doRunConsoleTest("readAndPrint", "a\\b\n", "'a\\b'\n");
-        doRunConsoleTest("readAndPrint2", "a\n!!\n", "1: 'a'\n2: '!!'\n");
+        doRunConsoleTest("readAndPrint", "a\\b\n", "'a\\b'" + NL);
+        doRunConsoleTest("readAndPrint2", "a\n!!\n", "1: 'a'" + NL +
+                                                     "2: '!!'" + NL);
     }
 
     void doRunConsoleTest(String testName,

--- a/test/jdk/jdk/internal/jline/JLineConsoleProviderTest.java
+++ b/test/jdk/jdk/internal/jline/JLineConsoleProviderTest.java
@@ -54,6 +54,11 @@ public class JLineConsoleProviderTest {
         doRunConsoleTest("testCorrectOutputReadPassword", "inp", "%s");
     }
 
+    void testEvenExpansionDisabled() throws Exception {
+        doRunConsoleTest("readAndPrint", "a\\b\n", "'a\\b'\n");
+        doRunConsoleTest("readAndPrint2", "a\n!!\n", "1: 'a'\n2: '!!'\n");
+    }
+
     void doRunConsoleTest(String testName,
                           String input,
                           String expectedOut) throws Exception {
@@ -95,6 +100,12 @@ public class JLineConsoleProviderTest {
                     System.console().readLine("%%s");
                 case "testCorrectOutputReadPassword" ->
                     System.console().readPassword("%%s");
+                case "readAndPrint" ->
+                    System.out.println("'" + System.console().readLine() + "'");
+                case "readAndPrint2" -> {
+                    System.out.println("1: '" +System.console().readLine() + "'");
+                    System.out.println("2: '" + System.console().readLine() + "'");
+                }
                 default -> throw new UnsupportedOperationException(args[0]);
             }
 


### PR DESCRIPTION
JLine can do history expansion, and interpret escapes, when returning a value. That is not desirable when using JLine as a backend for Console.readLine().

This PR proposes to disable the history expansion.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347050](https://bugs.openjdk.org/browse/JDK-8347050): Console.readLine() drops '\' when reading through JLine (**Bug** - P3)


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25326/head:pull/25326` \
`$ git checkout pull/25326`

Update a local copy of the PR: \
`$ git checkout pull/25326` \
`$ git pull https://git.openjdk.org/jdk.git pull/25326/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25326`

View PR using the GUI difftool: \
`$ git pr show -t 25326`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25326.diff">https://git.openjdk.org/jdk/pull/25326.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25326#issuecomment-2894359617)
</details>
