### PR TITLE
8360028: (fs) Path.relativize throws StringIndexOutOfBoundsException (win)

### DIFF
--- a/src/java.base/windows/classes/sun/nio/fs/WindowsLinkSupport.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsLinkSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -356,7 +356,9 @@ class WindowsLinkSupport {
             if (target.isEmpty()) {
                 throw new IOException("Symbolic link target is invalid");
             }
-            return target;
+
+            // return normalized path string
+            return WindowsPathParser.parse(target).path();
         }
     }
 

--- a/src/java.base/windows/classes/sun/nio/fs/WindowsPath.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsPath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/windows/classes/sun/nio/fs/WindowsPath.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsPath.java
@@ -524,12 +524,6 @@ class WindowsPath implements Path {
                     continue;
                 }
 
-                // skip empty names
-                if (name.isEmpty()) {
-                    ignore[i] = true;
-                    continue;
-                }
-
                 // not ".."
                 if (name.charAt(0) != '.' || name.charAt(1) != '.') {
                     prevName = i;

--- a/src/java.base/windows/classes/sun/nio/fs/WindowsPath.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsPath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -521,6 +521,12 @@ class WindowsPath implements Path {
                     } else {
                         prevName = i;
                     }
+                    continue;
+                }
+
+                // skip empty names
+                if (name.isEmpty()) {
+                    ignore[i] = true;
                     continue;
                 }
 


### PR DESCRIPTION
Ignore empty name elements in `WindowsPath.normalize()`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8360028](https://bugs.openjdk.org/browse/JDK-8360028): (fs) Path.relativize throws StringIndexOutOfBoundsException (win) (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26080/head:pull/26080` \
`$ git checkout pull/26080`

Update a local copy of the PR: \
`$ git checkout pull/26080` \
`$ git pull https://git.openjdk.org/jdk.git pull/26080/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26080`

View PR using the GUI difftool: \
`$ git pr show -t 26080`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26080.diff">https://git.openjdk.org/jdk/pull/26080.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26080#issuecomment-3025767549)
</details>
