### PR TITLE
8358593: Add ucontext accessors for *BSD on Aarch64

### DIFF
--- a/src/hotspot/os_cpu/bsd_aarch64/os_bsd_aarch64.cpp
+++ b/src/hotspot/os_cpu/bsd_aarch64/os_bsd_aarch64.cpp
@@ -87,7 +87,6 @@
 
 // 10.5 UNIX03 member name prefixes
 #define DU3_PREFIX(s, m) __ ## s.__ ## m
-#endif
 
 #define context_x    uc_mcontext->DU3_PREFIX(ss,x)
 #define context_fp   uc_mcontext->DU3_PREFIX(ss,fp)
@@ -96,6 +95,31 @@
 #define context_pc   uc_mcontext->DU3_PREFIX(ss,pc)
 #define context_cpsr uc_mcontext->DU3_PREFIX(ss,cpsr)
 #define context_esr  uc_mcontext->DU3_PREFIX(es,esr)
+#endif
+
+#ifdef __FreeBSD__
+# define context_x  uc_mcontext.mc_gpregs.gp_x
+# define context_fp context_x[REG_FP]
+# define context_lr uc_mcontext.mc_gpregs.gp_lr
+# define context_sp uc_mcontext.mc_gpregs.gp_sp
+# define context_pc uc_mcontext.mc_gpregs.gp_elr
+#endif
+
+#ifdef __NetBSD__
+# define context_x  uc_mcontext.__gregs
+# define context_fp uc_mcontext.__gregs[_REG_FP]
+# define context_lr uc_mcontext.__gregs[_REG_LR]
+# define context_sp uc_mcontext.__gregs[_REG_SP]
+# define context_pc uc_mcontext.__gregs[_REG_ELR]
+#endif
+
+#ifdef __OpenBSD__
+# define context_x  sc_x
+# define context_fp sc_x[REG_FP]
+# define context_lr sc_lr
+# define context_sp sc_sp
+# define context_pc sc_elr
+#endif
 
 #define REG_BCP context_x[22]
 
@@ -496,9 +520,11 @@ int os::extra_bang_size_in_bytes() {
   return 0;
 }
 
+#ifdef __APPLE__
 void os::current_thread_enable_wx(WXMode mode) {
   pthread_jit_write_protect_np(mode == WXExec);
 }
+#endif
 
 static inline void atomic_copy64(const volatile void *src, volatile void *dst) {
   *(jlong *) dst = *(const jlong *) src;

--- a/src/hotspot/os_cpu/bsd_aarch64/os_bsd_aarch64.cpp
+++ b/src/hotspot/os_cpu/bsd_aarch64/os_bsd_aarch64.cpp
@@ -81,7 +81,6 @@
 #endif
 
 #define SPELL_REG_SP "sp"
-#define SPELL_REG_FP "fp"
 
 #ifdef __APPLE__
 // see darwin-xnu/osfmk/mach/arm/_structs.h


### PR DESCRIPTION
This adds macros for non-OSX BSD variants to access the required fields from ucontext_t in os_bsd_aarch64.cpp, similar to how it's already done for x86_64 in os_bsd_x86.cpp.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8358593](https://bugs.openjdk.org/browse/JDK-8358593): Add ucontext accessors for *BSD on Aarch64 (**Enhancement** - P4)


### Reviewers
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)

### Contributors
 * Greg Lewis `<glewis@eyesbeyond.com>`
 * Kurt Miller `<bsdkurt@gmail.com>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25640/head:pull/25640` \
`$ git checkout pull/25640`

Update a local copy of the PR: \
`$ git checkout pull/25640` \
`$ git pull https://git.openjdk.org/jdk.git pull/25640/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25640`

View PR using the GUI difftool: \
`$ git pr show -t 25640`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25640.diff">https://git.openjdk.org/jdk/pull/25640.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25640#issuecomment-2940010355)
</details>
