### PR TITLE
8357919 Arena::allocate returns segments with address zero if the segment length is zero after JDK-8345687

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/SegmentFactories.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/SegmentFactories.java
@@ -192,6 +192,13 @@ public class SegmentFactories {
         }
         // Align the allocation size up to a multiple of 8 so we can init the memory with longs
         long alignedSize = init ? Utils.alignUp(byteSize, Long.BYTES) : byteSize;
+        // Check for wrap around
+        if (alignedSize < 0) {
+            throw new OutOfMemoryError();
+        }
+        // Always allocate at least some memory so that zero-length segments have distinct
+        // non-zero addresses.
+        alignedSize = Math.max(1, alignedSize);
 
         long allocationSize;
         long allocationBase;


### PR DESCRIPTION
After https://bugs.openjdk.org/browse/JDK-8345687 was integrated, zero-length segments always have an address of zero. This may cause problems in certain native methods that can receive segments and/or buffers derived from segments.

This PR also guards for overflow for extremely large allocation requests.