### PR TITLE
8251928: [macos] the printer DPI always be 72, cause some content lost when print out

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CGraphicsDevice.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CGraphicsDevice.m
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,12 +28,6 @@
 #include "GeomUtilities.h"
 #include "JNIUtilities.h"
 
-/**
- * Some default values for invalid CoreGraphics display ID.
- */
-#define DEFAULT_DEVICE_WIDTH 1024
-#define DEFAULT_DEVICE_HEIGHT 768
-#define DEFAULT_DEVICE_DPI 72
 
 static NSInteger architecture = -1;
 /*

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/GeomUtilities.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/GeomUtilities.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,13 @@
 
 #import <Cocoa/Cocoa.h>
 #include "JNIUtilities.h"
+
+/**
+ * Some default values for invalid CoreGraphics display ID.
+ */
+#define DEFAULT_DEVICE_WIDTH 1024
+#define DEFAULT_DEVICE_HEIGHT 768
+#define DEFAULT_DEVICE_DPI 72
 
 jobject CGToJavaRect(JNIEnv *env, CGRect rect);
 

--- a/test/jdk/javax/print/PrintablePrintDPI.java
+++ b/test/jdk/javax/print/PrintablePrintDPI.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, BELLSOFT. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import javax.print.PrintService;
+import javax.print.PrintServiceLookup;
+import javax.print.attribute.HashPrintRequestAttributeSet;
+import javax.print.attribute.PrintRequestAttributeSet;
+import javax.print.attribute.ResolutionSyntax;
+import javax.print.attribute.standard.OrientationRequested;
+import javax.print.attribute.standard.PrinterResolution;
+import javax.swing.JButton;
+import javax.swing.JComboBox;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JList;
+import javax.swing.JPanel;
+import javax.swing.ListCellRenderer;
+import javax.swing.border.EmptyBorder;
+import java.awt.Component;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.GridLayout;
+import java.awt.Window;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.print.PageFormat;
+import java.awt.print.Printable;
+import java.awt.print.PrinterException;
+import java.awt.print.PrinterJob;
+
+/*
+ * @test
+ * @bug 8251928
+ * @key printer
+ * @summary Printable.print method should reflect printer's DPI
+ * @library /java/awt/regtesthelpers
+ * @requires (os.family == "linux") | (os.family == "mac")
+ * @build PassFailJFrame
+ * @run main/manual PrintablePrintDPI
+ */
+
+public class PrintablePrintDPI implements Printable {
+
+    private static final double PAPER_DPI = 72.0;
+    private static final int DEFAULT_PRINTER_DPI = 300;
+    private static final int UNITS = ResolutionSyntax.DPI;
+
+    private static final String INSTRUCTIONS = """
+           This test checks printing DPI.
+           To be able to run this test it is required to have a
+           printer configured in your user environment.
+           Test's steps:
+             - Choose a printer.
+             - Choose a printer resolution.
+             - Press 'Print' button.
+           Visual inspection of the printed pages is needed.
+           A passing test will print choosen DPI on the printed page
+           """;
+
+    private final PrintService printService;
+    private final PrinterResolution printerResolution;
+
+    public static void main(String[] args) throws Exception {
+        PrintService[] availablePrintServices = PrintServiceLookup.lookupPrintServices(null, null);
+        if (availablePrintServices.length == 0) {
+            System.out.println("Available print services not found");
+            return;
+        }
+        PassFailJFrame.builder()
+                .instructions(INSTRUCTIONS)
+                .testTimeOut(300)
+                .title("Printing DPI test")
+                .testUI(createTestWindow(availablePrintServices))
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static Window createTestWindow(final PrintService[] availablePrintServices) {
+        final Window frame = new JFrame("Choose service to test");
+        JPanel pnlMain = new JPanel();
+        pnlMain.setBorder(new EmptyBorder(5, 5, 5, 5));
+        pnlMain.setLayout(new GridLayout(3, 1, 5, 5));
+        JLabel lblServices = new JLabel("Available services");
+        JLabel lblResolutions = new JLabel("Available resolutions");
+        JButton btnPrint = new JButton("Print");
+        btnPrint.setEnabled(false);
+        JComboBox<PrinterResolution> cbResolutions = new JComboBox<>();
+        cbResolutions.setRenderer(new ListCellRenderer<PrinterResolution>() {
+            @Override
+            public Component getListCellRendererComponent(JList<? extends PrinterResolution> list,
+                                                          PrinterResolution value,
+                                                          int index, boolean isSelected, boolean cellHasFocus) {
+                String str = value == null ? "" :
+                        String.format("%dx%d DPI",
+                                value.getCrossFeedResolution(UNITS), value.getFeedResolution(UNITS));
+                return new JLabel(str);
+            }
+        });
+        cbResolutions.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                btnPrint.setEnabled(cbResolutions.getSelectedItem() != null);
+            }
+        });
+
+        JComboBox<PrintService> cbServices = new JComboBox<>();
+        cbServices.setRenderer(new ListCellRenderer<PrintService>() {
+            @Override
+            public Component getListCellRendererComponent(JList<? extends PrintService> list, PrintService value,
+                                                          int index, boolean isSelected, boolean cellHasFocus) {
+                return new JLabel(value == null ? "" : value.getName());
+            }
+        });
+        cbServices.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                PrintService ps = (PrintService) cbServices.getSelectedItem();
+                cbResolutions.removeAllItems();
+                btnPrint.setEnabled(ps != null);
+                if (ps != null) {
+                    PrinterResolution[] supportedResolutions = (PrinterResolution[])ps
+                            .getSupportedAttributeValues(PrinterResolution.class, null, null);
+                    if (supportedResolutions == null || supportedResolutions.length == 0) {
+                        cbResolutions.addItem(new PrinterResolution(DEFAULT_PRINTER_DPI, DEFAULT_PRINTER_DPI, UNITS));
+                    } else {
+                        for (PrinterResolution pr : supportedResolutions) {
+                            cbResolutions.addItem(pr);
+                        }
+                    }
+                }
+            }
+        });
+        for (PrintService ps : availablePrintServices) {
+            cbServices.addItem(ps);
+        }
+        lblServices.setLabelFor(cbServices);
+        btnPrint.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                PrintService printService = (PrintService) cbServices.getSelectedItem();
+                PrinterResolution resolution = (PrinterResolution) cbResolutions.getSelectedItem();
+                if (printService != null && resolution != null) {
+                    cbServices.setEnabled(false);
+                    cbResolutions.setEnabled(false);
+                    btnPrint.setEnabled(false);
+                    frame.setVisible(false);
+                    new PrintablePrintDPI(printService, resolution).test();
+                }
+            }
+        });
+        pnlMain.add(lblServices);
+        pnlMain.add(cbServices);
+        pnlMain.add(lblResolutions);
+        pnlMain.add(cbResolutions);
+        pnlMain.add(btnPrint);
+        frame.add(pnlMain);
+        frame.pack();
+        return frame;
+    }
+
+    private PrintablePrintDPI(PrintService printService, PrinterResolution printerResolution) {
+        this.printService = printService;
+        this.printerResolution = printerResolution;
+    }
+
+    private void test() {
+        System.out.printf("Perform test using %s and %dx%d DPI\n",
+                printService.getName(),
+                printerResolution.getCrossFeedResolution(UNITS),
+                printerResolution.getFeedResolution(UNITS));
+
+        PrinterJob job = PrinterJob.getPrinterJob();
+        try {
+            PrintRequestAttributeSet attributeSet = new HashPrintRequestAttributeSet();
+            attributeSet.add(printerResolution);
+            attributeSet.add(OrientationRequested.PORTRAIT);
+            job.setPrintService(printService);
+            job.setPrintable(this);
+            job.print(attributeSet);
+        } catch (PrinterException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    @Override
+    public int print(Graphics graphics, PageFormat pageFormat, int pageIndex) throws PrinterException {
+        if (pageIndex > 0) {
+            return NO_SUCH_PAGE;
+        }
+        final int printOffset = 20;
+        final int[] deviceRes = printerResolution.getResolution(ResolutionSyntax.DPI);
+
+        Graphics2D g2 = (Graphics2D)graphics;
+        double hRes = g2.getTransform().getScaleX() * PAPER_DPI;
+        double vRes = g2.getTransform().getScaleY() * PAPER_DPI;
+        String msg = String.format(
+                "Expected DPI: %dx%d, actual: %dx%d.\n",
+                deviceRes[0], deviceRes[1], (int)hRes, (int)vRes);
+        System.out.println(msg);
+        g2.drawString(msg, (int)(pageFormat.getImageableX() + printOffset),
+                (int)(pageFormat.getImageableY() + printOffset));
+        return PAGE_EXISTS;
+    }
+}


### PR DESCRIPTION
The fix for the https://bugs.openjdk.org/browse/JDK-8251928.

**Description**.
This PR contains changes to be able to print with DPI higher than 72 on macOS, set default CPrinterJob DPI is 300 like in the PSPrinterJob.

As described in the macOS drawing guide, the following steps are required to draw with high DPI (https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/CocoaDrawingGuide/Transforms/Transforms.html#//apple_ref/doc/uid/TP40003290-CH204-BCICIJAJ):
1. Convert the user-space point, size, or rectangle value to device space coordinates;
2. Normalize the value in device space so that it is aligned to the appropriate pixel boundary;
3. Convert the normalized value back to user space;
4. Draw your content using the adjusted value. 
    
The 1-st step is now implemented in the CPrinterJob, a Graphics provided to the print method adjusted to a printer's DPI.
The 2-nd step is a drawing process in the java code (without changes).
The 3-rd step is now implemented in the PrinterView.m, the drawing scaled back to the 72 DPI.
The 4-th step is a drawing process in the native code (without changes).

**Tests**.
I run all tests from javax.print package and there is no any regression.
New test covers macOS and Linux only because we know its default DPI - 300.