### PR TITLE
8358815: Exception event spec has stale reference to catch_klass parameter

### DIFF
--- a/src/hotspot/share/prims/jvmti.xml
+++ b/src/hotspot/share/prims/jvmti.xml
@@ -12866,7 +12866,8 @@ myInit() {
       exception object. The <code>catch_method</code>
       and <code>catch_location</code> identify the location of the catch clause,
       if any, that handles the thrown exception. If there is no such catch clause,
-      the <code>catch_method</code> is set to null. There is no guarantee that the thread will ever
+      the <code>catch_method</code> is set to null and the <code>catch_location</code>is set to 0.
+      There is no guarantee that the thread will ever
       reach this catch clause. If there are native methods on the call stack
       between the throw location and the catch clause, the exception may
       be reset by one of those native methods.


### PR DESCRIPTION
The JVMTI Exception event callback spec refers to the `catch_klass` parameter which does not exist anymore. Instead the Exception event callback spec should refer to the `catch_method` and `catch_location` parameters.
I treat this as a bug and doubt we need a CSR for this issue.

Testing: N/A

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8358815](https://bugs.openjdk.org/browse/JDK-8358815): Exception event spec has stale reference to catch_klass parameter (**Bug** - P4)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25710/head:pull/25710` \
`$ git checkout pull/25710`

Update a local copy of the PR: \
`$ git checkout pull/25710` \
`$ git pull https://git.openjdk.org/jdk.git pull/25710/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25710`

View PR using the GUI difftool: \
`$ git pr show -t 25710`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25710.diff">https://git.openjdk.org/jdk/pull/25710.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25710#issuecomment-2957957141)
</details>
