### PR TITLE
8358538: Update GHA Windows runner to 2025

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -114,7 +114,7 @@ jobs:
       - name: 'Install toolchain and dependencies'
         run: |
           # Run Visual Studio Installer
-          '/c/Program Files/Microsoft Visual Studio/Installer/vs_installer.exe' \
+          '/c/Program Files (x86)/Microsoft Visual Studio/Installer/vs_installer.exe' \
             modify --quiet --installPath 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise' \
             --add Microsoft.VisualStudio.Component.VC.${{ inputs.msvc-toolset-version }}.${{ inputs.msvc-toolset-architecture }}
         if: steps.toolchain-check.outputs.toolchain-installed != 'true'

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -63,7 +63,7 @@ env:
 jobs:
   build-windows:
     name: build
-    runs-on: windows-2025
+    runs-on: windows-2022
     defaults:
       run:
         shell: bash

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -63,7 +63,7 @@ env:
 jobs:
   build-windows:
     name: build
-    runs-on: windows-2022
+    runs-on: windows-2025
     defaults:
       run:
         shell: bash
@@ -98,25 +98,6 @@ jobs:
         id: gtest
         uses: ./.github/actions/get-gtest
 
-      - name: 'check computer'
-        id: check-files
-        run: |
-          echo listing '/c/Program Files'
-          find '/c/Program Files' -type d
-          echo listing '/c/Program Files (x86)'
-          find '/c/Program Files (x86)' -type d
-          echo using ls:
-          echo listing '/c/Program Files'
-          ls -lR '/c/Program Files'
-          echo listing '/c/Program Files (x86)'
-          echo using ls:
-          ls -lR '/c/Program Files (x86)'
-        env:
-          # We need a minimal PATH on Windows
-          # Set PATH to "", so just GITHUB_PATH is included
-          PATH: ''
-        shell: env /usr/bin/bash --login -eo pipefail {0}
-
       - name: 'Check toolchain installed'
         id: toolchain-check
         run: |
@@ -147,6 +128,7 @@ jobs:
           --with-boot-jdk=${{ steps.bootjdk.outputs.path }}
           --with-jtreg=${{ steps.jtreg.outputs.path }}
           --with-gtest=${{ steps.gtest.outputs.path }}
+          --with-msvc-toolset-version=${{ inputs.msvc-toolset-version }}
           --with-jmod-compress=zip-1
           ${{ inputs.extra-conf-options }} ${{ inputs.configure-arguments }} || (
           echo "Dumping config.log:" &&

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -63,7 +63,7 @@ env:
 jobs:
   build-windows:
     name: build
-    runs-on: windows-2019
+    runs-on: windows-2025
     defaults:
       run:
         shell: bash

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -98,6 +98,23 @@ jobs:
         id: gtest
         uses: ./.github/actions/get-gtest
 
+      - name: 'check computer'
+        id: check-files
+        run: |
+          echo listing '/c/Program Files'
+          find '/c/Program Files'
+          echo using ls:
+          ls -lR '/c/Program Files'
+          echo listing '/c/Program Files (x86)'
+          find '/c/Program Files (x86)'
+          echo using ls:
+          ls -lR '/c/Program Files (x86)'
+        env:
+          # We need a minimal PATH on Windows
+          # Set PATH to "", so just GITHUB_PATH is included
+          PATH: ''
+        shell: env /usr/bin/bash --login -eo pipefail {0}
+
       - name: 'Check toolchain installed'
         id: toolchain-check
         run: |
@@ -128,7 +145,6 @@ jobs:
           --with-boot-jdk=${{ steps.bootjdk.outputs.path }}
           --with-jtreg=${{ steps.jtreg.outputs.path }}
           --with-gtest=${{ steps.gtest.outputs.path }}
-          --with-msvc-toolset-version=${{ inputs.msvc-toolset-version }}
           --with-jmod-compress=zip-1
           ${{ inputs.extra-conf-options }} ${{ inputs.configure-arguments }} || (
           echo "Dumping config.log:" &&

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -128,6 +128,7 @@ jobs:
           --with-boot-jdk=${{ steps.bootjdk.outputs.path }}
           --with-jtreg=${{ steps.jtreg.outputs.path }}
           --with-gtest=${{ steps.gtest.outputs.path }}
+          --with-msvc-toolset-version=${{ inputs.msvc-toolset-version }}
           --with-jmod-compress=zip-1
           ${{ inputs.extra-conf-options }} ${{ inputs.configure-arguments }} || (
           echo "Dumping config.log:" &&

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -102,7 +102,7 @@ jobs:
         id: toolchain-check
         run: |
           set +e
-          '/c/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/vc/auxiliary/build/vcvars64.bat' -vcvars_ver=${{ inputs.msvc-toolset-version }}
+          '/c/Program Files/Microsoft Visual Studio/2022/Enterprise/vc/auxiliary/build/vcvars64.bat' -vcvars_ver=${{ inputs.msvc-toolset-version }}
           if [ $? -eq 0 ]; then
             echo "Toolchain is already installed"
             echo "toolchain-installed=true" >> $GITHUB_OUTPUT
@@ -114,8 +114,8 @@ jobs:
       - name: 'Install toolchain and dependencies'
         run: |
           # Run Visual Studio Installer
-          '/c/Program Files (x86)/Microsoft Visual Studio/Installer/vs_installer.exe' \
-            modify --quiet --installPath 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise' \
+          '/c/Program Files/Microsoft Visual Studio/Installer/vs_installer.exe' \
+            modify --quiet --installPath 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise' \
             --add Microsoft.VisualStudio.Component.VC.${{ inputs.msvc-toolset-version }}.${{ inputs.msvc-toolset-architecture }}
         if: steps.toolchain-check.outputs.toolchain-installed != 'true'
 

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -128,7 +128,6 @@ jobs:
           --with-boot-jdk=${{ steps.bootjdk.outputs.path }}
           --with-jtreg=${{ steps.jtreg.outputs.path }}
           --with-gtest=${{ steps.gtest.outputs.path }}
-          --with-msvc-toolset-version=${{ inputs.msvc-toolset-version }}
           --with-jmod-compress=zip-1
           ${{ inputs.extra-conf-options }} ${{ inputs.configure-arguments }} || (
           echo "Dumping config.log:" &&

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -98,6 +98,25 @@ jobs:
         id: gtest
         uses: ./.github/actions/get-gtest
 
+      - name: 'check computer'
+        id: check-files
+        run: |
+          echo listing '/c/Program Files'
+          find '/c/Program Files' -type d
+          echo listing '/c/Program Files (x86)'
+          find '/c/Program Files (x86)' -type d
+          echo using ls:
+          echo listing '/c/Program Files'
+          ls -lR '/c/Program Files'
+          echo listing '/c/Program Files (x86)'
+          echo using ls:
+          ls -lR '/c/Program Files (x86)'
+        env:
+          # We need a minimal PATH on Windows
+          # Set PATH to "", so just GITHUB_PATH is included
+          PATH: ''
+        shell: env /usr/bin/bash --login -eo pipefail {0}
+
       - name: 'Check toolchain installed'
         id: toolchain-check
         run: |

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -98,23 +98,6 @@ jobs:
         id: gtest
         uses: ./.github/actions/get-gtest
 
-      - name: 'check computer'
-        id: check-files
-        run: |
-          echo listing '/c/Program Files'
-          find '/c/Program Files'
-          echo using ls:
-          ls -lR '/c/Program Files'
-          echo listing '/c/Program Files (x86)'
-          find '/c/Program Files (x86)'
-          echo using ls:
-          ls -lR '/c/Program Files (x86)'
-        env:
-          # We need a minimal PATH on Windows
-          # Set PATH to "", so just GITHUB_PATH is included
-          PATH: ''
-        shell: env /usr/bin/bash --login -eo pipefail {0}
-
       - name: 'Check toolchain installed'
         id: toolchain-check
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -393,5 +393,5 @@ jobs:
     with:
       platform: windows-x64
       bootjdk-platform: windows-x64
-      runs-on: windows-2019
+      runs-on: windows-2025
       debug-suffix: -debug

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -310,7 +310,7 @@ jobs:
     uses: ./.github/workflows/build-windows.yml
     with:
       platform: windows-x64
-      msvc-toolset-version: '14.42'
+      msvc-toolset-version: '14.43'
       msvc-toolset-architecture: 'x86.x64'
       configure-arguments: ${{ github.event.inputs.configure-arguments }}
       make-arguments: ${{ github.event.inputs.make-arguments }}
@@ -322,7 +322,7 @@ jobs:
     uses: ./.github/workflows/build-windows.yml
     with:
       platform: windows-aarch64
-      msvc-toolset-version: '14.42'
+      msvc-toolset-version: '14.43'
       msvc-toolset-architecture: 'arm64'
       make-target: 'hotspot'
       extra-conf-options: '--openjdk-target=aarch64-unknown-cygwin'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -310,7 +310,7 @@ jobs:
     uses: ./.github/workflows/build-windows.yml
     with:
       platform: windows-x64
-      msvc-toolset-version: '14.44'
+      msvc-toolset-version: '14.42'
       msvc-toolset-architecture: 'x86.x64'
       configure-arguments: ${{ github.event.inputs.configure-arguments }}
       make-arguments: ${{ github.event.inputs.make-arguments }}
@@ -322,7 +322,7 @@ jobs:
     uses: ./.github/workflows/build-windows.yml
     with:
       platform: windows-aarch64
-      msvc-toolset-version: '14.44'
+      msvc-toolset-version: '14.42'
       msvc-toolset-architecture: 'arm64'
       make-target: 'hotspot'
       extra-conf-options: '--openjdk-target=aarch64-unknown-cygwin'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -310,7 +310,7 @@ jobs:
     uses: ./.github/workflows/build-windows.yml
     with:
       platform: windows-x64
-      msvc-toolset-version: '14.29'
+      msvc-toolset-version: '17.13'
       msvc-toolset-architecture: 'x86.x64'
       configure-arguments: ${{ github.event.inputs.configure-arguments }}
       make-arguments: ${{ github.event.inputs.make-arguments }}
@@ -322,7 +322,7 @@ jobs:
     uses: ./.github/workflows/build-windows.yml
     with:
       platform: windows-aarch64
-      msvc-toolset-version: '14.29'
+      msvc-toolset-version: '17.13'
       msvc-toolset-architecture: 'arm64'
       make-target: 'hotspot'
       extra-conf-options: '--openjdk-target=aarch64-unknown-cygwin'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -310,7 +310,7 @@ jobs:
     uses: ./.github/workflows/build-windows.yml
     with:
       platform: windows-x64
-      msvc-toolset-version: '17.13'
+      msvc-toolset-version: '17.13.2'
       msvc-toolset-architecture: 'x86.x64'
       configure-arguments: ${{ github.event.inputs.configure-arguments }}
       make-arguments: ${{ github.event.inputs.make-arguments }}
@@ -322,7 +322,7 @@ jobs:
     uses: ./.github/workflows/build-windows.yml
     with:
       platform: windows-aarch64
-      msvc-toolset-version: '17.13'
+      msvc-toolset-version: '17.13.2'
       msvc-toolset-architecture: 'arm64'
       make-target: 'hotspot'
       extra-conf-options: '--openjdk-target=aarch64-unknown-cygwin'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -310,7 +310,7 @@ jobs:
     uses: ./.github/workflows/build-windows.yml
     with:
       platform: windows-x64
-      msvc-toolset-version: '17.13.2'
+      msvc-toolset-version: '14.44'
       msvc-toolset-architecture: 'x86.x64'
       configure-arguments: ${{ github.event.inputs.configure-arguments }}
       make-arguments: ${{ github.event.inputs.make-arguments }}
@@ -322,7 +322,7 @@ jobs:
     uses: ./.github/workflows/build-windows.yml
     with:
       platform: windows-aarch64
-      msvc-toolset-version: '17.13.2'
+      msvc-toolset-version: '14.44'
       msvc-toolset-architecture: 'arm64'
       make-target: 'hotspot'
       extra-conf-options: '--openjdk-target=aarch64-unknown-cygwin'


### PR DESCRIPTION
GitHub is retiring the windows-2019 runner, starting with brownouts now, and complete removal in about a month. We need to upgrade to Windows 2022 or possible Windows 2025.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8358538](https://bugs.openjdk.org/browse/JDK-8358538): Update GHA Windows runner to 2025 (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25628/head:pull/25628` \
`$ git checkout pull/25628`

Update a local copy of the PR: \
`$ git checkout pull/25628` \
`$ git pull https://git.openjdk.org/jdk.git pull/25628/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25628`

View PR using the GUI difftool: \
`$ git pr show -t 25628`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25628.diff">https://git.openjdk.org/jdk/pull/25628.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25628#issuecomment-2937063228)
</details>
