### PR TITLE
Backport e7f63ba3109adf614cee1bc392cfeef85e9ca778

### DIFF
--- a/src/hotspot/cpu/x86/stubDeclarations_x86.hpp
+++ b/src/hotspot/cpu/x86/stubDeclarations_x86.hpp
@@ -239,7 +239,7 @@
                                     do_arch_blob,                       \
                                     do_arch_entry,                      \
                                     do_arch_entry_init)                 \
-  do_arch_blob(final, 31000                                             \
+  do_arch_blob(final, 33000                                             \
                WINDOWS_ONLY(+22000) ZGC_ONLY(+20000))                   \
 
 #endif // CPU_X86_STUBDECLARATIONS_HPP

--- a/src/hotspot/cpu/x86/vm_version_x86.cpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.cpp
@@ -2111,7 +2111,7 @@ bool VM_Version::is_intel_cascade_lake() {
 // has improved implementation of 64-byte load/stores and so the default
 // threshold is set to 0 for these platforms.
 int VM_Version::avx3_threshold() {
-  return (is_intel_family_core() &&
+  return (is_intel_server_family() &&
           supports_serialize() &&
           FLAG_IS_DEFAULT(AVX3Threshold)) ? 0 : AVX3Threshold;
 }


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [e7f63ba3](https://github.com/openjdk/jdk/commit/e7f63ba3109adf614cee1bc392cfeef85e9ca778) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Jatin Bhateja on 13 Jun 2025 and was reviewed by Sandhya Viswanathan.

Thanks!