### PR TITLE
8357525: Default CDS archive becomes non-deterministic after JDK-8305895

### DIFF
--- a/src/hotspot/share/oops/klass.cpp
+++ b/src/hotspot/share/oops/klass.cpp
@@ -810,10 +810,18 @@ void Klass::remove_unshareable_info() {
   set_class_loader_data(nullptr);
   set_is_shared();
 
-  // FIXME: validation in Klass::hash_secondary_supers() may fail for shared klasses.
-  // Even though the bitmaps always match, the canonical order of elements in the table
-  // is not guaranteed to stay the same (see tie breaker during Robin Hood hashing in Klass::hash_insert).
-  //assert(compute_secondary_supers_bitmap(secondary_supers()) == _secondary_supers_bitmap, "broken table");
+  if (CDSConfig::is_dumping_classic_static_archive()) {
+    // "Classic" static archives are required to have deterministic contents.
+    // The elements in _secondary_supers are addresses in the ArchiveBuilder
+    // output buffer, so they should have deterministic values. If we rehash
+    // _secondary_supers, its elements will appear in a deterministic order.
+    //
+    // Note that the bitmap is guatanteed to be deterministic, regardless of the
+    // actual addresses of the elements in _secondary_supers. So rehashing shouldn't
+    // change it.
+    uintx bitmap = hash_secondary_supers(secondary_supers(), true);
+    assert(bitmap == _secondary_supers_bitmap, "bitmap should not be changed due to rehashing");
+  }
 }
 
 void Klass::remove_java_mirror() {

--- a/src/hotspot/share/oops/klass.cpp
+++ b/src/hotspot/share/oops/klass.cpp
@@ -816,7 +816,7 @@ void Klass::remove_unshareable_info() {
     // output buffer, so they should have deterministic values. If we rehash
     // _secondary_supers, its elements will appear in a deterministic order.
     //
-    // Note that the bitmap is guatanteed to be deterministic, regardless of the
+    // Note that the bitmap is guaranteed to be deterministic, regardless of the
     // actual addresses of the elements in _secondary_supers. So rehashing shouldn't
     // change it.
     uintx bitmap = hash_secondary_supers(secondary_supers(), true);


### PR DESCRIPTION
Since [JDK-8305895](https://bugs.openjdk.org/browse/JDK-8305895), interfaces and abstract classes are allocated outside of the class space. See [here for the triggering condition](https://github.com/openjdk/jdk/blame/4d7068923cd87fbfc2edee25406521b11580d153/src/hotspot/share/classfile/classFileParser.cpp#L5835-L5842)

Theoretically such InstanceKlasses can have arbitrary addresses, so the  "tie breaker test" of `(uintptr_t(existing) < uintptr_t(klass))` in [Klass::hash_insert()](https://github.com/openjdk/jdk/blob/4d7068923cd87fbfc2edee25406521b11580d153/src/hotspot/share/oops/klass.cpp#L458) no longer produces a deterministic result across two JVM runs. As a result, we have seen several occurrence of non-deterministic CDS archives in our test pipeline for a short period after  [JDK-8305895](https://bugs.openjdk.org/browse/JDK-8305895) for pushed.

Thereafter, for some unknown reason, the problem disappears. However, we could just be lucky due to allocation policy changes in metaspace. The underlying cause still exists.

I wrote a proof of concept that shows the problem. See https://github.com/openjdk/jdk/commit/33185705f85986e1ee1e529005898e834cc8a88f

```
(Without fix)

$ java -Xshare:dump -XX:+UseNewCode -XX:SharedArchiveFile=f1.jsa
$ java -Xshare:dump -XX:+UseNewCode2 -XX:SharedArchiveFile=f2.jsa
$ cksum f1.jsa f2.jsa
  2834014305 16105472 f1.jsa
  4126337207 16105472 f2.jsa

(With the fix in this PR)

$ java -Xshare:dump -XX:+UseNewCode -XX:+UseNewCode3 -XX:SharedArchiveFile=f1.jsa
$ java -Xshare:dump -XX:+UseNewCode2 -XX:+UseNewCode3 -XX:SharedArchiveFile=f2.jsa
$ cksum f1.jsa f2.jsa
  3637571299 16105472 f1.jsa
  3637571299 16105472 f2.jsa
```

With the fix, we re-hash the copy of the `secondary_supers` in the CDS archive. When InstanceKlasses are copied into the CDS archive, they are sorted by their names. This makes the `(uintptr_t(existing) < uintptr_t(klass))`  comparison produce deterministic results.

Unfortunately it's not possible to write a jtreg test for this problem.

Note: the "tie breaker test" was introduced in [JDK-8180450](https://bugs.openjdk.org/browse/JDK-8180450). It adds an assumption that the address order of classes in the CDS archive buffer is the same as the classes in the class space, which can become invalid if the class space allocation algorithm changes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8357525](https://bugs.openjdk.org/browse/JDK-8357525): Default CDS archive becomes non-deterministic after JDK-8305895 (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25373/head:pull/25373` \
`$ git checkout pull/25373`

Update a local copy of the PR: \
`$ git checkout pull/25373` \
`$ git pull https://git.openjdk.org/jdk.git pull/25373/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25373`

View PR using the GUI difftool: \
`$ git pr show -t 25373`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25373.diff">https://git.openjdk.org/jdk/pull/25373.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25373#issuecomment-2900026879)
</details>
