### PR TITLE
8355556: JVM crash because archived method handle intrinsics are not restored

### DIFF
--- a/src/hotspot/share/runtime/threads.cpp
+++ b/src/hotspot/share/runtime/threads.cpp
@@ -771,8 +771,8 @@ jint Threads::create_vm(JavaVMInitArgs* args, bool* canTryAgain) {
 #endif
 
   if (CDSConfig::is_using_aot_linked_classes()) {
-    AOTLinkedClassBulkLoader::finish_loading_javabase_classes(CHECK_JNI_ERR);
     SystemDictionary::restore_archived_method_handle_intrinsics();
+    AOTLinkedClassBulkLoader::finish_loading_javabase_classes(CHECK_JNI_ERR);
   }
 
   // Start string deduplication thread if requested.


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [366650a4](https://github.com/openjdk/jdk/commit/366650a438d046f3da5b490c42e37faaf3a9abc5) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Ioi Lam on 13 Jun 2025 and was reviewed by Andrew Dinn, Vladimir Ivanov and Aleksey Shipilev.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8355556](https://bugs.openjdk.org/browse/JDK-8355556): JVM crash because archived method handle intrinsics are not restored (**Bug** - P3)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25815/head:pull/25815` \
`$ git checkout pull/25815`

Update a local copy of the PR: \
`$ git checkout pull/25815` \
`$ git pull https://git.openjdk.org/jdk.git pull/25815/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25815`

View PR using the GUI difftool: \
`$ git pr show -t 25815`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25815.diff">https://git.openjdk.org/jdk/pull/25815.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25815#issuecomment-2974897073)
</details>
