### PR TITLE
8358578: Small -XX:NMethodSizeLimit triggers "not in CodeBuffer memory" assert in C1

### DIFF
--- a/src/hotspot/share/c1/c1_Compilation.cpp
+++ b/src/hotspot/share/c1/c1_Compilation.cpp
@@ -330,7 +330,7 @@ bool Compilation::setup_code_buffer(CodeBuffer* code, int call_stub_estimate) {
   char* locs_buffer = NEW_RESOURCE_ARRAY(char, locs_buffer_size);
   code->insts()->initialize_shared_locs((relocInfo*)locs_buffer,
                                         locs_buffer_size / sizeof(relocInfo));
-  code->initialize_consts_size(Compilation::desired_max_constant_size());
+  code->initialize_consts_size(Compilation::desired_max_constant_size);
   // Call stubs + two deopt handlers (regular and MH) + exception handler
   int stub_size = (call_stub_estimate * LIR_Assembler::call_stub_size()) +
                    LIR_Assembler::exception_handler_size() +

--- a/src/hotspot/share/c1/c1_Compilation.hpp
+++ b/src/hotspot/share/c1/c1_Compilation.hpp
@@ -216,12 +216,8 @@ class Compilation: public StackObj {
   const char* bailout_msg() const                { return _bailout_msg; }
   const CompilationFailureInfo* first_failure_details() const { return _first_failure_details; }
 
-  static uint desired_max_code_buffer_size() {
-    return (uint)NMethodSizeLimit;  // default 64K
-  }
-  static uint desired_max_constant_size() {
-    return desired_max_code_buffer_size() / 10;
-  }
+  const static uint desired_max_code_buffer_size = 64*K * wordSize;
+  const static uint desired_max_constant_size = desired_max_code_buffer_size / 10;
 
   static bool setup_code_buffer(CodeBuffer* cb, int call_stub_estimate);
 

--- a/src/hotspot/share/c1/c1_Compiler.cpp
+++ b/src/hotspot/share/c1/c1_Compiler.cpp
@@ -79,7 +79,7 @@ void Compiler::initialize() {
 }
 
 uint Compiler::code_buffer_size() {
-  return Compilation::desired_max_code_buffer_size() + Compilation::desired_max_constant_size();
+  return Compilation::desired_max_code_buffer_size + Compilation::desired_max_constant_size;
 }
 
 BufferBlob* Compiler::init_buffer_blob() {
@@ -87,8 +87,7 @@ BufferBlob* Compiler::init_buffer_blob() {
   // compilation seems to be too expensive (at least on Intel win32).
   assert (CompilerThread::current()->get_buffer_blob() == nullptr, "Should initialize only once");
 
-  // setup CodeBuffer.  Preallocate a BufferBlob of size
-  // NMethodSizeLimit plus some extra space for constants.
+  // Setup CodeBuffer.
   BufferBlob* buffer_blob = BufferBlob::create("C1 temporary CodeBuffer", code_buffer_size());
   if (buffer_blob != nullptr) {
     CompilerThread::current()->set_buffer_blob(buffer_blob);

--- a/src/hotspot/share/c1/c1_globals.hpp
+++ b/src/hotspot/share/c1/c1_globals.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -273,12 +273,6 @@
                                                                             \
   develop(bool, InstallMethods, true,                                       \
           "Install methods at the end of successful compilations")          \
-                                                                            \
-  /* The compiler assumes, in many places, that methods are at most 1MB. */ \
-  /* Therefore, we restrict this flag to at most 1MB.                    */ \
-  develop(intx, NMethodSizeLimit, (64*K)*wordSize,                          \
-          "Maximum size of a compiled method.")                             \
-          range(0, 1*M)                                                     \
                                                                             \
   develop(intx, InstructionCountCutoff, 37000,                              \
           "If GraphBuilder adds this many instructions, bails out")         \

--- a/test/hotspot/jtreg/compiler/arguments/TestC1Globals.java
+++ b/test/hotspot/jtreg/compiler/arguments/TestC1Globals.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -19,42 +19,6 @@
  * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
  * or visit www.oracle.com if you need additional information or have any
  * questions.
- */
-
-/**
- * @test
- * @bug 8316653
- * @requires vm.debug
- * @summary Test flag with max value.
- *
- * @run main/othervm -XX:NMethodSizeLimit=1M
- *                   compiler.arguments.TestC1Globals
- */
-
-/**
- * @test
- * @bug 8318817
- * @requires vm.debug
- * @requires os.family == "linux"
- * @summary Test flag with max value combined with transparent huge pages on
- *          Linux.
- *
- * @run main/othervm -XX:NMethodSizeLimit=1M
- *                   -XX:+UseTransparentHugePages
- *                   compiler.arguments.TestC1Globals
- */
-
-/**
- * @test
- * @bug 8320682
- * @requires vm.debug
- * @summary Test flag with max value and specific compilation.
- *
- * @run main/othervm -XX:NMethodSizeLimit=1M
- *                   -XX:CompileOnly=java.util.HashMap::putMapEntries
- *                   -Xcomp
- *                   compiler.arguments.TestC1Globals
- *
  */
 
 /**

--- a/test/hotspot/jtreg/compiler/c1/TestLinearScanOrderMain.java
+++ b/test/hotspot/jtreg/compiler/c1/TestLinearScanOrderMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,6 @@
  * @bug 8207355
  * @compile TestLinearScanOrder.jasm
  * @run main/othervm -Xcomp -XX:+TieredCompilation -XX:TieredStopAtLevel=1
- *                   -XX:+IgnoreUnrecognizedVMOptions -XX:NMethodSizeLimit=655360
  *                   -XX:CompileCommand=compileonly,compiler.c1.TestLinearScanOrder::test
  *                   compiler.c1.TestLinearScanOrderMain
  */


### PR DESCRIPTION
Running `java -XX:NMethodSizeLimit=100 -version` triggers an assert because the lower limit of the debug flag `NMethodSizeLimit` is too low.

`NMethodSizeLimit` corresponds more or less directly to the C1 code buffer size. It was added as a debug flag in 2005 to make it easier to stress the code paths related to the buffer size. Nowadays, it is not used for any stressing, but it has caused a bunch of bugs ([JDK-8316653](https://bugs.openjdk.org/browse/JDK-8316653), [JDK-8318817](https://bugs.openjdk.org/browse/JDK-8318817), [JDK-8320682](https://bugs.openjdk.org/browse/JDK-8320682)). Therefore, this PR removes the debug flag `NMethodSizeLimit` and converts it to a constant.

Because this removes the code causing the error, this bug does not have a regression test (in fact, it removes regression tests).

# Testing

- [x] [Github Actions](https://github.com/mhaessig/jdk/actions/runs/15735062162)
- [x] tier1 through tier3 plus Oracle internal testing on all Oracle supported platforms

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8358578](https://bugs.openjdk.org/browse/JDK-8358578): Small -XX:NMethodSizeLimit triggers "not in CodeBuffer memory" assert in C1 (**Bug** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [SendaoYan](https://openjdk.org/census#syan) (@sendaoYan - Committer)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25876/head:pull/25876` \
`$ git checkout pull/25876`

Update a local copy of the PR: \
`$ git checkout pull/25876` \
`$ git pull https://git.openjdk.org/jdk.git pull/25876/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25876`

View PR using the GUI difftool: \
`$ git pr show -t 25876`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25876.diff">https://git.openjdk.org/jdk/pull/25876.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25876#issuecomment-2984570174)
</details>
