### PR TITLE
8357473: Compilation spike leaves many CompileTasks in free list

### DIFF
--- a/src/hotspot/share/compiler/compileBroker.hpp
+++ b/src/hotspot/share/compiler/compileBroker.hpp
@@ -140,7 +140,7 @@ class CompileQueue : public CHeapObj<mtCompiler> {
 
   // Redefine Classes support
   void mark_on_stack();
-  void free_all();
+  void delete_all();
   void print_tty();
   void print(outputStream* st = tty);
 

--- a/src/hotspot/share/compiler/compileTask.hpp
+++ b/src/hotspot/share/compiler/compileTask.hpp
@@ -113,8 +113,7 @@ class CompileTask : public CHeapObj<mtCompiler> {
 
  public:
   CompileTask(int compile_id, const methodHandle& method, int osr_bci, int comp_level,
-              int hot_count,
-              CompileReason compile_reason, bool is_blocking);
+              int hot_count, CompileReason compile_reason, bool is_blocking);
   ~CompileTask();
 
   int          compile_id() const                { return _compile_id; }


### PR DESCRIPTION
See bug for more discussion.

This PR implements the "all the way" solution by removing the free list completely.

Additional testing:
 - [x] Linux x86_64 server fastdebug, `compiler`
 - [x] Linux AArch64 server fastdebug, `all`