### PR TITLE
8360783: CTW: Skip deoptimization between tiers

### DIFF
--- a/test/hotspot/jtreg/testlibrary/ctw/src/sun/hotspot/tools/ctw/Compiler.java
+++ b/test/hotspot/jtreg/testlibrary/ctw/src/sun/hotspot/tools/ctw/Compiler.java
@@ -171,7 +171,7 @@ public class Compiler {
         @Override
         public final void run() {
             // Make sure method is not compiled at any level before starting
-            // progressive compilations. No deopt in-between tiers deopt is needed,
+            // progressive compilations. No deopt in-between tiers is needed,
             // as long as we increase the compilation levels one by one.
             WHITE_BOX.deoptimizeMethod(method);
 

--- a/test/hotspot/jtreg/testlibrary/ctw/src/sun/hotspot/tools/ctw/Compiler.java
+++ b/test/hotspot/jtreg/testlibrary/ctw/src/sun/hotspot/tools/ctw/Compiler.java
@@ -170,17 +170,22 @@ public class Compiler {
 
         @Override
         public final void run() {
+            // Make sure method is not compiled at any level before starting
+            // progressive compilations. No deopt in-between tiers deopt is needed,
+            // as long as we increase the compilation levels one by one.
+            WHITE_BOX.deoptimizeMethod(method);
+
             int compLevel = Utils.INITIAL_COMP_LEVEL;
             if (Utils.TIERED_COMPILATION) {
                 for (int i = compLevel; i <= Utils.TIERED_STOP_AT_LEVEL; ++i) {
-                    WHITE_BOX.deoptimizeMethod(method);
                     compileAtLevel(i);
                 }
             } else {
                 compileAtLevel(compLevel);
             }
 
-            // Make the method eligible for sweeping sooner
+            // Ditch all the compiled versions of the code, make the method
+            // eligible for sweeping sooner.
             WHITE_BOX.deoptimizeMethod(method);
         }
 


### PR DESCRIPTION
When profiling CTW runs, I noticed we spend a lot of time dealing with deoptimization. We do this excessively, deoptimizing before compilation on every tier. This is excessive: Hotspot honors compilation requests on subsequent levels without the need for explicit deoptimization. Not doing deopt between tiers greatly improves CTW performance. 

A taste of improvements, about 15% less CPU spent:

```
$ time make test TEST=applications/ctw/modules

# Current
real	5m1.616s
user	79m41.398s
sys	14m39.607s

# Patched
real	3m55.411s
user	69m19.227s
sys	5m24.323s
```

The compilation still works as expected, progressing through tiers 1..4:

```
$ JAVA_OPTIONS="-XX:+PrintCompilation -XX:CICompilerCount=2" ./ctw.sh modules:jdk.compiler | tee out
...
$ grep sun.tools.serialver.resources.serialver_de::getContents out
101783 55033    b  1       sun.tools.serialver.resources.serialver_de::getContents (108 bytes)
101785 55036    b  2       sun.tools.serialver.resources.serialver_de::getContents (108 bytes)
101786 55033       1       sun.tools.serialver.resources.serialver_de::getContents (108 bytes)   made not entrant: not used
101786 55038    b  3       sun.tools.serialver.resources.serialver_de::getContents (108 bytes)
101787 55036       2       sun.tools.serialver.resources.serialver_de::getContents (108 bytes)   made not entrant: not used
101792 55040    b  4       sun.tools.serialver.resources.serialver_de::getContents (108 bytes)
101797 55038       3       sun.tools.serialver.resources.serialver_de::getContents (108 bytes)   made not entrant: not used
101798 55040       4       sun.tools.serialver.resources.serialver_de::getContents (108 bytes)   made not entrant: marked for deoptimization
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8360783](https://bugs.openjdk.org/browse/JDK-8360783): CTW: Skip deoptimization between tiers (**Enhancement** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Manuel Hässig](https://openjdk.org/census#mhaessig) (@mhaessig - Committer)
 * [Damon Fenacci](https://openjdk.org/census#dfenacci) (@dafedafe - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26013/head:pull/26013` \
`$ git checkout pull/26013`

Update a local copy of the PR: \
`$ git checkout pull/26013` \
`$ git pull https://git.openjdk.org/jdk.git pull/26013/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26013`

View PR using the GUI difftool: \
`$ git pr show -t 26013`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26013.diff">https://git.openjdk.org/jdk/pull/26013.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26013#issuecomment-3012170976)
</details>
