### PR TITLE
8305567: serviceability/tmtools/jstat/GcTest01.java failed utils.JstatGcResults.assertConsistency

### DIFF
--- a/test/hotspot/jtreg/serviceability/tmtools/jstat/GarbageProducerTest.java
+++ b/test/hotspot/jtreg/serviceability/tmtools/jstat/GarbageProducerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@ import java.lang.management.ManagementFactory;
 import utils.GarbageProducer;
 import common.TmTool;
 import utils.JstatResults;
+import utils.JstatGcCauseTool;
 
 /**
  * Base class for jstat testing which uses GarbageProducer to allocate garbage.
@@ -36,19 +37,19 @@ public class GarbageProducerTest {
     private final static float TARGET_MEMORY_USAGE = 0.7f;
     private final static float MEASUREMENT_TOLERANCE = 0.05f;
     private final GarbageProducer garbageProducer;
-    private final TmTool<? extends JstatResults> jstatTool;
+    private final JstatGcCauseTool jstatTool;
 
-    public GarbageProducerTest(TmTool<? extends JstatResults> tool) {
+    public GarbageProducerTest(JstatGcCauseTool tool) {
         garbageProducer = new GarbageProducer(TARGET_MEMORY_USAGE);
         // We will be running jstat tool
         jstatTool = tool;
     }
 
     public void run() throws Exception {
-        // Run once and get the  results asserting that they are reasonable
-        JstatResults measurement1 = jstatTool.measure();
-        measurement1.assertConsistency();
-        // Eat metaspace and heap then run the tool again and get the results  asserting that they are reasonable
+        // Run once and get the results asserting that they are reasonable
+        JstatResults measurement1 = jstatTool.measureAndAssertConsistency();
+
+        // Eat metaspace and heap then run the tool again and get the results, asserting that they are reasonable
         System.gc();
         garbageProducer.allocateMetaspaceAndHeap();
         // Collect garbage. Also update VM statistics

--- a/test/hotspot/jtreg/serviceability/tmtools/jstat/GcNewTest.java
+++ b/test/hotspot/jtreg/serviceability/tmtools/jstat/GcNewTest.java
@@ -44,15 +44,13 @@ public class GcNewTest {
         JstatGcNewTool jstatGcTool = new JstatGcNewTool(ProcessHandle.current().pid());
 
         // Run once and get the  results asserting that they are reasonable
-        JstatGcNewResults measurement1 = jstatGcTool.measure();
-        measurement1.assertConsistency();
+        JstatGcNewResults measurement1 = jstatGcTool.measureAndAssertConsistency();
 
         GcProvoker gcProvoker = new GcProvoker();
 
         // Provoke GC and run the tool again
         gcProvoker.provokeGc();
-        JstatGcNewResults measurement2 = jstatGcTool.measure();
-        measurement2.assertConsistency();
+        JstatGcNewResults measurement2 = jstatGcTool.measureAndAssertConsistency();
 
         // Assert the increase in GC events and time between the measurements
         assertThat(measurement2.getFloatValue("YGC") > measurement1.getFloatValue("YGC"), "YGC didn't increase between measurements 1 and 2");
@@ -60,8 +58,7 @@ public class GcNewTest {
 
         // Provoke GC and run the tool again
         gcProvoker.provokeGc();
-        JstatGcNewResults measurement3 = jstatGcTool.measure();
-        measurement3.assertConsistency();
+        JstatGcNewResults measurement3 = jstatGcTool.measureAndAssertConsistency();
 
         // Assert the increase in GC events and time between the measurements
         assertThat(measurement3.getFloatValue("YGC") > measurement2.getFloatValue("YGC"), "YGC didn't increase between measurements 1 and 2");

--- a/test/hotspot/jtreg/serviceability/tmtools/jstat/GcTest01.java
+++ b/test/hotspot/jtreg/serviceability/tmtools/jstat/GcTest01.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,17 +47,15 @@ public class GcTest01 {
         // We will be running "jstat -gc" tool
         JstatGcTool jstatGcTool = new JstatGcTool(ProcessHandle.current().pid());
 
-        // Run once and get the  results asserting that they are reasonable
-        JstatGcResults measurement1 = jstatGcTool.measure();
-        measurement1.assertConsistency();
+        // Run once and get the results asserting that they are reasonable
+        JstatGcResults measurement1 = jstatGcTool.measureAndAssertConsistency();
 
         GcProvoker gcProvoker = new GcProvoker();
 
         // Provoke GC then run the tool again and get the results
         // asserting that they are reasonable
         gcProvoker.provokeGc();
-        JstatGcResults measurement2 = jstatGcTool.measure();
-        measurement2.assertConsistency();
+        JstatGcResults measurement2 = jstatGcTool.measureAndAssertConsistency();
 
         // Assert the increase in GC events and time between the measurements
         JstatResults.assertGCEventsIncreased(measurement1, measurement2);
@@ -66,13 +64,10 @@ public class GcTest01 {
         // Provoke GC again and get the results
         // asserting that they are reasonable
         gcProvoker.provokeGc();
-        JstatGcResults measurement3 = jstatGcTool.measure();
-        measurement3.assertConsistency();
+        JstatGcResults measurement3 = jstatGcTool.measureAndAssertConsistency();
 
         // Assert the increase in GC events and time between the measurements
         JstatResults.assertGCEventsIncreased(measurement2, measurement3);
         JstatResults.assertGCTimeIncreased(measurement2, measurement3);
-
     }
-
 }

--- a/test/hotspot/jtreg/serviceability/tmtools/jstat/GcTest02.java
+++ b/test/hotspot/jtreg/serviceability/tmtools/jstat/GcTest02.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,6 +42,6 @@ import utils.*;
 public class GcTest02 {
 
     public static void main(String[] args) throws Exception {
-        new GarbageProducerTest(new JstatGcTool(ProcessHandle.current().pid())).run();
+        new GarbageProducerTest(new JstatGcCauseTool(ProcessHandle.current().pid())).run();
     }
 }

--- a/test/hotspot/jtreg/serviceability/tmtools/jstat/utils/JstatGcCapacityTool.java
+++ b/test/hotspot/jtreg/serviceability/tmtools/jstat/utils/JstatGcCapacityTool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,10 +28,9 @@ import common.TmTool;
  * This tool executes "jstat -gccapacity <pid>" and returns the results as
  * JstatGcCapacityoolResults
  */
-public class JstatGcCapacityTool extends TmTool<JstatGcCapacityResults> {
+public class JstatGcCapacityTool extends JstatTool<JstatGcCapacityResults> {
 
     public JstatGcCapacityTool(long pid) {
         super(JstatGcCapacityResults.class, "jstat", "-gccapacity " + pid);
     }
-
 }

--- a/test/hotspot/jtreg/serviceability/tmtools/jstat/utils/JstatGcCauseTool.java
+++ b/test/hotspot/jtreg/serviceability/tmtools/jstat/utils/JstatGcCauseTool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,34 +28,9 @@ import common.TmTool;
  * This tool executes "jstat -gc <pid>" and returns the results as
  * JstatGcToolResults
  */
-public class JstatGcCauseTool extends TmTool<JstatGcCauseResults> {
-
-    private static final int TRIES = 3;
+public class JstatGcCauseTool extends JstatTool<JstatGcCauseResults> {
 
     public JstatGcCauseTool(long pid) {
         super(JstatGcCauseResults.class, "jstat", "-gc " + pid);
-    }
-
-    /**
-      * Measure, and call assertConsistency() on the results,
-      * tolerating a set number of failures to account for inconsistency in PerfData.
-      */
-    public JstatGcCauseResults measureAndAssertConsistency() throws Exception {
-        JstatGcCauseResults results = null;
-        for (int i = 1; i <= TRIES; i++) {
-            try {
-                results = measure();
-                results.assertConsistency();
-                break;
-            } catch (RuntimeException e) {
-                System.out.println("Attempt " + i + ": " + e);
-                if (i == TRIES) {
-                    System.out.println("Too many failures.");
-                    throw(e);
-                }
-                // Inconsistent, will retry.
-            }
-        }
-        return results;
     }
 }

--- a/test/hotspot/jtreg/serviceability/tmtools/jstat/utils/JstatGcNewTool.java
+++ b/test/hotspot/jtreg/serviceability/tmtools/jstat/utils/JstatGcNewTool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,10 +28,9 @@ import common.TmTool;
  * This tool executes "jstat -gcnew <pid>" and returns the results as
  * JstatGcNewResults
  */
-public class JstatGcNewTool extends TmTool<JstatGcNewResults> {
+public class JstatGcNewTool extends JstatTool<JstatGcNewResults> {
 
     public JstatGcNewTool(long pid) {
         super(JstatGcNewResults.class, "jstat", "-gcnew " + pid);
     }
-
 }

--- a/test/hotspot/jtreg/serviceability/tmtools/jstat/utils/JstatGcTool.java
+++ b/test/hotspot/jtreg/serviceability/tmtools/jstat/utils/JstatGcTool.java
@@ -28,34 +28,9 @@ import common.TmTool;
  * This tool executes "jstat -gc <pid>" and returns the results as
  * JstatGcToolResults
  */
-public class JstatGcTool extends TmTool<JstatGcResults> {
-
-    private static final int TRIES = 3;
+public class JstatGcTool extends JstatTool<JstatGcResults> {
 
     public JstatGcTool(long pid) {
         super(JstatGcResults.class, "jstat", "-gc " + pid);
-    }
-
-    /**
-      * Measure, and call assertConsistency() on the results,
-      * tolerating a set number of failures to account for inconsistency in PerfData.
-      */
-    public JstatGcResults measureAndAssertConsistency() throws Exception {
-        JstatGcResults results = null;
-        for (int i = 1; i <= TRIES; i++) {
-            try {
-                results = measure();
-                results.assertConsistency();
-                break;
-            } catch (RuntimeException e) {
-                System.out.println("Attempt " + i + ": " + e);
-                if (i == TRIES) {
-                    System.out.println("Too many failures.");
-                    throw(e);
-                }
-                // Inconsistent, will retry.
-            }
-        }
-        return results;
     }
 }

--- a/test/hotspot/jtreg/serviceability/tmtools/jstat/utils/JstatGcTool.java
+++ b/test/hotspot/jtreg/serviceability/tmtools/jstat/utils/JstatGcTool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,32 @@ import common.TmTool;
  */
 public class JstatGcTool extends TmTool<JstatGcResults> {
 
+    private static final int TRIES = 3;
+
     public JstatGcTool(long pid) {
         super(JstatGcResults.class, "jstat", "-gc " + pid);
     }
 
+    /**
+      * Measure, and call assertConsistency() on the results,
+      * tolerating a set number of failures to account for inconsistency in PerfData.
+      */
+    public JstatGcResults measureAndAssertConsistency() throws Exception {
+        JstatGcResults results = null;
+        for (int i = 1; i <= TRIES; i++) {
+            try {
+                results = measure();
+                results.assertConsistency();
+                break;
+            } catch (RuntimeException e) {
+                System.out.println("Attempt " + i + ": " + e);
+                if (i == TRIES) {
+                    System.out.println("Too many failures.");
+                    throw(e);
+                }
+                // Inconsistent, will retry.
+            }
+        }
+        return results;
+    }
 }

--- a/test/hotspot/jtreg/serviceability/tmtools/jstat/utils/JstatTool.java
+++ b/test/hotspot/jtreg/serviceability/tmtools/jstat/utils/JstatTool.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package utils;
+
+import common.TmTool;
+
+/**
+ * Common base class for Jstat tools.
+ */
+public class JstatTool<T extends JstatResults> extends TmTool<T> {
+
+    private static final int TRIES = 3;
+
+     public JstatTool(Class<T> resultsClz, String toolName, String otherArgs) {
+        super(resultsClz, toolName, otherArgs);
+    }
+
+    /**
+     * Measure, and call assertConsistency() on the results,
+     * tolerating a set number of failures to account for inconsistencies in PerfData.
+     */
+    public T measureAndAssertConsistency() throws Exception {
+        T results = null;
+        for (int i = 1; i <= TRIES; i++) {
+            try {
+                results = measure();
+                results.assertConsistency();
+            } catch (RuntimeException e) {
+                System.out.println("Attempt " + i + ": " + e);
+                if (i == TRIES) {
+                    System.out.println("Too many failures.");
+                    throw(e);
+                }
+                // Will retry.
+            }
+        }
+        return results;
+    }
+}


### PR DESCRIPTION
There is no guarantee of consistency when sampling jstat data, and we're asserting these figures are always consistent.
Tests should retry some small number of times, rerunning the jstat tool to recapture data.

