### PR TITLE
8358588: ThreadSnapshot.ThreadLock should be static nested class

### DIFF
--- a/src/java.base/share/classes/jdk/internal/vm/ThreadSnapshot.java
+++ b/src/java.base/share/classes/jdk/internal/vm/ThreadSnapshot.java
@@ -175,7 +175,7 @@ class ThreadSnapshot {
     /**
      * Represents a locking operation of a thread at a specific stack depth.
      */
-    private class ThreadLock {
+    private static class ThreadLock {
         private static final OwnedLockType[] lockTypeValues = OwnedLockType.values(); // cache
 
         // set by the VM


### PR DESCRIPTION
SonarCloud points out that ThreadLock class introduced by [JDK-8357650](https://bugs.openjdk.org/browse/JDK-8357650) can be turned into static nested class. I don't think this shows any real bug yet, as unreferenced enclosing class reference gets nowhere. But it would be nice to be extra crisp here.

Additional testing:
 - [x] Linux x86_64 server fastdebug, `serviceability/`
 - [x] Linux x86_64 server fastdebug, `jdk_management`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8358588](https://bugs.openjdk.org/browse/JDK-8358588): ThreadSnapshot.ThreadLock should be static nested class (**Enhancement** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25638/head:pull/25638` \
`$ git checkout pull/25638`

Update a local copy of the PR: \
`$ git checkout pull/25638` \
`$ git pull https://git.openjdk.org/jdk.git pull/25638/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25638`

View PR using the GUI difftool: \
`$ git pr show -t 25638`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25638.diff">https://git.openjdk.org/jdk/pull/25638.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25638#issuecomment-2940016268)
</details>
