### PR TITLE
8361215: Add AOT test case: verification constraint classes are excluded

### DIFF
--- a/test/hotspot/jtreg/TEST.groups
+++ b/test/hotspot/jtreg/TEST.groups
@@ -416,6 +416,7 @@ hotspot_appcds_dynamic = \
  -runtime/cds/appcds/aotClassLinking \
  -runtime/cds/appcds/aotCode \
  -runtime/cds/appcds/aotFlags \
+ -runtime/cds/appcds/aotProfile \
  -runtime/cds/appcds/applications \
  -runtime/cds/appcds/cacheObject \
  -runtime/cds/appcds/complexURI \
@@ -510,14 +511,17 @@ hotspot_cds_epsilongc = \
   runtime/cds/appcds/jigsaw \
   runtime/cds/appcds/loaderConstraints
 
-# Run CDS tests with -XX:+AOTClassLinking. This should include most CDS tests, except for
+# Run "old" CDS tests with -XX:+AOTClassLinking. This should include most CDS tests, except for
 # those that rely on redefining classes that are already archived.
+# Note that appcds/aotXXX directories are excluded -- those tests already specifically
+# test AOT class linking, so there's no need to run them again with -XX:+AOTClassLinking.
 hotspot_aot_classlinking = \
   runtime/cds \
  -runtime/cds/appcds/aotCache \
  -runtime/cds/appcds/aotClassLinking \
  -runtime/cds/appcds/aotCode \
  -runtime/cds/appcds/aotFlags \
+ -runtime/cds/appcds/aotProfile \
  -runtime/cds/appcds/BadBSM.java \
  -runtime/cds/appcds/cacheObject/ArchivedIntegerCacheTest.java \
  -runtime/cds/appcds/cacheObject/ArchivedModuleCompareTest.java \

--- a/test/lib/jdk/test/lib/cds/CDSAppTester.java
+++ b/test/lib/jdk/test/lib/cds/CDSAppTester.java
@@ -262,7 +262,7 @@ abstract public class CDSAppTester {
                                                              "class+load=debug",
                                                              "aot=debug",
                                                              "cds=debug",
-                                                             "cds+class=debug"));
+                                                             "aot+class=debug"));
         cmdLine = addCommonVMArgs(runMode, cmdLine);
         cmdLine = StringArrayUtils.concat(cmdLine, appCommandLine(runMode));
         return executeAndCheck(cmdLine, runMode, aotConfigurationFile, aotConfigurationFileLog);
@@ -275,8 +275,9 @@ abstract public class CDSAppTester {
                                                    "-XX:AOTCacheOutput=" + aotCacheFile,
                                                    logToFile(aotCacheFileLog,
                                                              "class+load=debug",
-                                                             "cds=debug",
-                                                             "cds+class=debug"));
+                                                             "aot=debug",
+                                                             "aot+class=debug",
+                                                             "cds=debug"));
         cmdLine = addCommonVMArgs(runMode, cmdLine);
         cmdLine = StringArrayUtils.concat(cmdLine, appCommandLine(runMode));
         OutputAnalyzer out =  executeAndCheck(cmdLine, runMode, aotCacheFile, aotCacheFileLog);
@@ -310,7 +311,7 @@ abstract public class CDSAppTester {
                                                              "cds=debug",
                                                              "cds+class=debug",
                                                              "aot+heap=warning",
-                                                             "cds+resolve=debug"));
+                                                             "aot+resolve=debug"));
         cmdLine = addCommonVMArgs(runMode, cmdLine);
         cmdLine = StringArrayUtils.concat(cmdLine, appCommandLine(runMode));
         return executeAndCheck(cmdLine, runMode, staticArchiveFile, staticArchiveFileLog);
@@ -326,11 +327,11 @@ abstract public class CDSAppTester {
                                                    "-XX:AOTConfiguration=" + aotConfigurationFile,
                                                    "-XX:AOTCache=" + aotCacheFile,
                                                    logToFile(aotCacheFileLog,
-                                                             "aot=debug",
                                                              "cds=debug",
-                                                             "cds+class=debug",
+                                                             "aot=debug",
+                                                             "aot+class=debug",
                                                              "aot+heap=warning",
-                                                             "cds+resolve=debug"));
+                                                             "aot+resolve=debug"));
         cmdLine = addCommonVMArgs(runMode, cmdLine);
         cmdLine = StringArrayUtils.concat(cmdLine, appCommandLine(runMode));
         return executeAndCheck(cmdLine, runMode, aotCacheFile, aotCacheFileLog);
@@ -377,7 +378,7 @@ abstract public class CDSAppTester {
                                                       "aot=debug",
                                                       "cds=debug",
                                                       "cds+class=debug",
-                                                      "cds+resolve=debug",
+                                                      "aot+resolve=debug",
                                                       "class+load=debug"));
           cmdLine = addCommonVMArgs(runMode, cmdLine);
         }


### PR DESCRIPTION
If the AOT cache contains a class like this:

```
class A {
    X foo() {
        return new Y();
    }
}
```
A will be stored with the following verification constraint:

- `X` must be a supertype of `Y`

This constraint is checked when class `A` is linked.

I added a test case for this scenario to make sure it works properly even when `X` and/or `Y` are excluded from the AOT cache.

I also fixed some pre-existing problems with test exclusion and logging.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8361215](https://bugs.openjdk.org/browse/JDK-8361215): Add AOT test case: verification constraint classes are excluded (**Enhancement** - P4)


### Reviewers
 * [Calvin Cheung](https://openjdk.org/census#ccheung) (@calvinccheung - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26079/head:pull/26079` \
`$ git checkout pull/26079`

Update a local copy of the PR: \
`$ git checkout pull/26079` \
`$ git pull https://git.openjdk.org/jdk.git pull/26079/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26079`

View PR using the GUI difftool: \
`$ git pr show -t 26079`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26079.diff">https://git.openjdk.org/jdk/pull/26079.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26079#issuecomment-3025415098)
</details>
