### PR TITLE
8358077: sun.tools.attach.VirtualMachineImpl::checkCatchesAndSendQuitTo on Linux leaks file handles after JDK-8327114

### DIFF
--- a/src/jdk.attach/linux/classes/sun/tools/attach/VirtualMachineImpl.java
+++ b/src/jdk.attach/linux/classes/sun/tools/attach/VirtualMachineImpl.java
@@ -35,6 +35,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+import java.util.Optional;
+
 import java.util.regex.Pattern;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -358,7 +360,11 @@ public class VirtualMachineImpl extends HotSpotVirtualMachine {
         if (okToSendQuit) {
             sendQuitTo(pid);
         } else if (throwIfNotReady) {
-            final var cmdline = Files.lines(procPid.resolve("cmdline")).findFirst();
+            Optional<String> cmdline = Optional.empty();
+
+            try (final var clf = Files.lines(procPid.resolve("cmdline"))) {
+                cmdline = clf.findFirst();
+            }
 
             var cmd = "null"; // default
 


### PR DESCRIPTION
JDK-8358077:sun.tools.attach.VirtualMachineImpl::checkCatchesAndSendQuitTo on Linux leaks file handles after JDK-8327114

modified the code to place the `Files::lines` in a `try-with-resources` block in order to autoclose the `Stream` and underlying file resources immediately.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8358077](https://bugs.openjdk.org/browse/JDK-8358077): sun.tools.attach.VirtualMachineImpl::checkCatchesAndSendQuitTo on Linux leaks file handles after JDK-8327114 (**Bug** - P4)


### Reviewers
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [SendaoYan](https://openjdk.org/census#syan) (@sendaoYan - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25529/head:pull/25529` \
`$ git checkout pull/25529`

Update a local copy of the PR: \
`$ git checkout pull/25529` \
`$ git pull https://git.openjdk.org/jdk.git pull/25529/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25529`

View PR using the GUI difftool: \
`$ git pr show -t 25529`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25529.diff">https://git.openjdk.org/jdk/pull/25529.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25529#issuecomment-2922822110)
</details>
