### PR TITLE
8358313: G1: Refactor G1CollectedHeap::is_maximal_no_gc

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -1031,7 +1031,7 @@ bool G1CollectedHeap::expand_single_region(uint node_index) {
   uint expanded_by = _hrm.expand_on_preferred_node(node_index);
 
   if (expanded_by == 0) {
-    assert(num_inactive_regions() == 0, "Should be no regions left, available: %u", _hrm.num_inactive_regions());
+    assert(num_inactive_regions() == 0, "Should be no regions left, available: %u", num_inactive_regions());
     log_debug(gc, ergo, heap)("Did not expand the heap (heap already fully expanded)");
     return false;
   }

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -1004,7 +1004,7 @@ bool G1CollectedHeap::expand(size_t expand_bytes, WorkerThreads* pretouch_worker
   log_debug(gc, ergo, heap)("Expand the heap. requested expansion amount: %zuB expansion amount: %zuB",
                             expand_bytes, aligned_expand_bytes);
 
-  if (is_maximal_no_gc()) {
+  if (num_inactive_regions() == 0) {
     log_debug(gc, ergo, heap)("Did not expand the heap (heap already fully expanded)");
     return false;
   }
@@ -1031,7 +1031,7 @@ bool G1CollectedHeap::expand_single_region(uint node_index) {
   uint expanded_by = _hrm.expand_on_preferred_node(node_index);
 
   if (expanded_by == 0) {
-    assert(is_maximal_no_gc(), "Should be no regions left, available: %u", _hrm.num_inactive_regions());
+    assert(num_inactive_regions() == 0, "Should be no regions left, available: %u", _hrm.num_inactive_regions());
     log_debug(gc, ergo, heap)("Did not expand the heap (heap already fully expanded)");
     return false;
   }

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -966,15 +966,14 @@ public:
   // end fields defining the extent of the contiguous allocation region.)
   // But G1CollectedHeap doesn't yet support this.
 
-  bool is_maximal_no_gc() const {
-    return _hrm.num_inactive_regions() == 0;
-  }
-
   // Returns true if an incremental GC should be upgrade to a full gc. This
   // is done when there are no free regions and the heap can't be expanded.
   bool should_upgrade_to_full_gc() const {
-    return is_maximal_no_gc() && num_free_regions() == 0;
+    return num_inactive_regions() == 0 && num_free_regions() == 0;
   }
+
+  // The number of inactive regions.
+  uint num_inactive_regions() const { return _hrm.num_inactive_regions(); }
 
   // The current number of regions in the heap.
   uint num_committed_regions() const { return _hrm.num_committed_regions(); }


### PR DESCRIPTION
Simple changing of a method name and return-type to be more consistent with the surrounding code.

Test: tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8358313](https://bugs.openjdk.org/browse/JDK-8358313): G1: Refactor G1CollectedHeap::is_maximal_no_gc (**Enhancement** - P4)


### Reviewers
 * [Joel Sikström](https://openjdk.org/census#jsikstro) (@jsikstro - Committer)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25579/head:pull/25579` \
`$ git checkout pull/25579`

Update a local copy of the PR: \
`$ git checkout pull/25579` \
`$ git pull https://git.openjdk.org/jdk.git pull/25579/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25579`

View PR using the GUI difftool: \
`$ git pr show -t 25579`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25579.diff">https://git.openjdk.org/jdk/pull/25579.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25579#issuecomment-2929709501)
</details>
