### PR TITLE
8358602: JFR: Annotations in jdk.jfr package should not use "not null" in specification

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/DataAmount.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/DataAmount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -59,7 +59,7 @@ public @interface DataAmount {
     /**
      * Returns the unit for the data amount, by default bytes.
      *
-     * @return the data amount unit, default {@code BYTES}, not {@code null}
+     * @return the data amount unit, default {@code BYTES}
      */
     String value() default BYTES;
 }

--- a/src/jdk.jfr/share/classes/jdk/jfr/Description.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/Description.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,7 +46,7 @@ public @interface Description {
     /**
      * Returns a sentence or two that describes the annotated element.
      *
-     * @return a description, not {@code null}
+     * @return a description
      */
     String value();
 }

--- a/src/jdk.jfr/share/classes/jdk/jfr/Label.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/Label.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,7 +49,7 @@ public @interface Label {
     /**
      * Returns a human-readable name for the annotated element.
      *
-     * @return a human-readable name, not {@code null}
+     * @return a human-readable name
      */
     String value();
 }

--- a/src/jdk.jfr/share/classes/jdk/jfr/Period.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/Period.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -71,7 +71,7 @@ public @interface Period {
      * least once for every recording file. The number of events that are emitted
      * depends on how many times the file rotations occur when data is recorded.
      *
-     * @return the default setting value, not {@code null}
+     * @return the default setting value, default {@code "everyChunk"}
      */
     String value() default "everyChunk";
 }

--- a/src/jdk.jfr/share/classes/jdk/jfr/Threshold.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/Threshold.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -63,7 +63,7 @@ public @interface Threshold {
      * <p>
      * Example values are {@code "0 ns"}, {@code "10 ms"}, and {@code "1 s"}.
      *
-     * @return the threshold, default {@code "0 ns"}, not {@code null}
+     * @return the threshold, default {@code "0 ns"}
      */
     String value() default "0 ns";
 }

--- a/src/jdk.jfr/share/classes/jdk/jfr/Throttle.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/Throttle.java
@@ -74,7 +74,7 @@ public @interface Throttle {
      * <p>
      * Specifying {@code "off"} (case-sensitive) results in all events being emitted.
      *
-     * @return the throttle value, default {@code "off"} not {@code null}
+     * @return the throttle value, default {@code "off"}
      */
     String value() default "off";
 }

--- a/src/jdk.jfr/share/classes/jdk/jfr/Timespan.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/Timespan.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -71,7 +71,7 @@ public @interface Timespan {
      * <p>
      * By default, the unit is nanoseconds.
      *
-     * @return the time span unit, default {@link #NANOSECONDS}, not {@code null}
+     * @return the time span unit, default {@code NANOSECONDS}
      */
     String value() default NANOSECONDS;
 }

--- a/src/jdk.jfr/share/classes/jdk/jfr/Timestamp.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/Timestamp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -57,7 +57,7 @@ public @interface Timestamp {
     /**
      * Unit for the time stamp.
      *
-     * @return time stamp unit, not {@code null}
+     * @return time stamp unit, default {@code MILLISECONDS_SINCE_EPOCH}
      */
     String value() default Timestamp.MILLISECONDS_SINCE_EPOCH;
 }


### PR DESCRIPTION
Could I have review of PR that fixes the specification / documentation for annotations in the jdk.jfr package.

Testing: tier1 + jdk/jdk/jfr

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8358969](https://bugs.openjdk.org/browse/JDK-8358969) to be approved

### Issues
 * [JDK-8358602](https://bugs.openjdk.org/browse/JDK-8358602): JFR: Annotations in jdk.jfr package should not use "not null" in specification (**Enhancement** - P3)
 * [JDK-8358969](https://bugs.openjdk.org/browse/JDK-8358969): JFR: Annotations in jdk.jfr package should not use "not null" in specification (**CSR**)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25723/head:pull/25723` \
`$ git checkout pull/25723`

Update a local copy of the PR: \
`$ git checkout pull/25723` \
`$ git pull https://git.openjdk.org/jdk.git pull/25723/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25723`

View PR using the GUI difftool: \
`$ git pr show -t 25723`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25723.diff">https://git.openjdk.org/jdk/pull/25723.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25723#issuecomment-2959227022)
</details>
