### PR TITLE
8359922: Incorrect comment for variable NMethodSizeLimit

### DIFF
--- a/src/hotspot/share/c1/c1_Compilation.hpp
+++ b/src/hotspot/share/c1/c1_Compilation.hpp
@@ -217,7 +217,7 @@ class Compilation: public StackObj {
   const CompilationFailureInfo* first_failure_details() const { return _first_failure_details; }
 
   static uint desired_max_code_buffer_size() {
-    return (uint)NMethodSizeLimit;  // default 64K
+    return (uint)NMethodSizeLimit;  // default 64K*wordSize
   }
   static uint desired_max_constant_size() {
     return desired_max_code_buffer_size() / 10;


### PR DESCRIPTION
Hi all,

This PR fix a incorrect for variable `NMethodSizeLimit`. The [default value](https://github.com/openjdk/jdk/blob/master/src/hotspot/share/c1/c1_globals.hpp#L279) of `NMethodSizeLimit` is `64K * wordSize`.

Trivial fix, no risk.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8359922](https://bugs.openjdk.org/browse/JDK-8359922): Incorrect comment for variable NMethodSizeLimit (**Bug** - P5)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25873/head:pull/25873` \
`$ git checkout pull/25873`

Update a local copy of the PR: \
`$ git checkout pull/25873` \
`$ git pull https://git.openjdk.org/jdk.git pull/25873/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25873`

View PR using the GUI difftool: \
`$ git pr show -t 25873`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25873.diff">https://git.openjdk.org/jdk/pull/25873.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25873#issuecomment-2984233067)
</details>
