### PR TITLE
8358801: javac produces class that does not pass verifier.

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Gen.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Gen.java
@@ -756,6 +756,11 @@ public class Gen extends JCTree.Visitor {
             }
             CondItem result = genCond(tree.expr, markBranches);
             code.endScopes(limit);
+            //make sure variables defined in the let expression are not included
+            //in the defined variables for jumps that go outside of this let
+            //expression:
+            undefineVariablesInChain(result.falseJumps, limit);
+            undefineVariablesInChain(result.trueJumps, limit);
             return result;
         } else {
             CondItem result = genExpr(_tree, syms.booleanType).mkCond();
@@ -763,6 +768,13 @@ public class Gen extends JCTree.Visitor {
             return result;
         }
     }
+        //where:
+        private void undefineVariablesInChain(Chain toClear, int limit) {
+            while (toClear != null) {
+                toClear.state.defined.excludeFrom(limit);
+                toClear = toClear.next;
+            }
+        }
 
     public Code getCode() {
         return code;

--- a/test/langtools/tools/javac/patterns/T8358801.java
+++ b/test/langtools/tools/javac/patterns/T8358801.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8358801
+ * @summary Verify variables introduced by let expressions are correctly undefined
+ * @library /tools/lib
+ */
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+
+import javax.tools.JavaFileObject;
+import javax.tools.ToolProvider;
+
+import com.sun.source.util.JavacTask;
+import java.lang.classfile.ClassFile;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import javax.tools.JavaCompiler;
+
+import toolbox.JavaTask;
+import toolbox.Task;
+import toolbox.TestRunner;
+import toolbox.ToolBox;
+
+public class T8358801 extends TestRunner {
+    private ToolBox tb;
+
+    public static void main(String... args) throws Exception {
+        new T8358801().runTests();
+    }
+
+    T8358801() {
+        super(System.err);
+        tb = new ToolBox();
+    }
+
+    public void runTests() throws Exception {
+        runTests(m -> new Object[] { Paths.get(m.getName()) });
+    }
+
+    @Test
+    public void testPatternsInJava(Path base) throws Exception {
+        Path classes = base.resolve("classes");
+
+        List<JavaFileObject> files = new ArrayList<>();
+        files.add(new ToolBox.JavaSource(
+            """
+            public class Main {
+                private boolean test(String s, int i) {
+                    if (s.subSequence(0, 1) instanceof Runnable r) {
+                        return true;
+                    }
+
+                    switch (i) {
+                        case 0:
+                            String clashing1 = null;
+                            String clashing2 = null;
+                            String clashing3 = null;
+                            String clashing4 = null;
+                            return true;
+                        default:
+                            System.out.println("correct");
+                            return true;
+                    }
+                }
+
+                public static void main(String[] args) {
+                    new Main().test("hello", 1);
+                }
+            }
+            """
+        ));
+
+        if (Files.exists(classes)) {
+            tb.cleanDirectory(classes);
+        } else {
+            Files.createDirectories(classes);
+        }
+
+        JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+        Iterable<String> options = Arrays.asList("-d", classes.toString());
+        JavacTask task = (JavacTask) compiler.getTask(null, null, null, options, null, files);
+
+        task.generate();
+
+        List<VerifyError> errors = ClassFile.of().verify(classes.resolve("Main.class"));
+
+        if (!errors.isEmpty()) {
+            throw new AssertionError("verify errors found: " + errors);
+        }
+
+        List<String> log =
+            new JavaTask(tb).classpath(classes.toString())
+                            .className("Main")
+                            .run()
+                            .writeAll()
+                            .getOutputLines(Task.OutputKind.STDOUT);
+        List<String> expected = List.of("correct");
+
+        if (!Objects.equals(log, expected)) {
+            throw new AssertionError("Incorrect result, expected: " + expected +
+                                     ", got: " + log);
+        }
+    }
+
+}


### PR DESCRIPTION
Consider code like:

```
public class Main {

    private boolean test(String s, int i) {
        if (s.subSequence(0, 1) instanceof Runnable r) {
            return true;
        }

        Integer dummy;
        switch (i) {
            case 0:
                String clashing = null;
                return true;
            default:
                return true;
        }
    }

    public static void main(String[] args) {
    }
}
```

javac will produce code that won't (rightfully) pass the verifier:

```
$ java Main.java
Exception in thread "main" java.lang.VerifyError: Inconsistent stackmap frames at branch target 49
Exception Details:
  Location:
    Main.test(Ljava/lang/String;I)Z @49: iconst_1
  Reason:
    Type top (current frame, locals[4]) is not assignable to 'java/lang/String' (stack map, locals[4])
  Current Frame:
    bci: @25
    flags: { }
    locals: { 'Main', 'java/lang/String', integer }
    stack: { integer }
  Stackmap Frame:
    bci: @49
    flags: { }
    locals: { 'Main', 'java/lang/String', integer, top, 'java/lang/String' }
    stack: { }
  Bytecode:
    0000000: 2b03 04b6 0007 3a04 1904 c100 0d99 000b
    0000010: 1904 c000 0d4e 04ac 1cab 0000 0000 0018
    0000020: 0000 0001 0000 0000 0000 0013 013a 0404
    0000030: ac04 ac
  Stackmap Table:
    same_frame(@24)
    same_frame(@44)
    append_frame(@49,Top,Object[#8])

        at java.base/java.lang.Class.getDeclaredMethods0(Native Method)
        at java.base/java.lang.Class.privateGetDeclaredMethods(Class.java:3035)
        at java.base/java.lang.Class.getMethodsRecursive(Class.java:3177)
        at java.base/java.lang.Class.findMethod(Class.java:2465)
        at java.base/java.lang.System$1.findMethod(System.java:1980)
        at java.base/jdk.internal.misc.MethodFinder.findMainMethod(MethodFinder.java:86)
        at jdk.compiler/com.sun.tools.javac.launcher.SourceLauncher.execute(SourceLauncher.java:194)
        at jdk.compiler/com.sun.tools.javac.launcher.SourceLauncher.run(SourceLauncher.java:138)
        at jdk.compiler/com.sun.tools.javac.launcher.SourceLauncher.main(SourceLauncher.java:76)

```

Now, the problem, as far as I can tell, is this: javac will desugar the pattern matching instanceof along the lines of:

```
if (... (var $temp = s.subSequence(0, 1) in ... && ...) ...) {
    return true;
}
```

(`$temp` is register/local variable number 4)
specifically, note the `&&` in the middle of the let expression, and that the expression is in the conditional position. What happens here is that at the position of the `&&` will basically generate a jump to skip the if (i.e. a jump whose target is just behind the if, for the case where the `...` left to it evaluates to false). The problem here is that at the source position of the jump, the variable `$temp` is defined/has value. And the set of variables which are defined/have value is stored at the moment of jump, and restored at the target place of the jump. I.e. in this case, javac will think variable number 4 has a value.

This, by itself, while it does not seem right, but does not lead to a breakage, as the variable is not in `code.lvar`, and hence javac will ignore it.

The problem is that inside the first case, variable number 4 is declared, and `lvar` is filled for it. In the first case, it is still not problematic, as the variable is defined/has value there as well. But, for the default case, the variable still has an `lvar` entry (as the variable is still declared, just should be unassigned), but the defined/has value flag stored earlier is restored again. So, javac thinks the variable is fully valid, and generates a bogus StackMapTable entry listing the variable, leading to the verifier failure.

I think the source of all trouble is the wrong "defined" flag. The solution in this PR is to make sure the variables declared by the let expression are removed from the `defined` variables stored in the conditional jump chains.

Note this only applies to jumps that go outside of the left expression (and hence outside of the scope of the variable), internal jumps inside the let expression, if there would be any, shouldn't be affected.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found trailing period in issue title for `8358801: javac produces class that does not pass verifier.`
Found leading lowercase letter in issue title for `8358801: javac produces class that does not pass verifier.`

### Issue
 * [JDK-8358801](https://bugs.openjdk.org/browse/JDK-8358801): javac produces class that does not pass verifier. (**Bug** - P3)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25849/head:pull/25849` \
`$ git checkout pull/25849`

Update a local copy of the PR: \
`$ git checkout pull/25849` \
`$ git pull https://git.openjdk.org/jdk.git pull/25849/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25849`

View PR using the GUI difftool: \
`$ git pr show -t 25849`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25849.diff">https://git.openjdk.org/jdk/pull/25849.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25849#issuecomment-2979758061)
</details>
