### PR TITLE
8310831: Some methods are missing from CDS regenerated JLI holder class

### DIFF
--- a/src/hotspot/share/cds/regeneratedClasses.cpp
+++ b/src/hotspot/share/cds/regeneratedClasses.cpp
@@ -23,7 +23,6 @@
  */
 
 #include "cds/archiveBuilder.hpp"
-#include "cds/lambdaFormInvokers.hpp"
 #include "cds/regeneratedClasses.hpp"
 #include "memory/universe.hpp"
 #include "oops/instanceKlass.hpp"

--- a/src/hotspot/share/cds/regeneratedClasses.cpp
+++ b/src/hotspot/share/cds/regeneratedClasses.cpp
@@ -23,6 +23,7 @@
  */
 
 #include "cds/archiveBuilder.hpp"
+#include "cds/lambdaFormInvokers.hpp"
 #include "cds/regeneratedClasses.hpp"
 #include "memory/universe.hpp"
 #include "oops/instanceKlass.hpp"
@@ -57,8 +58,10 @@ void RegeneratedClasses::add_class(InstanceKlass* orig_klass, InstanceKlass* reg
     Method* regen_m = regen_klass->find_method(orig_m->name(), orig_m->signature());
     if (regen_m == nullptr) {
       ResourceMark rm;
-      log_warning(aot)("Method in original class is missing from regenerated class: " INTPTR_FORMAT " %s",
-                       p2i(orig_m), orig_m->external_name());
+      if (strstr(orig_m->external_name(), "$Holder.<init>") == nullptr) {
+        log_warning(aot)("Method in original class is missing from regenerated class: " INTPTR_FORMAT " %s",
+                         p2i(orig_m), orig_m->external_name());
+      }
     } else {
       _renegerated_objs->put((address)orig_m, (address)regen_m);
     }


### PR DESCRIPTION
Per the [suggested fix](https://bugs.openjdk.org/browse/JDK-8310831?focusedId=14788065&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-14788065), this patch doesn't issue a warning if the missing method is the constructor of a holder class.

Sanity tier1 tested.

Manually tested by building the `images` with the `-Xlog:cds=off` removed from the `GenerateLinkOptData.gmk` and with build logging enabled (`LOG=info`).