### PR TITLE
8357361: Exception when compiling switch expression with inferred type

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransTypes.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransTypes.java
@@ -810,9 +810,6 @@ public class TransTypes extends TreeTranslator {
     }
 
     public void visitSwitch(JCSwitch tree) {
-        Type selsuper = types.supertype(tree.selector.type);
-        boolean enumSwitch = selsuper != null &&
-            selsuper.tsym == syms.enumSym;
         tree.selector = translate(tree.selector, erasure(tree.selector.type));
         tree.cases = translateCases(tree.cases);
         result = tree;
@@ -848,11 +845,8 @@ public class TransTypes extends TreeTranslator {
     }
 
     public void visitSwitchExpression(JCSwitchExpression tree) {
-        Type selsuper = types.supertype(tree.selector.type);
-        boolean enumSwitch = selsuper != null &&
-            selsuper.tsym == syms.enumSym;
         tree.selector = translate(tree.selector, erasure(tree.selector.type));
-        tree.cases = translate(tree.cases, tree.type);
+        tree.cases = translate(tree.cases, erasure(tree.type));
         tree.type = erasure(tree.type);
         result = retype(tree, tree.type, pt);
     }

--- a/test/langtools/tools/javac/switchexpr/ExpressionSwitchBugsInGen.java
+++ b/test/langtools/tools/javac/switchexpr/ExpressionSwitchBugsInGen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,11 +23,13 @@
 
 /*
  * @test
- * @bug 8214031
+ * @bug 8214031 8357361
  * @summary Verify various corner cases with nested switch expressions.
  * @compile ExpressionSwitchBugsInGen.java
  * @run main ExpressionSwitchBugsInGen
  */
+
+import java.util.Objects;
 
 public class ExpressionSwitchBugsInGen {
     public static void main(String... args) {
@@ -43,6 +45,8 @@ public class ExpressionSwitchBugsInGen {
         new ExpressionSwitchBugsInGen().testSwitchExpressionInConditional(1, 1, 1);
         new ExpressionSwitchBugsInGen().testIntBoxing(0, 10, 10);
         new ExpressionSwitchBugsInGen().testIntBoxing(1, 10, -1);
+        new ExpressionSwitchBugsInGen().testSwitchExpressionTypeErased(0);
+        new ExpressionSwitchBugsInGen().testSwitchExpressionTypeErased(1);
     }
 
     private void test(int a, int b, int c, boolean expected) {
@@ -88,6 +92,23 @@ public class ExpressionSwitchBugsInGen {
         };
         if (r != expected) {
             throw new IllegalStateException();
+        }
+    }
+
+    //JDK-8357361:
+    private void testSwitchExpressionTypeErased(int i) {
+        interface Readable<R extends String> {
+            R getReader();
+        }
+        Readable<?> readable = () -> "";
+        var v = switch (i) {
+            case 0 -> readable.getReader();
+            default -> null;
+        };
+        var expected = i == 0 ? "" : null;
+        if (!Objects.equals(v, expected)) {
+            throw new IllegalStateException("Expected: " + expected +
+                                            ", got: " + v);
         }
     }
 


### PR DESCRIPTION
There's a missing erasure in `TransTypes`, which eventually leads to an attempt to cast to a captured wildcard type (for the case shown in the bug report), which cannot be done. (In this case, `TransTypes` will report an error.)

(There's a unused/unnecessary code in the close vicinity of the added erasure, and a similar code in `visitSwitch`. I could resist deleting that unnecessary code.)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8357361](https://bugs.openjdk.org/browse/JDK-8357361): Exception when compiling switch expression with inferred type (**Bug** - P4)


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25358/head:pull/25358` \
`$ git checkout pull/25358`

Update a local copy of the PR: \
`$ git checkout pull/25358` \
`$ git pull https://git.openjdk.org/jdk.git pull/25358/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25358`

View PR using the GUI difftool: \
`$ git pr show -t 25358`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25358.diff">https://git.openjdk.org/jdk/pull/25358.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25358#issuecomment-2898400337)
</details>
