### PR TITLE
8357550: GenShen crashes during freeze: assert(!chunk->requires_barriers()) failed

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.hpp
@@ -128,6 +128,8 @@ public:
 
   void stop() override;
 
+  bool requires_barriers(stackChunkOop obj) const override;
+
   // Used for logging the result of a region transfer outside the heap lock
   struct TransferResult {
     bool success;


### PR DESCRIPTION
This is a low risk change that addresses an assertion failure when Shenandoah's generational mode is used with virtual threads.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8357550](https://bugs.openjdk.org/browse/JDK-8357550): GenShen crashes during freeze: assert(!chunk-&gt;requires_barriers()) failed (**Bug** - P3)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25918/head:pull/25918` \
`$ git checkout pull/25918`

Update a local copy of the PR: \
`$ git checkout pull/25918` \
`$ git pull https://git.openjdk.org/jdk.git pull/25918/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25918`

View PR using the GUI difftool: \
`$ git pr show -t 25918`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25918.diff">https://git.openjdk.org/jdk/pull/25918.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25918#issuecomment-2992536461)
</details>
