### PR TITLE
8357513: Disable AOT caching for runtime stubs

### DIFF
--- a/src/hotspot/share/opto/output.cpp
+++ b/src/hotspot/share/opto/output.cpp
@@ -3488,7 +3488,8 @@ void PhaseOutput::install_stub(const char* stub_name) {
       } else {
         assert(rs->is_runtime_stub(), "sanity check");
         C->set_stub_entry_point(rs->entry_point());
-        AOTCodeCache::store_code_blob(*rs, AOTCodeEntry::C2Blob, C->stub_id(), stub_name);
+        // Disable C2 runtime stubs caching until JDK-8357398 is fixed.
+        // AOTCodeCache::store_code_blob(*rs, AOTCodeEntry::C2Blob, C->stub_id(), stub_name);
       }
     }
   }


### PR DESCRIPTION
After [JDK-8354887](https://bugs.openjdk.org/browse/JDK-8354887) was integrated we hit strange failures which looks like memory stomps during our JCK testing of AOT new JEPs:
```
# Internal Error (/workspace/open/src/hotspot/share/opto/regmask.hpp:222), pid=4186624, tid=4186658
# assert(_RM_UP[i] == 0) failed: _hwm too low: 5 regs at: 4
```
or
```
# Internal Error (/workspace/open/src/hotspot/share/opto/type.cpp:996), pid=2832821, tid=2832868
# fatal error: meet not symmetric
```
or other strange issues during C2 compilation.

After investigating (running tests in loop) I narrowed done the issue to AOT caching of C2 runtime stubs:

https://github.com/openjdk/jdk/blob/master/src/hotspot/share/opto/output.cpp#L3491

To avoid the issue in out testing I propose comment out that line until we proper fix the issue.

Or we can disable AOTStubCaching at all.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Failed to retrieve information on issue `8357513`. Please make sure it exists and is accessible.

### Issue
 * ⚠️ Failed to retrieve information on issue `8357513`.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25377/head:pull/25377` \
`$ git checkout pull/25377`

Update a local copy of the PR: \
`$ git checkout pull/25377` \
`$ git pull https://git.openjdk.org/jdk.git pull/25377/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25377`

View PR using the GUI difftool: \
`$ git pr show -t 25377`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25377.diff">https://git.openjdk.org/jdk/pull/25377.diff</a>

</details>
