### PR TITLE
8357662: applications/runthese/RunThese8H.java Crash: 'Failed to uncommit metaspace'

### DIFF
--- a/src/hotspot/share/memory/metaspace/virtualSpaceNode.cpp
+++ b/src/hotspot/share/memory/metaspace/virtualSpaceNode.cpp
@@ -190,7 +190,8 @@ void VirtualSpaceNode::uncommit_range(MetaWord* p, size_t word_size) {
   // Uncommit...
   if (os::uncommit_memory((char*)p, word_size * BytesPerWord) == false) {
     // Note: this can actually happen, since uncommit may increase the number of mappings.
-    fatal("Failed to uncommit metaspace.");
+    UL(warning, "Failed to uncommit metaspace.");
+    return;
   }
 
   UL2(debug, "... uncommitted %zu words.", committed_words_in_range);


### PR DESCRIPTION
Make the fatal error a log warning and return. The metaspace commit accounting is done after this return.  Tested with this always returning here, and it seems okay.  Tested with this change tier 1-4 and 8.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8357662](https://bugs.openjdk.org/browse/JDK-8357662): applications/runthese/RunThese8H.java Crash: 'Failed to uncommit metaspace' (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25720/head:pull/25720` \
`$ git checkout pull/25720`

Update a local copy of the PR: \
`$ git checkout pull/25720` \
`$ git pull https://git.openjdk.org/jdk.git pull/25720/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25720`

View PR using the GUI difftool: \
`$ git pr show -t 25720`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25720.diff">https://git.openjdk.org/jdk/pull/25720.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25720#issuecomment-2959140978)
</details>
