### PR TITLE
8357286: (bf) Remove obsolete instanceof checks in CharBuffer.append

### DIFF
--- a/src/java.base/share/classes/java/nio/Direct-X-Buffer.java.template
+++ b/src/java.base/share/classes/java/nio/Direct-X-Buffer.java.template
@@ -434,6 +434,9 @@ class Direct$Type$Buffer$RW$$BO$
 
     public $Type$Buffer append(CharSequence csq, int start, int end) {
 #if[rw]
+        if (csq == null)
+            return super.append(csq, start, end);
+
         Objects.checkFromToIndex(start, end, csq.length());
 
         int pos = position();

--- a/src/java.base/share/classes/java/nio/Direct-X-Buffer.java.template
+++ b/src/java.base/share/classes/java/nio/Direct-X-Buffer.java.template
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -430,8 +430,10 @@ class Direct$Type$Buffer$RW$$BO$
 
 #if[rw] 
     private static final int APPEND_BUF_SIZE = 1024;
+#end[rw]
 
-    private $Type$Buffer appendChars(CharSequence csq, int start, int end) {
+    public $Type$Buffer append(CharSequence csq, int start, int end) {
+#if[rw]
         Objects.checkFromToIndex(start, end, csq.length());
 
         int pos = position();
@@ -448,13 +450,7 @@ class Direct$Type$Buffer$RW$$BO$
             if (count > buf.length)
                 count = buf.length;
 
-            if (csq instanceof String str) {
-                str.getChars(start, start + count, buf, 0);
-            } else if (csq instanceof StringBuilder sb) {
-                sb.getChars(start, start + count, buf, 0);
-            } else if (csq instanceof StringBuffer sb) {
-                sb.getChars(start, start + count, buf, 0);
-            }
+            csq.getChars(start, start + count, buf, 0);
 
             putArray(index, buf, 0, count);
 
@@ -465,27 +461,19 @@ class Direct$Type$Buffer$RW$$BO$
         position(pos + length);
 
         return this;
-    }
-#end[rw] 
 
-    public $Type$Buffer append(CharSequence csq) {
-#if[rw] 
-        if (csq instanceof StringBuilder) 
-            return appendChars(csq, 0, csq.length());
- 
-        return super.append(csq);
 #else[rw]
         throw new ReadOnlyBufferException();
 #end[rw]
     }
- 
-    public $Type$Buffer append(CharSequence csq, int start, int end) { 
-#if[rw]
-        if (csq instanceof String || csq instanceof StringBuffer ||
-            csq instanceof StringBuilder)
-            return appendChars(csq, start, end);
 
-        return super.append(csq, start, end);
+    public $Type$Buffer append(CharSequence csq) {
+#if[rw]
+        // See comment regarding StringBuilder on HeapBuffer.append.
+        if (csq instanceof StringBuilder)
+            return append(csq, 0, csq.length());
+
+        return super.append(csq);
 #else[rw]
         throw new ReadOnlyBufferException();
 #end[rw]

--- a/src/java.base/share/classes/java/nio/Heap-X-Buffer.java.template
+++ b/src/java.base/share/classes/java/nio/Heap-X-Buffer.java.template
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -290,7 +290,8 @@ class Heap$Type$Buffer$RW$
     // or the full sequence of chars is being appended, copying the chars to
     // an intermedite String in StringBuilder::toString is avoided.
     //
-    private $Type$Buffer appendChars(CharSequence csq, int start, int end) {
+    public $Type$Buffer append(CharSequence csq, int start, int end) {
+#if[rw]
         checkSession();
 
         Objects.checkFromToIndex(start, end, csq.length());
@@ -302,37 +303,23 @@ class Heap$Type$Buffer$RW$
         if (length > rem)
             throw new BufferOverflowException();
 
-        if (csq instanceof String str) {
-            str.getChars(start, end, hb, ix(pos));
-        } else if (csq instanceof StringBuilder sb) {
-            sb.getChars(start, end, hb, ix(pos));
-        } else if (csq instanceof StringBuffer sb) {
-            sb.getChars(start, end, hb, ix(pos));
-        }
+        csq.getChars(start, end, hb, ix(pos));
 
         position(pos + length);
 
         return this;
-    }
-
-    public $Type$Buffer append(CharSequence csq) {
-#if[rw]
-        if (csq instanceof StringBuilder)
-            return appendChars(csq, 0, csq.length());
-
-        return super.append(csq);
 #else[rw]
         throw new ReadOnlyBufferException();
 #end[rw]
     }
 
-    public $Type$Buffer append(CharSequence csq, int start, int end) {
+    public $Type$Buffer append(CharSequence csq) {
 #if[rw]
-        if (csq instanceof String || csq instanceof StringBuffer ||
-            csq instanceof StringBuilder)
-            return appendChars(csq, start, end);
+        // See comment regarding StringBuilder on method append() above.
+        if (csq instanceof StringBuilder)
+            return append(csq, 0, csq.length());
 
-        return super.append(csq, start, end);
+        return super.append(csq);
 #else[rw]
         throw new ReadOnlyBufferException();
 #end[rw]

--- a/src/java.base/share/classes/java/nio/Heap-X-Buffer.java.template
+++ b/src/java.base/share/classes/java/nio/Heap-X-Buffer.java.template
@@ -292,6 +292,9 @@ class Heap$Type$Buffer$RW$
     //
     public $Type$Buffer append(CharSequence csq, int start, int end) {
 #if[rw]
+        if (csq == null)
+            return super.append(csq, start, end);
+
         checkSession();
 
         Objects.checkFromToIndex(start, end, csq.length());


### PR DESCRIPTION
Remove some instanceof checks which are vestigial now that `CharSequence` itself defines `getChars(int,int,char[],int)`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8357286](https://bugs.openjdk.org/browse/JDK-8357286): (bf) Remove obsolete instanceof checks in CharBuffer.append (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25739/head:pull/25739` \
`$ git checkout pull/25739`

Update a local copy of the PR: \
`$ git checkout pull/25739` \
`$ git pull https://git.openjdk.org/jdk.git pull/25739/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25739`

View PR using the GUI difftool: \
`$ git pr show -t 25739`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25739.diff">https://git.openjdk.org/jdk/pull/25739.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25739#issuecomment-2960901537)
</details>
