### PR TITLE
8357396: Refactor nmethod::make_not_entrant to use Enum instead of "const char*"

### DIFF
--- a/src/hotspot/share/c1/c1_Runtime1.cpp
+++ b/src/hotspot/share/c1/c1_Runtime1.cpp
@@ -800,7 +800,7 @@ JRT_ENTRY(void, Runtime1::deoptimize(JavaThread* current, jint trap_request))
   Deoptimization::DeoptReason reason = Deoptimization::trap_request_reason(trap_request);
 
   if (action == Deoptimization::Action_make_not_entrant) {
-    if (nm->make_not_entrant("C1 deoptimize")) {
+    if (nm->make_not_entrant(nmethod::C1_deoptimize)) {
       if (reason == Deoptimization::Reason_tenured) {
         MethodData* trap_mdo = Deoptimization::get_method_data(current, method, true /*create_if_missing*/);
         if (trap_mdo != nullptr) {
@@ -1092,7 +1092,7 @@ JRT_ENTRY(void, Runtime1::patch_code(JavaThread* current, C1StubId stub_id ))
     // safepoint, but if it's still alive then make it not_entrant.
     nmethod* nm = CodeCache::find_nmethod(caller_frame.pc());
     if (nm != nullptr) {
-      nm->make_not_entrant("C1 code patch");
+      nm->make_not_entrant(nmethod::C1_codepatch);
     }
 
     Deoptimization::deoptimize_frame(current, caller_frame.id());
@@ -1340,7 +1340,7 @@ void Runtime1::patch_code(JavaThread* current, C1StubId stub_id) {
     // Make sure the nmethod is invalidated, i.e. made not entrant.
     nmethod* nm = CodeCache::find_nmethod(caller_frame.pc());
     if (nm != nullptr) {
-      nm->make_not_entrant("C1 deoptimize for patching");
+      nm->make_not_entrant(nmethod::C1_deoptimize_for_patching);
     }
   }
 
@@ -1468,7 +1468,7 @@ JRT_ENTRY(void, Runtime1::predicate_failed_trap(JavaThread* current))
 
   nmethod* nm = CodeCache::find_nmethod(caller_frame.pc());
   assert (nm != nullptr, "no more nmethod?");
-  nm->make_not_entrant("C1 predicate failed trap");
+  nm->make_not_entrant(nmethod::C1_predicate_failed_trap);
 
   methodHandle m(current, nm->method());
   MethodData* mdo = m->method_data();

--- a/src/hotspot/share/c1/c1_Runtime1.cpp
+++ b/src/hotspot/share/c1/c1_Runtime1.cpp
@@ -800,7 +800,7 @@ JRT_ENTRY(void, Runtime1::deoptimize(JavaThread* current, jint trap_request))
   Deoptimization::DeoptReason reason = Deoptimization::trap_request_reason(trap_request);
 
   if (action == Deoptimization::Action_make_not_entrant) {
-    if (nm->make_not_entrant(nmethod::NMethodChangeReason::C1_deoptimize)) {
+    if (nm->make_not_entrant(nmethod::ChangeReason::C1_deoptimize)) {
       if (reason == Deoptimization::Reason_tenured) {
         MethodData* trap_mdo = Deoptimization::get_method_data(current, method, true /*create_if_missing*/);
         if (trap_mdo != nullptr) {
@@ -1092,7 +1092,7 @@ JRT_ENTRY(void, Runtime1::patch_code(JavaThread* current, C1StubId stub_id ))
     // safepoint, but if it's still alive then make it not_entrant.
     nmethod* nm = CodeCache::find_nmethod(caller_frame.pc());
     if (nm != nullptr) {
-      nm->make_not_entrant(nmethod::NMethodChangeReason::C1_codepatch);
+      nm->make_not_entrant(nmethod::ChangeReason::C1_codepatch);
     }
 
     Deoptimization::deoptimize_frame(current, caller_frame.id());
@@ -1468,7 +1468,7 @@ JRT_ENTRY(void, Runtime1::predicate_failed_trap(JavaThread* current))
 
   nmethod* nm = CodeCache::find_nmethod(caller_frame.pc());
   assert (nm != nullptr, "no more nmethod?");
-  nm->make_not_entrant(nmethod::NMethodChangeReason::C1_predicate_failed_trap);
+  nm->make_not_entrant(nmethod::ChangeReason::C1_predicate_failed_trap);
 
   methodHandle m(current, nm->method());
   MethodData* mdo = m->method_data();

--- a/src/hotspot/share/c1/c1_Runtime1.cpp
+++ b/src/hotspot/share/c1/c1_Runtime1.cpp
@@ -1340,7 +1340,7 @@ void Runtime1::patch_code(JavaThread* current, C1StubId stub_id) {
     // Make sure the nmethod is invalidated, i.e. made not entrant.
     nmethod* nm = CodeCache::find_nmethod(caller_frame.pc());
     if (nm != nullptr) {
-      nm->make_not_entrant(nmethod::NMethodChangeReason::C1_deoptimize_for_patching);
+      nm->make_not_entrant(nmethod::ChangeReason::C1_deoptimize_for_patching);
     }
   }
 

--- a/src/hotspot/share/c1/c1_Runtime1.cpp
+++ b/src/hotspot/share/c1/c1_Runtime1.cpp
@@ -800,7 +800,7 @@ JRT_ENTRY(void, Runtime1::deoptimize(JavaThread* current, jint trap_request))
   Deoptimization::DeoptReason reason = Deoptimization::trap_request_reason(trap_request);
 
   if (action == Deoptimization::Action_make_not_entrant) {
-    if (nm->make_not_entrant(nmethod::C1_deoptimize)) {
+    if (nm->make_not_entrant(nmethod::NMethodChangeReason::C1_deoptimize)) {
       if (reason == Deoptimization::Reason_tenured) {
         MethodData* trap_mdo = Deoptimization::get_method_data(current, method, true /*create_if_missing*/);
         if (trap_mdo != nullptr) {
@@ -1092,7 +1092,7 @@ JRT_ENTRY(void, Runtime1::patch_code(JavaThread* current, C1StubId stub_id ))
     // safepoint, but if it's still alive then make it not_entrant.
     nmethod* nm = CodeCache::find_nmethod(caller_frame.pc());
     if (nm != nullptr) {
-      nm->make_not_entrant(nmethod::C1_codepatch);
+      nm->make_not_entrant(nmethod::NMethodChangeReason::C1_codepatch);
     }
 
     Deoptimization::deoptimize_frame(current, caller_frame.id());
@@ -1340,7 +1340,7 @@ void Runtime1::patch_code(JavaThread* current, C1StubId stub_id) {
     // Make sure the nmethod is invalidated, i.e. made not entrant.
     nmethod* nm = CodeCache::find_nmethod(caller_frame.pc());
     if (nm != nullptr) {
-      nm->make_not_entrant(nmethod::C1_deoptimize_for_patching);
+      nm->make_not_entrant(nmethod::NMethodChangeReason::C1_deoptimize_for_patching);
     }
   }
 
@@ -1468,7 +1468,7 @@ JRT_ENTRY(void, Runtime1::predicate_failed_trap(JavaThread* current))
 
   nmethod* nm = CodeCache::find_nmethod(caller_frame.pc());
   assert (nm != nullptr, "no more nmethod?");
-  nm->make_not_entrant(nmethod::C1_predicate_failed_trap);
+  nm->make_not_entrant(nmethod::NMethodChangeReason::C1_predicate_failed_trap);
 
   methodHandle m(current, nm->method());
   MethodData* mdo = m->method_data();

--- a/src/hotspot/share/ci/ciReplay.cpp
+++ b/src/hotspot/share/ci/ciReplay.cpp
@@ -802,7 +802,7 @@ class CompileReplay : public StackObj {
     // Make sure the existence of a prior compile doesn't stop this one
     nmethod* nm = (entry_bci != InvocationEntryBci) ? method->lookup_osr_nmethod_for(entry_bci, comp_level, true) : method->code();
     if (nm != nullptr) {
-      nm->make_not_entrant("CI replay");
+      nm->make_not_entrant(nmethod::CI_replay);
     }
     replay_state = this;
     CompileBroker::compile_method(methodHandle(THREAD, method), entry_bci, comp_level,

--- a/src/hotspot/share/ci/ciReplay.cpp
+++ b/src/hotspot/share/ci/ciReplay.cpp
@@ -802,7 +802,7 @@ class CompileReplay : public StackObj {
     // Make sure the existence of a prior compile doesn't stop this one
     nmethod* nm = (entry_bci != InvocationEntryBci) ? method->lookup_osr_nmethod_for(entry_bci, comp_level, true) : method->code();
     if (nm != nullptr) {
-      nm->make_not_entrant(nmethod::NMethodChangeReason::CI_replay);
+      nm->make_not_entrant(nmethod::ChangeReason::CI_replay);
     }
     replay_state = this;
     CompileBroker::compile_method(methodHandle(THREAD, method), entry_bci, comp_level,

--- a/src/hotspot/share/ci/ciReplay.cpp
+++ b/src/hotspot/share/ci/ciReplay.cpp
@@ -802,7 +802,7 @@ class CompileReplay : public StackObj {
     // Make sure the existence of a prior compile doesn't stop this one
     nmethod* nm = (entry_bci != InvocationEntryBci) ? method->lookup_osr_nmethod_for(entry_bci, comp_level, true) : method->code();
     if (nm != nullptr) {
-      nm->make_not_entrant(nmethod::CI_replay);
+      nm->make_not_entrant(nmethod::NMethodChangeReason::CI_replay);
     }
     replay_state = this;
     CompileBroker::compile_method(methodHandle(THREAD, method), entry_bci, comp_level,

--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -1361,7 +1361,7 @@ void CodeCache::make_marked_nmethods_deoptimized() {
   while(iter.next()) {
     nmethod* nm = iter.method();
     if (nm->is_marked_for_deoptimization() && !nm->has_been_deoptimized() && nm->can_be_deoptimized()) {
-      nm->make_not_entrant("marked for deoptimization");
+      nm->make_not_entrant(nmethod::marked_for_deoptimization);
       nm->make_deoptimized();
     }
   }

--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -1361,7 +1361,7 @@ void CodeCache::make_marked_nmethods_deoptimized() {
   while(iter.next()) {
     nmethod* nm = iter.method();
     if (nm->is_marked_for_deoptimization() && !nm->has_been_deoptimized() && nm->can_be_deoptimized()) {
-      nm->make_not_entrant(nmethod::NMethodChangeReason::marked_for_deoptimization);
+      nm->make_not_entrant(nmethod::ChangeReason::marked_for_deoptimization);
       nm->make_deoptimized();
     }
   }

--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -1361,7 +1361,7 @@ void CodeCache::make_marked_nmethods_deoptimized() {
   while(iter.next()) {
     nmethod* nm = iter.method();
     if (nm->is_marked_for_deoptimization() && !nm->has_been_deoptimized() && nm->can_be_deoptimized()) {
-      nm->make_not_entrant(nmethod::marked_for_deoptimization);
+      nm->make_not_entrant(nmethod::NMethodChangeReason::marked_for_deoptimization);
       nm->make_deoptimized();
     }
   }

--- a/src/hotspot/share/code/nmethod.cpp
+++ b/src/hotspot/share/code/nmethod.cpp
@@ -1964,13 +1964,11 @@ void nmethod::invalidate_osr_method() {
   }
 }
 
-void nmethod::log_state_change(const char* reason) const {
-  assert(reason != nullptr, "Must provide a reason");
-
+void nmethod::log_state_change(NMethodChangeReason reason) const {
   if (LogCompilation) {
     if (xtty != nullptr) {
       ttyLocker ttyl;  // keep the following output all in one block
-      xtty->begin_elem("make_not_entrant thread='%zu' reason='%s'",
+      xtty->begin_elem("make_not_entrant thread='%zu' reason='%d'",
                        os::current_thread_id(), reason);
       log_identity(xtty);
       xtty->stamp();
@@ -1980,7 +1978,7 @@ void nmethod::log_state_change(const char* reason) const {
 
   ResourceMark rm;
   stringStream ss(NEW_RESOURCE_ARRAY(char, 256), 256);
-  ss.print("made not entrant: %s", reason);
+  ss.print("made not entrant: %d", reason);
 
   CompileTask::print_ul(this, ss.freeze());
   if (PrintCompilation) {
@@ -1995,9 +1993,7 @@ void nmethod::unlink_from_method() {
 }
 
 // Invalidate code
-bool nmethod::make_not_entrant(const char* reason) {
-  assert(reason != nullptr, "Must provide a reason");
-
+bool nmethod::make_not_entrant(NMethodChangeReason reason) {
   // This can be called while the system is already at a safepoint which is ok
   NoSafepointVerifier nsv;
 

--- a/src/hotspot/share/code/nmethod.cpp
+++ b/src/hotspot/share/code/nmethod.cpp
@@ -1968,8 +1968,8 @@ void nmethod::log_state_change(NMethodChangeReason reason) const {
   if (LogCompilation) {
     if (xtty != nullptr) {
       ttyLocker ttyl;  // keep the following output all in one block
-      xtty->begin_elem("make_not_entrant thread='%zu' reason='%d'",
-                       os::current_thread_id(), reason);
+      xtty->begin_elem("make_not_entrant thread='%zu' reason='%s'",
+                       os::current_thread_id(), NMethodChangeReason_to_string(reason));
       log_identity(xtty);
       xtty->stamp();
       xtty->end_elem();
@@ -1978,7 +1978,7 @@ void nmethod::log_state_change(NMethodChangeReason reason) const {
 
   ResourceMark rm;
   stringStream ss(NEW_RESOURCE_ARRAY(char, 256), 256);
-  ss.print("made not entrant: %d", reason);
+  ss.print("made not entrant: %s", NMethodChangeReason_to_string(reason));
 
   CompileTask::print_ul(this, ss.freeze());
   if (PrintCompilation) {

--- a/src/hotspot/share/code/nmethod.cpp
+++ b/src/hotspot/share/code/nmethod.cpp
@@ -1968,7 +1968,7 @@ void nmethod::log_state_change(ChangeReason change_reason) const {
   if (LogCompilation) {
     if (xtty != nullptr) {
       ttyLocker ttyl;  // keep the following output all in one block
-      xtty->begin_elem("make_not_entrant thread='%zu' change_reason='%s'",
+      xtty->begin_elem("make_not_entrant thread='%zu' reason='%s'",
                        os::current_thread_id(), change_reason_to_string(change_reason));
       log_identity(xtty);
       xtty->stamp();

--- a/src/hotspot/share/code/nmethod.cpp
+++ b/src/hotspot/share/code/nmethod.cpp
@@ -1964,12 +1964,12 @@ void nmethod::invalidate_osr_method() {
   }
 }
 
-void nmethod::log_state_change(NMethodChangeReason reason) const {
+void nmethod::log_state_change(ChangeReason change_reason) const {
   if (LogCompilation) {
     if (xtty != nullptr) {
       ttyLocker ttyl;  // keep the following output all in one block
-      xtty->begin_elem("make_not_entrant thread='%zu' reason='%s'",
-                       os::current_thread_id(), NMethodChangeReason_to_string(reason));
+      xtty->begin_elem("make_not_entrant thread='%zu' change_reason='%s'",
+                       os::current_thread_id(), change_reason_to_string(change_reason));
       log_identity(xtty);
       xtty->stamp();
       xtty->end_elem();
@@ -1978,7 +1978,7 @@ void nmethod::log_state_change(NMethodChangeReason reason) const {
 
   ResourceMark rm;
   stringStream ss(NEW_RESOURCE_ARRAY(char, 256), 256);
-  ss.print("made not entrant: %s", NMethodChangeReason_to_string(reason));
+  ss.print("made not entrant: %s", change_reason_to_string(change_reason));
 
   CompileTask::print_ul(this, ss.freeze());
   if (PrintCompilation) {
@@ -1993,7 +1993,7 @@ void nmethod::unlink_from_method() {
 }
 
 // Invalidate code
-bool nmethod::make_not_entrant(NMethodChangeReason reason) {
+bool nmethod::make_not_entrant(ChangeReason change_reason) {
   // This can be called while the system is already at a safepoint which is ok
   NoSafepointVerifier nsv;
 
@@ -2051,7 +2051,7 @@ bool nmethod::make_not_entrant(NMethodChangeReason reason) {
     assert(success, "Transition can't fail");
 
     // Log the transition once
-    log_state_change(reason);
+    log_state_change(change_reason);
 
     // Remove nmethod from method.
     unlink_from_method();

--- a/src/hotspot/share/code/nmethod.hpp
+++ b/src/hotspot/share/code/nmethod.hpp
@@ -469,6 +469,31 @@ class nmethod : public CodeBlob {
   void oops_do_set_strong_done(nmethod* old_head);
 
 public:
+  enum NMethodChangeReason : s4 {
+    C1_deoptimize = 0,
+    C1_codepatch,
+    C1_predicate_failed_trap,
+    C1_deoptimize_for_patching,
+    CI_replay,
+    marked_for_deoptimization,
+    not_used,
+    OSR_invalidation_for_compiling_with_C1,
+    OSR_invalidation_back_branch,
+    JVMCI_reprofile,
+    JVMCI_materialize_virtual_object,
+    JVMCI_invalidate_nmethod_mirror,
+    JVMCI_register_method,
+    OSR_invalidation_of_lower_level,
+    set_native_function,
+    whitebox_deoptimization,
+    missing_exception_handler,
+    uncommon_trap,
+    zombie,
+    JVMCI_invalidate_nmethod,
+    JVMCI_new_installation,
+    JVMCI_replacing_with_new_code,
+  };
+
   // create nmethod with entry_bci
   static nmethod* new_nmethod(const methodHandle& method,
                               int compile_id,
@@ -631,8 +656,8 @@ public:
   // alive.  It is used when an uncommon trap happens.  Returns true
   // if this thread changed the state of the nmethod or false if
   // another thread performed the transition.
-  bool  make_not_entrant(const char* reason);
-  bool  make_not_used()    { return make_not_entrant("not used"); }
+  bool  make_not_entrant(NMethodChangeReason reason);
+  bool  make_not_used()    { return make_not_entrant(nmethod::not_used); }
 
   bool  is_marked_for_deoptimization() const { return deoptimization_status() != not_marked; }
   bool  has_been_deoptimized() const { return deoptimization_status() == deoptimize_done; }
@@ -945,7 +970,7 @@ public:
   // Logging
   void log_identity(xmlStream* log) const;
   void log_new_nmethod() const;
-  void log_state_change(const char* reason) const;
+  void log_state_change(NMethodChangeReason reason) const;
 
   // Prints block-level comments, including nmethod specific block labels:
   void print_nmethod_labels(outputStream* stream, address block_begin, bool print_section_labels=true) const;

--- a/src/hotspot/share/code/nmethod.hpp
+++ b/src/hotspot/share/code/nmethod.hpp
@@ -469,79 +469,59 @@ class nmethod : public CodeBlob {
   void oops_do_set_strong_done(nmethod* old_head);
 
 public:
-  enum class NMethodChangeReason : u1 {
-    C1_deoptimize,
+  enum class ChangeReason : u1 {
     C1_codepatch,
-    C1_predicate_failed_trap,
+    C1_deoptimize,
     C1_deoptimize_for_patching,
+    C1_predicate_failed_trap,
     CI_replay,
+    JVMCI_invalidate_nmethod,
+    JVMCI_invalidate_nmethod_mirror,
+    JVMCI_materialize_virtual_object,
+    JVMCI_new_installation,
+    JVMCI_register_method,
+    JVMCI_replacing_with_new_code,
+    JVMCI_reprofile,
     marked_for_deoptimization,
+    missing_exception_handler,
     not_used,
-    OSR_invalidation_for_compiling_with_C1,
     OSR_invalidation_back_branch,
+    OSR_invalidation_for_compiling_with_C1,
     OSR_invalidation_of_lower_level,
     set_native_function,
-    whitebox_deoptimization,
-    missing_exception_handler,
     uncommon_trap,
+    whitebox_deoptimization,
     zombie,
-    JVMCI_reprofile,
-    JVMCI_materialize_virtual_object,
-    JVMCI_invalidate_nmethod_mirror,
-    JVMCI_register_method,
-    JVMCI_invalidate_nmethod,
-    JVMCI_new_installation,
-    JVMCI_replacing_with_new_code,
   };
 
 
-  static const char* NMethodChangeReason_to_string(NMethodChangeReason reason) {
-    if (reason == nmethod::NMethodChangeReason::C1_deoptimize) {
-        return "C1 deoptimized";
-    } else if (reason == nmethod::NMethodChangeReason::C1_codepatch) {
-        return "C1 code patch";
-    } else if (reason == nmethod::NMethodChangeReason::C1_predicate_failed_trap) {
-        return "C1 predicate failed trap";
-    } else if (reason == nmethod::NMethodChangeReason::C1_deoptimize_for_patching) {
-        return "C1 deoptimize for patching";
-    } else if (reason == nmethod::NMethodChangeReason::CI_replay) {
-        return "CI replay";
-    } else if (reason == nmethod::NMethodChangeReason::marked_for_deoptimization) {
-        return "marked for deoptimization";
-    } else if (reason == nmethod::NMethodChangeReason::not_used) {
-        return "not used";
-    } else if (reason == nmethod::NMethodChangeReason::OSR_invalidation_for_compiling_with_C1) {
-        return "OSR invalidation for compiling with C1";
-    } else if (reason == nmethod::NMethodChangeReason::OSR_invalidation_back_branch) {
-        return "OSR invalidation back branch";
-    } else if (reason == nmethod::NMethodChangeReason::JVMCI_reprofile) {
-        return "JVMCI reprofile";
-    } else if (reason == nmethod::NMethodChangeReason::JVMCI_materialize_virtual_object) {
-        return "JVMCI materialize virtual object";
-    } else if (reason == nmethod::NMethodChangeReason::JVMCI_invalidate_nmethod_mirror) {
-        return "JVMCI invalidate nmethod mirror";
-    } else if (reason == nmethod::NMethodChangeReason::JVMCI_register_method) {
-        return "JVMCI register method";
-    } else if (reason == nmethod::NMethodChangeReason::OSR_invalidation_of_lower_level) {
-        return "OSR invalidation of lower level";
-    } else if (reason == nmethod::NMethodChangeReason::set_native_function) {
-        return "set native function";
-    } else if (reason == nmethod::NMethodChangeReason::whitebox_deoptimization) {
-        return "whitebox deoptimization";
-    } else if (reason == nmethod::NMethodChangeReason::missing_exception_handler) {
-        return "missing exception handler";
-    } else if (reason == nmethod::NMethodChangeReason::uncommon_trap) {
-        return "uncommon trap";
-    } else if (reason == nmethod::NMethodChangeReason::JVMCI_invalidate_nmethod) {
-        return "JVMCI invalidate nmethod";
-    } else if (reason == nmethod::NMethodChangeReason::zombie) {
-        return "zombie";
-    } else if (reason == nmethod::NMethodChangeReason::JVMCI_new_installation) {
-        return "JVMCI new installation";
-    } else if (reason == nmethod::NMethodChangeReason::JVMCI_replacing_with_new_code) {
-        return "JVMCI replacing with new code";
-    } else {
-        return "Unknown";
+  static const char* change_reason_to_string(ChangeReason change_reason) {
+    switch (change_reason) {
+        case ChangeReason::C1_codepatch:                            return "C1 code patch";
+        case ChangeReason::C1_deoptimize:                           return "C1 deoptimized";
+        case ChangeReason::C1_deoptimize_for_patching:              return "C1 deoptimize for patching";
+        case ChangeReason::C1_predicate_failed_trap:                return "C1 predicate failed trap";
+        case ChangeReason::CI_replay:                               return "CI replay";
+        case ChangeReason::JVMCI_invalidate_nmethod:                return "JVMCI invalidate nmethod";
+        case ChangeReason::JVMCI_invalidate_nmethod_mirror:         return "JVMCI invalidate nmethod mirror";
+        case ChangeReason::JVMCI_materialize_virtual_object:        return "JVMCI materialize virtual object";
+        case ChangeReason::JVMCI_new_installation:                  return "JVMCI new installation";
+        case ChangeReason::JVMCI_register_method:                   return "JVMCI register method";
+        case ChangeReason::JVMCI_replacing_with_new_code:           return "JVMCI replacing with new code";
+        case ChangeReason::JVMCI_reprofile:                         return "JVMCI reprofile";
+        case ChangeReason::marked_for_deoptimization:               return "marked for deoptimization";
+        case ChangeReason::missing_exception_handler:               return "missing exception handler";
+        case ChangeReason::not_used:                                return "not used";
+        case ChangeReason::OSR_invalidation_back_branch:            return "OSR invalidation back branch";
+        case ChangeReason::OSR_invalidation_for_compiling_with_C1:  return "OSR invalidation for compiling with C1";
+        case ChangeReason::OSR_invalidation_of_lower_level:         return "OSR invalidation of lower level";
+        case ChangeReason::set_native_function:                     return "set native function";
+        case ChangeReason::uncommon_trap:                           return "uncommon trap";
+        case ChangeReason::whitebox_deoptimization:                 return "whitebox deoptimization";
+        case ChangeReason::zombie:                                  return "zombie";
+        default:
+            assert(false, "Unhandled reason");
+            return "Unknown";
     }
   }
 
@@ -707,8 +687,8 @@ public:
   // alive.  It is used when an uncommon trap happens.  Returns true
   // if this thread changed the state of the nmethod or false if
   // another thread performed the transition.
-  bool  make_not_entrant(NMethodChangeReason reason);
-  bool  make_not_used()    { return make_not_entrant(NMethodChangeReason::not_used); }
+  bool  make_not_entrant(ChangeReason change_reason);
+  bool  make_not_used()    { return make_not_entrant(ChangeReason::not_used); }
 
   bool  is_marked_for_deoptimization() const { return deoptimization_status() != not_marked; }
   bool  has_been_deoptimized() const { return deoptimization_status() == deoptimize_done; }
@@ -1021,7 +1001,7 @@ public:
   // Logging
   void log_identity(xmlStream* log) const;
   void log_new_nmethod() const;
-  void log_state_change(NMethodChangeReason reason) const;
+  void log_state_change(ChangeReason change_reason) const;
 
   // Prints block-level comments, including nmethod specific block labels:
   void print_nmethod_labels(outputStream* stream, address block_begin, bool print_section_labels=true) const;

--- a/src/hotspot/share/code/nmethod.hpp
+++ b/src/hotspot/share/code/nmethod.hpp
@@ -497,31 +497,54 @@ public:
 
   static const char* change_reason_to_string(ChangeReason change_reason) {
     switch (change_reason) {
-        case ChangeReason::C1_codepatch:                            return "C1 code patch";
-        case ChangeReason::C1_deoptimize:                           return "C1 deoptimized";
-        case ChangeReason::C1_deoptimize_for_patching:              return "C1 deoptimize for patching";
-        case ChangeReason::C1_predicate_failed_trap:                return "C1 predicate failed trap";
-        case ChangeReason::CI_replay:                               return "CI replay";
-        case ChangeReason::JVMCI_invalidate_nmethod:                return "JVMCI invalidate nmethod";
-        case ChangeReason::JVMCI_invalidate_nmethod_mirror:         return "JVMCI invalidate nmethod mirror";
-        case ChangeReason::JVMCI_materialize_virtual_object:        return "JVMCI materialize virtual object";
-        case ChangeReason::JVMCI_new_installation:                  return "JVMCI new installation";
-        case ChangeReason::JVMCI_register_method:                   return "JVMCI register method";
-        case ChangeReason::JVMCI_replacing_with_new_code:           return "JVMCI replacing with new code";
-        case ChangeReason::JVMCI_reprofile:                         return "JVMCI reprofile";
-        case ChangeReason::marked_for_deoptimization:               return "marked for deoptimization";
-        case ChangeReason::missing_exception_handler:               return "missing exception handler";
-        case ChangeReason::not_used:                                return "not used";
-        case ChangeReason::OSR_invalidation_back_branch:            return "OSR invalidation back branch";
-        case ChangeReason::OSR_invalidation_for_compiling_with_C1:  return "OSR invalidation for compiling with C1";
-        case ChangeReason::OSR_invalidation_of_lower_level:         return "OSR invalidation of lower level";
-        case ChangeReason::set_native_function:                     return "set native function";
-        case ChangeReason::uncommon_trap:                           return "uncommon trap";
-        case ChangeReason::whitebox_deoptimization:                 return "whitebox deoptimization";
-        case ChangeReason::zombie:                                  return "zombie";
-        default:
-            assert(false, "Unhandled reason");
-            return "Unknown";
+      case ChangeReason::C1_codepatch:
+        return "C1 code patch";
+      case ChangeReason::C1_deoptimize:
+        return "C1 deoptimized";
+      case ChangeReason::C1_deoptimize_for_patching:
+        return "C1 deoptimize for patching";
+      case ChangeReason::C1_predicate_failed_trap:
+        return "C1 predicate failed trap";
+      case ChangeReason::CI_replay:
+        return "CI replay";
+      case ChangeReason::JVMCI_invalidate_nmethod:
+        return "JVMCI invalidate nmethod";
+      case ChangeReason::JVMCI_invalidate_nmethod_mirror:
+        return "JVMCI invalidate nmethod mirror";
+      case ChangeReason::JVMCI_materialize_virtual_object:
+        return "JVMCI materialize virtual object";
+      case ChangeReason::JVMCI_new_installation:
+        return "JVMCI new installation";
+      case ChangeReason::JVMCI_register_method:
+        return "JVMCI register method";
+      case ChangeReason::JVMCI_replacing_with_new_code:
+        return "JVMCI replacing with new code";
+      case ChangeReason::JVMCI_reprofile:
+        return "JVMCI reprofile";
+      case ChangeReason::marked_for_deoptimization:
+        return "marked for deoptimization";
+      case ChangeReason::missing_exception_handler:
+        return "missing exception handler";
+      case ChangeReason::not_used:
+        return "not used";
+      case ChangeReason::OSR_invalidation_back_branch:
+        return "OSR invalidation back branch";
+      case ChangeReason::OSR_invalidation_for_compiling_with_C1:
+        return "OSR invalidation for compiling with C1";
+      case ChangeReason::OSR_invalidation_of_lower_level:
+        return "OSR invalidation of lower level";
+      case ChangeReason::set_native_function:
+        return "set native function";
+      case ChangeReason::uncommon_trap:
+        return "uncommon trap";
+      case ChangeReason::whitebox_deoptimization:
+        return "whitebox deoptimization";
+      case ChangeReason::zombie:
+        return "zombie";
+      default: {
+        assert(false, "Unhandled reason");
+        return "Unknown";
+      }
     }
   }
 
@@ -688,7 +711,7 @@ public:
   // if this thread changed the state of the nmethod or false if
   // another thread performed the transition.
   bool  make_not_entrant(ChangeReason change_reason);
-  bool  make_not_used()    { return make_not_entrant(ChangeReason::not_used); }
+  bool  make_not_used() { return make_not_entrant(ChangeReason::not_used); }
 
   bool  is_marked_for_deoptimization() const { return deoptimization_status() != not_marked; }
   bool  has_been_deoptimized() const { return deoptimization_status() == deoptimize_done; }

--- a/src/hotspot/share/code/nmethod.hpp
+++ b/src/hotspot/share/code/nmethod.hpp
@@ -469,8 +469,8 @@ class nmethod : public CodeBlob {
   void oops_do_set_strong_done(nmethod* old_head);
 
 public:
-  enum NMethodChangeReason : s4 {
-    C1_deoptimize = 0,
+  enum class NMethodChangeReason : u1 {
+    C1_deoptimize,
     C1_codepatch,
     C1_predicate_failed_trap,
     C1_deoptimize_for_patching,
@@ -479,20 +479,71 @@ public:
     not_used,
     OSR_invalidation_for_compiling_with_C1,
     OSR_invalidation_back_branch,
-    JVMCI_reprofile,
-    JVMCI_materialize_virtual_object,
-    JVMCI_invalidate_nmethod_mirror,
-    JVMCI_register_method,
     OSR_invalidation_of_lower_level,
     set_native_function,
     whitebox_deoptimization,
     missing_exception_handler,
     uncommon_trap,
     zombie,
+    JVMCI_reprofile,
+    JVMCI_materialize_virtual_object,
+    JVMCI_invalidate_nmethod_mirror,
+    JVMCI_register_method,
     JVMCI_invalidate_nmethod,
     JVMCI_new_installation,
     JVMCI_replacing_with_new_code,
   };
+
+
+  static const char* NMethodChangeReason_to_string(NMethodChangeReason reason) {
+    if (reason == nmethod::NMethodChangeReason::C1_deoptimize) {
+        return "C1 deoptimized";
+    } else if (reason == nmethod::NMethodChangeReason::C1_codepatch) {
+        return "C1 code patch";
+    } else if (reason == nmethod::NMethodChangeReason::C1_predicate_failed_trap) {
+        return "C1 predicate failed trap";
+    } else if (reason == nmethod::NMethodChangeReason::C1_deoptimize_for_patching) {
+        return "C1 deoptimize for patching";
+    } else if (reason == nmethod::NMethodChangeReason::CI_replay) {
+        return "CI replay";
+    } else if (reason == nmethod::NMethodChangeReason::marked_for_deoptimization) {
+        return "marked for deoptimization";
+    } else if (reason == nmethod::NMethodChangeReason::not_used) {
+        return "not used";
+    } else if (reason == nmethod::NMethodChangeReason::OSR_invalidation_for_compiling_with_C1) {
+        return "OSR invalidation for compiling with C1";
+    } else if (reason == nmethod::NMethodChangeReason::OSR_invalidation_back_branch) {
+        return "OSR invalidation back branch";
+    } else if (reason == nmethod::NMethodChangeReason::JVMCI_reprofile) {
+        return "JVMCI reprofile";
+    } else if (reason == nmethod::NMethodChangeReason::JVMCI_materialize_virtual_object) {
+        return "JVMCI materialize virtual object";
+    } else if (reason == nmethod::NMethodChangeReason::JVMCI_invalidate_nmethod_mirror) {
+        return "JVMCI invalidate nmethod mirror";
+    } else if (reason == nmethod::NMethodChangeReason::JVMCI_register_method) {
+        return "JVMCI register method";
+    } else if (reason == nmethod::NMethodChangeReason::OSR_invalidation_of_lower_level) {
+        return "OSR invalidation of lower level";
+    } else if (reason == nmethod::NMethodChangeReason::set_native_function) {
+        return "set native function";
+    } else if (reason == nmethod::NMethodChangeReason::whitebox_deoptimization) {
+        return "whitebox deoptimization";
+    } else if (reason == nmethod::NMethodChangeReason::missing_exception_handler) {
+        return "missing exception handler";
+    } else if (reason == nmethod::NMethodChangeReason::uncommon_trap) {
+        return "uncommon trap";
+    } else if (reason == nmethod::NMethodChangeReason::JVMCI_invalidate_nmethod) {
+        return "JVMCI invalidate nmethod";
+    } else if (reason == nmethod::NMethodChangeReason::zombie) {
+        return "zombie";
+    } else if (reason == nmethod::NMethodChangeReason::JVMCI_new_installation) {
+        return "JVMCI new installation";
+    } else if (reason == nmethod::NMethodChangeReason::JVMCI_replacing_with_new_code) {
+        return "JVMCI replacing with new code";
+    } else {
+        return "Unknown";
+    }
+  }
 
   // create nmethod with entry_bci
   static nmethod* new_nmethod(const methodHandle& method,
@@ -657,7 +708,7 @@ public:
   // if this thread changed the state of the nmethod or false if
   // another thread performed the transition.
   bool  make_not_entrant(NMethodChangeReason reason);
-  bool  make_not_used()    { return make_not_entrant(nmethod::not_used); }
+  bool  make_not_used()    { return make_not_entrant(NMethodChangeReason::not_used); }
 
   bool  is_marked_for_deoptimization() const { return deoptimization_status() != not_marked; }
   bool  has_been_deoptimized() const { return deoptimization_status() == deoptimize_done; }

--- a/src/hotspot/share/compiler/compilationPolicy.cpp
+++ b/src/hotspot/share/compiler/compilationPolicy.cpp
@@ -796,7 +796,7 @@ void CompilationPolicy::compile(const methodHandle& mh, int bci, CompLevel level
         nmethod* osr_nm = mh->lookup_osr_nmethod_for(bci, CompLevel_simple, false);
         if (osr_nm != nullptr && osr_nm->comp_level() > CompLevel_simple) {
           // Invalidate the existing OSR nmethod so that a compile at CompLevel_simple is permitted.
-          osr_nm->make_not_entrant("OSR invalidation for compiling with C1");
+          osr_nm->make_not_entrant(nmethod::OSR_invalidation_for_compiling_with_C1);
         }
         compile(mh, bci, CompLevel_simple, THREAD);
       }
@@ -1201,7 +1201,7 @@ void CompilationPolicy::method_back_branch_event(const methodHandle& mh, const m
               int osr_bci = nm->is_osr_method() ? nm->osr_entry_bci() : InvocationEntryBci;
               print_event(MAKE_NOT_ENTRANT, mh(), mh(), osr_bci, level);
             }
-            nm->make_not_entrant("OSR invalidation, back branch");
+            nm->make_not_entrant(nmethod::OSR_invalidation_back_branch);
           }
         }
         // Fix up next_level if necessary to avoid deopts

--- a/src/hotspot/share/compiler/compilationPolicy.cpp
+++ b/src/hotspot/share/compiler/compilationPolicy.cpp
@@ -796,7 +796,7 @@ void CompilationPolicy::compile(const methodHandle& mh, int bci, CompLevel level
         nmethod* osr_nm = mh->lookup_osr_nmethod_for(bci, CompLevel_simple, false);
         if (osr_nm != nullptr && osr_nm->comp_level() > CompLevel_simple) {
           // Invalidate the existing OSR nmethod so that a compile at CompLevel_simple is permitted.
-          osr_nm->make_not_entrant(nmethod::OSR_invalidation_for_compiling_with_C1);
+          osr_nm->make_not_entrant(nmethod::NMethodChangeReason::OSR_invalidation_for_compiling_with_C1);
         }
         compile(mh, bci, CompLevel_simple, THREAD);
       }
@@ -1201,7 +1201,7 @@ void CompilationPolicy::method_back_branch_event(const methodHandle& mh, const m
               int osr_bci = nm->is_osr_method() ? nm->osr_entry_bci() : InvocationEntryBci;
               print_event(MAKE_NOT_ENTRANT, mh(), mh(), osr_bci, level);
             }
-            nm->make_not_entrant(nmethod::OSR_invalidation_back_branch);
+            nm->make_not_entrant(nmethod::NMethodChangeReason::OSR_invalidation_back_branch);
           }
         }
         // Fix up next_level if necessary to avoid deopts

--- a/src/hotspot/share/compiler/compilationPolicy.cpp
+++ b/src/hotspot/share/compiler/compilationPolicy.cpp
@@ -796,7 +796,7 @@ void CompilationPolicy::compile(const methodHandle& mh, int bci, CompLevel level
         nmethod* osr_nm = mh->lookup_osr_nmethod_for(bci, CompLevel_simple, false);
         if (osr_nm != nullptr && osr_nm->comp_level() > CompLevel_simple) {
           // Invalidate the existing OSR nmethod so that a compile at CompLevel_simple is permitted.
-          osr_nm->make_not_entrant(nmethod::NMethodChangeReason::OSR_invalidation_for_compiling_with_C1);
+          osr_nm->make_not_entrant(nmethod::ChangeReason::OSR_invalidation_for_compiling_with_C1);
         }
         compile(mh, bci, CompLevel_simple, THREAD);
       }
@@ -1201,7 +1201,7 @@ void CompilationPolicy::method_back_branch_event(const methodHandle& mh, const m
               int osr_bci = nm->is_osr_method() ? nm->osr_entry_bci() : InvocationEntryBci;
               print_event(MAKE_NOT_ENTRANT, mh(), mh(), osr_bci, level);
             }
-            nm->make_not_entrant(nmethod::NMethodChangeReason::OSR_invalidation_back_branch);
+            nm->make_not_entrant(nmethod::ChangeReason::OSR_invalidation_back_branch);
           }
         }
         // Fix up next_level if necessary to avoid deopts

--- a/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
@@ -1194,7 +1194,7 @@ C2V_VMENTRY_0(jint, installCode0, (JNIEnv *env, jobject,
         assert(JVMCIENV->isa_HotSpotNmethod(installed_code_handle), "wrong type");
         // Clear the link to an old nmethod first
         JVMCIObject nmethod_mirror = installed_code_handle;
-        JVMCIENV->invalidate_nmethod_mirror(nmethod_mirror, true, nmethod::NMethodChangeReason::JVMCI_replacing_with_new_code, JVMCI_CHECK_0);
+        JVMCIENV->invalidate_nmethod_mirror(nmethod_mirror, true, nmethod::ChangeReason::JVMCI_replacing_with_new_code, JVMCI_CHECK_0);
       } else {
         assert(JVMCIENV->isa_InstalledCode(installed_code_handle), "wrong type");
       }
@@ -1370,7 +1370,7 @@ C2V_VMENTRY(void, reprofile, (JNIEnv* env, jobject, ARGUMENT_PAIR(method)))
 
   nmethod* code = method->code();
   if (code != nullptr) {
-    code->make_not_entrant(nmethod::NMethodChangeReason::JVMCI_reprofile);
+    code->make_not_entrant(nmethod::ChangeReason::JVMCI_reprofile);
   }
 
   MethodData* method_data = method->method_data();
@@ -1385,7 +1385,7 @@ C2V_END
 
 C2V_VMENTRY(void, invalidateHotSpotNmethod, (JNIEnv* env, jobject, jobject hs_nmethod, jboolean deoptimize))
   JVMCIObject nmethod_mirror = JVMCIENV->wrap(hs_nmethod);
-  JVMCIENV->invalidate_nmethod_mirror(nmethod_mirror, deoptimize, nmethod::NMethodChangeReason::JVMCI_invalidate_nmethod, JVMCI_CHECK);
+  JVMCIENV->invalidate_nmethod_mirror(nmethod_mirror, deoptimize, nmethod::ChangeReason::JVMCI_invalidate_nmethod, JVMCI_CHECK);
 C2V_END
 
 C2V_VMENTRY_NULL(jlongArray, collectCounters, (JNIEnv* env, jobject))
@@ -1810,7 +1810,7 @@ C2V_VMENTRY(void, materializeVirtualObjects, (JNIEnv* env, jobject, jobject _hs_
     if (!fst.current()->is_compiled_frame()) {
       JVMCI_THROW_MSG(IllegalStateException, "compiled stack frame expected");
     }
-    fst.current()->cb()->as_nmethod()->make_not_entrant(nmethod::NMethodChangeReason::JVMCI_materialize_virtual_object);
+    fst.current()->cb()->as_nmethod()->make_not_entrant(nmethod::ChangeReason::JVMCI_materialize_virtual_object);
   }
   Deoptimization::deoptimize(thread, *fst.current(), Deoptimization::Reason_none);
   // look for the frame again as it has been updated by deopt (pc, deopt state...)

--- a/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
@@ -1194,7 +1194,7 @@ C2V_VMENTRY_0(jint, installCode0, (JNIEnv *env, jobject,
         assert(JVMCIENV->isa_HotSpotNmethod(installed_code_handle), "wrong type");
         // Clear the link to an old nmethod first
         JVMCIObject nmethod_mirror = installed_code_handle;
-        JVMCIENV->invalidate_nmethod_mirror(nmethod_mirror, true, nmethod::JVMCI_replacing_with_new_code, JVMCI_CHECK_0);
+        JVMCIENV->invalidate_nmethod_mirror(nmethod_mirror, true, nmethod::NMethodChangeReason::JVMCI_replacing_with_new_code, JVMCI_CHECK_0);
       } else {
         assert(JVMCIENV->isa_InstalledCode(installed_code_handle), "wrong type");
       }
@@ -1370,7 +1370,7 @@ C2V_VMENTRY(void, reprofile, (JNIEnv* env, jobject, ARGUMENT_PAIR(method)))
 
   nmethod* code = method->code();
   if (code != nullptr) {
-    code->make_not_entrant(nmethod::JVMCI_reprofile);
+    code->make_not_entrant(nmethod::NMethodChangeReason::JVMCI_reprofile);
   }
 
   MethodData* method_data = method->method_data();
@@ -1810,7 +1810,7 @@ C2V_VMENTRY(void, materializeVirtualObjects, (JNIEnv* env, jobject, jobject _hs_
     if (!fst.current()->is_compiled_frame()) {
       JVMCI_THROW_MSG(IllegalStateException, "compiled stack frame expected");
     }
-    fst.current()->cb()->as_nmethod()->make_not_entrant(nmethod::JVMCI_materialize_virtual_object);
+    fst.current()->cb()->as_nmethod()->make_not_entrant(nmethod::NMethodChangeReason::JVMCI_materialize_virtual_object);
   }
   Deoptimization::deoptimize(thread, *fst.current(), Deoptimization::Reason_none);
   // look for the frame again as it has been updated by deopt (pc, deopt state...)

--- a/src/hotspot/share/jvmci/jvmciEnv.cpp
+++ b/src/hotspot/share/jvmci/jvmciEnv.cpp
@@ -1752,7 +1752,7 @@ void JVMCIEnv::initialize_installed_code(JVMCIObject installed_code, CodeBlob* c
 }
 
 
-void JVMCIEnv::invalidate_nmethod_mirror(JVMCIObject mirror, bool deoptimize, JVMCI_TRAPS) {
+void JVMCIEnv::invalidate_nmethod_mirror(JVMCIObject mirror, bool deoptimize, nmethod::NMethodChangeReason statusReason, JVMCI_TRAPS) {
   if (mirror.is_null()) {
     JVMCI_THROW(NullPointerException);
   }
@@ -1775,7 +1775,7 @@ void JVMCIEnv::invalidate_nmethod_mirror(JVMCIObject mirror, bool deoptimize, JV
 
   if (!deoptimize) {
     // Prevent future executions of the nmethod but let current executions complete.
-    nm->make_not_entrant("JVMCI invalidate nmethod mirror");
+    nm->make_not_entrant(statusReason);
 
     // Do not clear the address field here as the Java code may still
     // want to later call this method with deoptimize == true. That requires
@@ -1784,7 +1784,7 @@ void JVMCIEnv::invalidate_nmethod_mirror(JVMCIObject mirror, bool deoptimize, JV
     // Deoptimize the nmethod immediately.
     DeoptimizationScope deopt_scope;
     deopt_scope.mark(nm);
-    nm->make_not_entrant("JVMCI invalidate nmethod mirror");
+    nm->make_not_entrant(statusReason);
     nm->make_deoptimized();
     deopt_scope.deoptimize_marked();
 

--- a/src/hotspot/share/jvmci/jvmciEnv.cpp
+++ b/src/hotspot/share/jvmci/jvmciEnv.cpp
@@ -1752,7 +1752,7 @@ void JVMCIEnv::initialize_installed_code(JVMCIObject installed_code, CodeBlob* c
 }
 
 
-void JVMCIEnv::invalidate_nmethod_mirror(JVMCIObject mirror, bool deoptimize, nmethod::NMethodChangeReason statusReason, JVMCI_TRAPS) {
+void JVMCIEnv::invalidate_nmethod_mirror(JVMCIObject mirror, bool deoptimize, nmethod::ChangeReason change_reason, JVMCI_TRAPS) {
   if (mirror.is_null()) {
     JVMCI_THROW(NullPointerException);
   }
@@ -1775,7 +1775,7 @@ void JVMCIEnv::invalidate_nmethod_mirror(JVMCIObject mirror, bool deoptimize, nm
 
   if (!deoptimize) {
     // Prevent future executions of the nmethod but let current executions complete.
-    nm->make_not_entrant(statusReason);
+    nm->make_not_entrant(change_reason);
 
     // Do not clear the address field here as the Java code may still
     // want to later call this method with deoptimize == true. That requires
@@ -1784,7 +1784,7 @@ void JVMCIEnv::invalidate_nmethod_mirror(JVMCIObject mirror, bool deoptimize, nm
     // Deoptimize the nmethod immediately.
     DeoptimizationScope deopt_scope;
     deopt_scope.mark(nm);
-    nm->make_not_entrant(statusReason);
+    nm->make_not_entrant(change_reason);
     nm->make_deoptimized();
     deopt_scope.deoptimize_marked();
 

--- a/src/hotspot/share/jvmci/jvmciEnv.hpp
+++ b/src/hotspot/share/jvmci/jvmciEnv.hpp
@@ -462,7 +462,7 @@ public:
   // field of `mirror` to prevent it from being called.
   // If `deoptimize` is true, the nmethod is immediately deoptimized.
   // The HotSpotNmethod.address field is zero upon returning.
-  void invalidate_nmethod_mirror(JVMCIObject mirror, bool deoptimze, JVMCI_TRAPS);
+  void invalidate_nmethod_mirror(JVMCIObject mirror, bool deoptimze, nmethod::NMethodChangeReason statusReason, JVMCI_TRAPS);
 
   void initialize_installed_code(JVMCIObject installed_code, CodeBlob* cb, JVMCI_TRAPS);
 

--- a/src/hotspot/share/jvmci/jvmciEnv.hpp
+++ b/src/hotspot/share/jvmci/jvmciEnv.hpp
@@ -462,7 +462,7 @@ public:
   // field of `mirror` to prevent it from being called.
   // If `deoptimize` is true, the nmethod is immediately deoptimized.
   // The HotSpotNmethod.address field is zero upon returning.
-  void invalidate_nmethod_mirror(JVMCIObject mirror, bool deoptimze, nmethod::NMethodChangeReason statusReason, JVMCI_TRAPS);
+  void invalidate_nmethod_mirror(JVMCIObject mirror, bool deoptimze, nmethod::ChangeReason change_reason, JVMCI_TRAPS);
 
   void initialize_installed_code(JVMCIObject installed_code, CodeBlob* cb, JVMCI_TRAPS);
 

--- a/src/hotspot/share/jvmci/jvmciRuntime.cpp
+++ b/src/hotspot/share/jvmci/jvmciRuntime.cpp
@@ -2196,7 +2196,7 @@ JVMCI::CodeInstallResult JVMCIRuntime::register_method(JVMCIEnv* JVMCIENV,
               tty->print_cr("Replacing method %s", method_name);
             }
             if (old != nullptr) {
-              old->make_not_entrant("JVMCI register method");
+              old->make_not_entrant(nmethod::JVMCI_register_method);
             }
 
             LogTarget(Info, nmethod, install) lt;

--- a/src/hotspot/share/jvmci/jvmciRuntime.cpp
+++ b/src/hotspot/share/jvmci/jvmciRuntime.cpp
@@ -2196,7 +2196,7 @@ JVMCI::CodeInstallResult JVMCIRuntime::register_method(JVMCIEnv* JVMCIENV,
               tty->print_cr("Replacing method %s", method_name);
             }
             if (old != nullptr) {
-              old->make_not_entrant(nmethod::NMethodChangeReason::JVMCI_register_method);
+              old->make_not_entrant(nmethod::ChangeReason::JVMCI_register_method);
             }
 
             LogTarget(Info, nmethod, install) lt;

--- a/src/hotspot/share/jvmci/jvmciRuntime.cpp
+++ b/src/hotspot/share/jvmci/jvmciRuntime.cpp
@@ -2196,7 +2196,7 @@ JVMCI::CodeInstallResult JVMCIRuntime::register_method(JVMCIEnv* JVMCIENV,
               tty->print_cr("Replacing method %s", method_name);
             }
             if (old != nullptr) {
-              old->make_not_entrant(nmethod::JVMCI_register_method);
+              old->make_not_entrant(nmethod::NMethodChangeReason::JVMCI_register_method);
             }
 
             LogTarget(Info, nmethod, install) lt;

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -3494,7 +3494,7 @@ void InstanceKlass::add_osr_nmethod(nmethod* n) {
   for (int l = CompLevel_limited_profile; l < n->comp_level(); l++) {
     nmethod *inv = lookup_osr_nmethod(n->method(), n->osr_entry_bci(), l, true);
     if (inv != nullptr && inv->is_in_use()) {
-      inv->make_not_entrant("OSR invalidation of lower levels");
+      inv->make_not_entrant(nmethod::OSR_invalidation_of_lower_level);
     }
   }
 }

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -3494,7 +3494,7 @@ void InstanceKlass::add_osr_nmethod(nmethod* n) {
   for (int l = CompLevel_limited_profile; l < n->comp_level(); l++) {
     nmethod *inv = lookup_osr_nmethod(n->method(), n->osr_entry_bci(), l, true);
     if (inv != nullptr && inv->is_in_use()) {
-      inv->make_not_entrant(nmethod::NMethodChangeReason::OSR_invalidation_of_lower_level);
+      inv->make_not_entrant(nmethod::ChangeReason::OSR_invalidation_of_lower_level);
     }
   }
 }

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -3494,7 +3494,7 @@ void InstanceKlass::add_osr_nmethod(nmethod* n) {
   for (int l = CompLevel_limited_profile; l < n->comp_level(); l++) {
     nmethod *inv = lookup_osr_nmethod(n->method(), n->osr_entry_bci(), l, true);
     if (inv != nullptr && inv->is_in_use()) {
-      inv->make_not_entrant(nmethod::OSR_invalidation_of_lower_level);
+      inv->make_not_entrant(nmethod::NMethodChangeReason::OSR_invalidation_of_lower_level);
     }
   }
 }

--- a/src/hotspot/share/oops/method.cpp
+++ b/src/hotspot/share/oops/method.cpp
@@ -970,7 +970,7 @@ void Method::set_native_function(address function, bool post_event_flag) {
   // If so, we have to make it not_entrant.
   nmethod* nm = code(); // Put it into local variable to guard against concurrent updates
   if (nm != nullptr) {
-    nm->make_not_entrant("set native function");
+    nm->make_not_entrant(nmethod::set_native_function);
   }
 }
 

--- a/src/hotspot/share/oops/method.cpp
+++ b/src/hotspot/share/oops/method.cpp
@@ -970,7 +970,7 @@ void Method::set_native_function(address function, bool post_event_flag) {
   // If so, we have to make it not_entrant.
   nmethod* nm = code(); // Put it into local variable to guard against concurrent updates
   if (nm != nullptr) {
-    nm->make_not_entrant(nmethod::set_native_function);
+    nm->make_not_entrant(nmethod::NMethodChangeReason::set_native_function);
   }
 }
 

--- a/src/hotspot/share/oops/method.cpp
+++ b/src/hotspot/share/oops/method.cpp
@@ -970,7 +970,7 @@ void Method::set_native_function(address function, bool post_event_flag) {
   // If so, we have to make it not_entrant.
   nmethod* nm = code(); // Put it into local variable to guard against concurrent updates
   if (nm != nullptr) {
-    nm->make_not_entrant(nmethod::NMethodChangeReason::set_native_function);
+    nm->make_not_entrant(nmethod::ChangeReason::set_native_function);
   }
 }
 

--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -794,7 +794,7 @@ class VM_WhiteBoxDeoptimizeFrames : public VM_WhiteBoxOperation {
             if (_make_not_entrant) {
                 nmethod* nm = CodeCache::find_nmethod(f->pc());
                 assert(nm != nullptr, "did not find nmethod");
-                nm->make_not_entrant("Whitebox deoptimization");
+                nm->make_not_entrant(nmethod::whitebox_deoptimization);
             }
             ++_result;
           }

--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -794,7 +794,7 @@ class VM_WhiteBoxDeoptimizeFrames : public VM_WhiteBoxOperation {
             if (_make_not_entrant) {
                 nmethod* nm = CodeCache::find_nmethod(f->pc());
                 assert(nm != nullptr, "did not find nmethod");
-                nm->make_not_entrant(nmethod::NMethodChangeReason::whitebox_deoptimization);
+                nm->make_not_entrant(nmethod::ChangeReason::whitebox_deoptimization);
             }
             ++_result;
           }

--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -794,7 +794,7 @@ class VM_WhiteBoxDeoptimizeFrames : public VM_WhiteBoxOperation {
             if (_make_not_entrant) {
                 nmethod* nm = CodeCache::find_nmethod(f->pc());
                 assert(nm != nullptr, "did not find nmethod");
-                nm->make_not_entrant(nmethod::whitebox_deoptimization);
+                nm->make_not_entrant(nmethod::NMethodChangeReason::whitebox_deoptimization);
             }
             ++_result;
           }

--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -1813,7 +1813,7 @@ void Deoptimization::deoptimize(JavaThread* thread, frame fr, DeoptReason reason
 #if INCLUDE_JVMCI
 address Deoptimization::deoptimize_for_missing_exception_handler(nmethod* nm) {
   // there is no exception handler for this pc => deoptimize
-  nm->make_not_entrant("missing exception handler");
+  nm->make_not_entrant(nmethod::missing_exception_handler);
 
   // Use Deoptimization::deoptimize for all of its side-effects:
   // gathering traps statistics, logging...
@@ -2442,7 +2442,7 @@ JRT_ENTRY(void, Deoptimization::uncommon_trap_inner(JavaThread* current, jint tr
 
     // Recompile
     if (make_not_entrant) {
-      if (!nm->make_not_entrant("uncommon trap")) {
+      if (!nm->make_not_entrant(nmethod::uncommon_trap)) {
         return; // the call did not change nmethod's state
       }
 

--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -1813,7 +1813,7 @@ void Deoptimization::deoptimize(JavaThread* thread, frame fr, DeoptReason reason
 #if INCLUDE_JVMCI
 address Deoptimization::deoptimize_for_missing_exception_handler(nmethod* nm) {
   // there is no exception handler for this pc => deoptimize
-  nm->make_not_entrant(nmethod::missing_exception_handler);
+  nm->make_not_entrant(nmethod::NMethodChangeReason::missing_exception_handler);
 
   // Use Deoptimization::deoptimize for all of its side-effects:
   // gathering traps statistics, logging...
@@ -2442,7 +2442,7 @@ JRT_ENTRY(void, Deoptimization::uncommon_trap_inner(JavaThread* current, jint tr
 
     // Recompile
     if (make_not_entrant) {
-      if (!nm->make_not_entrant(nmethod::uncommon_trap)) {
+      if (!nm->make_not_entrant(nmethod::NMethodChangeReason::uncommon_trap)) {
         return; // the call did not change nmethod's state
       }
 

--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -1813,7 +1813,7 @@ void Deoptimization::deoptimize(JavaThread* thread, frame fr, DeoptReason reason
 #if INCLUDE_JVMCI
 address Deoptimization::deoptimize_for_missing_exception_handler(nmethod* nm) {
   // there is no exception handler for this pc => deoptimize
-  nm->make_not_entrant(nmethod::NMethodChangeReason::missing_exception_handler);
+  nm->make_not_entrant(nmethod::ChangeReason::missing_exception_handler);
 
   // Use Deoptimization::deoptimize for all of its side-effects:
   // gathering traps statistics, logging...
@@ -2442,7 +2442,7 @@ JRT_ENTRY(void, Deoptimization::uncommon_trap_inner(JavaThread* current, jint tr
 
     // Recompile
     if (make_not_entrant) {
-      if (!nm->make_not_entrant(nmethod::NMethodChangeReason::uncommon_trap)) {
+      if (!nm->make_not_entrant(nmethod::ChangeReason::uncommon_trap)) {
         return; // the call did not change nmethod's state
       }
 

--- a/src/hotspot/share/runtime/javaThread.cpp
+++ b/src/hotspot/share/runtime/javaThread.cpp
@@ -1339,7 +1339,7 @@ void JavaThread::make_zombies() {
       // it is a Java nmethod
       nmethod* nm = CodeCache::find_nmethod(fst.current()->pc());
       assert(nm != nullptr, "did not find nmethod");
-      nm->make_not_entrant("zombie");
+      nm->make_not_entrant(nmethod::zombie);
     }
   }
 }

--- a/src/hotspot/share/runtime/javaThread.cpp
+++ b/src/hotspot/share/runtime/javaThread.cpp
@@ -1339,7 +1339,7 @@ void JavaThread::make_zombies() {
       // it is a Java nmethod
       nmethod* nm = CodeCache::find_nmethod(fst.current()->pc());
       assert(nm != nullptr, "did not find nmethod");
-      nm->make_not_entrant(nmethod::NMethodChangeReason::zombie);
+      nm->make_not_entrant(nmethod::ChangeReason::zombie);
     }
   }
 }

--- a/src/hotspot/share/runtime/javaThread.cpp
+++ b/src/hotspot/share/runtime/javaThread.cpp
@@ -1339,7 +1339,7 @@ void JavaThread::make_zombies() {
       // it is a Java nmethod
       nmethod* nm = CodeCache::find_nmethod(fst.current()->pc());
       assert(nm != nullptr, "did not find nmethod");
-      nm->make_not_entrant(nmethod::zombie);
+      nm->make_not_entrant(nmethod::NMethodChangeReason::zombie);
     }
   }
 }


### PR DESCRIPTION
Please review this refactor to transform the reasons for making an nmethod not entrant from `const char*` into enum values.

Tested on Linux x64 with JTREG tier1-3 in fastdebug and release mode.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8357396](https://bugs.openjdk.org/browse/JDK-8357396): Refactor nmethod::make_not_entrant to use Enum instead of "const char*" (**Enhancement** - P4)


### Reviewers
 * [Manuel Hässig](https://openjdk.org/census#mhaessig) (@mhaessig - Author)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25338/head:pull/25338` \
`$ git checkout pull/25338`

Update a local copy of the PR: \
`$ git checkout pull/25338` \
`$ git pull https://git.openjdk.org/jdk.git pull/25338/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25338`

View PR using the GUI difftool: \
`$ git pr show -t 25338`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25338.diff">https://git.openjdk.org/jdk/pull/25338.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25338#issuecomment-2902760272)
</details>
