### PR TITLE
8357171: Test tools/jpackage/windows/WinOSConditionTest.java fails for non administrator

### DIFF
--- a/test/jdk/tools/jpackage/windows/WinOSConditionTest.java
+++ b/test/jdk/tools/jpackage/windows/WinOSConditionTest.java
@@ -62,6 +62,17 @@ public class WinOSConditionTest {
                     "--resource-dir", resourceDir.toString()).setFakeRuntime();
         })
         .addUninstallVerifier(cmd -> {
+            // Installation could have ended up with 1603 or 1625 error codes.
+            // MSI error code 1625 indicates the test is being executed in an environment
+            // that doesn't allow per-user installations. This means the test should be skipped.
+            try (final var lines = cmd.winMsiLogFileContents().orElseThrow()) {
+                if (lines.anyMatch(line -> {
+                    return line.endsWith("Installation success or error status: 1625.");
+                })) {
+                    TKit.throwSkippedException("Installation of per-user packages by the current user is forbidden by system policy");
+                }
+            }
+
             // MSI error code 1603 is generic.
             // Dig into the last msi log file for log messages specific to failed condition.
             try (final var lines = cmd.winMsiLogFileContents().orElseThrow()) {
@@ -72,7 +83,7 @@ public class WinOSConditionTest {
             }
         })
         .createMsiLog(true)
-        .setExpectedInstallExitCode(1603)
+        .setExpectedInstallExitCode(1603, 1625)
         // Create, try install the package (installation should fail) and verify it is not installed.
         .run(Action.CREATE, Action.INSTALL, Action.VERIFY_UNINSTALL);
     }


### PR DESCRIPTION
- Allow to configure multiple expected installation exit codes for jpackage native packaging tests.
 - Adjusted the test to get skipped if executed in a restricted environment that doesn't allow per-user installations for non-administrators.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8357171](https://bugs.openjdk.org/browse/JDK-8357171): Test tools/jpackage/windows/WinOSConditionTest.java fails for non administrator (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25400/head:pull/25400` \
`$ git checkout pull/25400`

Update a local copy of the PR: \
`$ git checkout pull/25400` \
`$ git pull https://git.openjdk.org/jdk.git pull/25400/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25400`

View PR using the GUI difftool: \
`$ git pr show -t 25400`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25400.diff">https://git.openjdk.org/jdk/pull/25400.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25400#issuecomment-2902395503)
</details>
