### PR TITLE
8361238

### DIFF
--- a/src/hotspot/share/runtime/java.cpp
+++ b/src/hotspot/share/runtime/java.cpp
@@ -471,6 +471,7 @@ void before_exit(JavaThread* thread, bool halt) {
 
   NativeHeapTrimmer::cleanup();
 
+  Universe::heap()->print_tracing_info();
   // Stop concurrent GC threads
   Universe::heap()->stop();
 
@@ -513,7 +514,6 @@ void before_exit(JavaThread* thread, bool halt) {
   os::terminate_signal_thread();
 
   print_statistics();
-  Universe::heap()->print_tracing_info();
 
   { MutexLocker ml(BeforeExit_lock);
     _before_exit_status = BEFORE_EXIT_DONE;


### PR DESCRIPTION
Hi all,

  please review this fix after the recent changes in void JDK-8274051 where G1 tries to get thread cpu time on already terminated threads.

The fix is to move the printing/statistics before stopping the threads. This seems fine for the two implementors of the method.

In a future change, since so few GCs implement `print_tracing_info`, the call should probably move to `stop()/begin_exit()`.

Testing: gha

Thanks,
  Thomas