### PR TITLE
8360523: Parallel: Remove unused local variable in MutableNUMASpace::initialize

### DIFF
--- a/src/hotspot/share/gc/parallel/mutableNUMASpace.cpp
+++ b/src/hotspot/share/gc/parallel/mutableNUMASpace.cpp
@@ -412,7 +412,7 @@ void MutableNUMASpace::initialize(MemRegion mr,
     MutableSpace *s = ls->space();
     old_region = s->region();
 
-    size_t chunk_byte_size = 0, old_chunk_byte_size = 0;
+    size_t chunk_byte_size = 0;
     if (i < lgrp_spaces()->length() - 1) {
       if (!UseAdaptiveNUMAChunkSizing                                ||
           (UseAdaptiveNUMAChunkSizing && NUMAChunkResizeWeight == 0) ||


### PR DESCRIPTION
Trivial removing dead code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8360523](https://bugs.openjdk.org/browse/JDK-8360523): Parallel: Remove unused local variable in MutableNUMASpace::initialize (**Enhancement** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25977/head:pull/25977` \
`$ git checkout pull/25977`

Update a local copy of the PR: \
`$ git checkout pull/25977` \
`$ git pull https://git.openjdk.org/jdk.git pull/25977/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25977`

View PR using the GUI difftool: \
`$ git pr show -t 25977`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25977.diff">https://git.openjdk.org/jdk/pull/25977.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25977#issuecomment-3004644775)
</details>
