### PR TITLE
8357801: Parallel: Remove deprecated PSVirtualSpace methods

### DIFF
--- a/src/hotspot/share/gc/parallel/objectStartArray.cpp
+++ b/src/hotspot/share/gc/parallel/objectStartArray.cpp
@@ -36,13 +36,8 @@ static size_t num_bytes_required(MemRegion mr) {
   return mr.word_size() / CardTable::card_size_in_words();
 }
 
-ObjectStartArray::ObjectStartArray(char* start_addr, size_t num_bytes)
-  : _virtual_space(ReservedSpace{}, os::vm_page_size()) {
-  MemRegion covered_region{(HeapWord*)start_addr, (HeapWord*) (start_addr + num_bytes)};
-  initialize(covered_region);
-}
-
-void ObjectStartArray::initialize(MemRegion covered_region) {
+ObjectStartArray::ObjectStartArray(MemRegion covered_region)
+  : _virtual_space(nullptr) {
   // Calculate how much space must be reserved
   size_t bytes_to_reserve = num_bytes_required(covered_region);
   assert(bytes_to_reserve > 0, "Sanity");
@@ -58,21 +53,21 @@ void ObjectStartArray::initialize(MemRegion covered_region) {
   }
 
   // We do not commit any memory initially
-  _virtual_space.initialize(backing_store);
+  _virtual_space = new PSVirtualSpace(backing_store, os::vm_page_size());
 
-  assert(_virtual_space.low_boundary() != nullptr, "set from the backing_store");
+  assert(_virtual_space->low_boundary() != nullptr, "set from the backing_store");
 
-  _offset_base = (uint8_t*)(_virtual_space.low_boundary() - (uintptr_t(covered_region.start()) >> CardTable::card_shift()));
+  _offset_base = (uint8_t*)(_virtual_space->low_boundary() - (uintptr_t(covered_region.start()) >> CardTable::card_shift()));
 }
 
 void ObjectStartArray::set_covered_region(MemRegion mr) {
   DEBUG_ONLY(_covered_region = mr;)
 
   size_t requested_size = num_bytes_required(mr);
-  // Only commit memory in page sized chunks
+  // Only commit memory in page-sized chunks
   requested_size = align_up(requested_size, os::vm_page_size());
 
-  size_t current_size = _virtual_space.committed_size();
+  size_t current_size = _virtual_space->committed_size();
 
   if (requested_size == current_size) {
     return;
@@ -81,13 +76,13 @@ void ObjectStartArray::set_covered_region(MemRegion mr) {
   if (requested_size > current_size) {
     // Expand
     size_t expand_by = requested_size - current_size;
-    if (!_virtual_space.expand_by(expand_by)) {
+    if (!_virtual_space->expand_by(expand_by)) {
       vm_exit_out_of_memory(expand_by, OOM_MMAP_ERROR, "object start array expansion");
     }
   } else {
     // Shrink
     size_t shrink_by = current_size - requested_size;
-    _virtual_space.shrink_by(shrink_by);
+    _virtual_space->shrink_by(shrink_by);
   }
 }
 

--- a/src/hotspot/share/gc/parallel/objectStartArray.hpp
+++ b/src/hotspot/share/gc/parallel/objectStartArray.hpp
@@ -72,9 +72,10 @@ class ObjectStartArray : public CHeapObj<mtGC> {
   void update_for_block_work(HeapWord* blk_start, HeapWord* blk_end);
 
   void verify_for_block(HeapWord* blk_start, HeapWord* blk_end) const;
+  void initialize(MemRegion covered_region);
 
  public:
-  void initialize(MemRegion reserved_region);
+  ObjectStartArray(char* start_addr, size_t num_bytes);
 
   // Heap old-gen resizing
   void set_covered_region(MemRegion mr);

--- a/src/hotspot/share/gc/parallel/objectStartArray.hpp
+++ b/src/hotspot/share/gc/parallel/objectStartArray.hpp
@@ -42,7 +42,7 @@ class ObjectStartArray : public CHeapObj<mtGC> {
   DEBUG_ONLY(MemRegion  _covered_region;)
 
   // BOT array
-  PSVirtualSpace  _virtual_space;
+  PSVirtualSpace* _virtual_space;
 
   // Biased array-start of BOT array for fast heap-addr / BOT entry translation
   uint8_t*        _offset_base;
@@ -72,10 +72,9 @@ class ObjectStartArray : public CHeapObj<mtGC> {
   void update_for_block_work(HeapWord* blk_start, HeapWord* blk_end);
 
   void verify_for_block(HeapWord* blk_start, HeapWord* blk_end) const;
-  void initialize(MemRegion covered_region);
 
  public:
-  ObjectStartArray(char* start_addr, size_t num_bytes);
+  ObjectStartArray(MemRegion covered_region);
 
   // Heap old-gen resizing
   void set_covered_region(MemRegion mr);

--- a/src/hotspot/share/gc/parallel/psOldGen.cpp
+++ b/src/hotspot/share/gc/parallel/psOldGen.cpp
@@ -38,6 +38,7 @@
 
 PSOldGen::PSOldGen(ReservedSpace rs, size_t initial_size, size_t min_size,
                    size_t max_size, const char* perf_data_name, int level):
+  _start_array(rs.base(), max_size),
   _min_gen_size(min_size),
   _max_gen_size(max_size)
 {
@@ -66,9 +67,6 @@ void PSOldGen::initialize_virtual_space(ReservedSpace rs,
 void PSOldGen::initialize_work(const char* perf_data_name, int level) {
   MemRegion const reserved_mr = reserved();
   assert(reserved_mr.byte_size() == max_gen_size(), "invariant");
-
-  // Object start stuff: for all reserved memory
-  start_array()->initialize(reserved_mr);
 
   // Card table stuff: for all committed memory
   MemRegion committed_mr((HeapWord*)virtual_space()->low(),

--- a/src/hotspot/share/gc/parallel/psOldGen.cpp
+++ b/src/hotspot/share/gc/parallel/psOldGen.cpp
@@ -38,7 +38,6 @@
 
 PSOldGen::PSOldGen(ReservedSpace rs, size_t initial_size, size_t min_size,
                    size_t max_size, const char* perf_data_name, int level):
-  _start_array(rs.base(), max_size),
   _min_gen_size(min_size),
   _max_gen_size(max_size)
 {
@@ -106,6 +105,7 @@ void PSOldGen::initialize_work(const char* perf_data_name, int level) {
                              &ParallelScavengeHeap::heap()->workers());
 
   // Update the start_array
+  _start_array = new ObjectStartArray(reserved_mr);
   start_array()->set_covered_region(committed_mr);
 }
 
@@ -280,7 +280,7 @@ void PSOldGen::complete_loaded_archive_space(MemRegion archive_space) {
   HeapWord* cur = archive_space.start();
   while (cur < archive_space.end()) {
     size_t word_size = cast_to_oop(cur)->size();
-    _start_array.update_for_block(cur, cur + word_size);
+    _start_array->update_for_block(cur, cur + word_size);
     cur += word_size;
   }
 }

--- a/src/hotspot/share/gc/parallel/psOldGen.hpp
+++ b/src/hotspot/share/gc/parallel/psOldGen.hpp
@@ -38,7 +38,7 @@ class PSOldGen : public CHeapObj<mtGC> {
   friend class VMStructs;
  private:
   PSVirtualSpace*          _virtual_space;     // Controls mapping and unmapping of virtual mem
-  ObjectStartArray         _start_array;       // Keeps track of where objects start in a 512b block
+  ObjectStartArray*        _start_array;       // Keeps track of where objects start in a 512b block
   MutableSpace*            _object_space;      // Where all the objects live
 
   // Performance Counters
@@ -56,7 +56,7 @@ class PSOldGen : public CHeapObj<mtGC> {
     assert_locked_or_safepoint(Heap_lock);
     HeapWord* res = object_space()->cas_allocate(word_size);
     if (res != nullptr) {
-      _start_array.update_for_block(res, res + word_size);
+      _start_array->update_for_block(res, res + word_size);
     }
     return res;
   }
@@ -103,7 +103,7 @@ class PSOldGen : public CHeapObj<mtGC> {
   }
 
   MutableSpace*         object_space() const      { return _object_space; }
-  ObjectStartArray*     start_array()             { return &_start_array; }
+  ObjectStartArray*     start_array()             { return _start_array;  }
   PSVirtualSpace*       virtual_space() const     { return _virtual_space;}
 
   // Size info

--- a/src/hotspot/share/gc/parallel/psVirtualspace.cpp
+++ b/src/hotspot/share/gc/parallel/psVirtualspace.cpp
@@ -27,17 +27,9 @@
 #include "runtime/os.hpp"
 #include "utilities/align.hpp"
 
-// PSVirtualSpace
-
 PSVirtualSpace::PSVirtualSpace(ReservedSpace rs, size_t alignment) :
   _alignment(alignment)
 {
-  set_reserved(rs);
-  set_committed(reserved_low_addr(), reserved_low_addr());
-  DEBUG_ONLY(verify());
-}
-
-void PSVirtualSpace::initialize(ReservedSpace rs) {
   set_reserved(rs);
   set_committed(reserved_low_addr(), reserved_low_addr());
   DEBUG_ONLY(verify());

--- a/src/hotspot/share/gc/parallel/psVirtualspace.cpp
+++ b/src/hotspot/share/gc/parallel/psVirtualspace.cpp
@@ -37,17 +37,6 @@ PSVirtualSpace::PSVirtualSpace(ReservedSpace rs, size_t alignment) :
   DEBUG_ONLY(verify());
 }
 
-// Deprecated.
-PSVirtualSpace::PSVirtualSpace():
-  _alignment(os::vm_page_size()),
-  _reserved_low_addr(nullptr),
-  _reserved_high_addr(nullptr),
-  _committed_low_addr(nullptr),
-  _committed_high_addr(nullptr),
-  _special(false) {
-}
-
-// Deprecated.
 void PSVirtualSpace::initialize(ReservedSpace rs) {
   set_reserved(rs);
   set_committed(reserved_low_addr(), reserved_low_addr());

--- a/src/hotspot/share/gc/parallel/psVirtualspace.hpp
+++ b/src/hotspot/share/gc/parallel/psVirtualspace.hpp
@@ -58,8 +58,6 @@ class PSVirtualSpace : public CHeapObj<mtGC> {
 
   ~PSVirtualSpace();
 
-  void initialize(ReservedSpace rs);
-
   bool is_in_committed(const void* p) const {
     return (p >= committed_low_addr()) && (p < committed_high_addr());
   }

--- a/src/hotspot/share/gc/parallel/psVirtualspace.hpp
+++ b/src/hotspot/share/gc/parallel/psVirtualspace.hpp
@@ -58,7 +58,6 @@ class PSVirtualSpace : public CHeapObj<mtGC> {
 
   ~PSVirtualSpace();
 
-  PSVirtualSpace();
   void initialize(ReservedSpace rs);
 
   bool is_in_committed(const void* p) const {


### PR DESCRIPTION
Simple removing some deprecated methods by changing to pointer-type for some fields.

Test: tier1-3

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8357801](https://bugs.openjdk.org/browse/JDK-8357801): Parallel: Remove deprecated PSVirtualSpace methods (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25459/head:pull/25459` \
`$ git checkout pull/25459`

Update a local copy of the PR: \
`$ git checkout pull/25459` \
`$ git pull https://git.openjdk.org/jdk.git pull/25459/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25459`

View PR using the GUI difftool: \
`$ git pr show -t 25459`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25459.diff">https://git.openjdk.org/jdk/pull/25459.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25459#issuecomment-2910337742)
</details>
