### PR TITLE
8343580: Type error with inner classes of generic classes in functions generic by outer

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Type.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Type.java
@@ -1152,8 +1152,8 @@ public abstract class Type extends AnnoConstruct implements TypeMirror, PoolCons
         public List<Type> allparams() {
             if (allparams_field == null) {
                 Type enclosingType = getEnclosingType();
-                if (!enclosingType.isUnbound() && enclosingType.getUpperBound() instanceof Type t) {
-                    enclosingType = t;
+                while (enclosingType.hasTag(TYPEVAR)) {
+                    enclosingType = enclosingType.getUpperBound();
                 }
                 allparams_field = getTypeArguments().prependList(enclosingType.allparams());
             }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Type.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Type.java
@@ -1151,7 +1151,11 @@ public abstract class Type extends AnnoConstruct implements TypeMirror, PoolCons
 
         public List<Type> allparams() {
             if (allparams_field == null) {
-                allparams_field = getTypeArguments().prependList(getEnclosingType().allparams());
+                Type enclosingType = getEnclosingType();
+                if (!enclosingType.isUnbound() && enclosingType.getUpperBound() instanceof Type t) {
+                    enclosingType = t;
+                }
+                allparams_field = getTypeArguments().prependList(enclosingType.allparams());
             }
             return allparams_field;
         }

--- a/test/langtools/tools/javac/T8343580.java
+++ b/test/langtools/tools/javac/T8343580.java
@@ -35,8 +35,27 @@ class T8343580 {
       }
    }
 
-   static class Usage<T, G extends Getters<T>> {
+   static class Usage1<T, G extends Getters<T>> {
       public T test(G.Getter getter) {
+         return getter.get();
+      }
+   }
+
+   static class Usage2<T, U extends Getters<T>, G extends U> {
+      public T test(G.Getter getter) {
+         return getter.get();
+      }
+   }
+
+   static class Usage3<T, U extends T, G extends Getters<T>> {
+      public T test(G.Getter getter) {
+         return getter.get();
+      }
+   }
+
+   class G2<K> extends Getters<K> {}
+   static class Usage4<M, L extends G2<M>> {
+      M test(L.Getter getter) {
          return getter.get();
       }
    }

--- a/test/langtools/tools/javac/T8343580.java
+++ b/test/langtools/tools/javac/T8343580.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8343580
+ * @summary Type error with inner classes of generic classes in functions generic by outer
+ * @compile T8343580.java
+ */
+
+class T8343580 {
+   static abstract class Getters<T> {
+      abstract class Getter {
+         abstract T get();
+      }
+   }
+
+   static class Usage<T, G extends Getters<T>> {
+      public T test(G.Getter getter) {
+         return getter.get();
+      }
+   }
+}


### PR DESCRIPTION
javac determines erroneously that `getter` has a raw type (`G.Getter`). The type of `getter` is deduced as the raw type `Getters<T>.Getter` by javac. Thus, the `Object` in the following example. The question is whether it should be treated as raw or not in the scenario where the qualifying type *is* a type parameter, as in `G.Getter`. In this case `Getter` is inherited from the supertype `Getters<T>`:

```java
static abstract class Getters<T> {
    abstract class Getter {
        abstract T get();
    }
}

static class Usage<T, G extends Getters<T>> {
    public T test(G.Getter getter) {
        return getter.get(); // incompatible types: Object cannot be converted to T
    }
}
```

It seems that this is a compiler bug. According to 4.8 Raw Types a “rare” type occurs when the inner is a partially raw type but the definition of Getter doesn’t take any type variables, so this is not a case of a "rare" type. `G.Getter` describes a type with a qualifying type being a type parameter which is not raw and moreover there is an instantiation of its bound. Simply not looking into the bounds of `G` seems like a compiler bug.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343580](https://bugs.openjdk.org/browse/JDK-8343580): Type error with inner classes of generic classes in functions generic by outer (**Bug** - P4)


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25346/head:pull/25346` \
`$ git checkout pull/25346`

Update a local copy of the PR: \
`$ git checkout pull/25346` \
`$ git pull https://git.openjdk.org/jdk.git pull/25346/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25346`

View PR using the GUI difftool: \
`$ git pr show -t 25346`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25346.diff">https://git.openjdk.org/jdk/pull/25346.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25346#issuecomment-2897370600)
</details>
