### PR TITLE
8360069: Problem list CodeInvalidationReasonTest.java until JDK-8360049 is fixed

### DIFF
--- a/test/hotspot/jtreg/ProblemList-zgc.txt
+++ b/test/hotspot/jtreg/ProblemList-zgc.txt
@@ -125,3 +125,5 @@ compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/NativeCallTest.java  
 compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/SimpleCodeInstallationTest.java      8343233 generic-aarch64
 compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/SimpleDebugInfoTest.java             8343233 generic-aarch64
 compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/VirtualObjectDebugInfoTest.java      8343233 generic-aarch64
+
+compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/CodeInvalidationReasonTest.java      8360049 generic-aarch64


### PR DESCRIPTION
Problem listing with ZGC until [JDK-8360049](https://bugs.openjdk.org/browse/JDK-8360049) is fixed because it fails in our CI.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8360069](https://bugs.openjdk.org/browse/JDK-8360069): Problem list CodeInvalidationReasonTest.java until JDK-8360049 is fixed (**Sub-task** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25908/head:pull/25908` \
`$ git checkout pull/25908`

Update a local copy of the PR: \
`$ git checkout pull/25908` \
`$ git pull https://git.openjdk.org/jdk.git pull/25908/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25908`

View PR using the GUI difftool: \
`$ git pr show -t 25908`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25908.diff">https://git.openjdk.org/jdk/pull/25908.diff</a>

</details>
