### PR TITLE
8358529: GenShen: Heuristics do not respond to changes in SoftMaxHeapSize

### DIFF
--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.cpp
@@ -91,7 +91,7 @@ void ShenandoahAdaptiveHeuristics::choose_collection_set_from_regiondata(Shenand
   // we hit max_cset. When max_cset is hit, we terminate the cset selection. Note that in this scheme,
   // ShenandoahGarbageThreshold is the soft threshold which would be ignored until min_garbage is hit.
 
-  size_t capacity    = _space_info->soft_max_capacity();
+  size_t capacity    = ShenandoahHeap::heap()->soft_max_capacity();
   size_t max_cset    = (size_t)((1.0 * capacity / 100 * ShenandoahEvacReserve) / ShenandoahEvacWaste);
   size_t free_target = (capacity / 100 * ShenandoahMinFreeThreshold) + max_cset;
   size_t min_garbage = (free_target > actual_free ? (free_target - actual_free) : 0);
@@ -233,7 +233,7 @@ static double saturate(double value, double min, double max) {
 //    in operation mode.  We want some way to decide that the average rate has changed, while keeping average
 //    allocation rate computation independent.
 bool ShenandoahAdaptiveHeuristics::should_start_gc() {
-  size_t capacity = _space_info->soft_max_capacity();
+  size_t capacity = ShenandoahHeap::heap()->soft_max_capacity();
   size_t available = _space_info->soft_available();
   size_t allocated = _space_info->bytes_allocated_since_gc_start();
 

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahCompactHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahCompactHeuristics.cpp
@@ -47,7 +47,7 @@ ShenandoahCompactHeuristics::ShenandoahCompactHeuristics(ShenandoahSpaceInfo* sp
 
 bool ShenandoahCompactHeuristics::should_start_gc() {
   size_t max_capacity = _space_info->max_capacity();
-  size_t capacity = _space_info->soft_max_capacity();
+  size_t capacity = ShenandoahHeap::heap()->soft_max_capacity();
   size_t available = _space_info->available();
 
   // Make sure the code below treats available without the soft tail.

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahCompactHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahCompactHeuristics.cpp
@@ -57,6 +57,8 @@ bool ShenandoahCompactHeuristics::should_start_gc() {
   size_t threshold_bytes_allocated = capacity / 100 * ShenandoahAllocationThreshold;
   size_t min_threshold = capacity / 100 * ShenandoahMinFreeThreshold;
 
+  log_debug(gc)("should_start_gc? available: %zu, soft_max_capacity: %zu", available, capacity);
+
   if (available < min_threshold) {
     log_trigger("Free (%zu%s) is below minimum threshold (%zu%s)",
                 byte_size_in_proper_unit(available),     proper_unit_for_byte_size(available),
@@ -66,6 +68,8 @@ bool ShenandoahCompactHeuristics::should_start_gc() {
   }
 
   size_t bytes_allocated = _space_info->bytes_allocated_since_gc_start();
+  log_debug(gc)("should_start_gc? allocated: %zu", bytes_allocated);
+
   if (bytes_allocated > threshold_bytes_allocated) {
     log_trigger("Allocated since last cycle (%zu%s) is larger than allocation threshold (%zu%s)",
                 byte_size_in_proper_unit(bytes_allocated),           proper_unit_for_byte_size(bytes_allocated),

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahCompactHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahCompactHeuristics.cpp
@@ -57,8 +57,6 @@ bool ShenandoahCompactHeuristics::should_start_gc() {
   size_t threshold_bytes_allocated = capacity / 100 * ShenandoahAllocationThreshold;
   size_t min_threshold = capacity / 100 * ShenandoahMinFreeThreshold;
 
-  log_debug(gc)("should_start_gc? available: %zu, soft_max_capacity: %zu", available, capacity);
-
   if (available < min_threshold) {
     log_trigger("Free (%zu%s) is below minimum threshold (%zu%s)",
                 byte_size_in_proper_unit(available),     proper_unit_for_byte_size(available),
@@ -68,8 +66,6 @@ bool ShenandoahCompactHeuristics::should_start_gc() {
   }
 
   size_t bytes_allocated = _space_info->bytes_allocated_since_gc_start();
-  log_debug(gc)("should_start_gc? allocated: %zu", bytes_allocated);
-
   if (bytes_allocated > threshold_bytes_allocated) {
     log_trigger("Allocated since last cycle (%zu%s) is larger than allocation threshold (%zu%s)",
                 byte_size_in_proper_unit(bytes_allocated),           proper_unit_for_byte_size(bytes_allocated),

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahSpaceInfo.hpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahSpaceInfo.hpp
@@ -37,7 +37,6 @@
 class ShenandoahSpaceInfo {
 public:
   virtual const char* name() const = 0;
-  virtual size_t soft_max_capacity() const = 0;
   virtual size_t max_capacity() const = 0;
   virtual size_t soft_available() const = 0;
   virtual size_t available() const = 0;

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahStaticHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahStaticHeuristics.cpp
@@ -42,7 +42,7 @@ ShenandoahStaticHeuristics::~ShenandoahStaticHeuristics() {}
 
 bool ShenandoahStaticHeuristics::should_start_gc() {
   size_t max_capacity = _space_info->max_capacity();
-  size_t capacity = _space_info->soft_max_capacity();
+  size_t capacity = ShenandoahHeap::heap()->soft_max_capacity();
   size_t available = _space_info->available();
 
   // Make sure the code below treats available without the soft tail.

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
@@ -1011,3 +1011,9 @@ void ShenandoahGeneration::record_success_concurrent(bool abbreviated) {
   heuristics()->record_success_concurrent();
   ShenandoahHeap::heap()->shenandoah_policy()->record_success_concurrent(is_young(), abbreviated);
 }
+
+size_t ShenandoahGeneration::soft_max_capacity() const {
+  size_t capacity = ShenandoahGenerationalHeap::heap()->soft_max_capacity();
+  log_debug(gc)("soft_max_capacity: %zu", capacity);
+  return capacity;
+}

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
@@ -806,7 +806,7 @@ ShenandoahGeneration::ShenandoahGeneration(ShenandoahGenerationType type,
   _ref_processor(new ShenandoahReferenceProcessor(MAX2(max_workers, 1U))),
   _affiliated_region_count(0), _humongous_waste(0), _evacuation_reserve(0),
   _used(0), _bytes_allocated_since_gc_start(0),
-  _max_capacity(max_capacity), _soft_max_capacity(soft_max_capacity),
+  _max_capacity(max_capacity),
   _heuristics(nullptr)
 {
   _is_marking_complete.set();
@@ -1014,6 +1014,6 @@ void ShenandoahGeneration::record_success_concurrent(bool abbreviated) {
 
 size_t ShenandoahGeneration::soft_max_capacity() const {
   size_t capacity = ShenandoahGenerationalHeap::heap()->soft_max_capacity();
-  log_debug(gc)("soft_max_capacity: %zu", capacity);
+  log_debug(gc)("soft_max_capacity: %zu", capacity); // TestDynamicSoftMaxHeapSize needs the log line to validate
   return capacity;
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
@@ -183,7 +183,7 @@ void ShenandoahGeneration::log_status(const char *msg) const {
   // byte size in proper unit and proper unit for byte size are consistent.
   const size_t v_used = used();
   const size_t v_used_regions = used_regions_size();
-  const size_t v_soft_max_capacity = soft_max_capacity();
+  const size_t v_soft_max_capacity = ShenandoahHeap::heap()->soft_max_capacity();
   const size_t v_max_capacity = max_capacity();
   const size_t v_available = available();
   const size_t v_humongous_waste = get_humongous_waste();
@@ -799,8 +799,7 @@ void ShenandoahGeneration::cancel_marking() {
 
 ShenandoahGeneration::ShenandoahGeneration(ShenandoahGenerationType type,
                                            uint max_workers,
-                                           size_t max_capacity,
-                                           size_t soft_max_capacity) :
+                                           size_t max_capacity) :
   _type(type),
   _task_queues(new ShenandoahObjToScanQueueSet(max_workers)),
   _ref_processor(new ShenandoahReferenceProcessor(MAX2(max_workers, 1U))),
@@ -952,7 +951,7 @@ size_t ShenandoahGeneration::available_with_reserve() const {
 }
 
 size_t ShenandoahGeneration::soft_available() const {
-  return available(soft_max_capacity());
+  return available(ShenandoahHeap::heap()->soft_max_capacity());
 }
 
 size_t ShenandoahGeneration::available(size_t capacity) const {
@@ -1010,10 +1009,4 @@ size_t ShenandoahGeneration::decrease_capacity(size_t decrement) {
 void ShenandoahGeneration::record_success_concurrent(bool abbreviated) {
   heuristics()->record_success_concurrent();
   ShenandoahHeap::heap()->shenandoah_policy()->record_success_concurrent(is_young(), abbreviated);
-}
-
-size_t ShenandoahGeneration::soft_max_capacity() const {
-  size_t capacity = ShenandoahGenerationalHeap::heap()->soft_max_capacity();
-  log_debug(gc)("soft_max_capacity: %zu", capacity); // TestDynamicSoftMaxHeapSize needs the log line to validate
-  return capacity;
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.hpp
@@ -71,7 +71,6 @@ protected:
   volatile size_t _used;
   volatile size_t _bytes_allocated_since_gc_start;
   size_t _max_capacity;
-  size_t _soft_max_capacity;
 
   ShenandoahHeuristics* _heuristics;
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.hpp
@@ -104,8 +104,7 @@ private:
  public:
   ShenandoahGeneration(ShenandoahGenerationType type,
                        uint max_workers,
-                       size_t max_capacity,
-                       size_t soft_max_capacity);
+                       size_t max_capacity);
   ~ShenandoahGeneration();
 
   bool is_young() const  { return _type == YOUNG; }
@@ -125,7 +124,6 @@ private:
 
   virtual ShenandoahHeuristics* initialize_heuristics(ShenandoahMode* gc_mode);
 
-  size_t soft_max_capacity() const override;
   size_t max_capacity() const override      { return _max_capacity; }
   virtual size_t used_regions() const;
   virtual size_t used_regions_size() const;

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.hpp
@@ -126,7 +126,7 @@ private:
 
   virtual ShenandoahHeuristics* initialize_heuristics(ShenandoahMode* gc_mode);
 
-  size_t soft_max_capacity() const override { return _soft_max_capacity; }
+  size_t soft_max_capacity() const override;
   size_t max_capacity() const override      { return _max_capacity; }
   virtual size_t used_regions() const;
   virtual size_t used_regions_size() const;

--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.cpp
@@ -53,21 +53,6 @@ public:
     ShenandoahGenerationalInitLogger logger;
     logger.print_all();
   }
-
-  void print_heap() override {
-    ShenandoahInitLogger::print_heap();
-
-    ShenandoahGenerationalHeap* heap = ShenandoahGenerationalHeap::heap();
-
-    ShenandoahYoungGeneration* young = heap->young_generation();
-    log_info(gc, init)("Young Generation Soft Size: " EXACTFMT, EXACTFMTARGS(young->soft_max_capacity()));
-    log_info(gc, init)("Young Generation Max: " EXACTFMT, EXACTFMTARGS(young->max_capacity()));
-
-    ShenandoahOldGeneration* old = heap->old_generation();
-    log_info(gc, init)("Old Generation Soft Size: " EXACTFMT, EXACTFMTARGS(old->soft_max_capacity()));
-    log_info(gc, init)("Old Generation Max: " EXACTFMT, EXACTFMTARGS(old->max_capacity()));
-  }
-
 protected:
   void print_gc_specific() override {
     ShenandoahInitLogger::print_gc_specific();
@@ -141,8 +126,8 @@ void ShenandoahGenerationalHeap::initialize_heuristics() {
   size_t initial_capacity_old = max_capacity() - max_capacity_young;
   size_t max_capacity_old = max_capacity() - initial_capacity_young;
 
-  _young_generation = new ShenandoahYoungGeneration(max_workers(), max_capacity_young, initial_capacity_young);
-  _old_generation = new ShenandoahOldGeneration(max_workers(), max_capacity_old, initial_capacity_old);
+  _young_generation = new ShenandoahYoungGeneration(max_workers(), max_capacity_young);
+  _old_generation = new ShenandoahOldGeneration(max_workers(), max_capacity_old);
   _young_generation->initialize_heuristics(mode());
   _old_generation->initialize_heuristics(mode());
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahGlobalGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGlobalGeneration.cpp
@@ -50,10 +50,6 @@ size_t ShenandoahGlobalGeneration::used_regions_size() const {
   return ShenandoahHeap::heap()->capacity();
 }
 
-size_t ShenandoahGlobalGeneration::soft_max_capacity() const {
-  return ShenandoahHeap::heap()->soft_max_capacity();
-}
-
 size_t ShenandoahGlobalGeneration::available() const {
   // The collector reserve may eat into what the mutator is allowed to use. Make sure we are looking
   // at what is available to the mutator when reporting how much memory is available.
@@ -65,8 +61,8 @@ size_t ShenandoahGlobalGeneration::soft_available() const {
   size_t available = this->available();
 
   // Make sure the code below treats available without the soft tail.
-  assert(max_capacity() >= soft_max_capacity(), "Max capacity must be greater than soft max capacity.");
-  size_t soft_tail = max_capacity() - soft_max_capacity();
+  assert(max_capacity() >= ShenandoahHeap::heap()->soft_max_capacity(), "Max capacity must be greater than soft max capacity.");
+  size_t soft_tail = max_capacity() - ShenandoahHeap::heap()->soft_max_capacity();
   return (available > soft_tail) ? (available - soft_tail) : 0;
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahGlobalGeneration.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGlobalGeneration.hpp
@@ -32,14 +32,13 @@
 // A "generation" that represents the whole heap.
 class ShenandoahGlobalGeneration : public ShenandoahGeneration {
 public:
-  ShenandoahGlobalGeneration(bool generational, uint max_queues, size_t max_capacity, size_t soft_max_capacity)
-  : ShenandoahGeneration(generational ? GLOBAL : NON_GEN, max_queues, max_capacity, soft_max_capacity) { }
+  ShenandoahGlobalGeneration(bool generational, uint max_queues, size_t max_capacity)
+  : ShenandoahGeneration(generational ? GLOBAL : NON_GEN, max_queues, max_capacity) { }
 
 public:
   const char* name() const override;
 
   size_t max_capacity() const override;
-  size_t soft_max_capacity() const override;
   size_t used_regions() const override;
   size_t used_regions_size() const override;
   size_t available() const override;

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -524,7 +524,7 @@ void ShenandoahHeap::initialize_mode() {
 }
 
 void ShenandoahHeap::initialize_heuristics() {
-  _global_generation = new ShenandoahGlobalGeneration(mode()->is_generational(), max_workers(), max_capacity(), max_capacity());
+  _global_generation = new ShenandoahGlobalGeneration(mode()->is_generational(), max_workers(), max_capacity());
   _global_generation->initialize_heuristics(mode());
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -77,8 +77,6 @@
 #include "gc/shenandoah/shenandoahWorkerPolicy.hpp"
 #include "gc/shenandoah/shenandoahWorkGroup.hpp"
 #include "gc/shenandoah/shenandoahYoungGeneration.hpp"
-#include "logging/log.hpp"
-#include "logging/logTag.hpp"
 #include "memory/allocation.hpp"
 #include "memory/classLoaderMetaspace.hpp"
 #include "memory/memoryReserver.hpp"

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -98,6 +98,8 @@
 #include "utilities/events.hpp"
 #include "utilities/globalDefinitions.hpp"
 #include "utilities/powerOfTwo.hpp"
+#include "logging/log.hpp"
+#include "logging/logTag.hpp"
 #if INCLUDE_JVMCI
 #include "jvmci/jvmci.hpp"
 #endif
@@ -201,8 +203,7 @@ jint ShenandoahHeap::initialize() {
   assert(num_min_regions <= _num_regions, "sanity");
   _minimum_size = num_min_regions * reg_size_bytes;
 
-  // Default to max heap size.
-  _soft_max_size = _num_regions * reg_size_bytes;
+  _soft_max_size = Atomic::load(&SoftMaxHeapSize);
 
   _committed = _initial_size;
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -77,6 +77,8 @@
 #include "gc/shenandoah/shenandoahWorkerPolicy.hpp"
 #include "gc/shenandoah/shenandoahWorkGroup.hpp"
 #include "gc/shenandoah/shenandoahYoungGeneration.hpp"
+#include "logging/log.hpp"
+#include "logging/logTag.hpp"
 #include "memory/allocation.hpp"
 #include "memory/classLoaderMetaspace.hpp"
 #include "memory/memoryReserver.hpp"
@@ -98,8 +100,6 @@
 #include "utilities/events.hpp"
 #include "utilities/globalDefinitions.hpp"
 #include "utilities/powerOfTwo.hpp"
-#include "logging/log.hpp"
-#include "logging/logTag.hpp"
 #if INCLUDE_JVMCI
 #include "jvmci/jvmci.hpp"
 #endif

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -32,6 +32,7 @@
 #include "gc/shared/gcArguments.hpp"
 #include "gc/shared/gcTimer.hpp"
 #include "gc/shared/gcTraceTime.inline.hpp"
+#include "gc/shared/gc_globals.hpp"
 #include "gc/shared/locationPrinter.inline.hpp"
 #include "gc/shared/memAllocator.hpp"
 #include "gc/shared/plab.hpp"
@@ -201,7 +202,7 @@ jint ShenandoahHeap::initialize() {
   assert(num_min_regions <= _num_regions, "sanity");
   _minimum_size = num_min_regions * reg_size_bytes;
 
-  _soft_max_size = Atomic::load(&SoftMaxHeapSize);
+  _soft_max_size = SoftMaxHeapSize;
 
   _committed = _initial_size;
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahInitLogger.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahInitLogger.cpp
@@ -43,6 +43,7 @@ void ShenandoahInitLogger::print_heap() {
   log_info(gc, init)("Heap Region Count: %zu", ShenandoahHeapRegion::region_count());
   log_info(gc, init)("Heap Region Size: " EXACTFMT, EXACTFMTARGS(ShenandoahHeapRegion::region_size_bytes()));
   log_info(gc, init)("TLAB Size Max: " EXACTFMT, EXACTFMTARGS(ShenandoahHeapRegion::max_tlab_size_bytes()));
+  log_info(gc, init)("Soft Max Heap Size: " EXACTFMT, EXACTFMTARGS(ShenandoahHeap::heap()->soft_max_capacity()));
 }
 
 void ShenandoahInitLogger::print_gc_specific() {

--- a/src/hotspot/share/gc/shenandoah/shenandoahOldGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahOldGeneration.cpp
@@ -196,8 +196,8 @@ public:
   }
 };
 
-ShenandoahOldGeneration::ShenandoahOldGeneration(uint max_queues, size_t max_capacity, size_t soft_max_capacity)
-  : ShenandoahGeneration(OLD, max_queues, max_capacity, soft_max_capacity),
+ShenandoahOldGeneration::ShenandoahOldGeneration(uint max_queues, size_t max_capacity)
+  : ShenandoahGeneration(OLD, max_queues, max_capacity),
     _coalesce_and_fill_region_array(NEW_C_HEAP_ARRAY(ShenandoahHeapRegion*, ShenandoahHeap::heap()->num_regions(), mtGC)),
     _old_heuristics(nullptr),
     _region_balance(0),

--- a/src/hotspot/share/gc/shenandoah/shenandoahOldGeneration.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahOldGeneration.hpp
@@ -88,7 +88,7 @@ private:
   bool coalesce_and_fill();
 
 public:
-  ShenandoahOldGeneration(uint max_queues, size_t max_capacity, size_t soft_max_capacity);
+  ShenandoahOldGeneration(uint max_queues, size_t max_capacity);
 
   ShenandoahHeuristics* initialize_heuristics(ShenandoahMode* gc_mode) override;
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahYoungGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahYoungGeneration.cpp
@@ -30,8 +30,8 @@
 #include "gc/shenandoah/shenandoahUtils.hpp"
 #include "gc/shenandoah/shenandoahYoungGeneration.hpp"
 
-ShenandoahYoungGeneration::ShenandoahYoungGeneration(uint max_queues, size_t max_capacity, size_t soft_max_capacity) :
-  ShenandoahGeneration(YOUNG, max_queues, max_capacity, soft_max_capacity),
+ShenandoahYoungGeneration::ShenandoahYoungGeneration(uint max_queues, size_t max_capacity) :
+  ShenandoahGeneration(YOUNG, max_queues, max_capacity),
   _old_gen_task_queues(nullptr) {
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahYoungGeneration.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahYoungGeneration.hpp
@@ -34,7 +34,7 @@ private:
   ShenandoahYoungHeuristics* _young_heuristics;
 
 public:
-  ShenandoahYoungGeneration(uint max_queues, size_t max_capacity, size_t max_soft_capacity);
+  ShenandoahYoungGeneration(uint max_queues, size_t max_capacity);
 
   ShenandoahHeuristics* initialize_heuristics(ShenandoahMode* gc_mode) override;
 

--- a/test/hotspot/gtest/gc/shenandoah/test_shenandoahOldGeneration.cpp
+++ b/test/hotspot/gtest/gc/shenandoah/test_shenandoahOldGeneration.cpp
@@ -52,7 +52,7 @@ protected:
 
     ShenandoahHeap::heap()->lock()->lock(false);
 
-    old = new ShenandoahOldGeneration(8, 1024 * 1024, 1024);
+    old = new ShenandoahOldGeneration(8, 1024 * 1024);
     old->set_promoted_reserve(512 * HeapWordSize);
     old->expend_promoted(256 * HeapWordSize);
     old->set_evacuation_reserve(512 * HeapWordSize);

--- a/test/hotspot/jtreg/gc/shenandoah/TestDynamicSoftMaxHeapSize.java
+++ b/test/hotspot/jtreg/gc/shenandoah/TestDynamicSoftMaxHeapSize.java
@@ -24,104 +24,131 @@
  */
 
 /*
- * @test id=passive
+ * @test id=dynamicSoftMaxHeapSize
  * @requires vm.gc.Shenandoah
  * @library /test/lib
  *
- * @run main/othervm -Xms16m -Xmx512m -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
- *      -XX:+UseShenandoahGC -XX:ShenandoahGCMode=passive
- *      -XX:+ShenandoahDegeneratedGC
- *      -Dtarget=10000
- *      TestDynamicSoftMaxHeapSize
- *
- * @run main/othervm -Xms16m -Xmx512m -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
- *      -XX:+UseShenandoahGC -XX:ShenandoahGCMode=passive
- *      -XX:-ShenandoahDegeneratedGC
- *      -Dtarget=10000
- *      TestDynamicSoftMaxHeapSize
+ * @run driver TestDynamicSoftMaxHeapSize
  */
-
-/*
- * @test id=aggressive
- * @requires vm.gc.Shenandoah
- * @library /test/lib
- *
- * @run main/othervm -Xms16m -Xmx512m -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
- *      -XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=aggressive
- *      -Dtarget=1000
- *      TestDynamicSoftMaxHeapSize
- */
-
-/*
- * @test id=adaptive
- * @requires vm.gc.Shenandoah
- * @library /test/lib
- *
- * @run main/othervm -Xms16m -Xmx512m -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
- *      -XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=adaptive
- *      -Dtarget=10000
- *      TestDynamicSoftMaxHeapSize
- */
-
-/*
- * @test id=generational
- * @requires vm.gc.Shenandoah
- * @library /test/lib
- *
- * @run main/othervm -Xms16m -Xmx512m -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
- *      -XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=adaptive -XX:ShenandoahGCMode=generational
- *      -Dtarget=10000
- *      TestDynamicSoftMaxHeapSize
- */
-
-/*
- * @test id=static
- * @requires vm.gc.Shenandoah
- * @library /test/lib
- *
- * @run main/othervm -Xms16m -Xmx512m -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
- *      -XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=static
- *      -Dtarget=10000
- *      TestDynamicSoftMaxHeapSize
- */
-
-/*
- * @test id=compact
- * @requires vm.gc.Shenandoah
- * @library /test/lib
- *
- * @run main/othervm -Xms16m -Xmx512m -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
- *      -XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=compact
- *      -Dtarget=1000
- *     TestDynamicSoftMaxHeapSize
- */
-
-import java.util.Random;
 import jdk.test.lib.Utils;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.dcmd.PidJcmdExecutor;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+
 public class TestDynamicSoftMaxHeapSize {
+    static final int K = 1024;
+    static final List<String> COMMON_COMMANDS = Arrays.asList("-Xms16m",
+            "-Xmx512m",
+            "-XX:+UnlockDiagnosticVMOptions",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+UseShenandoahGC",
+            "-Xlog:gc=debug",
+            "-Dtest.jdk=" + System.getProperty("test.jdk"),
+            "-Dcompile.jdk=" + System.getProperty("compile.jdk"),
+            "-Dtarget=10000"
+            );
+    static final List<String> HEURISTICS = Arrays.asList("adaptive", "aggressive", "compact", "static");
 
-    static final long TARGET_MB = Long.getLong("target", 10_000); // 10 Gb allocation
-    static final long STRIDE = 10_000_000;
-
-    static volatile Object sink;
 
     public static void main(String[] args) throws Exception {
-        long count = TARGET_MB * 1024 * 1024 / 16;
-        Random r = Utils.getRandomInstance();
-        PidJcmdExecutor jcmd = new PidJcmdExecutor();
+        // satb gc mode
+        List<String> satbGCModeArgsNoDegeneratedGC = new ArrayList<>(COMMON_COMMANDS);
+        satbGCModeArgsNoDegeneratedGC.add("-XX:ShenandoahGCMode=satb");
 
-        for (long c = 0; c < count; c += STRIDE) {
-            // Sizes specifically include heaps below Xms and above Xmx to test saturation code.
-            jcmd.execute("VM.set_flag SoftMaxHeapSize " + r.nextInt(768*1024*1024), true);
-            for (long s = 0; s < STRIDE; s++) {
-                sink = new Object();
-            }
-            Thread.sleep(1);
+        for (String heuristic : HEURISTICS) {
+            satbGCModeArgsNoDegeneratedGC.add("-XX:ShenandoahGCHeuristics=" + heuristic);
+            satbGCModeArgsNoDegeneratedGC.add(SoftMaxSetFlagOnlyTest.class.getName());
+
+            ProcessBuilder satbPb = ProcessTools.createLimitedTestJavaProcessBuilder(satbGCModeArgsNoDegeneratedGC);
+            (new OutputAnalyzer(satbPb.start())).shouldHaveExitValue(0);
+        }
+
+        // passive gc mode
+        List<String> degeneratedJvmArgs = Arrays.asList("-XX:+ShenandoahDegeneratedGC", "-XX:-ShenandoahDegeneratedGC");
+
+        List<String> passiveGCModeArgs = new ArrayList<>(COMMON_COMMANDS);
+        passiveGCModeArgs.add("-XX:ShenandoahGCMode=passive");
+
+        for (String degeneratedJvmArg : degeneratedJvmArgs) {
+            passiveGCModeArgs.add(degeneratedJvmArg);
+            passiveGCModeArgs.add(SoftMaxSetFlagOnlyTest.class.getName());
+
+            ProcessBuilder passivePb = ProcessTools.createLimitedTestJavaProcessBuilder(passiveGCModeArgs);
+            (new OutputAnalyzer(passivePb.start())).shouldHaveExitValue(0);
+        }
+
+        // generational gc mode
+        List<String> genShenGCModeArgs = new ArrayList<>(COMMON_COMMANDS);
+        genShenGCModeArgs.add("-XX:ShenandoahGCMode=generational");
+
+        for (String heuristic : HEURISTICS) {
+            genShenGCModeArgs.add("-XX:ShenandoahGCHeuristics=" + heuristic);
+            genShenGCModeArgs.add(SoftMaxSetFlagOnlyTest.class.getName());
+
+            ProcessBuilder genShenPb = ProcessTools.createLimitedTestJavaProcessBuilder(genShenGCModeArgs);
+            (new OutputAnalyzer(genShenPb.start())).shouldHaveExitValue(0);
+        }
+
+        // generational gc mode. Verify if it can detect soft max heap change when app is running
+        int xMsHeapInByte = 16 * K * K;
+        int xMxHeapInByte = 512 * K * K;
+        int softMaxInByte = Utils.getRandomInstance().nextInt(xMsHeapInByte, xMxHeapInByte + 1);
+
+        List<String> generationalGCModeArgs = new ArrayList<>(COMMON_COMMANDS);
+        generationalGCModeArgs.add("-XX:ShenandoahGCMode=generational");
+        generationalGCModeArgs.add("-DsoftMaxCapacity=" + softMaxInByte);
+
+        for (String heuristic : HEURISTICS) {
+            generationalGCModeArgs.add("-XX:ShenandoahGCHeuristics=" + heuristic);
+            generationalGCModeArgs.add(SoftMaxWithExpectationTest.class.getName());
+
+            ProcessBuilder genShenPb = ProcessTools.createLimitedTestJavaProcessBuilder(generationalGCModeArgs);
+            OutputAnalyzer output = new OutputAnalyzer(genShenPb.start());
+            output.shouldHaveExitValue(0);
+            output.shouldContain("soft_max_capacity: " + softMaxInByte);
         }
     }
 
+    public static class SoftMaxSetFlagOnlyTest {
+        static final long TARGET_MB = Long.getLong("target", 10_000); // 10 Gb allocation
+        static final long STRIDE = 10_000_000;
+
+        static volatile Object sink;
+
+        public static void main(String[] args) throws Exception {
+            long count = TARGET_MB * 1024 * 1024 / 16;
+            Random r = Utils.getRandomInstance();
+            PidJcmdExecutor jcmd = new PidJcmdExecutor();
+
+            for (long c = 0; c < count; c += STRIDE) {
+                // Sizes specifically include heaps below Xms and above Xmx to test saturation code.
+                jcmd.execute("VM.set_flag SoftMaxHeapSize " + r.nextInt(768*1024*1024), true);
+                for (long s = 0; s < STRIDE; s++) {
+                    sink = new Object();
+                }
+                Thread.sleep(1);
+            }
+        }
+    }
+
+    public static class SoftMaxWithExpectationTest {
+        static final long TOTAL = 100_000_000;
+
+        static volatile Object sink;
+
+        public static void main(String[] args) throws Exception {
+            int expectedSoftMaxHeapSize = Integer.getInteger("softMaxCapacity", 0);
+            PidJcmdExecutor jcmd = new PidJcmdExecutor();
+            jcmd.execute("VM.set_flag SoftMaxHeapSize " + expectedSoftMaxHeapSize, false);
+
+            for (long s = 0; s < TOTAL; s++) {
+                sink = new Object();
+            }
+        }
+    }
 }


### PR DESCRIPTION
Generational shenandoah currently doesn't pick up the changes of managed flag `SoftMaxHeapSize` when the app is running. This is because the value of `_soft_max_capacity` in `shenandoahGeneration` is never changed.

This change delegates the soft max heap size in `shenandoahGeneration` to `ShenandoahGenerationalHeap::heap()->soft_max_capacity()`, which does pick up the flag value changes.

Also, found `ShenandoahHeap:: initialize` uses `_num_regions * reg_size_bytes` rather than user input flag value. Updated to using actual flag value.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8358529](https://bugs.openjdk.org/browse/JDK-8358529): GenShen: Heuristics do not respond to changes in SoftMaxHeapSize (**Bug** - P4)


### Reviewers
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25943/head:pull/25943` \
`$ git checkout pull/25943`

Update a local copy of the PR: \
`$ git checkout pull/25943` \
`$ git pull https://git.openjdk.org/jdk.git pull/25943/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25943`

View PR using the GUI difftool: \
`$ git pr show -t 25943`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25943.diff">https://git.openjdk.org/jdk/pull/25943.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25943#issuecomment-3001279076)
</details>
