### PR TITLE
8277394

### DIFF
--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -1704,25 +1704,12 @@ void G1ConcurrentMark::weak_refs_work() {
     // Prefer to grow the stack until the max capacity.
     _global_mark_stack.set_should_grow();
 
-    // We need at least one active thread. If reference processing
-    // is not multi-threaded we use the current (VMThread) thread,
-    // otherwise we use the workers from the G1CollectedHeap and
-    // we utilize all the worker threads we can.
-    uint active_workers = (ParallelRefProcEnabled ? _g1h->workers()->active_workers() : 1U);
-    active_workers = clamp(active_workers, 1u, _max_num_tasks);
-
-    // Set the degree of MT processing here.  If the discovery was done MT,
-    // the number of threads involved during discovery could differ from
-    // the number of active workers.  This is OK as long as the discovered
-    // Reference lists are balanced (see balance_all_queues() and balance_queues()).
-    rp->set_active_mt_degree(active_workers);
-
     // Parallel processing task executor.
     G1CMRefProcProxyTask task(rp->max_num_queues(), *_g1h, *this);
     ReferenceProcessorPhaseTimes pt(_gc_timer_cm, rp->max_num_queues());
 
     // Process the weak references.
-    const ReferenceProcessorStats& stats = rp->process_discovered_references(task, pt);
+    const ReferenceProcessorStats& stats = rp->process_discovered_references(task, _g1h->workers(), pt);
     _gc_tracer_cm->report_gc_reference_stats(stats);
     pt.print_all_references();
 
@@ -1732,8 +1719,6 @@ void G1ConcurrentMark::weak_refs_work() {
 
     assert(has_overflown() || _global_mark_stack.is_empty(),
            "Mark stack should be empty (unless it has overflown)");
-
-    assert(rp->num_queues() == active_workers, "why not");
   }
 
   if (has_overflown()) {

--- a/src/hotspot/share/gc/g1/g1FullCollector.cpp
+++ b/src/hotspot/share/gc/g1/g1FullCollector.cpp
@@ -299,18 +299,14 @@ void G1FullCollector::phase1_mark_live_objects() {
   }
 
   {
-    uint old_active_mt_degree = reference_processor()->num_queues();
-    reference_processor()->set_active_mt_degree(workers());
     GCTraceTime(Debug, gc, phases) debug("Phase 1: Reference Processing", scope()->timer());
     // Process reference objects found during marking.
     ReferenceProcessorPhaseTimes pt(scope()->timer(), reference_processor()->max_num_queues());
     G1FullGCRefProcProxyTask task(*this, reference_processor()->max_num_queues());
-    const ReferenceProcessorStats& stats = reference_processor()->process_discovered_references(task, pt);
+    const ReferenceProcessorStats& stats = reference_processor()->process_discovered_references(task, _heap->workers(), pt);
     scope()->tracer()->report_gc_reference_stats(stats);
     pt.print_all_references();
     assert(marker(0)->oop_stack()->is_empty(), "Should be no oops on the stack");
-
-    reference_processor()->set_active_mt_degree(old_active_mt_degree);
   }
 
   {

--- a/src/hotspot/share/gc/g1/g1YoungCollector.cpp
+++ b/src/hotspot/share/gc/g1/g1YoungCollector.cpp
@@ -971,12 +971,9 @@ void G1YoungCollector::process_discovered_references(G1ParScanThreadStateSet* pe
   ReferenceProcessor* rp = ref_processor_stw();
   assert(rp->discovery_enabled(), "should have been enabled");
 
-  uint no_of_gc_workers = workers()->active_workers();
-  rp->set_active_mt_degree(no_of_gc_workers);
-
   G1STWRefProcProxyTask task(rp->max_num_queues(), *_g1h, *per_thread_states, *task_queues());
   ReferenceProcessorPhaseTimes& pt = *phase_times()->ref_phase_times();
-  ReferenceProcessorStats stats = rp->process_discovered_references(task, pt);
+  ReferenceProcessorStats stats = rp->process_discovered_references(task, _g1h->workers(), pt);
 
   gc_tracer_stw()->report_gc_reference_stats(stats);
 

--- a/src/hotspot/share/gc/parallel/psParallelCompact.cpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.cpp
@@ -1310,9 +1310,8 @@ void PSParallelCompact::marking_phase(ParallelOldTracer *gc_tracer) {
     ReferenceProcessorStats stats;
     ReferenceProcessorPhaseTimes pt(&_gc_timer, ref_processor()->max_num_queues());
 
-    ref_processor()->set_active_mt_degree(active_gc_threads);
     ParallelCompactRefProcProxyTask task(ref_processor()->max_num_queues());
-    stats = ref_processor()->process_discovered_references(task, pt);
+    stats = ref_processor()->process_discovered_references(task, &ParallelScavengeHeap::heap()->workers(), pt);
 
     gc_tracer->report_gc_reference_stats(stats);
     pt.print_all_references();

--- a/src/hotspot/share/gc/parallel/psScavenge.cpp
+++ b/src/hotspot/share/gc/parallel/psScavenge.cpp
@@ -410,12 +410,11 @@ bool PSScavenge::invoke(bool clear_soft_refs) {
     {
       GCTraceTime(Debug, gc, phases) tm("Reference Processing", &_gc_timer);
 
-      reference_processor()->set_active_mt_degree(active_workers);
       ReferenceProcessorStats stats;
       ReferenceProcessorPhaseTimes pt(&_gc_timer, reference_processor()->max_num_queues());
 
       ParallelScavengeRefProcProxyTask task(reference_processor()->max_num_queues());
-      stats = reference_processor()->process_discovered_references(task, pt);
+      stats = reference_processor()->process_discovered_references(task, &ParallelScavengeHeap::heap()->workers(), pt);
 
       _gc_tracer.report_gc_reference_stats(stats);
       pt.print_all_references();

--- a/src/hotspot/share/gc/serial/defNewGeneration.cpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.cpp
@@ -631,7 +631,7 @@ bool DefNewGeneration::collect(bool clear_all_soft_refs) {
     ReferenceProcessor* rp = ref_processor();
     ReferenceProcessorPhaseTimes pt(_gc_timer, rp->max_num_queues());
     SerialGCRefProcProxyTask task(is_alive, keep_alive, evacuate_followers);
-    const ReferenceProcessorStats& stats = rp->process_discovered_references(task, pt);
+    const ReferenceProcessorStats& stats = rp->process_discovered_references(task, nullptr, pt);
     _gc_tracer->report_gc_reference_stats(stats);
     _gc_tracer->report_tenuring_threshold(tenuring_threshold());
     pt.print_all_references();

--- a/src/hotspot/share/gc/serial/serialFullGC.cpp
+++ b/src/hotspot/share/gc/serial/serialFullGC.cpp
@@ -498,7 +498,7 @@ void SerialFullGC::phase1_mark(bool clear_all_softrefs) {
 
     ReferenceProcessorPhaseTimes pt(_gc_timer, ref_processor()->max_num_queues());
     SerialGCRefProcProxyTask task(is_alive, keep_alive, follow_stack_closure);
-    const ReferenceProcessorStats& stats = ref_processor()->process_discovered_references(task, pt);
+    const ReferenceProcessorStats& stats = ref_processor()->process_discovered_references(task, nullptr, pt);
     pt.print_all_references();
     gc_tracer()->report_gc_reference_stats(stats);
   }

--- a/src/hotspot/share/gc/shared/referenceProcessor.cpp
+++ b/src/hotspot/share/gc/shared/referenceProcessor.cpp
@@ -179,6 +179,7 @@ void ReferenceProcessor::verify_total_count_zero(DiscoveredList lists[], const c
 #endif
 
 ReferenceProcessorStats ReferenceProcessor::process_discovered_references(RefProcProxyTask& proxy_task,
+                                                                          WorkerThreads* workers,
                                                                           ReferenceProcessorPhaseTimes& phase_times) {
 
   double start_time = os::elapsedTime();
@@ -197,17 +198,17 @@ ReferenceProcessorStats ReferenceProcessor::process_discovered_references(RefPro
 
   {
     RefProcTotalPhaseTimesTracker tt(SoftWeakFinalRefsPhase, &phase_times);
-    process_soft_weak_final_refs(proxy_task, phase_times);
+    process_soft_weak_final_refs(proxy_task, workers, phase_times);
   }
 
   {
     RefProcTotalPhaseTimesTracker tt(KeepAliveFinalRefsPhase, &phase_times);
-    process_final_keep_alive(proxy_task, phase_times);
+    process_final_keep_alive(proxy_task, workers, phase_times);
   }
 
   {
     RefProcTotalPhaseTimesTracker tt(PhantomRefsPhase, &phase_times);
-    process_phantom_refs(proxy_task, phase_times);
+    process_phantom_refs(proxy_task, workers, phase_times);
   }
 
   phase_times.set_total_time_ms((os::elapsedTime() - start_time) * 1000);
@@ -699,7 +700,7 @@ void ReferenceProcessor::balance_queues(DiscoveredList ref_lists[])
 #endif
 }
 
-void ReferenceProcessor::run_task(RefProcTask& task, RefProcProxyTask& proxy_task, bool marks_oops_alive) {
+void ReferenceProcessor::run_task(RefProcTask& task, RefProcProxyTask& proxy_task, WorkerThreads* workers, bool marks_oops_alive) {
   log_debug(gc, ref)("ReferenceProcessor::execute queues: %d, %s, marks_oops_alive: %s",
                      num_queues(),
                      processing_is_mt() ? "RefProcThreadModel::Multi" : "RefProcThreadModel::Single",
@@ -707,7 +708,6 @@ void ReferenceProcessor::run_task(RefProcTask& task, RefProcProxyTask& proxy_tas
 
   proxy_task.prepare_run_task(task, num_queues(), processing_is_mt() ? RefProcThreadModel::Multi : RefProcThreadModel::Single, marks_oops_alive);
   if (processing_is_mt()) {
-    WorkerThreads* workers = Universe::heap()->safepoint_workers();
     assert(workers != nullptr, "can not dispatch multi threaded without workers");
     assert(workers->active_workers() >= num_queues(),
            "Ergonomically chosen workers(%u) should be less than or equal to active workers(%u)",
@@ -720,7 +720,12 @@ void ReferenceProcessor::run_task(RefProcTask& task, RefProcProxyTask& proxy_tas
   }
 }
 
+static uint num_active_workers(WorkerThreads* workers) {
+  return workers != nullptr ? workers->active_workers() : 1;
+}
+
 void ReferenceProcessor::process_soft_weak_final_refs(RefProcProxyTask& proxy_task,
+                                                      WorkerThreads* workers,
                                                       ReferenceProcessorPhaseTimes& phase_times) {
 
   size_t const num_soft_refs = phase_times.ref_discovered(REF_SOFT);
@@ -733,7 +738,7 @@ void ReferenceProcessor::process_soft_weak_final_refs(RefProcProxyTask& proxy_ta
     return;
   }
 
-  RefProcMTDegreeAdjuster a(this, SoftWeakFinalRefsPhase, num_total_refs);
+  RefProcMTDegreeAdjuster a(this, SoftWeakFinalRefsPhase, num_active_workers(workers), num_total_refs);
 
   if (processing_is_mt()) {
     RefProcBalanceQueuesTimeTracker tt(SoftWeakFinalRefsPhase, &phase_times);
@@ -747,7 +752,7 @@ void ReferenceProcessor::process_soft_weak_final_refs(RefProcProxyTask& proxy_ta
   log_reflist("SoftWeakFinalRefsPhase Final before", _discoveredFinalRefs, _max_num_queues);
 
   RefProcSoftWeakFinalPhaseTask phase_task(*this, &phase_times);
-  run_task(phase_task, proxy_task, false);
+  run_task(phase_task, proxy_task, workers, false);
 
   verify_total_count_zero(_discoveredSoftRefs, "SoftReference");
   verify_total_count_zero(_discoveredWeakRefs, "WeakReference");
@@ -755,6 +760,7 @@ void ReferenceProcessor::process_soft_weak_final_refs(RefProcProxyTask& proxy_ta
 }
 
 void ReferenceProcessor::process_final_keep_alive(RefProcProxyTask& proxy_task,
+                                                  WorkerThreads* workers,
                                                   ReferenceProcessorPhaseTimes& phase_times) {
 
   size_t const num_final_refs = phase_times.ref_discovered(REF_FINAL);
@@ -764,7 +770,7 @@ void ReferenceProcessor::process_final_keep_alive(RefProcProxyTask& proxy_task,
     return;
   }
 
-  RefProcMTDegreeAdjuster a(this, KeepAliveFinalRefsPhase, num_final_refs);
+  RefProcMTDegreeAdjuster a(this, KeepAliveFinalRefsPhase, num_active_workers(workers), num_final_refs);
 
   if (processing_is_mt()) {
     RefProcBalanceQueuesTimeTracker tt(KeepAliveFinalRefsPhase, &phase_times);
@@ -773,12 +779,13 @@ void ReferenceProcessor::process_final_keep_alive(RefProcProxyTask& proxy_task,
 
   // Traverse referents of final references and keep them and followers alive.
   RefProcKeepAliveFinalPhaseTask phase_task(*this, &phase_times);
-  run_task(phase_task, proxy_task, true);
+  run_task(phase_task, proxy_task, workers, true);
 
   verify_total_count_zero(_discoveredFinalRefs, "FinalReference");
 }
 
 void ReferenceProcessor::process_phantom_refs(RefProcProxyTask& proxy_task,
+                                              WorkerThreads* workers,
                                               ReferenceProcessorPhaseTimes& phase_times) {
 
   size_t const num_phantom_refs = phase_times.ref_discovered(REF_PHANTOM);
@@ -788,7 +795,7 @@ void ReferenceProcessor::process_phantom_refs(RefProcProxyTask& proxy_task,
     return;
   }
 
-  RefProcMTDegreeAdjuster a(this, PhantomRefsPhase, num_phantom_refs);
+  RefProcMTDegreeAdjuster a(this, PhantomRefsPhase, num_active_workers(workers), num_phantom_refs);
 
   if (processing_is_mt()) {
     RefProcBalanceQueuesTimeTracker tt(PhantomRefsPhase, &phase_times);
@@ -798,7 +805,7 @@ void ReferenceProcessor::process_phantom_refs(RefProcProxyTask& proxy_task,
   log_reflist("PhantomRefsPhase Phantom before", _discoveredPhantomRefs, _max_num_queues);
 
   RefProcPhantomPhaseTask phase_task(*this, &phase_times);
-  run_task(phase_task, proxy_task, false);
+  run_task(phase_task, proxy_task, workers, false);
 
   verify_total_count_zero(_discoveredPhantomRefs, "PhantomReference");
 }
@@ -1137,10 +1144,11 @@ bool RefProcMTDegreeAdjuster::use_max_threads(RefProcPhases phase) const {
 
 RefProcMTDegreeAdjuster::RefProcMTDegreeAdjuster(ReferenceProcessor* rp,
                                                  RefProcPhases phase,
+                                                 uint num_active_workers,
                                                  size_t ref_count):
     _rp(rp),
     _saved_num_queues(_rp->num_queues()) {
-  uint workers = ergo_proc_thread_count(ref_count, _rp->num_queues(), phase);
+  uint workers = ergo_proc_thread_count(ref_count, num_active_workers, phase);
   _rp->set_active_mt_degree(workers);
 }
 


### PR DESCRIPTION
Hi all,

  please review this alternate implementation of 8277394. During the review of the first implementation (https://github.com/openjdk/jdk/pull/6453) the reviews did not like that the `WorkerThreads` were stashed away in the `ReferenceProcessor`.

This is an alternate implementation that implements the suggestion in the review comments, passing them along through the callers. While this requires a bit more changes, imo it better separates reference processor logic from the execution resources.

Testing: tier1-5

Thanks,
  Thomas