### PR TITLE
8357632: CDS test failures on static JDK

### DIFF
--- a/src/hotspot/share/cds/cdsConfig.cpp
+++ b/src/hotspot/share/cds/cdsConfig.cpp
@@ -108,12 +108,24 @@ const char* CDSConfig::default_archive_path() {
   // before CDSConfig::ergo_initialize() is called.
   assert(_cds_ergo_initialize_started, "sanity");
   if (_default_archive_path == nullptr) {
-    char jvm_path[JVM_MAXPATHLEN];
-    os::jvm_path(jvm_path, sizeof(jvm_path));
-    char *end = strrchr(jvm_path, *os::file_separator());
-    if (end != nullptr) *end = '\0';
     stringStream tmp;
-    tmp.print("%s%sclasses", jvm_path, os::file_separator());
+    if (is_vm_statically_linked()) {
+      // It's easier to form the path using JAVA_HOME as os::jvm_path
+      // gives the path to the launcher executable on static JDK.
+      const char* subdir = WINDOWS_ONLY("bin") NOT_WINDOWS("lib");
+      tmp.print("%s%s%s%s%s%sclasses",
+                Arguments::get_java_home(), os::file_separator(),
+                subdir, os::file_separator(),
+                Abstract_VM_Version::vm_variant(), os::file_separator());
+    } else {
+      // Assume .jsa is in the same directory where libjvm resides on
+      // non-static JDK.
+      char jvm_path[JVM_MAXPATHLEN];
+      os::jvm_path(jvm_path, sizeof(jvm_path));
+      char *end = strrchr(jvm_path, *os::file_separator());
+      if (end != nullptr) *end = '\0';
+      tmp.print("%s%sclasses", jvm_path, os::file_separator());
+    }
 #ifdef _LP64
     if (!UseCompressedOops) {
       tmp.print_raw("_nocoops");

--- a/test/hotspot/jtreg/ProblemList-StaticJdk.txt
+++ b/test/hotspot/jtreg/ProblemList-StaticJdk.txt
@@ -42,12 +42,3 @@ gtest/MetaspaceGtests.java#no-ccs                       8356201 generic-all
 gtest/NMTGtests.java#nmt-detail                         8356201 generic-all
 gtest/NMTGtests.java#nmt-off                            8356201 generic-all
 gtest/NMTGtests.java#nmt-summary                        8356201 generic-all
-
-# Need CDS archive
-runtime/cds/NonJVMVariantLocation.java                        8357632 generic-all
-runtime/cds/TestCDSVMCrash.java                               8357632 generic-all
-runtime/cds/TestDefaultArchiveLoading.java#coops_coh          8357632 generic-all
-runtime/cds/TestDefaultArchiveLoading.java#coops_nocoh        8357632 generic-all
-runtime/cds/TestDefaultArchiveLoading.java#nocoops_coh        8357632 generic-all
-runtime/cds/TestDefaultArchiveLoading.java#nocoops_nocoh      8357632 generic-all
-serviceability/jvmti/RedefineClasses/RedefineSharedClass.java 8357632 generic-all

--- a/test/hotspot/jtreg/runtime/cds/NonJVMVariantLocation.java
+++ b/test/hotspot/jtreg/runtime/cds/NonJVMVariantLocation.java
@@ -26,6 +26,7 @@
  * @test
  * @summary Test that CDS archive can be loaded if the archive is in a non-JVM variant directory.
  * @bug 8353504
+ * @requires !jdk.static
  * @requires vm.cds
  * @requires vm.flagless
  * @requires vm.flavor == "server"


### PR DESCRIPTION
Please review the fix in CDSConfig::default_archive_path to form the default .jsa path using Arguments::get_java_home on static-jdk. It basically reverts to the previous code before JDK-8353504, but for static-jdk case only. The change does not affect how default .jsa path is handled on regular JDK.

The PR removes the affected CDS tests from hotspot/jtreg/ProblemList-StaticJdk.txt. 

It adds '@requires !jdk.static' to runtime/cds/NonJVMVariantLocation.java to skip the test on static-jdk. NonJVMVariantLocation.java tests with VM variants specified in jvm.cfg, which is not processed on static-jdk.

Testing:
Tested the affected tests locally on static-jdk. 
https://github.com/jianglizhou/jdk/actions/runs/15312986693 is in progress.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8357632](https://bugs.openjdk.org/browse/JDK-8357632): CDS test failures on static JDK (**Bug** - P4)


### Reviewers
 * [Calvin Cheung](https://openjdk.org/census#ccheung) (@calvinccheung - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25516/head:pull/25516` \
`$ git checkout pull/25516`

Update a local copy of the PR: \
`$ git checkout pull/25516` \
`$ git pull https://git.openjdk.org/jdk.git pull/25516/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25516`

View PR using the GUI difftool: \
`$ git pr show -t 25516`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25516.diff">https://git.openjdk.org/jdk/pull/25516.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25516#issuecomment-2917907539)
</details>
