### PR TITLE
8360255: runtime/jni/checked/TestLargeUTF8Length.java fails with -XX:-CompactStrings

### DIFF
--- a/test/hotspot/jtreg/runtime/jni/checked/TestLargeUTF8Length.java
+++ b/test/hotspot/jtreg/runtime/jni/checked/TestLargeUTF8Length.java
@@ -44,9 +44,14 @@ public class TestLargeUTF8Length {
     static native void checkUTF8Length(String s, long utf8Length);
 
     static void test() {
-        int length = Integer.MAX_VALUE/2 + 1;
-        char character = (char)0XD1; // N with tilde
-        long utf8Length = 2L * length;
+        // We want a string whose UTF-8 length is > Integer.MAX_VALUE, but
+        // whose "natural" length is < Integer.MAX_VALUE/2 so it can be
+        // created regardless of whether compact-strings are enabled or not.
+        // So we use a character that encodes as 3-bytes in UTF-8.
+        //   U+08A0 : e0 a2 a0 : ARABIC LETTER BEH WITH SMALL V BELOW
+        char character = '\u08A0';
+        int length = Integer.MAX_VALUE/2 - 1;
+        long utf8Length = 3L * length;
         char[] chrs = new char[length];
         Arrays.fill(chrs, character);
         String s = new String(chrs);


### PR DESCRIPTION
The test creates a `String` with `Integer.MAX_VALUE/2 + 1` characters, where the character encodes as two bytes in UTF-8. That way we test when the UTF-8  length is greater than `Integer.MAX_VALUE`. However, when compact strings are disabled the maximum length of a `String`, in characters, is `Integer.MAX_VALUE/2` so the test throws a (synthetic) OOME.

The fix I chose was to change the test so that we create a slightly shorter `String` (that will always fit regardless of the compact-strings setting) but to fill it with a character that encodes to three bytes in UTF-8. Hence we still test that the UTF-8 length exceeds `Integer.MAX_LENGTH`.

Tested on Windows x64, Linux x64 and Aarch64, macOS x64 and Aarch64; on release and fastdebug builds.

Thanks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8360255](https://bugs.openjdk.org/browse/JDK-8360255): runtime/jni/checked/TestLargeUTF8Length.java fails with -XX:-CompactStrings (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25970/head:pull/25970` \
`$ git checkout pull/25970`

Update a local copy of the PR: \
`$ git checkout pull/25970` \
`$ git pull https://git.openjdk.org/jdk.git pull/25970/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25970`

View PR using the GUI difftool: \
`$ git pr show -t 25970`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25970.diff">https://git.openjdk.org/jdk/pull/25970.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25970#issuecomment-3003769202)
</details>
