### PR TITLE
8359895: JFR: method-timing view doesn't work

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/query/view.ini
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/query/view.ini
@@ -471,8 +471,8 @@ table = "COLUMN 'Alloc. Time', 'Application Method', 'Object Age', 'Heap Usage'
 
 [application.method-timing]
 label = "Method Timing"
-table = "COLUMN 'Timed Method', 'Invocations', 'Min. Tim', 'Max. Time', 'Average Time'
-         FORMAT none, none, ms-precision:6
+table = "COLUMN 'Timed Method', 'Invocations', 'Min. Time', 'Max. Time', 'Average Time'
+         FORMAT none, none, ms-precision:6, ms-precision:6, ms-precision:6
          SELECT LAST_BATCH(method) AS M, LAST_BATCH(invocations), LAST_BATCH(minimum), LAST_BATCH(maximum), LAST_BATCH(average)
          FROM jdk.MethodTiming GROUP BY method ORDER BY average"
 


### PR DESCRIPTION
Could I have review of PR that fixes the method timing view.

Testing: jdk/jdk/jfr 

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8359895](https://bugs.openjdk.org/browse/JDK-8359895): JFR: method-timing view doesn't work (**Bug** - P2)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25869/head:pull/25869` \
`$ git checkout pull/25869`

Update a local copy of the PR: \
`$ git checkout pull/25869` \
`$ git pull https://git.openjdk.org/jdk.git pull/25869/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25869`

View PR using the GUI difftool: \
`$ git pr show -t 25869`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25869.diff">https://git.openjdk.org/jdk/pull/25869.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25869#issuecomment-2983985366)
</details>
