### PR TITLE
8359687: Use PassFailJFrame for java/awt/print/Dialog/DialogType.java

### DIFF
--- a/test/jdk/java/awt/print/Dialog/DialogType.java
+++ b/test/jdk/java/awt/print/Dialog/DialogType.java
@@ -49,7 +49,7 @@ public class DialogType {
 
         On macOS & on Windows, the first dialog is a native
         dialog provided by the OS, the second dialog is
-        implemented in Swing, the dialog differ in appearance.
+        implemented in Swing, the dialogs differ in appearance.
 
         The test passes as long as no exceptions are thrown.
         (If there's an exception, the test will fail automatically.)


### PR DESCRIPTION
Use PassFailJFrame to streamline the test java/awt/print/Dialog/DialogType.java, as is for several of the manual tests.

Modified Manual Test Passed when run using jtreg.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8359687](https://bugs.openjdk.org/browse/JDK-8359687): Use PassFailJFrame for java/awt/print/Dialog/DialogType.java (**Bug** - P4)


### Reviewers
 * [Abhishek Kumar](https://openjdk.org/census#abhiscxk) (@kumarabhi006 - **Reviewer**)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25842/head:pull/25842` \
`$ git checkout pull/25842`

Update a local copy of the PR: \
`$ git checkout pull/25842` \
`$ git pull https://git.openjdk.org/jdk.git pull/25842/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25842`

View PR using the GUI difftool: \
`$ git pr show -t 25842`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25842.diff">https://git.openjdk.org/jdk/pull/25842.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25842#issuecomment-2978945874)
</details>
