### PR TITLE
8360554: Use the title from the JSON RFC for the @spec tag

### DIFF
--- a/src/jdk.management/share/classes/com/sun/management/HotSpotDiagnosticMXBean.java
+++ b/src/jdk.management/share/classes/com/sun/management/HotSpotDiagnosticMXBean.java
@@ -158,7 +158,8 @@ public interface HotSpotDiagnosticMXBean extends PlatformManagedObject {
         TEXT_PLAIN,
         /**
          * JSON (JavaScript Object Notation) format.
-         * @spec https://datatracker.ietf.org/doc/html/rfc8259 JavaScript Object Notation
+         * @spec https://datatracker.ietf.org/doc/html/rfc8259 RFC 8259: The JavaScript
+         *      Object Notation (JSON) Data Interchange Format
          */
         JSON,
     }


### PR DESCRIPTION
A minor doc fix. Avoiding @spec reference clash in the doc build