### PR TITLE
8346914: UB issue in scalbnA

### DIFF
--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64_trig.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64_trig.cpp
@@ -543,7 +543,7 @@ void MacroAssembler::generate__ieee754_rem_pio2(address npio2_hw,
 //  }
 //
 //  /* compute n */
-//  z  = scalbnA(z,q0);           /* actual value of z */
+//  z  = scalbn(z,q0);                    /* actual value of z */
 //  z -= 8.0*floor(z*0.125);              /* trim off integer >= 8 */
 //  n  = (int) z;
 //  z -= (double)n;
@@ -576,7 +576,7 @@ void MacroAssembler::generate__ieee754_rem_pio2(address npio2_hw,
 //    }
 //    if(ih==2) {
 //      z = one - z;
-//      if(carry!=0) z -= scalbnA(one,q0);
+//      if(carry!=0) z -= scalbn(one,q0);
 //    }
 //  }
 //
@@ -602,7 +602,7 @@ void MacroAssembler::generate__ieee754_rem_pio2(address npio2_hw,
 //    jz -= 1; q0 -= 24;
 //    while(iq[jz]==0) { jz--; q0-=24;}
 //  } else { /* break z into 24-bit if necessary */
-//    z = scalbnA(z,-q0);
+//    z = scalbn(z,-q0);
 //    if(z>=two24B) {
 //      fw = (double)((int)(twon24*z));
 //      iq[jz] = (int)(z-two24B*fw);
@@ -612,7 +612,7 @@ void MacroAssembler::generate__ieee754_rem_pio2(address npio2_hw,
 //  }
 //
 //  /* convert integer "bit" chunk to floating-point value */
-//  fw = scalbnA(one,q0);
+//  fw = scalbn(one,q0);
 //  for(i=jz;i>=0;i--) {
 //    q[i] = fw*(double)iq[i]; fw*=twon24;
 //  }
@@ -925,7 +925,7 @@ void MacroAssembler::generate__kernel_rem_pio2(address two_over_pi, address pio2
           fmovd(v25, 1.0);
           fsubd(v18, v25, v18);                            // z = one - z;
           cbzw(rscratch2, IH_HANDLED);
-          fsubd(v18, v18, v30);                            // z -= scalbnA(one,q0);
+          fsubd(v18, v18, v30);                            // z -= scalbn(one,q0);
         }
     }
     bind(IH_HANDLED);
@@ -1026,7 +1026,7 @@ void MacroAssembler::generate__kernel_rem_pio2(address two_over_pi, address pio2
       bind(Z_ZERO_CHECK_DONE);
         // convert integer "bit" chunk to floating-point value
         // v17 = twon24
-        // update v30, which was scalbnA(1.0, <old q0>);
+        // update v30, which was scalbn(1.0, <old q0>);
         addw(tmp2, rscratch1, 1023); // biased exponent
         lsl(tmp2, tmp2, 52); // put at correct position
         mov(i, jz);

--- a/src/hotspot/share/runtime/sharedRuntimeMath.hpp
+++ b/src/hotspot/share/runtime/sharedRuntimeMath.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/runtime/sharedRuntimeMath.hpp
+++ b/src/hotspot/share/runtime/sharedRuntimeMath.hpp
@@ -67,64 +67,10 @@ static inline void set_low(double* d, int low) {
   *d = conv.d;
 }
 
-static double copysignA(double x, double y) {
-  DoubleIntConv convX;
-  convX.d = x;
-  convX.split.hi = (convX.split.hi & 0x7fffffff) | (high(y) & 0x80000000);
-  return convX.d;
-}
-
-/*
- * ====================================================
- * Copyright (c) 1998 Oracle and/or its affiliates. All rights reserved.
- *
- * Developed at SunSoft, a Sun Microsystems, Inc. business.
- * Permission to use, copy, modify, and distribute this
- * software is freely granted, provided that this notice
- * is preserved.
- * ====================================================
- */
-
-/*
- * scalbn (double x, int n)
- * scalbn(x,n) returns x* 2**n  computed by  exponent
- * manipulation rather than by actually performing an
- * exponentiation or a multiplication.
- */
-
 static const double
 two54   =  1.80143985094819840000e+16, /* 0x43500000, 0x00000000 */
 twom54  =  5.55111512312578270212e-17, /* 0x3C900000, 0x00000000 */
 hugeX  = 1.0e+300,
 tiny   = 1.0e-300;
-
-static double scalbnA(double x, int n) {
-  int  k,hx,lx;
-  hx = high(x);
-  lx = low(x);
-  k = (hx&0x7ff00000)>>20;              /* extract exponent */
-  if (k==0) {                           /* 0 or subnormal x */
-    if ((lx|(hx&0x7fffffff))==0) return x; /* +-0 */
-    x *= two54;
-    hx = high(x);
-    k = ((hx&0x7ff00000)>>20) - 54;
-    if (n< -50000) return tiny*x;       /*underflow*/
-  }
-  if (k==0x7ff) return x+x;             /* NaN or Inf */
-  k = k+n;
-  if (k > 0x7fe) return hugeX*copysignA(hugeX,x); /* overflow  */
-  if (k > 0) {                          /* normal result */
-    set_high(&x, (hx&0x800fffff)|(k<<20));
-    return x;
-  }
-  if (k <= -54) {
-    if (n > 50000)      /* in case integer overflow in n+k */
-      return hugeX*copysignA(hugeX,x);  /*overflow*/
-    else return tiny*copysignA(tiny,x); /*underflow*/
-  }
-  k += 54;                              /* subnormal result */
-  set_high(&x, (hx&0x800fffff)|(k<<20));
-  return x*twom54;
-}
 
 #endif // SHARE_RUNTIME_SHAREDRUNTIMEMATH_HPP

--- a/src/hotspot/share/runtime/sharedRuntimeMath.hpp
+++ b/src/hotspot/share/runtime/sharedRuntimeMath.hpp
@@ -69,7 +69,6 @@ static inline void set_low(double* d, int low) {
 
 static const double
 two54   =  1.80143985094819840000e+16, /* 0x43500000, 0x00000000 */
-twom54  =  5.55111512312578270212e-17, /* 0x3C900000, 0x00000000 */
 hugeX  = 1.0e+300,
 tiny   = 1.0e-300;
 

--- a/src/hotspot/share/runtime/sharedRuntimeTrans.cpp
+++ b/src/hotspot/share/runtime/sharedRuntimeTrans.cpp
@@ -657,7 +657,7 @@ static double __ieee754_pow(double x, double y) {
   z  = one-(r-z);
   j  = high(z);
   j += (n<<20);
-  if((j>>20)<=0) z = scalbnA(z,n);       /* subnormal output */
+  if((j>>20)<=0) z = scalbn(z,n);       /* subnormal output */
   else set_high(&z, high(z) + (n<<20));
   return s*z;
 }

--- a/src/hotspot/share/runtime/sharedRuntimeTrig.cpp
+++ b/src/hotspot/share/runtime/sharedRuntimeTrig.cpp
@@ -200,7 +200,7 @@ recompute:
   }
 
   /* compute n */
-  z  = scalbnA(z,q0);           /* actual value of z */
+  z  = scalbn(z,q0);                    /* actual value of z */
   z -= 8.0*floor(z*0.125);              /* trim off integer >= 8 */
   n  = (int) z;
   z -= (double)n;
@@ -233,7 +233,7 @@ recompute:
     }
     if(ih==2) {
       z = one - z;
-      if(carry!=0) z -= scalbnA(one,q0);
+      if(carry!=0) z -= scalbn(one,q0);
     }
   }
 
@@ -259,7 +259,7 @@ recompute:
     jz -= 1; q0 -= 24;
     while(iq[jz]==0) { jz--; q0-=24;}
   } else { /* break z into 24-bit if necessary */
-    z = scalbnA(z,-q0);
+    z = scalbn(z,-q0);
     if(z>=two24B) {
       fw = (double)((int)(twon24*z));
       iq[jz] = (int)(z-two24B*fw);
@@ -269,7 +269,7 @@ recompute:
   }
 
   /* convert integer "bit" chunk to floating-point value */
-  fw = scalbnA(one,q0);
+  fw = scalbn(one,q0);
   for(i=jz;i>=0;i--) {
     q[i] = fw*(double)iq[i]; fw*=twon24;
   }


### PR DESCRIPTION
Please review this change that replaces uses of our scalbnA function with
using the standard scalbn function. Removed scalbnA, and also copysignA.

For more details, see first comment and JBS.

Testing: mach5 tier1-6. Though from discussion in
https://github.com/openjdk/jdk/pull/25656, it's hard to get to our uses of
scalbn/scalbnA.

Before removing it, I tested scalbnA via a gtest that is attached to the JBS
issue.

/label hotspot

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346914](https://bugs.openjdk.org/browse/JDK-8346914): UB issue in scalbnA (**Bug** - P4)


### Reviewers
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25917/head:pull/25917` \
`$ git checkout pull/25917`

Update a local copy of the PR: \
`$ git checkout pull/25917` \
`$ git pull https://git.openjdk.org/jdk.git pull/25917/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25917`

View PR using the GUI difftool: \
`$ git pr show -t 25917`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25917.diff">https://git.openjdk.org/jdk/pull/25917.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25917#issuecomment-2992163307)
</details>
