### PR TITLE
8361249: PlainHttpConnection connection logic can be simplified

### DIFF
--- a/src/java.net.http/share/classes/jdk/internal/net/http/PlainHttpConnection.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/PlainHttpConnection.java
@@ -58,14 +58,6 @@ class PlainHttpConnection extends HttpConnection {
     private final ReentrantLock stateLock = new ReentrantLock();
     private final AtomicReference<Throwable> errorRef = new AtomicReference<>();
 
-    // Indicates whether a connection attempt has succeeded.
-    // If the attempt failed there will be an exception
-    // instead.
-    // CONNECTED is used when connect() succeeded immediately
-    // CONNECT_FINISHED is used when connect succeeded asynchronously
-    private enum ConnectState { CONNECTED, CONNECT_FINISHED }
-
-
     /**
      * Returns a ConnectTimerEvent iff there is a connect timeout duration,
      * otherwise null.


### PR DESCRIPTION
The PlainHttpConnection::connectAsync method implements a retry logic that will call connect() again if connect() throws the first time. This will not work, as the channel is closed when connect() throws. That logic should be removed. Reconnection should only be attempted at a higher level (MultiExchange).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8361249](https://bugs.openjdk.org/browse/JDK-8361249): PlainHttpConnection connection logic can be simplified (**Bug** - P4)


### Reviewers
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - **Reviewer**)
 * [Volkan Yazici](https://openjdk.org/census#vyazici) (@vy - Committer)
 * [Michael McMahon](https://openjdk.org/census#michaelm) (@Michael-Mc-Mahon - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26087/head:pull/26087` \
`$ git checkout pull/26087`

Update a local copy of the PR: \
`$ git checkout pull/26087` \
`$ git pull https://git.openjdk.org/jdk.git pull/26087/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26087`

View PR using the GUI difftool: \
`$ git pr show -t 26087`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26087.diff">https://git.openjdk.org/jdk/pull/26087.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26087#issuecomment-3026989336)
</details>
