### PR TITLE
8358749: Fix input checks in Vector API intrinsics

### DIFF
--- a/src/hotspot/share/opto/vectorIntrinsics.cpp
+++ b/src/hotspot/share/opto/vectorIntrinsics.cpp
@@ -318,8 +318,10 @@ bool LibraryCallKit::inline_vector_nary_operation(int n) {
   const TypeInstPtr* elem_klass   = gvn().type(argument(3))->isa_instptr();
   const TypeInt*     vlen         = gvn().type(argument(4))->isa_int();
 
-  if (opr == nullptr || vector_klass == nullptr || elem_klass == nullptr || vlen == nullptr ||
-      !opr->is_con() || vector_klass->const_oop() == nullptr || elem_klass->const_oop() == nullptr || !vlen->is_con()) {
+  if (opr          == nullptr || !opr->is_con() ||
+      vector_klass == nullptr || vector_klass->const_oop() == nullptr ||
+      elem_klass   == nullptr || elem_klass->const_oop()   == nullptr ||
+      vlen         == nullptr || !vlen->is_con()) {
     log_if_needed("  ** missing constant: opr=%s vclass=%s etype=%s vlen=%s",
                     NodeClassNames[argument(0)->Opcode()],
                     NodeClassNames[argument(1)->Opcode()],
@@ -587,7 +589,11 @@ bool LibraryCallKit::inline_vector_mask_operation() {
   const TypeInt*     vlen       = gvn().type(argument(3))->isa_int();
   Node*              mask       = argument(4);
 
-  if (mask_klass == nullptr || elem_klass == nullptr || mask->is_top() || vlen == nullptr) {
+  if (mask_klass == nullptr || mask_klass->const_oop() == nullptr ||
+      elem_klass == nullptr || elem_klass->const_oop() == nullptr ||
+      vlen       == nullptr || !vlen->is_con() ||
+      oper       == nullptr || !oper->is_con() ||
+      mask->is_top()) {
     return false; // dead code
   }
 
@@ -647,9 +653,11 @@ bool LibraryCallKit::inline_vector_frombits_coerced() {
   // MODE_BITS_COERCED_LONG_TO_MASK for VectorMask.fromLong operation.
   const TypeInt*     mode         = gvn().type(argument(5))->isa_int();
 
-  if (vector_klass == nullptr || elem_klass == nullptr || vlen == nullptr || mode == nullptr ||
-      bits_type == nullptr || vector_klass->const_oop() == nullptr || elem_klass->const_oop() == nullptr ||
-      !vlen->is_con() || !mode->is_con()) {
+  if (vector_klass == nullptr || vector_klass->const_oop() == nullptr ||
+      elem_klass   == nullptr || elem_klass->const_oop()   == nullptr ||
+      vlen         == nullptr || !vlen->is_con() ||
+      bits_type    == nullptr ||
+      mode         == nullptr || !mode->is_con()) {
     log_if_needed("  ** missing constant: vclass=%s etype=%s vlen=%s bitwise=%s",
                     NodeClassNames[argument(0)->Opcode()],
                     NodeClassNames[argument(1)->Opcode()],
@@ -775,8 +783,10 @@ bool LibraryCallKit::inline_vector_mem_operation(bool is_store) {
   const TypeInt*     vlen         = gvn().type(argument(2))->isa_int();
   const TypeInt*     from_ms      = gvn().type(argument(6))->isa_int();
 
-  if (vector_klass == nullptr || elem_klass == nullptr || vlen == nullptr || !from_ms->is_con() ||
-      vector_klass->const_oop() == nullptr || elem_klass->const_oop() == nullptr || !vlen->is_con()) {
+  if (vector_klass == nullptr || vector_klass->const_oop() == nullptr ||
+      elem_klass   == nullptr || elem_klass->const_oop()   == nullptr ||
+      vlen         == nullptr || !vlen->is_con() ||
+      from_ms      == nullptr || !from_ms->is_con()) {
     log_if_needed("  ** missing constant: vclass=%s etype=%s vlen=%s from_ms=%s",
                     NodeClassNames[argument(0)->Opcode()],
                     NodeClassNames[argument(1)->Opcode()],
@@ -983,9 +993,11 @@ bool LibraryCallKit::inline_vector_mem_masked_operation(bool is_store) {
   const TypeInt*     vlen         = gvn().type(argument(3))->isa_int();
   const TypeInt*     from_ms      = gvn().type(argument(7))->isa_int();
 
-  if (vector_klass == nullptr || mask_klass == nullptr || elem_klass == nullptr || vlen == nullptr ||
-      vector_klass->const_oop() == nullptr || mask_klass->const_oop() == nullptr || from_ms == nullptr ||
-      elem_klass->const_oop() == nullptr || !vlen->is_con() || !from_ms->is_con()) {
+  if (vector_klass == nullptr || vector_klass->const_oop() == nullptr ||
+      mask_klass   == nullptr || mask_klass->const_oop()   == nullptr ||
+      elem_klass   == nullptr || elem_klass->const_oop()   == nullptr ||
+      vlen         == nullptr || !vlen->is_con() ||
+      from_ms      == nullptr || !from_ms->is_con()) {
     log_if_needed("  ** missing constant: vclass=%s mclass=%s etype=%s vlen=%s from_ms=%s",
                     NodeClassNames[argument(0)->Opcode()],
                     NodeClassNames[argument(1)->Opcode()],
@@ -1222,8 +1234,10 @@ bool LibraryCallKit::inline_vector_gather_scatter(bool is_scatter) {
   const TypeInt*     vlen             = gvn().type(argument(3))->isa_int();
   const TypeInstPtr* vector_idx_klass = gvn().type(argument(4))->isa_instptr();
 
-  if (vector_klass == nullptr || elem_klass == nullptr || vector_idx_klass == nullptr || vlen == nullptr ||
-      vector_klass->const_oop() == nullptr || elem_klass->const_oop() == nullptr || vector_idx_klass->const_oop() == nullptr || !vlen->is_con()) {
+  if (vector_klass     == nullptr || vector_klass->const_oop()     == nullptr ||
+      elem_klass       == nullptr || elem_klass->const_oop()       == nullptr ||
+      vlen             == nullptr || !vlen->is_con() ||
+      vector_idx_klass == nullptr || vector_idx_klass->const_oop() == nullptr) {
     log_if_needed("  ** missing constant: vclass=%s etype=%s vlen=%s viclass=%s",
                     NodeClassNames[argument(0)->Opcode()],
                     NodeClassNames[argument(2)->Opcode()],
@@ -1409,8 +1423,10 @@ bool LibraryCallKit::inline_vector_reduction() {
   const TypeInstPtr* elem_klass   = gvn().type(argument(3))->isa_instptr();
   const TypeInt*     vlen         = gvn().type(argument(4))->isa_int();
 
-  if (opr == nullptr || vector_klass == nullptr || elem_klass == nullptr || vlen == nullptr ||
-      !opr->is_con() || vector_klass->const_oop() == nullptr || elem_klass->const_oop() == nullptr || !vlen->is_con()) {
+  if (opr          == nullptr || !opr->is_con() ||
+      vector_klass == nullptr || vector_klass->const_oop() == nullptr ||
+      elem_klass   == nullptr || elem_klass->const_oop()   == nullptr ||
+      vlen         == nullptr || !vlen->is_con()) {
     log_if_needed("  ** missing constant: opr=%s vclass=%s etype=%s vlen=%s",
                     NodeClassNames[argument(0)->Opcode()],
                     NodeClassNames[argument(1)->Opcode()],
@@ -1547,8 +1563,10 @@ bool LibraryCallKit::inline_vector_test() {
   const TypeInstPtr* elem_klass   = gvn().type(argument(2))->isa_instptr();
   const TypeInt*     vlen         = gvn().type(argument(3))->isa_int();
 
-  if (cond == nullptr || vector_klass == nullptr || elem_klass == nullptr || vlen == nullptr ||
-      !cond->is_con() || vector_klass->const_oop() == nullptr || elem_klass->const_oop() == nullptr || !vlen->is_con()) {
+  if (cond         == nullptr || !cond->is_con() ||
+      vector_klass == nullptr || vector_klass->const_oop() == nullptr ||
+      elem_klass   == nullptr || elem_klass->const_oop()   == nullptr ||
+      vlen         == nullptr || !vlen->is_con()) {
     log_if_needed("  ** missing constant: cond=%s vclass=%s etype=%s vlen=%s",
                     NodeClassNames[argument(0)->Opcode()],
                     NodeClassNames[argument(1)->Opcode()],
@@ -2505,10 +2523,10 @@ bool LibraryCallKit::inline_vector_extract() {
   const TypeInt*     vlen         = gvn().type(argument(2))->isa_int();
   const TypeInt*     idx          = gvn().type(argument(4))->isa_int();
 
-  if (vector_klass == nullptr || elem_klass == nullptr || vlen == nullptr || idx == nullptr) {
-    return false; // dead code
-  }
-  if (vector_klass->const_oop() == nullptr || elem_klass->const_oop() == nullptr || !vlen->is_con()) {
+  if (vector_klass == nullptr || vector_klass->const_oop() == nullptr ||
+      elem_klass   == nullptr || elem_klass->const_oop()   == nullptr ||
+      vlen         == nullptr || !vlen->is_con() ||
+      idx          == nullptr || !idx->is_con()) {
     log_if_needed("  ** missing constant: vclass=%s etype=%s vlen=%s",
                     NodeClassNames[argument(0)->Opcode()],
                     NodeClassNames[argument(1)->Opcode()],
@@ -2811,9 +2829,11 @@ bool LibraryCallKit::inline_vector_compress_expand() {
   const TypeInstPtr* elem_klass   = gvn().type(argument(3))->isa_instptr();
   const TypeInt*     vlen         = gvn().type(argument(4))->isa_int();
 
-  if (vector_klass == nullptr || elem_klass == nullptr || mask_klass == nullptr || vlen == nullptr ||
-      vector_klass->const_oop() == nullptr || mask_klass->const_oop() == nullptr ||
-      elem_klass->const_oop() == nullptr || !vlen->is_con() || !opr->is_con()) {
+  if (opr          == nullptr || !opr->is_con() ||
+      vector_klass == nullptr || vector_klass->const_oop() == nullptr ||
+      mask_klass   == nullptr || mask_klass->const_oop()   == nullptr ||
+      elem_klass   == nullptr || elem_klass->const_oop()   == nullptr ||
+      vlen         == nullptr || !vlen->is_con()) {
     log_if_needed("  ** missing constant: opr=%s vclass=%s mclass=%s etype=%s vlen=%s",
                     NodeClassNames[argument(0)->Opcode()],
                     NodeClassNames[argument(1)->Opcode()],
@@ -2892,9 +2912,9 @@ bool LibraryCallKit::inline_index_vector() {
   const TypeInstPtr* elem_klass   = gvn().type(argument(1))->isa_instptr();
   const TypeInt*     vlen         = gvn().type(argument(2))->isa_int();
 
-  if (vector_klass == nullptr || elem_klass == nullptr || vlen == nullptr ||
-      vector_klass->const_oop() == nullptr || !vlen->is_con() ||
-      elem_klass->const_oop() == nullptr) {
+  if (vector_klass == nullptr || vector_klass->const_oop() == nullptr ||
+      elem_klass   == nullptr || elem_klass->const_oop()   == nullptr ||
+      vlen         == nullptr || !vlen->is_con() ) {
     log_if_needed("  ** missing constant: vclass=%s etype=%s vlen=%s",
                     NodeClassNames[argument(0)->Opcode()],
                     NodeClassNames[argument(1)->Opcode()],
@@ -3026,8 +3046,9 @@ bool LibraryCallKit::inline_index_partially_in_upper_range() {
   const TypeInstPtr* elem_klass   = gvn().type(argument(1))->isa_instptr();
   const TypeInt*     vlen         = gvn().type(argument(2))->isa_int();
 
-  if (mask_klass == nullptr || elem_klass == nullptr || vlen == nullptr ||
-      mask_klass->const_oop() == nullptr || elem_klass->const_oop() == nullptr || !vlen->is_con()) {
+  if (mask_klass == nullptr || mask_klass->const_oop() == nullptr ||
+      elem_klass == nullptr || elem_klass->const_oop() == nullptr ||
+      vlen       == nullptr || !vlen->is_con()) {
     log_if_needed("  ** missing constant: mclass=%s etype=%s vlen=%s",
                     NodeClassNames[argument(0)->Opcode()],
                     NodeClassNames[argument(1)->Opcode()],


### PR DESCRIPTION
We have been carrying this patch in Leyden/premain for a while: https://github.com/openjdk/leyden/commit/7faed7fc5c8e1bbd9a16ab22673a77099396179c. I believe it deserves to be in mainline. I polished it a little further.

It is _mostly_ a cleanup, but there are also new checks, on the paths where we do take constants off the arguments. In those cases, I believe the alternative is compiler SEGV-ing.

Additional testing:
 - [x] Linux x86_64 server fastdebug, `hotspot_vector_1 hotspot_vector_2`
 - [x] Linux x86_64 server fastdebug, `jdk_vector`
