### PR TITLE
8360146: Add system/security property to disable RSAES-PKCS-v1_5 padding

### DIFF
--- a/src/java.base/share/classes/sun/security/util/SecurityProperties.java
+++ b/src/java.base/share/classes/sun/security/util/SecurityProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2018 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -75,6 +75,18 @@ public class SecurityProperties {
             }
         }
         return false;
+    }
+
+    /**
+     * Convenience method for fetching the "jdk.crypto.supportPKCS1Padding"
+     * security property value as boolean.
+     *
+     * @return true unless the security property
+     *         "jdk.crypto.supportPKCS1Padding" is explicitly set to "false".
+     */
+    public static boolean getPKCS1PaddingSecurityProp() {
+        String value = Security.getProperty("jdk.crypto.supportPKCS1Padding");
+        return (value == null || !value.equalsIgnoreCase("false"));
     }
 
     /**

--- a/src/java.base/share/conf/security/java.security
+++ b/src/java.base/share/conf/security/java.security
@@ -1575,3 +1575,14 @@ jdk.tls.alpnCharset=ISO_8859_1
 # withEncryption method.
 #
 jdk.epkcs8.defaultAlgorithm=PBEWithHmacSHA256AndAES_128
+
+#
+# Whether to support the PKCS#1 Padding for RSA encryption/decryption
+#
+# This property defines whether the JDK providers support the
+# RSA/ECB/PKCS1Padding cipher. Note that "RSA" is an alias of
+# RSA/ECB/PKCS1Padding and will not be available either if this property is
+# set to false, i.e. disabling PKCS1Padding support.
+#
+#jdk.crypto.supportPKCS1Padding=false
+

--- a/src/java.base/share/conf/security/java.security
+++ b/src/java.base/share/conf/security/java.security
@@ -1577,12 +1577,12 @@ jdk.tls.alpnCharset=ISO_8859_1
 jdk.epkcs8.defaultAlgorithm=PBEWithHmacSHA256AndAES_128
 
 #
-# Whether to support the PKCS#1 Padding for RSA encryption/decryption
+# Whether to support the RSA cipher w/ PKCS#1 Padding
 #
 # This property defines whether the JDK providers support the
 # RSA/ECB/PKCS1Padding cipher. Note that "RSA" is an alias of
-# RSA/ECB/PKCS1Padding and will not be available either if this property is
-# set to false, i.e. disabling PKCS1Padding support.
+# RSA/ECB/PKCS1Padding and will also be unavailable if this
+# property is set to false.
 #
 #jdk.crypto.supportPKCS1Padding=false
 

--- a/src/jdk.crypto.mscapi/windows/classes/sun/security/mscapi/SunMSCAPI.java
+++ b/src/jdk.crypto.mscapi/windows/classes/sun/security/mscapi/SunMSCAPI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,6 +32,7 @@ import java.security.ProviderException;
 import java.util.HashMap;
 import java.util.List;
 
+import sun.security.util.SecurityProperties;
 import static sun.security.util.SecurityConstants.PROVIDER_VER;
 import static sun.security.util.SecurityProviderConstants.getAliases;
 
@@ -244,15 +245,14 @@ public final class SunMSCAPI extends Provider {
         /*
          * Cipher engines
          */
-        attrs.clear();
-        attrs.put("SupportedModes", "ECB");
-        attrs.put("SupportedPaddings", "PKCS1PADDING");
-        attrs.put("SupportedKeyClasses", "sun.security.mscapi.CKey");
-        putService(new ProviderService(p, "Cipher",
-                   "RSA", "sun.security.mscapi.CRSACipher",
-                   null, attrs));
-        putService(new ProviderService(p, "Cipher",
-                   "RSA/ECB/PKCS1Padding", "sun.security.mscapi.CRSACipher",
-                   null, attrs));
+        if (SecurityProperties.getPKCS1PaddingSecurityProp()) {
+            attrs.clear();
+            attrs.put("SupportedModes", "ECB");
+            attrs.put("SupportedPaddings", "PKCS1PADDING");
+            attrs.put("SupportedKeyClasses", "sun.security.mscapi.CKey");
+            putService(new ProviderService(p, "Cipher",
+                       "RSA", "sun.security.mscapi.CRSACipher",
+                       null, attrs));
+        }
     }
 }

--- a/test/jdk/javax/crypto/Cipher/TestPKCS1PaddingProp.java
+++ b/test/jdk/javax/crypto/Cipher/TestPKCS1PaddingProp.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8360146
+ * @summary Test Security property for disable PKCS1Padding against SunJCE
+ *         and SunMSCAPI (if present) providers
+ * @run main/othervm TestPKCS1PaddingProp true
+ * @run main/othervm TestPKCS1PaddingProp false
+ * @run main/othervm TestPKCS1PaddingProp huh
+ */
+import java.util.List;
+import java.security.NoSuchAlgorithmException;
+import java.security.Provider;
+import java.security.Security;
+import javax.crypto.Cipher;
+import javax.crypto.NoSuchPaddingException;
+
+public class TestPKCS1PaddingProp {
+
+    private static final String PROP_NAME = "jdk.crypto.supportPKCS1Padding";
+
+    private static void test(String alg, Provider p, boolean shouldThrow) {
+        System.out.println("Testing " + p.getName() + ": " + alg +
+                ", shouldThrow=" + shouldThrow);
+        try {
+            Cipher c = Cipher.getInstance(alg, p);
+            if (shouldThrow) {
+                throw new RuntimeException("Expected ex not thrown");
+            }
+        } catch (NoSuchAlgorithmException | NoSuchPaddingException e) {
+            if (!shouldThrow) {
+                throw new RuntimeException("Unexpected ex", e);
+            }
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        String[] provNames = new String[] {
+                System.getProperty("test.provider.name", "SunJCE"),
+                "SunMSCAPI"
+        };
+        String propValue = args[0];
+        System.out.println("Setting Security Prop " + PROP_NAME + " = " +
+                propValue);
+        Security.setProperty(PROP_NAME, propValue);
+        boolean shouldThrow =
+                Security.getProperty(PROP_NAME).equalsIgnoreCase("false");
+        for (String pn : provNames) {
+            Provider p = Security.getProvider(pn);
+            if (p == null) {
+                System.out.println("Skip testing " + pn + ": not available");
+                continue;
+            }
+            for (String a : List.of("RSA/ECB/PKCS1Padding", "RSA")) {
+                test(a, p, shouldThrow);
+            }
+        }
+        System.out.println("Done");
+    }
+}

--- a/test/jdk/sun/security/pkcs11/Cipher/TestPKCS1PaddingProp.java
+++ b/test/jdk/sun/security/pkcs11/Cipher/TestPKCS1PaddingProp.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8360146
+ * @summary Test Security property for disable PKCS1Padding against SunPKCS11
+ *         provider
+ * @library /test/lib ..
+ * @run main/othervm TestPKCS1PaddingProp true
+ * @run main/othervm TestPKCS1PaddingProp false
+ * @run main/othervm TestPKCS1PaddingProp huh
+ */
+
+import java.util.List;
+import java.security.NoSuchAlgorithmException;
+import java.security.Provider;
+import java.security.Security;
+import javax.crypto.Cipher;
+import javax.crypto.NoSuchPaddingException;
+
+public class TestPKCS1PaddingProp extends PKCS11Test {
+
+    private static final String PROP_NAME = "jdk.crypto.supportPKCS1Padding";
+
+    private static void test(String alg, Provider p, boolean shouldThrow) {
+        System.out.println("Testing " + p.getName() + ": " + alg +
+                ", shouldThrow=" + shouldThrow);
+        try {
+            Cipher c = Cipher.getInstance(alg, p);
+            if (shouldThrow) {
+                throw new RuntimeException("Expected ex not thrown");
+            }
+        } catch (NoSuchAlgorithmException | NoSuchPaddingException e) {
+            if (!shouldThrow) {
+                throw new RuntimeException("Unexpected ex", e);
+            }
+        }
+    }
+
+    @Override
+    public void main(Provider p) throws Exception {
+        boolean shouldThrow =
+                Security.getProperty(PROP_NAME).equalsIgnoreCase("false");
+        for (String a : List.of("RSA/ECB/PKCS1Padding", "RSA")) {
+            test(a, p, shouldThrow);
+        }
+        System.out.println("Done");
+    }
+
+    public static void main(String[] args) throws Exception {
+        String propValue = args[0];
+        System.out.println("Setting Security Prop " + PROP_NAME + " = " +
+                propValue);
+        Security.setProperty(PROP_NAME, propValue);
+        main(new TestPKCS1PaddingProp(), args);
+    }
+}


### PR DESCRIPTION
This PR adds a security property "jdk.crypto.supportPKCS1Padding". By default, this property is not set. 
However, if this security property "jdk.crypto.supportPKCS1Padding" is set to "false", existing JDK providers, e.g. SunJCE, SunPKCS11, and SunMSCAPI providers. will not provide the RSA w/ PKCS1Padding cipher implementation.
This security property can help users in checking their usage on RSA w/ PKCS1Padding cipher and facilitate the disabling of this particular cipher if so desired.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8360146](https://bugs.openjdk.org/browse/JDK-8360146): Add system/security property to disable RSAES-PKCS-v1_5 padding (**Enhancement** - P3) ⚠️ Issue is already resolved. Consider making this a "backport pull request" by setting the PR title to `Backport <hash>` with the hash of the original commit. See [Backports](https://wiki.openjdk.org/display/SKARA/Backports).


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26084/head:pull/26084` \
`$ git checkout pull/26084`

Update a local copy of the PR: \
`$ git checkout pull/26084` \
`$ git pull https://git.openjdk.org/jdk.git pull/26084/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26084`

View PR using the GUI difftool: \
`$ git pr show -t 26084`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26084.diff">https://git.openjdk.org/jdk/pull/26084.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26084#issuecomment-3026151129)
</details>
