### PR TITLE
8360192: C2: Make the type of count leading/trailing zero nodes more precise

### DIFF
--- a/src/hotspot/share/opto/countbitsnode.cpp
+++ b/src/hotspot/share/opto/countbitsnode.cpp
@@ -46,7 +46,7 @@ const Type* CountLeadingZerosINode::Value(PhaseGVN* phase) const {
     n -= x >> 31;
     return TypeInt::make(n);
   }
-  return TypeInt::INT;
+  return TypeInt::make(0, sizeof(jint) * BitsPerByte, Type::WidenMax);
 }
 
 //------------------------------Value------------------------------------------
@@ -69,7 +69,7 @@ const Type* CountLeadingZerosLNode::Value(PhaseGVN* phase) const {
     n -= x >> 31;
     return TypeInt::make(n);
   }
-  return TypeInt::INT;
+  return TypeInt::make(0, sizeof(jlong) * BitsPerByte, Type::WidenMax);
 }
 
 //------------------------------Value------------------------------------------
@@ -91,7 +91,7 @@ const Type* CountTrailingZerosINode::Value(PhaseGVN* phase) const {
     y = i <<  1; if (y != 0) { n = n -  1; }
     return TypeInt::make(n);
   }
-  return TypeInt::INT;
+  return TypeInt::make(0, sizeof(jint) * BitsPerByte, Type::WidenMax);
 }
 
 //------------------------------Value------------------------------------------
@@ -114,5 +114,5 @@ const Type* CountTrailingZerosLNode::Value(PhaseGVN* phase) const {
     y = x <<  1; if (y != 0) { n = n -  1; }
     return TypeInt::make(n);
   }
-  return TypeInt::INT;
+  return TypeInt::make(0, sizeof(jlong) * BitsPerByte, Type::WidenMax);
 }

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestCountBitsRange.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestCountBitsRange.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2025 Alibaba Group Holding Limited. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.c2.irTests;
+
+import compiler.lib.ir_framework.*;
+
+/*
+ * @test
+ * @bug 8360192
+ * @summary Tests that count bits nodes are handled correctly.
+ * @library /test/lib /
+ * @requires vm.compiler2.enabled
+ * @run driver compiler.c2.irTests.TestCountBitsRange
+ */
+public class TestCountBitsRange {
+    public static void main(String[] args) {
+        TestFramework.run();
+    }
+
+    static int i = RunInfo.getRandom().nextInt();
+    static long l = RunInfo.getRandom().nextLong();
+
+    @Test
+    @IR(failOn = IRNode.COUNT_LEADING_ZEROS_I)
+    public boolean clzCompareInt() {
+        return Integer.numberOfLeadingZeros(i) < 0 || Integer.numberOfLeadingZeros(i) > 32;
+    }
+
+    @Test
+    @IR(counts = {IRNode.COUNT_LEADING_ZEROS_I, "1",
+                  IRNode.RSHIFT_I, "1",
+                  IRNode.URSHIFT_I, "0",
+                  IRNode.ADD_I, "0"})
+    public int clzDiv8Int() {
+        return Integer.numberOfLeadingZeros(i) / 8;
+    }
+
+    @Test
+    @IR(failOn = IRNode.COUNT_LEADING_ZEROS_L)
+    public boolean clzCompareLong() {
+        return Long.numberOfLeadingZeros(l) < 0 || Long.numberOfLeadingZeros(l) > 64;
+    }
+
+    @Test
+    @IR(counts = {IRNode.COUNT_LEADING_ZEROS_L, "1",
+                  IRNode.RSHIFT_I, "1",
+                  IRNode.URSHIFT_I, "0",
+                  IRNode.ADD_I, "0"})
+    public int clzDiv8Long() {
+        return Long.numberOfLeadingZeros(l) / 8;
+    }
+
+    @Test
+    @IR(failOn = IRNode.COUNT_TRAILING_ZEROS_I)
+    public boolean ctzCompareInt() {
+        return Integer.numberOfTrailingZeros(i) < 0 || Integer.numberOfTrailingZeros(i) > 32;
+    }
+
+    @Test
+    @IR(counts = {IRNode.COUNT_TRAILING_ZEROS_I, "1",
+                  IRNode.RSHIFT_I, "1",
+                  IRNode.URSHIFT_I, "0",
+                  IRNode.ADD_I, "0"})
+    public int ctzDiv8Int() {
+        return Integer.numberOfTrailingZeros(i) / 8;
+    }
+
+    @Test
+    @IR(failOn = IRNode.COUNT_TRAILING_ZEROS_L)
+    public boolean ctzCompareLong() {
+        return Long.numberOfTrailingZeros(l) < 0 || Long.numberOfTrailingZeros(l) > 64;
+    }
+
+    @Test
+    @IR(counts = {IRNode.COUNT_TRAILING_ZEROS_L, "1",
+                  IRNode.RSHIFT_I, "1",
+                  IRNode.URSHIFT_I, "0",
+                  IRNode.ADD_I, "0"})
+    public int ctzDiv8Long() {
+        return Long.numberOfTrailingZeros(l) / 8;
+    }
+}

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
@@ -1607,6 +1607,16 @@ public class IRNode {
         vectorNode(POPCOUNT_VL, "PopCountVL", TYPE_LONG);
     }
 
+    public static final String COUNT_TRAILING_ZEROS_I = PREFIX + "COUNT_TRAILING_ZEROS_I" + POSTFIX;
+    static {
+        beforeMatchingNameRegex(COUNT_TRAILING_ZEROS_I, "CountTrailingZerosI");
+    }
+
+    public static final String COUNT_TRAILING_ZEROS_L = PREFIX + "COUNT_TRAILING_ZEROS_L" + POSTFIX;
+    static {
+        beforeMatchingNameRegex(COUNT_TRAILING_ZEROS_L, "CountTrailingZerosL");
+    }
+
     public static final String COUNT_TRAILING_ZEROS_VL = VECTOR_PREFIX + "COUNT_TRAILING_ZEROS_VL" + POSTFIX;
     static {
         vectorNode(COUNT_TRAILING_ZEROS_VL, "CountTrailingZerosV", TYPE_LONG);
@@ -1615,6 +1625,16 @@ public class IRNode {
     public static final String COUNT_TRAILING_ZEROS_VI = VECTOR_PREFIX + "COUNT_TRAILING_ZEROS_VI" + POSTFIX;
     static {
         vectorNode(COUNT_TRAILING_ZEROS_VI, "CountTrailingZerosV", TYPE_INT);
+    }
+
+    public static final String COUNT_LEADING_ZEROS_I = PREFIX + "COUNT_LEADING_ZEROS_I" + POSTFIX;
+    static {
+        beforeMatchingNameRegex(COUNT_LEADING_ZEROS_I, "CountLeadingZerosI");
+    }
+
+    public static final String COUNT_LEADING_ZEROS_L = PREFIX + "COUNT_LEADING_ZEROS_L" + POSTFIX;
+    static {
+        beforeMatchingNameRegex(COUNT_LEADING_ZEROS_L, "CountLeadingZerosL");
     }
 
     public static final String COUNT_LEADING_ZEROS_VL = VECTOR_PREFIX + "COUNT_LEADING_ZEROS_VL" + POSTFIX;


### PR DESCRIPTION
The result of count leading/trailing zeros is always non-negative, and the maximum value is integer type's size in bits. In previous versions, when C2 can not know the operand value of a CLZ/CTZ node at compile time, it will generate a full-width integer type for its result. This can significantly affect the efficiency of code in some cases.

This patch makes the type of CLZ/CTZ nodes more precise, to make C2 generate better code. For example, the following implementation runs ~115% faster on x86-64 with this patch:

```java
public static int numberOfNibbles(int i) {
  int mag = Integer.SIZE - Integer.numberOfLeadingZeros(i);
  return Math.max((mag + 3) / 4, 1);
}
```

Testing: tier1, IR test