### PR TITLE
8360042: GHA: Bump MSVC to 14.44

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -310,7 +310,7 @@ jobs:
     uses: ./.github/workflows/build-windows.yml
     with:
       platform: windows-x64
-      msvc-toolset-version: '14.43'
+      msvc-toolset-version: '14.44'
       msvc-toolset-architecture: 'x86.x64'
       configure-arguments: ${{ github.event.inputs.configure-arguments }}
       make-arguments: ${{ github.event.inputs.make-arguments }}
@@ -322,7 +322,7 @@ jobs:
     uses: ./.github/workflows/build-windows.yml
     with:
       platform: windows-aarch64
-      msvc-toolset-version: '14.43'
+      msvc-toolset-version: '14.44'
       msvc-toolset-architecture: 'arm64'
       make-target: 'hotspot'
       extra-conf-options: '--openjdk-target=aarch64-unknown-cygwin'


### PR DESCRIPTION
Fixes GHA for jdk25 branch as well, following the switch to windows-2025 runners in late JDK 25.

Additional testing:
 - [ ] GHA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8360042](https://bugs.openjdk.org/browse/JDK-8360042): GHA: Bump MSVC to 14.44 (**Bug** - P3)


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25939/head:pull/25939` \
`$ git checkout pull/25939`

Update a local copy of the PR: \
`$ git checkout pull/25939` \
`$ git pull https://git.openjdk.org/jdk.git pull/25939/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25939`

View PR using the GUI difftool: \
`$ git pr show -t 25939`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25939.diff">https://git.openjdk.org/jdk/pull/25939.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25939#issuecomment-2997184736)
</details>
