### PR TITLE
8361043: [ubsan] os::print_hex_dump runtime error: applying non-zero offset 8 to null pointer

### DIFF
--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -1042,7 +1042,7 @@ void os::print_hex_dump(outputStream* st, const_address start, const_address end
     }
     print_hex_location(st, p, unitsize, ascii_form);
     p += unitsize;
-    logical_p += unitsize;
+    logical_p = (const_address) ((uintptr_t)logical_p + unitsize);
     cols++;
     if (cols >= cols_per_line) {
        if (print_ascii && !ascii_form.is_empty()) {


### PR DESCRIPTION
When running jtreg test
runtime/cds/DeterministicDump
with ubsan-enabled binaries (opt) on macOS aarch64, the following issue is reported :

```
/jdk/src/hotspot/share/runtime/os.cpp:1045:15: runtime error: applying non-zero offset 8 to null pointer
    #0 0x106156ad4 in os::print_hex_dump(outputStream*, unsigned char const*, unsigned char const*, int, bool, int, unsigned char const*, unsigned char const*) os.cpp:1045
    #1 0x10524685c in ArchiveBuilder::CDSMapLogger::log(ArchiveBuilder*, FileMapInfo*, ArchiveHeapInfo*, char*, unsigned long) archiveBuilder.cpp:1573
    #2 0x105245e60 in ArchiveBuilder::write_archive(FileMapInfo*, ArchiveHeapInfo*) archiveBuilder.cpp:1634
    #3 0x106084fd4 in MetaspaceShared::write_static_archive(ArchiveBuilder*, FileMapInfo*, ArchiveHeapInfo*) metaspaceShared.cpp:1053
    #4 0x10608411c in MetaspaceShared::preload_and_dump_impl(StaticArchiveBuilder&, JavaThread*) metaspaceShared.cpp:1030
    #5 0x1060837b8 in MetaspaceShared::preload_and_dump(JavaThread*) metaspaceShared.cpp:812
    #6 0x10660457c in Threads::create_vm(JavaVMInitArgs*, bool*) threads.cpp:892
    #7 0x105ca60dc in JNI_CreateJavaVM jni.cpp:3680
    #8 0x100fbe4d0 in JavaMain java.c:494
    #9 0x100fc54fc in ThreadJavaMain java_md_macosx.m:679
    #10 0x197372f90 in _pthread_start+0x84 (libsystem_pthread.dylib:arm64e+0x6f90)
    #11 0x19736dd30 in thread_start+0x4 (libsystem_pthread.dylib:arm64e+0x1d30)
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8361043](https://bugs.openjdk.org/browse/JDK-8361043): [ubsan] os::print_hex_dump runtime error: applying non-zero offset 8 to null pointer (**Bug** - P4)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26037/head:pull/26037` \
`$ git checkout pull/26037`

Update a local copy of the PR: \
`$ git checkout pull/26037` \
`$ git pull https://git.openjdk.org/jdk.git pull/26037/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26037`

View PR using the GUI difftool: \
`$ git pr show -t 26037`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26037.diff">https://git.openjdk.org/jdk/pull/26037.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26037#issuecomment-3018159731)
</details>
