### PR TITLE
JDK-8357826: Avoid running some jtreg tests when asan is configured

### DIFF
--- a/src/hotspot/cpu/x86/gc/z/zAddress_x86.cpp
+++ b/src/hotspot/cpu/x86/gc/z/zAddress_x86.cpp
@@ -30,11 +30,15 @@
 size_t ZPointerLoadShift;
 
 size_t ZPlatformAddressOffsetBits() {
+#ifdef ADDRESS_SANITIZER
+  return 44;
+#else
   const size_t min_address_offset_bits = 42; // 4TB
   const size_t max_address_offset_bits = 44; // 16TB
   const size_t address_offset = ZGlobalsPointers::min_address_offset_request();
   const size_t address_offset_bits = log2i_exact(address_offset);
   return clamp(address_offset_bits, min_address_offset_bits, max_address_offset_bits);
+#endif
 }
 
 size_t ZPlatformAddressHeapBaseShift() {

--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -1097,6 +1097,22 @@ bool WhiteBox::validate_cgroup(bool cgroups_v2_enabled,
 }
 #endif
 
+bool WhiteBox::is_asan_enabled() {
+#ifdef ADDRESS_SANITIZER
+  return true;
+#else
+  return false;
+#endif
+}
+
+bool WhiteBox::is_ubsan_enabled() {
+#ifdef UNDEFINED_BEHAVIOR_SANITIZER
+  return true;
+#else
+  return false;
+#endif
+}
+
 bool WhiteBox::compile_method(Method* method, int comp_level, int bci, JavaThread* THREAD) {
   // Screen for unavailable/bad comp level or null method
   AbstractCompiler* comp = CompileBroker::compiler(comp_level);
@@ -1906,6 +1922,14 @@ WB_END
 WB_ENTRY(jboolean, WB_IsMonitorInflated(JNIEnv* env, jobject wb, jobject obj))
   oop obj_oop = JNIHandles::resolve(obj);
   return (jboolean) obj_oop->mark().has_monitor();
+WB_END
+
+WB_ENTRY(jboolean, WB_IsAsanEnabled(JNIEnv* env))
+  return (jboolean) WhiteBox::is_asan_enabled();
+WB_END
+
+WB_ENTRY(jboolean, WB_IsUbsanEnabled(JNIEnv* env))
+  return (jboolean) WhiteBox::is_ubsan_enabled();
 WB_END
 
 WB_ENTRY(jlong, WB_getInUseMonitorCount(JNIEnv* env, jobject wb))
@@ -2908,6 +2932,8 @@ static JNINativeMethod methods[] = {
                                                       (void*)&WB_AddModuleExportsToAll },
   {CC"deflateIdleMonitors", CC"()Z",                  (void*)&WB_DeflateIdleMonitors },
   {CC"isMonitorInflated0", CC"(Ljava/lang/Object;)Z", (void*)&WB_IsMonitorInflated  },
+  {CC"isAsanEnabled", CC"()Z",                        (void*)&WB_IsAsanEnabled },
+  {CC"isUbsanEnabled", CC"()Z",                       (void*)&WB_IsUbsanEnabled },
   {CC"getInUseMonitorCount", CC"()J", (void*)&WB_getInUseMonitorCount  },
   {CC"getLockStackCapacity", CC"()I",                 (void*)&WB_getLockStackCapacity },
   {CC"supportsRecursiveLightweightLocking", CC"()Z",  (void*)&WB_supportsRecursiveLightweightLocking },

--- a/src/hotspot/share/prims/whitebox.hpp
+++ b/src/hotspot/share/prims/whitebox.hpp
@@ -72,6 +72,8 @@ class WhiteBox : public AllStatic {
 #ifdef LINUX
   static bool validate_cgroup(bool cgroups_v2_enabled, const char* controllers_file, const char* proc_self_cgroup, const char* proc_self_mountinfo, u1* cg_flags);
 #endif
+  static bool is_asan_enabled();
+  static bool is_ubsan_enabled();
 };
 
 #endif // SHARE_PRIMS_WHITEBOX_HPP

--- a/test/hotspot/jtreg/TEST.ROOT
+++ b/test/hotspot/jtreg/TEST.ROOT
@@ -91,6 +91,8 @@ requires.properties= \
     vm.compiler1.enabled \
     vm.compiler2.enabled \
     vm.musl \
+    vm.asan \
+    vm.ubsan \
     vm.flagless \
     container.support \
     systemd.support \

--- a/test/hotspot/jtreg/gc/arguments/TestUseCompressedOopsFlagsWithUlimit.java
+++ b/test/hotspot/jtreg/gc/arguments/TestUseCompressedOopsFlagsWithUlimit.java
@@ -31,6 +31,7 @@ package gc.arguments;
  * @library /test/lib
  * @library /
  * @requires vm.bits == "64"
+ * @requires !vm.asan
  * @requires os.family == "linux"
  * @requires vm.gc != "Z"
  * @requires vm.opt.UseCompressedOops == null

--- a/test/hotspot/jtreg/runtime/XCheckJniJsig/XCheckJSig.java
+++ b/test/hotspot/jtreg/runtime/XCheckJniJsig/XCheckJSig.java
@@ -29,6 +29,7 @@
  * @modules java.base/jdk.internal.misc
  *          java.management
  * @requires os.family == "linux" | os.family == "mac"
+ * @requires !vm.asan
  * @comment TODO: Decide libjsig support on static JDK with 8351367
  * @requires !jdk.static
  * @run driver XCheckJSig

--- a/test/hotspot/jtreg/runtime/cds/appcds/aotCode/AOTCodeCompressedOopsTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotCode/AOTCodeCompressedOopsTest.java
@@ -26,6 +26,7 @@
  * @test
  * @summary Sanity test of AOT Code Cache with compressed oops configurations
  * @requires vm.cds.supports.aot.code.caching
+ * @requires !vm.asan
  * @requires vm.compMode != "Xcomp"
  * @comment The test verifies AOT checks during VM startup and not code generation.
  *          No need to run it with -Xcomp. It takes a lot of time to complete all

--- a/test/hotspot/jtreg/serviceability/dcmd/vm/SystemDumpMapTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/vm/SystemDumpMapTest.java
@@ -36,6 +36,7 @@ import java.util.regex.Pattern;
  * @summary Test of diagnostic command System.map
  * @library /test/lib
  * @requires (os.family == "linux" | os.family == "windows" | os.family == "mac")
+ * @requires !vm.asan
  * @requires os.arch != "riscv64" | !(vm.cpu.features ~= ".*qemu.*")
  * @modules java.base/jdk.internal.misc
  *          java.compiler

--- a/test/hotspot/jtreg/serviceability/dcmd/vm/SystemMapTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/vm/SystemMapTest.java
@@ -32,6 +32,7 @@ import jdk.test.lib.process.OutputAnalyzer;
  * @summary Test of diagnostic command System.map
  * @library /test/lib
  * @requires (vm.gc != "Z") & (os.family == "linux" | os.family == "windows" | os.family == "mac")
+ * @requires !vm.asan
  * @modules java.base/jdk.internal.misc
  *          java.compiler
  *          java.management
@@ -47,6 +48,7 @@ import jdk.test.lib.process.OutputAnalyzer;
  * @summary Test of diagnostic command System.map using ZGC
  * @library /test/lib
  * @requires vm.gc.Z & (os.family == "linux" | os.family == "windows" | os.family == "mac")
+ * @requires !vm.asan
  * @modules java.base/jdk.internal.misc
  *          java.compiler
  *          java.management

--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbCDSCore.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbCDSCore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,7 @@
  * @summary Test the clhsdb commands 'printmdo', 'printall', 'jstack' on a CDS enabled corefile.
  * @requires vm.cds
  * @requires vm.hasSA
+ * @requires !vm.asan
  * @requires vm.flavor == "server"
  * @library /test/lib
  * @modules java.base/jdk.internal.misc

--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbFindPC.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbFindPC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,6 +37,7 @@ import jtreg.SkippedException;
  * @summary Test the clhsdb 'findpc' command with Xcomp on live process
  * @requires vm.compMode != "Xcomp"
  * @requires vm.hasSA
+ * @requires !vm.asan
  * @requires (os.arch != "riscv64" | !(vm.cpu.features ~= ".*qemu.*"))
  * @requires vm.compiler1.enabled
  * @requires vm.opt.DeoptimizeALot != true
@@ -50,6 +51,7 @@ import jtreg.SkippedException;
  * @summary Test the clhsdb 'findpc' command with Xcomp on core file
  * @requires vm.compMode != "Xcomp"
  * @requires vm.hasSA
+ * @requires !vm.asan
  * @requires vm.compiler1.enabled
  * @requires vm.opt.DeoptimizeALot != true
  * @library /test/lib

--- a/test/jtreg-ext/requires/VMProps.java
+++ b/test/jtreg-ext/requires/VMProps.java
@@ -138,6 +138,8 @@ public class VMProps implements Callable<Map<String, String>> {
         map.put("container.support", this::containerSupport);
         map.put("systemd.support", this::systemdSupport);
         map.put("vm.musl", this::isMusl);
+        map.put("vm.asan", this::isAsanEnabled);
+        map.put("vm.ubsan", this::isUbsanEnabled);
         map.put("release.implementor", this::implementor);
         map.put("jdk.containerized", this::jdkContainerized);
         map.put("vm.flagless", this::isFlagless);
@@ -726,6 +728,15 @@ public class VMProps implements Callable<Map<String, String>> {
      */
     protected String isMusl() {
         return Boolean.toString(WB.getLibcName().contains("musl"));
+    }
+
+    // Sanitizer support
+    protected String isAsanEnabled() {
+        return "" + WB.isAsanEnabled();
+    }
+
+    protected String isUbsanEnabled() {
+        return "" + WB.isUbsanEnabled();
     }
 
     private String implementor() {

--- a/test/lib/jdk/test/whitebox/WhiteBox.java
+++ b/test/lib/jdk/test/whitebox/WhiteBox.java
@@ -326,6 +326,10 @@ public class WhiteBox {
   public native void NMTFreeArena(long arena);
   public native void NMTArenaMalloc(long arena, long size);
 
+  // Sanitizers
+  public native boolean isAsanEnabled();
+  public native boolean isUbsanEnabled();
+
   // Compiler
 
   // Determines if the libgraal shared library file is present.


### PR DESCRIPTION
There are a couple of jtreg tests, especially in the HS area, with very special assumptions about memory layout/sizes .
Those fail when the address sanitizer is configured ( --enable-asan ).
The change adds a way to tag those tests with 'requires' so that they can be avoided easily when running jtreg tests with ASAN enabled.
Adjusting the tests for "pleasing" the sanitizer is not always desired (if possible for some tests it can be done later) .
While at it, also same is also added for ubsan .