### PR TITLE
8360302: Update --release 25 symbol information for JDK 25 build 29

### DIFF
--- a/src/jdk.compiler/share/data/symbols/java.base-P.sym.txt
+++ b/src/jdk.compiler/share/data/symbols/java.base-P.sym.txt
@@ -484,19 +484,17 @@ method name withEncryption descriptor ([C)Ljava/security/PEMEncoder; flags 1
 class name java/security/PEMRecord
 header extends java/lang/Record implements java/security/DEREncodable record true flags 31 classAnnotations @Ljdk/internal/javac/PreviewFeature;(feature=eLjdk/internal/javac/PreviewFeature$Feature;PEM_API;)
 recordcomponent name type descriptor Ljava/lang/String;
-recordcomponent name pem descriptor Ljava/lang/String;
+recordcomponent name content descriptor Ljava/lang/String;
 recordcomponent name leadingData descriptor [B
-innerclass innerClass java/util/Base64$Decoder outerClass java/util/Base64 innerClassName Decoder flags 9
 innerclass innerClass java/lang/invoke/MethodHandles$Lookup outerClass java/lang/invoke/MethodHandles innerClassName Lookup flags 19
 method name <init> descriptor (Ljava/lang/String;Ljava/lang/String;[B)V flags 1 methodParameters 0:type,0:pem,0:leadingData
 method name <init> descriptor (Ljava/lang/String;Ljava/lang/String;)V flags 1
-method name getEncoded descriptor ()[B flags 1
 method name toString descriptor ()Ljava/lang/String; flags 1
 method name hashCode descriptor ()I flags 11
 method name equals descriptor (Ljava/lang/Object;)Z flags 11
 method name type descriptor ()Ljava/lang/String; flags 1
-method name pem descriptor ()Ljava/lang/String; flags 1
 method name leadingData descriptor ()[B flags 1
+method name content descriptor ()Ljava/lang/String; flags 1
 
 class name java/security/SecurityPermission
 header extends java/security/BasicPermission flags 31 deprecated true runtimeAnnotations @Ljava/lang/Deprecated;(forRemoval=Ztrue,since="25")


### PR DESCRIPTION
Usual symbol file update for a new JDK build. Looks like [JDK-8358099](https://bugs.openjdk.org/browse/JDK-8358099).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8360302](https://bugs.openjdk.org/browse/JDK-8360302): Update --release 25 symbol information for JDK 25 build 29 (**Sub-task** - P4)


### Reviewers
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26131/head:pull/26131` \
`$ git checkout pull/26131`

Update a local copy of the PR: \
`$ git checkout pull/26131` \
`$ git pull https://git.openjdk.org/jdk.git pull/26131/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26131`

View PR using the GUI difftool: \
`$ git pr show -t 26131`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26131.diff">https://git.openjdk.org/jdk/pull/26131.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26131#issuecomment-3035795095)
</details>
