### PR TITLE
8291652: (ch) java/nio/channels/SocketChannel/VectorIO.java failed with "Exception: Server 15: Timed out"

### DIFF
--- a/test/jdk/java/nio/channels/SocketChannel/VectorIO.java
+++ b/test/jdk/java/nio/channels/SocketChannel/VectorIO.java
@@ -90,8 +90,8 @@ public class VectorIO {
         System.arraycopy(bufs, 0, bufsPlus1, 0, bufs.length);
 
         // Get a connection to the server
-        InetAddress lh = InetAddress.getLocalHost();
-        InetSocketAddress isa = new InetSocketAddress(lh, port);
+        InetAddress loopback = InetAddress.getLoopbackAddress();
+        InetSocketAddress isa = new InetSocketAddress(loopback, port);
         SocketChannel sc = SocketChannel.open();
         sc.connect(isa);
         sc.configureBlocking(generator.nextBoolean());
@@ -131,7 +131,8 @@ public class VectorIO {
         Server(int testSize) throws IOException {
             super("Server " + testSize);
             this.testSize = testSize;
-            this.ssc = ServerSocketChannel.open().bind(new InetSocketAddress(0));
+            InetAddress loopback = InetAddress.getLoopbackAddress();
+            this.ssc = ServerSocketChannel.open().bind(new InetSocketAddress(loopback, 0));
         }
 
         int port() {

--- a/test/jdk/java/nio/channels/TestThread.java
+++ b/test/jdk/java/nio/channels/TestThread.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2002, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -85,6 +85,29 @@ public abstract class TestThread
             throw failure;
     }
 
+    /**
+     * Awaits the completion of this {@code Thread} and throws any failures
+     * that may have occurred during the execution of this {@code Thread}'s task
+     *
+     * @throws InterruptedException if the wait was interrupted
+     * @throws Exception any failure that may have occurred during the TestThread's execution
+     */
+    public final void awaitFinish() throws Exception {
+        try {
+            join();
+        } catch (InterruptedException ie) {
+            // we ignore interruption of only the main thread because the main thread
+            // is always interrupted by this TestThread upon failure of the Thread's task
+            if (Thread.currentThread() != main) {
+                throw ie;
+            }
+        }
+        if (this.failure != null) {
+            throw failure;
+        }
+    }
+
+    @Override
     public String toString() {
         return name;
     }


### PR DESCRIPTION
Can I please get a review of this test-only change which proposes to address an intermittent test failure in `java/nio/channels/SocketChannel/VectorIO.java`?

As noted in https://bugs.openjdk.org/browse/JDK-8291652, this test has been failing intermittently in our CI. Some years back the test was improved to include additional debug logs to identify the root cause https://bugs.openjdk.org/browse/JDK-8180085. In a recent failure, these test logs indicate that the `Server` thread hadn't yet `accept()`ed a Socket connection, when the client side of the test threw an exception because it had waited for 8 seconds for the server side of the test to complete.

The change in this PR updates the test to wait for the `Server` thread to reach a point where it is ready to `accept()` a Socket connection. Only after it reaches this state, the client side of the testing will be initiated. Furthermore, the artificial 8 second wait has been removed from this test and it now waits as long as it takes for the testing to complete. If the test waits far too long then the jtreg infrastructure will timeout the test and at the same time capture the necessary artifacts to help debug unexpected time outs.

While at it, the test has also been updated to use `InetAddress.getLoopbackAddress()` instead of localhost. This should prevent any unexpected address mappings for localhost from playing a role in this test.

With these changes, I've run the test more than 1000 times in our CI and it hasn't failed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8291652](https://bugs.openjdk.org/browse/JDK-8291652): (ch) java/nio/channels/SocketChannel/VectorIO.java failed with "Exception: Server 15: Timed out" (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26049/head:pull/26049` \
`$ git checkout pull/26049`

Update a local copy of the PR: \
`$ git checkout pull/26049` \
`$ git pull https://git.openjdk.org/jdk.git pull/26049/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26049`

View PR using the GUI difftool: \
`$ git pr show -t 26049`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26049.diff">https://git.openjdk.org/jdk/pull/26049.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26049#issuecomment-3019770709)
</details>
