### PR TITLE
8358701: Remove misleading javax.management.remote API doc wording about JMX spec, and historic link to JMXMP

### DIFF
--- a/src/java.management/share/classes/javax/management/remote/package-info.java
+++ b/src/java.management/share/classes/javax/management/remote/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,12 +27,9 @@
  * <p>Interfaces for remote access to
  * JMX MBean servers.
  * This package defines the essential interfaces for making a JMX
- * MBean server manageable remotely. The specification of this
- * functionality is completed by Part III of the
- * <a href="https://jcp.org/aboutJava/communityprocess/mrel/jsr160/index2.html">
- * JMX Specification, version 1.4</a></p>
+ * MBean server manageable remotely.</p>
  *
- * <p>The JMX specification defines the notion of <b>connectors</b>.
+ * <p>JMX defines the notion of <b>connectors</b>.
  * A connector is attached to a JMX API MBean server and makes it
  * accessible to remote Java clients. The client end of a
  * connector exports essentially the same interface as the MBean
@@ -41,32 +38,17 @@
  * interface.</p>
  *
  * <p>A connector makes an MBean server remotely accessible through
- * a given protocol. The JMX Remote API allows the use of different
- * type of connectors:
+ * a given protocol.
  *
- *       <ul>
+ *      <ul>
  *        <li>The JMX Remote API defines a standard connector,
  *     the <b>RMI Connector</b>, which provides remote access to an
- *         MBeanServer through RMI.
+ *     MBeanServer through RMI.
  *
- *        <li>The JMX Remote API also defines an optional connector called
- *         <b>JMXMP Connector</b> implementing the JMX Message Protocol
- *     (JMXMP). As it is optional, it is not part of this bundle (see
- *     note below).
- *
- *        <li>User-defined connector protocols are also possible using the
+ *        <li>Other connector protocols are also possible using the
  *     {@link javax.management.remote.JMXConnectorFactory
- *     JMXConnectorFactory} and, optionally, the Generic Connector
- *     (not part of this bundle, see note below).
- *       </ul>
- *
- *       <p><u>Note</u>: the optional packages implementing
- *         the optional part of the <em>JMX Remote API</em>
- *         are not included in the <em>Java SE Platform</em>
- *         but are available from the <em>JMX Remote API
- *     <a href="https://www.oracle.com/technetwork/java/javasebusiness/downloads/java-archive-downloads-java-plat-419418.html">
- *     Reference Implementation</a></em>.</p>
- *
+ *     JMXConnectorFactory}.
+ *     </ul>
  *
  *       <h2>Connector addresses</h2>
  *


### PR DESCRIPTION
Clean backport to jdk25 of this doc-only change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change requires CSR request [JDK-8358759](https://bugs.openjdk.org/browse/JDK-8358759) to be approved
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8358701](https://bugs.openjdk.org/browse/JDK-8358701): Remove misleading javax.management.remote API doc wording about JMX spec, and historic link to JMXMP (**Enhancement** - P3)
 * [JDK-8358759](https://bugs.openjdk.org/browse/JDK-8358759): Remove misleading javax.management.remote API doc wording about JMX spec, and historic link to JMXMP (**CSR**)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25795/head:pull/25795` \
`$ git checkout pull/25795`

Update a local copy of the PR: \
`$ git checkout pull/25795` \
`$ git pull https://git.openjdk.org/jdk.git pull/25795/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25795`

View PR using the GUI difftool: \
`$ git pr show -t 25795`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25795.diff">https://git.openjdk.org/jdk/pull/25795.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25795#issuecomment-2969765100)
</details>
