### PR TITLE
8358179: Performance regression in Math.cbrt

### DIFF
--- a/src/hotspot/cpu/x86/stubGenerator_x86_64_cbrt.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64_cbrt.cpp
@@ -46,7 +46,7 @@
 //
 /******************************************************************************/
 
-ATTRIBUTE_ALIGNED(4) static const juint _ABS_MASK[] =
+ATTRIBUTE_ALIGNED(16) static const juint _ABS_MASK[] =
 {
     4294967295, 2147483647
 };

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64_cbrt.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64_cbrt.cpp
@@ -46,9 +46,10 @@
 //
 /******************************************************************************/
 
+/* Represents 0x7FFFFFFFFFFFFFFF double precision in lower 64 bits*/
 ATTRIBUTE_ALIGNED(16) static const juint _ABS_MASK[] =
 {
-    4294967295, 2147483647
+    4294967295, 2147483647, 0, 0
 };
 
 ATTRIBUTE_ALIGNED(4) static const juint _SIG_MASK[] =
@@ -214,7 +215,7 @@ address StubGenerator::generate_libmCbrt() {
 
   __ bind(B1_1);
   __ ucomisd(xmm0, ExternalAddress(ZERON), r11 /*rscratch*/);
-  __ jcc(Assembler::zero, L_2TAG_PACKET_1_0_1); // Branch only if x is +/- zero or NaN
+  __ jcc(Assembler::equal, L_2TAG_PACKET_1_0_1); // Branch only if x is +/- zero or NaN
   __ movq(xmm1, xmm0);
   __ andpd(xmm1, ExternalAddress(ABS_MASK), r11 /*rscratch*/);
   __ ucomisd(xmm1, ExternalAddress(INF), r11 /*rscratch*/);

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64_cbrt.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64_cbrt.cpp
@@ -46,6 +46,11 @@
 //
 /******************************************************************************/
 
+ATTRIBUTE_ALIGNED(4) static const juint _ABS_MASK[] =
+{
+    4294967295, 2147483647
+};
+
 ATTRIBUTE_ALIGNED(4) static const juint _SIG_MASK[] =
 {
     0, 1032192
@@ -188,10 +193,10 @@ address StubGenerator::generate_libmCbrt() {
   StubCodeMark mark(this, stub_id);
   address start = __ pc();
 
-  Label L_2TAG_PACKET_0_0_1, L_2TAG_PACKET_1_0_1, L_2TAG_PACKET_2_0_1, L_2TAG_PACKET_3_0_1;
-  Label L_2TAG_PACKET_4_0_1, L_2TAG_PACKET_5_0_1, L_2TAG_PACKET_6_0_1;
+  Label L_2TAG_PACKET_0_0_1, L_2TAG_PACKET_1_0_1, L_2TAG_PACKET_2_0_1;
   Label B1_1, B1_2, B1_4;
 
+  address ABS_MASK        = (address)_ABS_MASK;
   address SIG_MASK        = (address)_SIG_MASK;
   address EXP_MASK        = (address)_EXP_MASK;
   address EXP_MSK2        = (address)_EXP_MSK2;
@@ -208,8 +213,12 @@ address StubGenerator::generate_libmCbrt() {
   __ enter(); // required for proper stackwalking of RuntimeStub frame
 
   __ bind(B1_1);
-  __ subq(rsp, 24);
-  __ movsd(Address(rsp), xmm0);
+  __ ucomisd(xmm0, ExternalAddress(ZERON), r11 /*rscratch*/);
+  __ jcc(Assembler::zero, L_2TAG_PACKET_1_0_1); // Branch only if x is +/- zero or NaN
+  __ movq(xmm1, xmm0);
+  __ andpd(xmm1, ExternalAddress(ABS_MASK), r11 /*rscratch*/);
+  __ ucomisd(xmm1, ExternalAddress(INF), r11 /*rscratch*/);
+  __ jcc(Assembler::equal, B1_4); // Branch only if x is +/- INF
 
   __ bind(B1_2);
   __ movq(xmm7, xmm0);
@@ -228,8 +237,6 @@ address StubGenerator::generate_libmCbrt() {
   __ andl(rdx, rax);
   __ cmpl(rdx, 0);
   __ jcc(Assembler::equal, L_2TAG_PACKET_0_0_1); // Branch only if |x| is denormalized
-  __ cmpl(rdx, 524032);
-  __ jcc(Assembler::equal, L_2TAG_PACKET_1_0_1); // Branch only if |x| is INF or NaN
   __ shrl(rdx, 8);
   __ shrq(r9, 8);
   __ andpd(xmm2, xmm0);
@@ -297,8 +304,6 @@ address StubGenerator::generate_libmCbrt() {
   __ andl(rdx, rax);
   __ shrl(rdx, 8);
   __ shrq(r9, 8);
-  __ cmpl(rdx, 0);
-  __ jcc(Assembler::equal, L_2TAG_PACKET_3_0_1); // Branch only if |x| is zero
   __ andpd(xmm2, xmm0);
   __ andpd(xmm0, xmm5);
   __ orpd(xmm3, xmm2);
@@ -322,41 +327,10 @@ address StubGenerator::generate_libmCbrt() {
   __ psllq(xmm7, 52);
   __ jmp(L_2TAG_PACKET_2_0_1);
 
-  __ bind(L_2TAG_PACKET_3_0_1);
-  __ cmpq(r9, 0);
-  __ jcc(Assembler::notEqual, L_2TAG_PACKET_4_0_1); // Branch only if x is negative zero
-  __ xorpd(xmm0, xmm0);
-  __ jmp(B1_4);
-
-  __ bind(L_2TAG_PACKET_4_0_1);
-  __ movsd(xmm0, ExternalAddress(ZERON), r11 /*rscratch*/);
-  __ jmp(B1_4);
-
   __ bind(L_2TAG_PACKET_1_0_1);
-  __ movl(rax, Address(rsp, 4));
-  __ movl(rdx, Address(rsp));
-  __ movl(rcx, rax);
-  __ andl(rcx, 2147483647);
-  __ cmpl(rcx, 2146435072);
-  __ jcc(Assembler::above, L_2TAG_PACKET_5_0_1); // Branch only if |x| is NaN
-  __ cmpl(rdx, 0);
-  __ jcc(Assembler::notEqual, L_2TAG_PACKET_5_0_1); // Branch only if |x| is NaN
-  __ cmpl(rax, 2146435072);
-  __ jcc(Assembler::notEqual, L_2TAG_PACKET_6_0_1); // Branch only if x is negative INF
-  __ movsd(xmm0, ExternalAddress(INF), r11 /*rscratch*/);
-  __ jmp(B1_4);
-
-  __ bind(L_2TAG_PACKET_6_0_1);
-  __ movsd(xmm0, ExternalAddress(NEG_INF), r11 /*rscratch*/);
-  __ jmp(B1_4);
-
-  __ bind(L_2TAG_PACKET_5_0_1);
-  __ movsd(xmm0, Address(rsp));
   __ addsd(xmm0, xmm0);
-  __ movq(Address(rsp, 8), xmm0);
 
   __ bind(B1_4);
-  __ addq(rsp, 24);
   __ leave(); // required for proper stackwalking of RuntimeStub frame
   __ ret(0);
 


### PR DESCRIPTION
The changes described below are meant to resolve the performance regression introduced by the **x86_64 cbrt** double precision floating point scalar intrinsic in #24470.

1. Check for +0, -0, +INF, -INF, and NaN before any other input values.
2. If these special values are found, return immediately with minimal modifications to the result register.
3. Performance testing shows the modified intrinsic improves throughput by 65.1% over the original intrinsic on average for the special values while throughput drops by 5.5% for the normal value range (-INF, -2^(-1022)], [2^(-1022), INF).

The commands to run all relevant micro-benchmarks are posted below.

`make test TEST="micro:CbrtPerf.CbrtPerfRanges"`
`make test TEST="micro:CbrtPerf.CbrtPerfSpecialValues"`

The results of all tests posted below were captured with an [Intel® Xeon 8488C](https://www.intel.com/content/www/us/en/products/sku/231730/intel-xeon-platinum-8480c-processor-105m-cache-2-00-ghz/specifications.html) using [OpenJDK v26-b1](https://github.com/openjdk/jdk/releases/tag/jdk-26%2B1) as the baseline version. The term _baseline1_ refers to runs with the intrinsic enabled and _baseline2_ refers to runs with the intrinsic disabled.

Each result is the mean of 8 individual runs, and the input ranges used match those from the original Java implementation. Overall, the changes provide a significant uplift over _baseline1_ except for a mild regression in the (**2^(-1022) <= |x| < INF**) input range, which is expected due to the extra checks. When comparing against _baseline2_, the modified intrinsic significantly still outperforms for the inputs (**-INF < x < INF**) that require heavy compute. However, the special value inputs that trigger fast path returns still perform better with _baseline2_.

| Input range(s)                                  | Baseline1 (ops/ms) | Change (ops/ms) | Change vs baseline1 (%) |
| :-------------------------------------: | :-------------------: | :------------------: | :--------------------------: |
| [-2^(-1022), 2^(-1022)]                   | 18470                     | 20847                   | +12.87                             |
| (-INF, -2^(-1022)], [2^(-1022), INF) | 210538                   | 198925                 | -5.52                                |
| [0]                                                     | 344990                  | 627561                 | +81.91                             |
| [-0]                                                   | 291983                   | 629941                 | +115.75                           |
| [INF]                                                 | 382685                   | 542211                 | +41.68                             |
| [-INF]                                                | 386174                  | 542291                 | +40.43                              |
| [NaN]                                               | 421700                   | 615157                 | +45.88                             |

| Input range(s)                                  | Baseline2 (ops/ms) | Change (ops/ms) | Change vs baseline2 (%) |
| :-------------------------------------: | :-------------------: | :------------------: | :--------------------------: |
| [-2^(-1022), 2^(-1022)]                   | 7072                       | 20847                   | +194.78                           |
| (-INF, -2^(-1022)], [2^(-1022), INF) | 147884                   | 198925                 | +34.51                             |
| [0]                                                     | 1890520                | 627561                 | -66.80                               |
| [-0]                                                   | 1890404                 | 629941                 | -66.68                              |
| [INF]                                                 | 1247633                 | 542211                 | -56.54                              |
| [-INF]                                                | 1242287                | 542291                 | -56.35                               |
| [NaN]                                               | 1253700                 | 615157                 | -50.93                               |

Finally, the `jtreg:test/jdk/java/lang/Math/CubeRootTests.java` test passed with the changes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8358179](https://bugs.openjdk.org/browse/JDK-8358179): Performance regression in Math.cbrt (**Bug** - P3)(⚠️ The fixVersion in this issue is [25] but the fixVersion in .jcheck/conf is 26, a new backport will be created when this pr is integrated.)


### Reviewers
 * [Sandhya Viswanathan](https://openjdk.org/census#sviswanathan) (@sviswa7 - **Reviewer**)
 * [Srinivas Vamsi Parasa](https://openjdk.org/census#sparasa) (@vamsi-parasa - Author)
 * [Emanuel Peter](https://openjdk.org/census#epeter) (@eme64 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25962/head:pull/25962` \
`$ git checkout pull/25962`

Update a local copy of the PR: \
`$ git checkout pull/25962` \
`$ git pull https://git.openjdk.org/jdk.git pull/25962/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25962`

View PR using the GUI difftool: \
`$ git pr show -t 25962`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25962.diff">https://git.openjdk.org/jdk/pull/25962.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25962#issuecomment-3005784019)
</details>
