### PR TITLE
8357924

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -106,7 +106,6 @@ runtime/os/TestTracePageSizes.java#compiler-options 8267460 linux-aarch64
 runtime/os/TestTracePageSizes.java#G1 8267460 linux-aarch64
 runtime/os/TestTracePageSizes.java#Parallel 8267460 linux-aarch64
 runtime/os/TestTracePageSizes.java#Serial 8267460 linux-aarch64
-runtime/ErrorHandling/CreateCoredumpOnCrash.java 8267433 macosx-x64
 runtime/StackGuardPages/TestStackGuardPagesNative.java 8303612 linux-all
 runtime/ErrorHandling/MachCodeFramesInErrorFile.java 8313315 linux-ppc64le
 runtime/NMT/VirtualAllocCommitMerge.java 8309698 linux-s390x


### PR DESCRIPTION
Remove CreateCoredumpOnCrash.java from problem list. JDK-8267433 was closed because it only reproduced with OSX 11, which is no longer supported. SA core file tests were removed from the problem list, but this test was missed.

Test by running 100 times on macosx-x64 and macosx-x64-debug. Also ran hotspot_tier2_runtime 5 tmes.