### PR TITLE
8360539: DTLS handshakes fails due to improper cookie validation logic

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/HelloCookieManager.java
+++ b/src/java.base/share/classes/sun/security/ssl/HelloCookieManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -187,7 +187,7 @@ abstract class HelloCookieManager {
             byte[] secret;
             d10ManagerLock.lock();
             try {
-                if (((cookieVersion >> 24) & 0xFF) == cookie[0]) {
+                if ((byte) ((cookieVersion >> 24) & 0xFF) == cookie[0]) {
                     secret = cookieSecret;
                 } else {
                     secret = legacySecret;  // including out of window cookies


### PR DESCRIPTION
DESCRIPTION OF THE PROBLEM:
There appears to be a bug in the isCookieValid method of HelloCookieManager that can lead to improper cookie validation results after a new cookieSecret is generated. The cookie version (cookieVersion) is initialized with a random number and increments with each cookie, regenerating the secret every 0xFFFFFF cookies.

When cookieVersion is negative, the expression ((cookieVersion >> 24) & 0xFF) results in an integer that does not match the signed byte value in cookie[0], causing the else clause to be executed incorrectly. This leads to the use of legacySecret even for valid cookies.