### PR TITLE
8361216: Do not fork javac in J2DBench ant build

### DIFF
--- a/src/demo/share/java2d/J2DBench/Makefile
+++ b/src/demo/share/java2d/J2DBench/Makefile
@@ -31,10 +31,10 @@
 
 
 ifndef SOURCE
-export SOURCE := 7
+export SOURCE := 8
 endif
 ifndef TARGET
-export TARGET := 7
+export TARGET := 8
 endif
 ifndef JAVAC
 export JAVAC := javac

--- a/src/demo/share/java2d/J2DBench/build.xml
+++ b/src/demo/share/java2d/J2DBench/build.xml
@@ -39,12 +39,12 @@
   <property name="dist"  location="dist"/>
   <property name="resources"  location="resources"/>
 
-  <condition property="source" value="7">
+  <condition property="source" value="8">
      <not>
         <isset property="source"/>
      </not>
   </condition>
-  <condition property="target" value="7">
+  <condition property="target" value="8">
      <not>
         <isset property="target"/>
      </not>
@@ -52,11 +52,6 @@
   <condition property="java" value="java">
      <not>
         <isset property="java"/>
-     </not>
-  </condition>
-  <condition property="javac" value="javac">
-     <not>
-        <isset property="javac"/>
      </not>
   </condition>
 
@@ -70,7 +65,7 @@
   <target name="compile" depends="init"
         description="compile the source " >
     <!-- Compile the java code from ${src} into ${build} -->
-    <javac debug="off" source="${source}" target="${target}" srcdir="${src}" destdir="${build}" fork="true" executable="${javac}"/>
+    <javac debug="off" source="${source}" target="${target}" srcdir="${src}" destdir="${build}"/>
   </target>
 
   <target name="run" depends="dist"


### PR DESCRIPTION
Build J2DBench in ant using JAVA_HOME, not using fork to possibly pick a different javac from the PATH.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8361216](https://bugs.openjdk.org/browse/JDK-8361216): Do not fork javac in J2DBench ant build (**Bug** - P4)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26077/head:pull/26077` \
`$ git checkout pull/26077`

Update a local copy of the PR: \
`$ git checkout pull/26077` \
`$ git pull https://git.openjdk.org/jdk.git pull/26077/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26077`

View PR using the GUI difftool: \
`$ git pr show -t 26077`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26077.diff">https://git.openjdk.org/jdk/pull/26077.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26077#issuecomment-3025280527)
</details>
