### PR TITLE
8358556: Assert when running with -XX:-UseLibmIntrinsic

### DIFF
--- a/src/hotspot/cpu/x86/templateInterpreterGenerator_x86_64.cpp
+++ b/src/hotspot/cpu/x86/templateInterpreterGenerator_x86_64.cpp
@@ -396,6 +396,13 @@ address TemplateInterpreterGenerator::generate_math_entry(AbstractInterpreter::M
   //        [ hi(arg) ]
   //
 
+  if (!UseLibmIntrinsic) {
+    if (kind == Interpreter::java_lang_math_tanh ||
+        kind == Interpreter::java_lang_math_cbrt) {
+      return nullptr; // Fallback to default implementation
+    }
+  }
+
   if (kind == Interpreter::java_lang_math_fmaD) {
     if (!UseFMA) {
       return nullptr; // Generate a vanilla entry

--- a/src/hotspot/cpu/x86/templateInterpreterGenerator_x86_64.cpp
+++ b/src/hotspot/cpu/x86/templateInterpreterGenerator_x86_64.cpp
@@ -396,13 +396,6 @@ address TemplateInterpreterGenerator::generate_math_entry(AbstractInterpreter::M
   //        [ hi(arg) ]
   //
 
-  if (!UseLibmIntrinsic) {
-    if (kind == Interpreter::java_lang_math_tanh ||
-        kind == Interpreter::java_lang_math_cbrt) {
-      return nullptr; // Fallback to default implementation
-    }
-  }
-
   if (kind == Interpreter::java_lang_math_fmaD) {
     if (!UseFMA) {
       return nullptr; // Generate a vanilla entry
@@ -472,13 +465,19 @@ address TemplateInterpreterGenerator::generate_math_entry(AbstractInterpreter::M
       __ call_VM_leaf0(CAST_FROM_FN_PTR(address, SharedRuntime::dtan));
     }
   } else if (kind == Interpreter::java_lang_math_tanh) {
-      assert(StubRoutines::dtanh() != nullptr, "not initialized");
+    if (StubRoutines::dtanh() != nullptr) {
       __ movdbl(xmm0, Address(rsp, wordSize));
       __ call(RuntimeAddress(CAST_FROM_FN_PTR(address, StubRoutines::dtanh())));
+    } else {
+      return nullptr; // Fallback to default implementation
+    }
   } else if (kind == Interpreter::java_lang_math_cbrt) {
-    assert(StubRoutines::dcbrt() != nullptr, "not initialized");
-    __ movdbl(xmm0, Address(rsp, wordSize));
-    __ call(RuntimeAddress(CAST_FROM_FN_PTR(address, StubRoutines::dcbrt())));
+    if (StubRoutines::dcbrt() != nullptr) {
+      __ movdbl(xmm0, Address(rsp, wordSize));
+      __ call(RuntimeAddress(CAST_FROM_FN_PTR(address, StubRoutines::dcbrt())));
+    } else {
+      return nullptr; // Fallback to default implementation
+    }
   } else if (kind == Interpreter::java_lang_math_abs) {
     assert(StubRoutines::x86::double_sign_mask() != nullptr, "not initialized");
     __ movdbl(xmm0, Address(rsp, wordSize));

--- a/src/hotspot/share/classfile/vmIntrinsics.cpp
+++ b/src/hotspot/share/classfile/vmIntrinsics.cpp
@@ -317,6 +317,9 @@ bool vmIntrinsics::disabled_by_jvm_flags(vmIntrinsics::ID id) {
   case vmIntrinsics::_dtanh:
   case vmIntrinsics::_dcbrt:
     if (!InlineMathNatives || !InlineIntrinsics) return true;
+#ifdef AMD64
+    if (!UseLibmIntrinsic) return true;
+#endif
     break;
   case vmIntrinsics::_floatToFloat16:
   case vmIntrinsics::_float16ToFloat:

--- a/src/hotspot/share/classfile/vmIntrinsics.cpp
+++ b/src/hotspot/share/classfile/vmIntrinsics.cpp
@@ -255,6 +255,18 @@ bool vmIntrinsics::disabled_by_jvm_flags(vmIntrinsics::ID id) {
     }
   }
 
+  // -XX:UseLibmIntrinsic or -XX:-InlineIntrinsics disables all intrinsics
+  // listed in the following switch statement
+  if (!UseLibmIntrinsic || !InlineIntrinsics) {
+    switch (id) {
+    case vmIntrinsics::_dtanh:
+    case vmIntrinsics::_dcbrt:
+      return true;
+    default:
+      break;
+    }
+  }
+
   switch (id) {
   case vmIntrinsics::_isInstance:
   case vmIntrinsics::_isAssignableFrom:

--- a/src/hotspot/share/classfile/vmIntrinsics.cpp
+++ b/src/hotspot/share/classfile/vmIntrinsics.cpp
@@ -255,9 +255,9 @@ bool vmIntrinsics::disabled_by_jvm_flags(vmIntrinsics::ID id) {
     }
   }
 
-  // -XX:UseLibmIntrinsic or -XX:-InlineIntrinsics disables all intrinsics
-  // listed in the following switch statement
-  if (!UseLibmIntrinsic || !InlineIntrinsics) {
+  // -XX:-InlineIntrinsics disables all intrinsics listed in the following
+  // switch statement
+  if (!InlineIntrinsics) {
     switch (id) {
     case vmIntrinsics::_dtanh:
     case vmIntrinsics::_dcbrt:

--- a/src/hotspot/share/classfile/vmIntrinsics.cpp
+++ b/src/hotspot/share/classfile/vmIntrinsics.cpp
@@ -316,7 +316,7 @@ bool vmIntrinsics::disabled_by_jvm_flags(vmIntrinsics::ID id) {
     break;
   case vmIntrinsics::_dtanh:
   case vmIntrinsics::_dcbrt:
-    if (!InlineMathNatives) return true;
+    if (!InlineMathNatives || !InlineIntrinsics) return true;
     break;
   case vmIntrinsics::_floatToFloat16:
   case vmIntrinsics::_float16ToFloat:

--- a/src/hotspot/share/classfile/vmIntrinsics.cpp
+++ b/src/hotspot/share/classfile/vmIntrinsics.cpp
@@ -317,7 +317,7 @@ bool vmIntrinsics::disabled_by_jvm_flags(vmIntrinsics::ID id) {
   case vmIntrinsics::_dtanh:
   case vmIntrinsics::_dcbrt:
     if (!InlineMathNatives || !InlineIntrinsics) return true;
-#ifdef AMD64
+#if defined(AMD64) && (defined(COMPILER1) || defined(COMPILER2))
     if (!UseLibmIntrinsic) return true;
 #endif
     break;

--- a/src/hotspot/share/classfile/vmIntrinsics.cpp
+++ b/src/hotspot/share/classfile/vmIntrinsics.cpp
@@ -255,18 +255,6 @@ bool vmIntrinsics::disabled_by_jvm_flags(vmIntrinsics::ID id) {
     }
   }
 
-  // -XX:-InlineIntrinsics disables all intrinsics listed in the following
-  // switch statement
-  if (!InlineIntrinsics) {
-    switch (id) {
-    case vmIntrinsics::_dtanh:
-    case vmIntrinsics::_dcbrt:
-      return true;
-    default:
-      break;
-    }
-  }
-
   switch (id) {
   case vmIntrinsics::_isInstance:
   case vmIntrinsics::_isAssignableFrom:
@@ -301,8 +289,6 @@ bool vmIntrinsics::disabled_by_jvm_flags(vmIntrinsics::ID id) {
   case vmIntrinsics::_dsin:
   case vmIntrinsics::_dcos:
   case vmIntrinsics::_dtan:
-  case vmIntrinsics::_dtanh:
-  case vmIntrinsics::_dcbrt:
   case vmIntrinsics::_dlog:
   case vmIntrinsics::_dexp:
   case vmIntrinsics::_dpow:
@@ -327,6 +313,10 @@ bool vmIntrinsics::disabled_by_jvm_flags(vmIntrinsics::ID id) {
   case vmIntrinsics::_fmaD:
   case vmIntrinsics::_fmaF:
     if (!InlineMathNatives || !UseFMA) return true;
+    break;
+  case vmIntrinsics::_dtanh:
+  case vmIntrinsics::_dcbrt:
+    if (!InlineMathNatives) return true;
     break;
   case vmIntrinsics::_floatToFloat16:
   case vmIntrinsics::_float16ToFloat:


### PR DESCRIPTION
This change fixes unwanted calls to the cbrt and tanh intrinsics on x86 when they are explicitly disabled by flags such as _-XX:-UseLibmIntrinsic_ or _-XX:-InlineIntrinsics_.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8358556](https://bugs.openjdk.org/browse/JDK-8358556): Assert when running with -XX:-UseLibmIntrinsic (**Bug** - P4)


### Reviewers
 * [Sandhya Viswanathan](https://openjdk.org/census#sviswanathan) (@sviswa7 - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25680/head:pull/25680` \
`$ git checkout pull/25680`

Update a local copy of the PR: \
`$ git checkout pull/25680` \
`$ git pull https://git.openjdk.org/jdk.git pull/25680/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25680`

View PR using the GUI difftool: \
`$ git pr show -t 25680`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25680.diff">https://git.openjdk.org/jdk/pull/25680.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25680#issuecomment-2950756993)
</details>
