### PR TITLE
8357282: Test vmTestbase/nsk/jvmti/AttachOnDemand/attach045/TestDescription.java times out after ClassNotFoundException

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -168,7 +168,6 @@ vmTestbase/metaspace/gc/firstGC_50m/TestDescription.java 8208250 generic-all
 vmTestbase/metaspace/gc/firstGC_99m/TestDescription.java 8208250 generic-all
 vmTestbase/metaspace/gc/firstGC_default/TestDescription.java 8208250 generic-all
 
-vmTestbase/nsk/jvmti/AttachOnDemand/attach045/TestDescription.java 8202971 generic-all
 vmTestbase/nsk/jvmti/scenarios/capability/CM03/cm03t001/TestDescription.java 8073470 linux-all
 vmTestbase/nsk/jvmti/InterruptThread/intrpthrd003/TestDescription.java 8288911 macosx-all
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/aod/AODRunnerArgParser.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/aod/AODRunnerArgParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -106,7 +106,12 @@ public class AODRunnerArgParser extends ArgumentParser {
             throw new TestBug("Target application isn't specified");
         }
 
-        return options.getProperty(TARGET_APP_PARAM);
+        String target = options.getProperty(TARGET_APP_PARAM);
+        // target may contain class and arguments in surrounding quotes
+        if (target.startsWith("\"") && target.endsWith("\"")) {
+            target = target.substring(1, target.length() - 1);
+        }
+        return target;
     }
 
     public String getTestedJDK() {


### PR DESCRIPTION
The change fixes failure of vmTestbase/nsk/jvmti/AttachOnDemand/attach045/TestDescription.java test.
The test was problem-listed in jdk 11 due intermittent timeouts, but in jdk15-16 changes in nsk framework made the test fail 100% (it wasn't noticed as the test was problemlisted)
The problem is attach045 has "target" parameter which contain class name and arguments (all other tests have only class name), and value of the argument is passed in surrounding quotes, so target application fails with ClassNotFoundException.
Now I cannot reproduce original test failure, so removing the test from problemlist