### PR TITLE
8334759: gc/g1/TestMixedGCLiveThreshold.java fails on Windows with JTREG_TEST_THREAD_FACTORY=Virtual due to extra memory allocation

### DIFF
--- a/test/hotspot/jtreg/ProblemList-Virtual.txt
+++ b/test/hotspot/jtreg/ProblemList-Virtual.txt
@@ -83,11 +83,6 @@ vmTestbase/nsk/jdi/VMOutOfMemoryException/VMOutOfMemoryException001/VMOutOfMemor
 # to make progress when all other threads are currently suspended.
 vmTestbase/nsk/jdi/ThreadReference/isSuspended/issuspended002/TestDescription.java 8338713 generic-all
 
-###
-# Fails on Windows because of additional memory allocation.
-
-gc/g1/TestMixedGCLiveThreshold.java#25percent 8334759 windows-x64
-
 ##########
 ## Tests incompatible with  with virtual test thread factory.
 ## There is no goal to run all test with virtual test thread factory.

--- a/test/hotspot/jtreg/gc/g1/TestMixedGCLiveThreshold.java
+++ b/test/hotspot/jtreg/gc/g1/TestMixedGCLiveThreshold.java
@@ -28,6 +28,7 @@ package gc.g1;
  * @summary Test G1MixedGCLiveThresholdPercent=0. Fill up a region to at least 33 percent,
  * the region should not be selected for mixed GC cycle.
  * @requires vm.gc.G1
+ * @requires test.thread.factory != "Virtual"
  * @library /test/lib
  * @build jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
@@ -39,6 +40,7 @@ package gc.g1;
  * @summary Test G1MixedGCLiveThresholdPercent=25. Fill up a region to at least 33 percent,
  * the region should not be selected for mixed GC cycle.
  * @requires vm.gc.G1
+ * @requires test.thread.factory != "Virtual"
  * @library /test/lib
  * @build jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
@@ -50,6 +52,7 @@ package gc.g1;
  * @summary Test G1MixedGCLiveThresholdPercent=100. Fill up a region to at least 33 percent,
  * the region should be selected for mixed GC cycle.
  * @requires vm.gc.G1
+ * @requires test.thread.factory != "Virtual"
  * @library /test/lib
  * @build jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox


### PR DESCRIPTION
Hi all,

  please review this change that "fixes" the `TestMixedGCLiveThreshold.java` test by requiring the thread factory used for these tests to not use virtual threads instead of platform threads.

That adds some additional memory consumption, and since the test is about testing G1 reaction due to particular known memory consumption, it can fail.

The fix is to add the appropriate `@requires` tag that has been introduced in jtreg 7.5.1 (which is current default/requirement for builds, https://bugs.openjdk.org/browse/JDK-8334759).

Testing: verified that the test is not run if the virtual thread test thread factory is used.

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334759](https://bugs.openjdk.org/browse/JDK-8334759): gc/g1/TestMixedGCLiveThreshold.java fails on Windows with JTREG_TEST_THREAD_FACTORY=Virtual due to extra memory allocation (**Bug** - P3)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25486/head:pull/25486` \
`$ git checkout pull/25486`

Update a local copy of the PR: \
`$ git checkout pull/25486` \
`$ git pull https://git.openjdk.org/jdk.git pull/25486/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25486`

View PR using the GUI difftool: \
`$ git pr show -t 25486`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25486.diff">https://git.openjdk.org/jdk/pull/25486.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25486#issuecomment-2915628906)
</details>
