### PR TITLE
8358035: Remove unused `compute_fingerprint` declaration in `ClassFileStream`

### DIFF
--- a/src/hotspot/share/classfile/classFileStream.cpp
+++ b/src/hotspot/share/classfile/classFileStream.cpp
@@ -23,7 +23,6 @@
  */
 
 #include "classfile/classFileStream.hpp"
-#include "classfile/classLoader.hpp"
 #include "classfile/vmSymbols.hpp"
 #include "memory/resourceArea.hpp"
 

--- a/src/hotspot/share/classfile/classFileStream.hpp
+++ b/src/hotspot/share/classfile/classFileStream.hpp
@@ -156,8 +156,6 @@ class ClassFileStream: public ResourceObj {
   // Tells whether eos is reached
   bool at_eos() const { return _current == _buffer_end; }
 
-  uint64_t compute_fingerprint() const;
-
   bool from_class_file_load_hook() const { return _from_class_file_load_hook; }
 };
 


### PR DESCRIPTION
In JDK-8264805 (part of JEP 410), the implementation of `compute_fingerprint` was removed from `ClassFileStream`, but its declaration was left in place, which was unused and should be removed. This patch removes that declaration.