### PR TITLE
8357563: Shenandoah headers leak un-prefixed defines

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.hpp
@@ -39,12 +39,6 @@ enum class ShenandoahFreeSetPartitionId : uint8_t {
   NotFree                       // Region is in no free set: it has no available memory
 };
 
-// We do not maintain counts, capacity, or used for regions that are not free.  Informally, if a region is NotFree, it is
-// in no partition.  NumPartitions represents the size of an array that may be indexed by Mutator or Collector.
-#define NumPartitions           (ShenandoahFreeSetPartitionId::NotFree)
-#define IntNumPartitions     int(ShenandoahFreeSetPartitionId::NotFree)
-#define UIntNumPartitions   uint(ShenandoahFreeSetPartitionId::NotFree)
-
 // ShenandoahRegionPartitions provides an abstraction to help organize the implementation of ShenandoahFreeSet.  This
 // class implements partitioning of regions into distinct sets.  Each ShenandoahHeapRegion is either in the Mutator free set,
 // the Collector free set, or in neither free set (NotFree).  When we speak of a "free partition", we mean partitions that
@@ -52,6 +46,12 @@ enum class ShenandoahFreeSetPartitionId : uint8_t {
 class ShenandoahRegionPartitions {
 
 private:
+  // We do not maintain counts, capacity, or used for regions that are not free.  Informally, if a region is NotFree, it is
+  // in no partition.  NumPartitions represents the size of an array that may be indexed by Mutator or Collector.
+  static constexpr ShenandoahFreeSetPartitionId NumPartitions     =      ShenandoahFreeSetPartitionId::NotFree;
+  static constexpr int                          IntNumPartitions  =  int(ShenandoahFreeSetPartitionId::NotFree);
+  static constexpr uint                         UIntNumPartitions = uint(ShenandoahFreeSetPartitionId::NotFree);
+
   const ssize_t _max;           // The maximum number of heap regions
   const size_t _region_size_bytes;
   const ShenandoahFreeSet* _free_set;


### PR DESCRIPTION
We hit a compilation error in ZGC when we defined a constant NumPartitions. This happened because there is a define name NumPartitions inside shenandoahFreeSet.hpp. I propose that this (and its friends) are hid inside the ShenandoahRegionPartitions class, which is the only user of these defines. An alternative would be to prefix the define with something that is unlikely to clash with other parts of HotSpot.

This PR is my suggestion for a change to solve this so this name conflict. Does this seem like an acceptable solution, or do you want something else? Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8357563](https://bugs.openjdk.org/browse/JDK-8357563): Shenandoah headers leak un-prefixed defines (**Enhancement** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25392/head:pull/25392` \
`$ git checkout pull/25392`

Update a local copy of the PR: \
`$ git checkout pull/25392` \
`$ git pull https://git.openjdk.org/jdk.git pull/25392/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25392`

View PR using the GUI difftool: \
`$ git pr show -t 25392`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25392.diff">https://git.openjdk.org/jdk/pull/25392.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25392#issuecomment-2901085680)
</details>
