### PR TITLE
JDK-8357683: (process) SIGQUIT still blocked after JDK-8234262 with jdk.lang.Process.launchMechanism=FORK or VFORK

### DIFF
--- a/src/java.base/unix/native/jspawnhelper/jspawnhelper.c
+++ b/src/java.base/unix/native/jspawnhelper/jspawnhelper.c
@@ -26,7 +26,6 @@
 #include <assert.h>
 #include <errno.h>
 #include <fcntl.h>
-#include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -145,7 +144,6 @@ int main(int argc, char *argv[]) {
     struct stat buf;
     /* argv[1] contains the fd number to read all the child info */
     int r, fdinr, fdinw, fdout;
-    sigset_t unblock_signals;
 
 #ifdef DEBUG
     jtregSimulateCrash(0, 4);
@@ -172,10 +170,6 @@ int main(int argc, char *argv[]) {
         fprintf(stdout, "Incorrect FD array data: %s\n", argv[2]);
         shutItDown();
     }
-
-    // Reset any mask signals from parent
-    sigemptyset(&unblock_signals);
-    sigprocmask(SIG_SETMASK, &unblock_signals, NULL);
 
     // Close the writing end of the pipe we use for reading from the parent.
     // We have to do this before we start reading from the parent to avoid

--- a/src/java.base/unix/native/libjava/childproc.c
+++ b/src/java.base/unix/native/libjava/childproc.c
@@ -26,6 +26,7 @@
 #include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -404,6 +405,13 @@ childProcess(void *arg)
     /* change to the new working directory */
     if (p->pdir != NULL && chdir(p->pdir) < 0)
         goto WhyCantJohnnyExec;
+
+    // Reset any mask signals from parent, but not in VFORK mode
+    if (p->mode != MODE_VFORK) {
+        sigset_t unblock_signals;
+        sigemptyset(&unblock_signals);
+        sigprocmask(SIG_SETMASK, &unblock_signals, NULL);
+    }
 
     if (fcntl(FAIL_FILENO, F_SETFD, FD_CLOEXEC) == -1)
         goto WhyCantJohnnyExec;

--- a/test/jdk/java/lang/ProcessBuilder/UnblockSignals.java
+++ b/test/jdk/java/lang/ProcessBuilder/UnblockSignals.java
@@ -24,15 +24,27 @@
 import java.io.IOException;
 
 /*
- * @test
- * @summary Verify Signal mask is cleared by ProcessBuilder start
+ * @test id=posix_spawn
+ * @summary Verify Signal mask is cleared by ProcessBuilder start when using posix_spawn mode
  * @bug 8234262
  * @requires (os.family == "linux" | os.family == "mac")
  * @comment Don't allow -Xcomp, it disturbs the relative timing of the sleep and kill commands
  * @requires (vm.compMode != "Xcomp")
- * @run main/othervm UnblockSignals
- * @run main/othervm -Xrs UnblockSignals
+ * @run main/othervm -Djdk.lang.Process.launchMechanism=POSIX_SPAWN UnblockSignals
+ * @run main/othervm -Djdk.lang.Process.launchMechanism=POSIX_SPAWN -Xrs UnblockSignals
  */
+
+/*
+ * @test id=fork
+ * @summary Verify Signal mask is cleared by ProcessBuilder start when using fork mode
+ * @bug 8357683
+ * @requires (os.family == "linux" | os.family == "mac")
+ * @comment Don't allow -Xcomp, it disturbs the relative timing of the sleep and kill commands
+ * @requires (vm.compMode != "Xcomp")
+ * @run main/othervm -Djdk.lang.Process.launchMechanism=FORK UnblockSignals
+ * @run main/othervm -Djdk.lang.Process.launchMechanism=FORK -Xrs UnblockSignals
+ */
+
 public class UnblockSignals {
     public static void main(String[] args)  throws IOException, InterruptedException {
         // Check that SIGQUIT is not masked, in previous releases it was masked


### PR DESCRIPTION
See bug description. We now unblock all signals in both FORK and POSIX_SPAWN launch modes. This fixes the problem and makes the behavior consistent across these two modes.

I left the VFORK mode alone since I am not sure the signal state is not still shared with the parent. One more reason to get rid of it soon (its deprecated with 25 and will be removed with 26)