### PR TITLE
8356246: C2: Compilation fails with "assert(bol->is_Bool()) failed: unexpected if shape" in StringConcat::eliminate_unneeded_control

### DIFF
--- a/src/hotspot/share/opto/stringopts.cpp
+++ b/src/hotspot/share/opto/stringopts.cpp
@@ -256,6 +256,13 @@ void StringConcat::eliminate_unneeded_control() {
       assert(n->req() == 3 && n->in(2)->in(0) == iff, "not a diamond");
       assert(iff->is_If(), "no if for the diamond");
       Node* bol = iff->in(1);
+      if (bol->is_Con()) {
+        // A BoolNode shared by two diamond Region/If sub-graphs
+        // was replaced by a constant zero in a previous call to this method.
+        // Do nothing as the transformation in the previous call ensures both are folded away.
+        assert(bol == _stringopts->gvn()->intcon(0), "set below.");
+        continue;
+      }
       assert(bol->is_Bool(), "unexpected if shape");
       Node* cmp = bol->in(1);
       assert(cmp->is_Cmp(), "unexpected if shape");

--- a/src/hotspot/share/opto/stringopts.cpp
+++ b/src/hotspot/share/opto/stringopts.cpp
@@ -260,7 +260,7 @@ void StringConcat::eliminate_unneeded_control() {
         // A BoolNode shared by two diamond Region/If sub-graphs
         // was replaced by a constant zero in a previous call to this method.
         // Do nothing as the transformation in the previous call ensures both are folded away.
-        assert(bol == _stringopts->gvn()->intcon(0), "set below.");
+        assert(bol == _stringopts->gvn()->intcon(0), "shared condition should have been set to false");
         continue;
       }
       assert(bol->is_Bool(), "unexpected if shape");

--- a/test/hotspot/jtreg/compiler/stringopts/TestStackedConcatsSharedNullCheck.java
+++ b/test/hotspot/jtreg/compiler/stringopts/TestStackedConcatsSharedNullCheck.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8356246
+ * @summary Test stacked string concatenations where the toString of the first chain
+ *          is subjected to two null checks using a shared test in the second chain.
+ * @run main/othervm -Xcomp -XX:-TieredCompilation
+ *                   -XX:CompileOnly=compiler.stringopts.TestStackedConcatsSharedNullCheck::*
+ *                   compiler.stringopts.TestStackedConcatsSharedNullCheck
+ */
+
+package compiler.stringopts;
+
+public class TestStackedConcatsSharedNullCheck {
+
+    public static void main(String... args) {
+      f();
+      f();
+    }
+
+    static void f() {
+        String s = "";
+        s = new StringBuilder().toString();
+        s = new StringBuilder(String.valueOf(s)).append(String.valueOf(s)).toString();
+    }
+}

--- a/test/hotspot/jtreg/compiler/stringopts/TestStackedConcatsSharedTest.java
+++ b/test/hotspot/jtreg/compiler/stringopts/TestStackedConcatsSharedTest.java
@@ -27,7 +27,7 @@
  * @summary Test stacked string concatenations where the toString of the first StringBuilder
  *          is used as a shared test by two diamond Ifs in the second StringBuilder.
  * @run main/othervm compiler.stringopts.TestStackedConcatsSharedTest
- * @run main/othervm -Xbatch -XX:-TieredCompilation -Xcomp
+ * @run main/othervm -XX:-TieredCompilation -Xcomp
  *                   -XX:CompileOnly=compiler.stringopts.TestStackedConcatsSharedTest::*
  *                   compiler.stringopts.TestStackedConcatsSharedTest
  */

--- a/test/hotspot/jtreg/compiler/stringopts/TestStackedConcatsSharedTest.java
+++ b/test/hotspot/jtreg/compiler/stringopts/TestStackedConcatsSharedTest.java
@@ -24,25 +24,30 @@
 /*
  * @test
  * @bug 8356246
- * @summary Test stacked string concatenations where the toString of the first chain
- *          is subjected to two null checks using a shared test in the second chain.
- * @run main/othervm -Xcomp -XX:-TieredCompilation
- *                   -XX:CompileOnly=compiler.stringopts.TestStackedConcatsSharedNullCheck::*
- *                   compiler.stringopts.TestStackedConcatsSharedNullCheck
+ * @summary Test stacked string concatenations where the toString of the first StringBuilder
+ *          is used as a shared test by two diamond Ifs in the second StringBuilder. 
+ * @run main/othervm compiler.stringopts.TestStackedConcatsSharedTest
+ * @run main/othervm -Xbatch -XX:-TieredCompilation -Xcomp
+ *                   -XX:CompileOnly=compiler.stringopts.TestStackedConcatsSharedTest::*
+ *                   compiler.stringopts.TestStackedConcatsSharedTest
  */
 
 package compiler.stringopts;
 
-public class TestStackedConcatsSharedNullCheck {
+public class TestStackedConcatsSharedTest {
 
     public static void main(String... args) {
-      f();
-      f();
+        f(); // one warmup call
+        String s = f();
+        if (!s.equals("")) {
+            throw new RuntimeException("wrong result"); 
+        }
     }
 
-    static void f() {
+    static String f() {
         String s = "";
         s = new StringBuilder().toString();
         s = new StringBuilder(String.valueOf(s)).append(String.valueOf(s)).toString();
+        return s;
     }
 }

--- a/test/hotspot/jtreg/compiler/stringopts/TestStackedConcatsSharedTest.java
+++ b/test/hotspot/jtreg/compiler/stringopts/TestStackedConcatsSharedTest.java
@@ -47,6 +47,8 @@ public class TestStackedConcatsSharedTest {
     static String f() {
         String s = "";
         s = new StringBuilder().toString();
+        // Warming up with many iterations invalidated the optimization due to an unstable If
+        // associated with the valueOf calls below. Using -Xcomp for the test.
         s = new StringBuilder(String.valueOf(s)).append(String.valueOf(s)).toString();
         return s;
     }

--- a/test/hotspot/jtreg/compiler/stringopts/TestStackedConcatsSharedTest.java
+++ b/test/hotspot/jtreg/compiler/stringopts/TestStackedConcatsSharedTest.java
@@ -25,7 +25,7 @@
  * @test
  * @bug 8356246
  * @summary Test stacked string concatenations where the toString of the first StringBuilder
- *          is used as a shared test by two diamond Ifs in the second StringBuilder. 
+ *          is used as a shared test by two diamond Ifs in the second StringBuilder.
  * @run main/othervm compiler.stringopts.TestStackedConcatsSharedTest
  * @run main/othervm -Xbatch -XX:-TieredCompilation -Xcomp
  *                   -XX:CompileOnly=compiler.stringopts.TestStackedConcatsSharedTest::*
@@ -40,7 +40,7 @@ public class TestStackedConcatsSharedTest {
         f(); // one warmup call
         String s = f();
         if (!s.equals("")) {
-            throw new RuntimeException("wrong result"); 
+            throw new RuntimeException("wrong result");
         }
     }
 


### PR DESCRIPTION
This pull request contains a fix for JDK-8356246.

During stacked concatenations, a pair of `StringBuilder.append().toString()` links SB and SB2 could have a diamond if structure `(Region -> <IfTrue, IfFalse> -> If)` created by String.valueOf that depends on the return value of SB1, which is going away (replaced by top() in `eliminate_call` in stringopts).

JDK-8271341 added folding of the region of the diamond-if to stringopts to avoid the case where a live part of the graph becomes unreachable as this top() propagates through the graph too quickly.

JDK-8291775 was a follow-up fix and instead used a constant test as input to the diamond If, as a case was discovered where the If was processed before the Region leading to a broken graph.

The code in JDK-8271341 assumes that the input to the If is a boolean, not a constant. If two diamond if-region structures in the same StringBuilder candidate share the same test, the second iteration in `eliminate_unneeded_control` will fail with an unexpected input. The proposed solution is to skip over the second iteration as the test has already been replaced by a constant -- both structures will be simplified independently during IGVN.

Testing:
T1-4.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8356246](https://bugs.openjdk.org/browse/JDK-8356246): C2: Compilation fails with "assert(bol-&gt;is_Bool()) failed: unexpected if shape" in StringConcat::eliminate_unneeded_control (**Bug** - P3)


### Reviewers
 * [Roberto Castañeda Lozano](https://openjdk.org/census#rcastanedalo) (@robcasloz - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25461/head:pull/25461` \
`$ git checkout pull/25461`

Update a local copy of the PR: \
`$ git checkout pull/25461` \
`$ git pull https://git.openjdk.org/jdk.git pull/25461/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25461`

View PR using the GUI difftool: \
`$ git pr show -t 25461`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25461.diff">https://git.openjdk.org/jdk/pull/25461.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25461#issuecomment-2911557739)
</details>
