### PR TITLE
Backport d024f58e61ec27f6c13fde5dadb95c31875815d6

### DIFF
--- a/src/java.base/share/classes/java/lang/IO.java
+++ b/src/java.base/share/classes/java/lang/IO.java
@@ -38,7 +38,7 @@ import java.nio.charset.StandardCharsets;
  * <p>
  * The {@link #readln()} and {@link #readln(String)} methods decode bytes read from
  * {@code System.in} into characters. The charset used for decoding is specified by the
- * {@link System#getProperties stdin.encoding} property. If this property is not present,
+ * {@link System##stdin.encoding stdin.encoding} property. If this property is not present,
  * or if the charset it names cannot be loaded, then UTF-8 is used instead. Decoding
  * always replaces malformed and unmappable byte sequences with the charset's default
  * replacement string.


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [d024f58e](https://github.com/openjdk/jdk/commit/d024f58e61ec27f6c13fde5dadb95c31875815d6) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Stuart Marks on 6 Jun 2025 and was reviewed by Naoto Sato.

Thanks!
