### PR TITLE
8360039: JFR: Improve parser logging of constants

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/ChunkParser.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/ChunkParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -421,12 +421,27 @@ public final class ChunkParser {
             return o.getClass().getName();
         }
         if (o.getClass().isArray()) {
-            Object[] array = (Object[]) o;
-            if (array.length > 0) {
-                return textify(array[0]) + "[]"; // can it be recursive?
-            }
+            return textifyArray((Object[])o);
         }
         return String.valueOf(o);
+    }
+
+    private String textifyArray(Object[] array) {
+        int length = array.length;
+        if (length > 0) {
+            Object element = array[0];
+            if (element != null) {
+                if (element instanceof String s) {
+                    // Probably an enumeration type, e.g. ThreadState. Remove array indirection
+                    return textify(s);
+                }
+                if (element.getClass().isArray()) {
+                    Object[] subArray = (Object[]) element;
+                    return element.getClass().getComponentType().getName() + "[" + subArray.length + "]" + "[" + length + "]";
+                }
+            }
+        }
+        return array.getClass().getComponentType().getName() + "[" + length + "]";
     }
 
     private String getName(long id) {


### PR DESCRIPTION
Could I have a review of the PR that improves logging in the JFR parser for arrays?

Testing: test/jdk/jdk/jfr

Thanks
Erik

<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8360039](https://bugs.openjdk.org/browse/JDK-8360039): JFR: Improve parser logging of constants (**Enhancement** - P4)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25903/head:pull/25903` \
`$ git checkout pull/25903`

Update a local copy of the PR: \
`$ git checkout pull/25903` \
`$ git pull https://git.openjdk.org/jdk.git pull/25903/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25903`

View PR using the GUI difftool: \
`$ git pr show -t 25903`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25903.diff">https://git.openjdk.org/jdk/pull/25903.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25903#issuecomment-2988525212)
</details>
