### PR TITLE
Backport e8ef93ae9de624f25166bdf010c915672b2c5cf4

### DIFF
--- a/src/hotspot/share/c1/c1_ValueMap.hpp
+++ b/src/hotspot/share/c1/c1_ValueMap.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -187,7 +187,13 @@ class ValueNumberingVisitor: public InstructionVisitor {
   void do_Convert        (Convert*         x) { /* nothing to do */ }
   void do_NullCheck      (NullCheck*       x) { /* nothing to do */ }
   void do_TypeCast       (TypeCast*        x) { /* nothing to do */ }
-  void do_NewInstance    (NewInstance*     x) { /* nothing to do */ }
+  void do_NewInstance    (NewInstance*     x) {
+    ciInstanceKlass* c = x->klass();
+    if (c != nullptr && !c->is_initialized() &&
+        (!c->is_loaded() || c->has_class_initializer())) {
+      kill_memory();
+    }
+  }
   void do_NewTypeArray   (NewTypeArray*    x) { /* nothing to do */ }
   void do_NewObjectArray (NewObjectArray*  x) { /* nothing to do */ }
   void do_NewMultiArray  (NewMultiArray*   x) { /* nothing to do */ }

--- a/src/hotspot/share/ci/ciInstanceKlass.cpp
+++ b/src/hotspot/share/ci/ciInstanceKlass.cpp
@@ -549,6 +549,11 @@ bool ciInstanceKlass::compute_has_trusted_loader() {
   return java_lang_ClassLoader::is_trusted_loader(loader_oop);
 }
 
+bool ciInstanceKlass::has_class_initializer() {
+  VM_ENTRY_MARK;
+  return get_instanceKlass()->class_initializer() != nullptr;
+}
+
 // ------------------------------------------------------------------
 // ciInstanceKlass::find_method
 //

--- a/src/hotspot/share/ci/ciInstanceKlass.hpp
+++ b/src/hotspot/share/ci/ciInstanceKlass.hpp
@@ -231,6 +231,8 @@ public:
   ciInstanceKlass* unique_concrete_subklass();
   bool has_finalizable_subclass();
 
+  bool has_class_initializer();
+
   bool contains_field_offset(int offset);
 
   // Get the instance of java.lang.Class corresponding to

--- a/test/hotspot/jtreg/compiler/c1/TestStaticInitializerSideEffect.java
+++ b/test/hotspot/jtreg/compiler/c1/TestStaticInitializerSideEffect.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @summary Test that C1 respects that static initializers can have memory side effects.
+ * @bug 8357782
+ * @requires vm.compiler1.enabled
+ * @comment Since static initializers only execute in the first execution of the class initializer, we need -Xcomp.
+ * @run main/othervm -Xcomp -XX:TieredStopAtLevel=1 -XX:CompileCommand=compileonly,compiler/c1/A$B.test compiler.c1.TestStaticInitializerSideEffect
+ */
+
+package compiler.c1;
+
+public class TestStaticInitializerSideEffect {
+    public static void main(String[] args) {
+        A.B.test();
+    }
+}
+
+class A {
+    static class B {
+        static String field;
+
+        static void test() {
+            // This unused variable triggers local value numbering to remove
+            // the field load in the constructor below if it is not killed
+            // before.
+            String tmp = field;
+            // The class initializer of C should kill the LVN effect of tmp due
+            // to the memory side effects of the static initializer.
+            new C(field);
+        }
+    }
+
+    static class C {
+        // When executing the class initializer, this has a side effect.
+        static {
+            B.field = "Hello";
+        }
+
+        C(String val) {
+            // If C1 does not respect that side effect, we crash here.
+            if (val == null) {
+                throw new RuntimeException("Should not reach here");
+            }
+        }
+    }
+}


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [e8ef93ae](https://github.com/openjdk/jdk/commit/e8ef93ae9de624f25166bdf010c915672b2c5cf4) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Manuel Hässig on 13 Jun 2025 and was reviewed by Tobias Hartmann, Dean Long and Damon Fenacci.

Thanks!