### PR TITLE
8359272: Several vmTestbase/compact tests timed out on large memory machine

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/vm/gc/compact/Compact_InternedStrings/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/gc/compact/Compact_InternedStrings/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,9 +34,11 @@
  * This testcase uses interned strings for both first and second phases
  * and multiple threads.
  *
+ * @requires os.maxMemory > 3G
  * @library /vmTestbase
  *          /test/lib
  * @run main/othervm
+ *      -Xmx2G
  *      -XX:-UseGCOverheadLimit
  *      vm.gc.compact.Compact
  *      -gp interned(randomString)

--- a/test/hotspot/jtreg/vmTestbase/vm/gc/compact/Compact_InternedStrings_NonbranchyTree/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/gc/compact/Compact_InternedStrings_NonbranchyTree/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,9 +34,11 @@
  * This testcase uses interned strings for first phase,
  * random arrays for second phases and multiple threads.
  *
+ * @requires os.maxMemory > 3G
  * @library /vmTestbase
  *          /test/lib
  * @run main/othervm
+ *      -Xmx2G
  *      -XX:-UseGCOverheadLimit
  *      vm.gc.compact.Compact
  *      -gp interned(randomString)

--- a/test/hotspot/jtreg/vmTestbase/vm/gc/compact/Compact_Strings_ArrayOf/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/gc/compact/Compact_Strings_ArrayOf/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,9 +34,11 @@
  * This testcase uses random strings for first phase, array of
  * random strings for second phase and multiple threads.
  *
+ * @requires os.maxMemory > 3G
  * @library /vmTestbase
  *          /test/lib
  * @run main/othervm
+ *      -Xmx2G
  *      -XX:-UseGCOverheadLimit
  *      vm.gc.compact.Compact
  *      -gp randomString

--- a/test/hotspot/jtreg/vmTestbase/vm/gc/compact/Humongous_InternedStrings/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/gc/compact/Humongous_InternedStrings/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,9 +34,11 @@
  * This testcase uses interned strings for both first and second phases
  * and multiple threads.
  *
+ * @requires os.maxMemory > 3G
  * @library /vmTestbase
  *          /test/lib
  * @run main/othervm
+ *      -Xmx2G
  *      -XX:-UseGCOverheadLimit
  *      vm.gc.compact.Compact
  *      -gp interned(randomString)


### PR DESCRIPTION
Hi all,

We observed 4 vmTestbase/vm/gc/compact tests run timed out on large physical memory machine (755G memory) with jtreg args `-timeoutFactor:4`. The other vmTestbase tests do not observed the same failure.
The tested class `vm.gc.compact.Compact` create lots objects util trigger OOM exception. But if the tested machine has very large physica memory, these tests need takes lots of time to finish.
So this PR add jvm args `-Xmx3G` to make these tests will run finish in a deterministic time. Change has been verified locally, test-fix only, no risk.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8359272](https://bugs.openjdk.org/browse/JDK-8359272): Several vmTestbase/compact tests timed out on large memory machine (**Bug** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25771/head:pull/25771` \
`$ git checkout pull/25771`

Update a local copy of the PR: \
`$ git checkout pull/25771` \
`$ git pull https://git.openjdk.org/jdk.git pull/25771/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25771`

View PR using the GUI difftool: \
`$ git pr show -t 25771`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25771.diff">https://git.openjdk.org/jdk/pull/25771.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25771#issuecomment-2965521101)
</details>
