### PR TITLE
8360312

### DIFF
--- a/src/hotspot/share/jfr/recorder/service/jfrRecorderThread.cpp
+++ b/src/hotspot/share/jfr/recorder/service/jfrRecorderThread.cpp
@@ -36,14 +36,6 @@
 #include "utilities/preserveException.hpp"
 #include "utilities/macros.hpp"
 
-class JfrRecorderThread : public JavaThread {
- public:
-  JfrRecorderThread(ThreadFunction entry_point) : JavaThread(entry_point) {}
-  virtual ~JfrRecorderThread() {}
-
-  virtual bool is_JfrRecorder_thread() const { return true; }
-};
-
 static Thread* start_thread(instanceHandle thread_oop, ThreadFunction proc, TRAPS) {
   assert(thread_oop.not_null(), "invariant");
   assert(proc != nullptr, "invariant");

--- a/src/hotspot/share/jfr/recorder/service/jfrRecorderThread.hpp
+++ b/src/hotspot/share/jfr/recorder/service/jfrRecorderThread.hpp
@@ -26,9 +26,9 @@
 #define SHARE_JFR_RECORDER_SERVICE_JFRRECORDERTHREAD_HPP
 
 #include "memory/allStatic.hpp"
+#include "runtime/javaThread.hpp"
 #include "utilities/debug.hpp"
 
-class JavaThread;
 class JfrCheckpointManager;
 class JfrPostBox;
 class Thread;
@@ -40,6 +40,14 @@ class JfrRecorderThreadEntry : AllStatic {
  public:
   static JfrPostBox& post_box();
   static bool start(JfrCheckpointManager* cp_manager, JfrPostBox* post_box, TRAPS);
+};
+
+class JfrRecorderThread : public JavaThread {
+ public:
+  JfrRecorderThread(ThreadFunction entry_point) : JavaThread(entry_point) {}
+  virtual ~JfrRecorderThread() {}
+
+  virtual bool is_JfrRecorder_thread() const { return true; }
 };
 
 #endif // SHARE_JFR_RECORDER_SERVICE_JFRRECORDERTHREAD_HPP

--- a/src/hotspot/share/runtime/vmStructs.cpp
+++ b/src/hotspot/share/runtime/vmStructs.cpp
@@ -40,6 +40,7 @@
 #include "code/vmreg.hpp"
 #include "compiler/compileBroker.hpp"
 #include "compiler/oopMap.hpp"
+#include "jfr/recorder/service/jfrRecorderThread.hpp"
 #include "gc/shared/stringdedup/stringDedupThread.hpp"
 #include "gc/shared/vmStructs_gc.hpp"
 #include "interpreter/bytecodes.hpp"
@@ -1027,6 +1028,7 @@
         declare_type(TrainingReplayThread, JavaThread)                    \
         declare_type(StringDedupThread, JavaThread)                       \
         declare_type(AttachListenerThread, JavaThread)                    \
+        declare_type(JfrRecorderThread, JavaThread)                       \
         DEBUG_ONLY(COMPILER2_OR_JVMCI_PRESENT(                            \
           declare_type(DeoptimizeObjectsALotThread, JavaThread)))         \
   declare_toplevel_type(OSThread)                                         \

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/Threads.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/Threads.java
@@ -158,6 +158,7 @@ public class Threads {
         virtualConstructor.addMapping("JvmtiAgentThread", JavaThread.class);
         virtualConstructor.addMapping("NotificationThread", JavaThread.class);
         virtualConstructor.addMapping("AttachListenerThread", JavaThread.class);
+        virtualConstructor.addMapping("JfrRecorderThread", JavaThread.class);
 
         // These are all the hidden JavaThread subclasses that don't execute java code.
         virtualConstructor.addMapping("StringDedupThread", HiddenJavaThread.class);
@@ -195,7 +196,8 @@ public class Threads {
         } catch (Exception e) {
             throw new RuntimeException("Unable to deduce type of thread from address " + threadAddr +
             " (expected type JavaThread, CompilerThread, MonitorDeflationThread, AttachListenerThread," +
-            " DeoptimizeObjectsALotThread, StringDedupThread, NotificationThread, ServiceThread or JvmtiAgentThread)", e);
+            " DeoptimizeObjectsALotThread, StringDedupThread, NotificationThread, ServiceThread," +
+            "JfrRecorderThread, or JvmtiAgentThread)", e);
         }
     }
 

--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbJstackWithConcurrentLock.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbJstackWithConcurrentLock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,7 +46,7 @@ public class ClhsdbJstackWithConcurrentLock {
 
             theApp = new LingeredAppWithConcurrentLock();
             // Use a small heap so the scan is quick.
-            LingeredApp.startApp(theApp, "-Xmx4m");
+            LingeredApp.startApp(theApp, "-Xmx8m");
             System.out.println("Started LingeredApp with pid " + theApp.getPid());
 
             // Run the 'jstack -l' command to get the stack and have java.util.concurrent


### PR DESCRIPTION
Update SA to know about JfrRecorderThread, which was made a JavaThread in JDK 25 by [JDK-8352251](https://bugs.openjdk.org/browse/JDK-8352251).

I'm also fixing ClhsdbJstackWithConcurrentLock, which was also failing with JFR enabled, but for a different reason (specified heap size was too small).

Testing (in progress):

- [ ] tier1 ci
- [ ] tier1 ci with -XX:StartFlightRecording 
- [ ] tier5 ci