### PR TITLE
8177650: JShell tool: packages in classpath don't appear in completions

### DIFF
--- a/src/jdk.jshell/share/classes/jdk/jshell/SourceCodeAnalysisImpl.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/SourceCodeAnalysisImpl.java
@@ -2003,7 +2003,7 @@ class SourceCodeAnalysisImpl extends SourceCodeAnalysis {
             appendPaths(fm, StandardLocation.PLATFORM_CLASS_PATH, paths);
             appendPaths(fm, StandardLocation.CLASS_PATH, paths);
             appendPaths(fm, StandardLocation.SOURCE_PATH, paths);
-            appendPaths(fm, StandardLocation.MODULE_PATH, paths);
+            appendModulePaths(fm, StandardLocation.MODULE_PATH, paths);
 
             Map<Path, ClassIndex> newIndexes = new HashMap<>();
 
@@ -2053,6 +2053,23 @@ class SourceCodeAnalysisImpl extends SourceCodeAnalysis {
             }
 
             paths.add(path);
+        }
+    }
+
+    private void appendModulePaths(MemoryFileManager fm, Location loc, Collection<Path> paths) {
+        Iterable<? extends Path> locationPaths = fm.getLocationAsPaths(loc);
+        if (locationPaths == null)
+            return ;
+        for (Path path : locationPaths) {
+            if (Files.isDirectory(path) && !Files.exists(path.resolve("module-info.class"))) {
+                try (var ds = Files.newDirectoryStream(path)) {
+                    ds.forEach(paths::add);
+                } catch (IOException ex) {
+                    proc.debug(ex, "appendModulePaths: " + path);
+                }
+            } else {
+                paths.add(path);
+            }
         }
     }
 

--- a/src/jdk.jshell/share/classes/jdk/jshell/SourceCodeAnalysisImpl.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/SourceCodeAnalysisImpl.java
@@ -1998,11 +1998,12 @@ class SourceCodeAnalysisImpl extends SourceCodeAnalysis {
     private void refreshIndexes(int version) {
         try {
             Collection<Path> paths = new ArrayList<>();
-            MemoryFileManager fm = proc.taskFactory.fileManager();
+            MemoryFileManager fm = proc.taskFactory.configuredFileManager();
 
             appendPaths(fm, StandardLocation.PLATFORM_CLASS_PATH, paths);
             appendPaths(fm, StandardLocation.CLASS_PATH, paths);
             appendPaths(fm, StandardLocation.SOURCE_PATH, paths);
+            appendPaths(fm, StandardLocation.MODULE_PATH, paths);
 
             Map<Path, ClassIndex> newIndexes = new HashMap<>();
 
@@ -2195,11 +2196,15 @@ class SourceCodeAnalysisImpl extends SourceCodeAnalysis {
             upToDate = classpathVersion == indexVersion;
         }
         while (!upToDate) {
-            INDEXER.submit(() -> {}).get();
+            waitCurrentBackgroundTasksFinished();
             synchronized (currentIndexes) {
                 upToDate = classpathVersion == indexVersion;
             }
         }
+    }
+
+    public static void waitCurrentBackgroundTasksFinished() throws Exception {
+        INDEXER.submit(() -> {}).get();
     }
 
     /**

--- a/src/jdk.jshell/share/classes/jdk/jshell/TaskFactory.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/TaskFactory.java
@@ -138,6 +138,11 @@ class TaskFactory {
         return fileManager;
     }
 
+    MemoryFileManager configuredFileManager() {
+        parse("", _ -> null);
+        return fileManager;
+    }
+
     public <Z> Z parse(String source,
                        boolean forceExpression,
                        Worker<ParseTask, Z> worker) {

--- a/test/langtools/jdk/jshell/CompletionSuggestionTest.java
+++ b/test/langtools/jdk/jshell/CompletionSuggestionTest.java
@@ -834,4 +834,20 @@ public class CompletionSuggestionTest extends KullaTesting {
         assertCompletionIncludesExcludes("import module ja|", Set.of("java.base"), Set.of("jdk.compiler"));
         assertCompletion("import module java/*c*/./*c*/ba|", "java.base");
     }
+
+    public void testCustomClassPathIndexing() {
+        Path p1 = outDir.resolve("dir1");
+        compiler.compile(p1,
+                "package p1.p2;\n" +
+                "public class Test {\n" +
+                "}",
+                "package p1.p3;\n" +
+                "public class Test {\n" +
+                "}");
+        String jarName = "test.jar";
+        compiler.jar(p1, jarName, "p1/p2/Test.class", "p1/p3/Test.class");
+        addToClasspath(compiler.getPath(p1.resolve(jarName)));
+
+        assertCompletion("p1.|", "p2.", "p3.");
+    }
 }

--- a/test/langtools/jdk/jshell/ReplToolTesting.java
+++ b/test/langtools/jdk/jshell/ReplToolTesting.java
@@ -567,8 +567,7 @@ public class ReplToolTesting {
         }
     }
 
-    public void assertCompletions(boolean after, String cmd, String out, String err,
-            String print, String usererr, String terminalOut) {
+    public void assertCompletions(boolean after, String input, String expectedCompletionsPattern) {
         if (!after) {
             try {
                 Class<?> sourceCodeAnalysisImpl = Class.forName("jdk.jshell.SourceCodeAnalysisImpl");
@@ -580,13 +579,21 @@ public class ReplToolTesting {
                 throw new AssertionError(ex.getMessage(), ex);
             }
 
-            setCommandInput(cmd + "\t");
+            setCommandInput(input + "\t");
         } else {
-            assertOutput(getCommandOutput().trim(), out==null? out : out.trim(), "command output: " + cmd);
-            assertOutput(getCommandErrorOutput(), err, "command error: " + cmd);
-            assertOutput(getUserOutput(), print, "user output: " + cmd);
-            assertOutput(getUserErrorOutput(), usererr, "user error: " + cmd);
-            assertOutput(getTerminalOutput(), terminalOut, "terminal output: " + cmd);
+            assertOutput(getCommandOutput().trim(), "", "command output: " + input);
+            assertOutput(getCommandErrorOutput(), "", "command error: " + input);
+            assertOutput(getUserOutput(), "", "user output: " + input);
+            assertOutput(getUserErrorOutput(), "", "user error: " + input);
+            String actualOutput = getTerminalOutput();
+            Pattern compiledPattern =
+                    Pattern.compile(expectedCompletionsPattern, Pattern.DOTALL);
+            if (!compiledPattern.asMatchPredicate().test(actualOutput)) {
+                throw new AssertionError("Actual output:\n" +
+                                         actualOutput + "\n" +
+                                         "does not match expected pattern: " +
+                                         expectedCompletionsPattern);
+            }
         }
     }
 

--- a/test/langtools/jdk/jshell/ReplToolTesting.java
+++ b/test/langtools/jdk/jshell/ReplToolTesting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintStream;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -563,6 +564,29 @@ public class ReplToolTesting {
     public void assertOutput(String got, String expected, String display) {
         if (expected != null) {
             assertEquals(got, expected, display + ".\n");
+        }
+    }
+
+    public void assertCompletions(boolean after, String cmd, String out, String err,
+            String print, String usererr, String terminalOut) {
+        if (!after) {
+            try {
+                Class<?> sourceCodeAnalysisImpl = Class.forName("jdk.jshell.SourceCodeAnalysisImpl");
+                Method waitBackgroundTaskFinished = sourceCodeAnalysisImpl.getDeclaredMethod("waitCurrentBackgroundTasksFinished");
+
+                waitBackgroundTaskFinished.setAccessible(true);
+                waitBackgroundTaskFinished.invoke(null);
+            } catch (ReflectiveOperationException ex) {
+                throw new AssertionError(ex.getMessage(), ex);
+            }
+
+            setCommandInput(cmd + "\t");
+        } else {
+            assertOutput(getCommandOutput().trim(), out==null? out : out.trim(), "command output: " + cmd);
+            assertOutput(getCommandErrorOutput(), err, "command error: " + cmd);
+            assertOutput(getUserOutput(), print, "user output: " + cmd);
+            assertOutput(getUserErrorOutput(), usererr, "user error: " + cmd);
+            assertOutput(getTerminalOutput(), terminalOut, "terminal output: " + cmd);
         }
     }
 

--- a/test/langtools/jdk/jshell/ToolCompletionTest.java
+++ b/test/langtools/jdk/jshell/ToolCompletionTest.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8177650
+ * @summary Verify JShell tool code completion
+ * @library /tools/lib
+ * @modules jdk.compiler/com.sun.tools.javac.api
+ *          jdk.compiler/com.sun.tools.javac.main
+ *          jdk.jdeps/com.sun.tools.javap
+ *          jdk.jshell/jdk.jshell:+open
+ *          jdk.jshell/jdk.internal.jshell.tool
+ *          java.desktop
+ * @build toolbox.ToolBox toolbox.JarTask toolbox.JavacTask
+ * @build ReplToolTesting TestingInputStream Compiler
+ * @run testng ToolCompletionTest
+ */
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.testng.annotations.Test;
+
+public class ToolCompletionTest extends ReplToolTesting {
+
+    private final Compiler compiler = new Compiler();
+    private final Path outDir = Paths.get("tool_completion_test");
+
+    @Test
+    public void testClassPathOnCmdLineIndexing() {
+        Path p1 = outDir.resolve("dir1");
+        compiler.compile(p1,
+                """
+                package p1.p2;
+                public class Test {
+                }
+                """,
+                """
+                package p1.p3;
+                public class Test {
+                }
+                """);
+        String jarName = "test.jar";
+        compiler.jar(p1, jarName, "p1/p2/Test.class", "p1/p3/Test.class");
+
+        test(false, new String[]{"--no-startup", "--class-path", compiler.getPath(p1.resolve(jarName)).toString()},
+                (a) -> assertCompletions(a, "p1.", null, null, null, null,
+                                         """
+                                         \u0005p1.
+                                         p2.   p3.\s\s\s\n\r"""),
+                 //cancel the input, so that JShell can be finished:
+                (a) -> assertCompletions(a, "\003", null, null, null, null, null)
+                );
+    }
+
+    @Test
+    public void testClassPathViaEnvIndexing() {
+        Path p1 = outDir.resolve("dir1");
+        compiler.compile(p1,
+                """
+                package p1.p2;
+                public class Test {
+                }
+                """,
+                """
+                package p1.p3;
+                public class Test {
+                }
+                """);
+        String jarName = "test.jar";
+        compiler.jar(p1, jarName, "p1/p2/Test.class", "p1/p3/Test.class");
+
+        test(false, new String[]{"--no-startup"},
+                (a) -> assertCommand(a, "/env --class-path " + compiler.getPath(p1.resolve(jarName)).toString(), null),
+                (a) -> assertCompletions(a, "p1.", null, null, null, null,
+                                         """
+                                         \u0005p1.
+                                         p2.   p3.\s\s\s\n\r"""),
+                 //cancel the input, so that JShell can be finished:
+                (a) -> assertCompletions(a, "\003", null, null, null, null, null)
+                );
+    }
+
+    @Test
+    public void testClassPathChangeIndexing() {
+        //verify that changing the classpath has effect:
+        Path dir1 = outDir.resolve("dir1");
+        compiler.compile(dir1,
+                """
+                package p1.p2;
+                public class Test {
+                }
+                """,
+                """
+                package p1.p3;
+                public class Test {
+                }
+                """);
+        String jarName1 = "test1.jar";
+        compiler.jar(dir1, jarName1, "p1/p2/Test.class", "p1/p3/Test.class");
+
+        Path dir2 = outDir.resolve("dir2");
+        compiler.compile(dir2,
+                """
+                package p1.p5;
+                public class Test {
+                }
+                """,
+                """
+                package p1.p6;
+                public class Test {
+                }
+                """);
+        String jarName2 = "test2.jar";
+        compiler.jar(dir2, jarName2, "p1/p5/Test.class", "p1/p6/Test.class");
+
+        test(false, new String[]{"--no-startup", "--class-path", compiler.getPath(dir1.resolve(jarName1)).toString()},
+                (a) -> assertCommand(a, "1", null),
+                (a) -> assertCommand(a, "/env --class-path " + compiler.getPath(dir2.resolve(jarName2)).toString(), null),
+                (a) -> assertCompletions(a, "p1.", null, null, null, null,
+                                         """
+                                         \u0005p1.
+                                         p5.   p6.\s\s\s\n\r"""),
+                 //cancel the input, so that JShell can be finished:
+                (a) -> assertCompletions(a, "\003", null, null, null, null, null)
+                );
+    }
+
+    @Test
+    public void testModulePathOnCmdLineIndexing() {
+        Path p1 = outDir.resolve("dir1");
+        compiler.compile(p1,
+                """
+                module m {
+                    exports p1.p2;
+                    exports p1.p3;
+                }
+                """,
+                """
+                package p1.p2;
+                public class Test {
+                }
+                """,
+                """
+                package p1.p3;
+                public class Test {
+                }
+                """);
+        String jarName = "test.jar";
+        compiler.jar(p1, jarName, "p1/p2/Test.class", "p1/p3/Test.class");
+
+        test(false, new String[]{"--no-startup", "--module-path", compiler.getPath(p1.resolve(jarName)).toString()},
+                (a) -> assertCompletions(a, "p1.", null, null, null, null,
+                                         """
+                                         \u0005p1.
+                                         p2.   p3.\s\s\s\n\r"""),
+                 //cancel the input, so that JShell can be finished:
+                (a) -> assertCompletions(a, "\003", null, null, null, null, null)
+                );
+    }
+}

--- a/test/langtools/jdk/jshell/ToolCompletionTest.java
+++ b/test/langtools/jdk/jshell/ToolCompletionTest.java
@@ -64,12 +64,9 @@ public class ToolCompletionTest extends ReplToolTesting {
         compiler.jar(p1, jarName, "p1/p2/Test.class", "p1/p3/Test.class");
 
         test(false, new String[]{"--no-startup", "--class-path", compiler.getPath(p1.resolve(jarName)).toString()},
-                (a) -> assertCompletions(a, "p1.", null, null, null, null,
-                                         """
-                                         \u0005p1.
-                                         p2.   p3.\s\s\s\n\r"""),
+                (a) -> assertCompletions(a, "p1.", ".*p2\\..*p3\\..*"),
                  //cancel the input, so that JShell can be finished:
-                (a) -> assertCompletions(a, "\003", null, null, null, null, null)
+                (a) -> assertCommand(a, "\003", null)
                 );
     }
 
@@ -92,12 +89,9 @@ public class ToolCompletionTest extends ReplToolTesting {
 
         test(false, new String[]{"--no-startup"},
                 (a) -> assertCommand(a, "/env --class-path " + compiler.getPath(p1.resolve(jarName)).toString(), null),
-                (a) -> assertCompletions(a, "p1.", null, null, null, null,
-                                         """
-                                         \u0005p1.
-                                         p2.   p3.\s\s\s\n\r"""),
+                (a) -> assertCompletions(a, "p1.", ".*p2\\..*p3\\..*"),
                  //cancel the input, so that JShell can be finished:
-                (a) -> assertCompletions(a, "\003", null, null, null, null, null)
+                (a) -> assertCommand(a, "\003", null)
                 );
     }
 
@@ -137,12 +131,9 @@ public class ToolCompletionTest extends ReplToolTesting {
         test(false, new String[]{"--no-startup", "--class-path", compiler.getPath(dir1.resolve(jarName1)).toString()},
                 (a) -> assertCommand(a, "1", null),
                 (a) -> assertCommand(a, "/env --class-path " + compiler.getPath(dir2.resolve(jarName2)).toString(), null),
-                (a) -> assertCompletions(a, "p1.", null, null, null, null,
-                                         """
-                                         \u0005p1.
-                                         p5.   p6.\s\s\s\n\r"""),
+                (a) -> assertCompletions(a, "p1.", ".*p5\\..*p6\\..*"),
                  //cancel the input, so that JShell can be finished:
-                (a) -> assertCompletions(a, "\003", null, null, null, null, null)
+                (a) -> assertCommand(a, "\003", null)
                 );
     }
 
@@ -170,12 +161,9 @@ public class ToolCompletionTest extends ReplToolTesting {
         compiler.jar(p1, jarName, "p1/p2/Test.class", "p1/p3/Test.class");
 
         test(false, new String[]{"--no-startup", "--module-path", compiler.getPath(p1.resolve(jarName)).toString()},
-                (a) -> assertCompletions(a, "p1.", null, null, null, null,
-                                         """
-                                         \u0005p1.
-                                         p2.   p3.\s\s\s\n\r"""),
+                (a) -> assertCompletions(a, "p1.", ".*p2\\..*p3\\..*"),
                  //cancel the input, so that JShell can be finished:
-                (a) -> assertCompletions(a, "\003", null, null, null, null, null)
+                (a) -> assertCommand(a, "\003", null)
                 );
     }
 }


### PR DESCRIPTION
JShell provides the code completion feature, where it suggests possible follow ups for a given snippet prefix. To allow completion for packages, JShell uses a background task to go through known classes and create an index for them.

There are two problems with this background task:
- the classpath is read from the JShell's FileManager, but the FileManager may not be configured with the compile options yet, so the classpath may not be filled yet,
- the module path is not included in the list of paths to paths to search

This PR proposes to:
- use FileManager configured by passing the compile options through javac
- include the module path in the search path
