### PR TITLE
G1: Flag constraint functions for G1SATBBufferSize and G1UpdateBufferSize are skipped during argument validation

### DIFF
--- a/src/hotspot/share/gc/g1/g1_globals.hpp
+++ b/src/hotspot/share/gc/g1/g1_globals.hpp
@@ -144,7 +144,7 @@
                                                                             \
   product(size_t, G1SATBBufferSize, 1*K,                                    \
           "Number of entries in an SATB log buffer.")                       \
-          constraint(G1SATBBufferSizeConstraintFunc, AtParse)               \
+          constraint(G1SATBBufferSizeConstraintFunc, AfterErgo)             \
                                                                             \
   develop(uintx, G1SATBProcessCompletedThreshold, 20,                       \
           "Number of completed buffers that triggers log processing.")      \
@@ -163,7 +163,7 @@
                                                                             \
   product(size_t, G1UpdateBufferSize, 256,                                  \
           "Size of an update buffer")                                       \
-          constraint(G1UpdateBufferSizeConstraintFunc, AtParse)             \
+          constraint(G1UpdateBufferSizeConstraintFunc, AfterErgo)           \
                                                                             \
   product(uint, G1RSetUpdatingPauseTimePercent, 10,                         \
           "A target percentage of time that is allowed to be spend on "     \


### PR DESCRIPTION
Hi,

Please review this change to move constraint function execution for  G1SATBBufferSize and G1UpdateBufferSize  to AfterErgo. These functions rely on the UseG1GC flag to determine whether to apply validations. However, during the AtParse phase of argument handling, UseG1GC may not yet be processed, which causes the constraints to be skipped.

Testing:
`java -XX:G1SATBBufferSize=0 -version
G1SATBBufferSize (0) must be in range [1, 4294967295]
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.`