### PR TITLE
8359135: New test TestCPUTimeSampleThrottling fails intermittently

### DIFF
--- a/test/jdk/jdk/jfr/event/profiling/TestCPUTimeSampleThrottling.java
+++ b/test/jdk/jdk/jfr/event/profiling/TestCPUTimeSampleThrottling.java
@@ -61,7 +61,7 @@ public class TestCPUTimeSampleThrottling {
 
     private static void testThrottleSettingsPeriod() throws Exception {
         float rate = countEvents(1000, "10ms").rate();
-        Asserts.assertTrue(rate > 90 && rate < 110, "Expected around 100 events per second, got " + rate);
+        Asserts.assertTrue(rate > 75 && rate < 125, "Expected around 100 events per second, got " + rate);
     }
 
     private record EventCount(long count, float time) {


### PR DESCRIPTION
I increased the tolerated rate deviation to make the test less flaky on systems like PowerPC. The deviation comes from the thread not being in the Java and native states on some platforms compared to others.