### PR TITLE
8359121: C2: Region added by vectorizedMismatch intrinsic can survive as a dead node after IGVN

### DIFF
--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -6580,6 +6580,10 @@ bool LibraryCallKit::inline_vectorizedMismatch() {
   memory_phi = _gvn.transform(memory_phi);
   result_phi = _gvn.transform(result_phi);
 
+  record_for_igvn(exit_block);
+  record_for_igvn(memory_phi);
+  record_for_igvn(result_phi);
+
   set_control(exit_block);
   set_all_memory(memory_phi);
   set_result(result_phi);

--- a/test/hotspot/jtreg/compiler/igvn/RemoveDeadRegionFromVectorizedMismatchIntrinsic.java
+++ b/test/hotspot/jtreg/compiler/igvn/RemoveDeadRegionFromVectorizedMismatchIntrinsic.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8359121
+ * @summary Region node introduced by ArraysSupport.mismatch must be disconnected,
+ *          and not just put aside as dead: when simplifying
+ *          Proj -> Region -> If -> ...
+ *          into
+ *          Proj -> If -> ...
+ *               -> Region
+ *          the dead Region node must be removed from Proj's outputs.
+ * @modules java.base/jdk.internal.util
+ * @run main/othervm -Xcomp
+ *                   -XX:CompileCommand=compileonly,compiler.igvn.RemoveDeadRegionFromVectorizedMismatchIntrinsic::test
+ *                   compiler.igvn.RemoveDeadRegionFromVectorizedMismatchIntrinsic
+ * @run main compiler.igvn.RemoveDeadRegionFromVectorizedMismatchIntrinsic
+ */
+package compiler.igvn;
+
+import jdk.internal.util.ArraysSupport;
+
+public class RemoveDeadRegionFromVectorizedMismatchIntrinsic {
+    public static void main(String[] args) {
+        ArraysSupport.mismatch(new int[0], new int[0], 0);  // loads ArraysSupport
+        test(new byte[0], new byte[0]);
+    }
+
+    public static int test(byte[] a, byte[] b) {
+        int i = ArraysSupport.vectorizedMismatch(a, 0, b, 0, 0, 0);
+        return i >= 0 ? i : 0;
+    }
+}


### PR DESCRIPTION
In `bool LibraryCallKit::inline_vectorizedMismatch()` the region created at:

https://github.com/openjdk/jdk/blob/0582bd290d5a8b6344ae7ada36492cc2f33df050/src/hotspot/share/opto/library_call.cpp#L6502

may have only one input, and be a copy (that is no self-loop) and a single input. It is thus safe to remove. Yet, in the reproducer case, the node is short-circuited, but stays in the graph after IGVN.

Left, after Parsing/before IGVN; right, after IGVN:
<img src="https://github.com/user-attachments/assets/2fc0e817-ccf5-4586-81dc-ea9daef21274" width="400">  <img src="https://github.com/user-attachments/assets/6032f54e-75ba-49a1-b00e-ac8053d9f592" width="400">
On the left, the :warning: is there because the Region doesn't have a self loop, which is expected for copies. On the right, it still doesn't have a self-loop, but IGV is also complaining the Region has no successor.

This transformation comes from `IfNode::Ideal`, that calls `IfNode::Ideal_common`, that calls `Node::remove_dead_region`,  that shortcuts a trivial Region input:
https://github.com/openjdk/jdk/blob/0582bd290d5a8b6344ae7ada36492cc2f33df050/src/hotspot/share/opto/node.cpp#L1480-L1484

Yet, the Region node is never enqueued for IGVN, so stays in the graph.  This is not nice because it gives both:
- a control node (50 Proj) has 2 successors,
- a control node (46 Region) has 0 successors.

While at the end of IGVN, we could expect the graph to be cleaned up. There are couple ways of doing, each being enough by itself:
1. explicitly record for IGVN the region node in `LibraryCallKit::inline_vectorizedMismatch`, and not hoping it would be collected by another consequence
2. change `Node::remove_dead_region` to use `set_req_X` instead of `set_req`, so that if the Region goes dead, it will be removed.
3. not introduce the region node in `LibraryCallKit::inline_vectorizedMismatch` if we are going to have only one path, and thus avoid the problem entirely.

The solution 3. is really not easy and would require quite some code restructuring for simply saving removing a node. After discussing with @chhagedorn, we concluded that the solution 1. was probably the best:
- usually, functions similar to `inline_vectorizedMismatch` call `record_for_igvn` themselves,
- unlike what I assumed at first seeing `remove_dead_region`, it's not a general problem at all: I couldn't find another case without using `inline_vectorizedMismatch` where the Region is put aside, and not entirely disconnected quickly after, but the Region is always processed in the same IGVN when `remove_dead_region` makes it dead.

And then, we find that:
<img src="https://github.com/user-attachments/assets/32f4d934-6849-43bf-915f-0710436a22c5" width="400">

This was found because it makes a check of JDK-8350864 to fail. My plan is to add this structural invariant check to the test once the flag is integrated, as for now, the test need manual inspection to see a difference. It's also not really possible to write an IR test with it: the Region node is not reachable by under (use to def traversal from Root), so the printout of the graph doesn't show the Region node, even if the `50 Proj` above is indeed printed to have 2 outputs, only the `57 If` is actually printed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8359121](https://bugs.openjdk.org/browse/JDK-8359121): C2: Region added by vectorizedMismatch intrinsic can survive as a dead node after IGVN (**Bug** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25749/head:pull/25749` \
`$ git checkout pull/25749`

Update a local copy of the PR: \
`$ git checkout pull/25749` \
`$ git pull https://git.openjdk.org/jdk.git pull/25749/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25749`

View PR using the GUI difftool: \
`$ git pr show -t 25749`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25749.diff">https://git.openjdk.org/jdk/pull/25749.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25749#issuecomment-2962618134)
</details>
