### PR TITLE
8360403: Disable constant pool ID assert during troubleshooting

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/ConstantMap.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/ConstantMap.java
@@ -77,7 +77,7 @@ final class ConstantMap {
             if (id != 0) {
                 String msg = "Missing object ID " + id + " in pool " + getName() + ". All IDs should reference an object";
                 Logger.log(LogTag.JFR_SYSTEM_PARSER, LogLevel.INFO, msg);
-                assert false : msg;
+                // assert false : msg;
             }
             return null;
         }


### PR DESCRIPTION
Greetings,

This is a workaround to disable the assert when the parser encounters a missing constant pool artifact ID, effective only for the duration of the deeper root cause analysis. The workaround is to avoid causing problems for any tests running JFR with -ea and -esa.

This bug is a subtask of the main issue that tracks the root cause of the problem and has arisen due to the complexities involved in deep troubleshooting.

[JDK-8356587 Missing object ID X in pool jdk.types.Method](https://bugs.openjdk.org/browse/JDK-8356587)

Thanks
Markus