### PR TITLE
8357823: Changes in StringBuilder (JDK-8351443) caused a 1-3% regression in biojava

### DIFF
--- a/src/java.base/share/classes/java/lang/AbstractStringBuilder.java
+++ b/src/java.base/share/classes/java/lang/AbstractStringBuilder.java
@@ -266,7 +266,6 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
      */
     private static byte[] ensureCapacityNewCoder(byte[] value, byte coder, int count,
                                                  int minimumCapacity, byte newCoder) {
-        assert coder == newCoder || newCoder == UTF16 : "bad new coder UTF16 -> LATIN1";
         // overflow-conscious code
         // Compute the new larger size if growth is requested, otherwise keep the capacity the same
         int oldCapacity = value.length >> coder;
@@ -274,7 +273,9 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
         int newCapacity = (growth <= 0)
                 ? oldCapacity               // Do not reduce capacity even if requested
                 : newCapacity(value, newCoder, minimumCapacity);
-        assert count <= newCapacity : "count exceeds new capacity";
+        // These asserts increase code size and reduce inlining, hurting performance
+        // assert coder == newCoder || newCoder == UTF16 : "bad new coder UTF16 -> LATIN1";
+        // assert count <= newCapacity : "count exceeds new capacity";
 
         if (coder == newCoder) {
             if (newCapacity > oldCapacity) {

--- a/test/micro/org/openjdk/bench/java/lang/StringBuilders.java
+++ b/test/micro/org/openjdk/bench/java/lang/StringBuilders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -235,8 +235,7 @@ public class StringBuilders {
 
     @Benchmark
     public int appendWithIntLatin1() {
-        StringBuilder buf = sbLatin1;
-        buf.setLength(0);
+        StringBuilder buf = new StringBuilder();
         for (int i : intArray) {
             buf.append(i);
         }
@@ -245,8 +244,7 @@ public class StringBuilders {
 
     @Benchmark
     public int appendWithIntUtf16() {
-        StringBuilder buf = sbUtf16;
-        buf.setLength(0);
+        StringBuilder buf = new StringBuilder("\uFF11");
         for (int i : intArray) {
             buf.append(i);
         }
@@ -255,8 +253,7 @@ public class StringBuilders {
 
     @Benchmark
     public int appendWithLongLatin1() {
-        StringBuilder buf = sbLatin1;
-        buf.setLength(0);
+        StringBuilder buf = new StringBuilder();
         for (long l : longArray) {
             buf.append(l);
         }
@@ -265,8 +262,7 @@ public class StringBuilders {
 
     @Benchmark
     public int appendWithLongUtf16() {
-        StringBuilder buf = sbUtf16;
-        buf.setLength(0);
+        StringBuilder buf = new StringBuilder("\uFF11");
         for (long l : longArray) {
             buf.append(l);
         }
@@ -290,8 +286,7 @@ public class StringBuilders {
 
     @Benchmark
     public int appendWithFloat8Latin1() {
-        StringBuilder buf = sbLatin1;
-        buf.setLength(0);
+        StringBuilder buf = new StringBuilder();
         buf.append(113.110F);
         buf.append(156456.36435637F);
         buf.append(65436434.64632F);
@@ -306,8 +301,7 @@ public class StringBuilders {
 
     @Benchmark
     public int appendWithFloat8Utf16() {
-        StringBuilder buf = sbUtf16;
-        buf.setLength(0);
+        StringBuilder buf = new StringBuilder("\uFF11");
         buf.append(113.110F);
         buf.append(156456.36435637F);
         buf.append(65436434.64632F);
@@ -322,8 +316,7 @@ public class StringBuilders {
 
     @Benchmark
     public int appendWithDouble8Latin1() {
-        StringBuilder buf = sbLatin1;
-        buf.setLength(0);
+        StringBuilder buf = new StringBuilder();
         buf.append(0.3005216476500575D);
         buf.append(0.39727691577802204D);
         buf.append(0.9869700323149287D);
@@ -338,8 +331,7 @@ public class StringBuilders {
 
     @Benchmark
     public int appendWithDouble8Utf16() {
-        StringBuilder buf = sbUtf16;
-        buf.setLength(0);
+        StringBuilder buf = new StringBuilder("\uFF11");
         buf.append(0.3005216476500575D);
         buf.append(0.39727691577802204D);
         buf.append(0.9869700323149287D);


### PR DESCRIPTION
Comment out assertions added in JDK-8351443 from AbstractStringBuilder.ensureCapacityNewCoder that increase the codesize, preventing some inlining, and reducing performance

       assert coder == newCoder || newCoder == UTF16 : "bad new coder UTF16 -> LATIN1";
       assert count <= newCapacity : "count exceeds new capacity";

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8357823](https://bugs.openjdk.org/browse/JDK-8357823): Changes in StringBuilder (JDK-8351443) caused a 1-3% regression in biojava (**Bug** - P3)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**) 🔄 Re-review required (review applies to [b51f52c9](https://git.openjdk.org/jdk/pull/25550/files/b51f52c97d5c52013d37128519fbe3f720500634))

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25550/head:pull/25550` \
`$ git checkout pull/25550`

Update a local copy of the PR: \
`$ git checkout pull/25550` \
`$ git pull https://git.openjdk.org/jdk.git pull/25550/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25550`

View PR using the GUI difftool: \
`$ git pr show -t 25550`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25550.diff">https://git.openjdk.org/jdk/pull/25550.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25550#issuecomment-2922495705)
</details>
