### PR TITLE
8361306: jdk.compiler-gendata needs to depend on java.base-launchers

### DIFF
--- a/make/Main.gmk
+++ b/make/Main.gmk
@@ -1014,7 +1014,7 @@ else
   else ifeq ($(EXTERNAL_BUILDJDK), false)
     # When not cross compiling, the BUILD_JDK is the interim jdk image, and
     # the javac launcher is needed.
-    jdk.compiler-gendata: jdk.compiler-launchers
+    jdk.compiler-gendata: jdk.compiler-launchers java.base-launchers
     jdk.javadoc-gendata: jdk.compiler-launchers
   endif
 


### PR DESCRIPTION
A recent run in the Oracle CI produced the following:
```
Creating ct.sym classes
/bin/bash: $WS/build/linux-aarch64-open/jdk/bin/java: No such file or directory
modules/jdk.compiler/Gendata.gmk:72: recipe for target '$WS/build/linux-aarch64-open/support/symbols/ct.sym' failed
make[3]: *** [$WS/build/linux-aarch64-open/support/symbols/ct.sym] Error 127
make[2]: *** [jdk.compiler-gendata] Error 2
make[2]: *** Waiting for unfinished jobs....
make/Main.gmk:136: recipe for target 'jdk.compiler-gendata' failed 
```

`jdk.compiler/Gendata.gmk` calls `$(BUILD_JAVA_SMALL)`, which is created by java.base-launchers (unless cross-compiling). This dependency is not recorded, and it has just worked due to pure luck since jdk/bin/java is usually produced much earlier in the build process.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8361306](https://bugs.openjdk.org/browse/JDK-8361306): jdk.compiler-gendata needs to depend on java.base-launchers (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26113/head:pull/26113` \
`$ git checkout pull/26113`

Update a local copy of the PR: \
`$ git checkout pull/26113` \
`$ git pull https://git.openjdk.org/jdk.git pull/26113/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26113`

View PR using the GUI difftool: \
`$ git pr show -t 26113`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26113.diff">https://git.openjdk.org/jdk/pull/26113.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26113#issuecomment-3031847265)
</details>
