### PR TITLE
8359127: Amend java/nio/channels/DatagramChannel/PromiscuousIPv6.java to use @requires for OS platform selection

### DIFF
--- a/test/jdk/java/nio/channels/DatagramChannel/PromiscuousIPv6.java
+++ b/test/jdk/java/nio/channels/DatagramChannel/PromiscuousIPv6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/nio/channels/DatagramChannel/PromiscuousIPv6.java
+++ b/test/jdk/java/nio/channels/DatagramChannel/PromiscuousIPv6.java
@@ -30,6 +30,7 @@
  *        PromiscuousIPv6
  * @run main PromiscuousIPv6
  * @key randomness
+ * @requires (os.family == "linux") | (os.family == "mac")
  */
 
 import java.nio.ByteBuffer;
@@ -212,15 +213,11 @@ public class PromiscuousIPv6 {
 
         boolean hasIPV6MulticastAll;
 
-        if (!supportedByPlatform()) {
-            throw new SkippedException("This test should not be run on this platform");
-        } else {
-            int major = Platform.getOsVersionMajor();
-            int minor = Platform.getOsVersionMinor();
-            hasIPV6MulticastAll =
-                Platform.isOSX() ||
-                (Platform.isLinux() && ((major > 4) || ((major == 4 && minor >= 20))));
-        }
+        int major = Platform.getOsVersionMajor();
+        int minor = Platform.getOsVersionMinor();
+        hasIPV6MulticastAll =
+            Platform.isOSX() ||
+            (Platform.isLinux() && ((major > 4) || ((major == 4 && minor >= 20))));
 
         NetworkConfiguration.printSystemConfiguration(System.out);
         List<NetworkInterface> nifs = NetworkConfiguration.probe()

--- a/test/jdk/java/nio/channels/DatagramChannel/PromiscuousIPv6.java
+++ b/test/jdk/java/nio/channels/DatagramChannel/PromiscuousIPv6.java
@@ -202,13 +202,6 @@ public class PromiscuousIPv6 {
         }
     }
 
-    /*
-     * returns true if platform allows an IPv6 socket join an IPv4 multicast group
-     */
-    private static boolean supportedByPlatform() {
-        return Platform.isOSX() || Platform.isLinux();
-    }
-
     public static void main(String[] args) throws IOException {
 
         boolean hasIPV6MulticastAll;


### PR DESCRIPTION
Replaced programmatic check for the OS platform (which threw a Skipped exception) with JTreg @requires.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8359127](https://bugs.openjdk.org/browse/JDK-8359127): Amend java/nio/channels/DatagramChannel/PromiscuousIPv6.java to use @<!---->requires for OS platform selection (**Bug** - P4)


### Reviewers
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - **Reviewer**)
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25781/head:pull/25781` \
`$ git checkout pull/25781`

Update a local copy of the PR: \
`$ git checkout pull/25781` \
`$ git pull https://git.openjdk.org/jdk.git pull/25781/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25781`

View PR using the GUI difftool: \
`$ git pr show -t 25781`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25781.diff">https://git.openjdk.org/jdk/pull/25781.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25781#issuecomment-2970104810)
</details>
