### PR TITLE
8341778: Some javac tests ignore the result of JavacTask::call

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/GenClassPoolJar.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/GenClassPoolJar.java
@@ -187,7 +187,9 @@ public class GenClassPoolJar {
         StandardJavaFileManager sjfm = compiler.getStandardFileManager(null, null, null);
         Iterable<? extends JavaFileObject> fileObjects = sjfm.getJavaFileObjects(files);
         JavaCompiler.CompilationTask task = compiler.getTask(null, null, null, optionList, null, fileObjects);
-        task.call();
+        if (!task.call()) {
+            throw new AssertionError("test failed due to a compilation error");
+        }
         sjfm.close();
     }
 

--- a/test/langtools/tools/javac/T6358024.java
+++ b/test/langtools/tools/javac/T6358024.java
@@ -87,7 +87,9 @@ public class T6358024 extends AbstractProcessor {
                                                           Arrays.asList(f));
         MyTaskListener tl = new MyTaskListener();
         task.setTaskListener(tl);
-        task.call();
+        if (!task.call()) {
+            throw new AssertionError("test failed due to a compilation error");
+        }
         if (tl.started != expect)
             throw new AssertionError("Unexpected number of TaskListener events; "
                                      + "expected " + expect + ", found " + tl.started);

--- a/test/langtools/tools/javac/T6358166.java
+++ b/test/langtools/tools/javac/T6358166.java
@@ -75,7 +75,9 @@ public class T6358166 extends AbstractProcessor {
 
         JavacTool tool = JavacTool.create();
         JavacTaskImpl task = (JavacTaskImpl) tool.getTask(null, fm, null, allArgs, null, List.of(f), context);
-        task.call();
+        if (!task.call()) {
+            throw new AssertionError("test failed due to a compilation error");
+        }
 
         JavaCompiler c = JavaCompiler.instance(context);
         if (c.errorCount() != 0)

--- a/test/langtools/tools/javac/T6361619.java
+++ b/test/langtools/tools/javac/T6361619.java
@@ -50,7 +50,8 @@ public class T6361619 extends AbstractProcessor {
 
         final PrintWriter out = new PrintWriter(System.err, true);
 
-        Iterable<String> flags = Arrays.asList("-processorpath", testClassDir,
+        Iterable<String> flags = Arrays.asList("--add-exports", "jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
+                                               "-processorpath", testClassDir,
                                                "-processor", self,
                                                "-d", ".");
         DiagnosticListener<JavaFileObject> dl = new DiagnosticListener<JavaFileObject>() {
@@ -69,7 +70,9 @@ public class T6361619 extends AbstractProcessor {
             task.setTaskListener(tl);
 
             // should complete, without exceptions
-            task.call();
+            if (!task.call()) {
+                throw new AssertionError("test failed due to a compilation error");
+            }
         }
     }
 

--- a/test/langtools/tools/javac/T6395974.java
+++ b/test/langtools/tools/javac/T6395974.java
@@ -63,7 +63,9 @@ public class T6395974 {
             MyTaskListener tl = new MyTaskListener();
             task.setTaskListener(tl);
 
-            task.call();
+            if (task.call()) {
+                throw new AssertionError("test compilation was expected to fail");
+            }
         }
     }
 

--- a/test/langtools/tools/javac/T6397286.java
+++ b/test/langtools/tools/javac/T6397286.java
@@ -56,6 +56,7 @@ public class T6397286 {
                 });
 
             try {
+                // no need to check the result of JavacTask::call, reevaluate if the test is modified
                 task.call();
                 throw new AssertionError("no exception thrown");
             } catch (RuntimeException e) {

--- a/test/langtools/tools/javac/T6458823/T6458823.java
+++ b/test/langtools/tools/javac/T6458823/T6458823.java
@@ -66,7 +66,9 @@ public class T6458823 {
             files.add(new File(T6458823.class.getResource("TestClass.java").toURI()));
             final CompilationTask task = compiler.getTask(null, fm, diagColl,
                 options, null, fm.getJavaFileObjectsFromFiles(files));
-            task.call();
+            if (!task.call()) {
+                throw new AssertionError("test failed due to a compilation error");
+            }
             int diagCount = 0;
             for (Diagnostic<? extends JavaFileObject> diag : diagColl.getDiagnostics()) {
                 if (diag.getKind() != Diagnostic.Kind.WARNING) {

--- a/test/langtools/tools/javac/TryWithResources/TwrAvoidNullCheck.java
+++ b/test/langtools/tools/javac/TryWithResources/TwrAvoidNullCheck.java
@@ -76,7 +76,9 @@ public class TwrAvoidNullCheck {
         DumpLower.preRegister(ctx);
         Iterable<ToolBox.JavaSource> files = Arrays.asList(new ToolBox.JavaSource(code));
         JavacTask task = JavacTool.create().getTask(null, null, null, null, null, files, ctx);
-        task.call();
+        if (!task.call()) {
+            throw new AssertionError("test failed due to a compilation error");
+        }
 
         boolean hasNullCheck = ((DumpLower) DumpLower.instance(ctx)).hasNullCheck;
 

--- a/test/langtools/tools/javac/TryWithResources/TwrSimpleClose.java
+++ b/test/langtools/tools/javac/TryWithResources/TwrSimpleClose.java
@@ -89,7 +89,9 @@ public class TwrSimpleClose {
              JFMImpl fm = new JFMImpl(sfm)) {
             Iterable<ToolBox.JavaSource> files = Arrays.asList(new ToolBox.JavaSource(code));
             JavacTask task = (JavacTask) compiler.getTask(null, fm, null, null, null, files);
-            task.call();
+            if (!task.call()) {
+                throw new AssertionError("test failed due to a compilation error");
+            }
 
             if (fm.classBytes.size() != 1) {
                 throw new AssertionError();

--- a/test/langtools/tools/javac/api/6406133/T6406133.java
+++ b/test/langtools/tools/javac/api/6406133/T6406133.java
@@ -90,7 +90,9 @@ public class T6406133 extends ToolTester {
         task = tool.getTask(pw, fm, listener, null, null, compilationUnits);
         task.setProcessors(Arrays.asList(processor));
         task.setLocale(locale); //6443132
-        task.call();
+        if (task.call()) {
+            throw new AssertionError("test compilation was expected to fail");
+        }
         if (!processor.locale.equals(locale))
             throw new AssertionError("Error in diagnostic localization during annotation processing");
         String res = useListener ? listener.result : pw.toString();

--- a/test/langtools/tools/javac/api/6410643/T6410643.java
+++ b/test/langtools/tools/javac/api/6410643/T6410643.java
@@ -53,6 +53,7 @@ public class T6410643 extends ToolTester {
     void test(String... args) {
         task = tool.getTask(null, null, null, null, null, null);
         try {
+            // no need to check the result of JavacTask::call, reevaluate if the test is modified
             task.call();
             throw new AssertionError("Error expected");
         } catch (IllegalStateException e) {

--- a/test/langtools/tools/javac/api/6412656/T6412656.java
+++ b/test/langtools/tools/javac/api/6412656/T6412656.java
@@ -47,7 +47,9 @@ public class T6412656 extends ToolTester {
         task = tool.getTask(null, fm, null, null,
                             Collections.singleton(T6412656.class.getName()), null);
         task.setProcessors(Collections.singleton(new MyProc(this)));
-        task.call();
+        if (!task.call()) {
+            throw new AssertionError("test failed due to a compilation error");
+        }
         if (count == 0)
             throw new AssertionError("Annotation processor not run");
         System.out.println("OK");

--- a/test/langtools/tools/javac/api/6423003/T6423003.java
+++ b/test/langtools/tools/javac/api/6423003/T6423003.java
@@ -41,11 +41,12 @@ public class T6423003 extends ToolTester {
     void test(String... args) {
         task = tool.getTask(null, fm, null, Arrays.asList("-Xlint:all"), null, null);
         try {
+            // no need to check the result of JavacTask::call, reevaluate if the test is modified
             task.call();
+            throw new AssertionError("Expected IllegalStateException not thrown");
         } catch (IllegalStateException ex) {
             return;
         }
-        throw new AssertionError("Expected IllegalStateException not thrown");
     }
     public static void main(String... args) throws IOException {
         try (T6423003 t = new T6423003()) {

--- a/test/langtools/tools/javac/api/6731573/T6731573.java
+++ b/test/langtools/tools/javac/api/6731573/T6731573.java
@@ -93,7 +93,9 @@ public class T6731573 extends ToolTester {
         if (sourceLine.optValue != null)
             options.add(sourceLine.optValue);
         task = tool.getTask(pw, fm, null, options, null, compilationUnits);
-        task.call();
+        if (task.call()) {
+            throw new AssertionError("test compilation was expected to fail");
+        }
         checkErrorLine(pw.toString(),
                 diagType.shouldDisplaySource(sourceLine),
                 options);

--- a/test/langtools/tools/javac/api/7086261/T7086261.java
+++ b/test/langtools/tools/javac/api/7086261/T7086261.java
@@ -71,7 +71,9 @@ public class T7086261 {
         try (JavaFileManager jfm = javac.getStandardFileManager(null, null, null)) {
             JavaCompiler.CompilationTask task =
                     javac.getTask(null, jfm, new DiagnosticChecker(), null, null, Arrays.asList(new ErroneousSource()));
-            task.call();
+            if (task.call()) {
+                throw new AssertionError("test compilation was expected to fail");
+            }
         }
     }
 

--- a/test/langtools/tools/javac/api/8007344/Test.java
+++ b/test/langtools/tools/javac/api/8007344/Test.java
@@ -38,6 +38,7 @@
 import java.io.File;
 import java.io.PrintWriter;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Set;
 
 import javax.annotation.processing.RoundEnvironment;
@@ -75,6 +76,12 @@ public class Test {
         }
     }
 
+    static final List<String> OPTIONS = List.of(
+            "--add-exports", "jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
+            "--add-exports", "jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
+            "--add-exports", "jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
+            "--add-exports", "jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED");
+
     PrintWriter out;
     int errors;
 
@@ -102,10 +109,12 @@ public class Test {
             Iterable<? extends JavaFileObject> files, PrintWriter out,
             int expectedDocComments) {
         out.println("Test annotation processor");
-        JavacTask task = javac.getTask(out, fm, null, null, null, files);
+        JavacTask task = javac.getTask(out, fm, null, OPTIONS, null, files);
         AnnoProc ap = new AnnoProc(DocTrees.instance(task));
         task.setProcessors(Arrays.asList(ap));
-        task.call();
+        if (!task.call()) {
+            throw new AssertionError("test failed due to a compilation error");
+        }
         ap.checker.checkDocComments(expectedDocComments);
     }
 
@@ -113,10 +122,12 @@ public class Test {
             Iterable<? extends JavaFileObject> files, PrintWriter out,
             int expectedDocComments) {
         out.println("Test task listener");
-        JavacTask task = javac.getTask(out, fm, null, null, null, files);
+        JavacTask task = javac.getTask(out, fm, null, OPTIONS, null, files);
         TaskListnr tl = new TaskListnr(DocTrees.instance(task));
         task.addTaskListener(tl);
-        task.call();
+        if (!task.call()) {
+            throw new AssertionError("test failed due to a compilation error");
+        }
         tl.checker.checkDocComments(expectedDocComments);
     }
 

--- a/test/langtools/tools/javac/api/DiagSpans.java
+++ b/test/langtools/tools/javac/api/DiagSpans.java
@@ -72,7 +72,8 @@ public class DiagSpans extends TestRunner {
                         }
                         """,
                         '/',
-                        '^');
+                        '^',
+                        false);
     }
 
     @Test
@@ -87,7 +88,8 @@ public class DiagSpans extends TestRunner {
                         }
                         """,
                         '/',
-                        '^');
+                        '^',
+                        false);
     }
 
     @Test
@@ -102,7 +104,8 @@ public class DiagSpans extends TestRunner {
                         }
                         """,
                         '/',
-                        '^');
+                        '^',
+                        false);
     }
 
     @Test
@@ -118,7 +121,8 @@ public class DiagSpans extends TestRunner {
                         }
                         """,
                         '/',
-                        '^');
+                        '^',
+                        false);
     }
 
     @Test
@@ -134,7 +138,8 @@ public class DiagSpans extends TestRunner {
                         }
                         """,
                         '/',
-                        '^');
+                        '^',
+                        false);
     }
 
     @Test
@@ -158,7 +163,8 @@ public class DiagSpans extends TestRunner {
                         class Sub2 extends Base2 {}
                         """,
                         '/',
-                        '^');
+                        '^',
+                        true);
     }
 
     @Test
@@ -175,7 +181,8 @@ public class DiagSpans extends TestRunner {
                         class Sub1 extends Base1 {}
                         """,
                         '/',
-                        '^');
+                        '^',
+                        false);
     }
 
     @Test
@@ -192,10 +199,11 @@ public class DiagSpans extends TestRunner {
                         class Sub1 extends Base1 {}
                         """,
                         '/',
-                        '^');
+                        '^',
+                        false);
     }
 
-    private void runDiagSpanTest(String code, char spanMarker, char prefMarker) throws Exception {
+    private void runDiagSpanTest(String code, char spanMarker, char prefMarker, boolean succCompilationExpected) throws Exception {
         var realCode = new StringBuilder();
         var expectedError = new ArrayList<String>();
         int startPos = -1;
@@ -238,7 +246,9 @@ public class DiagSpans extends TestRunner {
         };
         var sourceFiles = List.of(new JFOImpl(realCode.toString()));
         var task = compiler.getTask(null, null, dl, null, null, sourceFiles);
-        task.call();
+        if (task.call() != succCompilationExpected) {
+            throw new AssertionError("unexpected compilation result");
+        }
         if (!Objects.equals(expectedError, actualErrors)) {
             throw new AssertionError("Expected error spans not found, expected: " +
                                      expectedError + ", actual: " + actualErrors);

--- a/test/langtools/tools/javac/api/T6357331.java
+++ b/test/langtools/tools/javac/api/T6357331.java
@@ -53,7 +53,9 @@ public class T6357331
                     public void finished(TaskEvent e) { }
                 });
 
-            task.call();
+            if (!task.call()) {
+                throw new AssertionError("test failed due to a compilation error");
+            }
 
             // now the compilation is over, we expect IllegalStateException (not NPE)
             try {

--- a/test/langtools/tools/javac/api/TestTreePath.java
+++ b/test/langtools/tools/javac/api/TestTreePath.java
@@ -116,7 +116,9 @@ public class TestTreePath extends AbstractProcessor {
                         null, null, null,
                         Arrays.asList("-processor", this.getClass().getName()), null,
                         tests);
-            task.call();
+            if (!task.call()) {
+                throw new AssertionError("test failed due to a compilation error");
+            }
         }
     }
 

--- a/test/langtools/tools/javac/api/taskListeners/EventsBalancedTest.java
+++ b/test/langtools/tools/javac/api/taskListeners/EventsBalancedTest.java
@@ -79,7 +79,9 @@ public class EventsBalancedTest {
 
         task.setTaskListener(listener);
 
-        task.call();
+        if (!task.call()) {
+            throw new AssertionError("test failed due to a compilation error");
+        }
 
         for (Entry<Kind, Integer> e : listener.kind2Count.entrySet()) {
             if (e.getValue() != null && e.getValue() != 0) {

--- a/test/langtools/tools/javac/fatalErrors/ImproveFatalErrorHandling.java
+++ b/test/langtools/tools/javac/fatalErrors/ImproveFatalErrorHandling.java
@@ -76,7 +76,9 @@ public class ImproveFatalErrorHandling extends TestRunner {
                 .getSystemJavaCompiler()
                 .getTask(null, null, null, null, null, files);
         Context context = task.getContext();
-        task.call();
+        if (!task.call()) {
+            throw new AssertionError("test failed due to a compilation error");
+        }
         JavaCompiler compiler = context.get(compilerKey);
         compiler.closeables = com.sun.tools.javac.util.List.of(
                 new CloseException1(), new CloseException2(),

--- a/test/langtools/tools/javac/lib/DPrinter.java
+++ b/test/langtools/tools/javac/lib/DPrinter.java
@@ -1602,7 +1602,9 @@ public class DPrinter {
                 }
             });
 
-            task.call();
+            if (!task.call()) {
+                throw new AssertionError("compilation failed at DPrinter.Main::run");
+            }
         }
 
         TaskEvent.Kind getKind(String s) {

--- a/test/langtools/tools/javac/modules/QueryBeforeEnter.java
+++ b/test/langtools/tools/javac/modules/QueryBeforeEnter.java
@@ -359,7 +359,9 @@ public class QueryBeforeEnter extends ModuleTestBase {
                                                                             "-Xplugin:test"),
                                                               null,
                                                               fm.getJavaFileObjects(testSource));
-            task.call();
+            if (!task.call()) {
+                throw new AssertionError("test failed due to a compilation error");
+            }
         }
 
         Main.compile(new String[] {"--processor-path", processorPath,

--- a/test/langtools/tools/javac/patterns/SOEDeeplyNestedBlocksTest.java
+++ b/test/langtools/tools/javac/patterns/SOEDeeplyNestedBlocksTest.java
@@ -34,7 +34,7 @@ import javax.tools.*;
 
 public class SOEDeeplyNestedBlocksTest {
 
-    static final int NESTING_DEPTH = 1000;
+    static final int NESTING_DEPTH = 500;
 
     public static void main(String... args) {
         var lines = new ArrayList<String>();
@@ -48,7 +48,9 @@ public class SOEDeeplyNestedBlocksTest {
         var source = SimpleJavaFileObject.forSource(URI.create("mem://Test.java"), String.join("\n", lines));
         var compiler = ToolProvider.getSystemJavaCompiler();
         var task = compiler.getTask(null, null, noErrors, null, null, List.of(source));
-        task.call();
+        if (!task.call()) {
+            throw new AssertionError("test failed due to a compilation error");
+        }
     }
 
     static DiagnosticListener<? super JavaFileObject> noErrors = d -> {

--- a/test/langtools/tools/javac/positions/TreeEndPosTest.java
+++ b/test/langtools/tools/javac/positions/TreeEndPosTest.java
@@ -174,7 +174,9 @@ public class TreeEndPosTest {
                     compiler.getTask(writer, javaFileManager,
                     dc, options, null,
                     sources);
-            task.call();
+            if (task.call()) {
+                throw new AssertionError("test compilation was expected to fail");
+            }
             for (Diagnostic diagnostic : (List<Diagnostic>) dc.getDiagnostics()) {
                 long actualStart = diagnostic.getStartPosition();
                 long actualEnd = diagnostic.getEndPosition();

--- a/test/langtools/tools/javac/processing/6348499/T6348499.java
+++ b/test/langtools/tools/javac/processing/6348499/T6348499.java
@@ -61,7 +61,9 @@ public class T6348499 {
                                                   "-processorpath", testClassPath);
             StringWriter out = new StringWriter();
             JavacTask task = tool.getTask(out, fm, dl, opts, null, files);
-            task.call();
+            if (task.call()) {
+                throw new AssertionError("test compilation was expected to fail");
+            }
             String s = out.toString();
             System.err.print(s);
             // Expect the following 1 multi-line diagnostic, and no output to log

--- a/test/langtools/tools/javac/processing/6414633/T6414633.java
+++ b/test/langtools/tools/javac/processing/6414633/T6414633.java
@@ -60,7 +60,9 @@ public class T6414633 {
             String[] opts = { "-proc:only",
                               "-processor", A.class.getName() };
             JavacTask task = tool.getTask(null, fm, dl, Arrays.asList(opts), null, files);
-            task.call();
+            if (task.call()) {
+                throw new AssertionError("test compilation was expected to fail");
+            }
 
             // two annotations on the same element -- expect 2 diags from the processor
             if (dl.diags != 2)

--- a/test/langtools/tools/javac/processing/6430209/T6430209.java
+++ b/test/langtools/tools/javac/processing/6430209/T6430209.java
@@ -66,7 +66,9 @@ public class T6430209 {
                                                   "-processorpath", testClassPath);
             StringWriter out = new StringWriter();
             JavacTask task = tool.getTask(out, fm, null, opts, null, files);
-            task.call();
+            if (task.call()) {
+                throw new AssertionError("test compilation was expected to fail");
+            }
             String s = out.toString();
             System.err.print(s);
             s = s.replace(System.getProperty("line.separator"), "\n");

--- a/test/langtools/tools/javac/processing/T6439826.java
+++ b/test/langtools/tools/javac/processing/T6439826.java
@@ -55,7 +55,9 @@ public class T6439826 extends AbstractProcessor {
                                                   "-processorpath", testClasses);
             StringWriter out = new StringWriter();
             JavacTask task = tool.getTask(out, fm, dl, opts, null, files);
-            task.call();
+            if (task.call()) {
+                throw new AssertionError("test compilation was expected to fail");
+            }
             String s = out.toString();
             System.err.print(s);
             // Expect the following 2 diagnostics, and no output to log

--- a/test/langtools/tools/javac/processing/T8142931.java
+++ b/test/langtools/tools/javac/processing/T8142931.java
@@ -62,7 +62,9 @@ public class T8142931 extends AbstractProcessor {
                 "-processorpath", testClasses);
             StringWriter out = new StringWriter();
             JavacTask task = (JavacTask)tool.getTask(out, fm, dl, opts, null, files);
-            task.call();
+            if (!task.call()) {
+                throw new AssertionError("test failed due to a compilation error");
+            }
             String s = out.toString();
             System.err.print(s);
             System.err.println(dl.count + " diagnostics; " + s.length() + " characters");

--- a/test/langtools/tools/javac/processing/model/LocalInAnonymous.java
+++ b/test/langtools/tools/javac/processing/model/LocalInAnonymous.java
@@ -81,7 +81,9 @@ public class LocalInAnonymous {
         List<String> options = Arrays.asList("-d", classes.toString());
         StringWriter out = new StringWriter();
         JavacTask task = (JavacTask) compiler.getTask(out, null, noErrors, options, null, files);
-        task.call();
+        if (!task.call()) {
+            throw new AssertionError("test failed due to a compilation error");
+        }
         if (!out.toString().isEmpty()) {
             throw new AssertionError("Unexpected output: " + out);
         }
@@ -103,7 +105,9 @@ public class LocalInAnonymous {
                 }
             }
         });
-        task2.call();
+        if (!task2.call()) {
+            throw new AssertionError("test failed due to a compilation error");
+        }
         if (!out.toString().isEmpty()) {
             throw new AssertionError("Unexpected output: " + out);
         }
@@ -112,7 +116,9 @@ public class LocalInAnonymous {
                                 "-processorpath", System.getProperty("test.classes"),
                                 "-processor", Processor.class.getName());
         JavacTask task3 = (JavacTask) compiler.getTask(out, null, noErrors, options, null, files);
-        task3.call();
+        if (!task3.call()) {
+            throw new AssertionError("test failed due to a compilation error");
+        }
         if (!out.toString().isEmpty()) {
             throw new AssertionError("Unexpected output: " + out);
         }

--- a/test/langtools/tools/javac/processing/options/TestNoteOnImplicitProcessing.java
+++ b/test/langtools/tools/javac/processing/options/TestNoteOnImplicitProcessing.java
@@ -323,7 +323,9 @@ public class TestNoteOnImplicitProcessing extends TestRunner {
                 List<String> options = List.of("-classpath", jarFile.toString(), "-XDrawDiagnostics");
                 CompilationTask task = provider.getTask(compilerOut, null, null, options, null, inputFile);
 
-                task.call();
+                if (!task.call()) {
+                    throw new AssertionError("test failed due to a compilation error");
+                }
 
                 verifyMessages(out, compilerOut, false, false);
             }
@@ -335,7 +337,9 @@ public class TestNoteOnImplicitProcessing extends TestRunner {
                         (Processor) processorClass.getDeclaredConstructor().newInstance();
 
                 task.setProcessors(List.of(processor));
-                task.call();
+                if (!task.call()) {
+                    throw new AssertionError("test failed due to a compilation error");
+                }
 
                 verifyMessages(out, compilerOut, false, true);
             }

--- a/test/langtools/tools/javac/processing/rounds/CompleteOnClosed.java
+++ b/test/langtools/tools/javac/processing/rounds/CompleteOnClosed.java
@@ -56,7 +56,9 @@ public class CompleteOnClosed extends JavacTestingAbstractProcessor {
         Iterable<JavaFileObject> files = Arrays.<JavaFileObject>asList(new ToolBox.JavaSource(source));
         Iterable<String> options = Arrays.asList("-processor", "CompleteOnClosed");
         CompilationTask task = compiler.getTask(null, null, collector, options, null, files);
-        task.call();
+        if (task.call()) {
+            throw new AssertionError("test compilation was expected to fail");
+        }
         for (Diagnostic<? extends JavaFileObject> d : collector.getDiagnostics()) {
             System.out.println(d.toString());
         }


### PR DESCRIPTION
Several tests are ignoring the result of invoking com.sun.source.util.JavacTask::call which returns a `Boolean`. This implies that tests could seem to pass when in reality they are silently failing. This PR is fixing this issue by checking, in all applicable cases the result of the invocation.

TIA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341778](https://bugs.openjdk.org/browse/JDK-8341778): Some javac tests ignore the result of JavacTask::call (**Bug** - P3)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25645/head:pull/25645` \
`$ git checkout pull/25645`

Update a local copy of the PR: \
`$ git checkout pull/25645` \
`$ git pull https://git.openjdk.org/jdk.git pull/25645/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25645`

View PR using the GUI difftool: \
`$ git pr show -t 25645`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25645.diff">https://git.openjdk.org/jdk/pull/25645.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25645#issuecomment-2941466580)
</details>
