### PR TITLE
8355556: JVM crash because archived method handle intrinsics are not restored

### DIFF
--- a/src/hotspot/share/runtime/threads.cpp
+++ b/src/hotspot/share/runtime/threads.cpp
@@ -771,8 +771,8 @@ jint Threads::create_vm(JavaVMInitArgs* args, bool* canTryAgain) {
 #endif
 
   if (CDSConfig::is_using_aot_linked_classes()) {
-    AOTLinkedClassBulkLoader::finish_loading_javabase_classes(CHECK_JNI_ERR);
     SystemDictionary::restore_archived_method_handle_intrinsics();
+    AOTLinkedClassBulkLoader::finish_loading_javabase_classes(CHECK_JNI_ERR);
   }
 
   // Start string deduplication thread if requested.


### PR DESCRIPTION
`AOTLinkedClassBulkLoader::finish_loading_javabase_classes()` can execute Java bytecodes (from `<clinit>`). If one of these bytecodes is an AOT-resolved `invokedynamic`, it may be dispatched using an archived method handle intrinsic. Therefore, we should call `SystemDictionary::restore_archived_method_handle_intrinsics()` first to make sure that the method handle intrinsics are ready to be used.

In the JDK mainline, we only execute a very limited set of Java methods which happens to not include any `invokedynamic` bytecodes. That's why this bug has not been found in the mainline.

However, in the Leyden repo, we have other optimizations, such as archived ProtectionDomains, which will cause `invokedynamic` bytecodes to be executed inside `AOTLinkedClassBulkLoader::finish_loading_javabase_classes()`.

Since this is a potential issue even for the JDK mainline, we should fix it (and also backport to JDK 25).

Thanks to @iwanowww for providing the fix!