### PR TITLE
8361037: [ubsan] compiler/c2/irTests/TestFloat16ScalarOperations division by 0

### DIFF
--- a/src/hotspot/share/opto/divnode.cpp
+++ b/src/hotspot/share/opto/divnode.cpp
@@ -826,14 +826,22 @@ const Type* DivHFNode::Value(PhaseGVN* phase) const {
   if (t1->base() == Type::HalfFloatCon &&
       t2->base() == Type::HalfFloatCon)  {
     // IEEE 754 floating point comparison treats 0.0 and -0.0 as equals.
+
+    // Division of a zero by a zero results in NaN.
     if (t1->getf() == 0.0f && t2->getf() == 0.0f) {
       return TypeH::make(NAN);
     }
 
+    // As per C++ standard section 7.6.5 (expr.mul), behavior is undefined only if
+    // the second operand is 0.0. In all other situations, we can expect a standard-compliant
+    // C++ compiler to generate code following IEEE 754 semantics.
     if (t2->getf() == 0.0) {
+      // If either operand is NaN, the result is NaN
       if (g_isnan(t1->getf())) {
         return TypeH::make(NAN);
       } else {
+        // Division of a nonzero finite value by a zero results in a signed infinity. Also,
+        // division of an infinity by a finite value results in a signed infinity.
         bool res_sign_neg = (jint_cast(t1->getf()) < 0) ^ (jint_cast(t2->getf()) < 0);
         const TypeF* res = res_sign_neg ? TypeF::NEG_INF : TypeF::POS_INF;
         return TypeH::make(res->getf());


### PR DESCRIPTION
Floating point division by zero is undefined per the C and C++ standards, but is defined by Clang (and by ISO/IEC/IEEE 60559 / IEEE 754) as producing either an infinity or NaN value.

While Java semantics defined in section 15.17.2 "Division Operator" of JLS-24 are well-defined for these constant-folding scenarios

This bug fix patch fixes division by 0 error reported after integration of [JDK-8352635.](https://bugs.openjdk.org/browse/JDK-8352635)
Kindly review and share your feedback.

Best Regards,
Jatin

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8361037](https://bugs.openjdk.org/browse/JDK-8361037): [ubsan] compiler/c2/irTests/TestFloat16ScalarOperations division by 0 (**Bug** - P4)


### Reviewers
 * [Manuel Hässig](https://openjdk.org/census#mhaessig) (@mhaessig - Committer)
 * [Sandhya Viswanathan](https://openjdk.org/census#sviswanathan) (@sviswa7 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26062/head:pull/26062` \
`$ git checkout pull/26062`

Update a local copy of the PR: \
`$ git checkout pull/26062` \
`$ git pull https://git.openjdk.org/jdk.git pull/26062/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26062`

View PR using the GUI difftool: \
`$ git pr show -t 26062`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26062.diff">https://git.openjdk.org/jdk/pull/26062.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26062#issuecomment-3023172421)
</details>
