### PR TITLE
8357554: Enable vectorization of Bool -> CMove with different type size (on riscv)

### DIFF
--- a/src/hotspot/cpu/aarch64/matcher_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/matcher_aarch64.hpp
@@ -204,4 +204,19 @@
   static bool is_feat_fp16_supported() {
     return (VM_Version::supports_fphp() && VM_Version::supports_asimdhp());
   }
+
+  static bool supports_vectorize_cmove_bool_unconditionally() {
+    return false;
+  }
+
+  static bool supports_transform_cmove_to_vectorblend(int cmove_opc) {
+    switch (cmove_opc) {
+      case Op_CMoveF:
+      case Op_CMoveD:
+        return true;
+      default:
+        return false;
+    }
+  }
+
 #endif // CPU_AARCH64_MATCHER_AARCH64_HPP

--- a/src/hotspot/cpu/arm/matcher_arm.hpp
+++ b/src/hotspot/cpu/arm/matcher_arm.hpp
@@ -193,4 +193,18 @@
     return false;
   }
 
+  static bool supports_vectorize_cmove_bool_unconditionally() {
+    return false;
+  }
+
+  static bool supports_transform_cmove_to_vectorblend(int cmove_opc) {
+    switch (cmove_opc) {
+      case Op_CMoveF:
+      case Op_CMoveD:
+        return true;
+      default:
+        return false;
+    }
+  }
+
 #endif // CPU_ARM_MATCHER_ARM_HPP

--- a/src/hotspot/cpu/ppc/matcher_ppc.hpp
+++ b/src/hotspot/cpu/ppc/matcher_ppc.hpp
@@ -204,4 +204,18 @@
     return false;
   }
 
+  static bool supports_vectorize_cmove_bool_unconditionally() {
+    return false;
+  }
+
+  static bool supports_transform_cmove_to_vectorblend(int cmove_opc) {
+    switch (cmove_opc) {
+      case Op_CMoveF:
+      case Op_CMoveD:
+        return true;
+      default:
+        return false;
+    }
+  }
+
 #endif // CPU_PPC_MATCHER_PPC_HPP

--- a/src/hotspot/cpu/riscv/matcher_riscv.hpp
+++ b/src/hotspot/cpu/riscv/matcher_riscv.hpp
@@ -199,4 +199,18 @@
     return false;
   }
 
+  static bool supports_vectorize_cmove_bool_unconditionally() {
+    return true;
+  }
+
+  static bool supports_transform_cmove_to_vectorblend(int cmove_opc) {
+    switch (cmove_opc) {
+      case Op_CMoveF:
+      case Op_CMoveD:
+        return true;
+      default:
+        return false;
+    }
+  }
+
 #endif // CPU_RISCV_MATCHER_RISCV_HPP

--- a/src/hotspot/cpu/s390/matcher_s390.hpp
+++ b/src/hotspot/cpu/s390/matcher_s390.hpp
@@ -196,4 +196,18 @@
     return false;
   }
 
+  static bool supports_vectorize_cmove_bool_unconditionally() {
+    return false;
+  }
+
+  static bool supports_transform_cmove_to_vectorblend(int cmove_opc) {
+    switch (cmove_opc) {
+      case Op_CMoveF:
+      case Op_CMoveD:
+        return true;
+      default:
+        return false;
+    }
+  }
+
 #endif // CPU_S390_MATCHER_S390_HPP

--- a/src/hotspot/cpu/x86/matcher_x86.hpp
+++ b/src/hotspot/cpu/x86/matcher_x86.hpp
@@ -236,4 +236,18 @@
     }
   }
 
+  static bool supports_vectorize_cmove_bool_unconditionally() {
+    return false;
+  }
+
+  static bool supports_transform_cmove_to_vectorblend(int cmove_opc) {
+    switch (cmove_opc) {
+      case Op_CMoveF:
+      case Op_CMoveD:
+        return true;
+      default:
+        return false;
+    }
+  }
+
 #endif // CPU_X86_MATCHER_X86_HPP

--- a/src/hotspot/share/opto/superword.cpp
+++ b/src/hotspot/share/opto/superword.cpp
@@ -2352,9 +2352,17 @@ bool SuperWord::is_velt_basic_type_compatible_use_def(Node* use, Node* def) cons
            type2aelembytes(use_bt) == 4;
   }
 
-  // Default case: input size of use equals output size of def.
-  return (type2aelembytes(use_bt) == type2aelembytes(def_bt)) ||
-         (use->is_CMove() && def->is_Bool());
+  // Input size of use equals output size of def
+  if (type2aelembytes(use_bt) == type2aelembytes(def_bt)) {
+    return true;
+  }
+
+  if (use->is_CMove() && def->is_Bool() &&
+      VectorNode::is_vectorize_cmove_bool_unconditionally_supported()) {
+    return true;
+  }
+
+  return false;
 }
 
 // Return nullptr if success, else failure message

--- a/src/hotspot/share/opto/superword.cpp
+++ b/src/hotspot/share/opto/superword.cpp
@@ -2353,7 +2353,8 @@ bool SuperWord::is_velt_basic_type_compatible_use_def(Node* use, Node* def) cons
   }
 
   // Default case: input size of use equals output size of def.
-  return type2aelembytes(use_bt) == type2aelembytes(def_bt);
+  return (type2aelembytes(use_bt) == type2aelembytes(def_bt)) ||
+         (use->is_CMove() && def->is_Bool());
 }
 
 // Return nullptr if success, else failure message

--- a/src/hotspot/share/opto/vectornode.cpp
+++ b/src/hotspot/share/opto/vectornode.cpp
@@ -86,10 +86,6 @@ int VectorNode::opcode(int sopc, BasicType bt) {
     return (bt == T_FLOAT ? Op_FmaVF : 0);
   case Op_FmaHF:
     return (bt == T_SHORT ? Op_FmaVHF : 0);
-  case Op_CMoveI:
-    return (bt == T_INT ? Op_VectorBlend : 0);
-  case Op_CMoveL:
-    return (bt == T_LONG ? Op_VectorBlend : 0);
   case Op_CMoveF:
     return (bt == T_FLOAT ? Op_VectorBlend : 0);
   case Op_CMoveD:

--- a/src/hotspot/share/opto/vectornode.cpp
+++ b/src/hotspot/share/opto/vectornode.cpp
@@ -86,6 +86,10 @@ int VectorNode::opcode(int sopc, BasicType bt) {
     return (bt == T_FLOAT ? Op_FmaVF : 0);
   case Op_FmaHF:
     return (bt == T_SHORT ? Op_FmaVHF : 0);
+  case Op_CMoveI:
+    return (bt == T_INT ? Op_VectorBlend : 0);
+  case Op_CMoveL:
+    return (bt == T_LONG ? Op_VectorBlend : 0);
   case Op_CMoveF:
     return (bt == T_FLOAT ? Op_VectorBlend : 0);
   case Op_CMoveD:

--- a/src/hotspot/share/opto/vectornode.hpp
+++ b/src/hotspot/share/opto/vectornode.hpp
@@ -110,6 +110,9 @@ class VectorNode : public TypeNode {
   static bool is_vector_rotate_supported(int opc, uint vlen, BasicType bt);
   static bool is_vector_integral_negate_supported(int opc, uint vlen, BasicType bt, bool use_predicate);
   static bool is_populate_index_supported(BasicType bt);
+  // Supports to vectorize CMove which uses Bool unconditionally?
+  // Otherwise only same type size of CMove and Bool will be supported for this transformation.
+  static bool is_vectorize_cmove_bool_unconditionally_supported();
   // Return true if every bit in this vector is 1.
   static bool is_all_ones_vector(Node* n);
   // Return true if every bit in this vector is 0.
@@ -1736,6 +1739,8 @@ class VectorBlendNode : public VectorNode {
   Node* vec1() const { return in(1); }
   Node* vec2() const { return in(2); }
   Node* vec_mask() const { return in(3); }
+
+  static bool implemented(int opc);
 };
 
 class VectorRearrangeNode : public VectorNode {


### PR DESCRIPTION
Hi,
Can you help to review this patch?
This pr is splited from https://github.com/openjdk/jdk/pull/25341, and contains only share code change.

This patch enable the vectorization of statement like `fd_1 bop fd_2 ? res_1 : res_2` in a loop.

The current behaviour on other platforms support vecatorization of `fd_1 bop fd_2 ? res_1 : res_2` in a loop only when `fd` and `res` have the same size, but this constraint seems not necessary at least not necessary on riscv, so I relax this constraint on riscv, maybe on other platforms it can be relaxed too, but currently I only made it work on riscv.
Besides of this, I also relax the constraint on transforming Op_CMoveI/L to Op_VectorBlend on riscv, this bring some extra benefit when the `res` is not float or double types.
Both relaxation bring performance benefit via vectorization.

Compared with other runs (master, master with `-XX:+UseVectorCmov -XX:+UseCMoveUnconditionally` turned on, patch without flags turned on), average improvement introduced by the patch with `-XX:+UseVectorCmov -XX:+UseCMoveUnconditionally` turned on is more than 2.1 times, in some cases it can bring more than 4 times improvement.
When `-XX:-UseVectorCmov -XX:-UseCMoveUnconditionally` turned off, there is no regression on average.

Check more details at: https://github.com/openjdk/jdk/pull/25341.

Thanks


<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8357554](https://bugs.openjdk.org/browse/JDK-8357554): Enable vectorization of Bool -&gt; CMove with different type size (on riscv) (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25336/head:pull/25336` \
`$ git checkout pull/25336`

Update a local copy of the PR: \
`$ git checkout pull/25336` \
`$ git pull https://git.openjdk.org/jdk.git pull/25336/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25336`

View PR using the GUI difftool: \
`$ git pr show -t 25336`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25336.diff">https://git.openjdk.org/jdk/pull/25336.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25336#issuecomment-2909271480)
</details>
