### PR TITLE
8357829: Commented out sample limit in JfrSamplerThread::task_stacktrace

### DIFF
--- a/src/hotspot/share/jfr/periodic/sampling/jfrThreadSampler.cpp
+++ b/src/hotspot/share/jfr/periodic/sampling/jfrThreadSampler.cpp
@@ -221,8 +221,11 @@ static inline bool is_excluded(JavaThread* jt) {
   return jt->is_Compiler_thread() || jt->is_hidden_from_external_view() || jt->is_JfrRecorder_thread() || jt->jfr_thread_local()->is_excluded();
 }
 
+static const uint MAX_NR_OF_JAVA_SAMPLES = 5;
+static const uint MAX_NR_OF_NATIVE_SAMPLES = 1;
+
 void JfrSamplerThread::task_stacktrace(JfrSampleRequestType type, JavaThread** last_thread) {
-  const uint sample_limit = JAVA_SAMPLE == type ? 5 : 1;
+  const uint sample_limit = JAVA_SAMPLE == type ? MAX_NR_OF_JAVA_SAMPLES : MAX_NR_OF_NATIVE_SAMPLES;
   uint num_samples = 0;
   JavaThread* start = nullptr;
   elapsedTimer sample_time;
@@ -235,8 +238,7 @@ void JfrSamplerThread::task_stacktrace(JfrSampleRequestType type, JavaThread** l
     _cur_index = tlh.list()->find_index_of_JavaThread(*last_thread);
     JavaThread* current = _cur_index != -1 ? *last_thread : nullptr;
 
-    // while (num_samples < sample_limit) {
-    while (true) {
+    while (num_samples < sample_limit) {
       current = next_thread(tlh.list(), start, current);
       if (current == nullptr) {
         break;


### PR DESCRIPTION
Greetings,

SonarCloud identified this issue today following the integration of [JDK-8352251](https://bugs.openjdk.org/browse/JDK-8352251).

It's a remnant from increased sampling pressure during development.

A change will be coming in this area, just not yet.

Restoring sampling limits.

Testing: jdk_jfr

Thanks SonarCloud!

Markus

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8357829](https://bugs.openjdk.org/browse/JDK-8357829): Commented out sample limit in JfrSamplerThread::task_stacktrace (**Bug** - P3)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25464/head:pull/25464` \
`$ git checkout pull/25464`

Update a local copy of the PR: \
`$ git checkout pull/25464` \
`$ git pull https://git.openjdk.org/jdk.git pull/25464/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25464`

View PR using the GUI difftool: \
`$ git pr show -t 25464`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25464.diff">https://git.openjdk.org/jdk/pull/25464.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25464#issuecomment-2912335920)
</details>
