### PR TITLE
8357991: make bootcycle-images is broken after JDK-8349665

### DIFF
--- a/make/Main.gmk
+++ b/make/Main.gmk
@@ -417,12 +417,22 @@ $(eval $(call SetupTarget, create-source-revision-tracker, \
 ))
 
 BOOTCYCLE_TARGET := product-images
+BOOTCYCLE_SPEC := $(dir $(SPEC))bootcycle-spec.gmk
+
 bootcycle-images:
         ifneq ($(COMPILE_TYPE), cross)
 	  $(call LogWarn, Boot cycle build step 2: Building a new JDK image using previously built image)
 	  $(call MakeDir, $(OUTPUTDIR)/bootcycle-build)
+          # We need to create essential files for the bootcycle spec dir
+	  ( cd $(TOPDIR) && \
+	        $(MAKE) $(MAKE_ARGS) -f make/GenerateFindTests.gmk \
+	         SPEC=$(BOOTCYCLE_SPEC))
+	  ( cd $(TOPDIR) && \
+	        $(MAKE) $(MAKE_ARGS) -f $(TOPDIR)/make/Main.gmk \
+	        SPEC=$(BOOTCYCLE_SPEC) UPDATE_MODULE_DEPS=true NO_RECIPES=true \
+	        create-main-targets-include )
 	  +$(MAKE) $(MAKE_ARGS) -f $(TOPDIR)/make/Init.gmk PARALLEL_TARGETS=$(BOOTCYCLE_TARGET) \
-	      LOG_PREFIX="[bootcycle] " JOBS= SPEC=$(dir $(SPEC))bootcycle-spec.gmk main
+	      LOG_PREFIX="[bootcycle] " JOBS= SPEC=$(BOOTCYCLE_SPEC) main
         else
 	  $(call LogWarn, Boot cycle build disabled when cross compiling)
         endif


### PR DESCRIPTION
`make bootcycle-images` broke after JDK-8349665, with the symptom:

```
jdk.internal.md.interim/module-info.java:51: error: module not found: jdk.compiler.interim
    requires jdk.compiler.interim; 
```

This is since the bootcycle build use a special spec.gmk files which point to a special `make-support` directory, and this did not contain the necessary files needed to start running make targets. (Ever since JDK-8292944 they need to be explicitly generated.)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8357991: make bootcycle-images is broken after JDK-8349665`

### Issue
 * [JDK-8357991](https://bugs.openjdk.org/browse/JDK-8357991): make bootcycle-images is broken after JDK-8349665 (**Bug** - P1)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25594/head:pull/25594` \
`$ git checkout pull/25594`

Update a local copy of the PR: \
`$ git checkout pull/25594` \
`$ git pull https://git.openjdk.org/jdk.git pull/25594/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25594`

View PR using the GUI difftool: \
`$ git pr show -t 25594`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25594.diff">https://git.openjdk.org/jdk/pull/25594.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25594#issuecomment-2931559523)
</details>
