### PR TITLE
8358633 : Test ThreadPoolExecutorTest::testTimedInvokeAnyNullTimeUnit is broken by JDK-8347491

### DIFF
--- a/test/jdk/java/util/concurrent/tck/ThreadPoolExecutorTest.java
+++ b/test/jdk/java/util/concurrent/tck/ThreadPoolExecutorTest.java
@@ -1727,7 +1727,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                 e.invokeAny(l, randomTimeout(), null);
                 shouldThrow();
             } catch (NullPointerException success) {
-                assertEquals("Cannot invoke \"java.util.concurrent.TimeUnit.toNanos(long)\" because \"unit\" is null", success.getMessage());
+                // Do not check the message, as ThreadPoolExecutor does not override invokeAny
             }
         }
     }


### PR DESCRIPTION
It's too fragile to depend on generated NPE messages

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8358633](https://bugs.openjdk.org/browse/JDK-8358633): Test ThreadPoolExecutorTest::testTimedInvokeAnyNullTimeUnit is broken by JDK-8347491 (**Bug** - P3)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25655/head:pull/25655` \
`$ git checkout pull/25655`

Update a local copy of the PR: \
`$ git checkout pull/25655` \
`$ git pull https://git.openjdk.org/jdk.git pull/25655/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25655`

View PR using the GUI difftool: \
`$ git pr show -t 25655`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25655.diff">https://git.openjdk.org/jdk/pull/25655.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25655#issuecomment-2943130412)
</details>
