### PR TITLE
8358013: [PPC64] VSX has poor performance on Power8

### DIFF
--- a/src/hotspot/cpu/ppc/globals_ppc.hpp
+++ b/src/hotspot/cpu/ppc/globals_ppc.hpp
@@ -115,7 +115,7 @@ define_pd_global(intx, InitArrayShortSize, 9*BytesPerLong);
           "Use static branch prediction hints for uncommon paths.")         \
                                                                             \
   /* special instructions */                                                \
-  product(bool, SuperwordUseVSX, true,                                      \
+  product(bool, SuperwordUseVSX, false,                                     \
           "Use Power8 VSX instructions for superword optimization.")        \
                                                                             \
   product(bool, UseByteReverseInstructions, false, DIAGNOSTIC,              \

--- a/src/hotspot/cpu/ppc/vm_version_ppc.cpp
+++ b/src/hotspot/cpu/ppc/vm_version_ppc.cpp
@@ -95,6 +95,13 @@ void VM_Version::initialize() {
     FLAG_SET_ERGO(TrapBasedRangeChecks, false);
   }
 
+  if (PowerArchitecturePPC64 >= 9) {
+    // Performance is good since Power9.
+    if (FLAG_IS_DEFAULT(SuperwordUseVSX)) {
+      FLAG_SET_ERGO(SuperwordUseVSX, true);
+    }
+  }
+
   MaxVectorSize = SuperwordUseVSX ? 16 : 8;
   if (FLAG_IS_DEFAULT(AlignVector)) {
     FLAG_SET_ERGO(AlignVector, false);


### PR DESCRIPTION
Power8 only has limited VSX instructions for the superword optimization and the Vector API and the performance is bad. Let's only use it on Power9 and newer by default.