### PR TITLE
8357172: Extend try block in nsk/jdi tests to capture exceptions thrown by Debuggee.classByName()

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/invokeMethod/invokemethod009.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/invokeMethod/invokemethod009.java
@@ -112,19 +112,19 @@ public class invokemethod009 {
             return quitDebuggee();
         }
 
-        // debuggee main class
-        ReferenceType rType = debuggee.classByName(DEBUGGEE_CLASS);
+        try {
+            // debuggee main class
+            ReferenceType rType = debuggee.classByName(DEBUGGEE_CLASS);
 
-        thrRef = debuggee.threadByFieldName(rType, "testThread", DEBUGGEE_THRNAME);
-        if (thrRef == null) {
-            log.complain("TEST FAILURE: Method Debugee.threadByFieldName() returned null for debuggee thread "
-                + DEBUGGEE_THRNAME);
-            tot_res = Consts.TEST_FAILED;
-            return quitDebuggee();
-        }
+            thrRef = debuggee.threadByFieldName(rType, "testThread", DEBUGGEE_THRNAME);
+            if (thrRef == null) {
+                log.complain("TEST FAILURE: Method Debugee.threadByFieldName() returned null for debuggee thread "
+                             + DEBUGGEE_THRNAME);
+                tot_res = Consts.TEST_FAILED;
+                return quitDebuggee();
+            }
 
 // Check the tested assersion
-        try {
             suspendAtBP(rType, DEBUGGEE_STOPATLINE);
             ClassType clsType = (ClassType) rType;
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/invokeMethod/invokemethod010.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/invokeMethod/invokemethod010.java
@@ -111,36 +111,29 @@ public class invokemethod010 {
             return quitDebuggee();
         }
 
-        // debuggee main class
-        ReferenceType rType = debuggee.classByName(DEBUGGEE_CLASS);
-
-        thrRef = debuggee.threadByFieldName(rType, "testThread", DEBUGGEE_THRNAME);
-        if (thrRef == null) {
-            log.complain("TEST FAILURE: method Debugee.threadByFieldName() returned null for debuggee thread "
-                + DEBUGGEE_THRNAME);
-            tot_res = Consts.TEST_FAILED;
-            return quitDebuggee();
-        }
-        thrRef.suspend();
-        while(!thrRef.isSuspended()) {
-            num++;
-            if (num > ATTEMPTS) {
-                log.complain("TEST FAILED: unable to suspend debuggee thread");
-                tot_res = Consts.TEST_FAILED;
-                return quitDebuggee();
-            }
-            log.display("Waiting for debuggee thread suspension ...");
-            try {
-                Thread.currentThread().sleep(TIMEOUT_DELTA);
-            } catch(InterruptedException ie) {
-                ie.printStackTrace();
-                log.complain("TEST FAILED: caught: " + ie);
-                tot_res = Consts.TEST_FAILED;
-                return quitDebuggee();
-            }
-        }
-
         try {
+            // debuggee main class
+            ReferenceType rType = debuggee.classByName(DEBUGGEE_CLASS);
+
+            thrRef = debuggee.threadByFieldName(rType, "testThread", DEBUGGEE_THRNAME);
+            if (thrRef == null) {
+                log.complain("TEST FAILURE: method Debugee.threadByFieldName() returned null for debuggee thread "
+                             + DEBUGGEE_THRNAME);
+                tot_res = Consts.TEST_FAILED;
+                return quitDebuggee();
+            }
+            thrRef.suspend();
+            while(!thrRef.isSuspended()) {
+                num++;
+                if (num > ATTEMPTS) {
+                    log.complain("TEST FAILED: unable to suspend debuggee thread");
+                    tot_res = Consts.TEST_FAILED;
+                    return quitDebuggee();
+                }
+                log.display("Waiting for debuggee thread suspension ...");
+                Thread.currentThread().sleep(TIMEOUT_DELTA);
+            }
+
             // debuggee main class
             ClassType clsType = (ClassType) rType;
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/invokeMethod/invokemethod014.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/invokeMethod/invokemethod014.java
@@ -113,20 +113,20 @@ public class invokemethod014 {
             return quitDebuggee();
         }
 
-        // debuggee main class
-        ReferenceType rType = debuggee.classByName(DEBUGGEE_CLASS);
-        ClassType clsType = (ClassType) rType;
-
-        ThreadReference thrRef =
-            debuggee.threadByFieldName(rType, "testThread", DEBUGGEE_THRNAME);
-        if (thrRef == null) {
-            log.complain("TEST FAILURE: method Debugee.threadByFieldName() returned null for debuggee thread "
-                + DEBUGGEE_THRNAME);
-            tot_res = Consts.TEST_FAILED;
-            return quitDebuggee();
-        }
-
         try {
+            // debuggee main class
+            ReferenceType rType = debuggee.classByName(DEBUGGEE_CLASS);
+            ClassType clsType = (ClassType) rType;
+
+            ThreadReference thrRef =
+                debuggee.threadByFieldName(rType, "testThread", DEBUGGEE_THRNAME);
+            if (thrRef == null) {
+                log.complain("TEST FAILURE: method Debugee.threadByFieldName() returned null for debuggee thread "
+                             + DEBUGGEE_THRNAME);
+                tot_res = Consts.TEST_FAILED;
+                return quitDebuggee();
+            }
+
             suspendAtBP(rType, DEBUGGEE_STOPATLINE);
 
             for (int i=0; i<METH_NUM; i++) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/newInstance/newinstance009.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/newInstance/newinstance009.java
@@ -95,37 +95,30 @@ public class newinstance009 {
             return quitDebuggee();
         }
 
-        // debuggee main class
-        ReferenceType rType = debuggee.classByName(DEBUGGEE_CLASS);
-        ClassType clsType = (ClassType) rType;
-
-        ThreadReference thrRef = debuggee.threadByFieldName(rType, "thread", DEBUGGEE_THRNAME);
-        if (thrRef == null) {
-            log.complain("TEST FAILURE: method Debugee.threadByFieldName() returned null for debuggee thread "
-                + DEBUGGEE_THRNAME);
-            tot_res = Consts.TEST_FAILED;
-            return quitDebuggee();
-        }
-        thrRef.suspend();
-        while(!thrRef.isSuspended()) {
-            num++;
-            if (num > ATTEMPTS) {
-                log.complain("TEST FAILED: unable to suspend debuggee thread");
-                tot_res = Consts.TEST_FAILED;
-                return quitDebuggee();
-            }
-            log.display("Waiting for debuggee thread suspension ...");
-            try {
-                Thread.currentThread().sleep(DELAY);
-            } catch(InterruptedException ie) {
-                ie.printStackTrace();
-                log.complain("TEST FAILED: caught: " + ie);
-                tot_res = Consts.TEST_FAILED;
-                return quitDebuggee();
-            }
-        }
-
         try {
+            // debuggee main class
+            ReferenceType rType = debuggee.classByName(DEBUGGEE_CLASS);
+            ClassType clsType = (ClassType) rType;
+
+            ThreadReference thrRef = debuggee.threadByFieldName(rType, "thread", DEBUGGEE_THRNAME);
+            if (thrRef == null) {
+                log.complain("TEST FAILURE: method Debugee.threadByFieldName() returned null for debuggee thread "
+                             + DEBUGGEE_THRNAME);
+                tot_res = Consts.TEST_FAILED;
+                return quitDebuggee();
+            }
+            thrRef.suspend();
+            while(!thrRef.isSuspended()) {
+                num++;
+                if (num > ATTEMPTS) {
+                    log.complain("TEST FAILED: unable to suspend debuggee thread");
+                    tot_res = Consts.TEST_FAILED;
+                    return quitDebuggee();
+                }
+                log.display("Waiting for debuggee thread suspension ...");
+                Thread.currentThread().sleep(DELAY);
+            }
+
             List methList = rType.methodsByName("<init>");
             if (methList.isEmpty()) {
                 log.complain("TEST FAILURE: the expected constructor "

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod002.java
@@ -124,18 +124,18 @@ public class invokemethod002 {
             return quitDebuggee();
         }
 
-        rType[0] = debuggee.classByName(DEBUGGEE_CLASS); // debuggee main class
+        try {
+            rType[0] = debuggee.classByName(DEBUGGEE_CLASS); // debuggee main class
 
-        thrRef = debuggee.threadByFieldName(rType[0], "testThread", DEBUGGEE_THRNAME);
-        if (thrRef == null) {
-            log.complain("TEST FAILURE: Method Debugee.threadByFieldName() returned null for debuggee thread "
-                + DEBUGGEE_THRNAME);
-            tot_res = Consts.TEST_FAILED;
-            return quitDebuggee();
-        }
+            thrRef = debuggee.threadByFieldName(rType[0], "testThread", DEBUGGEE_THRNAME);
+            if (thrRef == null) {
+                log.complain("TEST FAILURE: Method Debugee.threadByFieldName() returned null for debuggee thread "
+                             + DEBUGGEE_THRNAME);
+                tot_res = Consts.TEST_FAILED;
+                return quitDebuggee();
+            }
 
 // Check the tested assersion
-        try {
             suspendAtBP(rType[0], DEBUGGEE_STOPATLINE);
             findObjRef(DEBUGGEE_LOCALVAR);
             rType[1] = objRef[1].referenceType(); // debuggee dummy class

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod003.java
@@ -135,24 +135,24 @@ public class invokemethod003 {
             return quitDebuggee();
         }
 
-        ReferenceType[] rType = new ReferenceType[3];
-        // debuggee main class
-        rType[0] = debuggee.classByName(DEBUGGEE_CLASS);
-        // debuggee dummy interface
-        rType[1] = debuggee.classByName(DEBUGGEE_INTERFACE);
-        // debuggee dummy abstract class
-        rType[2] = debuggee.classByName(DEBUGGEE_ABSTRACTCLASS);
+        try {
+            ReferenceType[] rType = new ReferenceType[3];
+            // debuggee main class
+            rType[0] = debuggee.classByName(DEBUGGEE_CLASS);
+            // debuggee dummy interface
+            rType[1] = debuggee.classByName(DEBUGGEE_INTERFACE);
+            // debuggee dummy abstract class
+            rType[2] = debuggee.classByName(DEBUGGEE_ABSTRACTCLASS);
 
-        thrRef = debuggee.threadByFieldName(rType[0], "testThread", DEBUGGEE_THRNAME);
-        if (thrRef == null) {
-            log.complain("TEST FAILURE: Method Debugee.threadByFieldName() returned null for debuggee thread "
-                + DEBUGGEE_THRNAME);
-            tot_res = Consts.TEST_FAILED;
-            return quitDebuggee();
-        }
+            thrRef = debuggee.threadByFieldName(rType[0], "testThread", DEBUGGEE_THRNAME);
+            if (thrRef == null) {
+                log.complain("TEST FAILURE: Method Debugee.threadByFieldName() returned null for debuggee thread "
+                             + DEBUGGEE_THRNAME);
+                tot_res = Consts.TEST_FAILED;
+                return quitDebuggee();
+            }
 
 // Check the tested assersion
-        try {
             suspendAtBP(rType[0], DEBUGGEE_STOPATLINE);
             ObjectReference objRef = findObjRef(DEBUGGEE_LOCALVAR);
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod004.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod004.java
@@ -111,36 +111,29 @@ public class invokemethod004 {
             return quitDebuggee();
         }
 
-        ReferenceType debuggeeClass = debuggee.classByName(DEBUGGEE_CLASS); // debuggee main class
+        try {
+            ReferenceType debuggeeClass = debuggee.classByName(DEBUGGEE_CLASS); // debuggee main class
 
-        thrRef = debuggee.threadByFieldName(debuggeeClass, "testThread", DEBUGGEE_THRNAME);
-        if (thrRef == null) {
-            log.complain("TEST FAILURE: method Debugee.threadByFieldName() returned null for debuggee thread "
-                + DEBUGGEE_THRNAME);
-            tot_res = Consts.TEST_FAILED;
-            return quitDebuggee();
-        }
-        thrRef.suspend();
-        while(!thrRef.isSuspended()) {
-            num++;
-            if (num > ATTEMPTS) {
-                log.complain("TEST FAILED: unable to suspend debuggee thread");
+            thrRef = debuggee.threadByFieldName(debuggeeClass, "testThread", DEBUGGEE_THRNAME);
+            if (thrRef == null) {
+                log.complain("TEST FAILURE: method Debugee.threadByFieldName() returned null for debuggee thread "
+                             + DEBUGGEE_THRNAME);
                 tot_res = Consts.TEST_FAILED;
                 return quitDebuggee();
             }
-            log.display("Waiting for debuggee thread suspension ...");
-            try {
+            thrRef.suspend();
+            while(!thrRef.isSuspended()) {
+                num++;
+                if (num > ATTEMPTS) {
+                    log.complain("TEST FAILED: unable to suspend debuggee thread");
+                    tot_res = Consts.TEST_FAILED;
+                    return quitDebuggee();
+                }
+                log.display("Waiting for debuggee thread suspension ...");
                 Thread.currentThread().sleep(1000);
-            } catch(InterruptedException ie) {
-                ie.printStackTrace();
-                log.complain("TEST FAILED: caught: " + ie);
-                tot_res = Consts.TEST_FAILED;
-                return quitDebuggee();
             }
-        }
 
 // Check the tested assersion
-        try {
             ObjectReference objRef = findObjRef(DEBUGGEE_LOCALVAR);
             ReferenceType rType = objRef.referenceType(); // debuggee dummy class
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod005.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod005.java
@@ -113,20 +113,20 @@ public class invokemethod005 {
             return quitDebuggee();
         }
 
-        ReferenceType[] rType = new ReferenceType[2];
-        // debuggee main class
-        rType[0] = debuggee.classByName(DEBUGGEE_CLASS);
+        try {
+            ReferenceType[] rType = new ReferenceType[2];
+            // debuggee main class
+            rType[0] = debuggee.classByName(DEBUGGEE_CLASS);
 
-        thrRef = debuggee.threadByFieldName(rType[0], "testThread", DEBUGGEE_THRNAME);
-        if (thrRef == null) {
-            log.complain("TEST FAILURE: Method Debugee.threadByFieldName() returned null for debuggee thread "
-                + DEBUGGEE_THRNAME);
-            tot_res = Consts.TEST_FAILED;
-            return quitDebuggee();
-        }
+            thrRef = debuggee.threadByFieldName(rType[0], "testThread", DEBUGGEE_THRNAME);
+            if (thrRef == null) {
+                log.complain("TEST FAILURE: Method Debugee.threadByFieldName() returned null for debuggee thread "
+                             + DEBUGGEE_THRNAME);
+                tot_res = Consts.TEST_FAILED;
+                return quitDebuggee();
+            }
 
 // Check the tested assersion
-        try {
             suspendAtBP(rType[0], DEBUGGEE_STOPATLINE);
             ObjectReference objRef = findObjRef(DEBUGGEE_LOCALVAR);
             rType[1] = objRef.referenceType(); // debuggee dummy class

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod006.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod006.java
@@ -111,20 +111,20 @@ public class invokemethod006 {
             return quitDebuggee();
         }
 
-        ReferenceType[] rType = new ReferenceType[2];
-        // debuggee main class
-        rType[0] = debuggee.classByName(DEBUGGEE_CLASS);
+        try {
+            ReferenceType[] rType = new ReferenceType[2];
+            // debuggee main class
+            rType[0] = debuggee.classByName(DEBUGGEE_CLASS);
 
-        thrRef = debuggee.threadByFieldName(rType[0], "testThread", DEBUGGEE_THRNAME);
-        if (thrRef == null) {
-            log.complain("TEST FAILURE: Method Debugee.threadByFieldName() returned null for debuggee thread "
-                + DEBUGGEE_THRNAME);
-            tot_res = Consts.TEST_FAILED;
-            return quitDebuggee();
-        }
+            thrRef = debuggee.threadByFieldName(rType[0], "testThread", DEBUGGEE_THRNAME);
+            if (thrRef == null) {
+                log.complain("TEST FAILURE: Method Debugee.threadByFieldName() returned null for debuggee thread "
+                             + DEBUGGEE_THRNAME);
+                tot_res = Consts.TEST_FAILED;
+                return quitDebuggee();
+            }
 
 // Check the tested assersion
-        try {
             suspendAtBP(rType[0], DEBUGGEE_STOPATLINE);
             ObjectReference objRef = findObjRef(DEBUGGEE_LOCALVAR);
             rType[1] = objRef.referenceType(); // debuggee dummy class

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod007.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod007.java
@@ -127,20 +127,20 @@ public class invokemethod007 {
             return quitDebuggee();
         }
 
-        ReferenceType[] rType = new ReferenceType[2];
-        // debuggee main class
-        rType[0] = debuggee.classByName(DEBUGGEE_CLASS);
+        try {
+            ReferenceType[] rType = new ReferenceType[2];
+            // debuggee main class
+            rType[0] = debuggee.classByName(DEBUGGEE_CLASS);
 
-        thrRef = debuggee.threadByFieldName(rType[0], "testThread", DEBUGGEE_THRNAME);
-        if (thrRef == null) {
-            log.complain("TEST FAILURE: Method Debugee.threadByFieldName() returned null for debuggee thread "
-                + DEBUGGEE_THRNAME);
-            tot_res = Consts.TEST_FAILED;
-            return quitDebuggee();
-        }
+            thrRef = debuggee.threadByFieldName(rType[0], "testThread", DEBUGGEE_THRNAME);
+            if (thrRef == null) {
+                log.complain("TEST FAILURE: Method Debugee.threadByFieldName() returned null for debuggee thread "
+                             + DEBUGGEE_THRNAME);
+                tot_res = Consts.TEST_FAILED;
+                return quitDebuggee();
+            }
 
 // Check the tested assersion
-        try {
             suspendAtBP(rType[0], DEBUGGEE_STOPATLINE);
             ObjectReference objRef = findObjRef(DEBUGGEE_LOCALVAR);
             rType[1] = objRef.referenceType(); // debuggee dummy class

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod008.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod008.java
@@ -120,22 +120,22 @@ public class invokemethod008 {
             return quitDebuggee();
         }
 
-        ReferenceType[] rType = new ReferenceType[3];
-        // reference types of debuggee main & dummy classes
-        rType[0] = debuggee.classByName(DEBUGGEE_CLASSES[0]);
-        rType[1] = debuggee.classByName(DEBUGGEE_CLASSES[1]);
-        rType[2] = debuggee.classByName(DEBUGGEE_CLASSES[2]);
+        try {
+            ReferenceType[] rType = new ReferenceType[3];
+            // reference types of debuggee main & dummy classes
+            rType[0] = debuggee.classByName(DEBUGGEE_CLASSES[0]);
+            rType[1] = debuggee.classByName(DEBUGGEE_CLASSES[1]);
+            rType[2] = debuggee.classByName(DEBUGGEE_CLASSES[2]);
 
-        thrRef = debuggee.threadByFieldName(rType[0], "testThread", DEBUGGEE_THRNAME);
-        if (thrRef == null) {
-            log.complain("TEST FAILURE: Method Debugee.threadByFieldName() returned null for debuggee thread "
-                + DEBUGGEE_THRNAME);
-            tot_res = Consts.TEST_FAILED;
-            return quitDebuggee();
-        }
+            thrRef = debuggee.threadByFieldName(rType[0], "testThread", DEBUGGEE_THRNAME);
+            if (thrRef == null) {
+                log.complain("TEST FAILURE: Method Debugee.threadByFieldName() returned null for debuggee thread "
+                             + DEBUGGEE_THRNAME);
+                tot_res = Consts.TEST_FAILED;
+                return quitDebuggee();
+            }
 
 // Check the tested assersion
-        try {
             suspendAtBP(rType[0], DEBUGGEE_STOPATLINE);
             ObjectReference objRef = findObjRef(DEBUGGEE_LOCALVAR);
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod009.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod009.java
@@ -120,22 +120,22 @@ public class invokemethod009 {
             return quitDebuggee();
         }
 
-        ReferenceType[] rType = new ReferenceType[3];
-        // reference types of debuggee main & dummy classes
-        rType[0] = debuggee.classByName(DEBUGGEE_CLASSES[0]);
-        rType[1] = debuggee.classByName(DEBUGGEE_CLASSES[1]);
-        rType[2] = debuggee.classByName(DEBUGGEE_CLASSES[2]);
+        try {
+            ReferenceType[] rType = new ReferenceType[3];
+            // reference types of debuggee main & dummy classes
+            rType[0] = debuggee.classByName(DEBUGGEE_CLASSES[0]);
+            rType[1] = debuggee.classByName(DEBUGGEE_CLASSES[1]);
+            rType[2] = debuggee.classByName(DEBUGGEE_CLASSES[2]);
 
-        thrRef = debuggee.threadByFieldName(rType[0], "testThread", DEBUGGEE_THRNAME);
-        if (thrRef == null) {
-            log.complain("TEST FAILURE: Method Debugee.threadByFieldName() returned null for debuggee thread "
-                + DEBUGGEE_THRNAME);
-            tot_res = Consts.TEST_FAILED;
-            return quitDebuggee();
-        }
+            thrRef = debuggee.threadByFieldName(rType[0], "testThread", DEBUGGEE_THRNAME);
+            if (thrRef == null) {
+                log.complain("TEST FAILURE: Method Debugee.threadByFieldName() returned null for debuggee thread "
+                             + DEBUGGEE_THRNAME);
+                tot_res = Consts.TEST_FAILED;
+                return quitDebuggee();
+            }
 
 // Check the tested assersion
-        try {
             suspendAtBP(rType[0], DEBUGGEE_STOPATLINE);
             ObjectReference objRef = findObjRef(DEBUGGEE_LOCALVAR);
             LinkedList<Value> argList = new LinkedList<Value>();

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod014.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod014.java
@@ -143,23 +143,23 @@ public class invokemethod014 {
             return quitDebuggee();
         }
 
-        ReferenceType[] rType = new ReferenceType[3];
-        // debuggee main & dummy classes
-        rType[0] = debuggee.classByName(DEBUGGEE_CLASSES[0]);
-        rType[1] = debuggee.classByName(DEBUGGEE_CLASSES[1]);
-        rType[2] = debuggee.classByName(DEBUGGEE_CLASSES[2]);
+        try {
+            ReferenceType[] rType = new ReferenceType[3];
+            // debuggee main & dummy classes
+            rType[0] = debuggee.classByName(DEBUGGEE_CLASSES[0]);
+            rType[1] = debuggee.classByName(DEBUGGEE_CLASSES[1]);
+            rType[2] = debuggee.classByName(DEBUGGEE_CLASSES[2]);
 
-        ThreadReference thrRef =
-            debuggee.threadByFieldName(rType[0], "testThread", DEBUGGEE_THRNAME);
-        if (thrRef == null) {
-            log.complain("TEST FAILURE: method Debugee.threadByFieldName() returned null for debuggee thread "
-                + DEBUGGEE_THRNAME);
-            tot_res = Consts.TEST_FAILED;
-            return quitDebuggee();
-        }
+            ThreadReference thrRef =
+                debuggee.threadByFieldName(rType[0], "testThread", DEBUGGEE_THRNAME);
+            if (thrRef == null) {
+                log.complain("TEST FAILURE: method Debugee.threadByFieldName() returned null for debuggee thread "
+                             + DEBUGGEE_THRNAME);
+                tot_res = Consts.TEST_FAILED;
+                return quitDebuggee();
+            }
 
 // Check the tested assersion
-        try {
             suspendAtBP(rType[0], DEBUGGEE_STOPATLINE);
             objRef = findObjRef(thrRef, DEBUGGEE_LOCALVAR);
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/setValue/setvalue002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/setValue/setvalue002.java
@@ -109,35 +109,29 @@ public class setvalue002 {
             return quitDebuggee();
         }
 
-        ReferenceType debuggeeClass = debuggee.classByName(DEBUGGEE_CLASS); // debuggee main class
+        try {
+            ReferenceType debuggeeClass = debuggee.classByName(DEBUGGEE_CLASS); // debuggee main class
 
-        thrRef = debuggee.threadByFieldName(debuggeeClass, "testThread", DEBUGGEE_THRNAME);
-        if (thrRef == null) {
-            log.complain("TEST FAILURE: Method Debugee.threadByFieldName() returned null for debuggee's thread "
-                + DEBUGGEE_THRNAME);
-            tot_res = Consts.TEST_FAILED;
-            return quitDebuggee();
-        }
-        thrRef.suspend();
-        while(!thrRef.isSuspended()) {
-            num++;
-            if (num > ATTEMPTS) {
-                log.complain("TEST FAILED: Unable to suspend debuggee's thread");
+            thrRef = debuggee.threadByFieldName(debuggeeClass, "testThread", DEBUGGEE_THRNAME);
+            if (thrRef == null) {
+                log.complain("TEST FAILURE: Method Debugee.threadByFieldName() returned null for debuggee's thread "
+                             + DEBUGGEE_THRNAME);
                 tot_res = Consts.TEST_FAILED;
                 return quitDebuggee();
             }
-            log.display("Waiting for debuggee's thread suspension ...");
-            try {
+            thrRef.suspend();
+            while(!thrRef.isSuspended()) {
+                num++;
+                if (num > ATTEMPTS) {
+                    log.complain("TEST FAILED: Unable to suspend debuggee's thread");
+                    tot_res = Consts.TEST_FAILED;
+                    return quitDebuggee();
+                }
+                log.display("Waiting for debuggee's thread suspension ...");
                 Thread.currentThread().sleep(1000);
-            } catch(InterruptedException ie) {
-                log.complain("TEST FAILED: caught: " + ie);
-                tot_res = Consts.TEST_FAILED;
-                return quitDebuggee();
             }
-        }
 
 // Check the tested assersion
-        try {
             findObjRefs(DEBUGGEE_LOCALVAR);
             rType[0] = objRef[0].referenceType();
             rType[1] = objRef[1].referenceType();

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/setValue/setvalue002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/setValue/setvalue002.java
@@ -120,7 +120,7 @@ public class setvalue002 {
                 return quitDebuggee();
             }
             thrRef.suspend();
-            while(!thrRef.isSuspended()) {
+            while (!thrRef.isSuspended()) {
                 num++;
                 if (num > ATTEMPTS) {
                     log.complain("TEST FAILED: Unable to suspend debuggee's thread");

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/setValue/setvalue003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/setValue/setvalue003.java
@@ -142,36 +142,29 @@ public class setvalue003 {
             return quitDebuggee();
         }
 
-        ReferenceType debuggeeClass = debuggee.classByName(DEBUGGEE_CLASS); // debuggee main class
+        try {
+            ReferenceType debuggeeClass = debuggee.classByName(DEBUGGEE_CLASS); // debuggee main class
 
-        thrRef = debuggee.threadByFieldName(debuggeeClass, "testThread", DEBUGGEE_THRNAME);
-        if (thrRef == null) {
-            log.complain("TEST FAILURE: Method Debugee.threadByFieldName() returned null for debuggee's thread "
-                + DEBUGGEE_THRNAME);
-            tot_res = Consts.TEST_FAILED;
-            return quitDebuggee();
-        }
-        thrRef.suspend();
-        while(!thrRef.isSuspended()) {
-            num++;
-            if (num > ATTEMPTS) {
-                log.complain("TEST FAILED: Unable to suspend debuggee's thread");
+            thrRef = debuggee.threadByFieldName(debuggeeClass, "testThread", DEBUGGEE_THRNAME);
+            if (thrRef == null) {
+                log.complain("TEST FAILURE: Method Debugee.threadByFieldName() returned null for debuggee's thread "
+                             + DEBUGGEE_THRNAME);
                 tot_res = Consts.TEST_FAILED;
                 return quitDebuggee();
             }
-            log.display("Waiting for debuggee's thread suspension ...");
-            try {
+            thrRef.suspend();
+            while(!thrRef.isSuspended()) {
+                num++;
+                if (num > ATTEMPTS) {
+                    log.complain("TEST FAILED: Unable to suspend debuggee's thread");
+                    tot_res = Consts.TEST_FAILED;
+                    return quitDebuggee();
+                }
+                log.display("Waiting for debuggee's thread suspension ...");
                 Thread.sleep(1000);
-            } catch(InterruptedException ie) {
-                ie.printStackTrace();
-                log.complain("TEST FAILED: caught: " + ie);
-                tot_res = Consts.TEST_FAILED;
-                return quitDebuggee();
-            }
         }
 
 // Check the tested assertion
-        try {
             objRef = findObjRef(DEBUGGEE_LOCALVAR);
             rType = objRef.referenceType();
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/setValue/setvalue003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/setValue/setvalue003.java
@@ -153,7 +153,7 @@ public class setvalue003 {
                 return quitDebuggee();
             }
             thrRef.suspend();
-            while(!thrRef.isSuspended()) {
+            while (!thrRef.isSuspended()) {
                 num++;
                 if (num > ATTEMPTS) {
                     log.complain("TEST FAILED: Unable to suspend debuggee's thread");

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/setValue/setvalue004.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/setValue/setvalue004.java
@@ -122,36 +122,29 @@ public class setvalue004 {
             return quitDebuggee();
         }
 
-        ReferenceType debuggeeClass = debuggee.classByName(DEBUGGEE_CLASS); // debuggee main class
+        try {
+            ReferenceType debuggeeClass = debuggee.classByName(DEBUGGEE_CLASS); // debuggee main class
 
-        thrRef = debuggee.threadByFieldName(debuggeeClass, "testThread", DEBUGGEE_THRNAME);
-        if (thrRef == null) {
-            log.complain("TEST FAILURE: Method Debugee.threadByFieldName() returned null for debuggee's thread "
-                + DEBUGGEE_THRNAME);
-            tot_res = Consts.TEST_FAILED;
-            return quitDebuggee();
-        }
-        thrRef.suspend();
-        while(!thrRef.isSuspended()) {
-            num++;
-            if (num > ATTEMPTS) {
-                log.complain("TEST FAILED: Unable to suspend debuggee's thread");
+            thrRef = debuggee.threadByFieldName(debuggeeClass, "testThread", DEBUGGEE_THRNAME);
+            if (thrRef == null) {
+                log.complain("TEST FAILURE: Method Debugee.threadByFieldName() returned null for debuggee's thread "
+                             + DEBUGGEE_THRNAME);
                 tot_res = Consts.TEST_FAILED;
                 return quitDebuggee();
             }
-            log.display("Waiting for debuggee's thread suspension ...");
-            try {
+            thrRef.suspend();
+            while(!thrRef.isSuspended()) {
+                num++;
+                if (num > ATTEMPTS) {
+                    log.complain("TEST FAILED: Unable to suspend debuggee's thread");
+                    tot_res = Consts.TEST_FAILED;
+                    return quitDebuggee();
+                }
+                log.display("Waiting for debuggee's thread suspension ...");
                 Thread.currentThread().sleep(1000);
-            } catch(InterruptedException ie) {
-                ie.printStackTrace();
-                log.complain("TEST FAILED: caught: " + ie);
-                tot_res = Consts.TEST_FAILED;
-                return quitDebuggee();
             }
-        }
 
 // Check the tested assersion
-        try {
             objRef = findObjRef(DEBUGGEE_LOCALVAR);
             rType = objRef.referenceType();
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/setValue/setvalue005.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/setValue/setvalue005.java
@@ -109,37 +109,30 @@ public class setvalue005 {
             return quitDebuggee();
         }
 
-        ReferenceType debuggeeClass = debuggee.classByName(DEBUGGEE_CLASS); // debuggee main class
+        try {
+            ReferenceType debuggeeClass = debuggee.classByName(DEBUGGEE_CLASS); // debuggee main class
 
-        thrRef = debuggee.threadByFieldName(debuggeeClass, "testThread", DEBUGGEE_THRNAME);
-        if (thrRef == null) {
-            log.complain("TEST FAILURE: Method Debugee.threadByFieldName() returned null for debuggee thread "
-                + DEBUGGEE_THRNAME);
-            tot_res = Consts.TEST_FAILED;
-            return quitDebuggee();
-        }
-        thrRef.suspend();
-        while(!thrRef.isSuspended()) {
-            num++;
-            if (num > ATTEMPTS) {
-                log.complain("TEST FAILED: Unable to suspend debuggee thread after "
-                    + ATTEMPTS + " attempts");
+            thrRef = debuggee.threadByFieldName(debuggeeClass, "testThread", DEBUGGEE_THRNAME);
+            if (thrRef == null) {
+                log.complain("TEST FAILURE: Method Debugee.threadByFieldName() returned null for debuggee thread "
+                             + DEBUGGEE_THRNAME);
                 tot_res = Consts.TEST_FAILED;
                 return quitDebuggee();
             }
-            log.display("Waiting for debuggee thread suspension ...");
-            try {
+            thrRef.suspend();
+            while(!thrRef.isSuspended()) {
+                num++;
+                if (num > ATTEMPTS) {
+                    log.complain("TEST FAILED: Unable to suspend debuggee thread after "
+                                 + ATTEMPTS + " attempts");
+                    tot_res = Consts.TEST_FAILED;
+                    return quitDebuggee();
+                }
+                log.display("Waiting for debuggee thread suspension ...");
                 Thread.currentThread().sleep(1000);
-            } catch(InterruptedException ie) {
-                ie.printStackTrace();
-                log.complain("TEST FAILED: caught: " + ie);
-                tot_res = Consts.TEST_FAILED;
-                return quitDebuggee();
             }
-        }
 
 // Check the tested assersion
-        try {
             objRef = findObjRef(DEBUGGEE_LOCALVAR);
             rType = objRef.referenceType();
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/setValue/setvalue005/setvalue005.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/setValue/setvalue005/setvalue005.java
@@ -156,19 +156,19 @@ public class setvalue005 {
             return quitDebuggee();
         }
 
-        // debuggee main class
-        ReferenceType rType = debuggee.classByName(DEBUGGEE_CLASS);
-
-        ThreadReference thrRef =
-            debuggee.threadByFieldName(rType, "mainThread", DEBUGGEE_THRDNAME);
-        if (thrRef == null) {
-            log.complain("TEST FAILURE: method Debugee.threadByFieldName() returned null for debuggee thread "
-                + DEBUGGEE_THRDNAME);
-            tot_res = Consts.TEST_FAILED;
-            return quitDebuggee();
-        }
-
         try {
+            // debuggee main class
+            ReferenceType rType = debuggee.classByName(DEBUGGEE_CLASS);
+
+            ThreadReference thrRef =
+                debuggee.threadByFieldName(rType, "mainThread", DEBUGGEE_THRDNAME);
+            if (thrRef == null) {
+                log.complain("TEST FAILURE: method Debugee.threadByFieldName() returned null for debuggee thread "
+                             + DEBUGGEE_THRDNAME);
+                tot_res = Consts.TEST_FAILED;
+                return quitDebuggee();
+            }
+
             suspendAtBP(rType, DEBUGGEE_STOPATLINE);
 
             // find a stack frame which belongs to the "setvalue005tMainThr" thread

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/ownedMonitors/ownedmonitors002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/ownedMonitors/ownedmonitors002.java
@@ -91,41 +91,34 @@ public class ownedmonitors002 {
             return quitDebuggee();
         }
 
-        // debuggee main class
-        ReferenceType rType = debuggee.classByName(DEBUGGEE_CLASS);
+        try {
+            // debuggee main class
+            ReferenceType rType = debuggee.classByName(DEBUGGEE_CLASS);
 
-        ThreadReference thrRef =
-            debuggee.threadByFieldName(rType, "testThread", DEBUGGEE_THRNAME);
-        if (thrRef == null) {
-            log.complain("TEST FAILURE: method Debugee.threadByFieldName() returned null for debuggee thread "
-                + DEBUGGEE_THRNAME);
-            tot_res = Consts.TEST_FAILED;
-            return quitDebuggee();
-        }
-
-        int num = 0;
-        thrRef.suspend();
-        while(!thrRef.isSuspended()) {
-            num++;
-            if (num > ATTEMPTS) {
-                log.complain("TEST FAILURE: Unable to suspend debuggee thread after "
-                    + ATTEMPTS + " attempts");
+            ThreadReference thrRef =
+                debuggee.threadByFieldName(rType, "testThread", DEBUGGEE_THRNAME);
+            if (thrRef == null) {
+                log.complain("TEST FAILURE: method Debugee.threadByFieldName() returned null for debuggee thread "
+                             + DEBUGGEE_THRNAME);
                 tot_res = Consts.TEST_FAILED;
                 return quitDebuggee();
             }
-            log.display("Waiting for debuggee thread suspension ...");
-            try {
+
+            int num = 0;
+            thrRef.suspend();
+            while(!thrRef.isSuspended()) {
+                num++;
+                if (num > ATTEMPTS) {
+                    log.complain("TEST FAILURE: Unable to suspend debuggee thread after "
+                                 + ATTEMPTS + " attempts");
+                    tot_res = Consts.TEST_FAILED;
+                    return quitDebuggee();
+                }
+                log.display("Waiting for debuggee thread suspension ...");
                 Thread.currentThread().sleep(DELAY);
-            } catch(InterruptedException ie) {
-                ie.printStackTrace();
-                log.complain("TEST FAILURE: caught: " + ie);
-                tot_res = Consts.TEST_FAILED;
-                return quitDebuggee();
             }
-        }
 
 // Check the tested assersion
-        try {
             List mons = thrRef.ownedMonitors();
             if (vm.canGetOwnedMonitorInfo()) {
                 log.display("CHECK PASSED: got a List of monitors owned by the thread,"

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/popFrames/popframes006.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/popFrames/popframes006.java
@@ -106,20 +106,20 @@ public class popframes006 {
             return quitDebuggee();
         }
 
-        // debuggee main class
-        ReferenceType rType = debuggee.classByName(DEBUGGEE_CLASS);
-
-        ThreadReference thrRef =
-            debuggee.threadByFieldName(rType, "testThread", DEBUGGEE_THRNAME);
-        if (thrRef == null) {
-            log.complain("TEST FAILURE: method Debugee.threadByFieldName() returned null for debuggee thread "
-                + DEBUGGEE_THRNAME);
-            tot_res = Consts.TEST_FAILED;
-            return quitDebuggee();
-        }
-
         Field doExit = null;
         try {
+            // debuggee main class
+            ReferenceType rType = debuggee.classByName(DEBUGGEE_CLASS);
+
+            ThreadReference thrRef =
+                debuggee.threadByFieldName(rType, "testThread", DEBUGGEE_THRNAME);
+            if (thrRef == null) {
+                log.complain("TEST FAILURE: method Debugee.threadByFieldName() returned null for debuggee thread "
+                             + DEBUGGEE_THRNAME);
+                tot_res = Consts.TEST_FAILED;
+                return quitDebuggee();
+            }
+
             suspendAtBP(rType, DEBUGGEE_STOPATLINE);
 
             // debuggee field used to indicate that popping has been done

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/popFrames/popframes007.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/popFrames/popframes007.java
@@ -106,29 +106,29 @@ public class popframes007 {
             return quitDebuggee();
         }
 
-        // debuggee main class
-        ReferenceType rType = debuggee.classByName(DEBUGGEE_CLASS);
-
-        ThreadReference mainThread =
-            debuggee.threadByFieldName(rType, "mainThread", DEBUGGEE_MAIN_THREAD_NAME);
-        if (mainThread == null) {
-            log.complain("TEST FAILURE: method Debugee.threadByFieldName() returned null for debuggee thread "
-                         + DEBUGGEE_MAIN_THREAD_NAME);
-            tot_res = Consts.TEST_FAILED;
-            return quitDebuggee();
-        }
-
-        ThreadReference auxThread =
-            debuggee.threadByFieldName(rType, "auxThr", DEBUGGEE_AUX_THREAD_NAME);
-        if (auxThread == null) {
-            log.complain("TEST FAILURE: method Debugee.threadByFieldName() returned null for debuggee thread "
-                         + DEBUGGEE_AUX_THREAD_NAME);
-            tot_res = Consts.TEST_FAILED;
-            return quitDebuggee();
-        }
-
         Field doExit = null;
         try {
+            // debuggee main class
+            ReferenceType rType = debuggee.classByName(DEBUGGEE_CLASS);
+
+            ThreadReference mainThread =
+                debuggee.threadByFieldName(rType, "mainThread", DEBUGGEE_MAIN_THREAD_NAME);
+            if (mainThread == null) {
+                log.complain("TEST FAILURE: method Debugee.threadByFieldName() returned null for debuggee thread "
+                             + DEBUGGEE_MAIN_THREAD_NAME);
+                tot_res = Consts.TEST_FAILED;
+                return quitDebuggee();
+            }
+
+            ThreadReference auxThread =
+                debuggee.threadByFieldName(rType, "auxThr", DEBUGGEE_AUX_THREAD_NAME);
+            if (auxThread == null) {
+                log.complain("TEST FAILURE: method Debugee.threadByFieldName() returned null for debuggee thread "
+                             + DEBUGGEE_AUX_THREAD_NAME);
+                tot_res = Consts.TEST_FAILED;
+                return quitDebuggee();
+            }
+
             suspendAtBP(rType, DEBUGGEE_STOPATLINE);
 
             // debuggee field used to indicate that popping has been done

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/stop/stop002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/stop/stop002.java
@@ -115,22 +115,23 @@ public class stop002 {
             return quitDebuggee();
         }
 
-        // debuggee main class
-        mainClass = debuggee.classByName(DEBUGGEE_CLASS);
-
-        ThreadReference thrRef = debuggee.threadByFieldName(mainClass, "testThread", DEBUGGEE_THRNAME);
-        if (thrRef == null) {
-            log.complain("TEST FAILURE: method Debugee.threadByFieldName() returned null for debuggee thread "
-                + DEBUGGEE_THRNAME);
-            tot_res = Consts.TEST_FAILED;
-            return quitDebuggee();
-        }
-
         Field stopLoop1 = null;
         Field stopLoop2 = null;
         ObjectReference objRef = null;
         ObjectReference throwableRef = null;
+
         try {
+            // debuggee main class
+            mainClass = debuggee.classByName(DEBUGGEE_CLASS);
+
+            ThreadReference thrRef = debuggee.threadByFieldName(mainClass, "testThread", DEBUGGEE_THRNAME);
+            if (thrRef == null) {
+                log.complain("TEST FAILURE: method Debugee.threadByFieldName() returned null for debuggee thread "
+                             + DEBUGGEE_THRNAME);
+                tot_res = Consts.TEST_FAILED;
+                return quitDebuggee();
+            }
+
             suspendAtBP(mainClass, DEBUGGEE_STOPATLINE);
             objRef = findObjRef(thrRef, DEBUGGEE_NON_THROWABLE_VAR);
             throwableRef = findObjRef(thrRef, DEBUGGEE_THROWABLE_VAR);


### PR DESCRIPTION
Extend try block to cover debuggee.classByname() call. I would suggest disabling whitespace diffs when doing the review. It makes code movement and deletions more obvious.

There are a number of places where I removed a try/catch of InterruptedException around a Thread.sleep. This will now be handled by the outer try which was moved to before this try/catch.

Tested nsk/jdi test locally. Will do more thorough ci testing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8357172](https://bugs.openjdk.org/browse/JDK-8357172): Extend try block in nsk/jdi tests to capture exceptions thrown by Debuggee.classByName() (**Enhancement** - P4)


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**) Review applies to [1ed374f5](https://git.openjdk.org/jdk/pull/25337/files/1ed374f5f4468bb1f30e1abde8871d16a4f11775)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25337/head:pull/25337` \
`$ git checkout pull/25337`

Update a local copy of the PR: \
`$ git checkout pull/25337` \
`$ git pull https://git.openjdk.org/jdk.git pull/25337/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25337`

View PR using the GUI difftool: \
`$ git pr show -t 25337`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25337.diff">https://git.openjdk.org/jdk/pull/25337.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25337#issuecomment-2895738782)
</details>
