### PR TITLE
8360201: JFR: Initialize JfrThreadLocal::_sampling_critical_section

### DIFF
--- a/src/hotspot/share/jfr/support/jfrThreadLocal.cpp
+++ b/src/hotspot/share/jfr/support/jfrThreadLocal.cpp
@@ -79,7 +79,8 @@ JfrThreadLocal::JfrThreadLocal() :
   _enqueued_requests(false),
   _vthread(false),
   _notified(false),
-  _dead(false)
+  _dead(false),
+  _sampling_critical_section(false)
 #ifdef LINUX
   ,_cpu_timer(nullptr),
   _cpu_time_jfr_locked(UNLOCKED),


### PR DESCRIPTION
Fixes the bug in the new feature in JDK 25. The fix is pretty trivial.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8360201](https://bugs.openjdk.org/browse/JDK-8360201): JFR: Initialize JfrThreadLocal::_sampling_critical_section (**Bug** - P3)


### Reviewers
 * [Zhengyu Gu](https://openjdk.org/census#zgu) (@zhengyu123 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25952/head:pull/25952` \
`$ git checkout pull/25952`

Update a local copy of the PR: \
`$ git checkout pull/25952` \
`$ git pull https://git.openjdk.org/jdk.git pull/25952/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25952`

View PR using the GUI difftool: \
`$ git pr show -t 25952`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25952.diff">https://git.openjdk.org/jdk/pull/25952.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25952#issuecomment-3000912327)
</details>
