### PR TITLE
8357695: RISC-V: Move vector intrinsic condition checks into match_rule_supported_vector

### DIFF
--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -1882,18 +1882,6 @@ bool Matcher::match_rule_supported(int opcode) {
     case Op_EncodeISOArray:
       return UseRVV;
 
-    // Current test shows that, it brings performance gain when MaxVectorSize >= 32, but brings
-    // regression when MaxVectorSize == 16. So only enable the intrinsic when MaxVectorSize >= 32.
-    case Op_RoundVF:
-      return UseRVV && MaxVectorSize >= 32;
-
-    // For double, current test shows that even with MaxVectorSize == 32, there is still some regression.
-    // Although there is no hardware to verify it for now, from the trend of performance data on hardwares
-    // (with vlenb == 16 and 32 respectively), it's promising to bring better performance rather than
-    // regression for double when MaxVectorSize == 64+. So only enable the intrinsic when MaxVectorSize >= 64.
-    case Op_RoundVD:
-      return UseRVV && MaxVectorSize >= 64;
-
     case Op_PopCountI:
     case Op_PopCountL:
       return UsePopCountInstruction;
@@ -1917,9 +1905,6 @@ bool Matcher::match_rule_supported(int opcode) {
     case Op_FmaF:
     case Op_FmaD:
       return UseFMA;
-    case Op_FmaVF:
-    case Op_FmaVD:
-      return UseRVV && UseFMA;
 
     case Op_ConvHF2F:
     case Op_ConvF2HF:

--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -122,6 +122,22 @@ source %{
         return UseZvfh;
       case Op_FmaVHF:
         return UseZvfh && UseFMA;
+      case Op_FmaVF:
+      case Op_FmaVD:
+        return UseRVV && UseFMA;
+
+      // Current test shows that, it brings performance gain when MaxVectorSize >= 32, but brings
+      // regression when MaxVectorSize == 16. So only enable the intrinsic when MaxVectorSize >= 32.
+      case Op_RoundVF:
+        return UseRVV && MaxVectorSize >= 32;
+
+      // For double, current test shows that even with MaxVectorSize == 32, there is still some regression.
+      // Although there is no hardware to verify it for now, from the trend of performance data on hardwares
+      // (with vlenb == 16 and 32 respectively), it's promising to bring better performance rather than
+      // regression for double when MaxVectorSize == 64+. So only enable the intrinsic when MaxVectorSize >= 64.
+      case Op_RoundVD:
+        return UseRVV && MaxVectorSize >= 64;
+
       default:
         break;
     }


### PR DESCRIPTION
Hi all,
Please take a look and review this PR, thanks!

Currently, the match_rule_supported function in riscv.ad contains checks for vector-related intrinsics (e.g., FmaVF, FmaVD, RoundVF, RoundVD). These checks can be centralized into the match_rule_supported_vector function in the riscv_v.ad file, ensuring consistent handling in their appropriate context.

### Testing
* [ ]  Linux riscv64 server release build on SG2042