### PR TITLE
8357690: Add @Stable and final to java.lang.CharacterDataLatin1 and other CharacterData classes

### DIFF
--- a/make/jdk/src/classes/build/tools/generatecharacter/GenerateCharacter.java
+++ b/make/jdk/src/classes/build/tools/generatecharacter/GenerateCharacter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1190,7 +1190,7 @@ OUTER:  for (int i = 0; i < n; i += m) {
         if (Csyntax)
             result.append("  static ");
         else
-            result.append("  static final ");
+            result.append("  @Stable static final ");
         result.append(atype);
         result.append(" ").append(name).append("[");
         if (Csyntax)

--- a/make/jdk/src/classes/build/tools/generatecharacter/GenerateCharacter.java
+++ b/make/jdk/src/classes/build/tools/generatecharacter/GenerateCharacter.java
@@ -1347,7 +1347,7 @@ OUTER:  for (int i = 0; i < n; i += m) {
     }
 
     static void genCaseMapTableDeclaration(StringBuffer result) {
-        result.append("    static final char[][][] charMap;\n");
+        result.append("    @Stable static final char[][][] charMap;\n");
     }
 
     static void genCaseMapTable(StringBuffer result, SpecialCaseMap[] specialCaseMaps){

--- a/src/java.base/share/classes/java/lang/CharacterData.java
+++ b/src/java.base/share/classes/java/lang/CharacterData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,9 @@
 
 package java.lang;
 
-abstract class CharacterData {
+abstract sealed class CharacterData
+    permits CharacterData00, CharacterData01, CharacterData02, CharacterData03,
+        CharacterData0E, CharacterDataLatin1, CharacterDataPrivateUse, CharacterDataUndefined {
     abstract int getProperties(int ch);
     abstract int getType(int ch);
     abstract boolean isDigit(int ch);

--- a/src/java.base/share/classes/java/lang/CharacterData00.java.template
+++ b/src/java.base/share/classes/java/lang/CharacterData00.java.template
@@ -32,7 +32,7 @@ import jdk.internal.vm.annotation.Stable;
  * java.lang.Character
 */
 
-class CharacterData00 extends CharacterData {
+final class CharacterData00 extends CharacterData {
     /* The character properties are currently encoded into 32 bits in the following manner:
         1 bit   mirrored property
         4 bits  directionality property

--- a/src/java.base/share/classes/java/lang/CharacterData00.java.template
+++ b/src/java.base/share/classes/java/lang/CharacterData00.java.template
@@ -25,6 +25,8 @@
 
 package java.lang;
 
+import jdk.internal.vm.annotation.Stable;
+
 /**
  * The CharacterData00 class encapsulates the large tables once found in
  * java.lang.Character

--- a/src/java.base/share/classes/java/lang/CharacterData01.java.template
+++ b/src/java.base/share/classes/java/lang/CharacterData01.java.template
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,8 @@
  */
 
 package java.lang;
+
+import jdk.internal.vm.annotation.Stable;
 
 /** The CharacterData class encapsulates the large tables once found in
  *  java.lang.Character. 

--- a/src/java.base/share/classes/java/lang/CharacterData01.java.template
+++ b/src/java.base/share/classes/java/lang/CharacterData01.java.template
@@ -27,7 +27,7 @@ package java.lang;
 
 import jdk.internal.vm.annotation.Stable;
 
-/** The CharacterData class encapsulates the large tables once found in
+/** The CharacterData01 class encapsulates the large tables once found in
  *  java.lang.Character. 
  */
 

--- a/src/java.base/share/classes/java/lang/CharacterData01.java.template
+++ b/src/java.base/share/classes/java/lang/CharacterData01.java.template
@@ -31,7 +31,7 @@ import jdk.internal.vm.annotation.Stable;
  *  java.lang.Character. 
  */
 
-class CharacterData01 extends CharacterData {
+final class CharacterData01 extends CharacterData {
     /* The character properties are currently encoded into 32 bits in the following manner:
         1 bit   mirrored property
         4 bits  directionality property

--- a/src/java.base/share/classes/java/lang/CharacterData02.java.template
+++ b/src/java.base/share/classes/java/lang/CharacterData02.java.template
@@ -27,7 +27,7 @@ package java.lang;
 
 import jdk.internal.vm.annotation.Stable;
 
-/** The CharacterData class encapsulates the large tables found in
+/** The CharacterData02 class encapsulates the large tables found in
     Java.lang.Character. */
 
 final class CharacterData02 extends CharacterData {

--- a/src/java.base/share/classes/java/lang/CharacterData02.java.template
+++ b/src/java.base/share/classes/java/lang/CharacterData02.java.template
@@ -30,7 +30,7 @@ import jdk.internal.vm.annotation.Stable;
 /** The CharacterData class encapsulates the large tables found in
     Java.lang.Character. */
 
-class CharacterData02 extends CharacterData {
+final class CharacterData02 extends CharacterData {
     /* The character properties are currently encoded into 32 bits in the following manner:
         1 bit   mirrored property
         4 bits  directionality property

--- a/src/java.base/share/classes/java/lang/CharacterData02.java.template
+++ b/src/java.base/share/classes/java/lang/CharacterData02.java.template
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,8 @@
  */
 
 package java.lang;
+
+import jdk.internal.vm.annotation.Stable;
 
 /** The CharacterData class encapsulates the large tables found in
     Java.lang.Character. */

--- a/src/java.base/share/classes/java/lang/CharacterData03.java.template
+++ b/src/java.base/share/classes/java/lang/CharacterData03.java.template
@@ -27,7 +27,7 @@ package java.lang;
 
 import jdk.internal.vm.annotation.Stable;
 
-/** The CharacterData class encapsulates the large tables found in
+/** The CharacterData03 class encapsulates the large tables found in
     Java.lang.Character. */
 
 final class CharacterData03 extends CharacterData {

--- a/src/java.base/share/classes/java/lang/CharacterData03.java.template
+++ b/src/java.base/share/classes/java/lang/CharacterData03.java.template
@@ -30,7 +30,7 @@ import jdk.internal.vm.annotation.Stable;
 /** The CharacterData class encapsulates the large tables found in
     Java.lang.Character. */
 
-class CharacterData03 extends CharacterData {
+final class CharacterData03 extends CharacterData {
     /* The character properties are currently encoded into 32 bits in the following manner:
         1 bit   mirrored property
         4 bits  directionality property

--- a/src/java.base/share/classes/java/lang/CharacterData03.java.template
+++ b/src/java.base/share/classes/java/lang/CharacterData03.java.template
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,8 @@
  */
 
 package java.lang;
+
+import jdk.internal.vm.annotation.Stable;
 
 /** The CharacterData class encapsulates the large tables found in
     Java.lang.Character. */

--- a/src/java.base/share/classes/java/lang/CharacterData0E.java.template
+++ b/src/java.base/share/classes/java/lang/CharacterData0E.java.template
@@ -30,7 +30,7 @@ import jdk.internal.vm.annotation.Stable;
 /** The CharacterData class encapsulates the large tables found in
     Java.lang.Character. */
 
-class CharacterData0E extends CharacterData {
+final class CharacterData0E extends CharacterData {
     /* The character properties are currently encoded into 32 bits in the following manner:
         1 bit   mirrored property
         4 bits  directionality property

--- a/src/java.base/share/classes/java/lang/CharacterData0E.java.template
+++ b/src/java.base/share/classes/java/lang/CharacterData0E.java.template
@@ -27,7 +27,7 @@ package java.lang;
 
 import jdk.internal.vm.annotation.Stable;
 
-/** The CharacterData class encapsulates the large tables found in
+/** The CharacterData0E class encapsulates the large tables found in
     Java.lang.Character. */
 
 final class CharacterData0E extends CharacterData {

--- a/src/java.base/share/classes/java/lang/CharacterData0E.java.template
+++ b/src/java.base/share/classes/java/lang/CharacterData0E.java.template
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,8 @@
  */
 
 package java.lang;
+
+import jdk.internal.vm.annotation.Stable;
 
 /** The CharacterData class encapsulates the large tables found in
     Java.lang.Character. */

--- a/src/java.base/share/classes/java/lang/CharacterDataLatin1.java.template
+++ b/src/java.base/share/classes/java/lang/CharacterDataLatin1.java.template
@@ -28,7 +28,7 @@ package java.lang;
 import jdk.internal.vm.annotation.IntrinsicCandidate;
 import jdk.internal.vm.annotation.Stable;
 
-/** The CharacterData class encapsulates the large tables found in
+/** The CharacterDataLatin1 class encapsulates the large tables found in
     Java.lang.Character. */
 
 final class CharacterDataLatin1 extends CharacterData {

--- a/src/java.base/share/classes/java/lang/CharacterDataLatin1.java.template
+++ b/src/java.base/share/classes/java/lang/CharacterDataLatin1.java.template
@@ -31,7 +31,7 @@ import jdk.internal.vm.annotation.Stable;
 /** The CharacterData class encapsulates the large tables found in
     Java.lang.Character. */
 
-class CharacterDataLatin1 extends CharacterData {
+final class CharacterDataLatin1 extends CharacterData {
 
     /* The character properties are currently encoded into 32 bits in the following manner:
         1 bit   mirrored property

--- a/src/java.base/share/classes/java/lang/CharacterDataLatin1.java.template
+++ b/src/java.base/share/classes/java/lang/CharacterDataLatin1.java.template
@@ -26,6 +26,7 @@
 package java.lang;
 
 import jdk.internal.vm.annotation.IntrinsicCandidate;
+import jdk.internal.vm.annotation.Stable;
 
 /** The CharacterData class encapsulates the large tables found in
     Java.lang.Character. */
@@ -230,6 +231,7 @@ class CharacterDataLatin1 extends CharacterData {
     //
     // Analysis has shown that generating the whole array allows the JIT to generate
     // better code compared to a slimmed down array, such as one cutting off after 'z'
+    @Stable
     private static final byte[] DIGITS = new byte[] {
         -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
         -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
@@ -314,6 +316,7 @@ class CharacterDataLatin1 extends CharacterData {
         return mapChar;
     }
 
+    @Stable
     static char[] sharpsMap = new char[] {'S', 'S'};
 
     char[] toUpperCaseCharArray(int ch) {

--- a/src/java.base/share/classes/java/lang/CharacterDataPrivateUse.java
+++ b/src/java.base/share/classes/java/lang/CharacterDataPrivateUse.java
@@ -28,7 +28,7 @@ package java.lang;
 /** The CharacterData class encapsulates the large tables found in
     Java.lang.Character. */
 
-class CharacterDataPrivateUse extends CharacterData {
+final class CharacterDataPrivateUse extends CharacterData {
 
     int getProperties(int ch) {
         return 0;

--- a/src/java.base/share/classes/java/lang/CharacterDataPrivateUse.java
+++ b/src/java.base/share/classes/java/lang/CharacterDataPrivateUse.java
@@ -25,7 +25,7 @@
 
 package java.lang;
 
-/** The CharacterData class encapsulates the large tables found in
+/** The CharacterDataPrivateUse class encapsulates the large tables found in
     Java.lang.Character. */
 
 final class CharacterDataPrivateUse extends CharacterData {

--- a/src/java.base/share/classes/java/lang/CharacterDataUndefined.java
+++ b/src/java.base/share/classes/java/lang/CharacterDataUndefined.java
@@ -25,7 +25,7 @@
 
 package java.lang;
 
-/** The CharacterData class encapsulates the large tables found in
+/** The CharacterDataUndefined class encapsulates the large tables found in
     Java.lang.Character. */
 
 final class CharacterDataUndefined extends CharacterData {

--- a/src/java.base/share/classes/java/lang/CharacterDataUndefined.java
+++ b/src/java.base/share/classes/java/lang/CharacterDataUndefined.java
@@ -28,7 +28,7 @@ package java.lang;
 /** The CharacterData class encapsulates the large tables found in
     Java.lang.Character. */
 
-class CharacterDataUndefined extends CharacterData {
+final class CharacterDataUndefined extends CharacterData {
 
     int getProperties(int ch) {
         return 0;


### PR DESCRIPTION
Classes such as java.lang.CharacterDataXXX have multiple static final arrays, these are immutable, We should add `@Stable` and final to provide information to the optimizer.

<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8357690](https://bugs.openjdk.org/browse/JDK-8357690): Add @<!---->Stable and final to java.lang.CharacterDataLatin1 and other CharacterData classes (**Enhancement** - P4)


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25430/head:pull/25430` \
`$ git checkout pull/25430`

Update a local copy of the PR: \
`$ git checkout pull/25430` \
`$ git pull https://git.openjdk.org/jdk.git pull/25430/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25430`

View PR using the GUI difftool: \
`$ git pr show -t 25430`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25430.diff">https://git.openjdk.org/jdk/pull/25430.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25430#issuecomment-2907515933)
</details>
