### PR TITLE
8360575: java.util.Properties.list() methods trim each value to 37 characters in the listed output

### DIFF
--- a/src/java.base/share/classes/java/util/Properties.java
+++ b/src/java.base/share/classes/java/util/Properties.java
@@ -1218,7 +1218,8 @@ public class Properties extends Hashtable<Object,Object> {
      * this method writes only the first 37 characters of that value
      * followed by 3 dot characters.
      * <p>
-     * An alternative for listing the {@code Properties} to a {@code PrintStream} is:
+     * An alternative for listing the {@code Properties} to a {@code PrintStream}
+     * without truncation is:
      * {@snippet lang=java :
      *      Properties p = ...
      *      PrintStream out = ...
@@ -1226,7 +1227,7 @@ public class Properties extends Hashtable<Object,Object> {
      *      p.forEach((k, v) -> out.println(k + "=" + v));
      * }
      *
-     * @param   out   a PrintStream
+     * @param   out   the output PrintStream
      * @throws  ClassCastException if any key in this property list
      *          is not a string.
      */
@@ -1252,7 +1253,8 @@ public class Properties extends Hashtable<Object,Object> {
      * this method writes only the first 37 characters of that value
      * followed by 3 dot characters.
      * <p>
-     * An alternative for listing the {@code Properties} to a {@code PrintWriter} is:
+     * An alternative for listing the {@code Properties} to a {@code PrintWriter}
+     * without truncation is:
      * {@snippet lang=java :
      *      Properties p = ...
      *      PrintWriter out = ...
@@ -1260,7 +1262,7 @@ public class Properties extends Hashtable<Object,Object> {
      *      p.forEach((k, v) -> out.println(k + "=" + v));
      * }
      *
-     * @param   out   a PrintWriter
+     * @param   out   the output PrintWriter
      * @throws  ClassCastException if any key in this property list
      *          is not a string.
      * @since   1.1

--- a/src/java.base/share/classes/java/util/Properties.java
+++ b/src/java.base/share/classes/java/util/Properties.java
@@ -1214,9 +1214,8 @@ public class Properties extends Hashtable<Object,Object> {
      * Prints this property list out to the specified {@link PrintStream}.
      * This method is useful for debugging.
      *
-     * @implNote If any property's value is greater than 40 characters then
-     * this method writes only the first 37 characters of that value
-     * followed by 3 dot characters.
+     * @implNote The implementation of this method truncates the output for very long
+     * property values.
      * <p>
      * An alternative for listing the {@code Properties} to a {@code PrintStream}
      * without truncation is:
@@ -1249,9 +1248,8 @@ public class Properties extends Hashtable<Object,Object> {
      * Prints this property list out to the specified {@link PrintWriter}.
      * This method is useful for debugging.
      *
-     * @implNote If any property's value is greater than 40 characters then
-     * this method writes only the first 37 characters of that value
-     * followed by 3 dot characters.
+     * @implNote The implementation of this method truncates the output for very long
+     * property values.
      * <p>
      * An alternative for listing the {@code Properties} to a {@code PrintWriter}
      * without truncation is:

--- a/src/java.base/share/classes/java/util/Properties.java
+++ b/src/java.base/share/classes/java/util/Properties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1211,10 +1211,18 @@ public class Properties extends Hashtable<Object,Object> {
     }
 
     /**
-     * Prints this property list out to the specified output stream.
+     * Prints this property list out to the specified {@code PrintStream}.
      * This method is useful for debugging.
      *
-     * @param   out   an output stream.
+     * @implNote This method first writes a header
+     * text {@code -- listing properties --} followed by a line separator
+     * to the {@code out}. Each property is then written to {@code out}
+     * in the form of {@code key=value} followed by a line separator.
+     * If any property's value is greater than 40 characters then only
+     * the first 37 characters of that value are written followed by 3 dot
+     * characters.
+     *
+     * @param   out   a PrintStream
      * @throws  ClassCastException if any key in this property list
      *          is not a string.
      */
@@ -1233,10 +1241,18 @@ public class Properties extends Hashtable<Object,Object> {
     }
 
     /**
-     * Prints this property list out to the specified output stream.
+     * Prints this property list out to the specified {@code PrintWriter}.
      * This method is useful for debugging.
      *
-     * @param   out   an output stream.
+     * @implNote This method first writes a header
+     * text {@code -- listing properties --} followed by a line separator
+     * to the {@code out}. Each property is then written to {@code out}
+     * in the form of {@code key=value} followed by a line separator.
+     * If any property's value is greater than 40 characters then only
+     * the first 37 characters of that value are written followed by 3 dot
+     * characters.
+     *
+     * @param   out   a PrintWriter
      * @throws  ClassCastException if any key in this property list
      *          is not a string.
      * @since   1.1

--- a/src/java.base/share/classes/java/util/Properties.java
+++ b/src/java.base/share/classes/java/util/Properties.java
@@ -1211,16 +1211,20 @@ public class Properties extends Hashtable<Object,Object> {
     }
 
     /**
-     * Prints this property list out to the specified {@code PrintStream}.
+     * Prints this property list out to the specified {@link PrintStream}.
      * This method is useful for debugging.
      *
-     * @implNote This method first writes a header
-     * text {@code -- listing properties --} followed by a line separator
-     * to the {@code out}. Each property is then written to {@code out}
-     * in the form of {@code key=value} followed by a line separator.
-     * If any property's value is greater than 40 characters then only
-     * the first 37 characters of that value are written followed by 3 dot
-     * characters.
+     * @implNote If any property's value is greater than 40 characters then
+     * this method writes only the first 37 characters of that value
+     * followed by 3 dot characters.
+     * <p>
+     * An alternative for listing the {@code Properties} to a {@code PrintStream} is:
+     * {@snippet lang=java :
+     *      Properties p = ...
+     *      PrintStream out = ...
+     *      // list the properties to PrintStream
+     *      p.forEach((k, v) -> out.println(k + "=" + v));
+     * }
      *
      * @param   out   a PrintStream
      * @throws  ClassCastException if any key in this property list
@@ -1241,16 +1245,20 @@ public class Properties extends Hashtable<Object,Object> {
     }
 
     /**
-     * Prints this property list out to the specified {@code PrintWriter}.
+     * Prints this property list out to the specified {@link PrintWriter}.
      * This method is useful for debugging.
      *
-     * @implNote This method first writes a header
-     * text {@code -- listing properties --} followed by a line separator
-     * to the {@code out}. Each property is then written to {@code out}
-     * in the form of {@code key=value} followed by a line separator.
-     * If any property's value is greater than 40 characters then only
-     * the first 37 characters of that value are written followed by 3 dot
-     * characters.
+     * @implNote If any property's value is greater than 40 characters then
+     * this method writes only the first 37 characters of that value
+     * followed by 3 dot characters.
+     * <p>
+     * An alternative for listing the {@code Properties} to a {@code PrintWriter} is:
+     * {@snippet lang=java :
+     *      Properties p = ...
+     *      PrintWriter out = ...
+     *      // list the properties to PrintWriter
+     *      p.forEach((k, v) -> out.println(k + "=" + v));
+     * }
      *
      * @param   out   a PrintWriter
      * @throws  ClassCastException if any key in this property list


### PR DESCRIPTION
Can I please get a review of this doc-only change which proposes to clarify the current implementation of the `java.util.Properties.list(...)` methods?

As noted in https://bugs.openjdk.org/browse/JDK-8360575, the current implementation trims each value to a size of 37 when printing out the value. This behaviour isn't documented by these methods. The change in this PR adds an `@implNote` to make a mention of this current behaviour.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change requires a CSR request matching fixVersion 26 to be approved (needs to be created)

### Warnings
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/javax/swing/beaninfo/images/JAppletColor16.gif)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/javax/swing/beaninfo/images/JAppletColor32.gif)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/javax/swing/beaninfo/images/JAppletMono16.gif)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/javax/swing/beaninfo/images/JAppletMono32.gif)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/javax/swing/doc-files/JRootPane-1.gif)
&nbsp;⚠️ Patch contains a binary file (test/jdk/javax/rmi/ssl/keystore)
&nbsp;⚠️ Patch contains a binary file (test/jdk/javax/rmi/ssl/truststore)
&nbsp;⚠️ Patch contains a binary file (test/jdk/sun/net/www/protocol/https/HttpsClient/dnsstore)
&nbsp;⚠️ Patch contains a binary file (test/jdk/sun/net/www/protocol/https/HttpsClient/ipstore)

### Issue
 * [JDK-8360575](https://bugs.openjdk.org/browse/JDK-8360575): java.util.Properties.list() methods trim each value to 37 characters in the listed output (**Bug** - P4)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - no project role) 🔄 Re-review required (review applies to [049e43ea](https://git.openjdk.org/jdk/pull/26018/files/049e43ea5d9ef40d6620a2850879c6736a9bbcfe))

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26018/head:pull/26018` \
`$ git checkout pull/26018`

Update a local copy of the PR: \
`$ git checkout pull/26018` \
`$ git pull https://git.openjdk.org/jdk.git pull/26018/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26018`

View PR using the GUI difftool: \
`$ git pr show -t 26018`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26018.diff">https://git.openjdk.org/jdk/pull/26018.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26018#issuecomment-3013092803)
</details>
