### PR TITLE
8357443: ZGC: Optimize old page iteration in remap remembered phase

### DIFF
--- a/src/hotspot/share/gc/z/zGeneration.cpp
+++ b/src/hotspot/share/gc/z/zGeneration.cpp
@@ -948,6 +948,14 @@ void ZGenerationYoung::register_with_remset(ZPage* page) {
   _remembered.register_found_old(page);
 }
 
+ZRemembered* ZGenerationYoung::remembered() {
+  return  &_remembered;
+}
+
+void ZGenerationYoung::remap_current_remset(ZRemsetTableIterator* iter) {
+  _remembered.remap_current(iter);
+}
+
 ZGenerationTracer* ZGenerationYoung::jfr_tracer() {
   return &_jfr_tracer;
 }
@@ -1435,7 +1443,7 @@ typedef ClaimingCLDToOopClosure<ClassLoaderData::_claim_none> ZRemapCLDClosure;
 
 class ZRemapYoungRootsTask : public ZTask {
 private:
-  ZGenerationPagesParallelIterator _old_pages_parallel_iterator;
+  ZRemsetTableIterator             _remset_table_iterator;
 
   ZRootsIteratorAllColored         _roots_colored;
   ZRootsIteratorAllUncolored       _roots_uncolored;
@@ -1449,7 +1457,7 @@ private:
 public:
   ZRemapYoungRootsTask(ZPageTable* page_table, ZPageAllocator* page_allocator)
     : ZTask("ZRemapYoungRootsTask"),
-      _old_pages_parallel_iterator(page_table, ZGenerationId::old, page_allocator),
+      _remset_table_iterator(ZGeneration::young()->remembered(), false /* previous */),
       _roots_colored(ZGenerationIdOptional::old),
       _roots_uncolored(ZGenerationIdOptional::old),
       _cl_colored(),
@@ -1472,11 +1480,8 @@ public:
 
     {
       ZStatTimerWorker timer(ZSubPhaseConcurrentRemapRememberedOld);
-      _old_pages_parallel_iterator.do_pages([&](ZPage* page) {
-        // Visit all object fields that potentially pointing into young generation
-        page->oops_do_current_remembered(ZBarrier::load_barrier_on_oop_field);
-        return true;
-      });
+      // Visit all object fields that potentially pointing into young generation
+      ZGeneration::young()->remap_current_remset(&_remset_table_iterator);
     }
   }
 };

--- a/src/hotspot/share/gc/z/zGeneration.hpp
+++ b/src/hotspot/share/gc/z/zGeneration.hpp
@@ -191,6 +191,7 @@ class ZGenerationYoung : public ZGeneration {
   friend class VM_ZMarkStartYoung;
   friend class VM_ZMarkStartYoungAndOld;
   friend class VM_ZRelocateStartYoung;
+  friend class ZRemapYoungRootsTask;
   friend class ZYoungTypeSetter;
 
 private:
@@ -218,6 +219,8 @@ private:
   void concurrent_select_relocation_set();
   void pause_relocate_start();
   void concurrent_relocate();
+
+  ZRemembered* remembered();
 
 public:
   ZGenerationYoung(ZPageTable* page_table,
@@ -251,6 +254,9 @@ public:
 
   // Register old pages with remembered set
   void register_with_remset(ZPage* page);
+
+  // Remap the oops of the current remembered set
+  void remap_current_remset(ZRemsetTableIterator* iter);
 
   // Serviceability
   ZGenerationTracer* jfr_tracer();

--- a/src/hotspot/share/gc/z/zRemembered.cpp
+++ b/src/hotspot/share/gc/z/zRemembered.cpp
@@ -392,69 +392,71 @@ struct ZRemsetTableEntry {
   ZForwarding* _forwarding;
 };
 
-class ZRemsetTableIterator {
-private:
-  ZRemembered* const            _remembered;
-  ZPageTable* const             _page_table;
-  const ZForwardingTable* const _old_forwarding_table;
-  volatile BitMap::idx_t        _claimed;
-
-public:
-  ZRemsetTableIterator(ZRemembered* remembered)
-    : _remembered(remembered),
-      _page_table(remembered->_page_table),
-      _old_forwarding_table(remembered->_old_forwarding_table),
-      _claimed(0) {}
+ZRemsetTableIterator::ZRemsetTableIterator(ZRemembered* remembered, bool previous)
+  : _remembered(remembered),
+    _bm(previous
+        ? _remembered->_found_old.previous_bitmap()
+        : _remembered->_found_old.current_bitmap()),
+    _page_table(remembered->_page_table),
+    _old_forwarding_table(remembered->_old_forwarding_table),
+    _claimed(0) {}
 
   // This iterator uses the "found old" optimization.
-  bool next(ZRemsetTableEntry* entry_addr)  {
-    BitMap* const bm = _remembered->_found_old.previous_bitmap();
+bool ZRemsetTableIterator::next(ZRemsetTableEntry* entry_addr)  {
+  BitMap::idx_t prev = Atomic::load(&_claimed);
 
-    BitMap::idx_t prev = Atomic::load(&_claimed);
-
-    for (;;) {
-      if (prev == bm->size()) {
-        return false;
-      }
-
-      const BitMap::idx_t page_index = bm->find_first_set_bit(_claimed);
-      if (page_index == bm->size()) {
-        Atomic::cmpxchg(&_claimed, prev, page_index, memory_order_relaxed);
-        return false;
-      }
-
-      const BitMap::idx_t res = Atomic::cmpxchg(&_claimed, prev, page_index + 1, memory_order_relaxed);
-      if (res != prev) {
-        // Someone else claimed
-        prev = res;
-        continue;
-      }
-
-      // Found bit - look around for page or forwarding to scan
-
-      ZForwarding* forwarding = nullptr;
-      if (ZGeneration::old()->is_phase_relocate()) {
-        forwarding = _old_forwarding_table->at(page_index);
-      }
-
-      ZPage* page = _page_table->at(page_index);
-      if (page != nullptr && !page->is_old()) {
-        page = nullptr;
-      }
-
-      if (page == nullptr && forwarding == nullptr) {
-        // Nothing to scan
-        continue;
-      }
-
-      // Found old page or old forwarding
-      entry_addr->_forwarding = forwarding;
-      entry_addr->_page = page;
-
-      return true;
+  for (;;) {
+    if (prev == _bm->size()) {
+      return false;
     }
+
+    const BitMap::idx_t page_index = _bm->find_first_set_bit(_claimed);
+    if (page_index == _bm->size()) {
+      Atomic::cmpxchg(&_claimed, prev, page_index, memory_order_relaxed);
+      return false;
+    }
+
+    const BitMap::idx_t res = Atomic::cmpxchg(&_claimed, prev, page_index + 1, memory_order_relaxed);
+    if (res != prev) {
+      // Someone else claimed
+      prev = res;
+      continue;
+    }
+
+    // Found bit - look around for page or forwarding to scan
+
+    ZForwarding* forwarding = nullptr;
+    if (ZGeneration::old()->is_phase_relocate()) {
+      forwarding = _old_forwarding_table->at(page_index);
+    }
+
+    ZPage* page = _page_table->at(page_index);
+    if (page != nullptr && !page->is_old()) {
+      page = nullptr;
+    }
+
+    if (page == nullptr && forwarding == nullptr) {
+      // Nothing to scan
+      continue;
+    }
+
+    // Found old page or old forwarding
+    entry_addr->_forwarding = forwarding;
+    entry_addr->_page = page;
+
+    return true;
   }
-};
+}
+
+void ZRemembered::remap_current(ZRemsetTableIterator* iter) {
+  for (ZRemsetTableEntry entry; iter->next(&entry);) {
+    assert(entry._forwarding == nullptr, "Shouldn't be looking for forwardings");
+    assert(entry._page != nullptr, "Must have found a page");
+    assert(entry._page->is_old(), "Should only have found old pages");
+
+    entry._page->oops_do_current_remembered(ZBarrier::load_barrier_on_oop_field);
+  }
+}
 
 // This task scans the remembered set and follows pointers when possible.
 // Interleaving remembered set scanning with marking makes the marking times
@@ -470,7 +472,7 @@ public:
     : ZRestartableTask("ZRememberedScanMarkFollowTask"),
       _remembered(remembered),
       _mark(mark),
-      _remset_table_iterator(remembered)  {
+      _remset_table_iterator(remembered, true /* previous */)  {
     _mark->prepare_work();
     _remembered->_page_allocator->enable_safe_destroy();
   }


### PR DESCRIPTION
Before starting the relocation phase of a major collection we remap all pointers into the young generation so that we can disambiguate when an oop has bad bits for both the young generation and the old generation. See comment in remap_young_roots.

One part of this is requires us to visit all old pages. To parallelize that part we have a class that distribute indices to the page table to the GC worker threads (See ZIndexDistributor).

While looking into a potential, minor performance regression on Windows I noticed that the usage of constexpr in ZIndexDistributorClaimTree wasn't giving us the inlining we hoped for, which caused a noticeable worse performance on Windows compared to the other platforms. I created a patch for this that gave us the expected inlining. See https://github.com/openjdk/jdk/compare/master...stefank:jdk:8357443_zgc_optimize_remap_remembered

While thinking about this a bit more I realized that we could use the "found old" optimization that we already use for the remset scanning. This finds the old pages without scanning the entire page table. This gives a significant enough boost that I propose that we do that instead. 

This mainly lowers the Major Collection times when you run a GC without any significant amount of objects in the old generation. So, most likely mostly important for micro benchmarks and small workloads.

The below is the average time (ms) of the Concurrent Remap Roots phase from only running `System.gc()` 50 times before and after this PR.

```
4 GB MaxHeapSize
                    Original       Patch
Default threads

mac:                0.27812        0.0507
win:                0.9485         0.10452
linux-x64:          0.53858        0.092
linux-x64 NUMA:     0.89974        0.15452
linux-aarch64:      0.32574        0.15832

4 threads

mac:                0.19112        0.04916
win:                0.83346        0.08796
linux-x64:          0.57692        0.09526
linux-x64 NUMA:     1.23684        0.17008
linux-aarch64:      0.334          0.21918

1 thread:

mac:                0.19678        0.0589
win:                1.96496        0.09928
linux-x64:          1.00788        0.1381
linux-x64 NUMA:     2.77312        0.21134
linux-aarch64:      0.63696        0.31286
```

The second set of data is from using the extreme end of the supported heap size. This mimics how we previously used to have a large page table even for smaller heap size (we don't do that anymore for JDK 25). It shows a quite significant difference, but it also will likely be in the noise when running larger workloads.

```
16 TB MaxHeapSize
                    Original       Patch
Default threads

mac:                11.4903        0.11098
win:                54.3666        0.37164
linux-x64:          18.0898        0.21094
linux-x64 NUMA:     26.9786        0.46134
linux-aarch64:      20.7151        0.32846

4 threads

mac:                6.4035         0.10096
win:                89.5496        0.32178
linux-x64:          27.883         0.2053
linux-x64 NUMA:     35.5636        0.30928
linux-aarch64:      15.4857        0.32004

1 thread:

mac:                21.2717        0.1275
win:                307.155        0.3361
linux-x64:          62.5843        0.2309
linux-x64 NUMA:     92.0048        0.3798
linux-aarch64:      61.0375        0.42458
```

This change removes the last usage of ZIndexDistributor. I don't know if we want to remove it, or leave it in case we need it for any of our upcoming features.

I've run this through tier1-7.
