### PR TITLE
8359678: C2: assert(static_cast<T1>(result) == thing) caused by ReverseBytesNode::Value()

### DIFF
--- a/src/hotspot/share/opto/subnode.cpp
+++ b/src/hotspot/share/opto/subnode.cpp
@@ -2023,10 +2023,12 @@ const Type* SqrtHFNode::Value(PhaseGVN* phase) const {
 
 static const Type* reverse_bytes(int opcode, const Type* con) {
   switch (opcode) {
-    case Op_ReverseBytesS:  return TypeInt::make(byteswap(checked_cast<jshort>(con->is_int()->get_con())));
-    case Op_ReverseBytesUS: return TypeInt::make(byteswap(checked_cast<jchar>(con->is_int()->get_con())));
-    case Op_ReverseBytesI:  return TypeInt::make(byteswap(checked_cast<jint>(con->is_int()->get_con())));
-    case Op_ReverseBytesL:  return TypeLong::make(byteswap(checked_cast<jlong>(con->is_long()->get_con())));
+    // It is valid in bytecode to load any int and pass it to a method that expects a smaller type (i.e., short, char).
+    // Let's cast the value to match the Java behavior.
+    case Op_ReverseBytesS:  return TypeInt::make(byteswap(static_cast<jshort>(con->is_int()->get_con())));
+    case Op_ReverseBytesUS: return TypeInt::make(byteswap(static_cast<jchar>(con->is_int()->get_con())));
+    case Op_ReverseBytesI:  return TypeInt::make(byteswap(con->is_int()->get_con()));
+    case Op_ReverseBytesL:  return TypeLong::make(byteswap(con->is_long()->get_con()));
     default: ShouldNotReachHere();
   }
 }

--- a/test/hotspot/jtreg/compiler/c2/gvn/ReverseBytesConstantsHelper.jasm
+++ b/test/hotspot/jtreg/compiler/c2/gvn/ReverseBytesConstantsHelper.jasm
@@ -21,6 +21,7 @@
  * questions.
  *
  */
+package compiler/c2/gvn;
 
 public class ReverseBytesConstantsHelper {
     public Method "<init>":"()V" stack 1 locals 1 {

--- a/test/hotspot/jtreg/compiler/c2/gvn/ReverseBytesConstantsHelper.jasm
+++ b/test/hotspot/jtreg/compiler/c2/gvn/ReverseBytesConstantsHelper.jasm
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+public class ReverseBytesConstantsHelper version 65:0 {
+    public Method "<init>":"()V" stack 1 locals 1 {
+        aload_0;
+        invokespecial Method java/lang/Object."<init>":"()V";
+        return;
+    }
+
+    public static Method reverseBytesShort:"(I)S" stack 1 locals 1 {
+        iload_0;
+        invokestatic Method java/lang/Short."reverseBytes":"(S)S";
+        ireturn;
+    }
+
+    public static Method reverseBytesChar:"(I)C" stack 1 locals 1 {
+        iload_0;
+        invokestatic Method java/lang/Character."reverseBytes":"(C)C";
+        ireturn;
+    }
+}

--- a/test/hotspot/jtreg/compiler/c2/gvn/ReverseBytesConstantsHelper.jasm
+++ b/test/hotspot/jtreg/compiler/c2/gvn/ReverseBytesConstantsHelper.jasm
@@ -22,7 +22,7 @@
  *
  */
 
-public class ReverseBytesConstantsHelper version 65:0 {
+public class ReverseBytesConstantsHelper {
     public Method "<init>":"()V" stack 1 locals 1 {
         aload_0;
         invokespecial Method java/lang/Object."<init>":"()V";

--- a/test/hotspot/jtreg/compiler/c2/gvn/ReverseBytesConstantsTests.java
+++ b/test/hotspot/jtreg/compiler/c2/gvn/ReverseBytesConstantsTests.java
@@ -100,8 +100,9 @@ public class ReverseBytesConstantsTests {
         Asserts.assertEQ(Character.reverseBytes((char) 0x7080), testUS2());
         Asserts.assertEQ(Character.reverseBytes((char) 0x8070), testUS3());
         Asserts.assertEQ(Character.reverseBytes(C_CHAR), testUS4());
-        Asserts.assertEQ(ReverseBytesConstantsHelper.reverseBytesChar(C_INT), testUS5());
-        Asserts.assertEQ(ReverseBytesConstantsHelper.reverseBytesChar(C_SHORT), testUS6());
+        // TODO: uncomment after integration of  JDK-8362046
+        // Asserts.assertEQ(ReverseBytesConstantsHelper.reverseBytesChar(C_INT), testUS5());
+        // Asserts.assertEQ(ReverseBytesConstantsHelper.reverseBytesChar(C_SHORT), testUS6());
     }
 
     @Test

--- a/test/hotspot/jtreg/compiler/c2/gvn/ReverseBytesConstantsTests.java
+++ b/test/hotspot/jtreg/compiler/c2/gvn/ReverseBytesConstantsTests.java
@@ -20,8 +20,6 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package compiler.c2.gvn;
-
 import compiler.lib.generators.Generators;
 import compiler.lib.generators.RestrictableGenerator;
 import compiler.lib.ir_framework.DontCompile;
@@ -34,10 +32,11 @@ import jdk.test.lib.Asserts;
 
 /*
  * @test
- * @bug 8353551
+ * @bug 8353551 8359678
  * @summary Test that ReverseBytes operations constant-fold.
  * @library /test/lib /
- * @run driver compiler.c2.gvn.ReverseBytesConstantsTests
+ * @compile ReverseBytesConstantsHelper.jasm
+ * @run driver ReverseBytesConstantsTests
  */
 public class ReverseBytesConstantsTests {
 
@@ -51,7 +50,7 @@ public class ReverseBytesConstantsTests {
     private static final int C_INT = GEN_INT.next();
 
     public static void main(String[] args) {
-        TestFramework.run();
+        TestFramework.runWithFlags("-XX:CompileCommand=inline,ReverseBytesConstantsHelper::*");
     }
 
     @Run(test = {
@@ -89,6 +88,8 @@ public class ReverseBytesConstantsTests {
         Asserts.assertEQ(Short.reverseBytes((short) 0x7080), testS2());
         Asserts.assertEQ(Short.reverseBytes((short) 0x8070), testS3());
         Asserts.assertEQ(Short.reverseBytes(C_SHORT), testS4());
+        Asserts.assertEQ(ReverseBytesConstantsHelper.reverseBytesShort(C_INT), testS5());
+        Asserts.assertEQ(ReverseBytesConstantsHelper.reverseBytesShort(C_CHAR), testS6());
     }
 
     @DontCompile
@@ -97,6 +98,8 @@ public class ReverseBytesConstantsTests {
         Asserts.assertEQ(Character.reverseBytes((char) 0x7080), testUS2());
         Asserts.assertEQ(Character.reverseBytes((char) 0x8070), testUS3());
         Asserts.assertEQ(Character.reverseBytes(C_CHAR), testUS4());
+        Asserts.assertEQ(ReverseBytesConstantsHelper.reverseBytesChar(C_INT), testUS5());
+        Asserts.assertEQ(ReverseBytesConstantsHelper.reverseBytesChar(C_SHORT), testUS6());
     }
 
     @Test
@@ -172,6 +175,18 @@ public class ReverseBytesConstantsTests {
     }
 
     @Test
+    @IR(failOn = {IRNode.REVERSE_BYTES_S, IRNode.CALL})
+    public short testS5() {
+        return ReverseBytesConstantsHelper.reverseBytesShort(C_INT);
+    }
+
+    @Test
+    @IR(failOn = {IRNode.REVERSE_BYTES_S, IRNode.CALL})
+    public short testS6() {
+        return ReverseBytesConstantsHelper.reverseBytesShort(C_CHAR);
+    }
+
+    @Test
     @IR(failOn = {IRNode.REVERSE_BYTES_US})
     public char testUS1() {
         return Character.reverseBytes((char) 0x0201);
@@ -193,6 +208,18 @@ public class ReverseBytesConstantsTests {
     @IR(failOn = {IRNode.REVERSE_BYTES_US})
     public char testUS4() {
         return Character.reverseBytes(C_CHAR);
+    }
+
+    @Test
+    @IR(failOn = {IRNode.REVERSE_BYTES_US, IRNode.CALL})
+    public char testUS5() {
+        return ReverseBytesConstantsHelper.reverseBytesChar(C_INT);
+    }
+
+    @Test
+    @IR(failOn = {IRNode.REVERSE_BYTES_US, IRNode.CALL})
+    public char testUS6() {
+        return ReverseBytesConstantsHelper.reverseBytesChar(C_SHORT);
     }
 
 }

--- a/test/hotspot/jtreg/compiler/c2/gvn/ReverseBytesConstantsTests.java
+++ b/test/hotspot/jtreg/compiler/c2/gvn/ReverseBytesConstantsTests.java
@@ -20,6 +20,8 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+package compiler.c2.gvn;
+
 import compiler.lib.generators.Generators;
 import compiler.lib.generators.RestrictableGenerator;
 import compiler.lib.ir_framework.DontCompile;
@@ -36,7 +38,7 @@ import jdk.test.lib.Asserts;
  * @summary Test that ReverseBytes operations constant-fold.
  * @library /test/lib /
  * @compile ReverseBytesConstantsHelper.jasm
- * @run driver ReverseBytesConstantsTests
+ * @run driver compiler.c2.gvn.ReverseBytesConstantsTests
  */
 public class ReverseBytesConstantsTests {
 
@@ -50,14 +52,14 @@ public class ReverseBytesConstantsTests {
     private static final int C_INT = GEN_INT.next();
 
     public static void main(String[] args) {
-        TestFramework.runWithFlags("-XX:CompileCommand=inline,ReverseBytesConstantsHelper::*");
+        TestFramework.runWithFlags("-XX:CompileCommand=inline,compiler.c2.gvn.ReverseBytesConstantsHelper::*");
     }
 
     @Run(test = {
-        "testI1", "testI2", "testI3",
-        "testL1", "testL2", "testL3",
-        "testS1", "testS2", "testS3",
-        "testUS1", "testUS2", "testUS3",
+        "testI1", "testI2", "testI3", "testI4",
+        "testL1", "testL2", "testL3", "testL4",
+        "testS1", "testS2", "testS3", "testS4", "testS5", "testS6",
+        "testUS1", "testUS2", "testUS3", "testUS4", "testUS5", "testUS6"
     })
     public void runMethod() {
         assertResultI();

--- a/test/hotspot/jtreg/compiler/c2/gvn/ReverseBytesConstantsTests.java
+++ b/test/hotspot/jtreg/compiler/c2/gvn/ReverseBytesConstantsTests.java
@@ -58,8 +58,8 @@ public class ReverseBytesConstantsTests {
     @Run(test = {
         "testI1", "testI2", "testI3", "testI4",
         "testL1", "testL2", "testL3", "testL4",
-        "testS1", "testS2", "testS3", "testS4", "testS5", "testS6",
-        "testUS1", "testUS2", "testUS3", "testUS4", "testUS5", "testUS6"
+        "testS1", "testS2", "testS3", "testS4",
+        "testUS1", "testUS2", "testUS3", "testUS4",
     })
     public void runMethod() {
         assertResultI();
@@ -90,8 +90,6 @@ public class ReverseBytesConstantsTests {
         Asserts.assertEQ(Short.reverseBytes((short) 0x7080), testS2());
         Asserts.assertEQ(Short.reverseBytes((short) 0x8070), testS3());
         Asserts.assertEQ(Short.reverseBytes(C_SHORT), testS4());
-        Asserts.assertEQ(ReverseBytesConstantsHelper.reverseBytesShort(C_INT), testS5());
-        Asserts.assertEQ(ReverseBytesConstantsHelper.reverseBytesShort(C_CHAR), testS6());
     }
 
     @DontCompile
@@ -100,9 +98,6 @@ public class ReverseBytesConstantsTests {
         Asserts.assertEQ(Character.reverseBytes((char) 0x7080), testUS2());
         Asserts.assertEQ(Character.reverseBytes((char) 0x8070), testUS3());
         Asserts.assertEQ(Character.reverseBytes(C_CHAR), testUS4());
-        // TODO: uncomment after integration of  JDK-8362046
-        // Asserts.assertEQ(ReverseBytesConstantsHelper.reverseBytesChar(C_INT), testUS5());
-        // Asserts.assertEQ(ReverseBytesConstantsHelper.reverseBytesChar(C_SHORT), testUS6());
     }
 
     @Test


### PR DESCRIPTION
Fixes an assertion when passing an int larger than short/char to the corresponding reverseBytes method in a constant-folding scenario. By just using static_cast, we can ignore the upper bytes and just swap the lower bytes.

Using jasm, I added a test case that covers such inputs. It felt easier to test this way than the other scenarios mentioned in the bug report.

I also removed the redundant checked_cast calls from the int/long case; we already have the correct type there.

Please review. Thanks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8359678](https://bugs.openjdk.org/browse/JDK-8359678): C2: assert(static_cast&lt;T1&gt;(result) == thing) caused by ReverseBytesNode::Value() (**Bug** - P3)(⚠️ The fixVersion in this issue is [25] but the fixVersion in .jcheck/conf is 26, a new backport will be created when this pr is integrated.)


### Reviewers
 * [Manuel Hässig](https://openjdk.org/census#mhaessig) (@mhaessig - Committer)
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25988/head:pull/25988` \
`$ git checkout pull/25988`

Update a local copy of the PR: \
`$ git checkout pull/25988` \
`$ git pull https://git.openjdk.org/jdk.git pull/25988/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25988`

View PR using the GUI difftool: \
`$ git pr show -t 25988`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25988.diff">https://git.openjdk.org/jdk/pull/25988.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25988#issuecomment-3006149388)
</details>
