### PR TITLE
8357821: Revert incorrectly named JavaLangAccess::unchecked* methods

### DIFF
--- a/src/java.base/share/classes/java/io/DataInputStream.java
+++ b/src/java.base/share/classes/java/io/DataInputStream.java
@@ -595,7 +595,7 @@ loop:   while (true) {
         int chararr_count=0;
 
         in.readFully(bytearr, 0, utflen);
-        int ascii = JLA.uncheckedCountPositives(bytearr, 0, utflen);
+        int ascii = JLA.countPositives(bytearr, 0, utflen);
         if (ascii == utflen) {
             String str;
             if (trusted) {
@@ -621,7 +621,7 @@ loop:   while (true) {
         }
 
         if (ascii != 0) {
-            JLA.uncheckedInflateBytesToChars(bytearr, 0, chararr, 0, ascii);
+            JLA.inflateBytesToChars(bytearr, 0, chararr, 0, ascii);
             count += ascii;
             chararr_count += ascii;
         }

--- a/src/java.base/share/classes/java/io/ObjectInputStream.java
+++ b/src/java.base/share/classes/java/io/ObjectInputStream.java
@@ -3536,7 +3536,7 @@ public class ObjectInputStream
             if (utflen > 0 && utflen < Integer.MAX_VALUE) {
                 // Scan for leading ASCII chars
                 int avail = end - pos;
-                int ascii = JLA.uncheckedCountPositives(buf, pos, Math.min(avail, (int)utflen));
+                int ascii = JLA.countPositives(buf, pos, Math.min(avail, (int)utflen));
                 if (ascii == utflen) {
                     // Complete match, consume the buf[pos ... pos + ascii] range and return.
                     // Modified UTF-8 and ISO-8859-1 are both ASCII-compatible encodings bytes
@@ -3549,7 +3549,7 @@ public class ObjectInputStream
                 // Avoid allocating a StringBuilder if there's enough data in buf and
                 // cbuf is large enough
                 if (avail >= utflen && utflen <= CHAR_BUF_SIZE) {
-                    JLA.uncheckedInflateBytesToChars(buf, pos, cbuf, 0, ascii);
+                    JLA.inflateBytesToChars(buf, pos, cbuf, 0, ascii);
                     pos += ascii;
                     int cbufPos = readUTFSpan(ascii, utflen - ascii);
                     return new String(cbuf, 0, cbufPos);

--- a/src/java.base/share/classes/java/lang/System.java
+++ b/src/java.base/share/classes/java/lang/System.java
@@ -2118,7 +2118,7 @@ public final class System {
                 return ModuleLayer.layers(loader);
             }
 
-            public int uncheckedCountPositives(byte[] bytes, int offset, int length) {
+            public int countPositives(byte[] bytes, int offset, int length) {
                 return StringCoding.countPositives(bytes, offset, length);
             }
             public int countNonZeroAscii(String s) {
@@ -2145,11 +2145,11 @@ public final class System {
                 return String.getBytesUTF8NoRepl(s);
             }
 
-            public void uncheckedInflateBytesToChars(byte[] src, int srcOff, char[] dst, int dstOff, int len) {
+            public void inflateBytesToChars(byte[] src, int srcOff, char[] dst, int dstOff, int len) {
                 StringLatin1.inflate(src, srcOff, dst, dstOff, len);
             }
 
-            public int uncheckedDecodeASCII(byte[] src, int srcOff, char[] dst, int dstOff, int len) {
+            public int decodeASCII(byte[] src, int srcOff, char[] dst, int dstOff, int len) {
                 return String.decodeASCII(src, srcOff, dst, dstOff, len);
             }
 

--- a/src/java.base/share/classes/java/util/zip/ZipCoder.java
+++ b/src/java.base/share/classes/java/util/zip/ZipCoder.java
@@ -266,7 +266,7 @@ class ZipCoder {
                 return 0;
             }
             int end = off + len;
-            int asciiLen = JLA.uncheckedCountPositives(a, off, len);
+            int asciiLen = JLA.countPositives(a, off, len);
             if (asciiLen != len) {
                 // Non-ASCII, fall back to decoding a String
                 // We avoid using decoder() here since the UTF8ZipCoder is

--- a/src/java.base/share/classes/jdk/internal/access/JavaLangAccess.java
+++ b/src/java.base/share/classes/jdk/internal/access/JavaLangAccess.java
@@ -302,10 +302,8 @@ public interface JavaLangAccess {
 
     /**
      * Count the number of leading positive bytes in the range.
-     * <p>
-     * <b>WARNING: This method does not perform any bound checks.</b>
      */
-    int uncheckedCountPositives(byte[] ba, int off, int len);
+    int countPositives(byte[] ba, int off, int len);
 
     /**
      * Count the number of leading non-zero ascii chars in the String.
@@ -390,20 +388,16 @@ public interface JavaLangAccess {
     /**
      * Inflated copy from {@code byte[]} to {@code char[]}, as defined by
      * {@code StringLatin1.inflate}.
-     * <p>
-     * <b>WARNING: This method does not perform any bound checks.</b>
      */
-    void uncheckedInflateBytesToChars(byte[] src, int srcOff, char[] dst, int dstOff, int len);
+    void inflateBytesToChars(byte[] src, int srcOff, char[] dst, int dstOff, int len);
 
     /**
      * Decodes ASCII from the source byte array into the destination
      * char array.
-     * <p>
-     * <b>WARNING: This method does not perform any bound checks.</b>
      *
      * @return the number of bytes successfully decoded, at most len
      */
-    int uncheckedDecodeASCII(byte[] src, int srcOff, char[] dst, int dstOff, int len);
+    int decodeASCII(byte[] src, int srcOff, char[] dst, int dstOff, int len);
 
     /**
      * Returns the initial `System.in` to determine if it is replaced

--- a/src/java.base/share/classes/jdk/internal/access/JavaLangAccess.java
+++ b/src/java.base/share/classes/jdk/internal/access/JavaLangAccess.java
@@ -302,6 +302,8 @@ public interface JavaLangAccess {
 
     /**
      * Count the number of leading positive bytes in the range.
+     *
+     * @implSpec Implementations of this method must perform bounds checks.
      */
     int countPositives(byte[] ba, int off, int len);
 
@@ -388,12 +390,16 @@ public interface JavaLangAccess {
     /**
      * Inflated copy from {@code byte[]} to {@code char[]}, as defined by
      * {@code StringLatin1.inflate}.
+     *
+     * @implSpec Implementations of this method must perform bounds checks.
      */
     void inflateBytesToChars(byte[] src, int srcOff, char[] dst, int dstOff, int len);
 
     /**
      * Decodes ASCII from the source byte array into the destination
      * char array.
+     *
+     * @implSpec Implementations of this method must perform bounds checks.
      *
      * @return the number of bytes successfully decoded, at most len
      */

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/AbstractPoolEntry.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/AbstractPoolEntry.java
@@ -218,7 +218,7 @@ public abstract sealed class AbstractPoolEntry {
          * two-times-three-byte format instead.
          */
         private void inflate() {
-            int singleBytes = JLA.uncheckedCountPositives(rawBytes, offset, rawLen);
+            int singleBytes = JLA.countPositives(rawBytes, offset, rawLen);
             int hash = ArraysSupport.hashCodeOfUnsigned(rawBytes, offset, singleBytes, 0);
             if (singleBytes == rawLen) {
                 this.contentHash = hash;
@@ -233,7 +233,7 @@ public abstract sealed class AbstractPoolEntry {
             char[] chararr = new char[rawLen];
             int chararr_count = singleBytes;
             // Inflate prefix of bytes to characters
-            JLA.uncheckedInflateBytesToChars(rawBytes, offset, chararr, 0, singleBytes);
+            JLA.inflateBytesToChars(rawBytes, offset, chararr, 0, singleBytes);
 
             int px = offset + singleBytes;
             int utfend = offset + rawLen;

--- a/src/java.base/share/classes/sun/nio/cs/CESU_8.java
+++ b/src/java.base/share/classes/sun/nio/cs/CESU_8.java
@@ -196,7 +196,7 @@ class CESU_8 extends Unicode
             int dp = doff + dst.position();
             int dl = doff + dst.limit();
 
-            int n = JLA.uncheckedDecodeASCII(sa, sp, da, dp, Math.min(sl - sp, dl - dp));
+            int n = JLA.decodeASCII(sa, sp, da, dp, Math.min(sl - sp, dl - dp));
             sp += n;
             dp += n;
 

--- a/src/java.base/share/classes/sun/nio/cs/DoubleByte.java
+++ b/src/java.base/share/classes/sun/nio/cs/DoubleByte.java
@@ -168,7 +168,7 @@ public class DoubleByte {
 
             try {
                 if (isASCIICompatible) {
-                    int n = JLA.uncheckedDecodeASCII(sa, sp, da, dp, Math.min(dl - dp, sl - sp));
+                    int n = JLA.decodeASCII(sa, sp, da, dp, Math.min(dl - dp, sl - sp));
                     dp += n;
                     sp += n;
                 }

--- a/src/java.base/share/classes/sun/nio/cs/ISO_8859_1.java
+++ b/src/java.base/share/classes/sun/nio/cs/ISO_8859_1.java
@@ -87,7 +87,7 @@ public class ISO_8859_1
             int dl = doff + dst.limit();
 
             int decodeLen = Math.min(sl - sp, dl - dp);
-            JLA.uncheckedInflateBytesToChars(sa, sp, da, dp, decodeLen);
+            JLA.inflateBytesToChars(sa, sp, da, dp, decodeLen);
             sp += decodeLen;
             dp += decodeLen;
             src.position(sp - soff);

--- a/src/java.base/share/classes/sun/nio/cs/SingleByte.java
+++ b/src/java.base/share/classes/sun/nio/cs/SingleByte.java
@@ -95,7 +95,7 @@ public class SingleByte
             }
 
             if (isASCIICompatible) {
-                int n = JLA.uncheckedDecodeASCII(sa, sp, da, dp, Math.min(dl - dp, sl - sp));
+                int n = JLA.decodeASCII(sa, sp, da, dp, Math.min(dl - dp, sl - sp));
                 sp += n;
                 dp += n;
             }

--- a/src/java.base/share/classes/sun/nio/cs/US_ASCII.java
+++ b/src/java.base/share/classes/sun/nio/cs/US_ASCII.java
@@ -83,7 +83,7 @@ public class US_ASCII
             int dl = doff + dst.limit();
 
             // ASCII only loop
-            int n = JLA.uncheckedDecodeASCII(sa, sp, da, dp, Math.min(sl - sp, dl - dp));
+            int n = JLA.decodeASCII(sa, sp, da, dp, Math.min(sl - sp, dl - dp));
             sp += n;
             dp += n;
             src.position(sp - soff);

--- a/src/java.base/share/classes/sun/nio/cs/UTF_8.java
+++ b/src/java.base/share/classes/sun/nio/cs/UTF_8.java
@@ -227,7 +227,7 @@ public final class UTF_8 extends Unicode {
             int dp = doff + dst.position();
             int dl = doff + dst.limit();
 
-            int n = JLA.uncheckedDecodeASCII(sa, sp, da, dp, Math.min(sl - sp, dl - dp));
+            int n = JLA.decodeASCII(sa, sp, da, dp, Math.min(sl - sp, dl - dp));
             sp += n;
             dp += n;
 


### PR DESCRIPTION
Reverts certain [JDK-8353197](https://bugs.openjdk.org/browse/JDK-8353197) (which implements JavaDoc improvement and precautionary naming for certain unsafe methods in `jdk.internal.access.JavaLangAccess`) changes that are found to be incorrect. See the JBS issue for details on the followed evaluation process.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8357821](https://bugs.openjdk.org/browse/JDK-8357821): Revert incorrectly named JavaLangAccess::unchecked* methods (**Enhancement** - P4)


### Reviewers
 * [Per Minborg](https://openjdk.org/census#pminborg) (@minborg - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25545/head:pull/25545` \
`$ git checkout pull/25545`

Update a local copy of the PR: \
`$ git checkout pull/25545` \
`$ git pull https://git.openjdk.org/jdk.git pull/25545/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25545`

View PR using the GUI difftool: \
`$ git pr show -t 25545`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25545.diff">https://git.openjdk.org/jdk/pull/25545.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25545#issuecomment-2922206404)
</details>
