### PR TITLE
8358129: compiler/startup/StartupOutput.java runs into out of memory on Windows after JDK-8347406

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -79,8 +79,6 @@ compiler/ciReplay/TestIncrementalInlining.java 8349191 generic-all
 
 compiler/c2/TestVerifyConstraintCasts.java 8355574 generic-all
 
-compiler/startup/StartupOutput.java 8358129 windows-all
-
 #############################################################################
 
 # :hotspot_gc

--- a/test/hotspot/jtreg/compiler/startup/StartupOutput.java
+++ b/test/hotspot/jtreg/compiler/startup/StartupOutput.java
@@ -60,21 +60,17 @@ public class StartupOutput {
             throw new Exception("VM crashed with exit code " + exitCode);
         }
 
-        Process[] pr = new Process[200];
         for (int i = 0; i < 200; i++) {
             int initialCodeCacheSizeInKb = 800 + rand.nextInt(400);
             int reservedCodeCacheSizeInKb = initialCodeCacheSizeInKb + rand.nextInt(200);
             pb = ProcessTools.createLimitedTestJavaProcessBuilder("-XX:InitialCodeCacheSize=" + initialCodeCacheSizeInKb + "K", "-XX:ReservedCodeCacheSize=" + reservedCodeCacheSizeInKb + "k", "-version");
-            pr[i] = pb.start();
-        }
-        for (int i = 0; i < 200; i++) {
-            out = new OutputAnalyzer(pr[i]);
-            // The VM should not crash but will probably fail with a "CodeCache is full. Compiler has been disabled." message
-            out.stdoutShouldNotContain("# A fatal error");
+            out = new OutputAnalyzer(pb.start());
             exitCode = out.getExitValue();
             if (exitCode != 1 && exitCode != 0) {
                 throw new Exception("VM crashed with exit code " + exitCode);
             }
+            // The VM should not crash but will probably fail with a "CodeCache is full. Compiler has been disabled." message
+            out.stdoutShouldNotContain("# A fatal error");
         }
     }
 }


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [534a8605](https://github.com/openjdk/jdk/commit/534a8605e5f4d771be69426687b2188d5353c91e) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Damon Fenacci on 16 Jun 2025 and was reviewed by Tobias Hartmann and Emanuel Peter.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8358129](https://bugs.openjdk.org/browse/JDK-8358129): compiler/startup/StartupOutput.java runs into out of memory on Windows after JDK-8347406 (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25821/head:pull/25821` \
`$ git checkout pull/25821`

Update a local copy of the PR: \
`$ git checkout pull/25821` \
`$ git pull https://git.openjdk.org/jdk.git pull/25821/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25821`

View PR using the GUI difftool: \
`$ git pr show -t 25821`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25821.diff">https://git.openjdk.org/jdk/pull/25821.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25821#issuecomment-2975520290)
</details>
