### PR TITLE
8358339: Handle MethodCounters::_method backlinks after JDK-8355003

### DIFF
--- a/src/hotspot/share/asm/codeBuffer.cpp
+++ b/src/hotspot/share/asm/codeBuffer.cpp
@@ -29,6 +29,7 @@
 #include "compiler/disassembler.hpp"
 #include "logging/log.hpp"
 #include "oops/klass.inline.hpp"
+#include "oops/methodCounters.hpp"
 #include "oops/methodData.hpp"
 #include "oops/oop.inline.hpp"
 #include "runtime/icache.hpp"
@@ -537,6 +538,9 @@ void CodeBuffer::finalize_oop_references(const methodHandle& mh) {
             if (m->is_methodData()) {
               m = ((MethodData*)m)->method();
             }
+            if (m->is_methodCounters()) {
+              m = ((MethodCounters*)m)->method();
+            }
             if (m->is_method()) {
               m = ((Method*)m)->method_holder();
             }
@@ -560,6 +564,9 @@ void CodeBuffer::finalize_oop_references(const methodHandle& mh) {
       if (oop_recorder()->is_real(m)) {
         if (m->is_methodData()) {
           m = ((MethodData*)m)->method();
+        }
+        if (m->is_methodCounters()) {
+          m = ((MethodCounters*)m)->method();
         }
         if (m->is_method()) {
           m = ((Method*)m)->method_holder();

--- a/src/hotspot/share/code/nmethod.cpp
+++ b/src/hotspot/share/code/nmethod.cpp
@@ -788,6 +788,8 @@ class CheckClass : public MetadataClosure {
       klass = ((Method*)md)->method_holder();
     } else if (md->is_methodData()) {
       klass = ((MethodData*)md)->method()->method_holder();
+    } else if (md->is_methodCounters()) {
+      klass = ((MethodCounters*)md)->method()->method_holder();
     } else {
       md->print();
       ShouldNotReachHere();

--- a/src/hotspot/share/oops/metadata.hpp
+++ b/src/hotspot/share/oops/metadata.hpp
@@ -44,6 +44,7 @@ class Metadata : public MetaspaceObj {
   virtual bool is_method()             const { return false; }
   virtual bool is_methodData()         const { return false; }
   virtual bool is_constantPool()       const { return false; }
+  virtual bool is_methodCounters()     const { return false; }
   virtual int  size()                  const = 0;
   virtual MetaspaceObj::Type type()    const = 0;
   virtual const char* internal_name()  const = 0;


### PR DESCRIPTION
Found this when reading mainline-vs-premain webrev. [JDK-8355003](https://bugs.openjdk.org/browse/JDK-8355003) introduced a backlink to `Method*` in `MethodCounters`. I believe we need to handle that backlink at least in `CodeBuffer::finalize_oop_references()`. premain does this, while mainline does not. Also, amusingly, we have `MethodCounters::is_methodCounters`, but not the super-class `Metadata::is_methodCounters`. 

I pulled in the hunks that use `is_methodCounters()` and `MethodCounters::method()` from premain into this PR.

Additional testing:
 - [x] Linux x86_64 server fastdebug, `runtime/cds`
 - [x] Linux x86_64 server fastdebug, `tier1`
 - [x] Linux x86_64 server fastdebug, `all`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8358339](https://bugs.openjdk.org/browse/JDK-8358339): Handle MethodCounters::_method backlinks after JDK-8355003 (**Bug** - P4)


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Igor Veresov](https://openjdk.org/census#iveresov) (@veresov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25599/head:pull/25599` \
`$ git checkout pull/25599`

Update a local copy of the PR: \
`$ git checkout pull/25599` \
`$ git pull https://git.openjdk.org/jdk.git pull/25599/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25599`

View PR using the GUI difftool: \
`$ git pr show -t 25599`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25599.diff">https://git.openjdk.org/jdk/pull/25599.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25599#issuecomment-2932027817)
</details>
