### PR TITLE
8358617: java/net/HttpURLConnection/HttpURLConnectionExpectContinueTest.java fails with 403 due to system proxies

### DIFF
--- a/test/jdk/java/net/HttpURLConnection/HttpURLConnectionExpectContinueTest.java
+++ b/test/jdk/java/net/HttpURLConnection/HttpURLConnectionExpectContinueTest.java
@@ -429,7 +429,7 @@ public class HttpURLConnectionExpectContinueTest {
                 .port(control.serverSocket.getLocalPort())
                 .toURL();
 
-        HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+        HttpURLConnection connection = (HttpURLConnection) url.openConnection(Proxy.NO_PROXY);
         connection.setDoOutput(true);
         connection.setReadTimeout(5000);
         connection.setUseCaches(false);


### PR DESCRIPTION
Intermittent failures have been seen with HttpURLConnectionExpectContinueTest on macOS possibly due to the test using the host systems proxy configurations. 
 
Failures seen on JDK11 and JDK17 but adding no proxy conifguration to other JDK versions as a preventative measure.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8358617](https://bugs.openjdk.org/browse/JDK-8358617): java/net/HttpURLConnection/HttpURLConnectionExpectContinueTest.java fails with 403 due to system proxies (**Bug** - P4)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25692/head:pull/25692` \
`$ git checkout pull/25692`

Update a local copy of the PR: \
`$ git checkout pull/25692` \
`$ git pull https://git.openjdk.org/jdk.git pull/25692/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25692`

View PR using the GUI difftool: \
`$ git pr show -t 25692`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25692.diff">https://git.openjdk.org/jdk/pull/25692.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25692#issuecomment-2955452073)
</details>
