### PR TITLE
8359388: Stricter checking for cipher transformations

### DIFF
--- a/src/java.base/share/classes/javax/crypto/Cipher.java
+++ b/src/java.base/share/classes/javax/crypto/Cipher.java
@@ -316,19 +316,22 @@ public class Cipher {
 
     private static final String SHA512TRUNCATED = "SHA512/2";
 
+    // Parse the specified cipher transformation for algorithm and the
+    // optional mode and padding. If the transformation contains only
+    // algorithm, then only algorithm is returned. Otherwise, the
+    // transformation must contain all 3 and they must be non-empty.
     private static String[] tokenizeTransformation(String transformation)
             throws NoSuchAlgorithmException {
         if (transformation == null) {
             throw new NoSuchAlgorithmException("No transformation given");
         }
         /*
-         * array containing the components of a cipher transformation:
+         * Components of a cipher transformation:
          *
-         * index 0: algorithm component (e.g., AES)
-         * index 1: feedback component (e.g., CFB)
-         * index 2: padding component (e.g., PKCS5Padding)
+         * 1) algorithm component (e.g., AES)
+         * 2) feedback component (e.g., CFB) - optional
+         * 3) padding component (e.g., PKCS5Padding) - optional
          */
-        String[] parts = { "", "", "" };
 
         // check if the transformation contains algorithms with "/" in their
         // name which can cause the parsing logic to go wrong
@@ -337,27 +340,35 @@ public class Cipher {
         int startIdx = (sha512Idx == -1 ? 0 :
                 sha512Idx + SHA512TRUNCATED.length());
         int endIdx = transformation.indexOf('/', startIdx);
-        if (endIdx == -1) {
-            // algorithm
-            parts[0] = transformation.trim();
+
+        boolean algorithmOnly = (endIdx == -1);
+        String algo = (algorithmOnly ? transformation.trim() :
+                transformation.substring(0, endIdx).trim());
+        if (algo.isEmpty()) {
+            throw new NoSuchAlgorithmException("Invalid transformation: " +
+                                   "algorithm not specified-"
+                                   + transformation);
+        }
+        if (algorithmOnly) { // done
+            return new String[] { algo };
         } else {
-            // algorithm/mode/padding
-            parts[0] = transformation.substring(0, endIdx).trim();
+            // continue parsing mode and padding
             startIdx = endIdx+1;
             endIdx = transformation.indexOf('/', startIdx);
             if (endIdx == -1) {
                 throw new NoSuchAlgorithmException("Invalid transformation"
                             + " format:" + transformation);
             }
-            parts[1] = transformation.substring(startIdx, endIdx).trim();
-            parts[2] = transformation.substring(endIdx+1).trim();
-        }
-        if (parts[0].isEmpty()) {
-            throw new NoSuchAlgorithmException("Invalid transformation: " +
-                                   "algorithm not specified-"
+            String mode = transformation.substring(startIdx, endIdx).trim();
+            String padding = transformation.substring(endIdx+1).trim();
+            // ensure mode and padding are specified
+            if (mode.isEmpty() || padding.isEmpty()) {
+                throw new NoSuchAlgorithmException("Invalid transformation: " +
+                                   "missing mode and/or padding-"
                                    + transformation);
+            }
+            return new String[] { algo, mode, padding };
         }
-        return parts;
     }
 
     // Provider attribute name for supported chaining mode
@@ -453,27 +464,18 @@ public class Cipher {
             throws NoSuchAlgorithmException {
         String[] parts = tokenizeTransformation(transformation);
 
-        String alg = parts[0];
-        String mode = (parts[1].length() == 0 ? null : parts[1]);
-        String pad = (parts[2].length() == 0 ? null : parts[2]);
-
-        if ((mode == null) && (pad == null)) {
+        if (parts.length == 1) {
             // Algorithm only
-            Transform tr = new Transform(alg, "", null, null);
+            Transform tr = new Transform(parts[0], "", null, null);
             return Collections.singletonList(tr);
         } else {
-            // Algorithm w/ at least mode or padding or both
+            // Algorithm w/ both mode and padding
             List<Transform> list = new ArrayList<>(4);
-            if ((mode != null) && (pad != null)) {
-                list.add(new Transform(alg, "/" + mode + "/" + pad, null, null));
-            }
-            if (mode != null) {
-                list.add(new Transform(alg, "/" + mode, null, pad));
-            }
-            if (pad != null) {
-                list.add(new Transform(alg, "//" + pad, mode, null));
-            }
-            list.add(new Transform(alg, "", mode, pad));
+            list.add(new Transform(parts[0], "/" + parts[1] + "/" + parts[2],
+                    null, null));
+            list.add(new Transform(parts[0], "/" + parts[1], null, parts[2]));
+            list.add(new Transform(parts[0], "//" + parts[2], parts[1], null));
+            list.add(new Transform(parts[0], "", parts[1], parts[2]));
             return list;
         }
     }

--- a/src/java.base/share/classes/javax/crypto/Cipher.java
+++ b/src/java.base/share/classes/javax/crypto/Cipher.java
@@ -466,17 +466,15 @@ public class Cipher {
 
         if (parts.length == 1) {
             // Algorithm only
-            Transform tr = new Transform(parts[0], "", null, null);
-            return Collections.singletonList(tr);
+            return List.of(new Transform(parts[0], "", null, null));
         } else {
             // Algorithm w/ both mode and padding
-            List<Transform> list = new ArrayList<>(4);
-            list.add(new Transform(parts[0], "/" + parts[1] + "/" + parts[2],
-                    null, null));
-            list.add(new Transform(parts[0], "/" + parts[1], null, parts[2]));
-            list.add(new Transform(parts[0], "//" + parts[2], parts[1], null));
-            list.add(new Transform(parts[0], "", parts[1], parts[2]));
-            return list;
+            return List.of(
+                    new Transform(parts[0], "/" + parts[1] + "/" + parts[2],
+                    null, null),
+                    new Transform(parts[0], "/" + parts[1], null, parts[2]),
+                    new Transform(parts[0], "//" + parts[2], parts[1], null),
+                    new Transform(parts[0], "", parts[1], parts[2]));
         }
     }
 

--- a/test/jdk/javax/crypto/Cipher/TestEmptyModePadding.java
+++ b/test/jdk/javax/crypto/Cipher/TestEmptyModePadding.java
@@ -27,12 +27,12 @@
  * @bug 8358159 8359388
  * @summary test that the Cipher.getInstance() would reject improper
  *     transformations with empty mode and/or padding.
- * @run main TestEmptyModePadding
  */
 
-
-import java.security.*;
-import javax.crypto.*;
+import java.security.NoSuchAlgorithmException;
+import java.security.Provider;
+import java.security.Security;
+import javax.crypto.Cipher;
 
 public class TestEmptyModePadding {
 
@@ -46,12 +46,17 @@ public class TestEmptyModePadding {
             // transformations w/ only 1 component, i.e. algo
             " ",
             // transformations w/ only 2 components
-            "AES/", "AES/ ", "AES/CBC",
+            "AES/",
+            "AES/ ",
+            "AES/CBC",
             "PBEWithHmacSHA512/224AndAES_128/",
             "PBEWithHmacSHA512/256AndAES_128/ ",
             "PBEWithHmacSHA512/224AndAES_128/CBC",
             // 3-component transformations w/ empty component(s)
-            "AES//", "AES/ /", "AES// ", "AES/ / ",
+            "AES//",
+            "AES/ /",
+            "AES// ",
+            "AES/ / ",
             "AES/CBC/", "AES/CBC/ ",
             "AES//PKCS5Padding", "AES/ /NoPadding",
             "PBEWithHmacSHA512/224AndAES_128//",

--- a/test/jdk/javax/crypto/Cipher/TestEmptyModePadding.java
+++ b/test/jdk/javax/crypto/Cipher/TestEmptyModePadding.java
@@ -40,41 +40,42 @@ public class TestEmptyModePadding {
         Provider provider = Security.getProvider(
                 System.getProperty("test.provider.name", "SunJCE"));
 
-        // transformations w/ only 2 components
-        test("AES/", provider);
-        test("AES/ ", provider);
-        test("AES/CBC", provider);
-        test("PBEWithHmacSHA512/224AndAES_128/", provider);
-        test("PBEWithHmacSHA512/256AndAES_128/ ", provider);
-        test("PBEWithHmacSHA512/224AndAES_128/CBC", provider);
+        System.out.println("Testing against " + provider.getName());
 
-        // 3-component transformations w/ empty component(s)
-        test("AES//", provider);
-        test("AES/ /", provider);
-        test("AES// ", provider);
-        test("AES/ / ", provider);
-        test("AES/CBC/", provider);
-        test("AES/CBC/ ", provider);
-        test("AES//PKCS5Padding", provider);
-        test("AES/ /NoPadding", provider);
-        test("PBEWithHmacSHA512/224AndAES_128//", provider);
-        test("PBEWithHmacSHA512/224AndAES_128/ /", provider);
-        test("PBEWithHmacSHA512/224AndAES_128// ", provider);
-        test("PBEWithHmacSHA512/224AndAES_128/ / ", provider);
-        test("PBEWithHmacSHA512/256AndAES_128/CBC/", provider);
-        test("PBEWithHmacSHA512/256AndAES_128/CBC/ ", provider);
-        test("PBEWithHmacSHA512/256AndAES_128//PKCS5Padding", provider);
-        test("PBEWithHmacSHA512/256AndAES_128/ /PKCS5Padding", provider);
+        String[] testTransformations = {
+            // transformations w/ only 1 component, i.e. algo
+            " ",
+            // transformations w/ only 2 components
+            "AES/", "AES/ ", "AES/CBC",
+            "PBEWithHmacSHA512/224AndAES_128/",
+            "PBEWithHmacSHA512/256AndAES_128/ ",
+            "PBEWithHmacSHA512/224AndAES_128/CBC",
+            // 3-component transformations w/ empty component(s)
+            "AES//", "AES/ /", "AES// ", "AES/ / ",
+            "AES/CBC/", "AES/CBC/ ",
+            "AES//PKCS5Padding", "AES/ /NoPadding",
+            "PBEWithHmacSHA512/224AndAES_128//",
+            "PBEWithHmacSHA512/224AndAES_128/ /",
+            "PBEWithHmacSHA512/224AndAES_128// ",
+            "PBEWithHmacSHA512/224AndAES_128/ / ",
+            "PBEWithHmacSHA512/256AndAES_128/CBC/",
+            "PBEWithHmacSHA512/256AndAES_128/CBC/ ",
+            "PBEWithHmacSHA512/256AndAES_128//PKCS5Padding",
+            "PBEWithHmacSHA512/256AndAES_128/ /PKCS5Padding",
+        };
+
+        for (String t : testTransformations) {
+            test(t, provider);
+        };
     }
 
-    private static void test(String transformation, Provider provider)
-            throws Exception {
-        System.out.println("Testing " + transformation);
+    private static void test(String t, Provider p) throws Exception {
         try {
-            Cipher c = Cipher.getInstance(transformation, provider);
-            throw new RuntimeException("Expected NSAE not thrown");
+            Cipher c = Cipher.getInstance(t, p);
+            throw new RuntimeException("Should throw NSAE for \'" + t + "\'");
         } catch (NoSuchAlgorithmException nsae) {
-            System.out.println("Expected NSAE thrown: " + nsae.getMessage());
+            // transformation info is already in the NSAE message
+            System.out.println("Expected NSAE: " + nsae.getMessage());
         }
     }
 }

--- a/test/jdk/javax/crypto/Cipher/TestEmptyModePadding.java
+++ b/test/jdk/javax/crypto/Cipher/TestEmptyModePadding.java
@@ -24,7 +24,7 @@
 
 /*
  * @test
- * @bug 8358159 8359388
+ * @bug 8359388
  * @summary test that the Cipher.getInstance() would reject improper
  *     transformations with empty mode and/or padding.
  */

--- a/test/jdk/javax/crypto/Cipher/TestEmptyModePadding.java
+++ b/test/jdk/javax/crypto/Cipher/TestEmptyModePadding.java
@@ -66,7 +66,7 @@ public class TestEmptyModePadding {
 
         for (String t : testTransformations) {
             test(t, provider);
-        };
+        }
     }
 
     private static void test(String t, Provider p) throws Exception {


### PR DESCRIPTION
Based on the javadoc of `javax.crypto.Cipher` class, the cipher transformation should be either "algorithm/mode/padding" or
"algorithm". When parsing the transformation, space(s) is trimmed off and empty strings are considered as "unspecified". This PR adds checks to ensure that transformations with empty "mode" and/or "padding" value in the "algorithm/mode/padding" form leads to `NoSuchAlgorithmException`. This reverts some changes made in [https://bugs.openjdk.org/browse/JDK-8358159](https://bugs.openjdk.org/browse/JDK-8358159) which allows empty mode and/or padding in the transformations.


Thanks in advance for the review~

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8359388](https://bugs.openjdk.org/browse/JDK-8359388): Stricter checking for cipher transformations (**Bug** - P4)


### Reviewers
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25808/head:pull/25808` \
`$ git checkout pull/25808`

Update a local copy of the PR: \
`$ git checkout pull/25808` \
`$ git pull https://git.openjdk.org/jdk.git pull/25808/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25808`

View PR using the GUI difftool: \
`$ git pr show -t 25808`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25808.diff">https://git.openjdk.org/jdk/pull/25808.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25808#issuecomment-2971079597)
</details>
