### PR TITLE
8358594: Misleading keyLength value captured in JFR event for ML-KEM key

### DIFF
--- a/src/java.base/share/classes/sun/security/tools/keytool/Main.java
+++ b/src/java.base/share/classes/sun/security/tools/keytool/Main.java
@@ -2064,8 +2064,8 @@ public final class Main {
     /**
      * Returns the full display name of the given key object. Could be
      * - "X25519", if its getParams() is NamedParameterSpec
-     * - "EC (secp256r1)", if it's an EC key
-     * - "1024-bit RSA", other known keys
+     * - "256-bit EC (secp256r1)", if it's an EC key
+     * - "1024-bit RSA", other keys with a defined key size
      * - plain algorithm name, otherwise
      *
      * Note: the same method appears in keytool and jarsigner which uses

--- a/src/java.base/share/classes/sun/security/util/KeyUtil.java
+++ b/src/java.base/share/classes/sun/security/util/KeyUtil.java
@@ -53,7 +53,7 @@ public final class KeyUtil {
      * <p>
      * Traditionally, the key size of an asymmetric key refers to the size of
      * its modulus. For example, a 2048-bit RSA key or a 256-bit NIST P-256 EC
-     * key. However, modern post-quantum algorithms based on lattice cryptography,
+     * key. However, new algorithms based on lattice cryptography,
      * such as ML-KEM, do not use a modulus, and the sizes of their public and
      * private keys can differ significantly from their security strength.
      * Instead of specifying a key length, NIST assigns a security category to
@@ -131,7 +131,7 @@ public final class KeyUtil {
     }
 
     /**
-     * Returns the NIST security categories defined for PQC algorithms. It was
+     * Returns the NIST security categories defined for PQC algorithms. It is
      * defined in Section 4.A.5 of "Submission Requirements and Evaluation Criteria
      * for the Post-Quantum Cryptography Standardization Process" which is available
      * at https://csrc.nist.gov/CSRC/media/Projects/Post-Quantum-Cryptography/documents/call-for-proposals-final-dec-2016.pdf.

--- a/src/java.base/share/classes/sun/security/util/KeyUtil.java
+++ b/src/java.base/share/classes/sun/security/util/KeyUtil.java
@@ -50,10 +50,19 @@ public final class KeyUtil {
 
     /**
      * Returns the key size of the given key object in bits.
+     * <p>
+     * Traditionally, the key size of an asymmetric key refers to the size of
+     * its modulus. For example, a 2048-bit RSA key or a 256-bit NIST P-256 EC
+     * key. However, modern post-quantum algorithms based on lattice cryptography,
+     * such as ML-KEM, do not use a modulus, and the sizes of their public and
+     * private keys can differ significantly from their security strength.
+     * Instead of specifying a key length, NIST assigns a security category to
+     * each standardized parameter set. For example, ML-KEM-768 is assigned to
+     * category 3, and ML-DSA-87 to category 5.
      *
      * @param key the key object, cannot be null
-     * @return the key size of the given key object in bits, or -1 if the
-     *       key size is not accessible
+     * @return the key size of the given key object in bits, or -1 if the key
+     *       size is not accessible (Ex: PKCS #11) or undefined (Ex: ML-KEM)
      */
     public static int getKeySize(Key key) {
         int size = -1;
@@ -119,6 +128,33 @@ public final class KeyUtil {
             // a key we are not able to handle.
 
         return size;
+    }
+
+    /**
+     * Returns the NIST security categories defined for PQC algorithms. It was
+     * defined in Section 4.A.5 of "Submission Requirements and Evaluation Criteria
+     * for the Post-Quantum Cryptography Standardization Process" which is available
+     * at https://csrc.nist.gov/CSRC/media/Projects/Post-Quantum-Cryptography/documents/call-for-proposals-final-dec-2016.pdf.
+     *
+     * Sources:
+     * ML-KEM: https://doi.org/10.6028/NIST.FIPS.203 Section 8
+     * ML-DSA: https://doi.org/10.6028/NIST.FIPS.204 Section 4
+     *
+     * @param k the key
+     * @return the security category, -1 if unknown or undefined
+     */
+    public static final int getNistCategory(Key k) {
+        String pname = (k instanceof AsymmetricKey ak
+                    && ak.getParams() instanceof NamedParameterSpec nps)
+                ? nps.getName()
+                : k.getAlgorithm();
+        return switch (pname) {
+            case "ML-KEM-512" -> 1;
+            case "ML-DSA-44" -> 2;
+            case "ML-KEM-768", "ML-DSA-65" -> 3;
+            case "ML-KEM-1024", "ML-DSA-87" -> 5;
+            default -> -1;
+        };
     }
 
     /**

--- a/test/jdk/sun/security/provider/all/NistCategories.java
+++ b/test/jdk/sun/security/provider/all/NistCategories.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import jdk.test.lib.Asserts;
+import sun.security.util.KeyUtil;
+import sun.security.util.RawKeySpec;
+
+import java.security.KeyFactory;
+import java.security.KeyPairGenerator;
+import java.util.HexFormat;
+
+/*
+ * @test
+ * @bug 8358594
+ * @library /test/lib
+ * @modules java.base/sun.security.util
+ * @summary confirm the hardcoded NIST categories in KeyUtil class
+ */
+public class NistCategories {
+    public static void main(String[] args) throws Exception {
+        check("ML-KEM-512", 1);
+        check("ML-KEM-768", 3);
+        check("ML-KEM-1024", 5);
+        check("ML-DSA-44", 2);
+        check("ML-DSA-65", 3);
+        check("ML-DSA-87", 5);
+        check("RSA", -1);
+        check("Ed25519", -1);
+
+        System.out.println("HSS/LMS");
+        var spec = new RawKeySpec(HexFormat.of().parseHex("""
+                00000002
+                00000005
+                00000004
+                61a5d57d37f5e46bfb7520806b07a1b8
+                50650e3b31fe4a773ea29a07f09cf2ea
+                30e579f0df58ef8e298da0434cb2b878
+                """.replaceAll("\\s", "")));
+        var key = KeyFactory.getInstance("HSS/LMS")
+                .generatePublic(spec);
+        // This is not really a confirmation that HSS/LMS keys should
+        // not have a category. It just shows they are not defined in JDK
+        // at the moment.
+        Asserts.assertEQ(-1, KeyUtil.getNistCategory(key));
+
+    }
+
+    static void check(String alg, int expected) throws Exception {
+        System.out.println(alg);
+        var kp = KeyPairGenerator.getInstance(alg).generateKeyPair();
+        Asserts.assertEQ(expected, KeyUtil.getNistCategory(kp.getPrivate()));
+        Asserts.assertEQ(expected, KeyUtil.getNistCategory(kp.getPublic()));
+    }
+}

--- a/test/jdk/sun/security/provider/all/NistCategories.java
+++ b/test/jdk/sun/security/provider/all/NistCategories.java
@@ -46,8 +46,8 @@ public class NistCategories {
         // Test all asymmetric keys we can generate
         for (var p : Security.getProviders()) {
             for (var s : p.getServices()) {
-                switch (s.getType()) {
-                    case "KeyPairGenerator" -> test(s);
+                if (s.getType().equals("KeyPairGenerator")) {
+                    test(s);
                 }
             }
         }

--- a/test/jdk/sun/security/provider/all/NistCategories.java
+++ b/test/jdk/sun/security/provider/all/NistCategories.java
@@ -25,6 +25,7 @@ import jdk.test.lib.Asserts;
 import sun.security.util.KeyUtil;
 import sun.security.util.RawKeySpec;
 
+import javax.crypto.spec.SecretKeySpec;
 import java.security.KeyFactory;
 import java.security.KeyPairGenerator;
 import java.security.Provider;
@@ -41,6 +42,8 @@ import java.util.HexFormat;
 public class NistCategories {
     public static void main(String[] args) throws Exception {
         Security.addProvider(PKCS11Test.getSunPKCS11(PKCS11Test.getNssConfig()));
+
+        // Test all asymmetric keys we can generate
         for (var p : Security.getProviders()) {
             for (var s : p.getServices()) {
                 switch (s.getType()) {
@@ -48,7 +51,13 @@ public class NistCategories {
                 }
             }
         }
+
+        // We cannot generate HSS/LMS keys
         testLMS();
+
+        // SecretKey has no NIST category
+        Asserts.assertEQ(-1, KeyUtil.getNistCategory(
+                new SecretKeySpec(new byte[32], "AES")));
     }
 
     static void test(Provider.Service s) throws Exception {


### PR DESCRIPTION
Add more comment on why `KeyUtil::getKeySize` could return -1. Add a new method `getNistCategory` to get the NIST security category.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8358594](https://bugs.openjdk.org/browse/JDK-8358594): Misleading keyLength value captured in JFR event for ML-KEM key (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25642/head:pull/25642` \
`$ git checkout pull/25642`

Update a local copy of the PR: \
`$ git checkout pull/25642` \
`$ git pull https://git.openjdk.org/jdk.git pull/25642/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25642`

View PR using the GUI difftool: \
`$ git pr show -t 25642`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25642.diff">https://git.openjdk.org/jdk/pull/25642.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25642#issuecomment-2940397496)
</details>
