### PR TITLE
8359685: Test stress/compiler/deoptimize/Test.java fails Out of space in CodeCache

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/vm/mlvm/meth/stress/compiler/deoptimize/Test.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/mlvm/meth/stress/compiler/deoptimize/Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,7 +45,7 @@
  * @requires vm.debug != true
  *
  * @run main/othervm/timeout=300
- *      -XX:ReservedCodeCacheSize=100m
+ *      -XX:ReservedCodeCacheSize=200m
  *      vm.mlvm.meth.stress.compiler.deoptimize.Test
  *      -threadsPerCpu 4
  *      -threadsExtra 2
@@ -66,7 +66,7 @@
  * @requires vm.debug == true
  *
  * @run main/othervm/timeout=300
- *      -XX:ReservedCodeCacheSize=100m
+ *      -XX:ReservedCodeCacheSize=200m
  *      vm.mlvm.meth.stress.compiler.deoptimize.Test
  *      -threadsPerCpu 2
  *      -threadsExtra 2


### PR DESCRIPTION
Hi all,

Test test/hotspot/jtreg/vmTestbase/vm/mlvm/meth/stress/compiler/deoptimize/Test.java fails "Out of space in CodeCache" on machine which has huge CPU core number. This test will create lots of compile threads to stress test the compiler deoptimize, the thread number depends on the CPU core number, so on huge CPU core number machine this test will report "Out of space in CodeCache" failure.
The "java.lang.OutOfMemoryError: Out of space in CodeCache" seems not the expected error, and increase the max code cache memory will make this test run pass steady. Could we change ReservedCodeCacheSize from 100m to 200m?

Test-fix only, change has been verified on 256 core number linux-x86 machine and on 64 core number linux-x86 machine.