### PR TITLE
8312198: [macos] metal pipeline - window rendering stops after display sleep

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLLayer.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLLayer.h
@@ -56,6 +56,7 @@
 @property (readwrite, assign) int leftInset;
 @property (readwrite, assign) CVDisplayLinkRef displayLink;
 @property (readwrite, atomic) int displayLinkCount;
+@property (readwrite, atomic) int displayLinkFailCount;
 
 - (id) initWithJavaLayer:(jobject)layer;
 

--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLLayer.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLLayer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLLayer.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLLayer.m
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,7 @@
 #import "JNIUtilities.h"
 #define KEEP_ALIVE_INC 4
 #define CV_DISPLAYLINK_FAIL_DELAY 1.0
+#define MAX_DISPLAYLINK_FAIL_COUNT 5
 
 @implementation MTLLayer
 
@@ -50,8 +51,7 @@
 - (void) createDisplayLink {
     CVReturn r = CVDisplayLinkCreateWithActiveCGDisplays(&displayLink);
     if (r != kCVReturnSuccess) {
-        if (self.displayLinkFailCount == 5) {
-            // We have tried for 5 seconds to create CVDisplayLink
+        if (self.displayLinkFailCount >= MAX_DISPLAYLINK_FAIL_COUNT) {
             J2dTraceLn(J2D_TRACE_ERROR,
                 "MTLLayer.createDisplayLink --- unable to create CVDisplayLink.");
             self.displayLinkFailCount = 0;


### PR DESCRIPTION
In stress based scenarios it is observed that nothing is drawn in UI content when display wakes up from sleep in Metal pipeline of macOS. Unfortunately i am not able to reproduce it, but based on details in the bug it looks like we are hitting a race condition. Call to CVDisplayLinkCreateWithActiveCGDisplays is becoming a no-op as there are no active displays right after NSWorkspaceScreensDidWakeNotification. Looks like if we continue to call CVDisplayLinkCreateWithActiveCGDisplays after screen wakeup we are able to get the list of ActiveDisplays and then able to create displayLink.

So now the code is modified to check whether CVDisplayLinkCreateWithActiveCGDisplays is successful or not. If not we will try to call CVDisplayLinkCreateWithActiveCGDisplays for 5 instances each with 1 second delay. There is no regression test for this change because it needs a stress based test with display wakeup/sleep(As captured in JBS, i am not able to reproduce this issue).

I have tested this change for sanity by running animation examples from SwingSet2 and continuously connecting/disconnecting external display. Also by multiple display sleep and wakeup scenarios, i don't see any regressions. Also whole clientlibs CI run is done with this patch and it is also green.

While working on this bug also noticed that many functions of CVDisplayLink is deprecated from macOS 14 and going forward we need to use CADisplayLink/CAMetalDisplayLink. I have raised [JDK-8357418](https://bugs.openjdk.org/browse/JDK-8357418) for the same.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312198](https://bugs.openjdk.org/browse/JDK-8312198): [macos] metal pipeline - window rendering stops after display sleep (**Bug** - P4)


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**) Review applies to [1e193339](https://git.openjdk.org/jdk/pull/25342/files/1e19333954c87c1011178de80623a7f1404f67af)
 * [Alexey Ushakov](https://openjdk.org/census#avu) (@avu - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25342/head:pull/25342` \
`$ git checkout pull/25342`

Update a local copy of the PR: \
`$ git checkout pull/25342` \
`$ git pull https://git.openjdk.org/jdk.git pull/25342/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25342`

View PR using the GUI difftool: \
`$ git pr show -t 25342`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25342.diff">https://git.openjdk.org/jdk/pull/25342.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25342#issuecomment-2896731891)
</details>
