### PR TITLE
8354383: C2: enable sinking of Type nodes out of loop

### DIFF
--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -1676,6 +1676,10 @@ bool PhaseIdealLoop::safe_for_if_replacement(const Node* dom) const {
 // like various versions of induction variable+offset.  Clone the
 // computation per usage to allow it to sink out of the loop.
 void PhaseIdealLoop::try_sink_out_of_loop(Node* n) {
+  bool is_raw_to_oop_cast = n->is_ConstraintCast() &&
+                            n->in(1)->bottom_type()->isa_rawptr() &&
+                            !n->bottom_type()->isa_rawptr();
+
   if (has_ctrl(n) &&
       !n->is_Phi() &&
       !n->is_Bool() &&
@@ -1684,7 +1688,9 @@ void PhaseIdealLoop::try_sink_out_of_loop(Node* n) {
       !n->is_CMove() &&
       !n->is_OpaqueNotNull() &&
       !n->is_OpaqueInitializedAssertionPredicate() &&
-      !n->is_OpaqueTemplateAssertionPredicate()) {
+      !n->is_OpaqueTemplateAssertionPredicate() &&
+      !is_raw_to_oop_cast // don't extend live ranges of raw oops
+      ) {
     Node *n_ctrl = get_ctrl(n);
     IdealLoopTree *n_loop = get_loop(n_ctrl);
 

--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -1684,8 +1684,7 @@ void PhaseIdealLoop::try_sink_out_of_loop(Node* n) {
       !n->is_CMove() &&
       !n->is_OpaqueNotNull() &&
       !n->is_OpaqueInitializedAssertionPredicate() &&
-      !n->is_OpaqueTemplateAssertionPredicate() &&
-      !n->is_Type()) {
+      !n->is_OpaqueTemplateAssertionPredicate()) {
     Node *n_ctrl = get_ctrl(n);
     IdealLoopTree *n_loop = get_loop(n_ctrl);
 


### PR DESCRIPTION
`PhaseIdealLoop::try_sink_out_of_loop()` excludes `Type` nodes because
we ran into some issues where a `Type` node is sunk and then becomes
`top` but the control path of its uses doesn't become unreachable.

8349479 should have fixed that so that exception no longer makes
sense.
