### PR TITLE
8357660: [JVMCI] Add Support for Retrieving All Indy BootstrapMethodInvocations directly from the ConstantPool

### DIFF
--- a/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
@@ -808,6 +808,14 @@ C2V_VMENTRY_NULL(jobject, lookupConstantInPool, (JNIEnv* env, jobject, ARGUMENT_
   return JVMCIENV->get_jobject(JVMCIENV->get_object_constant(obj));
 C2V_END
 
+C2V_VMENTRY_0(jint, getNumIndyEntries, (JNIEnv* env, jobject, ARGUMENT_PAIR(cp)))
+  constantPoolHandle cp(THREAD, UNPACK_PAIR(ConstantPool, cp));
+  if (cp->cache()->resolved_indy_entries() == nullptr) {
+    return 0;
+  }
+  return cp->resolved_indy_entries_length();
+C2V_END
+
 C2V_VMENTRY_NULL(jobjectArray, resolveBootstrapMethod, (JNIEnv* env, jobject, ARGUMENT_PAIR(cp), jint index))
   constantPoolHandle cp(THREAD, UNPACK_PAIR(ConstantPool, cp));
   constantTag tag = cp->tag_at(index);
@@ -3295,6 +3303,7 @@ JNINativeMethod CompilerToVM::methods[] = {
   {CC "lookupAppendixInPool",                         CC "(" HS_CONSTANT_POOL2 "II)" OBJECTCONSTANT,                                        FN_PTR(lookupAppendixInPool)},
   {CC "lookupMethodInPool",                           CC "(" HS_CONSTANT_POOL2 "IB" HS_METHOD2 ")" HS_METHOD,                               FN_PTR(lookupMethodInPool)},
   {CC "lookupConstantInPool",                         CC "(" HS_CONSTANT_POOL2 "IZ)" JAVACONSTANT,                                          FN_PTR(lookupConstantInPool)},
+  {CC "getNumIndyEntries",                            CC "(" HS_CONSTANT_POOL2 ")I",                                                        FN_PTR(getNumIndyEntries)},
   {CC "resolveBootstrapMethod",                       CC "(" HS_CONSTANT_POOL2 "I)[" OBJECT,                                                FN_PTR(resolveBootstrapMethod)},
   {CC "bootstrapArgumentIndexAt",                     CC "(" HS_CONSTANT_POOL2 "II)I",                                                      FN_PTR(bootstrapArgumentIndexAt)},
   {CC "getUncachedStringInPool",                      CC "(" HS_CONSTANT_POOL2 "I)" JAVACONSTANT,                                           FN_PTR(getUncachedStringInPool)},

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/CompilerToVM.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/CompilerToVM.java
@@ -468,9 +468,19 @@ final class CompilerToVM {
      */
     int decodeMethodIndexToCPIndex(HotSpotConstantPool constantPool, int rawIndex) {
       return decodeMethodIndexToCPIndex(constantPool, constantPool.getConstantPoolPointer(), rawIndex);
-  }
+    }
 
-  private native int decodeMethodIndexToCPIndex(HotSpotConstantPool constantPool, long constantPoolPointer, int rawIndex);
+    private native int decodeMethodIndexToCPIndex(HotSpotConstantPool constantPool, long constantPoolPointer, int rawIndex);
+
+	/**
+	 * Returns the number of {@code ResolvedIndyEntry} present within this constant
+	 * pool.
+	 */
+	int getNumIndyEntries(HotSpotConstantPool constantPool) {
+		return getNumIndyEntries(constantPool, constantPool.getConstantPoolPointer());
+	}
+
+    private native int getNumIndyEntries(HotSpotConstantPool constantPool, long constantPoolPointer);
 
     /**
      * Resolves the details for invoking the bootstrap method associated with the

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/meta/ConstantPool.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/meta/ConstantPool.java
@@ -191,7 +191,24 @@ public interface ConstantPool {
          * @jvms 5.4.3.6
          */
         List<JavaConstant> getStaticArguments();
-    }
+
+		/**
+		 * If this bootstrap method invocation is for a {@code
+		 * CONSTANTAdd_InvokeDynamic_info} pool entry, then this method ensures the invoke
+		 * dynamic is resolved. This can be used to compile time resolve the invoke
+		 * dynamic. If the bootstrap method is for a {@code CONSTANT_Dynamic_info}
+		 * entry, then no action is performed
+		 */
+		void resolveInvokeDynamic();
+
+		/**
+		 * If this bootstrap method invocation is for a {@code
+		 * CONSTANT_InvokeDynamic_info} pool entry, then this method looks up the
+		 * corresponding invoke dynamic's appendix. If the bootstrap method is for a
+		 * {@code CONSTANT_Dynamic_info} entry, then null is returned.
+		 */
+		JavaConstant lookupInvokeDynamicAppendix();
+	}
 
     /**
      * Gets the details for invoking a bootstrap method associated with the
@@ -210,6 +227,14 @@ public interface ConstantPool {
     default BootstrapMethodInvocation lookupBootstrapMethodInvocation(int index, int opcode) {
         throw new UnsupportedOperationException();
     }
+
+	/**
+	 * Returns all BootstrapMethodInvocations within the constant pool where
+	 * {@link BootstrapMethodMethodInvocation#isInvokeDynamic} is true. If this
+	 * constant pool contains no invokedynamic BootstrapMethodInvocations, then null
+	 * is returned.
+	 */
+	BootstrapMethodInvocation[] lookupAllIndyBootstrapMethodInvocations();
 
     /**
      * Looks up a reference to a type. If {@code opcode} is non-negative, then resolution checks


### PR DESCRIPTION
This PR adds support for directly retrieving all BootstrapMethodInvocations from a ConstantPool.

In addition, two methods are added to the BootstrapMethodInvocations:
1. `void resolveInvokeDynamic()`
2. `JavaConstant lookupInvokeDynamicAppendix()`

The combination of these two features allows one to directly interact with all invokedynamic information of a given ConstantPool without having to iterate through all of the Classfile's methods to find all invokedynamic bytecodes