### PR TITLE
8345292: Improve javadocs for MemorySegment::getStrings defining word boundary cases

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
@@ -407,6 +407,21 @@ import java.util.stream.Stream;
  * MemorySegment segment = ...
  * boolean isAligned = segment.maxByteAlignment() >= layout.byteAlignment();
  * }
+ * <h2 id="string-conversion">String conversion</h2>
+ * All methods involving conversion to or from Strings (such as
+ * {@linkplain #setString(long, String, Charset)} and
+ * {@linkplain #getString(long, Charset)}) are restricted to the
+ * {@linkplain StandardCharsets standard charsets}, all of which encodes bytes that are
+ * {@code N}-aligned (including the string terminator). Hence, every character in the
+ * segment (including the terminator) will be at an {@code N}-aligned offset counted from
+ * the beginning where conversion is about to begin. For example:
+ * <ul>
+ *     <li>{@code N}=1 for {@link StandardCharsets#UTF_8} (e.g., A BBB C DD 0)</li>
+ *     <li>{@code N}=2 for {@link StandardCharsets#UTF_16} (e.g., AA BBBB CC DDDD 00)</li>
+ *     <li>{@code N}=4 for {@link StandardCharsets#UTF_32} (e.g., AAAA BBBB CCCC DDDD 0000)</li>
+ * </ul>
+ * Note: UTF_8 and UFT_16 are using a variable-length encoder whereas UTF_32 is using
+ *       a constant-length encoder.
  *
  * <h2 id="wrapping-addresses">Zero-length memory segments</h2>
  *
@@ -1295,14 +1310,6 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      * java.nio.charset.CharsetDecoder} class should be used when more control
      * over the decoding process is required.
      * <p>
-     * All valid {@linkplain Charset Charsets} decode strings using chunks of a fixed
-     * octet length N. For example:
-     * <ul>
-     *     <li>N=1 for {@link StandardCharsets#UTF_8} (A B C D 0)</li>
-     *     <li>N=2 for {@link StandardCharsets#UTF_16} (AA BB CC DD 00)</li>
-     *     <li>N=4 for {@link StandardCharsets#UTF_16} (AAAA BBBB CCCC DDDD 0000)</li>
-     *</ul>
-     * <p>
      * Getting a string from a segment with a known byte offset and
      * known byte length can be done like so:
      * {@snippet lang=java :
@@ -1315,7 +1322,8 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      *                access operation will occur
      * @param charset the charset used to {@linkplain Charset#newDecoder() decode} the
      *                string bytes. The {@code charset} must be a
-     *                {@linkplain StandardCharsets standard charset}
+     *                {@linkplain StandardCharsets standard charset} as described
+     *                in the {@link ##string-conversion String conversion} section
      * @return a Java string constructed from the bytes read from the given starting
      *         address up to (but not including) the first {@code '\0'} terminator
      *         character (assuming one is found)
@@ -1382,7 +1390,8 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      * @param str     the Java string to be written into this segment
      * @param charset the charset used to {@linkplain Charset#newEncoder() encode} the
      *                string bytes. The {@code charset} must be a
-     *                {@linkplain StandardCharsets standard charset}
+     *                {@linkplain StandardCharsets standard charset} as described
+     *                in the {@link ##string-conversion String conversion} section
      * @throws IndexOutOfBoundsException if {@code offset < 0}
      * @throws IndexOutOfBoundsException if {@code offset > byteSize() - (B + N)}, where:
      *         <ul>


### PR DESCRIPTION
This PR proposes to improve the 'MemorySegment.getString(long offset, Charset charset)` method documentation with respect to multi-octet concerns.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345292](https://bugs.openjdk.org/browse/JDK-8345292): Improve javadocs for MemorySegment::getStrings defining word boundary cases (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25715/head:pull/25715` \
`$ git checkout pull/25715`

Update a local copy of the PR: \
`$ git checkout pull/25715` \
`$ git pull https://git.openjdk.org/jdk.git pull/25715/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25715`

View PR using the GUI difftool: \
`$ git pr show -t 25715`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25715.diff">https://git.openjdk.org/jdk/pull/25715.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25715#issuecomment-2958295930)
</details>
