### PR TITLE
8359889: java/awt/MenuItem/SetLabelTest.java inadvertently triggers clicks on items pinned to the taskbar

### DIFF
--- a/test/jdk/java/awt/MenuItem/SetLabelTest.java
+++ b/test/jdk/java/awt/MenuItem/SetLabelTest.java
@@ -120,7 +120,7 @@ public class SetLabelTest {
         });
         frame.setMenuBar(mb);
         frame.setSize(300, 200);
-        frame.setLocation(500,500);
+        frame.setLocationRelativeTo(null);
         frame.setVisible(true);
     }
 


### PR DESCRIPTION
Issue:
In Windows, java/awt/MenuItem/SetLabelTest.java inadvertently triggers clicks on items pinned to the taskbar. This may open some other UI item and may interfere further testing on that machine.

Fix:
Move the test UI to the centre of the screen by calling frame.setLocationRelativeTo(null).

Testing:
Tested manually and using Mach5(20 times in 3 machines) and got all PASS and never triggered unwanted clicks on taskbar.