### PR TITLE
8358076: KeyFactory.getInstance("EdDSA").generatePublic(null) throws NPE

### DIFF
--- a/src/java.base/share/classes/sun/security/ec/ECKeyFactory.java
+++ b/src/java.base/share/classes/sun/security/ec/ECKeyFactory.java
@@ -220,7 +220,7 @@ public final class ECKeyFactory extends KeyFactorySpi {
                 yield new ECPublicKeyImpl(p8key.getPubKeyEncoded());
             }
             case null -> throw new InvalidKeySpecException(
-                "keySpec most not be null");
+                "keySpec must not be null");
             default ->
                 throw new InvalidKeySpecException(keySpec.getClass().getName() +
                     " not supported.");
@@ -242,7 +242,7 @@ public final class ECKeyFactory extends KeyFactorySpi {
             case ECPrivateKeySpec e ->
                 new ECPrivateKeyImpl(e.getS(), e.getParams());
             case null -> throw new InvalidKeySpecException(
-                "keySpec most not be null");
+                "keySpec must not be null");
             default ->
                 throw new InvalidKeySpecException(keySpec.getClass().getName() +
                     " not supported.");

--- a/src/java.base/share/classes/sun/security/ec/XDHKeyFactory.java
+++ b/src/java.base/share/classes/sun/security/ec/XDHKeyFactory.java
@@ -170,7 +170,7 @@ public class XDHKeyFactory extends KeyFactorySpi {
                 yield result;
             }
             case null -> throw new InvalidKeySpecException(
-                "keySpec most not be null");
+                "keySpec must not be null");
             default ->
                 throw new InvalidKeySpecException(keySpec.getClass().getName() +
                     " not supported.");
@@ -205,7 +205,7 @@ public class XDHKeyFactory extends KeyFactorySpi {
                 }
             }
             case null -> throw new InvalidKeySpecException(
-                "keySpec most not be null");
+                "keySpec must not be null");
             default ->
                 throw new InvalidKeySpecException(keySpec.getClass().getName() +
                     " not supported.");

--- a/src/java.base/share/classes/sun/security/ec/ed/EdDSAKeyFactory.java
+++ b/src/java.base/share/classes/sun/security/ec/ed/EdDSAKeyFactory.java
@@ -159,7 +159,7 @@ public class EdDSAKeyFactory extends KeyFactorySpi {
                 yield new EdDSAPublicKeyImpl(p8key.getPubKeyEncoded());
             }
             case null -> throw new InvalidKeySpecException(
-                "keySpec most not be null");
+                "keySpec must not be null");
             default ->
                 throw new InvalidKeySpecException(keySpec.getClass().getName() +
                     " not supported.");
@@ -194,7 +194,7 @@ public class EdDSAKeyFactory extends KeyFactorySpi {
                 }
             }
             case null -> throw new InvalidKeySpecException(
-                "keySpec most not be null");
+                "keySpec must not be null");
             default ->
                 throw new InvalidKeySpecException(keySpec.getClass().getName() +
                     " not supported.");

--- a/src/java.base/share/classes/sun/security/rsa/RSAKeyFactory.java
+++ b/src/java.base/share/classes/sun/security/rsa/RSAKeyFactory.java
@@ -344,7 +344,7 @@ public class RSAKeyFactory extends KeyFactorySpi {
                     p8key.getPubKeyEncoded());
             }
             case null -> throw new InvalidKeySpecException(
-                "keySpec most not be null");
+                "keySpec must not be null");
             default ->
                 throw new InvalidKeySpecException(keySpec.getClass().getName() +
                     " not supported.");
@@ -392,7 +392,7 @@ public class RSAKeyFactory extends KeyFactorySpi {
                 }
             }
             case null -> throw new InvalidKeySpecException(
-                "keySpec most not be null");
+                "keySpec must not be null");
             default ->
                 throw new InvalidKeySpecException(keySpec.getClass().getName() +
                     " not supported.");


### PR DESCRIPTION
I need a code review to throw `InvalidKeySpecException` when null is passed with `generatePublic()` and `generatePrivate()`.  This change takes the opportunity to modernize the KeyFactory code by using `switch` syntax for `instanceof` checking, as well as, keeping the previous design of the implementation method handling the null case.  There are existing JCK test cover this case, so no regression test is added.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8358076](https://bugs.openjdk.org/browse/JDK-8358076): KeyFactory.getInstance("EdDSA").generatePublic(null) throws NPE (**Bug** - P3)


### Reviewers
 * [Weijun Wang](https://openjdk.org/census#weijun) (@wangweij - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25533/head:pull/25533` \
`$ git checkout pull/25533`

Update a local copy of the PR: \
`$ git checkout pull/25533` \
`$ git pull https://git.openjdk.org/jdk.git pull/25533/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25533`

View PR using the GUI difftool: \
`$ git pr show -t 25533`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25533.diff">https://git.openjdk.org/jdk/pull/25533.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25533#issuecomment-2920746064)
</details>
