### PR TITLE
8361032: Problem list TestOnSpinWaitAArch64 until JDK-8360936 is fixed

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -82,6 +82,8 @@ compiler/c2/TestVerifyConstraintCasts.java 8355574 generic-all
 
 compiler/c2/aarch64/TestStaticCallStub.java 8359963 linux-aarch64,macosx-aarch64
 
+compiler/onSpinWait/TestOnSpinWaitAArch64.java 8360936 linux-aarch64,macosx-aarch64
+
 #############################################################################
 
 # :hotspot_gc


### PR DESCRIPTION
The test fails consistently in our testing, let's problem list it.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8361032](https://bugs.openjdk.org/browse/JDK-8361032): Problem list TestOnSpinWaitAArch64 until JDK-8360936 is fixed (**Sub-task** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26036/head:pull/26036` \
`$ git checkout pull/26036`

Update a local copy of the PR: \
`$ git checkout pull/26036` \
`$ git pull https://git.openjdk.org/jdk.git pull/26036/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26036`

View PR using the GUI difftool: \
`$ git pr show -t 26036`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26036.diff">https://git.openjdk.org/jdk/pull/26036.diff</a>

</details>
