### PR TITLE
8358330: AsmRemarks and DbgStrings clear() method may not get called before their destructor

### DIFF
--- a/src/hotspot/share/asm/codeBuffer.cpp
+++ b/src/hotspot/share/asm/codeBuffer.cpp
@@ -143,8 +143,6 @@ CodeBuffer::~CodeBuffer() {
   if (_shared_trampoline_requests != nullptr) {
     delete _shared_trampoline_requests;
   }
-
-  NOT_PRODUCT(clear_strings());
 }
 
 void CodeBuffer::initialize_oop_recorder(OopRecorder* r) {
@@ -1104,7 +1102,10 @@ AsmRemarks::AsmRemarks() : _remarks(new AsmRemarkCollection()) {
 }
 
 AsmRemarks::~AsmRemarks() {
-  assert(_remarks == nullptr, "Must 'clear()' before deleting!");
+  if (_remarks != nullptr) {
+    clear();
+  }
+  assert(_remarks == nullptr, "must be");
 }
 
 const char* AsmRemarks::insert(uint offset, const char* remstr) {
@@ -1156,7 +1157,10 @@ DbgStrings::DbgStrings() : _strings(new DbgStringCollection()) {
 }
 
 DbgStrings::~DbgStrings() {
-  assert(_strings == nullptr, "Must 'clear()' before deleting!");
+  if (_strings != nullptr) {
+    clear();
+  }
+  assert(_strings == nullptr, "must be");
 }
 
 const char* DbgStrings::insert(const char* dbgstr) {

--- a/src/hotspot/share/asm/codeBuffer.hpp
+++ b/src/hotspot/share/asm/codeBuffer.hpp
@@ -821,11 +821,6 @@ class CodeBuffer: public StackObj DEBUG_ONLY(COMMA private Scrubber) {
 #ifndef PRODUCT
   AsmRemarks &asm_remarks() { return _asm_remarks; }
   DbgStrings &dbg_strings() { return _dbg_strings; }
-
-  void clear_strings() {
-    _asm_remarks.clear();
-    _dbg_strings.clear();
-  }
 #endif
 
   // Code generation

--- a/src/hotspot/share/code/codeBlob.cpp
+++ b/src/hotspot/share/code/codeBlob.cpp
@@ -303,9 +303,7 @@ CodeBlob* CodeBlob::create(CodeBlob* archived_blob,
                                     archived_oop_maps);
 #ifndef PRODUCT
       blob->use_remarks(archived_asm_remarks);
-      archived_asm_remarks.clear();
       blob->use_strings(archived_dbg_strings);
-      archived_dbg_strings.clear();
 #endif // PRODUCT
 
       assert(blob != nullptr, "sanity check");


### PR DESCRIPTION
This patch fixes a possible assert in debug builds if the allocation of memory for a CodeBlob fails when loading it from the AOT Code Cache.