### PR TITLE
8352187: Don't start management agent during AOT cache creation

### DIFF
--- a/src/hotspot/share/runtime/threads.cpp
+++ b/src/hotspot/share/runtime/threads.cpp
@@ -842,13 +842,22 @@ jint Threads::create_vm(JavaVMInitArgs* args, bool* canTryAgain) {
   JFR_ONLY(Jfr::on_create_vm_3();)
 
 #if INCLUDE_MANAGEMENT
-  Management::initialize(THREAD);
+  bool start_agent = true;
+#if INCLUDE_CDS
+  start_agent = !CDSConfig::is_dumping_final_static_archive();
+  if (!start_agent) {
+    log_info(aot)("Not starting management agent during creation of AOT cache.");
+  }
+#endif // INCLUDE_CDS
+  if (start_agent) {
+    Management::initialize(THREAD);
 
-  if (HAS_PENDING_EXCEPTION) {
-    // management agent fails to start possibly due to
-    // configuration problem and is responsible for printing
-    // stack trace if appropriate. Simply exit VM.
-    vm_exit(1);
+    if (HAS_PENDING_EXCEPTION) {
+      // management agent fails to start possibly due to
+      // configuration problem and is responsible for printing
+      // stack trace if appropriate. Simply exit VM.
+      vm_exit(1);
+    }
   }
 #endif // INCLUDE_MANAGEMENT
 

--- a/test/hotspot/jtreg/runtime/cds/appcds/aotCache/HelloAOTCache.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotCache/HelloAOTCache.java
@@ -49,6 +49,17 @@ public class HelloAOTCache {
                     out.shouldContain("HelloWorld");
                 })
             .runAOTWorkflow();
+
+        SimpleCDSAppTester.of("HelloAOTCache-with-manangment-agent")
+            // test with the initialization of a management agent
+            .addVmArgs("-Xlog:class+load", "-Dcom.sun.management.jmxremote=true")
+            .classpath("app.jar")
+            .appCommandLine("HelloAOTCacheApp")
+            .setProductionChecker((OutputAnalyzer out) -> {
+                    out.shouldMatch("class,load.*HelloAOTCacheApp.*shared objects");
+                    out.shouldContain("HelloWorld");
+                })
+            .runAOTWorkflow();
     }
 }
 

--- a/test/hotspot/jtreg/runtime/cds/appcds/aotCache/ManagementAgent.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotCache/ManagementAgent.java
@@ -41,7 +41,7 @@ import jdk.test.lib.process.OutputAnalyzer;
 
 public class ManagementAgent {
     public static void main(String... args) throws Exception {
-        SimpleCDSAppTester.of("HelloAOTCache-with-manangment-agent")
+        SimpleCDSAppTester.of("HelloAOTCache-with-management-agent")
             // test with the initialization of a management agent
             .addVmArgs("-Xlog:class+load", "-Dcom.sun.management.jmxremote=true")
             .classpath("app.jar")


### PR DESCRIPTION
If a management agent is specified when creating an AOT cache, it resulted in `java.lang.IllegalArgumentException`.
To avoid the exception, this fix is not to start the management agent when creating an AOT cache.

Passed tiers 1 - 4 testing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8352187](https://bugs.openjdk.org/browse/JDK-8352187): Don't start management agent during AOT cache creation (**Bug** - P3)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**) Review applies to [abeb7b6f](https://git.openjdk.org/jdk/pull/25562/files/abeb7b6f4561e7b892ec312aa8609bc00d7def5a)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25562/head:pull/25562` \
`$ git checkout pull/25562`

Update a local copy of the PR: \
`$ git checkout pull/25562` \
`$ git pull https://git.openjdk.org/jdk.git pull/25562/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25562`

View PR using the GUI difftool: \
`$ git pr show -t 25562`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25562.diff">https://git.openjdk.org/jdk/pull/25562.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25562#issuecomment-2923815591)
</details>
