### PR TITLE
JDK-8361303: L10n comment for javac.opt.Xlint.desc.synchronization in javac.properties

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/javac.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/javac.properties
@@ -291,6 +291,7 @@ javac.opt.Xlint.desc.preview=\
 javac.opt.Xlint.desc.restricted=\
     Warn about use of restricted methods.
 
+# L10N: do not localize: identity synchronization
 javac.opt.Xlint.desc.synchronization=\
     Warn about synchronization attempts on instances of value-based classes.\n\
 \                         This key is a deprecated alias for ''identity'', which has the same uses and\n\


### PR DESCRIPTION
Please review this PR which provides a comment to make apparent what should not be localized in the value for the key: `javac.opt.Xlint.desc.synchronization`. This was suggested by the translation team and is also consistent with other key values in the properties file that make similar comments.