### PR TITLE
8357458: Missing Highlight.js license file

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDoclet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDoclet.java
@@ -341,7 +341,7 @@ public class HtmlDoclet extends AbstractDoclet {
             copyResource(DocPaths.JQUERY_DIR.resolve(DocPaths.JQUERY_UI_CSS),
                     DocPaths.RESOURCE_FILES.resolve(DocPaths.JQUERY_UI_CSS), false);        }
 
-        copyLegalFiles(options.createIndex());
+        copyLegalFiles(options.createIndex(), options.syntaxHighlight());
         // Print a notice if the documentation contains diagnostic markers
         if (messages.containsDiagnosticMarkers()) {
             messages.notice("doclet.contains.diagnostic.markers");
@@ -357,7 +357,7 @@ public class HtmlDoclet extends AbstractDoclet {
         }
     }
 
-    private void copyLegalFiles(boolean includeJQuery) throws DocletException {
+    private void copyLegalFiles(boolean includeJQuery, boolean includeHighlightJs) throws DocletException {
         Path legalNoticesDir;
         String legalNotices = configuration.getOptions().legalNotices();
         switch (legalNotices) {
@@ -399,6 +399,9 @@ public class HtmlDoclet extends AbstractDoclet {
                         continue;
                     }
                     if (entry.getFileName().toString().startsWith("jquery") && !includeJQuery) {
+                        continue;
+                    }
+                    if (entry.getFileName().toString().equals("highlightjs.md") && !includeHighlightJs) {
                         continue;
                     }
                     DocPath filePath = DocPaths.LEGAL.resolve(entry.getFileName().toString());

--- a/src/jdk.javadoc/share/legal/highlightjs.md
+++ b/src/jdk.javadoc/share/legal/highlightjs.md
@@ -1,0 +1,34 @@
+## Highlight.js v11.11.1
+
+### Highlight.js license
+```
+BSD 3-Clause License
+
+Copyright (c) 2006, Ivan Sagalaev.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+```

--- a/test/langtools/jdk/javadoc/doclet/checkLibraryVersions/CheckLibraryVersions.java
+++ b/test/langtools/jdk/javadoc/doclet/checkLibraryVersions/CheckLibraryVersions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8293177 8324774
+ * @bug 8293177 8324774 8357458
  * @summary Verify version numbers in legal files
  * @library /test/lib
  * @build jtreg.SkippedException
@@ -47,7 +47,7 @@ import jtreg.SkippedException;
 public class CheckLibraryVersions {
     static class SourceDirNotFound extends Error {}
     // Regex pattern for library name and version in legal Markdown file
-    static final Pattern versionPattern = Pattern.compile("## ([\\w\\s]+) v(\\d+(\\.\\d+){1,2})");
+    static final Pattern versionPattern = Pattern.compile("## ([\\w\\s.]+) v(\\d+(\\.\\d+){1,2})");
 
     // Map of 3rd party libraries. The keys are the names of files in the legal directory,
     // the values are lists of templates for library files with the following placeholders:
@@ -56,7 +56,8 @@ public class CheckLibraryVersions {
     static final Map<String, List<String>> libraries = Map.of(
             "jquery.md", List.of("jquery/jquery-%V%M.js"),
             "jqueryUI.md", List.of("jquery/jquery-ui%M.js", "jquery/jquery-ui%M.css"),
-            "dejavufonts.md", List.of("fonts/dejavu.css")
+            "dejavufonts.md", List.of("fonts/dejavu.css"),
+            "highlightjs.md", List.of("highlight.js")
     );
 
     public static void main(String... args) throws Exception {


### PR DESCRIPTION
Please review a change to add the missing license file for Highlight.js required for the `--syntax-highlight` option. This also updates the tests for legal files and library versions to handle the file correctly.