### PR TITLE
7116990: (spec) Socket.connect(addr,timeout) not clear if IOException because of TCP timeout

### DIFF
--- a/src/java.base/share/classes/java/net/Socket.java
+++ b/src/java.base/share/classes/java/net/Socket.java
@@ -621,6 +621,12 @@ public class Socket implements java.io.Closeable {
      *        {@code SocketException} with the interrupt status set.
      * </ol>
      *
+     * @apiNote Establishing a TCP/IP connection is subject to connection timeout settings
+     * in the operating system. The typical timeout is 60 seconds. If the operating system
+     * timeout expires before the {@code timeout} specified to this method then an
+     * {@code IOException} is thrown. The {@code timeout} specified to this method is typically
+     * a timeout value that is shorter than the operating system timeout.
+     *
      * @param   endpoint the {@code SocketAddress}
      * @param   timeout  the timeout value to be used in milliseconds.
      * @throws  IOException if an error occurs during the connection, the socket


### PR DESCRIPTION
Can I please get a review of this doc-only change which proposes to add a `@apiNote` to the `Socket.connect(SocketAddress endpoint, int timeout)` method? This addresses https://bugs.openjdk.org/browse/JDK-7116990.

As noted in that issue, users can find it surprising that when the `Socket.connect(...)` method is called with a `timeout` value, then if that timeout value happens to be greater than the connect timeout that operating systems typically impose, then a `IOException` gets thrown instead of the `SocketTimeoutException`. The change in this PR proposes to add a `@apiNote` which explains this current behaviour.

If this requires a CSR, I'll open one once we settle on the proposed text.

