### PR TITLE
8357592: Update output parsing in test/jdk/sun/security/tools/jarsigner/compatibility/Compatibility.java

### DIFF
--- a/test/jdk/sun/security/tools/jarsigner/compatibility/Compatibility.java
+++ b/test/jdk/sun/security/tools/jarsigner/compatibility/Compatibility.java
@@ -516,7 +516,7 @@ public class Compatibility {
             String line;
             while ((line = reader.readLine()) != null) {
                 String item = line.trim();
-                if (!item.isEmpty()) {
+                if (!item.isEmpty() && !item.startsWith("#")) {
                     list.add(item);
                 }
             }
@@ -718,8 +718,8 @@ public class Compatibility {
             String match = "^  ("
                     + "  Signature algorithm: " + signItem.certInfo.
                             expectedSigalg(signItem) + ", " + signItem.certInfo.
-                            expectedKeySize() + "-bit " + signItem.certInfo.
-                            expectedKeyAlgorithm() + " key"
+                            expectedKeySize() + "-bit (" + signItem.certInfo.
+                            expectedKeyAlgorithm() + " key|key)"
                     + ")|("
                     + "  Digest algorithm: " + signItem.expectedDigestAlg()
                     + (isWeakAlg(signItem.expectedDigestAlg()) ? " \\(weak\\)" : "")

--- a/test/jdk/sun/security/tools/jarsigner/warnings/Test.java
+++ b/test/jdk/sun/security/tools/jarsigner/warnings/Test.java
@@ -149,7 +149,7 @@ public abstract class Test {
             + "This algorithm will be disabled in a future update.";
 
     static final String WEAK_KEY_WARNING
-            = "It will be disabled in a future update.";
+            = "will be disabled in a future update.";
 
     static final String JAR_SIGNED = "jar signed.";
 


### PR DESCRIPTION
In this PR, I updated the jarsigner compatibility test to handle minor differences in the output of jarsigner between versions.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8357592](https://bugs.openjdk.org/browse/JDK-8357592): Update output parsing in test/jdk/sun/security/tools/jarsigner/compatibility/Compatibility.java (**Enhancement** - P4)


### Reviewers
 * [Rajan Halade](https://openjdk.org/census#rhalade) (@rhalade - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25403/head:pull/25403` \
`$ git checkout pull/25403`

Update a local copy of the PR: \
`$ git checkout pull/25403` \
`$ git pull https://git.openjdk.org/jdk.git pull/25403/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25403`

View PR using the GUI difftool: \
`$ git pr show -t 25403`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25403.diff">https://git.openjdk.org/jdk/pull/25403.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25403#issuecomment-2902822824)
</details>
