### PR TITLE
8361183: JDK-8360887 needs fixes to avoid cycles and better tests (aix)

### DIFF
--- a/src/java.base/aix/classes/sun/nio/fs/AixFileSystemProvider.java
+++ b/src/java.base/aix/classes/sun/nio/fs/AixFileSystemProvider.java
@@ -52,9 +52,9 @@ class AixFileSystemProvider extends UnixFileSystemProvider {
         return new AixFileStore(path);
     }
 
-    static boolean supportsUserDefinedFileAttributeView(Path obj) {
+    private static boolean supportsUserDefinedFileAttributeView(UnixPath file) {
         try {
-            FileStore store = Files.getFileStore(obj);
+            FileStore store = new AixFileStore(file);
             return store.supportsFileAttributeView(UserDefinedFileAttributeView.class);
         } catch (IOException e) {
             return false;
@@ -68,8 +68,10 @@ class AixFileSystemProvider extends UnixFileSystemProvider {
                                                                 LinkOption... options)
     {
         if (type == UserDefinedFileAttributeView.class) {
-            return !supportsUserDefinedFileAttributeView(obj) ? null :
-                (V) new AixUserDefinedFileAttributeView(UnixPath.toUnixPath(obj), Util.followLinks(options));
+            UnixPath file = UnixPath.toUnixPath(obj);
+            return supportsUserDefinedFileAttributeView(file) ?
+                (V) new AixUserDefinedFileAttributeView(file, Util.followLinks(options))
+                : null;
         }
         return super.getFileAttributeView(obj, type, options);
     }
@@ -80,8 +82,10 @@ class AixFileSystemProvider extends UnixFileSystemProvider {
                                                          LinkOption... options)
     {
         if (name.equals("user")) {
-            return !supportsUserDefinedFileAttributeView(obj) ? null :
-                new AixUserDefinedFileAttributeView(UnixPath.toUnixPath(obj), Util.followLinks(options));
+            UnixPath file = UnixPath.toUnixPath(obj);
+            return supportsUserDefinedFileAttributeView(file) ?
+                new AixUserDefinedFileAttributeView(file, Util.followLinks(options))
+                : null;
         }
         return super.getFileAttributeView(obj, name, options);
     }

--- a/test/jdk/java/nio/file/FileStore/Basic.java
+++ b/test/jdk/java/nio/file/FileStore/Basic.java
@@ -67,6 +67,16 @@ public class Basic {
         }
     }
 
+    static <V extends FileAttributeView> void testFileAttributes(Path file,
+                                                                 Class<V> viewClass,
+                                                                 String viewName) throws IOException {
+        FileStore store = Files.getFileStore(file);
+        boolean supported = store.supportsFileAttributeView(viewClass);
+        assertTrue(store.supportsFileAttributeView(viewName) == supported);
+        boolean haveView = Files.getFileAttributeView(file, viewClass) != null;
+        assertTrue(haveView == supported);
+    }
+
     static void doTests(Path dir) throws IOException {
         /**
          * Test: Directory should be on FileStore that is writable
@@ -97,21 +107,11 @@ public class Basic {
          * Test: File and FileStore attributes
          */
         assertTrue(store1.supportsFileAttributeView("basic"));
-        assertTrue(store1.supportsFileAttributeView(BasicFileAttributeView.class));
-        assertTrue(store1.supportsFileAttributeView("posix") ==
-            store1.supportsFileAttributeView(PosixFileAttributeView.class));
-        assertTrue(store1.supportsFileAttributeView("dos") ==
-            store1.supportsFileAttributeView(DosFileAttributeView.class));
-        assertTrue(store1.supportsFileAttributeView("acl") ==
-            store1.supportsFileAttributeView(AclFileAttributeView.class));
-        assertTrue(store1.supportsFileAttributeView("user") ==
-            store1.supportsFileAttributeView(UserDefinedFileAttributeView.class));
-
-        // check if getFileAttributeView behaves as specified if the user defined view is unsupported
-        if (!store1.supportsFileAttributeView(UserDefinedFileAttributeView.class) &&
-            Files.getFileAttributeView(dir, UserDefinedFileAttributeView.class) != null) {
-            throw new RuntimeException("UserDefinedFileAttributeView not supported, getFileAttributeView should return null");
-        }
+        testFileAttributes(dir, BasicFileAttributeView.class, "basic");
+        testFileAttributes(dir, PosixFileAttributeView.class, "posix");
+        testFileAttributes(dir, DosFileAttributeView.class, "dos");
+        testFileAttributes(dir, AclFileAttributeView.class, "acl");
+        testFileAttributes(dir, UserDefinedFileAttributeView.class, "user");
 
         /**
          * Test: Space atributes


### PR DESCRIPTION
Clean backport of [JDK-8361183](https://bugs.openjdk.org/browse/JDK-8361183).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8361183](https://bugs.openjdk.org/browse/JDK-8361183): JDK-8360887 needs fixes to avoid cycles and better tests (aix) (**Bug** - P3)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26097/head:pull/26097` \
`$ git checkout pull/26097`

Update a local copy of the PR: \
`$ git checkout pull/26097` \
`$ git pull https://git.openjdk.org/jdk.git pull/26097/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26097`

View PR using the GUI difftool: \
`$ git pr show -t 26097`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26097.diff">https://git.openjdk.org/jdk/pull/26097.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26097#issuecomment-3028351721)
</details>
