### PR TITLE
8356888: (fs) FileSystems.newFileSystem that take an env must specify IllegalArgumentException

### DIFF
--- a/src/java.base/share/classes/java/nio/file/FileSystems.java
+++ b/src/java.base/share/classes/java/nio/file/FileSystems.java
@@ -372,6 +372,8 @@ public final class FileSystems {
      *          when an error occurs while loading a service provider
      * @throws  IOException
      *          if an I/O error occurs
+     *
+     * @since 13
      */
     public static FileSystem newFileSystem(Path path,
                                            ClassLoader loader)

--- a/src/java.base/share/classes/java/nio/file/FileSystems.java
+++ b/src/java.base/share/classes/java/nio/file/FileSystems.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -257,8 +257,9 @@ public final class FileSystems {
      *
      * @throws  IllegalArgumentException
      *          if the pre-conditions for the {@code uri} parameter are not met,
-     *          or the {@code env} parameter does not contain properties required
-     *          by the provider, or a property value is invalid
+     *          or if the {@code env} parameter does not contain properties
+     *          required by the provider, contains an invalid combination of
+     *          properties and values, or contains an invalid property value
      * @throws  FileSystemAlreadyExistsException
      *          if the file system has already been created
      * @throws  ProviderNotFoundException
@@ -296,8 +297,9 @@ public final class FileSystems {
      *
      * @throws  IllegalArgumentException
      *          if the pre-conditions for the {@code uri} parameter are not met,
-     *          or the {@code env} parameter does not contain properties required
-     *          by the provider, or a property value is invalid
+     *          or if the {@code env} parameter does not contain properties
+     *          required by the provider, contains an invalid combination of
+     *          properties and values, or contains an invalid property value
      * @throws  FileSystemAlreadyExistsException
      *          if the URI scheme identifies an installed provider and the file
      *          system has already been created
@@ -400,6 +402,10 @@ public final class FileSystems {
      *
      * @return  a new file system
      *
+     * @throws  IllegalArgumentException
+     *          if the {@code env} parameter does not contain properties
+     *          required by the provider, contains an invalid combination of
+     *          properties and values, or contains an invalid property value
      * @throws  ProviderNotFoundException
      *          if a provider supporting this file type cannot be located
      * @throws  ServiceConfigurationError
@@ -476,6 +482,10 @@ public final class FileSystems {
      *
      * @return  a new file system
      *
+     * @throws  IllegalArgumentException
+     *          if the {@code env} parameter does not contain properties
+     *          required by the provider, contains an invalid combination of
+     *          properties and values, or contains an invalid property value
      * @throws  ProviderNotFoundException
      *          if a provider supporting this file type cannot be located
      * @throws  ServiceConfigurationError


### PR DESCRIPTION
Add a throws clause for `IllegalArgumentException` to the `java.nio.file.FileSystems` methods `newFileSystem(Path, Map)` and `newFileSystem(Path, Map, ClassLoader)`. Also update the equivalent IAE verbiage for the analogous methods which accept a `URI` parameter instead of a `Path`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8357587](https://bugs.openjdk.org/browse/JDK-8357587) to be approved

### Issues
 * [JDK-8356888](https://bugs.openjdk.org/browse/JDK-8356888): (fs) FileSystems.newFileSystem that take an env must specify IllegalArgumentException (**Bug** - P4)
 * [JDK-8357587](https://bugs.openjdk.org/browse/JDK-8357587): (fs) FileSystems.newFileSystem that take an env must specify IllegalArgumentException (**CSR**)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**) Review applies to [03e3df16](https://git.openjdk.org/jdk/pull/25376/files/03e3df16c26d088e36f812fb0739ab35b3dd350d)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**) Review applies to [03e3df16](https://git.openjdk.org/jdk/pull/25376/files/03e3df16c26d088e36f812fb0739ab35b3dd350d)
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25376/head:pull/25376` \
`$ git checkout pull/25376`

Update a local copy of the PR: \
`$ git checkout pull/25376` \
`$ git pull https://git.openjdk.org/jdk.git pull/25376/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25376`

View PR using the GUI difftool: \
`$ git pr show -t 25376`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25376.diff">https://git.openjdk.org/jdk/pull/25376.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25376#issuecomment-2899557422)
</details>
