### PR TITLE
JDK-8358159: empty mode/padding in cipher transformations.

### DIFF
--- a/src/java.base/share/classes/javax/crypto/Cipher.java
+++ b/src/java.base/share/classes/javax/crypto/Cipher.java
@@ -389,8 +389,8 @@ public class Cipher {
         Transform(String alg, String suffix, String mode, String pad) {
             this.transform = alg + suffix;
             this.suffix = suffix.toUpperCase(Locale.ENGLISH);
-            this.mode = mode;
-            this.pad = pad;
+            this.mode = ((mode == null) || mode.isEmpty()) ? null : mode;
+            this.pad = ((pad == null) || pad.isEmpty()) ? null : pad;
         }
         // set mode and padding for the given SPI
         void setModePadding(CipherSpi spi) throws NoSuchAlgorithmException,


### PR DESCRIPTION
Omitting the mode/padding in a transformation string eg: "AES/ /NoPadding" throws NoSuchAlgorithmException.
This patch restores the behavior by ensuring that empty mode or padding strings are interpreted as null.

Testing done for : tier1 - fastdebug level

JBS: [JDK-8358159](https://bugs.openjdk.org/browse/JDK-8358159)