### PR TITLE
8359181: Error messages generated by configure --help after 8301197

### DIFF
--- a/make/autoconf/configure
+++ b/make/autoconf/configure
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -366,7 +366,7 @@ EOT
 
     # Print additional help, e.g. a list of toolchains and JVM features.
     # This must be done by the autoconf script.
-    ( CONFIGURE_PRINT_ADDITIONAL_HELP=true . $generated_script PRINTF=printf )
+    ( CONFIGURE_PRINT_ADDITIONAL_HELP=true . $generated_script PRINTF=printf ECHO=echo )
 
     cat <<EOT
 


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [7b7136b4](https://github.com/openjdk/jdk/commit/7b7136b4eca15693cfcd46ae63d644efc8a88d2c) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by SendaoYan on 12 Jun 2025 and was reviewed by Erik Joelsson and Magnus Ihse Bursie.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8359181](https://bugs.openjdk.org/browse/JDK-8359181): Error messages generated by configure --help after 8301197 (**Bug** - P4)


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25800/head:pull/25800` \
`$ git checkout pull/25800`

Update a local copy of the PR: \
`$ git checkout pull/25800` \
`$ git pull https://git.openjdk.org/jdk.git pull/25800/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25800`

View PR using the GUI difftool: \
`$ git pr show -t 25800`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25800.diff">https://git.openjdk.org/jdk/pull/25800.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25800#issuecomment-2970208246)
</details>
