### PR TITLE
8361299: (bf) CharBuffer.getChars(int,int,char[],int) violates pre-existing specification

### DIFF
--- a/src/java.base/share/classes/java/nio/X-Buffer.java.template
+++ b/src/java.base/share/classes/java/nio/X-Buffer.java.template
@@ -1897,21 +1897,30 @@ public abstract sealed class $Type$Buffer
 #if[char]
 
     /**
-     * Absolute bulk <i>get</i> method.
+     * Relative bulk <i>get</i> method.
      *
      * <p> This method transfers {@code srcEnd-srcBegin} characters from this
-     * buffer into the given array, starting at index {@code srcBegin} in this
-     * buffer and at offset {@code dstBegin} in the array. The position of this
-     * buffer is unchanged.
+     * buffer into the given array, starting at index {@code position() + srcBegin} in this
+     * buffer and at offset {@code dstBegin} in the array.
+     *
+     * <p> An invocation of this method behaves exaclty the same was as the
+     * invocation
+     *
+     * {@snippet lang=java :
+     *     get(position() + srcBegin, dst, dstBegin, srcEnd - srcBegin)
+     * }
      *
      * @param  srcBegin
-     *         The index in this buffer from which the first character will be
-     *         read; must be non-negative and less than {@code limit()}
+     *         The index in this buffer, relative to the current position,
+     *         of the first character to
+     *         read; must be non-negative and less than
+     *         {@code limit() - position()}
      *
      * @param  srcEnd
-     *         The index in this buffer directly before the last character to
-     *         read; must be non-negative and less or equal than {@code limit()}
-     *         and must be greater or equal than {@code srcBegin}
+     *         The index in this buffer, relative to the current position,
+     *         after the last character to read;
+     *         must be greater than or equal to {@code srcBegin} and less than
+     *         or equal to {@code limit() - position()}
      *
      * @param  dst
      *         The destination array
@@ -1924,14 +1933,11 @@ public abstract sealed class $Type$Buffer
      *          If the preconditions on the {@code srcBegin}, {@code srcEnd},
      *          and {@code dstBegin} parameters do not hold
      *
-     * @implSpec This method is equivalent to
-     *           {@code get(srcBegin, dst, dstBegin, srcEnd - srcBegin)}.
-     *
      * @since 25
      */
     @Override
     public void getChars(int srcBegin, int srcEnd, char[] dst, int dstBegin) {
-        get(srcBegin, dst, dstBegin, srcEnd - srcBegin);
+        get(position() + srcBegin, dst, dstBegin, srcEnd - srcBegin);
     }
 
     /**

--- a/test/jdk/java/nio/Buffer/GetChars.java
+++ b/test/jdk/java/nio/Buffer/GetChars.java
@@ -36,7 +36,7 @@ import static org.testng.Assert.assertEquals;
 
 /**
  * @test
- * @bug 8343110
+ * @bug 8343110 8361299
  * @summary Check for expected behavior of CharBuffer.getChars().
  * @run testng GetChars
  * @key randomness
@@ -200,7 +200,7 @@ public class GetChars {
         System.out.format("%s position=%d, limit=%d%n", type, cb.position(), cb.limit());
         int expected = intSum(cb);
         var dst = new char[cb.remaining()];
-        cb.getChars(cb.position(), cb.limit(), dst, 0);
+        cb.getChars(0, cb.remaining(), dst, 0);
         int actual = intSum(dst);
         assertEquals(actual, expected);
     }


### PR DESCRIPTION
Modify `CharBuffer.getChars` to respect the class level specification that the provided buffer offset `srcBegin` is relative to the buffer's current position.