### PR TITLE
8357822: C2: Multiple string optimization tests are no longer testing string concatenation optimizations

### DIFF
--- a/test/hotspot/jtreg/compiler/c2/Test7046096.java
+++ b/test/hotspot/jtreg/compiler/c2/Test7046096.java
@@ -33,7 +33,7 @@
 
 /*
  * @test id=stringConcatInline
- * @bug 7046096
+ * @bug 7046096 8357822
  * @summary The same test with an updated compile directive that produces
  *          StringBuilder-backed string concatenations.
  *

--- a/test/hotspot/jtreg/compiler/c2/Test7046096.java
+++ b/test/hotspot/jtreg/compiler/c2/Test7046096.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,18 @@
  * @run main/othervm -Xbatch -XX:+IgnoreUnrecognizedVMOptions -XX:+OptimizeStringConcat
  *    compiler.c2.Test7046096
  */
+
+
+/*
+ * @test id=stringConcatInline
+ * @bug 7046096
+ * @summary The same test with an updated compile directive that produces
+ *          StringBuilder-backed string concatenations.
+ *
+ * @compile -XDstringConcat=inline Test7046096.java
+ * @run main/othervm -Xbatch compiler.c2.Test7046096
+ */
+
 
 package compiler.c2;
 

--- a/test/hotspot/jtreg/compiler/c2/Test7179138_2.java
+++ b/test/hotspot/jtreg/compiler/c2/Test7179138_2.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2012 Skip Balk.  All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -31,6 +32,18 @@
  *
  * @author Skip Balk
  */
+
+
+/*
+ * @test id=stringConcatInline
+ * @bug 7179138
+ * @summary The same test with an updated compile directive that produces
+ *          StringBuilder-backed string concatenations.
+ *
+ * @compile -XDstringConcat=inline Test7179138_2.java
+ * @run main/othervm -Xbatch -XX:-TieredCompilation compiler.c2.Test7179138_2
+ */
+
 
 package compiler.c2;
 

--- a/test/hotspot/jtreg/compiler/intrinsics/string/TestStringIntrinsics.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/string/TestStringIntrinsics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,17 +27,6 @@
  * @summary Tests correctness of string related intrinsics and C2 optimizations.
  * @library /test/lib
  *
- * @run main/timeout=240 compiler.intrinsics.string.TestStringIntrinsics
- */
-
-/*
- * @test id=stringConcatInline
- * @bug 8054307
- * @summary The same test with an updated compile directive that produces
- *          StringBuilder-backed string concatenations.
- * @library /test/lib
- *
- * @compile -XDstringConcat=inline TestStringIntrinsics.java
  * @run main/timeout=240 compiler.intrinsics.string.TestStringIntrinsics
  */
 

--- a/test/hotspot/jtreg/compiler/intrinsics/string/TestStringIntrinsics.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/string/TestStringIntrinsics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,17 @@
  * @summary Tests correctness of string related intrinsics and C2 optimizations.
  * @library /test/lib
  *
+ * @run main/timeout=240 compiler.intrinsics.string.TestStringIntrinsics
+ */
+
+/*
+ * @test id=stringConcatInline
+ * @bug 8054307
+ * @summary The same test with an updated compile directive that produces
+ *          StringBuilder-backed string concatenations.
+ * @library /test/lib
+ *
+ * @compile -XDstringConcat=inline TestStringIntrinsics.java
  * @run main/timeout=240 compiler.intrinsics.string.TestStringIntrinsics
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/compiler/optimizations/stringconcat/implicit/Implicit01/cs_disabled/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/compiler/optimizations/stringconcat/implicit/Implicit01/cs_disabled/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,20 @@
  *
  * @library /vmTestbase
  *          /test/lib
+ * @run main/othervm -XX:-CompactStrings vm.compiler.optimizations.stringconcat.implicit.Implicit01
+ */
+
+
+/*
+ * @test id=stringConcatInline
+ *
+ * @summary The same test with an updated compile directive that produces
+ *          StringBuilder-backed string concatenations.
+ * VM Testbase keywords: [jit, quick]
+ *
+ * @library /vmTestbase
+ *          /test/lib
+ * @compile -XDstringConcat=inline ../../Implicit01.java
  * @run main/othervm -XX:-CompactStrings vm.compiler.optimizations.stringconcat.implicit.Implicit01
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/compiler/optimizations/stringconcat/implicit/Implicit01/cs_enabled/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/compiler/optimizations/stringconcat/implicit/Implicit01/cs_enabled/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,20 @@
  *
  * @library /vmTestbase
  *          /test/lib
+ * @run main/othervm -XX:+CompactStrings vm.compiler.optimizations.stringconcat.implicit.Implicit01
+ */
+
+
+/*
+ * @test id=stringConcatInline
+ *
+ * @summary The same test with an updated compile directive that produces
+ *          StringBuilder-backed string concatenations.
+ * VM Testbase keywords: [jit, quick]
+ *
+ * @library /vmTestbase
+ *          /test/lib
+ * @compile -XDstringConcat=inline ../../Implicit01.java
  * @run main/othervm -XX:+CompactStrings vm.compiler.optimizations.stringconcat.implicit.Implicit01
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/compiler/optimizations/stringconcat/implicit/Merge01/cs_disabled/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/compiler/optimizations/stringconcat/implicit/Merge01/cs_disabled/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,20 @@
  *
  * @library /vmTestbase
  *          /test/lib
+ * @run main/othervm -XX:-CompactStrings vm.compiler.optimizations.stringconcat.implicit.Merge01
+ */
+
+
+/*
+ * @test id=stringConcatInline
+ *
+ * @summary The same test with an updated compile directive that produces
+ *          StringBuilder-backed string concatenations.
+ * VM Testbase keywords: [jit, quick]
+ *
+ * @library /vmTestbase
+ *          /test/lib
+ * @compile -XDstringConcat=inline ../../Merge01.java
  * @run main/othervm -XX:-CompactStrings vm.compiler.optimizations.stringconcat.implicit.Merge01
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/compiler/optimizations/stringconcat/implicit/Merge01/cs_enabled/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/compiler/optimizations/stringconcat/implicit/Merge01/cs_enabled/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,20 @@
  *
  * @library /vmTestbase
  *          /test/lib
+ * @run main/othervm -XX:+CompactStrings vm.compiler.optimizations.stringconcat.implicit.Merge01
+ */
+
+
+/*
+ * @test id=stringConcatInline
+ *
+ * @summary The same test with an updated compile directive that produces
+ *          StringBuilder-backed string concatenations.
+ * VM Testbase keywords: [jit, quick]
+ *
+ * @library /vmTestbase
+ *          /test/lib
+ * @compile -XDstringConcat=inline ../../Merge01.java
  * @run main/othervm -XX:+CompactStrings vm.compiler.optimizations.stringconcat.implicit.Merge01
  */
 


### PR DESCRIPTION
This PR updates a few tests to reintroduce testing of string concatenation optimizations since a few bugs have recently been identified in this area.

Selection criteria: performed a text search on the test suite and identified tests for string concatenations or string optimizations that are not currently compiled with `-XDstringConcat=inline` and are not using StringBuilders explicitly.

Testing: T1-4.

Extra testing: ran the tests manually with `-XX:+PrintOptimizeStringConcat` and verified that the tests are exercising string optimizations after the fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8357822](https://bugs.openjdk.org/browse/JDK-8357822): C2: Multiple string optimization tests are no longer testing string concatenation optimizations (**Bug** - P4)


### Reviewers
 * [Emanuel Peter](https://openjdk.org/census#epeter) (@eme64 - **Reviewer**) Review applies to [731667f4](https://git.openjdk.org/jdk/pull/25610/files/731667f42329b74ba2289a75abdec572ce895ef7)
 * [Roberto Castañeda Lozano](https://openjdk.org/census#rcastanedalo) (@robcasloz - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25610/head:pull/25610` \
`$ git checkout pull/25610`

Update a local copy of the PR: \
`$ git checkout pull/25610` \
`$ git pull https://git.openjdk.org/jdk.git pull/25610/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25610`

View PR using the GUI difftool: \
`$ git pr show -t 25610`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25610.diff">https://git.openjdk.org/jdk/pull/25610.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25610#issuecomment-2933869531)
</details>
