### PR TITLE
8358254: [AOT] runtime/cds/appcds/applications/JavacBench.java#aot crashes with SEGV in ClassLoaderData::holder

### DIFF
--- a/src/hotspot/share/ci/ciMethodData.cpp
+++ b/src/hotspot/share/ci/ciMethodData.cpp
@@ -57,11 +57,7 @@ ciMethodData::ciMethodData(MethodData* md)
 
 
 static bool is_klass_loaded(Klass* k) {
-  if (TrainingData::have_data()) {
-    // If we're running in AOT mode some classes may not be loaded yet
-    return !k->is_instance_klass() || InstanceKlass::cast(k)->is_loaded();
-  }
-  return true;
+  return TrainingData::is_klass_loaded(k);
 }
 
 // Check for entries that reference an unloaded method

--- a/src/hotspot/share/oops/trainingData.hpp
+++ b/src/hotspot/share/oops/trainingData.hpp
@@ -283,6 +283,14 @@ private:
   static bool need_data() { return AOTRecordTraining;  } // Going to write
   static bool assembling_data() { return have_data() && CDSConfig::is_dumping_final_static_archive() && CDSConfig::is_dumping_aot_linked_classes(); }
 
+  static bool is_klass_loaded(Klass* k) {
+    if (have_data()) {
+      // If we're running in AOT mode some classes may not be loaded yet
+      return !k->is_instance_klass() || InstanceKlass::cast(k)->is_loaded();
+    }
+    return true;
+  }
+
   template<typename Function>
   static void iterate(const Function& fn) { iterate(const_cast<Function&>(fn)); }
 

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotMethodData.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotMethodData.java
@@ -443,19 +443,7 @@ final class HotSpotMethodData implements MetaspaceObject {
         }
     }
 
-    static class RawItemProfile<T> {
-        final int entries;
-        final T[] items;
-        final long[] counts;
-        final long totalCount;
-
-        RawItemProfile(int entries, T[] items, long[] counts, long totalCount) {
-            this.entries = entries;
-            this.items = items;
-            this.counts = counts;
-            this.totalCount = totalCount;
-        }
-    }
+    record RawItemProfile<T>(int entries, T[] items, long[] counts, long totalCount) {}
 
     abstract static class AbstractTypeData extends CounterData {
 


### PR DESCRIPTION
JVMCI needs to be aware of unloaded classes in type profiles just like [CI does](https://github.com/openjdk/jdk/pull/24886/files#diff-cda53c3ed39c4e59f73f3298933ebed1912daeaf854f0b31f40332be109f6c30R317).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8358254](https://bugs.openjdk.org/browse/JDK-8358254): [AOT] runtime/cds/appcds/applications/JavacBench.java#aot crashes with SEGV in ClassLoaderData::holder (**Bug** - P4)


### Reviewers
 * [Tom Rodriguez](https://openjdk.org/census#never) (@tkrodriguez - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25592/head:pull/25592` \
`$ git checkout pull/25592`

Update a local copy of the PR: \
`$ git checkout pull/25592` \
`$ git pull https://git.openjdk.org/jdk.git pull/25592/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25592`

View PR using the GUI difftool: \
`$ git pr show -t 25592`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25592.diff">https://git.openjdk.org/jdk/pull/25592.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25592#issuecomment-2931357361)
</details>
