### PR TITLE
8359182: Use @requires instead of SkippedException for MaxPath.java

### DIFF
--- a/test/jdk/java/io/File/MaxPath.java
+++ b/test/jdk/java/io/File/MaxPath.java
@@ -24,21 +24,14 @@
 /* @test
    @bug 6481955
    @summary Path length less than MAX_PATH (260) works on Windows
-   @library /test/lib
+   @requires (os.family == "windows")
  */
 
 import java.io.File;
 import java.io.IOException;
 
-import jtreg.SkippedException;
-
 public class MaxPath {
     public static void main(String[] args) throws Exception {
-        String osName = System.getProperty("os.name");
-        if (!osName.startsWith("Windows")) {
-            throw new SkippedException("This test is run only on Windows");
-        }
-
         int MAX_PATH = 260;
         String dir = new File(".").getAbsolutePath() + "\\";
         String padding = "1234567890123456789012345678901234567890012345678900123456789001234567890012345678900123456789001234567890012345678900123456789001234567890012345678900123456789001234567890012345678900123456789001234567890012345678900123456789001234567890012345678900123456789001234567890012345678900123456789001234567890012345678900123456789001234567890";


### PR DESCRIPTION
Hi all,

I think use `@requires (os.family == "windows")` is more elegrant than thow jtreg.SkippedException in test java/io/File/MaxPath.java.

On linux before this PR, run this test jtreg report:

```
TEST: java/io/File/MaxPath.java
TEST RESULT: Passed. Skipped: jtreg.SkippedException: This test is run only on Windows
```

On linux after this PR, run this test jtreg report:

```
Test results: no tests selected
```

Change has been verified locally both on linux and windows, test-fix only, no risk.
