### PR TITLE
fix

### DIFF
--- a/src/hotspot/share/jfr/periodic/jfrPeriodic.cpp
+++ b/src/hotspot/share/jfr/periodic/jfrPeriodic.cpp
@@ -291,7 +291,7 @@ static void send_agent_event(AgentEvent& event, const JvmtiAgent* agent) {
 }
 
 TRACE_REQUEST_FUNC(JavaAgent) {
-  const JvmtiAgentList::Iterator it =JvmtiAgentList::java_agents();
+  JvmtiAgentList::Iterator it =JvmtiAgentList::java_agents();
   while (it.has_next()) {
     const JvmtiAgent* agent = it.next();
     assert(agent->is_jplis(), "invariant");
@@ -300,7 +300,7 @@ TRACE_REQUEST_FUNC(JavaAgent) {
   }
 }
 
-static void send_native_agent_events(const JvmtiAgentList::Iterator& it) {
+static void send_native_agent_events(JvmtiAgentList::Iterator& it) {
   while (it.has_next()) {
     const JvmtiAgent* agent = it.next();
     assert(!agent->is_jplis(), "invariant");
@@ -311,9 +311,9 @@ static void send_native_agent_events(const JvmtiAgentList::Iterator& it) {
 }
 
 TRACE_REQUEST_FUNC(NativeAgent) {
-  const JvmtiAgentList::Iterator native_agents_it = JvmtiAgentList::native_agents();
+  JvmtiAgentList::Iterator native_agents_it = JvmtiAgentList::native_agents();
   send_native_agent_events(native_agents_it);
-  const JvmtiAgentList::Iterator xrun_agents_it = JvmtiAgentList::xrun_agents();
+  JvmtiAgentList::Iterator xrun_agents_it = JvmtiAgentList::xrun_agents();
   send_native_agent_events(xrun_agents_it);
 }
 #else  // INCLUDE_JVMTI

--- a/src/hotspot/share/prims/jvmtiAgent.cpp
+++ b/src/hotspot/share/prims/jvmtiAgent.cpp
@@ -31,6 +31,7 @@
 #include "prims/jvmtiEnvBase.hpp"
 #include "prims/jvmtiExport.hpp"
 #include "runtime/arguments.hpp"
+#include "runtime/atomic.hpp"
 #include "runtime/handles.inline.hpp"
 #include "runtime/interfaceSupport.inline.hpp"
 #include "runtime/java.hpp"
@@ -82,11 +83,11 @@ JvmtiAgent::JvmtiAgent(const char* name, const char* options, bool is_absolute_p
   _xrun(false) {}
 
 JvmtiAgent* JvmtiAgent::next() const {
-  return _next;
+  return Atomic::load(&_next);
 }
 
 void JvmtiAgent::set_next(JvmtiAgent* agent) {
-  _next = agent;
+  return Atomic::store(&_next, agent);
 }
 
 const char* JvmtiAgent::name() const {

--- a/src/hotspot/share/prims/jvmtiAgentList.cpp
+++ b/src/hotspot/share/prims/jvmtiAgentList.cpp
@@ -31,7 +31,8 @@
 #include "runtime/atomic.hpp"
 #include "runtime/os.inline.hpp"
 
-JvmtiAgent* JvmtiAgentList::_list = nullptr;
+JvmtiAgent* JvmtiAgentList::_head = nullptr;
+JvmtiAgent** JvmtiAgentList::_tail = nullptr;
 
 // Selection as a function of the filter.
 JvmtiAgent* JvmtiAgentList::Iterator::select(JvmtiAgent* agent) const {
@@ -61,68 +62,61 @@ JvmtiAgent* JvmtiAgentList::Iterator::select(JvmtiAgent* agent) const {
   return nullptr;
 }
 
-static inline JvmtiAgent* head(JvmtiAgent** list) {
-  assert(list != nullptr, "invariant");
-  return Atomic::load_acquire(list);
-}
-
-// The storage list is a single cas-linked-list, to allow for concurrent iterations.
-// Especially during initial loading of agents, there exist an order requirement to iterate oldest -> newest.
-// Our concurrent storage linked-list is newest -> oldest.
-// The correct order is preserved by the iterator, by storing a filtered set of entries in a stack.
-JvmtiAgentList::Iterator::Iterator(JvmtiAgent** list, Filter filter) :
-  _stack(new GrowableArrayCHeap<JvmtiAgent*, mtServiceability>(16)), _filter(filter) {
-  JvmtiAgent* next = head(list);
-  while (next != nullptr) {
-    next = select(next);
-    if (next != nullptr) {
-      _stack->push(next);
-      next = next->next();
-    }
-  }
+JvmtiAgentList::Iterator::Iterator(JvmtiAgent* head, Filter filter) : _filter(filter), _next(select(head)) {
 }
 
 bool JvmtiAgentList::Iterator::has_next() const {
-  assert(_stack != nullptr, "invariant");
-  return _stack->is_nonempty();
-}
-
-const JvmtiAgent* JvmtiAgentList::Iterator::next() const {
-  assert(has_next(), "invariant");
-  return _stack->pop();
+  return _next != nullptr;
 }
 
 JvmtiAgent* JvmtiAgentList::Iterator::next() {
-  return const_cast<JvmtiAgent*>(const_cast<const Iterator*>(this)->next());
+  assert(_next != nullptr, "must be");
+  JvmtiAgent* result = _next;
+  _next = select(_next->_next);
+  return result;
+
 }
 
 JvmtiAgentList::Iterator JvmtiAgentList::agents() {
-  return Iterator(&_list, Iterator::NOT_XRUN);
+  return Iterator(head(), Iterator::NOT_XRUN);
 }
 
 JvmtiAgentList::Iterator JvmtiAgentList::java_agents() {
-  return Iterator(&_list, Iterator::JAVA);
+  return Iterator(head(), Iterator::JAVA);
 }
 
 JvmtiAgentList::Iterator JvmtiAgentList::native_agents() {
-  return Iterator(&_list, Iterator::NATIVE);
+  return Iterator(head(), Iterator::NATIVE);
 }
 
 JvmtiAgentList::Iterator JvmtiAgentList::xrun_agents() {
-  return Iterator(&_list, Iterator::XRUN);
+  return Iterator(head(), Iterator::XRUN);
 }
 
 JvmtiAgentList::Iterator JvmtiAgentList::all() {
-  return Iterator(&_list, Iterator::ALL);
+  return Iterator(head(), Iterator::ALL);
 }
 
 void JvmtiAgentList::add(JvmtiAgent* agent) {
   assert(agent != nullptr, "invariant");
-  JvmtiAgent* next;
-  do {
-    next = head(&_list);
-    agent->set_next(next);
-  } while (Atomic::cmpxchg(&_list, next, agent) != next);
+
+  while (true) {
+    // set _tail to address of agent->_next
+    JvmtiAgent** tail = Atomic::load_acquire(&_tail);
+    if (Atomic::cmpxchg(&_tail, tail, &agent->_next) != tail) {
+      // _tail has been updated by another thread, retry
+      continue;
+    }
+
+    if (tail == nullptr) {
+      // the list was empty, set _head
+      Atomic::release_store(&_head, agent);
+    } else {
+      // set "_next" of the last element to point to agent
+      Atomic::store(tail, agent); // *tail = agent;
+    }
+    return;
+  }
 }
 
 void JvmtiAgentList::add(const char* name, const char* options, bool absolute_path) {
@@ -142,6 +136,10 @@ static void assert_initialized(JvmtiAgentList::Iterator& it) {
   }
 }
 #endif
+
+JvmtiAgent* JvmtiAgentList::head() {
+  return Atomic::load_acquire(&_head);
+}
 
 // In case an agent did not enable the VMInit callback, or if it is an -Xrun agent,
 // it gets an initializiation timestamp here.
@@ -283,6 +281,6 @@ void JvmtiAgentList::disable_agent_list() {
   assert(CDSConfig::is_dumping_final_static_archive(), "use this only for -XX:AOTMode=create!");
   assert(!Universe::is_bootstrapping() && !Universe::is_fully_initialized(), "must do this very early");
   log_info(aot)("Disabled all JVMTI agents during -XX:AOTMode=create");
-  _list = nullptr; // Pretend that no agents have been added.
+  _head = nullptr; // Pretend that no agents have been added.
 #endif
 }

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -1125,7 +1125,7 @@ void os::print_environment_variables(outputStream* st, const char** env_list) {
 
 void os::print_jvmti_agent_info(outputStream* st) {
 #if INCLUDE_JVMTI
-  const JvmtiAgentList::Iterator it = JvmtiAgentList::all();
+  JvmtiAgentList::Iterator it = JvmtiAgentList::all();
   if (it.has_next()) {
     st->print_cr("JVMTI agents:");
   } else {


### PR DESCRIPTION
Currently jvmtiAgentList keeps agents in reversed order (new agents are added to the head of the list).
To restore original order JvmtiAgentList::Iterator uses GrowableArray allocated in heap.
Iterators for different agent types are returned by value, and the iterator class nas no custom copy ctor, so if the constructor not elides, GrowableArray is deallocated twice.

The fix updates jvmtiAgentList to keep agents in the original order, agents are added to the tail.
Iterator now needs only single pointer to next agent.
Additionally removed `JvmtiAgentList::Iterator::next() const` method (it looks very strange as `next()` is expected to change state of the iterator).

Testing: tier1..4,hs-tier5-svc
