### PR TITLE
8357854: Parallel: Inline args of PSOldGen::initialize_performance_counters

### DIFF
--- a/src/hotspot/share/gc/parallel/parallelScavengeHeap.cpp
+++ b/src/hotspot/share/gc/parallel/parallelScavengeHeap.cpp
@@ -93,8 +93,7 @@ jint ParallelScavengeHeap::initialize() {
       old_rs,
       OldSize,
       MinOldSize,
-      MaxOldSize,
-      "old", 1);
+      MaxOldSize);
 
   assert(young_gen()->max_gen_size() == young_rs.size(),"Consistency check");
   assert(old_gen()->max_gen_size() == old_rs.size(), "Consistency check");

--- a/src/hotspot/share/gc/parallel/psOldGen.cpp
+++ b/src/hotspot/share/gc/parallel/psOldGen.cpp
@@ -37,19 +37,18 @@
 #include "utilities/align.hpp"
 
 PSOldGen::PSOldGen(ReservedSpace rs, size_t initial_size, size_t min_size,
-                   size_t max_size, const char* perf_data_name, int level):
+                   size_t max_size):
   _min_gen_size(min_size),
   _max_gen_size(max_size)
 {
-  initialize(rs, initial_size, GenAlignment, perf_data_name, level);
+  initialize(rs, initial_size, GenAlignment);
 }
 
-void PSOldGen::initialize(ReservedSpace rs, size_t initial_size, size_t alignment,
-                          const char* perf_data_name, int level) {
+void PSOldGen::initialize(ReservedSpace rs, size_t initial_size, size_t alignment) {
   initialize_virtual_space(rs, initial_size, alignment);
-  initialize_work(perf_data_name, level);
+  initialize_work();
 
-  initialize_performance_counters(perf_data_name, level);
+  initialize_performance_counters();
 }
 
 void PSOldGen::initialize_virtual_space(ReservedSpace rs,
@@ -63,7 +62,7 @@ void PSOldGen::initialize_virtual_space(ReservedSpace rs,
   }
 }
 
-void PSOldGen::initialize_work(const char* perf_data_name, int level) {
+void PSOldGen::initialize_work() {
   MemRegion const reserved_mr = reserved();
   assert(reserved_mr.byte_size() == max_gen_size(), "invariant");
 
@@ -109,9 +108,9 @@ void PSOldGen::initialize_work(const char* perf_data_name, int level) {
   start_array()->set_covered_region(committed_mr);
 }
 
-void PSOldGen::initialize_performance_counters(const char* perf_data_name, int level) {
-  // Generation Counters, generation 'level', 1 subspace
-  _gen_counters = new GenerationCounters(perf_data_name, level, 1, min_gen_size(),
+void PSOldGen::initialize_performance_counters() {
+  const char* perf_data_name = "old";
+  _gen_counters = new GenerationCounters(perf_data_name, 1, 1, min_gen_size(),
                                          max_gen_size(), virtual_space()->committed_size());
   _space_counters = new SpaceCounters(perf_data_name, 0,
                                       virtual_space()->reserved_size(),

--- a/src/hotspot/share/gc/parallel/psOldGen.hpp
+++ b/src/hotspot/share/gc/parallel/psOldGen.hpp
@@ -70,16 +70,15 @@ class PSOldGen : public CHeapObj<mtGC> {
 
   void post_resize();
 
-  void initialize(ReservedSpace rs, size_t initial_size, size_t alignment,
-                  const char* perf_data_name, int level);
+  void initialize(ReservedSpace rs, size_t initial_size, size_t alignment);
   void initialize_virtual_space(ReservedSpace rs, size_t initial_size, size_t alignment);
-  void initialize_work(const char* perf_data_name, int level);
-  void initialize_performance_counters(const char* perf_data_name, int level);
+  void initialize_work();
+  void initialize_performance_counters();
 
  public:
   // Initialize the generation.
   PSOldGen(ReservedSpace rs, size_t initial_size, size_t min_size,
-           size_t max_size, const char* perf_data_name, int level);
+           size_t max_size);
 
   MemRegion reserved() const {
     return MemRegion((HeapWord*)(_virtual_space->low_boundary()),


### PR DESCRIPTION
Trivial inlining some args in leaf-callee to avoid carrying them in the call-chain.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8357854](https://bugs.openjdk.org/browse/JDK-8357854): Parallel: Inline args of PSOldGen::initialize_performance_counters (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Joel Sikström](https://openjdk.org/census#jsikstro) (@jsikstro - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25466/head:pull/25466` \
`$ git checkout pull/25466`

Update a local copy of the PR: \
`$ git checkout pull/25466` \
`$ git pull https://git.openjdk.org/jdk.git pull/25466/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25466`

View PR using the GUI difftool: \
`$ git pr show -t 25466`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25466.diff">https://git.openjdk.org/jdk/pull/25466.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25466#issuecomment-2912774479)
</details>
