### PR TITLE
8357570: [macOS] os::Bsd::available_memory() might return too low values

### DIFF
--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -154,7 +154,8 @@ julong os::Bsd::available_memory() {
   assert(kerr == KERN_SUCCESS,
          "host_statistics64 failed - check mach_host_self() and count");
   if (kerr == KERN_SUCCESS) {
-    available = vmstat.free_count * os::vm_page_size();
+    // free_count is just a lowerbound, other page categories can be freed too and make memory available
+    available = (vmstat.free_count + vmstat.inactive_count + vmstat.purgeable_count) * os::vm_page_size();
   }
 #endif
   return available;


### PR DESCRIPTION
Currently os::Bsd::available_memory() returns on macOS
`vmstat.free_count * os::vm_page_size();`
But just using free_count is rather conservative because there are other memory categories on macOS that can be made available too. Unfortunately the different memory categories 
There is a bit of additional information here https://developer.apple.com/forums/thread/118867
that confirms that free memory / free_count is only a fraction of what is available.

There is also some info here
https://developer.apple.com/library/archive/documentation/Performance/Conceptual/ManagingMemory/Articles/AboutMemory.html#//apple_ref/doc/uid/20001880-BCICIHAB
containing this relevant info :
"The inactive list contains pages that are currently resident in physical memory but have not been accessed recently. These pages contain valid data but may be removed from memory at any time. The free list contains pages of physical memory that are not associated with any address space of VM object. These pages are available for immediate use by any process that needs them."

and also about purgeable memory at
https://developer.apple.com/library/archive/documentation/Performance/Conceptual/ManagingMemory/Articles/CachingandPurgeableMemory.html#//apple_ref/doc/uid/TP40013104-SW1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8357570](https://bugs.openjdk.org/browse/JDK-8357570): [macOS] os::Bsd::available_memory() might return too low values (**Bug** - P4)


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25657/head:pull/25657` \
`$ git checkout pull/25657`

Update a local copy of the PR: \
`$ git checkout pull/25657` \
`$ git pull https://git.openjdk.org/jdk.git pull/25657/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25657`

View PR using the GUI difftool: \
`$ git pr show -t 25657`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25657.diff">https://git.openjdk.org/jdk/pull/25657.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25657#issuecomment-2943157198)
</details>
