### PR TITLE
8339355: Test build/AbsPathsInImage.java fails configure with --enable-ccache

### DIFF
--- a/test/jdk/build/AbsPathsInImage.java
+++ b/test/jdk/build/AbsPathsInImage.java
@@ -50,7 +50,6 @@ public class AbsPathsInImage {
     // JTREG=JAVA_OPTIONS=-Djdk.test.build.AbsPathInImage.dir=/path/to/dir
     public static final String DIR_PROPERTY = "jdk.test.build.AbsPathsInImage.dir";
     private static final boolean IS_WINDOWS = System.getProperty("os.name").toLowerCase().contains("windows");
-    private static final boolean IS_LINUX   = System.getProperty("os.name").toLowerCase().contains("linux");
 
     private boolean matchFound = false;
 
@@ -167,7 +166,7 @@ public class AbsPathsInImage {
                 String fileName = file.toString();
                 if (Files.isSymbolicLink(file)) {
                     return super.visitFile(file, attrs);
-                } else if ((fileName.endsWith(".debuginfo") && !IS_LINUX) || fileName.endsWith(".pdb")) {
+                } else if (fileName.endsWith(".debuginfo") || fileName.endsWith(".pdb")) {
                     // Do nothing
                 } else if (fileName.endsWith(".zip")) {
                     scanZipFile(file, searchPatterns);


### PR DESCRIPTION
Hi all,

The debuginfo file will not ship to customers generally, so I think it's not necessary to check the debuginfo files contains absolutive path or not. And I can't find why the debuginfo file always contains workspace path info with --enable-ccache configure option.