### PR TITLE
8354930: IGV: dump C2 graph before and after live range stretching

### DIFF
--- a/src/hotspot/share/opto/chaitin.cpp
+++ b/src/hotspot/share/opto/chaitin.cpp
@@ -406,6 +406,8 @@ void PhaseChaitin::Register_Allocate() {
     _live = &live;                // Mark LIVE as being available
   }
 
+  C->print_method(PHASE_INITIAL_LIVENESS, 4);
+
   // Base pointers are currently "used" by instructions which define new
   // derived pointers.  This makes base pointers live up to the where the
   // derived pointer is made, but not beyond.  Really, they need to be live
@@ -422,9 +424,8 @@ void PhaseChaitin::Register_Allocate() {
     gather_lrg_masks(false);
     live.compute(_lrg_map.max_lrg_id());
     _live = &live;
+    C->print_method(PHASE_LIVE_RANGE_STRETCHING, 4);
   }
-
-  C->print_method(PHASE_INITIAL_LIVENESS, 4);
 
   // Create the interference graph using virtual copies
   build_ifg_virtual();  // Include stack slots this time

--- a/src/hotspot/share/opto/phasetype.hpp
+++ b/src/hotspot/share/opto/phasetype.hpp
@@ -100,6 +100,7 @@
   flags(MATCHING,                       "After matching") \
   flags(GLOBAL_CODE_MOTION,             "Global code motion") \
   flags(INITIAL_LIVENESS,               "Initial liveness") \
+  flags(LIVE_RANGE_STRETCHING,          "Live range stretching") \
   flags(AGGRESSIVE_COALESCING,          "Aggressive coalescing") \
   flags(INITIAL_SPILLING,               "Initial spilling") \
   flags(CONSERVATIVE_COALESCING,        "Conservative coalescing") \

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/CompilePhase.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/CompilePhase.java
@@ -108,6 +108,7 @@ public enum CompilePhase {
     MATCHING("After matching", RegexType.MACH),
     GLOBAL_CODE_MOTION("Global code motion", RegexType.MACH),
     INITIAL_LIVENESS("Initial liveness", RegexType.MACH),
+    LIVE_RANGE_STRETCHING("Live range stretching", RegexType.MACH),
     AGGRESSIVE_COALESCING("Aggressive coalescing", RegexType.MACH),
     INITIAL_SPILLING("Initial spilling", RegexType.MACH),
     CONSERVATIVE_COALESCING("Conservative coalescing", RegexType.MACH, ActionOnRepeat.KEEP_FIRST),


### PR DESCRIPTION
This PR introduces a new phase `LIVE_RANGE_STRETCHING` that prints after live ranges have been stretched, if that happens at all. The phase `INITIAL_LIVENESS` is moved before live range stretching so we can compare the live ranges before and after stretching in IGV, which is useful for debugging why an oop suddenly belongs to an oop map.

## Testing

 - [x] [Github Actions](https://github.com/mhaessig/jdk/actions/runs/15299362485)
 - [x] tier1 and tier1, plus additional Oracle internal testing for all Oracle supported platforms and OSs
 - [x] verified that the new phase prints when it should in IGV and with `-XX:PrintPhaseLevel=4`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8354930](https://bugs.openjdk.org/browse/JDK-8354930): IGV: dump C2 graph before and after live range stretching (**Enhancement** - P4)


### Reviewers
 * [Roberto Castañeda Lozano](https://openjdk.org/census#rcastanedalo) (@robcasloz - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25492/head:pull/25492` \
`$ git checkout pull/25492`

Update a local copy of the PR: \
`$ git checkout pull/25492` \
`$ git pull https://git.openjdk.org/jdk.git pull/25492/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25492`

View PR using the GUI difftool: \
`$ git pr show -t 25492`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25492.diff">https://git.openjdk.org/jdk/pull/25492.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25492#issuecomment-2916056291)
</details>
