### PR TITLE
8354872: Clarify java.lang.Process resource cleanup

### DIFF
--- a/src/java.base/share/classes/java/lang/Process.java
+++ b/src/java.base/share/classes/java/lang/Process.java
@@ -41,7 +41,7 @@ import java.util.stream.Stream;
 
 /**
  * {@code Process} provides control of native processes started by
- * ProcessBuilder.start and Runtime.exec.
+ * {@code ProcessBuilder.start} and {@code Runtime.exec}.
  * The class provides methods for performing input from the process, performing
  * output to the process, waiting for the process to complete,
  * checking the exit status of the process, and destroying (killing)
@@ -126,13 +126,13 @@ import java.util.stream.Stream;
  *     }
  * }
  * }
- * <p>Stream resources (file descriptord or handled) are always paired; one in the invoking process
+ * <p>Stream resources (file descriptor or handled) are always paired; one in the invoking process
  * and the other end of that connection in the invoked process.
  * Closing a stream at either end terminates communication but does not have any direct effect
  * on the other Process. The closing of the stream typically results in the other process exiting.
  *
  * <p> {@linkplain #destroy Destroying a process} signals the operating system to terminate the process.
- * It is up to the operating system to cleanup and release the resources of that process.
+ * It is up to the operating system to clean up and release the resources of that process.
  * Typically, file descriptors and handles are closed. When they are closed, any connections to
  * other processes are terminated and file descriptors and handles in the invoking process signal
  * end-of-file or closed. Usually, that is seen as an end-of-file or an exception.
@@ -430,7 +430,7 @@ public abstract class Process {
     /**
      * Returns a {@code BufferedWriter} connected to the normal input of the process
      * using the native encoding.
-     * Writes text to a character-output stream, buffering characters so as to provide
+     * Writes text to a character-output stream, buffering characters to provide
      * for the efficient writing of single characters, arrays, and strings.
      *
      * <p>This method delegates to {@link #outputWriter(Charset)} using the
@@ -452,7 +452,7 @@ public abstract class Process {
     /**
      * Returns a {@code BufferedWriter} connected to the normal input of the process
      * using a Charset.
-     * Writes text to a character-output stream, buffering characters so as to provide
+     * Writes text to a character-output stream, buffering characters to provide
      * for the efficient writing of single characters, arrays, and strings.
      *
      * <p>Characters written by the writer are encoded to bytes using {@link OutputStreamWriter}

--- a/src/java.base/share/classes/java/lang/Process.java
+++ b/src/java.base/share/classes/java/lang/Process.java
@@ -126,7 +126,7 @@ import java.util.stream.Stream;
  *     }
  * }
  * }
- * <p>Stream resources (file descriptor or handled) are always paired; one in the invoking process
+ * <p>Stream resources (file descriptor or handle) are always paired; one in the invoking process
  * and the other end of that connection in the invoked process.
  * Closing a stream at either end terminates communication but does not have any direct effect
  * on the other Process. The closing of the stream typically results in the other process exiting.
@@ -205,7 +205,7 @@ public abstract class Process {
      * when it is no longer needed.
      *
      * @apiNote
-     * Use either this method or an {@linkplain #inputReader(Charset) input reader}
+     * Use either this method or an {@linkplain #inputReader() input reader}
      * but not both on the same {@code Process}.
      * The input reader consumes and buffers bytes from the input stream.
      * Bytes read from the input stream would not be seen by the reader and
@@ -237,7 +237,7 @@ public abstract class Process {
      * when it is no longer needed.
      *
      * @apiNote
-     * Use either this method or an {@linkplain #errorReader(Charset) error reader}
+     * Use either this method or an {@linkplain #errorReader() error reader}
      * but not both on the same {@code Process}.
      * The error reader consumes and buffers bytes from the error stream.
      * Bytes read from the error stream would not be seen by the reader and the

--- a/src/java.base/share/classes/java/lang/Process.java
+++ b/src/java.base/share/classes/java/lang/Process.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -96,10 +96,10 @@ import java.util.stream.Stream;
  * <p>For example, to capture the output of a program known to produce some output and then exit:
  * {@snippet lang = "java" :
  * List<String> capture(List<String> args) throws Exception {
- *     ProcessBuilder pb = new ProcessBuilder().command(args);
+ *     ProcessBuilder pb = new ProcessBuilder(args);
  *     Process process = pb.start();
  *     try (BufferedReader in = process.inputReader()) {
- *         List<String> captured = in.lines().toList();
+ *         List<String> captured = in.readAllLines();
  *         int status = process.waitFor();
  *         if (status != 0) {
  *             throw new RuntimeException("Process %d: %s failed with %d"

--- a/src/java.base/share/classes/java/lang/ProcessBuilder.java
+++ b/src/java.base/share/classes/java/lang/ProcessBuilder.java
@@ -150,30 +150,33 @@ import jdk.internal.event.ProcessStartEvent;
  * <p>Starting a new process which uses the default working directory
  * and environment is easy:
  *
- * <pre> {@code
+ * {@snippet lang = "java" :
+
  * Process p = new ProcessBuilder("myCommand", "myArg").start();
- * }</pre>
+ * }
+
  *
  * <p>Here is an example that starts a process with a modified working
  * directory and environment, and redirects standard output and error
  * to be appended to a log file:
  *
- * <pre> {@code
- * ProcessBuilder pb =
- *   new ProcessBuilder("myCommand", "myArg1", "myArg2");
- * Map<String, String> env = pb.environment();
- * env.put("VAR1", "myValue");
- * env.remove("OTHERVAR");
- * env.put("VAR2", env.get("VAR1") + "suffix");
- * pb.directory(new File("myDir"));
- * File log = new File("log");
- * pb.redirectErrorStream(true);
- * pb.redirectOutput(Redirect.appendTo(log));
- * Process p = pb.start();
- * assert pb.redirectInput() == Redirect.PIPE;
- * assert pb.redirectOutput().file() == log;
- * assert p.getInputStream().read() == -1;
- * }</pre>
+ * {@snippet lang = "java":
+ *     ProcessBuilder pb = new ProcessBuilder("myCommand", "myArg1", "myArg2");
+ *     Map<String, String> env = pb.environment();
+ *     env.put("VAR1", "myValue");
+ *     env.remove("OTHERVAR");
+ *     env.put("VAR2", env.get("VAR1") + "suffix");
+ *
+ *     pb.directory(new File("myDir"));
+ *     File log = new File("log");
+ *     pb.redirectErrorStream(true);
+ *     pb.redirectOutput(Redirect.appendTo(log));
+ *
+ *     Process p = pb.start();
+ *     assert pb.redirectInput() == Redirect.PIPE;
+ *     assert pb.redirectOutput().file() == log;
+ *     assert p.getInputStream().read() == -1;
+ * }
  *
  * <p>To start a process with an explicit set of environment
  * variables, first call {@link java.util.Map#clear() Map.clear()}
@@ -506,10 +509,10 @@ public final class ProcessBuilder
          * This is the default handling of subprocess standard I/O.
          *
          * <p>It will always be true that
-         *  <pre> {@code
-         * Redirect.PIPE.file() == null &&
-         * Redirect.PIPE.type() == Redirect.Type.PIPE
-         * }</pre>
+         * {@snippet lang = "java" :
+         *     Redirect.PIPE.file() == null &&
+         *     Redirect.PIPE.type() == Redirect.Type.PIPE
+         * }
          */
         public static final Redirect PIPE = new Redirect() {
                 public Type type() { return Type.PIPE; }
@@ -521,10 +524,10 @@ public final class ProcessBuilder
          * behavior of most operating system command interpreters (shells).
          *
          * <p>It will always be true that
-         *  <pre> {@code
-         * Redirect.INHERIT.file() == null &&
-         * Redirect.INHERIT.type() == Redirect.Type.INHERIT
-         * }</pre>
+         * {@snippet lang = "java" :
+         *     Redirect.INHERIT.file() == null &&
+         *     Redirect.INHERIT.type() == Redirect.Type.INHERIT
+         * }
          */
         public static final Redirect INHERIT = new Redirect() {
                 public Type type() { return Type.INHERIT; }
@@ -537,11 +540,10 @@ public final class ProcessBuilder
          * an operating system specific "null file".
          *
          * <p>It will always be true that
-         * <pre> {@code
-         * Redirect.DISCARD.file() is the filename appropriate for the operating system
-         * and may be null &&
-         * Redirect.DISCARD.type() == Redirect.Type.WRITE
-         * }</pre>
+         * {@snippet lang = "java" :
+         *     Redirect.DISCARD.file() // is the filename appropriate for the operating system
+         *     Redirect.DISCARD.type() == Redirect.Type.WRITE
+         * }
          * @since 9
          */
         public static final Redirect DISCARD = new Redirect() {
@@ -572,10 +574,10 @@ public final class ProcessBuilder
          * Returns a redirect to read from the specified file.
          *
          * <p>It will always be true that
-         *  <pre> {@code
-         * Redirect.from(file).file() == file &&
-         * Redirect.from(file).type() == Redirect.Type.READ
-         * }</pre>
+         * {@snippet lang = "java" :
+         *     Redirect.from(file).file() == file &&
+         *     Redirect.from(file).type() == Redirect.Type.READ
+         * }
          *
          * @param file The {@code File} for the {@code Redirect}.
          * @return a redirect to read from the specified file
@@ -598,10 +600,10 @@ public final class ProcessBuilder
          * its previous contents will be discarded.
          *
          * <p>It will always be true that
-         *  <pre> {@code
-         * Redirect.to(file).file() == file &&
-         * Redirect.to(file).type() == Redirect.Type.WRITE
-         * }</pre>
+         * {@snippet lang = "java" :
+         *     Redirect.to(file).file() == file &&
+         *     Redirect.to(file).type() == Redirect.Type.WRITE
+         * }
          *
          * @param file The {@code File} for the {@code Redirect}.
          * @return a redirect to write to the specified file
@@ -628,10 +630,10 @@ public final class ProcessBuilder
          * system-dependent and therefore unspecified.
          *
          * <p>It will always be true that
-         *  <pre> {@code
-         * Redirect.appendTo(file).file() == file &&
-         * Redirect.appendTo(file).type() == Redirect.Type.APPEND
-         * }</pre>
+         * {@snippet lang = "java" :
+         *     Redirect.appendTo(file).file() == file &&
+         *     Redirect.appendTo(file).type() == Redirect.Type.APPEND
+         * }
          *
          * @param file The {@code File} for the {@code Redirect}.
          * @return a redirect to append to the specified file
@@ -914,15 +916,15 @@ public final class ProcessBuilder
      * to be the same as those of the current Java process.
      *
      * <p>This is a convenience method.  An invocation of the form
-     *  <pre> {@code
-     * pb.inheritIO()
-     * }</pre>
+     * {@snippet lang = "java" :
+     *      pb.inheritIO()
+     * }
      * behaves in exactly the same way as the invocation
-     *  <pre> {@code
-     * pb.redirectInput(Redirect.INHERIT)
-     *   .redirectOutput(Redirect.INHERIT)
-     *   .redirectError(Redirect.INHERIT)
-     * }</pre>
+     * {@snippet lang = "java" :
+     *      pb.redirectInput(Redirect.INHERIT)
+     *          .redirectOutput(Redirect.INHERIT)
+     *          .redirectError(Redirect.INHERIT)
+     * }
      *
      * This gives behavior equivalent to most operating system
      * command interpreters, or the standard C library function
@@ -1176,22 +1178,21 @@ public final class ProcessBuilder
      * @apiNote
      * For example to count the unique imports for all the files in a file hierarchy
      * on a Unix compatible platform:
-     * <pre>{@code
-     * String directory = "/home/duke/src";
-     * ProcessBuilder[] builders = {
+     * {@snippet lang = "java" :
+     *     String directory = "/home/duke/src";
+     *     ProcessBuilder[] builders = {
      *              new ProcessBuilder("find", directory, "-type", "f"),
      *              new ProcessBuilder("xargs", "grep", "-h", "^import "),
      *              new ProcessBuilder("awk", "{print $2;}"),
      *              new ProcessBuilder("sort", "-u")};
-     * List<Process> processes = ProcessBuilder.startPipeline(
-     *         Arrays.asList(builders));
-     * Process last = processes.get(processes.size()-1);
-     * try (InputStream is = last.getInputStream();
+     *     List<Process> processes = ProcessBuilder.startPipeline( Arrays.asList(builders));
+     *     Process last = processes.get(processes.size() - 1);
+     *     try (InputStream is = last.getInputStream();
      *         Reader isr = new InputStreamReader(is);
      *         BufferedReader r = new BufferedReader(isr)) {
-     *     long count = r.lines().count();
+     *         long count = r.lines().count();
+     *     }
      * }
-     * }</pre>
      *
      * @param builders a List of ProcessBuilders
      * @return a {@code List<Process>}es started from the corresponding

--- a/src/java.base/share/classes/java/lang/ProcessBuilder.java
+++ b/src/java.base/share/classes/java/lang/ProcessBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -541,8 +541,8 @@ public final class ProcessBuilder
          *
          * <p>It will always be true that
          * {@snippet lang = "java" :
-         *     Redirect.DISCARD.file() // is the filename appropriate for the operating system
-         *     Redirect.DISCARD.type() == Redirect.Type.WRITE
+         *     Redirect.DISCARD.file(); // is the filename appropriate for the operating system
+         *     Redirect.DISCARD.type() == Redirect.Type.WRITE;
          * }
          * @since 9
          */

--- a/src/java.base/share/classes/java/lang/ProcessBuilder.java
+++ b/src/java.base/share/classes/java/lang/ProcessBuilder.java
@@ -541,7 +541,7 @@ public final class ProcessBuilder
          *
          * <p>It will always be true that
          * {@snippet lang = "java" :
-         *     Redirect.DISCARD.file(); // is the filename appropriate for the operating system
+         *     Redirect.DISCARD.file() != null && // is the filename appropriate for the operating system
          *     Redirect.DISCARD.type() == Redirect.Type.WRITE;
          * }
          * @since 9


### PR DESCRIPTION
Improve the documentation of Process use of system resources.

Describe the implementation closing streams when no longer referenced.
Clarify the interactions between inputStream and inputReader and errorStream and errorReader.
Add advice and example using try-with-resources to open and close streams.
Recommend closing streams when no longer in use.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8356311](https://bugs.openjdk.org/browse/JDK-8356311) to be approved

### Issues
 * [JDK-8354872](https://bugs.openjdk.org/browse/JDK-8354872): Clarify java.lang.Process resource cleanup (**Bug** - P4)
 * [JDK-8356311](https://bugs.openjdk.org/browse/JDK-8356311): Clarify java.lang.Process resource cleanup (**CSR**)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25884/head:pull/25884` \
`$ git checkout pull/25884`

Update a local copy of the PR: \
`$ git checkout pull/25884` \
`$ git pull https://git.openjdk.org/jdk.git pull/25884/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25884`

View PR using the GUI difftool: \
`$ git pr show -t 25884`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25884.diff">https://git.openjdk.org/jdk/pull/25884.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25884#issuecomment-2985602590)
</details>
