### PR TITLE
Improve performance of parsing with DecimalFormat 

### DIFF
--- a/src/java.base/share/classes/jdk/internal/math/FloatingDecimal.java
+++ b/src/java.base/share/classes/jdk/internal/math/FloatingDecimal.java
@@ -123,6 +123,19 @@ public class FloatingDecimal{
     }
 
     /**
+     * Converts a sequence of digits ('0'-'9') as well as an exponent to a positive
+     * double value
+     *
+     * @param decExp The decimal exponent of the value to generate
+     * @param digits The digits of the significand.
+     * @param length Number of digits to use
+     * @return The double-precision value of the conversion
+     */
+    public static double parseDoubleDigits(int decExp, char[] digits, int length) throws NumberFormatException {
+        return readDoubleDigits(decExp, digits, length).doubleValue();
+    }
+
+    /**
      * A converter which can process single or double precision floating point
      * values into an ASCII <code>String</code> representation.
      */
@@ -1822,6 +1835,17 @@ public class FloatingDecimal{
         // call the routine that actually does all the hard work.
         buf.dtoa(binExp, ((long)fractBits)<<(EXP_SHIFT-SINGLE_EXP_SHIFT), nSignificantBits, true);
         return buf;
+    }
+
+    static ASCIIToBinaryConverter readDoubleDigits(int decExp, char[] digits, int length) {
+        if (decExp < MIN_DECIMAL_EXPONENT) {
+            return buildZero(BINARY_64_IX, 1);
+        }
+        byte[] buf = new byte[length];
+        for (int i = 0; i < length; i++) {
+            buf[i] = (byte) digits[i];
+        }
+        return new ASCIIToBinaryBuffer(false, decExp, buf, length);
     }
 
     /**

--- a/test/jdk/java/text/Format/DecimalFormat/CloneTest.java
+++ b/test/jdk/java/text/Format/DecimalFormat/CloneTest.java
@@ -95,11 +95,6 @@ public class CloneTest {
                     assertNotSame(data, valFromDigitList(dfClone, "data"));
                 }
 
-                Object tempBuilder = valFromDigitList(original, "tempBuilder");
-                if (tempBuilder != null) {
-                    assertNotSame(data, valFromDigitList(dfClone, "data"));
-                }
-
                 assertEquals(digitListField.get(original), digitListField.get(dfClone));
             } catch (ReflectiveOperationException e) {
                 throw new SkippedException("reflective access in white-box test failed", e);

--- a/test/micro/org/openjdk/bench/java/text/DecimalFormatParseBench.java
+++ b/test/micro/org/openjdk/bench/java/text/DecimalFormatParseBench.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.java.text;
+
+import java.text.NumberFormat;
+import java.text.DecimalFormat;
+import java.text.ParseException;
+import java.util.Locale;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(3)
+@State(Scope.Benchmark)
+public class DecimalFormatParseBench {
+
+    public String[] valuesLong;
+    public String[] valuesDouble;
+
+    @Setup
+    public void setup() {
+        valuesLong = new String[]{
+                "123", "149", "180", "170000000000000000", "0", "-149", "-15000", "99999123", "1494", "1495", "1030", "25996", "-25996"
+        };
+
+        valuesDouble = new String[]{
+                "1.23", "1.49", "1.80", "17000000000000000.1", "0.01", "-1.49", "-1.50", "9999.9123", "1.494", "1.495", "1.03", "25.996", "-25.996"
+        };
+    }
+
+    private NumberFormat dnf = new DecimalFormat();
+
+    @Benchmark
+    @OperationsPerInvocation(13)
+    public void testParseLongs(final Blackhole blackhole) throws ParseException {
+        for (String value : valuesLong) {
+            blackhole.consume(this.dnf.parse(value));
+        }
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(13)
+    public void testParseDoubles(final Blackhole blackhole) throws ParseException {
+        for (String value : valuesDouble) {
+            blackhole.consume(this.dnf.parse(value));
+        }
+    }
+    public static void main(String... args) throws Exception {
+        Options opts = new OptionsBuilder().include(DefFormatterBench.class.getSimpleName()).shouldDoGC(true).build();
+        new Runner(opts).run();
+    }
+
+}


### PR DESCRIPTION
This PR replaces construction of intermediate strings to be parsed with more direct manipulation of numbers. It also has a more streamlined mechanism of handling `Long.MIN_VALUE` when parsing longs by using `Long.parseUnsignedLong`

As a small side-effect it also eliminates the use of a cached StringBuilder in DigitList.
 