### PR TITLE
8357954: G1: No SATB barriers applied for runtime IN_NATIVE atomics

### DIFF
--- a/src/hotspot/share/gc/g1/g1BarrierSet.hpp
+++ b/src/hotspot/share/gc/g1/g1BarrierSet.hpp
@@ -112,6 +112,11 @@ class G1BarrierSet: public CardTableBarrierSet {
     // Defensive: will catch weak oops at addresses in heap
     template <typename T>
     static oop oop_load_in_heap(T* addr);
+
+    template <typename T>
+    static oop oop_atomic_cmpxchg_not_in_heap(T* addr, oop compare_value, oop new_value);
+    template <typename T>
+    static oop oop_atomic_xchg_not_in_heap(T* addr, oop new_value);
   };
 };
 

--- a/src/hotspot/share/gc/g1/g1BarrierSet.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1BarrierSet.inline.hpp
@@ -132,4 +132,26 @@ oop_store_not_in_heap(T* addr, oop new_value) {
   Raw::oop_store(addr, new_value);
 }
 
+template <DecoratorSet decorators, typename BarrierSetT>
+template <typename T>
+inline oop G1BarrierSet::AccessBarrier<decorators, BarrierSetT>::
+oop_atomic_cmpxchg_not_in_heap(T* addr, oop compare_value, oop new_value) {
+  // Apply SATB barriers for all non-heap references, to allow
+  // concurrent scanning of such references.
+  G1BarrierSet *bs = barrier_set_cast<G1BarrierSet>(BarrierSet::barrier_set());
+  bs->write_ref_field_pre<decorators>(addr);
+  return Raw::oop_atomic_cmpxchg(addr, compare_value, new_value);
+}
+
+template <DecoratorSet decorators, typename BarrierSetT>
+template <typename T>
+inline oop G1BarrierSet::AccessBarrier<decorators, BarrierSetT>::
+oop_atomic_xchg_not_in_heap(T* addr, oop new_value) {
+  // Apply SATB barriers for all non-heap references, to allow
+  // concurrent scanning of such references.
+  G1BarrierSet *bs = barrier_set_cast<G1BarrierSet>(BarrierSet::barrier_set());
+  bs->write_ref_field_pre<decorators>(addr);
+  return Raw::oop_atomic_xchg(addr, new_value);
+}
+
 #endif // SHARE_GC_G1_G1BARRIERSET_INLINE_HPP


### PR DESCRIPTION
OopHandle has had atomic xchg/cmpxchg operations added to it. Yet, the G1 access API backend doesn't really support that; there is no SATB barrier.

Fortunately the only use of OopHandle::xchg so far is appending to the pending list, which didn't need SATB barriers because young generation reference processing only adds young objects that the old gen doesn't care much about, and the old gen reference processor doesn't care about its own References that it publishes, because it's done after marking.

And fortunately the only use of OopHandle::cmpxchg so far is manipulating a lock-free list of virtual threads to unblock in JVM_TakeVirtualThreadListToUnblock. Since the virtual threads are blocked, they are externally kept alive.

But it's starting to feel quite scary, so let's be proactive and add the support to G1 before something inevitably blows up. This patch adds the missing SATB keep-alive code for G1 IN_NATIVE oop atomics.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8357954](https://bugs.openjdk.org/browse/JDK-8357954): G1: No SATB barriers applied for runtime IN_NATIVE atomics (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25576/head:pull/25576` \
`$ git checkout pull/25576`

Update a local copy of the PR: \
`$ git checkout pull/25576` \
`$ git pull https://git.openjdk.org/jdk.git pull/25576/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25576`

View PR using the GUI difftool: \
`$ git pr show -t 25576`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25576.diff">https://git.openjdk.org/jdk/pull/25576.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25576#issuecomment-2929398968)
</details>
