### PR TITLE
8357981: [PPC64] Remove old instructions from VM_Version::determine_features()

### DIFF
--- a/src/hotspot/cpu/ppc/vm_version_ppc.cpp
+++ b/src/hotspot/cpu/ppc/vm_version_ppc.cpp
@@ -479,29 +479,10 @@ void VM_Version::determine_features() {
   // Emit code.
   void (*test)(address addr, uint64_t offset)=(void(*)(address addr, uint64_t offset))(void *)a->function_entry();
   uint32_t *code = (uint32_t *)a->pc();
-  // Don't use R0 in ldarx.
   // Keep R3_ARG1 unmodified, it contains &field (see below).
   // Keep R4_ARG2 unmodified, it contains offset = 0 (see below).
-  a->fsqrt(F3, F4);                            // code[0]  -> fsqrt_m
-  a->fsqrts(F3, F4);                           // code[1]  -> fsqrts_m
-  a->isel(R7, R5, R6, 0);                      // code[2]  -> isel_m
-  a->ldarx_unchecked(R7, R3_ARG1, R4_ARG2, 1); // code[3]  -> lxarx_m
-  a->cmpb(R7, R5, R6);                         // code[4]  -> cmpb
-  a->popcntb(R7, R5);                          // code[5]  -> popcntb
-  a->popcntw(R7, R5);                          // code[6]  -> popcntw
-  a->fcfids(F3, F4);                           // code[7]  -> fcfids
-  a->vand(VR0, VR0, VR0);                      // code[8]  -> vand
-  // arg0 of lqarx must be an even register, (arg1 + arg2) must be a multiple of 16
-  a->lqarx_unchecked(R6, R3_ARG1, R4_ARG2, 1); // code[9]  -> lqarx_m
-  a->vcipher(VR0, VR1, VR2);                   // code[10] -> vcipher
-  a->vpmsumb(VR0, VR1, VR2);                   // code[11] -> vpmsumb
-  a->mfdscr(R0);                               // code[12] -> mfdscr
-  a->lxvd2x(VSR0, R3_ARG1);                    // code[13] -> vsx
-  a->ldbrx(R7, R3_ARG1, R4_ARG2);              // code[14] -> ldbrx
-  a->stdbrx(R7, R3_ARG1, R4_ARG2);             // code[15] -> stdbrx
-  a->vshasigmaw(VR0, VR1, 1, 0xF);             // code[16] -> vshasig
-  a->darn(R7);                                 // code[17] -> darn
-  a->brw(R5, R6);                              // code[18] -> brw
+  a->darn(R7);
+  a->brw(R5, R6);
   a->blr();
 
   // Emit function to set one cache line to zero. Emit function descriptor and get pointer to it.
@@ -536,23 +517,6 @@ void VM_Version::determine_features() {
 
   // determine which instructions are legal.
   int feature_cntr = 0;
-  if (code[feature_cntr++]) features |= fsqrt_m;
-  if (code[feature_cntr++]) features |= fsqrts_m;
-  if (code[feature_cntr++]) features |= isel_m;
-  if (code[feature_cntr++]) features |= lxarxeh_m;
-  if (code[feature_cntr++]) features |= cmpb_m;
-  if (code[feature_cntr++]) features |= popcntb_m;
-  if (code[feature_cntr++]) features |= popcntw_m;
-  if (code[feature_cntr++]) features |= fcfids_m;
-  if (code[feature_cntr++]) features |= vand_m;
-  if (code[feature_cntr++]) features |= lqarx_m;
-  if (code[feature_cntr++]) features |= vcipher_m;
-  if (code[feature_cntr++]) features |= vpmsumb_m;
-  if (code[feature_cntr++]) features |= mfdscr_m;
-  if (code[feature_cntr++]) features |= vsx_m;
-  if (code[feature_cntr++]) features |= ldbrx_m;
-  if (code[feature_cntr++]) features |= stdbrx_m;
-  if (code[feature_cntr++]) features |= vshasig_m;
   if (code[feature_cntr++]) features |= darn_m;
   if (code[feature_cntr++]) features |= brw_m;
 

--- a/src/hotspot/cpu/ppc/vm_version_ppc.hpp
+++ b/src/hotspot/cpu/ppc/vm_version_ppc.hpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2012, 2024 SAP SE. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,46 +32,12 @@
 class VM_Version: public Abstract_VM_Version {
 protected:
   enum Feature_Flag {
-    fsqrt,
-    fsqrts,
-    isel,
-    lxarxeh,
-    cmpb,
-    popcntb,
-    popcntw,
-    fcfids,
-    vand,
-    lqarx,
-    vcipher,
-    vpmsumb,
-    mfdscr,
-    vsx,
-    ldbrx,
-    stdbrx,
-    vshasig,
     darn,
     brw,
     num_features // last entry to count features
   };
   enum Feature_Flag_Set {
     unknown_m             = 0,
-    fsqrt_m               = (1 << fsqrt  ),
-    fsqrts_m              = (1 << fsqrts ),
-    isel_m                = (1 << isel   ),
-    lxarxeh_m             = (1 << lxarxeh),
-    cmpb_m                = (1 << cmpb   ),
-    popcntb_m             = (1 << popcntb),
-    popcntw_m             = (1 << popcntw),
-    fcfids_m              = (1 << fcfids ),
-    vand_m                = (1 << vand   ),
-    lqarx_m               = (1 << lqarx  ),
-    vcipher_m             = (1 << vcipher),
-    vpmsumb_m             = (1 << vpmsumb),
-    mfdscr_m              = (1 << mfdscr ),
-    vsx_m                 = (1 << vsx    ),
-    ldbrx_m               = (1 << ldbrx  ),
-    stdbrx_m              = (1 << stdbrx ),
-    vshasig_m             = (1 << vshasig),
     darn_m                = (1 << darn   ),
     brw_m                 = (1 << brw    ),
     all_features_m        = (unsigned long)-1
@@ -101,7 +67,6 @@ public:
 
   static bool is_determine_features_test_running() { return _is_determine_features_test_running; }
   // CPU instruction support
-  static bool has_mfdscr()  { return (_features & mfdscr_m) != 0; }
   static bool has_darn()    { return (_features & darn_m) != 0; }
   static bool has_brw()     { return (_features & brw_m) != 0; }
 


### PR DESCRIPTION
Simple cleanup after [JDK-8331859](https://bugs.openjdk.org/browse/JDK-8331859). The old instructions are always available and don't need to be tried in `VM_Version::determine_features()`.

On Power10:
```
--------------------------------------------------------------------------------
Decoding cpu-feature detection stub at 0x000079b9203c0380 after execution:
--------------------------------------------------------------------------------
  0x000079b9203c0380:   darn    r7,1
  0x000079b9203c0384:   brw     r5,r6
  0x000079b9203c0388:   blr     bo=0b10100,bh=0b00[subroutine_return]
  0x000079b9203c038c:   dcbz    0,r3
  0x000079b9203c0390:   blr     bo=0b10100,bh=0b00[subroutine_return]
```

Also tested on older processors: On Power9, `brw` gets zeroed out. On Power8, `darn` also gets zeroed out.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8357981](https://bugs.openjdk.org/browse/JDK-8357981): [PPC64] Remove old instructions from VM_Version::determine_features() (**Sub-task** - P4)


### Reviewers
 * [David Briemann](https://openjdk.org/census#dbriemann) (@dbriemann - Author)
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25495/head:pull/25495` \
`$ git checkout pull/25495`

Update a local copy of the PR: \
`$ git checkout pull/25495` \
`$ git pull https://git.openjdk.org/jdk.git pull/25495/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25495`

View PR using the GUI difftool: \
`$ git pr show -t 25495`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25495.diff">https://git.openjdk.org/jdk/pull/25495.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25495#issuecomment-2916590428)
</details>
