### PR TITLE
8358158: test/jdk/java/io/Console/CharsetTest.java failing with NoClassDefFoundError: jtreg/SkippedException

### DIFF
--- a/test/jdk/java/io/Console/ConsolePromptTest.java
+++ b/test/jdk/java/io/Console/ConsolePromptTest.java
@@ -104,10 +104,7 @@ public class ConsolePromptTest {
 
         OutputAnalyzer output = ProcessTools.executeProcess(command.toArray(String[]::new));
         output.reportDiagnosticSummary();
-        var eval = output.getExitValue();
-        if (eval != 0) {
-            throw new RuntimeException("Test failed. Exit value from 'expect' command: " + eval);
-        }
+        output.shouldHaveExitValue(0);
     }
 
     public static class ConsoleTest {

--- a/test/jdk/java/io/Console/RestoreEchoTest.java
+++ b/test/jdk/java/io/Console/RestoreEchoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,7 +32,6 @@ import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
-import static org.junit.jupiter.api.Assertions.*;
 
 
 /**
@@ -72,7 +71,7 @@ public class RestoreEchoTest {
                 "-classpath", testClasses,
                 "RestoreEchoTest");
         output.reportDiagnosticSummary();
-        assertEquals(0, output.getExitValue());
+        output.shouldHaveExitValue(0);
     }
 
     public static void main(String... args) throws Throwable {

--- a/test/jdk/java/io/Console/StdinEncodingTest.java
+++ b/test/jdk/java/io/Console/StdinEncodingTest.java
@@ -31,7 +31,6 @@ import static jdk.test.lib.Utils.*;
 
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * @test
@@ -64,8 +63,7 @@ public class StdinEncodingTest {
             "-Dstdin.encoding=Uppercasing", // <- gist of this test
             "StdinEncodingTest");
         output.reportDiagnosticSummary();
-        var eval = output.getExitValue();
-        assertEquals(0, eval, "Test failed. Exit value from 'expect' command: " + eval);
+        output.shouldHaveExitValue(0);
     }
 
     public static void main(String... args) throws Throwable {

--- a/test/jdk/java/io/Console/StdoutEncodingTest.java
+++ b/test/jdk/java/io/Console/StdoutEncodingTest.java
@@ -66,10 +66,7 @@ public class StdoutEncodingTest {
                 expectedCharset,
                 TEST_CLASSES);
         output.reportDiagnosticSummary();
-        var eval = output.getExitValue();
-        if (eval != 0) {
-            throw new RuntimeException("Test failed. Exit value from 'expect' command: " + eval);
-        }
+        output.shouldHaveExitValue(0);
     }
 
     public static void main(String... args) {

--- a/test/jdk/java/io/Console/StdoutEncodingTest.java
+++ b/test/jdk/java/io/Console/StdoutEncodingTest.java
@@ -35,13 +35,14 @@ import org.junit.jupiter.params.provider.CsvSource;
 /**
  * @test
  * @bug 8264208 8265918 8356985 8358158
- * @summary Tests Console.charset() method. "expect" command in Windows/Cygwin
+ * @summary Tests if "stdout.encoding" property is reflected in
+ *          Console.charset() method. "expect" command in Windows/Cygwin
  *          does not work as expected. Ignoring tests on Windows.
  * @requires (os.family == "linux") | (os.family == "mac")
  * @library /test/lib
- * @run junit CharsetTest
+ * @run junit StdoutEncodingTest
  */
-public class CharsetTest {
+public class StdoutEncodingTest {
 
     @ParameterizedTest
     @CsvSource({
@@ -59,7 +60,7 @@ public class CharsetTest {
         OutputAnalyzer output = ProcessTools.executeProcess(
                 "expect",
                 "-n",
-                TEST_SRC + "/script.exp",
+                TEST_SRC + "/stdoutEncoding.exp",
                 TEST_JDK + "/bin/java",
                 locale,
                 expectedCharset,

--- a/test/jdk/java/io/Console/stdoutEncoding.exp
+++ b/test/jdk/java/io/Console/stdoutEncoding.exp
@@ -26,9 +26,9 @@
 set java [lrange $argv 0 0]
 set locale [lrange $argv 1 1]
 set expected [lrange $argv 2 2]
-set args [lrange $argv 3 end]
+set classpath [lrange $argv 3 end]
 regexp {([a-zA-Z_]*).([a-zA-Z0-9\-]*)} $locale dummy lang_region encoding
 
-eval spawn $java -Dstdout.encoding=$encoding -classpath $args StdoutEncodingTest
+eval spawn $java -Dstdout.encoding=$encoding -classpath $classpath StdoutEncodingTest
 expect $expected
 expect eof

--- a/test/jdk/java/io/Console/stdoutEncoding.exp
+++ b/test/jdk/java/io/Console/stdoutEncoding.exp
@@ -21,12 +21,14 @@
 # questions.
 #
 
+# `expect` script for StdoutEncodingTest
+
 set java [lrange $argv 0 0]
 set locale [lrange $argv 1 1]
 set expected [lrange $argv 2 2]
 set args [lrange $argv 3 end]
 regexp {([a-zA-Z_]*).([a-zA-Z0-9\-]*)} $locale dummy lang_region encoding
 
-eval spawn $java -Dstdout.encoding=$encoding -classpath $args CharsetTest
+eval spawn $java -Dstdout.encoding=$encoding -classpath $args StdoutEncodingTest
 expect $expected
 expect eof


### PR DESCRIPTION
Fixing a regression caused by the fix to JDK-8356985. Although the fix in `CharsetTest` was a clean-up and not the gist of the original issue, the change seem to have caused not finding `SkippedException` at runtime in certain cases. Changing the test to JUnit based so that the offending `SkippedException` can be replaced with JUnit's `Assumptions`. Also renamed the test case itself to reflect what's actually tested in it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8358158](https://bugs.openjdk.org/browse/JDK-8358158): test/jdk/java/io/Console/CharsetTest.java failing with NoClassDefFoundError: jtreg/SkippedException (**Bug** - P4)


### Reviewers
 * [Joe Wang](https://openjdk.org/census#joehw) (@JoeWang-Java - **Reviewer**)
 * [Justin Lu](https://openjdk.org/census#jlu) (@justin-curtis-lu - Committer)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25601/head:pull/25601` \
`$ git checkout pull/25601`

Update a local copy of the PR: \
`$ git checkout pull/25601` \
`$ git pull https://git.openjdk.org/jdk.git pull/25601/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25601`

View PR using the GUI difftool: \
`$ git pr show -t 25601`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25601.diff">https://git.openjdk.org/jdk/pull/25601.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25601#issuecomment-2932776917)
</details>
