### PR TITLE
8356868

### DIFF
--- a/src/hotspot/os/linux/cgroupSubsystem_linux.cpp
+++ b/src/hotspot/os/linux/cgroupSubsystem_linux.cpp
@@ -62,7 +62,7 @@ CgroupSubsystem* CgroupSubsystemFactory::create() {
   CgroupV1MemoryController* memory = nullptr;
   CgroupV1Controller* cpuset = nullptr;
   CgroupV1CpuController* cpu = nullptr;
-  CgroupV1Controller* cpuacct = nullptr;
+  CgroupV1CpuacctController* cpuacct = nullptr;
   CgroupV1Controller* pids = nullptr;
   CgroupInfo cg_infos[CG_INFO_LENGTH];
   u1 cg_type_flags = INVALID_CGROUPS_GENERIC;
@@ -105,9 +105,10 @@ CgroupSubsystem* CgroupSubsystemFactory::create() {
     CgroupV2CpuController* cpu = new CgroupV2CpuController(CgroupV2Controller(cg_infos[CPU_IDX]._mount_path,
                                                                               cg_infos[CPU_IDX]._cgroup_path,
                                                                               cg_infos[CPU_IDX]._read_only));
+    CgroupV2CpuacctController* cpuacct = new CgroupV2CpuacctController(cpu);
     log_debug(os, container)("Detected cgroups v2 unified hierarchy");
     cleanup(cg_infos);
-    return new CgroupV2Subsystem(memory, cpu, mem_other);
+    return new CgroupV2Subsystem(memory, cpu, cpuacct, mem_other);
   }
 
   /*
@@ -150,7 +151,7 @@ CgroupSubsystem* CgroupSubsystemFactory::create() {
         cpu = new CgroupV1CpuController(CgroupV1Controller(info._root_mount_path, info._mount_path, info._read_only));
         cpu->set_subsystem_path(info._cgroup_path);
       } else if (strcmp(info._name, "cpuacct") == 0) {
-        cpuacct = new CgroupV1Controller(info._root_mount_path, info._mount_path, info._read_only);
+        cpuacct = new CgroupV1CpuacctController(CgroupV1Controller(info._root_mount_path, info._mount_path, info._read_only));
         cpuacct->set_subsystem_path(info._cgroup_path);
       } else if (strcmp(info._name, "pids") == 0) {
         pids = new CgroupV1Controller(info._root_mount_path, info._mount_path, info._read_only);
@@ -856,6 +857,10 @@ jlong CgroupSubsystem::memory_soft_limit_in_bytes() {
   return memory_controller()->controller()->memory_soft_limit_in_bytes(phys_mem);
 }
 
+jlong CgroupSubsystem::memory_throttle_limit_in_bytes() {
+  return memory_controller()->controller()->memory_throttle_limit_in_bytes();
+}
+
 jlong CgroupSubsystem::memory_usage_in_bytes() {
   return memory_controller()->controller()->memory_usage_in_bytes();
 }
@@ -882,6 +887,10 @@ int CgroupSubsystem::cpu_period() {
 
 int CgroupSubsystem::cpu_shares() {
   return cpu_controller()->controller()->cpu_shares();
+}
+
+jlong CgroupSubsystem::cpu_usage_in_micros() {
+  return cpuacct_controller()->cpu_usage_in_micros();
 }
 
 void CgroupSubsystem::print_version_specific_info(outputStream* st) {

--- a/src/hotspot/os/linux/cgroupSubsystem_linux.hpp
+++ b/src/hotspot/os/linux/cgroupSubsystem_linux.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -216,6 +216,18 @@ class CgroupCpuController: public CHeapObj<mtInternal> {
     virtual const char* cgroup_path() = 0;
 };
 
+// Pure virtual class representing version agnostic CPU accounting controllers
+class CgroupCpuacctController: public CHeapObj<mtInternal> {
+  public:
+    virtual jlong cpu_usage_in_micros() = 0;
+    virtual bool needs_hierarchy_adjustment() = 0;
+    virtual bool is_read_only() = 0;
+    virtual const char* subsystem_path() = 0;
+    virtual void set_subsystem_path(const char* cgroup_path) = 0;
+    virtual const char* mount_point() = 0;
+    virtual const char* cgroup_path() = 0;
+};
+
 // Pure virtual class representing version agnostic memory controllers
 class CgroupMemoryController: public CHeapObj<mtInternal> {
   public:
@@ -224,6 +236,7 @@ class CgroupMemoryController: public CHeapObj<mtInternal> {
     virtual jlong memory_and_swap_limit_in_bytes(julong host_mem, julong host_swap) = 0;
     virtual jlong memory_and_swap_usage_in_bytes(julong host_mem, julong host_swap) = 0;
     virtual jlong memory_soft_limit_in_bytes(julong upper_bound) = 0;
+    virtual jlong memory_throttle_limit_in_bytes() = 0;
     virtual jlong memory_max_usage_in_bytes() = 0;
     virtual jlong rss_usage_in_bytes() = 0;
     virtual jlong cache_usage_in_bytes() = 0;
@@ -250,15 +263,19 @@ class CgroupSubsystem: public CHeapObj<mtInternal> {
     virtual const char * container_type() = 0;
     virtual CachingCgroupController<CgroupMemoryController>* memory_controller() = 0;
     virtual CachingCgroupController<CgroupCpuController>* cpu_controller() = 0;
+    virtual CgroupCpuacctController* cpuacct_controller() = 0;
 
     int cpu_quota();
     int cpu_period();
     int cpu_shares();
 
+    jlong cpu_usage_in_micros();
+
     jlong memory_usage_in_bytes();
     jlong memory_and_swap_limit_in_bytes();
     jlong memory_and_swap_usage_in_bytes();
     jlong memory_soft_limit_in_bytes();
+    jlong memory_throttle_limit_in_bytes();
     jlong memory_max_usage_in_bytes();
     jlong rss_usage_in_bytes();
     jlong cache_usage_in_bytes();

--- a/src/hotspot/os/linux/cgroupV1Subsystem_linux.cpp
+++ b/src/hotspot/os/linux/cgroupV1Subsystem_linux.cpp
@@ -248,10 +248,16 @@ jlong CgroupV1MemoryController::memory_soft_limit_in_bytes(julong phys_mem) {
   }
 }
 
+jlong CgroupV1MemoryController::memory_throttle_limit_in_bytes() {
+  // Log this string at trace level so as to make tests happy.
+  log_trace(os, container)("Memory Throttle Limit is not supported.");
+  return OSCONTAINER_ERROR; // not supported
+}
+
 // Constructor
 CgroupV1Subsystem::CgroupV1Subsystem(CgroupV1Controller* cpuset,
                       CgroupV1CpuController* cpu,
-                      CgroupV1Controller* cpuacct,
+                      CgroupV1CpuacctController* cpuacct,
                       CgroupV1Controller* pids,
                       CgroupV1MemoryController* memory) :
     _cpuset(cpuset),
@@ -414,6 +420,13 @@ int CgroupV1CpuController::cpu_shares() {
   if (shares_int == 1024) return -1;
 
   return shares_int;
+}
+
+jlong CgroupV1CpuacctController::cpu_usage_in_micros() {
+  julong cpu_usage;
+  CONTAINER_READ_NUMBER_CHECKED(reader(), "/cpuacct.usage", "CPU Usage", cpu_usage);
+  // Output is in nanoseconds, convert to microseconds.
+  return (jlong)cpu_usage / 1000;
 }
 
 /* pids_max

--- a/src/hotspot/os/linux/osContainer_linux.cpp
+++ b/src/hotspot/os/linux/osContainer_linux.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -122,6 +122,11 @@ jlong OSContainer::memory_soft_limit_in_bytes() {
   return cgroup_subsystem->memory_soft_limit_in_bytes();
 }
 
+jlong OSContainer::memory_throttle_limit_in_bytes() {
+  assert(cgroup_subsystem != nullptr, "cgroup subsystem not available");
+  return cgroup_subsystem->memory_throttle_limit_in_bytes();
+}
+
 jlong OSContainer::memory_usage_in_bytes() {
   assert(cgroup_subsystem != nullptr, "cgroup subsystem not available");
   return cgroup_subsystem->memory_usage_in_bytes();
@@ -175,6 +180,11 @@ int OSContainer::cpu_period() {
 int OSContainer::cpu_shares() {
   assert(cgroup_subsystem != nullptr, "cgroup subsystem not available");
   return cgroup_subsystem->cpu_shares();
+}
+
+jlong OSContainer::cpu_usage_in_micros() {
+  assert(cgroup_subsystem != nullptr, "cgroup subsystem not available");
+  return cgroup_subsystem->cpu_usage_in_micros();
 }
 
 jlong OSContainer::pids_max() {

--- a/src/hotspot/os/linux/osContainer_linux.hpp
+++ b/src/hotspot/os/linux/osContainer_linux.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -54,6 +54,7 @@ class OSContainer: AllStatic {
   static jlong memory_and_swap_limit_in_bytes();
   static jlong memory_and_swap_usage_in_bytes();
   static jlong memory_soft_limit_in_bytes();
+  static jlong memory_throttle_limit_in_bytes();
   static jlong memory_usage_in_bytes();
   static jlong memory_max_usage_in_bytes();
   static jlong rss_usage_in_bytes();
@@ -68,6 +69,8 @@ class OSContainer: AllStatic {
   static int cpu_period();
 
   static int cpu_shares();
+
+  static jlong cpu_usage_in_micros();
 
   static jlong pids_max();
   static jlong pids_current();

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -2488,9 +2488,18 @@ bool os::Linux::print_container_info(outputStream* st) {
     st->print_cr("%s", i == OSCONTAINER_ERROR ? "not supported" : "no shares");
   }
 
+  jlong j = OSContainer::cpu_usage_in_micros();
+  st->print("cpu_usage_in_micros: ");
+  if (j > 0) {
+    st->print_cr(JLONG_FORMAT, j);
+  } else {
+    st->print_cr("%s", j == OSCONTAINER_ERROR ? "not supported" : "no usage");
+  }
+
   OSContainer::print_container_helper(st, OSContainer::memory_limit_in_bytes(), "memory_limit_in_bytes");
   OSContainer::print_container_helper(st, OSContainer::memory_and_swap_limit_in_bytes(), "memory_and_swap_limit_in_bytes");
   OSContainer::print_container_helper(st, OSContainer::memory_soft_limit_in_bytes(), "memory_soft_limit_in_bytes");
+  OSContainer::print_container_helper(st, OSContainer::memory_throttle_limit_in_bytes(), "memory_throttle_limit_in_bytes");
   OSContainer::print_container_helper(st, OSContainer::memory_usage_in_bytes(), "memory_usage_in_bytes");
   OSContainer::print_container_helper(st, OSContainer::memory_max_usage_in_bytes(), "memory_max_usage_in_bytes");
   OSContainer::print_container_helper(st, OSContainer::rss_usage_in_bytes(), "rss_usage_in_bytes");
@@ -2498,7 +2507,7 @@ bool os::Linux::print_container_info(outputStream* st) {
 
   OSContainer::print_version_specific_info(st);
 
-  jlong j = OSContainer::pids_max();
+  j = OSContainer::pids_max();
   st->print("maximum number of tasks: ");
   if (j > 0) {
     st->print_cr(JLONG_FORMAT, j);

--- a/test/hotspot/jtreg/containers/docker/TestMisc.java
+++ b/test/hotspot/jtreg/containers/docker/TestMisc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -110,9 +110,11 @@ public class TestMisc {
             "CPU Shares",
             "CPU Quota",
             "CPU Period",
+            "CPU Usage",
             "OSContainer::active_processor_count",
             "Memory Limit",
             "Memory Soft Limit",
+            "Memory Throttle Limit",
             "Memory Usage",
             "Maximum Memory Usage",
             "memory_max_usage_in_bytes",


### PR DESCRIPTION
Hi everyone,

This PR improves cgroup support by exposing additional parameters that are currently not available. These parameters would enable more advanced features that rely on CPU and memory usage data.

The new parameters are:

- CPU usage: `cpuacct.usage` (cgroup v1) and `cpu.stat` (cgroup v2), which allow precise tracking of consumed CPU time.

- Peak memory usage: `memory.peak` (cgroup v2). While the cgroup v1 equivalent (`memory.max_usage_in_bytes`) was already available, cgroup v2 previously returned `OSCONTAINER_ERROR` — this has now been fixed.

- Memory throttle limit: `memory.high` (cgroup v2). There is no direct equivalent in cgroup v1, but since most systems use cgroup v2, exposing this parameter enables finer-grained memory control for those systems.

Testing:
- All container tests under `/test/hotspot/jtreg/containers/`
- Manually inspected the new parameters in both cgroup v1 and v2 container environments with the relevant settings applied.