### PR TITLE
8358094: Test vmTestbase/nsk/jvmti/AttachOnDemand/attach045/TestDescription.java still times out after JDK-8357282

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -168,7 +168,6 @@ vmTestbase/metaspace/gc/firstGC_50m/TestDescription.java 8208250 generic-all
 vmTestbase/metaspace/gc/firstGC_99m/TestDescription.java 8208250 generic-all
 vmTestbase/metaspace/gc/firstGC_default/TestDescription.java 8208250 generic-all
 
-vmTestbase/nsk/jvmti/AttachOnDemand/attach045/TestDescription.java 8358094 generic-all
 vmTestbase/nsk/jvmti/scenarios/capability/CM03/cm03t001/TestDescription.java 8073470 linux-all
 vmTestbase/nsk/jvmti/InterruptThread/intrpthrd003/TestDescription.java 8288911 macosx-all
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach045/attach045Agent00.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach045/attach045Agent00.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,6 +51,7 @@ void JNICALL classLoadHandler(
         jclass klass) {
     char className[MAX_STRING_LENGTH];
     int success = 1;
+    bool finish = false;
 
     if (!nsk_jvmti_aod_getClassName(jvmti, klass, className)) {
         nsk_jvmti_aod_disableEventAndFinish(agentName, JVMTI_EVENT_CLASS_LOAD, 0, jvmti, jni);
@@ -65,7 +66,7 @@ void JNICALL classLoadHandler(
 
         if (eventsCounter == EXPECTED_EVENTS_NUMBER) {
             NSK_DISPLAY2("%s: all expected events were received (eventsCounter: %d)\n", agentName, eventsCounter);
-            nsk_jvmti_aod_disableEventAndFinish(agentName, JVMTI_EVENT_CLASS_LOAD, success, jvmti, jni);
+            finish = true;
         }
 
         if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorExit(eventsCounterMonitor))) {
@@ -75,8 +76,8 @@ void JNICALL classLoadHandler(
         success = 0;
     }
 
-    if (!success) {
-        nsk_jvmti_aod_disableEventAndFinish(agentName, JVMTI_EVENT_CLASS_LOAD, 0, jvmti, jni);
+    if (finish || !success) {
+        nsk_jvmti_aod_disableEventAndFinish(agentName, JVMTI_EVENT_CLASS_LOAD, success, jvmti, jni);
     }
 }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach045/attach045Agent01.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach045/attach045Agent01.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,6 +50,7 @@ void JNICALL classPrepareHandler(
         jthread thread,
         jclass klass) {
     int success = 1;
+    bool finish = false;
     char className[MAX_STRING_LENGTH];
     jint loadedClassesCount;
     jclass *loadedClasses;
@@ -75,8 +76,7 @@ void JNICALL classPrepareHandler(
 
         if (eventsCounter == EXPECTED_EVENTS_NUMBER) {
             NSK_DISPLAY2("%s: all expected events were received (eventsCounter: %d)\n", agentName, eventsCounter);
-
-            nsk_jvmti_aod_disableEventAndFinish(agentName, JVMTI_EVENT_CLASS_PREPARE, success, jvmti, jni);
+            finish = true;
         }
 
         if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorExit(eventsCounterMonitor))) {
@@ -86,8 +86,8 @@ void JNICALL classPrepareHandler(
         success = 0;
     }
 
-    if (!success) {
-        nsk_jvmti_aod_disableEventAndFinish(agentName, JVMTI_EVENT_CLASS_PREPARE, 0, jvmti, jni);
+    if (finish || !success) {
+        nsk_jvmti_aod_disableEventAndFinish(agentName, JVMTI_EVENT_CLASS_PREPARE, success, jvmti, jni);
     }
 }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach045/attach045Agent02.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach045/attach045Agent02.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -54,6 +54,7 @@ void eventHandler(jvmtiEnv *jvmti,
         int threadStartEvent) {
     char threadName[MAX_STRING_LENGTH];
     int success = 1;
+    bool finish = false;
     jint threadsCount = 0;
     jthread * threads;
 
@@ -81,8 +82,7 @@ void eventHandler(jvmtiEnv *jvmti,
 
         if (eventsCounter == EXPECTED_EVENTS_NUMBER) {
             NSK_DISPLAY2("%s: all expected events were received (eventsCounter: %d)\n", agentName, eventsCounter);
-
-            nsk_jvmti_aod_disableEventsAndFinish(agentName, testEvents, testEventsNumber, success, jvmti, jni);
+            finish = true;
         }
 
         if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorExit(eventsCounterMonitor))) {
@@ -92,8 +92,8 @@ void eventHandler(jvmtiEnv *jvmti,
         success = 0;
     }
 
-    if (!success) {
-        nsk_jvmti_aod_disableEventsAndFinish(agentName, testEvents, testEventsNumber, 0, jvmti, jni);
+    if (finish || !success) {
+        nsk_jvmti_aod_disableEventsAndFinish(agentName, testEvents, testEventsNumber, success, jvmti, jni);
     }
 }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach045/attach045Agent03.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach045/attach045Agent03.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -57,6 +57,7 @@ VMObjectAllocHandler(jvmtiEnv *jvmti,
     char threadName[MAX_STRING_LENGTH];
     char className[MAX_STRING_LENGTH];
     int success = 1;
+    bool finish = false;
 
     if (!nsk_jvmti_aod_getClassName(jvmti, object_klass, className)) {
         nsk_jvmti_aod_disableEventsAndFinish(agentName, testEvents, testEventsNumber, 0, jvmti, jni);
@@ -84,8 +85,7 @@ VMObjectAllocHandler(jvmtiEnv *jvmti,
 
         if (eventsCounter == EXPECTED_EVENTS_NUMBER) {
             NSK_DISPLAY2("%s: all expected events were received (eventsCounter: %d)\n", agentName, eventsCounter);
-
-            nsk_jvmti_aod_disableEventsAndFinish(agentName, testEvents, testEventsNumber, success, jvmti, jni);
+            finish = true;
         }
 
         if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorExit(eventsCounterMonitor))) {
@@ -95,8 +95,8 @@ VMObjectAllocHandler(jvmtiEnv *jvmti,
         success = 0;
     }
 
-    if (!success) {
-        nsk_jvmti_aod_disableEventsAndFinish(agentName, testEvents, testEventsNumber, 0, jvmti, jni);
+    if (finish || !success) {
+        nsk_jvmti_aod_disableEventsAndFinish(agentName, testEvents, testEventsNumber, success, jvmti, jni);
     }
 }
 


### PR DESCRIPTION
The test intermittently times out due to deadlock between 2 monitors: one monitor is JVMTI raw monitor used by agents, another is in Java (`nsk_jvmti_aod_disableEventAndFinish` does upcall) See JBS issue for details.
The fix updates agents to exit raw monitors before upcall.

Testing: no failures in 1000 runs

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8358094](https://bugs.openjdk.org/browse/JDK-8358094): Test vmTestbase/nsk/jvmti/AttachOnDemand/attach045/TestDescription.java still times out after JDK-8357282 (**Bug** - P4)


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25684/head:pull/25684` \
`$ git checkout pull/25684`

Update a local copy of the PR: \
`$ git checkout pull/25684` \
`$ git pull https://git.openjdk.org/jdk.git pull/25684/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25684`

View PR using the GUI difftool: \
`$ git pr show -t 25684`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25684.diff">https://git.openjdk.org/jdk/pull/25684.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25684#issuecomment-2951381386)
</details>
