### PR TITLE
8354727: CompilationPolicy creates too many compiler threads when code cache space is scarce

### DIFF
--- a/src/hotspot/share/compiler/compilationPolicy.cpp
+++ b/src/hotspot/share/compiler/compilationPolicy.cpp
@@ -37,6 +37,7 @@
 #include "runtime/arguments.hpp"
 #include "runtime/deoptimization.hpp"
 #include "runtime/frame.hpp"
+#include "runtime/frame.inline.hpp"
 #include "runtime/globals_extension.hpp"
 #include "runtime/handles.inline.hpp"
 #include "runtime/safepoint.hpp"


### PR DESCRIPTION
# Issue Summary

Running 
```bash
java -XX:+SegmentedCodeCache -XX:ReservedCodeCacheSize=10M -XX:NonNMethodCodeHeapSize=6M \
     -XX:ProfiledCodeHeapSize=5M -XX:NonProfiledCodeHeapSize=5M -version
```
on a machine with more than 255 cores, this would fail with the message that the specified `NonNMethodCodeHeapSize` is too small to fit all compiler buffers (instead of failing because the sum of the heaps is larger than the `ReservedCodeCacheSize`). Hence, the calculated compiler count is too high. This is due to  `CompilationPolicy::initialize()` checking how many compiler buffers fit into the `ReservedCodeCacheSize`. However, in the case above, this is significantly larger than `NonNMethodCodeHeapSize` and causes a new check introduced in #17244 to fail.

# Changes

This PR fixes the calculation of the `CICompilerCount` ergonomic. Firstly, @shipilev kindly provided a fix for the compiler buffer size used in the calculation is also correct if we only have C2. Secondly,`NonNMethodHeapSize`is used as the maximum buffers size available for compilers buffers instead of `ReservedCodeCacheSize` if it was provided as a commandline flag.

It might be debatable if this is the correct fix, since the `NonNMethodHeap` can spill into the other heaps if it is too small. However, I am of the opinion that if the `NonNMethodHeapSize` is explicitly specified, then the compiler count should be calculated accordingly.

# Testing

 - [x] [GHA](https://github.com/mhaessig/jdk/actions/runs/15603409859)
 - [x] tier1 and tier2 plus Oracle internal testing on our supported platforms
 - [x] tier1 with a manually fixed core count of 288 (this reproduced the problem before the fix)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Dependency #25791 must be integrated first

### Issue
 * [JDK-8354727](https://bugs.openjdk.org/browse/JDK-8354727): CompilationPolicy creates too many compiler threads when code cache space is scarce (**Bug** - P4)


### Reviewers
 * [Damon Fenacci](https://openjdk.org/census#dfenacci) (@dafedafe - Committer) 🔄 Re-review required (review was made when pull request targeted the [master](https://git.openjdk.org/jdk/tree/master) branch)

### Contributors
 * Aleksey Shipilev `<shade@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25770/head:pull/25770` \
`$ git checkout pull/25770`

Update a local copy of the PR: \
`$ git checkout pull/25770` \
`$ git pull https://git.openjdk.org/jdk.git pull/25770/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25770`

View PR using the GUI difftool: \
`$ git pr show -t 25770`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25770.diff">https://git.openjdk.org/jdk/pull/25770.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25770#issuecomment-2965440285)
</details>
