### PR TITLE
8360307: Problemlist tools/sincechecker/modules/jdk.management.jfr/JdkManagementJfrCheckSince.java

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -838,3 +838,5 @@ java/awt/Modal/NativeDialogToFrontBackTest.java 7188049 windows-all,linux-all
 # jdk_since_checks
 
 tools/sincechecker/modules/java.base/JavaBaseCheckSince.java 8358627 generic-all
+tools/sincechecker/modules/jdk.management.jfr/JdkManagementJfrCheckSince.java 8354921 generic-all
+


### PR DESCRIPTION
Can I please get a review of this problemlisting change which problem lists the `tools/sincechecker/modules/jdk.management.jfr/JdkManagementJfrCheckSince.java` test? This test has been failing regularly in our CI in tier2.

I have tier2 run in progress and I'll integrate this change once that run completes successfully.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8360307](https://bugs.openjdk.org/browse/JDK-8360307): Problemlist tools/sincechecker/modules/jdk.management.jfr/JdkManagementJfrCheckSince.java (**Sub-task** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25947/head:pull/25947` \
`$ git checkout pull/25947`

Update a local copy of the PR: \
`$ git checkout pull/25947` \
`$ git pull https://git.openjdk.org/jdk.git pull/25947/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25947`

View PR using the GUI difftool: \
`$ git pr show -t 25947`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25947.diff">https://git.openjdk.org/jdk/pull/25947.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25947#issuecomment-2998775736)
</details>
