### PR TITLE
8347027: String replaceAll with Function<String, String>

### DIFF
--- a/src/java.base/share/classes/java/lang/String.java
+++ b/src/java.base/share/classes/java/lang/String.java
@@ -3133,7 +3133,7 @@ public final class String
     /**
      * Replaces each substring of this string that matches the given
      * <a href="../util/regex/Pattern.html#sum">regular expression</a> with the result
-     * of applying the given function to the corresponding match result.
+     * of applying the given function to the match.
      *
      * <p> An invocation of this method of the form
      * <i>str</i>{@code .replaceAllMapped(}<i>regex</i>{@code ,} <i>replacer</i>{@code )}
@@ -3158,7 +3158,8 @@ public final class String
      * @throws  PatternSyntaxException
      *          if the regular expression's syntax is invalid
      * @throws  NullPointerException
-     *          if the replacement function is null
+     *          if the regular expression or the replacement
+     *          function is null
      *
      * @since 25
      */

--- a/src/java.base/share/classes/java/lang/String.java
+++ b/src/java.base/share/classes/java/lang/String.java
@@ -46,6 +46,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Spliterator;
 import java.util.function.Function;
+import java.util.regex.MatchResult;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 import java.util.stream.Collectors;
@@ -3127,6 +3128,42 @@ public final class String
      */
     public String replaceAll(String regex, String replacement) {
         return Pattern.compile(regex).matcher(this).replaceAll(replacement);
+    }
+
+    /**
+     * Replaces each substring of this string that matches the given
+     * <a href="../util/regex/Pattern.html#sum">regular expression</a> with the result
+     * of applying the given function to the corresponding match result.
+     *
+     * <p> An invocation of this method of the form
+     * <i>str</i>{@code .replaceAllMapped(}<i>regex</i>{@code ,} <i>replacer</i>{@code )}
+     * yields exactly the same result as the expression
+     *
+     * <blockquote>
+     * <code>
+     * {@link java.util.regex.Pattern}.{@link
+     * java.util.regex.Pattern#compile(String) compile}(<i>regex</i>).{@link
+     * java.util.regex.Pattern#matcher(java.lang.CharSequence) matcher}(<i>str</i>).{@link
+     * java.util.regex.Matcher#replaceAll(Function) replaceAll}(<i>replacer</i>)
+     * </code>
+     * </blockquote>
+     *
+     * @param   regex
+     *          the regular expression to which this string is to be matched
+     * @param   replacer
+     *          the function to be applied to each match
+     *
+     * @return  The resulting {@code String}
+     *
+     * @throws  PatternSyntaxException
+     *          if the regular expression's syntax is invalid
+     * @throws  NullPointerException
+     *          if the replacement function is null
+     *
+     * @since 25
+     */
+    public String replaceAllMapped(String regex, Function<MatchResult, String> replacer) {
+        return Pattern.compile(regex).matcher(this).replaceAll(replacer);
     }
 
     /**

--- a/test/jdk/java/lang/String/Exceptions.java
+++ b/test/jdk/java/lang/String/Exceptions.java
@@ -540,7 +540,7 @@ public class Exceptions {
     }
 
     private static void replaceAllMapped() {
-        System.out.println("replaceAllMapped(String regex,  Function<MatchResult, String> replacer)");
+        System.out.println("replaceAllMapped(String regex, Function<MatchResult, String> replacer)");
         tryCatch("  \".\", null", NullPointerException.class, new Runnable() {
             public void run() {
                 "foo".replaceAllMapped(".", null);

--- a/test/jdk/java/lang/String/Exceptions.java
+++ b/test/jdk/java/lang/String/Exceptions.java
@@ -29,6 +29,9 @@
 
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
+import java.util.function.Function;
+import java.util.regex.MatchResult;
+import java.util.regex.PatternSyntaxException;
 
 public class Exceptions {
     private static final byte [] b = { 0x48, 0x69, 0x2c, 0x20,
@@ -536,6 +539,22 @@ public class Exceptions {
                 }});
     }
 
+    private static void replaceAllMapped() {
+        System.out.println("replaceAllMapped(String regex,  Function<MatchResult, String> replacer)");
+        tryCatch("  \".\", null", NullPointerException.class, new Runnable() {
+            public void run() {
+                "foo".replaceAllMapped(".", null);
+            }});
+        tryCatch("  null, \"-\"", NullPointerException.class, new Runnable() {
+            public void run() {
+                "foo".replaceAllMapped(null, mr -> "-");
+            }});
+        tryCatch("  null, \"-\"", PatternSyntaxException.class, new Runnable() {
+            public void run() {
+                "foo".replaceAllMapped("[", mr -> "-");
+            }});
+    }
+
     private static void split() {
         System.out.println("split(String regex, int limit)");
         tryCatch("  null, 1", NullPointerException.class, new Runnable() {
@@ -653,6 +672,7 @@ public class Exceptions {
         matches();            // matches(String)
         replaceFirst();       // replaceFirst(String, String)
         replaceAll();         // replaceAll(String, String)
+        replaceAllMapped();   // replaceAllMapped(String, Function<MatchResult, String>)
         split();              // split(String, int), split(String)
         toLowerCase();        // toLowerCase(Locale)
         toUpperCase();        // toUpperCase(Locale)

--- a/test/jdk/java/lang/String/Regex.java
+++ b/test/jdk/java/lang/String/Regex.java
@@ -82,6 +82,9 @@ public class Regex {
         ck(foo.replaceAll("oo", "uu"), "buu:and:fuu");
         ck(foo.replaceAll("o+", "<$0>"), "b<oo>:and:f<oo>");
 
+        ck(foo.replaceAllMapped("\\w+", mr -> mr.group().toUpperCase()), "BOO:AND:FOO");
+        ck(foo.replaceAllMapped("\\w+", mr -> mr.group() + "(" + ")"), "boo():and():foo()");
+
         ck(foo.replaceFirst("oo", "uu"), "buu:and:foo");
         ck(foo.replaceFirst("o+", "<$0>"), "b<oo>:and:foo");
 


### PR DESCRIPTION
New API to the String.java class - replaceAllMapped(String, Function<MatchResult, String>) that allows regex based replacement via a user defined function allowing dynamic replacemnt based on the match. It delegates to the already existing Pattern.matcher().replaceAll(Function).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change requires CSR request [JDK-8357386](https://bugs.openjdk.org/browse/JDK-8357386) to be approved

### Issues
 * [JDK-8347027](https://bugs.openjdk.org/browse/JDK-8347027): String replaceAll with Function&lt;String, String&gt; (**Enhancement** - P4)
 * [JDK-8357386](https://bugs.openjdk.org/browse/JDK-8357386): String replaceAll with Function&lt;String, String&gt; (**CSR**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25335/head:pull/25335` \
`$ git checkout pull/25335`

Update a local copy of the PR: \
`$ git checkout pull/25335` \
`$ git pull https://git.openjdk.org/jdk.git pull/25335/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25335`

View PR using the GUI difftool: \
`$ git pr show -t 25335`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25335.diff">https://git.openjdk.org/jdk/pull/25335.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25335#issuecomment-2895220222)
</details>
