### PR TITLE
8360090: [TEST] RISC-V: disable some cds tests on qemu

### DIFF
--- a/test/hotspot/jtreg/TEST.ROOT
+++ b/test/hotspot/jtreg/TEST.ROOT
@@ -79,6 +79,7 @@ requires.properties= \
     vm.rtm.cpu \
     vm.rtm.compiler \
     vm.cds \
+    vm.cds.default.archive.available \
     vm.cds.custom.loaders \
     vm.cds.supports.aot.class.linking \
     vm.cds.supports.aot.code.caching \

--- a/test/hotspot/jtreg/runtime/cds/TestDefaultArchiveLoading.java
+++ b/test/hotspot/jtreg/runtime/cds/TestDefaultArchiveLoading.java
@@ -26,9 +26,9 @@
  * @test id=nocoops_nocoh
  * @summary Test Loading of default archives in all configurations
  * @requires vm.cds
+ * @requires vm.cds.default.archive.available
  * @requires vm.cds.write.archived.java.heap
  * @requires vm.bits == 64
- * @requires os.arch != "riscv64" | !(vm.cpu.features ~= ".*qemu.*")
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management
@@ -39,9 +39,9 @@
  * @test id=nocoops_coh
  * @summary Test Loading of default archives in all configurations (requires --enable-cds-archive-coh)
  * @requires vm.cds
+ * @requires vm.cds.default.archive.available
  * @requires vm.cds.write.archived.java.heap
  * @requires vm.bits == 64
- * @requires os.arch != "riscv64" | !(vm.cpu.features ~= ".*qemu.*")
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management
@@ -52,9 +52,9 @@
  * @test id=coops_nocoh
  * @summary Test Loading of default archives in all configurations
  * @requires vm.cds
+ * @requires vm.cds.default.archive.available
  * @requires vm.cds.write.archived.java.heap
  * @requires vm.bits == 64
- * @requires os.arch != "riscv64" | !(vm.cpu.features ~= ".*qemu.*")
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management
@@ -65,9 +65,9 @@
  * @test id=coops_coh
  * @summary Test Loading of default archives in all configurations (requires --enable-cds-archive-coh)
  * @requires vm.cds
+ * @requires vm.cds.default.archive.available
  * @requires vm.cds.write.archived.java.heap
  * @requires vm.bits == 64
- * @requires os.arch != "riscv64" | !(vm.cpu.features ~= ".*qemu.*")
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/hotspot/jtreg/runtime/cds/TestDefaultArchiveLoading.java
+++ b/test/hotspot/jtreg/runtime/cds/TestDefaultArchiveLoading.java
@@ -28,6 +28,7 @@
  * @requires vm.cds
  * @requires vm.cds.write.archived.java.heap
  * @requires vm.bits == 64
+ * @requires os.arch != "riscv64" | !(vm.cpu.features ~= ".*qemu.*")
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management
@@ -40,6 +41,7 @@
  * @requires vm.cds
  * @requires vm.cds.write.archived.java.heap
  * @requires vm.bits == 64
+ * @requires os.arch != "riscv64" | !(vm.cpu.features ~= ".*qemu.*")
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management
@@ -52,6 +54,7 @@
  * @requires vm.cds
  * @requires vm.cds.write.archived.java.heap
  * @requires vm.bits == 64
+ * @requires os.arch != "riscv64" | !(vm.cpu.features ~= ".*qemu.*")
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management
@@ -64,6 +67,7 @@
  * @requires vm.cds
  * @requires vm.cds.write.archived.java.heap
  * @requires vm.bits == 64
+ * @requires os.arch != "riscv64" | !(vm.cpu.features ~= ".*qemu.*")
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/hotspot/jtreg/runtime/cds/appcds/TestDumpClassListSource.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/TestDumpClassListSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,7 @@
  * @requires vm.cds
  * @requires vm.cds.custom.loaders
  * @requires vm.flagless
+ * @requires os.arch != "riscv64" | !(vm.cpu.features ~= ".*qemu.*")
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds
  * @compile test-classes/Hello.java ClassSpecializerTestApp.java ClassListWithCustomClassNoSource.java
  * @run main/othervm TestDumpClassListSource

--- a/test/hotspot/jtreg/runtime/cds/appcds/TestDumpClassListSource.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/TestDumpClassListSource.java
@@ -28,9 +28,9 @@
  * @summary test dynamic dump meanwhile output loaded class list
  * @bug 8279009 8275084
  * @requires vm.cds
+ * @requires vm.cds.default.archive.available
  * @requires vm.cds.custom.loaders
  * @requires vm.flagless
- * @requires os.arch != "riscv64" | !(vm.cpu.features ~= ".*qemu.*")
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds
  * @compile test-classes/Hello.java ClassSpecializerTestApp.java ClassListWithCustomClassNoSource.java
  * @run main/othervm TestDumpClassListSource

--- a/test/hotspot/jtreg/runtime/cds/appcds/TransformInterfaceOfLambda.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/TransformInterfaceOfLambda.java
@@ -28,9 +28,9 @@
  * @summary Transforming an interface of an archived lambda proxy class should not
  *          crash the VM. The lambda proxy class should be regenerated during runtime.
  * @requires vm.cds
+ * @requires vm.cds.default.archive.available
  * @requires vm.jvmti
  * @requires vm.flagless
- * @requires os.arch != "riscv64" | !(vm.cpu.features ~= ".*qemu.*")
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds/test-classes
  * @compile test-classes/SimpleTest.java
  * @compile test-classes/TransformBootClass.java

--- a/test/hotspot/jtreg/runtime/cds/appcds/TransformInterfaceOfLambda.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/TransformInterfaceOfLambda.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,7 @@
  * @requires vm.cds
  * @requires vm.jvmti
  * @requires vm.flagless
+ * @requires os.arch != "riscv64" | !(vm.cpu.features ~= ".*qemu.*")
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds/test-classes
  * @compile test-classes/SimpleTest.java
  * @compile test-classes/TransformBootClass.java

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/TestAutoCreateSharedArchiveNoDefaultArchive.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/TestAutoCreateSharedArchiveNoDefaultArchive.java
@@ -28,6 +28,7 @@
  * @bug 8261455
  * @requires vm.cds
  * @requires vm.flagless
+ * @requires os.arch != "riscv64" | !(vm.cpu.features ~= ".*qemu.*")
  * @comment This test doesn't work on Windows because it depends on symlinks
  * @requires os.family != "windows"
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/TestAutoCreateSharedArchiveNoDefaultArchive.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/TestAutoCreateSharedArchiveNoDefaultArchive.java
@@ -27,8 +27,8 @@
  * @summary Test -XX:+AutoCreateSharedArchive on a copied JDK without default shared archive
  * @bug 8261455
  * @requires vm.cds
+ * @requires vm.cds.default.archive.available
  * @requires vm.flagless
- * @requires os.arch != "riscv64" | !(vm.cpu.features ~= ".*qemu.*")
  * @comment This test doesn't work on Windows because it depends on symlinks
  * @requires os.family != "windows"
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds

--- a/test/jtreg-ext/requires/VMProps.java
+++ b/test/jtreg-ext/requires/VMProps.java
@@ -122,6 +122,7 @@ public class VMProps implements Callable<Map<String, String>> {
         map.put("vm.rtm.compiler", this::vmRTMCompiler);
         // vm.cds is true if the VM is compiled with cds support.
         map.put("vm.cds", this::vmCDS);
+        map.put("vm.cds.default.archive.available", this::vmCDSDefaultArchiveAvailable);
         map.put("vm.cds.custom.loaders", this::vmCDSForCustomLoaders);
         map.put("vm.cds.supports.aot.class.linking", this::vmCDSSupportsAOTClassLinking);
         map.put("vm.cds.supports.aot.code.caching", this::vmCDSSupportsAOTCodeCaching);
@@ -446,6 +447,16 @@ public class VMProps implements Callable<Map<String, String>> {
      */
     protected String vmCDS() {
         return "" + WB.isCDSIncluded();
+    }
+
+    /**
+     * Check for CDS default archive existence.
+     *
+     * @return true if CDS default archive classes.jsa exists in the JDK to be tested.
+     */
+    protected String vmCDSDefaultArchiveAvailable() {
+        Path archive = Paths.get(System.getProperty("java.home"), "lib", "server", "classes.jsa");
+        return "" + ("true".equals(vmCDS()) && Files.exists(archive));
     }
 
     /**


### PR DESCRIPTION
Hi,
Can you help to review this patch?

CDS does not work well in cross compilation env, this is by desgin, please check `JDKOPT_ENABLE_DISABLE_CDS_ARCHIVE` in make of jdk.

These tests depends on classes.jsa or classes_xxx.jsa which is not generated and will not be generated when build jdk in qemu environment for riscv, so we should disable them when qemu.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8360090](https://bugs.openjdk.org/browse/JDK-8360090): [TEST] RISC-V: disable some cds tests on qemu (**Sub-task** - P4)


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)
 * [Robbin Ehn](https://openjdk.org/census#rehn) (@robehn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25913/head:pull/25913` \
`$ git checkout pull/25913`

Update a local copy of the PR: \
`$ git checkout pull/25913` \
`$ git pull https://git.openjdk.org/jdk.git pull/25913/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25913`

View PR using the GUI difftool: \
`$ git pr show -t 25913`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25913.diff">https://git.openjdk.org/jdk/pull/25913.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25913#issuecomment-2990490038)
</details>
