### PR TITLE
8360515: PROPERFMTARGS should always use size_t template specialization for unit

### DIFF
--- a/src/hotspot/os/bsd/memMapPrinter_macosx.cpp
+++ b/src/hotspot/os/bsd/memMapPrinter_macosx.cpp
@@ -233,10 +233,10 @@ public:
     mach_msg_type_number_t num_out = TASK_VM_INFO_COUNT;
     kern_return_t err = task_info(mach_task_self(), TASK_VM_INFO, (task_info_t)(&vm_info), &num_out);
     if (err == KERN_SUCCESS) {
-      st->print_cr("             vsize: %llu (%llu%s)", vm_info.virtual_size, PROPERFMTARGS(vm_info.virtual_size));
-      st->print_cr("               rss: %llu (%llu%s)", vm_info.resident_size, PROPERFMTARGS(vm_info.resident_size));
-      st->print_cr("          peak rss: %llu (%llu%s)", vm_info.resident_size_peak, PROPERFMTARGS(vm_info.resident_size_peak));
-      st->print_cr("         page size: %d (%ld%s)", vm_info.page_size, PROPERFMTARGS((size_t)vm_info.page_size));
+      st->print_cr("             vsize: %llu (%llu%s)", vm_info.virtual_size, byte_size_in_proper_unit(vm_info.virtual_size), proper_unit_for_byte_size(vm_info.virtual_size));
+      st->print_cr("               rss: %llu (%llu%s)", vm_info.resident_size, byte_size_in_proper_unit(vm_info.resident_size), proper_unit_for_byte_size(vm_info.resident_size));
+      st->print_cr("          peak rss: %llu (%llu%s)", vm_info.resident_size_peak, byte_size_in_proper_unit(vm_info.resident_size_peak), proper_unit_for_byte_size(vm_info.resident_size_peak));
+      st->print_cr("         page size: %d (" PROPERFMT ")", vm_info.page_size, PROPERFMTARGS((size_t)vm_info.page_size));
     } else {
       st->print_cr("error getting vm_info %d", err);
     }

--- a/src/hotspot/share/utilities/globalDefinitions.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions.hpp
@@ -342,7 +342,7 @@ inline T byte_size_in_proper_unit(T s) {
 }
 
 #define PROPERFMT             "%zu%s"
-#define PROPERFMTARGS(s)      byte_size_in_proper_unit(s), proper_unit_for_byte_size(s)
+#define PROPERFMTARGS(s)      byte_size_in_proper_unit<size_t>(s), proper_unit_for_byte_size(s)
 
 // Printing a range, with start and bytes given
 #define RANGEFMT              "[" PTR_FORMAT " - " PTR_FORMAT "), (%zu bytes)"


### PR DESCRIPTION
Hello,

PROPERFMT is defined as the format string "%zu%s", which expects a size_t as input argument. When used in combination with PROPERFMTARGS, which uses the templated byte_size_in_proper_units, the byte size may not be size_t if the input is some other type.

To minimize confusion, PROPERFMTARGS should always use the size_t template specilization of byte_size_in_proper_units, to match PROPERFMT. Places that use byte_size_in_proper_units with other types can still use it, but should use their own format strings instead of PROPERFMT.

ProcSmapsSummary::print_on in memMapPrinter_macosx is the only place that uses PROPERFMTARGS with a type that is not size_t. I have changed those places to use the expanded version of the macro, which uses the templated version of byte_size_in_proper_unit instead.

Testing:
* Currently running Oracle's tier1-2