### PR TITLE
8334513: New test gc/TestAlwaysPreTouchBehavior.java is failing on MacOS aarch64

### DIFF
--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -142,7 +142,9 @@ julong os::free_memory() {
   return Bsd::available_memory();
 }
 
-// available here means free
+// Available here means free. Note that this number is of no much use. As an estimate
+// for future memory pressure it is far too conservative, since MacOS will use a lot
+// of unused memory for caches, and return it willingly in case of needs.
 julong os::Bsd::available_memory() {
   uint64_t available = physical_memory() >> 2;
 #ifdef __APPLE__

--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -2511,6 +2511,11 @@ WB_ENTRY(jlong, WB_HostPhysicalMemory(JNIEnv* env, jobject o))
   return os::physical_memory();
 WB_END
 
+// Available memory of the host machine (container-aware)
+WB_ENTRY(jlong, WB_HostAvailableMemory(JNIEnv* env, jobject o))
+  return os::available_memory();
+WB_END
+
 // Physical swap of the host machine (including containers), Linux only.
 WB_ENTRY(jlong, WB_HostPhysicalSwap(JNIEnv* env, jobject o))
   LINUX_ONLY(return (jlong)os::Linux::host_swap();)
@@ -2980,6 +2985,7 @@ static JNINativeMethod methods[] = {
                                                       (void*)&WB_ValidateCgroup },
   {CC"hostPhysicalMemory",        CC"()J",            (void*)&WB_HostPhysicalMemory },
   {CC"hostPhysicalSwap",          CC"()J",            (void*)&WB_HostPhysicalSwap },
+  {CC"hostAvailableMemory",       CC"()J",            (void*)&WB_HostAvailableMemory },
   {CC"hostCPUs",                  CC"()I",            (void*)&WB_HostCPUs },
   {CC"printOsInfo",               CC"()V",            (void*)&WB_PrintOsInfo },
   {CC"disableElfSectionCache",    CC"()V",            (void*)&WB_DisableElfSectionCache },

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -91,12 +91,6 @@ gc/TestAllocHumongousFragment.java#adaptive 8298781 generic-all
 gc/TestAllocHumongousFragment.java#aggressive 8298781 generic-all
 gc/TestAllocHumongousFragment.java#g1 8298781 generic-all
 gc/TestAllocHumongousFragment.java#static 8298781 generic-all
-gc/TestAlwaysPreTouchBehavior.java#ParallelCollector 8334513 generic-all
-gc/TestAlwaysPreTouchBehavior.java#SerialCollector 8334513 generic-all
-gc/TestAlwaysPreTouchBehavior.java#Shenandoah 8334513 generic-all
-gc/TestAlwaysPreTouchBehavior.java#G1 8334513 generic-all
-gc/TestAlwaysPreTouchBehavior.java#Z 8334513 generic-all
-gc/TestAlwaysPreTouchBehavior.java#Epsilon 8334513 generic-all
 gc/shenandoah/oom/TestAllocOutOfMemory.java#large 8344312 linux-ppc64le
 gc/shenandoah/TestEvilSyncBug.java#generational 8345501 generic-all
 

--- a/test/hotspot/jtreg/gc/TestAlwaysPreTouchBehavior.java
+++ b/test/hotspot/jtreg/gc/TestAlwaysPreTouchBehavior.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2014, 2024, Alibaba Group Holding Limited. All rights reserved.
- * Copyright (c) 2024, Red Hat Inc.
+ * Copyright (c) 2024, 2025, Red Hat Inc.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,23 +29,25 @@ package gc;
  * @summary tests AlwaysPreTouch
  * @requires vm.gc.Parallel
  * @requires os.maxMemory > 2G
- * @requires os.family != "aix"
+ * @requires vm.debug != true
+ * @requires os.family == "linux"
  * @library /test/lib
  * @build jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
- * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xmx512m -Xms512m -XX:+UseParallelGC -XX:+AlwaysPreTouch gc.TestAlwaysPreTouchBehavior
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xmx256m -Xms256m -XX:+UseParallelGC -XX:+AlwaysPreTouch gc.TestAlwaysPreTouchBehavior
  */
 
- /**
+/**
  * @test id=SerialCollector
  * @summary tests AlwaysPreTouch
  * @requires vm.gc.Serial
  * @requires os.maxMemory > 2G
- * @requires os.family != "aix"
+ * @requires vm.debug != true
+ * @requires os.family == "linux"
  * @library /test/lib
  * @build jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
- * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xmx512m -Xms512m -XX:+UseSerialGC -XX:+AlwaysPreTouch gc.TestAlwaysPreTouchBehavior
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xmx256m -Xms256m -XX:+UseSerialGC -XX:+AlwaysPreTouch gc.TestAlwaysPreTouchBehavior
  */
 
 /**
@@ -53,11 +55,12 @@ package gc;
  * @summary tests AlwaysPreTouch
  * @requires vm.gc.Shenandoah
  * @requires os.maxMemory > 2G
- * @requires os.family != "aix"
+ * @requires vm.debug != true
+ * @requires os.family == "linux"
  * @library /test/lib
  * @build jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
- * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xmx512m -Xms512m -XX:+UseShenandoahGC  -XX:+AlwaysPreTouch gc.TestAlwaysPreTouchBehavior
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xmx256m -Xms256m -XX:+UseShenandoahGC  -XX:+AlwaysPreTouch gc.TestAlwaysPreTouchBehavior
  */
 
 /**
@@ -65,11 +68,12 @@ package gc;
  * @summary tests AlwaysPreTouch
  * @requires vm.gc.G1
  * @requires os.maxMemory > 2G
- * @requires os.family != "aix"
+ * @requires vm.debug != true
+ * @requires os.family == "linux"
  * @library /test/lib
  * @build jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
- * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xmx512m -Xms512m -XX:+AlwaysPreTouch gc.TestAlwaysPreTouchBehavior
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xmx256m -Xms256m -XX:+AlwaysPreTouch gc.TestAlwaysPreTouchBehavior
  */
 
 /**
@@ -77,11 +81,12 @@ package gc;
  * @summary tests AlwaysPreTouch
  * @requires vm.gc.Z
  * @requires os.maxMemory > 2G
- * @requires os.family != "aix"
+ * @requires vm.debug != true
+ * @requires os.family == "linux"
  * @library /test/lib
  * @build jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
- * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -XX:+UseZGC -Xmx512m -Xms512m -XX:+AlwaysPreTouch gc.TestAlwaysPreTouchBehavior
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -XX:+UseZGC -Xmx256m -Xms256m -XX:+AlwaysPreTouch gc.TestAlwaysPreTouchBehavior
  */
 
 /**
@@ -89,30 +94,67 @@ package gc;
  * @summary tests AlwaysPreTouch
  * @requires vm.gc.Epsilon
  * @requires os.maxMemory > 2G
- * @requires os.family != "aix"
+ * @requires vm.debug != true
+ * @requires os.family == "linux"
  * @library /test/lib
  * @build jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
- * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC -Xmx512m -Xms512m -XX:+AlwaysPreTouch gc.TestAlwaysPreTouchBehavior
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC -Xmx256m -Xms256m -XX:+AlwaysPreTouch gc.TestAlwaysPreTouchBehavior
  */
 
 
 import jdk.test.lib.Asserts;
 
 import jdk.test.whitebox.WhiteBox;
+import jtreg.SkippedException;
 
 public class TestAlwaysPreTouchBehavior {
+    //
+    //    This test tests the ability of the JVM to pretouch its java heap for test purposes (AlwaysPreTouch). We start a
+    //    JVM with -XX:+AlwaysPreTouch, then observe RSS and expect to see RSS covering the entirety of the java heap,
+    //    since it should all be pre-touched now.
+    //
+    //    This test is important (we had pretouching break before) but very shaky since RSS of the JVM process is subject to
+    //    host machine conditions. If there is memory pressure, we may swap parts of the heap out after pretouching and
+    //    before measuring RSS, thus tainting the result.
+    //
+    //    This test attempts to minimize the risk of false positives stemming from memory pressure by:
+    //    - specifying @requires os.maxMemory > 2G
+    //    - checking  if the memory still available on the host machine after starting the process is lower than a
+    //      certain required threshold; if it is, we take this as a sign of memory pressure and disregard test errors.
+    //    - restricting the test to non-debug JVMs, since debug JVMs accrue much more non-heap RSS, and RSS is generally
+    //      more unpredictable.
+    //
+    //    Obviously, all of this is not bulletproof and only useful on Linux:
+    //    - On MacOS, os::available_memory() drastically underreports available memory, so this technique would almost
+    //      always fail to function
+    //    - On AIX, we dont have a way to measure rss yet.
+    //
 
     public static void main(String [] args) {
-    long rss = WhiteBox.getWhiteBox().rss();
-    System.out.println("RSS: " + rss);
-    if (rss == 0) {
-        System.out.println("cannot get RSS, just skip");
-        return; // Did not get available RSS, just ignore this test.
-    }
-    Runtime runtime = Runtime.getRuntime();
-    long committedMemory = runtime.totalMemory();
-    Asserts.assertGreaterThan(rss, committedMemory, "RSS of this process(" + rss + "b) should be bigger than or equal to committed heap mem(" + committedMemory + "b)");
-   }
-}
+        long rss = WhiteBox.getWhiteBox().rss();
+        System.out.println("RSS: " + rss);
+        long available = WhiteBox.getWhiteBox().hostAvailableMemory();
+        System.out.println("Host available memory: " + available);
 
+        long heapSize = 256 * 1024 * 1024;
+
+        // On Linux, a JVM that runs with 256M pre-committed heap will use about 60MB (release JVM) RSS. Barring
+        // memory pressure that causes us to lose RSS, pretouching should increase RSS to >256MB. So there should be a
+        // clear distinction between non-pretouched and pretouched.
+        long minRequiredRss = heapSize;
+
+        // The minimum required available memory size to count test errors as errors (to somewhat safely disregard
+        // outside memory pressure as the culprit)
+        // Note that we are over-generous and require at least 1G free. This is to make the chance for false positives
+        // very low.
+        long requiredAvailable = 1024 * 1024 * 1024;
+        if (rss == 0) {
+            throw new SkippedException("cannot get RSS?");
+        }
+        if (available > requiredAvailable) {
+            Asserts.assertGreaterThan(rss, minRequiredRss, "RSS of this process(" + rss + "b) should be bigger " +
+                                      "than or equal to heap size(" + heapSize + "b) (available memory: " + available + ")");
+        }
+    }
+}

--- a/test/hotspot/jtreg/gc/TestAlwaysPreTouchBehavior.java
+++ b/test/hotspot/jtreg/gc/TestAlwaysPreTouchBehavior.java
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, 2024, Alibaba Group Holding Limited. All rights reserved.
  * Copyright (c) 2024, 2025, Red Hat Inc.
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/lib/jdk/test/whitebox/WhiteBox.java
+++ b/test/lib/jdk/test/whitebox/WhiteBox.java
@@ -816,6 +816,7 @@ public class WhiteBox {
                                    String procSelfMountinfo);
   public native void printOsInfo();
   public native long hostPhysicalMemory();
+  public native long hostAvailableMemory();
   public native long hostPhysicalSwap();
   public native int hostCPUs();
 


### PR DESCRIPTION
I exhumed this old issue that fell through the cracks.

The test wants to make sure AlwaysPreTouch works by pretouching the java heap and comparing RSS with heap size. 

This technique is shaky: if the host machine experiences memory pressure, part of the pretouched memory will be swapped out before we measure RSS.

There is no way to make this bulletproof; still, this test is too useful to abandon it. Therefore I modified this test to make false positives (hopefully) very unlikely. See comment in test for details.

See old PR: https://github.com/openjdk/jdk/pull/19803

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334513](https://bugs.openjdk.org/browse/JDK-8334513): New test gc/TestAlwaysPreTouchBehavior.java is failing on MacOS aarch64 (**Bug** - P2)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25384/head:pull/25384` \
`$ git checkout pull/25384`

Update a local copy of the PR: \
`$ git checkout pull/25384` \
`$ git pull https://git.openjdk.org/jdk.git pull/25384/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25384`

View PR using the GUI difftool: \
`$ git pr show -t 25384`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25384.diff">https://git.openjdk.org/jdk/pull/25384.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25384#issuecomment-2900975435)
</details>
