### PR TITLE
8358530: Properties#list should warn against non-String values

### DIFF
--- a/src/java.base/share/classes/java/util/Properties.java
+++ b/src/java.base/share/classes/java/util/Properties.java
@@ -75,7 +75,7 @@ import jdk.internal.util.xml.PropertiesDefaultHandler;
  * non-{@code String} key or value, the call will fail. Similarly,
  * the call to the {@code propertyNames} or {@code list} method
  * will fail if it is called on a "compromised" {@code Properties}
- * object that contains a non-{@code String} key.
+ * object that contains a non-{@code String} key or value.
  *
  * <p>
  * The iterators returned by the {@code iterator} method of this class's
@@ -1215,8 +1215,8 @@ public class Properties extends Hashtable<Object,Object> {
      * This method is useful for debugging.
      *
      * @param   out   an output stream.
-     * @throws  ClassCastException if any key in this property list
-     *          is not a string.
+     * @throws  ClassCastException if either a key or a value
+     *          in this property list is not a string.
      */
     public void list(PrintStream out) {
         out.println("-- listing properties --");
@@ -1237,8 +1237,8 @@ public class Properties extends Hashtable<Object,Object> {
      * This method is useful for debugging.
      *
      * @param   out   an output stream.
-     * @throws  ClassCastException if any key in this property list
-     *          is not a string.
+     * @throws  ClassCastException if either a key or a value
+     *          in this property list is not a string.
      * @since   1.1
      */
     /*

--- a/src/java.base/share/classes/java/util/Properties.java
+++ b/src/java.base/share/classes/java/util/Properties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -70,12 +70,12 @@ import jdk.internal.util.xml.PropertiesDefaultHandler;
  * {@code Properties} object.  Their use is strongly discouraged as they
  * allow the caller to insert entries whose keys or values are not
  * {@code Strings}.  The {@code setProperty} method should be used
- * instead.  If the {@code store} or {@code save} method is called
+ * instead. If the {@code store}, {@code save} or {@code list} method is called
  * on a "compromised" {@code Properties} object that contains a
  * non-{@code String} key or value, the call will fail. Similarly,
- * the call to the {@code propertyNames} or {@code list} method
+ * the call to the {@code propertyNames} method
  * will fail if it is called on a "compromised" {@code Properties}
- * object that contains a non-{@code String} key or value.
+ * object that contains a non-{@code String} key.
  *
  * <p>
  * The iterators returned by the {@code iterator} method of this class's

--- a/src/java.base/share/classes/java/util/Properties.java
+++ b/src/java.base/share/classes/java/util/Properties.java
@@ -70,7 +70,7 @@ import jdk.internal.util.xml.PropertiesDefaultHandler;
  * {@code Properties} object.  Their use is strongly discouraged as they
  * allow the caller to insert entries whose keys or values are not
  * {@code Strings}.  The {@code setProperty} method should be used
- * instead. If the {@code store}, {@code save} or {@code list} method is called
+ * instead. If the {@code store}, {@code save}, or {@code list} method is called
  * on a "compromised" {@code Properties} object that contains a
  * non-{@code String} key or value, the call will fail. Similarly,
  * the call to the {@code propertyNames} method


### PR DESCRIPTION
Trivial PR to enhance Javadoc for the `Properties#list` method, which has cost me some debugging time.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8362447](https://bugs.openjdk.org/browse/JDK-8362447) to be approved

### Issues
 * [JDK-8358530](https://bugs.openjdk.org/browse/JDK-8358530): Properties#list should warn against non-String values (**Bug** - P4)
 * [JDK-8362447](https://bugs.openjdk.org/browse/JDK-8362447): Properties#list should warn against non-String values (**CSR**)


### Reviewers
 * [Justin Lu](https://openjdk.org/census#jlu) (@justin-curtis-lu - Committer)
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25334/head:pull/25334` \
`$ git checkout pull/25334`

Update a local copy of the PR: \
`$ git checkout pull/25334` \
`$ git pull https://git.openjdk.org/jdk.git pull/25334/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25334`

View PR using the GUI difftool: \
`$ git pr show -t 25334`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25334.diff">https://git.openjdk.org/jdk/pull/25334.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25334#issuecomment-3072913251)
</details>
