### PR TITLE
8055461: getNextID in ImageIcon class can lead to overflow

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/ImageIcon.java
+++ b/src/java.desktop/share/classes/javax/swing/ImageIcon.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -296,6 +296,12 @@ public class ImageIcon implements Icon, Serializable, Accessible {
         synchronized(mTracker) {
             int id = getNextID();
 
+            if (id < 0) {
+                loadStatus = MediaTracker.ABORTED;
+                width = image.getWidth(imageObserver);
+                height = image.getHeight(imageObserver);
+                return;
+            }
             mTracker.addImage(image, id);
             try {
                 mTracker.waitForID(id, 0);
@@ -321,6 +327,9 @@ public class ImageIcon implements Icon, Serializable, Accessible {
      */
     private int getNextID() {
         synchronized(getTracker()) {
+            if (mediaTrackerID >= Integer.MAX_VALUE) {
+                return -1;
+            }
             return ++mediaTrackerID;
         }
     }


### PR DESCRIPTION
ImageIcon.getNextID uses `mediaTrackerID ` which do not detect overflow.

Theoretically there is a possibility that there can be overflow in the long time run or for large number of created "imageIcon"

Made sure there is no overflow and treat that loadImage as ABORTED

No regression testcase as it addresses theoretical possibility..