### PR TITLE
8358537: (bf) JavaNioAccess::getBufferAddress bypasses direct buffer MemorySession state check

### DIFF
--- a/src/java.base/share/classes/java/nio/Buffer.java
+++ b/src/java.base/share/classes/java/nio/Buffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -700,6 +700,13 @@ public abstract sealed class Buffer
     abstract Object base();
 
     /**
+     * Returns the buffer's address.
+     */
+    long address() {
+        return address;
+    }
+
+    /**
      * Checks the current position against the limit, throwing a {@link
      * BufferUnderflowException} if it is not smaller than the limit, and then
      * increments the position.
@@ -860,7 +867,7 @@ public abstract sealed class Buffer
 
                 @Override
                 public long getBufferAddress(Buffer buffer) {
-                    return buffer.address;
+                    return buffer.address();
                 }
 
                 @Override

--- a/src/java.base/share/classes/java/nio/Heap-X-Buffer.java.template
+++ b/src/java.base/share/classes/java/nio/Heap-X-Buffer.java.template
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -158,6 +158,10 @@ class Heap$Type$Buffer$RW$
 #else[rw]
         return duplicate();
 #end[rw]
+    }
+
+    public long address() {
+        throw new UnsupportedOperationException();
     }
 
 #if[rw]

--- a/test/jdk/java/nio/channels/etc/MemorySegments.java
+++ b/test/jdk/java/nio/channels/etc/MemorySegments.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -58,7 +58,7 @@ class MemorySegments {
      * closing the Arena and failing (as some Arenas are not closable).
      */
     static Stream<Supplier<Arena>> arenaSuppliers() {
-        return Stream.of(Arena::global, Arena::ofAuto, Arena::ofConfined, Arena::ofShared);
+        return Stream.of(Arena::global, Arena::ofAuto, Arena::ofConfined);
     }
 
     /**

--- a/test/jdk/java/nio/channels/etc/MemorySegments.java
+++ b/test/jdk/java/nio/channels/etc/MemorySegments.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -58,7 +58,7 @@ class MemorySegments {
      * closing the Arena and failing (as some Arenas are not closable).
      */
     static Stream<Supplier<Arena>> arenaSuppliers() {
-        return Stream.of(Arena::global, Arena::ofAuto, Arena::ofConfined);
+        return Stream.of(Arena::global, Arena::ofAuto, Arena::ofConfined, Arena::ofShared);
     }
 
     /**


### PR DESCRIPTION
Add package-scope `long java.nio.Buffer::address()` to simply return the value of the `address` instance variable; use this method in `JavaNioAccess::getBufferAddress`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8358537](https://bugs.openjdk.org/browse/JDK-8358537): (bf) JavaNioAccess::getBufferAddress bypasses direct buffer MemorySession state check (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25631/head:pull/25631` \
`$ git checkout pull/25631`

Update a local copy of the PR: \
`$ git checkout pull/25631` \
`$ git pull https://git.openjdk.org/jdk.git pull/25631/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25631`

View PR using the GUI difftool: \
`$ git pr show -t 25631`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25631.diff">https://git.openjdk.org/jdk/pull/25631.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25631#issuecomment-2937155797)
</details>
