### PR TITLE
8357376: Disable syntax highlighting for JDK API docs

### DIFF
--- a/make/Docs.gmk
+++ b/make/Docs.gmk
@@ -98,7 +98,7 @@ JAVADOC_DISABLED_DOCLINT_PACKAGES := org.w3c.* javax.smartcardio
 JAVADOC_OPTIONS := -use -keywords -notimestamp \
     -serialwarn -encoding utf-8 -docencoding utf-8 -breakiterator \
     -splitIndex --system none -javafx --expand-requires transitive \
-    --override-methods=summary --syntax-highlight
+    --override-methods=summary
 
 # The reference options must stay stable to allow for comparisons across the
 # development cycle.


### PR DESCRIPTION
Please review a trivial change to disable syntax highlighting in JDK API docs.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8357376](https://bugs.openjdk.org/browse/JDK-8357376): Disable syntax highlighting for JDK API docs (**Task** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25348/head:pull/25348` \
`$ git checkout pull/25348`

Update a local copy of the PR: \
`$ git checkout pull/25348` \
`$ git pull https://git.openjdk.org/jdk.git pull/25348/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25348`

View PR using the GUI difftool: \
`$ git pr show -t 25348`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25348.diff">https://git.openjdk.org/jdk/pull/25348.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25348#issuecomment-2897478161)
</details>
