### PR TITLE
8338833: Error on reference not found for a snippet target

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/taglets/SnippetTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/taglets/SnippetTaglet.java
@@ -154,7 +154,9 @@ public class SnippetTaglet extends BaseTaglet {
                             linkTarget = l.target();
                             e = getLinkedElement(element, linkTarget);
                             if (e == null) {
-                                // TODO: diagnostic output
+                                messages.error(utils.getCommentHelper(element).getDocTreePath(tag),
+                                        "doclet.link.see.reference_not_found",
+                                        linkTarget);
                             }
                         }
                         case Style.Markup m -> markupEncountered = true;

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/taglets/SnippetTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/taglets/SnippetTaglet.java
@@ -136,7 +136,7 @@ public class SnippetTaglet extends BaseTaglet {
             if (styles.isEmpty()) {
                 code.add(text);
             } else {
-                Element e = null;
+                Element ref = null;
                 String linkTarget = null;
                 boolean markupEncountered = false;
                 Set<String> classes = new HashSet<>();
@@ -152,8 +152,8 @@ public class SnippetTaglet extends BaseTaglet {
                                         content.asCharSequence().toString().trim());
                             }
                             linkTarget = l.target();
-                            e = getLinkedElement(element, linkTarget);
-                            if (e == null) {
+                            ref = getLinkedElement(element, linkTarget);
+                            if (ref == null) {
                                 messages.error(utils.getCommentHelper(element).getDocTreePath(tag),
                                         "doclet.link.see.reference_not_found",
                                         linkTarget);
@@ -166,7 +166,6 @@ public class SnippetTaglet extends BaseTaglet {
                 if (markupEncountered) {
                     return;
                 } else if (linkTarget != null) {
-                    assert e != null;
                     //disable preview tagging inside the snippets:
                     Utils.PreviewFlagProvider prevPreviewProvider = utils.setPreviewFlagProvider(el -> false);
                     try {
@@ -174,10 +173,10 @@ public class SnippetTaglet extends BaseTaglet {
                         c = lt.linkSeeReferenceOutput(element,
                                 null,
                                 linkTarget,
-                                e,
+                                ref,
                                 false, // TODO: for now
                                 Text.of(sequence.toString()),
-                                (key, args) -> { /* TODO: report diagnostic */ },
+                                (key, args) -> { /* Error has already been reported above */ },
                                 tagletWriter);
                     } finally {
                         utils.setPreviewFlagProvider(prevPreviewProvider);


### PR DESCRIPTION
Please review a trivial fix to generate an error when a link in a snippet has an invalid target.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338833](https://bugs.openjdk.org/browse/JDK-8338833): Error on reference not found for a snippet target (**Bug** - P4)


### Reviewers
 * [Pavel Rappo](https://openjdk.org/census#prappo) (@pavelrappo - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25329/head:pull/25329` \
`$ git checkout pull/25329`

Update a local copy of the PR: \
`$ git checkout pull/25329` \
`$ git pull https://git.openjdk.org/jdk.git pull/25329/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25329`

View PR using the GUI difftool: \
`$ git pr show -t 25329`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25329.diff">https://git.openjdk.org/jdk/pull/25329.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25329#issuecomment-2894510317)
</details>
