### PR TITLE
8358645: Access violation in ThreadsSMRSupport::print_info_on during thread dump

### DIFF
--- a/src/hotspot/share/runtime/threadSMR.cpp
+++ b/src/hotspot/share/runtime/threadSMR.cpp
@@ -1168,9 +1168,10 @@ void ThreadsSMRSupport::print_info_on(const Thread* thread, outputStream* st) {
     // The count is only interesting if we have a _threads_list_ptr.
     st->print(", _nested_threads_hazard_ptr_cnt=%u", thread->_nested_threads_hazard_ptr_cnt);
   }
-  if (SafepointSynchronize::is_at_safepoint() || Thread::current() == thread) {
-    // It is only safe to walk the list if we're at a safepoint or the
-    // calling thread is walking its own list.
+  if ((SafepointSynchronize::is_at_safepoint() && thread->is_Java_thread()) ||
+      Thread::current() == thread) {
+    // It is only safe to walk the list if we're at a safepoint and processing a JavaThread,
+    // or the calling thread is walking its own list.
     SafeThreadsListPtr* current = thread->_threads_list_ptr;
     if (current != nullptr) {
       // Skip the top nesting level as it is always printed above.


### PR DESCRIPTION
We started observing these occasional crashes involving the JfrSamplerThread (which is a NonJavaThread) during JFR's termination thread dump. Examination of the `print_info_on` code showed that it was making an invalid assumption that it is safe to walk the thread's thread-list at a safepoint, as that is not true when you are dealing with a NonJavaThread, as it is not held at the safepoint and so the list you are walking can disappear whilst you examine it. I added some test code to make this more likely and was able to trigger similar crashes - see JBS for details.

The simple fix is to only walk JavaThreads.

Testing
 - tier 5 JFR tests
 - selected tests with JFR explicitly enabled
 - tier 1-3 (sanity)

Thanks