### PR TITLE
8357408: runtime/interpreter/CountBytecodesTest.java should be flagless

### DIFF
--- a/test/hotspot/jtreg/runtime/interpreter/CountBytecodesTest.java
+++ b/test/hotspot/jtreg/runtime/interpreter/CountBytecodesTest.java
@@ -25,6 +25,7 @@
 /*
  * @test
  * @bug 8350642
+ * @requires vm.debug & vm.bits == "64"
  * @requires vm.flagless
  * @summary Test the output for CountBytecodes and validate that the counter
  *          does not overflow for more than 2^32 bytecodes counted.

--- a/test/hotspot/jtreg/runtime/interpreter/CountBytecodesTest.java
+++ b/test/hotspot/jtreg/runtime/interpreter/CountBytecodesTest.java
@@ -25,7 +25,7 @@
 /*
  * @test
  * @bug 8350642
- * @requires vm.debug & vm.bits == "64"
+ * @requires vm.flagless
  * @summary Test the output for CountBytecodes and validate that the counter
  *          does not overflow for more than 2^32 bytecodes counted.
  * @library /test/lib


### PR DESCRIPTION
I changed `@requires` to `vm.flagless` and it passed the test. If there is anything inappropriate, please let me know and I will modify it in time.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8357408](https://bugs.openjdk.org/browse/JDK-8357408): runtime/interpreter/CountBytecodesTest.java should be flagless (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [SendaoYan](https://openjdk.org/census#syan) (@sendaoYan - Committer)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25427/head:pull/25427` \
`$ git checkout pull/25427`

Update a local copy of the PR: \
`$ git checkout pull/25427` \
`$ git pull https://git.openjdk.org/jdk.git pull/25427/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25427`

View PR using the GUI difftool: \
`$ git pr show -t 25427`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25427.diff">https://git.openjdk.org/jdk/pull/25427.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25427#issuecomment-2906449814)
</details>
