### PR TITLE
8359366: RunThese30M.java EXCEPTION_ACCESS_VIOLATION in JvmtiBreakpoints::clearall_in_class_at_safepoint

### DIFF
--- a/src/hotspot/share/prims/jvmtiImpl.cpp
+++ b/src/hotspot/share/prims/jvmtiImpl.cpp
@@ -259,7 +259,7 @@ int JvmtiBreakpoints::set(JvmtiBreakpoint& bp) {
     return JVMTI_ERROR_DUPLICATE;
   }
 
-  // ensure that bp._method is not deallocated before VM_ChangeBreakpoints::doit()
+  // Ensure that bp._method is not deallocated before VM_ChangeBreakpoints::doit().
   methodHandle mh(Thread::current(), bp.method());
   VM_ChangeBreakpoints set_breakpoint(VM_ChangeBreakpoints::SET_BREAKPOINT, &bp);
   VMThread::execute(&set_breakpoint);


### PR DESCRIPTION
The segv/eav happens in the case if JvmtiBreakpoint::_method's class redefined old between getting the Method* from jmethodid in the 
JvmtiEnv::SetBreakpoint(Method* method, jlocation location) {..} and 
and actual setting breakpoint in the VM operation VM_ChangeBreakpoints.

Here are details:
The breakpoint is set in 2 steps.
1) method jvmti_SetBreakpoint(jvmtiEnv* env, jmethodID method,  jlocation location)  convert jmethodID to Method* and call 
 JvmtiEnv::SetBreakpoint(Method* method, jlocation location)
where 
  JvmtiBreakpoint bp(method, location);
is created with this Method* 
Note: it is done while thread is in VM state, so Method can't become is_old while this is done.
 
2) The VMOp is used to add breakpoint into the list 
 VM_ChangeBreakpoints set_breakpoint(VM_ChangeBreakpoints::SET_BREAKPOINT, &bp);
  VMThread::execute(&set_breakpoint);
to call  JvmtiBreakpoints::set_at_safepoint()
that can modify JvmtiBreakpoints list and set breakpoint in safepoint without synchronization.

So it might be possible that class redefinition  VM_RedefineClasses  operation that redefine the class with this breakpoint happens between steps 1) and 2)
VM_RedefineClasses::redefine_single_class()
clear all class-related breakpoints in the JvmtiBreakpoints, however the "problematic" breakpoint is in VMThread  queue and thus we are still continue to do this operation.
So in the step 2) the the JvmtiBreakpoint with 'is_old' method is added to the JvmtiBreakpoints and breakpoint is set.

Then old method mights be purged any time once  they are not on the stack and any access to this breakpoint could lead to usage of Metthod* _method pointing to deallocated metaspace.

The VM_RedefineClasses clear all breakpoints so it is correct just to don't proceed with current breakpoint also.

Looks, like very unlikely but reproducing with stress test after some time.
Verified that the crash is not reproduced anymore with corresponding test after the fix.

Many thanks to Coleen for detailed explanation of class redefinition.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8359366](https://bugs.openjdk.org/browse/JDK-8359366): RunThese30M.java EXCEPTION_ACCESS_VIOLATION in JvmtiBreakpoints::clearall_in_class_at_safepoint (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) Review applies to [c7aaa804](https://git.openjdk.org/jdk/pull/26031/files/c7aaa80428c977e932f38bc6d279dc9bf7c21441)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**) Review applies to [c7aaa804](https://git.openjdk.org/jdk/pull/26031/files/c7aaa80428c977e932f38bc6d279dc9bf7c21441)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26031/head:pull/26031` \
`$ git checkout pull/26031`

Update a local copy of the PR: \
`$ git checkout pull/26031` \
`$ git pull https://git.openjdk.org/jdk.git pull/26031/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26031`

View PR using the GUI difftool: \
`$ git pr show -t 26031`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26031.diff">https://git.openjdk.org/jdk/pull/26031.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26031#issuecomment-3016910047)
</details>
