### PR TITLE
8360023: Add an insertion sort implementation to Hotspot

### DIFF
--- a/src/hotspot/share/utilities/growableArray.hpp
+++ b/src/hotspot/share/utilities/growableArray.hpp
@@ -27,12 +27,10 @@
 
 #include "memory/allocation.hpp"
 #include "memory/iterator.hpp"
-#include "utilities/checkedCast.hpp"
 #include "utilities/debug.hpp"
 #include "utilities/globalDefinitions.hpp"
 #include "utilities/ostream.hpp"
 #include "utilities/powerOfTwo.hpp"
-#include <type_traits>
 
 // A growable array.
 
@@ -103,10 +101,7 @@ public:
   }
 };
 
-template <typename E, bool is_const = true> class GrowableArrayIterator;
-
-template <typename E>
-using GrowableArrayNonConstIterator = GrowableArrayIterator<E, false>;
+template <typename E> class GrowableArrayIterator;
 
 // Extends GrowableArrayBase with a typed data array.
 //
@@ -192,14 +187,6 @@ public:
 
   GrowableArrayIterator<E> end() const {
     return GrowableArrayIterator<E>(this, length());
-  }
-
-  GrowableArrayIterator<E, false> ncbegin() {
-    return GrowableArrayNonConstIterator<E>(this, 0);
-  }
-
-  GrowableArrayIterator<E, false> ncend() {
-    return GrowableArrayNonConstIterator<E>(this, length());
   }
 
   E pop() {
@@ -878,84 +865,32 @@ public:
 
 // Custom STL-style iterator to iterate over GrowableArrays
 // It is constructed by invoking GrowableArray::begin() and GrowableArray::end()
-template <typename E, bool is_const>
+template <typename E>
 class GrowableArrayIterator : public StackObj {
   friend class GrowableArrayView<E>;
 
-private:
-  using C = std::conditional_t<is_const, const GrowableArrayView<E>, GrowableArrayView<E>>;
-
-  C* _array;     // GrowableArray we iterate over
-  int _position; // The current position in the GrowableArray
+ private:
+  const GrowableArrayView<E>* _array; // GrowableArray we iterate over
+  int _position;                      // The current position in the GrowableArray
 
   // Private constructor used in GrowableArray::begin() and GrowableArray::end()
-  GrowableArrayIterator(C* array, int position) : _array(array), _position(position) {
+  GrowableArrayIterator(const GrowableArrayView<E>* array, int position) : _array(array), _position(position) {
     assert(0 <= position && position <= _array->length(), "illegal position");
   }
 
-public:
-  using value_type = std::conditional_t<is_const, const E, E>;
-  using difference_type = int;
-  using reference = std::add_lvalue_reference_t<value_type>;
+ public:
+  GrowableArrayIterator() : _array(nullptr), _position(0) { }
+  GrowableArrayIterator& operator++() { ++_position; return *this; }
+  E operator*()                       { return _array->at(_position); }
 
-  GrowableArrayIterator() : _array(nullptr), _position(0) {}
-
-  GrowableArrayIterator operator+(difference_type i) const {
-    int new_pos = checked_cast<int>(jlong(_position) + jlong(i));
-    return GrowableArrayIterator(_array, new_pos);
-  }
-
-  GrowableArrayIterator operator-(difference_type i) const {
-    assert(i != min_jint, "invalid operand");
-    return *this + (-i);
-  }
-
-  GrowableArrayIterator& operator++() {
-    assert(_position < _array->length(), "illegal position");
-    ++_position;
-    return *this;
-  }
-
-  GrowableArrayIterator operator++(int) {
-    GrowableArrayIterator old = *this;
-    ++(*this);
-    return old;
-  }
-
-  GrowableArrayIterator& operator--() {
-    assert(_position > 0, "illegal position");
-    --_position;
-    return *this;
-  }
-
-  GrowableArrayIterator operator--(int) {
-    GrowableArrayIterator old = *this;
-    --(*this);
-    return old;
-  }
-
-  reference operator*() const {
-    return _array->at(_position);
-  }
-
-  bool operator==(const GrowableArrayIterator& rhs) const {
+  bool operator==(const GrowableArrayIterator& rhs)  {
     assert(_array == rhs._array, "iterator belongs to different array");
     return _position == rhs._position;
   }
 
-  bool operator!=(const GrowableArrayIterator& rhs) const {
+  bool operator!=(const GrowableArrayIterator& rhs)  {
     assert(_array == rhs._array, "iterator belongs to different array");
     return _position != rhs._position;
-  }
-
-  bool operator<(const GrowableArrayIterator& rhs) const {
-    assert(_array == rhs._array, "iterator belongs to different array");
-    return _position < rhs._position;
-  }
-
-  bool operator>(const GrowableArrayIterator& rhs) const {
-    assert(_array == rhs._array, "iterator belongs to different array");
-    return _position > rhs._position;
   }
 };
 

--- a/src/hotspot/share/utilities/growableArray.hpp
+++ b/src/hotspot/share/utilities/growableArray.hpp
@@ -105,6 +105,9 @@ public:
 
 template <typename E, bool is_const = true> class GrowableArrayIterator;
 
+template <typename E>
+using GrowableArrayNonConstIterator = GrowableArrayIterator<E, false>;
+
 // Extends GrowableArrayBase with a typed data array.
 //
 // E: Element type
@@ -192,11 +195,11 @@ public:
   }
 
   GrowableArrayIterator<E, false> ncbegin() {
-    return GrowableArrayIterator<E, false>(this, 0);
+    return GrowableArrayNonConstIterator<E>(this, 0);
   }
 
   GrowableArrayIterator<E, false> ncend() {
-    return GrowableArrayIterator<E, false>(this, length());
+    return GrowableArrayNonConstIterator<E>(this, length());
   }
 
   E pop() {

--- a/src/hotspot/share/utilities/sort.hpp
+++ b/src/hotspot/share/utilities/sort.hpp
@@ -61,7 +61,7 @@ public:
         pos = prev;
       }
 
-      // Shift all elements in [pos, current) up by one then move current_elem to pos
+      // Move current_elem to pos since all elements in [pos, current) have been shifted up by 1
       if (pos < current) {
         *pos = current_elem;
       }

--- a/src/hotspot/share/utilities/sort.hpp
+++ b/src/hotspot/share/utilities/sort.hpp
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+#ifndef SHARE_UTILITIES_SORT_HPP
+#define SHARE_UTILITIES_SORT_HPP
+
+#include "memory/allStatic.hpp"
+
+// An insertion sort that is stable and inplace.
+// This algorithm should be the ideal solution to sort a sequence with few elements. Arrays::sort
+// uses insertion sort for arrays up to around 50 elements.
+// For the requirements for the parameters, see those of std::sort.
+class InsertionSort : AllStatic {
+public:
+  template <class RandomIt, class Compare>
+  static void sort(RandomIt begin, RandomIt end, Compare comp) {
+    if (begin == end) {
+      // Empty array
+      return;
+    }
+
+    for (RandomIt current = begin + 1; current < end; current++) {
+      typename RandomIt::value_type current_elem = *current;
+
+      // Elements in [begin, current) has already been sorted, we search backward to find a
+      // location to insert the element at current
+      RandomIt pos = current;
+      while (pos > begin) {
+        // Since the sort is stable, we must insert the current element at the first location at
+        // which the element is not greater than the current element (note that we are traversing
+        // backward)
+        RandomIt prev = pos - 1;
+        if (!comp(current_elem, *prev)) {
+          break;
+        }
+
+        pos = prev;
+      }
+
+      // Shift all elements in [pos, current) up by one then move current_elem to pos
+      if (pos < current) {
+        for (RandomIt i = current; i > pos; i--) {
+          *i = *(i - 1);
+        }
+        *pos = current_elem;
+      }
+    }
+  }
+};
+
+#endif // SHARE_UTILITIES_SORT_HPP

--- a/src/hotspot/share/utilities/sort.hpp
+++ b/src/hotspot/share/utilities/sort.hpp
@@ -29,39 +29,41 @@
 // An insertion sort that is stable and inplace.
 // This algorithm should be the ideal solution to sort a sequence with few elements. Arrays::sort
 // uses insertion sort for arrays up to around 50 elements.
-// For the requirements for the parameters, see those of std::sort.
+// comp should return a value > 0 iff the first argument is larger than the second argument. A full
+// comparison function satisfies this requirement but a simple a > b ? 1 : 0 also satisfies it.
 class InsertionSort : AllStatic {
 public:
-  template <class RandomIt, class Compare>
-  static void sort(RandomIt begin, RandomIt end, Compare comp) {
-    if (begin == end) {
+  template <class T, class Compare>
+  static void sort(T* data, int size, Compare comp) {
+    if (size == 0) {
       // Empty array
       return;
     }
 
-    for (RandomIt current = begin + 1; current < end; current++) {
-      typename RandomIt::value_type current_elem = *current;
+    T* begin = data;
+    T* end = data + size;
+    for (T* current = begin + 1; current < end; current++) {
+      T current_elem = *current;
 
       // Elements in [begin, current) has already been sorted, we search backward to find a
-      // location to insert the element at current
-      RandomIt pos = current;
+      // location to insert the element at current. In the meantime, shift all elements on the way
+      // up by 1.
+      T* pos = current;
       while (pos > begin) {
         // Since the sort is stable, we must insert the current element at the first location at
         // which the element is not greater than the current element (note that we are traversing
         // backward)
-        RandomIt prev = pos - 1;
-        if (!comp(current_elem, *prev)) {
+        T* prev = pos - 1;
+        if (comp(*prev, current_elem) <= 0) {
           break;
         }
 
+        *pos = *prev;
         pos = prev;
       }
 
       // Shift all elements in [pos, current) up by one then move current_elem to pos
       if (pos < current) {
-        for (RandomIt i = current; i > pos; i--) {
-          *i = *(i - 1);
-        }
         *pos = current_elem;
       }
     }

--- a/src/hotspot/share/utilities/sort.hpp
+++ b/src/hotspot/share/utilities/sort.hpp
@@ -49,7 +49,7 @@ public:
       // up by 1.
       T* pos = current;
       while (pos > begin) {
-        // Since the sort is stable, we must insert the current element at the first location at
+        // Because the sort is stable, we must insert the current element at the first location at
         // which the element is not greater than the current element (note that we are traversing
         // backward)
         T* prev = pos - 1;

--- a/src/hotspot/share/utilities/sort.hpp
+++ b/src/hotspot/share/utilities/sort.hpp
@@ -36,7 +36,6 @@ public:
   template <class T, class Compare>
   static void sort(T* data, int size, Compare comp) {
     if (size == 0) {
-      // Empty array
       return;
     }
 

--- a/test/hotspot/gtest/utilities/test_sort.cpp
+++ b/test/hotspot/gtest/utilities/test_sort.cpp
@@ -23,9 +23,8 @@
  */
 
 #include "runtime/os.hpp"
-#include <utilities/globalDefinitions.hpp>
 #include "utilities/powerOfTwo.hpp"
-#include <utilities/sort.hpp>
+#include "utilities/sort.hpp"
 #include "unittest.hpp"
 
 constexpr int TEST_ARRAY_SIZE = 128;

--- a/test/hotspot/gtest/utilities/test_sort.cpp
+++ b/test/hotspot/gtest/utilities/test_sort.cpp
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#include "runtime/os.hpp"
+#include "utilities/growableArray.hpp"
+#include <utilities/globalDefinitions.hpp>
+#include <utilities/sort.hpp>
+#include "unittest.hpp"
+
+constexpr size_t SIZE = 128;
+
+class TwoInt {
+public:
+  int val;
+  int idx;
+
+  TwoInt() : val(0), idx(0) {}
+  TwoInt(int val, int idx) : val(val), idx(idx) {}
+};
+
+int ARRAY0[SIZE];
+TwoInt ARRAY1[SIZE];
+
+// Verify that the sort is correct, i.e. a[i] <= a[i + 1]
+void test_insertion_sort() {
+  for (size_t i = 0; i < SIZE; i++) {
+    ARRAY0[i] = os::random();
+  }
+  GrowableArrayFromArray<int> view(ARRAY0, SIZE);
+  InsertionSort::sort(view.ncbegin(), view.ncend(), [](int a, int b) {
+    return a < b;
+  });
+  for (size_t i = 0; i < SIZE - 1; i++) {
+    ASSERT_TRUE(ARRAY0[i] <= ARRAY0[i + 1]);
+  }
+}
+
+// Verify that the sort is stable. Since there are 128 elements but the keys can only take 16
+// values, there will inevitably be a lot of elements with the same key. We then verify that if the
+// keys of 2 elements are the same, then the element that has the smaller idx will be ordered
+// before the one with the larger idx.
+void test_insertion_sort_stable() {
+  for (size_t i = 0; i < SIZE; i++) {
+    ARRAY1[i] = TwoInt(os::random() & 15, i);
+  }
+  GrowableArrayFromArray<TwoInt> view(ARRAY1, SIZE);
+  InsertionSort::sort(view.ncbegin(), view.ncend(), [](TwoInt a, TwoInt b) {
+    return a.val < b.val;
+  });
+  for (size_t i = 0; i < SIZE - 1; i++) {
+    TwoInt a = ARRAY1[i];
+    TwoInt b = ARRAY1[i + 1];
+    ASSERT_TRUE(a.val <= b.val);
+    if (a.val == b.val) {
+      ASSERT_TRUE(a.idx < b.idx);
+    }
+  }
+}
+
+TEST(utilities, insertion_sort) {
+  for (int i = 0; i < 100; i++) {
+    test_insertion_sort();
+    test_insertion_sort_stable();
+  }
+}

--- a/test/hotspot/gtest/utilities/test_sort.cpp
+++ b/test/hotspot/gtest/utilities/test_sort.cpp
@@ -23,9 +23,9 @@
  */
 
 #include "runtime/os.hpp"
+#include "unittest.hpp"
 #include "utilities/powerOfTwo.hpp"
 #include "utilities/sort.hpp"
-#include "unittest.hpp"
 
 constexpr int TEST_ARRAY_SIZE = 128;
 

--- a/test/hotspot/gtest/utilities/test_sort.cpp
+++ b/test/hotspot/gtest/utilities/test_sort.cpp
@@ -28,7 +28,7 @@
 #include <utilities/sort.hpp>
 #include "unittest.hpp"
 
-constexpr size_t SIZE = 128;
+constexpr int TEST_ARRAY_SIZE = 128;
 
 class TwoInt {
 public:
@@ -39,19 +39,19 @@ public:
   TwoInt(int val, int idx) : val(val), idx(idx) {}
 };
 
-int ARRAY0[SIZE];
-TwoInt ARRAY1[SIZE];
+int ARRAY0[TEST_ARRAY_SIZE];
+TwoInt ARRAY1[TEST_ARRAY_SIZE];
 
 // Verify that the sort is correct, i.e. a[i] <= a[i + 1]
 void test_insertion_sort() {
-  for (size_t i = 0; i < SIZE; i++) {
+  for (int i = 0; i < TEST_ARRAY_SIZE; i++) {
     ARRAY0[i] = os::random();
   }
-  GrowableArrayFromArray<int> view(ARRAY0, SIZE);
+  GrowableArrayFromArray<int> view(ARRAY0, TEST_ARRAY_SIZE);
   InsertionSort::sort(view.ncbegin(), view.ncend(), [](int a, int b) {
     return a < b;
   });
-  for (size_t i = 0; i < SIZE - 1; i++) {
+  for (int i = 0; i < TEST_ARRAY_SIZE - 1; i++) {
     ASSERT_TRUE(ARRAY0[i] <= ARRAY0[i + 1]);
   }
 }
@@ -61,14 +61,14 @@ void test_insertion_sort() {
 // keys of 2 elements are the same, then the element that has the smaller idx will be ordered
 // before the one with the larger idx.
 void test_insertion_sort_stable() {
-  for (size_t i = 0; i < SIZE; i++) {
+  for (int i = 0; i < TEST_ARRAY_SIZE; i++) {
     ARRAY1[i] = TwoInt(os::random() & 15, i);
   }
-  GrowableArrayFromArray<TwoInt> view(ARRAY1, SIZE);
+  GrowableArrayFromArray<TwoInt> view(ARRAY1, TEST_ARRAY_SIZE);
   InsertionSort::sort(view.ncbegin(), view.ncend(), [](TwoInt a, TwoInt b) {
     return a.val < b.val;
   });
-  for (size_t i = 0; i < SIZE - 1; i++) {
+  for (int i = 0; i < TEST_ARRAY_SIZE - 1; i++) {
     TwoInt a = ARRAY1[i];
     TwoInt b = ARRAY1[i + 1];
     ASSERT_TRUE(a.val <= b.val);


### PR DESCRIPTION
Hi,

This PR adds an implementation of insertion sort to Hotspot. It is an algorithm that is inplace and stable, and it is the ideal algorithm for arrays with small numbers of elements. The motivation for this is [JDK-8357186](https://bugs.openjdk.org/browse/JDK-8357186) in which a stable sort is desired and the number of elements is small. Additionally, since insertion sort is the most efficient sorting algorithm for small arrays, it can be used in non-stable sort as well.

In addition, I make some improvements to `GrowableArrayIterator`:

- Make a non-const variant (our current iterator is const only).
- Add various utility operators to align with a typical iterator.

[JDK-8360032](https://bugs.openjdk.org/browse/JDK-8360032) is a follow-up work that will build a stable merge-insertion sort on top of this PR.

Please take a look and share your thoughts. Thanks very much.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8360023](https://bugs.openjdk.org/browse/JDK-8360023): Add an insertion sort implementation to Hotspot (**Enhancement** - P4)


### Reviewers
 * [Evgeny Astigeevich](https://openjdk.org/census#eastigeevich) (@eastig - Committer)
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@jdksjolen - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25895/head:pull/25895` \
`$ git checkout pull/25895`

Update a local copy of the PR: \
`$ git checkout pull/25895` \
`$ git pull https://git.openjdk.org/jdk.git pull/25895/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25895`

View PR using the GUI difftool: \
`$ git pr show -t 25895`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25895.diff">https://git.openjdk.org/jdk/pull/25895.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25895#issuecomment-2987691765)
</details>
