### PR TITLE
8317801: java/net/Socket/asyncClose/Race.java fails intermittently (aix)

### DIFF
--- a/src/java.base/unix/classes/sun/nio/ch/NativeThread.java
+++ b/src/java.base/unix/classes/sun/nio/ch/NativeThread.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/unix/classes/sun/nio/ch/NativeThread.java
+++ b/src/java.base/unix/classes/sun/nio/ch/NativeThread.java
@@ -78,6 +78,17 @@ public class NativeThread {
         return (tid == VIRTUAL_THREAD_ID);
     }
 
+    /**
+     * Return true if the operating system supports pending signals. If a signal is sent
+     * to a thread but cannot be delivered immediately then it will be delivered when the
+     * thread is in the appropriate state.
+     */
+    static boolean supportPendingSignals() {
+        return supportPendingSignals0();
+    }
+
+    private static native boolean supportPendingSignals0();
+
     // Returns an opaque token representing the native thread underlying the
     // invoking Java thread.  On systems that do not require signalling, this
     // method always returns 0.

--- a/src/java.base/unix/native/libnio/ch/NativeThread.c
+++ b/src/java.base/unix/native/libnio/ch/NativeThread.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/unix/native/libnio/ch/NativeThread.c
+++ b/src/java.base/unix/native/libnio/ch/NativeThread.c
@@ -88,3 +88,12 @@ Java_sun_nio_ch_NativeThread_signal0(JNIEnv *env, jclass cl, jlong thread)
 #endif
         JNU_ThrowIOExceptionWithLastError(env, "Thread signal failed");
 }
+
+JNIEXPORT jboolean JNICALL
+Java_sun_nio_ch_NativeThread_supportPendingSignals0(JNIEnv *env, jclass cl) {
+#if defined(_AIX)
+    return JNI_TRUE;
+#else
+    return JNI_FALSE;
+#endif
+}

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -592,8 +592,6 @@ java/net/MulticastSocket/SetLoopbackMode.java                   7122846,8308807 
 java/net/MulticastSocket/SetOutgoingIf.java                     8308807 aix-ppc64
 java/net/MulticastSocket/Test.java                              7145658,8308807 macosx-all,aix-ppc64
 
-java/net/Socket/asyncClose/Race.java                            8317801 aix-ppc64
-
 ############################################################################
 
 # jdk_nio


### PR DESCRIPTION
Resolved a race condition in socket close handling that led to intermittent failures in Race.java on AIX
The bug report for the same: https://bugs.openjdk.org/browse/JDK-8317801

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8317801](https://bugs.openjdk.org/browse/JDK-8317801): java/net/Socket/asyncClose/Race.java fails intermittently (aix) (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Joachim Kern](https://openjdk.org/census#jkern) (@JoKern65 - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25817/head:pull/25817` \
`$ git checkout pull/25817`

Update a local copy of the PR: \
`$ git checkout pull/25817` \
`$ git pull https://git.openjdk.org/jdk.git pull/25817/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25817`

View PR using the GUI difftool: \
`$ git pr show -t 25817`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25817.diff">https://git.openjdk.org/jdk/pull/25817.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25817#issuecomment-2975160610)
</details>
