### PR TITLE
8358809: Improve link to stdin.encoding from java.lang.IO

### DIFF
--- a/src/java.base/share/classes/java/lang/IO.java
+++ b/src/java.base/share/classes/java/lang/IO.java
@@ -38,7 +38,7 @@ import java.nio.charset.StandardCharsets;
  * <p>
  * The {@link #readln()} and {@link #readln(String)} methods decode bytes read from
  * {@code System.in} into characters. The charset used for decoding is specified by the
- * {@link System#getProperties stdin.encoding} property. If this property is not present,
+ * {@link System##stdin.encoding stdin.encoding} property. If this property is not present,
  * or if the charset it names cannot be loaded, then UTF-8 is used instead. Decoding
  * always replaces malformed and unmappable byte sequences with the charset's default
  * replacement string.


### PR DESCRIPTION
Use a link of the form `System##stdin.encoding` to link directly to the system property's description.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8358809](https://bugs.openjdk.org/browse/JDK-8358809): Improve link to stdin.encoding from java.lang.IO (**Bug** - P4)


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25676/head:pull/25676` \
`$ git checkout pull/25676`

Update a local copy of the PR: \
`$ git checkout pull/25676` \
`$ git pull https://git.openjdk.org/jdk.git pull/25676/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25676`

View PR using the GUI difftool: \
`$ git pr show -t 25676`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25676.diff">https://git.openjdk.org/jdk/pull/25676.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25676#issuecomment-2950147536)
</details>
