### PR TITLE
Draft : 8357390 : java/awt/Toolkit/ScreenInsetsTest/ScreenInsetsTest.java Test failing on Ubuntu 24.04 SBR Hosts

### DIFF
--- a/test/jdk/java/awt/Toolkit/ScreenInsetsTest/ScreenInsetsTest.java
+++ b/test/jdk/java/awt/Toolkit/ScreenInsetsTest/ScreenInsetsTest.java
@@ -44,7 +44,7 @@ import jdk.test.lib.Platform;
 public class ScreenInsetsTest {
     private static final int SIZE = 100;
     // Allow a margin tolerance of 1 pixel due to scaling
-    private static final int MARGIN_TOLERANCE = 1;
+    private static final int MARGIN_TOLERANCE = 3;
 
     public static void main(String[] args) throws InterruptedException {
         GraphicsEnvironment ge = GraphicsEnvironment.getLocalGraphicsEnvironment();


### PR DESCRIPTION
Issue:
The bottom inset is different from the expected value by 2 pixels.

Analysis:
In [JDK-8349351](https://bugs.openjdk.org/browse/JDK-8349351), we agreed that a small difference between the expected and actual inset values could happen due to scaling. So, we accepted a small margin of error. Harshita suggested allowing a margin of 2 or 3 pixels. However, we decided to accept only a 1-pixel margin, as the test was passing consistently on CI. But this doesn't seem to be the case on the new hosts.

Proposed Fix:
Increase the allowed margin to 3 pixels.