### PR TITLE
8359168: Revert stdin.encoding usage in test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach010/attach010Agent00.java

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach010/attach010Agent00.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach010/attach010Agent00.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,8 +60,7 @@ public class attach010Agent00 extends AbstractJarAgent {
         FileInputStream newInputStream = new FileInputStream(inStreamFileName);
         System.setIn(newInputStream);
 
-        BufferedReader inputStreamReader = new BufferedReader(new InputStreamReader(
-                System.in, System.getProperty("stdin.encoding")));
+        BufferedReader inputStreamReader = new BufferedReader(new InputStreamReader(System.in));
         int readValue = Integer.parseInt(inputStreamReader.readLine());
 
         if (readValue != valueToWrite) {


### PR DESCRIPTION
Revert `stdin.encoding` changes to `test/hotspot/.../attach010Agent00.java` introduced in [JDK-8357993](https://bugs.openjdk.org/browse/JDK-8357993) – @plummercj [reported](https://github.com/openjdk/jdk/pull/25542#issuecomment-2950447745) that they are unnecessary.

Note that I've reset the copyright year back to 2018.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8359168](https://bugs.openjdk.org/browse/JDK-8359168): Revert stdin.encoding usage in test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach010/attach010Agent00.java (**Enhancement** - P4)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25753/head:pull/25753` \
`$ git checkout pull/25753`

Update a local copy of the PR: \
`$ git checkout pull/25753` \
`$ git pull https://git.openjdk.org/jdk.git pull/25753/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25753`

View PR using the GUI difftool: \
`$ git pr show -t 25753`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25753.diff">https://git.openjdk.org/jdk/pull/25753.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25753#issuecomment-2962575036)
</details>
