### PR TITLE
8359024: Accessibility bugs in API documentation

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/Table.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/Table.java
@@ -385,12 +385,12 @@ public class Table<T> extends Content {
             table.add(getTableBody());
             main.add(table);
         } else {
-            var tablist = HtmlTree.DIV(HtmlStyles.tableTabs)
-                    .put(HtmlAttr.ROLE, "tablist")
-                    .put(HtmlAttr.ARIA_ORIENTATION, "horizontal");
+            var tablist = HtmlTree.DIV(HtmlStyles.tableTabs);
 
             HtmlId defaultTabId = HtmlIds.forTab(id, 0);
             if (renderTabs) {
+                tablist.put(HtmlAttr.ROLE, "tablist")
+                       .put(HtmlAttr.ARIA_ORIENTATION, "horizontal");
                 tablist.add(createTab(defaultTabId, HtmlStyles.activeTableTab, true, defaultTab));
                 for (var tab : tabs) {
                     if (occurringTabs.contains(tab)) {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/stylesheet.css
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/stylesheet.css
@@ -29,8 +29,8 @@
     --block-line-height: 1.5;
     --code-line-height: 1.6;
     /* Text colors for body and block elements */
-    --body-text-color: #282828;
-    --block-text-color: #282828;
+    --body-text-color: #181818;
+    --block-text-color: #181818;
     /* Background colors for various elements */
     --body-background-color: #ffffff;
     --section-background-color: var(--body-background-color);
@@ -656,14 +656,14 @@ ul.preview-feature-list input {
 .class-use-page .caption span,
 .package-use-page .caption span,
 .constants-summary-page .caption span,
-.inherited-list.expanded h3 {
+.inherited-list h3 {
     background-color: var(--subnav-background-color);
     color: var(--block-text-color);
 }
 .caption a:link,
 .caption a:visited,
-.inherited-list.expanded h3 a:link,
-.inherited-list.expanded h3 a:visited {
+.inherited-list h3 a:link,
+.inherited-list h3 a:visited {
     color:var(--subnav-link-color);
 }
 div.table-tabs {

--- a/test/langtools/jdk/javadoc/doclet/testNewApiList/TestNewApiList.java
+++ b/test/langtools/jdk/javadoc/doclet/testNewApiList/TestNewApiList.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug      8263468 8269401 8268422 8287524 8325874 8331873 8345555
+ * @bug      8263468 8269401 8268422 8287524 8325874 8331873 8345555 8359024
  * @summary  New page for "recent" new API
  * @library  ../../lib
  * @modules  jdk.javadoc/jdk.javadoc.internal.tool
@@ -126,7 +126,7 @@ public class TestNewApiList extends JavadocTester {
         checkOutput("new-list.html", true,
             """
                 <div id="module">
-                <div class="table-tabs" role="tablist" aria-orientation="horizontal">
+                <div class="table-tabs">
                 <div class="caption"><span>New Modules</span></div>
                 </div>
                 <div id="module.tabpanel" role="tabpanel" aria-labelledby="module-tab0">
@@ -142,7 +142,7 @@ public class TestNewApiList extends JavadocTester {
                 </div>""",
             """
                 <div id="package">
-                <div class="table-tabs" role="tablist" aria-orientation="horizontal">
+                <div class="table-tabs">
                 <div class="caption"><span>New Packages</span></div>
                 </div>
                 <div id="package.tabpanel" role="tabpanel" aria-labelledby="package-tab0">
@@ -158,7 +158,7 @@ public class TestNewApiList extends JavadocTester {
                 </div>""",
             """
                 <div id="interface">
-                <div class="table-tabs" role="tablist" aria-orientation="horizontal">
+                <div class="table-tabs">
                 <div class="caption"><span>New Interfaces</span></div>
                 </div>
                 <div id="interface.tabpanel" role="tabpanel" aria-labelledby="interface-tab0">
@@ -174,7 +174,7 @@ public class TestNewApiList extends JavadocTester {
                 </div>""",
             """
                 <div id="class">
-                <div class="table-tabs" role="tablist" aria-orientation="horizontal">
+                <div class="table-tabs">
                 <div class="caption"><span>New Classes</span></div>
                 </div>
                 <div id="class.tabpanel" role="tabpanel" aria-labelledby="class-tab0">
@@ -190,7 +190,7 @@ public class TestNewApiList extends JavadocTester {
                 </div>""",
             """
                 <div id="enum-class">
-                <div class="table-tabs" role="tablist" aria-orientation="horizontal">
+                <div class="table-tabs">
                 <div class="caption"><span>New Enum Classes</span></div>
                 </div>
                 <div id="enum-class.tabpanel" role="tabpanel" aria-labelledby="enum-class-tab0">
@@ -206,7 +206,7 @@ public class TestNewApiList extends JavadocTester {
                 </div>""",
             """
                 <div id="exception-class">
-                <div class="table-tabs" role="tablist" aria-orientation="horizontal">
+                <div class="table-tabs">
                 <div class="caption"><span>New Exception Classes</span></div>
                 </div>
                 <div id="exception-class.tabpanel" role="tabpanel" aria-labelledby="exception-class-tab0">
@@ -228,7 +228,7 @@ public class TestNewApiList extends JavadocTester {
                 </div>""",
             """
                 <div id="record-class">
-                <div class="table-tabs" role="tablist" aria-orientation="horizontal">
+                <div class="table-tabs">
                 <div class="caption"><span>New Record Classes</span></div>
                 </div>
                 <div id="record-class.tabpanel" role="tabpanel" aria-labelledby="record-class-tab0">
@@ -244,7 +244,7 @@ public class TestNewApiList extends JavadocTester {
                 </div>""",
             """
                 <div id="annotation-interface">
-                <div class="table-tabs" role="tablist" aria-orientation="horizontal">
+                <div class="table-tabs">
                 <div class="caption"><span>New Annotation Interfaces</span></div>
                 </div>
                 <div id="annotation-interface.tabpanel" role="tabpanel" aria-labelledby="annotation-interface-tab0">
@@ -259,7 +259,7 @@ public class TestNewApiList extends JavadocTester {
                 </div>""",
             """
                 <div id="field">
-                <div class="table-tabs" role="tablist" aria-orientation="horizontal">
+                <div class="table-tabs">
                 <div class="caption"><span>New Fields</span></div>
                 </div>
                 <div id="field.tabpanel" role="tabpanel" aria-labelledby="field-tab0">
@@ -293,7 +293,7 @@ public class TestNewApiList extends JavadocTester {
                 </div>""",
             """
                 <div id="method">
-                <div class="table-tabs" role="tablist" aria-orientation="horizontal">
+                <div class="table-tabs">
                 <div class="caption"><span>New Methods</span></div>
                 </div>
                 <div id="method.tabpanel" role="tabpanel" aria-labelledby="method-tab0">
@@ -359,7 +359,7 @@ public class TestNewApiList extends JavadocTester {
                 </div>""",
             """
                 <div id="constructor">
-                <div class="table-tabs" role="tablist" aria-orientation="horizontal">
+                <div class="table-tabs">
                 <div class="caption"><span>New Constructors</span></div>
                 </div>
                 <div id="constructor.tabpanel" role="tabpanel" aria-labelledby="constructor-tab0">
@@ -394,7 +394,7 @@ public class TestNewApiList extends JavadocTester {
                 </div>""",
             """
                 <div id="enum-constant">
-                <div class="table-tabs" role="tablist" aria-orientation="horizontal">
+                <div class="table-tabs">
                 <div class="caption"><span>New Enum Constants</span></div>
                 </div>
                 <div id="enum-constant.tabpanel" role="tabpanel" aria-labelledby="enum-constant-tab0">
@@ -428,7 +428,7 @@ public class TestNewApiList extends JavadocTester {
                 </div>""",
             """
                 <div id="annotation-interface-member">
-                <div class="table-tabs" role="tablist" aria-orientation="horizontal">
+                <div class="table-tabs">
                 <div class="caption"><span>New Annotation Interface Elements</span></div>
                 </div>
                 <div id="annotation-interface-member.tabpanel" role="tabpanel" aria-labelledby="annotation-interface-member-tab0">
@@ -456,7 +456,7 @@ public class TestNewApiList extends JavadocTester {
         checkOutput("deprecated-list.html", true,
             """
                 <div id="for-removal">
-                <div class="table-tabs" role="tablist" aria-orientation="horizontal">
+                <div class="table-tabs">
                 <div class="caption"><span>Terminally Deprecated Elements</span></div>
                 </div>
                 <div id="for-removal.tabpanel" role="tabpanel" aria-labelledby="for-removal-tab0">
@@ -471,7 +471,7 @@ public class TestNewApiList extends JavadocTester {
                 </div>""",
             """
                 <div id="method">
-                <div class="table-tabs" role="tablist" aria-orientation="horizontal">
+                <div class="table-tabs">
                 <div class="caption"><span>Deprecated Methods</span></div>
                 </div>
                 <div id="method.tabpanel" role="tabpanel" aria-labelledby="method-tab0">
@@ -486,7 +486,7 @@ public class TestNewApiList extends JavadocTester {
                 </div>""",
             """
                 <div id="constructor">
-                <div class="table-tabs" role="tablist" aria-orientation="horizontal">
+                <div class="table-tabs">
                 <div class="caption"><span>Deprecated Constructors</span></div>
                 </div>
                 <div id="constructor.tabpanel" role="tabpanel" aria-labelledby="constructor-tab0">
@@ -501,7 +501,7 @@ public class TestNewApiList extends JavadocTester {
                 </div>""",
             """
                 <div id="enum-constant">
-                <div class="table-tabs" role="tablist" aria-orientation="horizontal">
+                <div class="table-tabs">
                 <div class="caption"><span>Deprecated Enum Constants</span></div>
                 </div>
                 <div id="enum-constant.tabpanel" role="tabpanel" aria-labelledby="enum-constant-tab0">
@@ -516,7 +516,7 @@ public class TestNewApiList extends JavadocTester {
                 </div>""",
             """
                 <div id="annotation-interface-member">
-                <div class="table-tabs" role="tablist" aria-orientation="horizontal">
+                <div class="table-tabs">
                 <div class="caption"><span>Deprecated Annotation Interface Elements</span></div>
                 </div>
                 <div id="annotation-interface-member.tabpanel" role="tabpanel" aria-labelledby="annotation-interface-member-tab0">
@@ -606,7 +606,7 @@ public class TestNewApiList extends JavadocTester {
                 </ul>""",
             """
                 <div id="for-removal">
-                <div class="table-tabs" role="tablist" aria-orientation="horizontal">
+                <div class="table-tabs">
                 <div class="caption"><span>Terminally Deprecated Elements</span></div>
                 </div>
                 <div id="for-removal.tabpanel" role="tabpanel" aria-labelledby="for-removal-tab0">
@@ -621,7 +621,7 @@ public class TestNewApiList extends JavadocTester {
                 </div>""",
             """
                 <div id="method">
-                <div class="table-tabs" role="tablist" aria-orientation="horizontal">
+                <div class="table-tabs">
                 <div class="caption"><span>Deprecated Methods</span></div>
                 </div>
                 <div id="method.tabpanel" role="tabpanel" aria-labelledby="method-tab0">
@@ -636,7 +636,7 @@ public class TestNewApiList extends JavadocTester {
                 </div>""",
             """
                 <div id="constructor">
-                <div class="table-tabs" role="tablist" aria-orientation="horizontal">
+                <div class="table-tabs">
                 <div class="caption"><span>Deprecated Constructors</span></div>
                 </div>
                 <div id="constructor.tabpanel" role="tabpanel" aria-labelledby="constructor-tab0">
@@ -680,7 +680,7 @@ public class TestNewApiList extends JavadocTester {
         checkOutput("new-list.html", true,
             """
                 <div id="class">
-                <div class="table-tabs" role="tablist" aria-orientation="horizontal">
+                <div class="table-tabs">
                 <div class="caption"><span>New Classes</span></div>
                 </div>
                 <div id="class.tabpanel" role="tabpanel" aria-labelledby="class-tab0">
@@ -696,7 +696,7 @@ public class TestNewApiList extends JavadocTester {
                 </div>""",
             """
                 <div id="field">
-                <div class="table-tabs" role="tablist" aria-orientation="horizontal">
+                <div class="table-tabs">
                 <div class="caption"><span>New Fields</span></div>
                 </div>
                 <div id="field.tabpanel" role="tabpanel" aria-labelledby="field-tab0">
@@ -712,7 +712,7 @@ public class TestNewApiList extends JavadocTester {
                 </div>""",
             """
                 <div id="method">
-                <div class="table-tabs" role="tablist" aria-orientation="horizontal">
+                <div class="table-tabs">
                 <div class="caption"><span>New Methods</span></div>
                 </div>
                 <div id="method.tabpanel" role="tabpanel" aria-labelledby="method-tab0">
@@ -741,7 +741,7 @@ public class TestNewApiList extends JavadocTester {
                 </div>""",
             """
                 <div id="constructor">
-                <div class="table-tabs" role="tablist" aria-orientation="horizontal">
+                <div class="table-tabs">
                 <div class="caption"><span>New Constructors</span></div>
                 </div>
                 <div id="constructor.tabpanel" role="tabpanel" aria-labelledby="constructor-tab0">

--- a/test/langtools/jdk/javadoc/doclet/testPreview/TestPreview.java
+++ b/test/langtools/jdk/javadoc/doclet/testPreview/TestPreview.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug      8250768 8261976 8277300 8282452 8287597 8325325 8325874 8297879
- *           8331947 8281533 8343239 8318416 8346109
+ *           8331947 8281533 8343239 8318416 8346109 8359024
  * @summary  test generated docs for items declared using preview
  * @library  /tools/lib ../../lib
  * @modules jdk.javadoc/jdk.javadoc.internal.tool
@@ -104,7 +104,7 @@ public class TestPreview extends JavadocTester {
                     """,
                 """
                     <div id="package">
-                    <div class="table-tabs" role="tablist" aria-orientation="horizontal">
+                    <div class="table-tabs">
                     <div class="caption"><span>Packages</span></div>
                     </div>
                     <div id="package.tabpanel" role="tabpanel" aria-labelledby="package-tab0">
@@ -122,7 +122,7 @@ public class TestPreview extends JavadocTester {
                     """,
                 """
                     <div id="record-class">
-                    <div class="table-tabs" role="tablist" aria-orientation="horizontal">
+                    <div class="table-tabs">
                     <div class="caption"><span>Record Classes</span></div>
                     </div>
                     <div id="record-class.tabpanel" role="tabpanel" aria-labelledby="record-class-tab0">
@@ -139,7 +139,7 @@ public class TestPreview extends JavadocTester {
                     """,
                 """
                     <div id="method">
-                    <div class="table-tabs" role="tablist" aria-orientation="horizontal">
+                    <div class="table-tabs">
                     <div class="caption"><span>Methods</span></div>
                     </div>
                     <div id="method.tabpanel" role="tabpanel" aria-labelledby="method-tab0">


### PR DESCRIPTION
Please review a change to fix a couple of accessibility errors in JDK API documentation as detected by our accessibility testing. 

 - Contrast between link and normal text colors was below 3 and therefore would have required other styling (such as underlining). This is fixed by slightly darkening text color (our text color isn't black but dark-gray).
    Old colors: https://webaim.org/resources/linkcontrastchecker/?fcolor=282828&bcolor=FFFFFF&lcolor=437291
    New colors: https://webaim.org/resources/linkcontrastchecker/?fcolor=181818&bcolor=FFFFFF&lcolor=437291

 - Links in the headings of inherited member summaries used the wrong color and contrast to background color was below 4.5. This is fixed by removing a bogus `.expanded` selector that shouldn't have been there in the first place.
    Old colors: https://webaim.org/resources/linkcontrastchecker/?fcolor=181818&bcolor=DEE3E9&lcolor=437291
    New colors: https://webaim.org/resources/linkcontrastchecker/?fcolor=181818&bcolor=DEE3E9&lcolor=47688A

- Remove the `role="tablist"` and `aria-orientation="horizontal"` attributes from table captions if they do not contain tabs. This is the only code change, and the only change that comes with a test change (I guess the CSS changes are `noreg-hard` as we don't have a way to do automatic accessibility testing).

All changes are invisible or so subtle that they are practically impossible to spot in normal browsing, so I spare myself the task of uploading demo docs.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8359024](https://bugs.openjdk.org/browse/JDK-8359024): Accessibility bugs in API documentation (**Bug** - P3)


### Reviewers
 * [Volkan Yazici](https://openjdk.org/census#vyazici) (@vy - Committer)
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25716/head:pull/25716` \
`$ git checkout pull/25716`

Update a local copy of the PR: \
`$ git checkout pull/25716` \
`$ git pull https://git.openjdk.org/jdk.git pull/25716/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25716`

View PR using the GUI difftool: \
`$ git pr show -t 25716`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25716.diff">https://git.openjdk.org/jdk/pull/25716.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25716#issuecomment-2958522102)
</details>
