### PR TITLE
8359337: XML/JAXP tests that make network connections should ensure that no proxy is selected

### DIFF
--- a/test/jaxp/javax/xml/jaxp/unittest/common/catalog/DOMTest.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/common/catalog/DOMTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,8 +22,12 @@
  */
 package common.catalog;
 
-/**
- * @test @bug 8306055
+import java.net.ProxySelector;
+
+/*
+ * @test
+ * @bug 8306055 8359337
+ * @summary verifies DOM's support of the JDK Catalog.
  * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
  * @modules java.xml/jdk.xml.internal
  * @run driver common.catalog.DOMTest 0 // verifies default setting catalog.resolve=allow
@@ -36,11 +40,18 @@ package common.catalog;
  * @run driver common.catalog.DOMTest 7 // verifies external DTD resolution with a custom Catalog while resolve=strict in API setting
  * @run driver common.catalog.DOMTest 8 // verifies external parameter are resolved with a custom Catalog though resolve=strict in API setting
  * @run driver common.catalog.DOMTest 9 // verifies XInclude are resolved with a custom Catalog though resolve=strict in API setting
- * @summary verifies DOM's support of the JDK Catalog.
  */
 public class DOMTest extends CatalogTestBase {
-    public static void main(String args[]) throws Exception {
-        new DOMTest().run(args[0]);
+    public static void main(String[] args) throws Exception {
+        final ProxySelector previous = ProxySelector.getDefault();
+        // disable proxy
+        ProxySelector.setDefault(ProxySelector.of(null));
+        try {
+            new DOMTest().run(args[0]);
+        } finally {
+            // reset to the previous proxy selector
+            ProxySelector.setDefault(previous);
+        }
     }
 
     public void run(String index) throws Exception {

--- a/test/jaxp/javax/xml/jaxp/unittest/common/catalog/SAXTest.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/common/catalog/SAXTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,8 +22,12 @@
  */
 package common.catalog;
 
-/**
- * @test @bug 8306055
+import java.net.ProxySelector;
+
+/*
+ * @test
+ * @bug 8306055 8359337
+ * @summary verifies DOM's support of the JDK Catalog.
  * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
  * @modules java.xml/jdk.xml.internal
  * @run driver common.catalog.SAXTest 0 // verifies default setting catalog.resolve=allow
@@ -36,12 +40,18 @@ package common.catalog;
  * @run driver common.catalog.SAXTest 7 // verifies external DTD resolution with a custom Catalog while resolve=strict in API setting
  * @run driver common.catalog.SAXTest 8 // verifies external parameter are resolved with a custom Catalog though resolve=strict in API setting
  * @run driver common.catalog.SAXTest 9 // verifies XInclude are resolved with a custom Catalog though resolve=strict in API setting
- * @summary verifies DOM's support of the JDK Catalog.
-
  */
 public class SAXTest extends CatalogTestBase {
-    public static void main(String args[]) throws Exception {
-        new SAXTest().run(args[0]);
+    public static void main(String[] args) throws Exception {
+        final ProxySelector previous = ProxySelector.getDefault();
+        // disable proxy
+        ProxySelector.setDefault(ProxySelector.of(null));
+        try {
+            new SAXTest().run(args[0]);
+        } finally {
+            // reset to the previous proxy selector
+            ProxySelector.setDefault(previous);
+        }
     }
 
     public void run(String index) throws Exception {

--- a/test/jaxp/javax/xml/jaxp/unittest/common/dtd/DOMTest.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/common/dtd/DOMTest.java
@@ -1,11 +1,33 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
- * ORACLE PROPRIETARY/CONFIDENTIAL. Use is subject to license terms.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
  */
 package common.dtd;
 
-/**
- * @test @bug 8306632
+import java.net.ProxySelector;
+
+/*
+ * @test
+ * @bug 8306632 8359337
+ * @summary verifies DOM's support of the property jdk.xml.dtd.support.
  * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
  * @modules java.xml/jdk.xml.internal
  * @run driver common.dtd.DOMTest 0 // verifies default setting dtd.support=allow
@@ -15,11 +37,18 @@ package common.dtd;
  * @run driver common.dtd.DOMTest 4 // verifies DTD=ignore
  * @run driver common.dtd.DOMTest 5 // verifies disallow-doctype-decl=false
  * @run driver common.dtd.DOMTest 6 // verifies disallow-doctype-decl=true
- * @summary verifies DOM's support of the property jdk.xml.dtd.support.
  */
 public class DOMTest extends DTDTestBase {
-    public static void main(String args[]) throws Exception {
-        new DOMTest().run(args[0]);
+    public static void main(String[] args) throws Exception {
+        final ProxySelector previous = ProxySelector.getDefault();
+        // disable proxy
+        ProxySelector.setDefault(ProxySelector.of(null));
+        try {
+            new DOMTest().run(args[0]);
+        } finally {
+            // reset to the previous proxy selector
+            ProxySelector.setDefault(previous);
+        }
     }
 
     public void run(String index) throws Exception {

--- a/test/jaxp/javax/xml/jaxp/unittest/common/dtd/SAXTest.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/common/dtd/SAXTest.java
@@ -1,13 +1,35 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
- * ORACLE PROPRIETARY/CONFIDENTIAL. Use is subject to license terms.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
  */
 package common.dtd;
 
+import java.net.ProxySelector;
+
 import common.util.TestBase;
 
-/**
- * @test @bug 8306632
+/*
+ * @test
+ * @bug 8306632 8359337
+ * @summary verifies SAX's support of the property jdk.xml.dtd.support.
  * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
  * @modules java.xml/jdk.xml.internal
  * @run driver common.dtd.SAXTest 0 // verifies default setting dtd.support=allow
@@ -17,11 +39,18 @@ import common.util.TestBase;
  * @run driver common.dtd.SAXTest 4 // verifies DTD=ignore
  * @run driver common.dtd.SAXTest 5 // verifies disallow-doctype-decl=false
  * @run driver common.dtd.SAXTest 6 // verifies disallow-doctype-decl=true
- * @summary verifies SAX's support of the property jdk.xml.dtd.support.
  */
 public class SAXTest extends DTDTestBase {
-    public static void main(String args[]) throws Exception {
-        new SAXTest().run(args[0]);
+    public static void main(String[] args) throws Exception {
+        final ProxySelector previous = ProxySelector.getDefault();
+        // disable proxy
+        ProxySelector.setDefault(ProxySelector.of(null));
+        try {
+            new SAXTest().run(args[0]);
+        } finally {
+            // reset to the previous proxy selector
+            ProxySelector.setDefault(previous);
+        }
     }
 
     public void run(String index) throws Exception {

--- a/test/jaxp/javax/xml/jaxp/unittest/dom/DOMFeatureTest.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/dom/DOMFeatureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,10 +25,13 @@ package dom;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.ProxySelector;
+
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import org.w3c.dom.Document;
@@ -40,10 +43,11 @@ import org.xml.sax.SAXException;
 
 /*
  * @test
- * @bug 8206132
- * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
- * @run testng dom.DOMFeatureTest
+ * @bug 8206132 8359337
  * @summary Tests DOM features.
+ * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
+ * @comment we use othervm because the test configures a system wide ProxySelector
+ * @run testng/othervm dom.DOMFeatureTest
  */
 public class DOMFeatureTest {
 
@@ -105,6 +109,13 @@ public class DOMFeatureTest {
             {true, XML3},
         };
     }
+
+    @BeforeClass
+    static void beforeClass() {
+        // disable proxy
+        ProxySelector.setDefault(ProxySelector.of(null));
+    }
+
     /**
      * Verifies the EntityExpansion feature.
      * @param caseNo the case number


### PR DESCRIPTION
Can I please get a review of this backport of a test-only fix? 

This backports the fix for https://bugs.openjdk.org/browse/JDK-8359337 into JDK 25. The original fix was integrated into mainline a few minutes back https://github.com/openjdk/jdk/pull/26052. Backporting this fix should help prevent failure of these tests on macOS hosts which have proxies configured.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8359337](https://bugs.openjdk.org/browse/JDK-8359337): XML/JAXP tests that make network connections should ensure that no proxy is selected (**Bug** - P4)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)
 * [Joe Wang](https://openjdk.org/census#joehw) (@JoeWang-Java - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26065/head:pull/26065` \
`$ git checkout pull/26065`

Update a local copy of the PR: \
`$ git checkout pull/26065` \
`$ git pull https://git.openjdk.org/jdk.git pull/26065/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26065`

View PR using the GUI difftool: \
`$ git pr show -t 26065`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26065.diff">https://git.openjdk.org/jdk/pull/26065.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26065#issuecomment-3023652902)
</details>
