### PR TITLE
8357533: ZGC: ZIndexDistributorClaimTree functions not inlined on Windows

### DIFF
--- a/src/hotspot/share/gc/z/zForwardingTable.hpp
+++ b/src/hotspot/share/gc/z/zForwardingTable.hpp
@@ -25,7 +25,6 @@
 #define SHARE_GC_Z_ZFORWARDINGTABLE_HPP
 
 #include "gc/z/zGranuleMap.hpp"
-#include "gc/z/zIndexDistributor.hpp"
 
 class ZForwarding;
 

--- a/src/hotspot/share/gc/z/zForwardingTable.inline.hpp
+++ b/src/hotspot/share/gc/z/zForwardingTable.inline.hpp
@@ -30,7 +30,6 @@
 #include "gc/z/zForwarding.inline.hpp"
 #include "gc/z/zGlobals.hpp"
 #include "gc/z/zGranuleMap.inline.hpp"
-#include "gc/z/zIndexDistributor.inline.hpp"
 #include "utilities/debug.hpp"
 
 inline ZForwardingTable::ZForwardingTable()

--- a/src/hotspot/share/gc/z/zGeneration.cpp
+++ b/src/hotspot/share/gc/z/zGeneration.cpp
@@ -42,6 +42,7 @@
 #include "gc/z/zJNICritical.hpp"
 #include "gc/z/zMark.inline.hpp"
 #include "gc/z/zPageAllocator.hpp"
+#include "gc/z/zPageTable.inline.hpp"
 #include "gc/z/zRelocationSet.inline.hpp"
 #include "gc/z/zRelocationSetSelector.inline.hpp"
 #include "gc/z/zRemembered.hpp"

--- a/src/hotspot/share/gc/z/zIndexDistributor.inline.hpp
+++ b/src/hotspot/share/gc/z/zIndexDistributor.inline.hpp
@@ -27,12 +27,21 @@
 #include "gc/z/zIndexDistributor.hpp"
 
 #include "gc/shared/gc_globals.hpp"
+#include "gc/shared/workerThread.hpp"
 #include "gc/z/zGlobals.hpp"
+#include "logging/log.hpp"
 #include "runtime/atomic.hpp"
 #include "runtime/os.hpp"
 #include "runtime/thread.hpp"
 #include "utilities/align.hpp"
+#include "utilities/debug.hpp"
 #include "utilities/powerOfTwo.hpp"
+
+#define ZINDEXDISTRIBUTOR_LOGGING 0
+
+inline int zfetch_then_inc(volatile int* addr) {
+  return Atomic::fetch_then_add(addr, 1, memory_order_relaxed);
+}
 
 class ZIndexDistributorStriped : public CHeapObj<mtGC> {
   static const int MemSize = 4096;
@@ -45,7 +54,7 @@ class ZIndexDistributorStriped : public CHeapObj<mtGC> {
   char _mem[MemSize + ZCacheLineSize];
 
   int claim_stripe() {
-    return Atomic::fetch_then_add(&_claim_stripe, 1, memory_order_relaxed);
+    return zfetch_then_inc(&_claim_stripe);
   }
 
   volatile int* claim_addr(int index) {
@@ -66,7 +75,7 @@ public:
 
     // Use claiming
     for (int i; (i = claim_stripe()) < StripeCount;) {
-      for (int index; (index = Atomic::fetch_then_add(claim_addr(i), 1, memory_order_relaxed)) < stripe_max;) {
+      for (int index; (index = zfetch_then_inc(claim_addr(i))) < stripe_max;) {
         if (!function(i * stripe_max + index)) {
           return;
         }
@@ -75,7 +84,7 @@ public:
 
     // Use stealing
     for (int i = 0; i < StripeCount; i++) {
-      for (int index; (index = Atomic::fetch_then_add(claim_addr(i), 1, memory_order_relaxed)) < stripe_max;) {
+      for (int index; (index = zfetch_then_inc(claim_addr(i))) < stripe_max;) {
         if (!function(i * stripe_max + index)) {
           return;
         }
@@ -98,13 +107,6 @@ private:
   static constexpr int N = 4;
   static constexpr int ClaimLevels = N - 1;
 
-  // Describes the how the number of indices increases when going up from the given level
-  static constexpr int level_multiplier(int level) {
-    assert(level < ClaimLevels, "Must be");
-    constexpr int array[ClaimLevels]{16, 16, 16};
-    return array[level];
-  }
-
   // Number of indices in one segment at the last level
   const int     _last_level_segment_size_shift;
 
@@ -114,177 +116,170 @@ private:
   // Contains the tree of claim variables
   volatile int* _claim_array;
 
-  // Claim index functions
+  // Describes the how the number of indices increases when going up from the given level
+  template <int level>
+  static constexpr int level_multiplier() {
+    STATIC_ASSERT(level >= 0);
+    STATIC_ASSERT(level < ClaimLevels);
+
+    constexpr int array[ClaimLevels]{16, 16, 16};
+    constexpr int result = array[level];
+    return result;
+  }
 
   // Number of claim entries at the given level
-  static constexpr int claim_level_size(int level) {
-    if (level == 0) {
-      return 1;
-    }
-
-    return level_multiplier(level - 1) * claim_level_size(level - 1);
-  }
+  template <int level>
+  inline static constexpr int claim_level_size();
 
   // The index the next level starts at
-  static constexpr int claim_level_end_index(int level) {
-    if (level == 0) {
+  template <int level>
+  inline static constexpr int claim_level_end_index();
 
-      // First level uses padding
-      return ZCacheLineSize / sizeof(int);
-    }
-
-    return claim_level_size(level) + claim_level_end_index(level - 1);
-  }
-
-  static constexpr int claim_level_start_index(int level) {
-    return claim_level_end_index(level - 1);
-  }
+  template <int level>
+  inline static constexpr int claim_level_start_index();
 
   // Total size used to hold all claim variables
-  static size_t claim_variables_size() {
-    return sizeof(int) * (size_t)claim_level_end_index(ClaimLevels);
-  }
+  inline static size_t claim_variables_size();
 
   // Returns the index of the start of the current segment of the current level
-  static constexpr int claim_level_index_accumulate(int* indices, int level, int acc = 1) {
-    if (level == 0) {
-      return acc * indices[level];
-    }
+  template <int level>
+  inline static constexpr int claim_level_index_accumulate(int* indices, int acc = 1);
 
-    return acc * indices[level] + claim_level_index_accumulate(indices, level - 1, acc * level_multiplier(level));
-  }
-
-  static constexpr int claim_level_index(int* indices, int level) {
-    assert(level > 0, "Must be");
+  template <int level>
+  inline static constexpr int claim_level_index(int* indices) {
+    STATIC_ASSERT(level > 0);
 
     // The claim index for the current level is found in the previous levels
-    return claim_level_index_accumulate(indices, level - 1);
+    return claim_level_index_accumulate<level - 1>(indices);
   }
 
-  static constexpr int claim_index(int* indices, int level) {
-    if (level == 0) {
-      return 0;
-    }
-
-    return claim_level_start_index(level) + claim_level_index(indices, level);
-  }
+  template <int level>
+  inline static constexpr int claim_index(int* indices);
 
   // Claim functions
 
-  int claim(int index) {
-    return Atomic::fetch_then_add(&_claim_array[index], 1, memory_order_relaxed);
+  inline int claim(int index) {
+    return zfetch_then_inc(&_claim_array[index]);
   }
 
-  int claim_at(int* indices, int level) {
-    const int index = claim_index(indices, level);
-    const int value = claim(index);
-#if 0
-    if      (level == 0) { tty->print_cr("Claim at: %d index: %d got: %d",             indices[0], index, value); }
-    else if (level == 1) { tty->print_cr("Claim at: %d %d index: %d got: %d",          indices[0], indices[1], index, value); }
-    else if (level == 2) { tty->print_cr("Claim at: %d %d %d index: %d got: %d",       indices[0], indices[1], indices[2], index, value); }
-    else if (level == 3) { tty->print_cr("Claim at: %d %d %d %d index: %d got: %d",    indices[0], indices[1], indices[2], indices[3], index, value); }
-    else if (level == 4) { tty->print_cr("Claim at: %d %d %d %d %d index: %d got: %d", indices[0], indices[1], indices[2], indices[3], indices[4], index, value); }
-#endif
-    return value;
-  }
+  template <int level>
+  inline int level_segment_size();
 
   template <typename Function>
-  void claim_and_do(Function function, int* indices, int level) {
-    if (level < N) {
-      // Visit ClaimLevels and the last level
-      const int ci = claim_index(indices, level);
-      for (indices[level] = 0; (indices[level] = claim(ci)) < level_segment_size(level);) {
-        claim_and_do(function, indices, level + 1);
-      }
-      return;
-    }
-
+  inline void claim_and_do_N(Function function, int* indices) {
     doit(function, indices);
   }
 
+  template <int level, typename Function>
+  inline void claim_and_do_lt_N(Function function, int* indices) {
+    STATIC_ASSERT(level < N);
+
+    // Visit ClaimLevels and the last level
+    const int ci = claim_index<level>(indices);
+    for (indices[level] = 0; (indices[level] = claim(ci)) < level_segment_size<level>();) {
+      claim_and_do<level + 1>(function, indices);
+    }
+  }
+
+  template <int level, typename Function>
+  struct ClaimAndDo;
+
+  template <int level, typename Function>
+  inline void claim_and_do(Function function, int* indices) {
+    // Dispatch depending on value of level
+    ClaimAndDo<level, Function>::dispatch(*this, function, indices);
+  }
+
   template <typename Function>
-  void steal_and_do(Function function, int* indices, int level) {
-    for (indices[level] = 0; indices[level] < level_segment_size(level); indices[level]++) {
-      const int next_level = level + 1;
+  void steal_and_do_ClaimLevels_minus_1(Function function, int* indices) {
+    constexpr int level = ClaimLevels - 1;
+
+    for (indices[level] = 0; indices[level] < level_segment_size<level>(); indices[level]++) {
+      constexpr int next_level = level + 1;
       // First try to claim at next level
-      claim_and_do(function, indices, next_level);
+      claim_and_do<next_level>(function, indices);
+    }
+  }
+
+  template <int level, typename Function>
+  void steal_and_do_lt_ClaimLevels_minus_1(Function function, int* indices) {
+    STATIC_ASSERT(level < ClaimLevels - 1);
+
+    for (indices[level] = 0; indices[level] < level_segment_size<level>(); indices[level]++) {
+      constexpr int next_level = level + 1;
+      // First try to claim at next level
+      claim_and_do<next_level>(function, indices);
       // Then steal at next level
-      if (next_level < ClaimLevels) {
-        steal_and_do(function, indices, next_level);
-      }
+      steal_and_do<next_level>(function, indices);
     }
   }
 
-  // Functions to claimed values to an index
+  template <int level, typename Function>
+  struct StealAndDo;
 
-  static constexpr int levels_size(int level) {
-    if (level == 0) {
-      return level_multiplier(0);
-    }
-
-    return level_multiplier(level) * levels_size(level - 1);
+  template <int level, typename Function>
+  inline void steal_and_do(Function function, int* indices) {
+    // Dispatch depending on value of level
+    StealAndDo<level, Function>::dispatch(*this, function, indices);
   }
 
-  static int constexpr level_to_last_level_count_coverage(int level) {
-    return levels_size(ClaimLevels - 1) / levels_size(level);
-  }
+  template <int level>
+  inline static constexpr int levels_size();
 
-  static int constexpr calculate_last_level_count(int* indices, int level = 0) {
-    if (level == N - 1) {
-      return 0;
-    }
+  template <int level>
+  inline static int constexpr level_to_last_level_count_coverage();
 
-    return indices[level] * level_to_last_level_count_coverage(level) + calculate_last_level_count(indices, level + 1);
-  }
+  template <int level = 0>
+  inline static int constexpr calculate_last_level_count(int* indices);
 
-  int calculate_index(int* indices) {
-    const int segment_start = calculate_last_level_count(indices) << _last_level_segment_size_shift;
-    return segment_start + indices[N - 1];
-  }
-
-  int level_segment_size(int level) {
-    if (level == ClaimLevels) {
-      return 1 << _last_level_segment_size_shift;
-    }
-
-    return level_multiplier(level);
-  }
+  inline int calculate_index(int* indices);
 
   template <typename Function>
-  void doit(Function function, int* indices) {
-    //const int index = first_level * second_level_max * _third_level_max + second_level * _third_level_max + third_level;
-    const int index = calculate_index(indices);
+  inline void doit(Function function, int* indices);
 
-#if 0
-    tty->print_cr("doit Thread: " PTR_FORMAT ": %d %d %d %d => %d",
-        p2i(Thread::current()),
-        indices[0], indices[1], indices[2], indices[3], index);
+#if  ZINDEXDISTRIBUTOR_LOGGING
+  void log_claim_array() {
+    log_info(gc, reloc)("_claim_array[0]: %d", _claim_array[0]);
+
+    for (int i = level_segment_size<0>(); i < claim_level_end_index<ClaimLevels>(); i += 16) {
+      log_info(gc, reloc)("_claim_array[%d-%d]: %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d",
+          i, i + 15,
+          _claim_array[i],
+          _claim_array[i + 1],
+          _claim_array[i + 2],
+          _claim_array[i + 3],
+          _claim_array[i + 4],
+          _claim_array[i + 5],
+          _claim_array[i + 6],
+          _claim_array[i + 7],
+          _claim_array[i + 8],
+          _claim_array[i + 9],
+          _claim_array[i + 10],
+          _claim_array[i + 11],
+          _claim_array[i + 12],
+          _claim_array[i + 13],
+          _claim_array[i + 14],
+          _claim_array[i + 15]);
+    }
+  }
 #endif
 
-    function(index);
-  }
-
-  static int last_level_segment_size_shift(int count) {
-    const int last_level_size = count / levels_size(ClaimLevels - 1);
-    assert(levels_size(ClaimLevels - 1) * last_level_size == count, "Not exactly divisible");
-
-    return log2i_exact(last_level_size);
-  }
+  inline static int calculate_last_level_segment_size_shift(int count);
 
 public:
   ZIndexDistributorClaimTree(int count)
-    : _last_level_segment_size_shift(last_level_segment_size_shift(count)),
+    : _last_level_segment_size_shift(calculate_last_level_segment_size_shift(count)),
       _malloced((char*)os::malloc(claim_variables_size() + os::vm_page_size(), mtGC)),
       _claim_array((volatile int*)align_up(_malloced, os::vm_page_size())) {
 
-    assert((levels_size(ClaimLevels - 1) << _last_level_segment_size_shift) == count, "Incorrectly setup");
-
-#if 0
-    tty->print_cr("ZIndexDistributorClaimTree count: %d byte size: %zu", count, claim_variables_size() + os::vm_page_size());
-#endif
+    assert((levels_size<ClaimLevels - 1>() << _last_level_segment_size_shift) == count, "Incorrectly setup");
 
     memset(_malloced, 0, claim_variables_size() + os::vm_page_size());
-  }
+
+#if ZINDEXDISTRIBUTOR_LOGGING
+    tty->print_cr("ZIndexDistributorClaimTree count: %d byte size: " SIZE_FORMAT, count, claim_variables_size() + os::vm_page_size());
+#endif
+}
 
   ~ZIndexDistributorClaimTree() {
     os::free(_malloced);
@@ -293,27 +288,16 @@ public:
   template <typename Function>
   void do_indices(Function function) {
     int indices[N];
-    claim_and_do(function, indices, 0 /* level */);
-    steal_and_do(function, indices, 0 /* level */);
+    claim_and_do<0>(function, indices);
+    steal_and_do<0>(function, indices);
   }
 
   static size_t get_count(size_t max_count) {
     // Must be at least claim_level_size(ClaimLevels) and a power of two
-    const size_t min_count = claim_level_size(ClaimLevels);
+    const size_t min_count = claim_level_size<ClaimLevels>();
     return round_up_power_of_2(MAX2(max_count, min_count));
   }
 };
-
-// Using dynamically allocated objects just to be able to evaluate
-// different strategies. Revert when one has been choosen.
-
-inline void* ZIndexDistributor::create_strategy(int count) {
-  switch (ZIndexDistributorStrategy) {
-  case 0: return new ZIndexDistributorClaimTree(count);
-  case 1: return new ZIndexDistributorStriped(count);
-  default: fatal("Unknown ZIndexDistributorStrategy"); return nullptr;
-  };
-}
 
 inline ZIndexDistributor::ZIndexDistributor(int count)
   : _strategy(create_strategy(count)) {}
@@ -323,6 +307,17 @@ inline ZIndexDistributor::~ZIndexDistributor() {
   case 0: delete static_cast<ZIndexDistributorClaimTree*>(_strategy); break;
   case 1: delete static_cast<ZIndexDistributorStriped*>(_strategy); break;
   default: fatal("Unknown ZIndexDistributorStrategy"); break;
+  };
+}
+
+// Using dynamically allocated objects just to be able to evaluate
+// different strategies. Revert when one has been chosen.
+
+inline void* ZIndexDistributor::create_strategy(int count) {
+  switch (ZIndexDistributorStrategy) {
+  case 0: return new ZIndexDistributorClaimTree(count);
+  case 1: return new ZIndexDistributorStriped(count);
+  default: fatal("Unknown ZIndexDistributorStrategy"); return nullptr;
   };
 }
 
@@ -352,5 +347,150 @@ inline size_t ZIndexDistributor::get_count(size_t max_count) {
 
   return required_count;
 }
+
+template <>
+constexpr int ZIndexDistributorClaimTree::claim_level_size<0>() {
+  return 1;
+}
+
+template <int level>
+constexpr int ZIndexDistributorClaimTree::claim_level_size() {
+  STATIC_ASSERT(level > 0);
+
+  return level_multiplier<level - 1>() * claim_level_size<level - 1>();
+}
+
+template <>
+constexpr int ZIndexDistributorClaimTree::claim_level_end_index<0>() {
+  // First level uses padding
+  return ZCacheLineSize / sizeof(int);
+}
+
+template <int level>
+constexpr int ZIndexDistributorClaimTree::claim_level_end_index() {
+  STATIC_ASSERT(level > 0);
+
+  return claim_level_size<level>() + claim_level_end_index<level - 1>();
+}
+
+template <int level>
+constexpr int ZIndexDistributorClaimTree::claim_level_start_index() {
+  return claim_level_end_index<level - 1>();
+}
+
+inline size_t ZIndexDistributorClaimTree::claim_variables_size() {
+  return sizeof(int) * (size_t)claim_level_end_index<ClaimLevels>();
+}
+
+template <>
+inline int ZIndexDistributorClaimTree::level_segment_size<ZIndexDistributorClaimTree::ClaimLevels>() {
+  return 1 << _last_level_segment_size_shift;
+}
+
+template <int level>
+inline int ZIndexDistributorClaimTree::level_segment_size() {
+  return level_multiplier<level>();
+}
+
+template <>
+constexpr int ZIndexDistributorClaimTree::levels_size<0>() {
+  return level_multiplier<0>();
+}
+
+template <int level>
+constexpr int ZIndexDistributorClaimTree::levels_size() {
+  STATIC_ASSERT(level > 0);
+
+  return level_multiplier<level>() * levels_size<level - 1>();
+}
+
+template <int level>
+constexpr int ZIndexDistributorClaimTree::level_to_last_level_count_coverage() {
+  return levels_size<ClaimLevels - 1>() / levels_size<level>();
+}
+
+template <>
+constexpr int ZIndexDistributorClaimTree::calculate_last_level_count<ZIndexDistributorClaimTree::N - 1>(int* indices) {
+  return 0;
+}
+
+template <int level>
+constexpr int ZIndexDistributorClaimTree::calculate_last_level_count(int* indices) {
+  return indices[level] * level_to_last_level_count_coverage<level>() + calculate_last_level_count<level + 1>(indices);
+}
+
+inline int ZIndexDistributorClaimTree::calculate_index(int* indices) {
+  const int segment_start = calculate_last_level_count(indices) << _last_level_segment_size_shift;
+  return segment_start + indices[N - 1];
+}
+
+template <typename Function>
+inline void ZIndexDistributorClaimTree::doit(Function function, int* indices) {
+  const int index = calculate_index(indices);
+
+#if ZINDEXDISTRIBUTOR_LOGGING
+  log_debug(gc, reloc)("doit Thread: " PTR_FORMAT ": %d %d %d %d => %d",
+      p2i(Thread::current()),
+      indices[0], indices[1], indices[2], indices[3], index);
+#endif
+
+  function(index);
+}
+
+inline int ZIndexDistributorClaimTree::calculate_last_level_segment_size_shift(int count) {
+  const int last_level_size = count / levels_size<ClaimLevels - 1>();
+
+  assert(levels_size<ClaimLevels - 1>() * last_level_size == count, "Not exactly divisible");
+
+  return log2i_exact(last_level_size);
+}
+
+template <>
+constexpr int ZIndexDistributorClaimTree::claim_index<0>(int* indices) {
+  return 0;
+}
+
+template <int level>
+constexpr int ZIndexDistributorClaimTree::claim_index(int* indices) {
+  return claim_level_start_index<level>() + claim_level_index<level>(indices);
+}
+
+template <>
+constexpr int ZIndexDistributorClaimTree::claim_level_index_accumulate<0>(int* indices, int acc) {
+  return acc * indices[0];
+}
+
+template <int level>
+constexpr int ZIndexDistributorClaimTree::claim_level_index_accumulate(int* indices, int acc) {
+  return acc * indices[level] + claim_level_index_accumulate<level - 1>(indices, acc * level_multiplier<level>());
+}
+
+template <typename Function>
+struct ZIndexDistributorClaimTree::ClaimAndDo<ZIndexDistributorClaimTree::N, Function> {
+  inline static void dispatch(ZIndexDistributorClaimTree& instance, Function function, int* indices) {
+    instance.claim_and_do_N(function, indices);
+  }
+};
+
+template <int level, typename Function>
+struct ZIndexDistributorClaimTree::ClaimAndDo {
+  inline static void dispatch(ZIndexDistributorClaimTree& instance, Function function, int* indices) {
+    instance.claim_and_do_lt_N<level>(function, indices);
+  }
+};
+
+template <typename Function>
+struct ZIndexDistributorClaimTree::StealAndDo<ZIndexDistributorClaimTree::ClaimLevels - 1, Function> {
+  inline static void dispatch(ZIndexDistributorClaimTree& instance, Function function, int* indices) {
+    instance.steal_and_do_ClaimLevels_minus_1(function, indices);
+  }
+};
+
+template <int level, typename Function>
+struct ZIndexDistributorClaimTree::StealAndDo {
+  inline static void dispatch(ZIndexDistributorClaimTree& instance, Function function, int* indices) {
+    instance.steal_and_do_lt_ClaimLevels_minus_1<level>(function, indices);
+  }
+};
 
 #endif // SHARE_GC_Z_ZINDEXDISTRIBUTOR_INLINE_HPP

--- a/src/hotspot/share/gc/z/zPageTable.cpp
+++ b/src/hotspot/share/gc/z/zPageTable.cpp
@@ -76,6 +76,14 @@ void ZPageTable::replace(ZPage* old_page, ZPage* new_page) {
   }
 }
 
+ZPageTableParallelIterator::ZPageTableParallelIterator(const ZPageTable* table)
+  : _table(table),
+    _index_distributor(table->count()) {}
+
+ZPageTableParallelIterator::~ZPageTableParallelIterator() {
+  // Explicit destructor because dependency on the inline ZIndexDistributor destructor
+}
+
 ZGenerationPagesParallelIterator::ZGenerationPagesParallelIterator(const ZPageTable* page_table, ZGenerationId id, ZPageAllocator* page_allocator)
   : _iterator(page_table),
     _generation_id(id),

--- a/src/hotspot/share/gc/z/zPageTable.hpp
+++ b/src/hotspot/share/gc/z/zPageTable.hpp
@@ -74,6 +74,7 @@ class ZPageTableParallelIterator : public StackObj {
 
 public:
   ZPageTableParallelIterator(const ZPageTable* table);
+  ~ZPageTableParallelIterator();
 
   template <typename Function>
   void do_pages(Function function);

--- a/src/hotspot/share/gc/z/zPageTable.inline.hpp
+++ b/src/hotspot/share/gc/z/zPageTable.inline.hpp
@@ -71,10 +71,6 @@ inline bool ZPageTableIterator::next(ZPage** page) {
   return false;
 }
 
-inline ZPageTableParallelIterator::ZPageTableParallelIterator(const ZPageTable* table)
-  : _table(table),
-    _index_distributor(table->count()) {}
-
 template <typename Function>
 inline void ZPageTableParallelIterator::do_pages(Function function) {
   _index_distributor.do_indices([&](int index) {

--- a/src/hotspot/share/gc/z/zRelocate.cpp
+++ b/src/hotspot/share/gc/z/zRelocate.cpp
@@ -31,7 +31,6 @@
 #include "gc/z/zForwarding.inline.hpp"
 #include "gc/z/zGeneration.inline.hpp"
 #include "gc/z/zHeap.inline.hpp"
-#include "gc/z/zIndexDistributor.inline.hpp"
 #include "gc/z/zIterator.inline.hpp"
 #include "gc/z/zPage.inline.hpp"
 #include "gc/z/zPageAge.hpp"

--- a/test/hotspot/gtest/gc/z/test_zIndexDistributor.cpp
+++ b/test/hotspot/gtest/gc/z/test_zIndexDistributor.cpp
@@ -29,38 +29,38 @@ protected:
   static void test_claim_tree_claim_level_size() {
     // max_index: 16, 16, 16, rest
     // claim level: 1, 16, 16 * 16, 16 * 16 * 16
-    ASSERT_EQ(ZIndexDistributorClaimTree::claim_level_size(0), 1);
-    ASSERT_EQ(ZIndexDistributorClaimTree::claim_level_size(1), 16);
-    ASSERT_EQ(ZIndexDistributorClaimTree::claim_level_size(2), 16 * 16);
-    ASSERT_EQ(ZIndexDistributorClaimTree::claim_level_size(3), 16 * 16 * 16);
+    ASSERT_EQ(ZIndexDistributorClaimTree::claim_level_size<0>(), 1);
+    ASSERT_EQ(ZIndexDistributorClaimTree::claim_level_size<1>(), 16);
+    ASSERT_EQ(ZIndexDistributorClaimTree::claim_level_size<2>(), 16 * 16);
+    ASSERT_EQ(ZIndexDistributorClaimTree::claim_level_size<3>(), 16 * 16 * 16);
   }
 
   static void test_claim_tree_claim_level_end_index() {
     // First level is padded
     const int first_level_end = int(ZCacheLineSize / sizeof(int));
-    ASSERT_EQ(ZIndexDistributorClaimTree::claim_level_end_index(0), first_level_end);
-    ASSERT_EQ(ZIndexDistributorClaimTree::claim_level_end_index(1), first_level_end + 16);
-    ASSERT_EQ(ZIndexDistributorClaimTree::claim_level_end_index(2), first_level_end + 16 + 16 * 16);
-    ASSERT_EQ(ZIndexDistributorClaimTree::claim_level_end_index(3), first_level_end + 16 + 16 * 16 + 16 * 16 * 16);
+    ASSERT_EQ(ZIndexDistributorClaimTree::claim_level_end_index<0>(), first_level_end);
+    ASSERT_EQ(ZIndexDistributorClaimTree::claim_level_end_index<1>(), first_level_end + 16);
+    ASSERT_EQ(ZIndexDistributorClaimTree::claim_level_end_index<2>(), first_level_end + 16 + 16 * 16);
+    ASSERT_EQ(ZIndexDistributorClaimTree::claim_level_end_index<3>(), first_level_end + 16 + 16 * 16 + 16 * 16 * 16);
   }
 
   static void test_claim_tree_claim_index() {
     // First level should always give index 0
     {
       int indices[4] = {0, 0, 0, 0};
-      ASSERT_EQ(ZIndexDistributorClaimTree::claim_index(indices, 0), 0);
+      ASSERT_EQ(ZIndexDistributorClaimTree::claim_index<0>(indices), 0);
     }
     {
       int indices[4] = {1, 0, 0, 0};
-      ASSERT_EQ(ZIndexDistributorClaimTree::claim_index(indices, 0), 0);
+      ASSERT_EQ(ZIndexDistributorClaimTree::claim_index<0>(indices), 0);
     }
     {
       int indices[4] = {15, 0, 0, 0};
-      ASSERT_EQ(ZIndexDistributorClaimTree::claim_index(indices, 0), 0);
+      ASSERT_EQ(ZIndexDistributorClaimTree::claim_index<0>(indices), 0);
     }
     {
       int indices[4] = {16, 0, 0, 0};
-      ASSERT_EQ(ZIndexDistributorClaimTree::claim_index(indices, 0), 0);
+      ASSERT_EQ(ZIndexDistributorClaimTree::claim_index<0>(indices), 0);
     }
 
     // Second level should depend on first claimed index
@@ -70,15 +70,15 @@ protected:
 
     {
       int indices[4] = {0, 0, 0, 0};
-      ASSERT_EQ(ZIndexDistributorClaimTree::claim_index(indices, 1), second_level_start);
+      ASSERT_EQ(ZIndexDistributorClaimTree::claim_index<1>(indices), second_level_start);
     }
     {
       int indices[4] = {1, 0, 0, 0};
-      ASSERT_EQ(ZIndexDistributorClaimTree::claim_index(indices, 1), second_level_start + 1);
+      ASSERT_EQ(ZIndexDistributorClaimTree::claim_index<1>(indices), second_level_start + 1);
     }
     {
       int indices[4] = {15, 0, 0, 0};
-      ASSERT_EQ(ZIndexDistributorClaimTree::claim_index(indices, 1), second_level_start + 15);
+      ASSERT_EQ(ZIndexDistributorClaimTree::claim_index<1>(indices), second_level_start + 15);
     }
 
     // Third level
@@ -87,23 +87,23 @@ protected:
 
     {
       int indices[4] = {0, 0, 0, 0};
-      ASSERT_EQ(ZIndexDistributorClaimTree::claim_index(indices, 2), third_level_start);
+      ASSERT_EQ(ZIndexDistributorClaimTree::claim_index<2>(indices), third_level_start);
     }
     {
       int indices[4] = {1, 0, 0, 0};
-      ASSERT_EQ(ZIndexDistributorClaimTree::claim_index(indices, 2), third_level_start + 1 * 16);
+      ASSERT_EQ(ZIndexDistributorClaimTree::claim_index<2>(indices), third_level_start + 1 * 16);
     }
     {
       int indices[4] = {15, 0, 0, 0};
-      ASSERT_EQ(ZIndexDistributorClaimTree::claim_index(indices, 2), third_level_start + 15 * 16);
+      ASSERT_EQ(ZIndexDistributorClaimTree::claim_index<2>(indices), third_level_start + 15 * 16);
     }
     {
       int indices[4] = {1, 2, 0, 0};
-      ASSERT_EQ(ZIndexDistributorClaimTree::claim_index(indices, 2), third_level_start + 1 * 16 + 2);
+      ASSERT_EQ(ZIndexDistributorClaimTree::claim_index<2>(indices), third_level_start + 1 * 16 + 2);
     }
     {
       int indices[4] = {15, 14, 0, 0};
-      ASSERT_EQ(ZIndexDistributorClaimTree::claim_index(indices, 2), third_level_start + 15 * 16 + 14);
+      ASSERT_EQ(ZIndexDistributorClaimTree::claim_index<2>(indices), third_level_start + 15 * 16 + 14);
     }
 
   }
@@ -111,53 +111,53 @@ protected:
   static void test_claim_tree_claim_level_index() {
     {
       int indices[4] = {0,0,0,0};
-      ASSERT_EQ(ZIndexDistributorClaimTree::claim_level_index(indices, 1), 0);
+      ASSERT_EQ(ZIndexDistributorClaimTree::claim_level_index<1>(indices), 0);
     }
     {
       int indices[4] = {1,0,0,0};
-      ASSERT_EQ(ZIndexDistributorClaimTree::claim_level_index(indices, 1), 1);
+      ASSERT_EQ(ZIndexDistributorClaimTree::claim_level_index<1>(indices), 1);
     }
 
     {
       int indices[4] = {0,0,0,0};
-      ASSERT_EQ(ZIndexDistributorClaimTree::claim_level_index(indices, 2), 0);
+      ASSERT_EQ(ZIndexDistributorClaimTree::claim_level_index<2>(indices), 0);
     }
     {
       int indices[4] = {1,0,0,0};
-      ASSERT_EQ(ZIndexDistributorClaimTree::claim_level_index(indices, 2), 1 * 16);
+      ASSERT_EQ(ZIndexDistributorClaimTree::claim_level_index<2>(indices), 1 * 16);
     }
     {
       int indices[4] = {2,0,0,0};
-      ASSERT_EQ(ZIndexDistributorClaimTree::claim_level_index(indices, 2), 2 * 16);
+      ASSERT_EQ(ZIndexDistributorClaimTree::claim_level_index<2>(indices), 2 * 16);
     }
     {
       int indices[4] = {2,1,0,0};
-      ASSERT_EQ(ZIndexDistributorClaimTree::claim_level_index(indices, 2), 2 * 16 + 1);
+      ASSERT_EQ(ZIndexDistributorClaimTree::claim_level_index<2>(indices), 2 * 16 + 1);
     }
 
     {
       int indices[4] = {0,0,0,0};
-      ASSERT_EQ(ZIndexDistributorClaimTree::claim_level_index(indices, 3), 0);
+      ASSERT_EQ(ZIndexDistributorClaimTree::claim_level_index<3>(indices), 0);
     }
     {
       int indices[4] = {1,0,0,0};
-      ASSERT_EQ(ZIndexDistributorClaimTree::claim_level_index(indices, 3), 1 * 16 * 16);
+      ASSERT_EQ(ZIndexDistributorClaimTree::claim_level_index<3>(indices), 1 * 16 * 16);
     }
     {
       int indices[4] = {1,2,0,0};
-      ASSERT_EQ(ZIndexDistributorClaimTree::claim_level_index(indices, 3), 1 * 16 * 16 + 2 * 16);
+      ASSERT_EQ(ZIndexDistributorClaimTree::claim_level_index<3>(indices), 1 * 16 * 16 + 2 * 16);
     }
     {
       int indices[4] = {1,2,1,0};
-      ASSERT_EQ(ZIndexDistributorClaimTree::claim_level_index(indices, 3), 1 * 16 * 16 + 2 * 16 + 1);
+      ASSERT_EQ(ZIndexDistributorClaimTree::claim_level_index<3>(indices), 1 * 16 * 16 + 2 * 16 + 1);
     }
     {
       int indices[4] = {1,2,3,0};
-      ASSERT_EQ(ZIndexDistributorClaimTree::claim_level_index(indices, 3), 1 * 16 * 16 + 2 * 16 + 3);
+      ASSERT_EQ(ZIndexDistributorClaimTree::claim_level_index<3>(indices), 1 * 16 * 16 + 2 * 16 + 3);
     }
     {
       int indices[4] = {1,2,3,0};
-      ASSERT_EQ(ZIndexDistributorClaimTree::claim_level_index(indices, 2), 1 * 16 + 2);
+      ASSERT_EQ(ZIndexDistributorClaimTree::claim_level_index<2>(indices), 1 * 16 + 2);
     }
   }
 };


### PR DESCRIPTION
While investigating a minor performance regression in a System.gc() microbenchmark I saw that the Concurrent Remap Roots phase took a significant portion of the GC cycle time.

It turns out that even though we use constexpr we don't get the inlining of the the functions as we expected and this results in a noticeable performance loss.

When running System.gc() with on old GC worker thread with a 16TB max heap size we spend around 300 ms just iterating over the page table and its indices via ZIndexDistributorClaimTree. If the inlining is fixed this drops down to ~70 ms, which is similar to what we see on Linux and MacOS.

We already have a patch out to remove the last usage of the ZIndexDistributor mechanism in https://github.com/openjdk/jdk/pull/25345, but ZIndexDistributor has less restrictions and is easier to use so we might want to keep it around (with fixed performance) so that it can be used for prototyping and maybe future features.

Noteworthy in the patch is the following function:
```
  static constexpr int level_multiplier(int level) {
    assert(level < ClaimLevels, "Must be");
    constexpr int array[ClaimLevels]{16, 16, 16};
    return array[level];
  }
```

When the last statement is changed to:
```
    constexpr int result = array[level];
    return result;
```

The MS compiler complains that the expression is not a constant. And if we get the correct inlining the warning goes away.

To get the required inlining I've changed the `level` parameter to be a template parameter and restructured the code to use template specialization instead of if-statements. This required some finagling with template classes to get partial specialization to work.

Some other changes in the patch:
* Limited includes of zIndexDistributor.inline.hpp
* Extracted the atomic inc into zfetch_then_inc for easier evaluation of the performance impact of our Atomic implementation vs relaxed std::atomic vs non-atomic updates.
* Hid the logging under a compile-time define. The logging is useful when changing/debugging this code, but otherwise it is not.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8357533](https://bugs.openjdk.org/browse/JDK-8357533): ZGC: ZIndexDistributorClaimTree functions not inlined on Windows (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25385/head:pull/25385` \
`$ git checkout pull/25385`

Update a local copy of the PR: \
`$ git checkout pull/25385` \
`$ git pull https://git.openjdk.org/jdk.git pull/25385/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25385`

View PR using the GUI difftool: \
`$ git pr show -t 25385`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25385.diff">https://git.openjdk.org/jdk/pull/25385.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25385#issuecomment-2900313661)
</details>
