### PR TITLE
8360143: ProblemList runtime/NMT/VirtualAllocTestType.java

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -111,6 +111,7 @@ runtime/os/TestTracePageSizes.java#Serial 8267460 linux-aarch64
 runtime/StackGuardPages/TestStackGuardPagesNative.java 8303612 linux-all
 runtime/ErrorHandling/MachCodeFramesInErrorFile.java 8313315 linux-ppc64le
 runtime/NMT/VirtualAllocCommitMerge.java 8309698 linux-s390x
+runtime/NMT/VirtualAllocTestType.java 8359959 generic-all
 
 applications/jcstress/copy.java 8229852 linux-all
 


### PR DESCRIPTION
A trivial fix to ProblemList runtime/NMT/VirtualAllocTestType.java on all platforms.

Yes, there is a fix for [JDK-8359959](https://bugs.openjdk.org/browse/JDK-8359959) out for review, but that fix won't likely
integrate until next week and I want to reduce the noise for the weekend.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8360143](https://bugs.openjdk.org/browse/JDK-8360143): ProblemList runtime/NMT/VirtualAllocTestType.java (**Sub-task** - P4)


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25919/head:pull/25919` \
`$ git checkout pull/25919`

Update a local copy of the PR: \
`$ git checkout pull/25919` \
`$ git pull https://git.openjdk.org/jdk.git pull/25919/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25919`

View PR using the GUI difftool: \
`$ git pr show -t 25919`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25919.diff">https://git.openjdk.org/jdk/pull/25919.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25919#issuecomment-2992621381)
</details>
