### PR TITLE
8357647 : Stream gatherers forward upstream size information to downstream

### DIFF
--- a/src/java.base/share/classes/java/util/stream/GathererOp.java
+++ b/src/java.base/share/classes/java/util/stream/GathererOp.java
@@ -150,7 +150,7 @@ final class GathererOp<T, A, R> extends ReferencePipeline<T, R> {
             final var initializer = gatherer.initializer();
             if (initializer != Gatherer.defaultInitializer()) // Optimization
                 state = initializer.get();
-            sink.begin(size);
+            sink.begin(-1); // GathererOp does not know the size of the output
         }
 
         @Override

--- a/test/jdk/java/util/stream/GathererTest.java
+++ b/test/jdk/java/util/stream/GathererTest.java
@@ -493,7 +493,7 @@ public class GathererTest {
 
         var result = StreamSupport.stream(s, parallel)
                                   .gather(
-                                      Gatherer.ofSequential(
+                                      Gatherer.of(
                                           (_, i, d)
                                               -> d.push(i) && false
                                       )

--- a/test/jdk/java/util/stream/GathererTest.java
+++ b/test/jdk/java/util/stream/GathererTest.java
@@ -20,9 +20,9 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-import java.util.ArrayList;
 import java.util.List;
-import java.util.function.Predicate;
+import java.util.Spliterator;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.stream.*;
 import java.util.stream.Gatherer;
@@ -31,6 +31,7 @@ import static java.util.stream.DefaultMethodStreams.delegateTo;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assumptions.*;
 
@@ -463,6 +464,41 @@ public class GathererTest {
                     )
             ).toList()
         , expectedMessage);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { false, true })
+    public void mustNotPropagateSizeInformation(boolean parallel) {
+        // Constructs a spliterator of unbounded length but which
+        // reports SIZED and SUBSIZED characteristics so if its size
+        // of Long.MAX_VALUE gets propagated by gather() then the
+        // resulting toList() call would allocate a huge array and as
+        // such would yield an OutOfMemoryError
+        var s = new Spliterator<Integer>() {
+            @Override
+            public boolean tryAdvance(Consumer<? super Integer> action) {
+                action.accept(0);
+                return true;
+            }
+
+            @Override public Spliterator<Integer> trySplit() { return null; }
+
+            @Override public long estimateSize() { return Long.MAX_VALUE; }
+
+            @Override
+            public int characteristics() {
+                return Spliterator.SIZED | Spliterator.IMMUTABLE | Spliterator.SUBSIZED;
+            }
+        };
+
+        var result = StreamSupport.stream(s, parallel)
+                                  .gather(
+                                      Gatherer.ofSequential(
+                                          (_, i, d)
+                                              -> d.push(i) && false
+                                      )
+                                  ).toList();
+        assertEquals(result, List.of(0));
     }
 
     private final static void assertThrowsTestException(Supplier<?> supplier, String expectedMessage) {


### PR DESCRIPTION
While it could be argued that unbounded Spliterators should not report SIZED / SUBSIZED, GatherSink should report an unknown emission size, so switching to downstream.begin(-1) rather than downstream.begin(size).

Includes a regression test which yields an OOME if this change is omitted.