### PR TITLE
8357920: Add .rej and .orig to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ NashornProfile.txt
 /.gdbinit
 /.lldbinit
 **/core.[0-9]*
+*.rej
+*.orig


### PR DESCRIPTION
The file types .rej and .orig are often created by diff tools. Adding them to .gitignore will help people from mistakenly committing these files.

See https://github.com/openjdk/jdk/pull/25306#discussion_r2102407122 for an example of where this happened.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8357920](https://bugs.openjdk.org/browse/JDK-8357920): Add .rej and .orig to .gitignore (**Bug** - P4) ⚠️ Issue is already resolved. Consider making this a "backport pull request" by setting the PR title to `Backport <hash>` with the hash of the original commit. See [Backports](https://wiki.openjdk.org/display/SKARA/Backports).


### Reviewers
 * [SendaoYan](https://openjdk.org/census#syan) (@sendaoYan - Committer)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25474/head:pull/25474` \
`$ git checkout pull/25474`

Update a local copy of the PR: \
`$ git checkout pull/25474` \
`$ git pull https://git.openjdk.org/jdk.git pull/25474/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25474`

View PR using the GUI difftool: \
`$ git pr show -t 25474`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25474.diff">https://git.openjdk.org/jdk/pull/25474.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25474#issuecomment-2914268776)
</details>
