### PR TITLE
8355319: Update Manpage for Compact Object Headers (Production)

### DIFF
--- a/src/java.base/share/man/java.md
+++ b/src/java.base/share/man/java.md
@@ -1020,6 +1020,11 @@ These `java` options can be used to enable other advanced options.
 
 These `java` options control the runtime behavior of the Java HotSpot VM.
 
+`-XX:+UseCompactObjectHeaders`
+:   Enables compact object headers. By default, this option is disabled.
+    Enabling this option reduces memory footprint in the Java heap by
+    4 bytes per object (on average).
+
 `-XX:ActiveProcessorCount=`*x*
 :   Overrides the number of CPUs that the VM will use to calculate the size of
     thread pools it will use for various operations such as Garbage Collection

--- a/src/java.base/share/man/java.md
+++ b/src/java.base/share/man/java.md
@@ -1517,11 +1517,8 @@ These `java` options control the runtime behavior of the Java HotSpot VM.
 `-XX:+UseCompactObjectHeaders`
 :   Enables compact object headers. By default, this option is disabled.
     Enabling this option reduces memory footprint in the Java heap by
-    4 bytes per object (on average).
-
-    The feature remains disabled by default in this release whilst it
-    continues to be evaluated. In a future release it is expected to be
-    enabled by default, and eventually will be the only mode of operation.
+    4 bytes per object (on average). This option may become enabled by
+    default in a future release.
 
 `-XX:-UseCompressedOops`
 :   Disables the use of compressed pointers. By default, this option is

--- a/src/java.base/share/man/java.md
+++ b/src/java.base/share/man/java.md
@@ -1020,11 +1020,6 @@ These `java` options can be used to enable other advanced options.
 
 These `java` options control the runtime behavior of the Java HotSpot VM.
 
-`-XX:+UseCompactObjectHeaders`
-:   Enables compact object headers. By default, this option is disabled.
-    Enabling this option reduces memory footprint in the Java heap by
-    4 bytes per object (on average).
-
 `-XX:ActiveProcessorCount=`*x*
 :   Overrides the number of CPUs that the VM will use to calculate the size of
     thread pools it will use for various operations such as Garbage Collection
@@ -1518,6 +1513,15 @@ These `java` options control the runtime behavior of the Java HotSpot VM.
     ```
 
     This option is similar to `-Xss`.
+
+`-XX:+UseCompactObjectHeaders`
+:   Enables compact object headers. By default, this option is disabled.
+    Enabling this option reduces memory footprint in the Java heap by
+    4 bytes per object (on average).
+
+    The feature remains disabled by default in this release whilst it
+    continues to be evaluated. In a future release it is expected to be
+    enabled by default, and eventually will be the only mode of operation.
 
 `-XX:-UseCompressedOops`
 :   Disables the use of compressed pointers. By default, this option is

--- a/src/java.base/share/man/java.md
+++ b/src/java.base/share/man/java.md
@@ -1517,8 +1517,11 @@ These `java` options control the runtime behavior of the Java HotSpot VM.
 `-XX:+UseCompactObjectHeaders`
 :   Enables compact object headers. By default, this option is disabled.
     Enabling this option reduces memory footprint in the Java heap by
-    4 bytes per object (on average). This option may become enabled by
-    default in a future release.
+    4 bytes per object (on average) and often improves performance.
+
+    The feature remains disabled by default while it continues to be evaluated.
+    In a future release it is expected to be enabled by default, and
+    eventually will be the only mode of operation.
 
 `-XX:-UseCompressedOops`
 :   Disables the use of compressed pointers. By default, this option is


### PR DESCRIPTION
Adds an entry for -XX:+UseCompactObjectHeaders in the manpage for the java command, under 'Advanced runtime options'.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8355319](https://bugs.openjdk.org/browse/JDK-8355319): Update Manpage for Compact Object Headers (Production) (**Sub-task** - P4)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**) Review applies to [d189f600](https://git.openjdk.org/jdk/pull/25491/files/d189f6002a0b96ef894d225f4ca0e1e509e175f3)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25491/head:pull/25491` \
`$ git checkout pull/25491`

Update a local copy of the PR: \
`$ git checkout pull/25491` \
`$ git pull https://git.openjdk.org/jdk.git pull/25491/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25491`

View PR using the GUI difftool: \
`$ git pr show -t 25491`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25491.diff">https://git.openjdk.org/jdk/pull/25491.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25491#issuecomment-2931342243)
</details>
