### PR TITLE
8358697: TextLayout/MyanmarTextTest.java passes if no Myanmar font is found

### DIFF
--- a/test/jdk/java/awt/font/TextLayout/MyanmarTextTest.java
+++ b/test/jdk/java/awt/font/TextLayout/MyanmarTextTest.java
@@ -51,6 +51,7 @@ import jtreg.SkippedException;
 
 public class MyanmarTextTest {
     private static final String TEXT = "\u1000\u103C";
+
     private static final String OS_NAME = System.getProperty("os.name").toLowerCase();
 
     private static final String[] FONTS_WINDOWS = {"Myanmar Text", "Noto Sans Myanmar"};

--- a/test/jdk/java/awt/font/TextLayout/MyanmarTextTest.java
+++ b/test/jdk/java/awt/font/TextLayout/MyanmarTextTest.java
@@ -51,14 +51,14 @@ import jtreg.SkippedException;
 
 public class MyanmarTextTest {
     private static final String TEXT = "\u1000\u103C";
-
     private static final String OS_NAME = System.getProperty("os.name").toLowerCase();
 
-    private static final String FONT_WINDOWS = "Myanmar Text";
-    private static final String FONT_LINUX = "Padauk";
-    private static final String FONT_MACOS = "Myanmar MN";
+    private static final String[] FONTS_WINDOWS = {"Myanmar Text", "Noto Sans Myanmar"};
+    private static final String[] FONTS_LINUX = {"Padauk", "Noto Sans Myanmar", "Myanmar Text"};
+    private static final String[] FONTS_MACOS = {"Myanmar MN", "Noto Sans Myanmar", "Myanmar Text"};
 
-    private static final String FONT_NAME = selectFontName();
+    private static final String[] FONT_CANDIDATES = selectFontCandidates();
+    private static final String FONT_NAME = selectAvailableFont();
 
     private final JFrame frame;
     private final JTextField myanmarTF;
@@ -66,13 +66,16 @@ public class MyanmarTextTest {
     private static volatile MyanmarTextTest mtt;
 
     public static void main(String[] args) throws Exception {
-        if (FONT_NAME == null) {
+        if (FONT_CANDIDATES == null) {
             System.err.println("Unsupported OS: exiting");
             throw new SkippedException("Unsupported OS: " + OS_NAME);
         }
-        if (!fontExists()) {
-            System.err.println("Required font is not installed: " + FONT_NAME);
-            throw new SkippedException("Required font is not installed: " + FONT_NAME);
+        if (FONT_NAME == null) {
+            String fontList = String.join(", ", FONT_CANDIDATES);
+            System.err.println("Required font is not installed for OS: " + OS_NAME);
+            System.err.println("Checked fonts: " + fontList);
+            throw new SkippedException("Required fonts not installed for OS: "
+                    + OS_NAME + ". Checked fonts: " + fontList);
         }
 
         try {
@@ -98,7 +101,6 @@ public class MyanmarTextTest {
         JPanel main = new JPanel();
         main.setLayout(new BoxLayout(main, BoxLayout.Y_AXIS));
         main.add(myanmarTF);
-
         main.setBorder(BorderFactory.createEmptyBorder(7, 7, 7, 7));
 
         frame.getContentPane().add(main);
@@ -135,22 +137,32 @@ public class MyanmarTextTest {
         }
     }
 
-    private static String selectFontName() {
+    private static String[] selectFontCandidates() {
         if (OS_NAME.contains("windows")) {
-            return FONT_WINDOWS;
+            return FONTS_WINDOWS;
         } else if (OS_NAME.contains("linux")) {
-            return FONT_LINUX;
+            return FONTS_LINUX;
         } else if (OS_NAME.contains("mac")) {
-            return FONT_MACOS;
+            return FONTS_MACOS;
         } else {
             return null;
         }
     }
 
-    private static boolean fontExists() {
-        String[] fontFamilyNames = GraphicsEnvironment
-                                   .getLocalGraphicsEnvironment()
-                                   .getAvailableFontFamilyNames();
-        return Arrays.asList(fontFamilyNames).contains(FONT_NAME);
+    private static String selectAvailableFont() {
+        if (FONT_CANDIDATES == null) {
+            return null;
+        }
+        String[] installedFonts = GraphicsEnvironment
+                .getLocalGraphicsEnvironment()
+                .getAvailableFontFamilyNames();
+
+        for (String font : FONT_CANDIDATES) {
+            if (Arrays.asList(installedFonts).contains(font)) {
+                System.out.println("Using font: " + font);
+                return font;
+            }
+        }
+        return null;
     }
 }

--- a/test/jdk/java/awt/font/TextLayout/MyanmarTextTest.java
+++ b/test/jdk/java/awt/font/TextLayout/MyanmarTextTest.java
@@ -35,6 +35,7 @@
 import java.awt.Font;
 import java.awt.GraphicsEnvironment;
 import java.util.Arrays;
+import java.util.List;
 import javax.swing.BorderFactory;
 import javax.swing.BoxLayout;
 import javax.swing.JFrame;
@@ -54,12 +55,12 @@ public class MyanmarTextTest {
 
     private static final String OS_NAME = System.getProperty("os.name").toLowerCase();
 
-    private static final String[] FONTS_WINDOWS = {"Myanmar Text", "Noto Sans Myanmar"};
-    private static final String[] FONTS_LINUX = {"Padauk", "Noto Sans Myanmar", "Myanmar Text"};
-    private static final String[] FONTS_MACOS = {"Myanmar MN", "Noto Sans Myanmar", "Myanmar Text"};
-
-    private static final String[] FONT_CANDIDATES = selectFontCandidates();
-    private static final String FONT_NAME = selectAvailableFont();
+    private static final List<String> FONT_CANDIDATES =
+            List.of("Myanmar MN",
+                    "Padauk",
+                    "Myanmar Text",
+                    "Noto Sans Myanmar");
+    private static final String FONT_NAME = selectFontName();
 
     private final JFrame frame;
     private final JTextField myanmarTF;
@@ -67,10 +68,6 @@ public class MyanmarTextTest {
     private static volatile MyanmarTextTest mtt;
 
     public static void main(String[] args) throws Exception {
-        if (FONT_CANDIDATES == null) {
-            System.err.println("Unsupported OS: exiting");
-            throw new SkippedException("Unsupported OS: " + OS_NAME);
-        }
         if (FONT_NAME == null) {
             String fontList = String.join(", ", FONT_CANDIDATES);
             System.err.println("Required font is not installed for OS: " + OS_NAME);
@@ -102,6 +99,7 @@ public class MyanmarTextTest {
         JPanel main = new JPanel();
         main.setLayout(new BoxLayout(main, BoxLayout.Y_AXIS));
         main.add(myanmarTF);
+
         main.setBorder(BorderFactory.createEmptyBorder(7, 7, 7, 7));
 
         frame.getContentPane().add(main);
@@ -138,32 +136,13 @@ public class MyanmarTextTest {
         }
     }
 
-    private static String[] selectFontCandidates() {
-        if (OS_NAME.contains("windows")) {
-            return FONTS_WINDOWS;
-        } else if (OS_NAME.contains("linux")) {
-            return FONTS_LINUX;
-        } else if (OS_NAME.contains("mac")) {
-            return FONTS_MACOS;
-        } else {
-            return null;
-        }
+    private static String selectFontName() {
+        return Arrays.stream(GraphicsEnvironment
+                        .getLocalGraphicsEnvironment()
+                        .getAvailableFontFamilyNames())
+                .filter(FONT_CANDIDATES::contains)
+                .findFirst()
+                .orElse(null);
     }
 
-    private static String selectAvailableFont() {
-        if (FONT_CANDIDATES == null) {
-            return null;
-        }
-        String[] installedFonts = GraphicsEnvironment
-                .getLocalGraphicsEnvironment()
-                .getAvailableFontFamilyNames();
-
-        for (String font : FONT_CANDIDATES) {
-            if (Arrays.asList(installedFonts).contains(font)) {
-                System.out.println("Using font: " + font);
-                return font;
-            }
-        }
-        return null;
-    }
 }

--- a/test/jdk/java/awt/font/TextLayout/MyanmarTextTest.java
+++ b/test/jdk/java/awt/font/TextLayout/MyanmarTextTest.java
@@ -52,10 +52,12 @@ import jtreg.SkippedException;
 public class MyanmarTextTest {
     private static final String TEXT = "\u1000\u103C";
 
+    private static final String OS_NAME = System.getProperty("os.name").toLowerCase();
+
     private static final String FONT_WINDOWS = "Myanmar Text";
     private static final String FONT_LINUX = "Padauk";
     private static final String FONT_MACOS = "Myanmar MN";
-    private static final String osName = System.getProperty("os.name").toLowerCase();
+
     private static final String FONT_NAME = selectFontName();
 
     private final JFrame frame;
@@ -66,7 +68,7 @@ public class MyanmarTextTest {
     public static void main(String[] args) throws Exception {
         if (FONT_NAME == null) {
             System.err.println("Unsupported OS: exiting");
-            throw new SkippedException("Unsupported OS: "+osName);
+            throw new SkippedException("Unsupported OS: " + OS_NAME);
         }
         if (!fontExists()) {
             System.err.println("Required font is not installed: " + FONT_NAME);
@@ -134,11 +136,11 @@ public class MyanmarTextTest {
     }
 
     private static String selectFontName() {
-        if (osName.contains("windows")) {
+        if (OS_NAME.contains("windows")) {
             return FONT_WINDOWS;
-        } else if (osName.contains("linux")) {
+        } else if (OS_NAME.contains("linux")) {
             return FONT_LINUX;
-        } else if (osName.contains("mac")) {
+        } else if (OS_NAME.contains("mac")) {
             return FONT_MACOS;
         } else {
             return null;

--- a/test/jdk/java/awt/font/TextLayout/MyanmarTextTest.java
+++ b/test/jdk/java/awt/font/TextLayout/MyanmarTextTest.java
@@ -53,13 +53,12 @@ import jtreg.SkippedException;
 public class MyanmarTextTest {
     private static final String TEXT = "\u1000\u103C";
 
-    private static final String OS_NAME = System.getProperty("os.name").toLowerCase();
-
     private static final List<String> FONT_CANDIDATES =
             List.of("Myanmar MN",
                     "Padauk",
                     "Myanmar Text",
                     "Noto Sans Myanmar");
+
     private static final String FONT_NAME = selectFontName();
 
     private final JFrame frame;
@@ -69,11 +68,8 @@ public class MyanmarTextTest {
 
     public static void main(String[] args) throws Exception {
         if (FONT_NAME == null) {
-            String fontList = String.join(", ", FONT_CANDIDATES);
-            System.err.println("Required font is not installed for OS: " + OS_NAME);
-            System.err.println("Checked fonts: " + fontList);
-            throw new SkippedException("Required fonts not installed for OS: "
-                    + OS_NAME + ". Checked fonts: " + fontList);
+            throw new SkippedException("No suitable font found out of the list: "
+                    + String.join(", ", FONT_CANDIDATES));
         }
 
         try {
@@ -138,11 +134,11 @@ public class MyanmarTextTest {
 
     private static String selectFontName() {
         return Arrays.stream(GraphicsEnvironment
-                        .getLocalGraphicsEnvironment()
-                        .getAvailableFontFamilyNames())
-                .filter(FONT_CANDIDATES::contains)
-                .findFirst()
-                .orElse(null);
+                             .getLocalGraphicsEnvironment()
+                             .getAvailableFontFamilyNames())
+                     .filter(FONT_CANDIDATES::contains)
+                     .findFirst()
+                     .orElse(null);
     }
 
 }

--- a/test/jdk/java/awt/font/TextLayout/MyanmarTextTest.java
+++ b/test/jdk/java/awt/font/TextLayout/MyanmarTextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,8 @@
  * @key headful
  * @summary Verifies that Myanmar script is rendered correctly:
  *          two characters combined into one glyph
+ * @library /test/lib
+ * @build jtreg.SkippedException
  * @run main MyanmarTextTest
  */
 
@@ -45,13 +47,15 @@ import javax.swing.plaf.TextUI;
 import javax.swing.text.BadLocationException;
 import javax.swing.text.Position;
 
+import jtreg.SkippedException;
+
 public class MyanmarTextTest {
     private static final String TEXT = "\u1000\u103C";
 
     private static final String FONT_WINDOWS = "Myanmar Text";
     private static final String FONT_LINUX = "Padauk";
     private static final String FONT_MACOS = "Myanmar MN";
-
+    private static final String osName = System.getProperty("os.name").toLowerCase();
     private static final String FONT_NAME = selectFontName();
 
     private final JFrame frame;
@@ -62,11 +66,11 @@ public class MyanmarTextTest {
     public static void main(String[] args) throws Exception {
         if (FONT_NAME == null) {
             System.err.println("Unsupported OS: exiting");
-            return;
+            throw new SkippedException("Unsupported OS: "+osName);
         }
         if (!fontExists()) {
             System.err.println("Required font is not installed: " + FONT_NAME);
-            return;
+            throw new SkippedException("Required font is not installed: " + FONT_NAME);
         }
 
         try {
@@ -130,7 +134,6 @@ public class MyanmarTextTest {
     }
 
     private static String selectFontName() {
-        String osName = System.getProperty("os.name").toLowerCase();
         if (osName.contains("windows")) {
             return FONT_WINDOWS;
         } else if (osName.contains("linux")) {


### PR DESCRIPTION
Issue:
MyanmarTextTest.java produces a false positive result when some of the test preconditions are not met. It checks whether certain fonts are present in the system, for example, 'Padauk' on Linux. If the required font is missing, the test simply returns early, and the test ends up passing, which is incorrect. Ideally, it should throw a jtreg.SkippedException when the necessary preconditions are not satisfied.

Another scenario is that the test passes on headless machines even though it creates GUI components. Ideally, when GUI components are created in code running on a headless machine, a HeadlessException should be thrown. However, since MyanmarTextTest.java exits before reaching the point where the GUI is created (due to unmet preconditions), it incorrectly reports a pass. This behavior may lead to a misinterpretation of the test as being headless, which it is not.

Fix:
Need to throw jtreg.SkippedException in cases where some pre-conditions for running the test are not met.

Testing:
Tested using mach5 in all available platforms and got full PASS.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8358697](https://bugs.openjdk.org/browse/JDK-8358697): TextLayout/MyanmarTextTest.java passes if no Myanmar font is found (**Bug** - P4)


### Reviewers
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25879/head:pull/25879` \
`$ git checkout pull/25879`

Update a local copy of the PR: \
`$ git checkout pull/25879` \
`$ git pull https://git.openjdk.org/jdk.git pull/25879/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25879`

View PR using the GUI difftool: \
`$ git pr show -t 25879`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25879.diff">https://git.openjdk.org/jdk/pull/25879.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25879#issuecomment-2984919914)
</details>
