### PR TITLE
8361040: compiler/codegen/TestRedundantLea.java#StringInflate fails with failed IR rules

### DIFF
--- a/test/hotspot/jtreg/compiler/codegen/TestRedundantLea.java
+++ b/test/hotspot/jtreg/compiler/codegen/TestRedundantLea.java
@@ -224,23 +224,18 @@ class StringInflateTest {
     }
 
     @Test
+    // TODO: Make tests more precise
     @IR(counts = {IRNode.LEA_P, "=2"},
         phase = {CompilePhase.FINAL_CODE},
         applyIfPlatform = {"mac", "false"})
     // Negative
-    @IR(counts = {IRNode.DECODE_HEAP_OOP_NOT_NULL, "=5"},
+    @IR(counts = {IRNode.DECODE_HEAP_OOP_NOT_NULL, ">=5"},
         phase = {CompilePhase.FINAL_CODE},
-        applyIfAnd = {"OptoPeephole", "false", "UseAVX", ">=2"})
-    @IR(counts = {IRNode.DECODE_HEAP_OOP_NOT_NULL, "=13"},
-        phase = {CompilePhase.FINAL_CODE},
-        applyIfAnd = {"OptoPeephole", "false", "UseAVX", "<2"})
+        applyIf = {"OptoPeephole", "false"})
     // 2 decodes get removed
-    @IR(counts = {IRNode.DECODE_HEAP_OOP_NOT_NULL, "=3"},
+    @IR(counts = {IRNode.DECODE_HEAP_OOP_NOT_NULL, ">=3"},
         phase = {CompilePhase.FINAL_CODE},
-        applyIfAnd = {"OptoPeephole", "true", "UseAVX", ">=2"})
-    @IR(counts = {IRNode.DECODE_HEAP_OOP_NOT_NULL, "=11"},
-        phase = {CompilePhase.FINAL_CODE},
-        applyIfAnd = {"OptoPeephole", "true", "UseAVX", "<2"})
+        applyIf = {"OptoPeephole", "true"})
     @Arguments(setup = "setup")
     public static Name test(Name n1, Name n2) {
         return n1.append(n2);
@@ -258,6 +253,7 @@ class RegexFindTest {
     }
 
     @Test
+    // TODO: Make tests more precise
     @IR(counts = {IRNode.LEA_P, "=1"},
         phase = {CompilePhase.FINAL_CODE},
         applyIfPlatform = {"mac", "false"})


### PR DESCRIPTION
`TestRedundantLea.java#StringInflate` failed on Alpine Linux because fewer `DecodeHeapOop_not_null`s than expected are generated even though the expected reduction is still present. This PR fixes this.

Unfortunately, this fix makes the test less precise. I filed [JDK-8361045](https://bugs.openjdk.org/browse/JDK-8361045) to fix this when the IR-framework allows for it.

Testing:
 - [x] Github Actions
 - [x] tier1, tier2 plus Oracle internal testing
 - [x] `TestRedundantLea.java` on Alpine Linux

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8361040](https://bugs.openjdk.org/browse/JDK-8361040): compiler/codegen/TestRedundantLea.java#StringInflate fails with failed IR rules (**Bug** - P4)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)

### Contributors
 * Matthias Baesken `<mbaesken@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26046/head:pull/26046` \
`$ git checkout pull/26046`

Update a local copy of the PR: \
`$ git checkout pull/26046` \
`$ git pull https://git.openjdk.org/jdk.git pull/26046/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26046`

View PR using the GUI difftool: \
`$ git pr show -t 26046`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26046.diff">https://git.openjdk.org/jdk/pull/26046.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26046#issuecomment-3023877937)
</details>
