### PR TITLE
8360164: AOT cache creation crashes in ~ThreadTotalCPUTimeClosure()

### DIFF
--- a/src/hotspot/share/runtime/java.cpp
+++ b/src/hotspot/share/runtime/java.cpp
@@ -432,10 +432,8 @@ void before_exit(JavaThread* thread, bool halt) {
 #if INCLUDE_CDS
   // Dynamic CDS dumping must happen whilst we can still reliably
   // run Java code.
-  if (CDSConfig::is_dumping_dynamic_archive()) {
-    DynamicArchive::dump_at_exit(thread);
-    assert(!thread->has_pending_exception(), "must be");
-  }
+  DynamicArchive::dump_at_exit(thread);
+  assert(!thread->has_pending_exception(), "must be");
 #endif
 
   // Actual shutdown logic begins here.


### PR DESCRIPTION
`java -XX:AOTMode=create` calls `vm_exit(0)` to terminate the JVM (see [this e-mail thread](https://mail.openjdk.org/pipermail/hotspot-runtime-dev/2024-August/072122.html) for the reason for doing so). However, at this point, the JVM has executed quite a lot of Java code and there are many threads in the JVM that would require a proper shutdown. See [comments by @kimbarrett](https://bugs.openjdk.org/browse/JDK-8360164?focusedId=14792754&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-14792754) for a detailed analysis.

This fix calls `JVM_Halt(0)` instead of `vm_exit(0)` so that the proper shutdown code is executed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8360164](https://bugs.openjdk.org/browse/JDK-8360164): AOT cache creation crashes in ~ThreadTotalCPUTimeClosure() (**Bug** - P3)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**) Review applies to [deed0c9d](https://git.openjdk.org/jdk/pull/26008/files/deed0c9d475173d3cf7fe853189280893b3d466a)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) Review applies to [f8222e38](https://git.openjdk.org/jdk/pull/26008/files/f8222e38e41a26469089351343df45039ddb288f)
 * [Calvin Cheung](https://openjdk.org/census#ccheung) (@calvinccheung - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26008/head:pull/26008` \
`$ git checkout pull/26008`

Update a local copy of the PR: \
`$ git checkout pull/26008` \
`$ git pull https://git.openjdk.org/jdk.git pull/26008/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26008`

View PR using the GUI difftool: \
`$ git pr show -t 26008`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26008.diff">https://git.openjdk.org/jdk/pull/26008.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26008#issuecomment-3010693956)
</details>
