### PR TITLE
8358452: JNI exception pending in Java_sun_awt_screencast_ScreencastHelper_remoteDesktopKeyImpl of screencast_pipewire.c:1214 (ID: 51119)

### DIFF
--- a/src/java.desktop/unix/native/libawt_xawt/awt/screencast_pipewire.c
+++ b/src/java.desktop/unix/native/libawt_xawt/awt/screencast_pipewire.c
@@ -1016,6 +1016,7 @@ JNIEXPORT jint JNICALL Java_sun_awt_screencast_ScreencastHelper_getRGBPixelsImpl
     const gchar *token = jtoken
                          ? (*env)->GetStringUTFChars(env, jtoken, NULL)
                          : NULL;
+    JNU_CHECK_EXCEPTION_RETURN(env, RESULT_ERROR);
 
     isGtkMainThread = gtk->g_main_context_is_owner(gtk->g_main_context_default());
     DEBUG_SCREENCAST(
@@ -1121,7 +1122,7 @@ JNIEXPORT jint JNICALL Java_sun_awt_screencast_ScreencastHelper_remoteDesktopMou
     const gchar *token = jtoken
                          ? (*env)->GetStringUTFChars(env, jtoken, NULL)
                          : NULL;
-
+    JNU_CHECK_EXCEPTION_RETURN(env, RESULT_ERROR);
 
     DEBUG_SCREENCAST("moving mouse to\n\t%d %d\n\twith token |%s|\n", jx, jy, token);
 
@@ -1151,6 +1152,7 @@ JNIEXPORT jint JNICALL Java_sun_awt_screencast_ScreencastHelper_remoteDesktopMou
     const gchar *token = jtoken
                          ? (*env)->GetStringUTFChars(env, jtoken, NULL)
                          : NULL;
+    JNU_CHECK_EXCEPTION_RETURN(env, RESULT_ERROR);
 
     gboolean result = initPortal(token, NULL, 0);
     DEBUG_SCREENCAST("init result %b, mouse pressing %d\n", result, buttons)
@@ -1178,6 +1180,7 @@ JNIEXPORT jint JNICALL Java_sun_awt_screencast_ScreencastHelper_remoteDesktopMou
     const gchar *token = jtoken
                          ? (*env)->GetStringUTFChars(env, jtoken, NULL)
                          : NULL;
+    JNU_CHECK_EXCEPTION_RETURN(env, RESULT_ERROR);
 
     gboolean result = initPortal(token, NULL, 0);
     DEBUG_SCREENCAST("init result %b, mouse wheel %d\n", result, jWheelAmt)
@@ -1206,13 +1209,14 @@ JNIEXPORT jint JNICALL Java_sun_awt_screencast_ScreencastHelper_remoteDesktopKey
     int key = awt_getX11KeySym(jkey);
     AWT_UNLOCK();
 
-    if (key == NoSymbol) {
+    if (key == NoSymbol || (*env)->ExceptionCheck(env)) {
         return RESULT_ERROR;
     }
 
     const gchar *token = jtoken
                          ? (*env)->GetStringUTFChars(env, jtoken, NULL)
                          : NULL;
+    JNU_CHECK_EXCEPTION_RETURN(env, RESULT_ERROR);
 
     gboolean result = initPortal(token, NULL, 0);
     DEBUG_SCREENCAST("init result %b, key %d -> %d isPress %b\n", result, jkey, key, isPress)


### PR DESCRIPTION
Hi all,

  This pull request contains a backport of commit [2103dc15](https://github.com/openjdk/jdk/commit/2103dc15cb662fd8795b1b51d9cb61c389bed7a0) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

   The commit being backported was authored by Alexander Zvegintsev on 9 Jun 2025 and was reviewed by Prasanta Sadhukhan, Sergey Bylokhov, Alexey Ivanov and Alexey Ushakov.

   Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (2 reviews required, with at least 2 [Reviewers](https://openjdk.org/bylaws#reviewer))

### Issue
 * [JDK-8358452](https://bugs.openjdk.org/browse/JDK-8358452): JNI exception pending in Java_sun_awt_screencast_ScreencastHelper_remoteDesktopKeyImpl of screencast_pipewire.c:1214 (ID: 51119) (**Bug** - P3)


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25731/head:pull/25731` \
`$ git checkout pull/25731`

Update a local copy of the PR: \
`$ git checkout pull/25731` \
`$ git pull https://git.openjdk.org/jdk.git pull/25731/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25731`

View PR using the GUI difftool: \
`$ git pr show -t 25731`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25731.diff">https://git.openjdk.org/jdk/pull/25731.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25731#issuecomment-2959888544)
</details>
