### PR TITLE
8361383: LogFileStreamOutput::write_decorations uses wrong type for format precisions

### DIFF
--- a/src/hotspot/share/logging/logFileStreamOutput.cpp
+++ b/src/hotspot/share/logging/logFileStreamOutput.cpp
@@ -64,7 +64,7 @@ int LogFileStreamOutput::write_decorations(const LogDecorations& decorations) {
                               decorations.decoration(decorator, buf, sizeof(buf)));
     if (written <= 0) {
       return -1;
-    } else if (static_cast<size_t>(written - 2) > _decorator_padding[decorator]) {
+    } else if ((written - 2) > _decorator_padding[decorator]) {
       _decorator_padding[decorator] = written - 2;
     }
     total_written += written;

--- a/src/hotspot/share/logging/logFileStreamOutput.hpp
+++ b/src/hotspot/share/logging/logFileStreamOutput.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,13 +40,14 @@ class LogFileStreamOutput : public LogOutput {
 
  protected:
   FILE*               _stream;
-  size_t              _decorator_padding[LogDecorators::Count];
+  int                 _decorator_padding[LogDecorators::Count];
 
-  LogFileStreamOutput(FILE *stream) : _fold_multilines(false), _write_error_is_shown(false), _stream(stream) {
-    for (size_t i = 0; i < LogDecorators::Count; i++) {
-      _decorator_padding[i] = 0;
-    }
-  }
+  LogFileStreamOutput(FILE *stream)
+    : _fold_multilines(false),
+      _write_error_is_shown(false),
+      _stream(stream),
+      _decorator_padding()
+  {}
 
   int write_decorations(const LogDecorations& decorations);
   int write_internal(const LogDecorations& decorations, const char* msg);


### PR DESCRIPTION
Please review this change to LogFileStreamOutput to fix the type of the
precision values used when writing the decorations in a log message.

While I was at it, value-initialize the _decorator_padding in the
ctor-initializer rather than with a zero-filling loop.

Testing: mach5 tier1
Locally ran several tests that generate logging output and checked by eye the
decorator output.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8361383](https://bugs.openjdk.org/browse/JDK-8361383): LogFileStreamOutput::write_decorations uses wrong type for format precisions (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26124/head:pull/26124` \
`$ git checkout pull/26124`

Update a local copy of the PR: \
`$ git checkout pull/26124` \
`$ git pull https://git.openjdk.org/jdk.git pull/26124/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26124`

View PR using the GUI difftool: \
`$ git pr show -t 26124`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26124.diff">https://git.openjdk.org/jdk/pull/26124.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26124#issuecomment-3033993671)
</details>
