### PR TITLE
8361086: JVMCIGlobals::check_jvmci_flags_are_consistent has incorrect format string

### DIFF
--- a/src/hotspot/share/jvmci/jvmci_globals.cpp
+++ b/src/hotspot/share/jvmci/jvmci_globals.cpp
@@ -106,7 +106,7 @@ bool JVMCIGlobals::check_jvmci_flags_are_consistent() {
     }
     if (BootstrapJVMCI && (TieredStopAtLevel < CompLevel_full_optimization)) {
       jio_fprintf(defaultStream::error_stream(),
-          "-XX:+BootstrapJVMCI is not compatible with -XX:TieredStopAtLevel=%d\n", TieredStopAtLevel);
+          "-XX:+BootstrapJVMCI is not compatible with -XX:TieredStopAtLevel=%zd\n", TieredStopAtLevel);
       return false;
     }
   }


### PR DESCRIPTION
Please review this trivial fix of a format string. The value being printed is
TieredStopAtLevel, which is of type intx, so "%zd" should be used instead of "%d".

Testing: mach5 tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8361086](https://bugs.openjdk.org/browse/JDK-8361086): JVMCIGlobals::check_jvmci_flags_are_consistent has incorrect format string (**Bug** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Manuel Hässig](https://openjdk.org/census#mhaessig) (@mhaessig - Committer)
 * [Yudi Zheng](https://openjdk.org/census#yzheng) (@mur47x111 - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26051/head:pull/26051` \
`$ git checkout pull/26051`

Update a local copy of the PR: \
`$ git checkout pull/26051` \
`$ git pull https://git.openjdk.org/jdk.git pull/26051/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26051`

View PR using the GUI difftool: \
`$ git pr show -t 26051`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26051.diff">https://git.openjdk.org/jdk/pull/26051.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26051#issuecomment-3019859527)
</details>
