### PR TITLE
8358283: Inconsistent failure mode for MetaspaceObj::operator new(size_t, MemTag)

### DIFF
--- a/src/hotspot/share/memory/allocation.cpp
+++ b/src/hotspot/share/memory/allocation.cpp
@@ -86,7 +86,7 @@ void* MetaspaceObj::operator new(size_t size, ClassLoaderData* loader_data,
 }
 
 // This is used for allocating training data. We are allocating training data in many cases where a GC cannot be triggered.
-void* MetaspaceObj::operator new(size_t size, MemTag flags) throw() {
+void* MetaspaceObj::operator new(size_t size, MemTag flags) {
   void* p = AllocateHeap(size, flags, CALLER_PC);
   memset(p, 0, size);
   return p;

--- a/src/hotspot/share/memory/allocation.hpp
+++ b/src/hotspot/share/memory/allocation.hpp
@@ -358,7 +358,7 @@ class MetaspaceObj {
                      size_t word_size,
                      Type type) throw();
   // This is used for allocating training data. We are allocating training data in many cases where a GC cannot be triggered.
-  void* operator new(size_t size, MemTag flags) throw();
+  void* operator new(size_t size, MemTag flags);
   void operator delete(void* p) = delete;
 
   // Declare a *static* method with the same signature in any subclass of MetaspaceObj


### PR DESCRIPTION
Remove unnecessary no throw