### PR TITLE
8360533: ContainerRuntimeVersionTestUtils fromVersionString fails with some docker versions

### DIFF
--- a/test/lib/jdk/test/lib/containers/docker/ContainerRuntimeVersionTestUtils.java
+++ b/test/lib/jdk/test/lib/containers/docker/ContainerRuntimeVersionTestUtils.java
@@ -79,8 +79,9 @@ public class ContainerRuntimeVersionTestUtils implements Comparable<ContainerRun
         try {
             // Example 'docker version 20.10.0 or podman version 4.9.4-rhel'
             String versNums = version.split("\\s+", 3)[2];
-            // On some docker implementations e.g. RHEL8 ppc64le we have a version v25.0.3
-            // with a leading v, skip this
+            // On some docker implementations e.g. RHEL8 ppc64le we have the following version output:
+            //    Docker version v25.0.3, build 4debf41
+            // Trim potentially leading 'v' and trailing ','
             if (versNums.startsWith("v")) {
                 versNums = versNums.substring(1);
             }

--- a/test/lib/jdk/test/lib/containers/docker/ContainerRuntimeVersionTestUtils.java
+++ b/test/lib/jdk/test/lib/containers/docker/ContainerRuntimeVersionTestUtils.java
@@ -79,12 +79,20 @@ public class ContainerRuntimeVersionTestUtils implements Comparable<ContainerRun
         try {
             // Example 'docker version 20.10.0 or podman version 4.9.4-rhel'
             String versNums = version.split("\\s+", 3)[2];
+            // On some docker implementations e.g. RHEL8 ppc64le we have a version v25.0.3
+            // with a leading v, skip this
+            if (versNums.startsWith("v")) {
+                versNums = versNums.substring(1);
+            }
+            int cidx = versNums.indexOf(',');
+            versNums = (cidx != -1) ? versNums.substring(0, cidx) : versNums;
+
             String[] numbers = versNums.split("-")[0].split("\\.", 3);
             return new ContainerRuntimeVersionTestUtils(Integer.parseInt(numbers[0]),
                     Integer.parseInt(numbers[1]),
                     Integer.parseInt(numbers[2]));
         } catch (Exception e) {
-            throw new RuntimeException("Failed to parse container runtime version: " + version);
+            throw new RuntimeException("Failed to parse container runtime version: " + version, e);
         }
     }
 


### PR DESCRIPTION
On Linux ppc64le RHEL 8, we have such a docker version :
```
docker --version
Docker version v25.0.3, build 4debf41
```

Unfortunately, the leading 'v' is not expected in ContainerRuntimeVersionTestUtils fromVersionString so we get an exception.

Probably we should simply skip the leading 'v' .
Also the appended build info has to be considered.

Example failure
```
TEST: jdk/internal/platform/docker/TestDockerMemoryMetricsSubgroup.java
TEST RESULT: Failed. Execution failed: `main' threw exception: java.lang.RuntimeException: Failed to parse container runtime version: Docker version v25.0.3, build 4debf41
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8360533](https://bugs.openjdk.org/browse/JDK-8360533): ContainerRuntimeVersionTestUtils fromVersionString fails with some docker versions (**Bug** - P4)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**) Review applies to [a1d49a48](https://git.openjdk.org/jdk/pull/25996/files/a1d49a488f4b8c9a024768a6c58bf9cbccabd3e7)
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) Review applies to [a1d49a48](https://git.openjdk.org/jdk/pull/25996/files/a1d49a488f4b8c9a024768a6c58bf9cbccabd3e7)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/25996/head:pull/25996` \
`$ git checkout pull/25996`

Update a local copy of the PR: \
`$ git checkout pull/25996` \
`$ git pull https://git.openjdk.org/jdk.git pull/25996/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25996`

View PR using the GUI difftool: \
`$ git pr show -t 25996`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/25996.diff">https://git.openjdk.org/jdk/pull/25996.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/25996#issuecomment-3007836273)
</details>
