### PR TITLE
8360791: [ubsan] Adjust signal handling

### DIFF
--- a/make/data/ubsan/ubsan_default_options.c
+++ b/make/data/ubsan/ubsan_default_options.c
@@ -63,9 +63,7 @@
 // variable UBSAN_OPTIONS.
 ATTRIBUTE_DEFAULT_VISIBILITY ATTRIBUTE_USED const char* __ubsan_default_options() {
   return "halt_on_error=1,"
-#if defined(__clang__)
-          "handle_segv=0,"
-          "handle_sigbus=0,"
-#endif
-          "print_stacktrace=1" _LLVM_SYMBOLIZER(LLVM_SYMBOLIZER);
+         "handle_segv=0,"
+         "handle_sigbus=0,"
+         "print_stacktrace=1" _LLVM_SYMBOLIZER(LLVM_SYMBOLIZER);
 }


### PR DESCRIPTION
A couple of tests e.g. VendorInfoPluginsTest but also some Hotspot like runtime/ErrorHandling/CreateCoredumpOnCrash.java put (write) to special addresses like 0 to provoke crashs.
However this does not work well with ubsan-enabled binaries on the clang based platforms (macOS, AIX).
The mentioned tests generate a SIGSEGV.

Some other tests generate a SIGBUS, e.g.
```
runtime/memory/ReserveMemory.java
runtime/memory/ReadFromNoaccessArea.java
```
and this leads to similar issues with ubsan-enabled binaries.

We should adjust the signal handling with the sanitizer options, how to do this is documented here :
https://github.com/google/sanitizers/wiki/SanitizerCommonFlags

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8360791](https://bugs.openjdk.org/browse/JDK-8360791): [ubsan] Adjust signal handling (**Bug** - P4)


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26015/head:pull/26015` \
`$ git checkout pull/26015`

Update a local copy of the PR: \
`$ git checkout pull/26015` \
`$ git pull https://git.openjdk.org/jdk.git pull/26015/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26015`

View PR using the GUI difftool: \
`$ git pr show -t 26015`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26015.diff">https://git.openjdk.org/jdk/pull/26015.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26015#issuecomment-3012363335)
</details>
