### PR TITLE
8357979: Compile jdk.internal.vm.ci targeting the Boot JDK version

### DIFF
--- a/make/CompileJavaModules.gmk
+++ b/make/CompileJavaModules.gmk
@@ -115,6 +115,7 @@ $(eval $(call SetupJavaCompilation, $(MODULE), \
     EXCLUDE_FILES := $(EXCLUDE_FILES), \
     EXCLUDE_PATTERNS := -files, \
     KEEP_ALL_TRANSLATIONS := $(KEEP_ALL_TRANSLATIONS), \
+    TARGET_RELEASE := $(TARGET_RELEASE), \
     JAVAC_FLAGS := \
         $(DOCLINT) \
         $(JAVAC_FLAGS) \

--- a/make/autoconf/boot-jdk.m4
+++ b/make/autoconf/boot-jdk.m4
@@ -395,11 +395,9 @@ AC_DEFUN_ONCE([BOOTJDK_SETUP_BOOT_JDK],
 
   # When compiling code to be executed by the Boot JDK, force compatibility with the
   # oldest supported bootjdk.
-  OLDEST_BOOT_JDK=`$ECHO $DEFAULT_ACCEPTABLE_BOOT_VERSIONS \
+  OLDEST_BOOT_JDK_VERSION=`$ECHO $DEFAULT_ACCEPTABLE_BOOT_VERSIONS \
       | $TR " " "\n" | $SORT -n | $HEAD -n1`
-  # -Xlint:-options is added to avoid "warning: [options] system modules path not set in conjunction with -source"
-  BOOT_JDK_SOURCETARGET="-source $OLDEST_BOOT_JDK -target $OLDEST_BOOT_JDK -Xlint:-options"
-  AC_SUBST(BOOT_JDK_SOURCETARGET)
+  AC_SUBST(OLDEST_BOOT_JDK_VERSION)
 
   # Check if the boot jdk is 32 or 64 bit
   if $JAVA -version 2>&1 | $GREP -q "64-Bit"; then

--- a/make/autoconf/spec.gmk.template
+++ b/make/autoconf/spec.gmk.template
@@ -393,9 +393,8 @@ EXTERNAL_BUILDJDK := @EXTERNAL_BUILDJDK@
 # Whether the boot jdk jar supports --date=TIMESTAMP
 BOOT_JDK_JAR_SUPPORTS_DATE := @BOOT_JDK_JAR_SUPPORTS_DATE@
 
-# When compiling Java source to be run by the boot jdk
-# use these extra flags, eg -source 6 -target 6
-BOOT_JDK_SOURCETARGET := @BOOT_JDK_SOURCETARGET@
+# The oldest supported boot jdk version
+OLDEST_BOOT_JDK_VERSION := @OLDEST_BOOT_JDK_VERSION@
 
 # Information about the build system
 NUM_CORES := @NUM_CORES@

--- a/make/common/JavaCompilation.gmk
+++ b/make/common/JavaCompilation.gmk
@@ -38,7 +38,8 @@ include JarArchive.gmk
 ###
 
 # Create classes that can run on the bootjdk
-TARGET_RELEASE_BOOTJDK := $(BOOT_JDK_SOURCETARGET)
+# -Xlint:-options is added to avoid "warning: [options] system modules path not set in conjunction with -source"
+TARGET_RELEASE_BOOTJDK := -source $(OLDEST_BOOT_JDK_VERSION) -target $(OLDEST_BOOT_JDK_VERSION) -Xlint:-options
 
 # Create classes that can be used in (or be a part of) the new jdk we're building
 TARGET_RELEASE_NEWJDK := -source $(JDK_SOURCE_TARGET_VERSION) -target $(JDK_SOURCE_TARGET_VERSION)

--- a/make/modules/jdk.internal.vm.ci/Java.gmk
+++ b/make/modules/jdk.internal.vm.ci/Java.gmk
@@ -33,4 +33,6 @@ DISABLED_WARNINGS_java += dangling-doc-comments this-escape
 
 JAVAC_FLAGS += -parameters -XDstringConcat=inline
 
+TARGET_RELEASE := $(TARGET_RELEASE_BOOTJDK)
+
 ################################################################################


### PR DESCRIPTION
From the bug description:

There are plans to build libgraal in JDK master using a version of Native Image running on a JDK one version behind JDK master. This Native Image execution needs to be able to load the JVMCI classes as they are built into the libgraal image. As such, the JVMCI classes must have a class file major version of N-1 where N is the major class file version of JDK master. 

This PR is basically the same change as published by Doug in https://github.com/openjdk/jdk/pull/25494, but it contains some cleanup and adds and uses the `TARGET_RELEASE` argument that Doug correctly realized was needed.