### PR TITLE
8357299: Graphics copyArea doesn't copy any pixels when there is overflow

### DIFF
--- a/src/java.desktop/share/native/libawt/java2d/loops/Blit.c
+++ b/src/java.desktop/share/native/libawt/java2d/loops/Blit.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -74,19 +74,16 @@ Java_sun_java2d_loops_Blit_Blit
 
     srcInfo.bounds.x1 = srcx;
     srcInfo.bounds.y1 = srcy;
-    if (UNSAFE_TO_ADD(srcx, width) ||
-        UNSAFE_TO_ADD(srcy, height) ||
-        UNSAFE_TO_ADD(dstx, width) ||
-        UNSAFE_TO_ADD(dsty, height)) {
-        return;
-    }
-
-    srcInfo.bounds.x2 = srcx + width;
-    srcInfo.bounds.y2 = srcy + height;
+    srcInfo.bounds.x2 = UNSAFE_TO_ADD(srcx, width)
+                        ? clipInfo.bounds.x2 : (srcx + width);
+    srcInfo.bounds.y2 = UNSAFE_TO_ADD(srcy, height)
+                        ? clipInfo.bounds.y2 : (srcy + height);
     dstInfo.bounds.x1 = dstx;
     dstInfo.bounds.y1 = dsty;
-    dstInfo.bounds.x2 = dstx + width;
-    dstInfo.bounds.y2 = dsty + height;
+    dstInfo.bounds.x2 = UNSAFE_TO_ADD(dstx, width)
+                        ? clipInfo.bounds.x2 : (dstx + width);
+    dstInfo.bounds.y2 = UNSAFE_TO_ADD(dsty, height)
+                        ? clipInfo.bounds.y2 : (dsty + height);
     if (UNSAFE_TO_SUB(srcx, dstx) ||
         UNSAFE_TO_SUB(srcy, dsty)) {
         return;

--- a/test/jdk/java/awt/Graphics/BrokenBoundsClip.java
+++ b/test/jdk/java/awt/Graphics/BrokenBoundsClip.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8357299
+ * @summary Verifies if Graphics copyArea doesn't copy any pixels
+ *          when there is overflow
+ * @run main BrokenBoundsClip
+ */
+
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+
+import static java.awt.image.BufferedImage.TYPE_INT_RGB;
+
+public final class BrokenBoundsClip {
+
+     public static final int SIZE = 100;
+
+     public static void main(String[] args) {
+         BufferedImage bi = new BufferedImage(SIZE, SIZE, TYPE_INT_RGB);
+
+         Graphics2D g2d = bi.createGraphics();
+         g2d.setColor(Color.RED);
+         g2d.fillRect(SIZE / 2, SIZE / 2, SIZE / 2, SIZE / 2);
+
+         g2d.copyArea(bi.getWidth() / 2, bi.getHeight() / 2,
+                      Integer.MAX_VALUE , Integer.MAX_VALUE ,
+                      -bi.getWidth() / 2, -bi.getHeight() / 2);
+         int actual = bi.getRGB(0, 0);
+         int expected = Color.RED.getRGB();
+         if (actual != expected) {
+             System.err.println("Actual:   " + Integer.toHexString(actual));
+             System.err.println("Expected: " + Integer.toHexString(expected));
+             throw new RuntimeException("Wrong color");
+         }
+     }
+}


### PR DESCRIPTION
Graphics copyArea overflow check bails out of copying pixels if there is overflow.
The spec says ""If a portion of the source rectangle lies outside the bounds of the component, or is obscured by another window or component, {@code copyArea} *will be unable to copy* the associated pixels"

which suggests that we should always copy the parts inside the bounds and never the parts outside the bounds
but it seems currently, in the case of overflow it no longer copies any pixels, including the parts that are inside. 
So, the fix clips the copyarea region to clip bounds so it will only affect pixels within the valid bounds, and any pixels outside will be ignored.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8357299](https://bugs.openjdk.org/browse/JDK-8357299): Graphics copyArea doesn't copy any pixels when there is overflow (**Bug** - P3)


### Reviewers
 * [Alisen Chung](https://openjdk.org/census#achung) (@alisenchung - Committer)
 * [Alexander Zuev](https://openjdk.org/census#kizune) (@azuev-java - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25340/head:pull/25340` \
`$ git checkout pull/25340`

Update a local copy of the PR: \
`$ git checkout pull/25340` \
`$ git pull https://git.openjdk.org/jdk.git pull/25340/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25340`

View PR using the GUI difftool: \
`$ git pr show -t 25340`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25340.diff">https://git.openjdk.org/jdk/pull/25340.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25340#issuecomment-2896446299)
</details>
