### PR TITLE
8358536: jdk/jfr/api/consumer/TestRecordingFileWrite.java times out

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/PrettyWriter.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/PrettyWriter.java
@@ -117,11 +117,11 @@ public final class PrettyWriter extends EventPrintWriter {
     // At the same time, a too large window, means it will take more time
     // before the first event is printed and the tool will feel unresponsive.
     private static final int EVENT_WINDOW_SIZE = 1_000_000;
-    private final PriorityQueue<Timestamp> timeline = new PriorityQueue<>(EVENT_WINDOW_SIZE + 4);
-    private final Map<Long, TypeInformation> typeInformation = new HashMap<>();
-    private final Map<Long, SequencedSet<RecordedEvent>> contexts = new HashMap<>();
     private final boolean showExact;
     private RecordedEvent currentEvent;
+    private PriorityQueue<Timestamp> timeline;
+    private Map<Long, TypeInformation> typeInformation;
+    private Map<Long, SequencedSet<RecordedEvent>> contexts;
 
     public PrettyWriter(PrintWriter destination, boolean showExact) {
         super(destination);
@@ -133,6 +133,9 @@ public final class PrettyWriter extends EventPrintWriter {
     }
 
     void print(Path source) throws IOException {
+        timeline = new PriorityQueue<>(EVENT_WINDOW_SIZE + 4);
+        typeInformation = new HashMap<>();
+        contexts = new HashMap<>();
         printBegin();
         int counter = 0;
         try (RecordingFile file = new RecordingFile(source)) {

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -774,7 +774,6 @@ jdk/jfr/event/compiler/TestCodeSweeper.java                     8338127 generic-
 jdk/jfr/event/oldobject/TestShenandoah.java                     8342951 generic-all
 jdk/jfr/event/runtime/TestResidentSetSizeEvent.java             8309846 aix-ppc64
 jdk/jfr/jvm/TestWaste.java                                      8282427 generic-all
-jdk/jfr/api/consumer/TestRecordingFileWrite.java                8358536 generic-all
 
 ############################################################################
 


### PR DESCRIPTION
Could I have a review of the PR that fixes a regression caused by [JDK-8356698](https://bugs.openjdk.org/browse/JDK-8356698)?

The problem is that PrettyWriter is also used by RecordedObject::toString, and by allocating the priority queue when PrettyWriter is instantiated, the memory pressure increases enormously. The fix is to allocate them lazily. 

Testing: 10 * jdk/jdk/jfr/ on Linux, MacOS and Windows.

Thanks
Erik