### PR TITLE
8358617: java/net/HttpURLConnection/HttpURLConnectionExpectContinueTest.java fails with 403 due to system proxies

### DIFF
--- a/test/jdk/java/net/HttpURLConnection/HttpURLConnectionExpectContinueTest.java
+++ b/test/jdk/java/net/HttpURLConnection/HttpURLConnectionExpectContinueTest.java
@@ -429,7 +429,7 @@ public class HttpURLConnectionExpectContinueTest {
                 .port(control.serverSocket.getLocalPort())
                 .toURL();
 
-        HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+        HttpURLConnection connection = (HttpURLConnection) url.openConnection(Proxy.NO_PROXY);
         connection.setDoOutput(true);
         connection.setReadTimeout(5000);
         connection.setUseCaches(false);


### PR DESCRIPTION
I would like to backport this trivial test-only change to JDK 25.
This one-liner ensures that the test will not depend on the host proxy configuration when running in the CI.
This is a clean backport.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8358617](https://bugs.openjdk.org/browse/JDK-8358617): java/net/HttpURLConnection/HttpURLConnectionExpectContinueTest.java fails with 403 due to system proxies (**Bug** - P4)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25755/head:pull/25755` \
`$ git checkout pull/25755`

Update a local copy of the PR: \
`$ git checkout pull/25755` \
`$ git pull https://git.openjdk.org/jdk.git pull/25755/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25755`

View PR using the GUI difftool: \
`$ git pr show -t 25755`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25755.diff">https://git.openjdk.org/jdk/pull/25755.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25755#issuecomment-2962825210)
</details>
