### PR TITLE
8357816: Add test from JDK-8350576

### DIFF
--- a/test/hotspot/jtreg/compiler/loopopts/LoopReductionHasControlOrBadInput.java
+++ b/test/hotspot/jtreg/compiler/loopopts/LoopReductionHasControlOrBadInput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/loopopts/LoopReductionHasControlOrBadInput.java
+++ b/test/hotspot/jtreg/compiler/loopopts/LoopReductionHasControlOrBadInput.java
@@ -27,6 +27,7 @@
  * @summary Optimization bails out and hits an assert:
  *          assert(false) failed: reduction has ctrl or bad vector_input
  * @run main/othervm -XX:CompileCommand=compileonly,compiler.loopopts.LoopReductionHasControlOrBadInput::* -Xbatch -XX:-TieredCompilation compiler.loopopts.LoopReductionHasControlOrBadInput
+ * @run main compiler.loopopts.LoopReductionHasControlOrBadInput
  *
  */
 

--- a/test/hotspot/jtreg/compiler/loopopts/LoopReductionHasControlOrBadInput.java
+++ b/test/hotspot/jtreg/compiler/loopopts/LoopReductionHasControlOrBadInput.java
@@ -24,7 +24,8 @@
 /*
  * @test
  * @bug 8350576
- * @summary C2: assert(false) failed: reduction has ctrl or bad vector_input
+ * @summary Optimization bails out and hits an assert:
+ *          assert(false) failed: reduction has ctrl or bad vector_input
  * @run main/othervm -XX:CompileCommand=compileonly,compiler.loopopts.LoopReductionHasControlOrBadInput::* -Xbatch -XX:-TieredCompilation compiler.loopopts.LoopReductionHasControlOrBadInput
  *
  */

--- a/test/hotspot/jtreg/compiler/loopopts/LoopReductionHasControlOrBadInput.java
+++ b/test/hotspot/jtreg/compiler/loopopts/LoopReductionHasControlOrBadInput.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8350576
+ * @summary C2: assert(false) failed: reduction has ctrl or bad vector_input
+ * @run main/othervm -XX:CompileCommand=compileonly,compiler.loopopts.LoopReductionHasControlOrBadInput::* -Xbatch -XX:-TieredCompilation compiler.loopopts.LoopReductionHasControlOrBadInput
+ *
+ */
+
+package compiler.loopopts;
+
+public class LoopReductionHasControlOrBadInput {
+    static long lFld;
+    static long lArr[] = new long[400];
+
+    static void test() {
+        int i = 1;
+        do {
+            long x = -1;
+            lArr[i] = i;
+            lFld += i | x;
+        } while (++i < 355);
+    }
+
+    public static void main(String[] strArr) {
+        for (int i = 0; i < 100; i++) {
+            test();
+        }
+    }
+}

--- a/test/hotspot/jtreg/compiler/loopopts/LoopReductionHasControlOrBadInput.java
+++ b/test/hotspot/jtreg/compiler/loopopts/LoopReductionHasControlOrBadInput.java
@@ -26,7 +26,9 @@
  * @bug 8350576
  * @summary Optimization bails out and hits an assert:
  *          assert(false) failed: reduction has ctrl or bad vector_input
- * @run main/othervm -XX:CompileCommand=compileonly,compiler.loopopts.LoopReductionHasControlOrBadInput::* -Xbatch -XX:-TieredCompilation compiler.loopopts.LoopReductionHasControlOrBadInput
+ * @run main/othervm -Xbatch -XX:-TieredCompilation
+ *      -XX:CompileCommand=compileonly,compiler.loopopts.LoopReductionHasControlOrBadInput::*
+ *      compiler.loopopts.LoopReductionHasControlOrBadInput
  * @run main compiler.loopopts.LoopReductionHasControlOrBadInput
  *
  */


### PR DESCRIPTION
This PR adds a jtreg test for [JDK-8350576](https://bugs.openjdk.org/browse/JDK-8350576). The test consists of a code sample produced by the fuzzer, and it contains a loop that is supposed to get optimized.

Thanks!

### Testing

- [x] [GitHub Actions](https://github.com/benoitmaillard/jdk/actions?query=branch%3AJDK-8357816)
- [x] tier1-3, plus some internal testing
- [x] Ran the test with a debug build prior to the fix (JDK 25 build 16) and made sure it failed as a sanity check

Shout out to @TobiHartmann for helping out with jtreg

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8357816](https://bugs.openjdk.org/browse/JDK-8357816): Add test from JDK-8350576 (**Enhancement** - P4)


### Reviewers
 * [SendaoYan](https://openjdk.org/census#syan) (@sendaoYan - Committer)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Emanuel Peter](https://openjdk.org/census#epeter) (@eme64 - **Reviewer**)

### Contributors
 * Tobias Hartmann `<thartmann@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25774/head:pull/25774` \
`$ git checkout pull/25774`

Update a local copy of the PR: \
`$ git checkout pull/25774` \
`$ git pull https://git.openjdk.org/jdk.git pull/25774/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25774`

View PR using the GUI difftool: \
`$ git pr show -t 25774`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25774.diff">https://git.openjdk.org/jdk/pull/25774.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25774#issuecomment-2966393923)
</details>
