### PR TITLE
8359386: Fix incorrect value for max_size of C2CodeStub when APX is used

### DIFF
--- a/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
@@ -4655,6 +4655,7 @@ static void convertF2I_slowpath(C2_MacroAssembler& masm, C2GeneralStub<Register,
   __ subptr(rsp, 8);
   __ movdbl(Address(rsp), src);
   __ call(RuntimeAddress(target));
+  // APX REX2 encoding for pop(dst) increases the stub size by 1 byte.
   __ pop(dst);
   __ jmp(stub.continuation());
 #undef __
@@ -4687,7 +4688,9 @@ void C2_MacroAssembler::convertF2I(BasicType dst_bt, BasicType src_bt, Register 
     }
   }
 
-  auto stub = C2CodeStub::make<Register, XMMRegister, address>(dst, src, slowpath_target, 23, convertF2I_slowpath);
+  // Using the APX extended general purpose registers increases the instruction encoding size by 1 byte.
+  int max_size = 23 + (UseAPX ? 1 : 0);
+  auto stub = C2CodeStub::make<Register, XMMRegister, address>(dst, src, slowpath_target, max_size, convertF2I_slowpath);
   jcc(Assembler::equal, stub->entry());
   bind(stub->continuation());
 }


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [b52af182](https://github.com/openjdk/jdk/commit/b52af182c43380186decd7e35625e42c7cafb8c2) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Srinivas Vamsi Parasa on 18 Jun 2025 and was reviewed by Tobias Hartmann, Aleksey Shipilev, Jatin Bhateja and Sandhya Viswanathan.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8359386](https://bugs.openjdk.org/browse/JDK-8359386): Fix incorrect value for max_size of C2CodeStub when APX is used (**Bug** - P3)


### Reviewers
 * [Manuel Hässig](https://openjdk.org/census#mhaessig) (@mhaessig - Author)
 * [Emanuel Peter](https://openjdk.org/census#epeter) (@eme64 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25909/head:pull/25909` \
`$ git checkout pull/25909`

Update a local copy of the PR: \
`$ git checkout pull/25909` \
`$ git pull https://git.openjdk.org/jdk.git pull/25909/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25909`

View PR using the GUI difftool: \
`$ git pr show -t 25909`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25909.diff">https://git.openjdk.org/jdk/pull/25909.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25909#issuecomment-2989898886)
</details>
