### PR TITLE
8358750: JFR: EventInstrumentation MASK_THROTTLE* constants should be computed in longs

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/EventInstrumentation.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/EventInstrumentation.java
@@ -61,8 +61,8 @@ import jdk.jfr.internal.util.ImplicitFields;
  *
  */
 public final class EventInstrumentation {
-    public static final long MASK_THROTTLE               = 1 << 62;
-    public static final long MASK_THROTTLE_CHECK         = 1 << 63;
+    public static final long MASK_THROTTLE               = 1L << 62;
+    public static final long MASK_THROTTLE_CHECK         = 1L << 63;
     public static final long MASK_THROTTLE_BITS          = MASK_THROTTLE | MASK_THROTTLE_CHECK;
     public static final long MASK_THROTTLE_CHECK_SUCCESS = MASK_THROTTLE_CHECK | MASK_THROTTLE;
     public static final long MASK_THROTTLE_CHECK_FAIL    = MASK_THROTTLE_CHECK | 0;
@@ -482,6 +482,11 @@ public final class EventInstrumentation {
         blockCodeBuilder.ifne(durationEvent);
         invokestatic(blockCodeBuilder, TYPE_EVENT_CONFIGURATION, METHOD_TIME_STAMP);
         blockCodeBuilder.lstore(1);
+        if (throttled) {
+            blockCodeBuilder.aload(0);
+            blockCodeBuilder.lload(1);
+            putfield(blockCodeBuilder, eventClassDesc, ImplicitFields.FIELD_START_TIME);
+        }
         Label commit = blockCodeBuilder.newLabel();
         blockCodeBuilder.goto_(commit);
         //   if (duration == 0) {
@@ -491,7 +496,7 @@ public final class EventInstrumentation {
         blockCodeBuilder.labelBinding(durationEvent);
         blockCodeBuilder.aload(0);
         getfield(blockCodeBuilder, eventClassDesc, ImplicitFields.FIELD_DURATION);
-        blockCodeBuilder.lconst_0();
+        blockCodeBuilder.lconst_0(); // also blocks throttled event
         blockCodeBuilder.lcmp();
         blockCodeBuilder.ifne(commit);
         blockCodeBuilder.aload(0);
@@ -527,9 +532,7 @@ public final class EventInstrumentation {
             // write duration
             blockCodeBuilder.dup();
             // stack: [EW] [EW]
-            blockCodeBuilder.aload(0);
-            // stack: [EW] [EW] [this]
-            getfield(blockCodeBuilder, eventClassDesc, ImplicitFields.FIELD_DURATION);
+            getDuration(blockCodeBuilder);
             // stack: [EW] [EW] [long]
             invokevirtual(blockCodeBuilder, TYPE_EVENT_WRITER, EventWriterMethod.PUT_LONG.method());
             fieldIndex++;


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8358750](https://bugs.openjdk.org/browse/JDK-8358750): JFR: EventInstrumentation MASK_THROTTLE* constants should be computed in longs (**Bug** - P3)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26126/head:pull/26126` \
`$ git checkout pull/26126`

Update a local copy of the PR: \
`$ git checkout pull/26126` \
`$ git pull https://git.openjdk.org/jdk.git pull/26126/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26126`

View PR using the GUI difftool: \
`$ git pr show -t 26126`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26126.diff">https://git.openjdk.org/jdk/pull/26126.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26126#issuecomment-3035189633)
</details>
