### PR TITLE
8359126: [AIX] new test TestImplicitNullChecks.java fails

### DIFF
--- a/test/hotspot/jtreg/compiler/gcbarriers/TestImplicitNullChecks.java
+++ b/test/hotspot/jtreg/compiler/gcbarriers/TestImplicitNullChecks.java
@@ -67,7 +67,10 @@ public class TestImplicitNullChecks {
     }
 
     @Test
-    @IR(applyIfOr = {"UseZGC", "true", "UseG1GC", "true"},
+    // On AIX, implicit null checks are limited because the zero page is
+    // readable (but not writable). See os::zero_page_read_protected().
+    @IR(applyIfPlatform = {"aix", "false"},
+        applyIfOr = {"UseZGC", "true", "UseG1GC", "true"},
         counts = {IRNode.NULL_CHECK, "1"},
         phase = CompilePhase.FINAL_CODE)
     static Object testLoad(Outer o) {

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/test/IREncodingPrinter.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/test/IREncodingPrinter.java
@@ -62,6 +62,7 @@ public class IREncodingPrinter {
     // as adding non-existent platforms can lead to skipped tests.
     private static final List<String> irTestingPlatforms = new ArrayList<String>(Arrays.asList(
         // os.family
+        "aix",
         "linux",
         "mac",
         "windows",
@@ -346,7 +347,9 @@ public class IREncodingPrinter {
         }
 
         String os = "";
-        if (Platform.isLinux()) {
+        if (Platform.isAix()) {
+            os = "aix";
+        } else if (Platform.isLinux()) {
             os = "linux";
         } else if (Platform.isOSX()) {
             os = "mac";


### PR DESCRIPTION
Switch off the IR rule which expects no explicit null check for a load operation for AIX. I had to enhance the IR code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8359126](https://bugs.openjdk.org/browse/JDK-8359126): [AIX] new test TestImplicitNullChecks.java fails (**Bug** - P4)


### Reviewers
 * [Roberto Castañeda Lozano](https://openjdk.org/census#rcastanedalo) (@robcasloz - **Reviewer**)
 * [David Briemann](https://openjdk.org/census#dbriemann) (@dbriemann - Author)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25728/head:pull/25728` \
`$ git checkout pull/25728`

Update a local copy of the PR: \
`$ git checkout pull/25728` \
`$ git pull https://git.openjdk.org/jdk.git pull/25728/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25728`

View PR using the GUI difftool: \
`$ git pr show -t 25728`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25728.diff">https://git.openjdk.org/jdk/pull/25728.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25728#issuecomment-2959437502)
</details>
