### PR TITLE
8361198: [AIX] fix misleading error output in thread_cpu_time_unchecked

### DIFF
--- a/src/hotspot/os/aix/os_aix.cpp
+++ b/src/hotspot/os/aix/os_aix.cpp
@@ -2430,7 +2430,7 @@ static bool thread_cpu_time_unchecked(Thread* thread, jlong* p_sys_time, jlong* 
                           dummy, &dummy_size) == 0) {
     tid = pinfo.__pi_tid;
   } else {
-    tty->print_cr("pthread_getthrds_np failed.");
+    tty->print_cr("pthread_getthrds_np failed, errno: %d.", errno);
     error = true;
   }
 


### PR DESCRIPTION
Currently we have on AIX in thread_cpu_time_unchecked misleading error output in case of failing getthrds64 . This should be adjusted .

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8361198](https://bugs.openjdk.org/browse/JDK-8361198): [AIX] fix misleading error output in thread_cpu_time_unchecked (**Bug** - P4)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Arno Zeller](https://openjdk.org/census#azeller) (@ArnoZeller - Author)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26070/head:pull/26070` \
`$ git checkout pull/26070`

Update a local copy of the PR: \
`$ git checkout pull/26070` \
`$ git pull https://git.openjdk.org/jdk.git pull/26070/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26070`

View PR using the GUI difftool: \
`$ git pr show -t 26070`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26070.diff">https://git.openjdk.org/jdk/pull/26070.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26070#issuecomment-3024365263)
</details>
