### PR TITLE
8357253: Test test/jdk/sun/security/ssl/SSLSessionImpl/ResumeClientTLS12withSNI.java writes in src dir

### DIFF
--- a/test/jdk/sun/security/ssl/SSLSessionImpl/ResumeClientTLS12withSNI.java
+++ b/test/jdk/sun/security/ssl/SSLSessionImpl/ResumeClientTLS12withSNI.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8350830
+ * @bug 8350830 8357253
  * @summary TLS 1.2 Client session resumption having ServerNameIndication
  * @modules java.base/sun.security.tools.keytool
  * @run main/othervm -Djavax.net.debug=all ResumeClientTLS12withSNI
@@ -65,7 +65,7 @@ public class ResumeClientTLS12withSNI {
     /*
      * The following is to set up the keystores.
      */
-    private static final String pathToStores = System.getProperty("test.src", ".");
+    private static final String pathToStores = ".";
     private static final String keyStoreFile = "ks_san.p12";
     private static final String trustStoreFile = "ks_san.p12";
     private static final char[] passphrase = "123456".toCharArray();
@@ -83,7 +83,7 @@ public class ResumeClientTLS12withSNI {
      * Main entry point for this test.
      */
     public static void main(String args[]) throws Exception {
-        Files.deleteIfExists(Path.of(keyFilename));
+        Files.deleteIfExists(Path.of(keyFilename)); 
 
         sun.security.tools.keytool.Main.main(
                 ("-keystore " + keyFilename + " -storepass 123456 -keypass 123456 -dname"
@@ -118,7 +118,7 @@ public class ResumeClientTLS12withSNI {
     private static KeyManagerFactory makeKeyManagerFactory(String ksPath,
                                                            char[] pass) throws GeneralSecurityException, IOException {
         KeyManagerFactory kmf;
-        KeyStore ks = KeyStore.getInstance("JKS");
+        KeyStore ks = KeyStore.getInstance("PKCS12");
 
         try (FileInputStream fsIn = new FileInputStream(ksPath)) {
             ks.load(fsIn, pass);

--- a/test/jdk/sun/security/ssl/SSLSessionImpl/ResumeClientTLS12withSNI.java
+++ b/test/jdk/sun/security/ssl/SSLSessionImpl/ResumeClientTLS12withSNI.java
@@ -83,7 +83,7 @@ public class ResumeClientTLS12withSNI {
      * Main entry point for this test.
      */
     public static void main(String args[]) throws Exception {
-        Files.deleteIfExists(Path.of(keyFilename)); 
+        Files.deleteIfExists(Path.of(keyFilename));
 
         sun.security.tools.keytool.Main.main(
                 ("-keystore " + keyFilename + " -storepass 123456 -keypass 123456 -dname"

--- a/test/jdk/sun/security/ssl/SSLSessionImpl/ResumeClientTLS12withSNI.java
+++ b/test/jdk/sun/security/ssl/SSLSessionImpl/ResumeClientTLS12withSNI.java
@@ -65,15 +65,9 @@ public class ResumeClientTLS12withSNI {
     /*
      * The following is to set up the keystores.
      */
-    private static final String pathToStores = ".";
-    private static final String keyStoreFile = "ks_san.p12";
-    private static final String trustStoreFile = "ks_san.p12";
+    private static final String keyFilename = "ks_san.p12";
+    private static final String trustFilename = "ks_san.p12";
     private static final char[] passphrase = "123456".toCharArray();
-
-    private static final String keyFilename =
-            pathToStores + "/" + keyStoreFile;
-    private static final String trustFilename =
-            pathToStores + "/" + trustStoreFile;
 
     private static final String HOST_NAME = "arf.yak.foo.localhost123456.localhost123456.localhost123456.localhost123456.localhost123456.localhost123456."
             + "localhost123456.localhost123456.localhost123456.localhost123456.localhost123456.localhost123456";

--- a/test/jdk/sun/security/ssl/SSLSessionImpl/ResumeClientTLS12withSNI.java
+++ b/test/jdk/sun/security/ssl/SSLSessionImpl/ResumeClientTLS12withSNI.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8350830 8357253
+ * @bug 8350830
  * @summary TLS 1.2 Client session resumption having ServerNameIndication
  * @modules java.base/sun.security.tools.keytool
  * @run main/othervm -Djavax.net.debug=all ResumeClientTLS12withSNI


### PR DESCRIPTION
Generate intermediate/temporary files into the work directory, not in the test source directory.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8357253](https://bugs.openjdk.org/browse/JDK-8357253): Test test/jdk/sun/security/ssl/SSLSessionImpl/ResumeClientTLS12withSNI.java writes in src dir (**Bug** - P3)


### Reviewers
 * [Sean Coffey](https://openjdk.org/census#coffeys) (@coffeys - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25505/head:pull/25505` \
`$ git checkout pull/25505`

Update a local copy of the PR: \
`$ git checkout pull/25505` \
`$ git pull https://git.openjdk.org/jdk.git pull/25505/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25505`

View PR using the GUI difftool: \
`$ git pr show -t 25505`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25505.diff">https://git.openjdk.org/jdk/pull/25505.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25505#issuecomment-2917178338)
</details>
