### PR TITLE
8357649: IGV: add block index to the supplemental node properties

### DIFF
--- a/src/hotspot/share/opto/idealGraphPrinter.cpp
+++ b/src/hotspot/share/opto/idealGraphPrinter.cpp
@@ -474,6 +474,10 @@ void IdealGraphPrinter::visit_node(Node* n, bool edges) {
         // Enforce dots as decimal separators, as required by IGV.
         StringUtils::replace_no_expand(buffer, ",", ".");
         print_prop("frequency", buffer);
+        // Print block index for nodes that are placed in blocks and scheduled locally.
+        if (block->contains(node)) {
+          print_prop("block_index", block->find_node(node));
+        }
       }
     }
 


### PR DESCRIPTION
This PR adds the block index to IGV node properties as soon as the CFG has been scheduled. This is really handy when working on peepholes, where one has to work with block indices.

![Screenshot from 2025-05-23 15-35-29](https://github.com/user-attachments/assets/1a895e07-cf5f-4eed-afd0-08fe26cf0266)

Testing:
 - [x] [Github Actions](https://github.com/mhaessig/jdk/actions?query=branch%3AJDK-8357649-block-index)
 - [x] tier1, tier2, and some Oracle internal testing on Oracle supported platfors and OSs

Shout out to @robcasloz for coming up with an initial version of this patch.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8357649](https://bugs.openjdk.org/browse/JDK-8357649): IGV: add block index to the supplemental node properties (**Enhancement** - P4)


### Reviewers
 * [Roberto Castañeda Lozano](https://openjdk.org/census#rcastanedalo) (@robcasloz - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)

### Contributors
 * Roberto Castañeda Lozano `<rcastanedalo@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25414/head:pull/25414` \
`$ git checkout pull/25414`

Update a local copy of the PR: \
`$ git checkout pull/25414` \
`$ git pull https://git.openjdk.org/jdk.git pull/25414/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25414`

View PR using the GUI difftool: \
`$ git pr show -t 25414`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25414.diff">https://git.openjdk.org/jdk/pull/25414.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25414#issuecomment-2904482948)
</details>
