### PR TITLE
8357155: [asan] ZGC does not work (x86_64 and ppc64)

### DIFF
--- a/src/hotspot/cpu/aarch64/gc/z/zAddress_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/gc/z/zAddress_aarch64.cpp
@@ -94,14 +94,10 @@ static size_t probe_valid_max_address_bit() {
 size_t ZPlatformAddressOffsetBits() {
   static const size_t valid_max_address_offset_bits = probe_valid_max_address_bit() + 1;
   const size_t max_address_offset_bits = valid_max_address_offset_bits - 3;
-#ifdef ADDRESS_SANITIZER
-  return max_address_offset_bits;
-#else
   const size_t min_address_offset_bits = max_address_offset_bits - 2;
   const size_t address_offset = ZGlobalsPointers::min_address_offset_request();
   const size_t address_offset_bits = log2i_exact(address_offset);
   return clamp(address_offset_bits, min_address_offset_bits, max_address_offset_bits);
-#endif
 }
 
 size_t ZPlatformAddressHeapBaseShift() {

--- a/src/hotspot/cpu/aarch64/gc/z/zAddress_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/gc/z/zAddress_aarch64.cpp
@@ -94,10 +94,14 @@ static size_t probe_valid_max_address_bit() {
 size_t ZPlatformAddressOffsetBits() {
   static const size_t valid_max_address_offset_bits = probe_valid_max_address_bit() + 1;
   const size_t max_address_offset_bits = valid_max_address_offset_bits - 3;
+#ifdef ADDRESS_SANITIZER
+  return max_address_offset_bits;
+#else
   const size_t min_address_offset_bits = max_address_offset_bits - 2;
   const size_t address_offset = ZGlobalsPointers::min_address_offset_request();
   const size_t address_offset_bits = log2i_exact(address_offset);
   return clamp(address_offset_bits, min_address_offset_bits, max_address_offset_bits);
+#endif
 }
 
 size_t ZPlatformAddressHeapBaseShift() {

--- a/src/hotspot/cpu/ppc/gc/z/zAddress_ppc.cpp
+++ b/src/hotspot/cpu/ppc/gc/z/zAddress_ppc.cpp
@@ -91,10 +91,14 @@ static size_t probe_valid_max_address_bit() {
 size_t ZPlatformAddressOffsetBits() {
   static const size_t valid_max_address_offset_bits = probe_valid_max_address_bit() + 1;
   const size_t max_address_offset_bits = valid_max_address_offset_bits - 3;
+#ifdef ADDRESS_SANITIZER
+  return max_address_offset_bits;
+#else
   const size_t min_address_offset_bits = max_address_offset_bits - 2;
   const size_t address_offset = ZGlobalsPointers::min_address_offset_request();
   const size_t address_offset_bits = log2i_exact(address_offset);
   return clamp(address_offset_bits, min_address_offset_bits, max_address_offset_bits);
+#endif
 }
 
 size_t ZPlatformAddressHeapBaseShift() {

--- a/src/hotspot/cpu/ppc/gc/z/zAddress_ppc.cpp
+++ b/src/hotspot/cpu/ppc/gc/z/zAddress_ppc.cpp
@@ -92,6 +92,7 @@ size_t ZPlatformAddressOffsetBits() {
   static const size_t valid_max_address_offset_bits = probe_valid_max_address_bit() + 1;
   const size_t max_address_offset_bits = valid_max_address_offset_bits - 3;
 #ifdef ADDRESS_SANITIZER
+  // The max supported value is 44 because of other internal data structures.
   return MIN2(valid_max_address_offset_bits, (size_t)44);
 #else
   const size_t min_address_offset_bits = max_address_offset_bits - 2;

--- a/src/hotspot/cpu/ppc/gc/z/zAddress_ppc.cpp
+++ b/src/hotspot/cpu/ppc/gc/z/zAddress_ppc.cpp
@@ -92,7 +92,7 @@ size_t ZPlatformAddressOffsetBits() {
   static const size_t valid_max_address_offset_bits = probe_valid_max_address_bit() + 1;
   const size_t max_address_offset_bits = valid_max_address_offset_bits - 3;
 #ifdef ADDRESS_SANITIZER
-  return max_address_offset_bits;
+  return MIN2(valid_max_address_offset_bits, (size_t)44);
 #else
   const size_t min_address_offset_bits = max_address_offset_bits - 2;
   const size_t address_offset = ZGlobalsPointers::min_address_offset_request();

--- a/src/hotspot/cpu/x86/gc/z/zAddress_x86.cpp
+++ b/src/hotspot/cpu/x86/gc/z/zAddress_x86.cpp
@@ -30,11 +30,15 @@
 size_t ZPointerLoadShift;
 
 size_t ZPlatformAddressOffsetBits() {
+#ifdef ADDRESS_SANITIZER
+  return 44;
+#else
   const size_t min_address_offset_bits = 42; // 4TB
   const size_t max_address_offset_bits = 44; // 16TB
   const size_t address_offset = ZGlobalsPointers::min_address_offset_request();
   const size_t address_offset_bits = log2i_exact(address_offset);
   return clamp(address_offset_bits, min_address_offset_bits, max_address_offset_bits);
+#endif
 }
 
 size_t ZPlatformAddressHeapBaseShift() {


### PR DESCRIPTION
Many (all?) ZGC related jtreg tests do not work when the JDK is built with address sanitizer asan enabled (configure flag --enable-asan).
This can be seen on SUSE Linux x86_64 and also on ppc64le , opt binaries were used.
It has been suggested to do a workaround -  'But I think that simply adapting the zAddress_[...].cpp implementations to always select the largest heap base would go a long way for providing ASAN compatibility.'
This seems to work nicely on x86_64 and ppc64le,  however the zgc related tests still fail on Linux aarch64 (should I exclude this platform from my patch?) .

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8357155](https://bugs.openjdk.org/browse/JDK-8357155): [asan] ZGC does not work (x86_64 and ppc64) (**Bug** - P4)


### Reviewers
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - **Reviewer**) Review applies to [82a11f9b](https://git.openjdk.org/jdk/pull/25549/files/82a11f9b93ac2901e61dccb2affd39a9e256dc8f)
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)

### Contributors
 * Axel Boldt-Christmas `<aboldtch@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25549/head:pull/25549` \
`$ git checkout pull/25549`

Update a local copy of the PR: \
`$ git checkout pull/25549` \
`$ git pull https://git.openjdk.org/jdk.git pull/25549/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25549`

View PR using the GUI difftool: \
`$ git pr show -t 25549`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25549.diff">https://git.openjdk.org/jdk/pull/25549.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25549#issuecomment-2922256867)
</details>
