### PR TITLE
8357979: [JVMCI] jdk.internal.vm.ci should have earlier class file version

### DIFF
--- a/make/modules/jdk.internal.vm.ci/Java.gmk
+++ b/make/modules/jdk.internal.vm.ci/Java.gmk
@@ -27,10 +27,12 @@
 
 DISABLED_WARNINGS_java += dangling-doc-comments this-escape
 
+VERSION_JVMCI = $(shell $(EXPR) $(VERSION_FEATURE) - 1 )
+
 # -parameters provides method's parameters information in class file,
 # JVMCI compilers make use of that information for various sanity checks.
 # Don't use Indy strings concatenation to have good JVMCI startup performance.
 
-JAVAC_FLAGS += -parameters -XDstringConcat=inline
+JAVAC_FLAGS += -parameters -XDstringConcat=inline --source $(VERSION_JVMCI) --target $(VERSION_JVMCI)
 
 ################################################################################

--- a/make/modules/jdk.internal.vm.ci/Java.gmk
+++ b/make/modules/jdk.internal.vm.ci/Java.gmk
@@ -27,12 +27,14 @@
 
 DISABLED_WARNINGS_java += dangling-doc-comments this-escape
 
-VERSION_JVMCI = $(shell $(EXPR) $(VERSION_FEATURE) - 1 )
+# Target an older JDK so JVMCI class files can be read by Native Image
+# running on an older JDK.
+JVMCI_SOURCETARGET = $(BOOT_JDK_SOURCETARGET)
 
 # -parameters provides method's parameters information in class file,
 # JVMCI compilers make use of that information for various sanity checks.
 # Don't use Indy strings concatenation to have good JVMCI startup performance.
 
-JAVAC_FLAGS += -parameters -XDstringConcat=inline --source $(VERSION_JVMCI) --target $(VERSION_JVMCI)
+JAVAC_FLAGS += -parameters -XDstringConcat=inline $(JVMCI_SOURCETARGET)
 
 ################################################################################


### PR DESCRIPTION
There are plans to have libgraal be built for JDK master using a version of Native Image running on a JDK one version behind the current JDK. This Native Image execution needs to be able to load the JVMCI classes. As such, the JVMCI classes must have a class file major version of N-1 where N is the major class file version of the current JDK.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8357979](https://bugs.openjdk.org/browse/JDK-8357979)

### Issue
 * [JDK-8357979](https://bugs.openjdk.org/browse/JDK-8357979): Compile jdk.internal.vm.ci targeting the Boot JDK version (**Enhancement** - P4) ⚠️ Title mismatch between PR and JBS. ⚠️ Issue is already resolved. Consider making this a "backport pull request" by setting the PR title to `Backport <hash>` with the hash of the original commit. See [Backports](https://wiki.openjdk.org/display/SKARA/Backports).


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25494/head:pull/25494` \
`$ git checkout pull/25494`

Update a local copy of the PR: \
`$ git checkout pull/25494` \
`$ git pull https://git.openjdk.org/jdk.git pull/25494/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25494`

View PR using the GUI difftool: \
`$ git pr show -t 25494`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25494.diff">https://git.openjdk.org/jdk/pull/25494.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25494#issuecomment-2916596856)
</details>
