### PR TITLE
8357999: SA: FileMapInfo.metadataTypeArray initialization issue after JDK-8355003

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/memory/FileMapInfo.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/memory/FileMapInfo.java
@@ -126,7 +126,7 @@ public class FileMapInfo {
     metadataTypeArray[4] = db.lookupType("InstanceRefKlass");
     metadataTypeArray[5] = db.lookupType("InstanceStackChunkKlass");
     metadataTypeArray[6] = db.lookupType("Method");
-    metadataTypeArray[9] = db.lookupType("MethodData");
+    metadataTypeArray[7] = db.lookupType("MethodData");
     metadataTypeArray[8] = db.lookupType("MethodCounters");
     metadataTypeArray[9] = db.lookupType("ObjArrayKlass");
     metadataTypeArray[10] = db.lookupType("TypeArrayKlass");


### PR DESCRIPTION
SonarCloud reports an issue since [JDK-8355003](https://bugs.openjdk.org/browse/JDK-8355003) integration: duplicate index in `metadataTypeArray` initialization code. Looks like a simple typo, this PR fixes it. 

Additional testing:
 - [x] Linux x86_64 server fastdebug, `serviceability/sa`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8357999](https://bugs.openjdk.org/browse/JDK-8357999): SA: FileMapInfo.metadataTypeArray initialization issue after JDK-8355003 (**Bug** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25507/head:pull/25507` \
`$ git checkout pull/25507`

Update a local copy of the PR: \
`$ git checkout pull/25507` \
`$ git pull https://git.openjdk.org/jdk.git pull/25507/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25507`

View PR using the GUI difftool: \
`$ git pr show -t 25507`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25507.diff">https://git.openjdk.org/jdk/pull/25507.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25507#issuecomment-2917317642)
</details>
