### PR TITLE
8346884: Add since checker test to jdk.editpad

### DIFF
--- a/test/jdk/tools/sincechecker/modules/jdk.editpad/JdkEditpadCheckSince.java
+++ b/test/jdk/tools/sincechecker/modules/jdk.editpad/JdkEditpadCheckSince.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8346884
+ * @summary Test for `@since` in jdk.editpad module
+ * @library /test/lib /test/jdk/tools/sincechecker
+ * @run main SinceChecker jdk.editpad
+ */


### PR DESCRIPTION
Please review this patch to add a new test to check `@since` tags in the `jdk.editpad` module.

TIA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346884](https://bugs.openjdk.org/browse/JDK-8346884): Add since checker test to jdk.editpad (**Sub-task** - P4)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25613/head:pull/25613` \
`$ git checkout pull/25613`

Update a local copy of the PR: \
`$ git checkout pull/25613` \
`$ git pull https://git.openjdk.org/jdk.git pull/25613/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25613`

View PR using the GUI difftool: \
`$ git pr show -t 25613`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25613.diff">https://git.openjdk.org/jdk/pull/25613.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25613#issuecomment-2934763165)
</details>
