### PR TITLE
8360045: StringTokenizer.hasMoreTokens() throws NPE after nextToken(null)

### DIFF
--- a/src/java.base/share/classes/java/util/StringTokenizer.java
+++ b/src/java.base/share/classes/java/util/StringTokenizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -368,6 +368,8 @@ public class StringTokenizer implements Enumeration<Object> {
      * @throws    NullPointerException if delim is {@code null}
      */
     public String nextToken(String delim) {
+        Objects.requireNonNull(delim);
+
         delimiters = delim;
 
         /* delimiter string specified, so set the appropriate flag. */

--- a/test/jdk/java/util/StringTokenizer/NextTokenWithNullDelimTest.java
+++ b/test/jdk/java/util/StringTokenizer/NextTokenWithNullDelimTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8360045
+ * @summary Verify StringTokenizer.nextToken(null) does not alter the
+ *      existing delimiter
+ * @run junit NextTokenWithNullDelimTest
+ */
+
+import java.util.StringTokenizer;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class NextTokenWithNullDelimTest {
+    @Test
+    void testNextTokenWithNullDelim() {
+        StringTokenizer st = new StringTokenizer("test");
+        assertThrows(NullPointerException.class, () -> st.nextToken(null));
+        assertDoesNotThrow(st::hasMoreTokens);
+    }
+}


### PR DESCRIPTION
Fixing the side-effect caused by calling `StringTokenizer.nextToken(null)`, where the delimiter is set to `null` even if the method throws an NPE.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8360045](https://bugs.openjdk.org/browse/JDK-8360045): StringTokenizer.hasMoreTokens() throws NPE after nextToken(null) (**Bug** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25942/head:pull/25942` \
`$ git checkout pull/25942`

Update a local copy of the PR: \
`$ git checkout pull/25942` \
`$ git pull https://git.openjdk.org/jdk.git pull/25942/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25942`

View PR using the GUI difftool: \
`$ git pr show -t 25942`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25942.diff">https://git.openjdk.org/jdk/pull/25942.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25942#issuecomment-2997827739)
</details>
