### PR TITLE
8357539: TimeSource.now() is not monotonic

### DIFF
--- a/src/java.net.http/share/classes/jdk/internal/net/http/common/TimeSource.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/common/TimeSource.java
@@ -94,10 +94,10 @@ public final class TimeSource implements TimeLine {
 
     @Override
     public Deadline instant() {
+        // use localSource if possible to avoid a volatile read
         NanoSource source = localSource;
         long nanos = System.nanoTime();
         long delay = source.delay(nanos);
-        // use localSource if possible to avoid a volatile read
         if (source.isInWindow(delay)) {
             return source.instant(nanos, delay);
         } else {

--- a/src/java.net.http/share/classes/jdk/internal/net/http/common/TimeSource.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/common/TimeSource.java
@@ -65,7 +65,12 @@ public final class TimeSource implements TimeLine {
         }
 
         Deadline instant(long nanos) {
-            long delay = delay(nanos);
+            return instant(nanos, nanos - firstNanos);
+        }
+
+        Deadline instant(long nanos, long delay) {
+            assert firstNanos + delay == nanos :
+                    "%d + %d != %d".formatted(firstNanos, delay, nanos);
             Instant now = first.plusNanos(delay);
             if (!isInWindow(delay)) {
                 // Shifts the time reference (firstNanos) to
@@ -94,7 +99,7 @@ public final class TimeSource implements TimeLine {
         long delay = source.delay(nanos);
         // use localSource if possible to avoid a volatile read
         if (source.isInWindow(delay)) {
-            return source.instant(nanos);
+            return source.instant(nanos, delay);
         } else {
             // will cause the time reference to shift forward,
             // at the cost of a volatile write + a volatile read


### PR DESCRIPTION
We observed a case where the instants returned by `TimeSource.now()` were returned in non-monotonic order. The reason was that sometimes we were using a delay calculated with one `localSource` as an input to a different (updated on another thread) `localSource`. This was confirmed by putting `assert firstNanos + delay == nanos;` under `instant(long, long)`.

The fix ensures that we won't accidentally use the incorrect delay by removing the `instant(long, long)` overload, and calculating the delay in the method where it is used.

No new test; instrumenting this class for testing would likely double its size. Tier2 tests continue to pass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8357539](https://bugs.openjdk.org/browse/JDK-8357539): TimeSource.now() is not monotonic (**Bug** - P4)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25390/head:pull/25390` \
`$ git checkout pull/25390`

Update a local copy of the PR: \
`$ git checkout pull/25390` \
`$ git pull https://git.openjdk.org/jdk.git pull/25390/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25390`

View PR using the GUI difftool: \
`$ git pr show -t 25390`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25390.diff">https://git.openjdk.org/jdk/pull/25390.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25390#issuecomment-2900621092)
</details>
