### PR TITLE
8361404: Parallel: Group all class unloading logc at the end of marking phase

### DIFF
--- a/src/hotspot/share/gc/parallel/psParallelCompact.cpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.cpp
@@ -732,16 +732,6 @@ void PSParallelCompact::post_compact()
     ct->dirty_MemRegion(old_mr);
   }
 
-  {
-    // Delete metaspaces for unloaded class loaders and clean up loader_data graph
-    GCTraceTime(Debug, gc, phases) t("Purge Class Loader Data", gc_timer());
-    ClassLoaderDataGraph::purge(true /* at_safepoint */);
-    DEBUG_ONLY(MetaspaceUtils::verify();)
-  }
-
-  // Need to clear claim bits for the next mark.
-  ClassLoaderDataGraph::clear_claimed_marks();
-
   heap->prune_scavengable_nmethods();
 
 #if COMPILER2_OR_JVMCI
@@ -1044,10 +1034,6 @@ bool PSParallelCompact::invoke_no_policy(bool clear_all_soft_refs) {
 
     ref_processor()->start_discovery(clear_all_soft_refs);
 
-    ClassUnloadingContext ctx(1 /* num_nmethod_unlink_workers */,
-                              false /* unregister_nmethods_during_purge */,
-                              false /* lock_nmethod_free_separately */);
-
     marking_phase(&_gc_tracer);
 
     summary_phase();
@@ -1337,7 +1323,9 @@ void PSParallelCompact::marking_phase(ParallelOldTracer *gc_tracer) {
   {
     GCTraceTime(Debug, gc, phases) tm_m("Class Unloading", &_gc_timer);
 
-    ClassUnloadingContext* ctx = ClassUnloadingContext::context();
+    ClassUnloadingContext ctx(1 /* num_nmethod_unlink_workers */,
+                              false /* unregister_nmethods_during_purge */,
+                              false /* lock_nmethod_free_separately */);
 
     bool unloading_occurred;
     {
@@ -1353,7 +1341,7 @@ void PSParallelCompact::marking_phase(ParallelOldTracer *gc_tracer) {
     {
       GCTraceTime(Debug, gc, phases) t("Purge Unlinked NMethods", gc_timer());
       // Release unloaded nmethod's memory.
-      ctx->purge_nmethods();
+      ctx.purge_nmethods();
     }
     {
       GCTraceTime(Debug, gc, phases) ur("Unregister NMethods", &_gc_timer);
@@ -1361,7 +1349,7 @@ void PSParallelCompact::marking_phase(ParallelOldTracer *gc_tracer) {
     }
     {
       GCTraceTime(Debug, gc, phases) t("Free Code Blobs", gc_timer());
-      ctx->free_nmethods();
+      ctx.free_nmethods();
     }
 
     // Prune dead klasses from subklass/sibling/implementor lists.
@@ -1369,6 +1357,15 @@ void PSParallelCompact::marking_phase(ParallelOldTracer *gc_tracer) {
 
     // Clean JVMCI metadata handles.
     JVMCI_ONLY(JVMCI::do_unloading(unloading_occurred));
+    {
+      // Delete metaspaces for unloaded class loaders and clean up loader_data graph
+      GCTraceTime(Debug, gc, phases) t("Purge Class Loader Data", gc_timer());
+      ClassLoaderDataGraph::purge(true /* at_safepoint */);
+      DEBUG_ONLY(MetaspaceUtils::verify();)
+    }
+
+    // Need to clear claim bits for the next mark.
+    ClassLoaderDataGraph::clear_claimed_marks();
   }
 
   {


### PR DESCRIPTION
Simple patch of moving some out-of-place `ClassLoaderDataGraph` logic to the end of marking-phase in order group all class unloading logic at the same scope/site.

Test: tier1-8

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8361404](https://bugs.openjdk.org/browse/JDK-8361404): Parallel: Group all class unloading logc at the end of marking phase (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26130/head:pull/26130` \
`$ git checkout pull/26130`

Update a local copy of the PR: \
`$ git checkout pull/26130` \
`$ git pull https://git.openjdk.org/jdk.git pull/26130/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26130`

View PR using the GUI difftool: \
`$ git pr show -t 26130`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26130.diff">https://git.openjdk.org/jdk/pull/26130.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26130#issuecomment-3035701483)
</details>
