### PR TITLE
8357914: TestEmptyBootstrapMethodsAttr.java fails when run with TEST_THREAD_FACTORY=Virtual

### DIFF
--- a/test/hotspot/jtreg/ProblemList-Virtual.txt
+++ b/test/hotspot/jtreg/ProblemList-Virtual.txt
@@ -95,7 +95,6 @@ gc/g1/TestMixedGCLiveThreshold.java#25percent 8334759 windows-x64
 
 gc/arguments/TestNewSizeThreadIncrease.java 0000000 generic-all
 gc/g1/TestSkipRebuildRemsetPhase.java 0000000 generic-all
-runtime/classFileParserBug/TestEmptyBootstrapMethodsAttr.java 8346442 generic-all
 runtime/ErrorHandling/MachCodeFramesInErrorFile.java 0000000 generic-all
 runtime/logging/LoaderConstraintsTest.java 8346442 generic-all
 runtime/Thread/AsyncExceptionOnMonitorEnter.java 0000000 generic-all

--- a/test/hotspot/jtreg/runtime/classFileParserBug/TestEmptyBootstrapMethodsAttr.java
+++ b/test/hotspot/jtreg/runtime/classFileParserBug/TestEmptyBootstrapMethodsAttr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -54,8 +54,12 @@ public class TestEmptyBootstrapMethodsAttr {
                 "-Duser.language=en", "-Duser.country=US", className);
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         output.shouldNotContain("java.lang.ClassFormatError");
-        output.shouldContain("Main method not found in class " + className);
         output.shouldHaveExitValue(1);
+        if (Thread.currentThread().isVirtual()) {
+            output.shouldContain("java.lang.NoSuchMethodException: " + className + ".main");
+        } else {
+            output.shouldContain("Main method not found in class " + className);
+        }
 
         // Test case #2:
         // Try loading class with empty bootstrap_methods table where an
@@ -69,7 +73,11 @@ public class TestEmptyBootstrapMethodsAttr {
                 "-Duser.language=en", "-Duser.country=US", className);
         output = new OutputAnalyzer(pb.start());
         output.shouldNotContain("java.lang.ClassFormatError");
-        output.shouldContain("Main method not found in class " + className);
         output.shouldHaveExitValue(1);
+        if (Thread.currentThread().isVirtual()) {
+            output.shouldContain("java.lang.NoSuchMethodException: " + className + ".main");
+        } else {
+            output.shouldContain("Main method not found in class " + className);
+        }
     }
 }

--- a/test/hotspot/jtreg/runtime/classFileParserBug/TestEmptyBootstrapMethodsAttr.java
+++ b/test/hotspot/jtreg/runtime/classFileParserBug/TestEmptyBootstrapMethodsAttr.java
@@ -55,7 +55,8 @@ public class TestEmptyBootstrapMethodsAttr {
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         output.shouldNotContain("java.lang.ClassFormatError");
         output.shouldHaveExitValue(1);
-        if (Thread.currentThread().isVirtual()) {
+        boolean vthreadMode = pb.command().toString().contains("test.thread.factory=Virtual");
+        if (vthreadMode) {
             output.shouldContain("java.lang.NoSuchMethodException: " + className + ".main");
         } else {
             output.shouldContain("Main method not found in class " + className);
@@ -74,7 +75,8 @@ public class TestEmptyBootstrapMethodsAttr {
         output = new OutputAnalyzer(pb.start());
         output.shouldNotContain("java.lang.ClassFormatError");
         output.shouldHaveExitValue(1);
-        if (Thread.currentThread().isVirtual()) {
+        vthreadMode = pb.command().toString().contains("test.thread.factory=Virtual");
+        if (vthreadMode) {
             output.shouldContain("java.lang.NoSuchMethodException: " + className + ".main");
         } else {
             output.shouldContain("Main method not found in class " + className);


### PR DESCRIPTION
Please review this small test fix. The test launches a child process with the only purpose of validating that the load of the main class (`emptynumbootstrapmethods1`/`emptynumbootstrapmethods2`) completes successfully and doesn’t throw `ClassFormatError`. The class doesn’t define a main method, so later during execution of `LauncherHelper.validateMainMethod` the child VM exits with the following error message which we check from the `OutputAnalyzer` output:

```
Error: Main method not found in class emptynumbootstrapmethods1, please define the main method as:
   public static void main(String[] args)
or a JavaFX application class must extend javafx.application.Application
```

The issue when the test is run with `TEST_THREAD_FACTORY=Virtual` is that loading of `emptynumbootstrapmethods1` is done in `jdk.test.lib.process.ProcessTools.main` (the actual entry point), which instead of calling `MethodFinder.findMainMethod(mainClass)` and aborting if result is null like `LauncherHelper` uses
`Method mainMethod = c.getMethod("main", new Class<?>[] { String[].class });` which throws an exception instead and the test exits with the following error message:

```
[Exception in thread "main" java.lang.NoSuchMethodException: emptynumbootstrapmethods1.main([Ljava.lang.String;)
at java.base/java.lang.Class.getMethod(Class.java:2166)
at jdk.test.lib.process.ProcessTools.main(ProcessTools.java:984)
```

The proposed fix adjusts the output we check for based on whether the test was run on a platform thread or a virtual thread.

Thanks,
Patricio

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8357914](https://bugs.openjdk.org/browse/JDK-8357914): TestEmptyBootstrapMethodsAttr.java fails when run with TEST_THREAD_FACTORY=Virtual (**Bug** - P4)


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)
 * [SendaoYan](https://openjdk.org/census#syan) (@sendaoYan - Committer) Review applies to [0c39d822](https://git.openjdk.org/jdk/pull/25509/files/0c39d82283a74d398a8d8432570a97d90fb7e8ca)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25509/head:pull/25509` \
`$ git checkout pull/25509`

Update a local copy of the PR: \
`$ git checkout pull/25509` \
`$ git pull https://git.openjdk.org/jdk.git pull/25509/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25509`

View PR using the GUI difftool: \
`$ git pr show -t 25509`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25509.diff">https://git.openjdk.org/jdk/pull/25509.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25509#issuecomment-2917442039)
</details>
