### PR TITLE
JDK-8358449: Locale.getISOCountries does not specify the returned set is unmodifiable

### DIFF
--- a/src/java.base/share/classes/java/util/Locale.java
+++ b/src/java.base/share/classes/java/util/Locale.java
@@ -1310,7 +1310,7 @@ public final class Locale implements Cloneable, Serializable {
     }
 
     /**
-     * {@return a {@code Set} of ISO3166 country codes for the specified type}
+     * {@return an unmodifiable {@code Set} of ISO3166 country codes for the specified type}
      *
      * @param type {@link Locale.IsoCountryCode} specified ISO code type.
      * @see java.util.Locale.IsoCountryCode


### PR DESCRIPTION
Please review this trivial doc correction to `Locale.getISOCountries(Locale.IsoCountryCode type)` which makes it apparent that the returned Set is unmodifiable. Associated CSR filed.