### PR TITLE
8358158: test/jdk/java/io/Console/CharsetTest.java failing with NoClassDefFoundError: jtreg/SkippedException

### DIFF
--- a/test/jdk/java/io/Console/StdoutEncodingTest.java
+++ b/test/jdk/java/io/Console/StdoutEncodingTest.java
@@ -35,13 +35,14 @@ import org.junit.jupiter.params.provider.CsvSource;
 /**
  * @test
  * @bug 8264208 8265918 8356985 8358158
- * @summary Tests Console.charset() method. "expect" command in Windows/Cygwin
+ * @summary Tests if "stdout.encoding" property is reflected in
+ *          Console.charset() method. "expect" command in Windows/Cygwin
  *          does not work as expected. Ignoring tests on Windows.
  * @requires (os.family == "linux") | (os.family == "mac")
  * @library /test/lib
- * @run junit CharsetTest
+ * @run junit StdoutEncodingTest
  */
-public class CharsetTest {
+public class StdoutEncodingTest {
 
     @ParameterizedTest
     @CsvSource({
@@ -59,7 +60,7 @@ public class CharsetTest {
         OutputAnalyzer output = ProcessTools.executeProcess(
                 "expect",
                 "-n",
-                TEST_SRC + "/script.exp",
+                TEST_SRC + "/stdoutEncoding.exp",
                 TEST_JDK + "/bin/java",
                 locale,
                 expectedCharset,

--- a/test/jdk/java/io/Console/stdoutEncoding.exp
+++ b/test/jdk/java/io/Console/stdoutEncoding.exp
@@ -21,12 +21,14 @@
 # questions.
 #
 
+# `expect` script for StdoutEncodingTest
+
 set java [lrange $argv 0 0]
 set locale [lrange $argv 1 1]
 set expected [lrange $argv 2 2]
 set args [lrange $argv 3 end]
 regexp {([a-zA-Z_]*).([a-zA-Z0-9\-]*)} $locale dummy lang_region encoding
 
-eval spawn $java -Dstdout.encoding=$encoding -classpath $args CharsetTest
+eval spawn $java -Dstdout.encoding=$encoding -classpath $args StdoutEncodingTest
 expect $expected
 expect eof


### PR DESCRIPTION
Fixing a regression caused by the fix to [JDK-8356985](https://bugs.openjdk.org/browse/JDK-8356985). Although the fix in `CharsetTest` was a clean-up and not the gist of the original issue, the change seem to have tripped some jtreg library loading issue. As the failure is causing CI tests failing, replacing the offending `SkippedException` with JUnit's `Assumptions`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8358158](https://bugs.openjdk.org/browse/JDK-8358158): test/jdk/java/io/Console/CharsetTest.java failing with NoClassDefFoundError: jtreg/SkippedException (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25600/head:pull/25600` \
`$ git checkout pull/25600`

Update a local copy of the PR: \
`$ git checkout pull/25600` \
`$ git pull https://git.openjdk.org/jdk.git pull/25600/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25600`

View PR using the GUI difftool: \
`$ git pr show -t 25600`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25600.diff">https://git.openjdk.org/jdk/pull/25600.diff</a>

</details>
