### PR TITLE
8338474

### DIFF
--- a/src/hotspot/share/gc/parallel/parallel_globals.hpp
+++ b/src/hotspot/share/gc/parallel/parallel_globals.hpp
@@ -41,7 +41,7 @@
           "for a system GC")                                                \
                                                                             \
   product(bool, PSChunkLargeArrays, true,                                   \
-          "Process large arrays in chunks")
+          "(Deprecated) Process large arrays in chunks")
 
 // end of GC_PARALLEL_FLAGS
 

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -534,6 +534,7 @@ static SpecialFlag const special_jvm_flags[] = {
 #endif
   { "ParallelRefProcEnabled",       JDK_Version::jdk(26),  JDK_Version::jdk(27), JDK_Version::jdk(28) },
   { "ParallelRefProcBalancingEnabled", JDK_Version::jdk(26),  JDK_Version::jdk(27), JDK_Version::jdk(28) },
+  { "PSChunkLargeArrays",           JDK_Version::jdk(26),  JDK_Version::jdk(27), JDK_Version::jdk(28) },
   // --- Deprecated alias flags (see also aliased_jvm_flags) - sorted by obsolete_in then expired_in:
   { "CreateMinidumpOnCrash",        JDK_Version::jdk(9),  JDK_Version::undefined(), JDK_Version::undefined() },
 


### PR DESCRIPTION
Deprecating `PSChunkLargeArrays`, which is used only by Parallel and it is enabled by default.

Disabling it offers little benefit, so removing it do reduce the number of commandline flags.