### PR TITLE
Eliminate bounds check for CharacterDataLatin1

### DIFF
--- a/src/java.base/share/classes/java/lang/CharacterDataLatin1.java.template
+++ b/src/java.base/share/classes/java/lang/CharacterDataLatin1.java.template
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -69,15 +69,13 @@ class CharacterDataLatin1 extends CharacterData {
      */
 
     int getProperties(int ch) {
-        char offset = (char)ch;
-        int props = $$Lookup(offset);
-        return props;
+        int offset = ch & 0xff;
+        return $$Lookup(offset);
     }
 
     int getPropertiesEx(int ch) {
-        char offset = (char)ch;
-        int props = $$LookupEx(offset);
-        return props;
+        int offset = ch & 0xff;
+        return $$LookupEx(offset);
     }
 
     @IntrinsicCandidate

--- a/src/java.base/share/classes/java/lang/CharacterDataLatin1.java.template
+++ b/src/java.base/share/classes/java/lang/CharacterDataLatin1.java.template
@@ -244,7 +244,7 @@ class CharacterDataLatin1 extends CharacterData {
         -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1 };
 
     int digit(int ch, int radix) {
-        int value = DIGITS[ch];
+        int value = DIGITS[ch & 0xff];
         return (value >= 0 && value < radix && radix >= Character.MIN_RADIX
                 && radix <= Character.MAX_RADIX) ? value : -1;
     }


### PR DESCRIPTION
The length of the CharacterDataLatin1::A and CharacterDataLatin1::B arrays is 256. The code that accesses the arrays in the getProperties and getPropertiesEx methods can use `& 0xff` to eliminate bounds checks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25434/head:pull/25434` \
`$ git checkout pull/25434`

Update a local copy of the PR: \
`$ git checkout pull/25434` \
`$ git pull https://git.openjdk.org/jdk.git pull/25434/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25434`

View PR using the GUI difftool: \
`$ git pr show -t 25434`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25434.diff">https://git.openjdk.org/jdk/pull/25434.diff</a>

</details>
