### PR TITLE
8358891: Remove the PerfDataSamplingIntervalFunc code

### DIFF
--- a/src/hotspot/share/runtime/flags/jvmFlagConstraintsRuntime.cpp
+++ b/src/hotspot/share/runtime/flags/jvmFlagConstraintsRuntime.cpp
@@ -99,18 +99,6 @@ JVMFlag::Error ContendedPaddingWidthConstraintFunc(int value, bool verbose) {
   }
 }
 
-JVMFlag::Error PerfDataSamplingIntervalFunc(int value, bool verbose) {
-  if ((value % PeriodicTask::interval_gran != 0)) {
-    JVMFlag::printError(verbose,
-                        "PerfDataSamplingInterval (%d) must be "
-                        "evenly divisible by PeriodicTask::interval_gran (%d)\n",
-                        value, PeriodicTask::interval_gran);
-    return JVMFlag::VIOLATES_CONSTRAINT;
-  } else {
-    return JVMFlag::SUCCESS;
-  }
-}
-
 JVMFlag::Error VMPageSizeConstraintFunc(uintx value, bool verbose) {
   uintx min = (uintx)os::vm_page_size();
   if (value < min) {

--- a/src/hotspot/share/runtime/flags/jvmFlagConstraintsRuntime.hpp
+++ b/src/hotspot/share/runtime/flags/jvmFlagConstraintsRuntime.hpp
@@ -39,7 +39,6 @@
   f(ccstr,  AOTModeConstraintFunc)                    \
   f(int,    ObjectAlignmentInBytesConstraintFunc)     \
   f(int,    ContendedPaddingWidthConstraintFunc)      \
-  f(int,    PerfDataSamplingIntervalFunc)             \
   f(uintx,  VMPageSizeConstraintFunc)                 \
   f(size_t, NUMAInterleaveGranularityConstraintFunc)
 


### PR DESCRIPTION
Hi everyone,

#24872 removed the statsampler and the associated flag `PerfDataSamplingInterval`. However, the constraint function for the flag got overlooked. This change removes that function.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8358891](https://bugs.openjdk.org/browse/JDK-8358891): Remove the PerfDataSamplingIntervalFunc code (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25722/head:pull/25722` \
`$ git checkout pull/25722`

Update a local copy of the PR: \
`$ git checkout pull/25722` \
`$ git pull https://git.openjdk.org/jdk.git pull/25722/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25722`

View PR using the GUI difftool: \
`$ git pr show -t 25722`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25722.diff">https://git.openjdk.org/jdk/pull/25722.diff</a>

</details>
