### PR TITLE
8356634: VectorShape#largestShapeFor should have public access

### DIFF
--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/VectorShape.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/VectorShape.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/VectorShape.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/VectorShape.java
@@ -208,12 +208,20 @@ public enum VectorShape {
         }
     }
 
-    // non-public support for computing preferred shapes
-
-    /*package-private*/
-    static VectorShape largestShapeFor(Class<?> etype) {
+    /**
+     * Finds the largest vector shape supported by the current
+     * platform for the element type {@code etype}.
+     *
+     * @param etype the element type
+     * @return the largest vector shape supported by the platform
+     * for {@code etype}
+     * @throws IllegalArgumentException if no such vector shape exists
+     */
+    public static VectorShape largestShapeFor(Class<?> etype) {
         return VectorShape.forBitSize(getMaxVectorBitSize(etype));
     }
+
+    // non-public support for computing preferred shapes
 
     /**
      * Finds the vector shape preferred by the current platform

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/VectorShape.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/VectorShape.java
@@ -216,6 +216,7 @@ public enum VectorShape {
      * @return the largest vector shape supported by the platform
      * for {@code etype}
      * @throws IllegalArgumentException if no such vector shape exists
+     *         for the element type or the type is not a valid {@code ETYPE}.
      */
     public static VectorShape largestShapeFor(Class<?> etype) {
         return VectorShape.forBitSize(getMaxVectorBitSize(etype));

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/VectorShape.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/VectorShape.java
@@ -214,7 +214,7 @@ public enum VectorShape {
      *
      * @param etype the element type
      * @return the largest vector shape supported by the platform
-     * for {@code etype}
+     *         for {@code etype}
      * @throws IllegalArgumentException if no such vector shape exists
      *         for the element type or the type is not a valid {@code ETYPE}.
      */


### PR DESCRIPTION
VectorShape#largestShapeFor is referenced in existing JavaDoc but has been package-private. This propose change makes it public and adds documentation for it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8358009](https://bugs.openjdk.org/browse/JDK-8358009) to be approved

### Issues
 * [JDK-8356634](https://bugs.openjdk.org/browse/JDK-8356634): VectorShape#largestShapeFor should have public access (**Sub-task** - P4)
 * [JDK-8358009](https://bugs.openjdk.org/browse/JDK-8358009): VectorShape#largestShapeFor should have public access (**CSR**)


### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25513/head:pull/25513` \
`$ git checkout pull/25513`

Update a local copy of the PR: \
`$ git checkout pull/25513` \
`$ git pull https://git.openjdk.org/jdk.git pull/25513/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25513`

View PR using the GUI difftool: \
`$ git pr show -t 25513`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25513.diff">https://git.openjdk.org/jdk/pull/25513.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25513#issuecomment-2917707672)
</details>
