### PR TITLE
8359218: RISC-V: Only enable CRC32 intrinsic when AvoidUnalignedAccess == false

### DIFF
--- a/src/hotspot/cpu/riscv/vm_version_riscv.cpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.cpp
@@ -203,15 +203,15 @@ void VM_Version::common_initialize() {
     }
   }
 
-  // Misc Intrinsics could depend on RVV
+  // Misc Intrinsics that could depend on RVV.
 
-  if (UseZba || UseRVV) {
+  if (!AvoidUnalignedAccesses && (UseZba || UseRVV)) {
     if (FLAG_IS_DEFAULT(UseCRC32Intrinsics)) {
       FLAG_SET_DEFAULT(UseCRC32Intrinsics, true);
     }
   } else {
     if (!FLAG_IS_DEFAULT(UseCRC32Intrinsics)) {
-      warning("CRC32 intrinsic requires Zba or RVV instructions (not available on this CPU)");
+      warning("CRC32 intrinsic are not available on this CPU.");
     }
     FLAG_SET_DEFAULT(UseCRC32Intrinsics, false);
   }


### PR DESCRIPTION
When test **Specjvm** in p550, we can find the compress test result shown below.

```
before patch
-XX:-UseCompactObjectHeaders
Warmup (30s) begins: Wed Jun 11 16:10:18 CST 2025
Warmup (30s) ends:   Wed Jun 11 16:10:53 CST 2025
Warmup (30s) result: 68.98 ops/m

Iteration 1 (60s) begins: Wed Jun 11 16:10:53 CST 2025
Iteration 1 (60s) ends:   Wed Jun 11 16:11:57 CST 2025
Iteration 1 (60s) result: 71.25 ops/m


-XX:+UseCompactObjectHeaders
Warmup (30s) begins: Wed Jun 11 16:13:03 CST 2025
Warmup (30s) ends:   Wed Jun 11 16:13:42 CST 2025
Warmup (30s) result: 31.87 ops/m

Iteration 1 (60s) begins: Wed Jun 11 16:13:42 CST 2025
Iteration 1 (60s) ends:   Wed Jun 11 16:14:56 CST 2025
Iteration 1 (60s) result: 29.13 ops/m
```

Add flamegraph Before the patch
1. With parmater -XX:-UseCompactObjectHeaders
```
java -XX:-UseCompactObjectHeaders -XX:+UseParallelGC -XX:+AlwaysPreTouch -Xms8g -Xmx8g -jar SPECjvm2008.jar -ikv -ict -coe -crf 0 -bt 4 -wt 30s -it 1m -i 4 compress
```
![closeCompactObjectHeader](https://github.com/user-attachments/assets/cea7f230-799a-4e9c-a541-626dd485670f)


2. With parmater -XX:+UseCompactObjectHeaders
```
java -XX:+UseCompactObjectHeaders -XX:+UseParallelGC -XX:+AlwaysPreTouch -Xms8g -Xmx8g -jar SPECjvm2008.jar -ikv -ict -coe -crf 0 -bt 4 -wt 30s -it 1m -i 4 compress
```
![openparm](https://github.com/user-attachments/assets/24e07f17-4cb9-459d-b50d-8d1ad6355ebf)


The reason is that when enable compactObjectHeaders, the arraylist header turn to 4 Byte, but the copy instruction used in CRC intrinsic loop is 8 Byte one loop, which may reduce the performance when hardware is sensitive to unaligned access, we can close it when AvoidUnalignedAccesses is true

after patch 
```
-XX:-UseCompactObjectHeaders
Warmup (30s) begins: Wed Jun 11 16:23:22 CST 2025
Warmup (30s) ends:   Wed Jun 11 16:23:57 CST 2025
Warmup (30s) result: 68.61 ops/m

Iteration 1 (60s) begins: Wed Jun 11 16:23:57 CST 2025
Iteration 1 (60s) ends:   Wed Jun 11 16:25:00 CST 2025
Iteration 1 (60s) result: 71.57 ops/m


-XX:+UseCompactObjectHeaders
Warmup (30s) begins: Wed Jun 11 16:25:28 CST 2025
Warmup (30s) ends:   Wed Jun 11 16:26:03 CST 2025
Warmup (30s) result: 68.36 ops/m

Iteration 1 (60s) begins: Wed Jun 11 16:26:03 CST 2025
Iteration 1 (60s) ends:   Wed Jun 11 16:27:08 CST 2025
Iteration 1 (60s) result: 70.85 ops/m
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8359218](https://bugs.openjdk.org/browse/JDK-8359218): RISC-V: Only enable CRC32 intrinsic when AvoidUnalignedAccess == false (**Bug** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Feilong Jiang](https://openjdk.org/census#fjiang) (@feilongjiang - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25743/head:pull/25743` \
`$ git checkout pull/25743`

Update a local copy of the PR: \
`$ git checkout pull/25743` \
`$ git pull https://git.openjdk.org/jdk.git pull/25743/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25743`

View PR using the GUI difftool: \
`$ git pr show -t 25743`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25743.diff">https://git.openjdk.org/jdk/pull/25743.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25743#issuecomment-2961997847)
</details>
