### PR TITLE
8358515: make cmp-baseline is broken after JDK-8349665

### DIFF
--- a/make/Init.gmk
+++ b/make/Init.gmk
@@ -110,7 +110,18 @@ reconfigure:
 	    CUSTOM_CONFIG_DIR="$(CUSTOM_CONFIG_DIR)" \
 	    $(RECONFIGURE_COMMAND) )
 
-.PHONY: print-modules print-targets print-tests print-configuration reconfigure
+# Create files that are needed to run most targets in Main.gmk
+create-make-helpers:
+	    ( cd $(TOPDIR) && \
+	        $(MAKE) $(MAKE_ARGS) -j 1 -f make/GenerateFindTests.gmk \
+	        $(USER_MAKE_VARS) )
+	    ( cd $(TOPDIR) && \
+	        $(MAKE) $(MAKE_ARGS) -j 1 -f make/Main.gmk $(USER_MAKE_VARS) \
+	        UPDATE_MODULE_DEPS=true NO_RECIPES=true \
+	        create-main-targets-include )
+
+.PHONY: print-modules print-targets print-tests print-configuration \
+    reconfigure create-make-helpers
 
 ##############################################################################
 # The main target. This will delegate all other targets into Main.gmk.
@@ -130,7 +141,7 @@ TARGET_DESCRIPTION := target$(if $(word 2, $(MAIN_TARGETS)),s) \
 # variables are explicitly propagated using $(USER_MAKE_VARS).
 main: MAKEOVERRIDES :=
 
-main: $(INIT_TARGETS)
+main: $(INIT_TARGETS) create-make-helpers
         ifneq ($(SEQUENTIAL_TARGETS)$(PARALLEL_TARGETS), )
 	  $(call RotateLogFiles)
 	  $(ECHO) "Building $(TARGET_DESCRIPTION)" $(BUILD_LOG_PIPE_SIMPLE)
@@ -142,12 +153,7 @@ main: $(INIT_TARGETS)
 	        $(SEQUENTIAL_TARGETS) )
             # We might have cleaned away essential files, recreate them.
 	    ( cd $(TOPDIR) && \
-	        $(MAKE) $(MAKE_ARGS) -j 1 -f make/GenerateFindTests.gmk \
-	        $(USER_MAKE_VARS) )
-	    ( cd $(TOPDIR) && \
-	        $(MAKE) $(MAKE_ARGS) -j 1 -f make/Main.gmk $(USER_MAKE_VARS) \
-	        UPDATE_MODULE_DEPS=true NO_RECIPES=true \
-	        create-main-targets-include )
+	        $(MAKE) $(MAKE_ARGS) -j 1 -f make/Init.gmk create-make-helpers )
           endif
           ifneq ($(PARALLEL_TARGETS), )
 	    $(call PrepareFailureLogs)

--- a/make/Init.gmk
+++ b/make/Init.gmk
@@ -112,13 +112,13 @@ reconfigure:
 
 # Create files that are needed to run most targets in Main.gmk
 create-make-helpers:
-	    ( cd $(TOPDIR) && \
-	        $(MAKE) $(MAKE_ARGS) -j 1 -f make/GenerateFindTests.gmk \
-	        $(USER_MAKE_VARS) )
-	    ( cd $(TOPDIR) && \
-	        $(MAKE) $(MAKE_ARGS) -j 1 -f make/Main.gmk $(USER_MAKE_VARS) \
-	        UPDATE_MODULE_DEPS=true NO_RECIPES=true \
-	        create-main-targets-include )
+	( cd $(TOPDIR) && \
+	    $(MAKE) $(MAKE_ARGS) -j 1 -f make/GenerateFindTests.gmk \
+	    $(USER_MAKE_VARS) )
+	( cd $(TOPDIR) && \
+	    $(MAKE) $(MAKE_ARGS) -j 1 -f make/Main.gmk $(USER_MAKE_VARS) \
+	    UPDATE_MODULE_DEPS=true NO_RECIPES=true \
+	    create-main-targets-include )
 
 .PHONY: print-modules print-targets print-tests print-configuration \
     reconfigure create-make-helpers

--- a/make/Main.gmk
+++ b/make/Main.gmk
@@ -423,14 +423,6 @@ bootcycle-images:
         ifneq ($(COMPILE_TYPE), cross)
 	  $(call LogWarn, Boot cycle build step 2: Building a new JDK image using previously built image)
 	  $(call MakeDir, $(OUTPUTDIR)/bootcycle-build)
-          # We need to create essential files for the bootcycle spec dir
-	  ( cd $(TOPDIR) && \
-	      $(MAKE) $(MAKE_ARGS) -f make/GenerateFindTests.gmk \
-	      SPEC=$(BOOTCYCLE_SPEC))
-	  ( cd $(TOPDIR) && \
-	      $(MAKE) $(MAKE_ARGS) -f $(TOPDIR)/make/Main.gmk \
-	      SPEC=$(BOOTCYCLE_SPEC) UPDATE_MODULE_DEPS=true NO_RECIPES=true \
-	      create-main-targets-include )
 	  +$(MAKE) $(MAKE_ARGS) -f $(TOPDIR)/make/Init.gmk PARALLEL_TARGETS=$(BOOTCYCLE_TARGET) \
 	      LOG_PREFIX="[bootcycle] " JOBS= SPEC=$(BOOTCYCLE_SPEC) main
         else

--- a/make/PreInit.gmk
+++ b/make/PreInit.gmk
@@ -50,7 +50,8 @@ include $(TOPDIR)/make/Global.gmk
 
 # Targets provided by Init.gmk.
 ALL_INIT_TARGETS := print-modules print-targets print-configuration \
-    print-tests reconfigure pre-compare-build post-compare-build
+    print-tests reconfigure pre-compare-build post-compare-build \
+    create-make-helpers
 
 # CALLED_TARGETS is the list of targets that the user provided,
 # or "default" if unspecified.


### PR DESCRIPTION
The fix in to [JDK-8357991](https://bugs.openjdk.org/browse/JDK-8357991) was not enough to solve all problems that had been introduced with JDK-8349665. Also builds run using `COMPARE_BUILD` was affected.

The core of the problem was that there were multiple additional ways to run what esstentially amount to `make -f Init.gmk main`, in places that I did not find before. So I took a step back and chose a safer approach: now the `main` target in `Init.gmk` depends on an additional target, that will always make sure that the necessary helper files are present. This means the specific patch for bootcycle builds in JDK-8357991 could be reverted. This solution is also future-proof if we should figure out any new creative ways of calling `main` in `Init.gmk`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8358515: make cmp-baseline is broken after JDK-8349665`

### Issue
 * [JDK-8358515](https://bugs.openjdk.org/browse/JDK-8358515): make cmp-baseline is broken after JDK-8349665 (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25618/head:pull/25618` \
`$ git checkout pull/25618`

Update a local copy of the PR: \
`$ git checkout pull/25618` \
`$ git pull https://git.openjdk.org/jdk.git pull/25618/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25618`

View PR using the GUI difftool: \
`$ git pr show -t 25618`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25618.diff">https://git.openjdk.org/jdk/pull/25618.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25618#issuecomment-2936409622)
</details>
