### PR TITLE
8358558: (zipfs) Reorder the listing of "accessMode" property in the ZIP file system's documentation

### DIFF
--- a/src/jdk.zipfs/share/classes/module-info.java
+++ b/src/jdk.zipfs/share/classes/module-info.java
@@ -149,12 +149,52 @@ import java.util.Set;
  *
  * <tbody>
  * <tr>
+ *   <th scope="row">accessMode</th>
+ *   <td>{@link java.lang.String}</td>
+ *   <td>null/unset</td>
+ *   <td>
+ *       A value defining the desired access mode of the file system.
+ *       ZIP file systems can be created to allow for <em>read-write</em> or
+ *       <em>read-only</em> access.
+ *       <ul>
+ *           <li>
+ *               If no value is set, the file system is created as <em>read-write</em>
+ *               if possible. Use {@link java.nio.file.FileSystem#isReadOnly()
+ *               isReadOnly()} to determine the actual access mode.
+ *           </li>
+ *           <li>
+ *               If the value is {@code "readOnly"}, the file system is created
+ *               <em>read-only</em>, and {@link java.nio.file.FileSystem#isReadOnly()
+ *               isReadOnly()} will always return {@code true}. Creating a
+ *               <em>read-only</em> file system requires the underlying ZIP file to
+ *               already exist.
+ *           </li>
+ *           <li>
+ *               If the value is {@code "readWrite"}, the file system is created
+ *               <em>read-write</em>, and {@link java.nio.file.FileSystem#isReadOnly()
+ *               isReadOnly()} will always return {@code false}. If a writable file
+ *               system cannot be created, an {@code IOException} will be thrown
+ *               when creating the ZIP file system.
+ *           </li>
+ *           <li>
+ *               Any other values will cause an {@code IllegalArgumentException}
+ *               to be thrown when creating the ZIP file system.
+ *           </li>
+ *       </ul>
+ *       The {@code accessMode} property has no effect on reported POSIX file
+ *       permissions (in cases where POSIX support is enabled).
+ *   </td>
+ * </tr>
+ * <tr>
  *   <th scope="row">create</th>
  *   <td>{@link java.lang.String} or {@link java.lang.Boolean}</td>
  *   <td>false</td>
  *   <td>
  *       If the value is {@code true}, the ZIP file system provider creates a
- *       new ZIP or JAR file if it does not exist.
+ *       new ZIP or JAR file if it does not exist. Specifying the {@code create}
+ *       property as {@code true} with the {@code accessMode} as {@code readOnly}
+ *       will cause an {@code IllegalArgumentException} to be thrown when creating
+ *       the ZIP file system.
  *   </td>
  * </tr>
  * <tr>
@@ -264,47 +304,6 @@ import java.util.Set;
  *               the ZIP file system.
  *           </li>
  *       </ul>
- *   </td>
- * </tr>
- * <tr>
- *   <th scope="row">accessMode</th>
- *   <td>{@link java.lang.String}</td>
- *   <td>null/unset</td>
- *   <td>
- *       A value defining the desired access mode of the file system.
- *       ZIP file systems can be created to allow for <em>read-write</em> or
- *       <em>read-only</em> access.
- *       <ul>
- *           <li>
- *               If no value is set, the file system is created as <em>read-write</em>
- *               if possible. Use {@link java.nio.file.FileSystem#isReadOnly()
- *               isReadOnly()} to determine the actual access mode.
- *           </li>
- *           <li>
- *               If the value is {@code "readOnly"}, the file system is created
- *               <em>read-only</em>, and {@link java.nio.file.FileSystem#isReadOnly()
- *               isReadOnly()} will always return {@code true}. Creating a
- *               <em>read-only</em> file system requires the underlying ZIP file to
- *               already exist.
- *               Specifying the {@code create} property as {@code true} with the
- *               {@code accessMode} as {@code readOnly} will cause an {@code
- *               IllegalArgumentException} to be thrown when creating the ZIP file
- *               system.
- *           </li>
- *           <li>
- *               If the value is {@code "readWrite"}, the file system is created
- *               <em>read-write</em>, and {@link java.nio.file.FileSystem#isReadOnly()
- *               isReadOnly()} will always return {@code false}. If a writable file
- *               system cannot be created, an {@code IOException} will be thrown
- *               when creating the ZIP file system.
- *           </li>
- *           <li>
- *               Any other values will cause an {@code IllegalArgumentException}
- *               to be thrown when creating the ZIP file system.
- *           </li>
- *       </ul>
- *       The {@code accessMode} property has no effect on reported POSIX file
- *       permissions (in cases where POSIX support is enabled).
  *   </td>
  * </tr>
  * </tbody>

--- a/src/jdk.zipfs/share/classes/module-info.java
+++ b/src/jdk.zipfs/share/classes/module-info.java
@@ -192,7 +192,7 @@ import java.util.Set;
  *   <td>
  *       If the value is {@code true}, the ZIP file system provider creates a
  *       new ZIP or JAR file if it does not exist. Specifying the {@code create}
- *       property as {@code true} with the {@code accessMode} as {@code readOnly}
+ *       property as {@code true} with the {@code accessMode} as {@code "readOnly"}
  *       will cause an {@code IllegalArgumentException} to be thrown when creating
  *       the ZIP file system.
  *   </td>


### PR DESCRIPTION
Can I please get a review of this trivial doc-only change to the `jdk.zipfs`'s documentation? This moves the `accessMode` property listing to the top of the table instead of being at the bottom. With this change, the text about throwing `IllegalArgumentException` when `create=true` and `accessMode=readOnly` has been moved to the `create` property's description.

No functional or specification changes are involved. I verified that the generated documentation looks fine too.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8358558](https://bugs.openjdk.org/browse/JDK-8358558): (zipfs) Reorder the listing of "accessMode" property in the ZIP file system's documentation (**Enhancement** - P4)


### Reviewers
 * [Volkan Yazici](https://openjdk.org/census#vyazici) (@vy - Author) Review applies to [546afbb7](https://git.openjdk.org/jdk/pull/25634/files/546afbb7046421cd3f14e128c305d8bf3d08c1df)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**) Review applies to [546afbb7](https://git.openjdk.org/jdk/pull/25634/files/546afbb7046421cd3f14e128c305d8bf3d08c1df)
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**) Review applies to [546afbb7](https://git.openjdk.org/jdk/pull/25634/files/546afbb7046421cd3f14e128c305d8bf3d08c1df)
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25634/head:pull/25634` \
`$ git checkout pull/25634`

Update a local copy of the PR: \
`$ git checkout pull/25634` \
`$ git pull https://git.openjdk.org/jdk.git pull/25634/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25634`

View PR using the GUI difftool: \
`$ git pr show -t 25634`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25634.diff">https://git.openjdk.org/jdk/pull/25634.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25634#issuecomment-2940016603)
</details>
