### PR TITLE
8357637: Native resources cached in thread locals not released when FJP common pool threads clears thread locals

### DIFF
--- a/src/java.base/share/classes/java/lang/Thread.java
+++ b/src/java.base/share/classes/java/lang/Thread.java
@@ -1492,7 +1492,7 @@ public class Thread implements Runnable {
         }
 
         try {
-            if (threadLocals != null && TerminatingThreadLocal.REGISTRY.isPresent()) {
+            if (threadLocals != null) {
                 TerminatingThreadLocal.threadTerminated();
             }
         } finally {

--- a/src/java.base/share/classes/java/util/concurrent/ForkJoinWorkerThread.java
+++ b/src/java.base/share/classes/java/util/concurrent/ForkJoinWorkerThread.java
@@ -37,6 +37,7 @@ package java.util.concurrent;
 
 import jdk.internal.access.JavaLangAccess;
 import jdk.internal.access.SharedSecrets;
+import jdk.internal.misc.TerminatingThreadLocal;
 import jdk.internal.misc.Unsafe;
 
 /**
@@ -227,8 +228,10 @@ public class ForkJoinWorkerThread extends Thread {
      * Clears ThreadLocals
      */
     final void resetThreadLocals() {
-         if (U.getReference(this, THREADLOCALS) != null)
+         if (U.getReference(this, THREADLOCALS) != null) {
+             TerminatingThreadLocal.releaseResources();
              U.putReference(this, THREADLOCALS, null);
+         }
          if (U.getReference(this, INHERITABLETHREADLOCALS) != null)
              U.putReference(this, INHERITABLETHREADLOCALS, null);
          onThreadLocalReset();

--- a/src/java.base/share/classes/jdk/internal/misc/InnocuousThread.java
+++ b/src/java.base/share/classes/jdk/internal/misc/InnocuousThread.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -133,9 +133,14 @@ public final class InnocuousThread extends Thread {
     /**
      * Drops all thread locals (and inherited thread locals).
      */
-    public final void eraseThreadLocals() {
-        UNSAFE.putReference(this, THREAD_LOCALS, null);
-        UNSAFE.putReference(this, INHERITABLE_THREAD_LOCALS, null);
+    public void eraseThreadLocals() {
+        if (UNSAFE.getReference(this, THREAD_LOCALS) != null) {
+            TerminatingThreadLocal.releaseResources();
+            UNSAFE.putReference(this, THREAD_LOCALS, null);
+        }
+        if (UNSAFE.getReference(this, INHERITABLE_THREAD_LOCALS) != null) {
+            UNSAFE.putReference(this, INHERITABLE_THREAD_LOCALS, null);
+        }
     }
 
     // ensure run method is run only once

--- a/src/java.base/share/classes/sun/nio/ch/IOVecWrapper.java
+++ b/src/java.base/share/classes/sun/nio/ch/IOVecWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -76,10 +76,11 @@ class IOVecWrapper {
             return new IOVecWrapper[1];  // one slot cache
         }
         @Override
-        protected void threadTerminated(IOVecWrapper[] cache) {
+        protected void releaseResources(IOVecWrapper[] cache) { // will never be null
             IOVecWrapper wrapper = cache[0];
             if (wrapper != null) {
                 wrapper.vecArray.free();
+                cache[0] = null;
             }
         }
     };

--- a/src/java.base/share/classes/sun/nio/ch/Util.java
+++ b/src/java.base/share/classes/sun/nio/ch/Util.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,7 +60,7 @@ public class Util {
             return new BufferCache();
         }
         @Override
-        protected void threadTerminated(BufferCache cache) { // will never be null
+        protected void releaseResources(BufferCache cache) { // will never be null
             while (!cache.isEmpty()) {
                 ByteBuffer bb = cache.removeFirst();
                 free(bb);

--- a/src/java.base/share/classes/sun/nio/fs/NativeBuffers.java
+++ b/src/java.base/share/classes/sun/nio/fs/NativeBuffers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,7 +40,7 @@ class NativeBuffers {
     // per-carrier-thread cache of NativeBuffer(s)
     private static final TerminatingThreadLocal<NativeBuffer[]> threadLocal = new TerminatingThreadLocal<>() {
         @Override
-        protected void threadTerminated(NativeBuffer[] buffers) {
+        protected void releaseResources(NativeBuffer[] buffers) {
             // threadLocal may be initialized but with initialValue of null
             if (buffers != null) {
                 for (int i = 0; i < TEMP_BUF_POOL_SIZE; i++) {


### PR DESCRIPTION
Still under discussion, not ready for review.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8357637](https://bugs.openjdk.org/browse/JDK-8357637): Native resources cached in thread locals not released when FJP common pool threads clears thread locals (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25411/head:pull/25411` \
`$ git checkout pull/25411`

Update a local copy of the PR: \
`$ git checkout pull/25411` \
`$ git pull https://git.openjdk.org/jdk.git pull/25411/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25411`

View PR using the GUI difftool: \
`$ git pr show -t 25411`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25411.diff">https://git.openjdk.org/jdk/pull/25411.diff</a>

</details>
