### PR TITLE
8294226: Document missing UnsupportedTemporalTypeException

### DIFF
--- a/src/java.base/share/classes/java/time/chrono/ChronoLocalDate.java
+++ b/src/java.base/share/classes/java/time/chrono/ChronoLocalDate.java
@@ -455,6 +455,7 @@ public interface ChronoLocalDate
     /**
      * {@inheritDoc}
      * @throws DateTimeException {@inheritDoc}
+     * @throws UnsupportedTemporalTypeException {@inheritDoc}
      * @throws ArithmeticException {@inheritDoc}
      */
     @Override

--- a/src/java.base/share/classes/java/time/chrono/ChronoLocalDateTime.java
+++ b/src/java.base/share/classes/java/time/chrono/ChronoLocalDateTime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -84,6 +84,7 @@ import java.time.temporal.TemporalField;
 import java.time.temporal.TemporalQueries;
 import java.time.temporal.TemporalQuery;
 import java.time.temporal.TemporalUnit;
+import java.time.temporal.UnsupportedTemporalTypeException;
 import java.time.zone.ZoneRules;
 import java.util.Comparator;
 import java.util.Objects;
@@ -276,6 +277,7 @@ public interface ChronoLocalDateTime<D extends ChronoLocalDate>
     /**
      * {@inheritDoc}
      * @throws DateTimeException {@inheritDoc}
+     * @throws UnsupportedTemporalTypeException {@inheritDoc}
      * @throws ArithmeticException {@inheritDoc}
      */
     @Override
@@ -294,6 +296,7 @@ public interface ChronoLocalDateTime<D extends ChronoLocalDate>
     /**
      * {@inheritDoc}
      * @throws DateTimeException {@inheritDoc}
+     * @throws UnsupportedTemporalTypeException {@inheritDoc}
      * @throws ArithmeticException {@inheritDoc}
      */
     @Override
@@ -312,6 +315,7 @@ public interface ChronoLocalDateTime<D extends ChronoLocalDate>
     /**
      * {@inheritDoc}
      * @throws DateTimeException {@inheritDoc}
+     * @throws UnsupportedTemporalTypeException {@inheritDoc}
      * @throws ArithmeticException {@inheritDoc}
      */
     @Override

--- a/src/java.base/share/classes/java/time/chrono/ChronoZonedDateTime.java
+++ b/src/java.base/share/classes/java/time/chrono/ChronoZonedDateTime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -422,6 +422,7 @@ public interface ChronoZonedDateTime<D extends ChronoLocalDate>
     /**
      * {@inheritDoc}
      * @throws DateTimeException {@inheritDoc}
+     * @throws UnsupportedTemporalTypeException {@inheritDoc}
      * @throws ArithmeticException {@inheritDoc}
      */
     @Override
@@ -440,6 +441,7 @@ public interface ChronoZonedDateTime<D extends ChronoLocalDate>
     /**
      * {@inheritDoc}
      * @throws DateTimeException {@inheritDoc}
+     * @throws UnsupportedTemporalTypeException {@inheritDoc}
      * @throws ArithmeticException {@inheritDoc}
      */
     @Override
@@ -458,6 +460,7 @@ public interface ChronoZonedDateTime<D extends ChronoLocalDate>
     /**
      * {@inheritDoc}
      * @throws DateTimeException {@inheritDoc}
+     * @throws UnsupportedTemporalTypeException {@inheritDoc}
      * @throws ArithmeticException {@inheritDoc}
      */
     @Override


### PR DESCRIPTION
Some methods in the java.time.chrono interfaces—ChronoLocalDate, ChronoLocalDateTime, and ChronoZonedDateTime—override methods from the java.time.temporal.Temporal interface that are documented to throw UnsupportedTemporalTypeException when given unsupported fields or units.

These overridden methods include:

with(TemporalField, long)

plus(long, TemporalUnit)

minus(long, TemporalUnit)

However, their Javadoc in the chrono interfaces does not mention the possibility of this exception, resulting in incomplete or inconsistent documentation. This contrasts with the parent Temporal interface, which explicitly documents the exception.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8359303](https://bugs.openjdk.org/browse/JDK-8359303) to be approved

### Issues
 * [JDK-8294226](https://bugs.openjdk.org/browse/JDK-8294226): Document missing UnsupportedTemporalTypeException (**Bug** - P4)
 * [JDK-8359303](https://bugs.openjdk.org/browse/JDK-8359303): Document missing UnsupportedTemporalTypeException (**CSR**)


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25836/head:pull/25836` \
`$ git checkout pull/25836`

Update a local copy of the PR: \
`$ git checkout pull/25836` \
`$ git pull https://git.openjdk.org/jdk.git pull/25836/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25836`

View PR using the GUI difftool: \
`$ git pr show -t 25836`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25836.diff">https://git.openjdk.org/jdk/pull/25836.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25836#issuecomment-2977325997)
</details>
