### PR TITLE
8358534: Bailout in Conv2B::Ideal when type of cmp input is not supported

### DIFF
--- a/src/hotspot/share/opto/convertnode.cpp
+++ b/src/hotspot/share/opto/convertnode.cpp
@@ -79,6 +79,11 @@ Node* Conv2BNode::Ideal(PhaseGVN* phase, bool can_reshape) {
         assert(false, "Unrecognized comparison for Conv2B: %s", NodeClassNames[in(1)->Opcode()]);
       }
 
+      // Skip the transformation if input is unexpected.
+      if (cmp == nullptr) {
+        return nullptr;
+      }
+
       // Replace Conv2B with the cmove
       Node* bol = phase->transform(new BoolNode(cmp, BoolTest::eq));
       return new CMoveINode(bol, phase->intcon(1), phase->intcon(0), TypeInt::BOOL);


### PR DESCRIPTION
`Conv2BNode::ideal` segfaults in release builds when the type of `in(1)` is not INT or PTR. Creating a small test case to reproduce the issue is being a bit challenging so this PR only address the issue by bailing out of the method if the input type is unsupported. This other ticket https://bugs.openjdk.org/browse/JDK-8357885 will address creating a regression test for the problem.

Tested with JTREG tier1-3 and Renaissance on Linux x64.