### PR TITLE
8359394: GC cause cleanup

### DIFF
--- a/src/hotspot/share/gc/shared/gcCause.cpp
+++ b/src/hotspot/share/gc/shared/gcCause.cpp
@@ -89,11 +89,14 @@ const char* GCCause::to_string(GCCause::Cause cause) {
     case _dcmd_gc_run:
       return "Diagnostic Command";
 
+    case _shenandoah_stop_vm:
+      return "Stopping VM";
+
     case _shenandoah_allocation_failure_evac:
       return "Allocation Failure During Evacuation";
 
-    case _shenandoah_stop_vm:
-      return "Stopping VM";
+    case _shenandoah_humongous_allocation_failure:
+      return "Humongous Allocation Failure";
 
     case _shenandoah_concurrent_gc:
       return "Concurrent GC";

--- a/src/hotspot/share/gc/shared/gcCause.hpp
+++ b/src/hotspot/share/gc/shared/gcCause.hpp
@@ -55,7 +55,6 @@ class GCCause : public AllStatic {
 
     /* implementation independent, but reserved for GC use */
     _no_gc,
-    _no_cause_specified,
     _allocation_failure,
 
     /* implementation specific */
@@ -99,14 +98,13 @@ class GCCause : public AllStatic {
             cause == GCCause::_wb_full_gc);
   }
 
-  inline static bool is_serviceability_requested_gc(GCCause::Cause
-                                                             cause) {
+  inline static bool is_serviceability_requested_gc(GCCause::Cause cause) {
     return (cause == GCCause::_jvmti_force_gc ||
             cause == GCCause::_heap_inspection ||
             cause == GCCause::_heap_dump);
   }
 
-  // Causes for collection of the tenured gernation
+  // Causes for collection of the tenured generation
   inline static bool is_tenured_allocation_failure_gc(GCCause::Cause cause) {
     // _allocation_failure is the generic cause a collection which could result
     // in the collection of the tenured generation if there is not enough space
@@ -117,8 +115,7 @@ class GCCause : public AllStatic {
   // Causes for collection of the young generation
   inline static bool is_allocation_failure_gc(GCCause::Cause cause) {
     // _allocation_failure is the generic cause a collection for allocation failure
-    return (cause == GCCause::_allocation_failure ||
-            cause == GCCause::_shenandoah_allocation_failure_evac);
+    return cause == GCCause::_allocation_failure;
   }
 
   // Return a string describing the GCCause.

--- a/src/hotspot/share/gc/shared/gcVMOperations.cpp
+++ b/src/hotspot/share/gc/shared/gcVMOperations.cpp
@@ -99,8 +99,7 @@ static bool should_use_gclocker() {
 }
 
 bool VM_GC_Operation::doit_prologue() {
-  assert(((_gc_cause != GCCause::_no_gc) &&
-          (_gc_cause != GCCause::_no_cause_specified)), "Illegal GCCause");
+  assert(_gc_cause != GCCause::_no_gc, "Illegal GCCause");
 
   // To be able to handle a GC the VM initialization needs to be completed.
   if (!is_init_completed()) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
@@ -42,7 +42,7 @@
 
 ShenandoahControlThread::ShenandoahControlThread() :
   ShenandoahController(),
-  _requested_gc_cause(GCCause::_no_cause_specified),
+  _requested_gc_cause(GCCause::_no_gc),
   _degen_point(ShenandoahGC::_degenerated_outside_cycle) {
   set_name("Shenandoah Control Thread");
   create_and_start();

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/gc/shared/GCCause.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/gc/shared/GCCause.java
@@ -39,7 +39,6 @@ public enum GCCause {
   _wb_breakpoint ("WhiteBox Initiated Run to Breakpoint"),
 
   _no_gc ("No GC"),
-  _no_cause_specified ("Unknown GCCause"),
   _allocation_failure ("Allocation Failure"),
 
   _codecache_GC_threshold ("CodeCache GC Threshold"),
@@ -54,8 +53,9 @@ public enum GCCause {
 
   _dcmd_gc_run ("Diagnostic Command"),
 
-  _shenandoah_allocation_failure_evac ("Allocation Failure During Evacuation"),
   _shenandoah_stop_vm ("Stopping VM"),
+  _shenandoah_allocation_failure_evac ("Allocation Failure During Evacuation"),
+  __shenandoah_humongous_allocation_failure("Humongous Allocation Failure"),
   _shenandoah_concurrent_gc ("Concurrent GC"),
   _shenandoah_upgrade_to_full_gc ("Upgrade To Full GC"),
 

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/gc/shared/GCCause.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/gc/shared/GCCause.java
@@ -55,7 +55,7 @@ public enum GCCause {
 
   _shenandoah_stop_vm ("Stopping VM"),
   _shenandoah_allocation_failure_evac ("Allocation Failure During Evacuation"),
-  __shenandoah_humongous_allocation_failure("Humongous Allocation Failure"),
+  _shenandoah_humongous_allocation_failure("Humongous Allocation Failure"),
   _shenandoah_concurrent_gc ("Concurrent GC"),
   _shenandoah_upgrade_to_full_gc ("Upgrade To Full GC"),
 


### PR DESCRIPTION
Remove `GCCause::_no_cause_specified` (only referenced by Shenandoah) and add a case for `_shenandoah_humongous_allocation_failure` in `GCCause::to_string` and the `SA` analog.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8359394](https://bugs.openjdk.org/browse/JDK-8359394): GC cause cleanup (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - **Reviewer**)
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25789/head:pull/25789` \
`$ git checkout pull/25789`

Update a local copy of the PR: \
`$ git checkout pull/25789` \
`$ git pull https://git.openjdk.org/jdk.git pull/25789/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25789`

View PR using the GUI difftool: \
`$ git pr show -t 25789`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25789.diff">https://git.openjdk.org/jdk/pull/25789.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25789#issuecomment-2968458350)
</details>
