### PR TITLE
8358532: JFileChooser in GTK L&F still displays HTML filename

### DIFF
--- a/src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/GTKFileChooserUI.java
+++ b/src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/GTKFileChooserUI.java
@@ -1120,6 +1120,9 @@ class GTKFileChooserUI extends SynthFileChooserUI {
             if (showFileIcons) {
                 setIcon(getFileChooser().getIcon((File)value));
             }
+
+            putClientProperty("html.disable", getFileChooser().getClientProperty("html.disable"));
+
             return this;
         }
     }
@@ -1137,6 +1140,9 @@ class GTKFileChooserUI extends SynthFileChooserUI {
             } else {
                 setText(getFileChooser().getName((File)value) + "/");
             }
+
+            putClientProperty("html.disable", getFileChooser().getClientProperty("html.disable"));
+
             return this;
         }
     }

--- a/test/jdk/javax/swing/JFileChooser/HTMLFileName.java
+++ b/test/jdk/javax/swing/JFileChooser/HTMLFileName.java
@@ -41,7 +41,7 @@ import javax.swing.filechooser.FileSystemView;
 
 /*
  * @test id=system
- * @bug 8139228
+ * @bug 8139228 8358532
  * @summary JFileChooser should not render Directory names in HTML format
  * @library /java/awt/regtesthelpers
  * @build PassFailJFrame


### PR DESCRIPTION
[JDK-8139228](https://bugs.openjdk.org/browse/JDK-8139228) fix missed GTK updates for the same issue where file/directory name renders as `HTML text` instead of `plain text`.
Adding the same fix for GTK L&F.
Test for the fix : test/jdk/javax/swing/JFileChooser/HTMLFileName.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8358532](https://bugs.openjdk.org/browse/JDK-8358532): JFileChooser in GTK L&amp;F still displays HTML filename (**Bug** - P3)


### Reviewers
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Damon Nguyen](https://openjdk.org/census#dnguyen) (@DamonGuy - Committer)
 * [Alexander Zuev](https://openjdk.org/census#kizune) (@azuev-java - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25707/head:pull/25707` \
`$ git checkout pull/25707`

Update a local copy of the PR: \
`$ git checkout pull/25707` \
`$ git pull https://git.openjdk.org/jdk.git pull/25707/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25707`

View PR using the GUI difftool: \
`$ git pr show -t 25707`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25707.diff">https://git.openjdk.org/jdk/pull/25707.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25707#issuecomment-2957664791)
</details>
