### PR TITLE
8344556: [Graal] compiler/intrinsics/bmi/* fail when AOTCache cannot be loaded

### DIFF
--- a/test/hotspot/jtreg/compiler/intrinsics/bmi/BMITestRunner.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/bmi/BMITestRunner.java
@@ -122,10 +122,11 @@ public class BMITestRunner {
         List<String> vmOpts = new LinkedList<String>();
 
         Collections.addAll(vmOpts, additionalVMOpts);
-        // Hide timestamps from warnings (e.g. due to potential CDS
+        // Hide timestamps from warnings (e.g. due to potential AOT
         // saved/runtime state mismatch), to avoid false positives when
         // comparing output across runs.
         vmOpts.add("-Xlog:all=warning:stdout:level,tags");
+        vmOpts.add("-Xlog:aot=off");
 
         //setup mode-specific options
         switch (testVMMode) {


### PR DESCRIPTION
When running with 

```
$ make test-only JTREG=AOT_JDK=twostep \
  TEST_VM_OPTS='-XX:+UnlockExperimentalVMOptions -XX:+UseGraalJIT' \
  TEST=open/test/hotspot/jtreg/compiler/intrinsics/bmi/TestBlsmskL.java
```

One of the the -Xint or -Xcomp VM launched by these tests will not be able to load the AOT cache (due to [JDK-8358738](https://bugs.openjdk.org/browse/JDK-8358738) -- at this point, we are not sure if this behavior is intended or not).

Regardless on the decision about  [JDK-8358738](https://bugs.openjdk.org/browse/JDK-8358738) , we should make the bmi tests more resilient by filtering out AOT error logs, since the purpose of thethe bmi tests are for testing intrinsics, not AOT.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344556](https://bugs.openjdk.org/browse/JDK-8344556): [Graal] compiler/intrinsics/bmi/* fail when AOTCache cannot be loaded (**Bug** - P5)


### Reviewers
 * [Doug Simon](https://openjdk.org/census#dnsimon) (@dougxc - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25761/head:pull/25761` \
`$ git checkout pull/25761`

Update a local copy of the PR: \
`$ git checkout pull/25761` \
`$ git pull https://git.openjdk.org/jdk.git pull/25761/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25761`

View PR using the GUI difftool: \
`$ git pr show -t 25761`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25761.diff">https://git.openjdk.org/jdk/pull/25761.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25761#issuecomment-2963796695)
</details>
