### PR TITLE
8358104: Fix ZGC compilation error on GCC 10.2

### DIFF
--- a/src/hotspot/share/gc/z/zMappedCache.cpp
+++ b/src/hotspot/share/gc/z/zMappedCache.cpp
@@ -556,7 +556,7 @@ size_t ZMappedCache::remove_discontiguous_with_strategy(size_t size, ZArray<ZVir
 
 ZMappedCache::ZMappedCache()
   : _tree(),
-    _size_class_lists{},
+    _size_class_lists(),
     _size(0),
     _min(_size) {}
 


### PR DESCRIPTION
JDK-8350441 introduced Mapped Cache for ZGC. However, the constructor of `ZMappedCache` uses brace-initialization for `_size_class_lists`, i.e. a `ZList` array. `ZList` is a class with a deleted copy constructor and an explicit destructor, and when its array is brace-initialized in the constructor, it triggers [GCC bug 63707](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=63707). An example that can reproduce this bug: https://godbolt.org/z/3397bxc73

The bug causes compilation error of ZGC on GCC versions 10.1 to 10.2. Considering OpenJDK compilation is still requires GCC 10 or higher, this should be recorded as a bug.

This patch uses value-initialization for `_size_class_lists` instead of brace-initialization, which should be semantically equivalent and work on all GCC versions.