### PR TITLE
 8360884: Better scoped values

### DIFF
--- a/test/micro/org/openjdk/bench/java/lang/ScopedValues.java
+++ b/test/micro/org/openjdk/bench/java/lang/ScopedValues.java
@@ -82,6 +82,16 @@ public class ScopedValues {
 
     @Benchmark
     @OutputTimeUnit(TimeUnit.NANOSECONDS)
+    public int thousandUnboundQueries(Blackhole bh) throws Exception {
+        var result = 0;
+        for (int i = 0; i < 1_000; i++) {
+            result += ScopedValuesData.unbound.isBound() ? 1 : 0;
+        }
+        return result;
+    }
+
+    @Benchmark
+    @OutputTimeUnit(TimeUnit.NANOSECONDS)
     public int thousandMaybeGets(Blackhole bh) throws Exception {
         int result = 0;
         for (int i = 0; i < 1_000; i++) {
@@ -212,5 +222,12 @@ public class ScopedValues {
         // tl1.set(tl1.get() + 1);
         var ctr = tl_atomicInt.get();
         ctr.setPlain(ctr.getPlain() + 1);
+    }
+
+    @Benchmark
+    @OutputTimeUnit(TimeUnit.NANOSECONDS)
+    public Object newInstance() {
+        ScopedValue<Integer> val = ScopedValue.newInstance();
+        return val;
     }
 }

--- a/test/micro/org/openjdk/bench/java/lang/ScopedValuesData.java
+++ b/test/micro/org/openjdk/bench/java/lang/ScopedValuesData.java
@@ -57,7 +57,7 @@ public class ScopedValuesData {
     public static void run(Runnable action) {
         try {
             tl1.set(42); tl2.set(2); tl3.set(3); tl4.set(4); tl5.set(5); tl6.set(6);
-            tl1.get();  // Create the ScopedValue cache as a side effect
+            sl1.get();  // Create the ScopedValue cache as a side effect
             tl_atomicInt.set(new AtomicInteger());
             VALUES.where(sl_atomicInt, new AtomicInteger())
                   .where(sl_atomicRef, new AtomicReference<>())


### PR DESCRIPTION
Scoped values cannot be used early in the JDK boot process because of some dependencies on System.getProperty(). This repen dency should be removed in a way that allows scoped values to be created (but not necessarily bound) at any stage during boot.

Also, Scoped Value's constructor has a synchronized block, which limits the use of scoped values at runtime. Constructing a scoped value should be a thread-local operation. 