### PR TITLE
8355725: SPEC_FILTER stopped working

### DIFF
--- a/make/Docs.gmk
+++ b/make/Docs.gmk
@@ -542,7 +542,9 @@ $(eval $(call SetupApiDocsGeneration, REFERENCE_API, \
 # Format: space-delimited list of names, including at most one '%' as a
 # wildcard. Spec source files match if their filename or any enclosing folder
 # name matches one of the items in SPEC_FILTER.
-SPEC_FILTER := %
+ifeq ($(SPEC_FILTER), )
+  SPEC_FILTER := %
+endif
 
 ApplySpecFilter = \
     $(strip $(foreach file, $(1), \


### PR DESCRIPTION
From the bug description:

The SPEC_FILTER make variable is meant to be used to create small documentation bundles that just contain some selected files. Example usage:

`make docs-specs-zip SPEC_FILTER="%-jls.md copyright.html %logo.gif resources"`

The fix for [JDK-8349143](https://bugs.openjdk.org/browse/JDK-8349143) caused the feature to stop working: no matter what the filter variables says, all the specs get built. This is a regression, old behavior needs to be restored.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8355725](https://bugs.openjdk.org/browse/JDK-8355725): SPEC_FILTER stopped working (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25476/head:pull/25476` \
`$ git checkout pull/25476`

Update a local copy of the PR: \
`$ git checkout pull/25476` \
`$ git pull https://git.openjdk.org/jdk.git pull/25476/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25476`

View PR using the GUI difftool: \
`$ git pr show -t 25476`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25476.diff">https://git.openjdk.org/jdk/pull/25476.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25476#issuecomment-2914485976)
</details>
