### PR TITLE
8361367: AOT ExcludedClasses.java test failed with missing constant pool logs

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/aotCache/ExcludedClasses.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotCache/ExcludedClasses.java
@@ -96,11 +96,8 @@ public class ExcludedClasses {
 
         @Override
         public void checkExecution(OutputAnalyzer out, RunMode runMode) {
-            if (runMode == RunMode.TRAINING) {
-                out.shouldMatch("aot,resolve.*reverted field.*TestApp.Foo => TestApp.Foo.ShouldBeExcluded.f:I");
-            } else if (runMode == RunMode.ASSEMBLY) {
+            if (runMode == RunMode.ASSEMBLY) {
                 out.shouldNotMatch("aot,resolve.*archived field.*TestApp.Foo => TestApp.Foo.ShouldBeExcluded.f:I");
-                out.shouldMatch("aot,resolve.*archived method.*TestApp.Foo java/lang/Integer.intValue:[(][)]I => java/lang/Integer");
             } else if (runMode == RunMode.PRODUCTION) {
                 out.shouldContain("check_verification_constraint: TestApp$Foo$Taz: TestApp$Foo$ShouldBeExcludedChild must be subclass of TestApp$Foo$ShouldBeExcluded");
                 out.shouldContain("jdk.jfr.Event source: jrt:/jdk.jfr");


### PR DESCRIPTION
This is a test bug.

The failures happen with `-Xcomp`. The following method is executed completely in compiled code:

```
static int hotSpot() {
    ShouldBeExcluded s = new ShouldBeExcluded();
    [.....]
    return counter + s.m() + s.f + b.m() + b.f;
}

```

C1 can generate code for reading `s.f` without resolving the `ShouldBeExcluded:f:I` reference inside the constant pool. Therefore, I removed two log messages from the test that may not be printed if the compiler happens to compile the corresponding bytecodes.