### PR TITLE
8357550: GenShen crashes during freeze: assert(!chunk->requires_barriers()) failed

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.hpp
@@ -128,6 +128,8 @@ public:
 
   void stop() override;
 
+  bool requires_barriers(stackChunkOop obj) const override;
+
   // Used for logging the result of a region transfer outside the heap lock
   struct TransferResult {
     bool success;


### PR DESCRIPTION
Shenandoah captures a preliminary top-at-mark-start (TAMS) concurrently. Once concurrent marking has begun, any object beneath TAMS requires a barrier when accessed. The implementation of `ShenandoahHeap::requires_barrier` does not distinguish between _old_ and _young_ marking. This could lead to a race between freezing the stack and capturing TAMS:

1. Collector is marking old
2. Allocate stack chunk in young
3. Barrier is not needed, begin fast freeze path
4. Collector concurrently updates TAMS (young marking will start once init-mark safepoint is reached)
5. ShenandoahHeap now thinks the barrier is needed (because TAMS changed, and we are marking old)
6. Fast freeze asserts out

This fix has the generational mode check the appropriate generation and its marking state. It also enforces barriers for stackChunks in the old generation (for card marking).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8357550](https://bugs.openjdk.org/browse/JDK-8357550): GenShen crashes during freeze: assert(!chunk-&gt;requires_barriers()) failed (**Bug** - P4)


### Reviewers
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - Committer)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25905/head:pull/25905` \
`$ git checkout pull/25905`

Update a local copy of the PR: \
`$ git checkout pull/25905` \
`$ git pull https://git.openjdk.org/jdk.git pull/25905/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25905`

View PR using the GUI difftool: \
`$ git pr show -t 25905`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25905.diff">https://git.openjdk.org/jdk/pull/25905.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25905#issuecomment-2989092547)
</details>
