### PR TITLE
8335986: Test javax/swing/JCheckBox/4449413/bug4449413.java fails on Windows 11 x64 because RBMenuItem's and CBMenuItem's checkmark on the left side are not visible

### DIFF
--- a/test/jdk/javax/swing/JCheckBox/4449413/bug4449413.java
+++ b/test/jdk/javax/swing/JCheckBox/4449413/bug4449413.java
@@ -56,8 +56,16 @@ import java.util.concurrent.TimeUnit;
 
 public class bug4449413 extends JFrame {
 
+    private static boolean isWindowsLF;
+
+    private static String INSTRUCTIONS_WINDOWSLF =
+        "There are eight controls, JCheckBox/JRadioButton with black background\n" +
+        "and JRadioButtonMenuItem/JCheckboxMenuItem with gray background\n";
+
     private static final String INSTRUCTIONS =
-            "There are eight controls with black backgrounds.\n" +
+            "There are eight controls with black backgrounds.\n";
+
+    private static final String INSTRUCTIONS_COMMON =
             "Four enabled (on the left side) and four disabled (on the right side)\n" +
             "checkboxes and radiobuttons.\n\n" +
             "1. If at least one of the controls' check marks is not visible:\n" +
@@ -82,6 +90,8 @@ public class bug4449413 extends JFrame {
     }
 
     public static void main(String[] args) throws Exception {
+        isWindowsLF = "Windows".equals(UIManager.getLookAndFeel().getID());
+
         SwingUtilities.invokeLater(() -> {
             instance = new bug4449413();
             instance.createAndShowGUI();
@@ -150,8 +160,10 @@ public class bug4449413 extends JFrame {
 
         JTextArea instructionArea = new JTextArea(
                 isMetalLookAndFeel()
-                        ? INSTRUCTIONS + INSTRUCTIONS_ADDITIONS_METAL
-                        : INSTRUCTIONS
+                        ? INSTRUCTIONS + INSTRUCTIONS_COMMON + INSTRUCTIONS_ADDITIONS_METAL
+                        : isWindowsLF
+                            ? (INSTRUCTIONS_WINDOWSLF + INSTRUCTIONS_COMMON)
+                            : (INSTRUCTIONS + INSTRUCTIONS_COMMON)
                 );
 
         instructionArea.setEditable(false);
@@ -189,8 +201,14 @@ public class bug4449413 extends JFrame {
         };
 
         b.setOpaque(true);
-        b.setBackground(Color.red);
-        b.setForeground(Color.blue);
+        if (isWindowsLF
+            && ((b instanceof JRadioButtonMenuItem)
+               || (b instanceof JCheckBoxMenuItem))) {
+            b.setBackground(Color.lightGray);
+        } else {
+            b.setBackground(Color.black);
+        }
+        b.setForeground(Color.white);
         b.setEnabled(enabled == 1);
         b.setSelected(true);
         return b;

--- a/test/jdk/javax/swing/JCheckBox/4449413/bug4449413.java
+++ b/test/jdk/javax/swing/JCheckBox/4449413/bug4449413.java
@@ -24,7 +24,6 @@
 /* @test
  * @bug 4449413
  * @summary Tests that checkbox and radiobuttons' check marks are visible when background is black
- * @author Ilya Boyandin
  * @run main/manual bug4449413
  */
 

--- a/test/jdk/javax/swing/JCheckBox/4449413/bug4449413.java
+++ b/test/jdk/javax/swing/JCheckBox/4449413/bug4449413.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -189,8 +189,8 @@ public class bug4449413 extends JFrame {
         };
 
         b.setOpaque(true);
-        b.setBackground(Color.black);
-        b.setForeground(Color.white);
+        b.setBackground(Color.red);
+        b.setForeground(Color.blue);
         b.setEnabled(enabled == 1);
         b.setSelected(true);
         return b;


### PR DESCRIPTION
RBMenuItem's and CBMenuItem's checkmark on the left side are not visible while running on Windows L&F as background color is same as RBMenuItem/CBMenuItem's checkmark..
Modified the color so that they are visible..

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8335986](https://bugs.openjdk.org/browse/JDK-8335986): Test javax/swing/JCheckBox/4449413/bug4449413.java fails on Windows 11 x64 because RBMenuItem's and CBMenuItem's checkmark on the left side are not visible (**Bug** - P4)


### Reviewers
 * [Tejesh R](https://openjdk.org/census#tr) (@TejeshR13 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25864/head:pull/25864` \
`$ git checkout pull/25864`

Update a local copy of the PR: \
`$ git checkout pull/25864` \
`$ git pull https://git.openjdk.org/jdk.git pull/25864/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25864`

View PR using the GUI difftool: \
`$ git pr show -t 25864`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25864.diff">https://git.openjdk.org/jdk/pull/25864.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25864#issuecomment-2982604323)
</details>
