### PR TITLE
8360037: Refactor ImageReader in preparation for Valhalla support

### DIFF
--- a/src/java.base/share/classes/jdk/internal/jimage/ImageReader.java
+++ b/src/java.base/share/classes/jdk/internal/jimage/ImageReader.java
@@ -25,7 +25,6 @@
 package jdk.internal.jimage;
 
 import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.IntBuffer;
@@ -279,14 +278,14 @@ public final class ImageReader implements AutoCloseable {
         /// Returns a node in the JRT filesystem namespace, or null if no resource or
         /// directory of that name exists.
         ///
-        /// Node names are absolute, `/`-separated path strings, prefixed with
-        /// either "/modules" or "/packages".
-        ///
         /// This is the only public API by which anything outside this class can access
-        /// `Node` instances either directly, or by resolving a symbolic link.
+        /// `Node` instances either directly, or by resolving symbolic links.
         ///
         /// Note also that there is no reentrant calling back to this method from within
         /// the node handling code.
+        ///
+        /// @param name an absolute, `/`-separated path string, prefixed with either
+        ///     "/modules" or "/packages".
         synchronized Node findNode(String name) {
             Node node = nodes.get(name);
             if (node == null) {
@@ -531,7 +530,13 @@ public final class ImageReader implements AutoCloseable {
         private final String name;
         private final BasicFileAttributes fileAttrs;
 
-        // Only visible for use by ExplodedImage.
+        /**
+         * Creates an abstract {@code Node}, which is either a resource, directory
+         * or symbolic link.
+         *
+         * <p>This constructor is only non-private so it can be used by the
+         * {@code ExplodedImage} class, and must not be used otherwise.
+         */
         protected Node(String name, BasicFileAttributes fileAttrs) {
             this.name = Objects.requireNonNull(name);
             this.fileAttrs = Objects.requireNonNull(fileAttrs);

--- a/src/java.base/share/classes/jdk/internal/jimage/ImageReader.java
+++ b/src/java.base/share/classes/jdk/internal/jimage/ImageReader.java
@@ -86,10 +86,6 @@ public final class ImageReader implements AutoCloseable {
     /**
      * Opens an image reader for a jimage file at the specified path, using the
      * given byte order.
-     *
-     * <p>Almost all callers should use {@link #open(Path)} to obtain a reader
-     * with the platform native byte ordering. Using a non-native ordering is
-     * extremely unusual.
      */
     public static ImageReader open(Path imagePath, ByteOrder byteOrder) throws IOException {
         Objects.requireNonNull(imagePath);
@@ -101,9 +97,6 @@ public final class ImageReader implements AutoCloseable {
     /**
      * Opens an image reader for a jimage file at the specified path, using the
      * platform native byte order.
-     *
-     * <p>This is the expected was to open an {@code ImageReader}, and it should
-     * be rare for anything other than the native byte order to be needed.
      */
     public static ImageReader open(Path imagePath) throws IOException {
         return open(imagePath, ByteOrder.nativeOrder());

--- a/src/java.base/share/classes/jdk/internal/jimage/ImageReader.java
+++ b/src/java.base/share/classes/jdk/internal/jimage/ImageReader.java
@@ -67,7 +67,7 @@ import java.util.stream.Stream;
  * parent directory.
  *
  * <p>While similar to {@code BasicImageReader}, this class is not a conceptual
- * subtype of, it and deliberately hides types such as {@code ImageLocation} to
+ * subtype of it, and deliberately hides types such as {@code ImageLocation} to
  * give a focused API based only on nodes.
  *
  * @implNote This class needs to maintain JDK 8 source compatibility.
@@ -169,7 +169,7 @@ public final class ImageReader implements AutoCloseable {
     public ByteBuffer getResourceBuffer(Node node) {
         requireOpen();
         if (!node.isResource()) {
-            throw new IllegalStateException("Not a resource node: " + node);
+            throw new IllegalArgumentException("Not a resource node: " + node);
         }
         return reader.getResourceBuffer(node.getLocation());
     }
@@ -186,13 +186,13 @@ public final class ImageReader implements AutoCloseable {
         // List of openers for this shared image.
         private final Set<ImageReader> openers = new HashSet<>();
 
-        // Attributes of the .jimage file. The jimage file does not contain
+        // Attributes of the jimage file. The jimage file does not contain
         // attributes for the individual resources (yet). We use attributes
         // of the jimage file itself (creation, modification, access times).
         private final BasicFileAttributes imageFileAttributes;
 
         // Cache of all user visible nodes, guarded by synchronizing 'this' instance.
-        private final HashMap<String, Node> nodes;
+        private final Map<String, Node> nodes;
         // Used to classify ImageLocation instances without string comparison.
         private final int modulesStringOffset;
         private final int packagesStringOffset;
@@ -313,9 +313,9 @@ public final class ImageReader implements AutoCloseable {
          * <p>Called by {@link #findNode(String)} if a {@code /modules/...} node
          * is not present in the cache.
          */
-        Node buildModulesNode(String name) {
+        private Node buildModulesNode(String name) {
             assert name.startsWith(MODULES_ROOT + "/") : "Invalid module node name: " + name;
-            // Will fail for non-directory resources since the jimage name does not
+            // Returns null for non-directory resources, since the jimage name does not
             // start with "/modules" (e.g. "/java.base/java/lang/Object.class").
             ImageLocation loc = findLocation(name);
             if (loc != null) {
@@ -636,8 +636,8 @@ public final class ImageReader implements AutoCloseable {
         /**
          * Returns the fully qualified names of any child nodes for a directory.
          *
-         * <p>If this node is not a directory ({@code isDirectory() == false})
-         * then this method will throw {@link IllegalStateException}.
+         * <p>By default, this method throws {@link IllegalStateException} and
+         * is overridden for directories.
          */
         public Stream<String> getChildNames() {
             throw new IllegalStateException("not a directory: " + getName());

--- a/src/java.base/share/classes/jdk/internal/jimage/ImageReader.java
+++ b/src/java.base/share/classes/jdk/internal/jimage/ImageReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,16 +25,15 @@
 package jdk.internal.jimage;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.IntBuffer;
 import java.nio.file.Files;
-import java.nio.file.attribute.BasicFileAttributes;
-import java.nio.file.attribute.FileTime;
 import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -42,9 +41,34 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
 
 /**
+ * An adapter for {@link BasicImageReader} to present jimage resources in a
+ * file system friendly way. The jimage entries (resources, module and package
+ * information) are mapped into a unified hierarchy of named nodes, which serve
+ * as the underlying structure for the {@code JrtFileSystem} and other utilities.
+ *
+ * <p>This class is not a conceptual subtype of {@code BasicImageReader} and
+ * deliberately hides types such as {@code ImageLocation} to give a focused API
+ * based only on the {@link Node} type. Entries in jimage are expressed as one
+ * of three {@link Node} types resource nodes, directory nodes and link nodes.
+ *
+ * <p>When remapping jimage entries, jimage location names (e.g. {@code
+ * "/java.base/java/lang/Integer.class"}) are prefixed with {@code "/modules"}
+ * to form the names of resource nodes. This aligns with the naming of module
+ * entries in jimage (e.g. "/modules/java.base/java/lang"), which appear as
+ * directory nodes in {@code ImageReader}.
+ *
+ * <p>Package entries (e.g. {@code "/packages/java.lang"} appear as directory
+ * nodes containing link nodes, which resolve back to the root directory of the
+ * module in which that package exists (e.g. {@code "/modules/java.base"}).
+ * Unlike other nodes, the jimage file does not contain explicit entries for
+ * link nodes, and their existence is derived only from the contents of the
+ * parent directory.
+ *
  * @implNote This class needs to maintain JDK 8 source compatibility.
  *
  * It is used internally in the JDK to implement jimage/jrtfs access,
@@ -60,6 +84,14 @@ public final class ImageReader implements AutoCloseable {
         this.reader = reader;
     }
 
+    /**
+     * Opens an image reader for a jimage file at the specified path, using the
+     * given byte order.
+     *
+     * <p>Almost all callers should use {@link #open(Path)} to obtain a reader
+     * with the platform native byte ordering. Using a non-native ordering is
+     * extremely unusual.
+     */
     public static ImageReader open(Path imagePath, ByteOrder byteOrder) throws IOException {
         Objects.requireNonNull(imagePath);
         Objects.requireNonNull(byteOrder);
@@ -67,6 +99,13 @@ public final class ImageReader implements AutoCloseable {
         return SharedImageReader.open(imagePath, byteOrder);
     }
 
+    /**
+     * Opens an image reader for a jimage file at the specified path, using the
+     * platform native byte order.
+     *
+     * <p>This is the expected was to open an {@code ImageReader}, and it should
+     * be rare for anything other than the native byte order to be needed.
+     */
     public static ImageReader open(Path imagePath) throws IOException {
         return open(imagePath, ByteOrder.nativeOrder());
     }
@@ -92,146 +131,111 @@ public final class ImageReader implements AutoCloseable {
         }
     }
 
-    // directory management interface
-    public Directory getRootDirectory() throws IOException {
-        ensureOpen();
-        return reader.getRootDirectory();
-    }
-
-
+    /**
+     * Finds the node for the given JRT file system name.
+     *
+     * @param name a JRT file system name (path) of the form
+     * {@code "/modules/<module>/...} or {@code "/packages/<package>/...}.
+     * @return a node representing a resource, directory or symbolic link.
+     */
     public Node findNode(String name) throws IOException {
         ensureOpen();
         return reader.findNode(name);
     }
 
+    /**
+     * Returns a copy of the content of a resource node. The buffer returned by
+     * this method is not cached by the node, and each call returns a new array
+     * instance.
+     *
+     * @throws IOException if the content cannot be returned (including if the
+     * given node is not a resource node).
+     */
     public byte[] getResource(Node node) throws IOException {
         ensureOpen();
         return reader.getResource(node);
     }
 
-    public byte[] getResource(Resource rs) throws IOException {
-        ensureOpen();
-        return reader.getResource(rs);
-    }
-
-    public ImageHeader getHeader() {
-        requireOpen();
-        return reader.getHeader();
-    }
-
+    /**
+     * Releases a (possibly cached) {@link ByteBuffer} obtained via
+     * {@link #getResourceBuffer(Node)}.
+     *
+     * <p>Note that no testing is performed to check whether the buffer about
+     * to be released actually came from a call to {@code getResourceBuffer()}.
+     */
     public static void releaseByteBuffer(ByteBuffer buffer) {
         BasicImageReader.releaseByteBuffer(buffer);
     }
 
-    public String getName() {
+    /**
+     * Returns the content of a resource node in a possibly cached byte buffer.
+     * Callers of this method must call {@link #releaseByteBuffer(ByteBuffer)}
+     * when they are finished with it.
+     */
+    public ByteBuffer getResourceBuffer(Node node) {
         requireOpen();
-        return reader.getName();
-    }
-
-    public ByteOrder getByteOrder() {
-        requireOpen();
-        return reader.getByteOrder();
-    }
-
-    public Path getImagePath() {
-        requireOpen();
-        return reader.getImagePath();
-    }
-
-    public ImageStringsReader getStrings() {
-        requireOpen();
-        return reader.getStrings();
-    }
-
-    public ImageLocation findLocation(String mn, String rn) {
-        requireOpen();
-        return reader.findLocation(mn, rn);
-    }
-
-    public boolean verifyLocation(String mn, String rn) {
-        requireOpen();
-        return reader.verifyLocation(mn, rn);
-    }
-
-    public ImageLocation findLocation(String name) {
-        requireOpen();
-        return reader.findLocation(name);
-    }
-
-    public String[] getEntryNames() {
-        requireOpen();
-        return reader.getEntryNames();
-    }
-
-    public String[] getModuleNames() {
-        requireOpen();
-        int off = "/modules/".length();
-        return reader.findNode("/modules")
-                     .getChildren()
-                     .stream()
-                     .map(Node::getNameString)
-                     .map(s -> s.substring(off, s.length()))
-                     .toArray(String[]::new);
-    }
-
-    public long[] getAttributes(int offset) {
-        requireOpen();
-        return reader.getAttributes(offset);
-    }
-
-    public String getString(int offset) {
-        requireOpen();
-        return reader.getString(offset);
-    }
-
-    public byte[] getResource(String name) {
-        requireOpen();
-        return reader.getResource(name);
-    }
-
-    public byte[] getResource(ImageLocation loc) {
-        requireOpen();
-        return reader.getResource(loc);
-    }
-
-    public ByteBuffer getResourceBuffer(ImageLocation loc) {
-        requireOpen();
-        return reader.getResourceBuffer(loc);
-    }
-
-    public InputStream getResourceStream(ImageLocation loc) {
-        requireOpen();
-        return reader.getResourceStream(loc);
+        if (!node.isResource()) {
+            throw new IllegalStateException("Not a resource node: " + node);
+        }
+        return reader.getResourceBuffer(node.getLocation());
     }
 
     private static final class SharedImageReader extends BasicImageReader {
-        static final int SIZE_OF_OFFSET = Integer.BYTES;
-
-        static final Map<Path, SharedImageReader> OPEN_FILES = new HashMap<>();
+        private static final Map<Path, SharedImageReader> OPEN_FILES = new HashMap<>();
+        private static final String MODULES_ROOT = "/modules";
+        private static final String PACKAGES_ROOT = "/packages";
+        // There are >30,000 nodes in a complete jimage tree, and even relatively
+        // common tasks (e.g. starting up javac) load somewhere in the region of
+        // 1000 classes. Thus, an initial capacity of 2000 is a reasonable guess.
+        private static final int INITIAL_NODE_CACHE_CAPACITY = 2000;
 
         // List of openers for this shared image.
-        final Set<ImageReader> openers;
+        private final Set<ImageReader> openers = new HashSet<>();
 
-        // attributes of the .jimage file. jimage file does not contain
+        // Attributes of the .jimage file. The jimage file does not contain
         // attributes for the individual resources (yet). We use attributes
         // of the jimage file itself (creation, modification, access times).
-        // Iniitalized lazily, see {@link #imageFileAttributes()}.
-        BasicFileAttributes imageFileAttributes;
+        private final BasicFileAttributes imageFileAttributes;
 
-        // directory management implementation
-        final HashMap<String, Node> nodes;
-        volatile Directory rootDir;
-
-        Directory packagesDir;
-        Directory modulesDir;
+        // Cache of all user visible nodes, guarded by synchronizing 'this' instance.
+        private final HashMap<String, Node> nodes;
+        // Used to classify ImageLocation instances without string comparison.
+        private final int modulesStringOffset;
+        private final int packagesStringOffset;
 
         private SharedImageReader(Path imagePath, ByteOrder byteOrder) throws IOException {
             super(imagePath, byteOrder);
-            this.openers = new HashSet<>();
-            this.nodes = new HashMap<>();
+            this.imageFileAttributes = Files.readAttributes(imagePath, BasicFileAttributes.class);
+            this.nodes = new HashMap<>(INITIAL_NODE_CACHE_CAPACITY);
+            // Pick stable jimage names from which to extract string offsets (we cannot
+            // use "/modules" or "/packages", since those have a module offset of zero).
+            this.modulesStringOffset = getModuleOffset("/modules/java.base");
+            this.packagesStringOffset = getModuleOffset("/packages/java.lang");
+
+            // Node creation is very lazy, so we can just make the top-level directories
+            // now without the risk of triggering the building of lots of other nodes.
+            Directory packages = newDirectory(PACKAGES_ROOT);
+            nodes.put(packages.getName(), packages);
+            Directory modules = newDirectory(MODULES_ROOT);
+            nodes.put(modules.getName(), modules);
+
+            Directory root = newDirectory("/");
+            root.setChildren(Arrays.asList(packages, modules));
+            nodes.put(root.getName(), root);
         }
 
-        public static ImageReader open(Path imagePath, ByteOrder byteOrder) throws IOException {
+        /// Returns the offset of the string denoting the leading "module" segment
+        /// in the given path (e.g. `<module>/<path>`). We can't just pass in the
+        /// `/<module>` string here because that has a module offset of zero.
+        private int getModuleOffset(String path) {
+            ImageLocation location = findLocation(path);
+            assert location != null : "Cannot find expected jimage location: " + path;
+            int offset = location.getModuleOffset();
+            assert offset != 0 : "Invalid module offset for jimage location: " + path;
+            return offset;
+        }
+
+        private static ImageReader open(Path imagePath, ByteOrder byteOrder) throws IOException {
             Objects.requireNonNull(imagePath);
             Objects.requireNonNull(byteOrder);
 
@@ -264,7 +268,6 @@ public final class ImageReader implements AutoCloseable {
                 if (openers.isEmpty()) {
                     close();
                     nodes.clear();
-                    rootDir = null;
 
                     if (!OPEN_FILES.remove(this.getImagePath(), this)) {
                         throw new IOException("image file not found in open list");
@@ -273,448 +276,380 @@ public final class ImageReader implements AutoCloseable {
             }
         }
 
-        void addOpener(ImageReader reader) {
-            synchronized (OPEN_FILES) {
-                openers.add(reader);
+        /// Returns a node in the JRT filesystem namespace, or null if no resource or
+        /// directory of that name exists.
+        ///
+        /// Node names are absolute, `/`-separated path strings, prefixed with
+        /// either "/modules" or "/packages".
+        ///
+        /// This is the only public API by which anything outside this class can access
+        /// `Node` instances either directly, or by resolving a symbolic link.
+        ///
+        /// Note also that there is no reentrant calling back to this method from within
+        /// the node handling code.
+        synchronized Node findNode(String name) {
+            Node node = nodes.get(name);
+            if (node == null) {
+                // We cannot get the root paths ("/modules" or "/packages") here
+                // because those nodes are already in the nodes cache.
+                if (name.startsWith(MODULES_ROOT + "/")) {
+                    node = buildModulesNode(name);
+                } else if (name.startsWith(PACKAGES_ROOT + "/")) {
+                    node = buildPackagesNode(name);
+                }
+                if (node != null) {
+                    nodes.put(node.getName(), node);
+                }
+            } else if (!node.isCompleted()) {
+                // Only directories can be incomplete.
+                assert node instanceof Directory : "Invalid incomplete node: " + node;
+                completeDirectory((Directory) node);
             }
+            assert node == null || node.isCompleted() : "Incomplete node: " + node;
+            return node;
         }
 
-        boolean removeOpener(ImageReader reader) {
-            synchronized (OPEN_FILES) {
-                return openers.remove(reader);
-            }
-        }
-
-        // directory management interface
-        Directory getRootDirectory() {
-            return buildRootDirectory();
-        }
-
-        /**
-         * Lazily build a node from a name.
-         */
-        synchronized Node buildNode(String name) {
-            Node n;
-            boolean isPackages = name.startsWith("/packages");
-            boolean isModules = !isPackages && name.startsWith("/modules");
-
-            if (!(isModules || isPackages)) {
-                return null;
-            }
-
+        /// Builds a node in the "/modules/..." namespace.
+        ///
+        /// Called by `findNode()` if a `/modules/...` node is not present in the cache.
+        Node buildModulesNode(String name) {
+            assert name.startsWith(MODULES_ROOT + "/") : "Invalid module node name: " + name;
+            // Will fail for non-directory resources since the jimage name does not
+            // start with "/modules" (e.g. "/java.base/java/lang/Object.class").
             ImageLocation loc = findLocation(name);
-
-            if (loc != null) { // A sub tree node
-                if (isPackages) {
-                    n = handlePackages(name, loc);
-                } else { // modules sub tree
-                    n = handleModulesSubTree(name, loc);
-                }
-            } else { // Asking for a resource? /modules/java.base/java/lang/Object.class
-                if (isModules) {
-                    n = handleResource(name);
-                } else {
-                    // Possibly ask for /packages/java.lang/java.base
-                    // although /packages/java.base not created
-                    n = handleModuleLink(name);
-                }
+            if (loc != null) {
+                assert name.equals(loc.getFullName()) : "Mismatched location for directory: " + name;
+                assert isModulesSubdirectory(loc) : "Invalid modules directory: " + name;
+                return completeModuleDirectory(newDirectory(name), loc);
             }
-            return n;
+            // Now try the non-prefixed resource name.
+            loc = findLocation(name.substring(MODULES_ROOT.length()));
+            return loc != null ? newResource(name, loc) : null;
         }
 
-        synchronized Directory buildRootDirectory() {
-            Directory root = rootDir; // volatile read
-            if (root != null) {
-                return root;
-            }
-
-            root = newDirectory(null, "/");
-            root.setIsRootDir();
-
-            // /packages dir
-            packagesDir = newDirectory(root, "/packages");
-            packagesDir.setIsPackagesDir();
-
-            // /modules dir
-            modulesDir = newDirectory(root, "/modules");
-            modulesDir.setIsModulesDir();
-
-            root.setCompleted(true);
-            return rootDir = root;
-        }
-
-        /**
-         * To visit sub tree resources.
-         */
-        interface LocationVisitor {
-            void visit(ImageLocation loc);
-        }
-
-        void visitLocation(ImageLocation loc, LocationVisitor visitor) {
-            byte[] offsets = getResource(loc);
-            ByteBuffer buffer = ByteBuffer.wrap(offsets);
-            buffer.order(getByteOrder());
-            IntBuffer intBuffer = buffer.asIntBuffer();
-            for (int i = 0; i < offsets.length / SIZE_OF_OFFSET; i++) {
-                int offset = intBuffer.get(i);
-                ImageLocation pkgLoc = getLocation(offset);
-                visitor.visit(pkgLoc);
-            }
-        }
-
-        void visitPackageLocation(ImageLocation loc) {
-            // Retrieve package name
-            String pkgName = getBaseExt(loc);
-            // Content is array of offsets in Strings table
-            byte[] stringsOffsets = getResource(loc);
-            ByteBuffer buffer = ByteBuffer.wrap(stringsOffsets);
-            buffer.order(getByteOrder());
-            IntBuffer intBuffer = buffer.asIntBuffer();
-            // For each module, create a link node.
-            for (int i = 0; i < stringsOffsets.length / SIZE_OF_OFFSET; i++) {
-                // skip empty state, useless.
-                intBuffer.get(i);
-                i++;
-                int offset = intBuffer.get(i);
-                String moduleName = getString(offset);
-                Node targetNode = findNode("/modules/" + moduleName);
-                if (targetNode != null) {
-                    String pkgDirName = packagesDir.getName() + "/" + pkgName;
-                    Directory pkgDir = (Directory) nodes.get(pkgDirName);
-                    newLinkNode(pkgDir, pkgDir.getName() + "/" + moduleName, targetNode);
-                }
-            }
-        }
-
-        Node handlePackages(String name, ImageLocation loc) {
-            long size = loc.getUncompressedSize();
-            Node n = null;
-            // Only possibilities are /packages, /packages/package/module
-            if (name.equals("/packages")) {
-                visitLocation(loc, (childloc) -> {
-                    findNode(childloc.getFullName());
-                });
-                packagesDir.setCompleted(true);
-                n = packagesDir;
+        /// Builds a node in the "/packages/..." namespace.
+        ///
+        /// Called by `findNode()` if a `/packages/...` node is not present in the cache.
+        private Node buildPackagesNode(String name) {
+            // There are only locations for the root "/packages" or "/packages/xxx"
+            // directories, but not the symbolic links below them (the links can be
+            // entirely derived from the name information in the parent directory).
+            // However, unlike resources this means that we do not have a constant
+            // time lookup for link nodes when creating them.
+            int packageStart = PACKAGES_ROOT.length() + 1;
+            int packageEnd = name.indexOf('/', packageStart);
+            if (packageEnd == -1) {
+                ImageLocation loc = findLocation(name);
+                return loc != null ? completePackageDirectory(newDirectory(name), loc) : null;
             } else {
-                if (size != 0) { // children are offsets to module in StringsTable
-                    String pkgName = getBaseExt(loc);
-                    Directory pkgDir = newDirectory(packagesDir, packagesDir.getName() + "/" + pkgName);
-                    visitPackageLocation(loc);
-                    pkgDir.setCompleted(true);
-                    n = pkgDir;
-                } else { // Link to module
-                    String pkgName = loc.getParent();
-                    String modName = getBaseExt(loc);
-                    Node targetNode = findNode("/modules/" + modName);
-                    if (targetNode != null) {
-                        String pkgDirName = packagesDir.getName() + "/" + pkgName;
-                        Directory pkgDir = (Directory) nodes.get(pkgDirName);
-                        Node linkNode = newLinkNode(pkgDir, pkgDir.getName() + "/" + modName, targetNode);
-                        n = linkNode;
+                // We cannot assume that the parent directory exists for a link node, since
+                // the given name is untrusted and could reference a non-existent link.
+                // However, if the parent directory is present, we can conclude that the
+                // given name was not a valid link (or else it would already be cached).
+                String dirName = name.substring(0, packageEnd);
+                if (!nodes.containsKey(dirName)) {
+                    ImageLocation loc = findLocation(dirName);
+                    // If the parent location doesn't exist, the link node cannot exist.
+                    if (loc != null) {
+                        nodes.put(dirName, completePackageDirectory(newDirectory(dirName), loc));
+                        // When the parent is created its child nodes are created and cached,
+                        // but this can still return null if given name wasn't a valid link.
+                        return nodes.get(name);
                     }
                 }
             }
-            return n;
+            return null;
         }
 
-        // Asking for /packages/package/module although
-        // /packages/<pkg>/ not yet created, need to create it
-        // prior to return the link to module node.
-        Node handleModuleLink(String name) {
-            // eg: unresolved /packages/package/module
-            // Build /packages/package node
-            Node ret = null;
-            String radical = "/packages/";
-            String path = name;
-            if (path.startsWith(radical)) {
-                int start = radical.length();
-                int pkgEnd = path.indexOf('/', start);
-                if (pkgEnd != -1) {
-                    String pkg = path.substring(start, pkgEnd);
-                    String pkgPath = radical + pkg;
-                    Node n = findNode(pkgPath);
-                    // If not found means that this is a symbolic link such as:
-                    // /packages/java.util/java.base/java/util/Vector.class
-                    // and will be done by a retry of the filesystem
-                    for (Node child : n.getChildren()) {
-                        if (child.name.equals(name)) {
-                            ret = child;
-                            break;
-                        }
-                    }
-                }
+        /// Completes a directory by ensuring its child list is populated correctly.
+        private void completeDirectory(Directory dir) {
+            String name = dir.getName();
+            // Since the node exists, we can assert that its name starts with
+            // either "/modules" or "/packages", making differentiation easy.
+            // It also means that the name is valid, so it must yield a location.
+            assert name.startsWith(MODULES_ROOT) || name.startsWith(PACKAGES_ROOT);
+            ImageLocation loc = findLocation(name);
+            assert loc != null && name.equals(loc.getFullName()) : "Invalid location for name: " + name;
+            // We cannot use 'isXxxSubdirectory()' methods here since we could
+            // be given a top-level directory (for which that test doesn't work).
+            // The string MUST start "/modules" or "/packages" here.
+            if (name.charAt(1) == 'm') {
+                completeModuleDirectory(dir, loc);
+            } else {
+                completePackageDirectory(dir, loc);
             }
-            return ret;
+            assert dir.isCompleted() : "Directory must be complete by now: " + dir;
         }
 
-        Node handleModulesSubTree(String name, ImageLocation loc) {
-            Node n;
-            assert (name.equals(loc.getFullName()));
-            Directory dir = makeDirectories(name);
-            visitLocation(loc, (childloc) -> {
-                String path = childloc.getFullName();
-                if (path.startsWith("/modules")) { // a package
-                    makeDirectories(path);
-                } else { // a resource
-                    makeDirectories(childloc.buildName(true, true, false));
-                    // if we have already created a resource for this name previously, then don't
-                    // recreate it
-                    if (!nodes.containsKey(childloc.getFullName(true))) {
-                        newResource(dir, childloc);
-                    }
+        /// Completes a modules directory by setting the list of child nodes.
+        ///
+        /// The given directory can be the top level `/modules` directory, so
+        /// it is NOT safe to use `isModulesSubdirectory(loc)` here.
+        private Directory completeModuleDirectory(Directory dir, ImageLocation loc) {
+            assert dir.getName().equals(loc.getFullName()) : "Mismatched location for directory: " + dir;
+            List<Node> children = createChildNodes(loc, childLoc -> {
+                if (isModulesSubdirectory(childLoc)) {
+                    return nodes.computeIfAbsent(childLoc.getFullName(), this::newDirectory);
+                } else {
+                    // Add the "/modules" prefix to image location paths to get
+                    // Jrt file system names.
+                    String resourceName = childLoc.getFullName(true);
+                    return nodes.computeIfAbsent(resourceName, n -> newResource(n, childLoc));
                 }
             });
-            dir.setCompleted(true);
-            n = dir;
-            return n;
-        }
-
-        Node handleResource(String name) {
-            Node n = null;
-            if (!name.startsWith("/modules/")) {
-                return null;
-            }
-            // Make sure that the thing that follows "/modules/" is a module name.
-            int moduleEndIndex = name.indexOf('/', "/modules/".length());
-            if (moduleEndIndex == -1) {
-                return null;
-            }
-            ImageLocation moduleLoc = findLocation(name.substring(0, moduleEndIndex));
-            if (moduleLoc == null || moduleLoc.getModuleOffset() == 0) {
-                return null;
-            }
-
-            String locationPath = name.substring("/modules".length());
-            ImageLocation resourceLoc = findLocation(locationPath);
-            if (resourceLoc != null) {
-                Directory dir = makeDirectories(resourceLoc.buildName(true, true, false));
-                Resource res = newResource(dir, resourceLoc);
-                n = res;
-            }
-            return n;
-        }
-
-        String getBaseExt(ImageLocation loc) {
-            String base = loc.getBase();
-            String ext = loc.getExtension();
-            if (ext != null && !ext.isEmpty()) {
-                base = base + "." + ext;
-            }
-            return base;
-        }
-
-        synchronized Node findNode(String name) {
-            buildRootDirectory();
-            Node n = nodes.get(name);
-            if (n == null || !n.isCompleted()) {
-                n = buildNode(name);
-            }
-            return n;
-        }
-
-        /**
-         * Returns the file attributes of the image file.
-         */
-        BasicFileAttributes imageFileAttributes() {
-            BasicFileAttributes attrs = imageFileAttributes;
-            if (attrs == null) {
-                try {
-                    Path file = getImagePath();
-                    attrs = Files.readAttributes(file, BasicFileAttributes.class);
-                } catch (IOException ioe) {
-                    throw new UncheckedIOException(ioe);
-                }
-                imageFileAttributes = attrs;
-            }
-            return attrs;
-        }
-
-        Directory newDirectory(Directory parent, String name) {
-            Directory dir = Directory.create(parent, name, imageFileAttributes());
-            nodes.put(dir.getName(), dir);
+            dir.setChildren(children);
             return dir;
         }
 
-        Resource newResource(Directory parent, ImageLocation loc) {
-            Resource res = Resource.create(parent, loc, imageFileAttributes());
-            nodes.put(res.getName(), res);
-            return res;
-        }
-
-        LinkNode newLinkNode(Directory dir, String name, Node link) {
-            LinkNode linkNode = LinkNode.create(dir, name, link);
-            nodes.put(linkNode.getName(), linkNode);
-            return linkNode;
-        }
-
-        Directory makeDirectories(String parent) {
-            Directory last = rootDir;
-            for (int offset = parent.indexOf('/', 1);
-                    offset != -1;
-                    offset = parent.indexOf('/', offset + 1)) {
-                String dir = parent.substring(0, offset);
-                last = makeDirectory(dir, last);
+        /// Completes a package directory by setting the list of child nodes.
+        ///
+        /// The given directory can be the top level `/packages` directory, so
+        /// it is NOT safe to use `isPackagesSubdirectory(loc)` here.
+        private Directory completePackageDirectory(Directory dir, ImageLocation loc) {
+            assert dir.getName().equals(loc.getFullName()) : "Mismatched location for directory: " + dir;
+            // The only directories in the "/packages" namespace are "/packages" or
+            // "/packages/<package>". However, unlike "/modules" directories, the
+            // location offsets mean different things.
+            List<Node> children;
+            if (dir.getName().equals(PACKAGES_ROOT)) {
+                // Top-level directory just contains a list of subdirectories.
+                children = createChildNodes(loc, c -> nodes.computeIfAbsent(c.getFullName(), this::newDirectory));
+            } else {
+                // A package directory's content is array of offset PAIRS in the
+                // Strings table, but we only need the 2nd value of each pair.
+                IntBuffer intBuffer = getOffsetBuffer(loc);
+                int offsetCount = intBuffer.capacity();
+                assert (offsetCount & 0x1) == 0 : "Offset count must be even: " + offsetCount;
+                children = new ArrayList<>(offsetCount / 2);
+                // Iterate the 2nd offset in each pair (odd indices).
+                for (int i = 1; i < offsetCount; i += 2) {
+                    String moduleName = getString(intBuffer.get(i));
+                    children.add(nodes.computeIfAbsent(
+                            dir.getName() + "/" + moduleName,
+                            n -> newLinkNode(n, MODULES_ROOT + "/" + moduleName)));
+                }
             }
-            return makeDirectory(parent, last);
-
+            // This only happens once and "completes" the directory.
+            dir.setChildren(children);
+            return dir;
         }
 
-        Directory makeDirectory(String dir, Directory last) {
-            Directory nextDir = (Directory) nodes.get(dir);
-            if (nextDir == null) {
-                nextDir = newDirectory(last, dir);
+        /// Creates the list of child nodes for a `Directory` based on a given
+        /// node creation function.
+        ///
+        /// Note: This cannot be used for package subdirectories as they have
+        /// child offsets stored differently to other directories.
+        private List<Node> createChildNodes(ImageLocation loc, Function<ImageLocation, Node> newChildFn) {
+            IntBuffer offsets = getOffsetBuffer(loc);
+            int childCount = offsets.capacity();
+            List<Node> children = new ArrayList<>(childCount);
+            for (int i = 0; i < childCount; i++) {
+                children.add(newChildFn.apply(getLocation(offsets.get(i))));
             }
-            return nextDir;
+            return children;
         }
 
-        byte[] getResource(Node node) throws IOException {
+        /// Helper to extract the integer offset buffer from a directory location.
+        private IntBuffer getOffsetBuffer(ImageLocation dir) {
+            assert isDirectory(dir) : "Not a directory: " + dir.getFullName();
+            byte[] offsets = getResource(dir);
+            ByteBuffer buffer = ByteBuffer.wrap(offsets);
+            buffer.order(getByteOrder());
+            return buffer.asIntBuffer();
+        }
+
+        /// Determines if an image location is a directory in the `/modules`
+        /// namespace (if so, the location name is the Jrt filesystem name).
+        ///
+        /// In jimage, every `ImageLocation` under `/modules/` is a directory
+        /// and has the same value for `getModule()`, and `getModuleOffset()`.
+        private boolean isModulesSubdirectory(ImageLocation loc) {
+            return loc.getModuleOffset() == modulesStringOffset;
+        }
+
+        /// Determines if an image location is a directory in the `/packages``
+        /// namespace (if so, the location name is the Jrt filesystem name).
+        ///
+        /// In jimage, every `ImageLocation` under `/packages/` is a directory
+        /// and has the same value for `getModule()`, and `getModuleOffset()`.
+        private boolean isPackagesSubdirectory(ImageLocation loc) {
+            return loc.getModuleOffset() == packagesStringOffset;
+        }
+
+        /// Determines if an image location represents a directory of some kind.
+        private boolean isDirectory(ImageLocation loc) {
+            return isModulesSubdirectory(loc) || isPackagesSubdirectory(loc) || loc.getModuleOffset() == 0;
+        }
+
+        /// Creates an "incomplete" directory node with no child nodes set.
+        /// Directories need to be "completed" before they are returned by
+        /// `findNode()`.
+        private Directory newDirectory(String name) {
+            return new Directory(name, imageFileAttributes);
+        }
+
+        /// Creates a new resource from an image location. This is the only case
+        /// where the image location name does not match the requested node name.
+        /// In image files, resource locations are NOT prefixed by `/modules`.
+        private Resource newResource(String name, ImageLocation loc) {
+            assert name.equals(loc.getFullName(true)) : "Mismatched location for resource: " + name;
+            return new Resource(name, loc, imageFileAttributes);
+        }
+
+        /// Creates a new link node pointing at the given target name.
+        ///
+        /// Note that target node is resolved each time `resolve()` is called, so
+        /// if a link node is retained after its reader is closed, it will fail.
+        private LinkNode newLinkNode(String name, String targetName) {
+            return new LinkNode(name, () -> findNode(targetName), imageFileAttributes);
+        }
+
+        /// Returns the content of a resource node.
+        private byte[] getResource(Node node) throws IOException {
+            // We could have been given a non-resource node here.
             if (node.isResource()) {
                 return super.getResource(node.getLocation());
             }
             throw new IOException("Not a resource: " + node);
         }
-
-        byte[] getResource(Resource rs) throws IOException {
-            return super.getResource(rs.getLocation());
-        }
     }
 
-    // jimage file does not store directory structure. We build nodes
-    // using the "path" strings found in the jimage file.
-    // Node can be a directory or a resource
+    /**
+     * A directory, resource or symbolic link in the JRT file system namespace.
+     *
+     * <h3 id="node_equality">Node Equality</h3>
+     *
+     * Nodes are identified solely by their name, and it is not valid to attempt
+     * to compare nodes from different reader instances. Different readers may
+     * produce nodes with the same names, but different contents.
+     *
+     * <p>Furthermore, since a {@link ImageReader} provides "perfect" caching of
+     * nodes, equality of nodes from the same reader is equivalent to instance
+     * identity.
+     */
     public abstract static class Node {
-        private static final int ROOT_DIR = 0b0000_0000_0000_0001;
-        private static final int PACKAGES_DIR = 0b0000_0000_0000_0010;
-        private static final int MODULES_DIR = 0b0000_0000_0000_0100;
-
-        private int flags;
         private final String name;
         private final BasicFileAttributes fileAttrs;
-        private boolean completed;
 
+        // Only visible for use by ExplodedImage.
         protected Node(String name, BasicFileAttributes fileAttrs) {
             this.name = Objects.requireNonNull(name);
             this.fileAttrs = Objects.requireNonNull(fileAttrs);
         }
 
+        // A node is completed when all its direct children have been built.
+        // As such, non-directory nodes are always complete.
+        boolean isCompleted() {
+            return true;
+        }
+
+        // Only resources can return a location.
+        ImageLocation getLocation() {
+            throw new IllegalStateException("not a resource: " + getName());
+        }
+
         /**
-         * A node is completed when all its direct children have been built.
-         *
-         * @return
+         * Returns the JRT file system compatible name of this node (e.g.
+         * {@code "/modules/java.base/java/lang/Object.class"} or {@code
+         * "/packages/java.lang"}).
          */
-        public boolean isCompleted() {
-            return completed;
-        }
-
-        public void setCompleted(boolean completed) {
-            this.completed = completed;
-        }
-
-        public final void setIsRootDir() {
-            flags |= ROOT_DIR;
-        }
-
-        public final boolean isRootDir() {
-            return (flags & ROOT_DIR) != 0;
-        }
-
-        public final void setIsPackagesDir() {
-            flags |= PACKAGES_DIR;
-        }
-
-        public final boolean isPackagesDir() {
-            return (flags & PACKAGES_DIR) != 0;
-        }
-
-        public final void setIsModulesDir() {
-            flags |= MODULES_DIR;
-        }
-
-        public final boolean isModulesDir() {
-            return (flags & MODULES_DIR) != 0;
-        }
-
         public final String getName() {
             return name;
         }
 
+        /**
+         * Returns file attributes for this node. The value returned may be the
+         * same for all nodes, and should not be relied upon for accuracy.
+         */
         public final BasicFileAttributes getFileAttributes() {
             return fileAttrs;
         }
 
-        // resolve this Node (if this is a soft link, get underlying Node)
+        /**
+         * Resolves a symbolic link to its target node. If this code is not a
+         * symbolic link, then it resolves to itself.
+         */
         public final Node resolveLink() {
             return resolveLink(false);
         }
 
+        /**
+         * Resolves a symbolic link to its target node. If this code is not a
+         * symbolic link, then it resolves to itself.
+         */
         public Node resolveLink(boolean recursive) {
             return this;
         }
 
-        // is this a soft link Node?
+        /** Returns whether this node is a symbolic link. */
         public boolean isLink() {
             return false;
         }
 
+        /**
+         * Returns whether this node is a directory. Directory nodes can have
+         * {@link #getChildNames()} invoked to get the fully qualified names
+         * of any child nodes.
+         */
         public boolean isDirectory() {
             return false;
         }
 
-        public List<Node> getChildren() {
-            throw new IllegalArgumentException("not a directory: " + getNameString());
-        }
-
+        /**
+         * Returns whether this node is a resource. Resource nodes can have
+         * their contents obtained via {@link ImageReader#getResource(Node)}
+         * or {@link ImageReader#getResourceBuffer(Node)}.
+         */
         public boolean isResource() {
             return false;
         }
 
-        public ImageLocation getLocation() {
-            throw new IllegalArgumentException("not a resource: " + getNameString());
+        /**
+         * Returns the fully qualified names of any child nodes for a directory.
+         *
+         * <p>If this node is not a directory ({@code isDirectory() == false})
+         * then this method will throw {@link IllegalStateException}.
+         */
+        public Stream<String> getChildNames() {
+            throw new IllegalStateException("not a directory: " + getName());
         }
 
+        /**
+         * Returns the uncompressed size of this node's content. If this node is
+         * not a resource, this method returns zero.
+         */
         public long size() {
             return 0L;
         }
 
+        /**
+         * Returns the compressed size of this node's content. If this node is
+         * not a resource, this method returns zero.
+         */
         public long compressedSize() {
             return 0L;
         }
 
+        /**
+         * Returns the extension string of a resource node. If this node is not
+         * a resource, this method returns null.
+         */
         public String extension() {
             return null;
         }
 
-        public long contentOffset() {
-            return 0L;
-        }
-
-        public final FileTime creationTime() {
-            return fileAttrs.creationTime();
-        }
-
-        public final FileTime lastAccessTime() {
-            return fileAttrs.lastAccessTime();
-        }
-
-        public final FileTime lastModifiedTime() {
-            return fileAttrs.lastModifiedTime();
-        }
-
-        public final String getNameString() {
-            return name;
-        }
-
         @Override
         public final String toString() {
-            return getNameString();
+            return getName();
         }
 
+        /** See <a href="#node_equality">Node Equality</a>. */
         @Override
         public final int hashCode() {
             return name.hashCode();
         }
 
+        /** See <a href="#node_equality">Node Equality</a>. */
         @Override
         public final boolean equals(Object other) {
             if (this == other) {
@@ -729,21 +664,35 @@ public final class ImageReader implements AutoCloseable {
         }
     }
 
-    // directory node - directory has full path name without '/' at end.
-    static final class Directory extends Node {
-        private final List<Node> children;
+    /// Directory node (referenced from a full path, without a trailing '/').
+    ///
+    /// Directory nodes have two distinct states:
+    /// * Incomplete: The child list has not been set.
+    /// * Complete: The child list has been set.
+    ///
+    /// When a directory node is returned by `findNode()` it is always complete,
+    /// but this DOES NOT mean that its child nodes are complete yet.
+    ///
+    /// To avoid users being able to access incomplete child nodes, the
+    /// `Node` API offers only a way to obtain child node names, forcing
+    /// callers to invoke {@link ImageReader#findNode(String)} if they need to
+    /// access the child node itself.
+    ///
+    /// This approach allows directories to be implemented lazily with respect
+    /// to child nodes, while retaining efficiency when child nodes are accessed
+    /// (since any incomplete nodes will be created and placed in the node cache
+    /// when the parent was first returned to the user).
+    private static final class Directory extends Node {
+        // Monotonic reference, will be set to the unmodifiable child list exactly once.
+        private List<Node> children = null;
 
         private Directory(String name, BasicFileAttributes fileAttrs) {
             super(name, fileAttrs);
-            children = new ArrayList<>();
         }
 
-        static Directory create(Directory parent, String name, BasicFileAttributes fileAttrs) {
-            Directory d = new Directory(name, fileAttrs);
-            if (parent != null) {
-                parent.addChild(d);
-            }
-            return d;
+        @Override
+        boolean isCompleted() {
+            return children != null;
         }
 
         @Override
@@ -752,56 +701,45 @@ public final class ImageReader implements AutoCloseable {
         }
 
         @Override
-        public List<Node> getChildren() {
-            return Collections.unmodifiableList(children);
-        }
-
-        void addChild(Node node) {
-            assert !children.contains(node) : "Child " + node + " already added";
-            children.add(node);
-        }
-
-        public void walk(Consumer<? super Node> consumer) {
-            consumer.accept(this);
-            for (Node child : children) {
-                if (child.isDirectory()) {
-                    ((Directory)child).walk(consumer);
-                } else {
-                    consumer.accept(child);
-                }
+        public Stream<String> getChildNames() {
+            if (children != null) {
+                return children.stream().map(Node::getName);
             }
+            throw new IllegalStateException("Cannot get child nodes of an incomplete directory: " + getName());
+        }
+
+        private void setChildren(List<Node> children) {
+            assert this.children == null : this + ": Cannot set child nodes twice!";
+            this.children = Collections.unmodifiableList(children);
         }
     }
 
-    // "resource" is .class or any other resource (compressed/uncompressed) in a jimage.
-    // full path of the resource is the "name" of the resource.
-    static class Resource extends Node {
+    /// Resource node (e.g. a ".class" entry, or any other data resource).
+    ///
+    /// Resources are leaf nodes referencing an underlying image location. They
+    /// are lightweight, and do not cache their contents.
+    ///
+    /// Unlike directories (where the node name matches the jimage path for the
+    /// corresponding `ImageLocation`), resource node names are NOT the same as
+    /// the corresponding jimage path. The difference is that node names for
+    /// resources are prefixed with "/modules", which is missing from the
+    /// equivalent jimage path.
+    private static class Resource extends Node {
         private final ImageLocation loc;
 
-        private Resource(ImageLocation loc, BasicFileAttributes fileAttrs) {
-            super(loc.getFullName(true), fileAttrs);
+        private Resource(String name, ImageLocation loc, BasicFileAttributes fileAttrs) {
+            super(name, fileAttrs);
             this.loc = loc;
         }
 
-        static Resource create(Directory parent, ImageLocation loc, BasicFileAttributes fileAttrs) {
-            Resource rs = new Resource(loc, fileAttrs);
-            parent.addChild(rs);
-            return rs;
-        }
-
         @Override
-        public boolean isCompleted() {
-            return true;
+        ImageLocation getLocation() {
+            return loc;
         }
 
         @Override
         public boolean isResource() {
             return true;
-        }
-
-        @Override
-        public ImageLocation getLocation() {
-            return loc;
         }
 
         @Override
@@ -818,36 +756,25 @@ public final class ImageReader implements AutoCloseable {
         public String extension() {
             return loc.getExtension();
         }
-
-        @Override
-        public long contentOffset() {
-            return loc.getContentOffset();
-        }
     }
 
-    // represents a soft link to another Node
-    static class LinkNode extends Node {
-        private final Node link;
+    /// Link node (a symbolic link to a top-level modules directory).
+    ///
+    /// Link nodes resolve their target by invoking a given supplier, and do not
+    /// cache the result. Since nodes are cached by the `ImageReader`, this
+    /// means that only the first call to `resolveLink()` could do any
+    /// significant work.
+    private static class LinkNode extends Node {
+        private final Supplier<Node> link;
 
-        private LinkNode(String name, Node link) {
-            super(name, link.getFileAttributes());
+        private LinkNode(String name, Supplier<Node> link, BasicFileAttributes fileAttrs) {
+            super(name, fileAttrs);
             this.link = link;
-        }
-
-        static LinkNode create(Directory parent, String name, Node link) {
-            LinkNode ln = new LinkNode(name, link);
-            parent.addChild(ln);
-            return ln;
-        }
-
-        @Override
-        public boolean isCompleted() {
-            return true;
         }
 
         @Override
         public Node resolveLink(boolean recursive) {
-            return (recursive && link instanceof LinkNode) ? ((LinkNode)link).resolveLink(true) : link;
+            return link.get();
         }
 
         @Override

--- a/src/java.base/share/classes/jdk/internal/jrtfs/ExplodedImage.java
+++ b/src/java.base/share/classes/jdk/internal/jrtfs/ExplodedImage.java
@@ -119,9 +119,9 @@ class ExplodedImage extends SystemImage {
         }
 
         @Override
-        public List<Node> getChildren() {
+        public Stream<String> getChildNames() {
             if (!isDirectory())
-                throw new IllegalArgumentException("not a directory: " + getNameString());
+                throw new IllegalArgumentException("not a directory: " + getName());
             if (children == null) {
                 List<Node> list = new ArrayList<>();
                 try (DirectoryStream<Path> stream = Files.newDirectoryStream(path)) {
@@ -138,7 +138,7 @@ class ExplodedImage extends SystemImage {
                 }
                 children = list;
             }
-            return children;
+            return children.stream().map(Node::getName);
         }
 
         @Override

--- a/src/java.base/share/classes/jdk/internal/jrtfs/JrtFileAttributes.java
+++ b/src/java.base/share/classes/jdk/internal/jrtfs/JrtFileAttributes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,7 +49,7 @@ final class JrtFileAttributes  implements BasicFileAttributes {
     //-------- basic attributes --------
     @Override
     public FileTime creationTime() {
-        return node.creationTime();
+        return node.getFileAttributes().creationTime();
     }
 
     @Override
@@ -69,12 +69,12 @@ final class JrtFileAttributes  implements BasicFileAttributes {
 
     @Override
     public FileTime lastAccessTime() {
-        return node.lastAccessTime();
+        return node.getFileAttributes().lastAccessTime();
     }
 
     @Override
     public FileTime lastModifiedTime() {
-        return node.lastModifiedTime();
+        return node.getFileAttributes().lastModifiedTime();
     }
 
     @Override

--- a/src/java.base/share/classes/jdk/internal/jrtfs/JrtFileSystem.java
+++ b/src/java.base/share/classes/jdk/internal/jrtfs/JrtFileSystem.java
@@ -54,7 +54,6 @@ import java.nio.file.attribute.FileAttribute;
 import java.nio.file.attribute.FileTime;
 import java.nio.file.attribute.UserPrincipalLookupService;
 import java.nio.file.spi.FileSystemProvider;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -64,7 +63,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.regex.Pattern;
 import jdk.internal.jimage.ImageReader.Node;
-import static java.util.stream.Collectors.toList;
 
 /**
  * jrt file system implementation built on System jimage files.
@@ -225,19 +223,19 @@ class JrtFileSystem extends FileSystem {
             throw new NotDirectoryException(path.getName());
         }
         if (filter == null) {
-            return node.getChildren()
-                       .stream()
-                       .map(child -> (Path)(path.resolve(new JrtPath(this, child.getNameString()).getFileName())))
-                       .iterator();
+            return node.getChildNames()
+                    .map(child -> (Path) (path.resolve(new JrtPath(this, child).getFileName())))
+                    .iterator();
         }
-        return node.getChildren()
-                   .stream()
-                   .map(child -> (Path)(path.resolve(new JrtPath(this, child.getNameString()).getFileName())))
-                   .filter(p ->  { try { return filter.accept(p);
-                                   } catch (IOException x) {}
-                                   return false;
-                                  })
-                   .iterator();
+        return node.getChildNames()
+                .map(child -> (Path) (path.resolve(new JrtPath(this, child).getFileName())))
+                .filter(p -> {
+                    try {
+                        return filter.accept(p);
+                    } catch (IOException x) {}
+                    return false;
+                })
+                .iterator();
     }
 
     // returns the content of the file resource specified by the path

--- a/src/java.base/share/classes/jdk/internal/jrtfs/SystemImage.java
+++ b/src/java.base/share/classes/jdk/internal/jrtfs/SystemImage.java
@@ -58,7 +58,6 @@ abstract class SystemImage {
         if (modulesImageExists) {
             // open a .jimage and build directory structure
             final ImageReader image = ImageReader.open(moduleImageFile);
-            image.getRootDirectory();
             return new SystemImage() {
                 @Override
                 Node findNode(String path) throws IOException {

--- a/src/java.base/share/classes/jdk/internal/module/SystemModuleFinders.java
+++ b/src/java.base/share/classes/jdk/internal/module/SystemModuleFinders.java
@@ -256,13 +256,18 @@ public final class SystemModuleFinders {
         // System reader is a singleton and should not be closed by callers.
         ImageReader reader = SystemImage.reader();
         try {
-            return reader.findNode("/modules").getChildNames().map(mn -> readModuleAttributes(reader, mn));
+            return reader.findNode("/modules")
+                    .getChildNames()
+                    .map(mn -> readModuleAttributes(reader, mn));
         } catch (IOException e) {
             throw new Error("Error reading root /modules entry", e);
         }
     }
 
-    // Every module is required to have a valid module-info.class.
+    /**
+     * Returns the module's "module-info", returning a holder for its class file
+     * attributes. Every module is required to have a valid {@code module-info.class}.
+     */
     private static ModuleInfo.Attributes readModuleAttributes(ImageReader reader, String moduleName) {
         Exception err = null;
         try {
@@ -454,20 +459,21 @@ public final class SystemModuleFinders {
          * Returns the node for the given resource if found. If the name references
          * a non-resource node, then {@code null} is returned.
          */
-        private ImageReader.Node findResourceNode(ImageReader reader, String name) throws IOException {
+        private ImageReader.Node findResource(ImageReader reader, String name) throws IOException {
             Objects.requireNonNull(name);
             if (closed) {
                 throw new IOException("ModuleReader is closed");
             }
             String nodeName = "/modules/" + module + "/" + name;
             ImageReader.Node node = reader.findNode(nodeName);
-            return node != null && node.isResource() ? node : null;
+            return (node != null && node.isResource()) ? node : null;
         }
 
         @Override
         public Optional<ByteBuffer> read(String name) throws IOException {
             ImageReader reader = SystemImage.reader();
-            return Optional.ofNullable(findResourceNode(reader, name)).map(reader::getResourceBuffer);
+            return Optional.ofNullable(findResource(reader, name))
+                    .map(reader::getResourceBuffer);
         }
 
         @Override

--- a/src/java.base/share/classes/jdk/internal/module/SystemModuleFinders.java
+++ b/src/java.base/share/classes/jdk/internal/module/SystemModuleFinders.java
@@ -253,7 +253,7 @@ public final class SystemModuleFinders {
      * returned attributes are in no specific order.
      */
     private static Stream<ModuleInfo.Attributes> allModuleAttributes() {
-        // This reader is a singleton, so do not attempt to close it here.
+        // System-wide image reader.
         ImageReader reader = SystemImage.reader();
         try {
             return reader.findNode("/modules")

--- a/src/java.base/share/classes/jdk/internal/module/SystemModuleFinders.java
+++ b/src/java.base/share/classes/jdk/internal/module/SystemModuleFinders.java
@@ -253,7 +253,7 @@ public final class SystemModuleFinders {
      * returned attributes are in no specific order.
      */
     private static Stream<ModuleInfo.Attributes> allModuleAttributes() {
-        // System reader is a singleton and should not be closed by callers.
+        // This reader is a singleton, so do not attempt to close it here.
         ImageReader reader = SystemImage.reader();
         try {
             return reader.findNode("/modules")

--- a/src/java.base/share/classes/jdk/internal/module/SystemModuleFinders.java
+++ b/src/java.base/share/classes/jdk/internal/module/SystemModuleFinders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,6 @@ import java.lang.module.ModuleReader;
 import java.lang.module.ModuleReference;
 import java.lang.reflect.Constructor;
 import java.net.URI;
-import java.net.URLConnection;
 import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -54,7 +53,6 @@ import java.util.function.Supplier;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
-import jdk.internal.jimage.ImageLocation;
 import jdk.internal.jimage.ImageReader;
 import jdk.internal.jimage.ImageReaderFactory;
 import jdk.internal.access.JavaNetUriAccess;
@@ -210,7 +208,7 @@ public final class SystemModuleFinders {
     }
 
     /**
-     * Parses the module-info.class of all module in the runtime image and
+     * Parses the {@code module-info.class} of all modules in the runtime image and
      * returns a ModuleFinder to find the modules.
      *
      * @apiNote The returned ModuleFinder is thread safe.
@@ -219,20 +217,16 @@ public final class SystemModuleFinders {
         // parse the module-info.class in every module
         Map<String, ModuleInfo.Attributes> nameToAttributes = new HashMap<>();
         Map<String, byte[]> nameToHash = new HashMap<>();
-        ImageReader reader = SystemImage.reader();
-        for (String mn : reader.getModuleNames()) {
-            ImageLocation loc = reader.findLocation(mn, "module-info.class");
-            ModuleInfo.Attributes attrs
-                = ModuleInfo.read(reader.getResourceBuffer(loc), null);
 
-            nameToAttributes.put(mn, attrs);
+        allModuleAttributes().forEach(attrs -> {
+            nameToAttributes.put(attrs.descriptor().name(), attrs);
             ModuleHashes hashes = attrs.recordedHashes();
             if (hashes != null) {
                 for (String name : hashes.names()) {
                     nameToHash.computeIfAbsent(name, k -> hashes.hashFor(name));
                 }
             }
-        }
+        });
 
         // create a ModuleReference for each module
         Set<ModuleReference> mrefs = new HashSet<>();
@@ -251,6 +245,35 @@ public final class SystemModuleFinders {
         }
 
         return new SystemModuleFinder(mrefs, nameToModule);
+    }
+
+    /**
+     * Parses the {@code module-info.class} of all modules in the runtime image and
+     * returns a stream of {@link ModuleInfo.Attributes Attributes} for them. The
+     * returned attributes are in no specific order.
+     */
+    private static Stream<ModuleInfo.Attributes> allModuleAttributes() {
+        // System reader is a singleton and should not be closed by callers.
+        ImageReader reader = SystemImage.reader();
+        try {
+            return reader.findNode("/modules").getChildNames().map(mn -> readModuleAttributes(reader, mn));
+        } catch (IOException e) {
+            throw new Error("Error reading root /modules entry", e);
+        }
+    }
+
+    // Every module is required to have a valid module-info.class.
+    private static ModuleInfo.Attributes readModuleAttributes(ImageReader reader, String moduleName) {
+        Exception err = null;
+        try {
+            ImageReader.Node node = reader.findNode(moduleName + "/module-info.class");
+            if (node != null && node.isResource()) {
+                return ModuleInfo.read(reader.getResourceBuffer(node), null);
+            }
+        } catch (IOException | UncheckedIOException e) {
+            err = e;
+        }
+        throw new Error("Missing or invalid module-info.class for module: " + moduleName, err);
     }
 
     /**
@@ -383,33 +406,17 @@ public final class SystemModuleFinders {
         }
 
         /**
-         * Returns the ImageLocation for the given resource, {@code null}
-         * if not found.
-         */
-        private ImageLocation findImageLocation(String name) throws IOException {
-            Objects.requireNonNull(name);
-            if (closed)
-                throw new IOException("ModuleReader is closed");
-            ImageReader imageReader = SystemImage.reader();
-            if (imageReader != null) {
-                return imageReader.findLocation(module, name);
-            } else {
-                // not an images build
-                return null;
-            }
-        }
-
-        /**
          * Returns {@code true} if the given resource exists, {@code false}
          * if not found.
          */
-        private boolean containsImageLocation(String name) throws IOException {
-            Objects.requireNonNull(name);
+        private boolean containsResource(String resourcePath) throws IOException {
+            Objects.requireNonNull(resourcePath);
             if (closed)
                 throw new IOException("ModuleReader is closed");
             ImageReader imageReader = SystemImage.reader();
             if (imageReader != null) {
-                return imageReader.verifyLocation(module, name);
+                ImageReader.Node node = imageReader.findNode("/modules" + resourcePath);
+                return node != null && node.isResource();
             } else {
                 // not an images build
                 return false;
@@ -418,8 +425,9 @@ public final class SystemModuleFinders {
 
         @Override
         public Optional<URI> find(String name) throws IOException {
-            if (containsImageLocation(name)) {
-                URI u = JNUA.create("jrt", "/" + module + "/" + name);
+            String resourcePath = "/" + module + "/" + name;
+            if (containsResource(resourcePath)) {
+                URI u = JNUA.create("jrt", resourcePath);
                 return Optional.of(u);
             } else {
                 return Optional.empty();
@@ -442,14 +450,24 @@ public final class SystemModuleFinders {
             }
         }
 
+        /**
+         * Returns the node for the given resource if found. If the name references
+         * a non-resource node, then {@code null} is returned.
+         */
+        private ImageReader.Node findResourceNode(ImageReader reader, String name) throws IOException {
+            Objects.requireNonNull(name);
+            if (closed) {
+                throw new IOException("ModuleReader is closed");
+            }
+            String nodeName = "/modules/" + module + "/" + name;
+            ImageReader.Node node = reader.findNode(nodeName);
+            return node != null && node.isResource() ? node : null;
+        }
+
         @Override
         public Optional<ByteBuffer> read(String name) throws IOException {
-            ImageLocation location = findImageLocation(name);
-            if (location != null) {
-                return Optional.of(SystemImage.reader().getResourceBuffer(location));
-            } else {
-                return Optional.empty();
-            }
+            ImageReader reader = SystemImage.reader();
+            return Optional.ofNullable(findResourceNode(reader, name)).map(reader::getResourceBuffer);
         }
 
         @Override
@@ -481,7 +499,7 @@ public final class SystemModuleFinders {
     private static class ModuleContentSpliterator implements Spliterator<String> {
         final String moduleRoot;
         final Deque<ImageReader.Node> stack;
-        Iterator<ImageReader.Node> iterator;
+        Iterator<String> iterator;
 
         ModuleContentSpliterator(String module) throws IOException {
             moduleRoot = "/modules/" + module;
@@ -502,13 +520,10 @@ public final class SystemModuleFinders {
         private String next() throws IOException {
             for (;;) {
                 while (iterator.hasNext()) {
-                    ImageReader.Node node = iterator.next();
-                    String name = node.getName();
+                    String name = iterator.next();
+                    ImageReader.Node node = SystemImage.reader().findNode(name);
                     if (node.isDirectory()) {
-                        // build node
-                        ImageReader.Node dir = SystemImage.reader().findNode(name);
-                        assert dir.isDirectory();
-                        stack.push(dir);
+                        stack.push(node);
                     } else {
                         // strip /modules/$MODULE/ prefix
                         return name.substring(moduleRoot.length() + 1);
@@ -520,7 +535,7 @@ public final class SystemModuleFinders {
                 } else {
                     ImageReader.Node dir = stack.poll();
                     assert dir.isDirectory();
-                    iterator = dir.getChildren().iterator();
+                    iterator = dir.getChildNames().iterator();
                 }
             }
         }

--- a/test/jdk/jdk/internal/jimage/ImageReaderTest.java
+++ b/test/jdk/jdk/internal/jimage/ImageReaderTest.java
@@ -1,0 +1,279 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import jdk.internal.jimage.ImageReader;
+import jdk.internal.jimage.ImageReader.Node;
+import jdk.test.lib.compiler.InMemoryJavaCompiler;
+import jdk.test.lib.util.JarBuilder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.opentest4j.TestSkippedException;
+import tests.Helper;
+import tests.JImageGenerator;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+
+/*
+ * @test
+ * @summary Tests for ImageReader.
+ * @modules java.base/jdk.internal.jimage
+ *          jdk.jlink/jdk.tools.jimage
+ * @library /test/jdk/tools/lib
+ *          /test/lib
+ * @build tests.*
+ * @run junit/othervm ImageReaderTest
+ */
+
+/// Using PER_CLASS lifecycle means the (expensive) image file is only build once.
+/// There is no mutable test instance state to worry about.
+@TestInstance(PER_CLASS)
+public class ImageReaderTest {
+
+    private static final Map<String, List<String>> IMAGE_ENTRIES = Map.of(
+            "modfoo", Arrays.asList(
+                    "com.foo.Alpha",
+                    "com.foo.Beta",
+                    "com.foo.bar.Gamma"),
+            "modbar", Arrays.asList(
+                    "com.bar.One",
+                    "com.bar.Two"));
+    private final Path image = buildJImage(IMAGE_ENTRIES);
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "/",
+            "/modules",
+            "/modules/modfoo",
+            "/modules/modbar",
+            "/modules/modfoo/com",
+            "/modules/modfoo/com/foo",
+            "/modules/modfoo/com/foo/bar"})
+    public void testModuleDirectories_expected(String name) throws IOException {
+        try (ImageReader reader = ImageReader.open(image)) {
+            assertDir(reader, name);
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "",
+            "//",
+            "/modules/",
+            "/modules/unknown",
+            "/modules/modbar/",
+            "/modules/modfoo//com",
+            "/modules/modfoo/com/"})
+    public void testModuleNodes_absent(String name) throws IOException {
+        try (ImageReader reader = ImageReader.open(image)) {
+            assertAbsent(reader, name);
+        }
+    }
+
+    @Test
+    public void testModuleResources() throws IOException {
+        try (ImageReader reader = ImageReader.open(image)) {
+            assertNode(reader, "/modules/modfoo/com/foo/Alpha.class");
+            assertNode(reader, "/modules/modbar/com/bar/One.class");
+
+            ImageClassLoader loader = new ImageClassLoader(reader, IMAGE_ENTRIES.keySet());
+            assertEquals("Class: com.foo.Alpha", loader.loadAndGetToString("modfoo", "com.foo.Alpha"));
+            assertEquals("Class: com.foo.Beta", loader.loadAndGetToString("modfoo", "com.foo.Beta"));
+            assertEquals("Class: com.foo.bar.Gamma", loader.loadAndGetToString("modfoo", "com.foo.bar.Gamma"));
+            assertEquals("Class: com.bar.One", loader.loadAndGetToString("modbar", "com.bar.One"));
+        }
+    }
+
+    @Test
+    public void testPackageDirectories() throws IOException {
+        try (ImageReader reader = ImageReader.open(image)) {
+            Node root = assertDir(reader, "/packages");
+            Set<String> pkgNames = root.getChildNames().collect(Collectors.toSet());
+            assertTrue(pkgNames.contains("/packages/com"));
+            assertTrue(pkgNames.contains("/packages/com.foo"));
+            assertTrue(pkgNames.contains("/packages/com.bar"));
+
+            // Even though no classes exist directly in the "com" package, it still
+            // creates a directory with links back to all the modules which contain it.
+            Set<String> comLinks = assertDir(reader, "/packages/com").getChildNames().collect(Collectors.toSet());
+            assertTrue(comLinks.contains("/packages/com/modfoo"));
+            assertTrue(comLinks.contains("/packages/com/modbar"));
+        }
+    }
+
+    @Test
+    public void testPackageLinks() throws IOException {
+        try (ImageReader reader = ImageReader.open(image)) {
+            Node moduleFoo = assertDir(reader, "/modules/modfoo");
+            Node moduleBar = assertDir(reader, "/modules/modbar");
+            assertSame(assertLink(reader, "/packages/com.foo/modfoo").resolveLink(), moduleFoo);
+            assertSame(assertLink(reader, "/packages/com.bar/modbar").resolveLink(), moduleBar);
+        }
+    }
+
+    private static ImageReader.Node assertNode(ImageReader reader, String name) throws IOException {
+        ImageReader.Node node = reader.findNode(name);
+        assertNotNull(node, "Could not find node: " + name);
+        return node;
+    }
+
+    private static ImageReader.Node assertDir(ImageReader reader, String name) throws IOException {
+        ImageReader.Node dir = assertNode(reader, name);
+        assertTrue(dir.isDirectory(), "Node was not a directory: " + name);
+        return dir;
+    }
+
+    private static ImageReader.Node assertLink(ImageReader reader, String name) throws IOException {
+        ImageReader.Node link = assertNode(reader, name);
+        assertTrue(link.isLink(), "Node was not a symbolic link: " + name);
+        return link;
+    }
+
+    private static void assertAbsent(ImageReader reader, String name) throws IOException {
+        assertNull(reader.findNode(name), "Should not be able to find node: " + name);
+    }
+
+    /// Builds a jimage file with the specified class entries. The classes in the built
+    /// image can be loaded and executed to return their names via `toString()` to confirm
+    /// the correct bytes were returned.
+    public static Path buildJImage(Map<String, List<String>> entries) {
+        Helper helper = getHelper();
+        Path outDir = helper.createNewImageDir("test");
+        JImageGenerator.JLinkTask jlink = JImageGenerator.getJLinkTask()
+                .modulePath(helper.defaultModulePath())
+                .output(outDir);
+
+        Path jarDir = helper.getJarDir();
+        entries.forEach((module, classes) -> {
+            JarBuilder jar = new JarBuilder(jarDir.resolve(module + ".jar").toString());
+            String moduleInfo = "module " + module + " {}";
+            jar.addEntry("module-info.class", InMemoryJavaCompiler.compile("module-info", moduleInfo));
+
+            classes.forEach(fqn -> {
+                int lastDot = fqn.lastIndexOf('.');
+                String pkg = fqn.substring(0, lastDot);
+                String cls = fqn.substring(lastDot + 1);
+
+                String path = fqn.replace('.', '/') + ".class";
+                String source = String.format(
+                        """
+                        package %s;
+                        public class %s {
+                            public String toString() {
+                                return "Class: %s";
+                            }
+                        }
+                        """, pkg, cls, fqn);
+                jar.addEntry(path, InMemoryJavaCompiler.compile(fqn, source));
+            });
+            try {
+                jar.build();
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+            jlink.addMods(module);
+        });
+        return jlink.call().assertSuccess().resolve("lib", "modules");
+    }
+
+    ///  Returns the helper for building JAR and jimage files.
+    private static Helper getHelper() {
+        try {
+            Helper helper = Helper.newHelper();
+            if (helper == null) {
+                throw new TestSkippedException("Cannot create test helper (exploded image?)");
+            }
+            return helper;
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /// Loads and performs actions on classes stored in a given `ImageReader`.
+    private static class ImageClassLoader extends ClassLoader {
+        private final ImageReader reader;
+        private final Set<String> testModules;
+
+        private ImageClassLoader(ImageReader reader, Set<String> testModules) {
+            this.reader = reader;
+            this.testModules = testModules;
+        }
+
+        @FunctionalInterface
+        public interface ClassAction<R, T extends Exception> {
+            R call(Class<?> cls) throws T;
+        }
+
+        String loadAndGetToString(String module, String fqn) {
+            return loadAndCall(module, fqn, c -> c.getDeclaredConstructor().newInstance().toString());
+        }
+
+        <R> R loadAndCall(String module, String fqn, ClassAction<R, ?> action) {
+            Class<?> cls = findClass(module, fqn);
+            assertNotNull(cls, "Could not load class: " + module + "/" + fqn);
+            try {
+                return action.call(cls);
+            } catch (Exception e) {
+                fail("Class loading failed", e);
+                return null;
+            }
+        }
+
+        @Override
+        protected Class<?> findClass(String module, String fqn) {
+            assumeTrue(testModules.contains(module), "Can only load classes in modules: " + testModules);
+            String name = "/modules/" + module + "/" + fqn.replace('.', '/') + ".class";
+            Class<?> cls = findLoadedClass(fqn);
+            if (cls == null) {
+                try {
+                    ImageReader.Node node = reader.findNode(name);
+                    if (node != null && node.isResource()) {
+                        byte[] classBytes = reader.getResource(node);
+                        cls = defineClass(fqn, classBytes, 0, classBytes.length);
+                        resolveClass(cls);
+                        return cls;
+                    }
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+            return null;
+        }
+    }
+}

--- a/test/jdk/jdk/internal/jimage/JImageReadTest.java
+++ b/test/jdk/jdk/internal/jimage/JImageReadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -344,11 +344,9 @@ public class JImageReadTest {
             Assert.fail("Reader should be openable with native byte order.");
         }
 
+        // Reader should not be openable with the wrong byte order.
         ByteOrder otherOrder = ByteOrder.nativeOrder() == BIG_ENDIAN ? LITTLE_ENDIAN : BIG_ENDIAN;
-        try (ImageReader badReader = ImageReader.open(imageFile, otherOrder)) {
-            Assert.fail("Reader should not be openable with the wrong byte order.");
-        } catch (IOException expected) {
-        }
+        Assert.assertThrows(IOException.class, () -> ImageReader.open(imageFile, otherOrder));
     }
 
     // main method to run standalone from jtreg

--- a/test/jdk/tools/jimage/ImageReaderDuplicateChildNodesTest.java
+++ b/test/jdk/tools/jimage/ImageReaderDuplicateChildNodesTest.java
@@ -68,17 +68,17 @@ public class ImageReaderDuplicateChildNodesTest {
                         + " in " + imagePath);
             }
             // now verify that the parent node which is a directory, doesn't have duplicate children
-            final List<ImageReader.Node> children = parent.getChildren();
-            if (children == null || children.isEmpty()) {
+            final List<String> childNames = parent.getChildNames().toList();
+            if (childNames.isEmpty()) {
                 throw new RuntimeException("ImageReader did not return any child resources under "
                         + integersParentResource + " in " + imagePath);
             }
             final Set<ImageReader.Node> uniqueChildren = new HashSet<>();
-            for (final ImageReader.Node child : children) {
-                final boolean unique = uniqueChildren.add(child);
+            for (final String childName : childNames) {
+                final boolean unique = uniqueChildren.add(reader.findNode(childName));
                 if (!unique) {
                     throw new RuntimeException("ImageReader returned duplicate child resource "
-                            + child + " under " + parent + " from image " + imagePath);
+                            + childName + " under " + parent + " from image " + imagePath);
                 }
             }
         }

--- a/test/micro/org/openjdk/bench/jdk/internal/jrtfs/ImageReaderBenchmark.java
+++ b/test/micro/org/openjdk/bench/jdk/internal/jrtfs/ImageReaderBenchmark.java
@@ -195,9 +195,9 @@ public class ImageReaderBenchmark {
     static long countAllNodes(ImageReader reader, Node node) {
         long count = 1;
         if (node.isDirectory()) {
-            count += node.getChildren().stream().mapToLong(n -> {
+            count += node.getChildNames().mapToLong(n -> {
                 try {
-                    return countAllNodes(reader, reader.findNode(n.getName()));
+                    return countAllNodes(reader, reader.findNode(n));
                 } catch (IOException e) {
                     throw new RuntimeException(e);
                 }


### PR DESCRIPTION
Refactoring `ImageReader` to make it easy to add preview mode functionality for Valhalla.

This PR is a large change to `ImageReader` (effectively a rewrite) but reduces the surface area of the API significantly, reduces code complexity and increases performance/memory efficiency. The need for this sort of change comes from the need to support "preview mode" in Valhalla for classes loaded from core modules.

### Preview Mode

In the proposed preview mode support for Valhalla, a resource with the name `/modules/<module>/<path>` may come from one of two locations in the underlying jimage file; `/<module>/<path>` or `/<module>/META-INF/preview/<path>`. Furthermore, directories (represented as directory nodes via the API) will have a potentially different number of child nodes depending on whether preview mode is in effect, and some directories may only exist at all in preview mode.

Furthermore, the directories and symbolic link nodes in `/packages/...` will also be affected by the existence of new package directories. To retain consistency and avoid "surprises" later, all of this needs to be taken into account.

Below is a summary of the main changes for mainline JDK to better support preview mode later:

### 1: Improved encapsulation for preview mode

The current `ImageReader` code exposes the data from the jimage file in several ways; via the `Node` abstraction, but also with methods which return an `ImageLocation` instance directly. In preview mode it would not be acceptable to return the `ImageLocation`, since that would leak the existence of resources in the `META-INF/preview` namespace and lets users see resource nodes with names that don't match the underlying `ImageLocation` from which their contents come.

As such, the PR removes all methods which can leak `ImageLocation` or other "underlying" semantics about the jimage file. Luckily most of these are either used minimally and easily migrated to using nodes, or they were not being used at all. This PR also removes any methods which were already unused across the OpenJDK codebase (if I discover any issues with over-trimming of the API during full CI testing, it will be easy to address).

### 2. Simplification of directory child node handling

The current `ImageReader` code attempts to create parent directories "on demand" for any child nodes it creates. This results in parent directories having a non-empty but incomplete set of child nodes present. This is referred to as the directory being "incomplete" and requires users of the API to understand this and potentially "complete" these nodes by calling back into the `ImageReader` API.

This approach is an attempt to provide lazy node creation (which is a necessary trait since there are ~31,000 nodes in a typical jimage hierarchy) but isn't actually necessary since a child node has no "get parent" functionality and simply not creating parent nodes at the point is functionally equivalent.

The partially complete directory nodes also pose an issue for preview mode support, making it more complex to reason about where and when preview child nodes should be applied.

This PR simplifies directory node handling in two ways:
1. Directory nodes are either empty (incomplete) or have all child nodes present.
2. Directory nodes no longer have an API to return their (possibly incomplete) child nodes to users.

This results in simpler to reason about code for directory management and simpler changes later to support preview mode. Removing the on-demand parent directory creation and the partial child list management also has a noticeable performance improvement (based on the new `ImageReaderBenchmark` in pr/26044).

### 3. More comments and code assertions

Since `ImageReader` is a critical bit of internal tooling for OpenJDK, I made sure to add significant comments explaining the behaviour, as well as adding many new in-code assert statements. The version of `ImageReader` in this PR is 70 lines shorter than the current version, but if you account for new comments, it's really a reduction of almost 40% (640 -> 400 lines of code) and has over 200 more comment lines.

### 4. New tests

I added a new unit test for `ImageReader` since, until now, its API was not really being tested directly. These tests are useful now, but will really help when preview mode is added in Valhalla, since then there will need to be significant edge-case testing. I'm happy to improve or change tests in this PR, but they definitely cover the main cases.

### 5. Adding TODO comments for review discussion.

There are obviously some open questions about the exact design of the APIs, and some questions around behaviour. To make reviewing easier, I've added inline TODOs which are there to illicit feedback. I will account for an remove all of these before the PR is integrated, but I want reviewers to read and comment on them (even if there is no change expected).

### Performance Improvements

On my laptop (not objectively interesting, but good for comparison) I am seeing a significant performance improvement over all benchmarks and a reduction in timing variability. These benchmarks are awkward because of the need to test things in a "cold start" state, so timings will have larger variability than expected, but the performance improvements are consistent and non trivial:

Run with `make test TEST="micro:jdk.internal.jrtfs.ImageReaderBenchmark"` using the benchmark currently being added in `pr/26044`:

Current version:
```
Benchmark                                            Mode  Cnt   Score    Error  Units
ImageReaderBenchmark.warmCache_CountAllNodes         avgt    5   0.784 ±  0.023  ms/op
ImageReaderBenchmark.coldStart_CountOnly               ss    5  37.910 ± 28.554  ms/op
ImageReaderBenchmark.coldStart_InitAndCount            ss    5  37.471 ± 18.775  ms/op
ImageReaderBenchmark.coldStart_LoadJavacInitClasses    ss    5   4.279 ±  7.959  ms/op
```

This PR:
```
Benchmark                                            Mode  Cnt   Score   Error  Units
ImageReaderBenchmark.warmCache_CountAllNodes         avgt   10   0.880 ± 0.086  ms/op
ImageReaderBenchmark.coldStart_CountOnly               ss   10  14.303 ± 3.975  ms/op
ImageReaderBenchmark.coldStart_InitAndCount            ss   10  14.032 ± 3.068  ms/op
ImageReaderBenchmark.coldStart_LoadJavacInitClasses    ss   10   2.530 ± 0.348  ms/op
```

Shows a >2.5x speedup for traversing all nodes in a "cold start" state, and ~1.7x speedup for loading the core set of classes needed to start javac, as well as a very significant reduction in the variability of the timings (possibly due to a reduced chance of triggering GC due to reduced string manipulation/allocation).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8360037](https://bugs.openjdk.org/browse/JDK-8360037): Refactor ImageReader in preparation for Valhalla support (**Bug** - P3)


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**) Review applies to [332a1c84](https://git.openjdk.org/jdk/pull/26054/files/332a1c84c6f0f14a66aa1599129be94a07d57c09)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**) Review applies to [ca26e00b](https://git.openjdk.org/jdk/pull/26054/files/ca26e00b99edf99ca7275dc813c5ef40df88de38)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26054/head:pull/26054` \
`$ git checkout pull/26054`

Update a local copy of the PR: \
`$ git checkout pull/26054` \
`$ git pull https://git.openjdk.org/jdk.git pull/26054/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26054`

View PR using the GUI difftool: \
`$ git pr show -t 26054`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26054.diff">https://git.openjdk.org/jdk/pull/26054.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26054#issuecomment-3024246005)
</details>
