### PR TITLE
8358448: JFR: Incorrect time unit for MethodTiming event

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/events/MethodTimingEvent.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/events/MethodTimingEvent.java
@@ -43,7 +43,7 @@ public final class MethodTimingEvent extends AbstractJDKEvent {
     public long invocations;
 
     @Label("Average Time")
-    @Timespan
+    @Timespan(Timespan.TICKS)
     public long average;
 
     public static void commit(long start, long method, long invocations, long average) {


### PR DESCRIPTION
Could I have a review of a PR that fixes a regression introduced with [JDK-8047756](https://bugs.openjdk.org/projects/JDK/issues/JDK-8047756)?

The default unit for `@Timespan` in Java is nanos, but it should be set to ticks. Prior to JDK-8047756, annotations were taken from native code, so ticks were used.

Testing: 
100 * test/jdk//jdk/jfr/event/tracing/TestMethodTimingEvent.java on Windows, Linux and MacOS 
test/jdk//jdk/jfr/*

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8358448](https://bugs.openjdk.org/browse/JDK-8358448): JFR: Incorrect time unit for MethodTiming event (**Bug** - P4)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25615/head:pull/25615` \
`$ git checkout pull/25615`

Update a local copy of the PR: \
`$ git checkout pull/25615` \
`$ git pull https://git.openjdk.org/jdk.git pull/25615/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25615`

View PR using the GUI difftool: \
`$ git pr show -t 25615`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25615.diff">https://git.openjdk.org/jdk/pull/25615.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25615#issuecomment-2935624091)
</details>
