### PR TITLE
8361207: Build native Windows ARM64 MSI packages

### DIFF
--- a/src/jdk.jpackage/windows/classes/jdk/jpackage/internal/WixFragmentBuilder.java
+++ b/src/jdk.jpackage/windows/classes/jdk/jpackage/internal/WixFragmentBuilder.java
@@ -145,6 +145,25 @@ abstract class WixFragmentBuilder {
         return Architecture.is64bit();
     }
 
+    enum Arch {
+        X64,
+        X86,
+        AARCH64,
+        OTHER;
+    }
+
+    static Arch getArch() {
+        if (Architecture.isX64()) {
+            return Arch.X64;
+        } else if (Architecture.isX86()) {
+            return Arch.X86;
+        } else if (Architecture.isAARCH64()) {
+            return Arch.AARCH64;
+        } else {
+            return Arch.OTHER;
+        }
+    }
+
     protected final Path getConfigRoot() {
         return configRoot;
     }


### PR DESCRIPTION
Add support for native ARM64 Windows MSI pacakges to jpackage.

For some reasoning and more info, check out the ticket on JBS: https://bugs.openjdk.org/browse/JDK-8361207.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8361207](https://bugs.openjdk.org/browse/JDK-8361207): Build native Windows ARM64 MSI packages (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26093/head:pull/26093` \
`$ git checkout pull/26093`

Update a local copy of the PR: \
`$ git checkout pull/26093` \
`$ git pull https://git.openjdk.org/jdk.git pull/26093/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26093`

View PR using the GUI difftool: \
`$ git pr show -t 26093`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26093.diff">https://git.openjdk.org/jdk/pull/26093.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26093#issuecomment-3250244788)
</details>
