### PR TITLE
8358686: CDS and AOT can cause buffer truncation warning even when logging is disabled

### DIFF
--- a/src/hotspot/share/cds/metaspaceShared.cpp
+++ b/src/hotspot/share/cds/metaspaceShared.cpp
@@ -1288,6 +1288,10 @@ void MetaspaceShared::report_loading_error(const char* format, ...) {
   LogStream ls_cds(level, LogTagSetMapping<LOG_TAGS(cds)>::tagset());
 
   LogStream& ls = CDSConfig::new_aot_flags_used() ? ls_aot : ls_cds;
+  if (!ls.is_enabled()) {
+    return;
+  }
+
   va_list ap;
   va_start(ap, format);
 


### PR DESCRIPTION
When CDS and AOT loggings are disabled, HotSpot may still warn about `Mismatched values for property jdk.module.addexports:`. This warn message could be large and exceeds the current logging buffer length, and it leads to a non-informative message:
```
Java HotSpot(TM) 64-Bit Server VM warning: outputStream::do_vsnprintf output truncated -- buffer length is 2000 bytes but 4276 bytes are needed.
```
This PR skips reporting loading error when CDS and AOT loggings are disabled.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8358686](https://bugs.openjdk.org/browse/JDK-8358686): CDS and AOT can cause buffer truncation warning even when logging is disabled (**Bug** - P4)


### Reviewers
 * [Doug Simon](https://openjdk.org/census#dnsimon) (@dougxc - **Reviewer**)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25866/head:pull/25866` \
`$ git checkout pull/25866`

Update a local copy of the PR: \
`$ git checkout pull/25866` \
`$ git pull https://git.openjdk.org/jdk.git pull/25866/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25866`

View PR using the GUI difftool: \
`$ git pr show -t 25866`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25866.diff">https://git.openjdk.org/jdk/pull/25866.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25866#issuecomment-2983285073)
</details>
