### PR TITLE
8353815: [ubsan] compilationPolicy.cpp: division by zero related to tiered compilation flags

### DIFF
--- a/src/hotspot/share/compiler/compilationPolicy.cpp
+++ b/src/hotspot/share/compiler/compilationPolicy.cpp
@@ -385,7 +385,7 @@ public:
 
 double CompilationPolicy::threshold_scale(CompLevel level, int feedback_k) {
   int comp_count = compiler_count(level);
-  if (comp_count > 0) {
+  if (comp_count > 0 && feedback_k > 0) {
     double queue_size = CompileBroker::queue_size(level);
     double k = (double)queue_size / ((double)feedback_k * (double)comp_count) + 1;
 

--- a/src/hotspot/share/compiler/compiler_globals.hpp
+++ b/src/hotspot/share/compiler/compiler_globals.hpp
@@ -234,12 +234,14 @@
                                                                             \
   product(intx, Tier3LoadFeedback, 5,                                       \
           "Tier 3 thresholds will increase twofold when C1 queue size "     \
-          "reaches this amount per compiler thread")                        \
+          "reaches this amount per compiler thread"                         \
+          "Passing 0 disables the threshold scaling")                       \
           range(0, max_jint)                                                \
                                                                             \
   product(intx, Tier4LoadFeedback, 3,                                       \
           "Tier 4 thresholds will increase twofold when C2 queue size "     \
-          "reaches this amount per compiler thread")                        \
+          "reaches this amount per compiler thread"                         \
+          "Passing 0 disables the threshold scaling")                       \
           range(0, max_jint)                                                \
                                                                             \
   product(intx, TieredCompileTaskTimeout, 50,                               \

--- a/src/hotspot/share/compiler/compiler_globals.hpp
+++ b/src/hotspot/share/compiler/compiler_globals.hpp
@@ -265,11 +265,11 @@
                                                                             \
   product(intx, TieredRateUpdateMinTime, 1,                                 \
           "Minimum rate sampling interval (in milliseconds)")               \
-          range(0, max_intx)                                                \
+          range(1, max_intx)                                                \
                                                                             \
   product(intx, TieredRateUpdateMaxTime, 25,                                \
           "Maximum rate sampling interval (in milliseconds)")               \
-          range(0, max_intx)                                                \
+          range(1, max_intx)                                                \
                                                                             \
   product(double, Tier0ProfileDelayFactor, 100.0, DIAGNOSTIC,               \
           "Delay profiling/compiling of methods that were "                 \


### PR DESCRIPTION
A run of `runtime/CommandLine/OptionsValidation/TestOptionsWithRanges.java` with an ubsan enabled binary revealed that passing the value 0 to `Tier(3|4)LoadFeedback`, and `TieredRateUpdateMinTime` lead to division by zero.

Since `Tier(3|4)LoadFeedback` should disable the scaling of the compilation thresholds, 8bf37ee special cases the 0 case to disable scaling and documents it accordingly.

4893b28 sets the lower limit for `TieredRateUpdate(Min|Max)Time` to 1 since the code assumes that at least 1ms passes between each event:

https://github.com/openjdk/jdk/blob/c4fb00a7be51c7a05a29d3d57d787feb5c698ddf/src/hotspot/share/compiler/compilationPolicy.cpp#L968-L974

This PR was tested with:
 - [ ] [Github Actions](https://github.com/mhaessig/jdk/actions/runs/15760915006)
 - [x] tier1 and 2 plus Oracle internal testing on Oracle supported platforms
