### PR TITLE
8358102: GenShen: Age tables could be seeded with cumulative values

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahEvacTracker.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahEvacTracker.cpp
@@ -154,7 +154,7 @@ ShenandoahCycleStats ShenandoahEvacuationTracker::flush_cycle_to_global() {
     // for use in the next cycle.
     // The first argument is used for any age 0 cohort population that we may otherwise have
     // missed during the census. This is non-zero only when census happens at marking.
-    ShenandoahGenerationalHeap::heap()->age_census()->update_census(0, _mutators_global.age_table(), _workers_global.age_table());
+    ShenandoahGenerationalHeap::heap()->age_census()->update_census(0, mutators.age_table(), workers.age_table());
   }
 
   return {workers, mutators};


### PR DESCRIPTION
When dynamic tenuring threshold is disabled, or the age census is configured to be computed during evacuation, the first cohort is seeded with the cumulative counts, rather than the current cycle's counts. This is not the default configuration so this is not an urgent issue.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8358102](https://bugs.openjdk.org/browse/JDK-8358102): GenShen: Age tables could be seeded with cumulative values (**Bug** - P4)


### Reviewers
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25535/head:pull/25535` \
`$ git checkout pull/25535`

Update a local copy of the PR: \
`$ git checkout pull/25535` \
`$ git pull https://git.openjdk.org/jdk.git pull/25535/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25535`

View PR using the GUI difftool: \
`$ git pr show -t 25535`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25535.diff">https://git.openjdk.org/jdk/pull/25535.diff</a>

</details>
