### PR TITLE
8356648: runtime/Thread/AsyncExceptionTest.java fails with +StressCompiledExceptionHandlers

### DIFF
--- a/src/hotspot/share/c1/c1_Runtime1.cpp
+++ b/src/hotspot/share/c1/c1_Runtime1.cpp
@@ -508,7 +508,7 @@ static nmethod* counter_overflow_helper(JavaThread* current, int branch_bci, Met
 
 JRT_BLOCK_ENTRY(address, Runtime1::counter_overflow(JavaThread* current, int bci, Method* method))
   nmethod* osr_nm;
-  JRT_BLOCK
+  JRT_BLOCK_NO_ASYNC
     osr_nm = counter_overflow_helper(current, bci, method);
     if (osr_nm != nullptr) {
       RegisterMap map(current,

--- a/test/hotspot/jtreg/runtime/Thread/AsyncExceptionTest.java
+++ b/test/hotspot/jtreg/runtime/Thread/AsyncExceptionTest.java
@@ -68,7 +68,7 @@ public class AsyncExceptionTest extends Thread {
         }
 
         if (receivedThreadDeathinInternal2 == false && receivedThreadDeathinInternal1 == false) {
-            error =  new RuntimeException("Didn't catch ThreadDeath in internalRun2() nor in internalRun1().\n"
+            error = new RuntimeException("Didn't catch ThreadDeath in internalRun2() nor in internalRun1().\n"
                     + "receivedThreadDeathinInternal1=" + receivedThreadDeathinInternal1
                     + "; receivedThreadDeathinInternal2=" + receivedThreadDeathinInternal2);
         }

--- a/test/hotspot/jtreg/runtime/Thread/AsyncExceptionTest.java
+++ b/test/hotspot/jtreg/runtime/Thread/AsyncExceptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,11 +27,16 @@
  * @requires vm.compiler1.enabled | vm.compiler2.enabled
  * @summary Stress delivery of asynchronous exceptions.
  * @library /test/hotspot/jtreg/testlibrary
+ * @run main/othervm -Xcomp -XX:TieredStopAtLevel=3 -XX:+StressCompiledExceptionHandlers
+ *                   -XX:CompileCommand=dontinline,AsyncExceptionTest::internalRun2
+ *                   -XX:CompileCommand=compileonly,AsyncExceptionTest::internalRun1
+ *                   -XX:CompileCommand=compileonly,AsyncExceptionTest::internalRun2
+ *                   AsyncExceptionTest
  * @run main/othervm -Xcomp
-                     -XX:CompileCommand=dontinline,AsyncExceptionTest::internalRun2
-                     -XX:CompileCommand=compileonly,AsyncExceptionTest::internalRun1
-                     -XX:CompileCommand=compileonly,AsyncExceptionTest::internalRun2
-                     AsyncExceptionTest
+ *                   -XX:CompileCommand=dontinline,AsyncExceptionTest::internalRun2
+ *                   -XX:CompileCommand=compileonly,AsyncExceptionTest::internalRun1
+ *                   -XX:CompileCommand=compileonly,AsyncExceptionTest::internalRun2
+ *                   AsyncExceptionTest
  */
 
 import jvmti.JVMTIUtils;
@@ -42,19 +47,19 @@ public class AsyncExceptionTest extends Thread {
     private final static int DEF_TIME_MAX = 30;  // default max # secs to test
     private final static String PROG_NAME = "AsyncExceptionTest";
 
-    public CountDownLatch exitSyncObj = new CountDownLatch(1);
     public CountDownLatch startSyncObj = new CountDownLatch(1);
 
     private boolean firstEntry = true;
     private boolean receivedThreadDeathinInternal1 = false;
     private boolean receivedThreadDeathinInternal2 = false;
+    private volatile RuntimeException error = null;
 
     @Override
     public void run() {
         try {
             internalRun1();
         } catch (ThreadDeath td) {
-            throw new RuntimeException("Caught ThreadDeath in run() instead of internalRun2() or internalRun1().\n"
+            error = new RuntimeException("Caught ThreadDeath in run() instead of internalRun2() or internalRun1().\n"
                     + "receivedThreadDeathinInternal1=" + receivedThreadDeathinInternal1
                     + "; receivedThreadDeathinInternal2=" + receivedThreadDeathinInternal2);
         } catch (NoClassDefFoundError ncdfe) {
@@ -62,11 +67,10 @@ public class AsyncExceptionTest extends Thread {
         }
 
         if (receivedThreadDeathinInternal2 == false && receivedThreadDeathinInternal1 == false) {
-            throw new RuntimeException("Didn't catch ThreadDeath in internalRun2() nor in internalRun1().\n"
+            error =  new RuntimeException("Didn't catch ThreadDeath in internalRun2() nor in internalRun1().\n"
                     + "receivedThreadDeathinInternal1=" + receivedThreadDeathinInternal1
                     + "; receivedThreadDeathinInternal2=" + receivedThreadDeathinInternal2);
         }
-        exitSyncObj.countDown();
     }
 
     public void internalRun1() {
@@ -123,18 +127,9 @@ public class AsyncExceptionTest extends Thread {
             try {
                 // Wait for the worker thread to get going.
                 thread.startSyncObj.await();
-                while (true) {
-                    // Send async exception and wait until it is thrown
-                    JVMTIUtils.stopThread(thread);
-                    thread.exitSyncObj.await();
-                    Thread.sleep(100);
-
-                    if (!thread.isAlive()) {
-                        // Done with Thread.stop() calls since
-                        // thread is not alive.
-                        break;
-                    }
-                }
+                // Send async exception and wait until it is thrown
+                JVMTIUtils.stopThread(thread);
+                thread.join();
             } catch (InterruptedException e) {
                 throw new Error("Unexpected: " + e);
             } catch (NoClassDefFoundError ncdfe) {
@@ -143,11 +138,14 @@ public class AsyncExceptionTest extends Thread {
                 // in a worker thread can subsequently be seen in the
                 // main thread.
             }
-
-            try {
-                thread.join();
-            } catch (InterruptedException e) {
-                throw new Error("Unexpected: " + e);
+            if (thread.isAlive()) {
+                // Really shouldn't be possible after join() above...
+                throw new RuntimeException("Thread did not exit.\n"
+                    + "receivedThreadDeathinInternal1=" + thread.receivedThreadDeathinInternal1
+                    + "; receivedThreadDeathinInternal2=" + thread.receivedThreadDeathinInternal2);
+            }
+            if (thread.error != null) {
+                throw thread.error;
             }
         }
 

--- a/test/hotspot/jtreg/runtime/Thread/AsyncExceptionTest.java
+++ b/test/hotspot/jtreg/runtime/Thread/AsyncExceptionTest.java
@@ -27,7 +27,8 @@
  * @requires vm.compiler1.enabled | vm.compiler2.enabled
  * @summary Stress delivery of asynchronous exceptions.
  * @library /test/hotspot/jtreg/testlibrary
- * @run main/othervm -Xcomp -XX:TieredStopAtLevel=3 -XX:+StressCompiledExceptionHandlers
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:+StressCompiledExceptionHandlers
+ *                   -Xcomp -XX:TieredStopAtLevel=3
  *                   -XX:CompileCommand=dontinline,AsyncExceptionTest::internalRun2
  *                   -XX:CompileCommand=compileonly,AsyncExceptionTest::internalRun1
  *                   -XX:CompileCommand=compileonly,AsyncExceptionTest::internalRun2


### PR DESCRIPTION
The test fails (or times out) because Runtime1::counter_overflow offers a safepoint, allowing async exceptions, but there is no exception handler for the out-of-line slow path call to Runtime1::counter_overflow.  Rather than add an exception handler, the simple fix is to replace JRT_BLOCK with JRT_BLOCK_NO_ASYNC so that counter_overflow doesn't need to deal with async exceptions.  The GC poll point for backwards branches is sufficient to allow async exceptions.
I also improved the test so that it fails more quickly rather than waiting forever and eventually timing out, and added a C1-specific run using -XX:+StressCompiledExceptionHandlers.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8356648](https://bugs.openjdk.org/browse/JDK-8356648): runtime/Thread/AsyncExceptionTest.java fails with +StressCompiledExceptionHandlers (**Bug** - P5)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25375/head:pull/25375` \
`$ git checkout pull/25375`

Update a local copy of the PR: \
`$ git checkout pull/25375` \
`$ git pull https://git.openjdk.org/jdk.git pull/25375/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25375`

View PR using the GUI difftool: \
`$ git pr show -t 25375`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25375.diff">https://git.openjdk.org/jdk/pull/25375.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25375#issuecomment-2899557301)
</details>
