### PR TITLE
8357597: Proxy.getInvocationHandler throws NullPointerException instead of IllegalArgumentException for null

### DIFF
--- a/src/java.base/share/classes/java/lang/reflect/Proxy.java
+++ b/src/java.base/share/classes/java/lang/reflect/Proxy.java
@@ -967,6 +967,7 @@ public class Proxy implements java.io.Serializable {
      * @return  the invocation handler for the proxy instance
      * @throws  IllegalArgumentException if the argument is not a
      *          proxy instance
+     * @throws  NullPointerException if {@code proxy} is {@code null}
      */
     public static InvocationHandler getInvocationHandler(Object proxy)
         throws IllegalArgumentException


### PR DESCRIPTION
`Proxy#getInvocationHandler(Object)` throws a `NullPointerException` if the specified argument is `null`. This PR adds the missing `throws` declaration for the NPE.