### PR TITLE
8359242: JFR: Missing help text for method trace and timing

### DIFF
--- a/src/java.base/share/man/java.md
+++ b/src/java.base/share/man/java.md
@@ -1449,9 +1449,10 @@ These `java` options control the runtime behavior of the Java HotSpot VM.
 
     `report-on-exit=`*identifier*
     :   Specifies the name of the view to display when the Java Virtual Machine
-        (JVM) shuts down. This option is not available if the disk option is set
-        to false. For a list of available views, see `jfr help view`. By default,
-        no report is generated.
+        (JVM) shuts down. To specify more than one view, use the report-on-exit
+        parameter repeatedly. This option is not available if the disk option
+        is set to false. For a list of available views, see `jfr help view`.
+        By default, no report is generated.
 
     `settings=`*path*
     :   Specifies the path and name of the event settings file (of type JFC).

--- a/src/java.base/share/man/java.md
+++ b/src/java.base/share/man/java.md
@@ -1449,10 +1449,9 @@ These `java` options control the runtime behavior of the Java HotSpot VM.
 
     `report-on-exit=`*identifier*
     :   Specifies the name of the view to display when the Java Virtual Machine
-        (JVM) shuts down. To specify more than one view, use the report-on-exit
-        parameter repeatedly. This option is not available if the disk option
-        is set to false. For a list of available views, see `jfr help view`.
-        By default, no report is generated.
+        (JVM) shuts down. This option is not available if the disk option is set
+        to false. For a list of available views, see `jfr help view`. By default,
+        no report is generated.
 
     `settings=`*path*
     :   Specifies the path and name of the event settings file (of type JFC).

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/jfc/model/XmlElement.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/jfc/model/XmlElement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -104,6 +104,13 @@ class XmlElement {
     }
 
     final String getContent() {
+        return content;
+    }
+
+    final String getContentOrEmptyQuote() {
+        if (content == null || content.isEmpty()) {
+            return "\"\"";
+        }
         return content;
     }
 

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/jfc/model/XmlText.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/jfc/model/XmlText.java
@@ -37,7 +37,7 @@ final class XmlText extends XmlInput {
         sb.append(getContentType().orElse("text"));
         sb.append(">");
         sb.append("  (");
-        String content = getContent();
+        String content = getContentOrEmptyQuote();
         if (isTimespan()) {
             // "20 ms" becomes "20ms"
             content = content.replaceAll("\\s", "");
@@ -106,6 +106,6 @@ final class XmlText extends XmlInput {
     }
 
     private boolean isMethodFilter() {
-        return getContentType().orElse("text").equals("methodFilter");
+        return getContentType().orElse("text").equals("method-filter");
     }
 }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/jfc/model/XmlText.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/jfc/model/XmlText.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,8 @@
  * questions.
  */
 package jdk.jfr.internal.jfc.model;
+
+import jdk.jfr.internal.tracing.Filter;
 
 // Corresponds to <text>
 final class XmlText extends XmlInput {
@@ -57,7 +59,7 @@ final class XmlText extends XmlInput {
     @Override
     public void configure(UserInterface ui) throws AbortException {
         ui.println();
-        ui.println(getLabel() + ": " + getContent() + "  (default)");
+        ui.println(getLabel() + ": " + getContentOrEmptyQuote() + "  (default)");
         while (!readInput(ui)) {
             ;
         }
@@ -71,8 +73,20 @@ final class XmlText extends XmlInput {
     private boolean readInput(UserInterface ui) throws AbortException {
         String line = ui.readLine();
         if (line.isBlank()) {
-            ui.println("Using default: " + getContent());
+            ui.println("Using default: " + getContentOrEmptyQuote());
             return true;
+        }
+        if (isMethodFilter()) {
+            if (!Filter.isValid(line)) {
+                ui.println("""
+                Not a valid method filter. A filter can be an annotation \
+                (@jakarta.ws.rs.GET), a full qualified class name (com.example.Foo), \
+                a fully qualified method reference (java.lang.HashMap::resize) or a \
+                class initializer (::<clinit>). Use <init> for constructors. \
+                Separate multiple filters with semicolon.\
+                """);
+                return false;
+            }
         }
         if (isTimespan()) {
             try {
@@ -89,5 +103,9 @@ final class XmlText extends XmlInput {
 
     private boolean isTimespan() {
         return getContentType().orElse("text").equals("timespan");
+    }
+
+    private boolean isMethodFilter() {
+        return getContentType().orElse("text").equals("methodFilter");
     }
 }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/settings/MethodSetting.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/settings/MethodSetting.java
@@ -33,6 +33,7 @@ import jdk.jfr.Name;
 import jdk.jfr.internal.PlatformEventType;
 import jdk.jfr.internal.Type;
 import jdk.jfr.internal.tracing.Modification;
+import jdk.jfr.internal.tracing.Filter;
 import jdk.jfr.internal.tracing.PlatformTracer;
 
 @MetadataDefinition
@@ -47,8 +48,9 @@ public final class MethodSetting extends FilterSetting {
         this.modification = modification;
     }
 
+    @Override
     public boolean isValid(String text) {
-        return PlatformTracer.isValidFilter(text);
+        return Filter.isValid(text);
     }
 
     @Override

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/tracing/Filter.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/tracing/Filter.java
@@ -30,7 +30,11 @@ import jdk.internal.module.Checks;
  * Class that represents the filter a user can specify for the MethodTrace and
  * MethodTiming event.
  */
-record Filter(String className, String methodName, String annotationName, Modification modification) {
+public record Filter(String className, String methodName, String annotationName, Modification modification) {
+
+    public static boolean isValid(String filter) {
+        return of(filter, Modification.NONE) != null;
+    }
 
     static Filter of(String filter, Modification modification) {
         if (filter.startsWith("@")) {

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/tracing/PlatformTracer.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/tracing/PlatformTracer.java
@@ -158,10 +158,6 @@ public final class PlatformTracer {
         }
     }
 
-    public static boolean isValidFilter(String text) {
-        return Filter.of(text, null) != null;
-    }
-
     public static void setFilters(Modification modification, List<String> filters) {
         ensureInitialized();
         publishClasses(applyFilter(modification, filters));

--- a/src/jdk.jfr/share/conf/jfr/default.jfc
+++ b/src/jdk.jfr/share/conf/jfr/default.jfc
@@ -1189,9 +1189,11 @@
 
       <text name="locking-threshold" label="Locking Threshold" contentType="timespan" minimum="0 s">20 ms</text>
 
-      <text name="method-timing" label="Method Timing" contentType="text"></text>
+      <text name="method-timing" label="Method Timing Filter" contentType="methodFilter"
+            description="A filter can be an annotation (@jakarta.ws.rs.GET), a full qualified class name (com.example.Foo), a fully qualified method reference (java.lang.HashMap::resize) or a class initializer (::&lt;clinit&gt;). Use &lt;init&gt; for constructors. Separate multiple filters with semicolon."></text>
 
-      <text name="method-trace" label="Method Trace" contentType="text"></text>
+      <text name="method-trace" label="Method Trace Filter" contentType="methodFilter"
+            description="A filter can be an annotation (@jakarta.ws.rs.GET), a full qualified class name (com.example.Foo), a fully qualified method reference (java.lang.HashMap::resize) or a class initializer (::&lt;clinit&gt;). Use &lt;init&gt; for constructors. Separate multiple filters with semicolon."></text>
 
       <flag name="class-loading" label="Class Loading">false</flag>
     </control>

--- a/src/jdk.jfr/share/conf/jfr/default.jfc
+++ b/src/jdk.jfr/share/conf/jfr/default.jfc
@@ -1189,10 +1189,10 @@
 
       <text name="locking-threshold" label="Locking Threshold" contentType="timespan" minimum="0 s">20 ms</text>
 
-      <text name="method-timing" label="Method Timing Filter" contentType="methodFilter"
+      <text name="method-timing" label="Method Timing Filter" contentType="method-filter"
             description="A filter can be an annotation (@jakarta.ws.rs.GET), a full qualified class name (com.example.Foo), a fully qualified method reference (java.lang.HashMap::resize) or a class initializer (::&lt;clinit&gt;). Use &lt;init&gt; for constructors. Separate multiple filters with semicolon."></text>
 
-      <text name="method-trace" label="Method Trace Filter" contentType="methodFilter"
+      <text name="method-trace" label="Method Trace Filter" contentType="method-filter"
             description="A filter can be an annotation (@jakarta.ws.rs.GET), a full qualified class name (com.example.Foo), a fully qualified method reference (java.lang.HashMap::resize) or a class initializer (::&lt;clinit&gt;). Use &lt;init&gt; for constructors. Separate multiple filters with semicolon."></text>
 
       <flag name="class-loading" label="Class Loading">false</flag>

--- a/src/jdk.jfr/share/conf/jfr/profile.jfc
+++ b/src/jdk.jfr/share/conf/jfr/profile.jfc
@@ -1188,9 +1188,11 @@
 
       <text name="locking-threshold" label="Locking Threshold" contentType="timespan" minimum="0 s">10 ms</text>
 
-      <text name="method-timing" label="Method Timing" contentType="text"></text>
+      <text name="method-timing" label="Method Timing Filter" contentType="methodFilter"
+            description="A filter can be an annotation (@jakarta.ws.rs.GET), a full qualified class name (com.example.Foo), a fully qualified method reference (java.lang.HashMap::resize) or a class initializer (::&lt;clinit&gt;). Use &lt;init&gt; for constructors. Separate multiple filters with semicolon."></text>
 
-      <text name="method-trace" label="Method Trace" contentType="text"></text>
+      <text name="method-trace" label="Method Trace Filter" contentType="methodFilter"
+            description="A filter can be an annotation (@jakarta.ws.rs.GET), a full qualified class name (com.example.Foo), a fully qualified method reference (java.lang.HashMap::resize) or a class initializer (::&lt;clinit&gt;). Use &lt;init&gt; for constructors. Separate multiple filters with semicolon."></text>
 
       <flag name="class-loading" label="Class Loading">false</flag>
     </control>

--- a/src/jdk.jfr/share/conf/jfr/profile.jfc
+++ b/src/jdk.jfr/share/conf/jfr/profile.jfc
@@ -1188,10 +1188,10 @@
 
       <text name="locking-threshold" label="Locking Threshold" contentType="timespan" minimum="0 s">10 ms</text>
 
-      <text name="method-timing" label="Method Timing Filter" contentType="methodFilter"
+      <text name="method-timing" label="Method Timing Filter" contentType="method-filter"
             description="A filter can be an annotation (@jakarta.ws.rs.GET), a full qualified class name (com.example.Foo), a fully qualified method reference (java.lang.HashMap::resize) or a class initializer (::&lt;clinit&gt;). Use &lt;init&gt; for constructors. Separate multiple filters with semicolon."></text>
 
-      <text name="method-trace" label="Method Trace Filter" contentType="methodFilter"
+      <text name="method-trace" label="Method Trace Filter" contentType="method-filter"
             description="A filter can be an annotation (@jakarta.ws.rs.GET), a full qualified class name (com.example.Foo), a fully qualified method reference (java.lang.HashMap::resize) or a class initializer (::&lt;clinit&gt;). Use &lt;init&gt; for constructors. Separate multiple filters with semicolon."></text>
 
       <flag name="class-loading" label="Class Loading">false</flag>


### PR DESCRIPTION
Could I have a review of a PR that adds missing help text for method trace and method timing? Without it, it's hard for users to understand how the feature can be used in JMC or with `jfr configure --interactive`.

Testing:  test/jdk/jdk/jfr  + tier1

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8359242](https://bugs.openjdk.org/browse/JDK-8359242): JFR: Missing help text for method trace and timing (**Bug** - P3)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25759/head:pull/25759` \
`$ git checkout pull/25759`

Update a local copy of the PR: \
`$ git checkout pull/25759` \
`$ git pull https://git.openjdk.org/jdk.git pull/25759/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25759`

View PR using the GUI difftool: \
`$ git pr show -t 25759`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25759.diff">https://git.openjdk.org/jdk/pull/25759.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25759#issuecomment-2963484625)
</details>
