### PR TITLE
8357944: Remove unused CollectedHeap::is_maximal_no_gc

### DIFF
--- a/src/hotspot/share/gc/epsilon/epsilonHeap.hpp
+++ b/src/hotspot/share/gc/epsilon/epsilonHeap.hpp
@@ -80,11 +80,6 @@ public:
 
   bool requires_barriers(stackChunkOop obj) const override { return false; }
 
-  bool is_maximal_no_gc() const override {
-    // No GC is going to happen. Return "we are at max", when we are about to fail.
-    return used() == capacity();
-  }
-
   // Allocation
   HeapWord* allocate_work(size_t size, bool verbose = true);
   HeapWord* mem_allocate(size_t size, bool* gc_overhead_limit_was_exceeded) override;

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -966,7 +966,7 @@ public:
   // end fields defining the extent of the contiguous allocation region.)
   // But G1CollectedHeap doesn't yet support this.
 
-  bool is_maximal_no_gc() const override {
+  bool is_maximal_no_gc() const {
     return _hrm.num_inactive_regions() == 0;
   }
 

--- a/src/hotspot/share/gc/parallel/parallelScavengeHeap.cpp
+++ b/src/hotspot/share/gc/parallel/parallelScavengeHeap.cpp
@@ -208,12 +208,6 @@ size_t ParallelScavengeHeap::used() const {
   return value;
 }
 
-bool ParallelScavengeHeap::is_maximal_no_gc() const {
-  // We don't expand young-gen except at a GC.
-  return old_gen()->is_maximal_no_gc();
-}
-
-
 size_t ParallelScavengeHeap::max_capacity() const {
   size_t estimated = reserved_region().byte_size();
   if (UseAdaptiveSizePolicy) {

--- a/src/hotspot/share/gc/parallel/parallelScavengeHeap.hpp
+++ b/src/hotspot/share/gc/parallel/parallelScavengeHeap.hpp
@@ -158,11 +158,6 @@ public:
   size_t capacity() const override;
   size_t used() const override;
 
-  // Return "true" if all generations have reached the
-  // maximal committed limit that they can reach, without a garbage
-  // collection.
-  bool is_maximal_no_gc() const override;
-
   void register_nmethod(nmethod* nm) override;
   void unregister_nmethod(nmethod* nm) override;
   void verify_nmethod(nmethod* nm) override;

--- a/src/hotspot/share/gc/parallel/psOldGen.hpp
+++ b/src/hotspot/share/gc/parallel/psOldGen.hpp
@@ -110,10 +110,6 @@ class PSOldGen : public CHeapObj<mtGC> {
   size_t capacity_in_bytes() const        { return object_space()->capacity_in_bytes(); }
   size_t used_in_bytes() const            { return object_space()->used_in_bytes(); }
 
-  bool is_maximal_no_gc() const {
-    return virtual_space()->uncommitted_size() == 0;
-  }
-
   void complete_loaded_archive_space(MemRegion archive_space);
 
   // Calculating new sizes

--- a/src/hotspot/share/gc/serial/serialHeap.cpp
+++ b/src/hotspot/share/gc/serial/serialHeap.cpp
@@ -766,11 +766,6 @@ void SerialHeap::prepare_for_verify() {
   ensure_parsability(false);        // no need to retire TLABs
 }
 
-bool SerialHeap::is_maximal_no_gc() const {
-  // We don't expand young-gen except at a GC.
-  return _old_gen->is_maximal_no_gc();
-}
-
 void SerialHeap::save_marks() {
   _young_gen_saved_top = _young_gen->to()->top();
   _old_gen_saved_top = _old_gen->space()->top();

--- a/src/hotspot/share/gc/serial/serialHeap.hpp
+++ b/src/hotspot/share/gc/serial/serialHeap.hpp
@@ -216,11 +216,6 @@ public:
 
   void print_heap_change(const PreGenGCValues& pre_gc_values) const;
 
-  // Return "true" if all generations have reached the
-  // maximal committed limit that they can reach, without a garbage
-  // collection.
-  virtual bool is_maximal_no_gc() const override;
-
   // This function returns the CardTableRS object that allows us to scan
   // generations in a fully generational heap.
   CardTableRS* rem_set() { return _rem_set; }

--- a/src/hotspot/share/gc/serial/tenuredGeneration.hpp
+++ b/src/hotspot/share/gc/serial/tenuredGeneration.hpp
@@ -102,12 +102,6 @@ public:
   MemRegion prev_used_region() const { return _prev_used_region; }
   void save_used_region()   { _prev_used_region = used_region(); }
 
-  // Returns true if this generation cannot be expanded further
-  // without a GC.
-  bool is_maximal_no_gc() const {
-    return _virtual_space.uncommitted_size() == 0;
-  }
-
   HeapWord* block_start(const void* addr) const;
 
   void scan_old_to_young_refs(HeapWord* saved_top_in_old_gen);

--- a/src/hotspot/share/gc/shared/collectedHeap.hpp
+++ b/src/hotspot/share/gc/shared/collectedHeap.hpp
@@ -259,11 +259,6 @@ protected:
   size_t used_at_last_gc() const { return _used_at_last_gc; }
   void update_capacity_and_used_at_gc();
 
-  // Return "true" if the part of the heap that allocates Java
-  // objects has reached the maximal committed limit that it can
-  // reach, without a garbage collection.
-  virtual bool is_maximal_no_gc() const = 0;
-
   // Support for java.lang.Runtime.maxMemory():  return the maximum amount of
   // memory that the vm could make available for storing 'normal' java objects.
   // This is based on the reserved address space, but should not include space

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
@@ -614,8 +614,6 @@ private:
 // and can be stubbed out.
 //
 public:
-  bool is_maximal_no_gc() const override shenandoah_not_implemented_return(false);
-
   // Check the pointer is in active part of Java heap.
   // Use is_in_reserved to check if object is within heap bounds.
   bool is_in(const void* p) const override;

--- a/src/hotspot/share/gc/z/zCollectedHeap.cpp
+++ b/src/hotspot/share/gc/z/zCollectedHeap.cpp
@@ -126,12 +126,6 @@ size_t ZCollectedHeap::unused() const {
   return _heap.unused();
 }
 
-bool ZCollectedHeap::is_maximal_no_gc() const {
-  // Not supported
-  ShouldNotReachHere();
-  return false;
-}
-
 bool ZCollectedHeap::is_in(const void* p) const {
   return _heap.is_in((uintptr_t)p);
 }

--- a/src/hotspot/share/gc/z/zCollectedHeap.hpp
+++ b/src/hotspot/share/gc/z/zCollectedHeap.hpp
@@ -70,7 +70,6 @@ public:
   size_t used() const override;
   size_t unused() const override;
 
-  bool is_maximal_no_gc() const override;
   bool is_in(const void* p) const override;
   bool requires_barriers(stackChunkOop obj) const override;
 


### PR DESCRIPTION
Removing effectively dead code/API for all GCs except G1.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8357944](https://bugs.openjdk.org/browse/JDK-8357944): Remove unused CollectedHeap::is_maximal_no_gc (**Enhancement** - P4)


### Reviewers
 * [Joel Sikström](https://openjdk.org/census#jsikstro) (@jsikstro - Committer)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25482/head:pull/25482` \
`$ git checkout pull/25482`

Update a local copy of the PR: \
`$ git checkout pull/25482` \
`$ git pull https://git.openjdk.org/jdk.git pull/25482/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25482`

View PR using the GUI difftool: \
`$ git pr show -t 25482`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25482.diff">https://git.openjdk.org/jdk/pull/25482.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25482#issuecomment-2915252413)
</details>
