### PR TITLE
8358333: Use VEX2 prefix in Assembler::psllq

### DIFF
--- a/src/hotspot/cpu/x86/assembler_x86.cpp
+++ b/src/hotspot/cpu/x86/assembler_x86.cpp
@@ -9140,7 +9140,8 @@ void Assembler::pslld(XMMRegister dst, int shift) {
 }
 
 void Assembler::psllq(XMMRegister dst, int shift) {
-  InstructionAttr attributes(AVX_128bit, /* rex_w */ true, /* legacy_mode */ false, /* no_mask_reg */ true, /* uses_vl */ true);
+  InstructionAttr attributes(AVX_128bit, /* rex_w */ VM_Version::supports_evex(), /* legacy_mode */ false, /* no_mask_reg */ true, /* uses_vl */ true);
+  attributes.set_rex_vex_w_reverted();
   // XMM6 is for /6 encoding: 66 0F 73 /6 ib
   int encode = simd_prefix_and_encode(xmm6, dst, dst, VEX_SIMD_66, VEX_OPCODE_0F, &attributes);
   emit_int24(0x73, (0xC0 | encode), shift & 0xFF);


### PR DESCRIPTION
While porting the commit https://github.com/openjdk/jdk/commit/0df8c9684b8782ef830e2bd425217864c3f51784 to Graal, I noticed that the Assembler::psllq instruction is using the VEX3 prefix. This results in the instruction being unrecognizable by my outdated version of hsdis. Currently, HotSpot generates the following bytes for vpsllq xmm7, xmm7, 0x34
https://github.com/openjdk/jdk/blob/0df8c9684b8782ef830e2bd425217864c3f51784/src/hotspot/cpu/x86/stubGenerator_x86_64_cbrt.cpp#L255

```
c4 e1 c1 73 f7 34
```

By setting the rex_w to WIG, the emitted bytes are:

```
c5 c1 73 f7 34
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8358333](https://bugs.openjdk.org/browse/JDK-8358333): Use VEX2 prefix in Assembler::psllq (**Bug** - P4)


### Reviewers
 * [Jatin Bhateja](https://openjdk.org/census#jbhateja) (@jatin-bhateja - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25593/head:pull/25593` \
`$ git checkout pull/25593`

Update a local copy of the PR: \
`$ git checkout pull/25593` \
`$ git pull https://git.openjdk.org/jdk.git pull/25593/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25593`

View PR using the GUI difftool: \
`$ git pr show -t 25593`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25593.diff">https://git.openjdk.org/jdk/pull/25593.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25593#issuecomment-2931378731)
</details>
