### PR TITLE
8360281: VMError::error_string has incorrect format usage

### DIFF
--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -266,7 +266,7 @@ char* VMError::error_string(char* buf, int buflen) {
   if (signame) {
     jio_snprintf(buf, buflen,
                  "%s (0x%x) at pc=" PTR_FORMAT ", pid=%d, tid=%zu",
-                 signame, _id, _pc,
+                 signame, _id, p2i(_pc),
                  os::current_process_id(), os::current_thread_id());
   } else if (_filename != nullptr && _lineno > 0) {
     // skip directory names


### PR DESCRIPTION
Please review this trivial change to VMError::error_string, applying the `p2i`
helper function to a pointer being used as the value for a PTR_FORMAT directive.

Testing: mach5 tier1
Locally tested with gcc printf warnings enabled for jio_snprintf, and verified
the warning for the changed call is no longer present.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8360281](https://bugs.openjdk.org/browse/JDK-8360281): VMError::error_string has incorrect format usage (**Enhancement** - P4)


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25935/head:pull/25935` \
`$ git checkout pull/25935`

Update a local copy of the PR: \
`$ git checkout pull/25935` \
`$ git pull https://git.openjdk.org/jdk.git pull/25935/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25935`

View PR using the GUI difftool: \
`$ git pr show -t 25935`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25935.diff">https://git.openjdk.org/jdk/pull/25935.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25935#issuecomment-2996410091)
</details>
