### PR TITLE
8357796: Stylesheet adjustments after JDK-8357452

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/stylesheet.css
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/stylesheet.css
@@ -23,7 +23,7 @@
     /* Base font sizes for body and code elements */
     --body-font-size: 14.2px;
     --block-font-size: 14.4px;
-    --code-font-size: 13.9px;
+    --code-font-size: 14px;
     --nav-font-size: 13.4px;
     /* Line height for continuous text blocks */
     --block-line-height: 1.5;
@@ -606,6 +606,7 @@ ul.tag-list li:not(:last-child):after,
 ul.tag-list-long li:not(:last-child):after
 {
     content: ", ";
+    white-space: pre-wrap;
 }
 ul.preview-feature-list {
     list-style: none;


### PR DESCRIPTION
Please review a simple stylesheet change to adjust for the removal of code span highlights in [JDK-8357452](https://bugs.openjdk.org/browse/JDK-8357452).

Both of the (subtle) changes undone in this PR were introduced with code span highlights and are no longer needed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8357796](https://bugs.openjdk.org/browse/JDK-8357796): Stylesheet adjustments after JDK-8357452 (**Enhancement** - P4)


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25454/head:pull/25454` \
`$ git checkout pull/25454`

Update a local copy of the PR: \
`$ git checkout pull/25454` \
`$ git pull https://git.openjdk.org/jdk.git pull/25454/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25454`

View PR using the GUI difftool: \
`$ git pr show -t 25454`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25454.diff">https://git.openjdk.org/jdk/pull/25454.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25454#issuecomment-2910272505)
</details>
