### PR TITLE
8357478: Fix copyright header in src/jdk.jpackage/share/classes/jdk/jpackage/internal/AppImageDesc.java

### DIFF
--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/AppImageDesc.java
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/AppImageDesc.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as


### PR DESCRIPTION
Add a missing line to the copyright header

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8357478](https://bugs.openjdk.org/browse/JDK-8357478): Fix copyright header in src/jdk.jpackage/share/classes/jdk/jpackage/internal/AppImageDesc.java (**Bug** - P2)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25362/head:pull/25362` \
`$ git checkout pull/25362`

Update a local copy of the PR: \
`$ git checkout pull/25362` \
`$ git pull https://git.openjdk.org/jdk.git pull/25362/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25362`

View PR using the GUI difftool: \
`$ git pr show -t 25362`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25362.diff">https://git.openjdk.org/jdk/pull/25362.diff</a>

</details>
