### PR TITLE
8359064: Expose reason for marking nmethod non-entrant to JVMCI client

### DIFF
--- a/src/hotspot/share/code/nmethod.cpp
+++ b/src/hotspot/share/code/nmethod.cpp
@@ -2084,7 +2084,7 @@ bool nmethod::make_not_entrant(ChangeReason change_reason) {
   // Invalidate can't occur while holding the NMethodState_lock
   JVMCINMethodData* nmethod_data = jvmci_nmethod_data();
   if (nmethod_data != nullptr) {
-    nmethod_data->invalidate_nmethod_mirror(this);
+    nmethod_data->invalidate_nmethod_mirror(this, change_reason);
   }
 #endif
 
@@ -2122,7 +2122,7 @@ void nmethod::unlink() {
   // Clear the link between this nmethod and a HotSpotNmethod mirror
   JVMCINMethodData* nmethod_data = jvmci_nmethod_data();
   if (nmethod_data != nullptr) {
-    nmethod_data->invalidate_nmethod_mirror(this);
+    nmethod_data->invalidate_nmethod_mirror(this, is_cold() ? nmethod::ChangeReason::GC_unlinking_cold : nmethod::ChangeReason::GC_unlinking);
   }
 #endif
 

--- a/src/hotspot/share/code/nmethod.hpp
+++ b/src/hotspot/share/code/nmethod.hpp
@@ -472,11 +472,14 @@ class nmethod : public CodeBlob {
 
 public:
   enum class ChangeReason : u1 {
+    unknown,
     C1_codepatch,
     C1_deoptimize,
     C1_deoptimize_for_patching,
     C1_predicate_failed_trap,
     CI_replay,
+    GC_unlinking,
+    GC_unlinking_cold,
     JVMCI_invalidate_nmethod,
     JVMCI_invalidate_nmethod_mirror,
     JVMCI_materialize_virtual_object,

--- a/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
@@ -1218,6 +1218,14 @@ C2V_VMENTRY_0(jint, installCode0, (JNIEnv *env, jobject,
   return result;
 C2V_END
 
+C2V_VMENTRY_0(jobject,  getChangeReasonDescription, (JNIEnv *env, jobject, jint change_reason))
+  HandleMark hm(THREAD);
+  JNIHandleMark jni_hm(thread);
+  nmethod::ChangeReason reason = static_cast<nmethod::ChangeReason>(change_reason);
+  JVMCIObject desc = JVMCIENV->create_string(nmethod::change_reason_to_string(reason), JVMCI_CHECK_NULL);
+  return JVMCIENV->get_jobject(desc);
+C2V_END
+
 C2V_VMENTRY(void, resetCompilationStatistics, (JNIEnv* env, jobject))
   JVMCICompiler* compiler = JVMCICompiler::instance(true, CHECK);
   CompilerStatistics* stats = compiler->stats();
@@ -1396,9 +1404,9 @@ C2V_VMENTRY(void, reprofile, (JNIEnv* env, jobject, ARGUMENT_PAIR(method)))
 C2V_END
 
 
-C2V_VMENTRY(void, invalidateHotSpotNmethod, (JNIEnv* env, jobject, jobject hs_nmethod, jboolean deoptimize))
+C2V_VMENTRY(void, invalidateHotSpotNmethod, (JNIEnv* env, jobject, jobject hs_nmethod, jboolean deoptimize, jint change_reason))
   JVMCIObject nmethod_mirror = JVMCIENV->wrap(hs_nmethod);
-  JVMCIENV->invalidate_nmethod_mirror(nmethod_mirror, deoptimize, nmethod::ChangeReason::JVMCI_invalidate_nmethod, JVMCI_CHECK);
+  JVMCIENV->invalidate_nmethod_mirror(nmethod_mirror, deoptimize, static_cast<nmethod::ChangeReason>(change_reason), JVMCI_CHECK);
 C2V_END
 
 C2V_VMENTRY_NULL(jlongArray, collectCounters, (JNIEnv* env, jobject))
@@ -3352,6 +3360,7 @@ JNINativeMethod CompilerToVM::methods[] = {
   {CC "getResolvedJavaType0",                         CC "(Ljava/lang/Object;JZ)" HS_KLASS,                                                 FN_PTR(getResolvedJavaType0)},
   {CC "readConfiguration",                            CC "()[" OBJECT,                                                                      FN_PTR(readConfiguration)},
   {CC "installCode0",                                 CC "(JJZ" HS_COMPILED_CODE "[" OBJECT INSTALLED_CODE "J[B)I",                         FN_PTR(installCode0)},
+  {CC "getChangeReasonDescription",                   CC "(I)" STRING,                                                                      FN_PTR(getChangeReasonDescription)},
   {CC "getInstallCodeFlags",                          CC "()I",                                                                             FN_PTR(getInstallCodeFlags)},
   {CC "resetCompilationStatistics",                   CC "()V",                                                                             FN_PTR(resetCompilationStatistics)},
   {CC "disassembleCodeBlob",                          CC "(" INSTALLED_CODE ")" STRING,                                                     FN_PTR(disassembleCodeBlob)},
@@ -3360,7 +3369,7 @@ JNINativeMethod CompilerToVM::methods[] = {
   {CC "getLocalVariableTableStart",                   CC "(" HS_METHOD2 ")J",                                                               FN_PTR(getLocalVariableTableStart)},
   {CC "getLocalVariableTableLength",                  CC "(" HS_METHOD2 ")I",                                                               FN_PTR(getLocalVariableTableLength)},
   {CC "reprofile",                                    CC "(" HS_METHOD2 ")V",                                                               FN_PTR(reprofile)},
-  {CC "invalidateHotSpotNmethod",                     CC "(" HS_NMETHOD "Z)V",                                                              FN_PTR(invalidateHotSpotNmethod)},
+  {CC "invalidateHotSpotNmethod",                     CC "(" HS_NMETHOD "ZI)V",                                                             FN_PTR(invalidateHotSpotNmethod)},
   {CC "collectCounters",                              CC "()[J",                                                                            FN_PTR(collectCounters)},
   {CC "getCountersSize",                              CC "()I",                                                                             FN_PTR(getCountersSize)},
   {CC "setCountersSize",                              CC "(I)Z",                                                                            FN_PTR(setCountersSize)},

--- a/src/hotspot/share/jvmci/jvmciEnv.cpp
+++ b/src/hotspot/share/jvmci/jvmciEnv.cpp
@@ -1744,6 +1744,7 @@ void JVMCIEnv::initialize_installed_code(JVMCIObject installed_code, CodeBlob* c
     set_InstalledCode_entryPoint(installed_code, (jlong) cb->code_begin());
   }
   set_InstalledCode_address(installed_code, (jlong) cb);
+  set_InstalledCode_changeReason(installed_code, static_cast<int>(nmethod::ChangeReason::JVMCI_new_installation));
   set_HotSpotInstalledCode_size(installed_code, cb->size());
   set_HotSpotInstalledCode_codeStart(installed_code, (jlong) cb->code_begin());
   set_HotSpotInstalledCode_codeSize(installed_code, cb->code_size());

--- a/src/hotspot/share/jvmci/jvmciJavaClasses.hpp
+++ b/src/hotspot/share/jvmci/jvmciJavaClasses.hpp
@@ -92,6 +92,7 @@
     long_field(InstalledCode, entryPoint)                                                                     \
     long_field(InstalledCode, version)                                                                        \
     object_field(InstalledCode, name, "Ljava/lang/String;")                                                   \
+    int_field(InstalledCode, changeReason)                                                                    \
   end_class                                                                                                   \
   start_class(HotSpotInstalledCode, jdk_vm_ci_hotspot_HotSpotInstalledCode)                                   \
     int_field(HotSpotInstalledCode, size)                                                                     \

--- a/src/hotspot/share/jvmci/jvmciRuntime.cpp
+++ b/src/hotspot/share/jvmci/jvmciRuntime.cpp
@@ -797,7 +797,7 @@ void JVMCINMethodData::set_nmethod_mirror(nmethod* nm, oop new_mirror) {
   Universe::heap()->register_nmethod(nm);
 }
 
-void JVMCINMethodData::invalidate_nmethod_mirror(nmethod* nm) {
+void JVMCINMethodData::invalidate_nmethod_mirror(nmethod* nm, nmethod::ChangeReason change_reason) {
   oop nmethod_mirror = get_nmethod_mirror(nm);
   if (nmethod_mirror == nullptr) {
     return;
@@ -815,12 +815,14 @@ void JVMCINMethodData::invalidate_nmethod_mirror(nmethod* nm) {
       // an InvalidInstalledCodeException.
       HotSpotJVMCI::InstalledCode::set_address(jvmciEnv, nmethod_mirror, 0);
       HotSpotJVMCI::InstalledCode::set_entryPoint(jvmciEnv, nmethod_mirror, 0);
+      HotSpotJVMCI::InstalledCode::set_changeReason(jvmciEnv, nmethod_mirror, static_cast<int>(change_reason));
       HotSpotJVMCI::HotSpotInstalledCode::set_codeStart(jvmciEnv, nmethod_mirror, 0);
     } else if (nm->is_not_entrant()) {
       // Zero the entry point so any new invocation will fail but keep
       // the address link around that so that existing activations can
       // be deoptimized via the mirror (i.e. JVMCIEnv::invalidate_installed_code).
       HotSpotJVMCI::InstalledCode::set_entryPoint(jvmciEnv, nmethod_mirror, 0);
+      HotSpotJVMCI::InstalledCode::set_changeReason(jvmciEnv, nmethod_mirror, static_cast<int>(change_reason));
       HotSpotJVMCI::HotSpotInstalledCode::set_codeStart(jvmciEnv, nmethod_mirror, 0);
     }
   }

--- a/src/hotspot/share/jvmci/jvmciRuntime.hpp
+++ b/src/hotspot/share/jvmci/jvmciRuntime.hpp
@@ -121,7 +121,7 @@ public:
 
   // Clears the HotSpotNmethod.address field in the  mirror. If nm
   // is dead, the HotSpotNmethod.entryPoint field is also cleared.
-  void invalidate_nmethod_mirror(nmethod* nm);
+  void invalidate_nmethod_mirror(nmethod* nm, nmethod::ChangeReason change_reason);
 
   // Gets the mirror from nm's oops table.
   oop get_nmethod_mirror(nmethod* nm);

--- a/src/hotspot/share/jvmci/vmStructs_jvmci.cpp
+++ b/src/hotspot/share/jvmci/vmStructs_jvmci.cpp
@@ -565,6 +565,10 @@
   declare_constant_with_value("OMCache::oop_to_oop_difference", OMCache::oop_to_oop_difference()) \
   declare_constant_with_value("OMCache::oop_to_monitor_difference", OMCache::oop_to_monitor_difference()) \
                                                                           \
+  declare_constant_with_value("nmethod::ChangeReason::GC_unlinking_cold", nmethod::ChangeReason::GC_unlinking_cold) \
+  declare_constant_with_value("nmethod::ChangeReason::JVMCI_new_installation", nmethod::ChangeReason::JVMCI_new_installation) \
+  declare_constant_with_value("nmethod::ChangeReason::JVMCI_invalidate_nmethod", nmethod::ChangeReason::JVMCI_invalidate_nmethod) \
+                                                                          \
   declare_constant(CodeInstaller::VERIFIED_ENTRY)                         \
   declare_constant(CodeInstaller::UNVERIFIED_ENTRY)                       \
   declare_constant(CodeInstaller::OSR_ENTRY)                              \

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/code/CodeCacheProvider.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/code/CodeCacheProvider.java
@@ -91,7 +91,7 @@ public interface CodeCacheProvider {
      * raised the next time {@code installedCode} is
      * {@linkplain InstalledCode#executeVarargs(Object...) executed}.
      */
-    void invalidateInstalledCode(InstalledCode installedCode);
+    void invalidateInstalledCode(InstalledCode installedCode, int changeReason);
 
     /**
      * Gets a name for a {@link Mark} mark.

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/code/InstalledCode.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/code/InstalledCode.java
@@ -47,6 +47,11 @@ public class InstalledCode {
     protected final String name;
 
     /**
+     * Identify the reason that caused this installed code to change.
+     */
+    protected int changeReason;
+
+    /**
      * The maximum length of an InstalledCode name. This name is typically installed into
      * the code cache so it should have a reasonable limit.
      */
@@ -119,6 +124,14 @@ public class InstalledCode {
         return address != 0;
     }
 
+    public int getChangeReason() {
+        return changeReason;
+    }
+
+    public String getChangeReasonDescription() {
+        return null;
+    }
+
     /**
      * Returns a copy of this installed code if it is {@linkplain #isValid() valid}, null otherwise.
      */
@@ -127,10 +140,10 @@ public class InstalledCode {
     }
 
     /**
-     * Equivalent to calling {@link #invalidate(boolean)} with a {@code true} argument.
+     * Equivalent to calling {@link #invalidate(boolean, int)} with {@code true} and {@code 0} as arguments.
      */
     public void invalidate() {
-        invalidate(true);
+        invalidate(true, 0);
     }
 
     /**
@@ -146,8 +159,9 @@ public class InstalledCode {
      *            If {@code false}, any existing invocation will continue until it completes or
      *            there is a subsequent call to this method with {@code deoptimize == true} before
      *            the invocation completes.
+     * @param changeReason an integer code representing the reason why this InstalledCode is being marked as invalidated.
      */
-    public void invalidate(boolean deoptimize) {
+    public void invalidate(boolean deoptimize, int statusReason) {
         throw new UnsupportedOperationException();
     }
 

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/CompilerToVM.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/CompilerToVM.java
@@ -654,6 +654,8 @@ final class CompilerToVM {
                     long failedSpeculationsAddress,
                     byte[] speculations);
 
+    native String getChangeReasonDescription(int changeReason);
+
     /**
      * Gets flags specifying optional parts of code info. Only if a flag is set, will the
      * corresponding code info being included in the {@linkplain HotSpotCompiledCodeStream
@@ -842,7 +844,7 @@ final class CompilerToVM {
      * {@code nmethod} associated with {@code nmethodMirror} is also made non-entrant and if
      * {@code deoptimize == true} any current activations of the {@code nmethod} are deoptimized.
      */
-    native void invalidateHotSpotNmethod(HotSpotNmethod nmethodMirror, boolean deoptimize);
+    native void invalidateHotSpotNmethod(HotSpotNmethod nmethodMirror, boolean deoptimize, int changeReason);
 
     /**
      * Collects the current values of all JVMCI benchmark counters, summed up over all threads.

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotCodeCacheProvider.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotCodeCacheProvider.java
@@ -155,10 +155,10 @@ public class HotSpotCodeCacheProvider implements CodeCacheProvider {
     }
 
     @Override
-    public void invalidateInstalledCode(InstalledCode installedCode) {
+    public void invalidateInstalledCode(InstalledCode installedCode, int changeReason) {
         if (installedCode instanceof HotSpotNmethod) {
             HotSpotNmethod nmethod = (HotSpotNmethod) installedCode;
-            nmethod.invalidate(true);
+            nmethod.invalidate(true, changeReason);
         } else {
             throw new IllegalArgumentException("Cannot invalidate a " + Objects.requireNonNull(installedCode).getClass().getName());
         }

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotInstalledCode.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotInstalledCode.java
@@ -82,4 +82,9 @@ public abstract class HotSpotInstalledCode extends InstalledCode {
     public byte[] getCode() {
         return compilerToVM().getCode(this);
     }
+
+    @Override
+    public String getChangeReasonDescription() {
+        return compilerToVM().getChangeReasonDescription(this.getChangeReason());
+    }
 }

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotNmethod.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotNmethod.java
@@ -123,8 +123,8 @@ public class HotSpotNmethod extends HotSpotInstalledCode {
     }
 
     @Override
-    public void invalidate(boolean deoptimize) {
-        compilerToVM().invalidateHotSpotNmethod(this, deoptimize);
+    public void invalidate(boolean deoptimize, int changeReason) {
+        compilerToVM().invalidateHotSpotNmethod(this, deoptimize, changeReason);
     }
 
     @Override

--- a/test/hotspot/jtreg/compiler/jvmci/common/patches/jdk.internal.vm.ci/jdk/vm/ci/hotspot/CompilerToVMHelper.java
+++ b/test/hotspot/jtreg/compiler/jvmci/common/patches/jdk.internal.vm.ci/jdk/vm/ci/hotspot/CompilerToVMHelper.java
@@ -229,8 +229,8 @@ public class CompilerToVMHelper {
         CTVM.reprofile((HotSpotResolvedJavaMethodImpl)method);
     }
 
-    public static void invalidateHotSpotNmethod(HotSpotNmethod nmethodMirror, boolean deoptimize) {
-        CTVM.invalidateHotSpotNmethod(nmethodMirror, deoptimize);
+    public static void invalidateHotSpotNmethod(HotSpotNmethod nmethodMirror, boolean deoptimize, int changeReason) {
+        CTVM.invalidateHotSpotNmethod(nmethodMirror, deoptimize, changeReason);
     }
 
     public static long[] collectCounters() {

--- a/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/TestHotSpotVMConfig.java
+++ b/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/TestHotSpotVMConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -54,6 +54,9 @@ public class TestHotSpotVMConfig extends HotSpotVMConfigAccess {
 
     public final int maxOopMapStackOffset = getFieldValue("CompilerToVM::Data::_max_oop_map_stack_offset", Integer.class, "int");
     public final int heapWordSize = getConstant("HeapWordSize", Integer.class);
+
+    public final int JVMCI_new_installation = getConstant("nmethod::ChangeReason::JVMCI_new_installation", Integer.class);
+    public final int JVMCI_invalidate_nmethod = getConstant("nmethod::ChangeReason::JVMCI_invalidate_nmethod", Integer.class);
 
     public final boolean ropProtection;
 


### PR DESCRIPTION
We recently introduced a way to set the reason why a nmethod was being marked as `not entrant`, see [here](https://github.com/openjdk/jdk/pull/23980) and [here](https://github.com/openjdk/jdk/pull/25338).

This PR is to expose in the JVMCI interface the reason why the nmethod was flagged as `not entrant`. This will allow JVMCI-based compilers to implement heuristics to handle re-compilations differently based on what happened to earlier versions of a method, for instance, this will likely be used to address this [RFE in Truffle](https://github.com/oracle/graal/issues/11045
). 

Tested on Linux x86_64, ARM with JTREG tier 1-3.