### PR TITLE
8357600: Patch nmethod flushing message to include more details

### DIFF
--- a/src/hotspot/share/code/nmethod.cpp
+++ b/src/hotspot/share/code/nmethod.cpp
@@ -2118,28 +2118,30 @@ void nmethod::unlink() {
 }
 
 void nmethod::purge(bool unregister_nmethod) {
-  MutexLocker ml(CodeCache_lock, Mutex::_no_safepoint_check_flag);
-  ResourceMark rm;
+  Events::log_nmethod_flush(Thread::current(), "Flushing %s nmethod " INTPTR_FORMAT,  is_osr_method() ? "osr" : "", p2i(this));
 
-  const char* name = method()->name()->as_C_string();
-  const char* is_jvmci = "";
-  const char* is_osr = is_osr_method() ? "osr" : "";
-  const size_t codecache_capacity = CodeCache::capacity()/1024;
-  const size_t codecache_free_space = CodeCache::unallocated_capacity(CodeCache::get_code_blob_type(this))/1024;
+  LogTarget(Debug, codecache) lt;
+  if (lt.is_enabled()) {
+    ResourceMark rm;
+    const char* name = method()->name()->as_C_string();
+    const char* is_jvmci = "";
+    const size_t codecache_capacity = CodeCache::capacity()/1024;
+    const size_t codecache_free_space = CodeCache::unallocated_capacity(CodeCache::get_code_blob_type(this))/1024;
 #if INCLUDE_JVMCI
-  if (is_compiled_by_jvmci()) {
-    if (jvmci_name() != nullptr) {
-      name = jvmci_name();
+    if (is_compiled_by_jvmci()) {
+      if (jvmci_name() != nullptr) {
+        name = jvmci_name();
+      }
+      is_jvmci = "JVMCI compiled ";
     }
-    is_jvmci = "JVMCI compiled ";
-  }
 #endif
-  Events::log_nmethod_flush(Thread::current(), "Flushing %s nmethod " INTPTR_FORMAT, is_osr, p2i(this));
-
-  log_debug(codecache)("Flushing nmethod %3d/" INTPTR_FORMAT ", level=%d, osr=%d, cold=%d, epoch=" UINT64_FORMAT ", cold_count=" UINT64_FORMAT ". "
+    log_debug(codecache)("Flushing nmethod %3d/" INTPTR_FORMAT ", level=%d, osr=%d, cold=%d, epoch=" UINT64_FORMAT ", cold_count=" UINT64_FORMAT ". "
                        "Cache capacity: %zuKb, free space: %zuKb. %smethod %s",
                        _compile_id, p2i(this), _comp_level, is_osr_method(), is_cold(), _gc_epoch, CodeCache::cold_gc_count(),
                        codecache_capacity, codecache_free_space, is_jvmci, name);
+  }
+
+  MutexLocker ml(CodeCache_lock, Mutex::_no_safepoint_check_flag);
 
   // We need to deallocate any ExceptionCache data.
   // Note that we do not need to grab the nmethod lock for this, it

--- a/src/hotspot/share/code/nmethod.cpp
+++ b/src/hotspot/share/code/nmethod.cpp
@@ -2127,22 +2127,14 @@ void nmethod::purge(bool unregister_nmethod) {
   LogTarget(Debug, codecache) lt;
   if (lt.is_enabled()) {
     ResourceMark rm;
-    const char* name = method()->name()->as_C_string();
-    const char* is_jvmci = "";
+    LogStream ls(lt);
+    const char* method_name = method()->name()->as_C_string();
     const size_t codecache_capacity = CodeCache::capacity()/1024;
     const size_t codecache_free_space = CodeCache::unallocated_capacity(CodeCache::get_code_blob_type(this))/1024;
-#if INCLUDE_JVMCI
-    if (is_compiled_by_jvmci()) {
-      if (jvmci_name() != nullptr) {
-        name = jvmci_name();
-      }
-      is_jvmci = "JVMCI compiled ";
-    }
-#endif
-    log_debug(codecache)("Flushing nmethod %3d/" INTPTR_FORMAT ", level=%d, osr=%d, cold=%d, epoch=" UINT64_FORMAT ", cold_count=" UINT64_FORMAT ". "
-                       "Cache capacity: %zuKb, free space: %zuKb. %smethod %s",
-                       _compile_id, p2i(this), _comp_level, is_osr_method(), is_cold(), _gc_epoch, CodeCache::cold_gc_count(),
-                       codecache_capacity, codecache_free_space, is_jvmci, name);
+    ls.print("Flushing nmethod %6d/" INTPTR_FORMAT ", level=%d, osr=%d, cold=%d, epoch=" UINT64_FORMAT ", cold_count=" UINT64_FORMAT ". "
+              "Cache capacity: %zuKb, free space: %zuKb. method %s (%s)",
+              _compile_id, p2i(this), _comp_level, is_osr_method(), is_cold(), _gc_epoch, CodeCache::cold_gc_count(),
+              codecache_capacity, codecache_free_space, method_name, compiler_name());
   }
 
   // We need to deallocate any ExceptionCache data.

--- a/src/hotspot/share/code/nmethod.cpp
+++ b/src/hotspot/share/code/nmethod.cpp
@@ -2118,7 +2118,11 @@ void nmethod::unlink() {
 }
 
 void nmethod::purge(bool unregister_nmethod) {
-  Events::log_nmethod_flush(Thread::current(), "Flushing %s nmethod " INTPTR_FORMAT,  is_osr_method() ? "osr" : "", p2i(this));
+
+  MutexLocker ml(CodeCache_lock, Mutex::_no_safepoint_check_flag);
+
+  // completely deallocate this method
+  Events::log_nmethod_flush(Thread::current(), "flushing %s nmethod " INTPTR_FORMAT, is_osr_method() ? "osr" : "", p2i(this));
 
   LogTarget(Debug, codecache) lt;
   if (lt.is_enabled()) {
@@ -2140,8 +2144,6 @@ void nmethod::purge(bool unregister_nmethod) {
                        _compile_id, p2i(this), _comp_level, is_osr_method(), is_cold(), _gc_epoch, CodeCache::cold_gc_count(),
                        codecache_capacity, codecache_free_space, is_jvmci, name);
   }
-
-  MutexLocker ml(CodeCache_lock, Mutex::_no_safepoint_check_flag);
 
   // We need to deallocate any ExceptionCache data.
   // Note that we do not need to grab the nmethod lock for this, it


### PR DESCRIPTION
Please review this patch for adding more details to nmethod flushing message. These details are particularly important when investigating interaction of JVMCI compiled code and code cache flushing heuristics.

Tested on Linux x64 with JTREG tier1-3 using fastdebug and release builds.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8357600](https://bugs.openjdk.org/browse/JDK-8357600): Patch nmethod flushing message to include more details (**Enhancement** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25402/head:pull/25402` \
`$ git checkout pull/25402`

Update a local copy of the PR: \
`$ git checkout pull/25402` \
`$ git pull https://git.openjdk.org/jdk.git pull/25402/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25402`

View PR using the GUI difftool: \
`$ git pr show -t 25402`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25402.diff">https://git.openjdk.org/jdk/pull/25402.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25402#issuecomment-2902773164)
</details>
