### PR TITLE
JDK-8358077:sun.tools.attach.VirtualMachineImpl::checkCatchesAndSendQ…

### DIFF
--- a/src/jdk.attach/linux/classes/sun/tools/attach/VirtualMachineImpl.java
+++ b/src/jdk.attach/linux/classes/sun/tools/attach/VirtualMachineImpl.java
@@ -34,6 +34,7 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Optional;
 
 import java.util.regex.Pattern;
 
@@ -358,7 +359,11 @@ public class VirtualMachineImpl extends HotSpotVirtualMachine {
         if (okToSendQuit) {
             sendQuitTo(pid);
         } else if (throwIfNotReady) {
-            final var cmdline = Files.lines(procPid.resolve("cmdline")).findFirst();
+            Optional<String> cmdline = Optional.empty();
+
+            try (final var clf = Files.lines(procPid.resolve("cmdline"))) {
+                cmdline = clf.findFirst();
+            }
 
             var cmd = "null"; // default
 


### PR DESCRIPTION
sun.tools.attach.VirtualMachineImpl::checkCatchesAndSendQuitTo on Linux leaks file handles after JDK-8327114

changed the code to encapsulate the Files::lines call in a try-with-resources block in order to close stream and release underlying file resources immediately.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25526/head:pull/25526` \
`$ git checkout pull/25526`

Update a local copy of the PR: \
`$ git checkout pull/25526` \
`$ git pull https://git.openjdk.org/jdk.git pull/25526/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25526`

View PR using the GUI difftool: \
`$ git pr show -t 25526`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25526.diff">https://git.openjdk.org/jdk/pull/25526.diff</a>

</details>
