### PR TITLE
8357675: Amend headless message

### DIFF
--- a/src/java.desktop/unix/classes/sun/awt/PlatformGraphicsInfo.java
+++ b/src/java.desktop/unix/classes/sun/awt/PlatformGraphicsInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -85,7 +85,6 @@ public final class PlatformGraphicsInfo {
 
             No X11 DISPLAY variable was set,
             or no headful library support was found,
-            but this program performed an operation which requires it,
-            """;
+            but this program performed an operation which requires it.""";
     }
 }


### PR DESCRIPTION
Currently, the default headless message ends with a comma instead of full stop and has an additional line break.

```text
Exception in thread "AWT-EventQueue-0" java.awt.HeadlessException:
No X11 DISPLAY variable was set,
or no headful library support was found,
but this program performed an operation which requires it,

        at java.desktop/java.awt.GraphicsEnvironment.checkHeadless(GraphicsEnvironment.java:158)
        at java.desktop/java.awt.Window.<init>(Window.java:518)
        at java.desktop/java.awt.Frame.<init>(Frame.java:428)
        at java.desktop/javax.swing.JFrame.<init>(JFrame.java:224) 
```

**Fix:**

Amend the message so that it ends with a full stop and remove the line break.

```text
Exception in thread "AWT-EventQueue-0" java.awt.HeadlessException:
No X11 DISPLAY variable was set,
or no headful library support was found,
but this program performed an operation which requires it.
        at java.desktop/java.awt.GraphicsEnvironment.checkHeadless(GraphicsEnvironment.java:158)
        at java.desktop/java.awt.Window.<init>(Window.java:518)
        at java.desktop/java.awt.Frame.<init>(Frame.java:428)
        at java.desktop/javax.swing.JFrame.<init>(JFrame.java:224)
```

**Testing:**

Build a headless-only JDK (pass `--enable-headless-only` to the `configure` script) and create a `JFrame`.

It's impossible to create an automated test for this change, and I don't think a test is required, it's a cosmetic change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8357675](https://bugs.openjdk.org/browse/JDK-8357675): Amend headless message (**Bug** - P4)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25453/head:pull/25453` \
`$ git checkout pull/25453`

Update a local copy of the PR: \
`$ git checkout pull/25453` \
`$ git pull https://git.openjdk.org/jdk.git pull/25453/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25453`

View PR using the GUI difftool: \
`$ git pr show -t 25453`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25453.diff">https://git.openjdk.org/jdk/pull/25453.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25453#issuecomment-2910249928)
</details>
