### PR TITLE
8359593: JFR: Instrumentation of java.lang.String corrupts recording

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/tracing/ExcludeList.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/tracing/ExcludeList.java
@@ -24,38 +24,46 @@
  */
 package jdk.jfr.internal.tracing;
 
+import java.util.Set;
+
 // // The JVM will skip all classes in the jdk.jfr module, so it's not added here.
 public final class ExcludeList {
     private static final String[] EXCLUDED_CLASSES = {
         // Used by MethodTiming event to accumulate invocations.
         "java/util/concurrent/atomic/AtomicLong",
-        // Used by EventWriter
+        // Used by EventWriter, directly or indirectly.
         "sun/misc/Unsafe",
-        "jdk/internal/misc/Unsafe;",
+        "jdk/internal/misc/Unsafe",
+        "java/lang/StringLatin1",
+        "java/lang/StringUTF16",
     };
 
     private static final String[] EXCLUDED_PREFIX = {
         // Used by MethodTiming event to store invocations, including inner classes.
         "java/util/concurrent/ConcurrentHashMap",
         // Can't trigger <clinit> of these classes during PlatformTracer::onMethodTrace(...)
-        "jdk/internal/", // jdk/internal/classfile, jdk/internal/loader and jdk/internal/foreign
+        // Also to avoid recursion with EventWriter::putString
+        "jdk/internal/", // jdk/internal/classfile, // jdk/internal/vm, jdk/internal/util, jdk/internal/loader and jdk/internal/foreign
         "java/lang/classfile/"
     };
 
-    private static final String[] EXCLUDED_METHODS = {
+    private static final Set<String> EXCLUDED_METHODS = Set.of(
         // Long used by MethodTiming event when looking up entry for timing entry
         "java.lang.Long::<init>",
         "java.lang.Long::valueOf",
-        "java.lang.Number::<init>"
-    };
+        "java.lang.Number::<init>",
+        // Used by EventWriter::putString, directly or indirectly.
+        "java.lang.String::charAt",
+        "java.lang.String::length",
+        "java.lang.String::coder", // Used by charAt(int)
+        "java.lang.String::checkIndex", // Used by charAt(int)
+        "java.lang.String::isLatin1", // Used by charAt()
+        "java.lang.String::equals", // Used by StringPool
+        "java.lang.String::hashCode" // Used by StringPool
+    );
 
     public static boolean containsMethod(String methodName) {
-        for (String method : EXCLUDED_METHODS) {
-            if (method.equals(methodName)) {
-                return true;
-            }
-        }
-        return false;
+        return EXCLUDED_METHODS.contains(methodName);
     }
 
     public static boolean containsClass(String className) {

--- a/test/jdk/jdk/jfr/event/tracing/TestTracedString.java
+++ b/test/jdk/jdk/jfr/event/tracing/TestTracedString.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jdk.jfr.event.tracing;
+
+import java.nio.file.Path;
+
+import jdk.jfr.Configuration;
+import jdk.jfr.Name;
+import jdk.jfr.Recording;
+import jdk.jfr.consumer.RecordedEvent;
+import jdk.jfr.consumer.RecordingFile;
+
+/**
+ * @test
+ * @summary Tests that java.lang.String can be traced.
+ * @requires vm.flagless
+ * @requires vm.hasJFR
+ * @library /test/lib
+ * @run main/othervm jdk.jfr.event.tracing.TestTracedString
+ **/
+public class TestTracedString {
+    private static long SEED = System.currentTimeMillis();
+
+    @Name("Message")
+    static class MessageEvent extends jdk.jfr.Event {
+        String message;
+        long checkSum;
+    }
+
+    public static void main(String[] args) throws Exception {
+        Configuration c = Configuration.getConfiguration("default");
+        Path file = Path.of("recording.jfr");
+        try (Recording r = new Recording(c)) {
+            r.enable("jdk.MethodTrace").with("filter", "java.lang.String");
+            r.start();
+            emit(100, "");
+            emit(100, "short");
+            emit(100, "medium medium medium medium medium medium 1");
+            emit(100, "medium medium medium medium medium medium 2");
+            emit(100, "long".repeat(100));
+            r.stop();
+            r.dump(file);
+            int count = 0;
+            for (RecordedEvent e : RecordingFile.readAllEvents(file)) {
+                if (e.getEventType().getName().equals("Message")) {
+                    String text = e.getString("message");
+                    long checkSum = e.getLong("checkSum");
+                    if (checkSum(text) != checkSum) {
+                        throw new Exception("Incorrect checksum for text " + text);
+                    }
+                    count++;
+                }
+            }
+            if (count != 500) {
+                throw new Exception("Expected 500 Message events. Got " + count);
+            }
+        }
+    }
+
+    private static void emit(int count, String text) {
+        long checkSum = checkSum(text);
+        for (int i = 0; i < count; i++) {
+            MessageEvent m = new MessageEvent();
+            m.message = text;
+            m.checkSum = checkSum;
+            m.commit();
+        }
+    }
+
+    private static long checkSum(String text) {
+        long checkSum = SEED;
+        for (int i = 0; i < text.length(); i++) {
+            checkSum += 17 * text.charAt(i);
+        }
+        return checkSum;
+    }
+}


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8359593](https://bugs.openjdk.org/browse/JDK-8359593): JFR: Instrumentation of java.lang.String corrupts recording (**Bug** - P2)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25886/head:pull/25886` \
`$ git checkout pull/25886`

Update a local copy of the PR: \
`$ git checkout pull/25886` \
`$ git pull https://git.openjdk.org/jdk.git pull/25886/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25886`

View PR using the GUI difftool: \
`$ git pr show -t 25886`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25886.diff">https://git.openjdk.org/jdk/pull/25886.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25886#issuecomment-2985769506)
</details>
