### PR TITLE
8359293: Make TestNoNULL extensible

### DIFF
--- a/test/hotspot/jtreg/sources/TestNoNULL.java
+++ b/test/hotspot/jtreg/sources/TestNoNULL.java
@@ -33,6 +33,8 @@ import java.nio.charset.MalformedInputException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.*;
 import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -41,10 +43,22 @@ import java.util.regex.Pattern;
 public class TestNoNULL {
     private static final Set<String> excludedSourceFiles = new HashSet<>();
     private static final Set<String> excludedTestFiles = new HashSet<>();
-    private static final Set<String> excludedTestExtensions = Set.of(".c", ".java", ".jar", ".class", ".zip");
+    private static final Set<String> excludedTestExtensions = extend(new HashSet<>(List.of(".c", ".java", ".jar", ".class", ".zip")), "excludedTestExtensions");
     private static final Pattern NULL_PATTERN = Pattern.compile("\\bNULL\\b");
     private static Path dir = Paths.get(System.getProperty("test.src"));
     private static int errorCount = 0;
+
+    /**
+     * Extends {@code toExtend} with the comma separated entries in the value of the
+     * {@code propertyName} system property.
+     */
+    private static <T extends Collection<String>> T extend(T toExtend, String propertyName) {
+        String extensions = System.getProperty(propertyName);
+        if (extensions != null) {
+            toExtend.addAll(List.of(extensions.split(",")));
+        }
+        return toExtend;
+    }
 
     public static void main(String[] args) throws IOException {
         int maxIter = 20;
@@ -72,15 +86,15 @@ public class TestNoNULL {
     }
 
     private static void initializeExcludedPaths(Path rootDir) {
-        List<String> sourceExclusions = List.of(
+        List<String> sourceExclusions = extend(new ArrayList<>(List.of(
                 "src/hotspot/share/prims/jvmti.xml",
                 "src/hotspot/share/prims/jvmti.xsl"
-        );
+        )), "sourceExclusions");
 
-        List<String> testExclusions = List.of(
+        List<String> testExclusions = extend(new ArrayList<>(List.of(
                 "test/hotspot/jtreg/vmTestbase/nsk/share/jvmti/README",
                 "test/hotspot/jtreg/vmTestbase/nsk/share/jni/README"
-        );
+        )), "testExclusions");
 
         sourceExclusions.forEach(relativePath ->
                 excludedSourceFiles.add(rootDir.resolve(relativePath).normalize().toString()));


### PR DESCRIPTION
There are some closed markdown files that contain "NULL". These should be excluded from checking by TestNoNULL. This PR makes TestNoNull extensible in terms of exclusions with the following system properties:

* `excludedTestExtensions` - command separated list of file extensions (e.g. `-DexcludedTestExtensions=.md,.txt`)
* `sourceExclusions` - command separated list of file paths relative to repo root (e.g. `-DsourceExclusions=src/hotspot/share/prims/jvmti.xml`)
* `testExclusions` - command separated list of file paths relative to repo root (e.g. `-DtestExclusions=test/hotspot/jtreg/vmTestbase/nsk/share/jvmti/README`)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8359293](https://bugs.openjdk.org/browse/JDK-8359293): Make TestNoNULL extensible (**Enhancement** - P4)


### Reviewers
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25777/head:pull/25777` \
`$ git checkout pull/25777`

Update a local copy of the PR: \
`$ git checkout pull/25777` \
`$ git pull https://git.openjdk.org/jdk.git pull/25777/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25777`

View PR using the GUI difftool: \
`$ git pr show -t 25777`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25777.diff">https://git.openjdk.org/jdk/pull/25777.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25777#issuecomment-2966127321)
</details>
