### PR TITLE
8361067: Test ExtraButtonDrag.java requires frame.dispose in finally block

### DIFF
--- a/test/jdk/java/awt/Mouse/MouseModifiersUnitTest/ExtraButtonDrag.java
+++ b/test/jdk/java/awt/Mouse/MouseModifiersUnitTest/ExtraButtonDrag.java
@@ -25,7 +25,7 @@
  * @test
  * @key headful
  * @bug 6315717
- * @summary Verifies that mouse drag events received for every button if the property is set to true
+ * @summary Verifies that the mouse drag events received for every button if the property is set to true
  * @run main ExtraButtonDrag
  */
 
@@ -50,7 +50,7 @@ public class ExtraButtonDrag {
     private static volatile boolean moved = false;
     private static volatile Point centerFrame;
     private static volatile Point outboundsFrame;
-    static String osName = System.getProperty("os.name");
+    private static final String OS_NAME = System.getProperty("os.name");
     private static MouseAdapter mAdapter = new MouseAdapter() {
         @Override
         public void mouseDragged(MouseEvent e) {
@@ -113,15 +113,15 @@ public class ExtraButtonDrag {
             // XToolkit: extra buttons should report MOVED events only
             // WToolkit: extra buttons should report DRAGGED events only
             if (i > 2) { // extra buttons only
-                if (osName.equals("Linux")) {
+                if (OS_NAME.equals("Linux")) {
                     if (!moved || dragged) {
-                        throw new RuntimeException("Test failed." + osName
+                        throw new RuntimeException("Test failed." + OS_NAME
                             + " Button = " + (i + 1) + " moved = " + moved
                             + " : dragged = " + dragged);
                     }
                 } else { // WToolkit
                     if (moved || !dragged) {
-                        throw new RuntimeException("Test failed." + osName
+                        throw new RuntimeException("Test failed." + OS_NAME
                             + " Button = " + (i + 1) + " moved = " + moved
                             + " : dragged = " + dragged);
                     }


### PR DESCRIPTION
Test test/jdk/java/awt/Mouse/MouseModifiersUnitTest/ExtraButtonDrag.java left debris on system whenever fails its required frame.dispose() in finally block.

```
 finally {
            EventQueue.invokeAndWait(ExtraButtonDrag::disposeFrame);
        }
    public static void disposeFrame() {
        if (frame != null) {
            frame.dispose();
            frame = null;
        }
    }


```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8361067](https://bugs.openjdk.org/browse/JDK-8361067): Test ExtraButtonDrag.java requires frame.dispose in finally block (**Bug** - P4)


### Reviewers
 * [Abhishek Kumar](https://openjdk.org/census#abhiscxk) (@kumarabhi006 - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**) Review applies to [995c93b1](https://git.openjdk.org/jdk/pull/26043/files/995c93b16263ba0ca81a05d15ecdedf2ca019036)
 * [Damon Nguyen](https://openjdk.org/census#dnguyen) (@DamonGuy - Committer)
 * [Manukumar V S](https://openjdk.org/census#mvs) (@manukumarvs - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26043/head:pull/26043` \
`$ git checkout pull/26043`

Update a local copy of the PR: \
`$ git checkout pull/26043` \
`$ git pull https://git.openjdk.org/jdk.git pull/26043/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26043`

View PR using the GUI difftool: \
`$ git pr show -t 26043`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26043.diff">https://git.openjdk.org/jdk/pull/26043.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26043#issuecomment-3018951026)
</details>
