### PR TITLE
8358230: Incorrect location for the assert for blob != nullptr in CodeBlob::create

### DIFF
--- a/src/hotspot/share/code/codeBlob.cpp
+++ b/src/hotspot/share/code/codeBlob.cpp
@@ -301,6 +301,8 @@ CodeBlob* CodeBlob::create(CodeBlob* archived_blob,
                                     name,
                                     archived_reloc_data,
                                     archived_oop_maps);
+      assert(blob != nullptr, "sanity check");
+
 #ifndef PRODUCT
       blob->use_remarks(archived_asm_remarks);
       archived_asm_remarks.clear();
@@ -308,7 +310,6 @@ CodeBlob* CodeBlob::create(CodeBlob* archived_blob,
       archived_dbg_strings.clear();
 #endif // PRODUCT
 
-      assert(blob != nullptr, "sanity check");
       // Flush the code block
       ICache::invalidate_range(blob->code_begin(), blob->code_size());
       CodeCache::commit(blob); // Count adapters


### PR DESCRIPTION
A trivial fix to moves the assert for `blob != nullptr` before any usage of the the `blob`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8358230](https://bugs.openjdk.org/browse/JDK-8358230): Incorrect location for the assert for blob != nullptr in CodeBlob::create (**Bug** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25566/head:pull/25566` \
`$ git checkout pull/25566`

Update a local copy of the PR: \
`$ git checkout pull/25566` \
`$ git pull https://git.openjdk.org/jdk.git pull/25566/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25566`

View PR using the GUI difftool: \
`$ git pr show -t 25566`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25566.diff">https://git.openjdk.org/jdk/pull/25566.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25566#issuecomment-2925714478)
</details>
