### PR TITLE
8360049: CodeInvalidationReasonTest.java fails with ZGC on AArch64

### DIFF
--- a/test/hotspot/jtreg/ProblemList-zgc.txt
+++ b/test/hotspot/jtreg/ProblemList-zgc.txt
@@ -125,5 +125,3 @@ compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/NativeCallTest.java  
 compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/SimpleCodeInstallationTest.java      8343233 generic-aarch64
 compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/SimpleDebugInfoTest.java             8343233 generic-aarch64
 compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/VirtualObjectDebugInfoTest.java      8343233 generic-aarch64
-
-compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/CodeInvalidationReasonTest.java      8360049 generic-aarch64

--- a/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/TestHotSpotVMConfig.java
+++ b/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/TestHotSpotVMConfig.java
@@ -67,10 +67,11 @@ public class TestHotSpotVMConfig extends HotSpotVMConfigAccess {
                 // There currently only 2 variants in use that differ only by the presence of a
                 // dmb instruction
                 int stw = getConstant("NMethodPatchingType::stw_instruction_and_data_patch", Integer.class);
-                int conc = getConstant("NMethodPatchingType::conc_data_patch", Integer.class);
+                int conc1 = getConstant("NMethodPatchingType::conc_data_patch", Integer.class);
+                int conc2 = getConstant("NMethodPatchingType::conc_instruction_and_data_patch", Integer.class);
                 if (patchingType == stw) {
                     patchConcurrent = false;
-                } else if (patchingType == conc) {
+                } else if (patchingType == conc1 || patchingType == conc2) {
                     patchConcurrent = true;
                 } else {
                     throw new IllegalArgumentException("unsupported barrier sequence " + patchingType);


### PR DESCRIPTION
[JDK-8359064](https://bugs.openjdk.org/browse/JDK-8359064) introduced a new test (CodeInvalidationReasonTest) which triggers a code path in TestHotSpotVMConfig that had apparently never been run on ZGC+AArch64.
This PR fixes an omission in that code to handle this configuration.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8360049](https://bugs.openjdk.org/browse/JDK-8360049): CodeInvalidationReasonTest.java fails with ZGC on AArch64 (**Bug** - P4)


### Reviewers
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25911/head:pull/25911` \
`$ git checkout pull/25911`

Update a local copy of the PR: \
`$ git checkout pull/25911` \
`$ git pull https://git.openjdk.org/jdk.git pull/25911/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25911`

View PR using the GUI difftool: \
`$ git pr show -t 25911`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25911.diff">https://git.openjdk.org/jdk/pull/25911.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25911#issuecomment-2990289609)
</details>
