### PR TITLE
8357559: G1HeapRegionManager refactor rename functions related to the number of regions in different states

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -359,7 +359,7 @@ HeapWord* G1CollectedHeap::humongous_obj_allocate(size_t word_size) {
       // We managed to find a region by expanding the heap.
       log_debug(gc, ergo, heap)("Heap expansion (humongous allocation request). Allocation request: %zuB",
                                 word_size * HeapWordSize);
-      policy()->record_new_heap_size(active_regions());
+      policy()->record_new_heap_size(committed_regions());
     } else {
       // Policy: Potentially trigger a defragmentation GC.
     }
@@ -1031,7 +1031,7 @@ bool G1CollectedHeap::expand(size_t expand_bytes, WorkerThreads* pretouch_worker
 
   size_t actual_expand_bytes = expanded_by * G1HeapRegion::GrainBytes;
   assert(actual_expand_bytes <= aligned_expand_bytes, "post-condition");
-  policy()->record_new_heap_size(active_regions());
+  policy()->record_new_heap_size(committed_regions());
 
   return true;
 }
@@ -1045,7 +1045,7 @@ bool G1CollectedHeap::expand_single_region(uint node_index) {
     return false;
   }
 
-  policy()->record_new_heap_size(active_regions());
+  policy()->record_new_heap_size(committed_regions());
   return true;
 }
 
@@ -1061,7 +1061,7 @@ void G1CollectedHeap::shrink_helper(size_t shrink_bytes) {
                             shrink_bytes, aligned_shrink_bytes, shrunk_bytes);
   if (num_regions_removed > 0) {
     log_debug(gc, heap)("Uncommittable regions after shrink: %u", num_regions_removed);
-    policy()->record_new_heap_size(active_regions());
+    policy()->record_new_heap_size(committed_regions());
   } else {
     log_debug(gc, ergo, heap)("Did not shrink the heap (heap shrinking operation failed)");
   }
@@ -1557,7 +1557,7 @@ void G1CollectedHeap::ref_processing_init() {
 }
 
 size_t G1CollectedHeap::capacity() const {
-  return _hrm.active_regions() * G1HeapRegion::GrainBytes;
+  return _hrm.committed_regions() * G1HeapRegion::GrainBytes;
 }
 
 size_t G1CollectedHeap::unused_committed_regions_in_bytes() const {
@@ -2217,7 +2217,7 @@ G1HeapSummary G1CollectedHeap::create_g1_heap_summary() {
 
   VirtualSpaceSummary heap_summary = create_heap_space_summary();
   return G1HeapSummary(heap_summary, heap_used, eden_used_bytes, eden_capacity_bytes,
-                       survivor_used_bytes, old_gen_used_bytes, active_regions());
+                       survivor_used_bytes, old_gen_used_bytes, committed_regions());
 }
 
 G1EvacSummary G1CollectedHeap::create_g1_evac_summary(G1EvacStats* stats) {

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -359,7 +359,7 @@ HeapWord* G1CollectedHeap::humongous_obj_allocate(size_t word_size) {
       // We managed to find a region by expanding the heap.
       log_debug(gc, ergo, heap)("Heap expansion (humongous allocation request). Allocation request: %zuB",
                                 word_size * HeapWordSize);
-      policy()->record_new_heap_size(committed_regions());
+      policy()->record_new_heap_size(num_committed_regions());
     } else {
       // Policy: Potentially trigger a defragmentation GC.
     }
@@ -1031,7 +1031,7 @@ bool G1CollectedHeap::expand(size_t expand_bytes, WorkerThreads* pretouch_worker
 
   size_t actual_expand_bytes = expanded_by * G1HeapRegion::GrainBytes;
   assert(actual_expand_bytes <= aligned_expand_bytes, "post-condition");
-  policy()->record_new_heap_size(committed_regions());
+  policy()->record_new_heap_size(num_committed_regions());
 
   return true;
 }
@@ -1040,12 +1040,12 @@ bool G1CollectedHeap::expand_single_region(uint node_index) {
   uint expanded_by = _hrm.expand_on_preferred_node(node_index);
 
   if (expanded_by == 0) {
-    assert(is_maximal_no_gc(), "Should be no regions left, available: %u", _hrm.inactive_regions());
+    assert(is_maximal_no_gc(), "Should be no regions left, available: %u", _hrm.num_inactive_regions());
     log_debug(gc, ergo, heap)("Did not expand the heap (heap already fully expanded)");
     return false;
   }
 
-  policy()->record_new_heap_size(committed_regions());
+  policy()->record_new_heap_size(num_committed_regions());
   return true;
 }
 
@@ -1061,7 +1061,7 @@ void G1CollectedHeap::shrink_helper(size_t shrink_bytes) {
                             shrink_bytes, aligned_shrink_bytes, shrunk_bytes);
   if (num_regions_removed > 0) {
     log_debug(gc, heap)("Uncommittable regions after shrink: %u", num_regions_removed);
-    policy()->record_new_heap_size(committed_regions());
+    policy()->record_new_heap_size(num_committed_regions());
   } else {
     log_debug(gc, ergo, heap)("Did not shrink the heap (heap shrinking operation failed)");
   }
@@ -1373,15 +1373,15 @@ jint G1CollectedHeap::initialize() {
   // 6843694 - ensure that the maximum region index can fit
   // in the remembered set structures.
   const uint max_region_idx = (1U << (sizeof(RegionIdx_t)*BitsPerByte-1)) - 1;
-  guarantee((max_reserved_regions() - 1) <= max_region_idx, "too many regions");
+  guarantee((max_num_regions() - 1) <= max_region_idx, "too many regions");
 
   // The G1FromCardCache reserves card with value 0 as "invalid", so the heap must not
   // start within the first card.
   guarantee((uintptr_t)(heap_rs.base()) >= G1CardTable::card_size(), "Java heap must not start within the first card.");
-  G1FromCardCache::initialize(max_reserved_regions());
+  G1FromCardCache::initialize(max_num_regions());
   // Also create a G1 rem set.
   _rem_set = new G1RemSet(this, _card_table);
-  _rem_set->initialize(max_reserved_regions());
+  _rem_set->initialize(max_num_regions());
 
   size_t max_cards_per_region = ((size_t)1 << (sizeof(CardIdx_t)*BitsPerByte-1)) - 1;
   guarantee(G1HeapRegion::CardsPerRegion > 0, "make sure it's initialized");
@@ -1390,7 +1390,7 @@ jint G1CollectedHeap::initialize() {
 
   G1HeapRegionRemSet::initialize(_reserved);
 
-  G1FreeRegionList::set_unrealistically_long_length(max_regions() + 1);
+  G1FreeRegionList::set_unrealistically_long_length(max_num_regions() + 1);
 
   _bot = new G1BlockOffsetTable(reserved(), bot_storage);
 
@@ -1458,7 +1458,7 @@ jint G1CollectedHeap::initialize() {
   // values in the heap have been properly initialized.
   _monitoring_support = new G1MonitoringSupport(this);
 
-  _collection_set.initialize(max_reserved_regions());
+  _collection_set.initialize(max_num_regions());
 
   allocation_failure_injector()->reset();
 
@@ -1557,7 +1557,7 @@ void G1CollectedHeap::ref_processing_init() {
 }
 
 size_t G1CollectedHeap::capacity() const {
-  return _hrm.committed_regions() * G1HeapRegion::GrainBytes;
+  return _hrm.num_committed_regions() * G1HeapRegion::GrainBytes;
 }
 
 size_t G1CollectedHeap::unused_committed_regions_in_bytes() const {
@@ -2069,7 +2069,7 @@ size_t G1CollectedHeap::unsafe_max_tlab_alloc(Thread* ignored) const {
 }
 
 size_t G1CollectedHeap::max_capacity() const {
-  return max_regions() * G1HeapRegion::GrainBytes;
+  return max_num_regions() * G1HeapRegion::GrainBytes;
 }
 
 void G1CollectedHeap::prepare_for_verify() {
@@ -2217,7 +2217,7 @@ G1HeapSummary G1CollectedHeap::create_g1_heap_summary() {
 
   VirtualSpaceSummary heap_summary = create_heap_space_summary();
   return G1HeapSummary(heap_summary, heap_used, eden_used_bytes, eden_capacity_bytes,
-                       survivor_used_bytes, old_gen_used_bytes, committed_regions());
+                       survivor_used_bytes, old_gen_used_bytes, num_committed_regions());
 }
 
 G1EvacSummary G1CollectedHeap::create_g1_evac_summary(G1EvacStats* stats) {

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -971,7 +971,7 @@ public:
   // But G1CollectedHeap doesn't yet support this.
 
   bool is_maximal_no_gc() const override {
-    return _hrm.available() == 0;
+    return _hrm.inactive_regions() == 0;
   }
 
   // Returns true if an incremental GC should be upgrade to a full gc. This
@@ -981,27 +981,28 @@ public:
   }
 
   // The current number of regions in the heap.
-  uint num_regions() const { return _hrm.length(); }
+  uint active_regions() const { return _hrm.active_regions(); }
 
   // The max number of regions reserved for the heap. Except for static array
   // sizing purposes you probably want to use max_regions().
-  uint max_reserved_regions() const { return _hrm.reserved_length(); }
+  uint max_reserved_regions() const { return _hrm.max_reserved_regions(); }
 
   // Max number of regions that can be committed.
-  uint max_regions() const { return _hrm.max_length(); }
+  uint max_regions() const { return _hrm.max_reserved_regions(); }
 
   // The number of regions that are completely free.
   uint num_free_regions() const { return _hrm.num_free_regions(); }
 
+  // The number of regions that are not completely free.
+  uint num_used_regions() const { return _hrm.num_used_regions(); }
+
   // The number of regions that can be allocated into.
-  uint num_free_or_available_regions() const { return num_free_regions() + _hrm.available(); }
+  uint num_free_or_inactive_regions() const { return _hrm.free_or_inactive_regions(); }
 
   MemoryUsage get_auxiliary_data_memory_usage() const {
     return _hrm.get_auxiliary_data_memory_usage();
   }
 
-  // The number of regions that are not completely free.
-  uint num_used_regions() const { return num_regions() - num_free_regions(); }
 
 #ifdef ASSERT
   bool is_on_master_free_list(G1HeapRegion* hr) {

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -981,7 +981,7 @@ public:
   }
 
   // The current number of regions in the heap.
-  uint active_regions() const { return _hrm.active_regions(); }
+  uint committed_regions() const { return _hrm.committed_regions(); }
 
   // The max number of regions reserved for the heap. Except for static array
   // sizing purposes you probably want to use max_regions().

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -90,7 +90,7 @@ class WorkerThreads;
 typedef OverflowTaskQueue<ScannerTask, mtGC>           G1ScannerTasksQueue;
 typedef GenericTaskQueueSet<G1ScannerTasksQueue, mtGC> G1ScannerTasksQueueSet;
 
-typedef int RegionIdx_t;   // needs to hold [ 0..max_reserved_regions() )
+typedef int RegionIdx_t;   // needs to hold [ 0..max_num_regions() )
 typedef int CardIdx_t;     // needs to hold [ 0..CardsPerRegion )
 
 // The G1 STW is alive closure.
@@ -971,7 +971,7 @@ public:
   // But G1CollectedHeap doesn't yet support this.
 
   bool is_maximal_no_gc() const override {
-    return _hrm.inactive_regions() == 0;
+    return _hrm.num_inactive_regions() == 0;
   }
 
   // Returns true if an incremental GC should be upgrade to a full gc. This
@@ -981,14 +981,10 @@ public:
   }
 
   // The current number of regions in the heap.
-  uint committed_regions() const { return _hrm.committed_regions(); }
+  uint num_committed_regions() const { return _hrm.num_committed_regions(); }
 
-  // The max number of regions reserved for the heap. Except for static array
-  // sizing purposes you probably want to use max_regions().
-  uint max_reserved_regions() const { return _hrm.max_reserved_regions(); }
-
-  // Max number of regions that can be committed.
-  uint max_regions() const { return _hrm.max_reserved_regions(); }
+  // The max number of regions reserved for the heap.
+  uint max_num_regions() const { return _hrm.max_num_regions(); }
 
   // The number of regions that are completely free.
   uint num_free_regions() const { return _hrm.num_free_regions(); }
@@ -997,7 +993,7 @@ public:
   uint num_used_regions() const { return _hrm.num_used_regions(); }
 
   // The number of regions that can be allocated into.
-  uint num_free_or_inactive_regions() const { return _hrm.free_or_inactive_regions(); }
+  uint num_available_regions() const { return _hrm.num_available_regions(); }
 
   MemoryUsage get_auxiliary_data_memory_usage() const {
     return _hrm.get_auxiliary_data_memory_usage();

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -782,7 +782,7 @@ public:
 void G1ConcurrentMark::clear_bitmap(WorkerThreads* workers, bool may_yield) {
   assert(may_yield || SafepointSynchronize::is_at_safepoint(), "Non-yielding bitmap clear only allowed at safepoint.");
 
-  size_t const num_bytes_to_clear = (G1HeapRegion::GrainBytes * _g1h->active_regions()) / G1CMBitMap::heap_map_factor();
+  size_t const num_bytes_to_clear = (G1HeapRegion::GrainBytes * _g1h->committed_regions()) / G1CMBitMap::heap_map_factor();
   size_t const num_chunks = align_up(num_bytes_to_clear, G1ClearBitMapTask::chunk_size()) / G1ClearBitMapTask::chunk_size();
 
   uint const num_workers = (uint)MIN2(num_chunks, (size_t)workers->active_workers());
@@ -1434,20 +1434,20 @@ void G1ConcurrentMark::remark() {
       GCTraceTime(Debug, gc, phases) debug("Select For Rebuild and Reclaim Empty Regions", _gc_timer_cm);
 
       G1UpdateRegionLivenessAndSelectForRebuildTask cl(_g1h, this, _g1h->workers()->active_workers());
-      uint const num_workers = MIN2(G1UpdateRegionLivenessAndSelectForRebuildTask::desired_num_workers(_g1h->active_regions()),
+      uint const num_workers = MIN2(G1UpdateRegionLivenessAndSelectForRebuildTask::desired_num_workers(_g1h->committed_regions()),
                                     _g1h->workers()->active_workers());
-      log_debug(gc,ergo)("Running %s using %u workers for %u regions in heap", cl.name(), num_workers, _g1h->active_regions());
+      log_debug(gc,ergo)("Running %s using %u workers for %u regions in heap", cl.name(), num_workers, _g1h->committed_regions());
       _g1h->workers()->run_task(&cl, num_workers);
 
       log_debug(gc, remset, tracking)("Remembered Set Tracking update regions total %u, selected %u",
-                                        _g1h->active_regions(), cl.total_selected_for_rebuild());
+                                        _g1h->committed_regions(), cl.total_selected_for_rebuild());
 
       _needs_remembered_set_rebuild = (cl.total_selected_for_rebuild() > 0);
 
       if (_needs_remembered_set_rebuild) {
         // Prune rebuild candidates based on G1HeapWastePercent.
         // Improves rebuild time in addition to remembered set memory usage.
-        G1CollectionSetChooser::build(_g1h->workers(), _g1h->active_regions(), _g1h->policy()->candidates());
+        G1CollectionSetChooser::build(_g1h->workers(), _g1h->committed_regions(), _g1h->policy()->candidates());
       }
     }
 

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.inline.hpp
@@ -186,7 +186,7 @@ inline size_t G1CMTask::scan_objArray(objArrayOop obj, MemRegion mr) {
 
 inline void G1ConcurrentMark::update_top_at_mark_start(G1HeapRegion* r) {
   uint const region = r->hrm_index();
-  assert(region < _g1h->max_reserved_regions(), "Tried to access TAMS for region %u out of bounds", region);
+  assert(region < _g1h->max_num_regions(), "Tried to access TAMS for region %u out of bounds", region);
   _top_at_mark_starts[region] = r->top();
 }
 
@@ -199,13 +199,13 @@ inline HeapWord* G1ConcurrentMark::top_at_mark_start(const G1HeapRegion* r) cons
 }
 
 inline HeapWord* G1ConcurrentMark::top_at_mark_start(uint region) const {
-  assert(region < _g1h->max_reserved_regions(), "Tried to access TARS for region %u out of bounds", region);
+  assert(region < _g1h->max_num_regions(), "Tried to access TARS for region %u out of bounds", region);
   return _top_at_mark_starts[region];
 }
 
 inline bool G1ConcurrentMark::obj_allocated_since_mark_start(oop obj) const {
   uint const region = _g1h->addr_to_region(obj);
-  assert(region < _g1h->max_reserved_regions(), "obj " PTR_FORMAT " outside heap %u", p2i(obj), region);
+  assert(region < _g1h->max_num_regions(), "obj " PTR_FORMAT " outside heap %u", p2i(obj), region);
   return cast_from_oop<HeapWord*>(obj) >= top_at_mark_start(region);
 }
 
@@ -217,7 +217,7 @@ inline void G1ConcurrentMark::update_top_at_rebuild_start(G1HeapRegion* r) {
   assert(r->is_old() || r->is_humongous(), "precondition");
 
   uint const region = r->hrm_index();
-  assert(region < _g1h->max_reserved_regions(), "Tried to access TARS for region %u out of bounds", region);
+  assert(region < _g1h->max_num_regions(), "Tried to access TARS for region %u out of bounds", region);
   assert(_top_at_rebuild_starts[region] == nullptr,
          "TARS for region %u has already been set to " PTR_FORMAT " should be null",
          region, p2i(_top_at_rebuild_starts[region]));

--- a/src/hotspot/share/gc/g1/g1FullCollector.cpp
+++ b/src/hotspot/share/gc/g1/g1FullCollector.cpp
@@ -83,7 +83,7 @@ uint G1FullCollector::calc_active_workers() {
 
   // Consider G1HeapWastePercent to decide max number of workers. Each worker
   // will in average cause half a region waste.
-  uint max_wasted_regions_allowed = ((heap->active_regions() * G1HeapWastePercent) / 100);
+  uint max_wasted_regions_allowed = ((heap->committed_regions() * G1HeapWastePercent) / 100);
   uint waste_worker_count = MAX2((max_wasted_regions_allowed * 2) , 1u);
   uint heap_waste_worker_limit = MIN2(waste_worker_count, max_worker_count);
 

--- a/src/hotspot/share/gc/g1/g1FullCollector.cpp
+++ b/src/hotspot/share/gc/g1/g1FullCollector.cpp
@@ -83,7 +83,7 @@ uint G1FullCollector::calc_active_workers() {
 
   // Consider G1HeapWastePercent to decide max number of workers. Each worker
   // will in average cause half a region waste.
-  uint max_wasted_regions_allowed = ((heap->committed_regions() * G1HeapWastePercent) / 100);
+  uint max_wasted_regions_allowed = ((heap->num_committed_regions() * G1HeapWastePercent) / 100);
   uint waste_worker_count = MAX2((max_wasted_regions_allowed * 2) , 1u);
   uint heap_waste_worker_limit = MIN2(waste_worker_count, max_worker_count);
 
@@ -133,9 +133,9 @@ G1FullCollector::G1FullCollector(G1CollectedHeap* heap,
   _markers = NEW_C_HEAP_ARRAY(G1FullGCMarker*, _num_workers, mtGC);
   _compaction_points = NEW_C_HEAP_ARRAY(G1FullGCCompactionPoint*, _num_workers, mtGC);
 
-  _live_stats = NEW_C_HEAP_ARRAY(G1RegionMarkStats, _heap->max_regions(), mtGC);
-  _compaction_tops = NEW_C_HEAP_ARRAY(HeapWord*, _heap->max_regions(), mtGC);
-  for (uint j = 0; j < heap->max_regions(); j++) {
+  _live_stats = NEW_C_HEAP_ARRAY(G1RegionMarkStats, _heap->max_num_regions(), mtGC);
+  _compaction_tops = NEW_C_HEAP_ARRAY(HeapWord*, _heap->max_num_regions(), mtGC);
+  for (uint j = 0; j < heap->max_num_regions(); j++) {
     _live_stats[j].clear();
     _compaction_tops[j] = nullptr;
   }
@@ -415,7 +415,7 @@ void G1FullCollector::phase2c_prepare_serial_compaction() {
   // lowest and the highest region in the tails of the compaction points.
 
   uint start_serial = truncate_parallel_cps();
-  assert(start_serial < _heap->max_reserved_regions(), "Called on empty parallel compaction queues");
+  assert(start_serial < _heap->max_num_regions(), "Called on empty parallel compaction queues");
 
   G1FullGCCompactionPoint* serial_cp = serial_compaction_point();
   assert(!serial_cp->is_initialized(), "sanity!");
@@ -427,7 +427,7 @@ void G1FullCollector::phase2c_prepare_serial_compaction() {
   HeapWord* dense_prefix_top = compaction_top(start_hr);
   G1SerialRePrepareClosure re_prepare(serial_cp, dense_prefix_top);
 
-  for (uint i = start_serial + 1; i < _heap->max_reserved_regions(); i++) {
+  for (uint i = start_serial + 1; i < _heap->max_num_regions(); i++) {
     if (is_compaction_target(i)) {
       G1HeapRegion* current = _heap->region_at(i);
       set_compaction_top(current, current->bottom());
@@ -445,11 +445,11 @@ void G1FullCollector::phase2d_prepare_humongous_compaction() {
 
   uint last_serial_target = serial_cp->current_region()->hrm_index();
   uint region_index = last_serial_target + 1;
-  uint max_reserved_regions = _heap->max_reserved_regions();
+  uint max_num_regions = _heap->max_num_regions();
 
   G1FullGCCompactionPoint* humongous_cp = humongous_compaction_point();
 
-  while (region_index < max_reserved_regions) {
+  while (region_index < max_num_regions) {
     G1HeapRegion* hr = _heap->region_at_or_null(region_index);
 
     if (hr == nullptr) {

--- a/src/hotspot/share/gc/g1/g1FullCollector.cpp
+++ b/src/hotspot/share/gc/g1/g1FullCollector.cpp
@@ -83,7 +83,7 @@ uint G1FullCollector::calc_active_workers() {
 
   // Consider G1HeapWastePercent to decide max number of workers. Each worker
   // will in average cause half a region waste.
-  uint max_wasted_regions_allowed = ((heap->num_regions() * G1HeapWastePercent) / 100);
+  uint max_wasted_regions_allowed = ((heap->active_regions() * G1HeapWastePercent) / 100);
   uint waste_worker_count = MAX2((max_wasted_regions_allowed * 2) , 1u);
   uint heap_waste_worker_limit = MIN2(waste_worker_count, max_worker_count);
 

--- a/src/hotspot/share/gc/g1/g1FullCollector.hpp
+++ b/src/hotspot/share/gc/g1/g1FullCollector.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -121,7 +121,7 @@ public:
   G1CMBitMap*              mark_bitmap();
   ReferenceProcessor*      reference_processor();
   size_t live_words(uint region_index) const {
-    assert(region_index < _heap->max_regions(), "sanity");
+    assert(region_index < _heap->max_num_regions(), "sanity");
     return _live_stats[region_index]._live_words;
   }
 

--- a/src/hotspot/share/gc/g1/g1HeapRegionManager.cpp
+++ b/src/hotspot/share/gc/g1/g1HeapRegionManager.cpp
@@ -658,13 +658,13 @@ uint G1HeapRegionManager::find_empty_from_idx_reverse(uint start_idx, uint* res_
 
 void G1HeapRegionManager::verify() {
   guarantee(num_committed_regions() <= _next_highest_used_hrm_index,
-            "invariant: _length: %u _next_highest_used_hrm_index: %u",
+            "invariant: committed regions: %u _next_highest_used_hrm_index: %u",
             num_committed_regions(), _next_highest_used_hrm_index);
   guarantee(_next_highest_used_hrm_index <= max_num_regions(),
-            "invariant: _next_highest_used_hrm_index: %u _max_length: %u",
+            "invariant: _next_highest_used_hrm_index: %u max_num_regions: %u",
             _next_highest_used_hrm_index, max_num_regions());
   guarantee(num_committed_regions() <= max_num_regions(),
-            "invariant: committed regions: %u max_regions: %u",
+            "invariant: committed regions: %u max_num_regions: %u",
             num_committed_regions(), max_num_regions());
 
   bool prev_committed = true;

--- a/src/hotspot/share/gc/g1/g1HeapRegionManager.cpp
+++ b/src/hotspot/share/gc/g1/g1HeapRegionManager.cpp
@@ -86,7 +86,7 @@ void G1HeapRegionManager::initialize(G1RegionToSpaceMapper* heap_storage,
 
   _regions.initialize(heap_storage->reserved(), G1HeapRegion::GrainBytes);
 
-  _committed_map.initialize(max_reserved_regions());
+  _committed_map.initialize(max_num_regions());
 }
 
 G1HeapRegion* G1HeapRegionManager::allocate_free_region(G1HeapRegionType type, uint requested_node_index) {
@@ -177,7 +177,7 @@ void G1HeapRegionManager::expand(uint start, uint num_regions, WorkerThreads* pr
 
 void G1HeapRegionManager::commit_regions(uint index, size_t num_regions, WorkerThreads* pretouch_workers) {
   guarantee(num_regions > 0, "Must commit more than zero regions");
-  guarantee(num_regions <= inactive_regions(),
+  guarantee(num_regions <= num_inactive_regions(),
             "Cannot commit more than the maximum amount of regions");
 
   _heap_mapper->commit_regions(index, num_regions, pretouch_workers);
@@ -242,7 +242,7 @@ void G1HeapRegionManager::reactivate_regions(uint start, uint num_regions) {
 
 void G1HeapRegionManager::deactivate_regions(uint start, uint num_regions) {
   assert(num_regions > 0, "Need to specify at least one region to uncommit, tried to uncommit zero regions at %u", start);
-  assert(committed_regions() >= num_regions, "pre-condition");
+  assert(num_committed_regions() >= num_regions, "pre-condition");
 
   // Reset NUMA index to and print state change.
   uint end = start + num_regions;
@@ -395,8 +395,8 @@ void G1HeapRegionManager::expand_exact(uint start, uint num_regions, WorkerThrea
 uint G1HeapRegionManager::expand_on_preferred_node(uint preferred_index) {
   uint expand_candidate = UINT_MAX;
 
-  if (inactive_regions() >= 1) {
-    for (uint i = 0; i < max_reserved_regions(); i++) {
+  if (num_inactive_regions() >= 1) {
+    for (uint i = 0; i < max_num_regions(); i++) {
       if (is_available(i)) {
         // Already in use continue
         continue;
@@ -471,18 +471,18 @@ uint G1HeapRegionManager::find_contiguous_in_free_list(uint num_regions) {
   do {
     range = _committed_map.next_active_range(range.end());
     candidate = find_contiguous_in_range(range.start(), range.end(), num_regions);
-  } while (candidate == G1_NO_HRM_INDEX && range.end() < max_reserved_regions());
+  } while (candidate == G1_NO_HRM_INDEX && range.end() < max_num_regions());
 
   return candidate;
 }
 
 uint G1HeapRegionManager::find_contiguous_allow_expand(uint num_regions) {
   // Check if we can actually satisfy the allocation.
-  if (num_regions > free_or_inactive_regions()) {
+  if (num_regions > num_available_regions()) {
     return G1_NO_HRM_INDEX;
   }
   // Find any candidate.
-  return find_contiguous_in_range(0, max_reserved_regions(), num_regions);
+  return find_contiguous_in_range(0, max_num_regions(), num_regions);
 }
 
 G1HeapRegion* G1HeapRegionManager::next_region_in_heap(const G1HeapRegion* r) const {
@@ -498,7 +498,7 @@ G1HeapRegion* G1HeapRegionManager::next_region_in_heap(const G1HeapRegion* r) co
 }
 
 void G1HeapRegionManager::iterate(G1HeapRegionClosure* blk) const {
-  uint len = max_reserved_regions();
+  uint len = max_num_regions();
 
   for (uint i = 0; i < len; i++) {
     if (!is_available(i)) {
@@ -514,7 +514,7 @@ void G1HeapRegionManager::iterate(G1HeapRegionClosure* blk) const {
 }
 
 void G1HeapRegionManager::iterate(G1HeapRegionIndexClosure* blk) const {
-  uint len = max_reserved_regions();
+  uint len = max_num_regions();
 
   for (uint i = 0; i < len; i++) {
     if (!is_available(i)) {
@@ -581,10 +581,10 @@ void G1HeapRegionManager::par_iterate(G1HeapRegionClosure* blk, G1HeapRegionClai
 }
 
 uint G1HeapRegionManager::shrink_by(uint num_regions_to_remove) {
-  assert(committed_regions() > 0, "the region sequence should not be empty");
-  assert(committed_regions() <= _next_highest_used_hrm_index, "invariant");
+  assert(num_committed_regions() > 0, "the region sequence should not be empty");
+  assert(num_committed_regions() <= _next_highest_used_hrm_index, "invariant");
   assert(_next_highest_used_hrm_index > 0, "we should have at least one region committed");
-  assert(num_regions_to_remove < committed_regions(), "We should never remove all regions");
+  assert(num_regions_to_remove < num_committed_regions(), "We should never remove all regions");
 
   if (num_regions_to_remove == 0) {
     return 0;
@@ -657,15 +657,15 @@ uint G1HeapRegionManager::find_empty_from_idx_reverse(uint start_idx, uint* res_
 }
 
 void G1HeapRegionManager::verify() {
-  guarantee(committed_regions() <= _next_highest_used_hrm_index,
+  guarantee(num_committed_regions() <= _next_highest_used_hrm_index,
             "invariant: _length: %u _next_highest_used_hrm_index: %u",
-            committed_regions(), _next_highest_used_hrm_index);
-  guarantee(_next_highest_used_hrm_index <= max_reserved_regions(),
+            num_committed_regions(), _next_highest_used_hrm_index);
+  guarantee(_next_highest_used_hrm_index <= max_num_regions(),
             "invariant: _next_highest_used_hrm_index: %u _max_length: %u",
-            _next_highest_used_hrm_index, max_reserved_regions());
-  guarantee(committed_regions() <= max_reserved_regions(),
+            _next_highest_used_hrm_index, max_num_regions());
+  guarantee(num_committed_regions() <= max_num_regions(),
             "invariant: committed regions: %u max_regions: %u",
-            committed_regions(), max_reserved_regions());
+            num_committed_regions(), max_num_regions());
 
   bool prev_committed = true;
   uint num_committed = 0;
@@ -692,11 +692,11 @@ void G1HeapRegionManager::verify() {
     prev_committed = true;
     prev_end = hr->end();
   }
-  for (uint i = _next_highest_used_hrm_index; i < max_reserved_regions(); i++) {
+  for (uint i = _next_highest_used_hrm_index; i < max_num_regions(); i++) {
     guarantee(_regions.get_by_index(i) == nullptr, "invariant i: %u", i);
   }
 
-  guarantee(num_committed == committed_regions(), "Found %u committed regions, but should be %u", num_committed, committed_regions());
+  guarantee(num_committed == num_committed_regions(), "Found %u committed regions, but should be %u", num_committed, num_committed_regions());
   _free_list.verify();
 }
 
@@ -745,7 +745,7 @@ public:
       WorkerTask("G1 Rebuild Free List Task"),
       _hrm(hrm),
       _worker_freelists(NEW_C_HEAP_ARRAY(G1FreeRegionList, num_workers, mtGC)),
-      _worker_chunk_size((_hrm->max_reserved_regions() + num_workers - 1) / num_workers),
+      _worker_chunk_size((_hrm->max_num_regions() + num_workers - 1) / num_workers),
       _num_workers(num_workers) {
     for (uint worker = 0; worker < _num_workers; worker++) {
       ::new (&_worker_freelists[worker]) G1FreeRegionList("Appendable Worker Free List");
@@ -770,7 +770,7 @@ public:
     EventGCPhaseParallel event;
 
     uint start = worker_id * _worker_chunk_size;
-    uint end = MIN2(start + _worker_chunk_size, _hrm->max_reserved_regions());
+    uint end = MIN2(start + _worker_chunk_size, _hrm->max_num_regions());
 
     // If start is outside the heap, this worker has nothing to do.
     if (start > end) {
@@ -796,7 +796,7 @@ void G1HeapRegionManager::rebuild_free_list(WorkerThreads* workers) {
   // Abandon current free list to allow a rebuild.
   _free_list.abandon();
 
-  uint const num_workers = clamp(max_reserved_regions(), 1u, workers->active_workers());
+  uint const num_workers = clamp(max_num_regions(), 1u, workers->active_workers());
   G1RebuildFreeListTask task(this, num_workers);
 
   log_debug(gc, ergo)("Running %s using %u workers for rebuilding free list of regions",

--- a/src/hotspot/share/gc/g1/g1HeapRegionManager.cpp
+++ b/src/hotspot/share/gc/g1/g1HeapRegionManager.cpp
@@ -242,7 +242,7 @@ void G1HeapRegionManager::reactivate_regions(uint start, uint num_regions) {
 
 void G1HeapRegionManager::deactivate_regions(uint start, uint num_regions) {
   assert(num_regions > 0, "Need to specify at least one region to uncommit, tried to uncommit zero regions at %u", start);
-  assert(active_regions() >= num_regions, "pre-condition");
+  assert(committed_regions() >= num_regions, "pre-condition");
 
   // Reset NUMA index to and print state change.
   uint end = start + num_regions;
@@ -581,10 +581,10 @@ void G1HeapRegionManager::par_iterate(G1HeapRegionClosure* blk, G1HeapRegionClai
 }
 
 uint G1HeapRegionManager::shrink_by(uint num_regions_to_remove) {
-  assert(active_regions() > 0, "the region sequence should not be empty");
-  assert(active_regions() <= _next_highest_used_hrm_index, "invariant");
+  assert(committed_regions() > 0, "the region sequence should not be empty");
+  assert(committed_regions() <= _next_highest_used_hrm_index, "invariant");
   assert(_next_highest_used_hrm_index > 0, "we should have at least one region committed");
-  assert(num_regions_to_remove < active_regions(), "We should never remove all regions");
+  assert(num_regions_to_remove < committed_regions(), "We should never remove all regions");
 
   if (num_regions_to_remove == 0) {
     return 0;
@@ -657,15 +657,15 @@ uint G1HeapRegionManager::find_empty_from_idx_reverse(uint start_idx, uint* res_
 }
 
 void G1HeapRegionManager::verify() {
-  guarantee(active_regions() <= _next_highest_used_hrm_index,
+  guarantee(committed_regions() <= _next_highest_used_hrm_index,
             "invariant: _length: %u _next_highest_used_hrm_index: %u",
-            active_regions(), _next_highest_used_hrm_index);
+            committed_regions(), _next_highest_used_hrm_index);
   guarantee(_next_highest_used_hrm_index <= max_reserved_regions(),
             "invariant: _next_highest_used_hrm_index: %u _max_length: %u",
             _next_highest_used_hrm_index, max_reserved_regions());
-  guarantee(active_regions() <= max_reserved_regions(),
+  guarantee(committed_regions() <= max_reserved_regions(),
             "invariant: committed regions: %u max_regions: %u",
-            active_regions(), max_reserved_regions());
+            committed_regions(), max_reserved_regions());
 
   bool prev_committed = true;
   uint num_committed = 0;
@@ -696,7 +696,7 @@ void G1HeapRegionManager::verify() {
     guarantee(_regions.get_by_index(i) == nullptr, "invariant i: %u", i);
   }
 
-  guarantee(num_committed == active_regions(), "Found %u committed regions, but should be %u", num_committed, active_regions());
+  guarantee(num_committed == committed_regions(), "Found %u committed regions, but should be %u", num_committed, committed_regions());
   _free_list.verify();
 }
 

--- a/src/hotspot/share/gc/g1/g1HeapRegionManager.cpp
+++ b/src/hotspot/share/gc/g1/g1HeapRegionManager.cpp
@@ -86,7 +86,7 @@ void G1HeapRegionManager::initialize(G1RegionToSpaceMapper* heap_storage,
 
   _regions.initialize(heap_storage->reserved(), G1HeapRegion::GrainBytes);
 
-  _committed_map.initialize(reserved_length());
+  _committed_map.initialize(max_reserved_regions());
 }
 
 G1HeapRegion* G1HeapRegionManager::allocate_free_region(G1HeapRegionType type, uint requested_node_index) {
@@ -177,7 +177,7 @@ void G1HeapRegionManager::expand(uint start, uint num_regions, WorkerThreads* pr
 
 void G1HeapRegionManager::commit_regions(uint index, size_t num_regions, WorkerThreads* pretouch_workers) {
   guarantee(num_regions > 0, "Must commit more than zero regions");
-  guarantee(num_regions <= available(),
+  guarantee(num_regions <= inactive_regions(),
             "Cannot commit more than the maximum amount of regions");
 
   _heap_mapper->commit_regions(index, num_regions, pretouch_workers);
@@ -242,7 +242,7 @@ void G1HeapRegionManager::reactivate_regions(uint start, uint num_regions) {
 
 void G1HeapRegionManager::deactivate_regions(uint start, uint num_regions) {
   assert(num_regions > 0, "Need to specify at least one region to uncommit, tried to uncommit zero regions at %u", start);
-  assert(length() >= num_regions, "pre-condition");
+  assert(active_regions() >= num_regions, "pre-condition");
 
   // Reset NUMA index to and print state change.
   uint end = start + num_regions;
@@ -395,8 +395,8 @@ void G1HeapRegionManager::expand_exact(uint start, uint num_regions, WorkerThrea
 uint G1HeapRegionManager::expand_on_preferred_node(uint preferred_index) {
   uint expand_candidate = UINT_MAX;
 
-  if (available() >= 1) {
-    for (uint i = 0; i < reserved_length(); i++) {
+  if (inactive_regions() >= 1) {
+    for (uint i = 0; i < max_reserved_regions(); i++) {
       if (is_available(i)) {
         // Already in use continue
         continue;
@@ -471,18 +471,18 @@ uint G1HeapRegionManager::find_contiguous_in_free_list(uint num_regions) {
   do {
     range = _committed_map.next_active_range(range.end());
     candidate = find_contiguous_in_range(range.start(), range.end(), num_regions);
-  } while (candidate == G1_NO_HRM_INDEX && range.end() < reserved_length());
+  } while (candidate == G1_NO_HRM_INDEX && range.end() < max_reserved_regions());
 
   return candidate;
 }
 
 uint G1HeapRegionManager::find_contiguous_allow_expand(uint num_regions) {
   // Check if we can actually satisfy the allocation.
-  if (num_regions > (num_free_regions() + available())) {
+  if (num_regions > free_or_inactive_regions()) {
     return G1_NO_HRM_INDEX;
   }
   // Find any candidate.
-  return find_contiguous_in_range(0, reserved_length(), num_regions);
+  return find_contiguous_in_range(0, max_reserved_regions(), num_regions);
 }
 
 G1HeapRegion* G1HeapRegionManager::next_region_in_heap(const G1HeapRegion* r) const {
@@ -498,7 +498,7 @@ G1HeapRegion* G1HeapRegionManager::next_region_in_heap(const G1HeapRegion* r) co
 }
 
 void G1HeapRegionManager::iterate(G1HeapRegionClosure* blk) const {
-  uint len = reserved_length();
+  uint len = max_reserved_regions();
 
   for (uint i = 0; i < len; i++) {
     if (!is_available(i)) {
@@ -514,7 +514,7 @@ void G1HeapRegionManager::iterate(G1HeapRegionClosure* blk) const {
 }
 
 void G1HeapRegionManager::iterate(G1HeapRegionIndexClosure* blk) const {
-  uint len = reserved_length();
+  uint len = max_reserved_regions();
 
   for (uint i = 0; i < len; i++) {
     if (!is_available(i)) {
@@ -581,10 +581,10 @@ void G1HeapRegionManager::par_iterate(G1HeapRegionClosure* blk, G1HeapRegionClai
 }
 
 uint G1HeapRegionManager::shrink_by(uint num_regions_to_remove) {
-  assert(length() > 0, "the region sequence should not be empty");
-  assert(length() <= _next_highest_used_hrm_index, "invariant");
+  assert(active_regions() > 0, "the region sequence should not be empty");
+  assert(active_regions() <= _next_highest_used_hrm_index, "invariant");
   assert(_next_highest_used_hrm_index > 0, "we should have at least one region committed");
-  assert(num_regions_to_remove < length(), "We should never remove all regions");
+  assert(num_regions_to_remove < active_regions(), "We should never remove all regions");
 
   if (num_regions_to_remove == 0) {
     return 0;
@@ -657,15 +657,15 @@ uint G1HeapRegionManager::find_empty_from_idx_reverse(uint start_idx, uint* res_
 }
 
 void G1HeapRegionManager::verify() {
-  guarantee(length() <= _next_highest_used_hrm_index,
+  guarantee(active_regions() <= _next_highest_used_hrm_index,
             "invariant: _length: %u _next_highest_used_hrm_index: %u",
-            length(), _next_highest_used_hrm_index);
-  guarantee(_next_highest_used_hrm_index <= reserved_length(),
+            active_regions(), _next_highest_used_hrm_index);
+  guarantee(_next_highest_used_hrm_index <= max_reserved_regions(),
             "invariant: _next_highest_used_hrm_index: %u _max_length: %u",
-            _next_highest_used_hrm_index, reserved_length());
-  guarantee(length() <= max_length(),
+            _next_highest_used_hrm_index, max_reserved_regions());
+  guarantee(active_regions() <= max_reserved_regions(),
             "invariant: committed regions: %u max_regions: %u",
-            length(), max_length());
+            active_regions(), max_reserved_regions());
 
   bool prev_committed = true;
   uint num_committed = 0;
@@ -692,11 +692,11 @@ void G1HeapRegionManager::verify() {
     prev_committed = true;
     prev_end = hr->end();
   }
-  for (uint i = _next_highest_used_hrm_index; i < reserved_length(); i++) {
+  for (uint i = _next_highest_used_hrm_index; i < max_reserved_regions(); i++) {
     guarantee(_regions.get_by_index(i) == nullptr, "invariant i: %u", i);
   }
 
-  guarantee(num_committed == length(), "Found %u committed regions, but should be %u", num_committed, length());
+  guarantee(num_committed == active_regions(), "Found %u committed regions, but should be %u", num_committed, active_regions());
   _free_list.verify();
 }
 
@@ -745,7 +745,7 @@ public:
       WorkerTask("G1 Rebuild Free List Task"),
       _hrm(hrm),
       _worker_freelists(NEW_C_HEAP_ARRAY(G1FreeRegionList, num_workers, mtGC)),
-      _worker_chunk_size((_hrm->reserved_length() + num_workers - 1) / num_workers),
+      _worker_chunk_size((_hrm->max_reserved_regions() + num_workers - 1) / num_workers),
       _num_workers(num_workers) {
     for (uint worker = 0; worker < _num_workers; worker++) {
       ::new (&_worker_freelists[worker]) G1FreeRegionList("Appendable Worker Free List");
@@ -770,7 +770,7 @@ public:
     EventGCPhaseParallel event;
 
     uint start = worker_id * _worker_chunk_size;
-    uint end = MIN2(start + _worker_chunk_size, _hrm->reserved_length());
+    uint end = MIN2(start + _worker_chunk_size, _hrm->max_reserved_regions());
 
     // If start is outside the heap, this worker has nothing to do.
     if (start > end) {
@@ -796,7 +796,7 @@ void G1HeapRegionManager::rebuild_free_list(WorkerThreads* workers) {
   // Abandon current free list to allow a rebuild.
   _free_list.abandon();
 
-  uint const num_workers = clamp(max_length(), 1u, workers->active_workers());
+  uint const num_workers = clamp(max_reserved_regions(), 1u, workers->active_workers());
   G1RebuildFreeListTask task(this, num_workers);
 
   log_debug(gc, ergo)("Running %s using %u workers for rebuilding free list of regions",

--- a/src/hotspot/share/gc/g1/g1HeapRegionManager.hpp
+++ b/src/hotspot/share/gc/g1/g1HeapRegionManager.hpp
@@ -67,7 +67,7 @@ class G1HeapRegionTable : public G1BiasedMappedArray<G1HeapRegion*> {
 // * _next_highest_used_hrm_index (not exposed outside this class) is the
 //   highest heap region index +1 for which we have G1HeapRegions.
 // * max_length() returns the maximum number of regions the heap may commit.
-// * reserved_length() returns the maximum number of regions the heap has reserved.
+// * max_reserved_regions() returns the maximum number of regions the heap has reserved.
 //
 
 class G1HeapRegionManager: public CHeapObj<mtGC> {
@@ -221,6 +221,8 @@ public:
     return _free_list.length();
   }
 
+  uint num_used_regions() const { return active_regions() - num_free_regions(); }
+
   uint num_free_regions(uint node_index) const {
     return _free_list.length(node_index);
   }
@@ -229,17 +231,16 @@ public:
     return num_free_regions() * G1HeapRegion::GrainBytes;
   }
 
-  // Return the number of regions available (uncommitted) regions.
-  uint available() const { return max_length() - length(); }
+  // Return the number of regions uncommitted or ready to be uncommitted.
+  uint inactive_regions() const { return max_reserved_regions() - active_regions(); }
 
   // Return the number of regions currently active and available for use.
-  uint length() const { return _committed_map.num_active(); }
+  uint active_regions() const { return _committed_map.num_active(); }
 
   // The number of regions reserved for the heap.
-  uint reserved_length() const { return (uint)_regions.length(); }
+  uint max_reserved_regions() const { return (uint)_regions.length(); }
 
-  // Return maximum number of regions that heap can expand to.
-  uint max_length() const { return reserved_length(); }
+  uint free_or_inactive_regions() const { return num_free_regions() + inactive_regions(); }
 
   MemoryUsage get_auxiliary_data_memory_usage() const;
 

--- a/src/hotspot/share/gc/g1/g1HeapRegionManager.hpp
+++ b/src/hotspot/share/gc/g1/g1HeapRegionManager.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -66,8 +66,7 @@ class G1HeapRegionTable : public G1BiasedMappedArray<G1HeapRegion*> {
 //   committed regions. These may not be contiguous.
 // * _next_highest_used_hrm_index (not exposed outside this class) is the
 //   highest heap region index +1 for which we have G1HeapRegions.
-// * max_length() returns the maximum number of regions the heap may commit.
-// * max_reserved_regions() returns the maximum number of regions the heap has reserved.
+// * max_num_regions() returns the maximum number of regions the heap has reserved.
 //
 
 class G1HeapRegionManager: public CHeapObj<mtGC> {
@@ -221,7 +220,7 @@ public:
     return _free_list.length();
   }
 
-  uint num_used_regions() const { return committed_regions() - num_free_regions(); }
+  uint num_used_regions() const { return num_committed_regions() - num_free_regions(); }
 
   uint num_free_regions(uint node_index) const {
     return _free_list.length(node_index);
@@ -232,15 +231,15 @@ public:
   }
 
   // Return the number of regions uncommitted or ready to be uncommitted.
-  uint inactive_regions() const { return max_reserved_regions() - committed_regions(); }
+  uint num_inactive_regions() const { return max_num_regions() - num_committed_regions(); }
 
   // Return the number of regions currently active and available for use.
-  uint committed_regions() const { return _committed_map.num_active(); }
+  uint num_committed_regions() const { return _committed_map.num_active(); }
 
   // The number of regions reserved for the heap.
-  uint max_reserved_regions() const { return (uint)_regions.length(); }
+  uint max_num_regions() const { return (uint)_regions.length(); }
 
-  uint free_or_inactive_regions() const { return num_free_regions() + inactive_regions(); }
+  uint num_available_regions() const { return num_free_regions() + num_inactive_regions(); }
 
   MemoryUsage get_auxiliary_data_memory_usage() const;
 

--- a/src/hotspot/share/gc/g1/g1HeapRegionManager.hpp
+++ b/src/hotspot/share/gc/g1/g1HeapRegionManager.hpp
@@ -221,7 +221,7 @@ public:
     return _free_list.length();
   }
 
-  uint num_used_regions() const { return active_regions() - num_free_regions(); }
+  uint num_used_regions() const { return committed_regions() - num_free_regions(); }
 
   uint num_free_regions(uint node_index) const {
     return _free_list.length(node_index);
@@ -232,10 +232,10 @@ public:
   }
 
   // Return the number of regions uncommitted or ready to be uncommitted.
-  uint inactive_regions() const { return max_reserved_regions() - active_regions(); }
+  uint inactive_regions() const { return max_reserved_regions() - committed_regions(); }
 
   // Return the number of regions currently active and available for use.
-  uint active_regions() const { return _committed_map.num_active(); }
+  uint committed_regions() const { return _committed_map.num_active(); }
 
   // The number of regions reserved for the heap.
   uint max_reserved_regions() const { return (uint)_regions.length(); }

--- a/src/hotspot/share/gc/g1/g1HeapRegionManager.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1HeapRegionManager.inline.hpp
@@ -66,7 +66,7 @@ inline G1HeapRegion* G1HeapRegionManager::next_region_in_humongous(G1HeapRegion*
   assert(is_available(index), "pre-condition");
   assert(hr->is_humongous(), "next_region_in_humongous should only be called for a humongous region.");
   index++;
-  if (index < reserved_length() && is_available(index) && at(index)->is_continues_humongous()) {
+  if (index < max_reserved_regions() && is_available(index) && at(index)->is_continues_humongous()) {
     return at(index);
   } else {
     return nullptr;

--- a/src/hotspot/share/gc/g1/g1HeapRegionManager.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1HeapRegionManager.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -66,7 +66,7 @@ inline G1HeapRegion* G1HeapRegionManager::next_region_in_humongous(G1HeapRegion*
   assert(is_available(index), "pre-condition");
   assert(hr->is_humongous(), "next_region_in_humongous should only be called for a humongous region.");
   index++;
-  if (index < max_reserved_regions() && is_available(index) && at(index)->is_continues_humongous()) {
+  if (index < max_num_regions() && is_available(index) && at(index)->is_continues_humongous()) {
     return at(index);
   } else {
     return nullptr;

--- a/src/hotspot/share/gc/g1/g1Policy.cpp
+++ b/src/hotspot/share/gc/g1/g1Policy.cpp
@@ -94,7 +94,7 @@ void G1Policy::init(G1CollectedHeap* g1h, G1CollectionSet* collection_set) {
 
   assert(Heap_lock->owned_by_self(), "Locking discipline.");
 
-  _young_gen_sizer.adjust_max_new_size(_g1h->max_regions());
+  _young_gen_sizer.adjust_max_new_size(_g1h->max_num_regions());
 
   _free_regions_at_end_of_collection = _g1h->num_free_regions();
 
@@ -676,9 +676,9 @@ void G1Policy::record_young_collection_start() {
   // every time we calculate / recalculate the target young length.
   update_survivors_policy();
 
-  assert(max_survivor_regions() + _g1h->num_used_regions() <= _g1h->max_regions(),
+  assert(max_survivor_regions() + _g1h->num_used_regions() <= _g1h->max_num_regions(),
          "Maximum survivor regions %u plus used regions %u exceeds max regions %u",
-         max_survivor_regions(), _g1h->num_used_regions(), _g1h->max_regions());
+         max_survivor_regions(), _g1h->num_used_regions(), _g1h->max_num_regions());
   assert_used_and_recalculate_used_equal(_g1h);
 
   phase_times()->record_cur_collection_start_sec(now.seconds());
@@ -1200,7 +1200,7 @@ void G1Policy::update_survivors_policy() {
   // The real maximum survivor size is bounded by the number of regions that can
   // be allocated into.
   _max_survivor_regions = MIN2(desired_max_survivor_regions,
-                               _g1h->num_free_or_inactive_regions());
+                               _g1h->num_available_regions());
 }
 
 bool G1Policy::force_concurrent_start_if_outside_cycle(GCCause::Cause gc_cause) {
@@ -1445,7 +1445,7 @@ uint G1Policy::calc_max_old_cset_length() const {
   // as a percentage of the heap size. I.e., it should bound the
   // number of old regions added to the CSet irrespective of how many
   // of them are available.
-  double result = (double)_g1h->committed_regions() * G1OldCSetRegionThresholdPercent / 100;
+  double result = (double)_g1h->num_committed_regions() * G1OldCSetRegionThresholdPercent / 100;
   // Round up to be conservative.
   return (uint)ceil(result);
 }

--- a/src/hotspot/share/gc/g1/g1Policy.cpp
+++ b/src/hotspot/share/gc/g1/g1Policy.cpp
@@ -1445,7 +1445,7 @@ uint G1Policy::calc_max_old_cset_length() const {
   // as a percentage of the heap size. I.e., it should bound the
   // number of old regions added to the CSet irrespective of how many
   // of them are available.
-  double result = (double)_g1h->active_regions() * G1OldCSetRegionThresholdPercent / 100;
+  double result = (double)_g1h->committed_regions() * G1OldCSetRegionThresholdPercent / 100;
   // Round up to be conservative.
   return (uint)ceil(result);
 }

--- a/src/hotspot/share/gc/g1/g1Policy.cpp
+++ b/src/hotspot/share/gc/g1/g1Policy.cpp
@@ -1200,7 +1200,7 @@ void G1Policy::update_survivors_policy() {
   // The real maximum survivor size is bounded by the number of regions that can
   // be allocated into.
   _max_survivor_regions = MIN2(desired_max_survivor_regions,
-                               _g1h->num_free_or_available_regions());
+                               _g1h->num_free_or_inactive_regions());
 }
 
 bool G1Policy::force_concurrent_start_if_outside_cycle(GCCause::Cause gc_cause) {
@@ -1445,7 +1445,7 @@ uint G1Policy::calc_max_old_cset_length() const {
   // as a percentage of the heap size. I.e., it should bound the
   // number of old regions added to the CSet irrespective of how many
   // of them are available.
-  double result = (double)_g1h->num_regions() * G1OldCSetRegionThresholdPercent / 100;
+  double result = (double)_g1h->active_regions() * G1OldCSetRegionThresholdPercent / 100;
   // Round up to be conservative.
   return (uint)ceil(result);
 }

--- a/src/hotspot/share/gc/g1/g1RemSet.cpp
+++ b/src/hotspot/share/gc/g1/g1RemSet.cpp
@@ -1432,7 +1432,7 @@ void G1RemSet::print_merge_heap_roots_stats() {
 
     G1CollectedHeap* g1h = G1CollectedHeap::heap();
     size_t total_old_region_cards =
-      (g1h->active_regions() - (g1h->num_free_regions() - g1h->collection_set()->cur_length())) * G1HeapRegion::CardsPerRegion;
+      (g1h->committed_regions() - (g1h->num_free_regions() - g1h->collection_set()->cur_length())) * G1HeapRegion::CardsPerRegion;
 
     ls.print_cr("Visited cards %zu Total dirty %zu (%.2lf%%) Total old %zu (%.2lf%%)",
                 num_visited_cards,

--- a/src/hotspot/share/gc/g1/g1RemSet.cpp
+++ b/src/hotspot/share/gc/g1/g1RemSet.cpp
@@ -1432,7 +1432,7 @@ void G1RemSet::print_merge_heap_roots_stats() {
 
     G1CollectedHeap* g1h = G1CollectedHeap::heap();
     size_t total_old_region_cards =
-      (g1h->committed_regions() - (g1h->num_free_regions() - g1h->collection_set()->cur_length())) * G1HeapRegion::CardsPerRegion;
+      (g1h->num_committed_regions() - (g1h->num_free_regions() - g1h->collection_set()->cur_length())) * G1HeapRegion::CardsPerRegion;
 
     ls.print_cr("Visited cards %zu Total dirty %zu (%.2lf%%) Total old %zu (%.2lf%%)",
                 num_visited_cards,

--- a/src/hotspot/share/gc/g1/g1RemSet.cpp
+++ b/src/hotspot/share/gc/g1/g1RemSet.cpp
@@ -1432,7 +1432,7 @@ void G1RemSet::print_merge_heap_roots_stats() {
 
     G1CollectedHeap* g1h = G1CollectedHeap::heap();
     size_t total_old_region_cards =
-      (g1h->num_regions() - (g1h->num_free_regions() - g1h->collection_set()->cur_length())) * G1HeapRegion::CardsPerRegion;
+      (g1h->active_regions() - (g1h->num_free_regions() - g1h->collection_set()->cur_length())) * G1HeapRegion::CardsPerRegion;
 
     ls.print_cr("Visited cards %zu Total dirty %zu (%.2lf%%) Total old %zu (%.2lf%%)",
                 num_visited_cards,

--- a/src/hotspot/share/gc/g1/g1RemSet.hpp
+++ b/src/hotspot/share/gc/g1/g1RemSet.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -76,7 +76,7 @@ private:
 
 public:
   // Initialize data that depends on the heap size being known.
-  void initialize(uint max_reserved_regions);
+  void initialize(uint max_num_regions);
 
   G1RemSet(G1CollectedHeap* g1h, G1CardTable* ct);
   ~G1RemSet();

--- a/src/hotspot/share/gc/g1/g1YoungCollector.cpp
+++ b/src/hotspot/share/gc/g1/g1YoungCollector.cpp
@@ -496,7 +496,7 @@ void G1YoungCollector::pre_evacuate_collection_set(G1EvacInfo* evacuation_info) 
   // reference processing currently works in G1.
   ref_processor_stw()->start_discovery(false /* always_clear */);
 
-  _evac_failure_regions.pre_collection(_g1h->max_reserved_regions());
+  _evac_failure_regions.pre_collection(_g1h->max_num_regions());
 
   _g1h->gc_prologue(false);
 

--- a/src/hotspot/share/gc/g1/g1YoungGCAllocationFailureInjector.cpp
+++ b/src/hotspot/share/gc/g1/g1YoungGCAllocationFailureInjector.cpp
@@ -54,7 +54,7 @@ G1YoungGCAllocationFailureInjector::G1YoungGCAllocationFailureInjector()
 
 void G1YoungGCAllocationFailureInjector::select_allocation_failure_regions() {
   G1CollectedHeap* g1h = G1CollectedHeap::heap();
-  _allocation_failure_regions.reinitialize(g1h->max_reserved_regions());
+  _allocation_failure_regions.reinitialize(g1h->max_num_regions());
   SelectAllocationFailureRegionClosure closure(_allocation_failure_regions, g1h->collection_set()->cur_length());
   g1h->collection_set_iterate_all(&closure);
 }

--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -537,7 +537,7 @@ WB_END
 WB_ENTRY(jlong, WB_G1NumMaxRegions(JNIEnv* env, jobject o))
   if (UseG1GC) {
     G1CollectedHeap* g1h = G1CollectedHeap::heap();
-    size_t nr = g1h->max_regions();
+    size_t nr = g1h->max_num_regions();
     return (jlong)nr;
   }
   THROW_MSG_0(vmSymbols::java_lang_UnsupportedOperationException(), "WB_G1NumMaxRegions: G1 GC is not enabled");


### PR DESCRIPTION
Hi,

Please review this refactoring of functions names in G1HeapRegionManager and removing duplicate methods.

Testing: gha

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8357559](https://bugs.openjdk.org/browse/JDK-8357559): G1HeapRegionManager refactor rename functions related to the number of regions in different states (**Enhancement** - P5)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25408/head:pull/25408` \
`$ git checkout pull/25408`

Update a local copy of the PR: \
`$ git checkout pull/25408` \
`$ git pull https://git.openjdk.org/jdk.git pull/25408/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25408`

View PR using the GUI difftool: \
`$ git pr show -t 25408`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25408.diff">https://git.openjdk.org/jdk/pull/25408.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25408#issuecomment-2904064242)
</details>
