### PR TITLE
8358259: ProblemList compiler/startup/StartupOutput.java on Windows

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -79,6 +79,8 @@ compiler/ciReplay/TestIncrementalInlining.java 8349191 generic-all
 
 compiler/c2/TestVerifyConstraintCasts.java 8355574 generic-all
 
+compiler/startup/StartupOutput.java 8358129 windows-all
+
 #############################################################################
 
 # :hotspot_gc


### PR DESCRIPTION
This test is causing a lot of failures in itself and other tests running at the same time due to excessive memory consumption.

Thank you.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8358259](https://bugs.openjdk.org/browse/JDK-8358259): ProblemList compiler/startup/StartupOutput.java on Windows (**Sub-task** - P3)


### Reviewers
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25572/head:pull/25572` \
`$ git checkout pull/25572`

Update a local copy of the PR: \
`$ git checkout pull/25572` \
`$ git pull https://git.openjdk.org/jdk.git pull/25572/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25572`

View PR using the GUI difftool: \
`$ git pr show -t 25572`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25572.diff">https://git.openjdk.org/jdk/pull/25572.diff</a>

</details>
