### PR TITLE
8357579: Compilation error: first argument in call to 'memset' is a pointer to non-trivially copyable type

### DIFF
--- a/src/hotspot/share/oops/resolvedFieldEntry.cpp
+++ b/src/hotspot/share/oops/resolvedFieldEntry.cpp
@@ -46,7 +46,7 @@ void ResolvedFieldEntry::print_on(outputStream* st) const {
 #if INCLUDE_CDS
 void ResolvedFieldEntry::remove_unshareable_info() {
   u2 saved_cpool_index = _cpool_index;
-  memset(this, 0, sizeof(*this));
+  memset((void *) this, 0, sizeof(*this));
   _cpool_index = saved_cpool_index;
 }
 

--- a/src/hotspot/share/oops/resolvedMethodEntry.cpp
+++ b/src/hotspot/share/oops/resolvedMethodEntry.cpp
@@ -40,12 +40,12 @@ void ResolvedMethodEntry::reset_entry() {
   if (has_resolved_references_index()) {
     u2 saved_resolved_references_index = _entry_specific._resolved_references_index;
     u2 saved_cpool_index = _cpool_index;
-    memset(this, 0, sizeof(*this));
+    memset((void *) this, 0, sizeof(*this));
     set_resolved_references_index(saved_resolved_references_index);
     _cpool_index = saved_cpool_index;
   } else {
     u2 saved_cpool_index = _cpool_index;
-    memset(this, 0, sizeof(*this));
+    memset((void *) this, 0, sizeof(*this));
     _cpool_index = saved_cpool_index;
   }
 }


### PR DESCRIPTION
```
src/hotspot/share/oops/resolvedFieldEntry.cpp:49:10: error: first argument in call to 'memset' is a pointer to non-trivially copyable type 'ResolvedFieldEntry' [-Werror,-Wnontrivial-memcall]
   49 |   memset(this, 0, sizeof(*this));
      |          ^
src/hotspot/share/oops/resolvedFieldEntry.cpp:49:10: note: explicitly cast the pointer to silence this warning
   49 |   memset(this, 0, sizeof(*this));
      |          ^
      |          (void*)
1 error generated.
src/hotspot/share/oops/resolvedMethodEntry.cpp:43:12: error: first argument in call to 'memset' is a pointer to non-trivially copyable type 'ResolvedMethodEntry' [-Werror,-Wnontrivial-memcall]
   43 |     memset(this, 0, sizeof(*this));
      |            ^
src/hotspot/share/oops/resolvedMethodEntry.cpp:43:12: note: explicitly cast the pointer to silence this warning
   43 |     memset(this, 0, sizeof(*this));
      |            ^
      |            (void*)
src/hotspot/share/oops/resolvedMethodEntry.cpp:48:12: error: first argument in call to 'memset' is a pointer to non-trivially copyable type 'ResolvedMethodEntry' [-Werror,-Wnontrivial-memcall]
   48 |     memset(this, 0, sizeof(*this));
      |            ^
src/hotspot/share/oops/resolvedMethodEntry.cpp:48:12: note: explicitly cast the pointer to silence this warning
   48 |     memset(this, 0, sizeof(*this));
      |            ^
      |            (void*)
2 errors generated.
```
