### PR TITLE
8360131: Remove use of soon-to-be-removed APIs by CTW framework

### DIFF
--- a/test/hotspot/jtreg/testlibrary/ctw/src/sun/hotspot/tools/ctw/ClassPathJimageEntry.java
+++ b/test/hotspot/jtreg/testlibrary/ctw/src/sun/hotspot/tools/ctw/ClassPathJimageEntry.java
@@ -57,7 +57,7 @@ public class ClassPathJimageEntry extends PathHandler.PathEntry {
         try {
             Files.walkFileTree(modulesRoot, collectClassNames);
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            throw new Error(e);
         }
         return classNames.stream();
     }
@@ -79,7 +79,6 @@ public class ClassPathJimageEntry extends PathHandler.PathEntry {
         }
     }
 
-    //private final ImageReader reader;
     private final FileSystem jrtFileSystem;
 
     public ClassPathJimageEntry(Path root) {

--- a/test/hotspot/jtreg/testlibrary/ctw/src/sun/hotspot/tools/ctw/Utils.java
+++ b/test/hotspot/jtreg/testlibrary/ctw/src/sun/hotspot/tools/ctw/Utils.java
@@ -205,8 +205,6 @@ public class Utils {
      *
      * @param classname fully qualified class name to convert
      * @return corresponding filename
-     * @throws AssertionError if filename isn't valid filename for class file -
-     *                        {@link #isClassFile(String)}
      */
     public static String classNameToFileName(String classname) {
         return classname.replace('.', '/')


### PR DESCRIPTION
Migrate the CWT framework to use only supported JRT file system access for fetching class bytes.
This avoids accessing APIs in ImageReader which are scheduled to be removed as part of preview mode class support in Valhalla (essentially these APIs are "too low level" and expose semantics that are incompatible with supporting preview classes in Valhalla).

This will be a further change to this code when the preview mode work goes in, but this will be limited to how the file system is opened (with or without preview mode).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8360131](https://bugs.openjdk.org/browse/JDK-8360131): Remove use of soon-to-be-removed APIs by CTW framework (**Enhancement** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25916/head:pull/25916` \
`$ git checkout pull/25916`

Update a local copy of the PR: \
`$ git checkout pull/25916` \
`$ git pull https://git.openjdk.org/jdk.git pull/25916/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25916`

View PR using the GUI difftool: \
`$ git pr show -t 25916`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25916.diff">https://git.openjdk.org/jdk/pull/25916.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25916#issuecomment-2991867224)
</details>
