### PR TITLE
8359327: Incorrect AVX3Threshold results into code buffer overflows on APX targets

### DIFF
--- a/src/hotspot/cpu/x86/stubDeclarations_x86.hpp
+++ b/src/hotspot/cpu/x86/stubDeclarations_x86.hpp
@@ -239,7 +239,7 @@
                                     do_arch_blob,                       \
                                     do_arch_entry,                      \
                                     do_arch_entry_init)                 \
-  do_arch_blob(final, 31000                                             \
+  do_arch_blob(final, 33000                                             \
                WINDOWS_ONLY(+22000) ZGC_ONLY(+20000))                   \
 
 #endif // CPU_X86_STUBDECLARATIONS_HPP

--- a/src/hotspot/cpu/x86/vm_version_x86.cpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.cpp
@@ -2111,7 +2111,7 @@ bool VM_Version::is_intel_cascade_lake() {
 // has improved implementation of 64-byte load/stores and so the default
 // threshold is set to 0 for these platforms.
 int VM_Version::avx3_threshold() {
-  return (is_intel_family_core() &&
+  return (is_intel_server_family() &&
           supports_serialize() &&
           FLAG_IS_DEFAULT(AVX3Threshold)) ? 0 : AVX3Threshold;
 }


### PR DESCRIPTION
As per the latest architecture-instruction-set-extensions-programming-reference manual version 57[1] , upcoming Diamond Rapids server with APX feature has a different CPU family ID (19) than prior Xeons (6).

Recently integrated EEVEX to REX2 demotion support with [JDK-8351994](https://bugs.openjdk.org/browse/JDK-8351994) already handles this through a newly defined _VM_Version::is_intel_server_family()_ API, but the existing AVX3Therehold setting is agnostic to this change, which causes code buffer overflows during arraycopy stubs generation.

Patch fixes this issue and also appropriately increments final code buffer size to prevent buffer overruns during stub generation with non zero AVX3Thereshold. 

[1] https://www.intel.com/content/www/us/en/content-details/851355/intel-architecture-instruction-set-extensions-programming-reference.html?wapkw=intel%20architecture%20instruction%20set%20extensions%20programming%20reference

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8359327](https://bugs.openjdk.org/browse/JDK-8359327): Incorrect AVX3Threshold results into code buffer overflows on APX targets (**Bug** - P3)(⚠️ The fixVersion in this issue is [25] but the fixVersion in .jcheck/conf is 26, a new backport will be created when this pr is integrated.)


### Reviewers
 * [Sandhya Viswanathan](https://openjdk.org/census#sviswanathan) (@sviswa7 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25780/head:pull/25780` \
`$ git checkout pull/25780`

Update a local copy of the PR: \
`$ git checkout pull/25780` \
`$ git pull https://git.openjdk.org/jdk.git pull/25780/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25780`

View PR using the GUI difftool: \
`$ git pr show -t 25780`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25780.diff">https://git.openjdk.org/jdk/pull/25780.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25780#issuecomment-2966396960)
</details>
