### PR TITLE
8357425: (fs) SecureDirectoryStream setPermissions should use fchmodat

### DIFF
--- a/src/java.base/unix/classes/sun/nio/fs/UnixNativeDispatcher.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixNativeDispatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -348,6 +348,18 @@ class UnixNativeDispatcher {
     private static native void fchmod0(int fd, int mode) throws UnixException;
 
     /**
+     * fchmodat(int fd, const char *path, mode_t mode, int flag)
+     */
+    static void fchmodat(int fd, UnixPath path, int mode, int flag)
+        throws UnixException {
+        try (NativeBuffer buffer = copyToNativeBuffer(path)) {
+            fchmodat0(fd, buffer.address(), mode, flag);
+        }
+    }
+    private static native void fchmodat0(int fd, long pathAddress, int mode, int flag)
+        throws UnixException;
+
+    /**
      * futimens(int fildes, const struct timespec times[2])
      */
     static void futimens(int fd, long times0, long times1) throws UnixException {
@@ -557,6 +569,14 @@ class UnixNativeDispatcher {
     static boolean xattrSupported() {
         return (capabilities & SUPPORTS_XATTR) != 0;
     }
+
+    /**
+     * Supports fchmodat with AT_SYMLINK_NOFOLLOW flag
+     */
+    static boolean fchmodatNoFollowSupported() {
+        return fchmodatNoFollowSupported0();
+    }
+    private static native boolean fchmodatNoFollowSupported0();
 
     private static native int init();
     static {

--- a/src/java.base/unix/classes/sun/nio/fs/UnixSecureDirectoryStream.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixSecureDirectoryStream.java
@@ -414,17 +414,17 @@ class UnixSecureDirectoryStream
                 if (!ds.isOpen())
                     throw new ClosedDirectoryStreamException();
 
+                int mode = UnixFileModeAttribute.toUnixMode(perms);
                 if (file == null)
-                    fchmod(dfd, UnixFileModeAttribute.toUnixMode(perms));
+                    fchmod(dfd, mode);
                 else if (followLinks)
-                    fchmodat(dfd, file, UnixFileModeAttribute.toUnixMode(perms), 0);
+                    fchmodat(dfd, file, mode, 0);
                 else if (fchmodatNoFollowSupported())
-                    fchmodat(dfd, file, UnixFileModeAttribute.toUnixMode(perms),
-                             AT_SYMLINK_NOFOLLOW);
+                    fchmodat(dfd, file, mode, AT_SYMLINK_NOFOLLOW);
                 else {
                     int fd = open();
                     try {
-                        fchmod(fd, UnixFileModeAttribute.toUnixMode(perms));
+                        fchmod(fd, mode);
                     } finally {
                         if (fd >= 0)
                             UnixNativeDispatcher.close(fd, e-> null);

--- a/test/jdk/java/nio/file/DirectoryStream/SecureDS.java
+++ b/test/jdk/java/nio/file/DirectoryStream/SecureDS.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,10 +22,12 @@
  */
 
 /* @test
- * @bug 4313887 6838333 8343020
+ * @bug 4313887 6838333 8343020 8357425
  * @summary Unit test for java.nio.file.SecureDirectoryStream
  * @requires (os.family == "linux" | os.family == "mac")
- * @library ..
+ * @library .. /test/lib
+ * @build jdk.test.lib.Platform
+ * @run main SecureDS
  */
 
 import java.nio.file.*;
@@ -36,6 +38,8 @@ import java.nio.file.attribute.*;
 import java.nio.channels.*;
 import java.io.IOException;
 import java.util.*;
+
+import jdk.test.lib.Platform;
 
 public class SecureDS {
     static boolean supportsSymbolicLinks;
@@ -54,6 +58,7 @@ public class SecureDS {
             // run tests
             doBasicTests(dir);
             doMoveTests(dir);
+            doSetPermissions(dir);
             miscTests(dir);
 
         } finally {
@@ -170,6 +175,62 @@ public class SecureDS {
         // clean-up
         stream.close();
         delete(dir2);
+    }
+
+    // Exercise setting permisions on the SecureDirectoryStream's view
+    static void doSetPermissions(Path dir) throws IOException {
+        Path aDir = createDirectory(dir.resolve("dir"));
+
+        Set<PosixFilePermission> noperms = EnumSet.noneOf(PosixFilePermission.class);
+        Set<PosixFilePermission> permsDir = getPosixFilePermissions(aDir);
+
+        SecureDirectoryStream<Path> stream =
+            (SecureDirectoryStream<Path>)newDirectoryStream(aDir);
+
+        // Test setting permission on directory with no permissions
+        setPosixFilePermissions(aDir, noperms);
+        assertTrue(getPosixFilePermissions(aDir).equals(noperms));
+        PosixFileAttributeView view = stream.getFileAttributeView(aDir, PosixFileAttributeView.class);
+        view.setPermissions(permsDir);
+        assertTrue(getPosixFilePermissions(aDir).equals(permsDir));
+
+        if (supportsSymbolicLinks) {
+            // Create a file and a link to the file
+            Path fileEntry = Path.of("file");
+            Path file = createFile(aDir.resolve(fileEntry));
+            Set<PosixFilePermission> permsFile = getPosixFilePermissions(file);
+            Path linkEntry = Path.of("link");
+            Path link = createSymbolicLink(aDir.resolve(linkEntry), fileEntry);
+            Set<PosixFilePermission> permsLink = getPosixFilePermissions(link, NOFOLLOW_LINKS);
+
+            // Test following link to file
+            view = stream.getFileAttributeView(link, PosixFileAttributeView.class);
+            view.setPermissions(noperms);
+            assertTrue(getPosixFilePermissions(file).equals(noperms));
+            assertTrue(getPosixFilePermissions(link, NOFOLLOW_LINKS).equals(permsLink));
+            view.setPermissions(permsFile);
+            assertTrue(getPosixFilePermissions(file).equals(permsFile));
+            assertTrue(getPosixFilePermissions(link, NOFOLLOW_LINKS).equals(permsLink));
+
+            // Symbolic link permissions do not apply on Linux
+            if (!Platform.isLinux()) {
+                // Test not following link to file
+                view = stream.getFileAttributeView(link, PosixFileAttributeView.class, NOFOLLOW_LINKS);
+                view.setPermissions(noperms);
+                assertTrue(getPosixFilePermissions(file).equals(permsFile));
+                assertTrue(getPosixFilePermissions(link, NOFOLLOW_LINKS).equals(noperms));
+                view.setPermissions(permsLink);
+                assertTrue(getPosixFilePermissions(file).equals(permsFile));
+                assertTrue(getPosixFilePermissions(link, NOFOLLOW_LINKS).equals(permsLink));
+            }
+
+            delete(link);
+            delete(file);
+        }
+
+        // clean-up
+        stream.close();
+        delete(aDir);
     }
 
     // Exercise SecureDirectoryStream's move method

--- a/test/jdk/java/nio/file/DirectoryStream/SecureDS.java
+++ b/test/jdk/java/nio/file/DirectoryStream/SecureDS.java
@@ -190,7 +190,7 @@ public class SecureDS {
         // Test setting permission on directory with no permissions
         setPosixFilePermissions(aDir, noperms);
         assertTrue(getPosixFilePermissions(aDir).equals(noperms));
-        PosixFileAttributeView view = stream.getFileAttributeView(aDir, PosixFileAttributeView.class);
+        PosixFileAttributeView view = stream.getFileAttributeView(PosixFileAttributeView.class);
         view.setPermissions(permsDir);
         assertTrue(getPosixFilePermissions(aDir).equals(permsDir));
 


### PR DESCRIPTION
Modify to use the `fchmodat(2)` system call to set permissions where possible to do so. This fixes the problem presented in the issue description.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8357425](https://bugs.openjdk.org/browse/JDK-8357425): (fs) SecureDirectoryStream setPermissions should use fchmodat (**Enhancement** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25534/head:pull/25534` \
`$ git checkout pull/25534`

Update a local copy of the PR: \
`$ git checkout pull/25534` \
`$ git pull https://git.openjdk.org/jdk.git pull/25534/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25534`

View PR using the GUI difftool: \
`$ git pr show -t 25534`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25534.diff">https://git.openjdk.org/jdk/pull/25534.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25534#issuecomment-2920822497)
</details>
