### PR TITLE
8357955: java.lang.classfile.Signature.ArrayTypeSig.of IAE not thrown for dims > 255

### DIFF
--- a/src/java.base/share/classes/java/lang/classfile/Signature.java
+++ b/src/java.base/share/classes/java/lang/classfile/Signature.java
@@ -417,15 +417,18 @@ public sealed interface Signature {
          * {@return a signature for an array type}
          * @param dims the dimension of the array
          * @param componentSignature the component type
-         * @throws IllegalArgumentException if the resulting array type exceeds
-         *         255 dimensions
+         * @throws IllegalArgumentException if {@code dims < 1} or the
+         *         resulting array type exceeds 255 dimensions
          */
         public static ArrayTypeSig of(int dims, Signature componentSignature) {
             requireNonNull(componentSignature);
+            if (componentSignature instanceof SignaturesImpl.ArrayTypeSigImpl arr) {
+                if (dims < 1 || dims > 255 - arr.arrayDepth())
+                    throw new IllegalArgumentException("illegal array depth value");
+                return new SignaturesImpl.ArrayTypeSigImpl(dims + arr.arrayDepth(), arr.elemType());
+            }
             if (dims < 1 || dims > 255)
                 throw new IllegalArgumentException("illegal array depth value");
-            if (componentSignature instanceof SignaturesImpl.ArrayTypeSigImpl arr)
-                return new SignaturesImpl.ArrayTypeSigImpl(dims + arr.arrayDepth(), arr.elemType());
             return new SignaturesImpl.ArrayTypeSigImpl(dims, componentSignature);
         }
     }

--- a/test/jdk/jdk/classfile/SignaturesTest.java
+++ b/test/jdk/jdk/classfile/SignaturesTest.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @summary Testing Signatures.
- * @bug 8321540 8319463
+ * @bug 8321540 8319463 8357955
  * @run junit SignaturesTest
  */
 import java.io.IOException;
@@ -298,6 +298,20 @@ class SignaturesTest {
         <T::LA>()V
         (TT;I)VI
         """.lines().forEach(assertThrows(MethodSignature::parseFrom));
+    }
+
+    @Test
+    void testArraySignatureLimits() {
+        var sig = Signature.parseFrom("I");
+        var arrSig = Signature.parseFrom("[I");
+        for (int dim : List.of(256, -1, 0))
+            Assertions.assertThrows(IllegalArgumentException.class, () -> Signature.ArrayTypeSig.of(dim, sig));
+        for (int dim : List.of(255, -1, 0))
+            Assertions.assertThrows(IllegalArgumentException.class, () -> Signature.ArrayTypeSig.of(dim, arrSig));
+        for (int dim : List.of(255, 1))
+            Signature.ArrayTypeSig.of(dim, sig);
+        for (int dim : List.of(254, 1))
+            Signature.ArrayTypeSig.of(dim, arrSig);
     }
 
     private Consumer<String> assertThrows(Function<String, ?> parser) {


### PR DESCRIPTION
java.lang.classfile.Signature.ArrayTypeSig.of constraint check did not include dimensions of the given component if the component is an array.

This patch fixes the constraint check, corrects the @throws description and adds test of the subj.

Please review.

Thanks,
Adam

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8357998](https://bugs.openjdk.org/browse/JDK-8357998) to be approved

### Issues
 * [JDK-8357955](https://bugs.openjdk.org/browse/JDK-8357955): java.lang.classfile.Signature.ArrayTypeSig.of IAE not thrown for dims &gt; 255 (**Bug** - P3)
 * [JDK-8357998](https://bugs.openjdk.org/browse/JDK-8357998): java.lang.classfile.Signature.ArrayTypeSig.of IAE not thrown for dims &gt; 255 (**CSR**)


### Reviewers
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25506/head:pull/25506` \
`$ git checkout pull/25506`

Update a local copy of the PR: \
`$ git checkout pull/25506` \
`$ git pull https://git.openjdk.org/jdk.git pull/25506/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25506`

View PR using the GUI difftool: \
`$ git pr show -t 25506`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25506.diff">https://git.openjdk.org/jdk/pull/25506.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25506#issuecomment-2917173121)
</details>
