### PR TITLE
8360022: ClassRefDupInConstantPoolTest.java fails when running in repeat

### DIFF
--- a/test/langtools/tools/javac/jvm/ClassRefDupInConstantPoolTest.java
+++ b/test/langtools/tools/javac/jvm/ClassRefDupInConstantPoolTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,7 @@
  * @test
  * @bug 8015927
  * @summary Class reference duplicates in constant pool
- * @clean ClassRefDupInConstantPoolTest$Duplicates
+ * @clean ClassRefDupInConstantPoolTest ClassRefDupInConstantPoolTest$Duplicates
  * @run main ClassRefDupInConstantPoolTest
  */
 


### PR DESCRIPTION
The javac test `ClassRefDupInConstantPoolTest.java` has an incorrect clean directive: when its subsidary Duplicates class is cleaned, the main class is not, and jtreg eagerly reexecutes the main class and then the test fails by not able to find the nested class.

This problem is evident when running from intellij idea. It can also be reproduced consistently by:
```
make test TEST=langtools/tools/javac/jvm/ClassRefDupInConstantPoolTest.java JTREG=REPEAT_COUNT=2
```

Testing: that make test line above now passes.