### PR TITLE
8341370: Test java/awt/Frame/ShapeNotSetSometimes/ShapeNotSetSometimes.java fails intermittently on macOS-aarch64

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -123,7 +123,6 @@ java/awt/Frame/MaximizedToMaximized/MaximizedToMaximized.java 8340374 macosx-all
 java/awt/Frame/MaximizedUndecorated/MaximizedUndecorated.java 8022302 generic-all
 java/awt/Frame/RestoreToOppositeScreen/RestoreToOppositeScreen.java 8286840 linux-all
 java/awt/Frame/InitialIconifiedTest.java 7144049,8203920 macosx-all,linux-all
-java/awt/Frame/ShapeNotSetSometimes/ShapeNotSetSometimes.java 8341370 macosx-all
 java/awt/Frame/FocusTest.java 8341480 macosx-all
 java/awt/FileDialog/FileDialogIconTest/FileDialogIconTest.java 8160558 windows-all
 java/awt/event/MouseWheelEvent/InfiniteRecursion/InfiniteRecursion.java 8060176 windows-all,macosx-all

--- a/test/jdk/java/awt/Frame/ShapeNotSetSometimes/ShapeNotSetSometimes.java
+++ b/test/jdk/java/awt/Frame/ShapeNotSetSometimes/ShapeNotSetSometimes.java
@@ -151,14 +151,17 @@ public class ShapeNotSetSometimes {
         Rectangle screenBounds = window.getGraphicsConfiguration().getBounds();
         BufferedImage screenCapture = robot.createScreenCapture(screenBounds);
         try {
-            colorCheck(innerPoint.x, innerPoint.y, SHAPE_COLOR, true, screenCapture);
+            colorCheck(innerPoint.x, innerPoint.y, SHAPE_COLOR,
+                    true, screenCapture);
 
             for (Point point : pointsOutsideToCheck) {
-                colorCheck(point.x, point.y, BACKGROUND_COLOR, true, screenCapture);
+                colorCheck(point.x, point.y, BACKGROUND_COLOR,
+                        true, screenCapture);
             }
 
             for (Point point : shadedPointsToCheck) {
-                colorCheck(point.x, point.y, SHAPE_COLOR, false, screenCapture);
+                colorCheck(point.x, point.y, SHAPE_COLOR,
+                        false, screenCapture);
             }
         } finally {
             EventQueue.invokeAndWait(() -> {
@@ -172,7 +175,8 @@ public class ShapeNotSetSometimes {
         }
     }
 
-    private void colorCheck(int x, int y, Color expectedColor, boolean mustBeExpectedColor,BufferedImage screenCapture) {
+    private void colorCheck(int x, int y, Color expectedColor,
+                            boolean mustBeExpectedColor, BufferedImage screenCapture) {
         int screenX = window.getX() + x;
         int screenY = window.getY() + y;
 

--- a/test/jdk/java/awt/Frame/ShapeNotSetSometimes/ShapeNotSetSometimes.java
+++ b/test/jdk/java/awt/Frame/ShapeNotSetSometimes/ShapeNotSetSometimes.java
@@ -33,6 +33,7 @@ import java.awt.Toolkit;
 import java.awt.geom.Area;
 import java.awt.geom.Ellipse2D;
 import java.awt.geom.Rectangle2D;
+import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
 import javax.imageio.ImageIO;
@@ -42,7 +43,7 @@ import javax.imageio.ImageIO;
  * @key headful
  * @bug 6988428
  * @summary Tests whether shape is always set
- * @run main/othervm -Dsun.java2d.uiScale=1 ShapeNotSetSometimes
+ * @run main/othervm/timeout=300 -Dsun.java2d.uiScale=1 ShapeNotSetSometimes
  */
 
 public class ShapeNotSetSometimes {
@@ -147,15 +148,17 @@ public class ShapeNotSetSometimes {
         robot.waitForIdle();
         robot.delay(500);
 
+        Rectangle screenBounds = window.getGraphicsConfiguration().getBounds();
+        BufferedImage screenCapture = robot.createScreenCapture(screenBounds);
         try {
-            colorCheck(innerPoint.x, innerPoint.y, SHAPE_COLOR, true);
+            colorCheck(innerPoint.x, innerPoint.y, SHAPE_COLOR, true, screenCapture);
 
             for (Point point : pointsOutsideToCheck) {
-                colorCheck(point.x, point.y, BACKGROUND_COLOR, true);
+                colorCheck(point.x, point.y, BACKGROUND_COLOR, true, screenCapture);
             }
 
             for (Point point : shadedPointsToCheck) {
-                colorCheck(point.x, point.y, SHAPE_COLOR, false);
+                colorCheck(point.x, point.y, SHAPE_COLOR, false, screenCapture);
             }
         } finally {
             EventQueue.invokeAndWait(() -> {
@@ -169,15 +172,11 @@ public class ShapeNotSetSometimes {
         }
     }
 
-    private void colorCheck(int x, int y, Color expectedColor, boolean mustBeExpectedColor) {
+    private void colorCheck(int x, int y, Color expectedColor, boolean mustBeExpectedColor,BufferedImage screenCapture) {
         int screenX = window.getX() + x;
         int screenY = window.getY() + y;
 
-        robot.mouseMove(screenX, screenY);
-        robot.waitForIdle();
-        robot.delay(50);
-
-        Color actualColor = robot.getPixelColor(screenX, screenY);
+        Color actualColor = new Color(screenCapture.getRGB(screenX, screenY));
 
         System.out.printf(
                 "Checking %3d, %3d, %35s should %sbe %35s\n",


### PR DESCRIPTION
ShapeNotSetSometimes.java fails intermittently with a RuntimeException on macOS-aarch64
Test threw exception: java.lang.RuntimeException: Test failed. The shape has not been applied.

Fix:
The test has been modified to take a screenshot of the area and then analyse the pixel color in the screenshot rather than getting individual pixels from the screen for each test.
Also the timeout of the test has been increased to 5 minutes(300 seconds) as sometimes it times out with the default timeout of 2 minutes(120 seconds).

Testing:
After fixing the test, it has been run 40 times per platform(Windows, Linux, MacOS x64 and MacOS aarch64) using Mach5 and got 100% pass rate .

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341370](https://bugs.openjdk.org/browse/JDK-8341370): Test java/awt/Frame/ShapeNotSetSometimes/ShapeNotSetSometimes.java fails intermittently on macOS-aarch64 (**Bug** - P4)


### Reviewers
 * [Damon Nguyen](https://openjdk.org/census#dnguyen) (@DamonGuy - Committer) Review applies to [7512d0e2](https://git.openjdk.org/jdk/pull/25354/files/7512d0e28c46baae749e4012b71fd19172181125)
 * [Alexander Zuev](https://openjdk.org/census#kizune) (@azuev-java - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25354/head:pull/25354` \
`$ git checkout pull/25354`

Update a local copy of the PR: \
`$ git checkout pull/25354` \
`$ git pull https://git.openjdk.org/jdk.git pull/25354/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25354`

View PR using the GUI difftool: \
`$ git pr show -t 25354`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25354.diff">https://git.openjdk.org/jdk/pull/25354.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25354#issuecomment-2897948674)
</details>
