### PR TITLE
8360405: [PPC64] some environments don't support mfdscr instruction

### DIFF
--- a/src/hotspot/cpu/ppc/macroAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/macroAssembler_ppc.cpp
@@ -3928,8 +3928,10 @@ void MacroAssembler::kernel_crc32_vpmsum_aligned(Register crc, Register buf, Reg
   Label L_outer_loop, L_inner_loop, L_last;
 
   // Set DSCR pre-fetch to deepest.
-  load_const_optimized(t0, VM_Version::_dscr_val | 7);
-  mtdscr(t0);
+  if (VM_Version::has_mfdscr()) {
+    load_const_optimized(t0, VM_Version::_dscr_val | 7);
+    mtdscr(t0);
+  }
 
   mtvrwz(VCRC, crc); // crc lives in VCRC, now
 
@@ -4073,8 +4075,10 @@ void MacroAssembler::kernel_crc32_vpmsum_aligned(Register crc, Register buf, Reg
   // ********** Main loop end **********
 
   // Restore DSCR pre-fetch value.
-  load_const_optimized(t0, VM_Version::_dscr_val);
-  mtdscr(t0);
+  if (VM_Version::has_mfdscr()) {
+    load_const_optimized(t0, VM_Version::_dscr_val);
+    mtdscr(t0);
+  }
 
   // ********** Simple loop for remaining 16 byte blocks **********
   {

--- a/src/hotspot/cpu/ppc/stubGenerator_ppc.cpp
+++ b/src/hotspot/cpu/ppc/stubGenerator_ppc.cpp
@@ -1376,6 +1376,7 @@ class StubGenerator: public StubCodeGenerator {
             __ load_const_optimized(tmp2, VM_Version::_dscr_val);
             __ mtdscr(tmp2);
           }
+
       } // FasterArrayCopy
       __ bind(l_6);
 

--- a/src/hotspot/cpu/ppc/stubGenerator_ppc.cpp
+++ b/src/hotspot/cpu/ppc/stubGenerator_ppc.cpp
@@ -952,8 +952,10 @@ class StubGenerator: public StubCodeGenerator {
     address start_pc = __ pc();
     Register tmp1 = R6_ARG4;
     // probably copy stub would have changed value reset it.
-    __ load_const_optimized(tmp1, VM_Version::_dscr_val);
-    __ mtdscr(tmp1);
+    if (VM_Version::has_mfdscr()) {
+      __ load_const_optimized(tmp1, VM_Version::_dscr_val);
+      __ mtdscr(tmp1);
+    }
     __ li(R3_RET, 0); // return 0
     __ blr();
     return start_pc;
@@ -1070,9 +1072,10 @@ class StubGenerator: public StubCodeGenerator {
         __ dcbt(R3_ARG1, 0);
 
         // If supported set DSCR pre-fetch to deepest.
-        __ load_const_optimized(tmp2, VM_Version::_dscr_val | 7);
-        __ mtdscr(tmp2);
-
+        if (VM_Version::has_mfdscr()) {
+          __ load_const_optimized(tmp2, VM_Version::_dscr_val | 7);
+          __ mtdscr(tmp2);
+        }
         __ li(tmp1, 16);
 
         // Backbranch target aligned to 32-byte. Not 16-byte align as
@@ -1092,8 +1095,10 @@ class StubGenerator: public StubCodeGenerator {
         __ bdnz(l_10);                       // Dec CTR and loop if not zero.
 
         // Restore DSCR pre-fetch value.
-        __ load_const_optimized(tmp2, VM_Version::_dscr_val);
-        __ mtdscr(tmp2);
+        if (VM_Version::has_mfdscr()) {
+          __ load_const_optimized(tmp2, VM_Version::_dscr_val);
+          __ mtdscr(tmp2);
+        }
 
      } // FasterArrayCopy
 
@@ -1344,8 +1349,10 @@ class StubGenerator: public StubCodeGenerator {
           __ dcbt(R3_ARG1, 0);
 
           // If supported set DSCR pre-fetch to deepest.
-          __ load_const_optimized(tmp2, VM_Version::_dscr_val | 7);
-          __ mtdscr(tmp2);
+          if (VM_Version::has_mfdscr()) {
+            __ load_const_optimized(tmp2, VM_Version::_dscr_val | 7);
+            __ mtdscr(tmp2);
+          }
           __ li(tmp1, 16);
 
           // Backbranch target aligned to 32-byte. It's not aligned 16-byte
@@ -1365,8 +1372,10 @@ class StubGenerator: public StubCodeGenerator {
           __ bdnz(l_9);                        // Dec CTR and loop if not zero.
 
           // Restore DSCR pre-fetch value.
-          __ load_const_optimized(tmp2, VM_Version::_dscr_val);
-          __ mtdscr(tmp2);
+          if (VM_Version::has_mfdscr()) {
+            __ load_const_optimized(tmp2, VM_Version::_dscr_val);
+            __ mtdscr(tmp2);
+          }
       } // FasterArrayCopy
       __ bind(l_6);
 
@@ -1527,9 +1536,10 @@ class StubGenerator: public StubCodeGenerator {
     __ dcbt(R3_ARG1, 0);
 
     // Set DSCR pre-fetch to deepest.
-    __ load_const_optimized(tmp2, VM_Version::_dscr_val | 7);
-    __ mtdscr(tmp2);
-
+    if (VM_Version::has_mfdscr()) {
+      __ load_const_optimized(tmp2, VM_Version::_dscr_val | 7);
+      __ mtdscr(tmp2);
+    }
     __ li(tmp1, 16);
 
     // Backbranch target aligned to 32-byte. Not 16-byte align as
@@ -1549,9 +1559,10 @@ class StubGenerator: public StubCodeGenerator {
     __ bdnz(l_7);                        // Dec CTR and loop if not zero.
 
     // Restore DSCR pre-fetch value.
-    __ load_const_optimized(tmp2, VM_Version::_dscr_val);
-    __ mtdscr(tmp2);
-
+    if (VM_Version::has_mfdscr()) {
+      __ load_const_optimized(tmp2, VM_Version::_dscr_val);
+      __ mtdscr(tmp2);
+    }
 
    } // FasterArrayCopy
 
@@ -1672,9 +1683,10 @@ class StubGenerator: public StubCodeGenerator {
       __ dcbt(R3_ARG1, 0);
 
       // Set DSCR pre-fetch to deepest.
-      __ load_const_optimized(tmp2, VM_Version::_dscr_val | 7);
-      __ mtdscr(tmp2);
-
+      if (VM_Version::has_mfdscr()) {
+        __ load_const_optimized(tmp2, VM_Version::_dscr_val | 7);
+        __ mtdscr(tmp2);
+      }
       __ li(tmp1, 16);
 
       // Backbranch target aligned to 32-byte. Not 16-byte align as
@@ -1694,8 +1706,10 @@ class StubGenerator: public StubCodeGenerator {
       __ bdnz(l_4);
 
       // Restore DSCR pre-fetch value.
-      __ load_const_optimized(tmp2, VM_Version::_dscr_val);
-      __ mtdscr(tmp2);
+      if (VM_Version::has_mfdscr()) {
+        __ load_const_optimized(tmp2, VM_Version::_dscr_val);
+        __ mtdscr(tmp2);
+      }
 
       __ cmpwi(CR0, R5_ARG3, 0);
       __ beq(CR0, l_6);
@@ -1788,9 +1802,10 @@ class StubGenerator: public StubCodeGenerator {
       __ dcbt(R3_ARG1, 0);
 
       // Set DSCR pre-fetch to deepest.
-      __ load_const_optimized(tmp2, VM_Version::_dscr_val | 7);
-      __ mtdscr(tmp2);
-
+      if (VM_Version::has_mfdscr()) {
+        __ load_const_optimized(tmp2, VM_Version::_dscr_val | 7);
+        __ mtdscr(tmp2);
+      }
       __ li(tmp1, 16);
 
       // Backbranch target aligned to 32-byte. Not 16-byte align as
@@ -1810,8 +1825,10 @@ class StubGenerator: public StubCodeGenerator {
       __ bdnz(l_5);                        // Dec CTR and loop if not zero.
 
       // Restore DSCR pre-fetch value.
-      __ load_const_optimized(tmp2, VM_Version::_dscr_val);
-      __ mtdscr(tmp2);
+      if (VM_Version::has_mfdscr()) {
+        __ load_const_optimized(tmp2, VM_Version::_dscr_val);
+        __ mtdscr(tmp2);
+      }
 
    } // FasterArrayCopy
 
@@ -1910,9 +1927,10 @@ class StubGenerator: public StubCodeGenerator {
       __ dcbt(R3_ARG1, 0);
 
       // Set DSCR pre-fetch to deepest.
-      __ load_const_optimized(tmp2, VM_Version::_dscr_val | 7);
-      __ mtdscr(tmp2);
-
+      if (VM_Version::has_mfdscr()) {
+        __ load_const_optimized(tmp2, VM_Version::_dscr_val | 7);
+        __ mtdscr(tmp2);
+      }
       __ li(tmp1, 16);
 
       // Backbranch target aligned to 32-byte. Not 16-byte align as
@@ -1932,8 +1950,10 @@ class StubGenerator: public StubCodeGenerator {
       __ bdnz(l_4);
 
       // Restore DSCR pre-fetch value.
-      __ load_const_optimized(tmp2, VM_Version::_dscr_val);
-      __ mtdscr(tmp2);
+      if (VM_Version::has_mfdscr()) {
+        __ load_const_optimized(tmp2, VM_Version::_dscr_val);
+        __ mtdscr(tmp2);
+      }
 
       __ cmpwi(CR0, R5_ARG3, 0);
       __ beq(CR0, l_1);

--- a/src/hotspot/cpu/ppc/vm_version_ppc.cpp
+++ b/src/hotspot/cpu/ppc/vm_version_ppc.cpp
@@ -80,7 +80,9 @@ void VM_Version::initialize() {
             "%zu on this machine", PowerArchitecturePPC64);
 
   // Power 8: Configure Data Stream Control Register.
-  config_dscr();
+  if (VM_Version::has_mfdscr()) {
+    config_dscr();
+  }
 
   if (!UseSIGTRAP) {
     MSG(TrapBasedICMissChecks);
@@ -170,7 +172,8 @@ void VM_Version::initialize() {
   // Create and print feature-string.
   char buf[(num_features+1) * 16]; // Max 16 chars per feature.
   jio_snprintf(buf, sizeof(buf),
-               "ppc64 sha aes%s%s",
+               "ppc64 sha aes%s%s%s",
+               (has_mfdscr()  ? " mfdscr"  : ""),
                (has_darn()    ? " darn"    : ""),
                (has_brw()     ? " brw"     : "")
                // Make sure number of %s matches num_features!
@@ -488,6 +491,7 @@ void VM_Version::determine_features() {
   uint32_t *code = (uint32_t *)a->pc();
   // Keep R3_ARG1 unmodified, it contains &field (see below).
   // Keep R4_ARG2 unmodified, it contains offset = 0 (see below).
+  a->mfdscr(R0);
   a->darn(R7);
   a->brw(R5, R6);
   a->blr();
@@ -524,6 +528,7 @@ void VM_Version::determine_features() {
 
   // determine which instructions are legal.
   int feature_cntr = 0;
+  if (code[feature_cntr++]) features |= mfdscr_m;
   if (code[feature_cntr++]) features |= darn_m;
   if (code[feature_cntr++]) features |= brw_m;
 

--- a/src/hotspot/cpu/ppc/vm_version_ppc.hpp
+++ b/src/hotspot/cpu/ppc/vm_version_ppc.hpp
@@ -69,9 +69,9 @@ public:
 
   static bool is_determine_features_test_running() { return _is_determine_features_test_running; }
   // CPU instruction support
-  static bool has_mfdscr()  { return (_features & mfdscr_m) != 0; }
-  static bool has_darn()    { return (_features & darn_m) != 0; }
-  static bool has_brw()     { return (_features & brw_m) != 0; }
+  static bool has_mfdscr() { return (_features & mfdscr_m) != 0; } // Power8, but may be unavailable (QEMU)
+  static bool has_darn()   { return (_features & darn_m) != 0; }
+  static bool has_brw()    { return (_features & brw_m) != 0; }
 
   // Assembler testing
   static void allow_all();

--- a/src/hotspot/cpu/ppc/vm_version_ppc.hpp
+++ b/src/hotspot/cpu/ppc/vm_version_ppc.hpp
@@ -32,12 +32,14 @@
 class VM_Version: public Abstract_VM_Version {
 protected:
   enum Feature_Flag {
+    mfdscr,
     darn,
     brw,
     num_features // last entry to count features
   };
   enum Feature_Flag_Set {
     unknown_m             = 0,
+    mfdscr_m              = (1 << mfdscr ),
     darn_m                = (1 << darn   ),
     brw_m                 = (1 << brw    ),
     all_features_m        = (unsigned long)-1
@@ -67,6 +69,7 @@ public:
 
   static bool is_determine_features_test_running() { return _is_determine_features_test_running; }
   // CPU instruction support
+  static bool has_mfdscr()  { return (_features & mfdscr_m) != 0; }
   static bool has_darn()    { return (_features & darn_m) != 0; }
   static bool has_brw()     { return (_features & brw_m) != 0; }
 


### PR DESCRIPTION
Add back `has_mfdscr()` checks which were recently removed. See https://github.com/openjdk/jdk/pull/20262#issuecomment-2999872960

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8360405](https://bugs.openjdk.org/browse/JDK-8360405): [PPC64] some environments don't support mfdscr instruction (**Bug** - P3)


### Reviewers
 * [Hao Sun](https://openjdk.org/census#haosun) (@shqking - Committer)
 * [Richard Reingruber](https://openjdk.org/census#rrich) (@reinrich - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25953/head:pull/25953` \
`$ git checkout pull/25953`

Update a local copy of the PR: \
`$ git checkout pull/25953` \
`$ git pull https://git.openjdk.org/jdk.git pull/25953/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25953`

View PR using the GUI difftool: \
`$ git pr show -t 25953`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25953.diff">https://git.openjdk.org/jdk/pull/25953.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25953#issuecomment-3000955017)
</details>
