### PR TITLE
6955128: Spec for javax.swing.plaf.basic.BasicTextUI.getVisibleEditorRect contains inappropriate wording

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTextUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTextUI.java
@@ -1029,7 +1029,7 @@ public abstract class BasicTextUI extends TextUI implements ViewFactory {
 
 
     /**
-     * Gets the allocation (i.e. the allocated size) for the root view.
+     * Gets the allocation (that is the allocated size) for the root view.
      * <p>
      * The returned rectangle is unrelated to visibility.
      * It is used to set the size of the root view.


### PR DESCRIPTION
BasicTextUI.getVisibleEditorRect wording is rephrased to remove the wording "Due to an unfortunate set of historical events this method is inappropriately named".

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 2 [Reviewers](https://openjdk.org/bylaws#reviewer))
- [x] Change requires CSR request [JDK-8361384](https://bugs.openjdk.org/browse/JDK-8361384) to be approved

### Issues
 * [JDK-6955128](https://bugs.openjdk.org/browse/JDK-6955128): Spec for javax.swing.plaf.basic.BasicTextUI.getVisibleEditorRect contains inappropriate wording (**Enhancement** - P4)
 * [JDK-8361384](https://bugs.openjdk.org/browse/JDK-8361384): Spec for javax.swing.plaf.basic.BasicTextUI.getVisibleEditorRect contains inappropriate wording (**CSR**)


### Reviewers
 * [Damon Nguyen](https://openjdk.org/census#dnguyen) (@DamonGuy - Committer) Review applies to [aeed7361](https://git.openjdk.org/jdk/pull/25850/files/aeed73616bf37c7f802f6141661828a67279bbd1)
 * [Abhishek Kumar](https://openjdk.org/census#abhiscxk) (@kumarabhi006 - **Reviewer**) Review applies to [aeed7361](https://git.openjdk.org/jdk/pull/25850/files/aeed73616bf37c7f802f6141661828a67279bbd1)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Tejesh R](https://openjdk.org/census#tr) (@TejeshR13 - **Reviewer**) Review applies to [6289a27a](https://git.openjdk.org/jdk/pull/25850/files/6289a27a2c131b315159f825102d20ff4863e486)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25850/head:pull/25850` \
`$ git checkout pull/25850`

Update a local copy of the PR: \
`$ git checkout pull/25850` \
`$ git pull https://git.openjdk.org/jdk.git pull/25850/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25850`

View PR using the GUI difftool: \
`$ git pr show -t 25850`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25850.diff">https://git.openjdk.org/jdk/pull/25850.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25850#issuecomment-2980252710)
</details>
