### PR TITLE
8354727: CompilationPolicy creates too many compiler threads when code cache space is scarce

### DIFF
--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -268,7 +268,7 @@ void CodeCache::initialize_heaps() {
 
   // Validation
   // Check minimal required sizes
-  check_min_size("non-nmethod code heap", non_nmethod.size, non_nmethod_min_size);
+  check_min_size("non-nmethod code heap", non_nmethod.size, min_cache_size);
   if (profiled.enabled) {
     check_min_size("profiled code heap", profiled.size, min_size);
   }

--- a/test/hotspot/jtreg/compiler/codecache/CheckSegmentedCodeCache.java
+++ b/test/hotspot/jtreg/compiler/codecache/CheckSegmentedCodeCache.java
@@ -196,7 +196,7 @@ public class CheckSegmentedCodeCache {
                                                               "-XX:ReservedCodeCacheSize=" + minSize,
                                                               "-XX:InitialCodeCacheSize=100K",
                                                               "-version");
-        failsWith(pb, "Not enough space in non-nmethod code heap to run VM");
+        failsWith(pb, "Invalid code heap sizes");
 
         // Try different combination of Segment Sizes
 


### PR DESCRIPTION
# Issue Summary

Running
```
java -XX:+SegmentedCodeCache -XX:ReservedCodeCacheSize=10M -XX:NonNMethodCodeHeapSize=6M \
     -XX:ProfiledCodeHeapSize=5M -XX:NonProfiledCodeHeapSize=5M -version
```
on a machine with more than 255 cores, this would fail with the message that the specified `NonNMethodCodeHeapSize` is too small to fit all compiler buffers (instead of failing because the sum of the heaps is larger than the `ReservedCodeCacheSize`). Hence, the calculated compiler count is too high. This is due to CompilationPolicy::initialize() checking how many compiler buffers fit into the `ReservedCodeCacheSize`. However, in the case above, this is significantly larger than `NonNMethodCodeHeapSize` and causes a check updated in #17244 to fail that should ensure that `NonNMethodCodeHeapSize` is at least `CodeCacheMinimumUseSpace` plus the size of all `CICompilerCount` compiler buffers. This is stronger than before #17244 where this check merely required `NonNMethodCodeHeapSize >= CodeCacheMinimumUseSpace` due to the fact that compiler buffers can also use the rest of the code cache if the non-nmethod heap is not sufficient.

# Change Rationale

This PR reverts the failing check to ensuring `NonNMethodCodeHeapSize >= CodeCacheMinimumUseSpace` since the computation of the ergonomic `CICompilerCount` in `CompilationPolicy::initialize()` does not support the assumption that all compiler buffers must always fit inside the non-nmethod code heap. 

This change required to adjust a test, because with the weaker check, it is currently not possible to trigger it from the commandline.

# Testing

- [x] [Github Actions](https://github.com/mhaessig/jdk/actions/runs/15681197877)
- [x] tier1 and tier2 plus some Oracle internal testing

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8354727](https://bugs.openjdk.org/browse/JDK-8354727): CompilationPolicy creates too many compiler threads when code cache space is scarce (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25830/head:pull/25830` \
`$ git checkout pull/25830`

Update a local copy of the PR: \
`$ git checkout pull/25830` \
`$ git pull https://git.openjdk.org/jdk.git pull/25830/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25830`

View PR using the GUI difftool: \
`$ git pr show -t 25830`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25830.diff">https://git.openjdk.org/jdk/pull/25830.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25830#issuecomment-2979346718)
</details>
