### PR TITLE
8357959: (bf) ByteBuffer.allocateDirect initialization can result in large TTSP spikes

### DIFF
--- a/src/java.base/share/classes/java/nio/Bits.java
+++ b/src/java.base/share/classes/java/nio/Bits.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/nio/Bits.java
+++ b/src/java.base/share/classes/java/nio/Bits.java
@@ -244,16 +244,15 @@ class Bits {                            // package-private
      *
      * @param srcAddr
      *        the starting memory address
-     * @param size
+     * @param count
      *        the number of bytes to set
      * @param value
      *        the byte value to set
      */
-    static void setMemory(long srcAddr, long size, byte value) {
+    static void setMemory(long srcAddr, long count, byte value) {
         long offset = 0;
-        long len = 0;
-        while (offset < size) {
-            len = Math.min(UNSAFE_SET_THRESHOLD, size - offset);
+        while (offset < count) {
+            long len = Math.min(UNSAFE_SET_THRESHOLD, count - offset);
             UNSAFE.setMemory(srcAddr + offset, len, value);
             offset += len;
         }

--- a/src/java.base/share/classes/java/nio/Bits.java
+++ b/src/java.base/share/classes/java/nio/Bits.java
@@ -234,4 +234,30 @@ class Bits {                            // package-private
     // of an element by element copy.  These numbers may change over time.
     static final int JNI_COPY_TO_ARRAY_THRESHOLD   = 6;
     static final int JNI_COPY_FROM_ARRAY_THRESHOLD = 6;
+
+    // Maximum number of bytes to set in one call to {@code Unsafe.setMemory}.
+    // This threshold allows safepoint polling during large memory operations.
+    static final long UNSAFE_SET_THRESHOLD = 1024 * 1024;
+
+    /**
+     * Sets a block of memory starting from a given address to a specified byte value.
+     *
+     * @param srcAddr
+     *        the starting memory address
+     * @param size
+     *        the number of bytes to set
+     * @param value
+     *        the byte value to set
+     */
+    static void setMemory(long srcAddr, long size, byte value) {
+        // Zero in chunks to avoid blocking safepoints for too long
+        long offset = 0;
+        long len = 0;
+        while (offset < size) {
+            len = Math.min(UNSAFE_SET_THRESHOLD, size - offset);
+            UNSAFE.setMemory(srcAddr + offset, len, value);
+            offset += len;
+        }
+    }
+
 }

--- a/src/java.base/share/classes/java/nio/Bits.java
+++ b/src/java.base/share/classes/java/nio/Bits.java
@@ -250,7 +250,6 @@ class Bits {                            // package-private
      *        the byte value to set
      */
     static void setMemory(long srcAddr, long size, byte value) {
-        // Zero in chunks to avoid blocking safepoints for too long
         long offset = 0;
         long len = 0;
         while (offset < size) {

--- a/src/java.base/share/classes/java/nio/Direct-X-Buffer.java.template
+++ b/src/java.base/share/classes/java/nio/Direct-X-Buffer.java.template
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -114,7 +114,17 @@ class Direct$Type$Buffer$RW$$BO$
             Bits.unreserveMemory(size, cap);
             throw x;
         }
-        UNSAFE.setMemory(base, size, (byte) 0);
+
+        long chunkSize = 1024 * 1024; // 1MB per chunk
+        long offset = 0;
+
+        while (offset < size) {
+            long len = Math.min(chunkSize, size - offset);
+            UNSAFE.setMemory(base + offset, len, (byte) 0);
+            offset += len;
+        }
+
+
         if (pa && (base % ps != 0)) {
             // Round up to page boundary
             address = base + ps - (base & (ps - 1));

--- a/src/java.base/share/classes/java/nio/Direct-X-Buffer.java.template
+++ b/src/java.base/share/classes/java/nio/Direct-X-Buffer.java.template
@@ -71,6 +71,7 @@ class Direct$Type$Buffer$RW$$BO$
 #if[byte]
     // Cached unaligned-access capability
     static final boolean UNALIGNED = Bits.unaligned();
+    private static final long MEM_ZERO_CHUNK_SIZE = 1024 * 1024;
 
     private record Deallocator(long address, long size, int capacity) implements Runnable {
         private Deallocator {
@@ -116,11 +117,9 @@ class Direct$Type$Buffer$RW$$BO$
         }
 
         // Zero in chunks to avoid blocking safepoints for too long
-        long chunkSize = 1024 * 1024;
         long offset = 0;
-
         while (offset < size) {
-            long len = Math.min(chunkSize, size - offset);
+            long len = Math.min(MEM_ZERO_CHUNK_SIZE, size - offset);
             UNSAFE.setMemory(base + offset, len, (byte) 0);
             offset += len;
         }

--- a/src/java.base/share/classes/java/nio/Direct-X-Buffer.java.template
+++ b/src/java.base/share/classes/java/nio/Direct-X-Buffer.java.template
@@ -115,7 +115,8 @@ class Direct$Type$Buffer$RW$$BO$
             throw x;
         }
 
-        long chunkSize = 1024 * 1024; // 1MB per chunk
+        // Zero in chunks to avoid blocking safepoints for too long
+        long chunkSize = 1024 * 1024;
         long offset = 0;
 
         while (offset < size) {
@@ -123,7 +124,6 @@ class Direct$Type$Buffer$RW$$BO$
             UNSAFE.setMemory(base + offset, len, (byte) 0);
             offset += len;
         }
-
 
         if (pa && (base % ps != 0)) {
             // Round up to page boundary

--- a/src/java.base/share/classes/java/nio/Direct-X-Buffer.java.template
+++ b/src/java.base/share/classes/java/nio/Direct-X-Buffer.java.template
@@ -71,7 +71,6 @@ class Direct$Type$Buffer$RW$$BO$
 #if[byte]
     // Cached unaligned-access capability
     static final boolean UNALIGNED = Bits.unaligned();
-    private static final long MEM_ZERO_CHUNK_SIZE = 1024 * 1024;
 
     private record Deallocator(long address, long size, int capacity) implements Runnable {
         private Deallocator {
@@ -115,15 +114,7 @@ class Direct$Type$Buffer$RW$$BO$
             Bits.unreserveMemory(size, cap);
             throw x;
         }
-
-        // Zero in chunks to avoid blocking safepoints for too long
-        long offset = 0;
-        while (offset < size) {
-            long len = Math.min(MEM_ZERO_CHUNK_SIZE, size - offset);
-            UNSAFE.setMemory(base + offset, len, (byte) 0);
-            offset += len;
-        }
-
+        Bits.setMemory(base, size, (byte) 0);
         if (pa && (base % ps != 0)) {
             // Round up to page boundary
             address = base + ps - (base & (ps - 1));

--- a/test/jdk/java/nio/Buffer/AllocateDirectInit.java
+++ b/test/jdk/java/nio/Buffer/AllocateDirectInit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -67,7 +67,7 @@ public class AllocateDirectInit {
     }
 
     private static void check(ByteBuffer bb) {
-        for (bb.position(0); bb.position() < bb.limit(); ) {
+        while (bb.hasRemaining()) {
             if (bb.get() != 0) {
                 int mismatchPos = bb.position();
                 System.out.print("byte [");

--- a/test/jdk/java/nio/Buffer/AllocateDirectInit.java
+++ b/test/jdk/java/nio/Buffer/AllocateDirectInit.java
@@ -23,29 +23,60 @@
 
 /**
  * @test
- * @bug 4490253 6535542
+ * @bug 4490253 6535542 8357959
+ * @key randomness
+ * @library /test/lib
+ * @build jdk.test.lib.RandomFactory
  * @summary Verify that newly allocated direct buffers are initialized.
+ * @run main/othervm AllocateDirectInit
  */
 
 import java.nio.ByteBuffer;
+import java.util.Random;
+
+import jdk.test.lib.RandomFactory;
 
 public class AllocateDirectInit {
+    private static final int MAX_BIN_LIMIT = 16 * 1024 * 1024;
+    private static final int MAX_DEC_LIMIT = 10 * 1000 * 1000;
+    private static final int TRIES_PER_LIMIT = 1024;
+
+    private static final Random RND = RandomFactory.getRandom();
+
     public static void main(String [] args){
-        for (int i = 0; i < 1024; i++) {
-            ByteBuffer bb = ByteBuffer.allocateDirect(1024);
-//          printByteBuffer(bb);
-            for (bb.position(0); bb.position() < bb.limit(); ) {
-                if ((bb.get() & 0xff) != 0)
-                    throw new RuntimeException("uninitialized buffer, position = "
-                                               + bb.position());
+        // Try power of two limits
+        for (int limit = 1; limit < MAX_BIN_LIMIT; limit *= 2) {
+            check(ByteBuffer.allocateDirect(limit - 1));
+            check(ByteBuffer.allocateDirect(limit));
+            check(ByteBuffer.allocateDirect(limit + 1));
+        }
+
+        // Try power of ten limits
+        for (int limit = 1; limit < MAX_DEC_LIMIT; limit *= 10) {
+            check(ByteBuffer.allocateDirect(limit - 1));
+            check(ByteBuffer.allocateDirect(limit));
+            check(ByteBuffer.allocateDirect(limit + 1));
+        }
+
+        // Try random sizes within power of two limits
+        for (int limit = 1; limit < MAX_BIN_LIMIT; limit *= 2) {
+            for (int t = 0; t < TRIES_PER_LIMIT; t++) {
+                check(ByteBuffer.allocateDirect(RND.nextInt(limit)));
             }
         }
     }
 
-    private static void printByteBuffer(ByteBuffer bb) {
-        System.out.print("byte [");
-        for (bb.position(0); bb.position() < bb.limit(); )
-            System.out.print(" " + Integer.toHexString(bb.get() & 0xff));
-        System.out.println(" ]");
+    private static void check(ByteBuffer bb) {
+        for (bb.position(0); bb.position() < bb.limit(); ) {
+            if (bb.get() != 0) {
+                int mismatchPos = bb.position();
+                System.out.print("byte [");
+                for (bb.position(0); bb.position() < bb.limit(); ) {
+                    System.out.print(" " + Integer.toHexString(bb.get() & 0xff));
+                }
+                System.out.println(" ]");
+                throw new RuntimeException("uninitialized buffer, position = " + mismatchPos);
+            }
+        }
     }
 }

--- a/test/micro/org/openjdk/bench/java/nio/ByteBufferAllocationBenchmark.java
+++ b/test/micro/org/openjdk/bench/java/nio/ByteBufferAllocationBenchmark.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.java.nio;
+
+
+import java.nio.ByteBuffer;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Thread)
+@Measurement(iterations = 5)
+@Warmup(iterations = 5)
+public class ByteBufferAllocationBenchmark {
+
+    @Param({
+            "128", // 128 bytes
+            "1024", // 1KB
+            "1048576", // 1 MB
+            "2000000000" // ~2 GB
+    })
+    public int bytes;
+
+    @Benchmark
+    public ByteBuffer allocateDirectBuffer() {
+        return ByteBuffer.allocateDirect(bytes);
+    }
+}

--- a/test/micro/org/openjdk/bench/java/nio/ByteBufferAllocationBenchmark.java
+++ b/test/micro/org/openjdk/bench/java/nio/ByteBufferAllocationBenchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -19,6 +19,7 @@
  * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
  * or visit www.oracle.com if you need additional information or have any
  * questions.
+ *
  */
 package org.openjdk.bench.java.nio;
 

--- a/test/micro/org/openjdk/bench/java/nio/ByteBufferAllocationBenchmark.java
+++ b/test/micro/org/openjdk/bench/java/nio/ByteBufferAllocationBenchmark.java
@@ -36,7 +36,7 @@ import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
 
 @BenchmarkMode(Mode.AverageTime)
-@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Thread)
 @Measurement(iterations = 5)
 @Warmup(iterations = 5)
@@ -46,7 +46,7 @@ public class ByteBufferAllocationBenchmark {
             "128", // 128 bytes
             "1024", // 1KB
             "1048576", // 1 MB
-            "2000000000" // ~2 GB
+            "2147483647" // ~2 GB
     })
     public int bytes;
 

--- a/test/micro/org/openjdk/bench/java/nio/ByteBufferAllocationBenchmark.java
+++ b/test/micro/org/openjdk/bench/java/nio/ByteBufferAllocationBenchmark.java
@@ -39,8 +39,9 @@ import org.openjdk.jmh.annotations.Warmup;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Thread)
-@Measurement(iterations = 5)
-@Warmup(iterations = 5)
+@Warmup(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(3)
 public class ByteBufferAllocationBenchmark {
 
     @Param({

--- a/test/micro/org/openjdk/bench/java/nio/DirectByteBufferAlloc.java
+++ b/test/micro/org/openjdk/bench/java/nio/DirectByteBufferAlloc.java
@@ -28,6 +28,7 @@ import java.nio.ByteBuffer;
 import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
@@ -42,13 +43,13 @@ import org.openjdk.jmh.annotations.Warmup;
 @Warmup(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
 @Fork(3)
-public class ByteBufferAllocationBenchmark {
+public class DirectByteBufferAlloc {
 
     @Param({
             "128", // 128 bytes
             "1024", // 1KB
             "1048576", // 1 MB
-            "2147483647" // ~2 GB
+            "16777216" // 16MB
     })
     public int bytes;
 


### PR DESCRIPTION
ByteBuffer.allocateDirect uses UNSAFE.setMemory, causing high time-to-safepoint (100+ ms) for large (100 MB+) allocations.

This PR applies a simple fix by chunking the zeroing operation within ByteBuffers. A more robust solution would be to add chunking inside UNSAFE.setMemory itself. However Its not that straightforward as mentioned by Aleksey in [JDK-8357959](https://bugs.openjdk.org/browse/JDK-8357959)
>Looks like all current uses we care about are in Buffers. Taking a safepoint within cleaning would open some questions whether any VM code expect to see semi-initialized area we are busy cleaning up. For Buffers, this question does not arise. Therefore, we can do the fix in Buffers first, without changing the Unsafe itself.
 
I can pursue that if its preferred. I chose 1 MB as a chunk size some what arbitrarily I am open to suggestion, if there are better options.

For verification, I tested the fix against the reproducer - [gist](https://gist.github.com/rk-kmr/be4322b72a14ae04aeefc0260c01acf6) and confirmed that ttsp timing were lower.

**before**
```
0.444s][info][safepoint,stats] ThreadDump                   [             13               1 ][        194156625      65291  194221916 ]               0
[0.662s][info][safepoint,stats] ThreadDump                   [             13               1 ][        200013875      87834  200101709 ]               0
[0.858s][info][safepoint,stats] ThreadDump                   [             13               1 ][        183762583      43417  183806000 ]               0
[1
```
**after**
```
1.705s][info][safepoint,stats] ThreadDump                   [             11               1 ][            92792      24958     117750 ]               0
[1.724s][info][safepoint,stats] ThreadDump                   [             11               1 ][           497375      94041     591416 ]               0
[1.736s][info][safepoint,stats] ThreadDump                   [             11               1 ][           156750      47208     203958 ]               0
[1.747s][info][safepoint,stats] ThreadDump                   [             11               1 ][           121958      28334     150292 ]               0

```
I added a benchmark to ensure that chunking doesn't introduce significant overhead across different allocation sizes, and following results confirm that. 

**Before**
```
Benchmark                                              (bytes)  Mode  Cnt          Score         Error  Units
ByteBufferAllocationBenchmark.allocateDirectBuffer         128  avgt   25        860.869 ±     170.921  ns/op
ByteBufferAllocationBenchmark.allocateDirectBuffer        1024  avgt   25       1368.599 ±     320.159  ns/op
ByteBufferAllocationBenchmark.allocateDirectBuffer     1048576  avgt   25      80169.230 ±     448.075  ns/op
ByteBufferAllocationBenchmark.allocateDirectBuffer  2147483647  avgt   25  635047372.458 ± 5461328.161  ns/op
```
**After**
```
Benchmark                                              (bytes)  Mode  Cnt          Score         Error  Units
ByteBufferAllocationBenchmark.allocateDirectBuffer         128  avgt   25        869.676 ±     160.633  ns/op
ByteBufferAllocationBenchmark.allocateDirectBuffer        1024  avgt   25       1328.623 ±     282.198  ns/op
ByteBufferAllocationBenchmark.allocateDirectBuffer     1048576  avgt   25      80224.157 ±     454.906  ns/op
ByteBufferAllocationBenchmark.allocateDirectBuffer  2147483647  avgt   25  667037308.198 ± 4818648.535  ns/op
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8357959](https://bugs.openjdk.org/browse/JDK-8357959): (bf) ByteBuffer.allocateDirect initialization can result in large TTSP spikes (**Enhancement** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25487/head:pull/25487` \
`$ git checkout pull/25487`

Update a local copy of the PR: \
`$ git checkout pull/25487` \
`$ git pull https://git.openjdk.org/jdk.git pull/25487/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25487`

View PR using the GUI difftool: \
`$ git pr show -t 25487`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25487.diff">https://git.openjdk.org/jdk/pull/25487.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25487#issuecomment-2916093452)
</details>
