### PR TITLE
optimize BufferedWriter

### DIFF
--- a/src/java.base/share/classes/java/io/BufferedWriter.java
+++ b/src/java.base/share/classes/java/io/BufferedWriter.java
@@ -27,6 +27,8 @@ package java.io;
 
 import java.util.Arrays;
 import java.util.Objects;
+
+import sun.nio.cs.StreamEncoder;
 import jdk.internal.misc.VM;
 
 /**
@@ -75,13 +77,7 @@ public class BufferedWriter extends Writer {
     private static final int DEFAULT_INITIAL_BUFFER_SIZE = 512;
     private static final int DEFAULT_MAX_BUFFER_SIZE = 8192;
 
-    private Writer out;
-
-    private char[] cb;
-    private int nChars;
-    private int nextChar;
-    private final int maxChars;  // maximum number of buffers chars
-
+    private final BufferedImpl impl;
     /**
      * Returns the buffer size to use when no output buffer size specified
      */
@@ -102,10 +98,11 @@ public class BufferedWriter extends Writer {
             throw new IllegalArgumentException("Buffer size <= 0");
         }
 
-        this.out = out;
-        this.cb = new char[initialSize];
-        this.nChars = initialSize;
-        this.maxChars = maxSize;
+        if (out instanceof OutputStreamWriter w) {
+            this.impl = new OutputStreamWriterImpl((OutputStreamWriter) out);
+        } else {
+            this.impl = new WriterImpl(out, initialSize, maxSize);
+        }
     }
 
     /**
@@ -133,26 +130,7 @@ public class BufferedWriter extends Writer {
 
     /** Checks to make sure that the stream has not been closed */
     private void ensureOpen() throws IOException {
-        if (out == null)
-            throw new IOException("Stream closed");
-    }
-
-    /**
-     * Grow char array to fit an additional len characters if needed.
-     * If possible, it grows by len+1 to avoid flushing when len chars
-     * are added.
-     *
-     * This method should only be called while holding the lock.
-     */
-    private void growIfNeeded(int len) {
-        int neededSize = nextChar + len + 1;
-        if (neededSize < 0)
-            neededSize = Integer.MAX_VALUE;
-        if (neededSize > nChars && nChars < maxChars) {
-            int newSize = min(neededSize, maxChars);
-            cb = Arrays.copyOf(cb, newSize);
-            nChars = newSize;
-        }
+        impl.ensureOpen();
     }
 
     /**
@@ -162,11 +140,7 @@ public class BufferedWriter extends Writer {
      */
     void flushBuffer() throws IOException {
         synchronized (lock) {
-            ensureOpen();
-            if (nextChar == 0)
-                return;
-            out.write(cb, 0, nextChar);
-            nextChar = 0;
+            impl.flushBuffer();
         }
     }
 
@@ -177,21 +151,8 @@ public class BufferedWriter extends Writer {
      */
     public void write(int c) throws IOException {
         synchronized (lock) {
-            ensureOpen();
-            growIfNeeded(1);
-            if (nextChar >= nChars)
-                flushBuffer();
-            cb[nextChar++] = (char) c;
+            impl.write(c);
         }
-    }
-
-    /**
-     * Our own little min method, to avoid loading java.lang.Math if we've run
-     * out of file descriptors and we're trying to print a stack trace.
-     */
-    private int min(int a, int b) {
-        if (a < b) return a;
-        return b;
     }
 
     /**
@@ -217,32 +178,7 @@ public class BufferedWriter extends Writer {
      */
     public void write(char[] cbuf, int off, int len) throws IOException {
         synchronized (lock) {
-            ensureOpen();
-            Objects.checkFromIndexSize(off, len, cbuf.length);
-            if (len == 0) {
-                return;
-            }
-
-            if (len >= maxChars) {
-                /* If the request length exceeds the max size of the output buffer,
-                   flush the buffer and then write the data directly.  In this
-                   way buffered streams will cascade harmlessly. */
-                flushBuffer();
-                out.write(cbuf, off, len);
-                return;
-            }
-
-            growIfNeeded(len);
-            int b = off, t = off + len;
-            while (b < t) {
-                int d = min(nChars - nextChar, t - b);
-                System.arraycopy(cbuf, b, cb, nextChar, d);
-                b += d;
-                nextChar += d;
-                if (nextChar >= nChars) {
-                    flushBuffer();
-                }
-            }
+            impl.write(cbuf, off, len);
         }
     }
 
@@ -270,17 +206,7 @@ public class BufferedWriter extends Writer {
      */
     public void write(String s, int off, int len) throws IOException {
         synchronized (lock) {
-            ensureOpen();
-            growIfNeeded(len);
-            int b = off, t = off + len;
-            while (b < t) {
-                int d = min(nChars - nextChar, t - b);
-                s.getChars(b, b + d, cb, nextChar);
-                b += d;
-                nextChar += d;
-                if (nextChar >= nChars)
-                    flushBuffer();
-            }
+            impl.write(s, off, len);
         }
     }
 
@@ -302,14 +228,184 @@ public class BufferedWriter extends Writer {
      */
     public void flush() throws IOException {
         synchronized (lock) {
-            flushBuffer();
-            out.flush();
+            impl.flush();
         }
     }
 
     @SuppressWarnings("try")
     public void close() throws IOException {
         synchronized (lock) {
+            impl.close();
+        }
+    }
+
+    static abstract sealed class BufferedImpl permits WriterImpl, OutputStreamWriterImpl {
+        Writer out;
+
+        public BufferedImpl(Writer out) {
+            this.out = out;
+        }
+
+        /** Checks to make sure that the stream has not been closed */
+        final void ensureOpen() throws IOException {
+            if (out == null)
+                throw new IOException("Stream closed");
+        }
+
+        abstract void flushBuffer() throws IOException;
+
+        abstract void write(int c) throws IOException;
+
+        abstract void write(char[] cbuf, int off, int len) throws IOException;
+
+        abstract void write(String s, int off, int len) throws IOException;
+
+        abstract void flush() throws IOException;
+
+        abstract void close() throws IOException;
+    }
+
+    static final class WriterImpl extends BufferedImpl {
+        private char[] cb;
+        private int nChars;
+        private int nextChar;
+        private final int maxChars;  // maximum number of buffers chars
+
+        WriterImpl(Writer out, int initialSize, int maxSize) {
+            super(out);
+            this.cb = new char[initialSize];
+            this.nChars = initialSize;
+            this.maxChars = maxSize;
+        }
+
+        /**
+         * Grow char array to fit an additional len characters if needed.
+         * If possible, it grows by len+1 to avoid flushing when len chars
+         * are added.
+         *
+         * This method should only be called while holding the lock.
+         */
+        private void growIfNeeded(int len) {
+            int neededSize = nextChar + len + 1;
+            if (neededSize < 0)
+                neededSize = Integer.MAX_VALUE;
+            if (neededSize > nChars && nChars < maxChars) {
+                int newSize = min(neededSize, maxChars);
+                cb = Arrays.copyOf(cb, newSize);
+                nChars = newSize;
+            }
+        }
+
+        void flushBuffer() throws IOException {
+            ensureOpen();
+            if (nextChar == 0)
+                return;
+            out.write(cb, 0, nextChar);
+            nextChar = 0;
+        }
+
+        /**
+         * Writes a single character.
+         *
+         * @throws     IOException  If an I/O error occurs
+         */
+        public void write(int c) throws IOException {
+            ensureOpen();
+            growIfNeeded(1);
+            if (nextChar >= nChars)
+                flushBuffer();
+            cb[nextChar++] = (char) c;
+        }
+
+        /**
+         * Writes a portion of an array of characters.
+         *
+         * <p> Ordinarily this method stores characters from the given array into
+         * this stream's buffer, flushing the buffer to the underlying stream as
+         * needed.  If the requested length is at least as large as the buffer,
+         * however, then this method will flush the buffer and write the characters
+         * directly to the underlying stream.  Thus redundant
+         * {@code BufferedWriter}s will not copy data unnecessarily.
+         *
+         * @param  cbuf  A character array
+         * @param  off   Offset from which to start reading characters
+         * @param  len   Number of characters to write
+         *
+         * @throws  IndexOutOfBoundsException
+         *          If {@code off} is negative, or {@code len} is negative,
+         *          or {@code off + len} is negative or greater than the length
+         *          of the given array
+         *
+         * @throws  IOException  If an I/O error occurs
+         */
+        public void write(char[] cbuf, int off, int len) throws IOException {
+            ensureOpen();
+            Objects.checkFromIndexSize(off, len, cbuf.length);
+            if (len == 0) {
+                return;
+            }
+
+            if (len >= maxChars) {
+                /* If the request length exceeds the max size of the output buffer,
+                   flush the buffer and then write the data directly.  In this
+                   way buffered streams will cascade harmlessly. */
+                flushBuffer();
+                out.write(cbuf, off, len);
+                return;
+            }
+
+            growIfNeeded(len);
+            int b = off, t = off + len;
+            while (b < t) {
+                int d = min(nChars - nextChar, t - b);
+                System.arraycopy(cbuf, b, cb, nextChar, d);
+                b += d;
+                nextChar += d;
+                if (nextChar >= nChars) {
+                    flushBuffer();
+                }
+            }
+        }
+
+
+        /**
+         * Writes a portion of a String.
+         *
+         * @implSpec
+         * While the specification of this method in the
+         * {@linkplain java.io.Writer#write(java.lang.String,int,int) superclass}
+         * recommends that an {@link IndexOutOfBoundsException} be thrown
+         * if {@code len} is negative or {@code off + len} is negative,
+         * the implementation in this class does not throw such an exception in
+         * these cases but instead simply writes no characters.
+         *
+         * @param  s     String to be written
+         * @param  off   Offset from which to start reading characters
+         * @param  len   Number of characters to be written
+         *
+         * @throws  IndexOutOfBoundsException
+         *          If {@code off} is negative,
+         *          or {@code off + len} is greater than the length
+         *          of the given string
+         *
+         * @throws  IOException  If an I/O error occurs
+         */
+        public void write(String s, int off, int len) throws IOException {
+            ensureOpen();
+            growIfNeeded(len);
+            int b = off, t = off + len;
+            while (b < t) {
+                int d = min(nChars - nextChar, t - b);
+                s.getChars(b, b + d, cb, nextChar);
+                b += d;
+                nextChar += d;
+                if (nextChar >= nChars)
+                    flushBuffer();
+            }
+        }
+
+        @SuppressWarnings("try")
+        public void close() throws IOException {
             if (out == null) {
                 return;
             }
@@ -318,6 +414,64 @@ public class BufferedWriter extends Writer {
             } finally {
                 out = null;
                 cb = null;
+            }
+        }
+
+        /**
+         * Flushes the stream.
+         *
+         * @throws     IOException  If an I/O error occurs
+         */
+        public void flush() throws IOException {
+            flushBuffer();
+            out.flush();
+        }
+
+        /**
+         * Our own little min method, to avoid loading java.lang.Math if we've run
+         * out of file descriptors and we're trying to print a stack trace.
+         */
+        private static int min(int a, int b) {
+            return a < b ? a : b;
+        }
+    }
+
+    static final class OutputStreamWriterImpl extends BufferedImpl {
+        OutputStreamWriter os;
+        OutputStreamWriterImpl(OutputStreamWriter out) {
+            super(out);
+            this.os = out;
+        }
+
+        public void flushBuffer() throws IOException {
+            os.flushBuffer();
+        }
+
+        public void write(int c) throws IOException {
+            os.write(new char[] {(char) c});
+        }
+
+        public void write(char[] cbuf, int off, int len) throws IOException {
+            os.write(cbuf, off, len);
+        }
+
+        public void write(String s, int off, int len) throws IOException {
+            os.write(s, off, len);
+        }
+
+        public void flush() throws IOException {
+            os.flush();
+        }
+
+        public void close() throws IOException {
+            if (out == null) {
+                return;
+            }
+            try (OutputStreamWriter w = os) {
+                w.flushBuffer();
+            } finally {
+                out = null;
+                os = null;
             }
         }
     }

--- a/src/java.base/share/classes/java/io/PrintStream.java
+++ b/src/java.base/share/classes/java/io/PrintStream.java
@@ -74,7 +74,6 @@ public class PrintStream extends FilterOutputStream
      * can be flushed without flushing the entire stream.
      */
     private BufferedWriter textOut;
-    private OutputStreamWriter charOut;
 
     /**
      * requireNonNull is explicitly declared here so as not to create an extra
@@ -109,8 +108,7 @@ public class PrintStream extends FilterOutputStream
         super(out);
         this.autoFlush = autoFlush;
         this.charset = out instanceof PrintStream ps ? ps.charset() : Charset.defaultCharset();
-        this.charOut = new OutputStreamWriter(this, charset);
-        this.textOut = new BufferedWriter(charOut);
+        this.textOut = new BufferedWriter(new OutputStreamWriter(this, charset));
     }
 
     /* Variant of the private constructor so that the given charset name
@@ -204,8 +202,7 @@ public class PrintStream extends FilterOutputStream
     public PrintStream(OutputStream out, boolean autoFlush, Charset charset) {
         super(out);
         this.autoFlush = autoFlush;
-        this.charOut = new OutputStreamWriter(this, charset);
-        this.textOut = new BufferedWriter(charOut);
+        this.textOut = new BufferedWriter(new OutputStreamWriter(this, charset));
         this.charset = charset;
     }
 
@@ -432,7 +429,6 @@ public class PrintStream extends FilterOutputStream
                     trouble = true;
                 }
                 textOut = null;
-                charOut = null;
                 out = null;
             }
         }
@@ -617,7 +613,6 @@ public class PrintStream extends FilterOutputStream
                 ensureOpen();
                 textOut.write(buf);
                 textOut.flushBuffer();
-                charOut.flushBuffer();
                 if (autoFlush) {
                     for (int i = 0; i < buf.length; i++)
                         if (buf[i] == '\n') {
@@ -644,7 +639,6 @@ public class PrintStream extends FilterOutputStream
                 textOut.write(buf);
                 textOut.newLine();
                 textOut.flushBuffer();
-                charOut.flushBuffer();
                 if (autoFlush)
                     out.flush();
             }
@@ -663,7 +657,6 @@ public class PrintStream extends FilterOutputStream
                 ensureOpen();
                 textOut.write(s);
                 textOut.flushBuffer();
-                charOut.flushBuffer();
                 if (autoFlush && (s.indexOf('\n') >= 0))
                     out.flush();
             }
@@ -687,7 +680,6 @@ public class PrintStream extends FilterOutputStream
                 textOut.write(s);
                 textOut.newLine();
                 textOut.flushBuffer();
-                charOut.flushBuffer();
                 if (autoFlush)
                     out.flush();
             }
@@ -706,7 +698,6 @@ public class PrintStream extends FilterOutputStream
                 ensureOpen();
                 textOut.newLine();
                 textOut.flushBuffer();
-                charOut.flushBuffer();
                 if (autoFlush)
                     out.flush();
             }

--- a/src/java.base/share/classes/java/lang/System.java
+++ b/src/java.base/share/classes/java/lang/System.java
@@ -2209,6 +2209,14 @@ public final class System {
                 return StringConcatHelper.concat(prefix, value, suffix);
             }
 
+            public long computeSizeUTF8(String s, int sp, int sl) {
+                return s.computeSizeUTF8(sp, sl);
+            }
+
+            public int encodeUTF8(String s, int sp, int sl, byte[] dst, int dp) {
+                return s.encodeUTF8(sp, sl, dst, dp);
+            }
+
             public Object classData(Class<?> c) {
                 return c.getClassData();
             }

--- a/src/java.base/share/classes/jdk/internal/access/JavaLangAccess.java
+++ b/src/java.base/share/classes/jdk/internal/access/JavaLangAccess.java
@@ -487,6 +487,10 @@ public interface JavaLangAccess {
      */
     String concat(String prefix, Object value, String suffix);
 
+    long computeSizeUTF8(String s, int sp, int sl);
+
+    int encodeUTF8(String s, int sp, int sl, byte[] dst, int dp);
+
     /*
      * Get the class data associated with the given class.
      * @param c the class

--- a/src/java.base/share/classes/sun/nio/cs/StreamEncoderUTF8.java
+++ b/src/java.base/share/classes/sun/nio/cs/StreamEncoderUTF8.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, Alibaba Group Holding Limited. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package sun.nio.cs;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.nio.charset.UnmappableCharacterException;
+
+import jdk.internal.access.JavaLangAccess;
+import jdk.internal.access.SharedSecrets;
+
+public final class StreamEncoderUTF8 extends StreamEncoder {
+    private static final JavaLangAccess JLA = SharedSecrets.getJavaLangAccess();
+
+    StreamEncoderUTF8(OutputStream out, Object lock) {
+        super(out, lock, UTF_8.INSTANCE);
+    }
+
+    public void write(String str, int off, int len) throws IOException {
+        /* Check the len before creating a char buffer */
+        if (len < 0)
+            throw new IndexOutOfBoundsException();
+        if (haveLeftoverChar) {
+            super.write(str, off, len);
+            return;
+        }
+
+        int utf8Size = (int) JLA.computeSizeUTF8(str, off, len);
+        if (utf8Size >= maxBufferCapacity) {
+            byte[] utf8 = new byte[utf8Size];
+            JLA.encodeUTF8(str, off, len, utf8, 0);
+                /* If the request length exceeds the max size of the output buffer,
+                   flush the buffer and then write the data directly.  In this
+                   way buffered streams will cascade harmlessly. */
+            implFlushBuffer();
+            out.write(utf8, 0, utf8.length);
+            return;
+        }
+
+
+        int cap = bb.capacity();
+        int newCap = bb.position() + utf8Size;
+        if (newCap >= maxBufferCapacity) {
+            implFlushBuffer();
+        }
+
+        if (newCap > cap) {
+            implFlushBuffer();
+            bb = ByteBuffer.allocate(newCap);
+        }
+
+        byte[] cb = bb.array();
+        int lim = bb.limit();
+        int pos = bb.position();
+
+        pos = JLA.encodeUTF8(str, off, len, cb, pos);
+        bb.position(pos);
+    }
+}


### PR DESCRIPTION
BufferedWriter -> OutputStreamWriter -> StreamEncoder

In this call chain, BufferedWriter has a char[] buffer, and StreamEncoder has a ByteBuffer. There are two layers of cache here, or the BufferedWriter layer can be removed. And when charset is UTF8, if the content of write(String) is LATIN1, a conversion from LATIN1 to UTF16 and then to LATIN1 will occur here.

We can improve BufferedWriter. When the parameter Writer instanceof OutputStreamWriter is passed in, remove the cache and call it directly. In addition, improve write(String) in StreamEncoder to avoid unnecessary encoding conversion.