### PR TITLE
8191963: Path.equals() and File.equals() return true for two different files on Windows

### DIFF
--- a/src/java.base/windows/classes/java/io/WinNTFileSystem.java
+++ b/src/java.base/windows/classes/java/io/WinNTFileSystem.java
@@ -44,8 +44,8 @@ final class WinNTFileSystem extends FileSystem {
     private static final boolean ALLOW_DELETE_READ_ONLY_FILES =
         Boolean.getBoolean("jdk.io.File.allowDeleteReadOnlyFiles");
 
-    private static final boolean LEGACY_EQUALS =
-        Boolean.getBoolean("jdk.io.File.legacyEquals");
+    private static final boolean NIO_COMPATIBLE_EQUALS =
+        Boolean.getBoolean("jdk.io.File.windowsUseNIOStyleEquals");
 
     private final char slash;
     private final char altSlash;
@@ -638,28 +638,30 @@ final class WinNTFileSystem extends FileSystem {
 
     @Override
     public int compare(File f1, File f2) {
-        // Use legacy pathname comparison if property is set
-        if (LEGACY_EQUALS)
-            return f1.getPath().compareToIgnoreCase(f2.getPath());
-
-        // Compare pathname strings as in sun.nio.fs.WindowsPath.compareTo
-        String s1 = f1.getPath();
-        String s2 = f2.getPath();
-        int n1 = s1.length();
-        int n2 = s2.length();
-        int min = Math.min(n1, n2);
-        for (int i = 0; i < min; i++) {
-            char c1 = s1.charAt(i);
-            char c2 = s2.charAt(i);
-             if (c1 != c2) {
-                 c1 = Character.toUpperCase(c1);
-                 c2 = Character.toUpperCase(c2);
-                 if (c1 != c2) {
-                     return c1 - c2;
-                 }
-             }
+        // If property is set, compare pathname strings as in
+        // sun.nio.fs.WindowsPath.compareTo
+        if (NIO_COMPATIBLE_EQUALS) {
+            String s1 = f1.getPath();
+            String s2 = f2.getPath();
+            int n1 = s1.length();
+            int n2 = s2.length();
+            int min = Math.min(n1, n2);
+            for (int i = 0; i < min; i++) {
+                char c1 = s1.charAt(i);
+                char c2 = s2.charAt(i);
+                if (c1 != c2) {
+                    c1 = Character.toUpperCase(c1);
+                    c2 = Character.toUpperCase(c2);
+                    if (c1 != c2) {
+                        return c1 - c2;
+                    }
+                }
+            }
+            return n1 - n2;
         }
-        return n1 - n2;
+
+        // If property is not set, use legacy pathname comparison
+        return f1.getPath().compareToIgnoreCase(f2.getPath());
     }
 
     @Override

--- a/test/jdk/java/io/File/CompareTo.java
+++ b/test/jdk/java/io/File/CompareTo.java
@@ -43,20 +43,29 @@ public class CompareTo {
 
         // U+0131 = ı 'LATIN SMALL LETTER DOTLESS I'
         File smallDotlessI = new File("\u0131");
+        File latinLowerI   = new File("i");
         // U+0130 = İ 'LATIN CAPITAL LETTER I WITH DOT ABOVE'
         File largeDotfullI = new File("\u0130");
         File latinCapitalI = new File("I");
 
-        boolean shouldBeEqual= smallDotlessI.equals(latinCapitalI);
-        if (!shouldBeEqual)
+        if (!smallDotlessI.equals(latinCapitalI))
             throw new Exception("Small dotless \"i\" does not equal \"I\"");
+        if (!smallDotlessI.equals(latinLowerI))
+            throw new Exception("Small dotless \"i\" does not equal \"i\"");
 
-        boolean legacyEquals = Boolean.getBoolean("jdk.io.File.legacyEquals");
-        boolean shouldNotBeEqual = largeDotfullI.equals(latinCapitalI);
-        if (shouldNotBeEqual && !legacyEquals)
+        boolean legacyEquals = !Boolean.getBoolean("jdk.io.File.windowsUseNIOStyleEquals");
+
+        boolean shouldNotBeEqualUpper = largeDotfullI.equals(latinCapitalI);
+        if (shouldNotBeEqualUpper && !legacyEquals)
             throw new Exception("Large dotted \"I\" equals \"I\"");
-        else if (!shouldNotBeEqual && legacyEquals)
+        else if (!shouldNotBeEqualUpper && legacyEquals)
             throw new Exception("Large dotted \"I\" does not equal \"I\"");
+
+        boolean shouldNotBeEqualLower = largeDotfullI.equals(latinLowerI);
+        if (shouldNotBeEqualLower && !legacyEquals)
+            throw new Exception("Large dotted \"I\" equals \"i\"");
+        else if (!shouldNotBeEqualLower && legacyEquals)
+            throw new Exception("Large dotted \"I\" does not equal \"i\"");
     }
 
     private static void testUnix() throws Exception {


### PR DESCRIPTION
Replace logic in `java.io.WinNTFileSystems.compare(File,File)` with that from `sun.nio.fs.WindowsPath.compareTo(Path)`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (2 reviews required, with at least 2 [Reviewers](https://openjdk.org/bylaws#reviewer))
- [ ] Change requires a CSR request matching fixVersion 26 to be approved (needs to be created)

### Issue
 * [JDK-8191963](https://bugs.openjdk.org/browse/JDK-8191963): Path.equals() and File.equals() return true for two different files on Windows (**Bug** - P4) ⚠️ Issue is not open.


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25788/head:pull/25788` \
`$ git checkout pull/25788`

Update a local copy of the PR: \
`$ git checkout pull/25788` \
`$ git pull https://git.openjdk.org/jdk.git pull/25788/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25788`

View PR using the GUI difftool: \
`$ git pr show -t 25788`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25788.diff">https://git.openjdk.org/jdk/pull/25788.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25788#issuecomment-2968179661)
</details>
