### PR TITLE
8357436: Change jspawnhelper warning recommendation from VFORK to FORK

### DIFF
--- a/src/java.base/unix/native/libjava/ProcessImpl_md.c
+++ b/src/java.base/unix/native/libjava/ProcessImpl_md.c
@@ -328,7 +328,7 @@ releaseBytes(JNIEnv *env, jbyteArray arr, const char* parr)
   "  - Restart JVM, especially after in-place JDK updates\n" \
   "  - Check system logs for JDK-related errors\n" \
   "  - Re-install JDK to fix permission/versioning problems\n" \
-  "  - Switch to legacy launch mechanism with -Djdk.lang.Process.launchMechanism=VFORK\n"
+  "  - Switch to legacy launch mechanism with -Djdk.lang.Process.launchMechanism=FORK\n"
 
 static void
 throwIOExceptionImpl(JNIEnv *env, int errnum, const char *externalDetail, const char *internalDetail)


### PR DESCRIPTION
In [JDK-8352533](https://bugs.openjdk.org/browse/JDK-8352533), we print the suggestion to use VFORK in jspawnhelper misbehaves. But [JDK-8357179](https://bugs.openjdk.org/browse/JDK-8357179) deprecated VFORK! So the warning message should actually suggest using FORK. This seems to be in line with [JDK-8357180](https://bugs.openjdk.org/browse/JDK-8357180) CSR discussion and the pending [JDK-8357181](https://bugs.openjdk.org/browse/JDK-8357181) release note.

Additional testing:
 - [x] Linux x86_64 server fastdebug, `java/lang/Process java/lang/ProcessBuilder`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8357436](https://bugs.openjdk.org/browse/JDK-8357436): Change jspawnhelper warning recommendation from VFORK to FORK (**Enhancement** - P4)


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25344/head:pull/25344` \
`$ git checkout pull/25344`

Update a local copy of the PR: \
`$ git checkout pull/25344` \
`$ git pull https://git.openjdk.org/jdk.git pull/25344/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25344`

View PR using the GUI difftool: \
`$ git pr show -t 25344`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25344.diff">https://git.openjdk.org/jdk/pull/25344.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25344#issuecomment-2897106932)
</details>
