### PR TITLE
8357382: runtime/cds/appcds/aotClassLinking/BulkLoaderTest.java#aot fails with Xcomp and C1

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/aotClassLinking/BulkLoaderTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotClassLinking/BulkLoaderTest.java
@@ -72,6 +72,7 @@ import java.io.File;
 import java.lang.StackWalker.StackFrame;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -312,12 +313,15 @@ class BulkLoaderTestApp {
         }
     }
 
+    static ArrayList<ClassLoader> savedLoaders = new ArrayList<>();
+
     static Object initFromCustomLoader() throws Exception {
         String path = "cust.jar";
         URL url = new File(path).toURI().toURL();
         URL[] urls = new URL[] {url};
         URLClassLoader urlClassLoader =
             new URLClassLoader("MyLoader", urls, null);
+        savedLoaders.add(urlClassLoader);
         Class c = Class.forName("SimpleCusty", true, urlClassLoader);
         return c.newInstance();
     }


### PR DESCRIPTION
One possible cause of the failure is that one of the `SimpleCusty` test classes was garbaged collected. To make the test run more reliably, the fix is to store the class loaders in a static `ArrayList`.

Testing: ran the test 20 times on Oracle supported platforms with the VM options listed in the bug report description.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8357382](https://bugs.openjdk.org/browse/JDK-8357382): runtime/cds/appcds/aotClassLinking/BulkLoaderTest.java#aot fails with Xcomp and C1 (**Bug** - P4)


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25737/head:pull/25737` \
`$ git checkout pull/25737`

Update a local copy of the PR: \
`$ git checkout pull/25737` \
`$ git pull https://git.openjdk.org/jdk.git pull/25737/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25737`

View PR using the GUI difftool: \
`$ git pr show -t 25737`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25737.diff">https://git.openjdk.org/jdk/pull/25737.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25737#issuecomment-2960729208)
</details>
