### PR TITLE
8357910: LoaderConstraintsTest.java fails when run with TEST_THREAD_FACTORY=Virtual

### DIFF
--- a/test/hotspot/jtreg/ProblemList-Virtual.txt
+++ b/test/hotspot/jtreg/ProblemList-Virtual.txt
@@ -97,7 +97,6 @@ gc/arguments/TestNewSizeThreadIncrease.java 0000000 generic-all
 gc/g1/TestSkipRebuildRemsetPhase.java 0000000 generic-all
 runtime/classFileParserBug/TestEmptyBootstrapMethodsAttr.java 8346442 generic-all
 runtime/ErrorHandling/MachCodeFramesInErrorFile.java 0000000 generic-all
-runtime/logging/LoaderConstraintsTest.java 8346442 generic-all
 runtime/Thread/AsyncExceptionOnMonitorEnter.java 0000000 generic-all
 runtime/Thread/StopAtExit.java 0000000 generic-all
 runtime/handshake/HandshakeWalkStackTest.java 0000000 generic-all

--- a/test/hotspot/jtreg/runtime/logging/LoaderConstraintsTest.java
+++ b/test/hotspot/jtreg/runtime/logging/LoaderConstraintsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,8 +29,6 @@
  * @modules java.base/jdk.internal.misc
  * @library /test/lib classes
  * @build test.Empty
- * @build jdk.test.whitebox.WhiteBox
- * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
  * @run driver LoaderConstraintsTest
  */
 
@@ -38,6 +36,7 @@ import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.process.OutputAnalyzer;
 import java.lang.ref.WeakReference;
 import java.lang.reflect.Method;
+import java.lang.reflect.Constructor;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -49,22 +48,23 @@ public class LoaderConstraintsTest {
     private static ProcessBuilder pb;
     private static class ClassUnloadTestMain {
         public static void main(String... args) throws Exception {
-            String className = "test.Empty";
             ClassLoader cl = ClassUnloadCommon.newClassLoader();
-            Class<?> c = cl.loadClass(className);
-            cl = null; c = null;
-            ClassUnloadCommon.triggerUnloading();
+            Class<?> c = cl.loadClass("test.Empty");
+            // Causes class test.Emtpy to be linked, which triggers the
+            // constraint on class String due to override of toString().
+            Constructor<?> constructor = c.getDeclaredConstructor();
         }
     }
 
     // Use the same command-line heap size setting as ../ClassUnload/UnloadTest.java
     static ProcessBuilder exec(String... args) throws Exception {
+        String classPath = System.getProperty("test.class.path", ".");
+
         List<String> argsList = new ArrayList<>();
         Collections.addAll(argsList, args);
         Collections.addAll(argsList, "-Xmn8m");
         Collections.addAll(argsList, "-Xbootclasspath/a:.");
-        Collections.addAll(argsList, "-XX:+UnlockDiagnosticVMOptions");
-        Collections.addAll(argsList, "-XX:+WhiteBoxAPI");
+        Collections.addAll(argsList, "-Dtest.class.path=" + classPath);
         Collections.addAll(argsList, ClassUnloadTestMain.class.getName());
         return ProcessTools.createLimitedTestJavaProcessBuilder(argsList);
     }
@@ -75,13 +75,12 @@ public class LoaderConstraintsTest {
         pb = exec("-Xlog:class+loader+constraints=info");
         out = new OutputAnalyzer(pb.start());
         out.shouldHaveExitValue(0);
-        out.shouldContain("[class,loader,constraints] adding new constraint for name: java/lang/Class, loader[0]: 'app', loader[1]: 'bootstrap'");
+        out.stdoutShouldMatch("\\[class,loader,constraints\\] adding new constraint for name: java/lang/String, loader\\[0\\]: 'ClassUnloadCommonClassLoader' @[\\da-f]+, loader\\[1\\]: 'bootstrap'");
 
         // -Xlog:class+loader+constraints=off
         pb = exec("-Xlog:class+loader+constraints=off");
         out = new OutputAnalyzer(pb.start());
         out.shouldHaveExitValue(0);
         out.shouldNotContain("[class,loader,constraints]");
-
     }
 }


### PR DESCRIPTION
Please review this small test fix. When running LoaderConstraintsTest with `TEST_THREAD_FACTORY=Virtual` we load class `java.lang.Class` earlier than expected which causes the test to fail because of a missing loader constraint logging output. I added the full details of the issue in the JBS comments. 

The fix changes the constraint we look for to be on class `java.lang.String` between classloader `ClassUnloadCommonClassLoader` and the bootstrap classloader. This allows the test to be more robust and not depend on some hidden behavior. In fact, the only line that is currently needed for the test to pass for the platform thread case is the call to `ClassUnloadCommon.newClassLoader()`, which seems a bit obscure. Also as explained in JBS, the defining loader of `test.Empty` is currently the builtin system classloader, not `ClassUnloadCommonClassLoader` as the test would suggest.

Thanks,
Patricio