### PR TITLE
8354727: CompilationPolicy creates too many compiler threads when code cache space is scarce

### DIFF
--- a/src/hotspot/share/compiler/compilationPolicy.cpp
+++ b/src/hotspot/share/compiler/compilationPolicy.cpp
@@ -571,7 +571,14 @@ void CompilationPolicy::initialize() {
 #ifdef COMPILER2
       c2_size = C2Compiler::initial_code_buffer_size();
 #endif
-      size_t buffer_size = c1_only ? c1_size : (c1_size/3 + 2*c2_size/3);
+      size_t buffer_size = 0;
+      if (c1_only) {
+        buffer_size = c1_size;
+      } else if (c2_only) {
+        buffer_size = c2_size;
+      } else {
+        buffer_size = c1_size / 3 + 2 * c2_size / 3;
+      }
       size_t max_count = (NonNMethodCodeHeapSize - (CodeCacheMinimumUseSpace DEBUG_ONLY(* 3))) / buffer_size;
       if ((size_t)count > max_count) {
         // Lower the compiler count such that all buffers fit into the code cache

--- a/src/hotspot/share/compiler/compilationPolicy.cpp
+++ b/src/hotspot/share/compiler/compilationPolicy.cpp
@@ -591,7 +591,7 @@ void CompilationPolicy::initialize() {
       count = 3;
       FLAG_SET_ERGO(CICompilerCount, count);
     }
-#endif
+#endif // _LP64
 
     if (c1_only) {
       // No C2 compiler threads are needed

--- a/src/hotspot/share/compiler/compilationPolicy.cpp
+++ b/src/hotspot/share/compiler/compilationPolicy.cpp
@@ -572,7 +572,7 @@ void CompilationPolicy::initialize() {
       c2_size = C2Compiler::initial_code_buffer_size();
 #endif
       size_t buffer_size = c1_only ? c1_size : (c1_size/3 + 2*c2_size/3);
-      size_t max_count = (ReservedCodeCacheSize - (CodeCacheMinimumUseSpace DEBUG_ONLY(* 3))) / buffer_size;
+      size_t max_count = (NonNMethodCodeHeapSize - (CodeCacheMinimumUseSpace DEBUG_ONLY(* 3))) / buffer_size;
       if ((size_t)count > max_count) {
         // Lower the compiler count such that all buffers fit into the code cache
         count = MAX2((int)max_count, min_count);


### PR DESCRIPTION
Running

```
java -XX:+SegmentedCodeCache -XX:ReservedCodeCacheSize=10M -XX:NonNMethodCodeHeapSize=6M \
     -XX:ProfiledCodeHeapSize=5M -XX:NonProfiledCodeHeapSize=5M -version
```

on a machine with more than 285 cores, this would fail with the message that the specified `NonNMethodCodeHeapSize` is too small to fit all compiler buffers (instead of failing because the sum of the heaps is larger than the `ReservedCodeCacheSize`). Hence, the calculated compiler count is too high. This is due to CompilationPolicy::initialize() checking how many compiler buffers fit into the `ReservedCodeCacheSize`. However, in the case above, this is significantly larger than `NonNMethodCodeHeapSize` (especially on a debug build) and causes a check changed in #17244 to fail. That check was changed to check that all compiler buffers fit into the `NonNMethodCodeHeap` instead of the `NonNMethodCodeHeap` having at least a size of `CodeCacheMinimumUseSpace`.

# Changes

This PR fixes the calculation of the `CICompilerCount` ergonomic. Firstly, @shipilev kindly provided a fix for the compiler buffer size used in the calculation is also correct if we only have C2. Secondly, `NonNMethodHeapSize` is used as the maximum buffer size available for compilers buffers in the calculation of the maximum number of compiler threads instead of `ReservedCodeCacheSize`. Therefore, the check failing in the explanation above can never fail because we set the number of compiler threads only so high that they will always fit into the `NonNMethodCodeHeap`.

This change changes how many compiler threads are created by the `CICompilerCount` ergonomic. For the default value `NonNMethodCodeHeapSize=5M`this limit is 24 compiler threads for product builds and 20 threads for debug builds.

# Testing

- [ ] [Github Actions](https://github.com/mhaessig/jdk/actions/runs/15733154809)
- [ ] tier1 through tier3 plus Oracle internal testing on our supported platforms