### PR TITLE
8361253: CommandLineOptionTest library should report observed values on failure

### DIFF
--- a/test/lib/jdk/test/lib/cli/CommandLineOptionTest.java
+++ b/test/lib/jdk/test/lib/cli/CommandLineOptionTest.java
@@ -122,8 +122,8 @@ public abstract class CommandLineOptionTest {
                 outputAnalyzer.shouldHaveExitValue(exitCode.value);
         } catch (RuntimeException e) {
             String errorMessage = String.format(
-                    "JVM process should have exit value '%d'.%n%s",
-                    exitCode.value, exitErrorMessage);
+                    "JVM process should have exit value '%d', but has '%d'.%n%s",
+                    exitCode.value, outputAnalyzer.getExitValue(), exitErrorMessage);
             throw new AssertionError(errorMessage, e);
         }
 
@@ -302,9 +302,12 @@ public abstract class CommandLineOptionTest {
                     CommandLineOptionTest.PRINT_FLAGS_FINAL_FORMAT,
                     optionName, expectedValue));
         } catch (RuntimeException e) {
+            String observedValue = outputAnalyzer.firstMatch(String.format(
+                CommandLineOptionTest.PRINT_FLAGS_FINAL_FORMAT,
+                optionName, "\\S"));
             String errorMessage = String.format(
-                    "Option '%s' is expected to have '%s' value%n%s",
-                    optionName, expectedValue,
+                    "Option '%s' is expected to have '%s' value, but is '%s'.%n%s",
+                    optionName, expectedValue, observedValue,
                     optionErrorString);
             throw new AssertionError(errorMessage, e);
         }


### PR DESCRIPTION
When a check in `CommandLineOptionTest` fails, the `AssertionError` message contains the expected value, but not the observed value. To reduce the amount of digging in the logs we have to do when analyzing a failure, this PR adds the observed value to the error messages. So instead of 

```
java.lang.AssertionError: Option 'CICompilerCount' is expected to have '12' value
```

a mismatch in the `CICompilerCount` will now print

```
java.lang.AssertionError: Option 'CICompilerCount' is expected to have '12' value, but is 'CICompilerCount = 6'.
```

Testing:
 - [x] Github Actions
 - [x] tier1 through tier3 plus Oracle internal testing

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8361253](https://bugs.openjdk.org/browse/JDK-8361253): CommandLineOptionTest library should report observed values on failure (**Enhancement** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26092/head:pull/26092` \
`$ git checkout pull/26092`

Update a local copy of the PR: \
`$ git checkout pull/26092` \
`$ git pull https://git.openjdk.org/jdk.git pull/26092/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26092`

View PR using the GUI difftool: \
`$ git pr show -t 26092`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26092.diff">https://git.openjdk.org/jdk/pull/26092.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26092#issuecomment-3027541363)
</details>
