### PR TITLE
8354428

### DIFF
--- a/src/hotspot/share/gc/g1/g1BiasedArray.cpp
+++ b/src/hotspot/share/gc/g1/g1BiasedArray.cpp
@@ -29,7 +29,7 @@ G1BiasedMappedArrayBase::G1BiasedMappedArrayBase() :
   _alloc_base(nullptr),
   _base(nullptr),
   _length(0),
-  _biased_base(nullptr),
+  _biased_base(0),
   _bias(0),
   _shift_by(0) { }
 
@@ -51,7 +51,7 @@ void G1BiasedMappedArrayBase::verify_index(idx_t index) const {
 }
 
 void G1BiasedMappedArrayBase::verify_biased_index(idx_t biased_index) const {
-  guarantee(_biased_base != nullptr, "Array not initialized");
+  guarantee(_biased_base != 0, "Array not initialized");
   guarantee(biased_index >= bias() && biased_index < (bias() + length()),
             "Biased index out of bounds, index: %zu bias: %zu length: %zu",
             biased_index, bias(), length());

--- a/src/hotspot/share/gc/g1/vmStructs_g1.hpp
+++ b/src/hotspot/share/gc/g1/vmStructs_g1.hpp
@@ -48,7 +48,7 @@
                                                                               \
   nonstatic_field(G1HeapRegionTable, _base,             address)              \
   nonstatic_field(G1HeapRegionTable, _length,           size_t)               \
-  nonstatic_field(G1HeapRegionTable, _biased_base,      address)              \
+  nonstatic_field(G1HeapRegionTable, _biased_base,      size_t)               \
   nonstatic_field(G1HeapRegionTable, _bias,             size_t)               \
   nonstatic_field(G1HeapRegionTable, _shift_by,         uint)                 \
                                                                               \

--- a/test/hotspot/gtest/gc/g1/test_g1BiasedArray.cpp
+++ b/test/hotspot/gtest/gc/g1/test_g1BiasedArray.cpp
@@ -26,7 +26,7 @@
 
 class TestMappedArray : public G1BiasedMappedArray<int> {
   void verify_biased_index_inclusive_end(idx_t biased_index) const {
-    guarantee(_biased_base != nullptr, "Array not initialized");
+    guarantee(_biased_base != 0, "Array not initialized");
     guarantee(biased_index >= bias() && biased_index <= (bias() + length()),
               "Biased index out of inclusive bounds, index: %zu bias: %zu length: %zu",
               biased_index, bias(), length());
@@ -37,17 +37,13 @@ public:
     return 0xBAADBABE;
   }
 
-  // Returns the address of the element the given address maps to
   int* my_address_mapped_to(HeapWord* address) {
     idx_t biased_index = ((uintptr_t)address) >> shift_by();
     verify_biased_index_inclusive_end(biased_index);
-    return biased_base() + biased_index;
+    return biased_base_at(biased_index);
   }
 
   int* base() const { return G1BiasedMappedArray<int>::base(); }
-
-  // The raw biased base pointer.
-  int* biased_base() const { return G1BiasedMappedArray<int>::biased_base(); }
 };
 
 TEST_VM(G1BiasedArray, simple) {


### PR DESCRIPTION
Hi all,

  please review this fix for an ubsan error related to pointer under- or overflows when using the biased array helper.

The fix is, instead of using direct address calculations that can cause these errors, use `uintptr_t` where the overflow behavior is defined in C++. Only convert to pointer at the actual access.

Testing: gha, tier1

