### PR TITLE
8359701

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -1001,7 +1001,7 @@ HeapWord* G1CollectedHeap::expand_and_allocate(size_t word_size) {
   return nullptr;
 }
 
-bool G1CollectedHeap::expand(size_t expand_bytes, WorkerThreads* pretouch_workers, double* expand_time_ms) {
+bool G1CollectedHeap::expand(size_t expand_bytes, WorkerThreads* pretouch_workers) {
   size_t aligned_expand_bytes = os::align_up_vm_page_size(expand_bytes);
   aligned_expand_bytes = align_up(aligned_expand_bytes, G1HeapRegion::GrainBytes);
 
@@ -1013,15 +1013,10 @@ bool G1CollectedHeap::expand(size_t expand_bytes, WorkerThreads* pretouch_worker
     return false;
   }
 
-  double expand_heap_start_time_sec = os::elapsedTime();
   uint regions_to_expand = (uint)(aligned_expand_bytes / G1HeapRegion::GrainBytes);
   assert(regions_to_expand > 0, "Must expand by at least one region");
 
   uint expanded_by = _hrm.expand_by(regions_to_expand, pretouch_workers);
-  if (expand_time_ms != nullptr) {
-    *expand_time_ms = (os::elapsedTime() - expand_heap_start_time_sec) * MILLIUNITS;
-  }
-
   assert(expanded_by > 0, "must have failed during commit.");
 
   size_t actual_expand_bytes = expanded_by * G1HeapRegion::GrainBytes;
@@ -2397,11 +2392,11 @@ void G1CollectedHeap::expand_heap_after_young_collection(){
   if (expand_bytes > 0) {
     // No need for an ergo logging here,
     // expansion_amount() does this when it returns a value > 0.
-    double expand_ms = 0.0;
-    if (!expand(expand_bytes, _workers, &expand_ms)) {
-      // We failed to expand the heap. Cannot do anything about it.
+    Ticks expand_start_instant = Ticks::now();
+    if (expand(expand_bytes, _workers)) {
+      double expand_ms = (Ticks::now() - expand_start_instant).seconds() * MILLIUNITS;
+      phase_times()->record_expand_heap_time(expand_ms);
     }
-    phase_times()->record_expand_heap_time(expand_ms);
   }
 }
 

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -572,7 +572,7 @@ public:
   // Returns true if the heap was expanded by the requested amount;
   // false otherwise.
   // (Rounds up to a G1HeapRegion boundary.)
-  bool expand(size_t expand_bytes, WorkerThreads* pretouch_workers, double* expand_time_ms = nullptr);
+  bool expand(size_t expand_bytes, WorkerThreads* pretouch_workers);
   bool expand_single_region(uint node_index);
 
   // Returns the PLAB statistics for a given destination.


### PR DESCRIPTION
Simple patch of moving time-tracking logic from callee to caller, which removes a default arg. The default-arg is there because there are other callers that don't use/need this time-tracking logic.

Test: tier1