### PR TITLE
8360651: Create OSContainer API for memory limit

### DIFF
--- a/src/hotspot/os/linux/osContainer_linux.cpp
+++ b/src/hotspot/os/linux/osContainer_linux.cpp
@@ -35,6 +35,7 @@
 
 bool  OSContainer::_is_initialized   = false;
 bool  OSContainer::_is_containerized = false;
+bool  OSContainer::_has_memory_limit = false;
 CgroupSubsystem* cgroup_subsystem;
 
 /* init
@@ -76,6 +77,7 @@ void OSContainer::init() {
   const char *reason;
   bool any_mem_cpu_limit_present = false;
   bool controllers_read_only = cgroup_subsystem->is_containerized();
+  _has_memory_limit = cgroup_subsystem->memory_limit_in_bytes() > 0;
   if (controllers_read_only) {
     // in-container case
     reason = " because all controllers are mounted read-only (container case)";
@@ -83,7 +85,7 @@ void OSContainer::init() {
     // We can be in one of two cases:
     //  1.) On a physical Linux system without any limit
     //  2.) On a physical Linux system with a limit enforced by other means (like systemd slice)
-    any_mem_cpu_limit_present = cgroup_subsystem->memory_limit_in_bytes() > 0 ||
+    any_mem_cpu_limit_present = _has_memory_limit ||
                                      os::Linux::active_processor_count() != cgroup_subsystem->active_processor_count();
     if (any_mem_cpu_limit_present) {
       reason = " because either a cpu or a memory limit is present";

--- a/src/hotspot/os/linux/osContainer_linux.hpp
+++ b/src/hotspot/os/linux/osContainer_linux.hpp
@@ -40,6 +40,7 @@ class OSContainer: AllStatic {
  private:
   static bool   _is_initialized;
   static bool   _is_containerized;
+  static bool   _has_memory_limit;
   static int    _active_processor_count;
 
  public:
@@ -48,6 +49,7 @@ class OSContainer: AllStatic {
   static void print_container_helper(outputStream* st, jlong j, const char* metrics);
 
   static inline bool is_containerized();
+  static inline bool has_memory_limit();
   static const char * container_type();
 
   static jlong memory_limit_in_bytes();
@@ -78,6 +80,10 @@ class OSContainer: AllStatic {
 
 inline bool OSContainer::is_containerized() {
   return _is_containerized;
+}
+
+inline bool OSContainer::has_memory_limit() {
+  return _has_memory_limit;
 }
 
 #endif // OS_LINUX_OSCONTAINER_LINUX_HPP

--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -2508,6 +2508,11 @@ WB_ENTRY(jboolean, WB_IsContainerized(JNIEnv* env, jobject o))
   return false;
 WB_END
 
+WB_ENTRY(jboolean, WB_HasMemoryLimit(JNIEnv* env, jobject o))
+  LINUX_ONLY(return OSContainer::has_memory_limit();)
+  return false;
+WB_END
+
 // Physical memory of the host machine (including containers)
 WB_ENTRY(jlong, WB_HostPhysicalMemory(JNIEnv* env, jobject o))
   LINUX_ONLY(return os::Linux::physical_memory();)
@@ -2981,6 +2986,7 @@ static JNINativeMethod methods[] = {
   {CC"checkLibSpecifiesNoexecstack", CC"(Ljava/lang/String;)Z",
                                                       (void*)&WB_CheckLibSpecifiesNoexecstack},
   {CC"isContainerized",           CC"()Z",            (void*)&WB_IsContainerized },
+  {CC"hasMemoryLimit",            CC"()Z",            (void*)&WB_HasMemoryLimit },
   {CC"validateCgroup",
       CC"(ZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;)I",
                                                       (void*)&WB_ValidateCgroup },

--- a/test/hotspot/jtreg/containers/ContainerMemory.java
+++ b/test/hotspot/jtreg/containers/ContainerMemory.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2025, Red Hat, Inc.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import jdk.test.whitebox.WhiteBox;
+
+/*
+ * Checks OSContainer::has_memory_limit() and related APIs when run with
+ * a container limit.
+ */
+public class ContainerMemory {
+
+    public static void main(String[] args) {
+        if (args.length < 1) {
+            throw new RuntimeException("Illegal number of arguments. Expected at least one argument.");
+        }
+        switch (args[0]) {
+            case "hasMemoryLimit": {
+                testHasMemoryLimit(args[0], args[1]);
+                break;
+            }
+            default: {
+                throw new RuntimeException("Unknown test argument: " + args[0]);
+            }
+        }
+    }
+
+    private static void testHasMemoryLimit(String testCase, String strExpected) {
+        WhiteBox wb = WhiteBox.getWhiteBox();
+        boolean expected = Boolean.parseBoolean(strExpected);
+        boolean actual = wb.hasMemoryLimit();
+        if (expected != actual) {
+            throw new RuntimeException("hasMemoryLimit test failed. Expected '" + expected + "' but got '" + actual + "'");
+        }
+        // PASS
+        System.out.printf("%s=%s", testCase, strExpected);
+    }
+}

--- a/test/hotspot/jtreg/containers/cgroup/TestContainerized.java
+++ b/test/hotspot/jtreg/containers/cgroup/TestContainerized.java
@@ -43,6 +43,9 @@ public class TestContainerized {
         if (wb.isContainerized()) {
             throw new RuntimeException("Test failed! Expected not containerized on plain Linux.");
         }
+        if (wb.hasMemoryLimit()) {
+            throw new RuntimeException("Test failed! Expected no memory limit for plain Linux.");
+        }
         System.out.println("Plain linux, no limits. Passed!");
     }
 }

--- a/test/hotspot/jtreg/containers/docker/TestContainerInfo.java
+++ b/test/hotspot/jtreg/containers/docker/TestContainerInfo.java
@@ -33,7 +33,7 @@
  * @modules java.base/jdk.internal.misc
  *          java.management
  *          jdk.jartool/sun.tools.jar
- * @build CheckContainerized jdk.test.whitebox.WhiteBox PrintContainerInfo
+ * @build jdk.test.whitebox.WhiteBox PrintContainerInfo
  * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar whitebox.jar jdk.test.whitebox.WhiteBox
  * @run driver TestContainerInfo
  */

--- a/test/hotspot/jtreg/containers/docker/TestContainerMemory.java
+++ b/test/hotspot/jtreg/containers/docker/TestContainerMemory.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2025, Red Hat, Inc.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+
+/*
+ * @test
+ * @bug 8360651
+ * @key cgroups
+ * @summary Test JVM's correct detection of memory limit in a container
+ * @requires container.support
+ * @library /test/lib ../
+ * @modules java.base/jdk.internal.misc
+ *          java.base/jdk.internal.platform
+ *          java.management
+ *          jdk.jartool/sun.tools.jar
+ * @build ContainerMemory jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar whitebox.jar jdk.test.whitebox.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:whitebox.jar -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI TestContainerMemory
+ */
+import java.util.function.Consumer;
+import jdk.test.lib.containers.docker.Common;
+import jdk.test.lib.containers.docker.DockerRunOptions;
+import jdk.test.lib.containers.docker.DockerTestUtils;
+import jdk.test.whitebox.WhiteBox;
+
+import static jdk.test.lib.Asserts.assertNotNull;
+
+public class TestContainerMemory {
+    private static final String imageName = Common.imageName("container-memory");
+    private static final WhiteBox wb = WhiteBox.getWhiteBox();
+
+    public static void main(String[] args) throws Exception {
+        if (!DockerTestUtils.canTestDocker()) {
+            return;
+        }
+
+        Common.prepareWhiteBox();
+        DockerTestUtils.buildJdkContainerImage(imageName);
+
+        try {
+            testWithMemoryLimit();
+            testWithoutMemoryLimit();
+        } finally {
+            if (!DockerTestUtils.RETAIN_IMAGE_AFTER_TEST) {
+                DockerTestUtils.removeDockerImage(imageName);
+            }
+        }
+    }
+
+
+    private static void testWithMemoryLimit() throws Exception {
+        String memLimit = "100m"; // Any limit will do
+        Common.logNewTestCase("testing container memory with limit: " + memLimit);
+
+        DockerRunOptions opts = Common.newOpts(imageName, "ContainerMemory");
+        opts.addClassOptions("hasMemoryLimit", "true");
+        Common.addWhiteBoxOpts(opts);
+        Common.addTestClassPath(opts);
+        opts.addDockerOpts("--memory", memLimit);
+        // We are interested in the default option when run in a container, so
+        // don't append test java options
+        opts.appendTestJavaOptions = false;
+	Common.run(opts)
+            .shouldContain("hasMemoryLimit=true");
+    }
+
+    private static void testWithoutMemoryLimit() throws Exception {
+        Common.logNewTestCase("testing container without limit");
+
+        DockerRunOptions opts = Common.newOpts(imageName, "ContainerMemory");
+        opts.addClassOptions("hasMemoryLimit", "false");
+        Common.addWhiteBoxOpts(opts);
+        Common.addTestClassPath(opts);
+        // We are interested in the default option when run in a container, so
+        // don't append test java options
+        opts.appendTestJavaOptions = false;
+	Common.run(opts)
+            .shouldContain("hasMemoryLimit=false");
+    }
+}

--- a/test/hotspot/jtreg/containers/systemd/MemoryLimitTest.java
+++ b/test/hotspot/jtreg/containers/systemd/MemoryLimitTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2025, Red Hat, Inc.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import jdk.test.lib.containers.systemd.SystemdRunOptions;
+import jdk.test.lib.containers.systemd.SystemdTestUtils;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.whitebox.WhiteBox;
+import jtreg.SkippedException;
+
+/*
+ * @test
+ * @bug 8360651
+ * @summary Verify OSContainer::has_memory_limit() in a systemd slice
+ * @requires systemd.support
+ * @library /test/lib ../
+ * @modules java.base/jdk.internal.platform
+ * @build ContainerMemory jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar whitebox.jar jdk.test.whitebox.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:whitebox.jar -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI MemoryLimitTest
+ */
+public class MemoryLimitTest {
+
+    private static final int MB = 1024 * 1024;
+    private static final WhiteBox wb = WhiteBox.getWhiteBox();
+    private static final String TEST_SLICE_NAME = MemoryLimitTest.class.getSimpleName() + "HS";
+
+    public static void main(String[] args) throws Exception {
+       testHasMemoryLimit();
+    }
+
+    private static void testHasMemoryLimit() throws Exception {
+        SystemdRunOptions opts = SystemdTestUtils.newOpts("ContainerMemory");
+	opts.addClassOptions("hasMemoryLimit", "true");
+        opts.memoryLimit("100M");
+        opts.sliceName(TEST_SLICE_NAME);
+        SystemdTestUtils.addWhiteBoxOpts(opts);
+
+        OutputAnalyzer out = SystemdTestUtils.buildAndRunSystemdJava(opts);
+        out.shouldHaveExitValue(0);
+        try {
+            out.shouldContain("hasMemoryLimit=true");
+        } catch (RuntimeException e) {
+            // memory delegation needs to be enabled when run as user on cg v2
+            if (SystemdTestUtils.RUN_AS_USER) {
+                String hint = "When run as user on cg v2 memory delegation needs to be configured!";
+                throw new SkippedException(hint);
+            }
+            throw e;
+        }
+    }
+
+}

--- a/test/lib/jdk/test/lib/containers/docker/Common.java
+++ b/test/lib/jdk/test/lib/containers/docker/Common.java
@@ -31,6 +31,10 @@ import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import jdk.test.lib.Utils;
 import jdk.test.lib.process.OutputAnalyzer;
 
@@ -98,6 +102,19 @@ public class Common {
     public static DockerRunOptions addWhiteBoxOpts(DockerRunOptions opts) {
         opts.addJavaOpts("-Xbootclasspath/a:/test-classes/whitebox.jar",
                          "-XX:+UnlockDiagnosticVMOptions", "-XX:+WhiteBoxAPI");
+        return opts;
+    }
+
+    public static DockerRunOptions addTestClassPath(DockerRunOptions opts) {
+        int num = 0;
+        List<String> classPath = new ArrayList<>();
+        for (String item: Utils.TEST_CLASS_PATH.split(Pattern.quote(System.getProperty("path.separator")))) {
+           String name = String.format("/test_class_path_%d", num);
+           opts.addDockerOpts("--volume", String.format("%s:%s", item, name));
+           classPath.add(name);
+           num++;
+        }
+        opts.addJavaOpts("-cp", classPath.stream().collect(Collectors.joining(":")));
         return opts;
     }
 

--- a/test/lib/jdk/test/lib/containers/systemd/SystemdTestUtils.java
+++ b/test/lib/jdk/test/lib/containers/systemd/SystemdTestUtils.java
@@ -72,7 +72,13 @@ public class SystemdTestUtils {
         return new SystemdRunOptions(testClass,
                                      "-Xlog:os+container=trace",
                                      "-cp",
-                                     Utils.TEST_CLASSES);
+                                     Utils.TEST_CLASS_PATH);
+    }
+
+    public static SystemdRunOptions addWhiteBoxOpts(SystemdRunOptions opts) {
+        opts.addJavaOpts("-Xbootclasspath/a:whitebox.jar",
+                         "-XX:+UnlockDiagnosticVMOptions", "-XX:+WhiteBoxAPI");
+        return opts;
     }
 
     /**

--- a/test/lib/jdk/test/whitebox/WhiteBox.java
+++ b/test/lib/jdk/test/whitebox/WhiteBox.java
@@ -810,6 +810,7 @@ public class WhiteBox {
 
   // Container testing
   public native boolean isContainerized();
+  public native boolean hasMemoryLimit();
   public native int validateCgroup(boolean cgroupsV2Enabled,
                                    String controllersFile,
                                    String procSelfCgroup,


### PR DESCRIPTION
Please review this small addition to add a new `OSContainer::has_memory_limit()` API in preparation for [JDK-8350596](https://bugs.openjdk.org/browse/JDK-8350596) which proposes to increase the default `MaxRAMPercentage` when this new API returns true. The patch is pretty trivial. It's only the testing which amounts to the most lines in this patch.

Testing:
- [ ] GHA (still running)
- [x] Hotspot container tests on x86_64 Linux on cgroup v1 and cgroup v2 (including the new tests).

Thoughts?