### PR TITLE
8357504: Refactor the assignment of loader bits in InstanceKlassFlags

### DIFF
--- a/src/hotspot/share/cds/aotArtifactFinder.cpp
+++ b/src/hotspot/share/cds/aotArtifactFinder.cpp
@@ -240,7 +240,7 @@ void AOTArtifactFinder::add_cached_instance_class(InstanceKlass* ik) {
       add_cached_instance_class(intf);
     }
 
-    if (CDSConfig::is_dumping_final_static_archive() && ik->is_shared_unregistered_class()) {
+    if (CDSConfig::is_dumping_final_static_archive() && ik->defined_by_other_loaders()) {
       // The following are not appliable to unregistered classes
       return;
     }

--- a/src/hotspot/share/cds/aotClassLinker.cpp
+++ b/src/hotspot/share/cds/aotClassLinker.cpp
@@ -137,7 +137,7 @@ bool AOTClassLinker::try_add_candidate(InstanceKlass* ik) {
   }
 
   if (ik->is_hidden()) {
-    assert(ik->class_loader_type() != ClassLoader::OTHER, "must have been set");
+    assert(!ik->defined_by_other_loaders(), "hidden classes are archived only for builtin loaders");
     if (!CDSConfig::is_dumping_method_handles()) {
       return false;
     }

--- a/src/hotspot/share/cds/aotClassLinker.cpp
+++ b/src/hotspot/share/cds/aotClassLinker.cpp
@@ -137,7 +137,7 @@ bool AOTClassLinker::try_add_candidate(InstanceKlass* ik) {
   }
 
   if (ik->is_hidden()) {
-    assert(ik->shared_class_loader_type() != ClassLoader::OTHER, "must have been set");
+    assert(ik->class_loader_type() != ClassLoader::OTHER, "must have been set");
     if (!CDSConfig::is_dumping_method_handles()) {
       return false;
     }

--- a/src/hotspot/share/cds/aotLinkedClassBulkLoader.cpp
+++ b/src/hotspot/share/cds/aotLinkedClassBulkLoader.cpp
@@ -372,7 +372,7 @@ bool AOTLinkedClassBulkLoader::is_pending_aot_linked_class(Klass* k) {
   // the four AOTLinkedClassCategory of classes that can be aot-linked.
 
   InstanceKlass* ik = InstanceKlass::cast(k);
-  if (ik->is_shared_boot_class()) {
+  if (ik->defined_by_boot_loader()) {
     if (ik->module() != nullptr && ik->in_javabase_module()) {
       // AOTLinkedClassCategory::BOOT1 -- all aot-linked classes in
       // java.base must have been loaded before a GC can ever happen.
@@ -382,11 +382,11 @@ bool AOTLinkedClassBulkLoader::is_pending_aot_linked_class(Klass* k) {
       // module system is ready.
       return !_boot2_completed;
     }
-  } else if (ik->is_shared_platform_class()) {
+  } else if (ik->defined_by_platform_loader()) {
     // AOTLinkedClassCategory::PLATFORM classes cannot be loaded until
     // the platform class loader is initialized.
     return !_platform_completed;
-  } else if (ik->is_shared_app_class()) {
+  } else if (ik->defined_by_app_loader()) {
     // AOTLinkedClassCategory::APP cannot be loaded until the app class loader
     // is initialized.
     return !_app_completed;

--- a/src/hotspot/share/cds/archiveBuilder.cpp
+++ b/src/hotspot/share/cds/archiveBuilder.cpp
@@ -861,17 +861,17 @@ void ArchiveBuilder::make_klasses_shareable() {
           // Legacy CDS support for lambda proxies
           CDS_JAVA_HEAP_ONLY(assert(HeapShared::is_lambda_proxy_klass(ik), "sanity");)
         }
-      } else if (ik->is_shared_boot_class()) {
+      } else if (ik->defined_by_boot_loader()) {
         type = "boot";
         ADD_COUNT(num_boot_klasses);
-      } else if (ik->is_shared_platform_class()) {
+      } else if (ik->defined_by_platform_loader()) {
         type = "plat";
         ADD_COUNT(num_platform_klasses);
-      } else if (ik->is_shared_app_class()) {
+      } else if (ik->defined_by_app_loader()) {
         type = "app";
         ADD_COUNT(num_app_klasses);
       } else {
-        assert(ik->is_shared_unregistered_class(), "must be");
+        assert(ik->defined_by_other_loaders(), "must be");
         type = "unreg";
         ADD_COUNT(num_unregistered_klasses);
       }
@@ -883,11 +883,11 @@ void ArchiveBuilder::make_klasses_shareable() {
       if (!ik->is_linked()) {
         num_unlinked_klasses ++;
         unlinked = " unlinked";
-        if (ik->is_shared_boot_class()) {
+        if (ik->defined_by_boot_loader()) {
           boot_unlinked ++;
-        } else if (ik->is_shared_platform_class()) {
+        } else if (ik->defined_by_platform_loader()) {
           platform_unlinked ++;
-        } else if (ik->is_shared_app_class()) {
+        } else if (ik->defined_by_app_loader()) {
           app_unlinked ++;
         } else {
           unreg_unlinked ++;

--- a/src/hotspot/share/cds/archiveBuilder.cpp
+++ b/src/hotspot/share/cds/archiveBuilder.cpp
@@ -834,10 +834,6 @@ void ArchiveBuilder::make_klasses_shareable() {
       bool aotlinked = AOTClassLinker::is_candidate(src_ik);
       inited = ik->has_aot_initialized_mirror();
       ADD_COUNT(num_instance_klasses);
-      if (CDSConfig::is_dumping_dynamic_archive()) {
-        // For static dump, class loader type are already set.
-        ik->assign_class_loader_type();
-      }
       if (ik->is_hidden()) {
         ADD_COUNT(num_hidden_klasses);
         hidden = " hidden";

--- a/src/hotspot/share/cds/cdsProtectionDomain.cpp
+++ b/src/hotspot/share/cds/cdsProtectionDomain.cpp
@@ -120,7 +120,7 @@ PackageEntry* CDSProtectionDomain::get_package_entry_from_class(InstanceKlass* i
   PackageEntry* pkg_entry = ik->package();
   if (CDSConfig::is_using_full_module_graph() && ik->is_shared() && pkg_entry != nullptr) {
     assert(MetaspaceShared::is_in_shared_metaspace(pkg_entry), "must be");
-    assert(!ik->is_shared_unregistered_class(), "unexpected archived package entry for an unregistered class");
+    assert(!ik->defined_by_other_loaders(), "unexpected archived package entry for an unregistered class");
     assert(ik->module()->is_named(), "unexpected archived package entry for a class in an unnamed module");
     return pkg_entry;
   }

--- a/src/hotspot/share/cds/classListParser.cpp
+++ b/src/hotspot/share/cds/classListParser.cpp
@@ -511,7 +511,7 @@ void ClassListParser::constant_pool_resolution_warning(const char* msg, ...) {
 // S2 will be incorrectly used as the supertype of U instead of S1 due to
 // limitations in the loading mechanism of unregistered classes.
 void ClassListParser::check_supertype_obstruction(int specified_supertype_id, const InstanceKlass* specified_supertype, TRAPS) {
-  if (specified_supertype->is_shared_unregistered_class()) {
+  if (specified_supertype->defined_by_other_loaders()) {
     return; // Only registered supertypes can be obstructed
   }
   const InstanceKlass* obstructor = SystemDictionaryShared::get_unregistered_class(specified_supertype->name());
@@ -582,7 +582,7 @@ InstanceKlass* ClassListParser::load_class_from_source(Symbol* class_name, TRAPS
       }
   }
 
-  assert(k->is_shared_unregistered_class(), "must be");
+  assert(k->defined_by_other_loaders(), "must be");
 
   bool added = SystemDictionaryShared::add_unregistered_class(THREAD, k);
   if (!added) {

--- a/src/hotspot/share/cds/dumpTimeClassInfo.inline.hpp
+++ b/src/hotspot/share/cds/dumpTimeClassInfo.inline.hpp
@@ -46,7 +46,7 @@ void DumpTimeSharedClassTable::iterate_all_live_classes(Function function) const
     assert(SafepointSynchronize::is_at_safepoint(), "invariant");
     assert_lock_strong(DumpTimeTable_lock);
     if (CDSConfig::is_dumping_final_static_archive() && !k->is_loaded()) {
-      assert(k->is_shared_unregistered_class(), "must be");
+      assert(k->defined_by_other_loaders(), "must be");
       function(k, info);
     } else if (k->is_loader_alive()) {
       function(k, info);

--- a/src/hotspot/share/cds/finalImageRecipes.cpp
+++ b/src/hotspot/share/cds/finalImageRecipes.cpp
@@ -173,7 +173,7 @@ void FinalImageRecipes::load_all_classes(TRAPS) {
     Klass* k = _all_klasses->at(i);
     if (k->is_instance_klass()) {
       InstanceKlass* ik = InstanceKlass::cast(k);
-      if (ik->is_shared_unregistered_class()) {
+      if (ik->defined_by_other_loaders()) {
         SystemDictionaryShared::init_dumptime_info(ik);
         SystemDictionaryShared::add_unregistered_class(THREAD, ik);
         SystemDictionaryShared::copy_unregistered_class_size_and_crc32(ik);

--- a/src/hotspot/share/cds/heapShared.cpp
+++ b/src/hotspot/share/cds/heapShared.cpp
@@ -803,7 +803,7 @@ void KlassSubGraphInfo::add_subgraph_object_klass(Klass* orig_k) {
   } else if (orig_k->is_objArray_klass()) {
     Klass* abk = ObjArrayKlass::cast(orig_k)->bottom_klass();
     if (abk->is_instance_klass()) {
-      assert(InstanceKlass::cast(abk)->is_shared_boot_class(),
+      assert(InstanceKlass::cast(abk)->defined_by_boot_loader(),
             "must be boot class");
       check_allowed_klass(InstanceKlass::cast(ObjArrayKlass::cast(orig_k)->bottom_klass()));
     }
@@ -1097,7 +1097,7 @@ void HeapShared::resolve_classes_for_subgraphs(JavaThread* current, ArchivableSt
     ArchivableStaticFieldInfo* info = &fields[i];
     TempNewSymbol klass_name = SymbolTable::new_symbol(info->klass_name);
     InstanceKlass* k = SystemDictionaryShared::find_builtin_class(klass_name);
-    assert(k != nullptr && k->is_shared_boot_class(), "sanity");
+    assert(k != nullptr && k->defined_by_boot_loader(), "sanity");
     resolve_classes_for_subgraph_of(current, k);
   }
 }
@@ -1284,7 +1284,7 @@ void HeapShared::resolve_or_init(const char* klass_name, bool do_init, TRAPS) {
   if (k == nullptr) {
     return;
   }
-  assert(k->is_shared_boot_class(), "sanity");
+  assert(k->defined_by_boot_loader(), "sanity");
   resolve_or_init(k, false, CHECK);
   if (do_init) {
     resolve_or_init(k, true, CHECK);
@@ -1644,7 +1644,7 @@ void HeapShared::archive_reachable_objects_from_static_field(InstanceKlass *k,
                                                              int field_offset,
                                                              const char* field_name) {
   assert(CDSConfig::is_dumping_heap(), "dump time only");
-  assert(k->is_shared_boot_class(), "must be boot class");
+  assert(k->defined_by_boot_loader(), "must be boot class");
 
   oop m = k->java_mirror();
 
@@ -1695,7 +1695,7 @@ class VerifySharedOopClosure: public BasicOopIterateClosure {
 
 void HeapShared::verify_subgraph_from_static_field(InstanceKlass* k, int field_offset) {
   assert(CDSConfig::is_dumping_heap(), "dump time only");
-  assert(k->is_shared_boot_class(), "must be boot class");
+  assert(k->defined_by_boot_loader(), "must be boot class");
 
   oop m = k->java_mirror();
   oop f = m->obj_field(field_offset);
@@ -1869,7 +1869,7 @@ void HeapShared::init_subgraph_entry_fields(ArchivableStaticFieldInfo fields[],
     }
 
     InstanceKlass* ik = InstanceKlass::cast(k);
-    assert(InstanceKlass::cast(ik)->is_shared_boot_class(),
+    assert(InstanceKlass::cast(ik)->defined_by_boot_loader(),
            "Only support boot classes");
 
     if (is_test_class) {

--- a/src/hotspot/share/cds/lambdaProxyClassDictionary.cpp
+++ b/src/hotspot/share/cds/lambdaProxyClassDictionary.cpp
@@ -170,7 +170,6 @@ void LambdaProxyClassDictionary::add_lambda_proxy_class(InstanceKlass* caller_ik
 
   MutexLocker ml(DumpTimeTable_lock, Mutex::_no_safepoint_check_flag);
 
-  lambda_ik->assign_class_loader_type();
   lambda_ik->set_shared_classpath_index(caller_ik->shared_classpath_index());
   InstanceKlass* nest_host = caller_ik->nest_host(CHECK);
   assert(nest_host != nullptr, "unexpected nullptr nest_host");

--- a/src/hotspot/share/cds/metaspaceShared.cpp
+++ b/src/hotspot/share/cds/metaspaceShared.cpp
@@ -733,7 +733,7 @@ bool MetaspaceShared::may_be_eagerly_linked(InstanceKlass* ik) {
     // linked/verified at runtime.
     return false;
   }
-  if (CDSConfig::is_dumping_dynamic_archive() && ik->is_shared_unregistered_class()) {
+  if (CDSConfig::is_dumping_dynamic_archive() && ik->defined_by_other_loaders()) {
     // Linking of unregistered classes at this stage may cause more
     // classes to be resolved, resulting in calls to ClassLoader.loadClass()
     // that may not be expected by custom class loaders.
@@ -1046,7 +1046,7 @@ bool MetaspaceShared::try_link_class(JavaThread* current, InstanceKlass* ik) {
   if (ik->is_loaded() && !ik->is_linked() && ik->can_be_verified_at_dumptime() &&
       !SystemDictionaryShared::has_class_failed_verification(ik)) {
     bool saved = BytecodeVerificationLocal;
-    if (ik->is_shared_unregistered_class() && ik->class_loader() == nullptr) {
+    if (ik->defined_by_other_loaders() && ik->class_loader() == nullptr) {
       // The verification decision is based on BytecodeVerificationRemote
       // for non-system classes. Since we are using the null classloader
       // to load non-system classes for customized class loaders during dumping,

--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -5015,6 +5015,7 @@ void ClassFileParser::fill_instance_klass(InstanceKlass* ik,
 
   // Set name and CLD before adding to CLD
   ik->set_class_loader_data(_loader_data);
+  ik->set_class_loader_type();
   ik->set_name(_class_name);
 
   // Add all classes to our internal class loader list here,

--- a/src/hotspot/share/classfile/classLoader.cpp
+++ b/src/hotspot/share/classfile/classLoader.cpp
@@ -1195,7 +1195,7 @@ void ClassLoader::record_result(JavaThread* current, InstanceKlass* ik,
     if (loader == nullptr) {
       // JFR classes
       ik->set_shared_classpath_index(0);
-      ik->set_shared_class_loader_type(ClassLoader::BOOT_LOADER);
+      ik->set_class_loader_type(ClassLoader::BOOT_LOADER);
     }
     return;
   }
@@ -1308,7 +1308,7 @@ void ClassLoader::record_hidden_class(InstanceKlass* ik) {
       return;
     }
   }
-  ik->set_shared_class_loader_type(classloader_type);
+  ik->set_class_loader_type(classloader_type);
 
   if (HeapShared::is_lambda_proxy_klass(ik)) {
     InstanceKlass* nest_host = ik->nest_host_not_null();

--- a/src/hotspot/share/classfile/classLoader.cpp
+++ b/src/hotspot/share/classfile/classLoader.cpp
@@ -1195,7 +1195,6 @@ void ClassLoader::record_result(JavaThread* current, InstanceKlass* ik,
     if (loader == nullptr) {
       // JFR classes
       ik->set_shared_classpath_index(0);
-      ik->set_class_loader_type(ClassLoader::BOOT_LOADER);
     }
     return;
   }
@@ -1290,25 +1289,10 @@ void ClassLoader::record_result(JavaThread* current, InstanceKlass* ik,
 void ClassLoader::record_hidden_class(InstanceKlass* ik) {
   assert(ik->is_hidden(), "must be");
 
-  s2 classloader_type;
-  if (HeapShared::is_lambda_form_klass(ik)) {
-    classloader_type = ClassLoader::BOOT_LOADER;
-  } else {
-    oop loader = ik->class_loader();
-
-    if (loader == nullptr) {
-      classloader_type = ClassLoader::BOOT_LOADER;
-    } else if (SystemDictionary::is_platform_class_loader(loader)) {
-      classloader_type = ClassLoader::PLATFORM_LOADER;
-    } else if (SystemDictionary::is_system_class_loader(loader)) {
-      classloader_type = ClassLoader::APP_LOADER;
-    } else {
-      // This class won't be archived, so no need to update its
-      // classloader_type/classpath_index.
-      return;
-    }
+  if (ik->defined_by_other_loaders()) {
+    // We don't archive hidden classes for non-builtin loaders.
+    return;
   }
-  ik->set_class_loader_type(classloader_type);
 
   if (HeapShared::is_lambda_proxy_klass(ik)) {
     InstanceKlass* nest_host = ik->nest_host_not_null();
@@ -1317,7 +1301,7 @@ void ClassLoader::record_hidden_class(InstanceKlass* ik) {
     ik->set_shared_classpath_index(0);
   } else {
     // Generated invoker classes.
-    if (classloader_type == ClassLoader::APP_LOADER) {
+    if (ik->defined_by_app_loader()) {
       ik->set_shared_classpath_index(AOTClassLocationConfig::dumptime()->app_cp_start_index());
     } else {
       ik->set_shared_classpath_index(0);

--- a/src/hotspot/share/classfile/classLoaderExt.cpp
+++ b/src/hotspot/share/classfile/classLoaderExt.cpp
@@ -91,7 +91,7 @@ void ClassLoaderExt::record_result_for_builtin_loader(s2 classpath_index, Instan
 
   AOTClassLocationConfig::dumptime_update_max_used_index(classpath_index);
   result->set_shared_classpath_index(classpath_index);
-  result->set_shared_class_loader_type(classloader_type);
+  result->set_class_loader_type(classloader_type);
 
 #if INCLUDE_CDS_JAVA_HEAP
   if (CDSConfig::is_dumping_heap() && AllowArchivingWithJavaAgent && classloader_type == ClassLoader::BOOT_LOADER &&

--- a/src/hotspot/share/classfile/classLoaderExt.cpp
+++ b/src/hotspot/share/classfile/classLoaderExt.cpp
@@ -71,16 +71,12 @@ void ClassLoaderExt::record_result_for_builtin_loader(s2 classpath_index, Instan
   assert(CDSConfig::is_dumping_archive(), "sanity");
 
   oop loader = result->class_loader();
-  s2 classloader_type;
   if (SystemDictionary::is_system_class_loader(loader)) {
-    classloader_type = ClassLoader::APP_LOADER;
     AOTClassLocationConfig::dumptime_set_has_app_classes();
   } else if (SystemDictionary::is_platform_class_loader(loader)) {
-    classloader_type = ClassLoader::PLATFORM_LOADER;
     AOTClassLocationConfig::dumptime_set_has_platform_classes();
   } else {
     precond(loader == nullptr);
-    classloader_type = ClassLoader::BOOT_LOADER;
   }
 
   if (CDSConfig::is_dumping_preimage_static_archive() || CDSConfig::is_dumping_dynamic_archive()) {
@@ -91,10 +87,9 @@ void ClassLoaderExt::record_result_for_builtin_loader(s2 classpath_index, Instan
 
   AOTClassLocationConfig::dumptime_update_max_used_index(classpath_index);
   result->set_shared_classpath_index(classpath_index);
-  result->set_class_loader_type(classloader_type);
 
 #if INCLUDE_CDS_JAVA_HEAP
-  if (CDSConfig::is_dumping_heap() && AllowArchivingWithJavaAgent && classloader_type == ClassLoader::BOOT_LOADER &&
+  if (CDSConfig::is_dumping_heap() && AllowArchivingWithJavaAgent && result->defined_by_boot_loader() &&
       classpath_index < 0 && redefined) {
     // When dumping the heap (which happens only during static dump), classes for the built-in
     // loaders are always loaded from known locations (jimage, classpath or modulepath),

--- a/src/hotspot/share/classfile/klassFactory.cpp
+++ b/src/hotspot/share/classfile/klassFactory.cpp
@@ -98,7 +98,6 @@ InstanceKlass* KlassFactory::check_shared_class_file_load_hook(
 
       if (class_loader.is_null()) {
         new_ik->set_classpath_index(path_index);
-        new_ik->assign_class_loader_type();
       }
 
       return new_ik;

--- a/src/hotspot/share/classfile/vmClasses.cpp
+++ b/src/hotspot/share/classfile/vmClasses.cpp
@@ -81,7 +81,7 @@ bool vmClasses::resolve(vmClassID id, TRAPS) {
 #if INCLUDE_CDS
   if (CDSConfig::is_using_archive() && !JvmtiExport::should_post_class_prepare()) {
     InstanceKlass* k = *klassp;
-    assert(k->is_shared_boot_class(), "must be");
+    assert(k->defined_by_boot_loader(), "must be");
 
     ClassLoaderData* loader_data = ClassLoaderData::the_null_class_loader_data();
     resolve_shared_class(k, loader_data, Handle(), CHECK_false);

--- a/src/hotspot/share/oops/constantPool.cpp
+++ b/src/hotspot/share/oops/constantPool.cpp
@@ -446,7 +446,7 @@ void ConstantPool::remove_unshareable_info() {
   if (CDSConfig::is_dumping_final_static_archive()) {
     ConstantPool* src_cp = ArchiveBuilder::current()->get_source_addr(this);
     InstanceKlass* src_holder = src_cp->pool_holder();
-    if (src_holder->is_shared_unregistered_class()) {
+    if (src_holder->defined_by_other_loaders()) {
       // Unregistered classes are not loaded in the AOT assembly phase. The resolved reference length
       // is already saved during the training run.
       precond(!src_holder->is_loaded());

--- a/src/hotspot/share/oops/cpCache.cpp
+++ b/src/hotspot/share/oops/cpCache.cpp
@@ -538,8 +538,9 @@ void ConstantPoolCache::remove_resolved_indy_entries_if_non_deterministic() {
 
 bool ConstantPoolCache::can_archive_resolved_method(ConstantPool* src_cp, ResolvedMethodEntry* method_entry) {
   InstanceKlass* pool_holder = constant_pool()->pool_holder();
-  if (!(pool_holder->is_shared_boot_class() || pool_holder->is_shared_platform_class() ||
-        pool_holder->is_shared_app_class())) {
+  // FIXME -- change to pool_holder->defined_by_other_loaders()
+  if (!(pool_holder->defined_by_boot_loader() || pool_holder->defined_by_platform_loader() ||
+        pool_holder->defined_by_app_loader())) {
     // Archiving resolved cp entries for classes from non-builtin loaders
     // is not yet supported.
     return false;

--- a/src/hotspot/share/oops/cpCache.cpp
+++ b/src/hotspot/share/oops/cpCache.cpp
@@ -538,9 +538,7 @@ void ConstantPoolCache::remove_resolved_indy_entries_if_non_deterministic() {
 
 bool ConstantPoolCache::can_archive_resolved_method(ConstantPool* src_cp, ResolvedMethodEntry* method_entry) {
   InstanceKlass* pool_holder = constant_pool()->pool_holder();
-  // FIXME -- change to pool_holder->defined_by_other_loaders()
-  if (!(pool_holder->defined_by_boot_loader() || pool_holder->defined_by_platform_loader() ||
-        pool_holder->defined_by_app_loader())) {
+  if (pool_holder->defined_by_other_loaders()) {
     // Archiving resolved cp entries for classes from non-builtin loaders
     // is not yet supported.
     return false;

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -2734,7 +2734,7 @@ void InstanceKlass::init_shared_package_entry() {
   _package_entry = nullptr;
 #else
   if (CDSConfig::is_dumping_full_module_graph()) {
-    if (is_shared_unregistered_class()) {
+    if (defined_by_other_loaders()) {
       _package_entry = nullptr;
     } else {
       _package_entry = PackageEntry::get_archived_entry(_package_entry);
@@ -2842,12 +2842,12 @@ bool InstanceKlass::can_be_verified_at_dumptime() const {
   return true;
 }
 
-int InstanceKlass::shared_class_loader_type() const {
-  if (is_shared_boot_class()) {
+int InstanceKlass::class_loader_type() const {
+  if (defined_by_boot_loader()) {
     return ClassLoader::BOOT_LOADER;
-  } else if (is_shared_platform_class()) {
+  } else if (defined_by_platform_loader()) {
     return ClassLoader::PLATFORM_LOADER;
-  } else if (is_shared_app_class()) {
+  } else if (defined_by_app_loader()) {
     return ClassLoader::APP_LOADER;
   } else {
     return ClassLoader::OTHER;

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -2842,17 +2842,6 @@ bool InstanceKlass::can_be_verified_at_dumptime() const {
   return true;
 }
 
-int InstanceKlass::class_loader_type() const {
-  if (defined_by_boot_loader()) {
-    return ClassLoader::BOOT_LOADER;
-  } else if (defined_by_platform_loader()) {
-    return ClassLoader::PLATFORM_LOADER;
-  } else if (defined_by_app_loader()) {
-    return ClassLoader::APP_LOADER;
-  } else {
-    return ClassLoader::OTHER;
-  }
-}
 #endif // INCLUDE_CDS
 
 #if INCLUDE_JVMTI

--- a/src/hotspot/share/oops/instanceKlass.hpp
+++ b/src/hotspot/share/oops/instanceKlass.hpp
@@ -311,6 +311,7 @@ class InstanceKlass: public Klass {
   bool defined_by_platform_loader() const  { return _misc_flags.defined_by_platform_loader(); }
   bool defined_by_app_loader() const       { return _misc_flags.defined_by_app_loader(); }
   bool defined_by_other_loaders() const    { return _misc_flags.defined_by_other_loaders(); }
+  void set_class_loader_type()             { _misc_flags.set_class_loader_type(_class_loader_data); }
 
   // Check if the class can be shared in CDS
   bool is_shareable() const;
@@ -318,12 +319,6 @@ class InstanceKlass: public Klass {
   bool shared_loading_failed() const { return _misc_flags.shared_loading_failed(); }
 
   void set_shared_loading_failed() { _misc_flags.set_shared_loading_failed(true); }
-
-#if INCLUDE_CDS
-  int  class_loader_type() const;
-  void set_class_loader_type(s2 loader_type) { _misc_flags.set_class_loader_type(loader_type); }
-  void assign_class_loader_type()            { _misc_flags.assign_class_loader_type(_class_loader_data); }
-#endif
 
   bool has_nonstatic_fields() const        { return _misc_flags.has_nonstatic_fields(); }
   void set_has_nonstatic_fields(bool b)    { _misc_flags.set_has_nonstatic_fields(b); }

--- a/src/hotspot/share/oops/instanceKlass.hpp
+++ b/src/hotspot/share/oops/instanceKlass.hpp
@@ -306,12 +306,11 @@ class InstanceKlass: public Klass {
   // Sets finalization state
   static void set_finalization_enabled(bool val) { _finalization_enabled = val; }
 
-  // The three BUILTIN class loader types
-  bool is_shared_boot_class() const { return _misc_flags.is_shared_boot_class(); }
-  bool is_shared_platform_class() const { return _misc_flags.is_shared_platform_class(); }
-  bool is_shared_app_class() const {  return _misc_flags.is_shared_app_class(); }
-  // The UNREGISTERED class loader type
-  bool is_shared_unregistered_class() const { return _misc_flags.is_shared_unregistered_class(); }
+  // Quick checks for the loader that defined this class (without switching on this->class_loader())
+  bool defined_by_boot_loader() const      { return _misc_flags.defined_by_boot_loader(); }
+  bool defined_by_platform_loader() const  { return _misc_flags.defined_by_platform_loader(); }
+  bool defined_by_app_loader() const       { return _misc_flags.defined_by_app_loader(); }
+  bool defined_by_other_loaders() const    { return _misc_flags.defined_by_other_loaders(); }
 
   // Check if the class can be shared in CDS
   bool is_shareable() const;
@@ -321,9 +320,9 @@ class InstanceKlass: public Klass {
   void set_shared_loading_failed() { _misc_flags.set_shared_loading_failed(true); }
 
 #if INCLUDE_CDS
-  int  shared_class_loader_type() const;
-  void set_shared_class_loader_type(s2 loader_type) { _misc_flags.set_shared_class_loader_type(loader_type); }
-  void assign_class_loader_type() { _misc_flags.assign_class_loader_type(_class_loader_data); }
+  int  class_loader_type() const;
+  void set_class_loader_type(s2 loader_type) { _misc_flags.set_class_loader_type(loader_type); }
+  void assign_class_loader_type()            { _misc_flags.assign_class_loader_type(_class_loader_data); }
 #endif
 
   bool has_nonstatic_fields() const        { return _misc_flags.has_nonstatic_fields(); }

--- a/src/hotspot/share/oops/instanceKlassFlags.cpp
+++ b/src/hotspot/share/oops/instanceKlassFlags.cpp
@@ -37,36 +37,19 @@ void InstanceKlassFlags::print_on(outputStream* st) const {
 #undef IK_FLAGS_PRINT
 }
 
-#if INCLUDE_CDS
-void InstanceKlassFlags::set_class_loader_type(s2 loader_type) {
-  switch (loader_type) {
-  case ClassLoader::BOOT_LOADER:
-    _flags |= _misc_defined_by_boot_loader;
-    break;
-  case ClassLoader::PLATFORM_LOADER:
-    _flags |= _misc_defined_by_platform_loader;
-    break;
-  case ClassLoader::APP_LOADER:
-    _flags |= _misc_defined_by_app_loader;
-    break;
-  default:
-    ShouldNotReachHere();
-    break;
-  }
-}
+void InstanceKlassFlags::set_class_loader_type(const ClassLoaderData* cld) {
+  assert((_flags & builtin_loader_type_bits()) == 0, "set only once");
 
-void InstanceKlassFlags::assign_class_loader_type(const ClassLoaderData* cld) {
   if (cld->is_boot_class_loader_data()) {
-    set_class_loader_type(ClassLoader::BOOT_LOADER);
+    _flags |= _misc_defined_by_boot_loader;
   }
   else if (cld->is_platform_class_loader_data()) {
-    set_class_loader_type(ClassLoader::PLATFORM_LOADER);
+    _flags |= _misc_defined_by_platform_loader;
   }
   else if (cld->is_system_class_loader_data()) {
-    set_class_loader_type(ClassLoader::APP_LOADER);
+    _flags |= _misc_defined_by_app_loader;
   }
 }
-#endif // INCLUDE_CDS
 
 #ifdef ASSERT
 void InstanceKlassFlags::assert_is_safe(bool set) {

--- a/src/hotspot/share/oops/instanceKlassFlags.cpp
+++ b/src/hotspot/share/oops/instanceKlassFlags.cpp
@@ -38,16 +38,16 @@ void InstanceKlassFlags::print_on(outputStream* st) const {
 }
 
 #if INCLUDE_CDS
-void InstanceKlassFlags::set_shared_class_loader_type(s2 loader_type) {
+void InstanceKlassFlags::set_class_loader_type(s2 loader_type) {
   switch (loader_type) {
   case ClassLoader::BOOT_LOADER:
-    _flags |= _misc_is_shared_boot_class;
+    _flags |= _misc_defined_by_boot_loader;
     break;
   case ClassLoader::PLATFORM_LOADER:
-    _flags |= _misc_is_shared_platform_class;
+    _flags |= _misc_defined_by_platform_loader;
     break;
   case ClassLoader::APP_LOADER:
-    _flags |= _misc_is_shared_app_class;
+    _flags |= _misc_defined_by_app_loader;
     break;
   default:
     ShouldNotReachHere();
@@ -57,13 +57,13 @@ void InstanceKlassFlags::set_shared_class_loader_type(s2 loader_type) {
 
 void InstanceKlassFlags::assign_class_loader_type(const ClassLoaderData* cld) {
   if (cld->is_boot_class_loader_data()) {
-    set_shared_class_loader_type(ClassLoader::BOOT_LOADER);
+    set_class_loader_type(ClassLoader::BOOT_LOADER);
   }
   else if (cld->is_platform_class_loader_data()) {
-    set_shared_class_loader_type(ClassLoader::PLATFORM_LOADER);
+    set_class_loader_type(ClassLoader::PLATFORM_LOADER);
   }
   else if (cld->is_system_class_loader_data()) {
-    set_shared_class_loader_type(ClassLoader::APP_LOADER);
+    set_class_loader_type(ClassLoader::APP_LOADER);
   }
 }
 #endif // INCLUDE_CDS

--- a/src/hotspot/share/oops/instanceKlassFlags.hpp
+++ b/src/hotspot/share/oops/instanceKlassFlags.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,9 +47,9 @@ class InstanceKlassFlags {
     flag(has_nonstatic_concrete_methods     , 1 << 4) /* class/superclass/implemented interfaces has non-static, concrete methods */ \
     flag(declares_nonstatic_concrete_methods, 1 << 5) /* directly declares non-static, concrete methods */ \
     flag(shared_loading_failed              , 1 << 6) /* class has been loaded from shared archive */ \
-    flag(is_shared_boot_class               , 1 << 7) /* defining class loader is boot class loader */ \
-    flag(is_shared_platform_class           , 1 << 8) /* defining class loader is platform class loader */ \
-    flag(is_shared_app_class                , 1 << 9) /* defining class loader is app class loader */ \
+    flag(defined_by_boot_loader             , 1 << 7) /* defining class loader is boot class loader */ \
+    flag(defined_by_platform_loader         , 1 << 8) /* defining class loader is platform class loader */ \
+    flag(defined_by_app_loader              , 1 << 9) /* defining class loader is app class loader */ \
     flag(has_contended_annotations          , 1 << 10) /* has @Contended annotation */ \
     flag(has_localvariable_table            , 1 << 11) /* has localvariable information */ \
     flag(has_miranda_methods                , 1 << 12) /* True if this class has miranda methods in it's vtable */ \
@@ -76,8 +76,8 @@ class InstanceKlassFlags {
   };
 #undef IK_STATUS_ENUM_NAME
 
-  u2 shared_loader_type_bits() const {
-    return _misc_is_shared_boot_class|_misc_is_shared_platform_class|_misc_is_shared_app_class;
+  u2 loader_type_bits() const {
+    return _misc_defined_by_boot_loader|_misc_defined_by_platform_loader|_misc_defined_by_app_loader;
   }
 
   // These flags are write-once before the class is published and then read-only so don't require atomic updates.
@@ -100,13 +100,13 @@ class InstanceKlassFlags {
   IK_FLAGS_DO(IK_FLAGS_GET_SET)
 #undef IK_FLAGS_GET_SET
 
-  bool is_shared_unregistered_class() const {
-    return (_flags & shared_loader_type_bits()) == 0;
+  bool defined_by_other_loaders() const {
+    return (_flags & loader_type_bits()) == 0;
   }
 
-  void set_shared_class_loader_type(s2 loader_type);
-
+  void set_class_loader_type(s2 loader_type);
   void assign_class_loader_type(const ClassLoaderData* cld);
+
   void assert_is_safe(bool set) NOT_DEBUG_RETURN;
 
   // Create getters and setters for the status values.

--- a/src/hotspot/share/oops/instanceKlassFlags.hpp
+++ b/src/hotspot/share/oops/instanceKlassFlags.hpp
@@ -76,7 +76,7 @@ class InstanceKlassFlags {
   };
 #undef IK_STATUS_ENUM_NAME
 
-  u2 loader_type_bits() const {
+  u2 builtin_loader_type_bits() const {
     return _misc_defined_by_boot_loader|_misc_defined_by_platform_loader|_misc_defined_by_app_loader;
   }
 
@@ -101,11 +101,10 @@ class InstanceKlassFlags {
 #undef IK_FLAGS_GET_SET
 
   bool defined_by_other_loaders() const {
-    return (_flags & loader_type_bits()) == 0;
+    return (_flags & builtin_loader_type_bits()) == 0;
   }
 
-  void set_class_loader_type(s2 loader_type);
-  void assign_class_loader_type(const ClassLoaderData* cld);
+  void set_class_loader_type(const ClassLoaderData* cld);
 
   void assert_is_safe(bool set) NOT_DEBUG_RETURN;
 

--- a/src/hotspot/share/oops/klass.cpp
+++ b/src/hotspot/share/oops/klass.cpp
@@ -831,12 +831,12 @@ void Klass::remove_java_mirror() {
     if (orig_mirror == nullptr) {
       assert(CDSConfig::is_dumping_final_static_archive(), "sanity");
       if (is_instance_klass()) {
-        assert(InstanceKlass::cast(this)->is_shared_unregistered_class(), "sanity");
+        assert(InstanceKlass::cast(this)->defined_by_other_loaders(), "sanity");
       } else {
         precond(is_objArray_klass());
         Klass *k = ObjArrayKlass::cast(this)->bottom_klass();
         precond(k->is_instance_klass());
-        assert(InstanceKlass::cast(k)->is_shared_unregistered_class(), "sanity");
+        assert(InstanceKlass::cast(k)->defined_by_other_loaders(), "sanity");
       }
     } else {
       oop scratch_mirror = HeapShared::scratch_java_mirror(orig_mirror);


### PR DESCRIPTION
These bits are renamed to

```
flag(defined_by_boot_loader , 1 << 7) /* defining class loader is boot class loader */ \
flag(defined_by_platform_loader , 1 << 8) /* defining class loader is platform class loader */ \
flag(defined_by_app_loader , 1 << 9) /* defining class loader is app class loader */ \
```

They are not set exactly once inside `ClassFileParser::fill_instance_klass()`, to avoid race conditions

Also, set these flags even when AOT/CDS is not used -- the cost is trivial. That way, we don't need to worry if a code path might be invalid when AOT/CDS is disabled.

This RFE simplifies the bug fix in https://github.com/openjdk/jdk/pull/25171

For reviewers
- The first commit is strictly renaming. No functional changes
- The second commit moves the bit setting to `ClassFileParser::fill_instance_klass()`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8357504](https://bugs.openjdk.org/browse/JDK-8357504): Refactor the assignment of loader bits in InstanceKlassFlags (**Enhancement** - P4)


### Reviewers
 * [Matias Saavedra Silva](https://openjdk.org/census#matsaave) (@matias9927 - **Reviewer**)
 * [Calvin Cheung](https://openjdk.org/census#ccheung) (@calvinccheung - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25365/head:pull/25365` \
`$ git checkout pull/25365`

Update a local copy of the PR: \
`$ git checkout pull/25365` \
`$ git pull https://git.openjdk.org/jdk.git pull/25365/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25365`

View PR using the GUI difftool: \
`$ git pr show -t 25365`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25365.diff">https://git.openjdk.org/jdk/pull/25365.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25365#issuecomment-2899097061)
</details>
