### PR TITLE
8359110: Log accumulated GC and process CPU time upon VM exit

### DIFF
--- a/src/hotspot/os/posix/os_posix.cpp
+++ b/src/hotspot/os/posix/os_posix.cpp
@@ -76,6 +76,7 @@
 #include <sys/resource.h>
 #include <sys/socket.h>
 #include <spawn.h>
+#include <sys/resource.h>
 #include <sys/time.h>
 #include <sys/times.h>
 #include <sys/types.h>
@@ -1510,6 +1511,17 @@ jlong os::elapsed_frequency() {
 }
 
 bool os::supports_vtime() { return true; }
+
+double os::elapsed_process_vtime() {
+  struct rusage usage;
+  int retval = getrusage(RUSAGE_SELF, &usage);
+  if (retval == 0) {
+    return usage.ru_utime.tv_sec + usage.ru_stime.tv_sec +
+         (usage.ru_utime.tv_usec + usage.ru_stime.tv_usec) / (1000.0 * 1000.0);
+  } else {
+    return -1;
+  }
+}
 
 // Return the real, user, and system times in seconds from an
 // arbitrary fixed point in the past.

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -1209,6 +1209,39 @@ double os::elapsedVTime() {
   }
 }
 
+double os::elapsed_process_vtime() {
+  FILETIME create;
+  FILETIME exit;
+  FILETIME kernel;
+  FILETIME user;
+
+  if (GetProcessTimes(GetCurrentProcess(), &create, &exit, &kernel, &user) == 0) {
+    return -1;
+  }
+
+  SYSTEMTIME user_total;
+  if (FileTimeToSystemTime(&user, &user_total) == 0) {
+    return -1;
+  }
+
+
+  SYSTEMTIME kernel_total;
+  if (FileTimeToSystemTime(&kernel, &kernel_total) == 0) {
+    return -1;
+  }
+
+  double user_seconds =
+      double(user_total.wHour) * 3600.0 + double(user_total.wMinute) * 60.0 +
+      double(user_total.wSecond) + double(user_total.wMilliseconds) / 1000.0;
+
+  double kernel_seconds = double(kernel_total.wHour) * 3600.0 +
+                          double(kernel_total.wMinute) * 60.0 +
+                          double(kernel_total.wSecond) +
+                          double(kernel_total.wMilliseconds) / 1000.0;
+
+  return user_seconds + kernel_seconds;
+}
+
 jlong os::javaTimeMillis() {
   FILETIME wt;
   GetSystemTimeAsFileTime(&wt);

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -1470,6 +1470,8 @@ bool G1CollectedHeap::concurrent_mark_is_terminating() const {
 }
 
 void G1CollectedHeap::stop() {
+  log_gc_vtime();
+
   // Stop all concurrent threads. We do this to make sure these threads
   // do not continue to execute and access resources (e.g. logging)
   // that are destroyed during shutdown.
@@ -1477,6 +1479,26 @@ void G1CollectedHeap::stop() {
   _service_thread->stop();
   _cm_thread->stop();
 }
+
+class G1VCPUThreadClosure : public ThreadClosure {
+private:
+  volatile jlong _vtime = 0;
+
+public:
+  virtual void do_thread(Thread *thread) {
+    Atomic::add(&_vtime, os::thread_cpu_time(thread));
+  }
+  jlong vtime() { return _vtime; };
+};
+
+double G1CollectedHeap::elapsed_gc_vtime() {
+  G1VCPUThreadClosure cl;
+  _cr->threads_do(&cl);
+  _cm->threads_do(&cl);
+  _workers->threads_do(&cl);
+  return ((double) cl.vtime() + os::thread_cpu_time(_service_thread) + os::thread_cpu_time(_cm_thread) + Universe::heap()->vm_vtime()) / NANOSECS_PER_SEC;
+}
+
 
 void G1CollectedHeap::safepoint_synchronize_begin() {
   SuspendibleThreadSet::synchronize();

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -932,6 +932,8 @@ public:
   GrowableArray<GCMemoryManager*> memory_managers() override;
   GrowableArray<MemoryPool*> memory_pools() override;
 
+  double elapsed_gc_vtime() override;
+
   void fill_with_dummy_object(HeapWord* start, HeapWord* end, bool zap) override;
 
   static void start_codecache_marking_cycle_if_inactive(bool concurrent_mark_start);

--- a/src/hotspot/share/gc/parallel/parallelScavengeHeap.cpp
+++ b/src/hotspot/share/gc/parallel/parallelScavengeHeap.cpp
@@ -160,6 +160,27 @@ void ParallelScavengeHeap::initialize_serviceability() {
 
 }
 
+void ParallelScavengeHeap::stop() {
+  log_gc_vtime();
+}
+
+class ParallelVCPUThreadClosure : public ThreadClosure {
+private:
+  volatile jlong _vtime = 0;
+
+public:
+  virtual void do_thread(Thread *thread) {
+    Atomic::add(&_vtime, os::thread_cpu_time(thread));
+  }
+  jlong vtime() { return _vtime; };
+};
+
+double ParallelScavengeHeap::elapsed_gc_vtime() {
+  ParallelVCPUThreadClosure cl;
+  workers().threads_do(&cl);
+  return (double)(cl.vtime() + Universe::heap()->vm_vtime()) / NANOSECS_PER_SEC;
+}
+
 void ParallelScavengeHeap::safepoint_synchronize_begin() {
   if (UseStringDeduplication) {
     SuspendibleThreadSet::synchronize();

--- a/src/hotspot/share/gc/parallel/parallelScavengeHeap.hpp
+++ b/src/hotspot/share/gc/parallel/parallelScavengeHeap.hpp
@@ -214,6 +214,9 @@ public:
   void gc_threads_do(ThreadClosure* tc) const override;
   void print_tracing_info() const override;
 
+  void stop() override;
+  double elapsed_gc_vtime() override;
+
   WorkerThreads* safepoint_workers() override { return &_workers; }
 
   PreGenGCValues get_pre_gc_values() const;

--- a/src/hotspot/share/gc/serial/serialHeap.cpp
+++ b/src/hotspot/share/gc/serial/serialHeap.cpp
@@ -145,6 +145,14 @@ GrowableArray<MemoryPool*> SerialHeap::memory_pools() {
   return memory_pools;
 }
 
+void SerialHeap::stop() {
+  log_gc_vtime();
+}
+
+double SerialHeap::elapsed_gc_vtime() {
+  return (double) Universe::heap()->vm_vtime() / NANOSECS_PER_SEC;
+}
+
 void SerialHeap::safepoint_synchronize_begin() {
   if (UseStringDeduplication) {
     SuspendibleThreadSet::synchronize();

--- a/src/hotspot/share/gc/serial/serialHeap.hpp
+++ b/src/hotspot/share/gc/serial/serialHeap.hpp
@@ -274,6 +274,9 @@ public:
   GrowableArray<GCMemoryManager*> memory_managers() override;
   GrowableArray<MemoryPool*> memory_pools() override;
 
+  void stop() override;
+  double elapsed_gc_vtime() override;
+
   DefNewGeneration* young_gen() const {
     return _young_gen;
   }

--- a/src/hotspot/share/gc/shared/collectedHeap.hpp
+++ b/src/hotspot/share/gc/shared/collectedHeap.hpp
@@ -132,6 +132,8 @@ class CollectedHeap : public CHeapObj<mtGC> {
   NOT_PRODUCT(volatile size_t _promotion_failure_alot_count;)
   NOT_PRODUCT(volatile size_t _promotion_failure_alot_gc_number;)
 
+  static jlong _vm_vtime;
+
   // Reason for current garbage collection.  Should be set to
   // a value reflecting no collection between collections.
   GCCause::Cause _gc_cause;
@@ -245,6 +247,14 @@ protected:
   // Stop and resume concurrent GC threads interfering with safepoint operations
   virtual void safepoint_synchronize_begin() {}
   virtual void safepoint_synchronize_end() {}
+
+  static jlong vm_vtime() {
+    return _vm_vtime;
+  }
+
+  static void add_vm_vtime(jlong time) {
+    _vm_vtime += time;
+  }
 
   void initialize_reserved_region(const ReservedHeapSpace& rs);
 
@@ -454,6 +464,9 @@ protected:
   // Print any relevant tracing info that flags imply.
   // Default implementation does nothing.
   virtual void print_tracing_info() const = 0;
+
+  virtual double elapsed_gc_vtime() { return -1; };
+  void log_gc_vtime();
 
   void print_before_gc() const;
   void print_after_gc() const;

--- a/src/hotspot/share/gc/shared/gcVMOperations.hpp
+++ b/src/hotspot/share/gc/shared/gcVMOperations.hpp
@@ -93,6 +93,8 @@ public:
   virtual bool doit_prologue();
   // Releases the Heap_lock.
   virtual void doit_epilogue();
+
+  bool operation_is_gc() const { return true; }
 };
 
 class VM_Verify : public VM_GC_Sync_Operation {

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
@@ -209,6 +209,8 @@ public:
 
   void stop() override;
 
+  double elapsed_gc_vtime() override;
+
   void prepare_for_verify() override;
   void verify(VerifyOption vo) override;
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahVMOperations.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahVMOperations.hpp
@@ -55,6 +55,8 @@ public:
   void log_active_generation(const char* prefix);
   bool doit_prologue() override;
   void doit_epilogue() override;
+
+  bool operation_is_gc() const override { return true; }
 };
 
 class VM_ShenandoahReferenceOperation : public VM_ShenandoahOperation {

--- a/src/hotspot/share/gc/z/zCollectedHeap.hpp
+++ b/src/hotspot/share/gc/z/zCollectedHeap.hpp
@@ -91,6 +91,8 @@ public:
   GrowableArray<GCMemoryManager*> memory_managers() override;
   GrowableArray<MemoryPool*> memory_pools() override;
 
+  double elapsed_gc_vtime() override;
+
   void object_iterate(ObjectClosure* cl) override;
   ParallelObjectIteratorImpl* parallel_object_iterator(uint nworkers) override;
 

--- a/src/hotspot/share/gc/z/zGeneration.cpp
+++ b/src/hotspot/share/gc/z/zGeneration.cpp
@@ -442,6 +442,8 @@ public:
     OopMapCache::try_trigger_cleanup();
   }
 
+  bool operation_is_gc() const { return true; }
+
   bool success() const {
     return _success;
   }

--- a/src/hotspot/share/runtime/cpuTimeCounters.cpp
+++ b/src/hotspot/share/runtime/cpuTimeCounters.cpp
@@ -126,3 +126,7 @@ void ThreadTotalCPUTimeClosure::do_thread(Thread* thread) {
   // must ensure the thread exists and has not terminated.
   _total += os::thread_cpu_time(thread);
 }
+
+void ThreadTotalCPUTimeClosure::inc_total(jlong value) {
+  _total += value;
+}

--- a/src/hotspot/share/runtime/cpuTimeCounters.hpp
+++ b/src/hotspot/share/runtime/cpuTimeCounters.hpp
@@ -109,6 +109,7 @@ class ThreadTotalCPUTimeClosure: public ThreadClosure {
   ~ThreadTotalCPUTimeClosure();
 
   virtual void do_thread(Thread* thread);
+  void inc_total(jlong value);
 };
 
 #endif // SHARE_RUNTIME_CPUTIMECOUNTERS_HPP

--- a/src/hotspot/share/runtime/os.hpp
+++ b/src/hotspot/share/runtime/os.hpp
@@ -299,6 +299,7 @@ class os: AllStatic {
   // returns the elapsed virtual time for the current thread.
   static bool supports_vtime();
   static double elapsedVTime();
+  static double elapsed_process_vtime();
 
   // Return current local time in a string (YYYY-MM-DD HH:MM:SS).
   // It is MT safe, but not async-safe, as reading time zone

--- a/src/hotspot/share/runtime/vmOperation.hpp
+++ b/src/hotspot/share/runtime/vmOperation.hpp
@@ -168,6 +168,8 @@ class VM_Operation : public StackObj {
   // or concurrently with Java threads running.
   virtual bool evaluate_at_safepoint() const { return true; }
 
+  virtual bool operation_is_gc() const { return false; }
+
   // Debugging
   virtual void print_on_error(outputStream* st) const;
   virtual const char* name() const  { return _names[type()]; }


### PR DESCRIPTION
Add support to log CPU cost for GC during VM exit with `-Xlog:gc`.

```
[1.500s][info ][gc] GC CPU cost: 1.75%
```

Additionally, detailed information may be retrieved with `-Xlog:gc=trace`

```
[1.500s][trace][gc] Process CPU time: 4.945370s
[1.500s][trace][gc] GC CPU time: 0.086382s
[1.500s][info ][gc] GC CPU cost: 1.75%
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8359110](https://bugs.openjdk.org/browse/JDK-8359110): Log accumulated GC and process CPU time upon VM exit (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25724/head:pull/25724` \
`$ git checkout pull/25724`

Update a local copy of the PR: \
`$ git checkout pull/25724` \
`$ git pull https://git.openjdk.org/jdk.git pull/25724/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25724`

View PR using the GUI difftool: \
`$ git pr show -t 25724`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25724.diff">https://git.openjdk.org/jdk/pull/25724.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25724#issuecomment-2959297430)
</details>
