### PR TITLE
8358577: Test serviceability/jvmti/thread/GetCurrentContendedMonitor/contmon01/contmon01.java failed: unexpexcted monitor object

### DIFF
--- a/test/hotspot/jtreg/serviceability/jvmti/thread/GetCurrentContendedMonitor/contmon01/contmon01.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/thread/GetCurrentContendedMonitor/contmon01/contmon01.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -154,9 +154,9 @@ class contmon01Task implements Runnable {
         System.out.println("check #2 done");
 
         System.out.println("notifying main thread");
+        System.out.println("thread is going to loop while <flag> is true ...");
         contmon01.startingBarrier = false;
 
-        System.out.println("thread is going to loop while <flag> is true ...");
         int i = 0;
         int n = 1000;
         while (flag) {


### PR DESCRIPTION
The change fixes race in the test.
Tested thread is expected to have no contended monitor when main thread checks it, but System.out.println() can cause waiting on a monitor when concurrent printing is performed, so printing should not be performed after signalling main thread to continue.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8358577](https://bugs.openjdk.org/browse/JDK-8358577): Test serviceability/jvmti/thread/GetCurrentContendedMonitor/contmon01/contmon01.java failed: unexpexcted monitor object (**Bug** - P4)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [SendaoYan](https://openjdk.org/census#syan) (@sendaoYan - Committer)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25683/head:pull/25683` \
`$ git checkout pull/25683`

Update a local copy of the PR: \
`$ git checkout pull/25683` \
`$ git pull https://git.openjdk.org/jdk.git pull/25683/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25683`

View PR using the GUI difftool: \
`$ git pr show -t 25683`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25683.diff">https://git.openjdk.org/jdk/pull/25683.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25683#issuecomment-2951233275)
</details>
