### PR TITLE
8359788: Internal Error: assert(get_instanceKlass()->is_loaded()) failed: must be at least loaded

### DIFF
--- a/src/hotspot/share/oops/trainingData.hpp
+++ b/src/hotspot/share/oops/trainingData.hpp
@@ -34,6 +34,7 @@
 #include "memory/metaspaceClosure.hpp"
 #include "oops/instanceKlass.hpp"
 #include "oops/method.hpp"
+#include "oops/objArrayKlass.hpp"
 #include "runtime/handles.hpp"
 #include "runtime/mutexLocker.hpp"
 #include "utilities/resizeableResourceHash.hpp"
@@ -286,7 +287,12 @@ private:
   static bool is_klass_loaded(Klass* k) {
     if (have_data()) {
       // If we're running in AOT mode some classes may not be loaded yet
-      return !k->is_instance_klass() || InstanceKlass::cast(k)->is_loaded();
+      if (k->is_objArray_klass()) {
+        k = ObjArrayKlass::cast(k)->bottom_klass();
+      }
+      if (k->is_instance_klass()) {
+        return InstanceKlass::cast(k)->is_loaded();
+      }
     }
     return true;
   }


### PR DESCRIPTION
For object arrays we forgot to check if the element type if loaded and always returned `true` from `is_klass_loaded()`.
Testing is a bit noisy but seems to be clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8359788](https://bugs.openjdk.org/browse/JDK-8359788): Internal Error: assert(get_instanceKlass()-&gt;is_loaded()) failed: must be at least loaded (**Bug** - P3)(⚠️ The fixVersion in this issue is [25] but the fixVersion in .jcheck/conf is 26, a new backport will be created when this pr is integrated.)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25965/head:pull/25965` \
`$ git checkout pull/25965`

Update a local copy of the PR: \
`$ git checkout pull/25965` \
`$ git pull https://git.openjdk.org/jdk.git pull/25965/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25965`

View PR using the GUI difftool: \
`$ git pr show -t 25965`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25965.diff">https://git.openjdk.org/jdk/pull/25965.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25965#issuecomment-3002298053)
</details>
