### PR TITLE
8360120: Bundled macOS applications not receiving OpenURL events when launched as subprocess

### DIFF
--- a/src/java.desktop/macosx/classes/com/apple/eawt/Application.java
+++ b/src/java.desktop/macosx/classes/com/apple/eawt/Application.java
@@ -75,6 +75,7 @@ import sun.lwawt.macosx.CPlatformWindow;
  */
 public class Application {
     private static native void nativeInitializeApplicationDelegate();
+    private static native void nativeInstallOpenURLEventHandler();
 
     static Application sApplication = null;
 
@@ -211,6 +212,7 @@ public class Application {
      * @since Java for Mac OS X 10.5 Update 8
      */
     public void setOpenURIHandler(final OpenURIHandler openURIHandler) {
+        nativeInstallOpenURLEventHandler();
         eventHandler.openURIDispatcher.setHandler(openURIHandler);
     }
 

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/ApplicationDelegate.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/ApplicationDelegate.h
@@ -44,6 +44,7 @@
 
     BOOL fHandlesDocumentTypes;
     BOOL fHandlesURLTypes;
+    BOOL fOpenURLHandlerInstalled;
 }
 
 @property (nonatomic, retain) NSMenuItem *fPreferencesMenu;

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/ApplicationDelegate.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/ApplicationDelegate.m
@@ -243,11 +243,9 @@ AWT_ASSERT_APPKIT_THREAD;
     NSBundle *bundle = [NSBundle mainBundle];
     fHandlesDocumentTypes = [bundle objectForInfoDictionaryKey:@"CFBundleDocumentTypes"] != nil || [bundle _hasEAWTOverride:@"DocumentHandler"];
     fHandlesURLTypes = [bundle objectForInfoDictionaryKey:@"CFBundleURLTypes"] != nil || [bundle _hasEAWTOverride:@"URLHandler"];
+    fOpenURLHandlerInstalled = NO;
     if (fHandlesURLTypes) {
-        [[NSAppleEventManager sharedAppleEventManager] setEventHandler:self
-                                                           andSelector:@selector(_handleOpenURLEvent:withReplyEvent:)
-                                                         forEventClass:kInternetEventClass
-                                                            andEventID:kAEGetURL];
+        [self _installOpenURLHandler];
     }
 
     // By HIG, Preferences are not available unless there is a handler. By default in Mac OS X,
@@ -302,9 +300,19 @@ static jclass sjc_AppEventHandler = NULL;
 #define GET_APPEVENTHANDLER_CLASS_RETURN(ret) \
     GET_CLASS_RETURN(sjc_AppEventHandler, "com/apple/eawt/_AppEventHandler", ret);
 
-- (void)_handleOpenURLEvent:(NSAppleEventDescriptor *)openURLEvent withReplyEvent:(NSAppleEventDescriptor *)replyEvent {
-    if (!fHandlesURLTypes) return;
+- (void)_installOpenURLHandler {
+AWT_ASSERT_APPKIT_THREAD;
+    if (fOpenURLHandlerInstalled) return;
 
+    [[NSAppleEventManager sharedAppleEventManager] setEventHandler:self
+                                                       andSelector:@selector(_handleOpenURLEvent:withReplyEvent:)
+                                                     forEventClass:kInternetEventClass
+                                                        andEventID:kAEGetURL];
+
+    fOpenURLHandlerInstalled = YES;
+}
+
+- (void)_handleOpenURLEvent:(NSAppleEventDescriptor *)openURLEvent withReplyEvent:(NSAppleEventDescriptor *)replyEvent {
     NSString *url = [[openURLEvent paramDescriptorForKeyword:keyDirectObject] stringValue];
     [ApplicationDelegate _openURL:url];
 
@@ -622,6 +630,24 @@ JNI_COCOA_ENTER(env);
     // Force initialization to happen on AppKit thread!
     [ThreadUtilities performOnMainThreadWaiting:NO block:^(){
         [ApplicationDelegate sharedDelegate];
+    }];
+JNI_COCOA_EXIT(env);
+}
+
+/*
+ * Class:     com_apple_eawt_Application
+ * Method:    nativeInstallOpenURLEventHandler
+ * Signature: ()V
+ */
+JNIEXPORT void JNICALL Java_com_apple_eawt_Application_nativeInstallOpenURLEventHandler
+(JNIEnv *env, jclass clz)
+{
+JNI_COCOA_ENTER(env);
+    [ThreadUtilities performOnMainThreadWaiting:YES block:^(){
+        ApplicationDelegate *delegate = [ApplicationDelegate sharedDelegate];
+            if (delegate != nil) {
+                [delegate _installOpenURLHandler];
+            }
     }];
 JNI_COCOA_EXIT(env);
 }


### PR DESCRIPTION
Added an on-demand installation of the native OpenURL event handler to the `Application.setOpenURIHandler()`.

This does not break the specification for the affected API, since the requirement of the application being bundled and containing `CFBundleURLTypes` in the `Info.plist` is still valid: macOS will neither launch nor send OpenURL events to an application that does not declare such capabilities it the bundle.

Running tests on macOS showed no regressions after this patch. Other platforms are not affected.