### PR TITLE
8357402: Crash in AdapterHandlerLibrary::lookup

### DIFF
--- a/src/hotspot/share/cds/archiveBuilder.cpp
+++ b/src/hotspot/share/cds/archiveBuilder.cpp
@@ -537,7 +537,7 @@ ArchiveBuilder::FollowMode ArchiveBuilder::get_follow_mode(MetaspaceClosure::Ref
              ref->msotype() == MetaspaceObj::MethodCountersType) {
     return set_to_null;
   } else if (ref->msotype() == MetaspaceObj::AdapterHandlerEntryType) {
-    if (AOTCodeCache::is_dumping_adapter()) {
+    if (CDSConfig::is_dumping_adapters()) {
       AdapterHandlerEntry* entry = (AdapterHandlerEntry*)ref->obj();
       return AdapterHandlerLibrary::is_abstract_method_adapter(entry) ? set_to_null : make_a_copy;
     } else {

--- a/src/hotspot/share/cds/cdsConfig.cpp
+++ b/src/hotspot/share/cds/cdsConfig.cpp
@@ -895,3 +895,7 @@ void CDSConfig::disable_dumping_aot_code() {
 void CDSConfig::enable_dumping_aot_code() {
   _is_dumping_aot_code = true;
 }
+
+bool CDSConfig::is_dumping_adapters() {
+  return (AOTAdapterCaching && is_dumping_final_static_archive());
+}

--- a/src/hotspot/share/cds/cdsConfig.hpp
+++ b/src/hotspot/share/cds/cdsConfig.hpp
@@ -187,6 +187,7 @@ public:
   static bool is_dumping_aot_code()                          NOT_CDS_RETURN_(false);
   static void disable_dumping_aot_code()                     NOT_CDS_RETURN;
   static void enable_dumping_aot_code()                      NOT_CDS_RETURN;
+  static bool is_dumping_adapters()                          NOT_CDS_RETURN_(false);
 
   // Some CDS functions assume that they are called only within a single-threaded context. I.e.,
   // they are called from:

--- a/src/hotspot/share/cds/metaspaceShared.cpp
+++ b/src/hotspot/share/cds/metaspaceShared.cpp
@@ -613,7 +613,7 @@ char* VM_PopulateDumpSharedSpace::dump_read_only_tables(AOTClassLocationConfig*&
   // Write lambform lines into archive
   LambdaFormInvokers::dump_static_archive_invokers();
 
-  if (AOTCodeCache::is_dumping_adapter()) {
+  if (CDSConfig::is_dumping_adapters()) {
     AdapterHandlerLibrary::dump_aot_adapter_table();
   }
 

--- a/src/hotspot/share/code/aotCodeCache.cpp
+++ b/src/hotspot/share/code/aotCodeCache.cpp
@@ -902,7 +902,8 @@ CodeBlob* AOTCodeCache::load_code_blob(AOTCodeEntry::Kind entry_kind, uint id, c
   AOTCodeReader reader(cache, entry);
   CodeBlob* blob = reader.compile_code_blob(name, entry_offset_count, entry_offsets);
 
-  log_debug(aot, codecache, stubs)("Read blob '%s' (id=%u, kind=%s) from AOT Code Cache", name, id, aot_code_entry_kind_name[entry_kind]);
+  log_debug(aot, codecache, stubs)("%sRead blob '%s' (id=%u, kind=%s) from AOT Code Cache",
+                                   (blob == nullptr? "Failed to " : ""), name, id, aot_code_entry_kind_name[entry_kind]);
   return blob;
 }
 
@@ -917,8 +918,7 @@ CodeBlob* AOTCodeReader::compile_code_blob(const char* name, int entry_offset_co
   if (strncmp(stored_name, name, (name_size - 1)) != 0) {
     log_warning(aot, codecache, stubs)("Saved blob's name '%s' is different from the expected name '%s'",
                                        stored_name, name);
-    ((AOTCodeCache*)_cache)->set_failed();
-    report_load_failure();
+    set_lookup_failed(); // Skip this blob
     return nullptr;
   }
 

--- a/src/hotspot/share/oops/method.cpp
+++ b/src/hotspot/share/oops/method.cpp
@@ -135,6 +135,7 @@ void Method::deallocate_contents(ClassLoaderData* loader_data) {
   clear_method_data();
   MetadataFactory::free_metadata(loader_data, method_counters());
   clear_method_counters();
+  set_adapter_entry(nullptr);
   // The nmethod will be gone when we get here.
   if (code() != nullptr) _code = nullptr;
 }
@@ -407,8 +408,9 @@ void Method::metaspace_pointers_do(MetaspaceClosure* it) {
 
 void Method::remove_unshareable_info() {
   unlink_method();
-  if (AOTCodeCache::is_dumping_adapter() && _adapter != nullptr) {
+  if (CDSConfig::is_dumping_adapters() && _adapter != nullptr) {
     _adapter->remove_unshareable_info();
+    _adapter = nullptr;
   }
   JFR_ONLY(REMOVE_METHOD_ID(this);)
 }
@@ -1146,7 +1148,7 @@ void Method::unlink_code() {
 void Method::unlink_method() {
   assert(CDSConfig::is_dumping_archive(), "sanity");
   _code = nullptr;
-  if (!AOTCodeCache::is_dumping_adapter() || AdapterHandlerLibrary::is_abstract_method_adapter(_adapter)) {
+  if (!CDSConfig::is_dumping_adapters() || AdapterHandlerLibrary::is_abstract_method_adapter(_adapter)) {
     _adapter = nullptr;
   }
   _i2i_entry = nullptr;


### PR DESCRIPTION
See details in the bug report.

The issue is: AOT adapters table `_aot_adapter_handler_table` is accessed during "Assembly" phase when this table is not valid. It happened because the guard in `AdapterHandlerLibrary::lookup()` became invalid after we dumped and close AOT code cache. `AOTCodeCache::is_dumping_adapter()` will return `false` in such case. Instead we should use `AOTCodeCache::is_using_adapter()` check which is valid only during "Production" run when AOT adapters are loaded and `_aot_adapter_handler_table` is valid. I added this guard in all places where the table is accessed.

Because we can't rely on `AOTCodeCache::is_dumping_adapter()` during AOT archive creation I restored `CDSConfig::is_dumping_adapters()` to use instead. `AOTCodeCache::is_dumping_adapter()` check is only used when we  are storing adapters in AOT code cache.

I also noticed the hash clash for some adapters signature (we caught it by comparing recorded and actual signature) and as result we completely bailout AOT code loading. We should not do complete bail out - instead we should just skip this one blob. We are not modifying data in AOT code cache - it is still valid for other code blobs.

tested hs-tier1-10, jck, xcomp, stress

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8357402](https://bugs.openjdk.org/browse/JDK-8357402): Crash in AdapterHandlerLibrary::lookup (**Bug** - P2)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Igor Veresov](https://openjdk.org/census#iveresov) (@veresov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25398/head:pull/25398` \
`$ git checkout pull/25398`

Update a local copy of the PR: \
`$ git checkout pull/25398` \
`$ git pull https://git.openjdk.org/jdk.git pull/25398/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25398`

View PR using the GUI difftool: \
`$ git pr show -t 25398`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25398.diff">https://git.openjdk.org/jdk/pull/25398.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25398#issuecomment-2902003111)
</details>
