### PR TITLE
8358095: Cleanup tests with explicit locale provider set to only CLDR

### DIFF
--- a/test/jdk/java/text/Format/NumberFormat/CurrencyFormat.java
+++ b/test/jdk/java/text/Format/NumberFormat/CurrencyFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,7 @@
  * @summary Basic tests for currency formatting.
  *          Tests both COMPAT and CLDR data.
  * @modules jdk.localedata
- * @run junit/othervm -Djava.locale.providers=CLDR CurrencyFormat
+ * @run junit/othervm CurrencyFormat
  */
 
 import java.io.File;

--- a/test/jdk/java/util/Calendar/Bug8007038.java
+++ b/test/jdk/java/util/Calendar/Bug8007038.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,7 @@
  * @modules java.base/sun.util.locale.provider
  * @modules jdk.localedata
  * @compile -XDignore.symbol.file Bug8007038.java
- * @run main/othervm -Djava.locale.providers=CLDR Bug8007038 CLDR
+ * @run main/othervm Bug8007038 CLDR
  */
 
 import java.util.*;

--- a/test/jdk/java/util/Calendar/Bug8167273.java
+++ b/test/jdk/java/util/Calendar/Bug8167273.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,7 +35,7 @@
  *          java.base/sun.util.spi
  *          jdk.localedata
  * @run main Bug8167273 testEraName
- * @run main/othervm -Djava.locale.providers=CLDR Bug8167273 testCldr
+ * @run main/othervm Bug8167273 testCldr
  * @run main Bug8167273 testEmptyEraNames
  */
 import java.text.DateFormatSymbols;

--- a/test/jdk/java/util/Calendar/CldrFormatNamesTest.java
+++ b/test/jdk/java/util/Calendar/CldrFormatNamesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,7 @@
  * @modules java.base/sun.util.locale.provider
  *          jdk.localedata
  * @compile -XDignore.symbol.file CldrFormatNamesTest.java
- * @run main/othervm -Djava.locale.providers=CLDR CldrFormatNamesTest
+ * @run main/othervm CldrFormatNamesTest
  */
 
 import java.util.*;

--- a/test/jdk/java/util/Calendar/GenericTimeZoneNamesTest.java
+++ b/test/jdk/java/util/Calendar/GenericTimeZoneNamesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,7 @@
  * @comment Locale providers: default
  * @run main GenericTimeZoneNamesTest en-US
  * @comment Locale providers: CLDR
- * @run main/othervm -Djava.locale.providers=CLDR GenericTimeZoneNamesTest en-US
+ * @run main/othervm GenericTimeZoneNamesTest en-US
 */
 
 import java.util.Locale;

--- a/test/jdk/java/util/Calendar/JapaneseEraNameTest.java
+++ b/test/jdk/java/util/Calendar/JapaneseEraNameTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,7 @@
  *      is retrieved no matter CLDR provider contains the name or not.
  * @modules jdk.localedata
  * @run testng/othervm JapaneseEraNameTest
- * @run testng/othervm -Djava.locale.providers=CLDR JapaneseEraNameTest
+ * @run testng/othervm JapaneseEraNameTest
  */
 
 import static java.util.Calendar.*;

--- a/test/jdk/java/util/Calendar/NarrowNamesTest.java
+++ b/test/jdk/java/util/Calendar/NarrowNamesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,7 @@
  * @comment Locale providers: CLDR,SPI
  * @run main/othervm -Djava.locale.providers=CLDR,SPI NarrowNamesTest CLDR,SPI
  * @comment Locale providers: CLDR
- * @run main/othervm -Djava.locale.providers=CLDR NarrowNamesTest CLDR
+ * @run main/othervm NarrowNamesTest CLDR
  */
 
 import java.time.LocalDateTime;

--- a/test/jdk/java/util/Formatter/BasicTestLauncher.java
+++ b/test/jdk/java/util/Formatter/BasicTestLauncher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -58,8 +58,7 @@ import org.junit.jupiter.params.provider.ValueSource;
  * @run junit BasicTestLauncher
  */
 public class BasicTestLauncher {
-    // Locale flag for testJVM
-    private static final String JAVA_OPTS = "-Djava.locale.providers=CLDR";
+
     // Test class
     private static final String TEST_CLASS = "Basic";
 
@@ -82,7 +81,7 @@ public class BasicTestLauncher {
      */
     private static OutputAnalyzer RunTest(String timeZone) throws IOException{
         // Build and run Basic class with correct configuration
-        ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(JAVA_OPTS, TEST_CLASS);
+        ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(TEST_CLASS);
         pb.environment().put("TZ", timeZone);
         Process process = pb.start();
         return new OutputAnalyzer(process);

--- a/test/jdk/java/util/Locale/AliasesShouldBeRecognizedInCLDR.java
+++ b/test/jdk/java/util/Locale/AliasesShouldBeRecognizedInCLDR.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
  * @bug 8179071 8202537 8231273 8251317
  * @summary Test that language aliases of CLDR supplemental metadata are handled correctly.
  * @modules jdk.localedata
- * @run junit/othervm -Djava.locale.providers=CLDR AliasesShouldBeRecognizedInCLDR
+ * @run junit/othervm AliasesShouldBeRecognizedInCLDR
  */
 
 /*

--- a/test/jdk/java/util/Locale/RequiredAvailableLocalesTest.java
+++ b/test/jdk/java/util/Locale/RequiredAvailableLocalesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,7 @@
  * @bug 8276186 8174269
  * @summary Checks whether getAvailableLocales() returns at least Locale.ROOT and
  *      Locale.US instances.
- * @run testng/othervm -Djava.locale.providers=CLDR RequiredAvailableLocalesTest
+ * @run testng/othervm RequiredAvailableLocalesTest
  */
 
 import java.lang.invoke.MethodHandles;

--- a/test/jdk/java/util/Locale/bcp47u/CurrencyFormatTests.java
+++ b/test/jdk/java/util/Locale/bcp47u/CurrencyFormatTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,7 @@
  * @bug 8215181 8230284 8231273 8284840
  * @summary Tests the "u-cf" extension
  * @modules jdk.localedata
- * @run testng/othervm -Djava.locale.providers=CLDR CurrencyFormatTests
+ * @run testng/othervm CurrencyFormatTests
  */
 
 import static org.testng.Assert.assertEquals;

--- a/test/jdk/java/util/Locale/bcp47u/DisplayNameTests.java
+++ b/test/jdk/java/util/Locale/bcp47u/DisplayNameTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,7 @@
  * @bug 8176841 8202537
  * @summary Tests the display names for BCP 47 U extensions
  * @modules jdk.localedata
- * @run testng/othervm -Djava.locale.providers=CLDR DisplayNameTests
+ * @run testng/othervm DisplayNameTests
  */
 
 import static org.testng.Assert.assertEquals;

--- a/test/jdk/java/util/Locale/bcp47u/FormatTests.java
+++ b/test/jdk/java/util/Locale/bcp47u/FormatTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,7 @@
  * @summary Tests *Format class deals with Unicode extensions
  *      correctly.
  * @modules jdk.localedata
- * @run testng/othervm -Djava.locale.providers=CLDR FormatTests
+ * @run testng/othervm FormatTests
  */
 
 import static org.testng.Assert.assertEquals;

--- a/test/jdk/java/util/Locale/bcp47u/SymbolsTests.java
+++ b/test/jdk/java/util/Locale/bcp47u/SymbolsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,7 @@
  * @summary Tests *FormatSymbols class deals with Unicode extensions
  *      correctly.
  * @modules jdk.localedata
- * @run testng/othervm -Djava.locale.providers=CLDR SymbolsTests
+ * @run testng/othervm SymbolsTests
  */
 
 import static org.testng.Assert.assertEquals;

--- a/test/jdk/java/util/TimeZone/Bug8167143.java
+++ b/test/jdk/java/util/TimeZone/Bug8167143.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,7 +35,7 @@
  *          java.base/sun.util.spi
  *          jdk.localedata
  * @run main Bug8167143 testTimeZone
- * @run main/othervm -Djava.locale.providers=CLDR Bug8167143 testCldr
+ * @run main/othervm Bug8167143 testCldr
  * @run main Bug8167143 testCache
  * @run main Bug8167143 testCandidateLocales
  */

--- a/test/jdk/java/util/TimeZone/CLDRDisplayNamesTest.java
+++ b/test/jdk/java/util/TimeZone/CLDRDisplayNamesTest.java
@@ -26,7 +26,7 @@
  * @bug 8005471 8008577 8129881 8130845 8136518 8181157 8210490 8220037
  *      8234347 8236548 8317979
  * @modules jdk.localedata
- * @run main/othervm -Djava.locale.providers=CLDR CLDRDisplayNamesTest
+ * @run main/othervm CLDRDisplayNamesTest
  * @summary Make sure that localized time zone names of CLDR are used
  * if specified.
  */

--- a/test/jdk/sun/util/resources/TimeZone/ChineseTimeZoneNameTest.java
+++ b/test/jdk/sun/util/resources/TimeZone/ChineseTimeZoneNameTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
  * @bug 8275721 8174269
  * @modules jdk.localedata
  * @summary Checks Chinese time zone names for `UTC` using CLDR are consistent
- * @run testng/othervm -Djava.locale.providers=CLDR ChineseTimeZoneNameTest
+ * @run testng/othervm ChineseTimeZoneNameTest
  */
 
 import java.time.Instant;

--- a/test/jdk/sun/util/resources/cldr/Bug8134250.java
+++ b/test/jdk/sun/util/resources/cldr/Bug8134250.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
  * @bug 8134250 8134520
  * @modules jdk.localedata
  * @summary Tests CLDR/LDML features are correctly reflected in JDK.
- * @run main/othervm -Djava.locale.providers=CLDR Bug8134250
+ * @run main/othervm Bug8134250
  */
 
 // Note this test highly depends on a particular version of CLDR. Results

--- a/test/jdk/sun/util/resources/cldr/Bug8134384.java
+++ b/test/jdk/sun/util/resources/cldr/Bug8134384.java
@@ -25,7 +25,7 @@
  * @test
  * @bug 8134384 8234347 8236548 8347841
  * @summary Tests CLDR TimeZoneNames has English names for all tzids
- * @run main/othervm -Djava.locale.providers=CLDR Bug8134384
+ * @run main/othervm Bug8134384
  */
 
 import java.text.*;

--- a/test/jdk/sun/util/resources/cldr/LikelySubtagLocalesTest.java
+++ b/test/jdk/sun/util/resources/cldr/LikelySubtagLocalesTest.java
@@ -26,7 +26,7 @@
  * @bug 8145136 8202537 8221432 8251317 8258794 8265315 8306116 8346948
  * @modules jdk.localedata
  * @summary Tests LikelySubtags is correctly reflected in Locale.getAvailableLocales().
- * @run junit/othervm -Djava.locale.providers=CLDR LikelySubtagLocalesTest
+ * @run junit/othervm LikelySubtagLocalesTest
  */
 import java.util.Arrays;
 import java.util.List;

--- a/test/jdk/sun/util/resources/cldr/TimeZoneNamesTest.java
+++ b/test/jdk/sun/util/resources/cldr/TimeZoneNamesTest.java
@@ -27,7 +27,7 @@
  * @modules jdk.localedata
  * @summary Checks CLDR time zone names are generated correctly at
  * either build or runtime
- * @run testng/othervm -Djava.locale.providers=CLDR TimeZoneNamesTest
+ * @run testng/othervm TimeZoneNamesTest
  */
 
 import java.text.DateFormatSymbols;


### PR DESCRIPTION
Please review this PR which cleans up some i18n tests.

There are some i18n related tests that set the locale provider to CLDR (and only CLDR). Since JDK9, this is redundant and equivalent to the default. Thus, occurrences of "-Djava.locale.providers=CLDR" are just extra noise for these tests. 

As this change is trivial cleanup, bug IDs are not updated in this change.