### PR TITLE
8360867: CTW: Disable inline cache verification

### DIFF
--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -882,6 +882,7 @@ void CodeCache::do_unloading(bool unloading_occurred) {
 
 void CodeCache::verify_clean_inline_caches() {
 #ifdef ASSERT
+  if (!VerifyInlineCaches) return;
   NMethodIterator iter(NMethodIterator::not_unloading);
   while(iter.next()) {
     nmethod* nm = iter.method();

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -293,6 +293,9 @@ const int ObjectAlignmentInBytes = 8;
   product(bool, UseInlineCaches, true,                                      \
           "Use Inline Caches for virtual calls ")                           \
                                                                             \
+  develop(bool, VerifyInlineCaches, true,                                   \
+          "Verify Inline Caches")                                           \
+                                                                            \
   product(bool, InlineArrayCopy, true, DIAGNOSTIC,                          \
           "Inline arraycopy native that is known to be part of "            \
           "base library DLL")                                               \

--- a/test/hotspot/jtreg/testlibrary/ctw/src/sun/hotspot/tools/ctw/CtwRunner.java
+++ b/test/hotspot/jtreg/testlibrary/ctw/src/sun/hotspot/tools/ctw/CtwRunner.java
@@ -308,6 +308,8 @@ public class CtwRunner {
                 // Do not pay extra stack trace generation cost for normally thrown exceptions
                 "-XX:-StackTraceInThrowable",
                 "-XX:+IgnoreUnrecognizedVMOptions",
+                // Do not pay extra for verifying inline caches during nmethod cleanups
+                "-XX:-VerifyInlineCaches",
                 // Do not pay extra zapping cost for explicit GC invocations
                 "-XX:-ZapUnusedHeapArea",
                 // Stress* are c2-specific stress flags, so IgnoreUnrecognizedVMOptions is needed


### PR DESCRIPTION
In CTW profiling, I noticed we spend a lot of time doing inline cache verification when nmethods are unloaded. Due to the nature of CTW, we unload _a lot_ of nmethods. Since the goal for CTW is to stress the compilers themselves, not inline caches in particular (I assume those are blank even, given almost no real code is executed), it makes sense to disable that verification for CTW. 

A taste of performance improvement, about 2%:

```
$ time CONF=linux-x86_64-server-fastdebug make test TEST=applications/ctw/modules

# Current
real	5m1.616s
user	79m41.398s
sys	14m39.607s

# No verify inline caches
real	4m52.239s
user	77m41.886s
sys	14m25.352s
```

Additional testing:
 - [x] Linux x86_64 server {fastdebug,release}, `applications/ctw/modules`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8360867](https://bugs.openjdk.org/browse/JDK-8360867): CTW: Disable inline cache verification (**Enhancement** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26016/head:pull/26016` \
`$ git checkout pull/26016`

Update a local copy of the PR: \
`$ git checkout pull/26016` \
`$ git pull https://git.openjdk.org/jdk.git pull/26016/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26016`

View PR using the GUI difftool: \
`$ git pr show -t 26016`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26016.diff">https://git.openjdk.org/jdk/pull/26016.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26016#issuecomment-3012537331)
</details>
