### PR TITLE
JDK-8324720: Instruction selection does not respect -XX:-UseBMI2Instructions flag

### DIFF
--- a/src/hotspot/cpu/x86/vm_version_x86.cpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.cpp
@@ -1030,6 +1030,10 @@ void VM_Version::get_processor_features() {
     _features.clear_feature(CPU_APX_F);
   }
 
+  if (!UseBMI2Instructions && UseAVX < 3) {
+    _features.clear_feature(CPU_BMI2);
+  }
+
   if (UseAVX < 2) {
     _features.clear_feature(CPU_AVX2);
     _features.clear_feature(CPU_AVX_IFMA);

--- a/test/hotspot/jtreg/compiler/testlibrary/sha/predicate/IntrinsicPredicates.java
+++ b/test/hotspot/jtreg/compiler/testlibrary/sha/predicate/IntrinsicPredicates.java
@@ -97,11 +97,14 @@ public class IntrinsicPredicates {
               new OrPredicate(new CPUSpecificPredicate("ppc64.*",   new String[] { "sha"          }, null),
               new OrPredicate(new CPUSpecificPredicate("ppc64le.*", new String[] { "sha"          }, null),
               // x86 variants
-              new OrPredicate(new CPUSpecificPredicate("amd64.*",   new String[] { "sha"          }, null),
               new OrPredicate(new CPUSpecificPredicate("i386.*",    new String[] { "sha"          }, null),
               new OrPredicate(new CPUSpecificPredicate("x86.*",     new String[] { "sha"          }, null),
-              new OrPredicate(new CPUSpecificPredicate("amd64.*",   new String[] { "avx2", "bmi2" }, null),
-                              new CPUSpecificPredicate("x86_64",    new String[] { "avx2", "bmi2" }, null))))))))));
+              new OrPredicate(new AndPredicate(new CPUSpecificPredicate("amd64.*",   new String[] { "sha", "avx2" }, null),
+                                               new OrPredicate(new CPUSpecificPredicate("amd64.*",   new String[] { "bmi2" }, null),
+                                                               new CPUSpecificPredicate("amd64.*",   new String[] { "sha512" }, null))),
+                              (new AndPredicate(new CPUSpecificPredicate("x86_64",   new String[] { "sha", "avx2" }, null),
+                                                new OrPredicate(new CPUSpecificPredicate("x86_64",   new String[] { "bmi2" }, null),
+                                                                new CPUSpecificPredicate("x86_64",   new String[] { "sha512" }, null))))))))))));
 
     public static final BooleanSupplier SHA3_INSTRUCTION_AVAILABLE
             // sha3 is only implemented on aarch64 and avx512 for now


### PR DESCRIPTION
### Issue:
While executing a function  performing `a >> b` operation with `–XX:-UseBMI2Instructions` flag, the generated code contains BMI2 instruction `sarx eax,esi,edx`. The expected output should not contain any BMI2 instruction.  
 
### Analysis and solution 
 
As suggested by @merykitty in [JDK-8324720](https://bugs.openjdk.org/browse/JDK-8324720) , the initial fix worked on making `VM_Version::supports_bmi2()` respect` UseBMI2Instructions `flag by disabling BMI2 feature if `UseBMI2Instructions` runtime flag is explicitly set to false. This solution is similar to how other runtime flags such as, `UseAPX` and `UseAVX`, enable or disable specific code and register set. However, some test failures were encountered while running tests on this initial fix. 

The first set of failures were caused by assertion check on `VM_Version::supports_bmi2()` statement while generating certain BMI2 specific instructions in` assembler_x86.cpp` . This  was because the stub generator generating AVX512 specific code  also uses some BMI2 instructions. This was found to be a direct consequence of the fact that `UseAVX` flag is set by default to the highest supported version available in x86 machine. In order to not comprise the performance benefits of using AVX-512 when UseBMI2Instructions flag is explicitly disabled by the user,  the proposed fix only disables BMI2 feature if AVX-512 features are also disabled  (or not available) along with UseBMI2Instructions flag.  
 
The second failure occured in hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseSHA512IntrinsicsOptionOnSupportedCPU.java where a warning "Intrinsics for SHA-384 and SHA-512 crypto hash functions not available on this CPU." was returned on a AMD64 machine that had support for SHA512. On analysing the hotspot/jtreg/compiler/testlibrary/sha/predicate/IntrinsicPredicates.java that sets the predicate for this test, it was found that the predicate for AMD64 was in line with changes introduced by JDK-8341052 in commit.  