### PR TITLE
8353124: java/lang/Thread/virtual/stress/Skynet.java#Z times out on macosx-x64-debug

### DIFF
--- a/test/jdk/java/lang/Thread/virtual/stress/Skynet.java
+++ b/test/jdk/java/lang/Thread/virtual/stress/Skynet.java
@@ -32,7 +32,7 @@
  * @test id=Z
  * @requires vm.debug == true & vm.continuations
  * @requires vm.gc.Z
- * @run main/othervm/timeout=300 -XX:+UnlockDiagnosticVMOptions
+ * @run main/othervm/timeout=400 -XX:+UnlockDiagnosticVMOptions
  *     -XX:+UseZGC
  *     -XX:+ZVerifyOops -XX:ZCollectionInterval=0.01 -Xmx1500m Skynet
  */


### PR DESCRIPTION
Hi,

This is a simple test update which increases a timeout from 300s to 400 to account for slow mac os test machines.
A repeat 50 test of :jdk_lang passes. I will run this a few more times before pushing, if the change is acceptable.

Thanks,
Michael