### PR TITLE
8356553 : Incorrect uses of {@link} in AbstractQueuedLongSynchronizer and AbstractQueuedSynchronizer

### DIFF
--- a/src/java.base/share/classes/java/util/concurrent/locks/AbstractQueuedLongSynchronizer.java
+++ b/src/java.base/share/classes/java/util/concurrent/locks/AbstractQueuedLongSynchronizer.java
@@ -1303,8 +1303,8 @@ public abstract class AbstractQueuedLongSynchronizer
          * <li>Invoke {@link #release} with saved state as argument,
          *     throwing IllegalMonitorStateException if it fails.
          * <li>Block until signalled.
-         * <li>Reacquire by invoking specialized version of
-         *     {@link #acquire} with saved state as argument.
+         * <li>Reacquire by invoking underlying version of
+         *     {@link #acquire(long)} with saved state as argument.
          * </ol>
          */
         public final void awaitUninterruptibly() {
@@ -1346,8 +1346,8 @@ public abstract class AbstractQueuedLongSynchronizer
          * <li>Invoke {@link #release} with saved state as argument,
          *     throwing IllegalMonitorStateException if it fails.
          * <li>Block until signalled or interrupted.
-         * <li>Reacquire by invoking specialized version of
-         *     {@link #acquire} with saved state as argument.
+         * <li>Reacquire by invoking underlying version of
+         *     {@link #acquire(long)} with saved state as argument.
          * <li>If interrupted while blocked in step 4, throw InterruptedException.
          * </ol>
          */
@@ -1398,8 +1398,8 @@ public abstract class AbstractQueuedLongSynchronizer
          * <li>Invoke {@link #release} with saved state as argument,
          *     throwing IllegalMonitorStateException if it fails.
          * <li>Block until signalled, interrupted, or timed out.
-         * <li>Reacquire by invoking specialized version of
-         *     {@link #acquire} with saved state as argument.
+         * <li>Reacquire by invoking underlying version of
+         *     {@link #acquire(long)} with saved state as argument.
          * <li>If interrupted while blocked in step 4, throw InterruptedException.
          * </ol>
          */
@@ -1442,8 +1442,8 @@ public abstract class AbstractQueuedLongSynchronizer
          * <li>Invoke {@link #release} with saved state as argument,
          *     throwing IllegalMonitorStateException if it fails.
          * <li>Block until signalled, interrupted, or timed out.
-         * <li>Reacquire by invoking specialized version of
-         *     {@link #acquire} with saved state as argument.
+         * <li>Reacquire by invoking underlying version of
+         *     {@link #acquire(long)} with saved state as argument.
          * <li>If interrupted while blocked in step 4, throw InterruptedException.
          * <li>If timed out while blocked in step 4, return false, else true.
          * </ol>
@@ -1485,8 +1485,8 @@ public abstract class AbstractQueuedLongSynchronizer
          * <li>Invoke {@link #release} with saved state as argument,
          *     throwing IllegalMonitorStateException if it fails.
          * <li>Block until signalled, interrupted, or timed out.
-         * <li>Reacquire by invoking specialized version of
-         *     {@link #acquire} with saved state as argument.
+         * <li>Reacquire by invoking underlying version of
+         *     {@link #acquire(long)} with saved state as argument.
          * <li>If interrupted while blocked in step 4, throw InterruptedException.
          * <li>If timed out while blocked in step 4, return false, else true.
          * </ol>

--- a/src/java.base/share/classes/java/util/concurrent/locks/AbstractQueuedSynchronizer.java
+++ b/src/java.base/share/classes/java/util/concurrent/locks/AbstractQueuedSynchronizer.java
@@ -86,9 +86,10 @@ import jdk.internal.misc.Unsafe;
  * #isHeldExclusively} reports whether synchronization is exclusively
  * held with respect to the current thread, method {@link #release}
  * invoked with the current {@link #getState} value fully releases
- * this object, and {@link #acquire}, given this saved state value,
- * eventually restores this object to its previous acquired state.  No
- * {@code AbstractQueuedSynchronizer} method otherwise creates such a
+ * this object, and the underlying version of {@link #acquire(int)},
+ * given this saved state value, eventually restores this object to
+ * its previous acquired state.
+ * No {@code AbstractQueuedSynchronizer} method otherwise creates such a
  * condition, so if this constraint cannot be met, do not use it.  The
  * behavior of {@link ConditionObject} depends of course on the
  * semantics of its synchronizer implementation.
@@ -1682,8 +1683,8 @@ public abstract class AbstractQueuedSynchronizer
          * <li>Invoke {@link #release} with saved state as argument,
          *     throwing IllegalMonitorStateException if it fails.
          * <li>Block until signalled.
-         * <li>Reacquire by invoking specialized version of
-         *     {@link #acquire} with saved state as argument.
+         * <li>Reacquire by invoking underlying version of
+         *     {@link #acquire(int)} with saved state as argument.
          * </ol>
          */
         public final void awaitUninterruptibly() {
@@ -1725,8 +1726,8 @@ public abstract class AbstractQueuedSynchronizer
          * <li>Invoke {@link #release} with saved state as argument,
          *     throwing IllegalMonitorStateException if it fails.
          * <li>Block until signalled or interrupted.
-         * <li>Reacquire by invoking specialized version of
-         *     {@link #acquire} with saved state as argument.
+         * <li>Reacquire by invoking underlying version of
+         *     {@link #acquire(int)} with saved state as argument.
          * <li>If interrupted while blocked in step 4, throw InterruptedException.
          * </ol>
          */
@@ -1777,8 +1778,8 @@ public abstract class AbstractQueuedSynchronizer
          * <li>Invoke {@link #release} with saved state as argument,
          *     throwing IllegalMonitorStateException if it fails.
          * <li>Block until signalled, interrupted, or timed out.
-         * <li>Reacquire by invoking specialized version of
-         *     {@link #acquire} with saved state as argument.
+         * <li>Reacquire by invoking underlying version of
+         *     {@link #acquire(int)} with saved state as argument.
          * <li>If interrupted while blocked in step 4, throw InterruptedException.
          * </ol>
          */
@@ -1821,8 +1822,8 @@ public abstract class AbstractQueuedSynchronizer
          * <li>Invoke {@link #release} with saved state as argument,
          *     throwing IllegalMonitorStateException if it fails.
          * <li>Block until signalled, interrupted, or timed out.
-         * <li>Reacquire by invoking specialized version of
-         *     {@link #acquire} with saved state as argument.
+         * <li>Reacquire by invoking underlying version of
+         *     {@link #acquire(int)} with saved state as argument.
          * <li>If interrupted while blocked in step 4, throw InterruptedException.
          * <li>If timed out while blocked in step 4, return false, else true.
          * </ol>
@@ -1864,8 +1865,8 @@ public abstract class AbstractQueuedSynchronizer
          * <li>Invoke {@link #release} with saved state as argument,
          *     throwing IllegalMonitorStateException if it fails.
          * <li>Block until signalled, interrupted, or timed out.
-         * <li>Reacquire by invoking specialized version of
-         *     {@link #acquire} with saved state as argument.
+         * <li>Reacquire by invoking underlying version of
+         *     {@link #acquire(int)} with saved state as argument.
          * <li>If interrupted while blocked in step 4, throw InterruptedException.
          * <li>If timed out while blocked in step 4, return false, else true.
          * </ol>


### PR DESCRIPTION
I had to tweak the language a bit to better reflect the intent of the text.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8356553](https://bugs.openjdk.org/browse/JDK-8356553): Incorrect uses of {@<!---->link} in AbstractQueuedLongSynchronizer and AbstractQueuedSynchronizer (**Sub-task** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25462/head:pull/25462` \
`$ git checkout pull/25462`

Update a local copy of the PR: \
`$ git checkout pull/25462` \
`$ git pull https://git.openjdk.org/jdk.git pull/25462/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25462`

View PR using the GUI difftool: \
`$ git pr show -t 25462`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25462.diff">https://git.openjdk.org/jdk/pull/25462.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25462#issuecomment-2911871924)
</details>
