### PR TITLE
8358738: AOT cache created without graal jit should not be used with graal jit

### DIFF
--- a/src/hotspot/share/cds/filemap.cpp
+++ b/src/hotspot/share/cds/filemap.cpp
@@ -234,14 +234,7 @@ void FileMapHeader::populate(FileMapInfo *info, size_t core_region_alignment,
     _narrow_klass_pointer_bits = _narrow_klass_shift = -1;
   }
   // Which JIT compier is used
-  _compiler_type = (u1)CompilerType::compiler_none; // Interpreter only
-  if (CompilerConfig::is_c2_enabled()) {
-    _compiler_type = (u1)CompilerType::compiler_c2;
-  } else if (CompilerConfig::is_jvmci_compiler_enabled()) {
-    _compiler_type = (u1)CompilerType::compiler_jvmci;
-  } else if (CompilerConfig::is_c1_enabled()) {
-    _compiler_type = (u1)CompilerType::compiler_c1;
-  }
+  _compiler_type = (u1)CompilerConfig::compiler_type();
   _type_profile_level = TypeProfileLevel;
   _type_profile_args_limit = TypeProfileArgsLimit;
   _type_profile_parms_limit = TypeProfileParmsLimit;
@@ -1946,17 +1939,9 @@ bool FileMapHeader::validate() {
     return false;
   }
   bool jvmci_compiler_is_enabled = CompilerConfig::is_jvmci_compiler_enabled();
-  CompilerType compiler_type = CompilerType::compiler_none; // Interpreter only
-  if (CompilerConfig::is_c2_enabled()) {
-    compiler_type = CompilerType::compiler_c2;
-  } else if (jvmci_compiler_is_enabled) {
-    compiler_type = CompilerType::compiler_jvmci;
-  } else if (CompilerConfig::is_c1_enabled()) {
-    compiler_type = CompilerType::compiler_c1;
-  }
+  CompilerType compiler_type = CompilerConfig::compiler_type();
   CompilerType archive_compiler_type = CompilerType(_compiler_type);
-  // JVMCI compiler loads additional jdk.internal.vm.ci module,
-  // does different type profiling settigns and generate
+  // JVMCI compiler does different type profiling settigns and generate
   // different code. We can't use archive which was produced
   // without it and reverse.
   // Only allow mix when JIT compilation is disabled.

--- a/src/hotspot/share/cds/filemap.hpp
+++ b/src/hotspot/share/cds/filemap.hpp
@@ -147,6 +147,7 @@ private:
   size_t _ro_ptrmap_start_pos;          // The first bit in the ptrmap corresponds to this position in the ro region
 
   // The following are parameters that affect MethodData layout.
+  u1      _compiler_type;
   uint    _type_profile_level;
   int     _type_profile_args_limit;
   int     _type_profile_parms_limit;

--- a/src/hotspot/share/compiler/compilerDefinitions.hpp
+++ b/src/hotspot/share/compiler/compilerDefinitions.hpp
@@ -149,6 +149,8 @@ public:
   inline static bool is_c2_or_jvmci_compiler_only();
   inline static bool is_c2_or_jvmci_compiler_enabled();
 
+  inline static CompilerType compiler_type();
+
 private:
   static bool is_compilation_mode_selected();
   static void set_compilation_policy_flags();

--- a/src/hotspot/share/compiler/compilerDefinitions.inline.hpp
+++ b/src/hotspot/share/compiler/compilerDefinitions.inline.hpp
@@ -131,4 +131,17 @@ inline bool CompilerConfig::is_c2_or_jvmci_compiler_enabled() {
   return is_c2_enabled() || is_jvmci_compiler_enabled();
 }
 
+// Return type of most optimizing compiler which is used
+inline CompilerType CompilerConfig::compiler_type() {
+  CompilerType compiler_type = CompilerType::compiler_none; // Interpreter only
+  if (CompilerConfig::is_c2_enabled()) {
+    compiler_type = CompilerType::compiler_c2;
+  } else if (CompilerConfig::is_jvmci_compiler_enabled()) {
+    compiler_type = CompilerType::compiler_jvmci;
+  } else if (CompilerConfig::is_c1_enabled()) {
+    compiler_type = CompilerType::compiler_c1;
+  }
+  return compiler_type;
+}
+
 #endif // SHARE_COMPILER_COMPILERDEFINITIONS_INLINE_HPP


### PR DESCRIPTION
We can't mix generation and usage of AOT cache when different JIT compilers are used (C2 vs Graal). Graal does different profiling settings and generate different code. We can only allow mix with Interpreter.

Record used compiler type in archive and check it when using archive.

Tested with tiers which use Graal.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8358738](https://bugs.openjdk.org/browse/JDK-8358738): AOT cache created without graal jit should not be used with graal jit (**Bug** - P3)


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)
 * [Calvin Cheung](https://openjdk.org/census#ccheung) (@calvinccheung - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25782/head:pull/25782` \
`$ git checkout pull/25782`

Update a local copy of the PR: \
`$ git checkout pull/25782` \
`$ git pull https://git.openjdk.org/jdk.git pull/25782/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25782`

View PR using the GUI difftool: \
`$ git pr show -t 25782`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25782.diff">https://git.openjdk.org/jdk/pull/25782.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25782#issuecomment-2967061399)
</details>
