### PR TITLE
8347114: JMXServiceURL should require an explicit protocol

### DIFF
--- a/src/java.management/share/classes/javax/management/remote/JMXConnectorServer.java
+++ b/src/java.management/share/classes/javax/management/remote/JMXConnectorServer.java
@@ -133,8 +133,7 @@ public abstract class JMXConnectorServer
      * one new connection to this connector server.</p>
      *
      * <p>A given connector need not support the generation of client
-     * stubs.  However, the connectors specified by the JMX Remote API do
-     * (JMXMP Connector and RMI Connector).</p>
+     * stubs.  The RMI Connector does so.</p>
      *
      * <p>The default implementation of this method uses {@link
      * #getAddress} and {@link JMXConnectorFactory} to generate the

--- a/src/java.management/share/classes/javax/management/remote/JMXConnectorServerMBean.java
+++ b/src/java.management/share/classes/javax/management/remote/JMXConnectorServerMBean.java
@@ -186,8 +186,7 @@ public interface JMXConnectorServerMBean {
      * one new connection to this connector server.</p>
      *
      * <p>A given connector need not support the generation of client
-     * stubs.  However, the connectors specified by the JMX Remote API do
-     * (JMXMP Connector and RMI Connector).</p>
+     * stubs.  The RMI Connector does so.</p>
      *
      * @param env client connection parameters of the same sort that
      * can be provided to {@link JMXConnector#connect(Map)

--- a/src/java.management/share/classes/javax/management/remote/JMXServiceURL.java
+++ b/src/java.management/share/classes/javax/management/remote/JMXServiceURL.java
@@ -239,7 +239,7 @@ public class JMXServiceURL implements Serializable {
      * JMXServiceURL(protocol, host, port, null)}.</p>
      *
      * @param protocol the protocol part of the URL.  Must be specified,
-     * there is no default,
+     * there is no default.
      *
      * @param host the host part of the URL. If host is null and if
      * local host name can be resolved to an IP, then host defaults
@@ -266,7 +266,7 @@ public class JMXServiceURL implements Serializable {
      * <p>Constructs a <code>JMXServiceURL</code> with the given parts.
      *
      * @param protocol the protocol part of the URL.  Must be specified,
-     * there is no default,
+     * there is no default.
      *
      * @param host the host part of the URL. If host is null and if
      * local host name can be resolved to an IP, then host defaults

--- a/src/java.management/share/classes/javax/management/remote/JMXServiceURL.java
+++ b/src/java.management/share/classes/javax/management/remote/JMXServiceURL.java
@@ -238,8 +238,8 @@ public class JMXServiceURL implements Serializable {
      * {@link #JMXServiceURL(String, String, int, String)
      * JMXServiceURL(protocol, host, port, null)}.</p>
      *
-     * @param protocol the protocol part of the URL.  If null, defaults
-     * to <code>jmxmp</code>.
+     * @param protocol the protocol part of the URL.  Must be specified,
+     * there is no default,
      *
      * @param host the host part of the URL. If host is null and if
      * local host name can be resolved to an IP, then host defaults
@@ -255,7 +255,7 @@ public class JMXServiceURL implements Serializable {
      * @exception MalformedURLException if one of the parts is
      * syntactically incorrect, or if <code>host</code> is null and it
      * is not possible to find the local host name, or if
-     * <code>port</code> is negative.
+     * <code>port</code> is negative, or if protocol is null.
      */
     public JMXServiceURL(String protocol, String host, int port)
             throws MalformedURLException {
@@ -265,8 +265,8 @@ public class JMXServiceURL implements Serializable {
     /**
      * <p>Constructs a <code>JMXServiceURL</code> with the given parts.
      *
-     * @param protocol the protocol part of the URL.  If null, defaults
-     * to <code>jmxmp</code>.
+     * @param protocol the protocol part of the URL.  Must be specified,
+     * there is no default,
      *
      * @param host the host part of the URL. If host is null and if
      * local host name can be resolved to an IP, then host defaults
@@ -285,14 +285,14 @@ public class JMXServiceURL implements Serializable {
      * @exception MalformedURLException if one of the parts is
      * syntactically incorrect, or if <code>host</code> is null and it
      * is not possible to find the local host name, or if
-     * <code>port</code> is negative.
+     * <code>port</code> is negative, or if protocol is null.
      */
     public JMXServiceURL(String protocol, String host, int port,
                          String urlPath)
             throws MalformedURLException {
-        if (protocol == null)
-            protocol = "jmxmp";
-
+        if (protocol == null) {
+            throw new MalformedURLException("Misssing protocol name");
+        }
         if (host == null) {
             InetAddress local;
             try {

--- a/test/jdk/javax/management/remote/mandatory/connection/JMXServiceURLProtocol.java
+++ b/test/jdk/javax/management/remote/mandatory/connection/JMXServiceURLProtocol.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8347114
+ * @summary Test JMXServiceURL does not accept a null protocol
+ *
+ * @run main JMXServiceURLProtocol
+ */
+
+import java.net.MalformedURLException;
+import javax.management.remote.JMXServiceURL;
+
+public class JMXServiceURLProtocol {
+
+    public static void main(String[] args) throws Exception {
+
+        try {
+            JMXServiceURL u = new JMXServiceURL("service:jmx:://");
+            String proto = u.getProtocol();
+            System.out.println("JMXServiceURL(String) with null protocol gets: " + u + " protocol: " + proto);
+            throw new RuntimeException("JMXServiceURL created using null protocol: " + u);
+        } catch (MalformedURLException e) {
+            System.out.println("JMXServiceURL with null protocol causes expected: " + e);
+        }
+
+        try {
+            JMXServiceURL u = new JMXServiceURL(null, "localhost", 1234);
+            String proto = u.getProtocol();
+            System.out.println("JMXServiceURL(params) with null protocol gets: " + u + " protocol: " + proto);
+            throw new RuntimeException("JMXServiceURL created using null protocol: " + u);
+        } catch (MalformedURLException e) {
+            System.out.println("JMXServiceURL with null protocol causes expected: " + e);
+        }
+
+    }
+}


### PR DESCRIPTION
Remove the historic oddity that JMXServiceURL defaults to jmxmp if a null protocol is specified.

This has been the case for JMXServiceURL constructors that take individual parameters, but not for JMXServiceURL(String serviceURL), which enforces that there must be a protocol (If empty in the String, it throws: java.net.MalformedURLException: Missing or invalid protocol name: "")

A missing (null) protocol should throw a MalformedURLException for all constructors.

JMXMP was never part of the JDK, but a separate component in the historic JMX Remote reference implementation.

While we are here, remove the last remaining JMXMP references in the source:
```
src/java.management/share/classes/javax/management/remote/JMXConnectorServerMBean.java:     * (JMXMP Connector and RMI Connector).</p>
src/java.management/share/classes/javax/management/remote/JMXConnectorServer.java:     * (JMXMP Connector and RMI Connector).</p>
```
These doc references are just examples of Connectors that support generation of client stubs.  There is no need for JMXMP to be mentioned here.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change requires CSR request [JDK-8359130](https://bugs.openjdk.org/browse/JDK-8359130) to be approved
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8347114](https://bugs.openjdk.org/browse/JDK-8347114): JMXServiceURL should require an explicit protocol (**Enhancement** - P4)
 * [JDK-8359130](https://bugs.openjdk.org/browse/JDK-8359130): JMXServiceURL should require an explicit protocol (**CSR**)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25674/head:pull/25674` \
`$ git checkout pull/25674`

Update a local copy of the PR: \
`$ git checkout pull/25674` \
`$ git pull https://git.openjdk.org/jdk.git pull/25674/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25674`

View PR using the GUI difftool: \
`$ git pr show -t 25674`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25674.diff">https://git.openjdk.org/jdk/pull/25674.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25674#issuecomment-2949618368)
</details>
