### PR TITLE
8357468: [asan] heap buffer overflow reported in PcDesc::pc_offset() pcDesc.hpp:57

### DIFF
--- a/src/hotspot/share/code/nmethod.cpp
+++ b/src/hotspot/share/code/nmethod.cpp
@@ -393,7 +393,9 @@ static inline bool match_desc(PcDesc* pc, int pc_offset, bool approximate) {
   if (!approximate) {
     return pc->pc_offset() == pc_offset;
   } else {
-    return (pc-1)->pc_offset() < pc_offset && pc_offset <= pc->pc_offset();
+    // Do not look before the sentinel
+    assert(pc_offset > PcDesc::lower_offset_limit, "illegal pc_offset");
+    return pc_offset <= pc->pc_offset() && (pc-1)->pc_offset() < pc_offset;
   }
 }
 


### PR DESCRIPTION
This appears to be mostly harmless, but we should fix it anyway.  The initial sentinel PcDesc has a pc_offset of -1.  We can prevent looking before the sentinel by reversing the condition so that pc[0] is checked before pc[-1].

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8357468](https://bugs.openjdk.org/browse/JDK-8357468): [asan] heap buffer overflow reported in PcDesc::pc_offset() pcDesc.hpp:57 (**Bug** - P2)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25404/head:pull/25404` \
`$ git checkout pull/25404`

Update a local copy of the PR: \
`$ git checkout pull/25404` \
`$ git pull https://git.openjdk.org/jdk.git pull/25404/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25404`

View PR using the GUI difftool: \
`$ git pr show -t 25404`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25404.diff">https://git.openjdk.org/jdk/pull/25404.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25404#issuecomment-2902869676)
</details>
