### PR TITLE
8356780: PhaseMacroExpand::_has_locks is unused

### DIFF
--- a/src/hotspot/share/opto/macro.cpp
+++ b/src/hotspot/share/opto/macro.cpp
@@ -2407,7 +2407,6 @@ void PhaseMacroExpand::eliminate_macro_nodes() {
     }
   }
   // Next, attempt to eliminate allocations
-  _has_locks = false;
   progress = true;
   while (progress) {
     progress = false;
@@ -2431,7 +2430,6 @@ void PhaseMacroExpand::eliminate_macro_nodes() {
       case Node::Class_Lock:
       case Node::Class_Unlock:
         assert(!n->as_AbstractLock()->is_eliminated(), "sanity");
-        _has_locks = true;
         break;
       case Node::Class_ArrayCopy:
         break;

--- a/src/hotspot/share/opto/macro.cpp
+++ b/src/hotspot/share/opto/macro.cpp
@@ -2415,6 +2415,7 @@ void PhaseMacroExpand::eliminate_macro_nodes() {
             Atomic::inc(&PhaseMacroExpand::_monitor_objects_removed_counter);
           }
 #endif
+        assert(!n->as_AbstractLock()->is_eliminated(), "sanity");
         break;
       case Node::Class_ArrayCopy:
         break;

--- a/src/hotspot/share/opto/macro.cpp
+++ b/src/hotspot/share/opto/macro.cpp
@@ -2415,7 +2415,6 @@ void PhaseMacroExpand::eliminate_macro_nodes() {
             Atomic::inc(&PhaseMacroExpand::_monitor_objects_removed_counter);
           }
 #endif
-        assert(!n->as_AbstractLock()->is_eliminated(), "sanity");
         break;
       case Node::Class_ArrayCopy:
         break;

--- a/src/hotspot/share/opto/macro.cpp
+++ b/src/hotspot/share/opto/macro.cpp
@@ -2386,8 +2386,28 @@ void PhaseMacroExpand::eliminate_macro_nodes() {
     C->mark_unbalanced_boxes();
   }
 
-  // Attempt to eliminate allocations and locks
+  // First, attempt to eliminate locks
   bool progress = true;
+  while (progress) {
+    progress = false;
+    for (int i = C->macro_count(); i > 0; i = MIN2(i - 1, C->macro_count())) { // more than 1 element can be eliminated at once
+      Node* n = C->macro_node(i - 1);
+      bool success = false;
+      DEBUG_ONLY(int old_macro_count = C->macro_count();)
+      if (n->is_AbstractLock()) {
+        success = eliminate_locking_node(n->as_AbstractLock());
+#ifndef PRODUCT
+        if (success && PrintOptoStatistics) {
+          Atomic::inc(&PhaseMacroExpand::_monitor_objects_removed_counter);
+        }
+#endif
+      }
+      assert(success == (C->macro_count() < old_macro_count), "elimination reduces macro count");
+      progress = progress || success;
+    }
+  }
+  // Next, attempt to eliminate allocations
+  progress = true;
   while (progress) {
     progress = false;
     for (int i = C->macro_count(); i > 0; i = MIN2(i - 1, C->macro_count())) { // more than 1 element can be eliminated at once
@@ -2409,12 +2429,6 @@ void PhaseMacroExpand::eliminate_macro_nodes() {
         break;
       case Node::Class_Lock:
       case Node::Class_Unlock:
-          success = eliminate_locking_node(n->as_AbstractLock());
-#ifndef PRODUCT
-          if (success && PrintOptoStatistics) {
-            Atomic::inc(&PhaseMacroExpand::_monitor_objects_removed_counter);
-          }
-#endif
         assert(!n->as_AbstractLock()->is_eliminated(), "sanity");
         break;
       case Node::Class_ArrayCopy:

--- a/src/hotspot/share/opto/macro.hpp
+++ b/src/hotspot/share/opto/macro.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/opto/macro.hpp
+++ b/src/hotspot/share/opto/macro.hpp
@@ -83,9 +83,6 @@ private:
   // projections extracted from a call node
   CallProjections _callprojs;
 
-  // Additional data collected during macro expansion
-  bool _has_locks;
-
   void expand_allocate(AllocateNode *alloc);
   void expand_allocate_array(AllocateArrayNode *alloc);
   void expand_allocate_common(AllocateNode* alloc,
@@ -199,7 +196,7 @@ private:
   Node* make_arraycopy_load(ArrayCopyNode* ac, intptr_t offset, Node* ctl, Node* mem, BasicType ft, const Type *ftype, AllocateNode *alloc);
 
 public:
-  PhaseMacroExpand(PhaseIterGVN &igvn) : Phase(Macro_Expand), _igvn(igvn), _has_locks(false) {
+  PhaseMacroExpand(PhaseIterGVN &igvn) : Phase(Macro_Expand), _igvn(igvn) {
     _igvn.set_delay_transform(true);
   }
 


### PR DESCRIPTION
This PR removes the unused field `PhaseMacroExpand::_has_locks`

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8356780](https://bugs.openjdk.org/browse/JDK-8356780): PhaseMacroExpand::_has_locks is unused (**Enhancement** - P4)


### Reviewers
 * [Manuel Hässig](https://openjdk.org/census#mhaessig) (@mhaessig - Author)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Marc Chevalier](https://openjdk.org/census#mchevalier) (@marc-chevalier - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25669/head:pull/25669` \
`$ git checkout pull/25669`

Update a local copy of the PR: \
`$ git checkout pull/25669` \
`$ git pull https://git.openjdk.org/jdk.git pull/25669/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25669`

View PR using the GUI difftool: \
`$ git pr show -t 25669`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25669.diff">https://git.openjdk.org/jdk/pull/25669.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25669#issuecomment-2948395030)
</details>
