### PR TITLE
8357987: [JVMCI] Add Support for Retrieving All Non-Static Methods of a ResolvedJavaType.

### DIFF
--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/CompilerToVM.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/CompilerToVM.java
@@ -177,6 +177,17 @@ final class CompilerToVM {
     private native boolean isCompilable(HotSpotResolvedJavaMethodImpl method, long methodPointer);
 
     /**
+     * Returns whether {@code method} is an overpass method.
+     * Overpass methods are instance methods which are created when otherwise a valid candidate
+     * for method resolution would not be found.
+     */
+    boolean isOverpass(HotSpotResolvedJavaMethodImpl method) {
+        return isOverpass(method, method.getMethodPointer());
+    }
+
+    private native boolean isOverpass(HotSpotResolvedJavaMethodImpl method, long methodPointer);
+
+    /**
      * Determines if {@code method} is targeted by a VM directive (e.g.,
      * {@code -XX:CompileCommand=dontinline,<pattern>}) or annotation (e.g.,
      * {@code jdk.internal.vm.annotation.DontInline}) that specifies it should not be inlined.
@@ -1148,13 +1159,22 @@ final class CompilerToVM {
     native ResolvedJavaMethod[] getDeclaredConstructors(HotSpotResolvedObjectTypeImpl klass, long klassPointer);
 
     /**
-     * Gets the {@link ResolvedJavaMethod}s for all the non-constructor methods of {@code klass}.
+     * Gets the {@link ResolvedJavaMethod}s for all non-overpass instance methods of {@code klass}.
      */
     ResolvedJavaMethod[] getDeclaredMethods(HotSpotResolvedObjectTypeImpl klass) {
         return getDeclaredMethods(klass, klass.getKlassPointer());
     }
 
     native ResolvedJavaMethod[] getDeclaredMethods(HotSpotResolvedObjectTypeImpl klass, long klassPointer);
+
+    /**
+     * Gets the {@link ResolvedJavaMethod}s for all instance methods of {@code klass}.
+     */
+    ResolvedJavaMethod[] getInstanceMethods(HotSpotResolvedObjectTypeImpl klass) {
+        return getInstanceMethods(klass, klass.getKlassPointer());
+    }
+
+    native ResolvedJavaMethod[] getInstanceMethods(HotSpotResolvedObjectTypeImpl klass, long klassPointer);
 
     HotSpotResolvedObjectTypeImpl.FieldInfo[] getDeclaredFieldsInfo(HotSpotResolvedObjectTypeImpl klass) {
         return getDeclaredFieldsInfo(klass, klass.getKlassPointer());

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotResolvedJavaMethodImpl.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotResolvedJavaMethodImpl.java
@@ -573,6 +573,19 @@ final class HotSpotResolvedJavaMethodImpl extends HotSpotMethod implements HotSp
         return ((getModifiers() & mask) == Modifier.PUBLIC) && getDeclaringClass().isInterface();
     }
 
+    /*
+     * Currently in hotspot an instance method can either be a "normal" or an "overpass" method.
+     * Overpass methods are instance methods which are created when otherwise a valid candidate
+     * for method resolution would not be found.
+     */
+    @Override
+    public boolean isDeclared() {
+        if (isConstructor() || isStatic()) {
+            return false;
+        }
+        return !compilerToVM().isOverpass(this);
+    }
+
     @Override
     public Type[] getGenericParameterTypes() {
         if (isClassInitializer()) {

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotResolvedObjectTypeImpl.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotResolvedObjectTypeImpl.java
@@ -1068,6 +1068,18 @@ final class HotSpotResolvedObjectTypeImpl extends HotSpotResolvedJavaType implem
     }
 
     @Override
+    public List<ResolvedJavaMethod> getNonStaticMethods(boolean forceLink) {
+        if (forceLink) {
+            link();
+        }
+        ResolvedJavaMethod[] instanceMethods = runtime().compilerToVm.getInstanceMethods(this);
+        if (instanceMethods.length == 0) {
+            return List.of();
+        }
+        return Collections.unmodifiableList(Arrays.asList(instanceMethods));
+    }
+
+    @Override
     public ResolvedJavaMethod getClassInitializer() {
         if (!isArray()) {
             return compilerToVM().getClassInitializer(this);

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotResolvedPrimitiveType.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotResolvedPrimitiveType.java
@@ -297,6 +297,11 @@ public final class HotSpotResolvedPrimitiveType extends HotSpotResolvedJavaType 
     }
 
     @Override
+    public List<ResolvedJavaMethod> getNonStaticMethods(boolean forceLink) {
+        return List.of();
+    }
+
+    @Override
     public ResolvedJavaMethod getClassInitializer() {
         return null;
     }

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/meta/ResolvedJavaMethod.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/meta/ResolvedJavaMethod.java
@@ -115,6 +115,12 @@ public interface ResolvedJavaMethod extends JavaMethod, InvokeTarget, ModifiersP
     boolean isDefault();
 
     /**
+     * Returns {@code true} if this method would be contained in the array returned by
+     * {@code getDeclaringClass().getDeclaredMethods()}
+     */
+    boolean isDeclared();
+
+    /**
      * Checks whether this method is a class initializer.
      *
      * @return {@code true} if the method is a class initializer

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/meta/ResolvedJavaType.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/meta/ResolvedJavaType.java
@@ -23,6 +23,7 @@
 package jdk.vm.ci.meta;
 
 import java.lang.reflect.AnnotatedElement;
+import java.util.List;
 
 import jdk.vm.ci.meta.Assumptions.AssumptionResult;
 
@@ -364,6 +365,13 @@ public interface ResolvedJavaType extends JavaType, ModifiersProvider, Annotated
     default ResolvedJavaMethod[] getDeclaredMethods(boolean forceLink) {
         throw new UnsupportedOperationException();
     }
+
+    /**
+     * Returns a list containing all the non-static methods present within this type.
+     *
+     * @param forceLink if {@code true}, forces this type to be {@link #link linked}
+     */
+    List<ResolvedJavaMethod> getNonStaticMethods(boolean forceLink);
 
     /**
      * Returns the {@code <clinit>} method for this class if there is one.

--- a/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.runtime.test/src/jdk/vm/ci/runtime/test/TestResolvedJavaMethod.java
+++ b/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.runtime.test/src/jdk/vm/ci/runtime/test/TestResolvedJavaMethod.java
@@ -426,6 +426,20 @@ public class TestResolvedJavaMethod extends MethodUniverse {
     }
 
     @Test
+    public void isDeclaredTest() {
+        for (Map.Entry<Method, ResolvedJavaMethod> e : methods.entrySet()) {
+            ResolvedJavaMethod m = e.getValue();
+            Method k = e.getKey();
+            boolean expectedDeclared = !Modifier.isStatic(k.getModifiers());
+            assertEquals(expectedDeclared, m.isDeclared());
+        }
+        for (Map.Entry<Constructor<?>, ResolvedJavaMethod> e : constructors.entrySet()) {
+            ResolvedJavaMethod m = e.getValue();
+            assertFalse(m.isDeclared());
+        }
+    }
+
+    @Test
     public void hasReceiverTest() {
         for (Map.Entry<Method, ResolvedJavaMethod> e : methods.entrySet()) {
             ResolvedJavaMethod m = e.getValue();

--- a/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.runtime.test/src/jdk/vm/ci/runtime/test/TestResolvedJavaType.java
+++ b/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.runtime.test/src/jdk/vm/ci/runtime/test/TestResolvedJavaType.java
@@ -1019,6 +1019,23 @@ public class TestResolvedJavaType extends TypeUniverse {
         }
     }
 
+    @Test
+    public void getNonStaticMethodsTest() {
+        for (Class<?> c : classes) {
+            ResolvedJavaType type = metaAccess.lookupJavaType(c);
+            Method[] raw = c.getDeclaredMethods();
+            Set<ResolvedJavaMethod> expected = new HashSet<>();
+            for (Method m : raw) {
+                ResolvedJavaMethod resolvedMethod = metaAccess.lookupJavaMethod(m);
+                assertNotNull(resolvedMethod);
+                expected.add(resolvedMethod);
+            }
+            Set<ResolvedJavaMethod> actual = new HashSet<>(type.getNonStaticMethods(false));
+            assertTrue(actual.size() >= expected.size());
+            assertTrue(actual.containsAll(expected));
+        }
+    }
+
     static class A {
         static String name = "foo";
     }


### PR DESCRIPTION
Currently from ResolvedJavaType one can retrieve all declared methods, static methods, and constructors of the given type. However, internally in HotSpot there are also VM-internal methods, such as overpass methods, associated with a given type which we cannot access via the API.

To correct this, we should add a new method which enables VM-internal methods, such as overpass methods, to be accessed.