### PR TITLE
8355379: Annotate lazy fields in java.security @Stable

### DIFF
--- a/src/java.base/share/classes/java/security/CodeSigner.java
+++ b/src/java.base/share/classes/java/security/CodeSigner.java
@@ -25,6 +25,8 @@
 
 package java.security;
 
+import jdk.internal.vm.annotation.Stable;
+
 import java.io.*;
 import java.security.cert.CertPath;
 import java.util.Objects;
@@ -59,7 +61,8 @@ public final class CodeSigner implements Serializable {
     /*
      * Hash code for this code signer.
      */
-    private transient int myhash = -1;
+    @Stable
+    private transient int myhash;
 
     /**
      * Constructs a {@code CodeSigner} object.
@@ -105,10 +108,11 @@ public final class CodeSigner implements Serializable {
      */
     @Override
     public int hashCode() {
-        if (myhash == -1) {
-            myhash = signerCertPath.hashCode() + Objects.hashCode(timestamp);
+        int h = myhash;
+        if (h == 0) {
+            myhash = h = signerCertPath.hashCode() + Objects.hashCode(timestamp);
         }
-        return myhash;
+        return h;
     }
 
     /**

--- a/src/java.base/share/classes/java/security/PKCS12Attribute.java
+++ b/src/java.base/share/classes/java/security/PKCS12Attribute.java
@@ -29,6 +29,8 @@ import java.io.IOException;
 import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.regex.Pattern;
+
+import jdk.internal.vm.annotation.Stable;
 import sun.security.util.*;
 
 /**
@@ -45,7 +47,9 @@ public final class PKCS12Attribute implements KeyStore.Entry.Attribute {
     private String name;
     private String value;
     private final byte[] encoded;
-    private int hashValue = -1;
+
+    @Stable
+    private int hashValue;
 
     /**
      * Constructs a PKCS12 attribute from its name and value.
@@ -207,7 +211,7 @@ public final class PKCS12Attribute implements KeyStore.Entry.Attribute {
     @Override
     public int hashCode() {
         int h = hashValue;
-        if (h == -1) {
+        if (h == 0) {
             hashValue = h = Arrays.hashCode(encoded);
         }
         return h;

--- a/src/java.base/share/classes/java/security/Timestamp.java
+++ b/src/java.base/share/classes/java/security/Timestamp.java
@@ -25,6 +25,8 @@
 
 package java.security;
 
+import jdk.internal.vm.annotation.Stable;
+
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.InvalidObjectException;
@@ -66,7 +68,8 @@ public final class Timestamp implements Serializable {
     /*
      * Hash code for this timestamp.
      */
-    private transient int myhash = -1;
+    @Stable
+    private transient int myhash;
 
     /**
      * Constructs a {@code Timestamp}.
@@ -112,10 +115,11 @@ public final class Timestamp implements Serializable {
      * @return a hash code value for this {@code Timestamp}.
      */
     public int hashCode() {
-        if (myhash == -1) {
-            myhash = timestamp.hashCode() + signerCertPath.hashCode();
+        int h = myhash;
+        if (h == 0) {
+            myhash = h = timestamp.hashCode() + signerCertPath.hashCode();
         }
-        return myhash;
+        return h;
     }
 
     /**
@@ -172,7 +176,7 @@ public final class Timestamp implements Serializable {
         if (isNull(timestamp, signerCertPath)) {
             throw new InvalidObjectException("Invalid null field(s)");
         }
-        myhash = -1;
+        myhash = 0;
         timestamp = new Date(timestamp.getTime());
     }
 

--- a/src/java.base/share/classes/java/security/cert/Certificate.java
+++ b/src/java.base/share/classes/java/security/cert/Certificate.java
@@ -34,6 +34,7 @@ import java.security.NoSuchProviderException;
 import java.security.InvalidKeyException;
 import java.security.SignatureException;
 
+import jdk.internal.vm.annotation.Stable;
 import sun.security.x509.X509CertImpl;
 
 /**
@@ -69,7 +70,8 @@ public abstract class Certificate implements java.io.Serializable {
     private final transient String type;
 
     /** The hash code for the certificate. */
-    private transient int hash = -1; // Default to -1
+    @Stable
+    private transient int hash; // Default to 0
 
     /**
      * Creates a certificate of the specified type.
@@ -130,7 +132,7 @@ public abstract class Certificate implements java.io.Serializable {
     @Override
     public int hashCode() {
         int h = hash;
-        if (h == -1) {
+        if (h == 0) {
             try {
                 h = Arrays.hashCode(X509CertImpl.getEncodedInternal(this));
             } catch (CertificateException e) {

--- a/src/java.base/share/classes/java/security/cert/URICertStoreParameters.java
+++ b/src/java.base/share/classes/java/security/cert/URICertStoreParameters.java
@@ -25,6 +25,8 @@
 
 package java.security.cert;
 
+import jdk.internal.vm.annotation.Stable;
+
 import java.net.URI;
 
 /**
@@ -57,7 +59,8 @@ public final class URICertStoreParameters implements CertStoreParameters {
     /*
      * Hash code for this parameters object.
      */
-    private int myhash = -1;
+    @Stable
+    private int myhash;
 
     /**
      * Creates an instance of {@code URICertStoreParameters} with the
@@ -105,10 +108,11 @@ public final class URICertStoreParameters implements CertStoreParameters {
      */
     @Override
     public int hashCode() {
-        if (myhash == -1) {
-            myhash = uri.hashCode()*7;
+        int h = myhash;
+        if (h == 0) {
+            myhash = h = uri.hashCode()*7;
         }
-        return myhash;
+        return h;
     }
 
     /**


### PR DESCRIPTION
Several classes in the `java.security` package lazily compute their hash value and store it in a field. These fields can typically be annotated with the `@Stable` annotation. Many of the current implementations are using -1 as a flag for not computed, this needs to be refactored away.

Here are some examples of such classes: PKCS12Attribute, Timestamp, Certificate, and URICertStoreParameters.