### PR TITLE
8359733: UnProblemList serviceability/jvmti/vthread/SuspendWithInterruptLock

### DIFF
--- a/test/hotspot/jtreg/ProblemList-Xcomp.txt
+++ b/test/hotspot/jtreg/ProblemList-Xcomp.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/ProblemList-Xcomp.txt
+++ b/test/hotspot/jtreg/ProblemList-Xcomp.txt
@@ -35,8 +35,6 @@ vmTestbase/vm/mlvm/mixed/stress/regression/b6969574/INDIFY_Test.java 8265295 lin
 
 serviceability/AsyncGetCallTrace/MyPackage/ASGCTBaseTest.java 8303168 linux-all
 
-serviceability/jvmti/vthread/SuspendWithInterruptLock/SuspendWithInterruptLock.java#default 8312064 generic-all
-
 serviceability/sa/ClhsdbInspect.java 8283578 windows-x64
 
 vmTestbase/vm/mlvm/indy/func/jvmti/mergeCP_indy2manyDiff_a/TestDescription.java 8308367 generic-all


### PR DESCRIPTION
The bug [JDK-8312064](https://bugs.openjdk.org/browse/JDK-8312064) is not reproducible anymore and will be closed as a dup of [JDK-8316682](https://bugs.openjdk.org/browse/JDK-8316682).
The test SuspendWithInterruptLock needs to be unproblem-listed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8359733](https://bugs.openjdk.org/browse/JDK-8359733): UnProblemList serviceability/jvmti/vthread/SuspendWithInterruptLock (**Sub-task** - P4)


### Reviewers
 * [SendaoYan](https://openjdk.org/census#syan) (@sendaoYan - Committer)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25837/head:pull/25837` \
`$ git checkout pull/25837`

Update a local copy of the PR: \
`$ git checkout pull/25837` \
`$ git pull https://git.openjdk.org/jdk.git pull/25837/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25837`

View PR using the GUI difftool: \
`$ git pr show -t 25837`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25837.diff">https://git.openjdk.org/jdk/pull/25837.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25837#issuecomment-2979083670)
</details>
