### PR TITLE
8353266: C2: Wrong execution with Integer.bitCount(int) intrinsic on AArch64

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -7761,14 +7761,14 @@ instruct popCountI(iRegINoSp dst, iRegIorL2I src, vRegF tmp) %{
   effect(TEMP tmp);
   ins_cost(INSN_COST * 13);
 
-  format %{ "movw   $src, $src\n\t"
-            "mov    $tmp, $src\t# vector (1D)\n\t"
+  format %{ "mov    $tmp, zr\t# vector (1S)\n\t"
+            "mov    $tmp, $src\t# vector (1S)\n\t"
             "cnt    $tmp, $tmp\t# vector (8B)\n\t"
             "addv   $tmp, $tmp\t# vector (8B)\n\t"
             "mov    $dst, $tmp\t# vector (1D)" %}
   ins_encode %{
-    __ movw($src$$Register, $src$$Register); // ensure top 32 bits 0
-    __ mov($tmp$$FloatRegister, __ D, 0, $src$$Register);
+    __ mov($tmp$$FloatRegister, __ S, 1, zr);             // tmp[32:63] <- 0
+    __ mov($tmp$$FloatRegister, __ S, 0, $src$$Register); // tmp[ 0:31] <- src
     __ cnt($tmp$$FloatRegister, __ T8B, $tmp$$FloatRegister);
     __ addv($tmp$$FloatRegister, __ T8B, $tmp$$FloatRegister);
     __ mov($dst$$Register, $tmp$$FloatRegister, __ D, 0);

--- a/test/hotspot/jtreg/compiler/intrinsics/BitCountIAarch64PreservesArgument.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/BitCountIAarch64PreservesArgument.java
@@ -25,6 +25,7 @@
  * @test
  * @bug 8353266
  * @summary Integer.bitCount modifies input register
+ * @library /test/lib /
  *
  * @run main/othervm
  *      -Xbatch
@@ -35,11 +36,14 @@
 /**
  * @test
  * @bug 8353266
+ * @library /test/lib /
  *
  * @run main compiler.intrinsics.BitCountIAarch64PreservesArgument
  */
 
 package compiler.intrinsics;
+
+import static compiler.lib.generators.Generators.G;
 
 public class BitCountIAarch64PreservesArgument {
     static long lFld;
@@ -51,7 +55,15 @@ public class BitCountIAarch64PreservesArgument {
             test();
             if (result != 0xfedc_ba98_7654_3210L) {
                 // Wrongly outputs the cut input 0x7654_3210 == 1985229328
-                throw new RuntimeException("Wrong result: " + result);
+                throw new RuntimeException("Wrong result. lFld=" + lFld + "; result=" + result);
+            }
+        }
+
+        lFld = G.longs().next();
+        for (int i = 0; i < 10_000; i++) {
+            test();
+            if (result != lFld) {
+                throw new RuntimeException("Wrong result. lFld=" + lFld + "; result=" + result);
             }
         }
     }

--- a/test/hotspot/jtreg/compiler/intrinsics/BitCountIAarch64PreservesArgument.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/BitCountIAarch64PreservesArgument.java
@@ -42,14 +42,15 @@
 package compiler.intrinsics;
 
 public class BitCountIAarch64PreservesArgument {
-    static long lFld = 0x3e34_3acb_0fb0_67a6L;
+    static long lFld;
     static long result;
 
     public static void main(String[] args) {
+        lFld = 0xfedc_ba98_7654_3210L;
         for (int i = 0; i < 10_000; i++) {
             test();
-            if (result != 0x3e34_3acb_0fb0_67a6L) {
-                // Wrongly outputs the cut input 0x0fb0_67a6 == 263219110
+            if (result != 0xfedc_ba98_7654_3210L) {
+                // Wrongly outputs the cut input 0x7654_3210 == 1985229328
                 throw new RuntimeException("Wrong result: " + result);
             }
         }
@@ -58,7 +59,7 @@ public class BitCountIAarch64PreservesArgument {
     static void test() {
         long x = lFld;
         try {
-            result = Integer.bitCount((int) x); // Cut input: 0x0fb0_67a6 == 263219110
+            result = Integer.bitCount((int) x); // Cut input: 0x7654_3210 == 1985229328
             throw new RuntimeException();
         } catch (RuntimeException _) {
         }

--- a/test/hotspot/jtreg/compiler/intrinsics/BitCountIAarch64PreservesArgument.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/BitCountIAarch64PreservesArgument.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8353266
+ * @summary Integer.bitCount modifies input register
+ *
+ * @run main/othervm
+ *      -Xbatch
+ *      -XX:CompileOnly=compiler.intrinsics.BitCountIAarch64PreservesArgument::test
+ *      compiler.intrinsics.BitCountIAarch64PreservesArgument
+ */
+
+/**
+ * @test
+ * @bug 8353266
+ *
+ * @run main compiler.intrinsics.BitCountIAarch64PreservesArgument
+ */
+
+package compiler.intrinsics;
+
+public class BitCountIAarch64PreservesArgument {
+    static long lFld = 0x3e34_3acb_0fb0_67a6L;
+    static long result;
+
+    public static void main(String[] args) {
+        for (int i = 0; i < 10_000; i++) {
+            test();
+            if (result != 0x3e34_3acb_0fb0_67a6L) {
+                // Wrongly outputs the cut input 0x0fb0_67a6 == 263219110
+                throw new RuntimeException("Wrong result: " + result);
+            }
+        }
+    }
+
+    static void test() {
+        long x = lFld;
+        try {
+            result = Integer.bitCount((int) x); // Cut input: 0x0fb0_67a6 == 263219110
+            throw new RuntimeException();
+        } catch (RuntimeException _) {
+        }
+        result = x;
+    }
+}


### PR DESCRIPTION
### Problem

On Aarch64, using  `Integer.bitCount` can modify its argument. The problem comes from the implementation of `popCountI` on Aarch64. For instance, that's what we get with the reproducer `Reduced.java` on the related issue:
```asm
; Load lFld into local x
ldr  x11,      [x10, #120]
; popCountI
mov  w11,      w11
mov  v16.d[0], x11
cnt  v16.8b,   v16.8b
addv b16,      v16.8b
mov  x13,      v16.d[0]
; [...]
; store local x (which is believed to still contain lFld) into result
str  x11,      [x10, #128]
```

The instruction `mov  w11, w11` is used to cut the 32 higher bits of `x11` since we use `popCountI` (from `Integer.bitCount`): on aarch64 (like other architectures), assigning the 32 lower bits of a register reset the 32 higher bits. Short: the input is modified, but the implementation of `popCountI` doesn't declare it:
```cpp
instruct popCountI(iRegINoSp dst, iRegIorL2I src, vRegF tmp) %{
  match(Set dst (PopCountI src));
  effect(TEMP tmp);
  [...]
%}
```

But then, why resetting the upper word of `x11`? It all starts with vector instructions:
```asm
cnt  v16.8b,   v16.8b
addv b16,      v16.8b
```
The `8b` specifies that it operates on the 8 lower bytes of `v16`, it would be nice to simply use `4b`, but that doesn't exist: vector instructions can only work on either the whole 128-bit register, or the 64 lower bits (by blocks of 1, 2, 4, 8 or 16 bytes). There is no suffix (and encoding) for a vector instruction to work only on the 32 lower bits, so not to pollute the bit count, we need to reset the 32 higher bits of `v16.d[0]` (aka `d16`), that is `v16.s[1]`, that is `v16[32:63]` in a more bit-explicit notation. Moreover, unlike with general purpose register doing
```asm
mov  v16.s[0], w11
```
would set `v16[0:31]` to `w11`, but not reset `v16[32:63]`. Which makes sense! Otherwise, using vector registers would be impractical if writing any piece would reset the rest... So we indeed need to set all of `v16[0:63]`, which
```asm
mov  w11,      w11
mov  v16.d[0], x11
```
does, but by destroying `x11`.

### Solution

Simply adding `USE_KILL src` in the effects would be nice, but unfortunately not possible: `iRegIorL2I` is an operand class (either a 32-bit register or a L2I of a 64-bit register) and those cannot be used in effect lists.

The way I went for is rather not to modify the source, but rather do write the two lower words of `v16` we are interested in separately:
```asm
mov  v16.s[1], wzr      ; Reset the 1-indexed word of v16, that is v16[32:63] <- 0
mov  v16.s[0], w11      ; Set the 0-indexed word of v16 to w11, that is v[0:31] <- w11
cnt  v16.8b,   v16.8b
addv b16,      v16.8b
mov  x13,      v16.s[0]
```
Unlike other solutions, this is relatively straightforward as it doesn't write twice the same bits, as for instance, this would:
```asm
mov  v16.d[0], xzr      ; Reset the 0-indexed double word of v16, that is v16[0:63] <- 0
mov  v16.s[0], w11      ; Set the 0-indexed word of v16 to w11, that is v[0:31] <- w11
```
and it doesn't use additional temporaries, like this would:
```asm
mov  w12,      w11      ; Using a fresh register x12
mov  v16.d[0], x12
```

Using the zero register rather than an immediate is convenient as it allows to set 32 bits at once, while a 32-bit immediate would not fit in a single instruction.

### Format

The printing of this instruction is not very satisfactory. We used to have something that renders in OptoAssembly
```asm
movw l2i(R29), l2i(R29)
mov  V16, l2i(R29) # vector (1D)
cnt  V16, V16      # vector (8B)
addv V16, V16      # vector (8B)
mov  R13, V16      # vector (1D)
```
This is... somewhat arguable. With context, I can understand or guess what `movw l2i(R29), l2i(R29)` means, but I don't think it's a very nice printout. Also, it's not clear that the second instruction works on the lower word of `V16`. Alas, my new version is not much better:
```asm
mov  V16, zr       # vector (1S)
mov  V16, l2i(R29) # vector (1S)
cnt  V16, V16      # vector (8B)
addv V16, V16      # vector (8B)
mov  R13, V16      # vector (1D)
```
It's not clear that the first instruction is on the 1-indexed word of `V16` while the second is on the 0-indexed word. I couldn't find a nicer example in a similar situation, so I'm open to suggestions! Maybe simply hardcoding it in the format? as such:
```
format %{ "mov    $tmp.s[1], zr\t# vector (1S)\n\t"
          "mov    $tmp.s[0], $src\t# vector (1S)\n\t"
          "cnt    $tmp, $tmp\t# vector (8B)\n\t"
          "addv   $tmp, $tmp\t# vector (8B)\n\t"
          "mov    $dst, $tmp\t# vector (1D)" %}
```
Not sure what's the best practice here.
