### PR TITLE
8358017: Various enhancements of jpackage test helpers

### DIFF
--- a/test/jdk/tools/jpackage/helpers-test/jdk/jpackage/test/AnnotationsTest.java
+++ b/test/jdk/tools/jpackage/helpers-test/jdk/jpackage/test/AnnotationsTest.java
@@ -225,7 +225,7 @@ public class AnnotationsTest extends JUnitAdapter {
             );
         }
 
-        private final static TestExecutionRecorder staticRecorder = new TestExecutionRecorder(ParameterizedInstanceTest.class);
+        private static final TestExecutionRecorder staticRecorder = new TestExecutionRecorder(ParameterizedInstanceTest.class);
     }
 
     public static class IfOSTest extends TestExecutionRecorder {

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/FileAssociations.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/FileAssociations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/FileAssociations.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/FileAssociations.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Stream;
 import jdk.jpackage.internal.util.PathUtils;
 
 
@@ -142,7 +143,18 @@ public final class FileAssociations {
             switch (invocationType) {
                 case DesktopOpenAssociatedFile: {
                     TKit.trace(String.format("Use desktop to open [%s] file", testFile));
-                    Desktop.getDesktop().open(testFile.toFile());
+                    if (!HelloApp.CLEAR_JAVA_ENV_VARS) {
+                        Desktop.getDesktop().open(testFile.toFile());
+                    } else {
+                        final var jsScript = TKit.createTempFile(Path.of("fa-scripts", testFile.getFileName().toString() + ".jsh"));
+                        TKit.createTextFile(jsScript, List.of(
+                                "import java.awt.Desktop",
+                                "import java.io.File",
+                                String.format("Desktop.getDesktop().open(new File(\"%s\"))", testFile.toString().replace('\\', '/')),
+                                "/exit"));
+                        final var exec = Executor.of(JavaTool.JSHELL.getPath().toString(), jsScript.toString());
+                        HelloApp.configureEnvironment(exec).dumpOutput().execute();
+                    }
                     return List.of(testFile.toString());
                 }
                 case WinCommandLine: {

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/JPackageCommand.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/JPackageCommand.java
@@ -52,6 +52,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
+import java.util.spi.ToolProvider;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import jdk.jpackage.internal.util.function.ThrowingConsumer;
@@ -664,12 +665,16 @@ public class JPackageCommand extends CommandArguments<JPackageCommand> {
         return hasArgument(UNPACKED_PATH_ARGNAME);
     }
 
+    public static void useToolProviderByDefault(ToolProvider jpackageToolProvider) {
+        defaultToolProvider = Optional.of(jpackageToolProvider);
+    }
+
     public static void useToolProviderByDefault() {
-        defaultWithToolProvider = true;
+        useToolProviderByDefault(JavaTool.JPACKAGE.asToolProvider());
     }
 
     public static void useExecutableByDefault() {
-        defaultWithToolProvider = false;
+        defaultToolProvider = Optional.empty();
     }
 
     public JPackageCommand useToolProvider(boolean v) {
@@ -778,8 +783,7 @@ public class JPackageCommand extends CommandArguments<JPackageCommand> {
     }
 
     public boolean isWithToolProvider() {
-        return Optional.ofNullable(withToolProvider).orElse(
-                defaultWithToolProvider);
+        return Optional.ofNullable(withToolProvider).orElseGet(defaultToolProvider::isPresent);
     }
 
     public JPackageCommand executePrerequisiteActions() {
@@ -800,7 +804,7 @@ public class JPackageCommand extends CommandArguments<JPackageCommand> {
                 .addArguments(args);
 
         if (isWithToolProvider()) {
-            exec.setToolProvider(JavaTool.JPACKAGE);
+            exec.setToolProvider(defaultToolProvider.orElseGet(JavaTool.JPACKAGE::asToolProvider));
         } else {
             exec.setExecutable(JavaTool.JPACKAGE);
             if (TKit.isWindows()) {
@@ -1472,7 +1476,7 @@ public class JPackageCommand extends CommandArguments<JPackageCommand> {
     private Set<ReadOnlyPathAssert> readOnlyPathAsserts = Set.of(ReadOnlyPathAssert.values());
     private Set<AppLayoutAssert> appLayoutAsserts = Set.of(AppLayoutAssert.values());
     private List<Consumer<Iterator<String>>> outputValidators = new ArrayList<>();
-    private static boolean defaultWithToolProvider;
+    private static Optional<ToolProvider> defaultToolProvider = Optional.empty();
 
     private static final Map<String, PackageType> PACKAGE_TYPES = Functional.identity(
             () -> {

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/JPackageCommand.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/JPackageCommand.java
@@ -977,7 +977,7 @@ public class JPackageCommand extends CommandArguments<JPackageCommand> {
             return getPaths.apply(cmd).stream().toList();
         }
 
-        private final static class Builder {
+        private static final class Builder {
 
             Builder(String argName) {
                 this.argName = Objects.requireNonNull(argName);

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/JavaTool.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/JavaTool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,7 @@ import java.nio.file.Path;
 import java.util.spi.ToolProvider;
 
 public enum JavaTool {
-    JAVA, JAVAC, JPACKAGE, JAR, JLINK, JMOD;
+    JAVA, JAVAC, JPACKAGE, JAR, JLINK, JMOD, JSHELL;
 
     JavaTool() {
         this.path = Path.of(System.getProperty("java.home")).resolve(

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/MacSign.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/MacSign.java
@@ -1037,7 +1037,7 @@ public final class MacSign {
         return !missingKeychain && !missingCertificates && !invalidCertificates;
     }
 
-    public final static class ResolvedKeychain {
+    public static final class ResolvedKeychain {
         public ResolvedKeychain(KeychainWithCertsSpec spec) {
             this.spec = Objects.requireNonNull(spec);
         }

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/MacSignVerify.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/MacSignVerify.java
@@ -83,7 +83,7 @@ public final class MacSignVerify {
             return value;
         }
 
-        final private String value;
+        private final String value;
     }
 
     public static final String ADHOC_SIGN_ORIGIN = "-";

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/RunnablePackageTest.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/RunnablePackageTest.java
@@ -71,7 +71,7 @@ public abstract class RunnablePackageTest {
     /**
      * Test action.
      */
-    static public enum Action {
+    public static enum Action {
         /**
          * Init test.
          */
@@ -114,7 +114,7 @@ public abstract class RunnablePackageTest {
             return name().toLowerCase().replace('_', '-');
         }
 
-        public final static Action[] CREATE_AND_UNPACK = new Action[] {
+        public static final Action[] CREATE_AND_UNPACK = new Action[] {
             CREATE, UNPACK, VERIFY_INSTALL
         };
     };
@@ -143,7 +143,7 @@ public abstract class RunnablePackageTest {
         return groups;
     }
 
-    private final static List<Action> DEFAULT_ACTIONS;
+    private static final List<Action> DEFAULT_ACTIONS;
 
     static {
         final String propertyName = "action";

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/TKit.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/TKit.java
@@ -130,7 +130,7 @@ public final class TKit {
     enum RunTestMode {
         FAIL_FAST;
 
-        final static Set<RunTestMode> DEFAULTS = Set.of();
+        static final Set<RunTestMode> DEFAULTS = Set.of();
     }
 
     static void runTests(List<TestInstance> tests) {

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/TKit.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/TKit.java
@@ -25,6 +25,7 @@ package jdk.jpackage.test;
 import static java.nio.file.StandardWatchEventKinds.ENTRY_CREATE;
 import static java.nio.file.StandardWatchEventKinds.ENTRY_MODIFY;
 import static java.util.stream.Collectors.toSet;
+import static jdk.jpackage.internal.util.function.ThrowingSupplier.toSupplier;
 
 import java.io.Closeable;
 import java.io.FileOutputStream;
@@ -126,7 +127,19 @@ public final class TKit {
         }
     }
 
+    enum RunTestMode {
+        FAIL_FAST;
+
+        final static Set<RunTestMode> DEFAULTS = Set.of();
+    }
+
     static void runTests(List<TestInstance> tests) {
+        runTests(tests, RunTestMode.DEFAULTS);
+    }
+
+    static void runTests(List<TestInstance> tests, Set<RunTestMode> modes) {
+        Objects.requireNonNull(tests);
+        Objects.requireNonNull(modes);
         if (currentTest != null) {
             throw new IllegalStateException(
                     "Unexpected nested or concurrent Test.run() call");
@@ -136,7 +149,11 @@ public final class TKit {
             tests.stream().forEach(test -> {
                 currentTest = test;
                 try {
-                    ignoreExceptions(test).run();
+                    if (modes.contains(RunTestMode.FAIL_FAST)) {
+                        ThrowingRunnable.toRunnable(test::run).run();
+                    } else {
+                        ignoreExceptions(test).run();
+                    }
                 } finally {
                     currentTest = null;
                     if (extraLogStream != null) {
@@ -145,6 +162,35 @@ public final class TKit {
                 }
             });
         });
+    }
+
+    static <T> T runAdhocTest(ThrowingSupplier<T> action) {
+        final List<T> box = new ArrayList<>();
+        runAdhocTest(() -> {
+            box.add(action.get());
+        });
+        return box.getFirst();
+    }
+
+    static void runAdhocTest(ThrowingRunnable action) {
+        Objects.requireNonNull(action);
+
+        final Path workDir = toSupplier(() -> Files.createTempDirectory("jdk.jpackage-test")).get();
+
+        final TestInstance test;
+        if (action instanceof TestInstance ti) {
+            test = new TestInstance(ti, workDir);
+        } else {
+            test = new TestInstance(() -> {
+                try {
+                    action.run();
+                } finally {
+                    TKit.deleteDirectoryRecursive(workDir);
+                }
+            }, workDir);
+        }
+
+        runTests(List.of(test), Set.of(RunTestMode.FAIL_FAST));
     }
 
     static Runnable ignoreExceptions(ThrowingRunnable action) {

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/TestBuilder.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/TestBuilder.java
@@ -74,17 +74,24 @@ final class TestBuilder implements AutoCloseable {
             return this;
         }
 
+        Builder testClassLoader(ClassLoader v) {
+            testClassLoader = v;
+            return this;
+        }
+
         TestBuilder create() {
-            return new TestBuilder(testConsumer, workDirRoot);
+            return new TestBuilder(testConsumer, workDirRoot, testClassLoader);
         }
 
         private Consumer<TestInstance> testConsumer;
         private Path workDirRoot = Path.of("");
+        private ClassLoader testClassLoader = TestBuilder.class.getClassLoader();
     }
 
-    private TestBuilder(Consumer<TestInstance> testConsumer, Path workDirRoot) {
+    private TestBuilder(Consumer<TestInstance> testConsumer, Path workDirRoot, ClassLoader testClassLoader) {
         this.testMethodSupplier = TestBuilderConfig.getDefault().createTestMethodSupplier();
         this.workDirRoot = Objects.requireNonNull(workDirRoot);
+        this.testClassLoader = Objects.requireNonNull(testClassLoader);
         argProcessors = Map.of(
                 CMDLINE_ARG_PREFIX + "after-run",
                 arg -> getJavaMethodsFromArg(arg).map(
@@ -233,9 +240,9 @@ final class TestBuilder implements AutoCloseable {
         testGroup = null;
     }
 
-    private static Class<?> probeClass(String name) {
+    private static Class<?> probeClass(String name, ClassLoader classLoader) {
         try {
-            return Class.forName(name);
+            return Class.forName(name, true, classLoader);
         } catch (ClassNotFoundException ex) {
             return null;
         }
@@ -254,7 +261,7 @@ final class TestBuilder implements AutoCloseable {
 
         String defaultClassName = null;
         for (String token : argValue.split(",")) {
-            Class<?> testSet = probeClass(token);
+            Class<?> testSet = probeClass(token, testClassLoader);
             if (testSet != null) {
                 if (testMethodSupplier.isTestClass(testSet)) {
                     toConsumer(testMethodSupplier::verifyTestClass).accept(testSet);
@@ -297,7 +304,7 @@ final class TestBuilder implements AutoCloseable {
 
         try {
             return testMethodSupplier.findNullaryLikeMethods(
-                    fromQualifiedMethodName(qualifiedMethodName));
+                    fromQualifiedMethodName(qualifiedMethodName), testClassLoader);
         } catch (NoSuchMethodException ex) {
             throw new ParseException(ex.getMessage() + ";", ex);
         }
@@ -371,6 +378,7 @@ final class TestBuilder implements AutoCloseable {
     private final Map<String, ThrowingConsumer<String>> argProcessors;
     private final Consumer<TestInstance> testConsumer;
     private final Path workDirRoot;
+    private final ClassLoader testClassLoader;
     private List<MethodCall> testGroup;
     private List<ThrowingConsumer<Object>> beforeActions;
     private List<ThrowingConsumer<Object>> afterActions;

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/TestBuilder.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/TestBuilder.java
@@ -60,7 +60,7 @@ final class TestBuilder implements AutoCloseable {
         return new Builder();
     }
 
-    final static class Builder {
+    static final class Builder {
         private Builder() {
         }
 

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/TestInstance.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/TestInstance.java
@@ -48,8 +48,16 @@ import jdk.jpackage.internal.util.function.ThrowingSupplier;
 
 final class TestInstance implements ThrowingRunnable {
 
-    static class TestDesc {
-        private TestDesc() {
+    final static class TestDesc {
+        private TestDesc(Class<?> clazz, String functionName, String functionArgs, String instanceArgs) {
+            this.clazz = Objects.requireNonNull(clazz);
+            this.functionName = functionName;
+            this.functionArgs = functionArgs;
+            this.instanceArgs = instanceArgs;
+        }
+
+        private TestDesc(Class<?> clazz) {
+            this(clazz, null, null, null);
         }
 
         String testFullName() {
@@ -93,16 +101,11 @@ final class TestInstance implements ThrowingRunnable {
 
             @Override
             public TestDesc get() {
-                TestDesc desc = new TestDesc();
                 if (method == null) {
-                    desc.clazz = enclosingMainMethodClass();
+                    return new TestDesc(enclosingMainMethodClass());
                 } else {
-                    desc.clazz = method.getDeclaringClass();
-                    desc.functionName = method.getName();
-                    desc.functionArgs = formatArgs(methodArgs);
-                    desc.instanceArgs = formatArgs(ctorArgs);
+                    return new TestDesc(method.getDeclaringClass(), method.getName(), formatArgs(methodArgs), formatArgs(ctorArgs));
                 }
-                return desc;
             }
 
             private static String formatArgs(List<Object> values) {
@@ -140,27 +143,10 @@ final class TestInstance implements ThrowingRunnable {
             private static final HexFormat ARGS_CHAR_FORMATTER = HexFormat.of().withUpperCase();
         }
 
-        static TestDesc create(Method m, Object... args) {
-            TestDesc desc = new TestDesc();
-            desc.clazz = m.getDeclaringClass();
-            desc.functionName = m.getName();
-            if (args.length != 0) {
-                desc.functionArgs = Stream.of(args).map(v -> {
-                    if (v.getClass().isArray()) {
-                        return String.format("%s(length=%d)",
-                                Arrays.deepToString((Object[]) v),
-                                Array.getLength(v));
-                    }
-                    return String.format("%s", v);
-                }).collect(Collectors.joining(", "));
-            }
-            return desc;
-        }
-
-        private Class<?> clazz;
-        private String functionName;
-        private String functionArgs;
-        private String instanceArgs;
+        private final Class<?> clazz;
+        private final String functionName;
+        private final String functionArgs;
+        private final String instanceArgs;
     }
 
     TestInstance(ThrowingRunnable testBody, Path workDirRoot) {
@@ -184,6 +170,17 @@ final class TestInstance implements ThrowingRunnable {
         this.testDesc = testBody.createDescription();
         this.dryRun = dryRun;
         this.workDir = workDirRoot.resolve(createWorkDirPath(testDesc));
+    }
+
+    TestInstance(TestInstance other, Path workDirRoot) {
+        assertCount = 0;
+        this.testConstructor = other.testConstructor;
+        this.testBody = other.testBody;
+        this.beforeActions = other.beforeActions;
+        this.afterActions = other.afterActions;
+        this.testDesc = other.testDesc;
+        this.dryRun = other.dryRun;
+        this.workDir = workDirRoot.resolve(createWorkDirPath(other.testDesc));
     }
 
     void notifyAssert() {

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/TestInstance.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/TestInstance.java
@@ -48,7 +48,7 @@ import jdk.jpackage.internal.util.function.ThrowingSupplier;
 
 final class TestInstance implements ThrowingRunnable {
 
-    final static class TestDesc {
+    static final class TestDesc {
         private TestDesc(Class<?> clazz, String functionName, String functionArgs, String instanceArgs) {
             this.clazz = Objects.requireNonNull(clazz);
             this.functionName = functionName;


### PR DESCRIPTION
Various enhancements of jpackage test helpers:
 - Can run fa tests when JAVA_TOOL_OPTIONS env variable contains `--module-path` option. This change makes support for `jpackage.test.clear-app-launcher-java-env-vars` system property redundant.
 - Rework JUnitAdapter to make it run jpackage TestInstance objects as JUnit5 DynamicTest tests. This integrates jpackage test runs in IDEs (Verified with Eclipse IDE).
 - Make jpackage tests fail fast when they are executed by JUnit test runner.
 - Applied `./bin/blessed-modifier-order.sh` script on jpackage test helpers.
 - Support loading jpackage tests from a custom classloader.
 - Add support for using a custom ToolProvider implementation of jpackage with JPackageCommand.

The last two features are not currently in use. They were picked from the work-in-progress [JDK-8333727](https://bugs.openjdk.org/browse/JDK-8333727).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8358017](https://bugs.openjdk.org/browse/JDK-8358017): Various enhancements of jpackage test helpers (**Enhancement** - P4)


### Reviewers
 * [Alexander Matveev](https://openjdk.org/census#almatvee) (@sashamatveev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25479/head:pull/25479` \
`$ git checkout pull/25479`

Update a local copy of the PR: \
`$ git checkout pull/25479` \
`$ git pull https://git.openjdk.org/jdk.git pull/25479/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25479`

View PR using the GUI difftool: \
`$ git pr show -t 25479`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25479.diff">https://git.openjdk.org/jdk/pull/25479.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25479#issuecomment-2919926292)
</details>
