### PR TITLE
8358319: Pem.decode should cache the Pattern

### DIFF
--- a/src/java.base/share/classes/sun/security/util/Pem.java
+++ b/src/java.base/share/classes/sun/security/util/Pem.java
@@ -49,7 +49,10 @@ public class Pem {
     public static final String DEFAULT_ALGO;
 
     // Pattern matching for EKPI operations
-    private static final Pattern pbePattern;
+    private static final Pattern PBE_PATTERN;
+
+    // Pattern matching for stripping whitespace.
+    private static final Pattern STRIP_WHITESPACE_PATTERN;
 
     // Lazy initialized PBES2 OID value
     private static ObjectIdentifier PBES2OID;
@@ -61,8 +64,9 @@ public class Pem {
         String algo = Security.getProperty("jdk.epkcs8.defaultAlgorithm");
         DEFAULT_ALGO = (algo == null || algo.isBlank()) ?
             "PBEWithHmacSHA256AndAES_128" : algo;
-        pbePattern = Pattern.compile("^PBEWith.*And.*",
+        PBE_PATTERN = Pattern.compile("^PBEWith.*And.*",
             Pattern.CASE_INSENSITIVE);
+        STRIP_WHITESPACE_PATTERN = Pattern.compile("\\s+");
     }
 
     public static final String CERTIFICATE = "CERTIFICATE";
@@ -84,9 +88,9 @@ public class Pem {
      * @return the decoded bytes
      */
     public static byte[] decode(String input) {
-        byte[] src = input.replaceAll("\\s+", "").
+        byte[] src = STRIP_WHITESPACE_PATTERN.matcher(input).replaceAll("").
             getBytes(StandardCharsets.ISO_8859_1);
-            return Base64.getDecoder().decode(src);
+        return Base64.getDecoder().decode(src);
     }
 
     /**
@@ -100,7 +104,7 @@ public class Pem {
     public static ObjectIdentifier getPBEID(String algorithm) {
 
         // Verify pattern matches PBE Standard Name spec
-        if (!pbePattern.matcher(algorithm).matches()) {
+        if (!PBE_PATTERN.matcher(algorithm).matches()) {
             throw new IllegalArgumentException("Invalid algorithm format.");
         }
 


### PR DESCRIPTION
SonarCloud complains we are using the String.replaceAll() method that creates Pattern internally every time. This looks a minor inefficiency in preview feature, but we can fix it from the day 1. Also fixed the variable name style in adjacent cached Pattern.

Additional testing:
 - [x] Linux x86_64 server fastdebug, `jdk_security`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8358319](https://bugs.openjdk.org/browse/JDK-8358319): Pem.decode should cache the Pattern (**Enhancement** - P4)


### Reviewers
 * [Anthony Scarpino](https://openjdk.org/census#ascarpino) (@ascarpino - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25583/head:pull/25583` \
`$ git checkout pull/25583`

Update a local copy of the PR: \
`$ git checkout pull/25583` \
`$ git pull https://git.openjdk.org/jdk.git pull/25583/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25583`

View PR using the GUI difftool: \
`$ git pr show -t 25583`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25583.diff">https://git.openjdk.org/jdk/pull/25583.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25583#issuecomment-2930105151)
</details>
