### PR TITLE
8358520: Improve lazy computation in BreakIteratorResourceBundle and related classes

### DIFF
--- a/src/java.base/share/classes/java/util/ResourceBundle.java
+++ b/src/java.base/share/classes/java/util/ResourceBundle.java
@@ -54,6 +54,7 @@ import java.net.URL;
 import java.net.URLConnection;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.function.Supplier;
 import java.util.jar.JarEntry;
 import java.util.spi.ResourceBundleControlProvider;
 import java.util.spi.ResourceBundleProvider;
@@ -487,7 +488,22 @@ public abstract class ResourceBundle {
     /**
      * A Set of the keys contained only in this ResourceBundle.
      */
-    private volatile Set<String> keySet;
+    private final Supplier<Set<String>> keySet = StableValue.supplier(
+            new Supplier<Set<String>>() {
+                @Override
+                public Set<String> get() {
+                    final Set<String> keys = new HashSet<>();
+                    final Enumeration<String> enumKeys = getKeys();
+                    while (enumKeys.hasMoreElements()) {
+                        final String key = enumKeys.nextElement();
+                        if (handleGetObject(key) != null) {
+                            keys.add(key);
+                        }
+                    }
+                    return Set.copyOf(keys);
+                }
+            }
+    );
 
     /**
      * Sole constructor.  (For invocation by subclass constructors, typically
@@ -2298,22 +2314,7 @@ public abstract class ResourceBundle {
      * @since 1.6
      */
     protected Set<String> handleKeySet() {
-        if (keySet == null) {
-            synchronized (this) {
-                if (keySet == null) {
-                    Set<String> keys = new HashSet<>();
-                    Enumeration<String> enumKeys = getKeys();
-                    while (enumKeys.hasMoreElements()) {
-                        String key = enumKeys.nextElement();
-                        if (handleGetObject(key) != null) {
-                            keys.add(key);
-                        }
-                    }
-                    keySet = keys;
-                }
-            }
-        }
-        return keySet;
+        return keySet.get();
     }
 
 

--- a/src/java.base/share/classes/sun/util/resources/BreakIteratorResourceBundle.java
+++ b/src/java.base/share/classes/sun/util/resources/BreakIteratorResourceBundle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,7 @@ import java.util.Collections;
 import java.util.Enumeration;
 import java.util.ResourceBundle;
 import java.util.Set;
+import java.util.function.Supplier;
 
 /**
  * BreakIteratorResourceBundle is an abstract class for loading BreakIterator
@@ -49,7 +50,17 @@ public abstract class BreakIteratorResourceBundle extends ResourceBundle {
     // those keys must be added to NON_DATA_KEYS.
     private static final Set<String> NON_DATA_KEYS = Set.of("BreakIteratorClasses");
 
-    private volatile Set<String> keys;
+    private final Supplier<Set<String>> keys = StableValue.supplier(
+            new Supplier<Set<String>>() {
+                @Override
+                public Set<String> get() {
+                    final ResourceBundle info = getBreakIteratorInfo();
+                    final Set<String> k = info.keySet();
+                    k.removeAll(NON_DATA_KEYS);
+                    return Set.copyOf(k);
+                }
+            }
+    );
 
     /**
      * Returns an instance of the corresponding {@code BreakIteratorInfo} (basename).
@@ -84,16 +95,6 @@ public abstract class BreakIteratorResourceBundle extends ResourceBundle {
 
     @Override
     protected Set<String> handleKeySet() {
-        if (keys == null) {
-            ResourceBundle info = getBreakIteratorInfo();
-            Set<String> k = info.keySet();
-            k.removeAll(NON_DATA_KEYS);
-            synchronized (this) {
-                if (keys == null) {
-                    keys = k;
-                }
-            }
-        }
-        return keys;
+        return keys.get();
     }
 }

--- a/src/java.base/share/classes/sun/util/resources/OpenListResourceBundle.java
+++ b/src/java.base/share/classes/sun/util/resources/OpenListResourceBundle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,8 +44,11 @@ import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Objects;
 import java.util.ResourceBundle;
 import java.util.Set;
+import java.util.function.Supplier;
+
 import sun.util.ResourceBundleEnumeration;
 
 /**
@@ -69,12 +72,9 @@ public abstract class OpenListResourceBundle extends ResourceBundle {
     // Implements java.util.ResourceBundle.handleGetObject; inherits javadoc specification.
     @Override
     protected Object handleGetObject(String key) {
-        if (key == null) {
-            throw new NullPointerException();
-        }
-
-        loadLookupTablesIfNecessary();
-        return lookup.get(key); // this class ignores locales
+        Objects.requireNonNull(key);
+        return lookup.get()
+                .get(key); // this class ignores locales
     }
 
     /**
@@ -93,64 +93,19 @@ public abstract class OpenListResourceBundle extends ResourceBundle {
      */
     @Override
     protected Set<String> handleKeySet() {
-        loadLookupTablesIfNecessary();
-        return lookup.keySet();
+        return lookup.get()
+                .keySet();
     }
 
     @Override
     public Set<String> keySet() {
-        if (keyset != null) {
-            return keyset;
-        }
-        Set<String> ks = createSet();
-        ks.addAll(handleKeySet());
-        if (parent != null) {
-            ks.addAll(parent.keySet());
-        }
-        synchronized (this) {
-            if (keyset == null) {
-                keyset = ks;
-            }
-        }
-        return keyset;
+        return keyset.get();
     }
 
     /**
      * See ListResourceBundle class description.
      */
     protected abstract Object[][] getContents();
-
-    /**
-     * Load lookup tables if they haven't been loaded already.
-     */
-    void loadLookupTablesIfNecessary() {
-        if (lookup == null) {
-            loadLookup();
-        }
-    }
-
-    /**
-     * We lazily load the lookup hashtable.  This function does the
-     * loading.
-     */
-    private void loadLookup() {
-        Object[][] contents = getContents();
-        Map<String, Object> temp = createMap(contents.length);
-        for (int i = 0; i < contents.length; ++i) {
-            // key must be non-null String, value must be non-null
-            String key = (String) contents[i][0];
-            Object value = contents[i][1];
-            if (key == null || value == null) {
-                throw new NullPointerException();
-            }
-            temp.put(key, value);
-        }
-        synchronized (this) {
-            if (lookup == null) {
-                lookup = temp;
-            }
-        }
-    }
 
     /**
      * Lets subclasses provide specialized Map implementations.
@@ -164,6 +119,33 @@ public abstract class OpenListResourceBundle extends ResourceBundle {
         return new HashSet<>();
     }
 
-    private volatile Map<String, Object> lookup;
-    private volatile Set<String> keyset;
+    private final Supplier<Map<String, Object>> lookup = StableValue.supplier(
+            new Supplier<Map<String, Object>>() {
+                @Override
+                public Map<String, Object> get() {
+                    final Object[][] contents = getContents();
+                    final Map<String, Object> temp = createMap(contents.length);
+                    for (Object[] content : contents) {
+                        // key must be non-null String, value must be non-null
+                        final String key = Objects.requireNonNull((String) content[0]);
+                        final Object value = Objects.requireNonNull(content[1]);
+                        temp.put(key, value);
+                    }
+                    return Map.copyOf(temp);
+                }
+            }
+    );
+    private final Supplier<Set<String>> keyset = StableValue.supplier(
+            new Supplier<Set<String>>() {
+                @Override
+                public Set<String> get() {
+                    final Set<String> ks = createSet();
+                    ks.addAll(handleKeySet());
+                    if (parent != null) {
+                        ks.addAll(parent.keySet());
+                    }
+                    return Set.copyOf(ks);
+                }
+            }
+    );
 }


### PR DESCRIPTION
This PR proposes to simplify lazy computation related to resource bundles. Previously, some objects were computed lazily using a double-checked locking algorithm. StableValues offers a more robust and succinct solution. The PR also proposes using immutable collections instead of mutable ones to enable more robust multi-threading handling.

 Both the above changes might unlock potential performance improvements, such as constant folding.