### PR TITLE
8361180: Disable CompiledDirectCall verification with -VerifyInlineCaches

### DIFF
--- a/src/hotspot/share/code/compiledIC.hpp
+++ b/src/hotspot/share/code/compiledIC.hpp
@@ -192,13 +192,13 @@ private:
 
   static inline CompiledDirectCall* before(address return_addr) {
     CompiledDirectCall* st = new CompiledDirectCall(nativeCall_before(return_addr));
-    st->verify();
+    if (VerifyInlineCaches) st->verify();
     return st;
   }
 
   static inline CompiledDirectCall* at(address native_call) {
     CompiledDirectCall* st = new CompiledDirectCall(nativeCall_at(native_call));
-    st->verify();
+    if (VerifyInlineCaches) st->verify();
     return st;
   }
 


### PR DESCRIPTION
Missed the spot when doing [JDK-8360867](https://bugs.openjdk.org/browse/JDK-8360867). There is a path from GC that calls into IC verification when cleaning the caches. See nmethod::cleanup_inline_caches_impl. It does verification per callsite, and does the whole thing during parallel GC cleanup, which is STW at least in G1. This gets expensive for CTW scenarios. We should wrap that under the same flag introduced by [JDK-8360867](https://bugs.openjdk.org/browse/JDK-8360867).

Motivational improvements:

```
$ time CONF=linux-x86_64-server-fastdebug make test TEST=applications/ctw/modules/

# Current mainline
real	3m59.274s
user	68m9.663s
sys	5m19.026s

# This PR
real	3m49.118s
user	65m37.962s
sys	5m15.441s
```