### PR TITLE
8357048: RunTest variables should always be assigned

### DIFF
--- a/make/RunTests.gmk
+++ b/make/RunTests.gmk
@@ -583,6 +583,8 @@ define SetMicroValue
   else
     ifneq ($3, )
       $1_$2 := $3
+    else
+      $1_$2 :=
     endif
   endif
 endef
@@ -709,6 +711,8 @@ define SetJtregValue
     else
       ifneq ($3, )
         $1_$2 := $3
+      else
+        $1_$2 :=
       endif
     endif
   endif
@@ -869,7 +873,7 @@ define SetupRunJtregTestBody
   # version of the JDK.
   $1_JTREG_BASIC_OPTIONS += -$$($1_JTREG_TEST_MODE) \
       -verbose:$$(JTREG_VERBOSE) -retain:$$(JTREG_RETAIN) \
-      -concurrency:$$($1_JTREG_JOBS) -timeoutFactor:$$(JTREG_TIMEOUT_FACTOR) \
+      -concurrency:$$($1_JTREG_JOBS) \
       -vmoption:-XX:MaxRAMPercentage=$$($1_JTREG_MAX_RAM_PERCENTAGE) \
       -vmoption:-Dtest.boot.jdk="$$(BOOT_JDK)" \
       -vmoption:-Djava.io.tmpdir="$$($1_TEST_TMP_DIR)"
@@ -994,6 +998,7 @@ define SetupRunJtregTestBody
   endif
 
   JTREG_TIMEOUT_FACTOR ?= $$(JTREG_AUTO_TIMEOUT_FACTOR)
+  $1_JTREG_BASIC_OPTIONS += -timeoutFactor:$$(JTREG_TIMEOUT_FACTOR)
 
   clean-outputdirs-$1:
 	$$(call LogWarn, Clean up dirs for $1)


### PR DESCRIPTION
In `SetJtregValue` and `SetMicroValue`, if a default or user-supplied value was given, the corresponding "local" variable was assigned using :=, which will force future eager evaluation of the variable, most notably `+=`. However, if no default nor user-assigned value was given, the variable was not defined at all, which would lead the first `+=` to create a lazy evaluated definition (a macro).

Since this was the common behavior for `JTREG_BASIC_OPTIONS`, we did not notice that `JTREG_TIMEOUT_FACTOR` did not have a value when it was used, but that it was assigned later. This made the evaluation broke when we set that variable on the command line and thus forcing eager definition.

The fix is to make sure JTREG_TIMEOUT_FACTOR is defined before use. I also changed so SetJtregValue always assigns with :=, so a similar problem could not creep in again. The same problem also existed in SetMicroValue, so I fixed it there too. (There were no bugs caused by this, though.)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8357048](https://bugs.openjdk.org/browse/JDK-8357048): RunTest variables should always be assigned (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25327/head:pull/25327` \
`$ git checkout pull/25327`

Update a local copy of the PR: \
`$ git checkout pull/25327` \
`$ git pull https://git.openjdk.org/jdk.git pull/25327/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25327`

View PR using the GUI difftool: \
`$ git pr show -t 25327`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25327.diff">https://git.openjdk.org/jdk/pull/25327.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25327#issuecomment-2894458960)
</details>
