### PR TITLE
8358600: Template-Framework Library: Template for TestFramework test class

### DIFF
--- a/test/hotspot/jtreg/compiler/lib/template_framework/library/TestFrameworkClass.java
+++ b/test/hotspot/jtreg/compiler/lib/template_framework/library/TestFrameworkClass.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.lib.template_framework.library;
+
+import java.util.List;
+
+import compiler.lib.ir_framework.TestFramework;
+import compiler.lib.compile_framework.CompileFramework;
+import compiler.lib.template_framework.Template;
+import compiler.lib.template_framework.TemplateToken;
+import static compiler.lib.template_framework.Template.body;
+import static compiler.lib.template_framework.Template.let;
+
+/**
+ * This class provides a {@link #TEMPLATE} that can be used to simplify generating
+ * source code when using the {@link TestFramework} (also known as IR Framework) to run a list of tests.
+ *
+ * <p>
+ * The idea is that the user only has to generate the code for the individual tests,
+ * and can then pass the corresponding list of {@link TemplateToken}s to this
+ * provided {@link #TEMPLATE} which generates the surrounding class and the main
+ * method that invokes the {@link TestFramework}, so that all the generated tests
+ * are run.
+ */
+public final class TestFrameworkClass {
+
+    // Ensure there can be no instance, and we do not have to document the constructor.
+    private TestFrameworkClass() {}
+
+    /**
+     * To use the {@link TestFrameworkClass#TEMPLATE}, the user must specify the
+     * {@link #packageName} and {@link #className}, as well as a list of {@link #imports}
+     * and the {@link #classpath} from {@link CompileFramework#getEscapedClassPathOfCompiledClasses},
+     * so that the Test VM has access to the class files that are compiled from the generated
+     * source code.
+     *
+     * @param packageName The package name of the test class.
+     * @param className The name of the test class.
+     * @param imports A list of imports.
+     * @param classpath The classpath from {@link CompileFramework#getEscapedClassPathOfCompiledClasses},
+     *                  so that the Test VM has access to the class files that are compiled from the
+     *                  generated source code.
+     */
+    public record Info(String packageName, String className, List<String> imports, String classpath) {};
+
+    /**
+     * This {@link Template} simplifies generating source code when using the {@link TestFramework}
+     * (also known as IR Framework) to run a list of tests.
+     *
+     * <p>
+     * The {@code info} argument encapsulates the context information for the
+     * generated class. The {@code testTemplateTokens} is a list of {@link TemplateToken}s,
+     * which represent the tests that are to be generated inside this test class.
+     *
+     * <p>
+     * The {@code main} method is to be invoked with a {@code vmFlags} argument, where
+     * the Test VM flags can be specified with which the tests are to be run.
+     */
+    public static final Template.TwoArgs<Info, List<TemplateToken>> TEMPLATE =
+        Template.make("info", "testTemplateTokens", (Info info, List<TemplateToken> testTemplateTokens) -> body(
+            let("classpath", info.classpath),
+            let("packageName", info.packageName),
+            let("className", info.className),
+            """
+            package #packageName;
+            // --- IMPORTS start ---
+            import compiler.lib.ir_framework.*;
+            """,
+            info.imports.stream().map(i -> "import " + i + ";\n").toList(),
+            """
+            // --- IMPORTS end   ---
+            public class #className {
+            // --- CLASS_HOOK insertions start ---
+            """,
+            Hooks.CLASS_HOOK.anchor(
+            """
+            // --- CLASS_HOOK insertions end   ---
+                public static void main(String[] vmFlags) {
+                    TestFramework framework = new TestFramework(#className.class);
+                    framework.addFlags("-classpath", "#classpath");
+                    framework.addFlags(vmFlags);
+                    framework.start();
+                }
+            // --- LIST OF TESTS start ---
+            """,
+            testTemplateTokens
+            ),
+            """
+            // --- LIST OF TESTS end   ---
+            }
+            """
+        ));
+}

--- a/test/hotspot/jtreg/compiler/lib/template_framework/library/TestFrameworkClass.java
+++ b/test/hotspot/jtreg/compiler/lib/template_framework/library/TestFrameworkClass.java
@@ -24,6 +24,7 @@
 package compiler.lib.template_framework.library;
 
 import java.util.List;
+import java.util.Set;
 
 import compiler.lib.ir_framework.TestFramework;
 import compiler.lib.compile_framework.CompileFramework;
@@ -62,7 +63,7 @@ public final class TestFrameworkClass {
      *
      * @param packageName The package name of the test class.
      * @param className The name of the test class.
-     * @param imports A list of imports.
+     * @param imports A set of imports.
      * @param classpath The classpath from {@link CompileFramework#getEscapedClassPathOfCompiledClasses},
      *                  so that the Test VM has access to the class files that are compiled from the
      *                  generated source code.
@@ -73,7 +74,7 @@ public final class TestFrameworkClass {
      */
     public static String render(final String packageName,
                                 final String className,
-                                final List<String> imports,
+                                final Set<String> imports,
                                 final String classpath,
                                 final List<TemplateToken> testTemplateTokens) {
         var template = Template.make(() -> body(

--- a/test/hotspot/jtreg/compiler/lib/template_framework/library/TestFrameworkClass.java
+++ b/test/hotspot/jtreg/compiler/lib/template_framework/library/TestFrameworkClass.java
@@ -61,6 +61,10 @@ public final class TestFrameworkClass {
      * the tests will be run. Thus, one can generate the test class once, and invoke its
      * {@code main} method multiple times, each time with a different set of VM flags.
      *
+     * <p>
+     * The internal {@link Template} sets the {@link Hooks#CLASS_HOOK} for the scope of
+     * all test methods.
+     *
      * @param packageName The package name of the test class.
      * @param className The name of the test class.
      * @param imports A set of imports.

--- a/test/hotspot/jtreg/testlibrary_tests/template_framework/examples/TestWithTestFrameworkClass.java
+++ b/test/hotspot/jtreg/testlibrary_tests/template_framework/examples/TestWithTestFrameworkClass.java
@@ -35,6 +35,7 @@
 package template_framework.examples;
 
 import java.util.List;
+import java.util.Set;
 
 import compiler.lib.compile_framework.CompileFramework;
 
@@ -132,7 +133,7 @@ public class TestWithTestFrameworkClass {
             """
         ));
 
-        // Create a test for each operator..
+        // Create a test for each operator.
         List<String> ops = List.of("+", "-", "*", "&", "|");
         List<TemplateToken> testTemplateTokens = ops.stream().map(testTemplate::asToken).toList();
 
@@ -140,11 +141,9 @@ public class TestWithTestFrameworkClass {
         return TestFrameworkClass.render(
             // package and class name.
             "p.xyz", "InnerTest",
-            // List of imports. Duplicates are permitted.
-            List.of("compiler.lib.generators.*",
-                    "compiler.lib.ir_framework.*",
-                    "compiler.lib.verify.*",
-                    "compiler.lib.verify.*"),
+            // Set of imports.
+            Set.of("compiler.lib.generators.*",
+                   "compiler.lib.verify.*"),
             // classpath, so the Test VM has access to the compiled class files.
             comp.getEscapedClassPathOfCompiledClasses(),
             // The list of tests.

--- a/test/hotspot/jtreg/testlibrary_tests/template_framework/examples/TestWithTestFrameworkClass.java
+++ b/test/hotspot/jtreg/testlibrary_tests/template_framework/examples/TestWithTestFrameworkClass.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @summary Test TestFrameworkClass.TEMPLATE which allows generating many tests and running them with the IR TestFramework.
+ * @modules java.base/jdk.internal.misc
+ * @library /test/lib /
+ * @compile ../../../compiler/lib/ir_framework/TestFramework.java
+ * @compile ../../../compiler/lib/generators/Generators.java
+ * @compile ../../../compiler/lib/verify/Verify.java
+ * @run driver template_framework.examples.TestWithTestFrameworkClass
+ */
+
+package template_framework.examples;
+
+import java.util.List;
+
+import compiler.lib.compile_framework.CompileFramework;
+
+import compiler.lib.generators.Generators;
+
+import compiler.lib.template_framework.Template;
+import compiler.lib.template_framework.TemplateToken;
+import static compiler.lib.template_framework.Template.body;
+import static compiler.lib.template_framework.Template.let;
+
+import compiler.lib.template_framework.library.TestFrameworkClass;
+
+/**
+ * This is a basic IR verification test, in combination with Generators for random input generation
+ * and Verify for output verification.
+ * <p>
+ * The "@compile" command for JTREG is required so that the frameworks used in the Template code
+ * are compiled and available for the Test-VM.
+ * <p>
+ * Additionally, we must set the classpath for the Test VM, so that it has access to all compiled
+ * classes (see {@link CompileFramework#getEscapedClassPathOfCompiledClasses}).
+ */
+public class TestWithTestFrameworkClass {
+
+    public static void main(String[] args) {
+        // Create a new CompileFramework instance.
+        CompileFramework comp = new CompileFramework();
+
+        // Add a java source file.
+        comp.addJavaSourceCode("p.xyz.InnerTest", generate(comp));
+
+        // Compile the source file.
+        comp.compile();
+
+        // p.xyz.InnterTest.main(new String[] {});
+        comp.invoke("p.xyz.InnerTest", "main", new Object[] {new String[] {}});
+
+        // We can also pass VM flags for the Test VM.
+        // p.xyz.InnterTest.main(new String[] {"-Xbatch"});
+        comp.invoke("p.xyz.InnerTest", "main", new Object[] {new String[] {"-Xbatch"}});
+    }
+
+    // Generate a source Java file as String
+    public static String generate(CompileFramework comp) {
+        // Create the info required for the test class.
+        // It is imporant that we pass the classpath to the Test-VM, so that it has access
+        // to all compiled classes.
+        TestFrameworkClass.Info info = new TestFrameworkClass.Info(
+            // package and class name.
+            "p.xyz", "InnerTest",
+            // List of imports. Duplicates are permitted.
+            List.of("compiler.lib.generators.*",
+                    "compiler.lib.ir_framework.*",
+                    "compiler.lib.verify.*",
+                    "compiler.lib.verify.*"),
+            // classpath, so the Test VM has access to the compiled class files.
+            comp.getEscapedClassPathOfCompiledClasses()
+        );
+
+        // We define a Test-Template:
+        // - static fields for inputs: INPUT_A and INPUT_B
+        //   - Data generated with Generators and hashtag replacement #con1.
+        // - GOLD value precomputed with dedicated call to test.
+        //   - This ensures that the GOLD value is computed in the interpreter
+        //     most likely, since the test method is not yet compiled.
+        //     This allows us later to compare to the results of the compiled
+        //     code.
+        //     The input data is cloned, so that the original INPUT_A is never
+        //     modified and can serve as identical input in later calls to test.
+        // - In the Setup method, we clone the input data, since the input data
+        //   could be modified inside the test method.
+        // - The test method makes use of hashtag replacements (#con2 and #op).
+        // - The Check method verifies the results of the test method with the
+        //   GOLD value.
+        var testTemplate = Template.make("op", (String op) -> body(
+            let("size", Generators.G.safeRestrict(Generators.G.ints(), 10_000, 20_000).next()),
+            let("con1", Generators.G.ints().next()),
+            let("con2", Generators.G.safeRestrict(Generators.G.ints(), 1, Integer.MAX_VALUE).next()),
+            """
+            // --- $test start ---
+            // $test with size=#size and op=#op
+            private static int[] $INPUT_A = new int[#size];
+            static {
+                Generators.G.fill(Generators.G.ints(), $INPUT_A);
+            }
+            private static int $INPUT_B = #con1;
+            private static Object $GOLD = $test($INPUT_A.clone(), $INPUT_B);
+
+            @Setup
+            public static Object[] $setup() {
+                // Must make sure to clone input arrays, if it is mutated in the test.
+                return new Object[] {$INPUT_A.clone(), $INPUT_B};
+            }
+
+            @Test
+            @Arguments(setup = "$setup")
+            public static Object $test(int[] a, int b) {
+                for (int i = 0; i < a.length; i++) {
+                    int con = #con2;
+                    a[i] = (a[i] * con) #op b;
+                }
+                return a;
+            }
+
+            @Check(test = "$test")
+            public static void $check(Object result) {
+                Verify.checkEQ(result, $GOLD);
+            }
+            // --- $test end   ---
+            """
+        ));
+
+        // From a list of operators, create a list of templateTokens with applied arguments.
+        List<String> ops = List.of("+", "-", "*", "&", "|");
+        List<TemplateToken> templateTokens = ops.stream().map(op -> (TemplateToken)testTemplate.asToken(op)).toList();
+
+        // Create the test class, which runs all templateTokens.
+        return TestFrameworkClass.TEMPLATE.render(info, templateTokens);
+    }
+}

--- a/test/hotspot/jtreg/testlibrary_tests/template_framework/examples/TestWithTestFrameworkClass.java
+++ b/test/hotspot/jtreg/testlibrary_tests/template_framework/examples/TestWithTestFrameworkClass.java
@@ -46,6 +46,7 @@ import compiler.lib.template_framework.TemplateToken;
 import static compiler.lib.template_framework.Template.body;
 import static compiler.lib.template_framework.Template.let;
 
+import compiler.lib.template_framework.library.Hooks;
 import compiler.lib.template_framework.library.TestFrameworkClass;
 
 /**
@@ -80,6 +81,13 @@ public class TestWithTestFrameworkClass {
 
     // Generate a source Java file as String
     public static String generate(CompileFramework comp) {
+        // A simple template that adds a comment.
+        var commentTemplate = Template.make(() -> body(
+            """
+            // Comment inserted from test method to class hook.
+            """
+        ));
+
         // We define a Test-Template:
         // - static fields for inputs: INPUT_A and INPUT_B
         //   - Data generated with Generators and hashtag replacement #con1.
@@ -130,7 +138,10 @@ public class TestWithTestFrameworkClass {
                 Verify.checkEQ(result, $GOLD);
             }
             // --- $test end   ---
-            """
+            """,
+            // Good to know: we can insert to the class hook, which is set for the
+            // TestFrameworkClass scope:
+            Hooks.CLASS_HOOK.insert(commentTemplate.asToken())
         ));
 
         // Create a test for each operator.

--- a/test/hotspot/jtreg/testlibrary_tests/template_framework/examples/TestWithTestFrameworkClass.java
+++ b/test/hotspot/jtreg/testlibrary_tests/template_framework/examples/TestWithTestFrameworkClass.java
@@ -79,21 +79,6 @@ public class TestWithTestFrameworkClass {
 
     // Generate a source Java file as String
     public static String generate(CompileFramework comp) {
-        // Create the info required for the test class.
-        // It is imporant that we pass the classpath to the Test-VM, so that it has access
-        // to all compiled classes.
-        TestFrameworkClass.Info info = new TestFrameworkClass.Info(
-            // package and class name.
-            "p.xyz", "InnerTest",
-            // List of imports. Duplicates are permitted.
-            List.of("compiler.lib.generators.*",
-                    "compiler.lib.ir_framework.*",
-                    "compiler.lib.verify.*",
-                    "compiler.lib.verify.*"),
-            // classpath, so the Test VM has access to the compiled class files.
-            comp.getEscapedClassPathOfCompiledClasses()
-        );
-
         // We define a Test-Template:
         // - static fields for inputs: INPUT_A and INPUT_B
         //   - Data generated with Generators and hashtag replacement #con1.
@@ -147,11 +132,22 @@ public class TestWithTestFrameworkClass {
             """
         ));
 
-        // From a list of operators, create a list of templateTokens with applied arguments.
+        // Create a test for each operator..
         List<String> ops = List.of("+", "-", "*", "&", "|");
-        List<TemplateToken> templateTokens = ops.stream().map(op -> (TemplateToken)testTemplate.asToken(op)).toList();
+        List<TemplateToken> testTemplateTokens = ops.stream().map(testTemplate::asToken).toList();
 
-        // Create the test class, which runs all templateTokens.
-        return TestFrameworkClass.TEMPLATE.render(info, templateTokens);
+        // Create the test class, which runs all testTemplateTokens.
+        return TestFrameworkClass.render(
+            // package and class name.
+            "p.xyz", "InnerTest",
+            // List of imports. Duplicates are permitted.
+            List.of("compiler.lib.generators.*",
+                    "compiler.lib.ir_framework.*",
+                    "compiler.lib.verify.*",
+                    "compiler.lib.verify.*"),
+            // classpath, so the Test VM has access to the compiled class files.
+            comp.getEscapedClassPathOfCompiledClasses(),
+            // The list of tests.
+            testTemplateTokens);
     }
 }


### PR DESCRIPTION
We might want to write many IR/TestFramework tests, and so I would like to integrate a Template that generates the class, and the user has to only generate a list of tests.

This is a first extension for https://github.com/openjdk/jdk/pull/24217. I had already prototyped it earlier and plan to use it in multiple tests https://github.com/openjdk/jdk/pull/23418 (see `IRTestClass.java`).

https://github.com/openjdk/jdk/blob/dc640cbd8fb8ec76920a7ab52dfe7955ed1d77f2/test/hotspot/jtreg/compiler/lib/template_framework/library/TestFrameworkClass.java#L36-L45

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8358600](https://bugs.openjdk.org/browse/JDK-8358600): Template-Framework Library: Template for TestFramework test class (**Sub-task** - P4)


### Reviewers
 * [Manuel Hässig](https://openjdk.org/census#mhaessig) (@mhaessig - Author) Review applies to [256d922c](https://git.openjdk.org/jdk/pull/25643/files/256d922c347d3bf884dfbe289305341e4cd7f0a9)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25643/head:pull/25643` \
`$ git checkout pull/25643`

Update a local copy of the PR: \
`$ git checkout pull/25643` \
`$ git pull https://git.openjdk.org/jdk.git pull/25643/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25643`

View PR using the GUI difftool: \
`$ git pr show -t 25643`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25643.diff">https://git.openjdk.org/jdk/pull/25643.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25643#issuecomment-2940585191)
</details>
