### PR TITLE
Proof of concept: Leverage profiled compiled size to avoid aggressive inlining and code growth

### DIFF
--- a/extract_size_to_directives.py
+++ b/extract_size_to_directives.py
@@ -1,0 +1,74 @@
+#  Copyright (c) 2025, Arm Limited. All rights reserved.
+#  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+
+#  This code is free software; you can redistribute it and/or modify it
+#  under the terms of the GNU General Public License version 2 only, as
+#  published by the Free Software Foundation.
+
+#  This code is distributed in the hope that it will be useful, but WITHOUT
+#  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+#  version 2 for more details (a copy is included in the LICENSE file that
+#  accompanied this code).
+
+#  You should have received a copy of the GNU General Public License version
+#  2 along with this work; if not, write to the Free Software Foundation,
+#  Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+
+#  Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+#  or visit www.oracle.com if you need additional information or have any
+#  questions.
+
+import re
+import json
+import sys
+
+INPUT_FILE = sys.argv[1]
+OUTPUT_FILE = sys.argv[2]
+
+# Pattern to match log lines with inline instruction size data
+pattern = re.compile(
+    r"Collecting method size\s*\{class_name} &apos;([^\{]+)&apos;\s*"
+    r"\{method_name} &apos;([^\{]+)&apos;\s*"
+    r"\{signature} &apos;([^\{]+)&apos;\s*"
+    r"\{Inline instruction size: (\d+)}",
+    re.MULTILINE | re.DOTALL
+)
+
+def extract_and_generate_directives(input_file, output_file):
+    directives = {
+        "match": "*::*",
+        "inline": []
+    }
+    seen = {}
+    with open(input_file, 'r') as infile:
+        content = infile.read()
+        matches = pattern.findall(content)
+        allcount = 0
+        for match in matches:
+            class_name, method_name, signature, inline_size = match
+            allcount = allcount + 1
+            if "LambdaForm" in class_name:
+                continue  # Exclude LambdaForm methods
+            if "print" == method_name:
+                continue  # Exclude method_name pointing to an option type or option name
+            key = (class_name, method_name, signature)
+            size = int(inline_size)
+            if key not in seen or size < seen[key]:
+                # Conservatively keep the smallest size
+                seen[key] = size
+        for (class_name, method_name, signature), size in seen.items():
+            dotted_class_name = class_name.replace("/", ".")
+            record = f"{dotted_class_name}::{method_name}{signature}:{size}"
+            directives["inline"].append(record)
+
+    with open(output_file, 'w') as outfile:
+        json.dump(directives, outfile, indent=2)
+
+    print(f"Directive file written to: {output_file}")
+    count = len(directives["inline"])
+    print(f"Generating {count} entries from {allcount} records")
+
+if __name__ == "__main__":
+    extract_and_generate_directives(INPUT_FILE, OUTPUT_FILE)
+

--- a/src/hotspot/share/ci/ciMethod.cpp
+++ b/src/hotspot/share/ci/ciMethod.cpp
@@ -1145,9 +1145,8 @@ int ciMethod::inline_instructions_size() {
   if (_inline_instructions_size == -1) {
     GUARDED_VM_ENTRY(
       nmethod* code = get_Method()->code();
-      if (code != nullptr && (code->comp_level() == CompLevel_full_optimization)) {
-        int isize = code->insts_end() - code->verified_entry_point() - code->skipped_instructions_size();
-        _inline_instructions_size = isize > 0 ? isize : 0;
+      if (code != nullptr) {
+        _inline_instructions_size = code->inline_instructions_size();
       } else {
         _inline_instructions_size = 0;
       }

--- a/src/hotspot/share/code/nmethod.cpp
+++ b/src/hotspot/share/code/nmethod.cpp
@@ -3065,6 +3065,23 @@ void nmethod::print_on_impl(outputStream* st) const {
 
   print_on_with_msg(st, nullptr);
 
+  // Introduce a dumping interface for C2-compiled method sizes
+  if (PrintOptoMethodSize && comp_level() == CompLevel_full_optimization) {
+    Method* m = method();
+    // "InlineSmallCode / 4" used by C2 to block inlining of cold and medium methods
+    int inline_small_code_size  = InlineSmallCode / 4;
+    if (inline_instructions_size() > inline_small_code_size &&
+        m->code_size() < FreqInlineSize) {
+      st->print("Collecting method size {class_name} ");
+      m->method_holder()->name()->print_value_on(st);
+      st->print("{method_name} ");
+      m->name()->print_value_on(st);
+      st->print("{signature} ");
+      m->signature()->print_value_on(st);
+      st->print_cr("{Inline instruction size: %d}", inline_instructions_size());
+    }
+  }
+
   if (WizardMode) {
     st->print("((nmethod*) " INTPTR_FORMAT ") ", p2i(this));
     st->print(" for method " INTPTR_FORMAT , p2i(method()));

--- a/src/hotspot/share/code/nmethod.hpp
+++ b/src/hotspot/share/code/nmethod.hpp
@@ -577,6 +577,14 @@ public:
   int dependencies_size  () const { return int(          dependencies_end () -           dependencies_begin ()); }
   int handler_table_size () const { return int(          handler_table_end() -           handler_table_begin()); }
   int nul_chk_table_size () const { return int(          nul_chk_table_end() -           nul_chk_table_begin()); }
+  int inline_instructions_size() const {
+    int isize = 0;
+    if (comp_level() == CompLevel_full_optimization) {
+      isize = insts_end() - verified_entry_point() - skipped_instructions_size();
+    }
+    return isize > 0 ? isize : 0;
+  }
+
 #if INCLUDE_JVMCI
   int speculations_size  () const { return int(          speculations_end () -           speculations_begin ()); }
   int jvmci_data_size    () const { return int(          jvmci_data_end   () -           jvmci_data_begin   ()); }

--- a/src/hotspot/share/compiler/compilerDirectives.cpp
+++ b/src/hotspot/share/compiler/compilerDirectives.cpp
@@ -561,6 +561,19 @@ bool DirectiveSet::should_not_inline(ciMethod* inlinee) {
   return false;
 }
 
+bool DirectiveSet::is_estimated_size_bigger_than(ciMethod* inlinee, const int threshold) {
+  inlinee->check_is_loaded();
+  VM_ENTRY_MARK;
+  methodHandle mh(THREAD, inlinee->get_Method());
+
+  if (_inlinematchers != nullptr) {
+    if (_inlinematchers->match_if_bigger_than(mh, threshold)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 bool DirectiveSet::parse_and_add_inline(char* str, const char*& error_msg) {
   InlineMatcher* m = InlineMatcher::parse_inline_pattern(str, error_msg);
   if (m != nullptr) {

--- a/src/hotspot/share/compiler/compilerDirectives.hpp
+++ b/src/hotspot/share/compiler/compilerDirectives.hpp
@@ -141,6 +141,7 @@ public:
   void append_inline(InlineMatcher* m);
   bool should_inline(ciMethod* inlinee);
   bool should_not_inline(ciMethod* inlinee);
+  bool is_estimated_size_bigger_than(ciMethod* inlinee, const int threshold);
   void print_inline(outputStream* st);
   DirectiveSet* compilecommand_compatibility_init(const methodHandle& method);
   bool is_exclusive_copy() { return _directive == nullptr; }

--- a/src/hotspot/share/compiler/methodMatcher.hpp
+++ b/src/hotspot/share/compiler/methodMatcher.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -105,20 +105,26 @@ public:
 
 private:
   InlineType _inline_action;
+  int _inline_instructions_size;
   InlineMatcher * _next;
 
   InlineMatcher() : MethodMatcher(),
-    _inline_action(unknown_inline), _next(nullptr) {
+    _inline_action(unknown_inline), _inline_instructions_size(0), _next(nullptr) {
   }
 
 public:
-  static InlineMatcher* parse_method_pattern(char* line, const char*& error_msg);
+  static InlineMatcher* parse_method_pattern(char*& line, const char*& error_msg);
   bool match(const methodHandle& method, int inline_action);
+  bool match_if_bigger_than(const methodHandle& method, const int threshold);
   void print(outputStream* st);
   void set_next(InlineMatcher* next) { _next = next; }
   InlineMatcher* next() { return _next; }
   void set_action(InlineType inline_action) { _inline_action = inline_action; }
+  void set_size(const int size) { _inline_instructions_size = size; }
   int inline_action() { return _inline_action; }
+  // The attribute stores the estimated inlined size of a method, obtained
+  // from a compilerDirective JSON file generated in a previous profiling run.
+  int inline_instructions_size() { return _inline_instructions_size; }
   static InlineMatcher* parse_inline_pattern(char* line, const char*& error_msg);
   InlineMatcher* clone();
 };

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -630,6 +630,10 @@ const int ObjectAlignmentInBytes = 8;
   product(bool, PrintNMethods, false, DIAGNOSTIC,                           \
           "Print assembly code for nmethods when generated")                \
                                                                             \
+  product(bool, PrintOptoMethodSize, false, DIAGNOSTIC,                     \
+          "Print estimated inlined instruction size for nmethods compiled"  \
+          "by C2")                                                          \
+                                                                            \
   product(bool, PrintNativeNMethods, false, DIAGNOSTIC,                     \
           "Print assembly code for native nmethods when generated")         \
                                                                             \


### PR DESCRIPTION
**Implementation**

This patch introduces a dumping interface for C2-compiled method sizes, enabled via the `-XX:+PrintAssembly` and
`-XX:+PrintOptoMethodSize` flag.

It also adds a new attribute to InlineMatcher:` _inline_instructions_size`. This attribute stores the estimated inlined size of a method, obtained from a compilerDirective JSON file generated in a previous profiling run.

In current C2 behavior, the inliner considers the estimated inlined size of a callee only if the method has already been compiled by C2. Notably, C2 will explicitly reject inlining:
Hot methods with bytecode size > `FreqInlineSize (325)`
Cold methods with bytecode size > `MaxInlineSize (35)`

However, there's a common situation where a method's bytecode size is below `325`, but the method is later compiled by C2 into a very large machine code body. If this method hasn't been compiled yet when its caller is being compiled, the inliner may aggressively inline it - potentially bloating the caller, even though a compiled copy will exist independently later. This patch mitigates such cases by making previously profiled compiled sizes available early, helping the inliner make more informed decisions and avoid excessive code growth.

**How to use**

1. Profile method size (first run) Enable assembly output and log the compiled method size:
`-XX:+LogVMOutput -XX:+PrintOptoMethodSize -XX:+PrintAssembly -XX:LogFile=logmethodsize.out`
This will generate a log containing method size information from C2.

2. Generate the compiler directive file Use the provided Python script to extract method size info and generate a JSON file:
`python3 extract_size_to_directives.py output_directives.json`
This file contains estimated instruction sizes to guide inlining decisions in future runs. If the same method is compiled multiple times, the script conservatively retains the smallest observed size.

Note: Methods that are not accepted by the CompilerDirective format are automatically excluded. If new unsupported patterns appear, the script will need to be updated to handle and exclude them as well.

3. Use the compiler directive in a second run Pass the generated JSON to the JVM as a directive: `-XX:CompilerDirectivesFile=output_directives.json` This enables the inliner to make decisions using previously profiled method sizes, potentially avoiding aggressive inlining of large methods. Note: The patch reuse the existing `inline` directive attribute for inlining control. If multiple inline rules match the same method, only the first match is effective.

**Testing**

1. Test SPECjbb:
```
SPECjbb Config
  specjbb.controller.type=PRESET
  specjbb.controller.preset.ir=5000
  specjbb.controller.preset.duration=1800000
jvm flags: -Xms32g -Xmx32g -XX:+UseG1GC -XX:ReservedCodeCacheSize=1g
```

```
(Patch - baseline) / Baseline:
used            min       mean      median     max
non-profiled    -13.53%   -13.30%   -12.96%    -13.41%
profiled        -1.05%    -0.72%    -0.60%     -0.51%
non-nmethods    0.02%     4.12%     12.84%     0.00%
codecache       -3.15%    -3.98%    -4.41%     -4.36%
max_used        min       mean      median     max
non-profiled    -13.53%   -13.30%   -12.96%    -13.41%
profiled        -1.05%    -0.72%    -0.60%     -0.51%
non-nmethods    0.00%     1.19%     2.83%      0.76%
codecache       -4.21%    -4.36%    -4.28%     -4.59%
```

```
used            baseline CV    patch CV
non-profiled    1.78%          1.85%
profiled        0.35%          0.64%
non-nmethods    7.12%          6.83%
codecache       1.29%          0.71%
max_used
non-profiled    1.78%          1.85%
profiled        0.35%          0.64%
non-nmethods    1.46%          1.92%
codecache       0.80%          0.64%
```

Note: CV = stdev / mean

2. Tier 1 - 3 passed

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25353/head:pull/25353` \
`$ git checkout pull/25353`

Update a local copy of the PR: \
`$ git checkout pull/25353` \
`$ git pull https://git.openjdk.org/jdk.git pull/25353/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25353`

View PR using the GUI difftool: \
`$ git pr show -t 25353`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25353.diff">https://git.openjdk.org/jdk/pull/25353.diff</a>

</details>
