### PR TITLE
8361288: Fix build of JTReg: wget exited with exit code 4

### DIFF
--- a/.github/actions/build-jtreg/action.yml
+++ b/.github/actions/build-jtreg/action.yml
@@ -53,7 +53,14 @@ runs:
     - name: 'Build JTReg'
       run: |
         # Build JTReg and move files to the proper locations
-        bash make/build.sh --jdk "$JAVA_HOME_17_X64"
+        retry=0
+        while ! bash make/build.sh --jdk "$JAVA_HOME_17_X64"; do
+          retry=$[$retry+1]
+          if [ $retry -gt 20 ];then
+            echo >&2 "JTReg is failing to build"
+            exit 1
+          fi
+        done
         mkdir ../installed
         mv build/images/jtreg/* ../installed
       working-directory: jtreg/src

--- a/.github/actions/build-jtreg/action.yml
+++ b/.github/actions/build-jtreg/action.yml
@@ -56,10 +56,11 @@ runs:
         retry=0
         while ! bash make/build.sh --jdk "$JAVA_HOME_17_X64"; do
           retry=$[$retry+1]
-          if [ $retry -gt 20 ];then
+          if [ $retry -gt 3 ];then
             echo >&2 "JTReg is failing to build"
             exit 1
           fi
+          sleep 30
         done
         mkdir ../installed
         mv build/images/jtreg/* ../installed


### PR DESCRIPTION
https://github.com/jankratochvil/jdk21u-dev/actions/runs/16026488095/job/45215623689
[build.sh][INFO] Downloading https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.8-bin.zip to /home/runner/work/jdk21u-dev/jdk21u-dev/jtreg/src/make/../build/deps/apache-ant-1.10.8-bin.zip
Error: sh][ERROR] wget exited with exit code 4
Error: Process completed with exit code 1.

It is enough to make an empty commit "retry CI" and push it to re-run the Github CI.
It happened for me twice:
https://github.com/openjdk/jdk21u-dev/pull/1663#event-18416642257
-> (I did not save the log, unaware how to access it now)
https://github.com/openjdk/jdk21u-dev/pull/1664#commits-pushed-c00e2ab
-> https://github.com/jankratochvil/jdk21u-dev/actions/runs/16026488095/job/45215623689

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8361288](https://bugs.openjdk.org/browse/JDK-8361288): Fix build of JTReg: wget exited with exit code 4 (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26100/head:pull/26100` \
`$ git checkout pull/26100`

Update a local copy of the PR: \
`$ git checkout pull/26100` \
`$ git pull https://git.openjdk.org/jdk.git pull/26100/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26100`

View PR using the GUI difftool: \
`$ git pr show -t 26100`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26100.diff">https://git.openjdk.org/jdk/pull/26100.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26100#issuecomment-3028647977)
</details>
