### PR TITLE
Backport 8df6b2c4a355751cd8ca37cc5932be66bccaa123

### DIFF
--- a/src/java.base/macosx/native/libjava/java_props_macosx.c
+++ b/src/java.base/macosx/native/libjava/java_props_macosx.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
  * questions.
  */
 
+#include <stdbool.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
@@ -229,33 +230,50 @@ void setOSNameAndVersion(java_props_t *sprops) {
     NSString *nsVerStr = NULL;
     char* osVersionCStr = NULL;
     NSOperatingSystemVersion osVer = [[NSProcessInfo processInfo] operatingSystemVersion];
-    // Copy out the char* if running on version other than 10.16 Mac OS (10.16 == 11.x)
-    // or explicitly requesting version compatibility
-    if (!((long)osVer.majorVersion == 10 && (long)osVer.minorVersion >= 16) ||
-            (getenv("SYSTEM_VERSION_COMPAT") != NULL)) {
-        if (osVer.patchVersion == 0) { // Omit trailing ".0"
+    // Some macOS versions require special handling. For example,
+    // when the NSOperatingSystemVersion reports 10.16 as the version
+    // then it should be treated as 11. Similarly, when it reports 16.0
+    // as the version then it should be treated as 26.
+    // If the SYSTEM_VERSION_COMPAT environment variable (a macOS construct)
+    // is set to 1, then we don't do any special handling for any versions
+    // and just literally use the value that NSOperatingSystemVersion reports.
+    const char* envVal = getenv("SYSTEM_VERSION_COMPAT");
+    const bool versionCompatEnabled = envVal != NULL
+                                      && strncmp(envVal, "1", 1) == 0;
+    const bool requiresSpecialHandling =
+            ((long) osVer.majorVersion == 10 && (long) osVer.minorVersion >= 16)
+            || ((long) osVer.majorVersion == 16 && (long) osVer.minorVersion >= 0);
+    if (!requiresSpecialHandling || versionCompatEnabled) {
+        // no special handling - just use the version reported
+        // by NSOperatingSystemVersion
+        if (osVer.patchVersion == 0) {
+            // Omit trailing ".0"
             nsVerStr = [NSString stringWithFormat:@"%ld.%ld",
                     (long)osVer.majorVersion, (long)osVer.minorVersion];
         } else {
             nsVerStr = [NSString stringWithFormat:@"%ld.%ld.%ld",
-                    (long)osVer.majorVersion, (long)osVer.minorVersion, (long)osVer.patchVersion];
+                    (long)osVer.majorVersion, (long)osVer.minorVersion,
+                    (long)osVer.patchVersion];
         }
     } else {
-        // Version 10.16, without explicit env setting of SYSTEM_VERSION_COMPAT
-        // AKA 11+ Read the *real* ProductVersion from the hidden link to avoid SYSTEM_VERSION_COMPAT
-        // If not found, fallback below to the SystemVersion.plist
-        NSDictionary *version = [NSDictionary dictionaryWithContentsOfFile :
-                         @"/System/Library/CoreServices/.SystemVersionPlatform.plist"];
+        // Requires special handling. We ignore the version reported
+        // by the NSOperatingSystemVersion API and instead read the
+        // *real* ProductVersion from
+        // /System/Library/CoreServices/.SystemVersionPlatform.plist.
+        // If not found there, then as a last resort we fallback to
+        // /System/Library/CoreServices/SystemVersion.plist
+        NSDictionary *version = [NSDictionary dictionaryWithContentsOfFile:
+            @"/System/Library/CoreServices/.SystemVersionPlatform.plist"];
         if (version != NULL) {
-            nsVerStr = [version objectForKey : @"ProductVersion"];
+            nsVerStr = [version objectForKey: @"ProductVersion"];
         }
     }
-    // Fallback to reading the SystemVersion.plist
+    // Last resort - fallback to reading the SystemVersion.plist
     if (nsVerStr == NULL) {
-        NSDictionary *version = [NSDictionary dictionaryWithContentsOfFile :
-                                 @"/System/Library/CoreServices/SystemVersion.plist"];
+        NSDictionary *version = [NSDictionary dictionaryWithContentsOfFile:
+            @"/System/Library/CoreServices/SystemVersion.plist"];
         if (version != NULL) {
-            nsVerStr = [version objectForKey : @"ProductVersion"];
+            nsVerStr = [version objectForKey: @"ProductVersion"];
         }
     }
 


### PR DESCRIPTION
Can I please get a review of this backport to JDK 25? This backports https://bugs.openjdk.org/browse/JDK-8359830 which was integrated into mainline a few minutes back https://github.com/openjdk/jdk/pull/25865.

With this change it should now be possible to test JDK 25 on macOS 26 when it gets released. Java's standard `os.version` system property will correctly report the version as 26 on macOS 26 once this is integrated.