### PR TITLE
8358604: Trees for `var` do not have end positions

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -5715,11 +5715,13 @@ public class Attr extends JCTree.Visitor {
     }
 
     private void setSyntheticVariableType(JCVariableDecl tree, Type type) {
-        if (type.isErroneous()) {
-            tree.vartype = make.at(tree.pos()).Erroneous();
+        // Only set an ending position when the source contains an explicit type (i.e., "var")
+        if (tree.declaredUsingVar()) {
+            make.at(tree.varPos(), tree.varPos() + names.var.length() - 1, env.toplevel.endPositions);
         } else {
-            tree.vartype = make.at(tree.pos()).Type(type);
+            make.at(tree.pos());
         }
+        tree.vartype = type.isErroneous() ? make.Erroneous() : make.Type(type);
     }
 
     public void validateTypeAnnotations(JCTree tree, boolean sigOnly) {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
@@ -3785,7 +3785,7 @@ public class JavacParser implements Parser {
      */
     JCVariableDecl variableDeclaratorRest(int pos, JCModifiers mods, JCExpression type, Name name,
                                   boolean reqInit, Comment dc, boolean localDecl, boolean compound) {
-        boolean declaredUsingVar = false;
+        int varPos = Position.NOPOS;
         JCExpression init = null;
         type = bracketsOpt(type);
 
@@ -3822,7 +3822,7 @@ public class JavacParser implements Parser {
                     //error - 'var' and arrays
                     reportSyntaxError(elemType.pos, Errors.RestrictedTypeNotAllowedArray(typeName));
                 } else {
-                    declaredUsingVar = true;
+                    varPos = elemType.pos;
                     if (compound)
                         //error - 'var' in compound local var decl
                         reportSyntaxError(elemType.pos, Errors.RestrictedTypeNotAllowedCompound(typeName));
@@ -3834,7 +3834,7 @@ public class JavacParser implements Parser {
                 }
             }
         }
-        JCVariableDecl result = toP(F.at(pos).VarDef(mods, name, type, init, declaredUsingVar));
+        JCVariableDecl result = toP(F.at(pos).VarDef(mods, name, type, init, varPos));
         attach(result, dc);
         result.startPos = startPos;
         return result;
@@ -3951,7 +3951,7 @@ public class JavacParser implements Parser {
         }
 
         return toP(F.at(pos).VarDef(mods, name, type, null,
-                type != null && type.hasTag(IDENT) && ((JCIdent)type).name == names.var));
+                type != null && type.hasTag(IDENT) && ((JCIdent)type).name == names.var ? type.pos : Position.NOPOS));
     }
 
     /** Resources = Resource { ";" Resources }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/JCTree.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/JCTree.java
@@ -463,7 +463,15 @@ public abstract class JCTree implements Tree, Cloneable, DiagnosticPosition {
     /** Set position field and return this tree.
      */
     public JCTree setPos(int pos) {
+        return setPos(pos, Position.NOPOS, null);
+    }
+
+    /** Set start and end position and return this tree.
+     */
+    public JCTree setPos(int pos, int endPos, EndPosTable endPosTable) {
         this.pos = pos;
+        if (endPos != Position.NOPOS && endPosTable != null)
+            endPosTable.storeEnd(this, endPos);
         return this;
     }
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/JCTree.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/JCTree.java
@@ -1016,15 +1016,15 @@ public abstract class JCTree implements Tree, Cloneable, DiagnosticPosition {
         public VarSymbol sym;
         /** explicit start pos */
         public int startPos = Position.NOPOS;
-        /** declared using `var` */
-        private boolean declaredUsingVar;
+        /** if declared using "var", the "var" source position, otherwise NOPOS */
+        private final int varPos;
 
         protected JCVariableDecl(JCModifiers mods,
                          Name name,
                          JCExpression vartype,
                          JCExpression init,
                          VarSymbol sym) {
-            this(mods, name, vartype, init, sym, false);
+            this(mods, name, vartype, init, sym, Position.NOPOS);
         }
 
         protected JCVariableDecl(JCModifiers mods,
@@ -1032,19 +1032,19 @@ public abstract class JCTree implements Tree, Cloneable, DiagnosticPosition {
                                  JCExpression vartype,
                                  JCExpression init,
                                  VarSymbol sym,
-                                 boolean declaredUsingVar) {
+                                 int varPos) {
             this.mods = mods;
             this.name = name;
             this.vartype = vartype;
             this.init = init;
             this.sym = sym;
-            this.declaredUsingVar = declaredUsingVar;
+            this.varPos = varPos;
         }
 
         protected JCVariableDecl(JCModifiers mods,
                          JCExpression nameexpr,
                          JCExpression vartype) {
-            this(mods, null, vartype, null, null, false);
+            this(mods, null, vartype, null, null, Position.NOPOS);
             this.nameexpr = nameexpr;
             if (nameexpr.hasTag(Tag.IDENT)) {
                 this.name = ((JCIdent)nameexpr).name;
@@ -1059,7 +1059,11 @@ public abstract class JCTree implements Tree, Cloneable, DiagnosticPosition {
         }
 
         public boolean declaredUsingVar() {
-            return declaredUsingVar;
+            return varPos != Position.NOPOS;
+        }
+
+        public int varPos() {
+            return varPos;
         }
 
         @Override

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/Pretty.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/Pretty.java
@@ -724,7 +724,10 @@ public class Pretty extends JCTree.Visitor {
                     print("... ");
                     print(tree.name);
                 } else {
-                    printExpr(tree.vartype);
+                    if (tree.vartype == null && tree.declaredUsingVar())
+                        print("var");
+                    else
+                        printExpr(tree.vartype);
                     print(' ');
                     if (tree.name.isEmpty()) {
                         print('_');

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/TreeMaker.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/TreeMaker.java
@@ -237,8 +237,8 @@ public class TreeMaker implements JCTree.Factory {
         return tree;
     }
 
-    public JCVariableDecl VarDef(JCModifiers mods, Name name, JCExpression vartype, JCExpression init, boolean declaredUsingVar) {
-        JCVariableDecl tree = new JCVariableDecl(mods, name, vartype, init, null, declaredUsingVar);
+    public JCVariableDecl VarDef(JCModifiers mods, Name name, JCExpression vartype, JCExpression init, int varPos) {
+        JCVariableDecl tree = new JCVariableDecl(mods, name, vartype, init, null, varPos);
         tree.pos = pos;
         return tree;
     }

--- a/test/langtools/tools/javac/tree/VarWarnPosition.java
+++ b/test/langtools/tools/javac/tree/VarWarnPosition.java
@@ -22,6 +22,9 @@ public class VarWarnPosition {
 
         // Test 3
         Consumer<Depr> c2 = (var d) -> { };
+
+        // Test 4
+        Consumer<Depr> c3 = (final var d) -> { };
     }
 }
 

--- a/test/langtools/tools/javac/tree/VarWarnPosition.out
+++ b/test/langtools/tools/javac/tree/VarWarnPosition.out
@@ -3,4 +3,6 @@ VarWarnPosition.java:21:18: compiler.warn.has.been.deprecated: Depr, compiler.mi
 VarWarnPosition.java:21:28: compiler.warn.has.been.deprecated: Depr, compiler.misc.unnamed.package
 VarWarnPosition.java:24:18: compiler.warn.has.been.deprecated: Depr, compiler.misc.unnamed.package
 VarWarnPosition.java:24:30: compiler.warn.has.been.deprecated: Depr, compiler.misc.unnamed.package
-5 warnings
+VarWarnPosition.java:27:18: compiler.warn.has.been.deprecated: Depr, compiler.misc.unnamed.package
+VarWarnPosition.java:27:36: compiler.warn.has.been.deprecated: Depr, compiler.misc.unnamed.package
+7 warnings


### PR DESCRIPTION
The compiler replaces `var` nodes with synthetic tree nodes representing the inferred type. Previously, these nodes were not given either starting or ending source code positions. [JDK-8329951](https://bugs.openjdk.org/browse/JDK-8329951) fixed this for starting positions, but not ending positions. This PR seeks to finish that job by adding ending positions as well, and also fix a glitch in the previous starting position fix.

Unlike the previous fix, which was basically a two-liner, this one is more complicated due to the need to wrangle the `EndPosTable`.

This patch includes the following changes:

* Pretty print `var` as `var` instead of `/*missing*/` (drive-by improvement)
* Make "var" starting source position recoverable from a `JCVariableDecl` by replacing `boolean declaredUsingVar` with `int varPos`, where the previous `false` value is now represented by `Position.NOPOS`.
* Make `TreeMaker.at()` capable of handling ending positions, and also do some minor cleanup/refactoring.
* Fix the starting position glitch leftover by [JDK-8329951](https://bugs.openjdk.org/browse/JDK-8329951) and add a regression test for it
* Actually fix this bug ([JDK-8358604](https://bugs.openjdk.org/browse/JDK-8358604)): Set an ending position for the synthetic tree node that replaces `var`.
