### PR TITLE
8358236: [AOT] Graal crashes when trying to use persisted MDOs

### DIFF
--- a/src/hotspot/share/oops/methodData.cpp
+++ b/src/hotspot/share/oops/methodData.cpp
@@ -1996,6 +1996,9 @@ void MethodData::release_C_heap_structures() {
 #if INCLUDE_CDS
 void MethodData::remove_unshareable_info() {
   _extra_data_lock = nullptr;
+#if INCLUDE_JVMCI
+  _failed_speculations = nullptr;
+#endif
 }
 
 void MethodData::restore_unshareable_info(TRAPS) {


### PR DESCRIPTION
Forgot to null out MethodData::_failed_speculations before snapshotting. As a result it gets restored with a dangling pointer.
Testing looks clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8358236](https://bugs.openjdk.org/browse/JDK-8358236): [AOT] Graal crashes when trying to use persisted MDOs (**Bug** - P2)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25570/head:pull/25570` \
`$ git checkout pull/25570`

Update a local copy of the PR: \
`$ git checkout pull/25570` \
`$ git pull https://git.openjdk.org/jdk.git pull/25570/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25570`

View PR using the GUI difftool: \
`$ git pr show -t 25570`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25570.diff">https://git.openjdk.org/jdk/pull/25570.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25570#issuecomment-2927711987)
</details>
