### PR TITLE
8359923: Const accessors for the Deferred class

### DIFF
--- a/src/hotspot/share/utilities/deferred.hpp
+++ b/src/hotspot/share/utilities/deferred.hpp
@@ -56,11 +56,24 @@ public:
     return &_t;
   }
 
+  const T* get() const {
+    assert(_initialized, "must be initialized before access");
+    return &_t;
+  }
+
   T& operator*() {
     return *get();
   }
 
+  const T& operator*() const {
+    return *get();
+  }
+
   T* operator->() {
+    return get();
+  }
+
+  const T* operator->() const {
     return get();
   }
 


### PR DESCRIPTION
Hello,

This RFE adds const accessors to the `Deferred` class. We plan on using this in a future patch in ZGC. Thanks!

Testing:
 * Currently running tier1-2
 * Works in an WIP ZGC patch

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8359923](https://bugs.openjdk.org/browse/JDK-8359923): Const accessors for the Deferred class (**Enhancement** - P4)


### Reviewers
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@jdksjolen - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25874/head:pull/25874` \
`$ git checkout pull/25874`

Update a local copy of the PR: \
`$ git checkout pull/25874` \
`$ git pull https://git.openjdk.org/jdk.git pull/25874/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25874`

View PR using the GUI difftool: \
`$ git pr show -t 25874`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25874.diff">https://git.openjdk.org/jdk/pull/25874.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25874#issuecomment-2984240424)
</details>
