### PR TITLE
8346982: Remove JMX javadoc duplication that was in place due to JDK-6369229

### DIFF
--- a/src/java.management/share/classes/javax/management/ImmutableDescriptor.java
+++ b/src/java.management/share/classes/javax/management/ImmutableDescriptor.java
@@ -343,30 +343,6 @@ public class ImmutableDescriptor implements Descriptor {
         return names.clone();
     }
 
-    /**
-     * Compares this descriptor to the given object.  The objects are equal if
-     * the given object is also a Descriptor, and if the two Descriptors have
-     * the same field names (possibly differing in case) and the same
-     * associated values.  The respective values for a field in the two
-     * Descriptors are equal if the following conditions hold:
-     *
-     * <ul>
-     * <li>If one value is null then the other must be too.</li>
-     * <li>If one value is a primitive array then the other must be a primitive
-     * array of the same type with the same elements.</li>
-     * <li>If one value is an object array then the other must be too and
-     * {@link Arrays#deepEquals(Object[],Object[])} must return true.</li>
-     * <li>Otherwise {@link Object#equals(Object)} must return true.</li>
-     * </ul>
-     *
-     * @param o the object to compare with.
-     *
-     * @return {@code true} if the objects are the same; {@code false}
-     * otherwise.
-     *
-     */
-    // Note: this Javadoc is copied from javax.management.Descriptor
-    //       due to 6369229.
     @Override
     public boolean equals(Object o) {
         if (o == this)
@@ -394,28 +370,6 @@ public class ImmutableDescriptor implements Descriptor {
         return Arrays.deepEquals(values, ovalues);
     }
 
-    /**
-     * <p>Returns the hash code value for this descriptor.  The hash
-     * code is computed as the sum of the hash codes for each field in
-     * the descriptor.  The hash code of a field with name {@code n}
-     * and value {@code v} is {@code n.toLowerCase().hashCode() ^ h}.
-     * Here {@code h} is the hash code of {@code v}, computed as
-     * follows:</p>
-     *
-     * <ul>
-     * <li>If {@code v} is null then {@code h} is 0.</li>
-     * <li>If {@code v} is a primitive array then {@code h} is computed using
-     * the appropriate overloading of {@code java.util.Arrays.hashCode}.</li>
-     * <li>If {@code v} is an object array then {@code h} is computed using
-     * {@link Arrays#deepHashCode(Object[])}.</li>
-     * <li>Otherwise {@code h} is {@code v.hashCode()}.</li>
-     * </ul>
-     *
-     * @return A hash code value for this object.
-     *
-     */
-    // Note: this Javadoc is copied from javax.management.Descriptor
-    //       due to 6369229.
     @Override
     public int hashCode() {
         if (hashCode == -1) {

--- a/src/java.management/share/classes/javax/management/modelmbean/DescriptorSupport.java
+++ b/src/java.management/share/classes/javax/management/modelmbean/DescriptorSupport.java
@@ -696,31 +696,6 @@ public class DescriptorSupport
         descriptorMap.remove(fieldName);
     }
 
-    /**
-     * Compares this descriptor to the given object.  The objects are equal if
-     * the given object is also a Descriptor, and if the two Descriptors have
-     * the same field names (possibly differing in case) and the same
-     * associated values.  The respective values for a field in the two
-     * Descriptors are equal if the following conditions hold:
-     *
-     * <ul>
-     * <li>If one value is null then the other must be too.</li>
-     * <li>If one value is a primitive array then the other must be a primitive
-     * array of the same type with the same elements.</li>
-     * <li>If one value is an object array then the other must be too and
-     * {@link java.util.Arrays#deepEquals(Object[],Object[]) Arrays.deepEquals}
-     * must return true.</li>
-     * <li>Otherwise {@link Object#equals(Object)} must return true.</li>
-     * </ul>
-     *
-     * @param o the object to compare with.
-     *
-     * @return {@code true} if the objects are the same; {@code false}
-     * otherwise.
-     *
-     */
-    // Note: this Javadoc is copied from javax.management.Descriptor
-    //       due to 6369229.
     @Override
     public synchronized boolean equals(Object o) {
         if (o == this)
@@ -732,28 +707,6 @@ public class DescriptorSupport
         return new ImmutableDescriptor(descriptorMap).equals(o);
     }
 
-    /**
-     * <p>Returns the hash code value for this descriptor.  The hash
-     * code is computed as the sum of the hash codes for each field in
-     * the descriptor.  The hash code of a field with name {@code n}
-     * and value {@code v} is {@code n.toLowerCase().hashCode() ^ h}.
-     * Here {@code h} is the hash code of {@code v}, computed as
-     * follows:</p>
-     *
-     * <ul>
-     * <li>If {@code v} is null then {@code h} is 0.</li>
-     * <li>If {@code v} is a primitive array then {@code h} is computed using
-     * the appropriate overloading of {@code java.util.Arrays.hashCode}.</li>
-     * <li>If {@code v} is an object array then {@code h} is computed using
-     * {@link java.util.Arrays#deepHashCode(Object[]) Arrays.deepHashCode}.</li>
-     * <li>Otherwise {@code h} is {@code v.hashCode()}.</li>
-     * </ul>
-     *
-     * @return A hash code value for this object.
-     *
-     */
-    // Note: this Javadoc is copied from javax.management.Descriptor
-    //       due to 6369229.
     @Override
     public synchronized int hashCode() {
         final int size = descriptorMap.size();


### PR DESCRIPTION
Remove unnecessary javadoc duplication.

Both of these files:
src/java.management/share/classes/javax/management/modelmbean/DescriptorSupport.java
src/java.management/share/classes/javax/management/ImmutableDescriptor.java

..have two instances of this comment:
     // Note: this Javadoc is copied from javax.management.Descriptor
     //       due to 6369229.
	 	 
JDK-6369229 is long since resolved, the Javadoc duplication can be removed.

In the new doc build, we still have javadoc for equals() hashCode(), with e.g.:
"Description copied from interface: Descriptor"

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346982](https://bugs.openjdk.org/browse/JDK-8346982): Remove JMX javadoc duplication that was in place due to JDK-6369229 (**Bug** - P4)


### Reviewers
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25803/head:pull/25803` \
`$ git checkout pull/25803`

Update a local copy of the PR: \
`$ git checkout pull/25803` \
`$ git pull https://git.openjdk.org/jdk.git pull/25803/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25803`

View PR using the GUI difftool: \
`$ git pr show -t 25803`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25803.diff">https://git.openjdk.org/jdk/pull/25803.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25803#issuecomment-2970589564)
</details>
