### PR TITLE
8359825: Parallel: Simplify MutableNUMASpace::ensure_parsability

### DIFF
--- a/src/hotspot/share/gc/parallel/mutableNUMASpace.cpp
+++ b/src/hotspot/share/gc/parallel/mutableNUMASpace.cpp
@@ -92,18 +92,9 @@ void MutableNUMASpace::ensure_parsability() {
     LGRPSpace *ls = lgrp_spaces()->at(i);
     MutableSpace *s = ls->space();
     if (s->top() < top()) { // For all spaces preceding the one containing top()
-      if (s->free_in_words() > 0) {
-        HeapWord* cur_top = s->top();
-        size_t words_left_to_fill = pointer_delta(s->end(), s->top());;
-        while (words_left_to_fill > 0) {
-          size_t words_to_fill = MIN2(words_left_to_fill, CollectedHeap::filler_array_max_size());
-          assert(words_to_fill >= CollectedHeap::min_fill_size(),
-                 "Remaining size (%zu) is too small to fill (based on %zu and %zu)",
-                 words_to_fill, words_left_to_fill, CollectedHeap::filler_array_max_size());
-          CollectedHeap::fill_with_object(cur_top, words_to_fill);
-          cur_top += words_to_fill;
-          words_left_to_fill -= words_to_fill;
-        }
+      size_t free_words = s->free_in_words();
+      if (free_words > 0) {
+        CollectedHeap::fill_with_objects(s->top(), free_words);
       }
     } else {
       return;


### PR DESCRIPTION
Simple `fill_with_object` -> `fill_with_objects` API  change to push the implementation logic to the callee.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8359825](https://bugs.openjdk.org/browse/JDK-8359825): Parallel: Simplify MutableNUMASpace::ensure_parsability (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Sangheon Kim](https://openjdk.org/census#sangheki) (@sangheon - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25852/head:pull/25852` \
`$ git checkout pull/25852`

Update a local copy of the PR: \
`$ git checkout pull/25852` \
`$ git pull https://git.openjdk.org/jdk.git pull/25852/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25852`

View PR using the GUI difftool: \
`$ git pr show -t 25852`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25852.diff">https://git.openjdk.org/jdk/pull/25852.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25852#issuecomment-2980393821)
</details>
