### PR TITLE
8359131: JShell AbstractStopExecutionTest does not stop reliably

### DIFF
--- a/test/langtools/jdk/jshell/AbstractStopExecutionTest.java
+++ b/test/langtools/jdk/jshell/AbstractStopExecutionTest.java
@@ -31,7 +31,7 @@ import static org.testng.Assert.fail;
 public abstract class AbstractStopExecutionTest extends KullaTesting {
 
     private final Object lock = new Object();
-    private boolean isStopped;
+    private volatile boolean isStopped;
 
     protected void scheduleStop(String src) throws InterruptedException {
         JShell state = getState();


### PR DESCRIPTION
The JShell regression test support class `AbstractStopExecutionTest.java` provides code that starts a JShell evaluation in one thread and then invokes `JShell.stop()` to interrupt that evaluation from another thread.

This class uses a `boolean` field to synchronize the action between threads. However, this field is not marked `volatile` and so the communication is unreliable. As a result, in rare cases, the test can fail due to a timeout.

The simple fix is to make the field `volatile`. This has been verified in testing to resolve the problem (see discussion in [JDK-8355323](https://bugs.openjdk.org/browse/JDK-8355323)).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8359131](https://bugs.openjdk.org/browse/JDK-8359131): JShell AbstractStopExecutionTest does not stop reliably (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25730/head:pull/25730` \
`$ git checkout pull/25730`

Update a local copy of the PR: \
`$ git checkout pull/25730` \
`$ git pull https://git.openjdk.org/jdk.git pull/25730/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25730`

View PR using the GUI difftool: \
`$ git pr show -t 25730`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25730.diff">https://git.openjdk.org/jdk/pull/25730.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25730#issuecomment-2959478497)
</details>
