### PR TITLE
8359735: [Ubuntu 25.10] java/lang/ProcessBuilder/Basic.java, java/lang/ProcessHandle/InfoTest.java fail due to rust-coreutils

### DIFF
--- a/test/jdk/java/lang/ProcessBuilder/Basic.java
+++ b/test/jdk/java/lang/ProcessBuilder/Basic.java
@@ -696,7 +696,7 @@ public class Basic {
         public static String path() { return path; }
         private static final String path = path0();
         private static String path0(){
-            if (!Platform.isBusybox("/bin/true")) {
+            if (!Files.isSymbolicLink(Paths.get("/bin/true"))) {
                 return "/bin/true";
             } else {
                 File trueExe = new File("true");
@@ -711,7 +711,7 @@ public class Basic {
         public static String path() { return path; }
         private static final String path = path0();
         private static String path0(){
-            if (!Platform.isBusybox("/bin/false")) {
+            if (!Files.isSymbolicLink(Paths.get("/bin/false"))) {
                 return "/bin/false";
             } else {
                 File falseExe = new File("false");

--- a/test/jdk/java/lang/ProcessHandle/InfoTest.java
+++ b/test/jdk/java/lang/ProcessHandle/InfoTest.java
@@ -295,10 +295,12 @@ public class InfoTest {
                     String expected = "sleep";
                     if (Platform.isWindows()) {
                         expected = "sleep.exe";
-                    } else if (Platform.isBusybox("/bin/sleep")) {
-                        // With busybox sleep is just a sym link to busybox.
-                        // The busbox executable is seen as ProcessHandle.Info command.
-                        expected = "busybox";
+                    } else if (Files.isSymbolicLink(Paths.get("/bin/sleep"))) {
+                        // Busybox sleep is a symbolic link to /bin/busybox.
+                        // Rust coreutils sleep is a symbolic link to coreutils
+                        // The busbox/coreutils executables are seen as ProcessHandle.Info command.
+                        Path executable = Files.readSymbolicLink(Paths.get("/bin/sleep"));
+                        expected = executable.getFileName().toString();
                     }
                     Assert.assertTrue(command.endsWith(expected), "Command: expected: \'" +
                             expected + "\', actual: " + command);


### PR DESCRIPTION
To accommodate systems like Ubuntu 25.10 that use Rust coreutils, this PR updates tests that previously assumed BusyBox was the only environment to use symlinks for core utilities.

Changes:
-   `java/lang/ProcessBuilder/Basic.java`: The test is updated to simply verify that `/bin/true `and `/bin/false` are symlinks, removing the hardcoded check for a /bin/busybox target.
 -  ` java/lang/ProcessHandle/InfoTest.java`: The test logic is relaxed. It now confirms that `/bin/sleep` is a symlink and then uses the symlink's target as the expected executable name.