### PR TITLE
8357797: Use StructuredTaskScopeImpl.ST_NEW for state init

### DIFF
--- a/src/java.base/share/classes/java/util/concurrent/StructuredTaskScopeImpl.java
+++ b/src/java.base/share/classes/java/util/concurrent/StructuredTaskScopeImpl.java
@@ -64,6 +64,7 @@ final class StructuredTaskScopeImpl<T, R> implements StructuredTaskScope<T, R> {
     private StructuredTaskScopeImpl(Joiner<? super T, ? extends R> joiner,
                                     ThreadFactory threadFactory,
                                     String name) {
+        this.state = ST_NEW;
         this.joiner = joiner;
         this.threadFactory = threadFactory;
         this.flock = ThreadFlock.open((name != null) ? name : Objects.toIdentityString(this));

--- a/src/java.base/share/classes/java/util/concurrent/StructuredTaskScopeImpl.java
+++ b/src/java.base/share/classes/java/util/concurrent/StructuredTaskScopeImpl.java
@@ -64,10 +64,10 @@ final class StructuredTaskScopeImpl<T, R> implements StructuredTaskScope<T, R> {
     private StructuredTaskScopeImpl(Joiner<? super T, ? extends R> joiner,
                                     ThreadFactory threadFactory,
                                     String name) {
-        this.state = ST_NEW;
         this.joiner = joiner;
         this.threadFactory = threadFactory;
         this.flock = ThreadFlock.open((name != null) ? name : Objects.toIdentityString(this));
+        this.state = ST_NEW;
     }
 
     /**


### PR DESCRIPTION
SonarCloud complains `ST_NEW` constant is not used. Looks to me the constructor implicitly relies on default value for `state`. It would be cleaner to initialize it explicitly

Additional testing:
 - [x] Linux x86_64 server fastdebug, `java/util/concurrent`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8357797](https://bugs.openjdk.org/browse/JDK-8357797): Use StructuredTaskScopeImpl.ST_NEW for state init (**Enhancement** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25452/head:pull/25452` \
`$ git checkout pull/25452`

Update a local copy of the PR: \
`$ git checkout pull/25452` \
`$ git pull https://git.openjdk.org/jdk.git pull/25452/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25452`

View PR using the GUI difftool: \
`$ git pr show -t 25452`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25452.diff">https://git.openjdk.org/jdk/pull/25452.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25452#issuecomment-2910246924)
</details>
