### PR TITLE
8359083: Test jdkCheckHtml.java should report SkippedException rather than report fails when miss tidy

### DIFF
--- a/test/docs/jdk/javadoc/doccheck/DocCheck.java
+++ b/test/docs/jdk/javadoc/doccheck/DocCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -140,6 +140,9 @@ public class DocCheck extends TestRunner {
         var baseDir = DOCS_DIR.resolve(DIR);
         fileTester.processFiles(baseDir);
         files = fileTester.getFiles();
+        if (html) {
+            new TidyChecker();
+        }
     }
 
     public List<FileChecker> getCheckers() {

--- a/test/docs/jdk/javadoc/doccheck/checks/jdkCheckHtml.java
+++ b/test/docs/jdk/javadoc/doccheck/checks/jdkCheckHtml.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,6 @@
  * @bug 8337109
  * @summary Check the html in the generated documentation
  * @library /test/langtools/tools/lib ../../doccheck /test/lib ../../../../tools/tester
- * @build DocTester toolbox.TestRunner
+ * @build DocTester toolbox.TestRunner jtreg.SkippedException
  * @run main/othervm -Ddoccheck.checks=html DocCheck
  */

--- a/test/docs/jdk/javadoc/doccheck/doccheckutils/checkers/TidyChecker.java
+++ b/test/docs/jdk/javadoc/doccheck/doccheckutils/checkers/TidyChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,6 +38,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import jtreg.SkippedException;
 
 public class TidyChecker implements FileChecker, AutoCloseable {
     private final Path TIDY;
@@ -164,8 +165,7 @@ public class TidyChecker implements FileChecker, AutoCloseable {
             if (p.isPresent()) {
                 tidyExePath = p.get();
             } else {
-                System.err.println("tidy not found on PATH");
-                return Path.of("tidy"); //non-null placeholder return; exception would be better
+                throw new jtreg.SkippedException("tidy not found on PATH");
             }
         }
 


### PR DESCRIPTION
Hi all,

When there is no `tidy` command in PATH, the test test/docs/jdk/javadoc/doccheck/checks/jdkCheckHtml.java report failure, I think it shoule be report jtreg.SkippedException rather than report test failure.
In file test/docs/jdk/javadoc/doccheck/DocCheck.java, we need to call the `new TidyChecker()` before executing the test so that the `jtreg.SkippedException` exception can be thrown normally, that's why I add `new TidyChecker()` in `init()` function.

Change has been verified locally, only the test test/docs/jdk/javadoc/doccheck/checks/jdkCheckHtml.java observed this failure, test-fix only, no risk.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8359083](https://bugs.openjdk.org/browse/JDK-8359083): Test jdkCheckHtml.java should report SkippedException rather than report fails when miss tidy (**Bug** - P4)


### Reviewers
 * [Hannes Wallnöfer](https://openjdk.org/census#hannesw) (@hns - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25711/head:pull/25711` \
`$ git checkout pull/25711`

Update a local copy of the PR: \
`$ git checkout pull/25711` \
`$ git pull https://git.openjdk.org/jdk.git pull/25711/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25711`

View PR using the GUI difftool: \
`$ git pr show -t 25711`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25711.diff">https://git.openjdk.org/jdk/pull/25711.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25711#issuecomment-2957979971)
</details>
