### PR TITLE
8357728: Optimize Executable#synthesizeAllParams

### DIFF
--- a/src/java.base/share/classes/java/lang/reflect/Executable.java
+++ b/src/java.base/share/classes/java/lang/reflect/Executable.java
@@ -427,7 +427,7 @@ public abstract sealed class Executable extends AccessibleObject
             // modifiers?  Probably not in the general case, since
             // we'd have no way of knowing about them, but there
             // may be specific cases.
-            out[i] = new Parameter("arg" + i, 0, this, i);
+            out[i] = new Parameter(null, 0, this, i);
         return out;
     }
 

--- a/src/java.base/share/classes/java/lang/reflect/Parameter.java
+++ b/src/java.base/share/classes/java/lang/reflect/Parameter.java
@@ -55,7 +55,7 @@ public final class Parameter implements AnnotatedElement {
      * absent, however, then {@code Executable} uses this constructor
      * to synthesize them.
      *
-     * @param name The name of the parameter.
+     * @param name The name of the parameter, or {@code null} if absent
      * @param modifiers The modifier flags for the parameter.
      * @param executable The executable which defines this parameter.
      * @param index The index of the parameter.
@@ -104,7 +104,7 @@ public final class Parameter implements AnnotatedElement {
      * to the class file.
      */
     public boolean isNamePresent() {
-        return executable.hasRealParameterData() && name != null;
+        return name != null;
     }
 
     /**

--- a/test/jdk/java/lang/reflect/Parameter/SyntheticNameRetention.java
+++ b/test/jdk/java/lang/reflect/Parameter/SyntheticNameRetention.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.lang.invoke.MethodHandleProxies;
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Executable;
+import java.lang.reflect.Parameter;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/*
+ * @test
+ * @bug 8357728
+ * @summary Synthetic parameter names should not be retained.
+ * @modules java.base/java.lang.reflect:+open
+ * @run junit SyntheticNameRetention
+ */
+public class SyntheticNameRetention {
+
+    class Inner {
+        Inner() {}
+    }
+
+    public interface NameGetter {
+        String getRawName(Parameter parameter);
+    }
+    static final NameGetter GETTER;
+
+    static {
+        try {
+            var lookup = MethodHandles.privateLookupIn(Parameter.class, MethodHandles.lookup());
+            GETTER = MethodHandleProxies.asInterfaceInstance(NameGetter.class, lookup.findGetter(Parameter.class, "name", String.class));
+        } catch (ReflectiveOperationException ex) {
+            throw new ExceptionInInitializerError(ex);
+        }
+    }
+
+    static Stream<Executable> methods() throws Throwable {
+        return Stream.of(Inner.class.getDeclaredConstructor(SyntheticNameRetention.class), // Has MethodParameters with flags
+                         SyntheticNameRetention.class.getDeclaredMethod("test", Executable.class)); // No MethodParameters
+    }
+
+    @ParameterizedTest
+    @MethodSource("methods")
+    public void test(Executable exec) {
+        var params = exec.getParameters();
+        for (int i = 0; i < params.length; i++) {
+            var param = params[i];
+            assertEquals("arg" + i, param.getName(), "name " + i);
+            assertFalse(param.isNamePresent(), "name present " + i);
+            assertNull(GETTER.getRawName(param), "raw name " + i);
+            boolean mandated = exec instanceof Constructor<?> && i == 0;
+            assertEquals(mandated, param.isImplicit(), "mandated " + i);
+        }
+    }
+}


### PR DESCRIPTION
Currently, fake parameters are created with "arg0" etc. strings that are retained for class file methods with no MethodParameters attribute. The original issue report observes many of these strings present in the heap. To address this issue, we can remove these eagerly created fake names, bringing their behavior in line with nameless parameters from MethodParameters attribute, such as those from inner class constructors. A unit test verifies that no name is retained in the Parameter object when the name is fake.

The original report recommends using a pool to store the arg name strings. I did not take that approach as I don't think it is very necessary; if the issue of retained fake names persist, we can update `Parameter::getName` to return fake names from a pool instead.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change requires CSR request [JDK-8362626](https://bugs.openjdk.org/browse/JDK-8362626) to be approved

### Issues
 * [JDK-8357728](https://bugs.openjdk.org/browse/JDK-8357728): Optimize Executable#synthesizeAllParams (**Enhancement** - P4)
 * [JDK-8362626](https://bugs.openjdk.org/browse/JDK-8362626): Avoid caching synthesized names in synthesized parameters (**CSR**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25961/head:pull/25961` \
`$ git checkout pull/25961`

Update a local copy of the PR: \
`$ git checkout pull/25961` \
`$ git pull https://git.openjdk.org/jdk.git pull/25961/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25961`

View PR using the GUI difftool: \
`$ git pr show -t 25961`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25961.diff">https://git.openjdk.org/jdk/pull/25961.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25961#issuecomment-3002069702)
</details>
