### PR TITLE
8359224: G1: Incorrect size unit in logging of G1CollectedHeap::alloc_archive_region

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -495,7 +495,7 @@ HeapWord* G1CollectedHeap::alloc_archive_region(size_t word_size, HeapWord* pref
 
   if (reserved.word_size() <= word_size) {
     log_info(gc, heap)("Unable to allocate regions as archive heap is too large; size requested = %zu"
-                       " bytes, heap = %zu bytes", word_size, reserved.word_size());
+                       " bytes, heap = %zu bytes", word_size * HeapWordSize, reserved.byte_size());
     return nullptr;
   }
 


### PR DESCRIPTION
Simple fixing incorrect unit (byte vs word) in logging.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8359224](https://bugs.openjdk.org/browse/JDK-8359224): G1: Incorrect size unit in logging of G1CollectedHeap::alloc_archive_region (**Bug** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25746/head:pull/25746` \
`$ git checkout pull/25746`

Update a local copy of the PR: \
`$ git checkout pull/25746` \
`$ git pull https://git.openjdk.org/jdk.git pull/25746/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25746`

View PR using the GUI difftool: \
`$ git pr show -t 25746`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25746.diff">https://git.openjdk.org/jdk/pull/25746.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25746#issuecomment-2962248332)
</details>
