### PR TITLE
8359386: Fix incorrect value for max_size of C2CodeStub when APX is used

### DIFF
--- a/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
@@ -4687,7 +4687,9 @@ void C2_MacroAssembler::convertF2I(BasicType dst_bt, BasicType src_bt, Register 
     }
   }
 
-  auto stub = C2CodeStub::make<Register, XMMRegister, address>(dst, src, slowpath_target, 23, convertF2I_slowpath);
+  // Using the APX extended general purpose registers increases the instruction encoding size by 4 bytes.
+  int max_size = dst->encoding() <= 15 ? 23 : 27;
+  auto stub = C2CodeStub::make<Register, XMMRegister, address>(dst, src, slowpath_target, max_size, convertF2I_slowpath);
   jcc(Assembler::equal, stub->entry());
   bind(stub->continuation());
 }


### PR DESCRIPTION
The goal of this PR is to fix the value of max_size of the C2CodeStub hardcoded in the C2_MacroAssembler::convertF2I() function when Intel APX instrucitons are used. Currently, max_size is hardcoded to 23 (introduced in [JDK-8306706](https://bugs.openjdk.org/browse/JDK-8306706)) . However, this value is incorrect when Intel APX instructions with extended general-purpose registers (EGPRs) are used in the code stub as using EGPRs with APX instructions leads to an increase in the instruction encoding size by additional 4 bytes.

Without this fix, we see the following errors for the C2 compiler tests below:
compiler/vectorization/runner/ArrayTypeConvertTest.java
compiler/intrinsics/zip/TestFpRegsABI.java

#
# A fatal error has been detected by the Java Runtime Environment:
#
# Internal Error (/src/hotspot/share/opto/c2_CodeStubs.cpp:50), pid=3961123, tid=3961332
# assert(max_size >= actual_size) failed: Expected stub size (23) must be larger than or equal to actual stub size (24)
#
# JRE version: OpenJDK Runtime Environment (26.0) (fastdebug build 26-internal-adhoc.parasa.jdkdemotion)
# Java VM: OpenJDK 64-Bit Server VM (fastdebug 26-internal-adhoc.parasa.jdkdemotion, mixed mode, sharing, compressed oops, compressed class ptrs, g1 gc, linux-amd64)
# Problematic frame:
# V [libjvm.so+0x955a77] C2CodeStubList::emit(C2_MacroAssembler&)+0x227
#
#

This PR fixes the errors in the above-mentioned tests.