### PR TITLE
8357800: Initialize JvmtiThreadState bool fields with bool literals

### DIFF
--- a/src/hotspot/share/prims/jvmtiThreadState.cpp
+++ b/src/hotspot/share/prims/jvmtiThreadState.cpp
@@ -74,7 +74,7 @@ JvmtiThreadState::JvmtiThreadState(JavaThread* thread, oop thread_oop)
   _the_class_for_redefinition_verification = nullptr;
   _scratch_class_for_redefinition_verification = nullptr;
   _cur_stack_depth = UNKNOWN_STACK_DEPTH;
-  _saved_interp_only_mode = 0;
+  _saved_interp_only_mode = false;
 
   // JVMTI ForceEarlyReturn support
   _pending_step_for_earlyret = false;
@@ -800,7 +800,7 @@ void JvmtiThreadState::leave_interp_only_mode() {
   assert(is_interp_only_mode(), "leaving interp only when not in interp only mode");
   if (_thread == nullptr) {
     // Unmounted virtual thread updates the saved value.
-    _saved_interp_only_mode = 0;
+    _saved_interp_only_mode = false;
   } else {
     _thread->set_interp_only_mode(false);
   }


### PR DESCRIPTION
[JDK-8356251](https://bugs.openjdk.org/browse/JDK-8356251) changed `JvmtiThreadState._saved_interp_only_mode` from `int` to `bool`, which is good. But the initializations are still done with `0` literals. Even though it is benign, SonarCloud still complains about the intentionality of this initialization.

Additional testing:
 - [x] Linux x86_64 server fastdebug, `serviceability/jvmti`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8357800](https://bugs.openjdk.org/browse/JDK-8357800): Initialize JvmtiThreadState bool fields with bool literals (**Enhancement** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25458/head:pull/25458` \
`$ git checkout pull/25458`

Update a local copy of the PR: \
`$ git checkout pull/25458` \
`$ git pull https://git.openjdk.org/jdk.git pull/25458/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25458`

View PR using the GUI difftool: \
`$ git pr show -t 25458`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25458.diff">https://git.openjdk.org/jdk/pull/25458.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25458#issuecomment-2910324859)
</details>
