### PR TITLE
8351889: C2 crash: assertion failed:  Base pointers must match (addp 344)

### DIFF
--- a/src/hotspot/share/opto/cfgnode.cpp
+++ b/src/hotspot/share/opto/cfgnode.cpp
@@ -2153,6 +2153,14 @@ Node *PhiNode::Ideal(PhaseGVN *phase, bool can_reshape) {
       // If there is a chance that the region can be optimized out do
       // not add a cast node that we can't remove yet.
       !wait_for_region_igvn(phase)) {
+    PhaseIterGVN* igvn = phase->is_IterGVN();
+    for (uint i = 1, cnt = req(); i < cnt; ++i) {
+      Node* n = in(i);
+      if (n != nullptr && n->is_ConstraintCast() && igvn->_worklist.member(n)) {
+        igvn->_worklist.push(this);
+        return nullptr;
+      }
+    }
     uncasted = true;
     uin = unique_input(phase, true);
   }

--- a/src/hotspot/share/opto/cfgnode.hpp
+++ b/src/hotspot/share/opto/cfgnode.hpp
@@ -182,6 +182,8 @@ class PhiNode : public TypeNode {
 
   bool is_split_through_mergemem_terminating() const;
 
+  bool wait_for_cast_input_igvn(const PhaseIterGVN* igvn) const;
+
 public:
   // Node layout (parallels RegionNode):
   enum { Region,                // Control input is the Phi's region.

--- a/test/hotspot/jtreg/compiler/c2/TestMismatchedAddPAfterMaxUnroll.java
+++ b/test/hotspot/jtreg/compiler/c2/TestMismatchedAddPAfterMaxUnroll.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2025, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8351889
+ * @summary C2 crash: assertion failed: Base pointers must match (addp 344)
+ * @run main/othervm -XX:-BackgroundCompilation -XX:CompileOnly=TestMismatchedAddPAfterMaxUnroll::test1
+ *                   -XX:+UnlockDiagnosticVMOptions -XX:+IgnoreUnrecognizedVMOptions -XX:-UseLoopPredicate
+ *                   -XX:+StressIGVN -XX:StressSeed=1572080606 TestMismatchedAddPAfterMaxUnroll
+ * @run main/othervm -XX:-BackgroundCompilation -XX:CompileOnly=TestMismatchedAddPAfterMaxUnroll::test1
+ *                   -XX:+UnlockDiagnosticVMOptions -XX:+IgnoreUnrecognizedVMOptions -XX:-UseLoopPredicate
+ *                   -XX:+StressIGVN TestMismatchedAddPAfterMaxUnroll
+ * @run main/othervm TestMismatchedAddPAfterMaxUnroll
+ */
+
+public class TestMismatchedAddPAfterMaxUnroll {
+    private static C[] arrayField = new C[4];
+
+    public static void main(String[] args) {
+        C c = new C();
+        Object lock = new Object();
+        for (int i = 0; i < 20_000; i++) {
+            arrayField[3] = null;
+            test1(3, c, arrayField, true, true, lock);
+            arrayField[3] = null;
+            test1(3, c, arrayField, true, false, lock);
+            arrayField[3] = null;
+            test1(3, c, arrayField, false, false, lock);
+            arrayField[3] = c;
+            test1(3, c, arrayField, false, false, lock);
+        }
+    }
+
+    static class C {
+
+    }
+
+    private static void test1(int j, C c, C[] otherArray, boolean flag, boolean flag2, Object lock) {
+        C[] array = arrayField;
+        int i = 0;
+        for (;;) {
+            synchronized (lock) {}
+            if (array[j] == null) {
+                break;
+            }
+            otherArray[i] = c;
+            i++;
+            if (i >= 3) {
+                return;
+            }
+        }
+        if (flag) {
+            if (flag2) {
+            }
+        }
+        array[j] = c;
+    }
+}


### PR DESCRIPTION
The test case has an out of loop `Store` with an `AddP` address
expression that has other uses and is in the loop body. Schematically,
only showing the address subgraph and the bases for the `AddP`s:

```
Store#195 -> AddP#133 -> AddP#134 -> CastPP#110
                     \-> CastPP#110
```

Both `AddP`s have the same base, a `CastPP` that's also in the loop
body.

That loop is a counted loop and only has 3 iterations so is fully
unrolled. First, one iteration is peeled:

```
                                /-> CastPP#110
Store#195 -> Phi#360 -> AddP#133 -> AddP#134 -> CastPP#110
                    \-> AddP#277 -> AddP#278 -> CastPP#283
                                \-> CastPP#283

```

The `AddP`s and `CastPP` are cloned (because in the loop body). As
part of peeling, `PhaseIdealLoop::peeled_dom_test_elim()` is
called. It finds the test that guards `CastPP#283` in the peeled
iteration dominates and replaces the test that guards `CastPP#110`
(the test in the peeled iteration is the clone of the test in the
loop). That causes `CastPP#110`'s control to be updated to that of the
test in the peeled iteration and to be yanked from the loop. So now
`CastPP#283` and `CastPP#110` have the same inputs.

Next unrolling happens:

```
                                           /-> CastPP#110
                               /-> AddP#400 -> AddP#401 -> CastPP#110
Store#195 -> Phi#360 -> Phi#477 -> AddP#133 -> AddP#134 -> CastPP#110
                  \                        \-> CastPP#110
                   \-> AddP#277 -> AddP#278 -> CastPP#283
                               \-> CastPP#283

```

`AddP`s are cloned once more but not the `CastPP`s because they are
both in the peeled iteration now. A new `Phi` is added.

Next igvn runs. It's going to push the `AddP`s through the `Phi`s.

Through `Phi#477`:

```

                                /-> CastPP#110
Store#195 -> Phi#360 -> AddP#510 -> Phi#509 -> AddP#401 -> CastPP#110
                  \                        \-> AddP#134 -> CastPP#110
                   \-> AddP#277 -> AddP#278 -> CastPP#283
                               \-> CastPP#283

```

Through `Phi#360`:

```
                                           /-> AddP#134 -> CastPP#110
                                /-> Phi#509 -> AddP#401 -> CastPP#110
Store#195 -> AddP#516 -> Phi#515 -> AddP#278 -> CastPP#283
                     \-> Phi#514 -> CastPP#283
                                \-> CastP#110
```

Then `Phi#514` which has 2 `CastPP`s as input with identical inputs is
transformed into another `CastPP` at the `Phi` constrol with the data
control of the `CastPP` as input. `PhiNode::unique_input()` with
`uncast = true` is where that happens. That's where things go wrong I
think.

```
                                           /-> AddP#134 -> CastPP#110
                                /-> Phi#509 -> AddP#401 -> CastPP#110
Store#195 -> AddP#516 -> Phi#515 -> AddP#278 -> CastPP#283
                     \-> CastPP#529
```

Next `AddP`s pushed through `Phi#509`:

```
                                /-> AddP#536 -> CastPP#110
Store#195 -> AddP#516 -> Phi#515 -> AddP#278 -> CastPP#283
                     \-> CastPP#529
```

`CastPP#110` and `CastPP#283` commoned (they have the same inputs):

```
                                /-> AddP#536 -> CastPP#110
Store#195 -> AddP#516 -> Phi#515 -> AddP#278 -> CastPP#110
                     \-> CastPP#529
```

Finally, AddPs pushed through `Phi#515`:

```
Store#195 -> AddP#516 -> AddP#544 -> CastPP#110
                     \-> CastPP#529
```

And we end up with 2 `AddP`s with different bases. The 2 `CastPP`s
have the same data input but not same control and igvn can't common
them.


The fix I propose is to delay the call to `PhiNode::unique_input()`
with `uncast = true` if the `Phi`'s inputs are cast nodes and have yet
to be processed by igvn. This causes identical `CastPP`s to common and
then only the `Phi` has 2 identical inputs is transformed to that
input (rather than have a new `CastPP`s be created at a different
control).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8351889](https://bugs.openjdk.org/browse/JDK-8351889): C2 crash: assertion failed:  Base pointers must match (addp 344) (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25386/head:pull/25386` \
`$ git checkout pull/25386`

Update a local copy of the PR: \
`$ git checkout pull/25386` \
`$ git pull https://git.openjdk.org/jdk.git pull/25386/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25386`

View PR using the GUI difftool: \
`$ git pr show -t 25386`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25386.diff">https://git.openjdk.org/jdk/pull/25386.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25386#issuecomment-2900386140)
</details>
