### PR TITLE
8357064: cds/appcds/ArchiveRelocationTest.java failed with missing expected output

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/ArchiveRelocationTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/ArchiveRelocationTest.java
@@ -67,6 +67,8 @@ public class ArchiveRelocationTest {
         String logArg = "-Xlog:cds=debug,cds+reloc=debug,aot+heap";
         String unlockArg = "-XX:+UnlockDiagnosticVMOptions";
         String nmtArg = "-XX:NativeMemoryTracking=detail";
+        String relocMsg1 = "ArchiveRelocationMode == 1: always map archive(s) at an alternative address";
+        String relocMsg2 = "Try to map archive(s) at an alternative address";
 
         OutputAnalyzer out = TestCommon.dump(appJar,
                                              TestCommon.list(mainClass),
@@ -76,8 +78,10 @@ public class ArchiveRelocationTest {
         TestCommon.run("-cp", appJar, unlockArg, runRelocArg, logArg,  mainClass)
             .assertNormalExit(output -> {
                     if (run_reloc) {
-                        output.shouldContain("ArchiveRelocationMode == 1: always map archive(s) at an alternative address")
-                              .shouldContain("Try to map archive(s) at an alternative address");
+                        if (!output.contains(relocMsg1) && !output.contains(relocMsg2)) {
+                            throw new RuntimeException("Relocation messages \"" + relocMsg1 +
+                                "\" and \"" + relocMsg2 + "\" are missing from the output");
+                        }
                     } else {
                         output.shouldContain("ArchiveRelocationMode: 0");
                     }


### PR DESCRIPTION
The `cds/appcds/ArchiveRelocationTest.java` test failed intermittently on Windows when the "Failed to reserve spaces" error occurred. A fix is to relax the check of the expected output; just to check either one of the expected output exists.

Testing: ran the "hotspot_runtime" test group 60 times on Windows with the `-XX:+UseParallelGC -XX:+UseNUMA` VM options.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8357064](https://bugs.openjdk.org/browse/JDK-8357064): cds/appcds/ArchiveRelocationTest.java failed with missing expected output (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26075/head:pull/26075` \
`$ git checkout pull/26075`

Update a local copy of the PR: \
`$ git checkout pull/26075` \
`$ git pull https://git.openjdk.org/jdk.git pull/26075/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26075`

View PR using the GUI difftool: \
`$ git pr show -t 26075`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26075.diff">https://git.openjdk.org/jdk/pull/26075.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26075#issuecomment-3024966383)
</details>
