### PR TITLE
8357568: IGV: Show NULL and numbers up to 4 characters in "Condense graph" filter

### DIFF
--- a/src/hotspot/share/opto/idealGraphPrinter.cpp
+++ b/src/hotspot/share/opto/idealGraphPrinter.cpp
@@ -626,12 +626,8 @@ void IdealGraphPrinter::visit_node(Node* n, bool edges) {
     const char *short_name = "short_name";
     if (strcmp(node->Name(), "Parm") == 0 && node->as_Proj()->_con >= TypeFunc::Parms) {
       int index = node->as_Proj()->_con - TypeFunc::Parms;
-      if (index >= 10) {
-        print_prop(short_name, "PA");
-      } else {
-        os::snprintf_checked(buffer, sizeof(buffer), "P%d", index);
-        print_prop(short_name, buffer);
-      }
+      os::snprintf_checked(buffer, sizeof(buffer), "P%d", index);
+      print_prop(short_name, buffer);
     } else if (strcmp(node->Name(), "IfTrue") == 0) {
       print_prop(short_name, "T");
     } else if (strcmp(node->Name(), "IfFalse") == 0) {

--- a/src/hotspot/share/opto/idealGraphPrinter.cpp
+++ b/src/hotspot/share/opto/idealGraphPrinter.cpp
@@ -643,8 +643,8 @@ void IdealGraphPrinter::visit_node(Node* n, bool edges) {
         assert(typeInt->is_con(), "must be constant");
         jint value = typeInt->get_con();
 
-        // max. 2 chars allowed
-        if (value >= -9 && value <= 99) {
+        // Only use up to 4 chars and fall back to a generic "I" to keep it short.
+        if (value >= -999 && value <= 9999) {
           os::snprintf_checked(buffer, sizeof(buffer), "%d", value);
           print_prop(short_name, buffer);
         } else {
@@ -657,8 +657,8 @@ void IdealGraphPrinter::visit_node(Node* n, bool edges) {
         assert(typeLong->is_con(), "must be constant");
         jlong value = typeLong->get_con();
 
-        // max. 2 chars allowed
-        if (value >= -9 && value <= 99) {
+        // Only use up to 4 chars and fall back to a generic "L" to keep it short.
+        if (value >= -999 && value <= 9999) {
           os::snprintf_checked(buffer, sizeof(buffer), JLONG_FORMAT, value);
           print_prop(short_name, buffer);
         } else {
@@ -676,7 +676,11 @@ void IdealGraphPrinter::visit_node(Node* n, bool edges) {
       } else if (t->base() == Type::Return_Address) {
         print_prop(short_name, "RA");
       } else if (t->base() == Type::AnyPtr) {
-        print_prop(short_name, "P");
+        if (t->is_ptr()->ptr() == TypePtr::Null) {
+          print_prop(short_name, "NULL");
+        } else {
+          print_prop(short_name, "P");
+        }
       } else if (t->base() == Type::RawPtr) {
         print_prop(short_name, "RP");
       } else if (t->base() == Type::AryPtr) {

--- a/src/hotspot/share/opto/idealGraphPrinter.cpp
+++ b/src/hotspot/share/opto/idealGraphPrinter.cpp
@@ -640,8 +640,8 @@ void IdealGraphPrinter::visit_node(Node* n, bool edges) {
         jint value = typeInt->get_con();
 
         // Only use up to 4 chars and fall back to a generic "I" to keep it short.
-        if (value >= -999 && value <= 9999) {
-          os::snprintf_checked(buffer, sizeof(buffer), "%d", value);
+        int written_chars = os::snprintf_checked(buffer, sizeof(buffer), "%d", value);
+        if (written_chars <= 4) {
           print_prop(short_name, buffer);
         } else {
           print_prop(short_name, "I");
@@ -654,8 +654,8 @@ void IdealGraphPrinter::visit_node(Node* n, bool edges) {
         jlong value = typeLong->get_con();
 
         // Only use up to 4 chars and fall back to a generic "L" to keep it short.
-        if (value >= -999 && value <= 9999) {
-          os::snprintf_checked(buffer, sizeof(buffer), JLONG_FORMAT, value);
+        int written_chars = os::snprintf_checked(buffer, sizeof(buffer), JLONG_FORMAT, value);
+        if (written_chars <= 4) {
           print_prop(short_name, buffer);
         } else {
           print_prop(short_name, "L");
@@ -673,7 +673,7 @@ void IdealGraphPrinter::visit_node(Node* n, bool edges) {
         print_prop(short_name, "RA");
       } else if (t->base() == Type::AnyPtr) {
         if (t->is_ptr()->ptr() == TypePtr::Null) {
-          print_prop(short_name, "NULL");
+          print_prop(short_name, "Null");
         } else {
           print_prop(short_name, "P");
         }
@@ -681,6 +681,8 @@ void IdealGraphPrinter::visit_node(Node* n, bool edges) {
         print_prop(short_name, "RP");
       } else if (t->base() == Type::AryPtr) {
         print_prop(short_name, "AP");
+      } else if (t->base() == Type::NarrowOop && t->is_narrowoop() == TypeNarrowOop::NULL_PTR) {
+        print_prop(short_name, "Null");
       }
     }
 


### PR DESCRIPTION
When using the "Condense graph" filter in IGV, it would be useful to show `NULL` and numbers wider than 2 characters instead of `P` and `I/L` (fallback for larger numbers), respectively. There is a comment in `idealGrapPrinter.cpp` which says that maximally 2 chars are allowed for numbers:
https://github.com/openjdk/jdk/blob/428d33ef3ca0af34d8f164fe9d9b722e81e866a7/src/hotspot/share/opto/idealGraphPrinter.cpp#L646

But we already allow larger entries today:
![image](https://github.com/user-attachments/assets/e90d0518-148f-4a33-a9e8-0bdca14aa017)

I there propose to use `NULL` and allow up to 4 characters for numbers which could be a good trade-off between shortness and expressiveness. This allows us to quickly see null checks and larger constants.

Without patch:
![image](https://github.com/user-attachments/assets/e450f1d2-503c-4b84-8137-25892f8ab7f9)


With patch:
![image](https://github.com/user-attachments/assets/81371a53-be7e-4acd-afbf-e5613e96815a)

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8357568](https://bugs.openjdk.org/browse/JDK-8357568): IGV: Show NULL and numbers up to 4 characters in "Condense graph" filter (**Enhancement** - P4)


### Reviewers
 * [Manuel Hässig](https://openjdk.org/census#mhaessig) (@mhaessig - Author) Review applies to [4f77d003](https://git.openjdk.org/jdk/pull/25393/files/4f77d003cddd98f15809566031b4c8ed645084b0)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Marc Chevalier](https://openjdk.org/census#mchevalier) (@marc-chevalier - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25393/head:pull/25393` \
`$ git checkout pull/25393`

Update a local copy of the PR: \
`$ git checkout pull/25393` \
`$ git pull https://git.openjdk.org/jdk.git pull/25393/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25393`

View PR using the GUI difftool: \
`$ git pr show -t 25393`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25393.diff">https://git.openjdk.org/jdk/pull/25393.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25393#issuecomment-2901314183)
</details>
