### PR TITLE
[PATCH] Simplify reversed view operations for CopyOnWriteArrayList

### DIFF
--- a/src/java.base/share/classes/java/util/concurrent/CopyOnWriteArrayList.java
+++ b/src/java.base/share/classes/java/util/concurrent/CopyOnWriteArrayList.java
@@ -1997,22 +1997,11 @@ public class CopyOnWriteArrayList<E>
         }
 
         public E getFirst() {
-            synchronized (lock) {
-                int size = base.size();
-                if (size == 0)
-                    throw new NoSuchElementException();
-                else
-                    return base.get(size - 1);
-            }
+            return base.getLast();
         }
 
         public E getLast() {
-            synchronized (lock) {
-                if (base.size() == 0)
-                    throw new NoSuchElementException();
-                else
-                    return base.get(0);
-            }
+            return base.getFirst();
         }
 
         public int indexOf(Object o) {
@@ -2044,22 +2033,11 @@ public class CopyOnWriteArrayList<E>
         }
 
         public E removeFirst() {
-            synchronized (lock) {
-                int size = base.size();
-                if (size == 0)
-                    throw new NoSuchElementException();
-                else
-                    return base.remove(size - 1);
-            }
+            return base.removeLast();
         }
 
         public E removeLast() {
-            synchronized (lock) {
-                if (base.size() == 0)
-                    throw new NoSuchElementException();
-                else
-                    return base.remove(0);
-            }
+            return base.removeFirst();
         }
 
         public boolean removeIf(Predicate<? super E> filter) {


### PR DESCRIPTION
We can delegate methods to the `base` to simplify code a bit

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25671/head:pull/25671` \
`$ git checkout pull/25671`

Update a local copy of the PR: \
`$ git checkout pull/25671` \
`$ git pull https://git.openjdk.org/jdk.git pull/25671/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25671`

View PR using the GUI difftool: \
`$ git pr show -t 25671`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25671.diff">https://git.openjdk.org/jdk/pull/25671.diff</a>

</details>
