### PR TITLE
8358334: C2/Shenandoah: incorrect execution with Unsafe

### DIFF
--- a/src/hotspot/share/gc/shenandoah/c2/shenandoahSupport.hpp
+++ b/src/hotspot/share/gc/shenandoah/c2/shenandoahSupport.hpp
@@ -62,8 +62,12 @@ private:
                             PhaseIdealLoop* phase, int flags);
   static void call_lrb_stub(Node*& ctrl, Node*& val, Node* load_addr,
                             DecoratorSet decorators, PhaseIdealLoop* phase);
+
+  static void collect_nodes_above_barrier(Unique_Node_List &nodes_above_barrier, PhaseIdealLoop* phase, Node* ctrl,
+                                          Node* init_raw_mem);
+
   static void test_in_cset(Node*& ctrl, Node*& not_cset_ctrl, Node* val, Node* raw_mem, PhaseIdealLoop* phase);
-  static void fix_ctrl(Node* barrier, Node* region, const MemoryGraphFixer& fixer, Unique_Node_List& uses, Unique_Node_List& uses_to_ignore, uint last, PhaseIdealLoop* phase);
+  static void fix_ctrl(Node* barrier, Node* region, const MemoryGraphFixer& fixer, Unique_Node_List& uses, Unique_Node_List& nodes_above_barrier, uint last, PhaseIdealLoop* phase);
 
   static Node* get_load_addr(PhaseIdealLoop* phase, VectorSet& visited, Node* lrb);
 public:
@@ -76,6 +80,11 @@ public:
   static bool expand(Compile* C, PhaseIterGVN& igvn);
   static void pin_and_expand(PhaseIdealLoop* phase);
 
+  static void push_data_inputs_at_control(PhaseIdealLoop* phase, Node* n, Node* ctrl,
+                                          Unique_Node_List &wq);
+  static bool is_anti_dependent_load_at_control(PhaseIdealLoop* phase, Node* maybe_load, Node* store, Node* control);
+
+  static void maybe_push_anti_dependent_loads(PhaseIdealLoop* phase, Node* maybe_store, Node* control, Unique_Node_List &wq);
 #ifdef ASSERT
   static void verify(RootNode* root);
 #endif

--- a/test/hotspot/jtreg/gc/shenandoah/compiler/TestLostAntiDependencyAtExpansion.java
+++ b/test/hotspot/jtreg/gc/shenandoah/compiler/TestLostAntiDependencyAtExpansion.java
@@ -30,7 +30,7 @@
  *
  * @run main/othervm -XX:-UseOnStackReplacement -XX:-BackgroundCompilation -XX:-TieredCompilation -XX:+UseShenandoahGC
  *                   TestLostAntiDependencyAtExpansion
- *                   
+ *
  *
  */
 
@@ -58,10 +58,10 @@ public class TestLostAntiDependencyAtExpansion {
 
     private static long test1(long addr) {
         long tmp = UNSAFE.getLong(addr);
-        
+
         UNSAFE.putLong(addr, 0L);
 
         return tmp + a.field;
     }
-        
+
 }

--- a/test/hotspot/jtreg/gc/shenandoah/compiler/TestLostAntiDependencyAtExpansion.java
+++ b/test/hotspot/jtreg/gc/shenandoah/compiler/TestLostAntiDependencyAtExpansion.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2025, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8358334
+ * @summary C2/Shenandoah: incorrect execution with Unsafe
+ * @requires vm.gc.Shenandoah
+ * @modules java.base/jdk.internal.misc:+open
+ *
+ * @run main/othervm -XX:-UseOnStackReplacement -XX:-BackgroundCompilation -XX:-TieredCompilation -XX:+UseShenandoahGC
+ *                   TestLostAntiDependencyAtExpansion
+ *                   
+ *
+ */
+
+import jdk.internal.misc.Unsafe;
+
+public class TestLostAntiDependencyAtExpansion {
+    static final jdk.internal.misc.Unsafe UNSAFE = Unsafe.getUnsafe();
+
+    public static void main(String[] args) {
+        long addr = UNSAFE.allocateMemory(8);
+        for (int i = 0; i < 20_000; i++) {
+            UNSAFE.putLong(addr, 42L);
+            long res = test1(addr);
+            if (res != 42L) {
+                throw new RuntimeException("Incorrect result: " + res);
+            }
+        }
+    }
+
+    static class A {
+        long field;
+    }
+
+    static A a = new A();
+
+    private static long test1(long addr) {
+        long tmp = UNSAFE.getLong(addr);
+        
+        UNSAFE.putLong(addr, 0L);
+
+        return tmp + a.field;
+    }
+        
+}


### PR DESCRIPTION
When a barrier is expanded, some control is picked as a location for
the barrier. The control input of data nodes that depend on that
control are updated so the nodes are after the expanded barrier unless
the barrier itself depends on some of those nodes.

In this particular failure, a raw memoy `Store` is the input memory to
the barrier. That `Store` has an anti-dependent `Load`. All 3 nodes
(barrier, `Load` and `Store`) are at the same control. The `Store` is
an input to the barrier so it stays before the barrier. The `Load`'s
control is updated to be after the barrier which breaks the
anti-dependency. The bug is that the logic that sorts nodes that need
to be before the barrier and those that can be after ignores
anti-dependencies. The fix simply extends that logic to take them into
account.


/cc shenandoah,hotspot-compiler

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8358334](https://bugs.openjdk.org/browse/JDK-8358334): C2/Shenandoah: incorrect execution with Unsafe (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25729/head:pull/25729` \
`$ git checkout pull/25729`

Update a local copy of the PR: \
`$ git checkout pull/25729` \
`$ git pull https://git.openjdk.org/jdk.git pull/25729/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25729`

View PR using the GUI difftool: \
`$ git pr show -t 25729`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25729.diff">https://git.openjdk.org/jdk/pull/25729.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25729#issuecomment-2959448924)
</details>
