### PR TITLE
8357307: VM GC operations should have a public gc_succeeded()

### DIFF
--- a/src/hotspot/share/gc/g1/g1VMOperations.hpp
+++ b/src/hotspot/share/gc/g1/g1VMOperations.hpp
@@ -41,7 +41,6 @@ public:
     VM_GC_Operation(gc_count_before, cause, full_gc_count_before, true) { }
   VMOp_Type type() const override { return VMOp_G1CollectFull; }
   void doit() override;
-  bool gc_succeeded() const { return prologue_succeeded(); }
 };
 
 class VM_G1TryInitiateConcMark : public VM_GC_Operation {
@@ -63,7 +62,7 @@ public:
   bool cycle_already_in_progress() const { return _cycle_already_in_progress; }
   bool whitebox_attached() const { return _whitebox_attached; }
   bool terminating() const { return _terminating; }
-  bool gc_succeeded() const { return _gc_succeeded; }
+  bool gc_succeeded() const { return _gc_succeeded && VM_GC_Operation::gc_succeeded(); }
 };
 
 class VM_G1CollectForAllocation : public VM_CollectForAllocation {
@@ -74,7 +73,6 @@ public:
                             GCCause::Cause gc_cause);
   virtual VMOp_Type type() const { return VMOp_G1CollectForAllocation; }
   virtual void doit();
-  bool gc_succeeded() const { return prologue_succeeded(); }
 };
 
 // Concurrent G1 stop-the-world operations such as remark and cleanup.

--- a/src/hotspot/share/gc/parallel/parallelScavengeHeap.cpp
+++ b/src/hotspot/share/gc/parallel/parallelScavengeHeap.cpp
@@ -328,7 +328,7 @@ HeapWord* ParallelScavengeHeap::mem_allocate_work(size_t size,
       // Did the VM operation execute? If so, return the result directly.
       // This prevents us from looping until time out on requests that can
       // not be satisfied.
-      if (op.prologue_succeeded()) {
+      if (op.gc_succeeded()) {
         assert(is_in_or_null(op.result()), "result not in heap");
 
         // Exit the loop if the gc time limit has been exceeded.

--- a/src/hotspot/share/gc/serial/serialHeap.cpp
+++ b/src/hotspot/share/gc/serial/serialHeap.cpp
@@ -339,7 +339,7 @@ HeapWord* SerialHeap::mem_allocate_work(size_t size, bool is_tlab) {
 
     VM_SerialCollectForAllocation op(size, is_tlab, gc_count_before);
     VMThread::execute(&op);
-    if (op.prologue_succeeded()) {
+    if (op.gc_succeeded()) {
       result = op.result();
 
       assert(result == nullptr || is_in_reserved(result),

--- a/src/hotspot/share/gc/shared/collectedHeap.cpp
+++ b/src/hotspot/share/gc/shared/collectedHeap.cpp
@@ -382,7 +382,7 @@ MetaWord* CollectedHeap::satisfy_failed_metadata_allocation(ClassLoaderData* loa
 
     VMThread::execute(&op);
 
-    if (op.prologue_succeeded()) {
+    if (op.gc_succeeded()) {
       return op.result();
     }
     loop_count++;

--- a/src/hotspot/share/gc/shared/gcVMOperations.hpp
+++ b/src/hotspot/share/gc/shared/gcVMOperations.hpp
@@ -143,7 +143,7 @@ class VM_GC_Operation: public VM_GC_Sync_Operation {
   virtual void doit_epilogue();
 
   virtual bool allow_nested_vm_operations() const  { return true; }
-  bool prologue_succeeded() const { return _prologue_succeeded; }
+  virtual bool gc_succeeded() const { return _prologue_succeeded; }
 
   static void notify_gc_begin(bool full = false);
   static void notify_gc_end();


### PR DESCRIPTION
Hi all,

   please review this cleanup that changes `VM_GC_Operation` to use `gc_succeeded` instead of `prologue_succeeded()`to indicate that a GC has been executed (once a GC is started, it will always finish, so the only reason that a VM op does not get executed is that we decide in the prologue that there has already been a GC).

After recent changes the change is/was mostly a renaming of the `prologue_succeeded`method - there is only one case for G1 where additional checks can cause no execution of the GC (e.g. because we started a low-priority concurrent mark and we are already currently marking. No point for doing a GC in that case).

Testing: tier1-4, gha

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8357307](https://bugs.openjdk.org/browse/JDK-8357307): VM GC operations should have a public gc_succeeded() (**Enhancement** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25469/head:pull/25469` \
`$ git checkout pull/25469`

Update a local copy of the PR: \
`$ git checkout pull/25469` \
`$ git pull https://git.openjdk.org/jdk.git pull/25469/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25469`

View PR using the GUI difftool: \
`$ git pr show -t 25469`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25469.diff">https://git.openjdk.org/jdk/pull/25469.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25469#issuecomment-2913108058)
</details>
