### PR TITLE
8361401: Warnings for use of Sun APIs should not be mandatory

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
@@ -3759,7 +3759,7 @@ public class Check {
     void checkSunAPI(final DiagnosticPosition pos, final Symbol s) {
         if ((s.flags() & PROPRIETARY) != 0) {
             deferredLintHandler.report(_l -> {
-                log.strictWarning(pos, Warnings.SunProprietary(s));
+                log.warning(pos, Warnings.SunProprietary(s));
             });
         }
     }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
@@ -3759,7 +3759,7 @@ public class Check {
     void checkSunAPI(final DiagnosticPosition pos, final Symbol s) {
         if ((s.flags() & PROPRIETARY) != 0) {
             deferredLintHandler.report(_l -> {
-                log.mandatoryWarning(pos, Warnings.SunProprietary(s));
+                log.strictWarning(pos, Warnings.SunProprietary(s));
             });
         }
     }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
@@ -1969,6 +1969,7 @@ compiler.warn.has.been.deprecated.for.removal.module=\
     module {0} has been deprecated and marked for removal
 
 # 0: symbol
+# flags: strict
 compiler.warn.sun.proprietary=\
     {0} is internal proprietary API and may be removed in a future release
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/JCDiagnostic.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/JCDiagnostic.java
@@ -458,7 +458,9 @@ public class JCDiagnostic implements Diagnostic<JavaFileObject> {
         API,
         /** Flag for not-supported-in-source-X errors.
          */
-        SOURCE_LEVEL;
+        SOURCE_LEVEL,
+        /** Flag for warnings that cannot be disabled */
+        STRICT;
     }
 
     private final DiagnosticSource source;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Log.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Log.java
@@ -798,7 +798,8 @@ public class Log extends AbstractLog {
                 }
 
                 // Emit warning unless not mandatory and warnings are disabled
-                if (emitWarnings || diagnostic.isMandatory()) {
+                if (emitWarnings || diagnostic.isMandatory() ||
+                        diagnostic.isFlagSet(DiagnosticFlag.STRICT)) {
                     if (nwarnings < MaxWarnings) {
                         writeDiagnostic(diagnostic);
                         nwarnings++;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Log.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Log.java
@@ -680,16 +680,6 @@ public class Log extends AbstractLog {
         errWriter.flush();
     }
 
-    /** Report a warning that cannot be suppressed.
-     *  @param pos    The source position at which to report the warning.
-     *  @param key    The key for the localized warning message.
-     *  @param args   Fields of the warning message.
-     */
-    public void strictWarning(DiagnosticPosition pos, String key, Object ... args) {
-        writeDiagnostic(diags.warning(null, source, pos, key, args));
-        nwarnings++;
-    }
-
     /**
      * Primary method to report a diagnostic.
      * @param diagnostic

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Log.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Log.java
@@ -48,6 +48,7 @@ import com.sun.tools.javac.code.Source;
 import com.sun.tools.javac.main.Main;
 import com.sun.tools.javac.main.Option;
 import com.sun.tools.javac.tree.EndPosTable;
+import com.sun.tools.javac.util.JCDiagnostic.DiagnosticFlag;
 import com.sun.tools.javac.util.JCDiagnostic.DiagnosticInfo;
 import com.sun.tools.javac.util.JCDiagnostic.DiagnosticPosition;
 import com.sun.tools.javac.util.JCDiagnostic.DiagnosticType;
@@ -797,9 +798,15 @@ public class Log extends AbstractLog {
                         return;
                 }
 
-                // Emit warning unless not mandatory and warnings are disabled
-                if (emitWarnings || diagnostic.isMandatory() ||
-                        diagnostic.isFlagSet(DiagnosticFlag.STRICT)) {
+                // Strict warnings are always emitted
+                if (diagnostic.isFlagSet(DiagnosticFlag.STRICT)) {
+                    writeDiagnostic(diagnostic);
+                    nwarnings++;
+                    return;
+                }
+
+                // Emit other warning unless not mandatory and warnings are disabled
+                if (emitWarnings || diagnostic.isMandatory()) {
                     if (nwarnings < MaxWarnings) {
                         writeDiagnostic(diagnostic);
                         nwarnings++;

--- a/test/langtools/tools/lib/toolbox/JavacTask.java
+++ b/test/langtools/tools/lib/toolbox/JavacTask.java
@@ -37,6 +37,7 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.processing.Processor;
+import javax.tools.DiagnosticListener;
 import javax.tools.JavaCompiler;
 import javax.tools.JavaFileManager;
 import javax.tools.JavaFileObject;
@@ -62,6 +63,7 @@ public class JavacTask extends AbstractTask<JavacTask> {
     private JavaFileManager fileManager;
     private Consumer<com.sun.source.util.JavacTask> callback;
     private List<Processor> procs;
+    private DiagnosticListener<? super JavaFileObject> diagnosticListener;
 
     private JavaCompiler compiler;
     private StandardJavaFileManager internalFileManager;
@@ -286,6 +288,14 @@ public class JavacTask extends AbstractTask<JavacTask> {
     }
 
     /**
+     * Sets the diagnostic listener to be used.
+     */
+    public JavacTask diagnosticListener(DiagnosticListener<? super JavaFileObject> diagnosticListener) {
+        this.diagnosticListener = diagnosticListener;
+        return this;
+    }
+
+    /**
      * Sets the file manager to be used by this task.
      * @param fileManager the file manager
      * @return this task object
@@ -406,7 +416,7 @@ public class JavacTask extends AbstractTask<JavacTask> {
             Iterable<? extends JavaFileObject> allFiles = joinFiles(files, fileObjects);
             JavaCompiler.CompilationTask task = compiler.getTask(pw,
                     fileManager,
-                    null,  // diagnostic listener; should optionally collect diags
+                    diagnosticListener,  // diagnostic listener; should optionally collect diags
                     allOpts,
                     classes,
                     allFiles);


### PR DESCRIPTION
During Java 8, we changed the code that reported use of Sun API warnings (e.g. `com.sun.misc.Unsafe`) to use `Log::mandatoryWarning` instead of `Log::strictWarning`. This change had two effects:

* warnings for use of Sun API would *not* be emitted if more than 100 warnings were displayed
* warnings for use of Sun API would become [mandatory warnings](https://download.java.net/java/early_access/jdk25/docs/api/java.compiler/javax/tools/Diagnostic.Kind.html#MANDATORY_WARNING)

The latter is particularly bad, because the definition of a mandatory warning is that of a warning mandated by the specification. Currently we only use the mandatory status for unchecked, deprecation and preview warnings.

This PR reverts the behavior to what it was before Java 8. That is, the warning for Sun API use is now marked with the `STRICT` flag -- and `Log` will not attempt to filter out warnings with such flag. As a result, the (unused) method `Log::strictWarning` can be removed.

I've tweaked an existing test to check the kind of the Sun API warnings.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8361402](https://bugs.openjdk.org/browse/JDK-8361402) to be approved

### Issues
 * [JDK-8361401](https://bugs.openjdk.org/browse/JDK-8361401): Warnings for use of Sun APIs should not be mandatory (**Bug** - P4)
 * [JDK-8361402](https://bugs.openjdk.org/browse/JDK-8361402): Warnings for use of Sun APIs should not be mandatory (**CSR**)


### Reviewers
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**)
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26129/head:pull/26129` \
`$ git checkout pull/26129`

Update a local copy of the PR: \
`$ git checkout pull/26129` \
`$ git pull https://git.openjdk.org/jdk.git pull/26129/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26129`

View PR using the GUI difftool: \
`$ git pr show -t 26129`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26129.diff">https://git.openjdk.org/jdk/pull/26129.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26129#issuecomment-3036687771)
</details>
