### PR TITLE
8358205: Remove unused JFR array allocation code

### DIFF
--- a/src/hotspot/share/jfr/jni/jfrJavaCall.cpp
+++ b/src/hotspot/share/jfr/jni/jfrJavaCall.cpp
@@ -179,7 +179,7 @@ void JfrJavaArguments::Parameters::copy(JavaCallArguments& args, TRAPS) const {
   }
 }
 
-JfrJavaArguments::JfrJavaArguments(JavaValue* result) : _result(result), _klass(nullptr), _name(nullptr), _signature(nullptr), _array_length(-1) {
+JfrJavaArguments::JfrJavaArguments(JavaValue* result) : _result(result), _klass(nullptr), _name(nullptr), _signature(nullptr) {
   assert(result != nullptr, "invariant");
 }
 
@@ -187,8 +187,7 @@ JfrJavaArguments::JfrJavaArguments(JavaValue* result, const char* klass_name, co
   _result(result),
   _klass(nullptr),
   _name(nullptr),
-  _signature(nullptr),
-  _array_length(-1) {
+  _signature(nullptr) {
   assert(result != nullptr, "invariant");
   if (klass_name != nullptr) {
     set_klass(klass_name, CHECK);
@@ -204,8 +203,7 @@ JfrJavaArguments::JfrJavaArguments(JavaValue* result, const char* klass_name, co
 JfrJavaArguments::JfrJavaArguments(JavaValue* result, const Klass* klass, const Symbol* name, const Symbol* signature) : _result(result),
   _klass(nullptr),
   _name(nullptr),
-  _signature(nullptr),
-  _array_length(-1) {
+  _signature(nullptr) {
   assert(result != nullptr, "invariant");
   if (klass != nullptr) {
     set_klass(klass);
@@ -266,15 +264,6 @@ void JfrJavaArguments::set_signature(const char* signature) {
 void JfrJavaArguments::set_signature(const Symbol* signature) {
   assert(signature != nullptr, "invariant");
   _signature = signature;
-}
-
-int JfrJavaArguments::array_length() const {
-  return _array_length;
-}
-
-void JfrJavaArguments::set_array_length(int length) {
-  assert(length >= 0, "invariant");
-  _array_length = length;
 }
 
 JavaValue* JfrJavaArguments::result() const {

--- a/src/hotspot/share/jfr/jni/jfrJavaCall.hpp
+++ b/src/hotspot/share/jfr/jni/jfrJavaCall.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -54,9 +54,6 @@ class JfrJavaArguments : public StackObj {
   Symbol* signature() const;
   void set_signature(const char* signature);
   void set_signature(const Symbol* signature);
-
-  int array_length() const;
-  void set_array_length(int length);
 
   JavaValue* result() const;
 
@@ -117,7 +114,6 @@ class JfrJavaArguments : public StackObj {
   const Klass* _klass;
   const Symbol* _name;
   const Symbol* _signature;
-  int _array_length;
 
   int java_call_arg_slots() const;
   void copy(JavaCallArguments& args, TRAPS);

--- a/src/hotspot/share/jfr/jni/jfrJavaSupport.hpp
+++ b/src/hotspot/share/jfr/jni/jfrJavaSupport.hpp
@@ -69,7 +69,6 @@ class JfrJavaSupport : public AllStatic {
   static void get_field_local_ref(JfrJavaArguments* args, TRAPS);
 
   static jstring new_string(const char* c_str, TRAPS);
-  static jobjectArray new_string_array(int length, TRAPS);
 
   static jobject new_java_lang_Boolean(bool value, TRAPS);
   static jobject new_java_lang_Integer(jint value, TRAPS);

--- a/src/hotspot/share/memory/oopFactory.cpp
+++ b/src/hotspot/share/memory/oopFactory.cpp
@@ -107,7 +107,6 @@ typeArrayOop oopFactory::new_typeArray_nozero(BasicType type, int length, TRAPS)
 
 
 objArrayOop oopFactory::new_objArray(Klass* klass, int length, TRAPS) {
-  assert(klass->is_klass(), "must be instance class");
   if (klass->is_array_klass()) {
     return ArrayKlass::cast(klass)->allocate_arrayArray(1, length, THREAD);
   } else {


### PR DESCRIPTION
The JFR code is using ObjArray->allocate() directly rather than going through oopFactory.  In Valhalla, the oopFactory code is being changed to account for new array shapes and attributes, so all code should call that instead.  Turns out this function is unused, so this change removes it.  Tested with tier1-7 with a ShouldNotReachHere(), then jdk/jfr tests with the removal.

<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8358205](https://bugs.openjdk.org/browse/JDK-8358205): Remove unused JFR array allocation code (**Enhancement** - P4)


### Reviewers
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25553/head:pull/25553` \
`$ git checkout pull/25553`

Update a local copy of the PR: \
`$ git checkout pull/25553` \
`$ git pull https://git.openjdk.org/jdk.git pull/25553/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25553`

View PR using the GUI difftool: \
`$ git pr show -t 25553`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25553.diff">https://git.openjdk.org/jdk/pull/25553.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25553#issuecomment-2923344887)
</details>
