### PR TITLE
8346753: Test javax/swing/JMenuItem/RightLeftOrientation/RightLeftOrientation.java fails on Windows Server 2025 x64 because the icons of RBMenuItem and CBMenuItem are not visible in Nimbus LookAndFeel

### DIFF
--- a/test/jdk/javax/swing/JMenuItem/RightLeftOrientation.java
+++ b/test/jdk/javax/swing/JMenuItem/RightLeftOrientation.java
@@ -70,14 +70,11 @@ import javax.swing.JMenuBar;
 import javax.swing.JMenuItem;
 import javax.swing.JRadioButtonMenuItem;
 import javax.swing.KeyStroke;
-import javax.swing.LookAndFeel;
 import javax.swing.SwingConstants;
 import javax.swing.SwingUtilities;
 import javax.swing.UIManager;
 
 public class RightLeftOrientation {
-
-    static volatile JFrame frame;
 
     private static final String INSTRUCTIONS = """
         A menu bar is shown with a menu.
@@ -122,7 +119,7 @@ public class RightLeftOrientation {
     }
 
     private static JFrame createTestUI() {
-        frame = new JFrame("RightLeftOrientation");
+        JFrame frame = new JFrame("RightLeftOrientation");
         JMenuBar menuBar = new JMenuBar();
 
         menuBar.add(createMenu());

--- a/test/jdk/javax/swing/JMenuItem/RightLeftOrientation.java
+++ b/test/jdk/javax/swing/JMenuItem/RightLeftOrientation.java
@@ -110,13 +110,11 @@ public class RightLeftOrientation {
         });
         System.out.println("Test for LookAndFeel " + lafClassName);
         PassFailJFrame.builder()
-                .title("RightLeftOrientation Instructions")
                 .instructions(INSTRUCTIONS)
                 .columns(35)
                 .testUI(RightLeftOrientation::createTestUI)
                 .build()
                 .awaitAndCheck();
-       System.out.println("Test passed for LookAndFeel " + lafClassName);
     }
 
     private static JFrame createTestUI() {

--- a/test/jdk/javax/swing/JMenuItem/RightLeftOrientation.java
+++ b/test/jdk/javax/swing/JMenuItem/RightLeftOrientation.java
@@ -93,6 +93,7 @@ public class RightLeftOrientation {
         if (args.length < 1) {
             throw new IllegalArgumentException("Look-and-Feel keyword is required");
         }
+
         final String lafClassName;
         switch (args[0]) {
             case "metal" -> lafClassName = UIManager.getCrossPlatformLookAndFeelClassName();
@@ -101,6 +102,7 @@ public class RightLeftOrientation {
             default -> throw new IllegalArgumentException(
                            "Unsupported Look-and-Feel keyword for this test: " + args[0]);
         }
+
         SwingUtilities.invokeAndWait(() -> {
             try {
                 UIManager.setLookAndFeel(lafClassName);
@@ -108,7 +110,9 @@ public class RightLeftOrientation {
                 throw new RuntimeException(e);
             }
         });
+
         System.out.println("Test for LookAndFeel " + lafClassName);
+
         PassFailJFrame.builder()
                 .instructions(INSTRUCTIONS)
                 .columns(35)

--- a/test/jdk/javax/swing/JMenuItem/RightLeftOrientation.java
+++ b/test/jdk/javax/swing/JMenuItem/RightLeftOrientation.java
@@ -124,7 +124,7 @@ public class RightLeftOrientation {
         menuBar.add(createMenu());
 
         frame.setJMenuBar(menuBar);
-        frame.pack();
+        frame.setSize(250, 70);
         return frame;
     }
 

--- a/test/jdk/javax/swing/JMenuItem/RightLeftOrientation.java
+++ b/test/jdk/javax/swing/JMenuItem/RightLeftOrientation.java
@@ -54,9 +54,12 @@ import javax.swing.JRadioButtonMenuItem;
 import javax.swing.KeyStroke;
 import javax.swing.LookAndFeel;
 import javax.swing.SwingConstants;
+import javax.swing.SwingUtilities;
 import javax.swing.UIManager;
 
 public class RightLeftOrientation {
+
+    static volatile JFrame frame;
 
     private static final String INSTRUCTIONS = """
         A menu bar is shown containing a menu for each look and feel.
@@ -83,7 +86,7 @@ public class RightLeftOrientation {
     }
 
     private static JFrame createTestUI() {
-        JFrame frame = new JFrame("RightLeftOrientation");
+        frame = new JFrame("RightLeftOrientation");
         JMenuBar menuBar = new JMenuBar();
 
         menuBar.add(createMenu("javax.swing.plaf.metal.MetalLookAndFeel",
@@ -100,14 +103,15 @@ public class RightLeftOrientation {
 
 
     static JMenu createMenu(String laf, String name) {
-        JMenu menu = new JMenu(name);
+        JMenu menu;
         try {
             LookAndFeel save = UIManager.getLookAndFeel();
             UIManager.setLookAndFeel(laf);
+            SwingUtilities.updateComponentTreeUI(frame);
+            menu = new JMenu(name);
             addMenuItems(menu, ComponentOrientation.LEFT_TO_RIGHT);
             menu.addSeparator();
             addMenuItems(menu, ComponentOrientation.RIGHT_TO_LEFT);
-            UIManager.setLookAndFeel(save);
         } catch (Exception e) {
             menu = new JMenu(name);
             menu.setEnabled(false);

--- a/test/jdk/javax/swing/JMenuItem/RightLeftOrientation.java
+++ b/test/jdk/javax/swing/JMenuItem/RightLeftOrientation.java
@@ -22,18 +22,36 @@
  */
 
 /*
- * @test
+ * @test id=metal
  * @bug 4211052
  * @requires (os.family == "windows")
- * @summary
- *     This test checks if menu items lay out correctly when their
+ * @summary Verifies if menu items lay out correctly when their
  *     ComponentOrientation property is set to RIGHT_TO_LEFT.
- *     The tester is asked to compare left-to-right and
- *     right-to-left menus and judge whether they are mirror images of each
- *     other.
  * @library /java/awt/regtesthelpers
  * @build PassFailJFrame
- * @run main/manual RightLeftOrientation
+ * @run main/manual RightLeftOrientation metal
+ */
+
+/*
+ * @test id=motif
+ * @bug 4211052
+ * @requires (os.family == "windows")
+ * @summary Verifies if menu items lay out correctly when their
+ *     ComponentOrientation property is set to RIGHT_TO_LEFT.
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual RightLeftOrientation motif
+ */
+
+/*
+ * @test id=windows
+ * @bug 4211052
+ * @requires (os.family == "windows")
+ * @summary Verifies if menu items lay out correctly when their
+ *     ComponentOrientation property is set to RIGHT_TO_LEFT.
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual RightLeftOrientation windows
  */
 
 import java.awt.Color;
@@ -62,20 +80,35 @@ public class RightLeftOrientation {
     static volatile JFrame frame;
 
     private static final String INSTRUCTIONS = """
-        A menu bar is shown containing a menu for each look and feel.
-        A disabled menu means that the look and feel is not available for
-        testing in this environment.
-        Every effort should be made to run this test
-        in an environment that covers all look and feels.
+        A menu bar is shown with a menu.
 
-        Each menu is divided into two halves. The upper half is oriented
+        The menu is divided into two halves. The upper half is oriented
         left-to-right and the lower half is oriented right-to-left.
-        For each menu, ensure that the lower half mirrors the upper half.
+        Ensure that the lower half mirrors the upper half.
 
         Note that when checking the positioning of the sub-menus, it
         helps to position the frame away from the screen edges.""";
 
     public static void main(String[] args) throws Exception {
+        if (args.length < 1) {
+            throw new IllegalArgumentException("Look-and-Feel keyword is required");
+        }
+        final String lafClassName;
+        switch (args[0]) {
+            case "metal" -> lafClassName = UIManager.getCrossPlatformLookAndFeelClassName();
+            case "motif" -> lafClassName = "com.sun.java.swing.plaf.motif.MotifLookAndFeel";
+            case "windows" -> lafClassName = "com.sun.java.swing.plaf.windows.WindowsLookAndFeel";
+            default -> throw new IllegalArgumentException(
+                           "Unsupported Look-and-Feel keyword for this test: " + args[0]);
+        }
+        SwingUtilities.invokeAndWait(() -> {
+            try {
+                UIManager.setLookAndFeel(lafClassName);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+        System.out.println("Test for LookAndFeel " + lafClassName);
         PassFailJFrame.builder()
                 .title("RightLeftOrientation Instructions")
                 .instructions(INSTRUCTIONS)
@@ -83,18 +116,14 @@ public class RightLeftOrientation {
                 .testUI(RightLeftOrientation::createTestUI)
                 .build()
                 .awaitAndCheck();
+       System.out.println("Test passed for LookAndFeel " + lafClassName);
     }
 
     private static JFrame createTestUI() {
         frame = new JFrame("RightLeftOrientation");
         JMenuBar menuBar = new JMenuBar();
 
-        menuBar.add(createMenu("javax.swing.plaf.metal.MetalLookAndFeel",
-                                "Metal"));
-        menuBar.add(createMenu("com.sun.java.swing.plaf.motif.MotifLookAndFeel",
-                                "Motif"));
-        menuBar.add(createMenu("com.sun.java.swing.plaf.windows.WindowsLookAndFeel",
-                                "Windows"));
+        menuBar.add(createMenu());
 
         frame.setJMenuBar(menuBar);
         frame.pack();
@@ -102,20 +131,11 @@ public class RightLeftOrientation {
     }
 
 
-    static JMenu createMenu(String laf, String name) {
-        JMenu menu;
-        try {
-            LookAndFeel save = UIManager.getLookAndFeel();
-            UIManager.setLookAndFeel(laf);
-            SwingUtilities.updateComponentTreeUI(frame);
-            menu = new JMenu(name);
-            addMenuItems(menu, ComponentOrientation.LEFT_TO_RIGHT);
-            menu.addSeparator();
-            addMenuItems(menu, ComponentOrientation.RIGHT_TO_LEFT);
-        } catch (Exception e) {
-            menu = new JMenu(name);
-            menu.setEnabled(false);
-        }
+    static JMenu createMenu() {
+        JMenu menu = new JMenu(UIManager.getLookAndFeel().getID());
+        addMenuItems(menu, ComponentOrientation.LEFT_TO_RIGHT);
+        menu.addSeparator();
+        addMenuItems(menu, ComponentOrientation.RIGHT_TO_LEFT);
         return menu;
     }
 


### PR DESCRIPTION
Issue is RadioButtonMenuItem and CheckBoxMenuItem bullet/checkmark icon is not displayed in WindowsL&F when the test is run with NimbusL&F.
This is because `WindowsIconFactory#VistaMenuItemCheckIcon.paintIcon` called `getLaFIcon()` which returns a empty NimbusIcon which causes no icons to be drawn. This is because the test after setting WIndows L&F of the menuitem reverts back the Windows L&F to Nimbus L&F via `UIManager.setLookAndFeel(save);` call in the test so when frame is made visible, the L&F resets back to Nimbus L&F resulting in null NimbusIcon.

Fix is made to make sure the whole frame is updated to cater to L&F change via `SwingUtilities.updateComponentTreeUI(frame);` call and keep the L&F without reverting back to original L&F..

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346753](https://bugs.openjdk.org/browse/JDK-8346753): Test javax/swing/JMenuItem/RightLeftOrientation/RightLeftOrientation.java fails on Windows Server 2025 x64 because the icons of RBMenuItem and CBMenuItem are not visible in Nimbus LookAndFeel (**Bug** - P5)


### Reviewers
 * [Abhishek Kumar](https://openjdk.org/census#abhiscxk) (@kumarabhi006 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25907/head:pull/25907` \
`$ git checkout pull/25907`

Update a local copy of the PR: \
`$ git checkout pull/25907` \
`$ git pull https://git.openjdk.org/jdk.git pull/25907/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25907`

View PR using the GUI difftool: \
`$ git pr show -t 25907`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25907.diff">https://git.openjdk.org/jdk/pull/25907.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25907#issuecomment-2989694862)
</details>
