### PR TITLE
8228773: URLClassLoader constructors should include API note warning that the parent should not be null

### DIFF
--- a/src/java.base/share/classes/java/net/URLClassLoader.java
+++ b/src/java.base/share/classes/java/net/URLClassLoader.java
@@ -81,7 +81,7 @@ public class URLClassLoader extends SecureClassLoader implements Closeable {
      * bootstrap class loader) then there is no guarantee that all platform
      * classes are visible.
      * See {@linkplain ClassLoader##builtinLoaders Run-time Built-in Class Loaders}
-     * for information on the system class loader and other built-in class loaders.
+     * for information on the bootstrap class loader and other built-in class loaders.
      *
      * @param      urls the URLs from which to load classes and resources
      * @param      parent the parent class loader for delegation, can be {@code null}
@@ -124,7 +124,7 @@ public class URLClassLoader extends SecureClassLoader implements Closeable {
      * bootstrap class loader) then there is no guarantee that all platform
      * classes are visible.
      * See {@linkplain ClassLoader##builtinLoaders Run-time Built-in Class Loaders}
-     * for information on the system class loader and other built-in class loaders.
+     * for information on the bootstrap class loader and other built-in class loaders.
      *
      * @param  urls the URLs from which to load classes and resources
      * @param  parent the parent class loader for delegation, can be {@code null}
@@ -153,7 +153,7 @@ public class URLClassLoader extends SecureClassLoader implements Closeable {
      * bootstrap class loader) then there is no guarantee that all platform
      * classes are visible.
      * See {@linkplain ClassLoader##builtinLoaders Run-time Built-in Class Loaders}
-     * for information on the system class loader and other built-in class loaders.
+     * for information on the bootstrap class loader and other built-in class loaders.
      *
      * @param  name class loader name; or {@code null} if not named
      * @param  urls the URLs from which to load classes and resources
@@ -184,7 +184,7 @@ public class URLClassLoader extends SecureClassLoader implements Closeable {
      * bootstrap class loader) then there is no guarantee that all platform
      * classes are visible.
      * See {@linkplain ClassLoader##builtinLoaders Run-time Built-in Class Loaders}
-     * for information on the system class loader and other built-in class loaders.
+     * for information on the bootstrap class loader and other built-in class loaders.
      *
      * @param  name class loader name; or {@code null} if not named
      * @param  urls the URLs from which to load classes and resources

--- a/src/java.base/share/classes/java/security/SecureClassLoader.java
+++ b/src/java.base/share/classes/java/security/SecureClassLoader.java
@@ -68,7 +68,7 @@ public class SecureClassLoader extends ClassLoader {
      * bootstrap class loader) then there is no guarantee that all platform
      * classes are visible.
      * See {@linkplain ClassLoader##builtinLoaders Run-time Built-in Class Loaders}
-     * for information on the system class loader and other built-in class loaders.
+     * for information on the bootstrap class loader and other built-in class loaders.
      *
      * @param parent the parent ClassLoader, can be {@code null} for the bootstrap
      *               class loader
@@ -93,7 +93,7 @@ public class SecureClassLoader extends ClassLoader {
      * bootstrap class loader) then there is no guarantee that all platform
      * classes are visible.
      * See {@linkplain ClassLoader##builtinLoaders Run-time Built-in Class Loaders}
-     * for information on the system class loader and other built-in class loaders.
+     * for information on the bootstrap class loader and other built-in class loaders.
      *
      * @param name class loader name; or {@code null} if not named
      * @param parent the parent class loader, can be {@code null} for the bootstrap


### PR DESCRIPTION
Can I please get a review of this doc-only change which proposes to add an `@apiNote` on the constructors of `URLClassLoader` and `SecureClassLoader` to explain the current implementation of these constructors? This addresses https://bugs.openjdk.org/browse/JDK-8228773?

As noted in that issue, this updated documentation is to help applications be aware that a `null` value which represents the bootstrap class loader when passed for `parent` class loader will mean that the constructed `URLClassLoader` may not be able to load all platform classes.

Specifically, only a specific set of modules are mapped (at JDK build time) to the bootstrap class loader. Some modules like `java.sql` are visible to the platform class loader but not to the bootstrap classloader. The distinction between these class loaders is explained in the API documentation of `ClassLoader` class https://docs.oracle.com/en/java/javase/24/docs/api/java.base/java/lang/ClassLoader.html#builtinLoaders.

Using `null` (which represents a bootstrap class loader) for `parent` when constructing the `URLClassLoader` then means that the class loader would not be able to load some of these platform classes. For example, consider:

```java
import java.net.*;

public class Test {
    public static void main(String[] args) throws Exception {
        System.out.println("testing against Java " + System.getProperty("java.version"));

        final ClassLoader cl = new URLClassLoader(new URL[0], null);
        final Class<?> klass = cl.loadClass("java.sql.ResultSet"); // load a platform class that belongs to the java.sql module
        System.out.println("loaded " + klass + " using classloader: " + klass.getClassLoader());

    }
}
```
which constructs the `URLClassLoader` with the bootstrap class loader as its parent and then attempts to load a platform class `java.sql.ResultSet`. Since this class' module is mapped to the platform class loader and not the bootstrap class loader, running this code against Java 9+ will result in a `ClassNotFoundException`:

```
testing against Java 24
Exception in thread "main" java.lang.ClassNotFoundException: java.sql.ResultSet
    at java.base/java.net.URLClassLoader.findClass(URLClassLoader.java:349)
    at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:557)
    at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:490)
    at Test.main(Test.java:8)
```

No new tests have been introduced and existing tests in tier1, tier2 and tier3 continue to pass.

Once we settle on the proposed text, I'll file a CSR for this change. I've marked the issue as fix version "26" since there's no rush for this change. But if we settle down on this text and the change looks good, this week, then I'll go ahead and propose this for 25.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Change requires CSR request [JDK-8358126](https://bugs.openjdk.org/browse/JDK-8358126) to be approved
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8228773](https://bugs.openjdk.org/browse/JDK-8228773): URLClassLoader constructors should include API note warning that the parent should not be null (**Enhancement** - P3)
 * [JDK-8358126](https://bugs.openjdk.org/browse/JDK-8358126): URLClassLoader constructors should include API note warning that the parent should not be null (**CSR**)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25517/head:pull/25517` \
`$ git checkout pull/25517`

Update a local copy of the PR: \
`$ git checkout pull/25517` \
`$ git pull https://git.openjdk.org/jdk.git pull/25517/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25517`

View PR using the GUI difftool: \
`$ git pr show -t 25517`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25517.diff">https://git.openjdk.org/jdk/pull/25517.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25517#issuecomment-2918403737)
</details>
