### PR TITLE
8356443: Update open/test/jdk/TEST.groups manual test groups definitions with missing manual test

### DIFF
--- a/test/jdk/TEST.groups
+++ b/test/jdk/TEST.groups
@@ -387,7 +387,6 @@ jdk_foreign = \
     -java/foreign/TestUpcallStress.java
 
 jdk_foreign_stress = \
-    java/foreign/TestMatrix.java \
     java/foreign/TestUpcallStress.java
 
 jdk_vector = \
@@ -619,14 +618,14 @@ jdk_core_manual_no_input = \
     javax/net/ssl/compatibility/BasicConnectTest.java \
     javax/net/ssl/compatibility/HrrTest.java \
     javax/net/ssl/compatibility/SniTest.java \
-    jdk/nio/zipfs/TestLocOffsetFromZip64EF.java \
     jdk/nio/zipfs/LargeCompressedEntrySizeTest.java \
     java/util/ArrayList/Bug8146568.java \
     java/util/Vector/Bug8148174.java \
     com/sun/net/httpserver/simpleserver/CommandLinePortNotSpecifiedTest.java \
     com/sun/net/httpserver/simpleserver/jwebserver/CommandLinePortNotSpecifiedTest.java \
     com/sun/net/httpserver/simpleserver/DocRootDirPermissionsWinTest.java \
-    javax/xml/jaxp/datatype/8033980/GregorianCalAndDurSerDataUtil.java 
+    javax/xml/jaxp/datatype/8033980/GregorianCalAndDurSerDataUtil.java \
+    java/util/zip/ZipFile/CenSizeMaximum.java
 
 jdk_security_manual_no_input = \
     :jdk_security_infra \
@@ -650,7 +649,9 @@ jdk_core_manual_interactive = \
     java/util/TimeZone/DefaultTimeZoneTest.java \
     java/nio/MappedByteBuffer/PmemTest.java \
     java/rmi/registry/nonLocalRegistry/NonLocalRegistryTest.java \
-    java/rmi/registry/nonLocalRegistry/NonLocalSkeletonTest.java
+    java/rmi/registry/nonLocalRegistry/NonLocalSkeletonTest.java \
+    java/foreign/TestMatrix.java \
+    java/nio/channels/FileChannel/BlockDeviceSize.java
 
 jdk_security_manual_interactive = \
     sun/security/tools/keytool/i18n.java \


### PR DESCRIPTION
Update open/test/jdk/TEST.groups manual test groups definitions with missing manual test