### PR TITLE
8357449: ZGC: Multiple medium page sizes

### DIFF
--- a/src/hotspot/share/gc/z/vmStructs_z.hpp
+++ b/src/hotspot/share/gc/z/vmStructs_z.hpp
@@ -120,13 +120,13 @@ typedef ZValue<ZPerNUMAStorage, ZPartition> ZPerNUMAZPartition;
   declare_constant(ZPageType::small)                                                                 \
   declare_constant(ZPageType::medium)                                                                \
   declare_constant(ZPageType::large)                                                                 \
+  declare_constant(ZPageSizeMediumShift)                                                             \
   declare_constant(ZObjectAlignmentMediumShift)                                                      \
   declare_constant(ZObjectAlignmentLargeShift)
 
 #define VM_LONG_CONSTANTS_Z(declare_constant)                                                        \
   declare_constant(ZGranuleSizeShift)                                                                \
   declare_constant(ZPageSizeSmallShift)                                                              \
-  declare_constant(ZPageSizeMediumShift)                                                             \
   declare_constant(ZAddressOffsetShift)                                                              \
   declare_constant(ZAddressOffsetBits)                                                               \
   declare_constant(ZAddressOffsetMask)                                                               \

--- a/src/hotspot/share/gc/z/zAllocationFlags.hpp
+++ b/src/hotspot/share/gc/z/zAllocationFlags.hpp
@@ -31,22 +31,25 @@
 // Allocation flags layout
 // -----------------------
 //
-//   7      1 0
-//  +------+-+-+
-//  |000000|1|1|
-//  +------+-+-+
+//   7     2 1 0
+//  +-----+-+-+-+
+//  |00000|1|1|1|
+//  +-----+-+-+-+
+//  |      | | |
+//  |      | | * 0-0 Non-Blocking Flag (1-bit)
 //  |      | |
-//  |      | * 0-0 Non-Blocking Flag (1-bit)
+//  |      | * 1-1 GC Relocation Flag (1-bit)
 //  |      |
-//  |      * 1-1 GC Relocation Flag (1-bit)
+//  |      * 2-2 Fast Medium Flag (1-bit)
 //  |
-//  * 7-2 Unused (6-bits)
+//  * 7-3 Unused (5-bits)
 //
 
 class ZAllocationFlags {
 private:
   typedef ZBitField<uint8_t, bool, 0, 1> field_non_blocking;
   typedef ZBitField<uint8_t, bool, 1, 1> field_gc_relocation;
+  typedef ZBitField<uint8_t, bool, 2, 1> field_fast_medium;
 
   uint8_t _flags;
 
@@ -62,12 +65,20 @@ public:
     _flags |= field_gc_relocation::encode(true);
   }
 
+  void set_fast_medium() {
+    _flags |= field_fast_medium::encode(true);
+  }
+
   bool non_blocking() const {
     return field_non_blocking::decode(_flags);
   }
 
   bool gc_relocation() const {
     return field_gc_relocation::decode(_flags);
+  }
+
+  bool fast_medium() const {
+    return field_fast_medium::decode(_flags);
   }
 };
 

--- a/src/hotspot/share/gc/z/zArguments.cpp
+++ b/src/hotspot/share/gc/z/zArguments.cpp
@@ -162,9 +162,8 @@ void ZArguments::initialize() {
     uint tenuring_threshold;
     for (tenuring_threshold = 0; tenuring_threshold < MaxTenuringThreshold; ++tenuring_threshold) {
       // Reduce the number of object ages, if the resulting garbage is too high
-      const size_t medium_page_overhead = ZPageSizeMedium * tenuring_threshold;
-      const size_t small_page_overhead = ZPageSizeSmall * ConcGCThreads * tenuring_threshold;
-      if (small_page_overhead + medium_page_overhead >= ZHeuristics::significant_young_overhead()) {
+      const size_t per_age_overhead = ZHeuristics::relocation_headroom();
+      if (per_age_overhead * tenuring_threshold >= ZHeuristics::significant_young_overhead()) {
         break;
       }
     }

--- a/src/hotspot/share/gc/z/zGlobals.cpp
+++ b/src/hotspot/share/gc/z/zGlobals.cpp
@@ -23,7 +23,7 @@
 
 #include "gc/z/zGlobals.hpp"
 
-size_t     ZPageSizeMediumShift;
+int        ZPageSizeMediumShift;
 size_t     ZPageSizeMediumMax;
 size_t     ZPageSizeMediumMin;
 bool       ZPageSizeMediumEnabled;

--- a/src/hotspot/share/gc/z/zGlobals.cpp
+++ b/src/hotspot/share/gc/z/zGlobals.cpp
@@ -24,7 +24,9 @@
 #include "gc/z/zGlobals.hpp"
 
 size_t     ZPageSizeMediumShift;
-size_t     ZPageSizeMedium;
+size_t     ZPageSizeMediumMax;
+size_t     ZPageSizeMediumMin;
+bool       ZPageSizeMediumEnabled;
 
 size_t     ZObjectSizeLimitMedium;
 

--- a/src/hotspot/share/gc/z/zGlobals.hpp
+++ b/src/hotspot/share/gc/z/zGlobals.hpp
@@ -43,7 +43,7 @@ const size_t      ZMaxVirtualReservations       = 100; // Each reservation at le
 
 // Page size shifts
 const size_t      ZPageSizeSmallShift           = ZGranuleSizeShift;
-extern size_t     ZPageSizeMediumShift;
+extern int        ZPageSizeMediumShift;
 
 // Page sizes
 const size_t      ZPageSizeSmall                = (size_t)1 << ZPageSizeSmallShift;

--- a/src/hotspot/share/gc/z/zGlobals.hpp
+++ b/src/hotspot/share/gc/z/zGlobals.hpp
@@ -47,7 +47,9 @@ extern size_t     ZPageSizeMediumShift;
 
 // Page sizes
 const size_t      ZPageSizeSmall                = (size_t)1 << ZPageSizeSmallShift;
-extern size_t     ZPageSizeMedium;
+extern size_t     ZPageSizeMediumMax;
+extern size_t     ZPageSizeMediumMin;
+extern bool       ZPageSizeMediumEnabled;
 
 // Object size limits
 const size_t      ZObjectSizeLimitSmall         = ZPageSizeSmall / 8; // 12.5% max waste

--- a/src/hotspot/share/gc/z/zHeap.cpp
+++ b/src/hotspot/share/gc/z/zHeap.cpp
@@ -364,7 +364,15 @@ void ZHeap::print_globals_on(outputStream* st) const {
   st->print_cr(" Old Collection:     %s/%u", ZGeneration::old()->phase_to_string(), ZGeneration::old()->seqnum());
   st->print_cr(" Offset Max:         " EXACTFMT " (" PTR_FORMAT ")", EXACTFMTARGS(ZAddressOffsetMax), ZAddressOffsetMax);
   st->print_cr(" Page Size Small:    %zuM", ZPageSizeSmall / M);
-  st->print_cr(" Page Size Medium:   %zuM", ZPageSizeMedium / M);
+  if (ZPageSizeMediumEnabled) {
+    if (ZPageSizeMediumMin == ZPageSizeMediumMax) {
+      st->print_cr(" Page Size Medium: %zuM", ZPageSizeMediumMax / M);
+    } else {
+      st->print_cr(" Page Size Medium: Range [%zuM, %zuM]", ZPageSizeMediumMin / M, ZPageSizeMediumMax / M);
+    }
+  } else {
+    st->print_cr(" Page Size Medium: N/A");
+  }
   st->cr();
   st->print_cr("ZGC Metadata Bits:");
   st->print_cr(" LoadGood:           " PTR_FORMAT, ZPointerLoadGoodMask);

--- a/src/hotspot/share/gc/z/zHeuristics.cpp
+++ b/src/hotspot/share/gc/z/zHeuristics.cpp
@@ -46,9 +46,9 @@ void ZHeuristics::set_medium_page_size() {
   if (size > ZPageSizeSmall) {
     // Enable medium pages
     ZPageSizeMediumMax          = size;
-    ZPageSizeMediumShift        = (size_t)log2i_exact(ZPageSizeMediumMax);
+    ZPageSizeMediumShift        = log2i_exact(ZPageSizeMediumMax);
     ZObjectSizeLimitMedium      = ZPageSizeMediumMax / 8;
-    ZObjectAlignmentMediumShift = (int)ZPageSizeMediumShift - 13;
+    ZObjectAlignmentMediumShift = ZPageSizeMediumShift - 13;
     ZObjectAlignmentMedium      = 1 << ZObjectAlignmentMediumShift;
     ZPageSizeMediumEnabled      = true;
     ZPageSizeMediumMin          = ZUseMediumPageSizeRange

--- a/src/hotspot/share/gc/z/zHeuristics.cpp
+++ b/src/hotspot/share/gc/z/zHeuristics.cpp
@@ -28,6 +28,7 @@
 #include "gc/z/zHeuristics.hpp"
 #include "runtime/globals.hpp"
 #include "runtime/os.hpp"
+#include "utilities/align.hpp"
 #include "utilities/globalDefinitions.hpp"
 #include "utilities/powerOfTwo.hpp"
 
@@ -44,18 +45,22 @@ void ZHeuristics::set_medium_page_size() {
 
   if (size > ZPageSizeSmall) {
     // Enable medium pages
-    ZPageSizeMedium             = size;
-    ZPageSizeMediumShift        = (size_t)log2i_exact(ZPageSizeMedium);
-    ZObjectSizeLimitMedium      = ZPageSizeMedium / 8;
+    ZPageSizeMediumMax          = size;
+    ZPageSizeMediumShift        = (size_t)log2i_exact(ZPageSizeMediumMax);
+    ZObjectSizeLimitMedium      = ZPageSizeMediumMax / 8;
     ZObjectAlignmentMediumShift = (int)ZPageSizeMediumShift - 13;
     ZObjectAlignmentMedium      = 1 << ZObjectAlignmentMediumShift;
+    ZPageSizeMediumEnabled      = true;
+    ZPageSizeMediumMin          = ZUseMediumPageSizeRange
+                                ? align_up(ZObjectSizeLimitMedium, ZGranuleSize)
+                                : ZPageSizeMediumMax;
   }
 }
 
 size_t ZHeuristics::relocation_headroom() {
   // Calculate headroom needed to avoid in-place relocation. Each worker will try
   // to allocate a small page, and all workers will share a single medium page.
-  return (ConcGCThreads * ZPageSizeSmall) + ZPageSizeMedium;
+  return (ConcGCThreads * ZPageSizeSmall) + ZPageSizeMediumMax;
 }
 
 bool ZHeuristics::use_per_cpu_shared_small_pages() {

--- a/src/hotspot/share/gc/z/zMappedCache.cpp
+++ b/src/hotspot/share/gc/z/zMappedCache.cpp
@@ -312,6 +312,11 @@ ZVirtualMemory ZMappedCache::remove_vmem(ZMappedCacheEntry* const entry, size_t 
 template <typename SelectFunction, typename ConsumeFunction>
 bool ZMappedCache::try_remove_vmem_size_class(size_t min_size, SelectFunction select, ConsumeFunction consume) {
 new_max_size:
+  if (_size < min_size) {
+    // Not enough left in cache to satisfy the min_size
+    return false;
+  }
+
   // Query the max select size possible given the size of the cache
   const size_t max_size = select(_size);
 
@@ -543,6 +548,37 @@ ZVirtualMemory ZMappedCache::remove_contiguous(size_t size) {
     // Other sizes uses approximate best fit size classes first
     scan_remove_vmem<RemovalStrategy::SizeClasses>(size, select_size_fn, consume_vmem_fn);
   }
+
+  return result;
+}
+
+ZVirtualMemory ZMappedCache::remove_contiguous_power_of_2(size_t min_size, size_t max_size) {
+  precond(is_aligned(min_size, ZGranuleSize));
+  precond(is_power_of_2(min_size));
+  precond(is_aligned(max_size, ZGranuleSize));
+  precond(is_power_of_2(max_size));
+  precond(min_size <= max_size);
+
+  ZVirtualMemory result;
+
+  const auto select_size_fn = [&](size_t size) {
+    // Always select a power of 2 within the [min_size, max_size] interval.
+    return clamp(round_down_power_of_2(size), min_size, max_size);
+  };
+
+  const auto consume_vmem_fn = [&](ZVirtualMemory vmem) {
+    assert(result.is_null(), "only consume once");
+    assert(min_size <= vmem.size() && vmem.size() <= max_size,
+      "Must be %zu <= %zu <= %zu", min_size, vmem.size(), max_size);
+    assert(is_power_of_2(vmem.size()), "Must be power_of_2(%zu)", vmem.size());
+
+    result = vmem;
+
+    // Only require one vmem
+    return true;
+  };
+
+  scan_remove_vmem<RemovalStrategy::SizeClasses>(min_size, select_size_fn, consume_vmem_fn);
 
   return result;
 }

--- a/src/hotspot/share/gc/z/zMappedCache.hpp
+++ b/src/hotspot/share/gc/z/zMappedCache.hpp
@@ -100,6 +100,7 @@ public:
   void insert(const ZVirtualMemory& vmem);
 
   ZVirtualMemory remove_contiguous(size_t size);
+  ZVirtualMemory remove_contiguous_power_of_2(size_t min_size, size_t max_size);
   size_t remove_discontiguous(size_t size, ZArray<ZVirtualMemory>* out);
 
   size_t reset_min();

--- a/src/hotspot/share/gc/z/zPage.cpp
+++ b/src/hotspot/share/gc/z/zPage.cpp
@@ -23,6 +23,7 @@
 
 #include "gc/shared/gc_globals.hpp"
 #include "gc/z/zGeneration.inline.hpp"
+#include "gc/z/zGlobals.hpp"
 #include "gc/z/zPage.inline.hpp"
 #include "gc/z/zPageAge.hpp"
 #include "gc/z/zRememberedSet.inline.hpp"
@@ -43,7 +44,7 @@ ZPage::ZPage(ZPageType type, ZPageAge age, const ZVirtualMemory& vmem, ZMultiPar
     _multi_partition_tracker(multi_partition_tracker) {
   assert(!_virtual.is_null(), "Should not be null");
   assert((_type == ZPageType::small && size() == ZPageSizeSmall) ||
-         (_type == ZPageType::medium && size() == ZPageSizeMedium) ||
+         (_type == ZPageType::medium && size() <= ZPageSizeMediumMax && size() >= ZPageSizeMediumMin) ||
          (_type == ZPageType::large && is_aligned(size(), ZGranuleSize)),
          "Page type/size mismatch");
   reset(age);

--- a/src/hotspot/share/gc/z/zPageAllocator.cpp
+++ b/src/hotspot/share/gc/z/zPageAllocator.cpp
@@ -765,7 +765,9 @@ bool ZPartition::claim_capacity_fast_medium(ZMemoryAllocation* allocation) {
   precond(ZPageSizeMediumEnabled);
 
   // Try to allocate a medium page sized contiguous vmem
-  ZVirtualMemory vmem = _cache.remove_contiguous_power_of_2(ZPageSizeMediumMin, ZPageSizeMediumMax);
+  const size_t min_size = ZPageSizeMediumMin;
+  const size_t max_size = ZStressFastMediumPageAllocation ? min_size : ZPageSizeMediumMax;
+  ZVirtualMemory vmem = _cache.remove_contiguous_power_of_2(min_size, max_size);
 
   if (vmem.is_null()) {
     // Failed to find a contiguous vmem

--- a/src/hotspot/share/gc/z/zPageAllocator.cpp
+++ b/src/hotspot/share/gc/z/zPageAllocator.cpp
@@ -59,6 +59,7 @@
 #include "utilities/align.hpp"
 #include "utilities/debug.hpp"
 #include "utilities/globalDefinitions.hpp"
+#include "utilities/powerOfTwo.hpp"
 #include "utilities/ticks.hpp"
 #include "utilities/vmError.hpp"
 
@@ -182,6 +183,17 @@ public:
 
   ZVirtualMemory satisfied_from_cache_vmem() const {
     return _satisfied_from_cache_vmem;
+  }
+
+  void set_satisfied_from_cache_vmem_fast_medium(ZVirtualMemory vmem) {
+    precond(_satisfied_from_cache_vmem.is_null());
+    precond(_partial_vmems.is_empty());
+    precond(ZPageSizeMediumEnabled);
+    precond(vmem.size() >= ZPageSizeMediumMin);
+    precond(vmem.size() <= ZPageSizeMediumMax);
+    precond(is_power_of_2(vmem.size()));
+
+    _satisfied_from_cache_vmem = vmem;
   }
 
   void set_satisfied_from_cache_vmem(ZVirtualMemory vmem) {
@@ -434,6 +446,15 @@ public:
   }
 
   size_t size() const {
+    if (_flags.fast_medium()) {
+      // A fast medium allocation may have allocated less than the _size field
+      const ZVirtualMemory vmem = _single_partition_allocation.allocation()->satisfied_from_cache_vmem();
+      if (!vmem.is_null()) {
+        // The allocation has been satisfied, return the satisfied size.
+        return vmem.size();
+      }
+    }
+
     return _size;
   }
 
@@ -534,7 +555,7 @@ public:
     event.commit(_start_timestamp,
                  end_timestamp,
                  (u8)_type,
-                 _size,
+                 size(),
                  st._total_harvested,
                  st._total_committed_capacity,
                  (unsigned)st._num_harvested_vmems,
@@ -735,6 +756,30 @@ bool ZPartition::claim_capacity(ZMemoryAllocation* allocation) {
 
   // Updated used statistics
   increase_used(size);
+
+  // Success
+  return true;
+}
+
+bool ZPartition::claim_capacity_fast_medium(ZMemoryAllocation* allocation) {
+  precond(ZPageSizeMediumEnabled);
+
+  // Try to allocate a medium page sized contiguous vmem
+  ZVirtualMemory vmem = _cache.remove_contiguous_power_of_2(ZPageSizeMediumMin, ZPageSizeMediumMax);
+
+  if (vmem.is_null()) {
+    // Failed to find a contiguous vmem
+    return false;
+  }
+
+  // Found a satisfying vmem in the cache
+  allocation->set_satisfied_from_cache_vmem_fast_medium(vmem);
+
+  // Associate the allocation with this partition.
+  allocation->set_partition(this);
+
+  // Updated used statistics
+  increase_used(vmem.size());
 
   // Success
   return true;
@@ -1278,8 +1323,12 @@ ZPageAllocator::ZPageAllocator(size_t min_capacity,
   log_info_p(gc, init)("Initial Capacity: %zuM", initial_capacity / M);
   log_info_p(gc, init)("Max Capacity: %zuM", max_capacity / M);
   log_info_p(gc, init)("Soft Max Capacity: %zuM", soft_max_capacity / M);
-  if (ZPageSizeMedium > 0) {
-    log_info_p(gc, init)("Medium Page Size: %zuM", ZPageSizeMedium / M);
+  if (ZPageSizeMediumEnabled) {
+    if (ZPageSizeMediumMin == ZPageSizeMediumMax) {
+      log_info_p(gc, init)("Page Size Medium: %zuM", ZPageSizeMediumMax / M);
+    } else {
+      log_info_p(gc, init)("Page Size Medium: Range [%zuM, %zuM]", ZPageSizeMediumMin / M, ZPageSizeMediumMax / M);
+    }
   } else {
     log_info_p(gc, init)("Medium Page Size: N/A");
   }
@@ -1459,8 +1508,8 @@ ZPage* ZPageAllocator::alloc_page(ZPageType type, size_t size, ZAllocationFlags 
   if (!flags.gc_relocation() && is_init_completed()) {
     // Note that there are two allocation rate counters, which have
     // different purposes and are sampled at different frequencies.
-    ZStatInc(ZCounterMutatorAllocationRate, size);
-    ZStatMutatorAllocRate::sample_allocation(size);
+    ZStatInc(ZCounterMutatorAllocationRate, page->size());
+    ZStatMutatorAllocRate::sample_allocation(page->size());
   }
 
   const ZPageAllocationStats stats = allocation.stats();
@@ -1588,11 +1637,15 @@ bool ZPageAllocator::claim_capacity_or_stall(ZPageAllocation* allocation) {
 }
 
 bool ZPageAllocator::claim_capacity(ZPageAllocation* allocation) {
+  // Fast medium allocation
+  if (allocation->flags().fast_medium()) {
+    return claim_capacity_fast_medium(allocation);
+  }
+
+  // Round robin single-partition claiming
   const uint32_t start_numa_id = allocation->initiating_numa_id();
   const uint32_t start_partition = start_numa_id;
   const uint32_t num_partitions = _partitions.count();
-
-  // Round robin single-partition claiming
 
   for (uint32_t i = 0; i < num_partitions; ++i) {
     const uint32_t partition_id = (start_partition + i) % num_partitions;
@@ -1617,6 +1670,23 @@ bool ZPageAllocator::claim_capacity(ZPageAllocation* allocation) {
   claim_capacity_multi_partition(multi_partition_allocation, start_partition);
 
   return true;
+}
+
+bool ZPageAllocator::claim_capacity_fast_medium(ZPageAllocation* allocation) {
+  const uint32_t start_node = allocation->initiating_numa_id();
+  const uint32_t numa_nodes = ZNUMA::count();
+
+  for (uint32_t i = 0; i < numa_nodes; ++i) {
+    const uint32_t numa_id = (start_node + i) % numa_nodes;
+    ZPartition& partition = _partitions.get(numa_id);
+    ZSinglePartitionAllocation* single_partition_allocation = allocation->single_partition_allocation();
+
+    if (partition.claim_capacity_fast_medium(single_partition_allocation->allocation())) {
+      return true;
+    }
+  }
+
+  return false;
 }
 
 bool ZPageAllocator::claim_capacity_single_partition(ZSinglePartitionAllocation* single_partition_allocation, uint32_t partition_id) {
@@ -2076,6 +2146,8 @@ void ZPageAllocator::free_memory_alloc_failed(ZMemoryAllocation* allocation) {
 }
 
 ZPage* ZPageAllocator::create_page(ZPageAllocation* allocation, const ZVirtualMemory& vmem) {
+  assert(allocation->size() == vmem.size(), "Must be %zu == %zu", allocation->size(), vmem.size());
+
   // We don't track generation usage when claiming capacity, because this page
   // could have been allocated by a thread that satisfies a stalling allocation.
   // The stalled thread can wake up and potentially realize that the page alloc

--- a/src/hotspot/share/gc/z/zPageAllocator.hpp
+++ b/src/hotspot/share/gc/z/zPageAllocator.hpp
@@ -101,6 +101,7 @@ public:
 
   void claim_from_cache_or_increase_capacity(ZMemoryAllocation* allocation);
   bool claim_capacity(ZMemoryAllocation* allocation);
+  bool claim_capacity_fast_medium(ZMemoryAllocation* allocation);
 
   size_t uncommit(uint64_t* timeout);
 
@@ -174,6 +175,7 @@ private:
 
   bool claim_capacity_or_stall(ZPageAllocation* allocation);
   bool claim_capacity(ZPageAllocation* allocation);
+  bool claim_capacity_fast_medium(ZPageAllocation* allocation);
   bool claim_capacity_single_partition(ZSinglePartitionAllocation* single_partition_allocation, uint32_t partition_id);
   void claim_capacity_multi_partition(ZMultiPartitionAllocation* multi_partition_allocation, uint32_t start_partition);
 

--- a/src/hotspot/share/gc/z/zRelocationSetSelector.cpp
+++ b/src/hotspot/share/gc/z/zRelocationSetSelector.cpp
@@ -42,15 +42,15 @@ ZRelocationSetSelectorGroupStats::ZRelocationSetSelectorGroupStats()
 
 ZRelocationSetSelectorGroup::ZRelocationSetSelectorGroup(const char* name,
                                                          ZPageType page_type,
-                                                         size_t page_size,
+                                                         size_t max_page_size,
                                                          size_t object_size_limit,
                                                          double fragmentation_limit)
   : _name(name),
     _page_type(page_type),
-    _page_size(page_size),
+    _max_page_size(max_page_size),
     _object_size_limit(object_size_limit),
     _fragmentation_limit(fragmentation_limit),
-    _page_fragmentation_limit((size_t)(page_size * (fragmentation_limit / 100))),
+    _page_fragmentation_limit((size_t)(_max_page_size * (_fragmentation_limit / 100))),
     _live_pages(),
     _not_selected_pages(),
     _forwarding_entries(0),
@@ -58,7 +58,7 @@ ZRelocationSetSelectorGroup::ZRelocationSetSelectorGroup(const char* name,
 
 bool ZRelocationSetSelectorGroup::is_disabled() {
   // Medium pages are disabled when their page size is zero
-  return _page_type == ZPageType::medium && _page_size == 0;
+  return _page_type == ZPageType::medium && !ZPageSizeMediumEnabled;
 }
 
 bool ZRelocationSetSelectorGroup::is_selectable() {
@@ -66,26 +66,29 @@ bool ZRelocationSetSelectorGroup::is_selectable() {
   return _page_type != ZPageType::large;
 }
 
-void ZRelocationSetSelectorGroup::semi_sort() {
-  // Semi-sort live pages by number of live bytes in ascending order
-  const size_t npartitions_shift = 11;
-  const size_t npartitions = (size_t)1 << npartitions_shift;
-  const size_t partition_size = _page_size >> npartitions_shift;
+size_t ZRelocationSetSelectorGroup::partition_index(const ZPage* page) const {
+  const size_t partition_size = page->size() >> NumPartitionsShift;
   const int partition_size_shift = log2i_exact(partition_size);
 
+  return page->live_bytes() >> partition_size_shift;
+}
+
+void ZRelocationSetSelectorGroup::semi_sort() {
+  // Semi-sort live pages by number of live bytes in ascending order
+
   // Partition slots/fingers
-  int partitions[npartitions] = { /* zero initialize */ };
+  int partitions[NumPartitions] = { /* zero initialize */ };
 
   // Calculate partition slots
   ZArrayIterator<ZPage*> iter1(&_live_pages);
   for (ZPage* page; iter1.next(&page);) {
-    const size_t index = page->live_bytes() >> partition_size_shift;
+    const size_t index = partition_index(page);
     partitions[index]++;
   }
 
   // Calculate partition fingers
   int finger = 0;
-  for (size_t i = 0; i < npartitions; i++) {
+  for (size_t i = 0; i < NumPartitions; i++) {
     const int slots = partitions[i];
     partitions[i] = finger;
     finger += slots;
@@ -98,7 +101,7 @@ void ZRelocationSetSelectorGroup::semi_sort() {
   // Sort pages into partitions
   ZArrayIterator<ZPage*> iter2(&_live_pages);
   for (ZPage* page; iter2.next(&page);) {
-    const size_t index = page->live_bytes() >> partition_size_shift;
+    const size_t index = partition_index(page);
     const int finger = partitions[index]++;
     assert(sorted_live_pages.at(finger) == nullptr, "Invalid finger");
     sorted_live_pages.at_put(finger, page);
@@ -134,7 +137,7 @@ void ZRelocationSetSelectorGroup::select_inner() {
     // By subtracting the object size limit from the pages size we get the maximum
     // number of pages that the relocation set is guaranteed to fit in, regardless
     // of in which order the objects are relocated.
-    const int to = (int)ceil(from_live_bytes / (double)(_page_size - _object_size_limit));
+    const int to = (int)ceil(from_live_bytes / (double)(_max_page_size - _object_size_limit));
 
     // Calculate the relative difference in reclaimable space compared to our
     // currently selected final relocation set. If this number is larger than the
@@ -211,8 +214,8 @@ void ZRelocationSetSelectorGroup::select() {
 
 ZRelocationSetSelector::ZRelocationSetSelector(double fragmentation_limit)
   : _small("Small", ZPageType::small, ZPageSizeSmall, ZObjectSizeLimitSmall, fragmentation_limit),
-    _medium("Medium", ZPageType::medium, ZPageSizeMedium, ZObjectSizeLimitMedium, fragmentation_limit),
-    _large("Large", ZPageType::large, 0 /* page_size */, 0 /* object_size_limit */, fragmentation_limit),
+    _medium("Medium", ZPageType::medium, ZPageSizeMediumMax, ZObjectSizeLimitMedium, fragmentation_limit),
+    _large("Large", ZPageType::large, 0 /* max_page_size */, 0 /* object_size_limit */, fragmentation_limit),
     _empty_pages() {}
 
 void ZRelocationSetSelector::select() {

--- a/src/hotspot/share/gc/z/zRelocationSetSelector.cpp
+++ b/src/hotspot/share/gc/z/zRelocationSetSelector.cpp
@@ -77,7 +77,7 @@ void ZRelocationSetSelectorGroup::semi_sort() {
   // Semi-sort live pages by number of live bytes in ascending order
 
   // Partition slots/fingers
-  int partitions[NumPartitions] = { /* zero initialize */ };
+  int partitions[NPartitions] = { /* zero initialize */ };
 
   // Calculate partition slots
   ZArrayIterator<ZPage*> iter1(&_live_pages);
@@ -88,7 +88,7 @@ void ZRelocationSetSelectorGroup::semi_sort() {
 
   // Calculate partition fingers
   int finger = 0;
-  for (size_t i = 0; i < NumPartitions; i++) {
+  for (size_t i = 0; i < NPartitions; i++) {
     const int slots = partitions[i];
     partitions[i] = finger;
     finger += slots;

--- a/src/hotspot/share/gc/z/zRelocationSetSelector.hpp
+++ b/src/hotspot/share/gc/z/zRelocationSetSelector.hpp
@@ -79,7 +79,7 @@ public:
 class ZRelocationSetSelectorGroup {
 private:
   static constexpr int NumPartitionsShift = 11;
-  static constexpr int NumPartitions = int(1) << NumPartitionsShift;
+  static constexpr int NPartitions = int(1) << NumPartitionsShift;
 
   const char* const                _name;
   const ZPageType                  _page_type;

--- a/src/hotspot/share/gc/z/zRelocationSetSelector.hpp
+++ b/src/hotspot/share/gc/z/zRelocationSetSelector.hpp
@@ -78,9 +78,12 @@ public:
 
 class ZRelocationSetSelectorGroup {
 private:
+  static constexpr int NumPartitionsShift = 11;
+  static constexpr int NumPartitions = int(1) << NumPartitionsShift;
+
   const char* const                _name;
   const ZPageType                  _page_type;
-  const size_t                     _page_size;
+  const size_t                     _max_page_size;
   const size_t                     _object_size_limit;
   const double                     _fragmentation_limit;
   const size_t                     _page_fragmentation_limit;
@@ -91,13 +94,15 @@ private:
 
   bool is_disabled();
   bool is_selectable();
+
+  size_t partition_index(const ZPage* page) const;
   void semi_sort();
   void select_inner();
 
 public:
   ZRelocationSetSelectorGroup(const char* name,
                               ZPageType page_type,
-                              size_t page_size,
+                              size_t max_page_size,
                               size_t object_size_limit,
                               double fragmentation_limit);
 

--- a/src/hotspot/share/gc/z/zRelocationSetSelector.hpp
+++ b/src/hotspot/share/gc/z/zRelocationSetSelector.hpp
@@ -99,6 +99,8 @@ private:
   void semi_sort();
   void select_inner();
 
+  bool pre_filter_page(const ZPage* page, size_t live_bytes) const;
+
 public:
   ZRelocationSetSelectorGroup(const char* name,
                               ZPageType page_type,

--- a/src/hotspot/share/gc/z/zRelocationSetSelector.inline.hpp
+++ b/src/hotspot/share/gc/z/zRelocationSetSelector.inline.hpp
@@ -75,7 +75,8 @@ inline void ZRelocationSetSelectorGroup::register_live_page(ZPage* page) {
   const size_t garbage = size - live;
 
   // Pre-filter out pages that are guaranteed to not be selected
-  if (!page->is_large() && garbage > _page_fragmentation_limit) {
+  if ((page->is_small() && garbage > _page_fragmentation_limit) ||
+      (page->is_medium() && percent_of(garbage, size) > _fragmentation_limit)) {
     _live_pages.append(page);
   } else if (page->is_young()) {
     _not_selected_pages.append(page);

--- a/src/hotspot/share/gc/z/zStat.cpp
+++ b/src/hotspot/share/gc/z/zStat.cpp
@@ -1531,7 +1531,7 @@ void ZStatRelocation::print_page_summary() {
   };
 
   print_summary("Small", small_summary, _small_in_place_count);
-  if (ZPageSizeMedium != 0) {
+  if (ZPageSizeMediumEnabled) {
     print_summary("Medium", medium_summary, _medium_in_place_count);
   }
   print_summary("Large", large_summary, 0 /* in_place_count */);

--- a/src/hotspot/share/gc/z/z_globals.hpp
+++ b/src/hotspot/share/gc/z/z_globals.hpp
@@ -107,6 +107,10 @@
   product(bool, ZUseMediumPageSizeRange, true, DIAGNOSTIC,                  \
           "Allow multiple medium pages sizes")                              \
                                                                             \
+  product(bool, ZStressFastMediumPageAllocation, false, DIAGNOSTIC,         \
+          "Always use the minimum medium page size for fast medium page "   \
+          "allocations")                                                    \
+                                                                            \
   product(int, ZTenuringThreshold, -1, DIAGNOSTIC,                          \
           "Young generation tenuring threshold, -1 for dynamic computation")\
           range(-1, static_cast<int>(ZPageAgeMax))                          \

--- a/src/hotspot/share/gc/z/z_globals.hpp
+++ b/src/hotspot/share/gc/z/z_globals.hpp
@@ -104,6 +104,9 @@
   product(bool, ZVerifyRemembered, trueInDebug, DIAGNOSTIC,                 \
           "Verify remembered sets")                                         \
                                                                             \
+  product(bool, ZUseMediumPageSizeRange, true, DIAGNOSTIC,                  \
+          "Allow multiple medium pages sizes")                              \
+                                                                            \
   product(int, ZTenuringThreshold, -1, DIAGNOSTIC,                          \
           "Young generation tenuring threshold, -1 for dynamic computation")\
           range(-1, static_cast<int>(ZPageAgeMax))                          \

--- a/test/hotspot/jtreg/gc/z/TestZMediumPageSizes.java
+++ b/test/hotspot/jtreg/gc/z/TestZMediumPageSizes.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package gc.z;
+
+/**
+ * @test TestZMediumPageSizes
+ * @requires vm.gc.Z
+ * @summary Test TestZMediumPageSizes heap reservation / commits interactions.
+ * @library / /test/lib
+ * @run driver gc.z.TestZMediumPageSizes
+ */
+
+import static gc.testlibrary.Allocation.blackHole;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+import jtreg.SkippedException;
+
+public class TestZMediumPageSizes {
+    private static final int XmxInM = 1024;
+    private static final int XmsInM = 512;
+    static class Test {
+        private static final int K = 1024;
+        private static final int M = 1024 * K;
+        private static final int SMALL_PAGE_SIZE = 2 * M;
+        private static final int SMALL_OBJECTS_PER_PAGE = 20;
+        private static final int SMALL_OBJECT_SIZE = SMALL_PAGE_SIZE / SMALL_OBJECTS_PER_PAGE;
+        private static final int MEDIUM_OBJECT_SIZE = 3 * M;
+        private static final int CHUNK_COUNT = 32;
+        private static final int CHUNK_LENGTH = SMALL_OBJECTS_PER_PAGE * 3;
+        private static final int ITERATIONS = 10;
+
+        public static void main(String[] args) throws Exception {
+            for (int page = 0; page < ITERATIONS; ++page) {
+                var keep = new ArrayList<byte[]>();
+                try {
+                    System.gc();
+                    for (;;) {
+                        // Allocate objects on small pages until we're unable to
+                        keep.add(new byte[SMALL_OBJECT_SIZE]);
+                    }
+                } catch (OutOfMemoryError oome) {
+                    // Assume that most small allocations were allocated in
+                    // consecutive addresses. By making CHUNK_LENGTH consecutive
+                    // number of small objects eligible for collection, at least
+                    // CHUNK_LENGTH - 1 pages should get eligible for relocation
+                    // and be returned to the mapped cache. We do this for
+                    // CHUNK_COUNT number of chunks which should ensure that
+                    // there is enough free memory to allocate a full sized
+                    // medium page. These chunks are spread out, so as not to be
+                    // consecutive, so that a full sized medium page can only be
+                    // created harvesting some number of smaller memory chunks.
+                    for (int i = 0; i < CHUNK_COUNT; i++) {
+                        for (int j = 0; j < CHUNK_LENGTH; j++) {
+                            keep.set(2 * i * CHUNK_LENGTH + j, null);
+                        }
+                    }
+
+                    // Reclaim memory from pages
+                    System.gc();
+
+                    // Allocate a new medium page (may happen through flush/harvest)
+                    blackHole(new byte[MEDIUM_OBJECT_SIZE]);
+                }
+
+                blackHole(keep);
+            }
+
+        }
+    }
+
+    private static OutputAnalyzer createAndExecuteJava(String... extraOptions) throws Exception {
+        final var options = new ArrayList<String>(List.of(
+            "-XX:+UseZGC",
+            "-Xms" + XmsInM + "M",
+            "-Xmx" + XmxInM + "M",
+            "-Xlog:gc,gc+init,gc+heap=debug"));
+        Collections.addAll(options, extraOptions);
+        options.add(Test.class.getName());
+        OutputAnalyzer oa = ProcessTools
+                .executeTestJava(options)
+                .outputTo(System.out)
+                .errorTo(System.out)
+                .shouldHaveExitValue(0);
+        return oa;
+    }
+
+    private static void runTestDefault() throws Exception  {
+        var oa = createAndExecuteJava("-XX:+ZUseMediumPageSizeRange");
+        oa.shouldContain("Page Size Medium: Range");
+        oa.shouldNotContain("Mapped Cache Harvested");
+    }
+
+    private static void runTestFixedPageSize() throws Exception {
+        var oa = createAndExecuteJava("-XX:-ZUseMediumPageSizeRange");
+        oa.shouldNotContain("Page Size Medium: Range");
+        oa.shouldContain("Mapped Cache Harvested");
+    }
+
+    public static void main(String[] args) throws Exception {
+        runTestDefault();
+        runTestFixedPageSize();
+    }
+}


### PR DESCRIPTION
<details><summary><b>Background</b> (expandable section)</summary>
ZGC uses three different types of memory regions (Small, Medium and Large) as a compromise between memory waste and relocation induced latencies.

The allocated object size dictates which type of memory region it ends up in. These sizes are selected such that when an object allocation fails in a memory region because that object does not fit, the waste (unused bytes at the end) is at most 1/8th or 12.5%. This property is held for both the small and medium memory regions.

Objects larger than medium object allocation gets placed in a large memory region, which only ever contains one object. And because all memory region sizes are multiples of 2M, we end up with a memory waste which is the difference between object size rounded up to the nearest multiple of 2M and the exact object size.

For max heaps (Xmx) smaller than 1GB we use reduced medium memory region sizes at the cost of worse waste guarantees for large object allocation.

But for max heaps 1GB or larger our current selected medium memory region size is 32M. This results in a max medium object size of 4M (32M * 12.5%), which is the max size we want an application thread to have to relocate. So we end up with a guarantee that the waste in large memory regions is at most 33%.

A problem with medium pages is that they may cause allocation induced latencies. To reduce allocation latencies we track (cache) memory of memory regions which has been freed by the GC, so it can be reused for new memory regions used for allocations.

For small memory regions, as long as there is cached memory, it can use it, because the size of a small memory region (2M) is always a multiple of any other memory region that has been freed.

However for medium memory regions it may be that there is enough memory available in the cache, but it is only split into regions smaller than the medium memory regions size (32M). Currently this requires the allocating thread to remap multiple of these small memory regions into a new larger one, which involves calls into the operating system.

In ZGC we call our memory regions pages or zpages.
</details>

### Proposal
Allow for medium pages to have multiple sizes. Specifically allow all power of two sizes between the smallest size that can contain one medium object and the max medium page size. For a max medium page size of 32M the sizes ends up being {4M, 8M, 16M, 32M}.

And adds a "fast" medium page allocation path in the page allocator, which only claims memory from the cache, where the memory can directly satisfy one of these sizes. This will only fail if the cache is empty, or if all the memory is spread out in 2M segments. Then change the object allocator to use this for when mutator threads allocate or relocate objects. Reducing the probability that allocation or mutator relocation sees latencies induced by the page allocation.

GC relocation workers still allocate only the largest medium page size, and has the GC take the cost remapping memory. This way we can reduce mutator latencies at the cost of potential temporary increased memory waste.

The change from a fixed to variable size for medium pages requires some adaptation in relocation set selection. Earlier we simply used to compare live bytes sizes as a proxy for fragmentation, using pre-calculated values to avoid integer division and double arithmetic in the selection loop. I did something similar in ae2fa92f9356e2966726cc17f3e5d911be8b1f8e. May be a pre mature optimisation.

Also apparently we have a `NumPartitions` define in the codebase so had to name the constant differently. (I could probably move it to the .cpp file as well.)
https://github.com/openjdk/jdk/blob/f7619fd700ec6498948e5e84e8051be145683940/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.hpp#L44

#### Testing

* All ZGC test tasks tier1-tier8 on all Oracle supported platforms
* All ZGC test tasks tier1-tier8 on linux-x64,linux-x64-debug with `-XX:+ZStressFastMediumPageAllocation`

Ran performance testing on an earlier baseline,
Re-running performance testing on latest rebase