### PR TITLE
8357452: Remove code span highlight in JavaDoc default stylesheet

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/stylesheet.css
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/stylesheet.css
@@ -167,9 +167,6 @@ tt {
 code {
     font-family:var(--code-font-family);
     font-size:var(--code-font-size);
-    background-color: var(--code-background-color);
-    padding: 1px 2px;
-    border-radius: 3px;
 }
 button {
     font-family: var(--body-font-family);
@@ -846,12 +843,6 @@ div.block {
 [style*=font-size] code {
     font-size: inherit;
 }
-:is(pre, table, sup, sub) code,
-section[id$=-description] > dl.notes code,
-div.summary-table code {
-    background-color: inherit;
-    padding: initial;
-}
 .doc-file-page main {
     font-family: var(--block-font-family);
     font-size: var(--block-font-size);
@@ -912,8 +903,6 @@ sup.restricted-mark > a:link {
 }
 .deprecation-block code, .preview-block code, .restricted-block code {
     font-size: 0.97em;
-    background-color: inherit;
-    padding: 0;
 }
 div.block div.deprecation-comment {
     font-style:normal;


### PR DESCRIPTION
Please review a simple change to remove highlighting of code spans (background and padding) in the default JavaDoc stylesheet.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8357452](https://bugs.openjdk.org/browse/JDK-8357452): Remove code span highlight in JavaDoc default stylesheet (**Task** - P4)


### Reviewers
 * [Nizar Benalla](https://openjdk.org/census#nbenalla) (@nizarbenalla - Committer)
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25349/head:pull/25349` \
`$ git checkout pull/25349`

Update a local copy of the PR: \
`$ git checkout pull/25349` \
`$ git pull https://git.openjdk.org/jdk.git pull/25349/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25349`

View PR using the GUI difftool: \
`$ git pr show -t 25349`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25349.diff">https://git.openjdk.org/jdk/pull/25349.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25349#issuecomment-2897578195)
</details>
