### PR TITLE
8345347: Test runtime/cds/TestDefaultArchiveLoading.java should accept VM flags or be marked as flagless

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/TestDefaultArchiveLoading.java
+++ b/test/hotspot/jtreg/runtime/cds/TestDefaultArchiveLoading.java
@@ -26,6 +26,7 @@
  * @test id=nocoops_nocoh
  * @summary Test Loading of default archives in all configurations
  * @requires vm.cds
+ * @requires vm.gc != "Z"
  * @requires vm.bits == 64
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
@@ -37,6 +38,7 @@
  * @test id=nocoops_coh
  * @summary Test Loading of default archives in all configurations (requires --enable-cds-archive-coh)
  * @requires vm.cds
+ * @requires vm.gc != "Z"
  * @requires vm.bits == 64
  * @library /test/lib
  * @modules java.base/jdk.internal.misc

--- a/test/hotspot/jtreg/runtime/cds/TestDefaultArchiveLoading.java
+++ b/test/hotspot/jtreg/runtime/cds/TestDefaultArchiveLoading.java
@@ -48,6 +48,7 @@
  * @test id=coops_nocoh
  * @summary Test Loading of default archives in all configurations
  * @requires vm.cds
+ * @requires vm.gc != "Z"
  * @requires vm.bits == 64
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
@@ -59,6 +60,7 @@
  * @test id=coops_coh
  * @summary Test Loading of default archives in all configurations (requires --enable-cds-archive-coh)
  * @requires vm.cds
+ * @requires vm.gc != "Z"
  * @requires vm.bits == 64
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
@@ -131,7 +133,7 @@ public class TestDefaultArchiveLoading {
             default: throw new RuntimeException("Invalid argument " + args[0]);
         }
 
-        ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(
+        ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(
                 "-XX:" + coh + "UseCompactObjectHeaders",
                 "-XX:" + coops + "UseCompressedOops",
                 "-Xlog:cds",


### PR DESCRIPTION
Currently this test uses `ProcessTools.createLimitedTestJavaProcessBuilder()` to ignore vm flags, so this patch changes the method to `ProcessTools.createTestJavaProcessBuilder()` to allow for more extensive training. Because ZGC is incompatible with heap dumping, is is disabled on this test. Verified locally and through tiered testing.