### PR TITLE
8356645: JavaRuntimeURLConnection should only connect to non-directory resources

### DIFF
--- a/src/java.base/share/classes/sun/net/www/protocol/jrt/JavaRuntimeURLConnection.java
+++ b/src/java.base/share/classes/sun/net/www/protocol/jrt/JavaRuntimeURLConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,11 +31,10 @@ import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
 
-import jdk.internal.jimage.ImageLocation;
 import jdk.internal.jimage.ImageReader;
+import jdk.internal.jimage.ImageReader.Node;
 import jdk.internal.jimage.ImageReaderFactory;
 
-import jdk.internal.loader.Resource;
 import sun.net.www.ParseUtil;
 import sun.net.www.URLConnection;
 
@@ -45,99 +44,79 @@ import sun.net.www.URLConnection;
  */
 public class JavaRuntimeURLConnection extends URLConnection {
 
-    // ImageReader to access resources in jimage
-    private static final ImageReader reader = ImageReaderFactory.getImageReader();
+    // ImageReader to access resources in jimage (never null).
+    private static final ImageReader READER = ImageReaderFactory.getImageReader();
 
-    // the module and resource name in the URL
+    // The module and resource name in the URL ("jrt:/<module-name>/<resource-name>").
+    //
+    // It is important to note that all of this information comes from the given
+    // URL's path part, and there's no requirement for there to be distinct rules
+    // about percent encoding. However, we choose to treat the module name is if
+    // it were a URL authority (since Java package/module names are historically
+    // strongly associated with internet domain names).
+    //
+    // The module name is not percent-decoded, and can be empty.
     private final String module;
+    // The resource name permits UTF-8 percent encoding of non-ASCII characters.
     private final String name;
 
-    // the Resource when connected
-    private volatile Resource resource;
+    // The resource node (when connected).
+    private volatile Node resource;
 
     JavaRuntimeURLConnection(URL url) throws IOException {
         super(url);
-        String path = url.getPath();
-        if (path.isEmpty() || path.charAt(0) != '/')
+        // TODO: Reject module names which appear to be using percent encoding.
+        // TODO: Consider rejecting URLs with fragments, queries or authority.
+        String urlPath = url.getPath();
+        if (urlPath.isEmpty() || urlPath.charAt(0) != '/') {
             throw new MalformedURLException(url + " missing path or /");
-        if (path.length() == 1) {
-            this.module = null;
+        }
+        int pathSep = urlPath.indexOf('/', 1);
+        if (pathSep == -1) {
+            // No trailing resource path. This can never "connect" or return a
+            // resource, but might be useful as a representation to pass around.
+            // The module name *can* be empty here (e.g. "jrt:/") but not null.
+            this.module = urlPath.substring(1);
             this.name = null;
         } else {
-            int pos = path.indexOf('/', 1);
-            if (pos == -1) {
-                this.module = path.substring(1);
-                this.name = null;
-            } else {
-                this.module = path.substring(1, pos);
-                this.name = ParseUtil.decode(path.substring(pos+1));
-            }
+            this.module = urlPath.substring(1, pathSep);
+            this.name = percentDecode(urlPath.substring(pathSep + 1));
         }
     }
 
     /**
-     * Finds a resource in a module, returning {@code null} if the resource
-     * is not found.
+     * Finds and caches the resource node associated with this URL and marks the
+     * connection as "connected".
      */
-    private static Resource findResource(String module, String name) {
-        if (reader != null) {
-            URL url = toJrtURL(module, name);
-            ImageLocation location = reader.findLocation(module, name);
-            if (location != null) {
-                return new Resource() {
-                    @Override
-                    public String getName() {
-                        return name;
-                    }
-                    @Override
-                    public URL getURL() {
-                        return url;
-                    }
-                    @Override
-                    public URL getCodeSourceURL() {
-                        return toJrtURL(module);
-                    }
-                    @Override
-                    public InputStream getInputStream() throws IOException {
-                        byte[] resource = reader.getResource(location);
-                        return new ByteArrayInputStream(resource);
-                    }
-                    @Override
-                    public int getContentLength() {
-                        long size = location.getUncompressedSize();
-                        return (size > Integer.MAX_VALUE) ? -1 : (int) size;
-                    }
-                };
+    private synchronized Node getResourceNode() throws IOException {
+        if (resource == null) {
+            if (name == null) {
+                throw new IOException("cannot connect to jrt:/" + module);
             }
+            Node node = READER.findNode("/modules/" + module + "/" + name);
+            if (node == null || !node.isResource()) {
+                throw new IOException(module + "/" + name + " not found");
+            }
+            this.resource = node;
+            super.connected = true;
         }
-        return null;
+        return resource;
     }
 
     @Override
-    public synchronized void connect() throws IOException {
-        if (!connected) {
-            if (name == null) {
-                String s = (module == null) ? "" : module;
-                throw new IOException("cannot connect to jrt:/" + s);
-            }
-            resource = findResource(module, name);
-            if (resource == null)
-                throw new IOException(module + "/" + name + " not found");
-            connected = true;
-        }
+    public void connect() throws IOException {
+        getResourceNode();
     }
 
     @Override
     public InputStream getInputStream() throws IOException {
-        connect();
-        return resource.getInputStream();
+        return new ByteArrayInputStream(READER.getResource(getResourceNode()));
     }
 
     @Override
     public long getContentLengthLong() {
         try {
-            connect();
-            return resource.getContentLength();
+            return getResourceNode().size();
         } catch (IOException ioe) {
             return -1L;
         }
@@ -149,27 +128,17 @@ public class JavaRuntimeURLConnection extends URLConnection {
         return len > Integer.MAX_VALUE ? -1 : (int)len;
     }
 
-    /**
-     * Returns a jrt URL for the given module and resource name.
-     */
-    @SuppressWarnings("deprecation")
-    private static URL toJrtURL(String module, String name) {
-        try {
-            return new URL("jrt:/" + module + "/" + name);
-        } catch (MalformedURLException e) {
-            throw new InternalError(e);
+    // Perform percent decoding of the resource name/path from the URL.
+    private static String percentDecode(String path) throws MalformedURLException {
+        if (path.indexOf('%') == -1) {
+            // Nothing to decode (overwhelmingly common case).
+            return path;
         }
-    }
-
-    /**
-     * Returns a jrt URL for the given module.
-     */
-    @SuppressWarnings("deprecation")
-    private static URL toJrtURL(String module) {
+        // TODO: Reject over-encoded paths, especially %2F (/) and %24 ($).
         try {
-            return new URL("jrt:/" + module);
-        } catch (MalformedURLException e) {
-            throw new InternalError(e);
+            return ParseUtil.decode(path);
+        } catch (IllegalArgumentException e) {
+            throw new MalformedURLException(e.getMessage());
         }
     }
 }

--- a/test/jdk/sun/net/www/protocol/jrt/Basic.java
+++ b/test/jdk/sun/net/www/protocol/jrt/Basic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/sun/net/www/protocol/jrt/Basic.java
+++ b/test/jdk/sun/net/www/protocol/jrt/Basic.java
@@ -28,7 +28,6 @@
  */
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.URL;
 import java.net.URLConnection;
 
@@ -41,8 +40,28 @@ public class Basic {
     @DataProvider(name = "urls")
     public Object[][] urls() {
         Object[][] data = {
-            { "jrt:/java.base/java/lang/Object.class",    true },
-            { "jrt:/java.desktop/java/lang/Object.class", false },
+                {"jrt:/java.base/java/lang/Object.class", true},
+                // Valid resource with and without percent-encoding.
+                {"jrt:/java.base/java/lang/Runtime$Version.class", true},
+                {"jrt:/java.base/java%2Flang%2FRuntime%24Version.class", true},
+                // Unnecessary percent encoding (just Object again).
+                {"jrt:/java.base/%6a%61%76%61%2f%6c%61%6e%67%2f%4f%62%6a%65%63%74%2e%63%6c%61%73%73", true},
+                // Query parameters and fragments are silently ignored.
+                {"jrt:/java.base/java/lang/Object.class?yes=no", true},
+                {"jrt:/java.base/java/lang/Object.class#anchor", true},
+
+                // Missing resource (no such class).
+                {"jrt:/java.base/java/lang/NoSuchClass.class", false},
+                // Missing resource (wrong module).
+                {"jrt:/java.desktop/java/lang/Object.class", false},
+                // Entries in jimage which don't reference resources.
+                {"jrt:/modules/java.base/java/lang", false},
+                {"jrt:/packages/java.lang", false},
+                // Invalid (incomplete/corrupt) URIs.
+                {"jrt:/java.base", false},
+                {"jrt:/java.base/", false},
+                // Cannot escape anything in the module name.
+                {"jrt:/java%2Ebase/java/lang/Object.class", false},
         };
         return data;
     }


### PR DESCRIPTION
Simplifying JavaRuntimeURLConnection to avoid accidentally returning non-resource data to users.

This change has the following distinct parts:
1. Refactor code to use Node instead of directly accessing low level ImageLocation type.
2. Remove unnecessary use of "Resource" interface and related URL generation code (completely unreachable).
3. Adding comments explaining why there's a non-obvious distinction in how module and resource names are treated with respect to URL percent encoding.
4. Small constructor logic simplification (module name cannot be null anymore)
5. Small simplification around 'READER' use, since it is impossible for that to ever be null (other users of ImageReaderFactory already assume it could never be null, and code path analysis agrees).
6. Adding tests for the non-resource cases.
7. Adding extra test data to check the behaviour with respect to things like percent escaping (previously untested).
8. Adding TODO comments for things I could do in this PR or later (reviewer opinions welcome).