### PR TITLE
8314180: Disable XPath in XML Signatures

### DIFF
--- a/src/java.base/share/conf/security/java.security
+++ b/src/java.base/share/conf/security/java.security
@@ -1012,6 +1012,7 @@ jdk.xml.dsig.secureValidationPolicy=\
     disallowAlg http://www.w3.org/2000/09/xmldsig#rsa-sha1,\
     disallowAlg http://www.w3.org/2007/05/xmldsig-more#sha1-rsa-MGF1,\
     disallowAlg http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha1,\
+    disallowAlg http://www.w3.org/TR/1999/REC-xpath-19991116,\
     maxTransforms 5,\
     maxReferences 30,\
     disallowReferenceUriSchemes file http https,\

--- a/test/jdk/javax/xml/crypto/dsig/GenerationTests.java
+++ b/test/jdk/javax/xml/crypto/dsig/GenerationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -286,8 +286,8 @@ public class GenerationTests {
     private static boolean result = true;
 
     public static void main(String args[]) throws Exception {
-        // Re-enable sha1 algs
-        SecurityUtils.removeAlgsFromDSigPolicy("sha1");
+        // Re-enable sha1 and xpath algs
+        SecurityUtils.removeAlgsFromDSigPolicy("sha1", "xpath");
 
         setup();
         test_context_iterator();

--- a/test/jdk/javax/xml/crypto/dsig/HereFunction.java
+++ b/test/jdk/javax/xml/crypto/dsig/HereFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -85,8 +85,8 @@ public class HereFunction {
         if (!args[0].equals("default")) {
             Security.setProperty("jdk.xml.dsig.hereFunctionSupported", args[0]);
         }
-        // Re-enable sha1 algs
-        SecurityUtils.removeAlgsFromDSigPolicy("sha1");
+        // Re-enable sha1 and xpath algs
+        SecurityUtils.removeAlgsFromDSigPolicy("sha1", "xpath");
 
         boolean expected = Boolean.parseBoolean(args[1]);
 

--- a/test/jdk/javax/xml/crypto/dsig/SecureValidationPolicy.java
+++ b/test/jdk/javax/xml/crypto/dsig/SecureValidationPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /**
  * @test
- * @bug 8151893 8259709
+ * @bug 8151893 8259709 8314180
  * @summary Tests for the jdk.xml.dsig.secureValidationPolicy security property
  * @modules java.xml.crypto/org.jcp.xml.dsig.internal.dom
  */
@@ -47,7 +47,8 @@ public class SecureValidationPolicy {
             "http://www.w3.org/2000/09/xmldsig#dsa-sha1",
             "http://www.w3.org/2000/09/xmldsig#rsa-sha1",
             "http://www.w3.org/2007/05/xmldsig-more#sha1-rsa-MGF1",
-            "http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha1");
+            "http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha1",
+            "http://www.w3.org/TR/1999/REC-xpath-19991116");
 
         // Test expected defaults
         System.out.println("Testing defaults");

--- a/test/jdk/javax/xml/crypto/dsig/ValidationTests.java
+++ b/test/jdk/javax/xml/crypto/dsig/ValidationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -141,8 +141,8 @@ public class ValidationTests {
     };
 
     public static void main(String args[]) throws Exception {
-        // Re-enable sha1 algs
-        SecurityUtils.removeAlgsFromDSigPolicy("sha1");
+        // Re-enable sha1 and xpath algs
+        SecurityUtils.removeAlgsFromDSigPolicy("sha1", "xpath");
 
         httpUd = new HttpURIDereferencer();
 


### PR DESCRIPTION
The XPath Transform is rarely used, introduces complexity, and is not recommended by the [XML Signature Best Practices](https://www.w3.org/TR/xmldsig-bestpractices/) document. Applications should use the XPath Transform 2.0 Filter instead, which was designed to be an alternative to the XPath Transform. This change will disable the XPath Transform by default.