### PR TITLE
8356047: [macos] jpackage produces confusing post- and pre- installation PKG scripts

### DIFF
--- a/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/MacPkgPackager.java
+++ b/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/MacPkgPackager.java
@@ -368,16 +368,8 @@ record MacPkgPackager(MacPkgPackage pkg, BuildEnv env, Optional<Services> servic
 
         Files.createDirectories(scriptsRoot);
 
-        final Map<String, String> data = new HashMap<>();
-
-        final var appLocation = pkg.asInstalledPackageApplicationLayout().orElseThrow().appDirectory();
-
-        data.put("INSTALL_LOCATION", Path.of("/").resolve(pkg.relativeInstallDir()).toString());
-        data.put("APP_LOCATION", appLocation.toString());
-
         MacPkgInstallerScripts.createAppScripts()
                 .setResourceDir(env.resourceDir().orElse(null))
-                .setSubstitutionData(data)
                 .saveInFolder(scriptsRoot);
     }
 

--- a/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/resources/postinstall.template
+++ b/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/resources/postinstall.template
@@ -1,7 +1,3 @@
 #!/usr/bin/env sh
 
-chown root:wheel "INSTALL_LOCATION"
-chmod a+rX "INSTALL_LOCATION"
-chmod +r "APP_LOCATION/"*.jar
-
 exit 0

--- a/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/resources/preinstall.template
+++ b/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/resources/preinstall.template
@@ -1,8 +1,3 @@
 #!/usr/bin/env sh
 
-if [ ! -d "INSTALL_LOCATION" ]
-then
-    mkdir -p "INSTALL_LOCATION"
-fi
-
 exit 0


### PR DESCRIPTION
- Removed all code from pre- and post- installation PKG scripts.
- This code is not needed and PKG should create destination folder and set correct permissions.
- If for some reason it is not happens, permissions issues should be fixed when jpackage prepares application bundle. PKG should keep all permissions unchanged when packaging and installing bundle.
- pre- and post- installation PKG scripts are kept as empty scripts, so user can override them if needed.
- `INSTALL_LOCATION` and `APP_LOCATION` substitution is removed, since `$1` argument in scripts is same as `INSTALL_LOCATION`.
- I think code in these scripts are some legacy leftovers.