### PR TITLE
8359972: Problem list TestStaticCallStub until JDK-8359963 is fixed

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -79,6 +79,8 @@ compiler/ciReplay/TestIncrementalInlining.java 8349191 generic-all
 
 compiler/c2/TestVerifyConstraintCasts.java 8355574 generic-all
 
+compiler/c2/aarch64/TestStaticCallStub.java 8359963 linux-aarch64,macosx-aarch64
+
 #############################################################################
 
 # :hotspot_gc


### PR DESCRIPTION
The test is failing in our CI. Let's problem list it until [JDK-8359963](https://bugs.openjdk.org/browse/JDK-8359963) is fixed.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8359972](https://bugs.openjdk.org/browse/JDK-8359972): Problem list TestStaticCallStub until JDK-8359963 is fixed (**Sub-task** - P2)


### Reviewers
 * [Marc Chevalier](https://openjdk.org/census#mchevalier) (@marc-chevalier - Committer)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25890/head:pull/25890` \
`$ git checkout pull/25890`

Update a local copy of the PR: \
`$ git checkout pull/25890` \
`$ git pull https://git.openjdk.org/jdk.git pull/25890/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25890`

View PR using the GUI difftool: \
`$ git pr show -t 25890`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25890.diff">https://git.openjdk.org/jdk/pull/25890.diff</a>

</details>
