### PR TITLE
8358539: ProblemList jdk/jfr/api/consumer/TestRecordingFileWrite.java

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -774,6 +774,7 @@ jdk/jfr/event/compiler/TestCodeSweeper.java                     8338127 generic-
 jdk/jfr/event/oldobject/TestShenandoah.java                     8342951 generic-all
 jdk/jfr/event/runtime/TestResidentSetSizeEvent.java             8309846 aix-ppc64
 jdk/jfr/jvm/TestWaste.java                                      8282427 generic-all
+jdk/jfr/api/consumer/TestRecordingFileWrite.java                8358536 generic-all
 
 ############################################################################
 


### PR DESCRIPTION
A trivial fix to ProblemList jdk/jfr/api/consumer/TestRecordingFileWrite.java on all platforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8358539](https://bugs.openjdk.org/browse/JDK-8358539): ProblemList jdk/jfr/api/consumer/TestRecordingFileWrite.java (**Sub-task** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25626/head:pull/25626` \
`$ git checkout pull/25626`

Update a local copy of the PR: \
`$ git checkout pull/25626` \
`$ git pull https://git.openjdk.org/jdk.git pull/25626/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25626`

View PR using the GUI difftool: \
`$ git pr show -t 25626`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25626.diff">https://git.openjdk.org/jdk/pull/25626.diff</a>

</details>
