### PR TITLE
JFR: Help text for-XX:StartFlightRecording:report-on-exit should explain option can be repeated

### DIFF
--- a/src/java.base/share/man/java.md
+++ b/src/java.base/share/man/java.md
@@ -1449,9 +1449,10 @@ These `java` options control the runtime behavior of the Java HotSpot VM.
 
     `report-on-exit=`*identifier*
     :   Specifies the name of the view to display when the Java Virtual Machine
-        (JVM) shuts down. This option is not available if the disk option is set
-        to false. For a list of available views, see `jfr help view`. By default,
-        no report is generated.
+        (JVM) shuts down. To specify more than one view, use the report-on-exit
+        parameter repeatedly. This option is not available if the disk option
+        is set to false. For a list of available views, see `jfr help view`.
+        By default, no report is generated.
 
     `settings=`*path*
     :   Specifies the path and name of the event settings file (of type JFC).

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdStart.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdStart.java
@@ -502,9 +502,11 @@ final class DCmdStart extends AbstractDCmd {
         """
 
           report-on-exit   Specifies the name of the view to display when the Java Virtual
-                           Machine (JVM) shuts down. This option is not available if the
-                           disk option is set to false. For a list of available views,
-                           see 'jfr help view'. By default, no report is generated.
+                           Machine (JVM) shuts down. To specify more than one view, use
+                           the `report-on-exit` parameter repeatedly, for each view. This
+                           option is not available if the disk option is set to false.
+                           For a list of available views, see `jfr help view`. By default,
+                           no report is generated.
         """;
     }
 


### PR DESCRIPTION
Could I have review of a PR that updates the help text for report-on-exit so it clarifies that it can be used multiple times.

Testing: jdk/jdk/jfr + tier1

Thanks
Erik 