### PR TITLE
8359272: Several vmTestbase/compact tests timed out on large memory machine

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/vm/gc/compact/Compact_InternedStrings/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/gc/compact/Compact_InternedStrings/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,9 +34,11 @@
  * This testcase uses interned strings for both first and second phases
  * and multiple threads.
  *
+ * @requires os.maxMemory > 3G
  * @library /vmTestbase
  *          /test/lib
  * @run main/othervm
+ *      -Xmx2G
  *      -XX:-UseGCOverheadLimit
  *      vm.gc.compact.Compact
  *      -gp interned(randomString)

--- a/test/hotspot/jtreg/vmTestbase/vm/gc/compact/Compact_InternedStrings_NonbranchyTree/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/gc/compact/Compact_InternedStrings_NonbranchyTree/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,9 +34,11 @@
  * This testcase uses interned strings for first phase,
  * random arrays for second phases and multiple threads.
  *
+ * @requires os.maxMemory > 3G
  * @library /vmTestbase
  *          /test/lib
  * @run main/othervm
+ *      -Xmx2G
  *      -XX:-UseGCOverheadLimit
  *      vm.gc.compact.Compact
  *      -gp interned(randomString)

--- a/test/hotspot/jtreg/vmTestbase/vm/gc/compact/Compact_Strings_ArrayOf/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/gc/compact/Compact_Strings_ArrayOf/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,9 +34,11 @@
  * This testcase uses random strings for first phase, array of
  * random strings for second phase and multiple threads.
  *
+ * @requires os.maxMemory > 3G
  * @library /vmTestbase
  *          /test/lib
  * @run main/othervm
+ *      -Xmx2G
  *      -XX:-UseGCOverheadLimit
  *      vm.gc.compact.Compact
  *      -gp randomString

--- a/test/hotspot/jtreg/vmTestbase/vm/gc/compact/Humongous_InternedStrings/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/gc/compact/Humongous_InternedStrings/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,9 +34,11 @@
  * This testcase uses interned strings for both first and second phases
  * and multiple threads.
  *
+ * @requires os.maxMemory > 3G
  * @library /vmTestbase
  *          /test/lib
  * @run main/othervm
+ *      -Xmx2G
  *      -XX:-UseGCOverheadLimit
  *      vm.gc.compact.Compact
  *      -gp interned(randomString)


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [a0fb35c8](https://github.com/openjdk/jdk/commit/a0fb35c8379295d2927c18d694ea52f7b7488a2b) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by SendaoYan on 13 Jun 2025 and was reviewed by Thomas Schatzl and Albert Mingkun Yang.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8359272](https://bugs.openjdk.org/browse/JDK-8359272): Several vmTestbase/compact tests timed out on large memory machine (**Bug** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25794/head:pull/25794` \
`$ git checkout pull/25794`

Update a local copy of the PR: \
`$ git checkout pull/25794` \
`$ git pull https://git.openjdk.org/jdk.git pull/25794/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25794`

View PR using the GUI difftool: \
`$ git pr show -t 25794`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25794.diff">https://git.openjdk.org/jdk/pull/25794.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25794#issuecomment-2969640970)
</details>
