### PR TITLE
8360487: Remove unnecessary List.indexOf key from AbstractMidiDevice.TransmitterList.remove

### DIFF
--- a/src/java.desktop/share/classes/com/sun/media/sound/AbstractMidiDevice.java
+++ b/src/java.desktop/share/classes/com/sun/media/sound/AbstractMidiDevice.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -561,10 +561,7 @@ abstract class AbstractMidiDevice implements MidiDevice, ReferenceCountingDevice
 
         private void remove(Transmitter t) {
             synchronized(transmitters) {
-                int index = transmitters.indexOf(t);
-                if (index >= 0) {
-                    transmitters.remove(index);
-                }
+                transmitters.remove(t);
             }
         }
 


### PR DESCRIPTION
No need to call `List.indexOf(Object)` before `List.remove(int)`. Instead we can call `List.remove(Object)` directly. It's faster and cleaner.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8360487](https://bugs.openjdk.org/browse/JDK-8360487): Remove unnecessary List.indexOf key from AbstractMidiDevice.TransmitterList.remove (**Enhancement** - P5)


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25931/head:pull/25931` \
`$ git checkout pull/25931`

Update a local copy of the PR: \
`$ git checkout pull/25931` \
`$ git pull https://git.openjdk.org/jdk.git pull/25931/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25931`

View PR using the GUI difftool: \
`$ git pr show -t 25931`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25931.diff">https://git.openjdk.org/jdk/pull/25931.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25931#issuecomment-3003956949)
</details>
