### PR TITLE
8359165: AIX build broken after 8358799

### DIFF
--- a/src/hotspot/os/posix/os_posix.cpp
+++ b/src/hotspot/os/posix/os_posix.cpp
@@ -1077,7 +1077,7 @@ void os::jvm_path(char *buf, jint buflen) {
     return;
   }
 
-  char* fname;
+  const char* fname;
 #ifdef AIX
   Dl_info dlinfo;
   int ret = dladdr(CAST_FROM_FN_PTR(void *, os::jvm_path), &dlinfo);
@@ -1085,7 +1085,7 @@ void os::jvm_path(char *buf, jint buflen) {
   if (ret == 0) {
     return;
   }
-  fname = (char*)dlinfo.dli_fname;
+  fname = dlinfo.dli_fname;
 #else
   char dli_fname[MAXPATHLEN];
   dli_fname[0] = '\0';


### PR DESCRIPTION
This fixes the build.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8359165](https://bugs.openjdk.org/browse/JDK-8359165): AIX build broken after 8358799 (**Bug** - P1)


### Reviewers
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Joachim Kern](https://openjdk.org/census#jkern) (@JoKern65 - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25734/head:pull/25734` \
`$ git checkout pull/25734`

Update a local copy of the PR: \
`$ git checkout pull/25734` \
`$ git pull https://git.openjdk.org/jdk.git pull/25734/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25734`

View PR using the GUI difftool: \
`$ git pr show -t 25734`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25734.diff">https://git.openjdk.org/jdk/pull/25734.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25734#issuecomment-2960299204)
</details>
