### PR TITLE
8360177: ParallelArguments::initialize has incorrect format string

### DIFF
--- a/src/hotspot/share/gc/parallel/parallelArguments.cpp
+++ b/src/hotspot/share/gc/parallel/parallelArguments.cpp
@@ -70,7 +70,7 @@ void ParallelArguments::initialize() {
     if (FLAG_IS_CMDLINE(InitialSurvivorRatio)) {
       if (FLAG_IS_CMDLINE(MinSurvivorRatio)) {
         jio_fprintf(defaultStream::error_stream(),
-          "Inconsistent MinSurvivorRatio vs InitialSurvivorRatio: %d vs %d\n", MinSurvivorRatio, InitialSurvivorRatio);
+          "Inconsistent MinSurvivorRatio vs InitialSurvivorRatio: %zu vs %zu\n", MinSurvivorRatio, InitialSurvivorRatio);
       }
       FLAG_SET_DEFAULT(MinSurvivorRatio, InitialSurvivorRatio);
     } else {


### PR DESCRIPTION
Please review this trivial fix to a jio_fprintf format string. It should be using
"%zu" to print values of type uintx, rather than using "%d".

Testing: mach5 tier1
Locally tested with gcc printf warnings enabled for jio_fprintf, and verified
the warnings for the changed call are no longer present.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8360177](https://bugs.openjdk.org/browse/JDK-8360177): ParallelArguments::initialize has incorrect format string (**Bug** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Sangheon Kim](https://openjdk.org/census#sangheki) (@sangheon - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25926/head:pull/25926` \
`$ git checkout pull/25926`

Update a local copy of the PR: \
`$ git checkout pull/25926` \
`$ git pull https://git.openjdk.org/jdk.git pull/25926/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25926`

View PR using the GUI difftool: \
`$ git pr show -t 25926`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25926.diff">https://git.openjdk.org/jdk/pull/25926.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25926#issuecomment-2994644385)
</details>
