### PR TITLE
8354490: Pattern.CANON_EQ causes a pattern to not match a string with a UNICODE variation

### DIFF
--- a/src/java.base/share/classes/java/util/regex/Pattern.java
+++ b/src/java.base/share/classes/java/util/regex/Pattern.java
@@ -4154,7 +4154,7 @@ loop:   for(int x=0, offset=0; x<nCodePoints; x++, offset+=len) {
                     if (predicate.is(ch0))
                         return next.match(matcher, j, seq);
                 } else {
-                    while (i + n < j) {
+                    while (i + n <= j) {
                         String nfc = Normalizer.normalize(
                             seq.toString().substring(i, j), Normalizer.Form.NFC);
                         if (nfc.codePointCount(0, nfc.length()) == 1) {
@@ -4163,13 +4163,10 @@ loop:   for(int x=0, offset=0; x<nCodePoints; x++, offset+=len) {
                                 return true;
                             }
                         }
-
                         ch0 = Character.codePointBefore(seq, j);
                         j -= Character.charCount(ch0);
                     }
                 }
-                if (j < matcher.to)
-                    return false;
             } else {
                 matcher.hitEnd = true;
             }

--- a/test/jdk/java/util/regex/RegExTest.java
+++ b/test/jdk/java/util/regex/RegExTest.java
@@ -2324,6 +2324,21 @@ public class RegExTest {
         check(p, "test\u00e4\u0300\u0323", true);
 
         Object[][] data = new Object[][] {
+        // JDK-8354490
+        // emoji + emoji_component pair forms a single grapheme but remains
+        // as 2 separate characters in nfc. match & find should still work with the
+        // CANON_EQ flag, as long as the character class is appropriately specified.
+        {"^[^/]*\\.[^/]*$", "\u2764\ufe0ffile.txt",    "m", true},
+        { "\\p{IsEmoji}",     "ab\u2764\ufe0fcd",      "f", true },
+        { "[\\p{IsEmoji}]",   "ab\u2764\ufe0fcd",      "f", true },
+        { "\\p{IsEmoji}\\p{IsEmoji_Component}",       "\u2764\ufe0f", "m", true },
+        { "[\\p{IsEmoji}\\p{IsEmoji_Component}]{2}",  "\u2764\ufe0f", "m", true },
+        // greek with extra combining character
+        {"\\p{IsGreek}", "\u1f80\u0345", "f", true},
+        {"[\\p{IsGreek}]", "\u1f80\u0345", "f", true},
+        {"\\p{IsGreek}\\p{IsAlphabetic}",             "\u1f80\u0345", "m", true},
+        {"\\p{IsAlphabetic}*",                        "\u1f80\u0345", "m", true},
+        {"[\\p{IsAlphabetic}]*",                      "\u1f80\u0345", "m", true},
 
         // JDK-4867170
         { "[\u1f80-\u1f82]", "ab\u1f80cd",             "f", true },


### PR DESCRIPTION
The root cause is an off-by-one bug introduced in an old change we made years ago for Pattern.CANON_EQ.
See https://cr.openjdk.org/~sherman/regexCE/Note.txt for background info.

As described in the writeup above the basic logic of the change is to:

**generate the permutations, create the alternation and then put it appropriately into the character class (logically), we now use a special "Node", the NFCCharProperty to do the matching work. The NFCCharProperty tries to match a grapheme cluster at a time (nfc greedly, then backtrack) against the character class.**

It appears we have a off-by-one bug in the backtrack boundary condition check, when it backtracking to the position 'after' the base(main) character (in case where the resulting 'nfc' string is not a **single character'** string /not match). In such cases, we still need to match/compare the base character against the _predicate_ to find the potential match. 

For example in the reported scenario, the target string contains the pair of **u+2764** (emoji) + **u+fe0f** (variation selector/emoji_component). The boundary edge j = Grapheme.nextBoundary() starts at **2** (after u+fe0f), then it backtracks to 1. The current boundary check implementation incorrectly exits here because 0 + 1 < 1 fails, which is incorrect. 

This emoji pair should match correctly, s showed below

```
jshell> var p = Pattern.compile("\\p{IsEmoji}\\p{IsEmoji_Component}", Pattern.CANON_EQ);
p ==> \p{IsEmoji}\p{IsEmoji_Component}

jshell> p.matcher("\u2764\ufe0f").matches();
$53 ==> true
```

or

```
jshell> var p = Pattern.compile("\\p{IsEmoji}", Pattern.CANON_EQ);
p ==> \p{IsEmoji}

jshell> p.matcher("\u2764\ufe0f").find();
$55 ==> true
```

This bug is not limited to the emoji + variation selector pairs (which don't 'nfc' into a single character, even are treated as a single grapheme cluster). It also impacts cases involing dangling or unmatched combining character(s). For example, the following should work/match/find, even in Pattern.CANON_EQ mode.


```
jshell> p = Pattern.compile("\\p{IsGreek}\\p{IsAlphabetic}", Pattern.CANON_EQ);
p ==> \p{IsGreek}\p{IsAlphabetic}

jshell> p.matcher("\u1f80\u0345").matches();
$57 ==> true

jshell> p = Pattern.compile("[\\p{IsAlphabetic}]*", Pattern.CANON_EQ);
p ==> [\p{IsAlphabetic}]*

jshell> p.matcher("\u1f80\u0345").matches();
$59 ==> true
```

**note:** the grapheme boundary is not necessary the same as the resulting nfc boundary.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8354490](https://bugs.openjdk.org/browse/JDK-8354490): Pattern.CANON_EQ causes a pattern to not match a string with a UNICODE variation (**Bug** - P3)


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25986/head:pull/25986` \
`$ git checkout pull/25986`

Update a local copy of the PR: \
`$ git checkout pull/25986` \
`$ git pull https://git.openjdk.org/jdk.git pull/25986/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25986`

View PR using the GUI difftool: \
`$ git pr show -t 25986`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25986.diff">https://git.openjdk.org/jdk/pull/25986.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25986#issuecomment-3005826469)
</details>
