### PR TITLE
8336147: Clarify CDS documentation about static vs dynamic archive

### DIFF
--- a/src/java.base/share/man/java.md
+++ b/src/java.base/share/man/java.md
@@ -3760,7 +3760,7 @@ general form:
 The names "static" and "dynamic" are used for historical reasons. The dynamic
 archive, while still useful, supports fewer optimizations than
 available for the static CDS archive. If the full set of CDS/AOT
-optimizations are desired, consider using the AOT cache describe below.
+optimizations are desired, consider using the AOT cache described below.
 
 The JVM can use up to two archives. To use only a single `<static_archive>`,
 you can omit the `<dynamic_archive>` portion:

--- a/src/java.base/share/man/java.md
+++ b/src/java.base/share/man/java.md
@@ -3760,7 +3760,7 @@ general form:
 The names "static" and "dynamic" are used for historical reasons. The dynamic
 archive, while still useful, supports fewer optimizations than
 available for the static CDS archive. If the full set of CDS/AOT
-optimizations are desired, consider using the AOTCache features describe below.
+optimizations are desired, consider using the AOT cache describe below.
 
 The JVM can use up to two archives. To use only a single `<static_archive>`,
 you can omit the `<dynamic_archive>` portion:

--- a/src/java.base/share/man/java.md
+++ b/src/java.base/share/man/java.md
@@ -3757,9 +3757,15 @@ general form:
     be loaded on top of those in the `<static_archive>`.
 -   On Windows, the above path delimiter `:` should be replaced with `;`
 
-(The names "static" and "dynamic" are used for historical reasons.
-The only significance is that the "static" archive is loaded first and
-the "dynamic" archive is loaded second).
+The names "static" and "dynamic" are used for historical reasons.
+The dynamic archive may be less efficient as it does not support the
+following optimizations:
+
+-   Java heap objects cannot be stored in the dynamic archive.
+-   Class files that are created by JDK 5 or before cannot be
+    stored in the dynamic archive.
+-   Lambda expressions cannot be resolved ahead-of-time for classes
+    in the dynamic archive.
 
 The JVM can use up to two archives. To use only a single `<static_archive>`,
 you can omit the `<dynamic_archive>` portion:

--- a/src/java.base/share/man/java.md
+++ b/src/java.base/share/man/java.md
@@ -3757,15 +3757,10 @@ general form:
     be loaded on top of those in the `<static_archive>`.
 -   On Windows, the above path delimiter `:` should be replaced with `;`
 
-The names "static" and "dynamic" are used for historical reasons.
-The dynamic archive may be less efficient as it does not support the
-following optimizations:
-
--   Java heap objects cannot be stored in the dynamic archive.
--   Class files that are created by JDK 5 or before cannot be
-    stored in the dynamic archive.
--   Lambda expressions cannot be resolved ahead-of-time for classes
-    in the dynamic archive.
+The names "static" and "dynamic" are used for historical reasons. The dynamic
+archive, while still useful, supports fewer optimizations than
+available for the static CDS archive. If the full set of CDS/AOT
+optimizations are desired, consider using the AOTCache features describe below.
 
 The JVM can use up to two archives. To use only a single `<static_archive>`,
 you can omit the `<dynamic_archive>` portion:


### PR DESCRIPTION
Please review this doc clarification about the difference between CDS static and dynamic archives.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336147](https://bugs.openjdk.org/browse/JDK-8336147): Clarify CDS documentation about static vs dynamic archive (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**) Review applies to [bfb82882](https://git.openjdk.org/jdk/pull/26109/files/bfb8288273905f1df6389a5b605873f852a9bdcd)
 * [Calvin Cheung](https://openjdk.org/census#ccheung) (@calvinccheung - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26109/head:pull/26109` \
`$ git checkout pull/26109`

Update a local copy of the PR: \
`$ git checkout pull/26109` \
`$ git pull https://git.openjdk.org/jdk.git pull/26109/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26109`

View PR using the GUI difftool: \
`$ git pr show -t 26109`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26109.diff">https://git.openjdk.org/jdk/pull/26109.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26109#issuecomment-3032987958)
</details>
