### PR TITLE
8330940: Impossible to create a socket backlog greater than 200 on Windows 8+

### DIFF
--- a/src/java.base/windows/native/libnio/ch/Net.c
+++ b/src/java.base/windows/native/libnio/ch/Net.c
@@ -214,6 +214,17 @@ Java_sun_nio_ch_Net_bind0(JNIEnv *env, jclass clazz, jobject fdo, jboolean prefe
 JNIEXPORT void JNICALL
 Java_sun_nio_ch_Net_listen(JNIEnv *env, jclass cl, jobject fdo, jint backlog)
 {
+    /*
+     * On Windows, the backlog value of SOMAXCONN allows the underlying
+     * platform implementation to set the backlog to a maximum reasonable value.
+     * In order to use a backlog higher than what SOMAXCONN determines, Windows
+     * documentation of listen() function suggests using SOMAXCONN_HINT(N)
+     * (where N is a number).
+     * SOMAXCONN_HINT will adjust the value N to be within the range (200, 65535).
+     */
+    if (backlog >= 200) {
+        backlog = SOMAXCONN_HINT(backlog);
+    }
     if (listen(fdval(env,fdo), backlog) == SOCKET_ERROR) {
         NET_ThrowNew(env, WSAGetLastError(), "listen");
     }

--- a/src/java.base/windows/native/libnio/ch/Net.c
+++ b/src/java.base/windows/native/libnio/ch/Net.c
@@ -215,12 +215,8 @@ JNIEXPORT void JNICALL
 Java_sun_nio_ch_Net_listen(JNIEnv *env, jclass cl, jobject fdo, jint backlog)
 {
     /*
-     * On Windows, the backlog value of SOMAXCONN allows the underlying
-     * platform implementation to set the backlog to a maximum reasonable value.
-     * In order to use a backlog higher than what SOMAXCONN determines, Windows
-     * documentation of listen() function suggests using SOMAXCONN_HINT(N)
-     * (where N is a number).
-     * SOMAXCONN_HINT will adjust the value N to be within the range (200, 65535).
+     * Use SOMAXCONN_HINT when backlog larger than 200. It will adjust the value
+     * to be within the range (200, 65535).
      */
     if (backlog > 200) {
         backlog = SOMAXCONN_HINT(backlog);

--- a/src/java.base/windows/native/libnio/ch/Net.c
+++ b/src/java.base/windows/native/libnio/ch/Net.c
@@ -222,7 +222,7 @@ Java_sun_nio_ch_Net_listen(JNIEnv *env, jclass cl, jobject fdo, jint backlog)
      * (where N is a number).
      * SOMAXCONN_HINT will adjust the value N to be within the range (200, 65535).
      */
-    if (backlog >= 200) {
+    if (backlog > 200) {
         backlog = SOMAXCONN_HINT(backlog);
     }
     if (listen(fdval(env,fdo), backlog) == SOCKET_ERROR) {

--- a/test/jdk/java/net/ServerSocket/LargeBacklogTest.java
+++ b/test/jdk/java/net/ServerSocket/LargeBacklogTest.java
@@ -69,19 +69,19 @@ class LargeBacklogTest {
 
     private static void testBackloggedConnects(final int backlog, final int serverPort) {
         int numSuccessfulConnects = 0;
-        System.out.println("attempting " + backlog + " connections to port " + serverPort);
+        System.err.println("attempting " + backlog + " connections to port " + serverPort);
         // attempt the Socket connections
         for (int i = 1; i <= backlog; i++) {
             try (final Socket sock = new Socket(InetAddress.getLoopbackAddress(), serverPort)) {
                 numSuccessfulConnects++;
-                System.out.println("connection " + i + " established " + sock);
+                System.err.println("connection " + i + " established " + sock);
             } catch (IOException ioe) {
                 System.err.println("connection attempt " + i + " failed: " + ioe);
                 // do not attempt any more connections
                 break;
             }
         }
-        System.out.println(numSuccessfulConnects + " connections successfully established");
+        System.err.println(numSuccessfulConnects + " connections successfully established");
         // ideally we expect the number of successful connections to be equal to the backlog value.
         // however in certain environments, it's possible that some other process attempts a
         // connection to the server's port. so we allow for a small number of connection attempts

--- a/test/jdk/java/net/ServerSocket/LargeBacklogTest.java
+++ b/test/jdk/java/net/ServerSocket/LargeBacklogTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.channels.ServerSocketChannel;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/*
+ * @test
+ * @bug 8330940
+ * @summary verify that java.net.ServerSocket and java.nio.channels.ServerSocketChannel,
+ *          when configured with a backlog of >=200 on Windows, will allow for those many
+ *          backlogged Socket connections
+ * @requires os.family == "windows"
+ * @run junit LargeBacklogTest
+ */
+class LargeBacklogTest {
+
+    @Test
+    void testServerSocket() throws Exception {
+        final int backlog = 242;
+        // Create a ServerSocket configured with the given backlog.
+        // The channel never accept()s a connection so each connect() attempt
+        // will be backlogged.
+        try (var server = new ServerSocket(0, backlog, InetAddress.getLoopbackAddress())) {
+            final int serverPort = server.getLocalPort();
+            testBackloggedConnects(backlog, serverPort);
+        }
+    }
+
+    @Test
+    void testServerSocketChannel() throws Exception {
+        final int backlog = 213;
+        // Create a ServerSocketChannel configured with the given backlog.
+        // The channel never accept()s a connection so each connect() attempt
+        // will be backlogged.
+        try (var serverChannel = ServerSocketChannel.open()) {
+            serverChannel.bind(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), backlog);
+            final int serverPort = ((InetSocketAddress) serverChannel.getLocalAddress()).getPort();
+            testBackloggedConnects(backlog, serverPort);
+        }
+    }
+
+    private static void testBackloggedConnects(final int backlog, final int serverPort) {
+        int numSuccessfulConnects = 0;
+        System.out.println("attempting " + backlog + " connections to port " + serverPort);
+        // attempt the Socket connections
+        for (int i = 1; i <= backlog; i++) {
+            try (final Socket sock = new Socket(InetAddress.getLoopbackAddress(), serverPort)) {
+                numSuccessfulConnects++;
+                System.out.println("connection " + i + " established " + sock);
+            } catch (IOException ioe) {
+                System.err.println("connection attempt " + i + " failed: " + ioe);
+                // do not attempt any more connections
+                break;
+            }
+        }
+        System.out.println(numSuccessfulConnects + " connections successfully established");
+        // ideally we expect the number of successful connections to be equal to the backlog value.
+        // however in certain environments, it's possible that some other process attempts a
+        // connection to the server's port. so we allow for a small number of connection attempts
+        // to fail (due to exceeding the backlog)
+        final int minimumExpectedSuccessfulConns = backlog - 5;
+        if (numSuccessfulConnects < minimumExpectedSuccessfulConns) {
+            fail("expected at least " + minimumExpectedSuccessfulConns
+                    + " successful connections for a backlog of " + backlog + ", but only "
+                    + numSuccessfulConnects + " were successful");
+        }
+    }
+}

--- a/test/jdk/java/net/ServerSocket/LargeBacklogTest.java
+++ b/test/jdk/java/net/ServerSocket/LargeBacklogTest.java
@@ -46,7 +46,7 @@ class LargeBacklogTest {
     void testServerSocket() throws Exception {
         final int backlog = 242;
         // Create a ServerSocket configured with the given backlog.
-        // The channel never accept()s a connection so each connect() attempt
+        // The ServerSocket never accept()s a connection so each connect() attempt
         // will be backlogged.
         try (var server = new ServerSocket(0, backlog, InetAddress.getLoopbackAddress())) {
             final int serverPort = server.getLocalPort();


### PR DESCRIPTION
Can I please get a review of this change which proposes to enhance the implementation of `ServerSocket` and `ServerSocketChannel` to allow for `backlog` values to be greater than 200 on Windows? This addresses https://bugs.openjdk.org/browse/JDK-8330940.

As noted in that enhancement request, right now on Windows, if the backlog is specified to be more than 200, then Windows caps it to a platform internal `SOMAXCONN`. As noted in the documentation here https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-listen applications can increase that limit by using the `SOMAXCONN_HINT` macro. That macro then adjusts the value to be between 200 and 65535, thus allowing for a higher backlog of connections.

The commit in this PR uses this macro when the specified backlog is 200 or more. A new jtreg test has been introduced to verify this change. This test and other existing tests in tier1, tier2 and tier3 continue to pass.

A similar restriction on the backlog value applies in Linux too https://github.com/torvalds/linux/blob/master/Documentation/networking/ip-sysctl.rst#tcp-variables. But from what I can see, unlike Windows, it cannot be adjusted when calling `listen()`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8330940](https://bugs.openjdk.org/browse/JDK-8330940): Impossible to create a socket backlog greater than 200 on Windows 8+ (**Bug** - P4)


### Reviewers
 * [Michael McMahon](https://openjdk.org/census#michaelm) (@Michael-Mc-Mahon - **Reviewer**)
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25819/head:pull/25819` \
`$ git checkout pull/25819`

Update a local copy of the PR: \
`$ git checkout pull/25819` \
`$ git pull https://git.openjdk.org/jdk.git pull/25819/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25819`

View PR using the GUI difftool: \
`$ git pr show -t 25819`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25819.diff">https://git.openjdk.org/jdk/pull/25819.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25819#issuecomment-2975330001)
</details>
