### PR TITLE
8357576: FieldInfo::_index is not initialized by the constructor

### DIFF
--- a/src/hotspot/share/oops/fieldInfo.hpp
+++ b/src/hotspot/share/oops/fieldInfo.hpp
@@ -137,7 +137,8 @@ class FieldInfo {
 
  public:
 
-  FieldInfo() : _name_index(0),
+  FieldInfo() : _index(0),
+                _name_index(0),
                 _signature_index(0),
                 _offset(0),
                 _access_flags(AccessFlags(0)),
@@ -147,6 +148,7 @@ class FieldInfo {
                 _contention_group(0) { }
 
   FieldInfo(AccessFlags access_flags, u2 name_index, u2 signature_index, u2 initval_index, FieldInfo::FieldFlags fflags) :
+            _index(0),
             _name_index(name_index),
             _signature_index(signature_index),
             _offset(0),


### PR DESCRIPTION
FieldInfo::_index is not initialized in either of the FieldInfo constructors so this patch adds initialization to both constructors. Verified with tier 1-5 tests