### PR TITLE
8359181: Error messages generated by configure --help after 8301197

### DIFF
--- a/make/autoconf/configure
+++ b/make/autoconf/configure
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -366,7 +366,7 @@ EOT
 
     # Print additional help, e.g. a list of toolchains and JVM features.
     # This must be done by the autoconf script.
-    ( CONFIGURE_PRINT_ADDITIONAL_HELP=true . $generated_script PRINTF=printf )
+    ( CONFIGURE_PRINT_ADDITIONAL_HELP=true . $generated_script PRINTF=printf ECHO=echo )
 
     cat <<EOT
 

--- a/make/autoconf/help.m4
+++ b/make/autoconf/help.m4
@@ -228,19 +228,19 @@ AC_DEFUN_ONCE([HELP_PRINT_ADDITIONAL_HELP_AND_EXIT],
   if test "x$CONFIGURE_PRINT_ADDITIONAL_HELP" != x; then
 
     # Print available toolchains
-    $PRINTF "The following toolchains are valid as arguments to --with-toolchain-type.\n"
-    $PRINTF "Which are available to use depends on the build platform.\n"
+    $ECHO "The following toolchains are valid as arguments to --with-toolchain-type."
+    $ECHO "Which are available to use depends on the build platform."
     for toolchain in $VALID_TOOLCHAINS_all; do
       # Use indirect variable referencing
       toolchain_var_name=TOOLCHAIN_DESCRIPTION_$toolchain
       TOOLCHAIN_DESCRIPTION=${!toolchain_var_name}
       $PRINTF "  %-22s  %s\n" $toolchain "$TOOLCHAIN_DESCRIPTION"
     done
-    $PRINTF "\n"
+    $ECHO ""
 
     # Print available JVM features
-    $PRINTF "The following JVM features are valid as arguments to --with-jvm-features.\n"
-    $PRINTF "Which are available to use depends on the environment and JVM variant.\n"
+    $ECHO "The following JVM features are valid as arguments to --with-jvm-features."
+    $ECHO "Which are available to use depends on the environment and JVM variant."
     m4_foreach(FEATURE, m4_split(jvm_features_valid), [
       # Create an m4 variable containing the description for FEATURE.
       m4_define(FEATURE_DESCRIPTION, [jvm_feature_desc_]m4_translit(FEATURE, -, _))

--- a/make/autoconf/help.m4
+++ b/make/autoconf/help.m4
@@ -228,19 +228,19 @@ AC_DEFUN_ONCE([HELP_PRINT_ADDITIONAL_HELP_AND_EXIT],
   if test "x$CONFIGURE_PRINT_ADDITIONAL_HELP" != x; then
 
     # Print available toolchains
-    $ECHO "The following toolchains are valid as arguments to --with-toolchain-type."
-    $ECHO "Which are available to use depends on the build platform."
+    $PRINTF "The following toolchains are valid as arguments to --with-toolchain-type.\n"
+    $PRINTF "Which are available to use depends on the build platform.\n"
     for toolchain in $VALID_TOOLCHAINS_all; do
       # Use indirect variable referencing
       toolchain_var_name=TOOLCHAIN_DESCRIPTION_$toolchain
       TOOLCHAIN_DESCRIPTION=${!toolchain_var_name}
       $PRINTF "  %-22s  %s\n" $toolchain "$TOOLCHAIN_DESCRIPTION"
     done
-    $ECHO ""
+    $PRINTF "\n"
 
     # Print available JVM features
-    $ECHO "The following JVM features are valid as arguments to --with-jvm-features."
-    $ECHO "Which are available to use depends on the environment and JVM variant."
+    $PRINTF "The following JVM features are valid as arguments to --with-jvm-features.\n"
+    $PRINTF "Which are available to use depends on the environment and JVM variant.\n"
     m4_foreach(FEATURE, m4_split(jvm_features_valid), [
       # Create an m4 variable containing the description for FEATURE.
       m4_define(FEATURE_DESCRIPTION, [jvm_feature_desc_]m4_translit(FEATURE, -, _))


### PR DESCRIPTION
Hi all,

The macro `HELP_PRINT_ADDITIONAL_HELP_AND_EXIT` is only called directly from make/autoconf/configure. In JDK-8301197,  most uses of `printf` was changed to `echo`, but this explicit call wasn't updated to also set ` ECHO=echo`, this PR add ` ECHO=echo` when call this macro.

Change has been verified locally, almost no risk.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8359181](https://bugs.openjdk.org/browse/JDK-8359181): Error messages generated by configure --help after 8301197 (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25740/head:pull/25740` \
`$ git checkout pull/25740`

Update a local copy of the PR: \
`$ git checkout pull/25740` \
`$ git pull https://git.openjdk.org/jdk.git pull/25740/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25740`

View PR using the GUI difftool: \
`$ git pr show -t 25740`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25740.diff">https://git.openjdk.org/jdk/pull/25740.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25740#issuecomment-2961133497)
</details>
