### PR TITLE
8358316: PKCS8Key.getEncoded() can throw NPE after JDK-8298420

### DIFF
--- a/src/java.base/share/classes/sun/security/pkcs/PKCS8Key.java
+++ b/src/java.base/share/classes/sun/security/pkcs/PKCS8Key.java
@@ -256,7 +256,8 @@ public class PKCS8Key implements PrivateKey, InternalPrivateKey {
      * or {@code null} if an encoding error occurs.
      */
     public byte[] getEncoded() {
-        return getEncodedInternal().clone();
+        byte[] b = getEncodedInternal();
+        return (b != null) ? b.clone() : null;
     }
 
     /**


### PR DESCRIPTION
Found by static analysis, see more details in the bug.

Additional testing:
 - [x] Linux x86_64 server fastdebug, `jdk_security`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8358316](https://bugs.openjdk.org/browse/JDK-8358316): PKCS8Key.getEncoded() can throw NPE after JDK-8298420 (**Bug** - P4)


### Reviewers
 * [Anthony Scarpino](https://openjdk.org/census#ascarpino) (@ascarpino - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25581/head:pull/25581` \
`$ git checkout pull/25581`

Update a local copy of the PR: \
`$ git checkout pull/25581` \
`$ git pull https://git.openjdk.org/jdk.git pull/25581/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25581`

View PR using the GUI difftool: \
`$ git pr show -t 25581`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25581.diff">https://git.openjdk.org/jdk/pull/25581.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25581#issuecomment-2929935198)
</details>
