### PR TITLE
8361213: J2DAnalyzer should emit the score as a decimal

### DIFF
--- a/src/demo/share/java2d/J2DBench/src/j2dbench/report/J2DAnalyzer.java
+++ b/src/demo/share/java2d/J2DBench/src/j2dbench/report/J2DAnalyzer.java
@@ -270,7 +270,7 @@ public class J2DAnalyzer {
             } else {
                 double overallscore = totalscore[i]/numtests[i];
                 System.out.println("    Number of tests:  "+numtests[i]);
-                System.out.println("    Overall average:  "+overallscore);
+                System.out.printf("    Overall average:  %10.4f%n", overallscore);
                 System.out.println("    Best spread:      "+bestspread[i]+
                                    "% variance");
                 System.out.println("    Worst spread:     "+worstspread[i]+

--- a/src/demo/share/java2d/J2DBench/src/j2dbench/report/J2DAnalyzer.java
+++ b/src/demo/share/java2d/J2DBench/src/j2dbench/report/J2DAnalyzer.java
@@ -270,7 +270,7 @@ public class J2DAnalyzer {
             } else {
                 double overallscore = totalscore[i]/numtests[i];
                 System.out.println("    Number of tests:  "+numtests[i]);
-                System.out.printf("    Overall average:  %10.4f%n", overallscore);
+                System.out.printf( "    Overall average:  %-10.4f%n", overallscore);
                 System.out.println("    Best spread:      "+bestspread[i]+
                                    "% variance");
                 System.out.println("    Worst spread:     "+worstspread[i]+


### PR DESCRIPTION
As mentioned in the bug, I think it would be better to always emit the score as decimal instead of sometimes decimal, sometimes scientific notation.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8361213](https://bugs.openjdk.org/browse/JDK-8361213): J2DAnalyzer should emit the score as a decimal (**Bug** - P4)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26076/head:pull/26076` \
`$ git checkout pull/26076`

Update a local copy of the PR: \
`$ git checkout pull/26076` \
`$ git pull https://git.openjdk.org/jdk.git pull/26076/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26076`

View PR using the GUI difftool: \
`$ git pr show -t 26076`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26076.diff">https://git.openjdk.org/jdk/pull/26076.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26076#issuecomment-3024974303)
</details>
