### PR TITLE
8358634: RISC-V: Fix several broken documentation web-links

### DIFF
--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -666,7 +666,7 @@ class MacroAssembler: public Assembler {
   // We try to follow risc-v asm menomics.
   // But as we don't layout a reachable GOT,
   // we often need to resort to movptr, li <48imm>.
-  // https://github.com/riscv-non-isa/riscv-asm-manual/blob/master/riscv-asm.md
+  // https://github.com/riscv-non-isa/riscv-asm-manual/blob/main/src/asm-manual.adoc
 
   // Hotspot only use the standard calling convention using x1/ra.
   // The alternative calling convection using x5/t0 is not used.

--- a/src/hotspot/cpu/riscv/vm_version_riscv.hpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.hpp
@@ -221,13 +221,13 @@ class VM_Version : public Abstract_VM_Version {
       FLAG_SET_DEFAULT(UseExtension, true);     \
     }                                           \
 
-  // https://github.com/riscv/riscv-profiles/blob/main/profiles.adoc#rva20-profiles
+  // https://github.com/riscv/riscv-profiles/blob/main/src/profiles.adoc#rva20-profiles
   #define RV_USE_RVA20U64                            \
     RV_ENABLE_EXTENSION(UseRVC)                      \
 
   static void useRVA20U64Profile();
 
-  // https://github.com/riscv/riscv-profiles/blob/main/profiles.adoc#rva22-profiles
+  // https://github.com/riscv/riscv-profiles/blob/main/src/profiles.adoc#rva22-profiles
   #define RV_USE_RVA22U64                            \
     RV_ENABLE_EXTENSION(UseRVC)                      \
     RV_ENABLE_EXTENSION(UseZba)                      \
@@ -241,7 +241,7 @@ class VM_Version : public Abstract_VM_Version {
 
   static void useRVA22U64Profile();
 
-  // https://github.com/riscv/riscv-profiles/blob/main/rva23-profile.adoc#rva23u64-profile
+  // https://github.com/riscv/riscv-profiles/blob/main/src/rva23-profile.adoc#rva23u64-profile
   #define RV_USE_RVA23U64                           \
     RV_ENABLE_EXTENSION(UseRVC)                     \
     RV_ENABLE_EXTENSION(UseRVV)                     \


### PR DESCRIPTION
Hi all,
Please take a look and review this PR, thanks!

Several RISC-V related documentation web-links are broken.
This PR updates the web-links.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8358634](https://bugs.openjdk.org/browse/JDK-8358634): RISC-V: Fix several broken documentation web-links (**Bug** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25652/head:pull/25652` \
`$ git checkout pull/25652`

Update a local copy of the PR: \
`$ git checkout pull/25652` \
`$ git pull https://git.openjdk.org/jdk.git pull/25652/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25652`

View PR using the GUI difftool: \
`$ git pr show -t 25652`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25652.diff">https://git.openjdk.org/jdk/pull/25652.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25652#issuecomment-2942603659)
</details>
