### PR TITLE
8357514: Disable AOT caching for runtime stubs

### DIFF
--- a/src/hotspot/share/code/aotCodeCache.cpp
+++ b/src/hotspot/share/code/aotCodeCache.cpp
@@ -139,6 +139,9 @@ void AOTCodeCache::initialize() {
     return; // AOTCache must be specified to dump and use AOT code
   }
 
+  // Disable stubs caching until JDK-8357398 is fixed.
+  FLAG_SET_ERGO(AOTStubCaching, false);
+
   if (VerifyOops) {
     // Disable AOT stubs caching when VerifyOops flag is on.
     // Verify oops code generated a lot of C strings which overflow

--- a/test/hotspot/jtreg/runtime/cds/appcds/aotCode/AOTCodeFlags.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotCode/AOTCodeFlags.java
@@ -50,7 +50,7 @@ import jdk.test.lib.process.OutputAnalyzer;
 public class AOTCodeFlags {
     public static void main(String... args) throws Exception {
         Tester t = new Tester();
-        // Run only 2 modes (0 - no AOT code, 1 - AOT adapters) until stubs caching is restored
+        // Run only 2 modes (0 - no AOT code, 1 - AOT adapters) until JDK-8357398 is fixed
         for (int mode = 0; mode < 2; mode++) {
             t.setTestMode(mode);
             t.run(new String[] {"AOT"});

--- a/test/hotspot/jtreg/runtime/cds/appcds/aotCode/AOTCodeFlags.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotCode/AOTCodeFlags.java
@@ -50,7 +50,8 @@ import jdk.test.lib.process.OutputAnalyzer;
 public class AOTCodeFlags {
     public static void main(String... args) throws Exception {
         Tester t = new Tester();
-        for (int mode = 0; mode < 3; mode++) {
+        // Run only 2 modes (0 - no AOT code, 1 - AOT adapters) until stubs caching is restored
+        for (int mode = 0; mode < 2; mode++) {
             t.setTestMode(mode);
             t.run(new String[] {"AOT"});
         }


### PR DESCRIPTION
After [JDK-8354887](https://bugs.openjdk.org/browse/JDK-8354887) was integrated we hit strange failures which looks like memory stomps during our JCK testing of AOT new JEPs:
```
# Internal Error (/workspace/open/src/hotspot/share/opto/regmask.hpp:222), pid=4186624, tid=4186658
# assert(_RM_UP[i] == 0) failed: _hwm too low: 5 regs at: 4
```
or
```
# Internal Error (/workspace/open/src/hotspot/share/opto/type.cpp:996), pid=2832821, tid=2832868
# fatal error: meet not symmetric
```
or other strange issues during C2 compilation

After investigating (running tests in loop) I narrowed down the issue to AOT caching of C2 runtime stubs:

https://github.com/openjdk/jdk/blob/master/src/hotspot/share/opto/output.cpp#L3491

After internal discussion we decided disable all runtime stubs caching.
There is no guarantee that we may not have issues with C1 stubs too.

I propose hard code AOTStubCaching flag to `false` value until the issue is solved.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8357514](https://bugs.openjdk.org/browse/JDK-8357514): Disable AOT caching for runtime stubs (**Bug** - P2)


### Reviewers
 * [Igor Veresov](https://openjdk.org/census#iveresov) (@veresov - **Reviewer**)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25379/head:pull/25379` \
`$ git checkout pull/25379`

Update a local copy of the PR: \
`$ git checkout pull/25379` \
`$ git pull https://git.openjdk.org/jdk.git pull/25379/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25379`

View PR using the GUI difftool: \
`$ git pr show -t 25379`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25379.diff">https://git.openjdk.org/jdk/pull/25379.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25379#issuecomment-2899824333)
</details>
