### PR TITLE
8358066: Non-ascii package names gives compilation error "import requires canonical name"

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Convert.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Convert.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -223,10 +223,11 @@ public class Convert {
      */
     public static int utfNumChars(byte[] buf, int off, int len) {
         int numChars = 0;
-        while (len-- > 0) {
-            int byte1 = buf[off++];
-            if (byte1 < 0)
-                len -= ((byte1 & 0xe0) == 0xc0) ? 1 : 2;
+        while (len > 0) {
+            int byte1 = buf[off];
+            int nbytes = byte1 >= 0 ? 1 : ((byte1 & 0xe0) == 0xc0) ? 2 : 3;
+            off += nbytes;
+            len -= nbytes;
             numChars++;
         }
         return numChars;

--- a/test/langtools/tools/javac/nametable/TestUtfNumChars.java
+++ b/test/langtools/tools/javac/nametable/TestUtfNumChars.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8358066
+ * @summary Test for bug in Convert.utfNumChars()
+ * @modules jdk.compiler/com.sun.tools.javac.util
+ * @run main TestUtfNumChars
+ */
+
+import com.sun.tools.javac.util.Convert;
+
+public class TestUtfNumChars {
+
+    public static void main(String[] args) {
+        String s = "f\u00f8\u00f8bar";          // "føøbar"
+        byte[] utf8 = Convert.string2utf(s);    // UTF-8: 66 c3 b8 c3 b8 62 61 72
+                                                // Bytes: 00 01 02 03 04 05 06 07
+                                                // Chars: 00 01 -- 02 -- 03 04 05
+        int[] offsets = new int[] {
+            0, 1, 3, 5, 6, 7
+        };
+
+        for (int i = 0; i < offsets.length; i++) {
+            int i_off = offsets[i];
+            for (int j = i; j < offsets.length; j++) {
+                int j_off = offsets[j];
+                int nchars = Convert.utfNumChars(utf8, i_off, j_off - i_off);
+                if (nchars != j - i)
+                    throw new AssertionError(String.format("nchars is %d != %d", nchars, j - i));
+            }
+        }
+    }
+}


### PR DESCRIPTION
A simple counting bug in `Convert.utfNumChars()` causes weird problems when the compiler is configured with `-XDuseUnsharedTable=true` and it encounters an `import` statement with a non-ASCII class name.