### PR TITLE
8357982: Fix several failing BMI tests with -XX:+UseAPX

### DIFF
--- a/src/hotspot/cpu/x86/x86_64.ad
+++ b/src/hotspot/cpu/x86/x86_64.ad
@@ -10527,7 +10527,8 @@ instruct xorI_rReg_im1_ndd(rRegI dst, rRegI src, immI_M1 imm)
 // Xor Register with Immediate
 instruct xorI_rReg_imm(rRegI dst, immI src, rFlagsReg cr)
 %{
-  predicate(!UseAPX);
+  // Strict predicate check to make selection of xorI_rReg_im1 cost agnostic if immI src is -1.
+  predicate(!UseAPX && n->in(2)->bottom_type()->is_int()->get_con() != -1);
   match(Set dst (XorI dst src));
   effect(KILL cr);
   flag(PD::Flag_sets_sign_flag, PD::Flag_sets_zero_flag, PD::Flag_sets_parity_flag, PD::Flag_clears_overflow_flag, PD::Flag_clears_carry_flag);
@@ -10541,7 +10542,8 @@ instruct xorI_rReg_imm(rRegI dst, immI src, rFlagsReg cr)
 
 instruct xorI_rReg_rReg_imm_ndd(rRegI dst, rRegI src1, immI src2, rFlagsReg cr)
 %{
-  predicate(UseAPX);
+  // Strict predicate check to make selection of xorI_rReg_im1_ndd cost agnostic if immI src2 is -1.
+  predicate(UseAPX && n->in(2)->bottom_type()->is_int()->get_con() != -1);
   match(Set dst (XorI src1 src2));
   effect(KILL cr);
   flag(PD::Flag_sets_sign_flag, PD::Flag_sets_zero_flag, PD::Flag_sets_parity_flag, PD::Flag_clears_overflow_flag, PD::Flag_clears_carry_flag);
@@ -10559,6 +10561,7 @@ instruct xorI_rReg_mem_imm_ndd(rRegI dst, memory src1, immI src2, rFlagsReg cr)
   predicate(UseAPX);
   match(Set dst (XorI (LoadI src1) src2));
   effect(KILL cr);
+  ins_cost(150);
   flag(PD::Flag_sets_sign_flag, PD::Flag_sets_zero_flag, PD::Flag_sets_parity_flag, PD::Flag_clears_overflow_flag, PD::Flag_clears_carry_flag);
 
   format %{ "exorl    $dst, $src1, $src2\t# int ndd" %}
@@ -11201,7 +11204,8 @@ instruct xorL_rReg_im1_ndd(rRegL dst,rRegL src, immL_M1 imm)
 // Xor Register with Immediate
 instruct xorL_rReg_imm(rRegL dst, immL32 src, rFlagsReg cr)
 %{
-  predicate(!UseAPX);
+  // Strict predicate check to make selection of xorL_rReg_im1 cost agnostic if immL32 src is -1.
+  predicate(!UseAPX && n->in(2)->bottom_type()->is_long()->get_con() != -1L);
   match(Set dst (XorL dst src));
   effect(KILL cr);
   flag(PD::Flag_sets_sign_flag, PD::Flag_sets_zero_flag, PD::Flag_sets_parity_flag, PD::Flag_clears_overflow_flag, PD::Flag_clears_carry_flag);
@@ -11215,7 +11219,8 @@ instruct xorL_rReg_imm(rRegL dst, immL32 src, rFlagsReg cr)
 
 instruct xorL_rReg_rReg_imm(rRegL dst, rRegL src1, immL32 src2, rFlagsReg cr)
 %{
-  predicate(UseAPX);
+  // Strict predicate check to make selection of xorL_rReg_im1_ndd cost agnostic if immL32 src2 is -1.
+  predicate(UseAPX && n->in(2)->bottom_type()->is_long()->get_con() != -1L);
   match(Set dst (XorL src1 src2));
   effect(KILL cr);
   flag(PD::Flag_sets_sign_flag, PD::Flag_sets_zero_flag, PD::Flag_sets_parity_flag, PD::Flag_clears_overflow_flag, PD::Flag_clears_carry_flag);
@@ -11234,6 +11239,7 @@ instruct xorL_rReg_mem_imm(rRegL dst, memory src1, immL32 src2, rFlagsReg cr)
   match(Set dst (XorL (LoadL src1) src2));
   effect(KILL cr);
   flag(PD::Flag_sets_sign_flag, PD::Flag_sets_zero_flag, PD::Flag_sets_parity_flag, PD::Flag_clears_overflow_flag, PD::Flag_clears_carry_flag);
+  ins_cost(150);
 
   format %{ "exorq    $dst, $src1, $src2\t# long ndd" %}
   ins_encode %{

--- a/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/AndnTestI.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/AndnTestI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -55,6 +55,19 @@ public class AndnTestI extends BmiIntrinsicBase.BmiTestCase {
         instrPattern = new byte[]{
                 (byte) 0xC4, // prefix for 3-byte VEX instruction
                 (byte) 0x02, // 00010 implied 0F 38 leading opcode bytes
+                (byte) 0x00,
+                (byte) 0xF2};
+        // from intel apx specifications EVEX.128.NP.0F38.W0 F2 /r
+        instrMaskAPX = new byte[]{
+                (byte) 0xFF,
+                (byte) 0x07,
+                (byte) 0x00,
+                (byte) 0x00,
+                (byte) 0xFF};
+        instrPatternAPX = new byte[]{
+                (byte) 0x62, // fixed prefix byte 0x62 for extended EVEX instruction
+                (byte) 0x02, // 00010 implied 0F 38 leading opcode bytes
+                (byte) 0x00,
                 (byte) 0x00,
                 (byte) 0xF2};
     }

--- a/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/BlsiTestI.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/BlsiTestI.java
@@ -59,6 +59,23 @@ public class BlsiTestI extends BmiIntrinsicBase.BmiTestCase {
                 (byte) 0x00,
                 (byte) 0xF3,
                 (byte) 0b0001_1000}; // bits 543 == 011 (3)
+
+        // from intel apx specifications EVEX.128.NP.0F38.W0 F3 /3(opcode extension)
+        instrMaskAPX = new byte[]{
+                (byte) 0xFF,
+                (byte) 0x07,
+                (byte) 0x00,
+                (byte) 0x00,
+                (byte) 0xFF,
+                (byte) 0x38};
+
+        instrPatternAPX = new byte[]{
+                (byte) 0x62, // fixed prefix byte 0x62 for extended EVEX instruction
+                (byte) 0x02, // 00010 implied 0F 38 leading opcode bytes
+                (byte) 0x00,
+                (byte) 0x00,
+                (byte) 0xF3,
+                (byte) 0b0001_1000}; // bits 543 == 011 (3)
     }
 
     public static void main(String[] args) throws Exception {

--- a/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/BlsmskTestI.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/BlsmskTestI.java
@@ -57,7 +57,24 @@ public class BlsmskTestI extends BmiIntrinsicBase.BmiTestCase {
                 (byte) 0x02, // 00010 implied 0F 38 leading opcode bytes
                 (byte) 0x00,
                 (byte) 0xF3,
-                (byte) 0b0001_0000}; // bits 543 == 011 (3)
+                (byte) 0b0001_0000}; // bits 543 == 010 (2)
+
+        // from intel apx specifications EVEX.128.NP.0F38.W1 F3 /2(opcode extension part of ModRM.REG)
+        instrMaskAPX = new byte[]{
+                (byte) 0xFF,
+                (byte) 0x07,
+                (byte) 0x00,
+                (byte) 0x00,
+                (byte) 0xFF,
+                (byte) 0x38};
+
+        instrPatternAPX = new byte[]{
+                (byte) 0x62, // fixed prefix byte 0x62 for extended EVEX instruction
+                (byte) 0x02, // 00010 implied 0F 38 leading opcode bytes
+                (byte) 0x00,
+                (byte) 0x00,
+                (byte) 0xF3,
+                (byte) 0b0001_0000}; // bits 543 == 010 (2)
     }
 
     public static void main(String[] args) throws Exception {

--- a/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/BlsrTestI.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/BlsrTestI.java
@@ -58,7 +58,25 @@ public class BlsrTestI extends BmiIntrinsicBase.BmiTestCase {
                 (byte) 0x02, // 00010 implied 0F 38 leading opcode bytes
                 (byte) 0x00,
                 (byte) 0xF3,
-                (byte) 0b0000_1000}; // bits 543 == 011 (3)
+                (byte) 0b0000_1000}; // bits 543 == 001 (1)
+
+        // from intel apx specifications EVEX.128.NP.0F38.W1 F3 /1(opcode extension part of ModRM.REG)
+        instrMaskAPX = new byte[]{
+                (byte) 0xFF,
+                (byte) 0x07,
+                (byte) 0x00,
+                (byte) 0x00,
+                (byte) 0xFF,
+                (byte) 0x38};
+
+        instrPatternAPX = new byte[]{
+                (byte) 0x62, // fixed prefix byte 0x62 for extended EVEX instruction
+                (byte) 0x02, // 00010 implied 0F 38 leading opcode bytes
+                (byte) 0x00,
+                (byte) 0x00,
+                (byte) 0xF3,
+                (byte) 0b0000_1000}; // bits 543 == 001 (1)
+
     }
 
     public static void main(String[] args) throws Exception {

--- a/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/BzhiTestI2L.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/BzhiTestI2L.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -73,6 +73,21 @@ public class BzhiTestI2L extends BmiIntrinsicBase.BmiTestCase_x64 {
             (byte) 0x62,    // 00010 implied 0F 38 leading opcode bytes
             (byte) 0xA8,
             (byte) 0xF5};
+
+        // from intel apx specifications EVEX.128.NP.0F38.W0 F5 /r
+        instrMaskAPX = new byte[]{
+                (byte) 0xFF,
+                (byte) 0x07,
+                (byte) 0x00,
+                (byte) 0x00,
+                (byte) 0xFF};
+
+        instrPatternAPX = new byte[]{
+                (byte) 0x62, // fixed prefix byte 0x62 for extended EVEX instruction
+                (byte) 0x02, // 00010 implied 0F 38 leading opcode bytes
+                (byte) 0x00,
+                (byte) 0x00,
+                (byte) 0xF5};
     }
 
     public static void main(String[] args) throws Exception {

--- a/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/LZcntTestI.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/LZcntTestI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,6 +51,10 @@ public class LZcntTestI extends BmiIntrinsicBase.BmiTestCase_x64 {
 
         instrMask_x64 = new byte[]{(byte) 0xFF, (byte) 0x00, (byte) 0xFF, (byte) 0xFF};
         instrPattern_x64 = new byte[]{(byte) 0xF3, (byte) 0x00, (byte) 0x0F, (byte) 0xBD};
+
+        // REX2 variant
+        instrMaskAPX = new byte[]{(byte) 0xFF, (byte) 0xFF, (byte)0x80, (byte) 0xFF};
+        instrPatternAPX = new byte[]{(byte) 0xF3, (byte) 0xD5, (byte) 0x80, (byte) 0xBD};
     }
 
     public static void main(String[] args) throws Exception {

--- a/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/TZcntTestI.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/TZcntTestI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,6 +50,10 @@ public class TZcntTestI extends BmiIntrinsicBase.BmiTestCase_x64 {
 
         instrMask_x64 = new byte[]{(byte) 0xFF, (byte) 0x00, (byte) 0xFF, (byte) 0xFF};
         instrPattern_x64 = new byte[]{(byte) 0xF3, (byte) 0x00, (byte) 0x0F, (byte) 0xBC};
+
+        // REX2 variant
+        instrMaskAPX = new byte[]{(byte) 0xFF, (byte) 0xFF, (byte)0x80, (byte) 0xFF};
+        instrPatternAPX = new byte[]{(byte) 0xF3, (byte) 0xD5, (byte) 0x80, (byte) 0xBC};
     }
 
     public static void main(String[] args) throws Exception {


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [c98dffa1](https://github.com/openjdk/jdk/commit/c98dffa186d48c41e76fd3a60e0129a8da60310f) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Jatin Bhateja on 11 Jun 2025 and was reviewed by Emanuel Peter and Sandhya Viswanathan.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8357982](https://bugs.openjdk.org/browse/JDK-8357982): Fix several failing BMI tests with -XX:+UseAPX (**Bug** - P3)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25769/head:pull/25769` \
`$ git checkout pull/25769`

Update a local copy of the PR: \
`$ git checkout pull/25769` \
`$ git pull https://git.openjdk.org/jdk.git pull/25769/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25769`

View PR using the GUI difftool: \
`$ git pr show -t 25769`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25769.diff">https://git.openjdk.org/jdk/pull/25769.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25769#issuecomment-2965332715)
</details>
