### PR TITLE
8358179: Performance regression in Math.cbrt

### DIFF
--- a/src/hotspot/cpu/x86/stubGenerator_x86_64_cbrt.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64_cbrt.cpp
@@ -46,6 +46,12 @@
 //
 /******************************************************************************/
 
+/* Represents 0x7FFFFFFFFFFFFFFF double precision in lower 64 bits*/
+ATTRIBUTE_ALIGNED(16) static const juint _ABS_MASK[] =
+{
+    4294967295, 2147483647, 0, 0
+};
+
 ATTRIBUTE_ALIGNED(4) static const juint _SIG_MASK[] =
 {
     0, 1032192
@@ -188,10 +194,10 @@ address StubGenerator::generate_libmCbrt() {
   StubCodeMark mark(this, stub_id);
   address start = __ pc();
 
-  Label L_2TAG_PACKET_0_0_1, L_2TAG_PACKET_1_0_1, L_2TAG_PACKET_2_0_1, L_2TAG_PACKET_3_0_1;
-  Label L_2TAG_PACKET_4_0_1, L_2TAG_PACKET_5_0_1, L_2TAG_PACKET_6_0_1;
+  Label L_2TAG_PACKET_0_0_1, L_2TAG_PACKET_1_0_1, L_2TAG_PACKET_2_0_1;
   Label B1_1, B1_2, B1_4;
 
+  address ABS_MASK        = (address)_ABS_MASK;
   address SIG_MASK        = (address)_SIG_MASK;
   address EXP_MASK        = (address)_EXP_MASK;
   address EXP_MSK2        = (address)_EXP_MSK2;
@@ -208,8 +214,12 @@ address StubGenerator::generate_libmCbrt() {
   __ enter(); // required for proper stackwalking of RuntimeStub frame
 
   __ bind(B1_1);
-  __ subq(rsp, 24);
-  __ movsd(Address(rsp), xmm0);
+  __ ucomisd(xmm0, ExternalAddress(ZERON), r11 /*rscratch*/);
+  __ jcc(Assembler::equal, L_2TAG_PACKET_1_0_1); // Branch only if x is +/- zero or NaN
+  __ movq(xmm1, xmm0);
+  __ andpd(xmm1, ExternalAddress(ABS_MASK), r11 /*rscratch*/);
+  __ ucomisd(xmm1, ExternalAddress(INF), r11 /*rscratch*/);
+  __ jcc(Assembler::equal, B1_4); // Branch only if x is +/- INF
 
   __ bind(B1_2);
   __ movq(xmm7, xmm0);
@@ -228,8 +238,6 @@ address StubGenerator::generate_libmCbrt() {
   __ andl(rdx, rax);
   __ cmpl(rdx, 0);
   __ jcc(Assembler::equal, L_2TAG_PACKET_0_0_1); // Branch only if |x| is denormalized
-  __ cmpl(rdx, 524032);
-  __ jcc(Assembler::equal, L_2TAG_PACKET_1_0_1); // Branch only if |x| is INF or NaN
   __ shrl(rdx, 8);
   __ shrq(r9, 8);
   __ andpd(xmm2, xmm0);
@@ -297,8 +305,6 @@ address StubGenerator::generate_libmCbrt() {
   __ andl(rdx, rax);
   __ shrl(rdx, 8);
   __ shrq(r9, 8);
-  __ cmpl(rdx, 0);
-  __ jcc(Assembler::equal, L_2TAG_PACKET_3_0_1); // Branch only if |x| is zero
   __ andpd(xmm2, xmm0);
   __ andpd(xmm0, xmm5);
   __ orpd(xmm3, xmm2);
@@ -322,41 +328,10 @@ address StubGenerator::generate_libmCbrt() {
   __ psllq(xmm7, 52);
   __ jmp(L_2TAG_PACKET_2_0_1);
 
-  __ bind(L_2TAG_PACKET_3_0_1);
-  __ cmpq(r9, 0);
-  __ jcc(Assembler::notEqual, L_2TAG_PACKET_4_0_1); // Branch only if x is negative zero
-  __ xorpd(xmm0, xmm0);
-  __ jmp(B1_4);
-
-  __ bind(L_2TAG_PACKET_4_0_1);
-  __ movsd(xmm0, ExternalAddress(ZERON), r11 /*rscratch*/);
-  __ jmp(B1_4);
-
   __ bind(L_2TAG_PACKET_1_0_1);
-  __ movl(rax, Address(rsp, 4));
-  __ movl(rdx, Address(rsp));
-  __ movl(rcx, rax);
-  __ andl(rcx, 2147483647);
-  __ cmpl(rcx, 2146435072);
-  __ jcc(Assembler::above, L_2TAG_PACKET_5_0_1); // Branch only if |x| is NaN
-  __ cmpl(rdx, 0);
-  __ jcc(Assembler::notEqual, L_2TAG_PACKET_5_0_1); // Branch only if |x| is NaN
-  __ cmpl(rax, 2146435072);
-  __ jcc(Assembler::notEqual, L_2TAG_PACKET_6_0_1); // Branch only if x is negative INF
-  __ movsd(xmm0, ExternalAddress(INF), r11 /*rscratch*/);
-  __ jmp(B1_4);
-
-  __ bind(L_2TAG_PACKET_6_0_1);
-  __ movsd(xmm0, ExternalAddress(NEG_INF), r11 /*rscratch*/);
-  __ jmp(B1_4);
-
-  __ bind(L_2TAG_PACKET_5_0_1);
-  __ movsd(xmm0, Address(rsp));
   __ addsd(xmm0, xmm0);
-  __ movq(Address(rsp, 8), xmm0);
 
   __ bind(B1_4);
-  __ addq(rsp, 24);
   __ leave(); // required for proper stackwalking of RuntimeStub frame
   __ ret(0);
 


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [38f59f84](https://github.com/openjdk/jdk/commit/38f59f84c98dfd974eec0c05541b2138b149def7) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Mohamed Issa on 1 Jul 2025 and was reviewed by Sandhya Viswanathan, Srinivas Vamsi Parasa and Emanuel Peter.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8358179](https://bugs.openjdk.org/browse/JDK-8358179): Performance regression in Math.cbrt (**Bug** - P3)


### Reviewers
 * [Emanuel Peter](https://openjdk.org/census#epeter) (@eme64 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26085/head:pull/26085` \
`$ git checkout pull/26085`

Update a local copy of the PR: \
`$ git checkout pull/26085` \
`$ git pull https://git.openjdk.org/jdk.git pull/26085/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26085`

View PR using the GUI difftool: \
`$ git pr show -t 26085`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26085.diff">https://git.openjdk.org/jdk/pull/26085.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26085#issuecomment-3026517673)
</details>
