### PR TITLE
8359402: Test CloseDescriptors.java should throw SkippedException when there is no lsof/sctp

### DIFF
--- a/test/jdk/com/sun/nio/sctp/SctpChannel/CloseDescriptors.java
+++ b/test/jdk/com/sun/nio/sctp/SctpChannel/CloseDescriptors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,8 @@
  * @bug 8238274
  * @summary Potential leak file descriptor for SCTP
  * @requires (os.family == "linux")
+ * @library /test/lib
+ * @build jtreg.SkippedException
  * @run main/othervm/timeout=250 CloseDescriptors
  */
 
@@ -52,9 +54,7 @@ public class CloseDescriptors {
 
     public static void main(String[] args) throws Exception {
         if (!Util.isSCTPSupported()) {
-            System.out.println("SCTP protocol is not supported");
-            System.out.println("Test cannot be run");
-            return;
+            throw new jtreg.SkippedException("SCTP protocol is not supported");
         }
 
         List<String> lsofDirs = List.of("/usr/bin", "/usr/sbin");
@@ -63,9 +63,7 @@ public class CloseDescriptors {
                             .filter(f -> Files.isExecutable(f))
                             .findFirst();
         if (!lsof.isPresent()) {
-            System.out.println("Cannot locate lsof in " + lsofDirs);
-            System.out.println("Test cannot be run");
-            return;
+            throw new jtreg.SkippedException("Cannot locate lsof in " + lsofDirs);
         }
 
         try (ServerSocket ss = new ServerSocket(0)) {


### PR DESCRIPTION
Hi all,

Test com/sun/nio/sctp/SctpChannel/CloseDescriptors.java should throw jtreg.SkippedException when there is no lsof command or there is no SCTP in test machine.
Before this PR, this test report Execution successful when there is no SCTP.

```
--------------------------------------------------
TEST: com/sun/nio/sctp/SctpChannel/CloseDescriptors.java
TEST RESULT: Passed. Execution successful
--------------------------------------------------
```

After this PR, it will report `jtreg.SkippedException` when there is no SCTP

```
--------------------------------------------------
TEST: com/sun/nio/sctp/SctpChannel/CloseDescriptors.java
TEST RESULT: Passed. Skipped: jtreg.SkippedException: SCTP protocol is not supported
--------------------------------------------------
```

Change has been verified locally, test-fix only, no risk.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8359402](https://bugs.openjdk.org/browse/JDK-8359402): Test CloseDescriptors.java should throw SkippedException when there is no lsof/sctp (**Enhancement** - P4)


### Reviewers
 * [Volkan Yazici](https://openjdk.org/census#vyazici) (@vy - Committer)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25790/head:pull/25790` \
`$ git checkout pull/25790`

Update a local copy of the PR: \
`$ git checkout pull/25790` \
`$ git pull https://git.openjdk.org/jdk.git pull/25790/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25790`

View PR using the GUI difftool: \
`$ git pr show -t 25790`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25790.diff">https://git.openjdk.org/jdk/pull/25790.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25790#issuecomment-2969244842)
</details>
