### PR TITLE
8358284: doc/testing.html is not up to date after JDK-8355003

### DIFF
--- a/doc/testing.html
+++ b/doc/testing.html
@@ -72,9 +72,11 @@ id="toc-notes-for-specific-tests">Notes for Specific Tests</a>
 <li><a href="#non-us-locale" id="toc-non-us-locale">Non-US
 locale</a></li>
 <li><a href="#pkcs11-tests" id="toc-pkcs11-tests">PKCS11 Tests</a></li>
+</ul></li>
 <li><a href="#testing-ahead-of-time-optimizations"
-id="toc-testing-ahead-of-time-optimizations">Testing Ahead-of-time
-Optimizations</a></li>
+id="toc-testing-ahead-of-time-optimizations">### Testing Ahead-of-time
+Optimizations</a>
+<ul>
 <li><a href="#testing-with-alternative-security-providers"
 id="toc-testing-with-alternative-security-providers">Testing with
 alternative security providers</a></li>
@@ -599,8 +601,8 @@ element of the appropriate <code>@Artifact</code> class. (See
     JTREG=&quot;JAVA_OPTIONS=-Djdk.test.lib.artifacts.nsslib-linux_aarch64=/path/to/NSS-libs&quot;</code></pre>
 <p>For more notes about the PKCS11 tests, please refer to
 test/jdk/sun/security/pkcs11/README.</p>
-<h3 id="testing-ahead-of-time-optimizations">Testing Ahead-of-time
-Optimizations</h3>
+<h2 id="testing-ahead-of-time-optimizations">### Testing Ahead-of-time
+Optimizations</h2>
 <p>One way to improve test coverage of ahead-of-time (AOT) optimizations
 in the JDK is to run existing jtreg test cases in a special "AOT_JDK"
 mode. Example:</p>


### PR DESCRIPTION
Please review this trivial change to doc/testing.html, to bring it up to date
with the associated source file doc/testing.md.  The change was produced by
running `make update-build-docs` in an up-to-date local repository.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8358284](https://bugs.openjdk.org/browse/JDK-8358284): doc/testing.html is not up to date after JDK-8355003 (**Bug** - P4)


### Reviewers
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25573/head:pull/25573` \
`$ git checkout pull/25573`

Update a local copy of the PR: \
`$ git checkout pull/25573` \
`$ git pull https://git.openjdk.org/jdk.git pull/25573/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25573`

View PR using the GUI difftool: \
`$ git pr show -t 25573`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25573.diff">https://git.openjdk.org/jdk/pull/25573.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25573#issuecomment-2928615562)
</details>
