### PR TITLE
8361115: javax/swing/JComboBox/bug4276920.java unnecessarily throws Error instead of RuntimeException

### DIFF
--- a/test/jdk/javax/swing/JComboBox/bug4276920.java
+++ b/test/jdk/javax/swing/JComboBox/bug4276920.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,7 +44,7 @@ public class bug4276920 {
             SwingUtilities.invokeAndWait(combo::hidePopup);
             int after = combo.getRepaintCount();
             if (after > before) {
-                throw new Error("Failed 4276920: BasicComboPopup.hide() caused unnecessary repaint()");
+                throw new RuntimeException("Failed 4276920: BasicComboPopup.hide() caused unnecessary repaint()");
             }
          } finally {
             if (frame != null) {


### PR DESCRIPTION
Issue:
javax/swing/JComboBox/bug4276920.java unnecessarily throws Error instead of RuntimeException whenever a test failure occurs.
This causes unnecessary extra attention in CI systems and triggers task failures as throwing an Error will write the error message to System.err and the CI system will detect it as an 'Error' and fails the task eventually.
But this is just a normal test failure only and just need to throw 'RuntimeException' and no need to throw an 'Error'.

Fix:
Replace 'Error' with 'RuntimeException'

Testing:
Tested using mach5 in all the available platforms.
Tested manually the negative (failure) condition also and verified that its throwing 'RuntimeException' in cases of failure.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8361115](https://bugs.openjdk.org/browse/JDK-8361115): javax/swing/JComboBox/bug4276920.java unnecessarily throws Error instead of RuntimeException (**Bug** - P4)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26056/head:pull/26056` \
`$ git checkout pull/26056`

Update a local copy of the PR: \
`$ git checkout pull/26056` \
`$ git pull https://git.openjdk.org/jdk.git pull/26056/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26056`

View PR using the GUI difftool: \
`$ git pr show -t 26056`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26056.diff">https://git.openjdk.org/jdk/pull/26056.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26056#issuecomment-3021781195)
</details>
