### PR TITLE
8361363: ShenandoahAsserts::print_obj() does not work for forwarded objects and UseCompactObjectHeaders

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahAsserts.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahAsserts.cpp
@@ -64,7 +64,9 @@ void ShenandoahAsserts::print_obj(ShenandoahMessageBuffer& msg, oop obj) {
 
   ShenandoahMarkingContext* const ctx = heap->marking_context();
 
-  msg.append("  " PTR_FORMAT " - klass " PTR_FORMAT " %s\n", p2i(obj), p2i(obj->klass()), obj->klass()->external_name());
+  Klass* obj_klass = ShenandoahForwarding::klass(obj);
+
+  msg.append("  " PTR_FORMAT " - klass " PTR_FORMAT " %s\n", p2i(obj), p2i(obj_klass), obj_klass->external_name());
   msg.append("    %3s allocated after mark start\n", ctx->allocated_after_mark_start(obj) ? "" : "not");
   msg.append("    %3s after update watermark\n",     cast_from_oop<HeapWord*>(obj) >= r->get_update_watermark() ? "" : "not");
   msg.append("    %3s marked strong\n",              ctx->is_marked_strong(obj) ? "" : "not");


### PR DESCRIPTION
`ShenandoahAsserts::print_obj()` does not work for COH if the object is forwarded, since the mark word is overwritten with a forwarding pointer.

Depending on the size of the non-null bits of the forwardee (whether it spills into the nKlass bits), nKlass is either zero or garbage. So we get either an "assert(!is_null(v)) failed: narrow klass value can never be zero", or a SIGSEGV. 

Fix is trivial: don't use obj->klass() directly but get it from ShenandoahForwarding.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8361363](https://bugs.openjdk.org/browse/JDK-8361363): ShenandoahAsserts::print_obj() does not work for forwarded objects and UseCompactObjectHeaders (**Bug** - P4)


### Reviewers
 * [Roman Kennke](https://openjdk.org/census#rkennke) (@rkennke - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26117/head:pull/26117` \
`$ git checkout pull/26117`

Update a local copy of the PR: \
`$ git checkout pull/26117` \
`$ git pull https://git.openjdk.org/jdk.git pull/26117/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26117`

View PR using the GUI difftool: \
`$ git pr show -t 26117`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26117.diff">https://git.openjdk.org/jdk/pull/26117.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26117#issuecomment-3032947701)
</details>
