### PR TITLE
8357285 : JSR166 Test case testShutdownNow_delayedTasks failed

### DIFF
--- a/test/jdk/java/util/concurrent/tck/ScheduledExecutorTest.java
+++ b/test/jdk/java/util/concurrent/tck/ScheduledExecutorTest.java
@@ -700,11 +700,13 @@ public class ScheduledExecutorTest extends JSR166TestCase {
     public void testShutdownNow_delayedTasks() throws InterruptedException {
         final ScheduledThreadPoolExecutor p = new ScheduledThreadPoolExecutor(1);
         List<ScheduledFuture<?>> tasks = new ArrayList<>();
+        final int DELAY = 100;
+
         for (int i = 0; i < 3; i++) {
             Runnable r = new NoOpRunnable();
-            tasks.add(p.schedule(r, 9, SECONDS));
-            tasks.add(p.scheduleAtFixedRate(r, 9, 9, SECONDS));
-            tasks.add(p.scheduleWithFixedDelay(r, 9, 9, SECONDS));
+            tasks.add(p.schedule(r, DELAY, SECONDS));
+            tasks.add(p.scheduleAtFixedRate(r, DELAY, DELAY, SECONDS));
+            tasks.add(p.scheduleWithFixedDelay(r, DELAY, DELAY, SECONDS));
         }
         if (testImplementationDetails)
             assertEquals(new HashSet<Object>(tasks), new HashSet<Object>(p.getQueue()));


### PR DESCRIPTION
Barring other effects, it is likely that this test just needs to have some longer timeouts to ensure that a stall isn't likely to fail the test case. The shouldn't have any impact on test execution duration, as the test looks at tasks which *have not executed yet*.