### PR TITLE
8357982: Fix several failing BMI tests with -XX:+UseAPX

### DIFF
--- a/src/hotspot/cpu/x86/x86_64.ad
+++ b/src/hotspot/cpu/x86/x86_64.ad
@@ -10617,7 +10617,7 @@ instruct xorI_rReg_im1_ndd(rRegI dst, rRegI src, immI_M1 imm)
 // Xor Register with Immediate
 instruct xorI_rReg_imm(rRegI dst, immI src, rFlagsReg cr)
 %{
-  predicate(!UseAPX);
+  predicate(!UseAPX &&  n->in(2)->bottom_type()->is_int()->get_con() != -1);
   match(Set dst (XorI dst src));
   effect(KILL cr);
   flag(PD::Flag_sets_sign_flag, PD::Flag_sets_zero_flag, PD::Flag_sets_parity_flag, PD::Flag_clears_overflow_flag, PD::Flag_clears_carry_flag);
@@ -10631,7 +10631,7 @@ instruct xorI_rReg_imm(rRegI dst, immI src, rFlagsReg cr)
 
 instruct xorI_rReg_rReg_imm_ndd(rRegI dst, rRegI src1, immI src2, rFlagsReg cr)
 %{
-  predicate(UseAPX);
+  predicate(UseAPX && n->in(2)->bottom_type()->is_int()->get_con() != -1);
   match(Set dst (XorI src1 src2));
   effect(KILL cr);
   flag(PD::Flag_sets_sign_flag, PD::Flag_sets_zero_flag, PD::Flag_sets_parity_flag, PD::Flag_clears_overflow_flag, PD::Flag_clears_carry_flag);
@@ -10646,7 +10646,7 @@ instruct xorI_rReg_rReg_imm_ndd(rRegI dst, rRegI src1, immI src2, rFlagsReg cr)
 // Xor Memory with Immediate
 instruct xorI_rReg_mem_imm_ndd(rRegI dst, memory src1, immI src2, rFlagsReg cr)
 %{
-  predicate(UseAPX);
+  predicate(UseAPX && n->in(2)->bottom_type()->is_int()->get_con() != -1);
   match(Set dst (XorI (LoadI src1) src2));
   effect(KILL cr);
   flag(PD::Flag_sets_sign_flag, PD::Flag_sets_zero_flag, PD::Flag_sets_parity_flag, PD::Flag_clears_overflow_flag, PD::Flag_clears_carry_flag);
@@ -11321,7 +11321,7 @@ instruct xorL_rReg_im1_ndd(rRegL dst,rRegL src, immL_M1 imm)
 // Xor Register with Immediate
 instruct xorL_rReg_imm(rRegL dst, immL32 src, rFlagsReg cr)
 %{
-  predicate(!UseAPX);
+  predicate(!UseAPX && n->in(2)->bottom_type()->is_long()->get_con() != -1L);
   match(Set dst (XorL dst src));
   effect(KILL cr);
   flag(PD::Flag_sets_sign_flag, PD::Flag_sets_zero_flag, PD::Flag_sets_parity_flag, PD::Flag_clears_overflow_flag, PD::Flag_clears_carry_flag);
@@ -11335,7 +11335,7 @@ instruct xorL_rReg_imm(rRegL dst, immL32 src, rFlagsReg cr)
 
 instruct xorL_rReg_rReg_imm(rRegL dst, rRegL src1, immL32 src2, rFlagsReg cr)
 %{
-  predicate(UseAPX);
+  predicate(UseAPX && n->in(2)->bottom_type()->is_long()->get_con() != -1L);
   match(Set dst (XorL src1 src2));
   effect(KILL cr);
   flag(PD::Flag_sets_sign_flag, PD::Flag_sets_zero_flag, PD::Flag_sets_parity_flag, PD::Flag_clears_overflow_flag, PD::Flag_clears_carry_flag);
@@ -11350,7 +11350,7 @@ instruct xorL_rReg_rReg_imm(rRegL dst, rRegL src1, immL32 src2, rFlagsReg cr)
 // Xor Memory with Immediate
 instruct xorL_rReg_mem_imm(rRegL dst, memory src1, immL32 src2, rFlagsReg cr)
 %{
-  predicate(UseAPX);
+  predicate(UseAPX && n->in(2)->bottom_type()->is_long()->get_con() != -1L);
   match(Set dst (XorL (LoadL src1) src2));
   effect(KILL cr);
   flag(PD::Flag_sets_sign_flag, PD::Flag_sets_zero_flag, PD::Flag_sets_parity_flag, PD::Flag_clears_overflow_flag, PD::Flag_clears_carry_flag);

--- a/src/hotspot/cpu/x86/x86_64.ad
+++ b/src/hotspot/cpu/x86/x86_64.ad
@@ -10651,6 +10651,7 @@ instruct xorI_rReg_mem_imm_ndd(rRegI dst, memory src1, immI src2, rFlagsReg cr)
   predicate(UseAPX);
   match(Set dst (XorI (LoadI src1) src2));
   effect(KILL cr);
+  ins_cost(150);
   flag(PD::Flag_sets_sign_flag, PD::Flag_sets_zero_flag, PD::Flag_sets_parity_flag, PD::Flag_clears_overflow_flag, PD::Flag_clears_carry_flag);
 
   format %{ "exorl    $dst, $src1, $src2\t# int ndd" %}
@@ -11357,6 +11358,7 @@ instruct xorL_rReg_mem_imm(rRegL dst, memory src1, immL32 src2, rFlagsReg cr)
   match(Set dst (XorL (LoadL src1) src2));
   effect(KILL cr);
   flag(PD::Flag_sets_sign_flag, PD::Flag_sets_zero_flag, PD::Flag_sets_parity_flag, PD::Flag_clears_overflow_flag, PD::Flag_clears_carry_flag);
+  ins_cost(150);
 
   format %{ "exorq    $dst, $src1, $src2\t# long ndd" %}
   ins_encode %{

--- a/src/hotspot/cpu/x86/x86_64.ad
+++ b/src/hotspot/cpu/x86/x86_64.ad
@@ -10617,7 +10617,7 @@ instruct xorI_rReg_im1_ndd(rRegI dst, rRegI src, immI_M1 imm)
 // Xor Register with Immediate
 instruct xorI_rReg_imm(rRegI dst, immI src, rFlagsReg cr)
 %{
-  predicate(!UseAPX &&  n->in(2)->bottom_type()->is_int()->get_con() != -1);
+  predicate(!UseAPX && n->in(2)->bottom_type()->is_int()->get_con() != -1);
   match(Set dst (XorI dst src));
   effect(KILL cr);
   flag(PD::Flag_sets_sign_flag, PD::Flag_sets_zero_flag, PD::Flag_sets_parity_flag, PD::Flag_clears_overflow_flag, PD::Flag_clears_carry_flag);

--- a/src/hotspot/cpu/x86/x86_64.ad
+++ b/src/hotspot/cpu/x86/x86_64.ad
@@ -11324,6 +11324,7 @@ instruct xorL_rReg_im1_ndd(rRegL dst,rRegL src, immL_M1 imm)
 // Xor Register with Immediate
 instruct xorL_rReg_imm(rRegL dst, immL32 src, rFlagsReg cr)
 %{
+  // Strict predicate check to make selection of xorL_rReg_im1 cost agnostic if immL32 src is -1.
   predicate(!UseAPX && n->in(2)->bottom_type()->is_long()->get_con() != -1L);
   match(Set dst (XorL dst src));
   effect(KILL cr);

--- a/src/hotspot/cpu/x86/x86_64.ad
+++ b/src/hotspot/cpu/x86/x86_64.ad
@@ -10617,6 +10617,7 @@ instruct xorI_rReg_im1_ndd(rRegI dst, rRegI src, immI_M1 imm)
 // Xor Register with Immediate
 instruct xorI_rReg_imm(rRegI dst, immI src, rFlagsReg cr)
 %{
+  // Strict predicate check to make selection of xorI_rReg_im1 cost agnostic if immI src is -1.
   predicate(!UseAPX && n->in(2)->bottom_type()->is_int()->get_con() != -1);
   match(Set dst (XorI dst src));
   effect(KILL cr);
@@ -10631,6 +10632,7 @@ instruct xorI_rReg_imm(rRegI dst, immI src, rFlagsReg cr)
 
 instruct xorI_rReg_rReg_imm_ndd(rRegI dst, rRegI src1, immI src2, rFlagsReg cr)
 %{
+  // Strict predicate check to make selection of xorI_rReg_im1_ndd cost agnostic if immI src2 is -1.
   predicate(UseAPX && n->in(2)->bottom_type()->is_int()->get_con() != -1);
   match(Set dst (XorI src1 src2));
   effect(KILL cr);
@@ -10646,7 +10648,7 @@ instruct xorI_rReg_rReg_imm_ndd(rRegI dst, rRegI src1, immI src2, rFlagsReg cr)
 // Xor Memory with Immediate
 instruct xorI_rReg_mem_imm_ndd(rRegI dst, memory src1, immI src2, rFlagsReg cr)
 %{
-  predicate(UseAPX && n->in(2)->bottom_type()->is_int()->get_con() != -1);
+  predicate(UseAPX);
   match(Set dst (XorI (LoadI src1) src2));
   effect(KILL cr);
   flag(PD::Flag_sets_sign_flag, PD::Flag_sets_zero_flag, PD::Flag_sets_parity_flag, PD::Flag_clears_overflow_flag, PD::Flag_clears_carry_flag);
@@ -11335,6 +11337,7 @@ instruct xorL_rReg_imm(rRegL dst, immL32 src, rFlagsReg cr)
 
 instruct xorL_rReg_rReg_imm(rRegL dst, rRegL src1, immL32 src2, rFlagsReg cr)
 %{
+  // Strict predicate check to make selection of xorL_rReg_im1_ndd cost agnostic if immL32 src2 is -1.
   predicate(UseAPX && n->in(2)->bottom_type()->is_long()->get_con() != -1L);
   match(Set dst (XorL src1 src2));
   effect(KILL cr);
@@ -11350,7 +11353,7 @@ instruct xorL_rReg_rReg_imm(rRegL dst, rRegL src1, immL32 src2, rFlagsReg cr)
 // Xor Memory with Immediate
 instruct xorL_rReg_mem_imm(rRegL dst, memory src1, immL32 src2, rFlagsReg cr)
 %{
-  predicate(UseAPX && n->in(2)->bottom_type()->is_long()->get_con() != -1L);
+  predicate(UseAPX);
   match(Set dst (XorL (LoadL src1) src2));
   effect(KILL cr);
   flag(PD::Flag_sets_sign_flag, PD::Flag_sets_zero_flag, PD::Flag_sets_parity_flag, PD::Flag_clears_overflow_flag, PD::Flag_clears_carry_flag);

--- a/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/AndnTestI.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/AndnTestI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -55,6 +55,19 @@ public class AndnTestI extends BmiIntrinsicBase.BmiTestCase {
         instrPattern = new byte[]{
                 (byte) 0xC4, // prefix for 3-byte VEX instruction
                 (byte) 0x02, // 00010 implied 0F 38 leading opcode bytes
+                (byte) 0x00,
+                (byte) 0xF2};
+        // from intel apx specifications EVEX.128.NP.0F38.W0 F2 /r
+        instrMaskAPX = new byte[]{
+                (byte) 0xFF,
+                (byte) 0x07,
+                (byte) 0x00,
+                (byte) 0x00,
+                (byte) 0xFF};
+        instrPatternAPX = new byte[]{
+                (byte) 0x62, // fixed prefix byte 0x62 for extended EVEX instruction
+                (byte) 0x02, // 00010 implied 0F 38 leading opcode bytes
+                (byte) 0x00,
                 (byte) 0x00,
                 (byte) 0xF2};
     }

--- a/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/BlsiTestI.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/BlsiTestI.java
@@ -75,7 +75,7 @@ public class BlsiTestI extends BmiIntrinsicBase.BmiTestCase {
                 (byte) 0x00,
                 (byte) 0x00,
                 (byte) 0xF3,
-                (byte) 0x3};
+                (byte) 0b0001_1000}; // bits 543 == 011 (3)
     }
 
     public static void main(String[] args) throws Exception {

--- a/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/BlsiTestI.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/BlsiTestI.java
@@ -59,6 +59,23 @@ public class BlsiTestI extends BmiIntrinsicBase.BmiTestCase {
                 (byte) 0x00,
                 (byte) 0xF3,
                 (byte) 0b0001_1000}; // bits 543 == 011 (3)
+
+        // from intel apx specifications EVEX.128.NP.0F38.W0 F3 /3(opcode extension)
+        instrMaskAPX = new byte[]{
+                (byte) 0xFF,
+                (byte) 0x07,
+                (byte) 0x00,
+                (byte) 0x00,
+                (byte) 0xFF,
+                (byte) 0x38};
+
+        instrPatternAPX = new byte[]{
+                (byte) 0x62, // fixed prefix byte 0x62 for extended EVEX instruction
+                (byte) 0x02, // 00010 implied 0F 38 leading opcode bytes
+                (byte) 0x00,
+                (byte) 0x00,
+                (byte) 0xF3,
+                (byte) 0x3};
     }
 
     public static void main(String[] args) throws Exception {

--- a/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/BlsmskTestI.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/BlsmskTestI.java
@@ -57,7 +57,7 @@ public class BlsmskTestI extends BmiIntrinsicBase.BmiTestCase {
                 (byte) 0x02, // 00010 implied 0F 38 leading opcode bytes
                 (byte) 0x00,
                 (byte) 0xF3,
-                (byte) 0b0001_0000}; // bits 543 == 011 (3)
+                (byte) 0b0001_0000}; // bits 543 == 010 (2)
 
         // from intel apx specifications EVEX.128.NP.0F38.W1 F3 /2(opcode extension part of ModRM.REG)
         instrMaskAPX = new byte[]{
@@ -74,7 +74,7 @@ public class BlsmskTestI extends BmiIntrinsicBase.BmiTestCase {
                 (byte) 0x00,
                 (byte) 0x00,
                 (byte) 0xF3,
-                (byte) 0x2};
+                (byte) 0b0001_0000}; // bits 543 == 010 (2)
     }
 
     public static void main(String[] args) throws Exception {

--- a/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/BlsmskTestI.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/BlsmskTestI.java
@@ -58,6 +58,23 @@ public class BlsmskTestI extends BmiIntrinsicBase.BmiTestCase {
                 (byte) 0x00,
                 (byte) 0xF3,
                 (byte) 0b0001_0000}; // bits 543 == 011 (3)
+
+        // from intel apx specifications EVEX.128.NP.0F38.W1 F3 /2(opcode extension part of ModRM.REG)
+        instrMaskAPX = new byte[]{
+                (byte) 0xFF,
+                (byte) 0x07,
+                (byte) 0x00,
+                (byte) 0x00,
+                (byte) 0xFF,
+                (byte) 0x38};
+
+        instrPatternAPX = new byte[]{
+                (byte) 0x62, // fixed prefix byte 0x62 for extended EVEX instruction
+                (byte) 0x02, // 00010 implied 0F 38 leading opcode bytes
+                (byte) 0x00,
+                (byte) 0x00,
+                (byte) 0xF3,
+                (byte) 0x2};
     }
 
     public static void main(String[] args) throws Exception {

--- a/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/BlsrTestI.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/BlsrTestI.java
@@ -58,7 +58,7 @@ public class BlsrTestI extends BmiIntrinsicBase.BmiTestCase {
                 (byte) 0x02, // 00010 implied 0F 38 leading opcode bytes
                 (byte) 0x00,
                 (byte) 0xF3,
-                (byte) 0b0000_1000}; // bits 543 == 011 (3)
+                (byte) 0b0000_1000}; // bits 543 == 001 (1)
 
         // from intel apx specifications EVEX.128.NP.0F38.W1 F3 /1(opcode extension part of ModRM.REG)
         instrMaskAPX = new byte[]{
@@ -75,7 +75,7 @@ public class BlsrTestI extends BmiIntrinsicBase.BmiTestCase {
                 (byte) 0x00,
                 (byte) 0x00,
                 (byte) 0xF3,
-                (byte) 0x1};
+                (byte) 0b0000_1000}; // bits 543 == 001 (1)
 
     }
 

--- a/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/BlsrTestI.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/BlsrTestI.java
@@ -59,6 +59,24 @@ public class BlsrTestI extends BmiIntrinsicBase.BmiTestCase {
                 (byte) 0x00,
                 (byte) 0xF3,
                 (byte) 0b0000_1000}; // bits 543 == 011 (3)
+
+        // from intel apx specifications EVEX.128.NP.0F38.W1 F3 /1(opcode extension part of ModRM.REG)
+        instrMaskAPX = new byte[]{
+                (byte) 0xFF,
+                (byte) 0x07,
+                (byte) 0x00,
+                (byte) 0x00,
+                (byte) 0xFF,
+                (byte) 0x38};
+
+        instrPatternAPX = new byte[]{
+                (byte) 0x62, // fixed prefix byte 0x62 for extended EVEX instruction
+                (byte) 0x02, // 00010 implied 0F 38 leading opcode bytes
+                (byte) 0x00,
+                (byte) 0x00,
+                (byte) 0xF3,
+                (byte) 0x1};
+
     }
 
     public static void main(String[] args) throws Exception {

--- a/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/BzhiTestI2L.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/BzhiTestI2L.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -73,6 +73,21 @@ public class BzhiTestI2L extends BmiIntrinsicBase.BmiTestCase_x64 {
             (byte) 0x62,    // 00010 implied 0F 38 leading opcode bytes
             (byte) 0xA8,
             (byte) 0xF5};
+
+        // from intel apx specifications EVEX.128.NP.0F38.W0 F5 /r
+        instrMaskAPX = new byte[]{
+                (byte) 0xFF,
+                (byte) 0x07,
+                (byte) 0x00,
+                (byte) 0x00,
+                (byte) 0xFF};
+
+        instrPatternAPX = new byte[]{
+                (byte) 0x62, // fixed prefix byte 0x62 for extended EVEX instruction
+                (byte) 0x02, // 00010 implied 0F 38 leading opcode bytes
+                (byte) 0x00,
+                (byte) 0x00,
+                (byte) 0xF5};
     }
 
     public static void main(String[] args) throws Exception {

--- a/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/LZcntTestI.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/LZcntTestI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,6 +51,9 @@ public class LZcntTestI extends BmiIntrinsicBase.BmiTestCase_x64 {
 
         instrMask_x64 = new byte[]{(byte) 0xFF, (byte) 0x00, (byte) 0xFF, (byte) 0xFF};
         instrPattern_x64 = new byte[]{(byte) 0xF3, (byte) 0x00, (byte) 0x0F, (byte) 0xBD};
+
+        instrMaskAPX = new byte[]{(byte) 0xFF, (byte)0x80, (byte) 0xFF};
+        instrPatternAPX = new byte[]{(byte) 0xD5, (byte) 0x80, (byte) 0xBD};
     }
 
     public static void main(String[] args) throws Exception {

--- a/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/LZcntTestI.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/LZcntTestI.java
@@ -53,8 +53,8 @@ public class LZcntTestI extends BmiIntrinsicBase.BmiTestCase_x64 {
         instrPattern_x64 = new byte[]{(byte) 0xF3, (byte) 0x00, (byte) 0x0F, (byte) 0xBD};
 
         // REX2 variant
-        instrMaskAPX = new byte[]{(byte) 0xFF, (byte)0x80, (byte) 0xFF};
-        instrPatternAPX = new byte[]{(byte) 0xD5, (byte) 0x80, (byte) 0xBD};
+        instrMaskAPX = new byte[]{(byte) 0xFF, (byte) 0xFF, (byte)0x80, (byte) 0xFF};
+        instrPatternAPX = new byte[]{(byte) 0xF3, (byte) 0xD5, (byte) 0x80, (byte) 0xBD};
     }
 
     public static void main(String[] args) throws Exception {

--- a/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/LZcntTestI.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/LZcntTestI.java
@@ -52,6 +52,7 @@ public class LZcntTestI extends BmiIntrinsicBase.BmiTestCase_x64 {
         instrMask_x64 = new byte[]{(byte) 0xFF, (byte) 0x00, (byte) 0xFF, (byte) 0xFF};
         instrPattern_x64 = new byte[]{(byte) 0xF3, (byte) 0x00, (byte) 0x0F, (byte) 0xBD};
 
+        // REX2 variant
         instrMaskAPX = new byte[]{(byte) 0xFF, (byte)0x80, (byte) 0xFF};
         instrPatternAPX = new byte[]{(byte) 0xD5, (byte) 0x80, (byte) 0xBD};
     }

--- a/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/TZcntTestI.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/TZcntTestI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,6 +50,9 @@ public class TZcntTestI extends BmiIntrinsicBase.BmiTestCase_x64 {
 
         instrMask_x64 = new byte[]{(byte) 0xFF, (byte) 0x00, (byte) 0xFF, (byte) 0xFF};
         instrPattern_x64 = new byte[]{(byte) 0xF3, (byte) 0x00, (byte) 0x0F, (byte) 0xBC};
+
+        instrMaskAPX = new byte[]{(byte) 0xFF, (byte)0x80, (byte) 0xFF};
+        instrPatternAPX = new byte[]{(byte) 0xD5, (byte) 0x80, (byte) 0xBC};
     }
 
     public static void main(String[] args) throws Exception {

--- a/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/TZcntTestI.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/TZcntTestI.java
@@ -52,8 +52,8 @@ public class TZcntTestI extends BmiIntrinsicBase.BmiTestCase_x64 {
         instrPattern_x64 = new byte[]{(byte) 0xF3, (byte) 0x00, (byte) 0x0F, (byte) 0xBC};
 
         // REX2 variant
-        instrMaskAPX = new byte[]{(byte) 0xFF, (byte)0x80, (byte) 0xFF};
-        instrPatternAPX = new byte[]{(byte) 0xD5, (byte) 0x80, (byte) 0xBC};
+        instrMaskAPX = new byte[]{(byte) 0xFF, (byte) 0xFF, (byte)0x80, (byte) 0xFF};
+        instrPatternAPX = new byte[]{(byte) 0xF3, (byte) 0xD5, (byte) 0x80, (byte) 0xBC};
     }
 
     public static void main(String[] args) throws Exception {

--- a/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/TZcntTestI.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/TZcntTestI.java
@@ -51,6 +51,7 @@ public class TZcntTestI extends BmiIntrinsicBase.BmiTestCase_x64 {
         instrMask_x64 = new byte[]{(byte) 0xFF, (byte) 0x00, (byte) 0xFF, (byte) 0xFF};
         instrPattern_x64 = new byte[]{(byte) 0xF3, (byte) 0x00, (byte) 0x0F, (byte) 0xBC};
 
+        // REX2 variant
         instrMaskAPX = new byte[]{(byte) 0xFF, (byte)0x80, (byte) 0xFF};
         instrPatternAPX = new byte[]{(byte) 0xD5, (byte) 0x80, (byte) 0xBC};
     }


### PR DESCRIPTION
A) Patch extends the following tests with hard-coded encoding checks for various BMI instructions to cover REX2 or extended EVEX encodings supported by APX. 

```
     compiler/intrinsics/bmi/verifycode/AndnTestI.java
     compiler/intrinsics/bmi/verifycode/AndnTestL.java
     compiler/intrinsics/bmi/verifycode/BzhiTestI2L.java
     compiler/intrinsics/bmi/verifycode/LZcntTestL.java
     compiler/intrinsics/bmi/verifycode/TZcntTestL.java
```

B) After integration of JDK-8349582, which added APX NDD support, AndN instruction selection patterns that expect (Xor SRC, -1) as one of its operands were not getting selected because of a lower-cost generic immediate pattern match; patch fixes this issue through strict predicate checks.

Above tests are now passing, validations were carried out using Intel Software Development emulator.

Kindly review and share your feedback.

Best Regards,
Jatin

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8357982](https://bugs.openjdk.org/browse/JDK-8357982): Fix several failing BMI tests with -XX:+UseAPX (**Bug** - P3)(⚠️ The fixVersion in this issue is [25] but the fixVersion in .jcheck/conf is 26, a new backport will be created when this pr is integrated.)


### Reviewers
 * [Emanuel Peter](https://openjdk.org/census#epeter) (@eme64 - **Reviewer**)
 * [Sandhya Viswanathan](https://openjdk.org/census#sviswanathan) (@sviswa7 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25501/head:pull/25501` \
`$ git checkout pull/25501`

Update a local copy of the PR: \
`$ git checkout pull/25501` \
`$ git pull https://git.openjdk.org/jdk.git pull/25501/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25501`

View PR using the GUI difftool: \
`$ git pr show -t 25501`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25501.diff">https://git.openjdk.org/jdk/pull/25501.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25501#issuecomment-2916938915)
</details>
