### PR TITLE
Use ByteBuffer::putChar instead of ByteBuffer.put twice in UnicodeEncoder

### DIFF
--- a/src/java.base/share/classes/sun/nio/cs/UnicodeEncoder.java
+++ b/src/java.base/share/classes/sun/nio/cs/UnicodeEncoder.java
@@ -67,10 +67,13 @@ public abstract class UnicodeEncoder extends CharsetEncoder {
     private final Surrogate.Parser sgp = new Surrogate.Parser();
 
     protected CoderResult encodeLoop(CharBuffer src, ByteBuffer dst) {
-        if (!src.hasArray() || !dst.hasArray()) {
-            return encodeLoopBuffer(src, dst);
+        if (src.hasArray() && dst.hasArray()) {
+            return encodeArrayLoop(src, dst);
         }
+        return encodeBufferLoop(src, dst);
+    }
 
+    private CoderResult encodeArrayLoop(CharBuffer src, ByteBuffer dst) {
         char[] sa = src.array();
         int soff = src.arrayOffset();
         int sp = soff + src.position();
@@ -123,7 +126,7 @@ public abstract class UnicodeEncoder extends CharsetEncoder {
         return nativeOrder ? c : Character.reverseBytes(c);
     }
 
-    private CoderResult encodeLoopBuffer(CharBuffer src, ByteBuffer dst) {
+    private CoderResult encodeBufferLoop(CharBuffer src, ByteBuffer dst) {
         int mark = src.position();
         boolean nativeOrder = (byteOrder == BIG) == (dst.order() == ByteOrder.BIG_ENDIAN);
 

--- a/src/java.base/share/classes/sun/nio/cs/UnicodeEncoder.java
+++ b/src/java.base/share/classes/sun/nio/cs/UnicodeEncoder.java
@@ -69,7 +69,7 @@ public abstract class UnicodeEncoder extends CharsetEncoder {
     private final Surrogate.Parser sgp = new Surrogate.Parser();
 
     protected CoderResult encodeLoop(CharBuffer src, ByteBuffer dst) {
-        if (!src.hasArray() || !src.hasArray()) {
+        if (!src.hasArray() || !dst.hasArray()) {
             return encodeLoopBuffer(src, dst);
         }
 

--- a/src/java.base/share/classes/sun/nio/cs/UnicodeEncoder.java
+++ b/src/java.base/share/classes/sun/nio/cs/UnicodeEncoder.java
@@ -28,14 +28,12 @@ package sun.nio.cs;
 
 import java.nio.*;
 import java.nio.charset.*;
-import static jdk.internal.misc.Unsafe.ARRAY_BYTE_BASE_OFFSET;
 
 /**
  * Base class for different flavors of UTF-16 encoders
  */
 public abstract class UnicodeEncoder extends CharsetEncoder {
     protected static final char BYTE_ORDER_MARK = '\uFEFF';
-    protected static final char REVERSED_MARK = '\uFFFE';
 
     protected static final int BIG = 0;
     protected static final int LITTLE = 1;

--- a/src/java.base/share/classes/sun/nio/cs/UnicodeEncoder.java
+++ b/src/java.base/share/classes/sun/nio/cs/UnicodeEncoder.java
@@ -82,7 +82,7 @@ public abstract class UnicodeEncoder extends CharsetEncoder {
         boolean big = byteOrder == BIG;
 
         try {
-            if (needsMark && sl - sp > 0) {
+            if (needsMark && sp < sl) {
                 if (dl - dp < 2)
                     return CoderResult.OVERFLOW;
                 putChar(da, dp, BYTE_ORDER_MARK, big);

--- a/test/micro/org/openjdk/bench/java/io/BufferedWriterBench.java
+++ b/test/micro/org/openjdk/bench/java/io/BufferedWriterBench.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2025, Alibaba Group Holding Limited. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package org.openjdk.bench.java.io;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.io.*;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.HexFormat;
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Fork(2)
+@Measurement(iterations = 6, time = 1)
+@Warmup(iterations = 4, time = 2)
+@State(Scope.Thread)
+public class BufferedWriterBench {
+
+    @Param({"ascii", "utf8_2_bytes", "utf8_3_bytes", "emoji"})
+    public String charType;
+
+    @Param({"UTF8", "UTF16"})
+    public String charset;
+
+    ByteArrayOutputStream bytesOutput;
+    BufferedWriter dataOutput;
+    String[] strings;
+    char[][] charArrays;
+
+    @Setup(Level.Trial)
+    public void setup() throws Exception {
+        byte[] bytes = HexFormat.of().parseHex(
+                switch (charType) {
+                    case "ascii"        -> "78";
+                    case "utf8_2_bytes" -> "c2a9";
+                    case "utf8_3_bytes" -> "e6b8a9";
+                    case "emoji"        -> "e29da3efb88f";
+                    default -> throw new IllegalArgumentException("bad charType: " + charType);
+                }
+        );
+        String s = new String(bytes, 0, bytes.length, StandardCharsets.UTF_8);
+        strings = new String[128];
+        charArrays = new char[strings.length][];
+        for (int i = 0; i < strings.length; i++) {
+            strings[i] = "A".repeat(i).concat(s.repeat(i));
+            charArrays[i] = strings[i].toCharArray();
+        }
+
+        bytesOutput = new ByteArrayOutputStream(1024 * 64);
+        dataOutput = new BufferedWriter(
+                new OutputStreamWriter(bytesOutput, Charset.forName(charset)));
+    }
+
+    @Benchmark
+    public void writeString(Blackhole bh) throws Exception {
+        bytesOutput.reset();
+        for (var s : strings) {
+            dataOutput.write(s);
+        }
+        dataOutput.flush();
+        bh.consume(bytesOutput.size());
+    }
+
+    @Benchmark
+    public void writeCharArray(Blackhole bh) throws Exception {
+        bytesOutput.reset();
+        for (var s : charArrays) {
+            dataOutput.write(s);
+        }
+        dataOutput.flush();
+        bh.consume(bytesOutput.size());
+    }
+}


### PR DESCRIPTION
In the sun.nio.UnicodeEncoder::put method, the char is split into two bytes according to the ByteOrder and then the ByteBuffer::put method is called twice. We can directly use the Character::reverseBytes + ByteBuffer::putChar combination instead.

- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Warnings
&nbsp;⚠️ Patch contains a binary file (src/java.base/share/classes/jdk/internal/icu/impl/data/icudt76b/nfc.nrm)
&nbsp;⚠️ Patch contains a binary file (src/java.base/share/classes/jdk/internal/icu/impl/data/icudt76b/nfkc.nrm)
&nbsp;⚠️ Patch contains a binary file (src/java.base/share/classes/jdk/internal/icu/impl/data/icudt76b/ubidi.icu)
&nbsp;⚠️ Patch contains a binary file (src/java.base/share/classes/jdk/internal/icu/impl/data/icudt76b/uprops.icu)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/javax/swing/beaninfo/images/JAppletColor16.gif)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/javax/swing/beaninfo/images/JAppletColor32.gif)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/javax/swing/beaninfo/images/JAppletMono16.gif)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/javax/swing/beaninfo/images/JAppletMono32.gif)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/javax/swing/doc-files/JRootPane-1.gif)
&nbsp;⚠️ Patch contains a binary file (test/jdk/java/util/jar/JarEntry/test.jar)
&nbsp;⚠️ Patch contains a binary file (test/jdk/javax/net/ssl/HttpsURLConnection/crisubn.jks)
&nbsp;⚠️ Patch contains a binary file (test/jdk/javax/net/ssl/HttpsURLConnection/trusted.jks)
&nbsp;⚠️ Patch contains a binary file (test/jdk/javax/rmi/ssl/keystore)
&nbsp;⚠️ Patch contains a binary file (test/jdk/javax/rmi/ssl/truststore)
&nbsp;⚠️ Patch contains a binary file (test/jdk/sun/net/www/protocol/https/HttpsClient/dnsstore)
&nbsp;⚠️ Patch contains a binary file (test/jdk/sun/net/www/protocol/https/HttpsClient/ipstore)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26034/head:pull/26034` \
`$ git checkout pull/26034`

Update a local copy of the PR: \
`$ git checkout pull/26034` \
`$ git pull https://git.openjdk.org/jdk.git pull/26034/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26034`

View PR using the GUI difftool: \
`$ git pr show -t 26034`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26034.diff">https://git.openjdk.org/jdk/pull/26034.diff</a>

</details>
