### PR TITLE
8357448: AOT crashes on linux musl with AddReads.java

### DIFF
--- a/src/hotspot/share/cds/aotClassLocation.cpp
+++ b/src/hotspot/share/cds/aotClassLocation.cpp
@@ -490,8 +490,8 @@ void AOTClassLocationConfig::dumptime_init_helper(TRAPS) {
 
   const char* lcp = find_lcp(all_css.boot_and_app_cp(), _dumptime_lcp_len);
   if (_dumptime_lcp_len > 0) {
-    os::free((void*)lcp);
     log_info(class, path)("Longest common prefix = %s (%zu chars)", lcp, _dumptime_lcp_len);
+    os::free((void*)lcp);
   } else {
     assert(_dumptime_lcp_len == 0, "sanity");
     log_info(class, path)("Longest common prefix = <none> (0 chars)");


### PR DESCRIPTION
Trivial fix for a use-after-free. It was only an issue when AOT logging was enabled.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8357448](https://bugs.openjdk.org/browse/JDK-8357448): AOT crashes on linux musl with AddReads.java (**Bug** - P3)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25446/head:pull/25446` \
`$ git checkout pull/25446`

Update a local copy of the PR: \
`$ git checkout pull/25446` \
`$ git pull https://git.openjdk.org/jdk.git pull/25446/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25446`

View PR using the GUI difftool: \
`$ git pr show -t 25446`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25446.diff">https://git.openjdk.org/jdk/pull/25446.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25446#issuecomment-2909214484)
</details>
