### PR TITLE
8353504: CDS archives are not found when JVM is in non-variant location

### DIFF
--- a/src/hotspot/share/cds/cdsConfig.cpp
+++ b/src/hotspot/share/cds/cdsConfig.cpp
@@ -108,10 +108,12 @@ const char* CDSConfig::default_archive_path() {
   // before CDSConfig::ergo_initialize() is called.
   assert(_cds_ergo_initialize_started, "sanity");
   if (_default_archive_path == nullptr) {
+    char jvm_path[JVM_MAXPATHLEN];
+    os::jvm_path(jvm_path, sizeof(jvm_path));
+    char *end = strrchr(jvm_path, *os::file_separator());
+    if (end != nullptr) *end = '\0';
     stringStream tmp;
-    const char* subdir = WINDOWS_ONLY("bin") NOT_WINDOWS("lib");
-    tmp.print("%s%s%s%s%s%sclasses", Arguments::get_java_home(), os::file_separator(), subdir,
-              os::file_separator(), Abstract_VM_Version::vm_variant(), os::file_separator());
+    tmp.print("%s%sclasses", jvm_path, os::file_separator());
 #ifdef _LP64
     if (!UseCompressedOops) {
       tmp.print_raw("_nocoops");

--- a/test/hotspot/jtreg/runtime/cds/NonJVMVariantLocation.java
+++ b/test/hotspot/jtreg/runtime/cds/NonJVMVariantLocation.java
@@ -54,6 +54,7 @@ public class NonJVMVariantLocation {
         System.out.println("============== Cloned JDK at " + java_home_dst);
 
         // Replace "server" with "release" in jvm.cfg.
+        // The jvm.cfg is parsed by the java launcher in java.c.
         String locDir = java_home_dst + File.separator + "lib";
         String jvmCfg = locDir + File.separator + "jvm.cfg";
         String serverDir = "server";

--- a/test/hotspot/jtreg/runtime/cds/NonJVMVariantLocation.java
+++ b/test/hotspot/jtreg/runtime/cds/NonJVMVariantLocation.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test
+ * @summary Test that CDS archive can be loaded if the archive is in a non-JVM variant directory.
+ * @bug 8353504
+ * @requires vm.cds
+ * @requires vm.flagless
+ * @requires vm.flavor == "server"
+ * @comment This test doesn't work on Windows because it depends on symlinks
+ * @requires os.family != "windows"
+ * @library /test/lib appcds
+ * @run driver NonJVMVariantLocation
+ */
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.List;
+import jdk.test.lib.cds.CDSTestUtils;
+import jdk.test.lib.process.OutputAnalyzer;
+
+public class NonJVMVariantLocation {
+    public static void main(String[] args) throws Exception {
+        String java_home_src = System.getProperty("java.home");
+        String java_home_dst = CDSTestUtils.getOutputDir() + File.separator + "moved_jdk";
+        String homeJava = java_home_src + File.separator + "bin" + File.separator + "java";
+        String dstJava  = java_home_dst + File.separator + "bin" + File.separator + "java";
+
+        CDSTestUtils.clone(new File(java_home_src), new File(java_home_dst));
+        System.out.println("============== Cloned JDK at " + java_home_dst);
+
+        // Replace "server" with "release" in jvm.cfg.
+        String locDir = java_home_dst + File.separator + "lib";
+        String jvmCfg = locDir + File.separator + "jvm.cfg";
+        String serverDir = "server";
+        String releaseDir = "release";
+        replaceTextInFile(jvmCfg, serverDir, releaseDir);
+
+        // Rename "server" dir to "release" dir.
+        CDSTestUtils.rename(new File(locDir + File.separator + serverDir),
+                            new File(locDir + File.separator + releaseDir));
+
+        // Test runtime with cloned JDK
+        {
+            ProcessBuilder pb = CDSTestUtils.makeBuilder(dstJava,
+                                                         "-Xshare:on",
+                                                         "-Xlog:cds",
+                                                         "-version");
+            OutputAnalyzer out = TestCommon.executeAndLog(pb, "exec-dst");
+            out.shouldHaveExitValue(0)
+               .shouldMatch(".info..cds. Opened shared archive file.*classes.*\\.jsa");
+        }
+    }
+
+    private static void replaceTextInFile(String filePath, String oldText, String newText) {
+        try {
+            List<String> lines = Files.readAllLines(Paths.get(filePath));
+            lines.replaceAll(line -> line.replace(oldText, newText));
+            Files.write(Paths.get(filePath), lines);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/test/lib/jdk/test/lib/cds/CDSTestUtils.java
+++ b/test/lib/jdk/test/lib/cds/CDSTestUtils.java
@@ -778,8 +778,10 @@ public class CDSTestUtils {
 
     // Do a cheap clone of the JDK. Most files can be sym-linked. However, $JAVA_HOME/bin/java and $JAVA_HOME/lib/.../libjvm.so"
     // must be copied, because the java.home property is derived from the canonicalized paths of these 2 files.
-    // Set a list of {jvm, "java"} which will be physically copied. If a file needs copied physically, add it to the list.
-    private static String[] phCopied = {System.mapLibraryName("jvm"), "java"};
+    // The jvm.cfg file must be copied because the cds/NonJVMVariantLocation.java
+    // test is testing a CDS archive can be loaded from a non-JVM variant directory.
+    // Set a list of {jvm, "java", "jvm.cfg"} which will be physically copied. If a file needs copied physically, add it to the list.
+    private static String[] phCopied = {System.mapLibraryName("jvm"), "java", "jvm.cfg"};
     public static void clone(File src, File dst) throws Exception {
         if (dst.exists()) {
             if (!dst.isDirectory()) {


### PR DESCRIPTION
Although this fix reverts part of the change for [JDK-8348028](https://bugs.openjdk.org/browse/JDK-8348028), gtestLauncher still works the way it was described in JDK-8348028.
Also added a test case to test the default CDS archive can be found from a non-variant location.

Sanity tested tiers 1 and 2.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8353504](https://bugs.openjdk.org/browse/JDK-8353504): CDS archives are not found when JVM is in non-variant location (**Bug** - P4)


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**) Review applies to [7ab3b809](https://git.openjdk.org/jdk/pull/25361/files/7ab3b809e14142ae17957e585d78c7d0de10276f)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25361/head:pull/25361` \
`$ git checkout pull/25361`

Update a local copy of the PR: \
`$ git checkout pull/25361` \
`$ git pull https://git.openjdk.org/jdk.git pull/25361/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25361`

View PR using the GUI difftool: \
`$ git pr show -t 25361`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25361.diff">https://git.openjdk.org/jdk/pull/25361.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25361#issuecomment-2898484840)
</details>
