### PR TITLE
8358136: Make langtools/jdk/javadoc/doclet/testLinkOption/TestRedirectLinks.java intermittent

### DIFF
--- a/test/langtools/jdk/javadoc/doclet/testLinkOption/TestRedirectLinks.java
+++ b/test/langtools/jdk/javadoc/doclet/testLinkOption/TestRedirectLinks.java
@@ -24,6 +24,7 @@
 /*
  * @test
  * @bug 8190312
+ * @key intermittent
  * @summary test redirected URLs for -link
  * @library /tools/lib ../../lib /test/lib
  * @modules jdk.compiler/com.sun.tools.javac.api


### PR DESCRIPTION
Make langtools/jdk/javadoc/doclet/testLinkOption/TestRedirectLinks.java intermittent, add the respective keyword.
The test fails sometimes, see e.g. JDK-8338439 .

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8358136](https://bugs.openjdk.org/browse/JDK-8358136): Make langtools/jdk/javadoc/doclet/testLinkOption/TestRedirectLinks.java intermittent (**Sub-task** - P4)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Nizar Benalla](https://openjdk.org/census#nbenalla) (@nizarbenalla - Committer)
 * [SendaoYan](https://openjdk.org/census#syan) (@sendaoYan - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25540/head:pull/25540` \
`$ git checkout pull/25540`

Update a local copy of the PR: \
`$ git checkout pull/25540` \
`$ git pull https://git.openjdk.org/jdk.git pull/25540/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25540`

View PR using the GUI difftool: \
`$ git pr show -t 25540`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25540.diff">https://git.openjdk.org/jdk/pull/25540.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25540#issuecomment-2921862598)
</details>
