### PR TITLE
8358183: [JVMCI] crash accessing nmethod::jvmci_name in CodeCache::aggregate

### DIFF
--- a/src/hotspot/share/code/codeBlob.cpp
+++ b/src/hotspot/share/code/codeBlob.cpp
@@ -206,6 +206,8 @@ void CodeBlob::purge() {
   if (_mutable_data != blob_end()) {
     os::free(_mutable_data);
     _mutable_data = blob_end(); // Valid not null address
+    _mutable_data_size = 0;
+    _relocation_size = 0;
   }
   if (_oop_maps != nullptr) {
     delete _oop_maps;

--- a/src/hotspot/share/code/nmethod.cpp
+++ b/src/hotspot/share/code/nmethod.cpp
@@ -2169,6 +2169,7 @@ void nmethod::purge(bool unregister_nmethod) {
   }
   CodeCache::unregister_old_nmethod(this);
 
+  JVMCI_ONLY( _metadata_size = 0; )
   CodeBlob::purge();
 }
 


### PR DESCRIPTION
This change addresses an intermittent crash in CompileBroker::print_heapinfo() when accessing JVMCI metadata after a CodeBlob::purge().

The issue is a regression after:
- JDK-8343789: JVMCI metadata was moved from nmethod into a separate blob.
- JDK-8352112: CodeBlob::purge() was updated to set _mutable_data to blob_end().

The change zeroes out _mutable_data_size, _relocation_size, and _metadata_size in purge() so that after purge jvmci_data_size() returns 0 and CompileBroker::print_heapinfo() won’t touch an invalid _metadata.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8358183](https://bugs.openjdk.org/browse/JDK-8358183): [JVMCI] crash accessing nmethod::jvmci_name in CodeCache::aggregate (**Bug** - P3)(⚠️ The fixVersion in this issue is [25] but the fixVersion in .jcheck/conf is 26, a new backport will be created when this pr is integrated.)


### Reviewers
 * [Evgeny Astigeevich](https://openjdk.org/census#eastigeevich) (@eastig - Committer)
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25608/head:pull/25608` \
`$ git checkout pull/25608`

Update a local copy of the PR: \
`$ git checkout pull/25608` \
`$ git pull https://git.openjdk.org/jdk.git pull/25608/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25608`

View PR using the GUI difftool: \
`$ git pr show -t 25608`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25608.diff">https://git.openjdk.org/jdk/pull/25608.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25608#issuecomment-2938481077)
</details>
