### PR TITLE
8356016: Build fails by clang(XCode 16.3) on macOS after JDK-8347719

### DIFF
--- a/test/hotspot/gtest/jfr/test_networkUtilization.cpp
+++ b/test/hotspot/gtest/jfr/test_networkUtilization.cpp
@@ -39,12 +39,13 @@
 #include "logging/log.hpp"
 #include "runtime/os_perf.hpp"
 #include "utilities/globalDefinitions.hpp"
-#include "utilities/growableArray.hpp"
 
 #include "utilities/vmassert_uninstall.hpp"
-#include <vector>
+BEGIN_ALLOW_FORBIDDEN_FUNCTIONS
 #include <list>
-#include <map>
+#include <string>
+#include <vector>
+END_ALLOW_FORBIDDEN_FUNCTIONS
 #include "utilities/vmassert_reinstall.hpp"
 
 #include "unittest.hpp"
@@ -68,7 +69,6 @@ namespace {
   class MockJfrCheckpointWriter {
    public:
     traceid current;
-    std::map<traceid, std::string> ids;
 
     const JfrCheckpointContext context() const {
       return JfrCheckpointContext();


### PR DESCRIPTION
Please review this change to avoid a forbidden function warning when building
with Xcode 16.3.  (Note: There's no warning with Xcode 16.2 or earlier.)

The jfr/test_networkUtilization.cpp gtest uses several C++ standard library
containers. There is a change in the standard library in Xcode 16.3 that
exposes a call to `free` in the header, and we normally forbid the direct use
of that function.

To address this problem we surround the `#includes` for standard library
container headers with `BEGIN/END_ALLOW_FORBIDDEN_FUNCTIONS`, suppressing any
such warnings from them.

While there, also made a few minor cleanups to that file's header usage.

Testing: mach5 tier1.
Built macosx-aarch64 with Xcode 16.3.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8356016](https://bugs.openjdk.org/browse/JDK-8356016): Build fails by clang(XCode 16.3) on macOS after JDK-8347719 (**Bug** - P3)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25380/head:pull/25380` \
`$ git checkout pull/25380`

Update a local copy of the PR: \
`$ git checkout pull/25380` \
`$ git pull https://git.openjdk.org/jdk.git pull/25380/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25380`

View PR using the GUI difftool: \
`$ git pr show -t 25380`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25380.diff">https://git.openjdk.org/jdk/pull/25380.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25380#issuecomment-2900053769)
</details>
