### PR TITLE
8358572: C1 hits "need debug information" assert with -XX:-DeoptC1

### DIFF
--- a/src/hotspot/share/c1/c1_Compilation.cpp
+++ b/src/hotspot/share/c1/c1_Compilation.cpp
@@ -668,7 +668,7 @@ ciKlass* Compilation::cha_exact_type(ciType* type) {
   if (type != nullptr && type->is_loaded() && type->is_instance_klass()) {
     ciInstanceKlass* ik = type->as_instance_klass();
     assert(ik->exact_klass() == nullptr, "no cha for final klass");
-    if (DeoptC1 && UseCHA && !(ik->has_subklass() || ik->is_interface())) {
+    if (UseCHA && !(ik->has_subklass() || ik->is_interface())) {
       dependency_recorder()->assert_leaf_type(ik);
       return ik;
     }

--- a/src/hotspot/share/c1/c1_GraphBuilder.cpp
+++ b/src/hotspot/share/c1/c1_GraphBuilder.cpp
@@ -1855,7 +1855,6 @@ void GraphBuilder::access_field(Bytecodes::Code code) {
 
 
 Dependencies* GraphBuilder::dependency_recorder() const {
-  assert(DeoptC1, "need debug information");
   return compilation()->dependency_recorder();
 }
 
@@ -2001,7 +2000,7 @@ void GraphBuilder::invoke(Bytecodes::Code code) {
   ciMethod* cha_monomorphic_target = nullptr;
   ciMethod* exact_target = nullptr;
   Value better_receiver = nullptr;
-  if (UseCHA && DeoptC1 && target->is_loaded() &&
+  if (UseCHA && target->is_loaded() &&
       !(// %%% FIXME: Are both of these relevant?
         target->is_method_handle_intrinsic() ||
         target->is_compiled_lambda_form()) &&
@@ -2252,7 +2251,7 @@ bool GraphBuilder::direct_compare(ciKlass* k) {
     if (ik->is_final()) {
       return true;
     } else {
-      if (DeoptC1 && UseCHA && !(ik->has_subklass() || ik->is_interface())) {
+      if (UseCHA && !(ik->has_subklass() || ik->is_interface())) {
         // test class is leaf class
         dependency_recorder()->assert_leaf_type(ik);
         return true;

--- a/src/hotspot/share/c1/c1_globals.hpp
+++ b/src/hotspot/share/c1/c1_globals.hpp
@@ -244,9 +244,6 @@
   develop(bool, GenerateArrayStoreCheck, true,                              \
           "Generates code for array store checks")                          \
                                                                             \
-  develop(bool, DeoptC1, true,                                              \
-          "Use deoptimization in C1")                                       \
-                                                                            \
   develop(bool, PrintBailouts, false,                                       \
           "Print bailout and its reason")                                   \
                                                                             \


### PR DESCRIPTION
The debug flag `DeoptC1` is required to be true for dependency recording by an assert, but not all uses of dependency recording in C1 are guarded with `if (DeoptC1)`. Hence, running `java -XX:-DeoptC1 -version`fails at the aforementioned assert.

This error has been present unconditionally in debug builds since dependency recording was enabled outside of JVMTI in [JDK-8324241]([https://bugs.openjdk.org/browse/JDK-8324241) and at least since JDK7 with JVMTI. Because this issue was discovered by searching for crashes of `java -version` plus some other flag, which indicates this flag has not been used in at least one year since every invocation with `-XX:-DeoptC1`crashes. Further, `DeoptC1` is only used for guarding dependency recording in three places. Thus, this PR removes the `DeoptC1` flag.

This was tested with:
 - [ ] [Github Actions](https://github.com/mhaessig/jdk/actions/runs/15760179189)
 - [x] tier1, tier2 plus Oracle internal testing on Oracle supported platforms

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8358572](https://bugs.openjdk.org/browse/JDK-8358572): C1 hits "need debug information" assert with -XX:-DeoptC1 (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25900/head:pull/25900` \
`$ git checkout pull/25900`

Update a local copy of the PR: \
`$ git checkout pull/25900` \
`$ git pull https://git.openjdk.org/jdk.git pull/25900/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25900`

View PR using the GUI difftool: \
`$ git pr show -t 25900`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25900.diff">https://git.openjdk.org/jdk/pull/25900.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25900#issuecomment-2988431614)
</details>
