### PR TITLE
8356645: Javac should utilize new ZIP file system read-only access mode

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/file/FSInfo.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/file/FSInfo.java
@@ -180,7 +180,7 @@ public class FSInfo {
      *                       file-system from a multi-release JAR (or
      *                       {@code null} to ignore release versioning).
      */
-    public static Map<String, ?> readOnlyJarFSEnv(String releaseVersion) {
+    public Map<String, ?> readOnlyJarFSEnv(String releaseVersion) {
         if (releaseVersion == null) {
             return READ_ONLY_JARFS_ENV;
         }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/file/FSInfo.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/file/FSInfo.java
@@ -25,19 +25,19 @@
 
 package com.sun.tools.javac.file;
 
-import java.io.IOError;
 import java.io.IOException;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.nio.file.FileSystems;
 import java.nio.file.Files;
-import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.spi.FileSystemProvider;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.StringTokenizer;
 import java.util.jar.Attributes;
 import java.util.jar.JarFile;
@@ -163,4 +163,30 @@ public class FSInfo {
         return null;
     }
 
+    // Must match the keys/values expected by ZipFileSystem.java.
+    private static final Map<String, String> READ_ONLY_JARFS_ENV = Map.of(
+            // Jar files opened by Javac should always be read-only.
+            "accessMode", "readOnly",
+            // ignores timestamps not stored in ZIP central directory, reducing I/O.
+            "zipinfo-time", "false");
+
+    /**
+     * Returns a {@link java.nio.file.FileSystem FileSystem} environment map
+     * suitable for creating read-only JAR file-systems with default timestamp
+     * information via {@link FileSystemProvider#newFileSystem(Path, Map)}
+     * or {@link java.nio.file.FileSystems#newFileSystem(Path, Map)}.
+     *
+     * @param releaseVersion the release version to use when creating a
+     *                       file-system from a multi-release JAR (or
+     *                       {@code null} to ignore release versioning).
+     */
+    public static Map<String, ?> readOnlyJarFSEnv(String releaseVersion) {
+        if (releaseVersion == null) {
+            return READ_ONLY_JARFS_ENV;
+        }
+        // Multi-release JARs need an additional attribute.
+        Map<String, String> env = new HashMap<>(READ_ONLY_JARFS_ENV);
+        env.put("releaseVersion", releaseVersion);
+        return Collections.unmodifiableMap(env);
+    }
 }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/file/JavacFileManager.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/file/JavacFileManager.java
@@ -561,11 +561,10 @@ public class JavacFileManager extends BaseFileManager implements StandardJavaFil
 
         public ArchiveContainer(Path archivePath) throws IOException, ProviderNotFoundException {
             this.archivePath = archivePath;
-            // Common parameters for opening ZIP/JAR file systems in Javac.
-            Map<String, ?> env = FSInfo.readOnlyJarFSEnv(multiReleaseValue);
             if (multiReleaseValue != null && archivePath.toString().endsWith(".jar")) {
                 FileSystemProvider jarFSProvider = fsInfo.getJarFSProvider();
                 Assert.checkNonNull(jarFSProvider, "should have been caught before!");
+                Map<String, ?> env = fsInfo.readOnlyJarFSEnv(multiReleaseValue);
                 try {
                     this.fileSystem = jarFSProvider.newFileSystem(archivePath, env);
                 } catch (ZipException ze) {
@@ -575,7 +574,8 @@ public class JavacFileManager extends BaseFileManager implements StandardJavaFil
                 // Less common case is possible if the file manager was not initialized in JavacTask,
                 // or if non "*.jar" files are on the classpath. If this is not a ZIP/JAR file then it
                 // will ignore ZIP specific parameters in env, and may not end up being read-only.
-                // However Javac should never attempt to write back to archives either way.
+                // However, Javac should never attempt to write back to archives either way.
+                Map<String, ?> env = fsInfo.readOnlyJarFSEnv(null);
                 this.fileSystem = FileSystems.newFileSystem(archivePath, env);
             }
             packages = new HashMap<>();

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/file/Locations.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/file/Locations.java
@@ -1384,7 +1384,7 @@ public class Locations {
                         log.error(Errors.NoZipfsForArchive(p));
                         return null;
                     }
-                    try (FileSystem fs = jarFSProvider.newFileSystem(p, FSInfo.readOnlyJarFSEnv(releaseVersion))) {
+                    try (FileSystem fs = jarFSProvider.newFileSystem(p, fsInfo.readOnlyJarFSEnv(releaseVersion))) {
                         Path moduleInfoClass = fs.getPath("module-info.class");
                         if (Files.exists(moduleInfoClass)) {
                             String moduleName = readModuleName(moduleInfoClass);
@@ -1460,7 +1460,7 @@ public class Locations {
                                 log.error(Errors.LocnCantReadFile(p));
                                 return null;
                             }
-                            fs = jarFSProvider.newFileSystem(p, FSInfo.readOnlyJarFSEnv(null));
+                            fs = jarFSProvider.newFileSystem(p, fsInfo.readOnlyJarFSEnv(null));
                             try {
                                 Path moduleInfoClass = fs.getPath("classes/module-info.class");
                                 String moduleName = readModuleName(moduleInfoClass);

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/file/Locations.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/file/Locations.java
@@ -81,14 +81,10 @@ import com.sun.tools.javac.code.Lint;
 import com.sun.tools.javac.resources.CompilerProperties.LintWarnings;
 import jdk.internal.jmod.JmodFile;
 
-import com.sun.tools.javac.code.Lint;
-import com.sun.tools.javac.code.Lint.LintCategory;
 import com.sun.tools.javac.main.Option;
 import com.sun.tools.javac.resources.CompilerProperties.Errors;
-import com.sun.tools.javac.resources.CompilerProperties.Warnings;
 import com.sun.tools.javac.util.DefinedBy;
 import com.sun.tools.javac.util.DefinedBy.Api;
-import com.sun.tools.javac.util.JCDiagnostic.Warning;
 import com.sun.tools.javac.util.ListBuffer;
 import com.sun.tools.javac.util.Log;
 import com.sun.tools.javac.jvm.ModuleNameReader;
@@ -141,7 +137,7 @@ public class Locations {
 
     Map<Path, FileSystem> fileSystems = new LinkedHashMap<>();
     List<Closeable> closeables = new ArrayList<>();
-    private Map<String,String> fsEnv = Collections.emptyMap();
+    private String releaseVersion = null;
 
     Locations() {
         initHandlers();
@@ -233,7 +229,8 @@ public class Locations {
     }
 
     public void setMultiReleaseValue(String multiReleaseValue) {
-        fsEnv = Collections.singletonMap("releaseVersion", multiReleaseValue);
+        // Null is implicitly allowed and unsets the value.
+        this.releaseVersion = multiReleaseValue;
     }
 
     private boolean contains(Collection<Path> searchPath, Path file) throws IOException {
@@ -480,7 +477,7 @@ public class Locations {
         }
 
         /**
-         * @see JavaFileManager#getLocationForModule(Location, JavaFileObject, String)
+         * @see JavaFileManager#getLocationForModule(Location, JavaFileObject)
          */
         Location getLocationForModule(Path file) throws IOException  {
             return null;
@@ -1387,7 +1384,7 @@ public class Locations {
                         log.error(Errors.NoZipfsForArchive(p));
                         return null;
                     }
-                    try (FileSystem fs = jarFSProvider.newFileSystem(p, fsEnv)) {
+                    try (FileSystem fs = jarFSProvider.newFileSystem(p, FSInfo.readOnlyJarFSEnv(releaseVersion))) {
                         Path moduleInfoClass = fs.getPath("module-info.class");
                         if (Files.exists(moduleInfoClass)) {
                             String moduleName = readModuleName(moduleInfoClass);
@@ -1463,7 +1460,7 @@ public class Locations {
                                 log.error(Errors.LocnCantReadFile(p));
                                 return null;
                             }
-                            fs = jarFSProvider.newFileSystem(p, Collections.emptyMap());
+                            fs = jarFSProvider.newFileSystem(p, FSInfo.readOnlyJarFSEnv(null));
                             try {
                                 Path moduleInfoClass = fs.getPath("classes/module-info.class");
                                 String moduleName = readModuleName(moduleInfoClass);

--- a/test/langtools/tools/javac/api/file/SJFM_TestBase.java
+++ b/test/langtools/tools/javac/api/file/SJFM_TestBase.java
@@ -37,6 +37,7 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
@@ -160,7 +161,7 @@ class SJFM_TestBase {
     List<Path> getTestZipPaths() throws IOException {
         if (zipfs == null) {
             Path testZip = createSourceZip();
-            zipfs = FileSystems.newFileSystem(testZip);
+            zipfs = FileSystems.newFileSystem(testZip, Map.of("accessMode", "readOnly"));
             closeables.add(zipfs);
             zipPaths = Files.list(zipfs.getRootDirectories().iterator().next())
                 .filter(p -> p.getFileName().toString().endsWith(".java"))

--- a/test/langtools/tools/javac/jvm/ClassRefDupInConstantPoolTest.java
+++ b/test/langtools/tools/javac/jvm/ClassRefDupInConstantPoolTest.java
@@ -25,19 +25,37 @@
  * @test
  * @bug 8015927
  * @summary Class reference duplicates in constant pool
- * @clean ClassRefDupInConstantPoolTest$Duplicates
+ * @library /tools/lib
+ * @modules jdk.compiler/com.sun.tools.javac.api
+ *          jdk.compiler/com.sun.tools.javac.main
+ * @build toolbox.JavacTask toolbox.ToolBox
  * @run main ClassRefDupInConstantPoolTest
  */
 
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.TreeSet;
+
+import toolbox.JavacTask;
+import toolbox.ToolBox;
 
 import java.lang.classfile.*;
 import java.lang.classfile.constantpool.*;
 
 public class ClassRefDupInConstantPoolTest {
+
+    private static final String DUPLICATE_REFS_CLASS =
+            """
+            class Duplicates {
+                String concat(String s1, String s2) {
+                    return s1 + (s2 == s1 ? " " : s2);
+                }
+            }""";
+
     public static void main(String[] args) throws Exception {
-        ClassModel cls = ClassFile.of().parse(ClassRefDupInConstantPoolTest.class.
-                                       getResourceAsStream("ClassRefDupInConstantPoolTest$Duplicates.class").readAllBytes());
+        new JavacTask(new ToolBox()).sources(DUPLICATE_REFS_CLASS).run();
+
+        ClassModel cls = ClassFile.of().parse(Files.readAllBytes(Path.of("Duplicates.class")));
         ConstantPool pool = cls.constantPool();
 
         int duplicates = 0;

--- a/test/langtools/tools/javac/jvm/ClassRefDupInConstantPoolTest.java
+++ b/test/langtools/tools/javac/jvm/ClassRefDupInConstantPoolTest.java
@@ -25,37 +25,19 @@
  * @test
  * @bug 8015927
  * @summary Class reference duplicates in constant pool
- * @library /tools/lib
- * @modules jdk.compiler/com.sun.tools.javac.api
- *          jdk.compiler/com.sun.tools.javac.main
- * @build toolbox.JavacTask toolbox.ToolBox
+ * @clean ClassRefDupInConstantPoolTest$Duplicates
  * @run main ClassRefDupInConstantPoolTest
  */
 
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.TreeSet;
-
-import toolbox.JavacTask;
-import toolbox.ToolBox;
 
 import java.lang.classfile.*;
 import java.lang.classfile.constantpool.*;
 
 public class ClassRefDupInConstantPoolTest {
-
-    private static final String DUPLICATE_REFS_CLASS =
-            """
-            class Duplicates {
-                String concat(String s1, String s2) {
-                    return s1 + (s2 == s1 ? " " : s2);
-                }
-            }""";
-
     public static void main(String[] args) throws Exception {
-        new JavacTask(new ToolBox()).sources(DUPLICATE_REFS_CLASS).run();
-
-        ClassModel cls = ClassFile.of().parse(Files.readAllBytes(Path.of("Duplicates.class")));
+        ClassModel cls = ClassFile.of().parse(ClassRefDupInConstantPoolTest.class.
+                                       getResourceAsStream("ClassRefDupInConstantPoolTest$Duplicates.class").readAllBytes());
         ConstantPool pool = cls.constantPool();
 
         int duplicates = 0;


### PR DESCRIPTION
This PR seeks to integrate the new ZipFileSystem "accessMode" parameter to open internal ZIP/JAR files as read only, to act as defense in-depth against accidental modification.

Note that this currently also propagates the (currently undocumented) "zipinfo-time" parameter to several other places where ZIP/JAR files are opened, which is likely to improve performance. This was discussed and is expected to be safe (but it's something to be careful about).
This will, of course, be thoroughly tested before integration.

It also unifies several places to use a common helper method to obtain the environment map, adds more comments, and changes a small number of affected tests.

I'm also happy to update the original bug description to include the timestamp related changes as necessary.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8356645](https://bugs.openjdk.org/browse/JDK-8356645): Javac should utilize new ZIP file system read-only access mode (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25639/head:pull/25639` \
`$ git checkout pull/25639`

Update a local copy of the PR: \
`$ git checkout pull/25639` \
`$ git pull https://git.openjdk.org/jdk.git pull/25639/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25639`

View PR using the GUI difftool: \
`$ git pr show -t 25639`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25639.diff">https://git.openjdk.org/jdk/pull/25639.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25639#issuecomment-2940017312)
</details>
