### PR TITLE
8360220: Deprecate and obsolete ParallelRefProcBalancingEnabled

### DIFF
--- a/src/hotspot/share/gc/shared/gc_globals.hpp
+++ b/src/hotspot/share/gc/shared/gc_globals.hpp
@@ -203,7 +203,7 @@
           "whenever possible")                                              \
                                                                             \
   product(bool, ParallelRefProcBalancingEnabled, true,                      \
-          "Enable balancing of reference processing queues")                \
+          "(Deprecated) Enable balancing of reference processing queues")   \
                                                                             \
   product(size_t, ReferencesPerThread, 1000, EXPERIMENTAL,                  \
                "Ergonomically start one thread for this amount of "         \

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -533,6 +533,7 @@ static SpecialFlag const special_jvm_flags[] = {
   { "UseCompressedClassPointers",   JDK_Version::jdk(25),  JDK_Version::jdk(26), JDK_Version::undefined() },
 #endif
   { "ParallelRefProcEnabled",       JDK_Version::jdk(26),  JDK_Version::jdk(27), JDK_Version::jdk(28) },
+  { "ParallelRefProcBalancingEnabled", JDK_Version::jdk(26),  JDK_Version::jdk(27), JDK_Version::jdk(28) },
   // --- Deprecated alias flags (see also aliased_jvm_flags) - sorted by obsolete_in then expired_in:
   { "CreateMinidumpOnCrash",        JDK_Version::jdk(9),  JDK_Version::undefined(), JDK_Version::undefined() },
 


### PR DESCRIPTION
Deprecating `ParallelRefProcBalancingEnabled`, which is used only by Parallel and G1, and both have it enabled by default.

Disabling it offers little benefit, so removing it do reduce the number commandline flags.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Change requires CSR request [JDK-8360221](https://bugs.openjdk.org/browse/JDK-8360221) to be approved
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8360220](https://bugs.openjdk.org/browse/JDK-8360220): Deprecate and obsolete ParallelRefProcBalancingEnabled (**Enhancement** - P4)
 * [JDK-8360221](https://bugs.openjdk.org/browse/JDK-8360221): Deprecate and obsolete ParallelRefProcBalancingEnabled (**CSR**)


### Reviewers
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25932/head:pull/25932` \
`$ git checkout pull/25932`

Update a local copy of the PR: \
`$ git checkout pull/25932` \
`$ git pull https://git.openjdk.org/jdk.git pull/25932/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25932`

View PR using the GUI difftool: \
`$ git pr show -t 25932`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25932.diff">https://git.openjdk.org/jdk/pull/25932.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25932#issuecomment-2995637989)
</details>
