### PR TITLE
8298300: Filtering AccessFlags by class file format version (i.e. ACC_SYNTHETIC)

### DIFF
--- a/src/hotspot/share/oops/constMethodFlags.hpp
+++ b/src/hotspot/share/oops/constMethodFlags.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -61,6 +61,7 @@ class ConstMethodFlags {
    flag(deprecated                , 1 << 19) \
    flag(deprecated_for_removal    , 1 << 20) \
    flag(jvmti_hide_events         , 1 << 21) \
+   flag(has_synthetic_attribute   , 1 << 22) /* has the synthetic attribute */ \
    /* end of list */
 
 #define CM_FLAGS_ENUM_NAME(name, value)    _misc_##name = value,

--- a/src/hotspot/share/oops/fieldInfo.hpp
+++ b/src/hotspot/share/oops/fieldInfo.hpp
@@ -76,6 +76,7 @@ class FieldInfo {
       _ff_generic,      // has a generic signature
       _ff_stable,       // trust as stable b/c declared as @Stable
       _ff_contended,    // is contended, may have contention-group
+      _ff_has_synthetic_attribute   // has a synthetic attribute
     };
 
     // Some but not all of the flag bits signal the presence of an
@@ -110,12 +111,14 @@ class FieldInfo {
     bool is_generic() const         { return test_flag(_ff_generic); }
     bool is_stable() const          { return test_flag(_ff_stable); }
     bool is_contended() const       { return test_flag(_ff_contended); }
+    bool has_synthetic_attribute()  { return test_flag(_ff_has_synthetic_attribute); }
 
     void update_initialized(bool z) { update_flag(_ff_initialized, z); }
     void update_injected(bool z)    { update_flag(_ff_injected, z); }
     void update_generic(bool z)     { update_flag(_ff_generic, z); }
     void update_stable(bool z)      { update_flag(_ff_stable, z); }
     void update_contended(bool z)   { update_flag(_ff_contended, z); }
+    void update_has_synthetic_attribute(bool z) { update_flag(_ff_has_synthetic_attribute, z); }
   };
 
  private:

--- a/src/hotspot/share/oops/method.hpp
+++ b/src/hotspot/share/oops/method.hpp
@@ -517,7 +517,7 @@ public:
   bool is_synchronized() const                   { return access_flags().is_synchronized();}
   bool is_native() const                         { return access_flags().is_native();      }
   bool is_abstract() const                       { return access_flags().is_abstract();    }
-  bool is_synthetic() const                      { return access_flags().is_synthetic();   }
+  bool is_synthetic() const                      { return access_flags().is_synthetic() || constMethod()->has_synthetic_attribute();   }
 
   // returns true if contains only return operation
   bool is_empty_method() const;

--- a/src/hotspot/share/runtime/fieldDescriptor.hpp
+++ b/src/hotspot/share/runtime/fieldDescriptor.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -88,7 +88,7 @@ class fieldDescriptor {
   bool is_volatile()              const    { return access_flags().is_volatile(); }
   bool is_transient()             const    { return access_flags().is_transient(); }
 
-  bool is_synthetic()             const    { return access_flags().is_synthetic(); }
+  bool is_synthetic()             const    { return access_flags().is_synthetic() || field_flags().has_synthetic_attribute();  }
 
   bool is_field_access_watched()  const    { return field_status().is_access_watched(); }
   bool is_field_modification_watched() const

--- a/test/hotspot/jtreg/runtime/ClassFile/ClassAccessFlagsRawTest.java
+++ b/test/hotspot/jtreg/runtime/ClassFile/ClassAccessFlagsRawTest.java
@@ -27,12 +27,14 @@
  * @bug 8291360
  * @summary Test getting a class's raw access flags using java.lang.Class API
  * @modules java.base/java.lang:open
+ * @library /test/lib
  * @compile classAccessFlagsRaw.jcod
  * @run main/othervm ClassAccessFlagsRawTest
  */
 
 import java.lang.reflect.*;
 import java.util.Set;
+import jdk.test.lib.Asserts;
 
 public class ClassAccessFlagsRawTest {
 
@@ -41,10 +43,9 @@ public class ClassAccessFlagsRawTest {
     public static void testIt(String className, int expectedResult) throws Exception {
         Class<?> testClass = Class.forName(className);
         int flags = (int)m.invoke(testClass);
-        if (flags != expectedResult) {
-            throw new RuntimeException(
-                "expected 0x" + Integer.toHexString(expectedResult) + ", got 0x" + Integer.toHexString(flags) + " for class " + className);
-        }
+        Asserts.assertTrue(flags == expectedResult,
+                           "expected 0x" + Integer.toHexString(expectedResult) +
+                           ", got 0x" + Integer.toHexString(flags) + " for class " + className);
     }
 
     public static void main(String argv[]) throws Throwable {
@@ -54,6 +55,7 @@ public class ClassAccessFlagsRawTest {
 
         testIt("SUPERset", 0x21);  // ACC_SUPER 0x20 + ACC_PUBLIC 0x1
         testIt("SUPERnotset", Modifier.PUBLIC);
+        testIt("SYNTHETICset", 0x0001); // ACC_SYNTHETIC 0x1000 + ACC_PUBLIC 0x1
 
         // Test that primitive should return ACC_ABSTRACT | ACC_FINAL | ACC_PUBLIC.
         int[] arr = new int[3];

--- a/test/hotspot/jtreg/runtime/ClassFile/classAccessFlagsRaw.jcod
+++ b/test/hotspot/jtreg/runtime/ClassFile/classAccessFlagsRaw.jcod
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -200,3 +200,92 @@ class SUPERnotset {
     } // end SourceFile
   } // Attributes
 } // end class SUPERnotset
+
+// Class with ACC_SYNTHETIC set for an old classfile version.
+class SYNTHETICset {
+  0xCAFEBABE;
+  0; // minor version
+  49; // version
+  [14] { // Constant Pool
+    ; // first element is empty
+    Method #2 #3; // #1     at 0x0A
+    class #4; // #2     at 0x0F
+    NameAndType #5 #6; // #3     at 0x12
+    Utf8 "java/lang/Object"; // #4     at 0x17
+    Utf8 "<init>"; // #5     at 0x2A
+    Utf8 "()V"; // #6     at 0x33
+    class #8; // #7     at 0x39
+    Utf8 "SYNTHETICset"; // #8     at 0x3C
+    Utf8 "Code"; // #9     at 0x48
+    Utf8 "LineNumberTable"; // #10     at 0x4F
+    Utf8 "hi"; // #11     at 0x61
+    Utf8 "SourceFile"; // #12     at 0x66
+    Utf8 "SYNTHETICset.java"; // #13     at 0x73
+  } // Constant Pool
+
+  0x1001; // access [ ACC_SYNTHETIC | ACC_PUBLIC ]
+  #7;// this_cpx
+  #2;// super_cpx
+
+  [0] { // Interfaces
+  } // Interfaces
+
+  [0] { // Fields
+  } // Fields
+
+  [2] { // Methods
+    {  // method at 0x90
+      0x0001; // access
+      #5; // name_index       : <init>
+      #6; // descriptor_index : ()V
+      [1] { // Attributes
+        Attr(#9, 29) { // Code at 0x98
+          1; // max_stack
+          1; // max_locals
+          Bytes[5]{
+            0x2AB70001B1;
+          }
+          [0] { // Traps
+          } // end Traps
+          [1] { // Attributes
+            Attr(#10, 6) { // LineNumberTable at 0xAF
+              [1] { // line_number_table
+                0  1; //  at 0xBB
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    }
+    ;
+    {  // method at 0xBB
+      0x0009; // access
+      #11; // name_index       : hi
+      #6; // descriptor_index : ()V
+      [1] { // Attributes
+        Attr(#9, 25) { // Code at 0xC3
+          0; // max_stack
+          0; // max_locals
+          Bytes[1]{
+            0xB1;
+          }
+          [0] { // Traps
+          } // end Traps
+          [1] { // Attributes
+            Attr(#10, 6) { // LineNumberTable at 0xD6
+              [1] { // line_number_table
+                0  2; //  at 0xE2
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    }
+  } // Methods
+
+  [1] { // Attributes
+    Attr(#12, 2) { // SourceFile at 0xE4
+      #13;
+    } // end SourceFile
+  } // Attributes
+} // end class SYNTHENTICset


### PR DESCRIPTION
This differentiates the synthetic attribute from the ACC_SYNTHETIC flags and resets the ACC_SYNTHETIC flag when returning access-flags to the JDK for classfile version < 49.  The JCK tests set ACC_SYNTHETIC access flags though so this makes JCK tests fail.

FAILED: vm/jvmti/IsFieldSynthetic/isfs001/isfs00101/isfs00101.html (test failed)
FAILED: vm/jvmti/IsFieldSynthetic/isfs001/isfs00101/isfs00101a.html (test failed)
FAILED: vm/jvmti/IsMethodSynthetic/isms001/isms00101/isms00101.html (test failed)
FAILED: vm/jvmti/IsMethodSynthetic/isms001/isms00101/isms00101a.html (test failed)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298300](https://bugs.openjdk.org/browse/JDK-8298300): Filtering AccessFlags by class file format version (i.e. ACC_SYNTHETIC) (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26071/head:pull/26071` \
`$ git checkout pull/26071`

Update a local copy of the PR: \
`$ git checkout pull/26071` \
`$ git pull https://git.openjdk.org/jdk.git pull/26071/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26071`

View PR using the GUI difftool: \
`$ git pr show -t 26071`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26071.diff">https://git.openjdk.org/jdk/pull/26071.diff</a>

</details>
