### PR TITLE
8359268: 3 JNI exception pending defect groups in 2 files

### DIFF
--- a/src/java.base/share/native/libnet/net_util.c
+++ b/src/java.base/share/native/libnet/net_util.c
@@ -91,14 +91,7 @@ DEF_JNI_OnLoad(JavaVM *vm, void *reserved)
 }
 
 static int enhancedExceptionsInitialized = 0;
-static int enhancedExceptionsAllowed = -1;
-
-#define CHECK_NULL_THROW_ERROR(X) \
-    if (X == NULL) {                                        \
-        JNU_ThrowByName(env, "java/lang/InternalError",     \
-            "can't initialize enhanced exceptions");        \
-        return -1;                                          \
-    }
+static int enhancedExceptionsAllowed = 0;
 
 int getEnhancedExceptionsAllowed(JNIEnv *env) {
     jclass cls;
@@ -108,9 +101,9 @@ int getEnhancedExceptionsAllowed(JNIEnv *env) {
         return enhancedExceptionsAllowed;
     }
     cls = (*env)->FindClass(env, "jdk/internal/util/Exceptions");
-    CHECK_NULL_THROW_ERROR(cls);
+    CHECK_NULL_RETURN(cls, ENH_INIT_ERROR);
     fid = (*env)->GetStaticFieldID(env, cls, "enhancedNonSocketExceptionText", "Z");
-    CHECK_NULL_THROW_ERROR(fid);
+    CHECK_NULL_RETURN(fid, ENH_INIT_ERROR);
     enhancedExceptionsAllowed = (*env)->GetStaticBooleanField(env, cls, fid);
     enhancedExceptionsInitialized = 1;
     return enhancedExceptionsAllowed;

--- a/src/java.base/share/native/libnet/net_util.h
+++ b/src/java.base/share/native/libnet/net_util.h
@@ -183,6 +183,11 @@ int lookupCharacteristicsToAddressFamily(int characteristics);
 
 int addressesInSystemOrder(int characteristics);
 
+/* return codes */
+#define ENH_INIT_ERROR -1  /* initialization error: check exceptions */
+#define ENH_DISABLED    0  /* enhanced exceptions disabled */
+#define ENH_ENABLED     1  /* enhanced exceptions enabled */
+
 int getEnhancedExceptionsAllowed(JNIEnv *env);
 
 #endif /* NET_UTILS_H */

--- a/src/java.base/unix/native/libnet/net_util_md.c
+++ b/src/java.base/unix/native/libnet/net_util_md.c
@@ -188,8 +188,11 @@ void NET_ThrowUnknownHostExceptionWithGaiError(JNIEnv *env,
     if (error_string == NULL)
         error_string = "unknown error";
     int enhancedExceptions = getEnhancedExceptionsAllowed(env);
+    if (enhancedExceptions == ENH_INIT_ERROR && (*env)->ExceptionCheck(env)) {
+        return;
+    }
 
-    if (enhancedExceptions) {
+    if (enhancedExceptions == ENH_ENABLED) {
         size = strlen(hostname);
     } else {
         size = 0;
@@ -200,7 +203,7 @@ void NET_ThrowUnknownHostExceptionWithGaiError(JNIEnv *env,
     if (buf) {
         jstring s;
         int n;
-        if (enhancedExceptions) {
+        if (enhancedExceptions == ENH_ENABLED) {
             n = snprintf(buf, size, "%s: %s", hostname, error_string);
         } else {
             n = snprintf(buf, size, " %s", error_string);

--- a/src/java.base/windows/native/libnet/Inet4AddressImpl.c
+++ b/src/java.base/windows/native/libnet/Inet4AddressImpl.c
@@ -88,9 +88,12 @@ Java_java_net_Inet4AddressImpl_lookupAllHostAddr(JNIEnv *env, jobject this,
 
     if (error) {
         // report error
-        NET_ThrowByNameWithLastError(
-            env, "java/net/UnknownHostException",
-            getEnhancedExceptionsAllowed(env) ? hostname : "");
+        int enh = getEnhancedExceptionsAllowed(env);
+        if (enh == ENH_INIT_ERROR && (*env)->ExceptionCheck(env)) {
+            goto cleanupAndReturn;
+        }
+        const char *hmsg = (enh == ENH_ENABLED) ? hostname : "";
+        NET_ThrowByNameWithLastError( env, "java/net/UnknownHostException", hmsg);
         goto cleanupAndReturn;
     } else {
         int i = 0;

--- a/src/java.base/windows/native/libnet/Inet6AddressImpl.c
+++ b/src/java.base/windows/native/libnet/Inet6AddressImpl.c
@@ -83,8 +83,12 @@ Java_java_net_Inet6AddressImpl_lookupAllHostAddr(JNIEnv *env, jobject this,
 
     if (error) {
         // report error
-        NET_ThrowByNameWithLastError(env, "java/net/UnknownHostException",
-            getEnhancedExceptionsAllowed(env) ? hostname : "");
+        int enh = getEnhancedExceptionsAllowed(env);
+        if (enh == ENH_INIT_ERROR && (*env)->ExceptionCheck(env)) {
+            goto cleanupAndReturn;
+        }
+        const char *hmsg = (enh == ENH_ENABLED) ? hostname : "";
+        NET_ThrowByNameWithLastError(env, "java/net/UnknownHostException", hmsg);
         goto cleanupAndReturn;
     } else {
         int i = 0, inetCount = 0, inet6Count = 0, inetIndex = 0,


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [1fa09052](https://github.com/openjdk/jdk/commit/1fa090524a7c3bb5f2c92fb0f7217b9277ade9d9) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Michael McMahon on 25 Jun 2025 and was reviewed by Daniel Jeliński.

Thanks!
Michael

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8359268](https://bugs.openjdk.org/browse/JDK-8359268): 3 JNI exception pending defect groups in 2 files (**Bug** - P3)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25973/head:pull/25973` \
`$ git checkout pull/25973`

Update a local copy of the PR: \
`$ git checkout pull/25973` \
`$ git pull https://git.openjdk.org/jdk.git pull/25973/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25973`

View PR using the GUI difftool: \
`$ git pr show -t 25973`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25973.diff">https://git.openjdk.org/jdk/pull/25973.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25973#issuecomment-3004184915)
</details>
