### PR TITLE
8355298

### DIFF
--- a/test/hotspot/jtreg/runtime/logging/StressAsyncUL.java
+++ b/test/hotspot/jtreg/runtime/logging/StressAsyncUL.java
@@ -50,7 +50,8 @@ public class StressAsyncUL {
         // Stress test with a very small buffer. Note: Any valid buffer size must be able to hold a flush token.
         // Therefore the size of the buffer cannot be zero.
         analyze_output(false, "-Xlog:async:drop", "-Xlog:all=trace", "-XX:AsyncLogBufferSize=192", InnerClass.class.getName());
-        analyze_output(true, "-Xlog:async:stall", "-Xlog:all=trace", "-XX:AsyncLogBufferSize=192", InnerClass.class.getName());
+        // -Xlog:async:stall is very slow with a small buffer. In the interest of saving time, reduce the number of logs for this step.
+        analyze_output(true, "-Xlog:async:stall", "-Xlog:all=debug", "-XX:AsyncLogBufferSize=192", InnerClass.class.getName());
     }
 
     public static class InnerClass {


### PR DESCRIPTION
Hi,

Running async UL with stalling mode enabled is very slow if your buffer is very small. This turns out to become an issue on slow machines, where we run the risk of the test timing out.

The ticket's suggestion (and title) is to increase the timeout. I think that it'd be fine to reduce the logging level to 'debug' instead, thus reducing the time required to run the test.

Obviously, if we go with this solution then the ticket name and description must be adjusted.