### PR TITLE
8359114: [s390x] Add z17 detection code

### DIFF
--- a/src/hotspot/cpu/s390/vm_version_s390.cpp
+++ b/src/hotspot/cpu/s390/vm_version_s390.cpp
@@ -68,12 +68,13 @@ unsigned int  VM_Version::_Icache_lineSize                             = DEFAULT
 //   z14:  2017-09
 //   z15:  2019-09
 //   z16:  2022-05
+//   z17:  2025-04
 
-static const char* z_gen[]      = {"  ", "G1",         "G2",         "G3",         "G4",         "G5",         "G6",         "G7",         "G8",         "G9",         "G10" };
-static const char* z_machine[]  = {"  ", "2064",       "2084",       "2094",       "2097",       "2817",       "2827",       "2964",       "3906",       "8561",       "3931" };
-static const char* z_name[]     = {"  ", "z900",       "z990",       "z9 EC",      "z10 EC",     "z196 EC",    "ec12",       "z13",        "z14",        "z15",        "z16" };
-static const char* z_WDFM[]     = {"  ", "2006-06-30", "2008-06-30", "2010-06-30", "2012-06-30", "2014-06-30", "2016-12-31", "2019-06-30", "2021-06-30", "2024-12-31", "tbd" };
-static const char* z_EOS[]      = {"  ", "2014-12-31", "2014-12-31", "2017-10-31", "2019-12-31", "2021-12-31", "2023-12-31", "2024-12-31", "tbd",        "tbd",        "tbd" };
+static const char* z_gen[]      = {"  ", "G1",         "G2",         "G3",         "G4",         "G5",         "G6",         "G7",         "G8",         "G9",         "G10",         "G11" };
+static const char* z_machine[]  = {"  ", "2064",       "2084",       "2094",       "2097",       "2817",       "2827",       "2964",       "3906",       "8561",       "3931",        "9175" };
+static const char* z_name[]     = {"  ", "z900",       "z990",       "z9 EC",      "z10 EC",     "z196 EC",    "ec12",       "z13",        "z14",        "z15",        "z16",         "z17" };
+static const char* z_WDFM[]     = {"  ", "2006-06-30", "2008-06-30", "2010-06-30", "2012-06-30", "2014-06-30", "2016-12-31", "2019-06-30", "2021-06-30", "2024-12-31", "tbd",         "tbd" };
+static const char* z_EOS[]      = {"  ", "2014-12-31", "2014-12-31", "2017-10-31", "2019-12-31", "2021-12-31", "2023-12-31", "2024-12-31", "tbd",        "tbd",        "tbd",         "tbd" };
 static const char* z_features[] = {"  ",
                                    "system-z, g1-z900, ldisp",
                                    "system-z, g2-z990, ldisp_fast",
@@ -85,7 +86,9 @@ static const char* z_features[] = {"  ",
                                    "system-z, g8-z14, ldisp_fast, extimm, pcrel_load/store, cmpb, cond_load/store, interlocked_update, txm, vectorinstr, instrext2, venh1",
                                    "system-z, g9-z15, ldisp_fast, extimm, pcrel_load/store, cmpb, cond_load/store, interlocked_update, txm, vectorinstr, instrext2, venh1, instrext3, venh2",
                                    "system-z, g10-z16, ldisp_fast, extimm, pcrel_load/store, cmpb, cond_load/store, interlocked_update, txm, vectorinstr, instrext2, venh1, instrext3, venh2,"
-                                       "bear_enh, sort_enh, nnpa_assist, storage_key_removal, vpack_decimal_enh"
+                                       "bear_enh, sort_enh, nnpa_assist, storage_key_removal, vpack_decimal_enh",
+                                   "system-z, g11-z17, ldisp_fast, extimm, pcrel_load/store, cmpb, cond_load/store, interlocked_update, txm, vectorinstr, instrext2, venh1, instrext3, venh2,"
+                                       "bear_enh, sort_enh, nnpa_assist, storage_key_removal, vpack_decimal_enh, concurrent_function"
                                   };
 
 void VM_Version::initialize() {
@@ -339,6 +342,11 @@ int VM_Version::get_model_index() {
   //      is the index of the oldest detected model.
   int ambiguity = 0;
   int model_ix  = 0;
+  if (is_z17()) {
+    model_ix = 11;
+    ambiguity++;
+  }
+
   if (is_z16()) {
     model_ix = 10;
     ambiguity++;

--- a/src/hotspot/cpu/s390/vm_version_s390.hpp
+++ b/src/hotspot/cpu/s390/vm_version_s390.hpp
@@ -121,6 +121,7 @@ class VM_Version: public Abstract_VM_Version {
 // --- FeatureBitString Bits 193..200 (DW[3]) ---
 // ----------------------------------------------
 #define  BEAREnhFacilityMask            0x4000000000000000UL  // z16, BEAR-enhancement facility, Bit: 193
+#define  ConcurrentFunFacilityMask      0x0040000000000000UL  // z17, Concurrent-functions facility, Bit: 201
 
   enum {
     _max_cache_levels = 8,    // As limited by ECAG instruction.
@@ -189,7 +190,8 @@ class VM_Version: public Abstract_VM_Version {
   static bool is_z13()  { return has_CryptoExt5()             && !has_MiscInstrExt2(); }
   static bool is_z14()  { return has_MiscInstrExt2()          && !has_MiscInstrExt3(); }
   static bool is_z15()  { return has_MiscInstrExt3()          && !has_BEAR_Enh_Facility(); }
-  static bool is_z16()  { return has_BEAR_Enh_Facility(); }
+  static bool is_z16()  { return has_BEAR_Enh_Facility()      && !has_Concurrent_Fun_Facility(); }
+  static bool is_z17()  { return has_Concurrent_Fun_Facility();}
 
   // Need to use nested class with unscoped enum.
   // C++11 declaration "enum class Cipher { ... } is not supported.
@@ -497,6 +499,7 @@ class VM_Version: public Abstract_VM_Version {
 
   static bool has_BEAR_Enh_Facility()         { return  (_features[3] & BEAREnhFacilityMask)           == BEAREnhFacilityMask; }
   static bool has_NNP_Assist_Facility()       { return  (_features[2] & NNPAssistFacilityMask)         == NNPAssistFacilityMask; }
+  static bool has_Concurrent_Fun_Facility()   { return  (_features[3] & ConcurrentFunFacilityMask)     == ConcurrentFunFacilityMask; }
 
   // Crypto features query functions.
   static bool has_Crypto_AES_GCM128()         { return has_Crypto() && test_feature_bit(&_cipher_features_KMA[0], Cipher::_AES128, Cipher::_featureBits); }
@@ -573,6 +576,7 @@ class VM_Version: public Abstract_VM_Version {
   static void set_has_VectorPackedDecimalEnh()    { _features[2] |= VectorPackedDecimalEnhMask; }
   static void set_has_BEAR_Enh_Facility()         { _features[3] |= BEAREnhFacilityMask;}
   static void set_has_NNP_Assist_Facility()       { _features[2] |= NNPAssistFacilityMask;}
+  static void set_has_Concurrent_Fun_Facility()   { _features[3] |= ConcurrentFunFacilityMask;}
 
   static void reset_has_VectorFacility()          { _features[2] &= ~VectorFacilityMask; }
 

--- a/src/hotspot/cpu/s390/vm_version_s390.hpp
+++ b/src/hotspot/cpu/s390/vm_version_s390.hpp
@@ -100,7 +100,7 @@ class VM_Version: public Abstract_VM_Version {
 #define  CryptoExtension4Mask           0x0004000000000000UL  // z196 (aka message-security assist extension 4, for KMF, KMCTR, KMO)
 #define  DFPPackedConversionMask        0x0000800000000000UL  // z13
 // ----------------------------------------------
-// --- FeatureBitString Bits 128..192 (DW[2]) ---
+// --- FeatureBitString Bits 128..191 (DW[2]) ---
 // ----------------------------------------------
 //                                        11111111111111111
 //                                        23344455666778889
@@ -118,7 +118,7 @@ class VM_Version: public Abstract_VM_Version {
 #define NNPAssistFacilityMask           0x0000000004000000UL  // z16, Neural-network-processing-assist facility, Bit: 165
 
 // ----------------------------------------------
-// --- FeatureBitString Bits 193..200 (DW[3]) ---
+// --- FeatureBitString Bits 192..255 (DW[3]) ---
 // ----------------------------------------------
 #define  BEAREnhFacilityMask            0x4000000000000000UL  // z16, BEAR-enhancement facility, Bit: 193
 #define  ConcurrentFunFacilityMask      0x0040000000000000UL  // z17, Concurrent-functions facility, Bit: 201


### PR DESCRIPTION
Add support to detect the new generation of Z machine (z17).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8359114](https://bugs.openjdk.org/browse/JDK-8359114): [s390x] Add z17 detection code (**Enhancement** - P4)


### Reviewers
 * [Amit Kumar](https://openjdk.org/census#amitkumar) (@offamitkumar - Committer)
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25718/head:pull/25718` \
`$ git checkout pull/25718`

Update a local copy of the PR: \
`$ git checkout pull/25718` \
`$ git pull https://git.openjdk.org/jdk.git pull/25718/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25718`

View PR using the GUI difftool: \
`$ git pr show -t 25718`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25718.diff">https://git.openjdk.org/jdk/pull/25718.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25718#issuecomment-2959165962)
</details>
