### PR TITLE
8359123: Misleading examples in jmod man page

### DIFF
--- a/src/jdk.jlink/share/man/jmod.md
+++ b/src/jdk.jlink/share/man/jmod.md
@@ -183,7 +183,7 @@ e.g. "2022-02-12T12:30:00-05:00".
     operating system and architecture. The value should follow
     the format `<os>-<arch>`, where `<os>` is the operating system
     and `<arch>` is the hardware architecture. Example values include
-    `linux-x64`, `windows-x64`, and `macos-aarch64`.
+    `linux-amd64`, `windows-amd64`, and `macos-aarch64`.
 
 `--version`
 :   Prints version information of the `jmod` tool.

--- a/src/jdk.jlink/share/man/jmod.md
+++ b/src/jdk.jlink/share/man/jmod.md
@@ -180,7 +180,7 @@ e.g. "2022-02-12T12:30:00-05:00".
 
 `--target-platform` *platform*
 :   Specifies the target platform. The value is a string that identifies 
-    the plarform the module is intended for, typically in the form `<os>-<arch>`.
+    the platform this module is intended for, typically in the form `<os>-<arch>`.
 
 `--version`
 :   Prints version information of the `jmod` tool.

--- a/src/jdk.jlink/share/man/jmod.md
+++ b/src/jdk.jlink/share/man/jmod.md
@@ -190,7 +190,7 @@ e.g. "2022-02-12T12:30:00-05:00".
     An options file is a text file that contains the options and values that
     you would ordinarily enter in a command prompt. Options may appear on one
     line or on several lines. You may not specify environment variables for
-    path names. You may comment out lines by prefixinga hash symbol (`#`) to
+    path names. You may comment out lines by prefixing a hash symbol (`#`) to
     the beginning of the line.
 
     The following is an example of an options file for the `jmod` command:

--- a/src/jdk.jlink/share/man/jmod.md
+++ b/src/jdk.jlink/share/man/jmod.md
@@ -179,8 +179,8 @@ e.g. "2022-02-12T12:30:00-05:00".
     `--hash-modules`.
 
 `--target-platform` *platform*
-:   Specifies the target platform. The value is a string that identifies
-    the platform this module is intended for, typically in the form `<os>-<arch>`.
+:   Specifies the target platform. The value is a string identifying 
+    the module's intended platform, typically in the form `<os>-<arch>`.
 
 `--version`
 :   Prints version information of the `jmod` tool.
@@ -217,24 +217,24 @@ extra options that can be used with the command.
 :   Hint for a tool to issue a warning if the module is resolved. One of
     deprecated, deprecated-for-removal, or incubating.
 
-## jmod Create Example
+## jmod Create Examples
 
-The basic manner to create a JMOD file is by including only compiled classes:
+Create a JMOD file containing only compiled classes:
 
 ```
 jmod create --class-path build/foo/classes jmods/foo1.jmod
 ```
 
-To ensure reproducible artifacts, the following command creates
-a JMOD file specifying the date for the entries as `2022 March 15 00:00:00`:
+Create a JMOD file specifying the date for the entries as `2022 March 15 00:00:00`:
 
 ```
 jmod create --class-path build/foo/classes --date 2022-03-15T00:00:00Z
    jmods/foo2.jmod
 ```
 
-The command below creates a platform-specific JMOD file, bundling class files,
-user-editable configuration files, header files, native commands and libraries:
+Create a platform-specific JMOD file bundling compiled classes, configuration files,
+native commands and libraries, header files, man pages, and metadata including the 
+main class, module version, and target platform details:
 
 ```
 jmod create --class-path mods/com.greetings --cmds commands

--- a/src/jdk.jlink/share/man/jmod.md
+++ b/src/jdk.jlink/share/man/jmod.md
@@ -179,8 +179,8 @@ e.g. "2022-02-12T12:30:00-05:00".
     `--hash-modules`.
 
 `--target-platform` *platform*
-:   Specifies the target platform when creating a JMOD file intended
-    for a specific operating system and architecture. The value should follow
+:   Specifies the target platform of a JMOD file intended for a specific
+    operating system and architecture. The value should follow
     the format `<os>-<arch>`, where `<os>` is the operating system
     and `<arch>` is the hardware architecture. Example values include
     `linux-x64`, `windows-x64`, and `macos-aarch64`.
@@ -235,14 +235,14 @@ jmod create --class-path build/foo/classes --date 2022-03-15T00:00:00Z
    jmods/foo2.jmod
 ```
 
-Create a platform-specific JMOD file bundling compiled classes, configuration files,
-native commands and libraries, header files, man pages, and metadata including the
+Create a JMOD file bundling compiled classes, native commands, configuration files,
+header files, native libraries, man pages, and metadata including the
 main class, module version, and target platform details:
 
 ```
 jmod create --class-path mods/com.greetings --cmds commands
   --config configfiles --header-files src/h --libs lib
-  --main-class com.greetings.Main --man-pages man --module-version 1.0
+  --man-pages man --main-class com.greetings.Main --module-version 1.0
   --target-platform "macos-aarch64" greetingsmod
 ```
 

--- a/src/jdk.jlink/share/man/jmod.md
+++ b/src/jdk.jlink/share/man/jmod.md
@@ -179,7 +179,7 @@ e.g. "2022-02-12T12:30:00-05:00".
     `--hash-modules`.
 
 `--target-platform` *platform*
-:   Specifies the target platform. The value is a string that identifies 
+:   Specifies the target platform. The value is a string that identifies
     the platform this module is intended for, typically in the form `<os>-<arch>`.
 
 `--version`
@@ -225,7 +225,7 @@ The basic manner to create a JMOD file is by including only compiled classes:
 jmod create --class-path build/foo/classes jmods/foo1.jmod
 ```
 
-To ensure reproducible artifacts, the following command creates 
+To ensure reproducible artifacts, the following command creates
 a JMOD file specifying the date for the entries as `2022 March 15 00:00:00`:
 
 ```
@@ -233,7 +233,7 @@ jmod create --class-path build/foo/classes --date 2022-03-15T00:00:00Z
    jmods/foo2.jmod
 ```
 
-The command below creates a platform-specific JMOD file, bundling class files, 
+The command below creates a platform-specific JMOD file, bundling class files,
 user-editable configuration files, header files, native commands and libraries:
 
 ```

--- a/src/jdk.jlink/share/man/jmod.md
+++ b/src/jdk.jlink/share/man/jmod.md
@@ -1,5 +1,5 @@
 ---
-# Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.jlink/share/man/jmod.md
+++ b/src/jdk.jlink/share/man/jmod.md
@@ -179,7 +179,8 @@ e.g. "2022-02-12T12:30:00-05:00".
     `--hash-modules`.
 
 `--target-platform` *platform*
-:   Specifies the target platform.
+:   Specifies the target platform. The value is a string that identifies 
+    the plarform the module is intended for, typically in the form `<os>-<arch>`.
 
 `--version`
 :   Prints version information of the `jmod` tool.
@@ -201,8 +202,7 @@ e.g. "2022-02-12T12:30:00-05:00".
       --cmds commands --config configfiles --header-files src/h
       --libs lib --main-class com.greetings.Main
       --man-pages man --module-version 1.0
-      --os-arch "x86_x64" --os-name "macOS"
-      --os-version "10.10.5" greetingsmod
+      --target-platform "macOS-aarch64" greetingsmod
     ```
 
 ## Extra Options for jmod
@@ -219,21 +219,30 @@ extra options that can be used with the command.
 
 ## jmod Create Example
 
-The following is an example of creating a JMOD file:
+The basic manner to create a JMOD file is by including only compiled classes:
+
+```
+jmod create --class-path build/foo/classes jmods/foo1.jmod
+```
+
+To ensure reproducible artifacts, the following command creates 
+a JMOD file specifying the date for the entries as `2022 March 15 00:00:00`:
+
+```
+jmod create --class-path build/foo/classes --date 2022-03-15T00:00:00Z
+   jmods/foo2.jmod
+```
+
+The command below creates a platform-specific JMOD file, bundling class files, 
+user-editable configuration files, header files, native commands and libraries:
 
 ```
 jmod create --class-path mods/com.greetings --cmds commands
   --config configfiles --header-files src/h --libs lib
   --main-class com.greetings.Main --man-pages man --module-version 1.0
-  --os-arch "x86_x64" --os-name "macOS"
-  --os-version "10.10.5" greetingsmod
+  --target-platform "macOS-aarch64" greetingsmod
 ```
-Create a JMOD file specifying the date for the entries as `2022 March 15 00:00:00`:
 
-```
-jmod create --class-path build/foo/classes --date 2022-03-15T00:00:00Z
-   jmods/foo1.jmod
-```
 ## jmod Hash Example
 
 The following example demonstrates what happens when you try to link a leaf

--- a/src/jdk.jlink/share/man/jmod.md
+++ b/src/jdk.jlink/share/man/jmod.md
@@ -179,8 +179,11 @@ e.g. "2022-02-12T12:30:00-05:00".
     `--hash-modules`.
 
 `--target-platform` *platform*
-:   Specifies the target platform. The value is a string identifying
-    the module's intended platform, typically in the form `<os>-<arch>`.
+:   Specifies the target platform when creating a JMOD file intended
+    for a specific operating system and architecture. The value should follow
+    the format `<os>-<arch>`, where `<os>` is the operating system
+    and `<arch>` is the hardware architecture. Example values include
+    `linux-x64`, `windows-x64`, and `macos-aarch64`.
 
 `--version`
 :   Prints version information of the `jmod` tool.
@@ -202,7 +205,7 @@ e.g. "2022-02-12T12:30:00-05:00".
       --cmds commands --config configfiles --header-files src/h
       --libs lib --main-class com.greetings.Main
       --man-pages man --module-version 1.0
-      --target-platform "macOS-aarch64" greetingsmod
+      --target-platform "macos-aarch64" greetingsmod
     ```
 
 ## Extra Options for jmod
@@ -240,7 +243,7 @@ main class, module version, and target platform details:
 jmod create --class-path mods/com.greetings --cmds commands
   --config configfiles --header-files src/h --libs lib
   --main-class com.greetings.Main --man-pages man --module-version 1.0
-  --target-platform "macOS-aarch64" greetingsmod
+  --target-platform "macos-aarch64" greetingsmod
 ```
 
 ## jmod Hash Example

--- a/src/jdk.jlink/share/man/jmod.md
+++ b/src/jdk.jlink/share/man/jmod.md
@@ -179,7 +179,7 @@ e.g. "2022-02-12T12:30:00-05:00".
     `--hash-modules`.
 
 `--target-platform` *platform*
-:   Specifies the target platform. The value is a string identifying 
+:   Specifies the target platform. The value is a string identifying
     the module's intended platform, typically in the form `<os>-<arch>`.
 
 `--version`
@@ -233,7 +233,7 @@ jmod create --class-path build/foo/classes --date 2022-03-15T00:00:00Z
 ```
 
 Create a platform-specific JMOD file bundling compiled classes, configuration files,
-native commands and libraries, header files, man pages, and metadata including the 
+native commands and libraries, header files, man pages, and metadata including the
 main class, module version, and target platform details:
 
 ```


### PR DESCRIPTION
Please review my PR. This PR includes the following:

- [x] Fix a small typo in a word and copyright.
- [x] Enhance description for `--target-platform`.
- [x] Rearrange `jmod create` example from basic to complex.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8359123](https://bugs.openjdk.org/browse/JDK-8359123): Misleading examples in jmod man page (**Bug** - P4)


### Reviewers
 * [Christian Stein](https://openjdk.org/census#cstein) (@sormuras - Committer)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**) Review applies to [27052ebb](https://git.openjdk.org/jdk/pull/25772/files/27052ebb24474afd08705f3cd030907448b7172b)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25772/head:pull/25772` \
`$ git checkout pull/25772`

Update a local copy of the PR: \
`$ git checkout pull/25772` \
`$ git pull https://git.openjdk.org/jdk.git pull/25772/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25772`

View PR using the GUI difftool: \
`$ git pr show -t 25772`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25772.diff">https://git.openjdk.org/jdk/pull/25772.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25772#issuecomment-2965825941)
</details>
