### PR TITLE
8360024: Reorganize GC VM operations and implement is_gc_operation

### DIFF
--- a/src/hotspot/share/cds/dynamicArchive.cpp
+++ b/src/hotspot/share/cds/dynamicArchive.cpp
@@ -382,11 +382,11 @@ void DynamicArchiveBuilder::gather_array_klasses() {
   log_debug(aot)("Total array klasses gathered for dynamic archive: %d", DynamicArchive::num_array_klasses());
 }
 
-class VM_PopulateDynamicDumpSharedSpace: public VM_GC_Sync_Operation {
+class VM_PopulateDynamicDumpSharedSpace: public VM_Heap_Sync_Operation {
   DynamicArchiveBuilder _builder;
 public:
   VM_PopulateDynamicDumpSharedSpace(const char* archive_name)
-  : VM_GC_Sync_Operation(), _builder(archive_name) {}
+  : VM_Heap_Sync_Operation(), _builder(archive_name) {}
   VMOp_Type type() const { return VMOp_PopulateDumpSharedSpace; }
   void doit() {
     ResourceMark rm;

--- a/src/hotspot/share/gc/g1/g1VMOperations.cpp
+++ b/src/hotspot/share/gc/g1/g1VMOperations.cpp
@@ -57,7 +57,7 @@ void VM_G1CollectFull::doit() {
 
 VM_G1TryInitiateConcMark::VM_G1TryInitiateConcMark(uint gc_count_before,
                                                    GCCause::Cause gc_cause) :
-  VM_GC_Operation(gc_count_before, gc_cause),
+  VM_GC_Collect_Operation(gc_count_before, gc_cause),
   _transient_failure(false),
   _cycle_already_in_progress(false),
   _whitebox_attached(false),

--- a/src/hotspot/share/gc/g1/g1VMOperations.hpp
+++ b/src/hotspot/share/gc/g1/g1VMOperations.hpp
@@ -30,7 +30,7 @@
 
 // VM_operations for the G1 collector.
 
-class VM_G1CollectFull : public VM_GC_Operation {
+class VM_G1CollectFull : public VM_GC_Collect_Operation {
 protected:
   bool skip_operation() const override;
 
@@ -38,12 +38,12 @@ public:
   VM_G1CollectFull(uint gc_count_before,
                    uint full_gc_count_before,
                    GCCause::Cause cause) :
-    VM_GC_Operation(gc_count_before, cause, full_gc_count_before, true) { }
+    VM_GC_Collect_Operation(gc_count_before, cause, full_gc_count_before, true) { }
   VMOp_Type type() const override { return VMOp_G1CollectFull; }
   void doit() override;
 };
 
-class VM_G1TryInitiateConcMark : public VM_GC_Operation {
+class VM_G1TryInitiateConcMark : public VM_GC_Collect_Operation {
   bool _transient_failure;
   bool _cycle_already_in_progress;
   bool _whitebox_attached;
@@ -89,6 +89,7 @@ public:
   bool doit_prologue() override;
   void doit_epilogue() override;
   void doit() override;
+  bool is_gc_operation() const override { return true; }
 };
 
 class VM_G1PauseRemark : public VM_G1PauseConcurrent {

--- a/src/hotspot/share/gc/parallel/psVMOperations.cpp
+++ b/src/hotspot/share/gc/parallel/psVMOperations.cpp
@@ -52,9 +52,9 @@ static bool is_cause_full(GCCause::Cause cause) {
 
 // Only used for System.gc() calls
 VM_ParallelGCCollect::VM_ParallelGCCollect(uint gc_count,
-                                             uint full_gc_count,
-                                             GCCause::Cause gc_cause) :
-  VM_GC_Operation(gc_count, gc_cause, full_gc_count, is_cause_full(gc_cause)) {}
+                                           uint full_gc_count,
+                                           GCCause::Cause gc_cause) :
+  VM_GC_Collect_Operation(gc_count, gc_cause, full_gc_count, is_cause_full(gc_cause)) {}
 
 void VM_ParallelGCCollect::doit() {
   ParallelScavengeHeap* heap = ParallelScavengeHeap::heap();

--- a/src/hotspot/share/gc/parallel/psVMOperations.hpp
+++ b/src/hotspot/share/gc/parallel/psVMOperations.hpp
@@ -40,7 +40,7 @@ public:
   virtual void doit();
 };
 
-class VM_ParallelGCCollect: public VM_GC_Operation {
+class VM_ParallelGCCollect: public VM_GC_Collect_Operation {
  public:
   VM_ParallelGCCollect(uint gc_count, uint full_gc_count, GCCause::Cause gc_cause);
   virtual VMOp_Type type() const { return VMOp_ParallelGCCollect; }

--- a/src/hotspot/share/gc/serial/serialVMOperations.hpp
+++ b/src/hotspot/share/gc/serial/serialVMOperations.hpp
@@ -45,13 +45,13 @@ class VM_SerialCollectForAllocation : public VM_CollectForAllocation {
 
 // VM operation to invoke a collection of the heap as a
 // SerialHeap heap.
-class VM_SerialGCCollect: public VM_GC_Operation {
+class VM_SerialGCCollect: public VM_GC_Collect_Operation {
  public:
   VM_SerialGCCollect(bool full,
                      uint gc_count_before,
                      uint full_gc_count_before,
                      GCCause::Cause gc_cause)
-    : VM_GC_Operation(gc_count_before, gc_cause, full_gc_count_before, full) {}
+    : VM_GC_Collect_Operation(gc_count_before, gc_cause, full_gc_count_before, full) {}
 
   virtual VMOp_Type type() const { return VMOp_SerialGCCollect; }
   virtual void doit();

--- a/src/hotspot/share/gc/shared/gcVMOperations.cpp
+++ b/src/hotspot/share/gc/shared/gcVMOperations.cpp
@@ -48,12 +48,12 @@
 #include "gc/g1/g1Policy.hpp"
 #endif // INCLUDE_G1GC
 
-bool VM_GC_Sync_Operation::doit_prologue() {
+bool VM_Heap_Sync_Operation::doit_prologue() {
   Heap_lock->lock();
   return true;
 }
 
-void VM_GC_Sync_Operation::doit_epilogue() {
+void VM_Heap_Sync_Operation::doit_epilogue() {
   Heap_lock->unlock();
 }
 
@@ -115,7 +115,7 @@ bool VM_GC_Operation::doit_prologue() {
   if (should_use_gclocker()) {
     GCLocker::block();
   }
-  VM_GC_Sync_Operation::doit_prologue();
+  VM_Heap_Sync_Operation::doit_prologue();
 
   // Check invocations
   if (skip_operation()) {
@@ -139,7 +139,7 @@ void VM_GC_Operation::doit_epilogue() {
   if (Universe::has_reference_pending_list()) {
     Heap_lock->notify_all();
   }
-  VM_GC_Sync_Operation::doit_epilogue();
+  VM_Heap_Sync_Operation::doit_epilogue();
   if (should_use_gclocker()) {
     GCLocker::unblock();
   }
@@ -206,7 +206,7 @@ VM_CollectForMetadataAllocation::VM_CollectForMetadataAllocation(ClassLoaderData
                                                                  uint gc_count_before,
                                                                  uint full_gc_count_before,
                                                                  GCCause::Cause gc_cause)
-    : VM_GC_Operation(gc_count_before, gc_cause, full_gc_count_before, true),
+    : VM_GC_Collect_Operation(gc_count_before, gc_cause, full_gc_count_before, true),
       _result(nullptr), _size(size), _mdtype(mdtype), _loader_data(loader_data) {
   assert(_size != 0, "An allocation should always be requested with this operation.");
   AllocTracer::send_allocation_requiring_gc_event(_size * HeapWordSize, GCId::peek());
@@ -269,7 +269,7 @@ void VM_CollectForMetadataAllocation::doit() {
 }
 
 VM_CollectForAllocation::VM_CollectForAllocation(size_t word_size, uint gc_count_before, GCCause::Cause cause)
-    : VM_GC_Operation(gc_count_before, cause), _word_size(word_size), _result(nullptr) {
+    : VM_GC_Collect_Operation(gc_count_before, cause), _word_size(word_size), _result(nullptr) {
   // Only report if operation was really caused by an allocation.
   if (_word_size != 0) {
     AllocTracer::send_allocation_requiring_gc_event(_word_size * HeapWordSize, GCId::peek());

--- a/src/hotspot/share/gc/shared/gcVMOperations.hpp
+++ b/src/hotspot/share/gc/shared/gcVMOperations.hpp
@@ -37,19 +37,22 @@
 // a set of operations (VM_Operation) related to GC.
 //
 //  VM_Operation
-//    VM_GC_Sync_Operation
+//    VM_Heap_Sync_Operation
 //      VM_GC_Operation
-//        VM_GC_HeapInspection
-//        VM_PopulateDynamicDumpSharedSpace
-//        VM_SerialGCCollect
-//        VM_ParallelGCCollect
-//        VM_CollectForAllocation
-//          VM_SerialCollectForAllocation
-//          VM_ParallelCollectForAllocation
+//        VM_GC_Collect_Operation
+//          VM_SerialGCCollect
+//          VM_ParallelGCCollect
+//          VM_CollectForAllocation
+//            VM_SerialCollectForAllocation
+//            VM_ParallelCollectForAllocation
+//          VM_CollectForMetadataAllocation
+//        VM_GC_Service_Operation
+//          VM_GC_HeapInspection
 //      VM_Verify
+//      VM_PopulateDynamicDumpSharedSpace
 //      VM_PopulateDumpSharedSpace
 //
-//  VM_GC_Sync_Operation
+//  VM_Heap_Sync_Operation
 //   - implements only synchronization with other VM operations of the
 //     same kind using the Heap_lock, not actually doing a GC.
 //
@@ -84,10 +87,10 @@
 //   - creates the CDS archive
 //
 
-class VM_GC_Sync_Operation : public VM_Operation {
+class VM_Heap_Sync_Operation : public VM_Operation {
 public:
 
-  VM_GC_Sync_Operation() : VM_Operation() { }
+  VM_Heap_Sync_Operation() : VM_Operation() { }
 
   // Acquires the Heap_lock.
   virtual bool doit_prologue();
@@ -95,13 +98,13 @@ public:
   virtual void doit_epilogue();
 };
 
-class VM_Verify : public VM_GC_Sync_Operation {
+class VM_Verify : public VM_Heap_Sync_Operation {
  public:
   VMOp_Type type() const { return VMOp_Verify; }
   void doit();
 };
 
-class VM_GC_Operation: public VM_GC_Sync_Operation {
+class VM_GC_Operation: public VM_Heap_Sync_Operation {
  protected:
   uint           _gc_count_before;         // gc count before acquiring the Heap_lock
   uint           _full_gc_count_before;    // full gc count before acquiring the Heap_lock
@@ -115,7 +118,7 @@ class VM_GC_Operation: public VM_GC_Sync_Operation {
   VM_GC_Operation(uint gc_count_before,
                   GCCause::Cause _cause,
                   uint full_gc_count_before = 0,
-                  bool full = false) : VM_GC_Sync_Operation() {
+                  bool full = false) : VM_Heap_Sync_Operation() {
     _full = full;
     _prologue_succeeded = false;
     _gc_count_before    = gc_count_before;
@@ -149,16 +152,37 @@ class VM_GC_Operation: public VM_GC_Sync_Operation {
   static void notify_gc_end();
 };
 
+class VM_GC_Service_Operation : public VM_GC_Operation {
+public:
+  VM_GC_Service_Operation(uint gc_count_before,
+                          GCCause::Cause _cause,
+                          uint full_gc_count_before = 0,
+                          bool full = false) :
+    VM_GC_Operation(gc_count_before, _cause, full_gc_count_before, full) {}
+};
 
-class VM_GC_HeapInspection: public VM_GC_Operation {
+class VM_GC_Collect_Operation : public VM_GC_Operation {
+public:
+  VM_GC_Collect_Operation(uint gc_count_before,
+                          GCCause::Cause _cause,
+                          uint full_gc_count_before = 0,
+                          bool full = false) :
+    VM_GC_Operation(gc_count_before, _cause, full_gc_count_before, full) {}
+
+  bool is_gc_operation() const { return true; }
+};
+
+
+class VM_GC_HeapInspection : public VM_GC_Service_Operation {
  private:
   outputStream* _out;
   bool _full_gc;
   uint _parallel_thread_num;
+
  public:
   VM_GC_HeapInspection(outputStream* out, bool request_full_gc,
                        uint parallel_thread_num = 1) :
-    VM_GC_Operation(0 /* total collections,      dummy, ignored */,
+    VM_GC_Service_Operation(0 /* total collections,      dummy, ignored */,
                     GCCause::_heap_inspection /* GC Cause */,
                     0 /* total full collections, dummy, ignored */,
                     request_full_gc), _out(out), _full_gc(request_full_gc),
@@ -169,11 +193,12 @@ class VM_GC_HeapInspection: public VM_GC_Operation {
   virtual bool skip_operation() const;
   virtual bool doit_prologue();
   virtual void doit();
+
  protected:
   bool collect();
 };
 
-class VM_CollectForAllocation : public VM_GC_Operation {
+class VM_CollectForAllocation : public VM_GC_Collect_Operation {
  protected:
   size_t    _word_size; // Size of object to be allocated (in number of words)
   HeapWord* _result;    // Allocation result (null if allocation failed)
@@ -186,7 +211,7 @@ class VM_CollectForAllocation : public VM_GC_Operation {
   }
 };
 
-class VM_CollectForMetadataAllocation: public VM_GC_Operation {
+class VM_CollectForMetadataAllocation: public VM_GC_Collect_Operation {
  private:
   MetaWord*                _result;
   size_t                   _size;     // size of object to be allocated

--- a/src/hotspot/share/gc/shared/gcVMOperations.hpp
+++ b/src/hotspot/share/gc/shared/gcVMOperations.hpp
@@ -183,10 +183,10 @@ class VM_GC_HeapInspection : public VM_GC_Service_Operation {
   VM_GC_HeapInspection(outputStream* out, bool request_full_gc,
                        uint parallel_thread_num = 1) :
     VM_GC_Service_Operation(0 /* total collections,      dummy, ignored */,
-                    GCCause::_heap_inspection /* GC Cause */,
-                    0 /* total full collections, dummy, ignored */,
-                    request_full_gc), _out(out), _full_gc(request_full_gc),
-                    _parallel_thread_num(parallel_thread_num) {}
+                            GCCause::_heap_inspection /* GC Cause */,
+                            0 /* total full collections, dummy, ignored */,
+                            request_full_gc), _out(out), _full_gc(request_full_gc),
+                            _parallel_thread_num(parallel_thread_num) {}
 
   ~VM_GC_HeapInspection() {}
   virtual VMOp_Type type() const { return VMOp_GC_HeapInspection; }

--- a/src/hotspot/share/gc/shenandoah/shenandoahVMOperations.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahVMOperations.hpp
@@ -55,6 +55,8 @@ public:
   void log_active_generation(const char* prefix);
   bool doit_prologue() override;
   void doit_epilogue() override;
+
+  bool is_gc_operation() const override { return true; };
 };
 
 class VM_ShenandoahReferenceOperation : public VM_ShenandoahOperation {

--- a/src/hotspot/share/gc/z/zGeneration.cpp
+++ b/src/hotspot/share/gc/z/zGeneration.cpp
@@ -442,6 +442,8 @@ public:
     OopMapCache::try_trigger_cleanup();
   }
 
+  virtual bool is_gc_operation() const { return true; }
+
   bool success() const {
     return _success;
   }
@@ -1307,6 +1309,8 @@ class ZRendezvousGCThreads: public VM_Operation {
     fatal("Concurrent VMOps should not call this");
     return true;
   }
+
+  virtual bool is_gc_operation() const { return true; }
 
   void doit() {
     // Light weight "handshake" of the GC threads

--- a/src/hotspot/share/gc/z/zGeneration.cpp
+++ b/src/hotspot/share/gc/z/zGeneration.cpp
@@ -442,7 +442,9 @@ public:
     OopMapCache::try_trigger_cleanup();
   }
 
-  virtual bool is_gc_operation() const { return true; }
+  virtual bool is_gc_operation() const {
+    return true;
+  }
 
   bool success() const {
     return _success;
@@ -1310,7 +1312,9 @@ class ZRendezvousGCThreads: public VM_Operation {
     return true;
   }
 
-  virtual bool is_gc_operation() const { return true; }
+  virtual bool is_gc_operation() const {
+    return true;
+  }
 
   void doit() {
     // Light weight "handshake" of the GC threads

--- a/src/hotspot/share/gc/z/zMark.cpp
+++ b/src/hotspot/share/gc/z/zMark.cpp
@@ -579,7 +579,9 @@ public:
     return VMOp_ZMarkFlushOperation;
   }
 
-  virtual bool is_gc_operation() const { return true; }
+  virtual bool is_gc_operation() const {
+    return true;
+  }
 };
 
 bool ZMark::flush() {

--- a/src/hotspot/share/gc/z/zMark.cpp
+++ b/src/hotspot/share/gc/z/zMark.cpp
@@ -578,6 +578,8 @@ public:
   virtual VMOp_Type type() const {
     return VMOp_ZMarkFlushOperation;
   }
+
+  virtual bool is_gc_operation() const { return true; }
 };
 
 bool ZMark::flush() {

--- a/src/hotspot/share/runtime/vmOperation.hpp
+++ b/src/hotspot/share/runtime/vmOperation.hpp
@@ -160,8 +160,8 @@ class VM_Operation : public StackObj {
   virtual VMOp_Type type() const = 0;
   virtual bool allow_nested_vm_operations() const { return false; }
 
-  // VMOp_Type may belong to a category of operation
-  // Override is_XX_operation() appropriately in subclasses
+  // VMOp_Type may belong to a category of the operation.
+  // Override is_XX_operation() appropriately in subclasses.
   virtual bool is_gc_operation() const { return false; }
 
   // You may override skip_thread_oop_barriers to return true if the operation

--- a/src/hotspot/share/runtime/vmOperation.hpp
+++ b/src/hotspot/share/runtime/vmOperation.hpp
@@ -168,6 +168,8 @@ class VM_Operation : public StackObj {
   // or concurrently with Java threads running.
   virtual bool evaluate_at_safepoint() const { return true; }
 
+  virtual bool is_gc_operation() const { return false; }
+
   // Debugging
   virtual void print_on_error(outputStream* st) const;
   virtual const char* name() const  { return _names[type()]; }

--- a/src/hotspot/share/runtime/vmOperation.hpp
+++ b/src/hotspot/share/runtime/vmOperation.hpp
@@ -160,6 +160,10 @@ class VM_Operation : public StackObj {
   virtual VMOp_Type type() const = 0;
   virtual bool allow_nested_vm_operations() const { return false; }
 
+  // VMOp_Type may belong to a category of operation
+  // Override is_XX_operation() appropriately in subclasses
+  virtual bool is_gc_operation() const { return false; }
+
   // You may override skip_thread_oop_barriers to return true if the operation
   // does not access thread-private oops (including frames).
   virtual bool skip_thread_oop_barriers() const { return false; }
@@ -167,8 +171,6 @@ class VM_Operation : public StackObj {
   // An operation can either be done inside a safepoint
   // or concurrently with Java threads running.
   virtual bool evaluate_at_safepoint() const { return true; }
-
-  virtual bool is_gc_operation() const { return false; }
 
   // Debugging
   virtual void print_on_error(outputStream* st) const;


### PR DESCRIPTION
[JDK-8359110](https://bugs.openjdk.org/browse/JDK-8359110) introduces a need to be able to categorize VM operations to be able to track GC activity in the VM thread for CPU time tracking. This patch will reorganize the shared GC VM operations in gcVMOperations.hpp to make a distinction between GC operations and serviceability/CDS etc. operations performed in the VM thread for the GC.

Additionally the ability to query `is_gc_operation()` is introduced in the base class `VM_Operation` and overridden in appropriate VM operations. This provides a clear and efficient interface to query the category of a VM operation.

Proposed changes in the shared class hierarchy:

```
//  VM_Operation
//    VM_Heap_Sync_Operation
//      VM_GC_Operation
//        VM_GC_Collect_Operation
//          VM_SerialGCCollect
//          VM_ParallelGCCollect
//          VM_CollectForAllocation
//            VM_SerialCollectForAllocation
//            VM_ParallelCollectForAllocation
//          VM_CollectForMetadataAllocation
//        VM_GC_Service_Operation
//          VM_GC_HeapInspection
//      VM_Verify
//      VM_PopulateDynamicDumpSharedSpace
//      VM_PopulateDumpSharedSpace
```

Renaming `VM_GC_Sync_Operation` to `VM_Heap_Sync_Operation` to make it clear that not all sub-classes is related to GC (shout-out to @kstefanj / @stefank for that suggestion). While `VM_GC_HeapInspection` is a serviceability operation it attempts to trigger a collection, hence it is put underneath `VM_GC_Collect_Operation->VM_GC_Service_Operation`. However only classes that inherits from `VM_GC_Collect_Operation` are considered to return `true` for `is_gc_operation()` as `VM_GC_HeapInspection` is considered to not belong to "GC activity".

ZGC and Shenandoah do not use sub-classing of `VM_Heap_Sync_Operation`, but their respective base classes and special classes for GC activity are marked as returning `true` for `is_gc_operation()`.

The only `is_XX_operation` that is specified in `VM_Operation` is `is_gc_operation` to not clutter with cases that are not used (`is_gc_operation` will be used by JDK-8359110). That being said, these behavioral queries may be extended in case we want to explore CPU time tracking beyond the GC component.

_Note: PR for JDK-8359110 already contains a proposal for `is_gc_operation` but it was deemed that it was more appropriate to bring along that change during reorganization of GC VM operations since implementing it at the correct places without this change would require a lot more overrides..._

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8360024](https://bugs.openjdk.org/browse/JDK-8360024): Reorganize GC VM operations and implement is_gc_operation (**Enhancement** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) Review applies to [7c8e6d81](https://git.openjdk.org/jdk/pull/25896/files/7c8e6d817860dba0453c9fbb7fd52fe75d7264fa)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25896/head:pull/25896` \
`$ git checkout pull/25896`

Update a local copy of the PR: \
`$ git checkout pull/25896` \
`$ git pull https://git.openjdk.org/jdk.git pull/25896/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25896`

View PR using the GUI difftool: \
`$ git pr show -t 25896`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25896.diff">https://git.openjdk.org/jdk/pull/25896.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25896#issuecomment-2988078123)
</details>
