### PR TITLE
8359418: Test "javax/swing/text/GlyphView/bug4188841.java" failed because the phrase of text pane does not match the instructions

### DIFF
--- a/test/jdk/javax/swing/text/GlyphView/bug4188841.java
+++ b/test/jdk/javax/swing/text/GlyphView/bug4188841.java
@@ -69,7 +69,7 @@ public class bug4188841 {
         JFrame frame = new JFrame("bug4188841");
 
         NoWrapTextPane nwp = new NoWrapTextPane();
-        nwp.setText("the\tslow\tbrown\tfox\tjumps\tover\tthe\tlazy\tdog!");
+        nwp.setText("the\tquick\tbrown\tfox\tjumps\tover\tthe\tlazy\tdog!");
         nwp.setCaretPosition(nwp.getText().length());
 
         JScrollPane scrollPane = new JScrollPane(nwp,


### PR DESCRIPTION
Test instruction had "the quick brown fox jumps over the lazy dog" but the actual  "the\tslow\tbrown\tfox\tjumps\tover\tthe\tlazy\tdog!" 

Replaced slow with quick word to match the test instruction.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8359418](https://bugs.openjdk.org/browse/JDK-8359418): Test "javax/swing/text/GlyphView/bug4188841.java" failed because the phrase of text pane does not match the instructions (**Bug** - P5)


### Reviewers
 * [Harshitha Onkar](https://openjdk.org/census#honkar) (@honkar-jdk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25809/head:pull/25809` \
`$ git checkout pull/25809`

Update a local copy of the PR: \
`$ git checkout pull/25809` \
`$ git pull https://git.openjdk.org/jdk.git pull/25809/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25809`

View PR using the GUI difftool: \
`$ git pr show -t 25809`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25809.diff">https://git.openjdk.org/jdk/pull/25809.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25809#issuecomment-2981716707)
</details>
