### PR TITLE
8345745: Update mode of the Attach API communication pipe.

### DIFF
--- a/src/jdk.attach/windows/native/libattach/VirtualMachineImpl.c
+++ b/src/jdk.attach/windows/native/libattach/VirtualMachineImpl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -291,11 +291,12 @@ JNIEXPORT jlong JNICALL Java_sun_tools_attach_VirtualMachineImpl_createPipe
 
     hPipe = CreateNamedPipe(
           name,                         // pipe name
-          ver == 1 ? PIPE_ACCESS_INBOUND  // read access
-                   : PIPE_ACCESS_DUPLEX,  // read-write access
+          (ver == 1 ? PIPE_ACCESS_INBOUND : PIPE_ACCESS_DUPLEX) | // read or read-write access
+            FILE_FLAG_FIRST_PIPE_INSTANCE,
           PIPE_TYPE_BYTE |              // byte mode
             PIPE_READMODE_BYTE |
-            PIPE_WAIT,                  // blocking mode
+            PIPE_WAIT |                 // blocking mode
+            PIPE_REJECT_REMOTE_CLIENTS,
           1,                            // max. instances
           128,                          // output buffer size
           8192,                         // input buffer size


### PR DESCRIPTION
Please review this small fix to update pipe mode for attach operation communication.
- `FILE_FLAG_FIRST_PIPE_INSTANCE`: there is "retry" logic if pipe creation failed [1], with this flag `CreateNamedPipe` fails when pipe with the same name already exists;
- `PIPE_REJECT_REMOTE_CLIENTS`: attach works only for local processes, the flag adds extra protection from remote connections.

[1]: https://github.com/openjdk/jdk/blob/master/src/jdk.attach/windows/classes/sun/tools/attach/VirtualMachineImpl.java#L93

Testing: tier1..4, hs-tier5-svc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found trailing period in issue title for `8345745: Update mode of the Attach API communication pipe.`

### Issue
 * [JDK-8345745](https://bugs.openjdk.org/browse/JDK-8345745): Update mode of the Attach API communication pipe. (**Enhancement** - P4)


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25530/head:pull/25530` \
`$ git checkout pull/25530`

Update a local copy of the PR: \
`$ git checkout pull/25530` \
`$ git pull https://git.openjdk.org/jdk.git pull/25530/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25530`

View PR using the GUI difftool: \
`$ git pr show -t 25530`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25530.diff">https://git.openjdk.org/jdk/pull/25530.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25530#issuecomment-2920367704)
</details>
