### PR TITLE
8361175: JFR: Document differences between method sample events

### DIFF
--- a/src/hotspot/share/jfr/metadata/metadata.xml
+++ b/src/hotspot/share/jfr/metadata/metadata.xml
@@ -948,22 +948,24 @@
     <Field type="long" contentType="bytes" name="freeSize" label="Free Size" description="Free swap space" />
   </Event>
 
-  <Event name="ExecutionSample" category="Java Virtual Machine, Profiling" label="Method Profiling Sample" description="Snapshot of a threads state"
+  <Event name="ExecutionSample" category="Java Virtual Machine, Profiling" label="Java Execution Sample"
+         description="Snapshot of a thread executing Java code. Threads that are not executing Java code, including those waiting or executing native code, are not included."
     period="everyChunk">
     <Field type="Thread" name="sampledThread" label="Thread" />
     <Field type="StackTrace" name="stackTrace" label="Stack Trace" />
     <Field type="ThreadState" name="state" label="Thread State" />
   </Event>
 
-  <Event name="NativeMethodSample" category="Java Virtual Machine, Profiling" label="Method Profiling Sample Native" description="Snapshot of a threads state when in native"
+  <Event name="NativeMethodSample" category="Java Virtual Machine, Profiling" label="Native Sample"
+         description="Snapshot of a thread in native code, executing or waiting. Threads that are executing Java code are not included."
     period="everyChunk">
     <Field type="Thread" name="sampledThread" label="Thread" />
     <Field type="StackTrace" name="stackTrace" label="Stack Trace" />
     <Field type="ThreadState" name="state" label="Thread State" />
   </Event>
 
-  <Event name="CPUTimeSample" category="Java Virtual Machine, Profiling" label="CPU Time Method Sample"
-    description="Snapshot of a threads state from the CPU time sampler. The throttle can be either an upper bound for the event emission rate, e.g. 100/s, or the cpu-time period, e.g. 10ms, with s, ms, us and ns supported as time units."
+  <Event name="CPUTimeSample" category="Java Virtual Machine, Profiling" label="CPU Time Sample"
+    description="Snapshot of a threads state from the CPU time sampler, both threads executing native and Java code are included. The throttle setting can be either an upper bound for the event emission rate, e.g. 100/s, or the cpu-time period, e.g. 10ms, with s, ms, us and ns supported as time units."
     throttle="true" thread="false" experimental="true" startTime="false">
     <Field type="StackTrace" name="stackTrace" label="Stack Trace" />
     <Field type="Thread" name="eventThread" label="Thread" />
@@ -972,7 +974,7 @@
     <Field type="boolean" name="biased" label="Biased" description="The sample is safepoint-biased" />
   </Event>
 
-  <Event name="CPUTimeSamplesLost" category="Java Virtual Machine, Profiling" label="CPU Time Method Profiling Lost Samples" description="Records that the CPU time sampler lost samples"
+  <Event name="CPUTimeSamplesLost" category="Java Virtual Machine, Profiling" label="CPU Time Samples Lost" description="Records that the CPU time sampler lost samples"
     thread="false" stackTrace="false" startTime="false" experimental="true">
     <Field type="int" name="lostSamples" label="Lost Samples" />
     <Field type="Thread" name="eventThread" label="Thread" />

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/query/view.ini
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/query/view.ini
@@ -518,10 +518,10 @@ table = "COLUMN 'Memory Type', 'First Observed', 'Average', 'Last Observed', 'Ma
 
 [application.native-methods]
 label = "Waiting or Executing Native Methods"
-table = "COLUMN 'Method', 'Samples', 'Percent'
-         FORMAT none, none, normalized
-         SELECT stackTrace.topFrame AS T, COUNT(*), COUNT(*)
-         FROM NativeMethodSample GROUP BY T"
+table = "COLUMN 'Method', 'Samples'
+         FORMAT none, none
+         SELECT stackTrace.topFrame AS T, COUNT(*) AS C
+         FROM NativeMethodSample GROUP BY T ORDER BY C DESC"
 
 [environment.network-utilization]
 label = "Network Utilization"

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/query/view.ini
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/query/view.ini
@@ -395,7 +395,7 @@ form = "SELECT LAST(initialSize), LAST(minSize), LAST(maxSize),
                FROM GCHeapConfiguration"
 
 [application.hot-methods]
-label = "Java Methods that Executes the Most"
+label = "Java Methods that Execute the Most"
 table = "COLUMN 'Method', 'Samples', 'Percent'
          FORMAT none, none, normalized
          SELECT stackTrace.topFrame AS T, COUNT(*), COUNT(*)


### PR DESCRIPTION
Could I have a review that clarifies how the method sample events work?

- Added descriptions to NativeMethodSample, ExecutionSample and CPUTimeSample to clarify what they sample and what they don't sample.
- Removed the word "Method" from the labels of the CPUTimeSample and ExecutionSample events for consistency and to avoid overly verbose event labels.
- Added the word "setting" so that the description of CPUTimeSample reads "throttle setting" instead of just "throttle".
- Changed the label for the CPUTimeSamplesLost event to "CPU Time Samples Lost", making it easier to associate with "CPU Time Sample" event. 
- Removed the percentage column from the "native-methods" view, as normalization doesn't make sense when mixing executing and waiting samples.


Testing: tets/jdk/jdk/jfr + tier1

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8361175](https://bugs.openjdk.org/browse/JDK-8361175): JFR: Document differences between method sample events (**Bug** - P3)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26132/head:pull/26132` \
`$ git checkout pull/26132`

Update a local copy of the PR: \
`$ git checkout pull/26132` \
`$ git pull https://git.openjdk.org/jdk.git pull/26132/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26132`

View PR using the GUI difftool: \
`$ git pr show -t 26132`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26132.diff">https://git.openjdk.org/jdk/pull/26132.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26132#issuecomment-3037065591)
</details>
