### PR TITLE
8320189: vmTestbase/nsk/jvmti/scenarios/bcinstr/BI02/bi02t001 memory corruption when using -Xcheck:jni

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/bcinstr/BI02/bi02t001/bi02t001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/bcinstr/BI02/bi02t001/bi02t001.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,7 +49,7 @@ const char* CLASS_NAME = "nsk/jvmti/scenarios/bcinstr/BI02/bi02t001a";
 /** callback functions **/
 
 static void JNICALL
-ClassFileLoadHook(jvmtiEnv *jvmti_env, JNIEnv *jni_env,
+ClassFileLoadHook(jvmtiEnv *jvmti, JNIEnv *jni,
         jclass class_being_redefined, jobject loader,
         const char* name, jobject protection_domain,
         jint class_data_len, const unsigned char* class_data,
@@ -61,18 +61,7 @@ ClassFileLoadHook(jvmtiEnv *jvmti_env, JNIEnv *jni_env,
 
         if (class_being_redefined == nullptr) {
             /* sent by class load */
-
-            if (!NSK_JNI_VERIFY(jni_env, (*new_class_data_len =
-                    jni_env->GetArrayLength(classBytes)) > 0)) {
-                nsk_jvmti_setFailStatus();
-                return;
-            }
-
-            if (!NSK_JNI_VERIFY(jni_env, (*new_class_data = (unsigned char*)
-                    jni_env->GetByteArrayElements(classBytes, nullptr)) != nullptr)) {
-                nsk_jvmti_setFailStatus();
-                return;
-            }
+            *new_class_data = jni_array_to_jvmti_allocated(jvmti, jni, classBytes, new_class_data_len);
         }
     }
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/bcinstr/BI03/bi03t001/bi03t001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/bcinstr/BI03/bi03t001/bi03t001.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,7 +49,7 @@ const char* CLASS_NAME = "nsk/jvmti/scenarios/bcinstr/BI03/bi03t001a";
 /** callback functions **/
 
 static void JNICALL
-ClassFileLoadHook(jvmtiEnv *jvmti_env, JNIEnv *jni_env,
+ClassFileLoadHook(jvmtiEnv *jvmti, JNIEnv *jni,
         jclass class_being_redefined, jobject loader,
         const char* name, jobject protection_domain,
         jint class_data_len, const unsigned char* class_data,
@@ -62,17 +62,7 @@ ClassFileLoadHook(jvmtiEnv *jvmti_env, JNIEnv *jni_env,
         if (class_being_redefined == nullptr) {
             /* sent by class load */
 
-            if (!NSK_JNI_VERIFY(jni_env, (*new_class_data_len =
-                    jni_env->GetArrayLength(classBytes)) > 0)) {
-                nsk_jvmti_setFailStatus();
-                return;
-            }
-
-            if (!NSK_JNI_VERIFY(jni_env, (*new_class_data = (unsigned char*)
-                    jni_env->GetByteArrayElements(classBytes, nullptr)) != nullptr)) {
-                nsk_jvmti_setFailStatus();
-                return;
-            }
+            *new_class_data = jni_array_to_jvmti_allocated(jvmti, jni, classBytes, new_class_data_len);
         }
     }
 }

--- a/test/lib/jdk/test/lib/jvmti/jvmti_common.hpp
+++ b/test/lib/jdk/test/lib/jvmti/jvmti_common.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -447,7 +447,25 @@ static jthread get_current_thread(jvmtiEnv *jvmti, JNIEnv* jni) {
   return thread;
 }
 
+/* Used in a couple of nsk/jvmti/scenarios tests to convert jbyteArray to a JVMTI allocated */
+static unsigned char* jni_array_to_jvmti_allocated(jvmtiEnv *jvmti, JNIEnv *jni, jbyteArray arr, jint* len_ptr) {
+    unsigned char* new_arr = nullptr;
 
+    jint len = jni->GetArrayLength(arr);
+    if (len <= 0) {
+      fatal(jni, "JNI GetArrayLength returned a non-positive value");
+    }
+    jbyte* jni_arr = jni->GetByteArrayElements(arr, nullptr);
+    if (jni_arr == nullptr) {
+      fatal(jni, "JNI GetByteArrayElements returned nullptr");
+    }
+    jvmtiError err = jvmti->Allocate(len, &new_arr); 
+    check_jvmti_status(jni, err, "JVMTI Allocate returned an error code");
+
+    memcpy(new_arr, jni_arr, (size_t)len);
+    *len_ptr = len;
+    return new_arr;
+}
 
 /* Commonly used helper functions */
 const char*

--- a/test/lib/jdk/test/lib/jvmti/jvmti_common.hpp
+++ b/test/lib/jdk/test/lib/jvmti/jvmti_common.hpp
@@ -459,7 +459,7 @@ static unsigned char* jni_array_to_jvmti_allocated(jvmtiEnv *jvmti, JNIEnv *jni,
     if (jni_arr == nullptr) {
       fatal(jni, "JNI GetByteArrayElements returned nullptr");
     }
-    jvmtiError err = jvmti->Allocate(len, &new_arr); 
+    jvmtiError err = jvmti->Allocate(len, &new_arr);
     check_jvmti_status(jni, err, "JVMTI Allocate returned an error code");
 
     memcpy(new_arr, jni_arr, (size_t)len);

--- a/test/lib/jdk/test/lib/jvmti/jvmti_common.hpp
+++ b/test/lib/jdk/test/lib/jvmti/jvmti_common.hpp
@@ -463,7 +463,7 @@ static unsigned char* jni_array_to_jvmti_allocated(jvmtiEnv *jvmti, JNIEnv *jni,
     check_jvmti_status(jni, err, "JVMTI Allocate returned an error code");
 
     memcpy(new_arr, jni_arr, (size_t)len);
-    jni->ReleaseByteArrayElements(arr, jni_arr, 0);
+    jni->ReleaseByteArrayElements(arr, jni_arr, JNI_ABORT);
 
     *len_ptr = len;
     return new_arr;

--- a/test/lib/jdk/test/lib/jvmti/jvmti_common.hpp
+++ b/test/lib/jdk/test/lib/jvmti/jvmti_common.hpp
@@ -463,6 +463,8 @@ static unsigned char* jni_array_to_jvmti_allocated(jvmtiEnv *jvmti, JNIEnv *jni,
     check_jvmti_status(jni, err, "JVMTI Allocate returned an error code");
 
     memcpy(new_arr, jni_arr, (size_t)len);
+    jni->ReleaseByteArrayElements(arr, jni_arr, 0);
+
     *len_ptr = len;
     return new_arr;
 }


### PR DESCRIPTION
This update is fixing a couple of `nsk/jvmti/ scenarios` tests.
The tests in a JVMTI `ClassFileLoadHook` callback provide new class file bytes with the result returned by JNI `GetByteArrayElements()`.  It violates the JVMTI `ClassFileLoadHook` spec saying:
```
 "The agent must allocate the space for the modified class file data buffer using the memory allocation function Allocate because the VM is responsible for freeing the new class file data buffer using Deallocate."
```
Please, see the JVMTI ClassFileLoadHook spec:
   https://docs.oracle.com/en/java/javase/24/docs/specs/jvmti.html#ClassFileLoadHook

It is the root cause of a memory corruption detected with the VM option `-Xcheck:jni`.
The fix is to convert a JNI allocated array returned by `GetByteArrayElements()` to a JMVTI allocated array. New conversion function `jni_array_to_jvmti_allocated()` is added to the`jvmti_common.hpp`.

Testing:
 - ran updated tests individually
 - TBD: submit mach5 tiers 1-6

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8320189](https://bugs.openjdk.org/browse/JDK-8320189): vmTestbase/nsk/jvmti/scenarios/bcinstr/BI02/bi02t001 memory corruption when using -Xcheck:jni (**Bug** - P3)


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25422/head:pull/25422` \
`$ git checkout pull/25422`

Update a local copy of the PR: \
`$ git checkout pull/25422` \
`$ git pull https://git.openjdk.org/jdk.git pull/25422/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25422`

View PR using the GUI difftool: \
`$ git pr show -t 25422`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25422.diff">https://git.openjdk.org/jdk/pull/25422.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25422#issuecomment-2905910948)
</details>
