### PR TITLE
8342639: Global operator new in adlc has wrong exception spec

### DIFF
--- a/src/hotspot/share/adlc/main.cpp
+++ b/src/hotspot/share/adlc/main.cpp
@@ -481,7 +481,3 @@ int get_legal_text(FileBuff &fbuf, char **legal_text)
   *legal_text = legal_start;
   return (int) (legal_end - legal_start);
 }
-
-void *operator new( size_t size, int, const char *, int ) throw() {
-  return ::operator new( size );
-}


### PR DESCRIPTION
Please review this change to remove the definition of
`operator new(size_t, int, const char*, int) throw()`

It doesn't seem to be needed anymore, if it ever really was. See discussion in
JBS for some more details.

Testing: mach5 tier1-5, to cover various different build configurations.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8342639](https://bugs.openjdk.org/browse/JDK-8342639): Global operator new in adlc has wrong exception spec (**Enhancement** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25668/head:pull/25668` \
`$ git checkout pull/25668`

Update a local copy of the PR: \
`$ git checkout pull/25668` \
`$ git pull https://git.openjdk.org/jdk.git pull/25668/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25668`

View PR using the GUI difftool: \
`$ git pr show -t 25668`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25668.diff">https://git.openjdk.org/jdk/pull/25668.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25668#issuecomment-2948213193)
</details>
