### PR TITLE
8361085: MemoryReserver log_on_large_pages_failure has incorrect format usage

### DIFF
--- a/src/hotspot/share/memory/memoryReserver.cpp
+++ b/src/hotspot/share/memory/memoryReserver.cpp
@@ -22,7 +22,6 @@
  *
  */
 
-#include "jvm.h"
 #include "logging/log.hpp"
 #include "memory/memoryReserver.hpp"
 #include "oops/compressedOops.hpp"
@@ -65,11 +64,9 @@ static void log_on_large_pages_failure(char* req_addr, size_t bytes) {
     // Compressed oops logging.
     log_debug(gc, heap, coops)("Reserve regular memory without large pages");
     // JVM style warning that we did not succeed in using large pages.
-    char msg[128];
-    jio_snprintf(msg, sizeof(msg), "Failed to reserve and commit memory using large pages. "
-                                   "req_addr: " PTR_FORMAT " bytes: %zu",
-                                   req_addr, bytes);
-    warning("%s", msg);
+    warning("Failed to reserve and commit memory using large pages. "
+            "req_addr: " PTR_FORMAT " bytes: %zu",
+            p2i(req_addr), bytes);
   }
 }
 


### PR DESCRIPTION
Please review this fix of an incorrect format usage.

The function calls `jio_snprintf` to format a message into a buffer. That
message includes printing a pointer using `PTR_FORMAT`, but isn't using the
`p2i` helper function. Fixing that is just a matter of using that helper.

However, there's no need to use `jio_snprintf` here, as the resulting message
is then just passed to `warning`, which can handle output formatting directly.
So we also move the formatting to the `warning` call, and remove the use of
`jio_snprintf`. Note that calling `warning` without the `p2i` would have
produced a compiler warning about the incorrect format usage.

Testing: mach5 tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8361085](https://bugs.openjdk.org/browse/JDK-8361085): MemoryReserver log_on_large_pages_failure has incorrect format usage (**Enhancement** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26050/head:pull/26050` \
`$ git checkout pull/26050`

Update a local copy of the PR: \
`$ git checkout pull/26050` \
`$ git pull https://git.openjdk.org/jdk.git pull/26050/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26050`

View PR using the GUI difftool: \
`$ git pr show -t 26050`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26050.diff">https://git.openjdk.org/jdk/pull/26050.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26050#issuecomment-3019859094)
</details>
