### PR TITLE
8359602: Add users to IGVN worklist when type is refined in CCP

### DIFF
--- a/src/hotspot/share/opto/phaseX.cpp
+++ b/src/hotspot/share/opto/phaseX.cpp
@@ -3121,6 +3121,7 @@ Node *PhaseCCP::transform_once( Node *n ) {
     hash_delete(n);             // changing bottom type may force a rehash
     n->raise_bottom_type(t);
     _worklist.push(n);          // n re-enters the hash table via the worklist
+    add_users_to_worklist(n);
   }
 
   // TEMPORARY fix to ensure that 2nd GVN pass eliminates null checks


### PR DESCRIPTION
### Context
During the compilation of the input program, we end up with node `591 ModI` that takes
`138 Phi` as its divisor input. Because we are able to prove that the value of the
phi node can never be `0`, we would like to get rid of the control input of the modulo
node as an optimization.

![IGV screenshot](https://github.com/user-attachments/assets/5dee1ae6-9146-4115-922d-df33b7ccbd37)

### Detailed description

In `PhaseCCP::analyze`, we call `Value` for the `PhiNode`, which  
results in a type refinement: the range gets restricted to `int:-13957..-1191`.

```c++
  // Pull from worklist; compute new value; push changes out.
  // This loop is the meat of CCP.
  while (worklist.size() != 0) {
    Node* n = fetch_next_node(worklist);
    DEBUG_ONLY(worklist_verify.push(n);)
    if (n->is_SafePoint()) {
      // Make sure safepoints are processed by PhaseCCP::transform even if they are
      // not reachable from the bottom. Otherwise, infinite loops would be removed.
      _root_and_safepoints.push(n);
    }
    const Type* new_type = n->Value(this);
    if (new_type != type(n)) {
      DEBUG_ONLY(verify_type(n, new_type, type(n));)
      dump_type_and_node(n, new_type);
      set_type(n, new_type);
      push_child_nodes_to_worklist(worklist, n);
    }
    if (KillPathsReachableByDeadTypeNode && n->is_Type() && new_type == Type::TOP) {
      // Keep track of Type nodes to kill CFG paths that use Type
      // nodes that become dead.
      _maybe_top_type_nodes.push(n);
    }
  }
  DEBUG_ONLY(verify_analyze(worklist_verify);)
```

(The role of `PhaseCCP::analyze` is basically to populate the side table;  
at the beginning, everything is `TOP`.)

At the end of `PhaseCCP::analyze`, we obtain the following types in the side table:
- `int` for node `591` (`ModINode`)
- `int:-13957..-1191` for node `138` (`PhiNode`)

If we call `find_node(138)->bottom_type()`, we get:
- `int` for both nodes

There is no progress on the type of `ModINode`, because `ModINode::Value`  
does not reduce the type.

Then, in `PhaseCCP::transform_once`, nodes get added to the worklist  
based on the progress made in `PhaseCCP::analyze`.

The type from the side table is compared to the one returned  
by `n->bottom_type()`:
- For the `PhiNode`, this is the `_type` field for `TypeNode`
- For the `ModINode`, this is always `TypeInt::INT`

If these types are not equal for a given node, the node gets added to the IGVN worklist  
for later processing.

```c++
  // If x is a TypeNode, capture any more-precise type permanently into Node
  if (t != n->bottom_type()) {
    hash_delete(n);             // changing bottom type may force a rehash
    n->raise_bottom_type(t);
    _worklist.push(n);          // n re-enters the hash table via the worklist
  }
```

Because `Value` was able to refine the type for the `PhiNode` but not for the  
`ModINode`, only the `PhiNode` gets added to the IGVN worklist.

The `n->raise_bottom_type(t)` call also has the effect that the `_type` field is  
set for the `PhiNode`.

At the end of CCP, the `PhiNode` is in the worklist, but the `ModINode` is not.

An IGVN phase takes place after CCP. In `PhaseIterGVN::optimize`, we pop nodes  
from the worklist and apply ideal, value, and identity optimizations.  
If any of these lead to progress on a given node, the users of the node get added  
to the worklist.

For the `PhiNode`, however, no progress can be made at this phase (the type was  
already refined to the maximum during CCP).

As a result, the `ModINode` never makes it to the worklist and `ModINode::Value`  
is never called. Before returning from `PhaseIterGVN::optimize`, in debug mode,  
we run the verifications with `PhaseIterGVN::verify_optimize`. There,  
we call `Value` on the `ModINode` to attempt to optimize further.

In `ModINode::Ideal`, we check the type of the divisor and get rid of the  
control input if we can prove that the divisor can never be `0`:

```c++
  // Check for useless control input
  // Check for excluding mod-zero case
  if (in(0) && (ti->_hi < 0 || ti->_lo > 0)) {
    set_req(0, nullptr);        // Yank control input
    return this;
  }
```

Because the type range of the `PhiNode` was refined during CCP to  
`int:-13957..-1191`, the condition evaluates to `true`, and the node  
gets modified with `set_req(0, nullptr)`. Since an optimization is not expected  
to take place during verification, the assert gets triggered.

In summary, this optimization is missed because it is an `Ideal` optimization  
that depends on the type of the input, and because that type changes during CCP,  
right before the IGVN phase. Since there is no direct notification from the input  
to its users in CCP when the type changes, the optimization never gets triggered.

### Proposed fix
TODO