### PR TITLE
8361338: JFR: Min and max time in MethodTime event is confusing

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/events/MethodTimingEvent.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/events/MethodTimingEvent.java
@@ -29,11 +29,13 @@ import jdk.jfr.Label;
 import jdk.jfr.Name;
 import jdk.jfr.Timespan;
 import jdk.jfr.internal.RemoveFields;
+import jdk.jfr.Description;
 
 @Name("jdk.MethodTiming")
 @Label("Method Timing")
 @Category({ "Java Virtual Machine", "Method Tracing" })
 @RemoveFields({ "duration", "eventThread", "stackTrace" })
+@Description("Measures the approximate time it takes for a method to execute, including all delays, not just CPU processing time")
 public final class MethodTimingEvent extends AbstractJDKEvent {
 
     @Label("Method")
@@ -43,14 +45,17 @@ public final class MethodTimingEvent extends AbstractJDKEvent {
     public long invocations;
 
     @Label("Minimum Time")
+    @Description("The value may be missing (Long.MIN_VALUE) if the clock-resolution is too low to establish a minimum time")
     @Timespan(Timespan.TICKS)
     public long minimum;
 
     @Label("Average Time")
+    @Description("The value may be missing (Long.MIN_VALUE) if the clock-resolution is too low to establish an average time")
     @Timespan(Timespan.TICKS)
     public long average;
 
     @Label("Maximum Time")
+    @Description("The value may be missing (Long.MIN_VALUE) if the clock-resolution is too low to establish a maximum time")
     @Timespan(Timespan.TICKS)
     public long maximum;
 

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/query/view.ini
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/query/view.ini
@@ -471,9 +471,9 @@ table = "COLUMN 'Alloc. Time', 'Application Method', 'Object Age', 'Heap Usage'
 
 [application.method-timing]
 label = "Method Timing"
-table = "COLUMN 'Timed Method', 'Invocations', 'Min. Time', 'Max. Time', 'Average Time'
+table = "COLUMN 'Timed Method', 'Invocations', 'Minimum Time', 'Average Time', 'Maximum Time'
          FORMAT none, none, ms-precision:6, ms-precision:6, ms-precision:6
-         SELECT LAST_BATCH(method) AS M, LAST_BATCH(invocations), LAST_BATCH(minimum), LAST_BATCH(maximum), LAST_BATCH(average)
+         SELECT LAST_BATCH(method) AS M, LAST_BATCH(invocations), LAST_BATCH(minimum), LAST_BATCH(average), LAST_BATCH(maximum)
          FROM jdk.MethodTiming GROUP BY method ORDER BY average"
 
 [application.method-calls]

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/tracing/TimedClass.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/tracing/TimedClass.java
@@ -72,7 +72,7 @@ public final class TimedClass {
                         min = average;
                     }
                     if (max == Long.MIN_VALUE) {
-                        min = average;
+                        max = average;
                     }
                     min = Math.min(min, average);
                     max = Math.max(max, average);

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/tracing/TimedClass.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/tracing/TimedClass.java
@@ -33,6 +33,7 @@ import jdk.jfr.events.MethodTimingEvent;
  * Holds timed method for a class. Used when publishing method ids.
  */
 public final class TimedClass {
+    private static final long MISSING = Long.MIN_VALUE;
     private final ConcurrentHashMap<Long, TimedMethod> methods = new ConcurrentHashMap<>();
 
     public TimedMethod add(Method method) {
@@ -60,13 +61,23 @@ public final class TimedClass {
                 long methodId = tm.method().methodId();
                 long invocations = tm.invocations().get();
                 long time = tm.time().get();
-                long average = invocations == 0 ? Long.MIN_VALUE : time / invocations;
                 long min = tm.minimum().get();
-                if (min == Long.MAX_VALUE) {
-                    min = Long.MIN_VALUE; // Signals that the value is missing
-                }
                 long max = tm.maximum().get();
-                MethodTimingEvent.commit(timestamp, methodId, invocations, min, average, max);
+                if (time == 0 || invocations == 0) {
+                    // If time is zero, it's a low resolution clock and more invocations are needed.
+                    MethodTimingEvent.commit(timestamp, methodId, invocations, MISSING, MISSING, MISSING);
+                } else {
+                    long average = (time + invocations / 2) / invocations;
+                    if (min == Long.MAX_VALUE) {
+                        min = average;
+                    }
+                    if (max == Long.MIN_VALUE) {
+                        min = average;
+                    }
+                    min = Math.min(min, average);
+                    max = Math.max(max, average);
+                    MethodTimingEvent.commit(timestamp, methodId, invocations, min, average, max);
+                }
                 tm.method().log("Emitted event");
             }
         }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/tracing/TimedMethod.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/tracing/TimedMethod.java
@@ -39,6 +39,9 @@ record TimedMethod(AtomicLong invocations, AtomicLong time, AtomicLong minimum, 
     }
 
     public void updateMinMax(long duration) {
+        if (duration == 0) {
+            return; // Ignore data due to low-resolution clock
+        }
         if (duration > maximum.getPlain()) {
             while (true) {
                 long max = maximum.get();


### PR DESCRIPTION
Could I have a review of change that make the method timing event less confusing.

Testing: jdk/jdk/jfr

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8361338](https://bugs.openjdk.org/browse/JDK-8361338): JFR: Min and max time in MethodTime event is confusing (**Bug** - P3)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26112/head:pull/26112` \
`$ git checkout pull/26112`

Update a local copy of the PR: \
`$ git checkout pull/26112` \
`$ git pull https://git.openjdk.org/jdk.git pull/26112/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26112`

View PR using the GUI difftool: \
`$ git pr show -t 26112`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26112.diff">https://git.openjdk.org/jdk/pull/26112.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26112#issuecomment-3035587905)
</details>
