### PR TITLE
8357917: Assert in MetaspaceShared::preload_and_dump() when printing exception

### DIFF
--- a/src/hotspot/share/cds/metaspaceShared.cpp
+++ b/src/hotspot/share/cds/metaspaceShared.cpp
@@ -799,8 +799,9 @@ void MetaspaceShared::preload_and_dump(TRAPS) {
                      "%zuM", MaxHeapSize/M);
       MetaspaceShared::writing_error();
     } else {
+      oop message = java_lang_Throwable::message(PENDING_EXCEPTION);
       aot_log_error(aot)("%s: %s", PENDING_EXCEPTION->klass()->external_name(),
-                     java_lang_String::as_utf8_string(java_lang_Throwable::message(PENDING_EXCEPTION)));
+                         message == nullptr ? "(null)" : java_lang_String::as_utf8_string(message));
       MetaspaceShared::writing_error(err_msg("Unexpected exception, use -Xlog:aot%s,exceptions=trace for detail",
                                              CDSConfig::new_aot_flags_used() ? "" : ",cds"));
     }


### PR DESCRIPTION
Please review this trivial patch for printing exceptions that happened during AOT cache dumping.

We observed the crash when running tests with [JEP 514](https://openjdk.org/jeps/514), but the root cause is pre-existing.