### PR TITLE
8295851: Do not use ttyLock in BytecodeTracer::trace

### DIFF
--- a/src/hotspot/share/interpreter/bytecodeTracer.cpp
+++ b/src/hotspot/share/interpreter/bytecodeTracer.cpp
@@ -36,6 +36,7 @@
 #include "runtime/atomic.hpp"
 #include "runtime/handles.inline.hpp"
 #include "runtime/mutexLocker.hpp"
+#include "runtime/osthread.hpp"
 #include "utilities/align.hpp"
 
 // Prints the current bytecode and its attributes using bytecode-specific information.

--- a/src/hotspot/share/interpreter/bytecodeTracer.cpp
+++ b/src/hotspot/share/interpreter/bytecodeTracer.cpp
@@ -36,7 +36,7 @@
 #include "runtime/atomic.hpp"
 #include "runtime/handles.inline.hpp"
 #include "runtime/mutexLocker.hpp"
-#include "runtime/osthread.hpp"
+#include "runtime/osThread.hpp"
 #include "utilities/align.hpp"
 
 // Prints the current bytecode and its attributes using bytecode-specific information.

--- a/src/hotspot/share/interpreter/bytecodeTracer.cpp
+++ b/src/hotspot/share/interpreter/bytecodeTracer.cpp
@@ -29,18 +29,13 @@
 #include "interpreter/bytecodeTracer.hpp"
 #include "interpreter/bytecodes.hpp"
 #include "interpreter/interpreter.hpp"
-#include "interpreter/interpreterRuntime.hpp"
 #include "memory/resourceArea.hpp"
 #include "oops/constantPool.inline.hpp"
 #include "oops/methodData.hpp"
 #include "oops/method.hpp"
-#include "oops/resolvedFieldEntry.hpp"
-#include "oops/resolvedIndyEntry.hpp"
-#include "oops/resolvedMethodEntry.hpp"
+#include "runtime/atomic.hpp"
 #include "runtime/handles.inline.hpp"
 #include "runtime/mutexLocker.hpp"
-#include "runtime/osThread.hpp"
-#include "runtime/timer.hpp"
 #include "utilities/align.hpp"
 
 // Prints the current bytecode and its attributes using bytecode-specific information.
@@ -85,10 +80,11 @@ class BytecodePrinter {
   void      bytecode_epilog(int bci, outputStream* st);
 
  public:
-  BytecodePrinter(int flags = 0) {
-    _is_wide = false;
-    _code = Bytecodes::_illegal;
-    _flags = flags;
+  BytecodePrinter(int flags = 0) : _is_wide(false), _code(Bytecodes::_illegal), _flags(flags) {}
+
+#ifndef PRODUCT
+  BytecodePrinter(Method* prev_method) : BytecodePrinter(0) {
+    _current_method = prev_method;
   }
 
   // This method is called while executing the raw bytecodes, so none of
@@ -96,6 +92,10 @@ class BytecodePrinter {
   void trace(const methodHandle& method, address bcp, uintptr_t tos, uintptr_t tos2, outputStream* st) {
     ResourceMark rm;
     bool method_changed = _current_method != method();
+    _current_method = method();
+    _is_linked = method->method_holder()->is_linked();
+    assert(_is_linked, "this function must be called on methods that are already executing");
+
     if (method_changed) {
       // Note 1: This code will not work as expected with true MT/MP.
       //         Need an explicit lock or a different solution.
@@ -107,9 +107,6 @@ class BytecodePrinter {
       st->print("[%zu] ", Thread::current()->osthread()->thread_id_for_printing());
       method->print_name(st);
       st->cr();
-      _current_method = method();
-      _is_linked = method->method_holder()->is_linked();
-      assert(_is_linked, "this function must be called on methods that are already executing");
     }
     Bytecodes::Code code;
     if (is_wide()) {
@@ -142,14 +139,13 @@ class BytecodePrinter {
     _is_wide = (code == Bytecodes::_wide);
     _code = Bytecodes::_illegal;
 
-#ifndef PRODUCT
     if (TraceBytecodesStopAt != 0 && BytecodeCounter::counter_value() >= TraceBytecodesStopAt) {
       TraceBytecodes = false;
     }
-#endif
   }
+#endif
 
-  // Used for Method*::print_codes().  The input bcp comes from
+  // Used for Method::print_codes().  The input bcp comes from
   // BytecodeStream, which will skip wide bytecodes.
   void trace(const methodHandle& method, address bcp, outputStream* st) {
     _current_method = method();
@@ -179,19 +175,17 @@ class BytecodePrinter {
 };
 
 #ifndef PRODUCT
-// We need a global instance to keep track of the states when the bytecodes
-// are executed. Access by multiple threads are controlled by ttyLocker.
-static BytecodePrinter _interpreter_printer;
+// We need a global instance to keep track of the method being printed so we can report that
+// the method has changed. If this method is redefined and removed, that's ok because the method passed in won't match, and
+// this will print that one.
+static Method* _current_method = nullptr;
 
 void BytecodeTracer::trace_interpreter(const methodHandle& method, address bcp, uintptr_t tos, uintptr_t tos2, outputStream* st) {
   if (TraceBytecodes && BytecodeCounter::counter_value() >= TraceBytecodesAt) {
-    ttyLocker ttyl;  // 5065316: keep the following output coherent
-    // The ttyLocker also prevents races between two threads
-    // trying to use the single instance of BytecodePrinter.
-    //
-    // There used to be a leaf mutex here, but the ttyLocker will
-    // work just as well, as long as the printing operations never block.
-    _interpreter_printer.trace(method, bcp, tos, tos2, st);
+    BytecodePrinter printer(_current_method);
+    printer.trace(method, bcp, tos, tos2, st);
+    // Save current method to detect when method printing changes.
+    Atomic::release_store(&_current_method, method());
   }
 }
 #endif


### PR DESCRIPTION
This didn't need ttyLock for synchronization, the code only needs to see if the method changes so it can print the method name before the bytecodes, like:

[490166] static void java.lang.String.<clinit>()
[490166]       13    18  putstatic 613 <java/lang/String.CASE_INSENSITIVE_ORDER:Ljava/util/Comparator;>
[490166]       14    21  return

[490166] static void java.lang.System.<clinit>()
[490166]       15     0  invokestatic 471 <java/lang/System.registerNatives()V>
[490166]       16     3  aconst_null
[490166]       17     4  putstatic 474 <java/lang/System.in:Ljava/io/InputStream;>

Verified manually and added some parallelism to the test, and fixed trace() to initialize is_linked(), which it always is.
Also ran tier1-4.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295851](https://bugs.openjdk.org/browse/JDK-8295851): Do not use ttyLock in BytecodeTracer::trace (**Enhancement** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Matias Saavedra Silva](https://openjdk.org/census#matsaave) (@matias9927 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25915/head:pull/25915` \
`$ git checkout pull/25915`

Update a local copy of the PR: \
`$ git checkout pull/25915` \
`$ git pull https://git.openjdk.org/jdk.git pull/25915/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25915`

View PR using the GUI difftool: \
`$ git pr show -t 25915`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25915.diff">https://git.openjdk.org/jdk/pull/25915.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25915#issuecomment-2991227790)
</details>
