### PR TITLE
JDK-8349077 : Rename GenerationCounters::update_all

### DIFF
--- a/src/hotspot/share/gc/epsilon/epsilonMonitoringSupport.cpp
+++ b/src/hotspot/share/gc/epsilon/epsilonMonitoringSupport.cpp
@@ -75,7 +75,7 @@ public:
     FREE_C_HEAP_ARRAY(char, _name_space);
   }
 
-  inline void update_all(size_t capacity, size_t used) {
+  inline void update_capacity(size_t capacity, size_t used) {
     _capacity->set_value(capacity);
     _used->set_value(used);
   }
@@ -90,8 +90,8 @@ public:
           _heap(heap)
   {};
 
-  void update_all() {
-    GenerationCounters::update_all(_heap->capacity());
+  void update_capacity() {
+    GenerationCounters::update_capacity(_heap->capacity());
   }
 };
 
@@ -107,8 +107,8 @@ void EpsilonMonitoringSupport::update_counters() {
     EpsilonHeap* heap = EpsilonHeap::heap();
     size_t used = heap->used();
     size_t capacity = heap->capacity();
-    _heap_counters->update_all();
-    _space_counters->update_all(capacity, used);
+    _heap_counters->update_capacity();
+    _space_counters->update_capacity(capacity, used);
     MetaspaceCounters::update_performance_counters();
   }
 }

--- a/src/hotspot/share/gc/epsilon/epsilonMonitoringSupport.cpp
+++ b/src/hotspot/share/gc/epsilon/epsilonMonitoringSupport.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Red Hat, Inc. All rights reserved.
+ * Copyright (c) 2017, 2025, Red Hat, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/epsilon/epsilonMonitoringSupport.hpp
+++ b/src/hotspot/share/gc/epsilon/epsilonMonitoringSupport.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Red Hat, Inc. All rights reserved.
+ * Copyright (c) 2017, 2025, Red Hat, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/g1/g1MonitoringSupport.cpp
+++ b/src/hotspot/share/gc/g1/g1MonitoringSupport.cpp
@@ -56,13 +56,13 @@ public:
                          max_size,
                          0 /* curr_capacity */) {
     if (UsePerfData) {
-      update_all();
+      update_capacity();
     }
   }
 
-  void update_all() {
+  void update_capacity() {
     size_t committed = _monitoring_support->young_gen_committed();
-    GenerationCounters::update_all(committed);
+    GenerationCounters::update_capacity(committed);
   }
 };
 
@@ -77,13 +77,13 @@ public:
                          max_size,
                          0 /* curr_capacity */) {
     if (UsePerfData) {
-      update_all();
+      update_capacity();
     }
   }
 
-  void update_all() {
+  void update_capacity() {
     size_t committed = _monitoring_support->old_gen_committed();
-    GenerationCounters::update_all(committed);
+    GenerationCounters::update_capacity(committed);
   }
 };
 
@@ -305,8 +305,8 @@ void G1MonitoringSupport::update_sizes() {
     _old_space_counters->update_capacity(_old_gen_committed);
     _old_space_counters->update_used(_old_gen_used);
 
-    _young_gen_counters->update_all();
-    _old_gen_counters->update_all();
+    _young_gen_counters->update_capacity();
+    _old_gen_counters->update_capacity();
 
     MetaspaceCounters::update_performance_counters();
   }

--- a/src/hotspot/share/gc/parallel/psOldGen.cpp
+++ b/src/hotspot/share/gc/parallel/psOldGen.cpp
@@ -237,7 +237,7 @@ bool PSOldGen::expand_by(size_t bytes) {
     post_resize();
     if (UsePerfData) {
       _space_counters->update_capacity();
-      _gen_counters->update_all(_virtual_space->committed_size());
+      _gen_counters->update_capacity(_virtual_space->committed_size());
     }
   }
 
@@ -368,8 +368,8 @@ void PSOldGen::print_on(outputStream* st) const {
 
 void PSOldGen::update_counters() {
   if (UsePerfData) {
-    _space_counters->update_all();
-    _gen_counters->update_all(_virtual_space->committed_size());
+    _space_counters->update_capacity();
+    _gen_counters->update_capacity(_virtual_space->committed_size());
   }
 }
 

--- a/src/hotspot/share/gc/parallel/psYoungGen.cpp
+++ b/src/hotspot/share/gc/parallel/psYoungGen.cpp
@@ -807,10 +807,10 @@ void PSYoungGen::post_resize() {
 
 void PSYoungGen::update_counters() {
   if (UsePerfData) {
-    _eden_counters->update_all();
-    _from_counters->update_all();
-    _to_counters->update_all();
-    _gen_counters->update_all(_virtual_space->committed_size());
+    _eden_counters->update_capacity();
+    _from_counters->update_capacity();
+    _to_counters->update_capacity();
+    _gen_counters->update_capacity(_virtual_space->committed_size());
   }
 }
 

--- a/src/hotspot/share/gc/parallel/spaceCounters.hpp
+++ b/src/hotspot/share/gc/parallel/spaceCounters.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/parallel/spaceCounters.hpp
+++ b/src/hotspot/share/gc/parallel/spaceCounters.hpp
@@ -63,7 +63,7 @@ class SpaceCounters: public CHeapObj<mtGC> {
 
   void update_used();
 
-  inline void update_all() {
+  inline void update_capacity() {
     update_used();
     update_capacity();
   }

--- a/src/hotspot/share/gc/serial/cSpaceCounters.cpp
+++ b/src/hotspot/share/gc/serial/cSpaceCounters.cpp
@@ -80,7 +80,7 @@ void CSpaceCounters::update_used() {
   _used->set_value(new_used);
 }
 
-void CSpaceCounters::update_all() {
+void CSpaceCounters::update_capacity() {
   update_used();
   update_capacity();
 }

--- a/src/hotspot/share/gc/serial/cSpaceCounters.hpp
+++ b/src/hotspot/share/gc/serial/cSpaceCounters.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/serial/cSpaceCounters.hpp
+++ b/src/hotspot/share/gc/serial/cSpaceCounters.hpp
@@ -59,7 +59,7 @@ class CSpaceCounters: public CHeapObj<mtGC> {
 
   void update_capacity();
   void update_used();
-  void update_all();
+  void update_capacity();
 
   const char* name_space() const        { return _name_space; }
 };

--- a/src/hotspot/share/gc/serial/defNewGeneration.cpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.cpp
@@ -811,10 +811,10 @@ void DefNewGeneration::gc_epilogue(bool full) {
 
 void DefNewGeneration::update_counters() {
   if (UsePerfData) {
-    _eden_counters->update_all();
-    _from_counters->update_all();
-    _to_counters->update_all();
-    _gen_counters->update_all(_virtual_space.committed_size());
+    _eden_counters->update_capacity();
+    _from_counters->update_capacity();
+    _to_counters->update_capacity();
+    _gen_counters->update_capacity(_virtual_space.committed_size());
   }
 }
 

--- a/src/hotspot/share/gc/serial/tenuredGeneration.cpp
+++ b/src/hotspot/share/gc/serial/tenuredGeneration.cpp
@@ -367,8 +367,8 @@ void TenuredGeneration::update_promote_stats() {
 
 void TenuredGeneration::update_counters() {
   if (UsePerfData) {
-    _space_counters->update_all();
-    _gen_counters->update_all(_virtual_space.committed_size());
+    _space_counters->update_capacity();
+    _gen_counters->update_capacity(_virtual_space.committed_size());
   }
 }
 

--- a/src/hotspot/share/gc/shared/generationCounters.cpp
+++ b/src/hotspot/share/gc/shared/generationCounters.cpp
@@ -67,7 +67,7 @@ GenerationCounters::~GenerationCounters() {
   FREE_C_HEAP_ARRAY(char, _name_space);
 }
 
-void GenerationCounters::update_all(size_t curr_capacity) {
+void GenerationCounters::update_capacity(size_t curr_capacity) {
   _current_size->set_value(curr_capacity);
 }
 

--- a/src/hotspot/share/gc/shared/generationCounters.hpp
+++ b/src/hotspot/share/gc/shared/generationCounters.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/shared/generationCounters.hpp
+++ b/src/hotspot/share/gc/shared/generationCounters.hpp
@@ -52,7 +52,7 @@ class GenerationCounters: public CHeapObj<mtGC> {
 
   ~GenerationCounters();
 
-  void update_all(size_t curr_capacity);
+  void update_capacity(size_t curr_capacity);
 
   const char* name_space() const        { return _name_space; }
 };

--- a/src/hotspot/share/gc/shared/hSpaceCounters.cpp
+++ b/src/hotspot/share/gc/shared/hSpaceCounters.cpp
@@ -77,7 +77,7 @@ void HSpaceCounters::update_used(size_t v) {
   _used->set_value(v);
 }
 
-void HSpaceCounters::update_all(size_t capacity, size_t used) {
+void HSpaceCounters::update_capacity(size_t capacity, size_t used) {
   update_capacity(capacity);
   update_used(used);
 }

--- a/src/hotspot/share/gc/shared/hSpaceCounters.hpp
+++ b/src/hotspot/share/gc/shared/hSpaceCounters.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/shared/hSpaceCounters.hpp
+++ b/src/hotspot/share/gc/shared/hSpaceCounters.hpp
@@ -54,7 +54,7 @@ class HSpaceCounters: public CHeapObj<mtGC> {
   void update_capacity(size_t v);
   void update_used(size_t v);
 
-  void update_all(size_t capacity, size_t used);
+  void update_capacity(size_t capacity, size_t used);
 
   DEBUG_ONLY(
     // for security reasons, we do not allow arbitrary reads from

--- a/src/hotspot/share/gc/shenandoah/shenandoahMonitoringSupport.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahMonitoringSupport.cpp
@@ -36,7 +36,7 @@ public:
   ShenandoahYoungGenerationCounters() :
           GenerationCounters("Young", 0, 0, 0, (size_t)0, (size_t)0) {};
 
-  void update_all() {
+  void update_capacity() {
     // no update
   }
 };
@@ -50,8 +50,8 @@ public:
           _heap(heap)
   {};
 
-  void update_all() {
-    GenerationCounters::update_all(_heap->capacity());
+  void update_capacity() {
+    GenerationCounters::update_capacity(_heap->capacity());
   }
 };
 
@@ -98,8 +98,8 @@ void ShenandoahMonitoringSupport::update_counters() {
     ShenandoahHeap* heap = ShenandoahHeap::heap();
     size_t used = heap->used();
     size_t capacity = heap->max_capacity();
-    _heap_counters->update_all();
-    _space_counters->update_all(capacity, used);
+    _heap_counters->update_capacity();
+    _space_counters->update_capacity(capacity, used);
     _heap_region_counters->update();
 
     MetaspaceCounters::update_performance_counters();

--- a/src/hotspot/share/gc/shenandoah/shenandoahMonitoringSupport.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahMonitoringSupport.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Red Hat, Inc. All rights reserved.
+ * Copyright (c) 2015, 2025, Red Hat, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/z/zServiceability.cpp
+++ b/src/hotspot/share/gc/z/zServiceability.cpp
@@ -66,7 +66,7 @@ public:
                          curr_capacity) {}
 
   void update_capacity(size_t capacity) {
-    update_all(capacity);
+    update_capacity(capacity);
   }
 };
 


### PR DESCRIPTION
JBS Issue : [JDK-8349077](https://bugs.openjdk.org/browse/JDK-8349077)

we found the method names `update_all` of the class `GenerationCounters` and its subclasses are not so good. It is better to rename it to something like `update_capacity` (such as `ZGenerationCounters::update_capacity`).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8349077](https://bugs.openjdk.org/browse/JDK-8349077): Rename GenerationCounters::update_all (**Enhancement** - P5)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25831/head:pull/25831` \
`$ git checkout pull/25831`

Update a local copy of the PR: \
`$ git checkout pull/25831` \
`$ git pull https://git.openjdk.org/jdk.git pull/25831/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25831`

View PR using the GUI difftool: \
`$ git pr show -t 25831`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25831.diff">https://git.openjdk.org/jdk/pull/25831.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25831#issuecomment-2976754827)
</details>
