### PR TITLE
8361424: Eliminate Log methods mandatoryWarning() and mandatoryNote()

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/api/JavacTrees.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/api/JavacTrees.java
@@ -1324,7 +1324,7 @@ public class JavacTrees extends DocTrees {
             switch (kind) {
                 case ERROR ->             log.error(DiagnosticFlag.API, pos, Errors.ProcMessager(msg.toString()));
                 case WARNING ->           log.warning(pos, Warnings.ProcMessager(msg.toString()));
-                case MANDATORY_WARNING -> log.mandatoryWarning(pos, Warnings.ProcMessager(msg.toString()));
+                case MANDATORY_WARNING -> log.warning(DiagnosticFlag.MANDATORY, pos, Warnings.ProcMessager(msg.toString()));
                 default ->                log.note(pos, Notes.ProcMessager(msg.toString()));
             }
         } finally {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Preview.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Preview.java
@@ -171,7 +171,7 @@ public class Preview {
         Assert.check(isEnabled());
         Assert.check(isPreview(feature));
         markUsesPreview(pos);
-        log.mandatoryWarning(pos,
+        log.warning(pos,
             feature.isPlural() ?
                 LintWarnings.PreviewFeatureUsePlural(feature.nameFragment()) :
                 LintWarnings.PreviewFeatureUse(feature.nameFragment()));
@@ -185,8 +185,7 @@ public class Preview {
     public void warnPreview(JavaFileObject classfile, int majorVersion) {
         Assert.check(isEnabled());
         if (verbose) {
-            log.mandatoryWarning(null,
-                    LintWarnings.PreviewFeatureUseClassfile(classfile, majorVersionToSource.get(majorVersion).name));
+            log.warning(LintWarnings.PreviewFeatureUseClassfile(classfile, majorVersionToSource.get(majorVersion).name));
         }
     }
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
@@ -246,7 +246,7 @@ public class Check {
             }
         }
         if (warningKey != null)
-            log.mandatoryWarning(pos, warningKey);
+            log.warning(pos, warningKey);
     }
 
     /** Log a preview warning.
@@ -255,7 +255,7 @@ public class Check {
      */
     public void warnPreviewAPI(DiagnosticPosition pos, LintWarning warnKey) {
         if (!importSuppression && !lint.isSuppressed(LintCategory.PREVIEW))
-            log.mandatoryWarning(pos, warnKey);
+            log.warning(pos, warnKey);
     }
 
     /** Log a preview warning.
@@ -272,7 +272,7 @@ public class Check {
      */
     public void warnUnchecked(DiagnosticPosition pos, LintWarning warnKey) {
         if (!lint.isSuppressed(LintCategory.UNCHECKED))
-            log.mandatoryWarning(pos, warnKey);
+            log.warning(pos, warnKey);
     }
 
     /** Report a failure to complete a class.

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
@@ -3759,7 +3759,7 @@ public class Check {
     void checkSunAPI(final DiagnosticPosition pos, final Symbol s) {
         if ((s.flags() & PROPRIETARY) != 0) {
             deferredLintHandler.report(_l -> {
-                log.strictWarning(pos, Warnings.SunProprietary(s));
+                log.warning(pos, Warnings.SunProprietary(s));
             });
         }
     }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
@@ -3759,7 +3759,7 @@ public class Check {
     void checkSunAPI(final DiagnosticPosition pos, final Symbol s) {
         if ((s.flags() & PROPRIETARY) != 0) {
             deferredLintHandler.report(_l -> {
-                log.mandatoryWarning(pos, Warnings.SunProprietary(s));
+                log.strictWarning(pos, Warnings.SunProprietary(s));
             });
         }
     }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/main/JavaCompiler.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/main/JavaCompiler.java
@@ -1845,7 +1845,7 @@ public class JavaCompiler {
         }
         log.reportOutstandingNotes();
         if (log.compressedOutput) {
-            log.mandatoryNote(null, Notes.CompressedDiags);
+            log.note(Notes.CompressedDiags);
         }
     }
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/processing/JavacMessager.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/processing/JavacMessager.java
@@ -128,7 +128,7 @@ public class JavacMessager implements Messager {
 
             case MANDATORY_WARNING:
                 warningCount++;
-                log.mandatoryWarning(pos, Warnings.ProcMessager(msg.toString()));
+                log.warning(DiagnosticFlag.MANDATORY, pos, Warnings.ProcMessager(msg.toString()));
                 break;
 
             default:

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
@@ -1969,6 +1969,7 @@ compiler.warn.has.been.deprecated.for.removal.module=\
     module {0} has been deprecated and marked for removal
 
 # 0: symbol
+# flags: strict
 compiler.warn.sun.proprietary=\
     {0} is internal proprietary API and may be removed in a future release
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
@@ -1923,19 +1923,19 @@ compiler.warn.incubating.modules=\
 
 # 0: symbol, 1: symbol
 # lint: deprecation
-# flags: aggregate
+# flags: aggregate, mandatory
 compiler.warn.has.been.deprecated=\
     {0} in {1} has been deprecated
 
 # 0: symbol, 1: symbol
 # lint: removal
-# flags: aggregate
+# flags: aggregate, mandatory
 compiler.warn.has.been.deprecated.for.removal=\
     {0} in {1} has been deprecated and marked for removal
 
 # 0: symbol
 # lint: preview
-# flags: aggregate
+# flags: aggregate, mandatory
 compiler.warn.is.preview=\
     {0} is a preview API and may be removed in a future release.
 
@@ -1946,7 +1946,7 @@ compiler.err.is.preview=\
 
 # 0: symbol
 # lint: preview
-# flags: aggregate
+# flags: aggregate, mandatory
 compiler.warn.is.preview.reflective=\
     {0} is a reflective preview API and may be removed in a future release.
 
@@ -1958,13 +1958,13 @@ compiler.warn.restricted.method=\
 
 # 0: symbol
 # lint: deprecation
-# flags: aggregate
+# flags: aggregate, mandatory
 compiler.warn.has.been.deprecated.module=\
     module {0} has been deprecated
 
 # 0: symbol
 # lint: removal
-# flags: aggregate
+# flags: aggregate, mandatory
 compiler.warn.has.been.deprecated.for.removal.module=\
     module {0} has been deprecated and marked for removal
 
@@ -2364,13 +2364,13 @@ compiler.warn.unchecked.assign=\
 
 # 0: symbol, 1: type
 # lint: unchecked
-# flags: aggregate
+# flags: aggregate, mandatory
 compiler.warn.unchecked.assign.to.var=\
     unchecked assignment to variable {0} as member of raw type {1}
 
 # 0: symbol, 1: type
 # lint: unchecked
-# flags: aggregate
+# flags: aggregate, mandatory
 compiler.warn.unchecked.call.mbr.of.raw.type=\
     unchecked call to {0} as a member of the raw type {1}
 
@@ -2380,7 +2380,7 @@ compiler.warn.unchecked.cast.to.type=\
 
 # 0: kind name, 1: name, 2: object, 3: object, 4: kind name, 5: symbol
 # lint: unchecked
-# flags: aggregate
+# flags: aggregate, mandatory
 compiler.warn.unchecked.meth.invocation.applied=\
     unchecked method invocation: {0} {1} in {4} {5} is applied to given types\n\
     required: {2}\n\
@@ -2388,13 +2388,13 @@ compiler.warn.unchecked.meth.invocation.applied=\
 
 # 0: type
 # lint: unchecked
-# flags: aggregate
+# flags: aggregate, mandatory
 compiler.warn.unchecked.generic.array.creation=\
     unchecked generic array creation for varargs parameter of type {0}
 
 # 0: type
 # lint: unchecked
-# flags: aggregate
+# flags: aggregate, mandatory
 compiler.warn.unchecked.varargs.non.reifiable.type=\
     Possible heap pollution from parameterized vararg type {0}
 
@@ -2793,7 +2793,7 @@ compiler.misc.prob.found.req=\
 
 # 0: message segment, 1: type, 2: type
 # lint: unchecked
-# flags: aggregate
+# flags: aggregate, mandatory
 compiler.warn.prob.found.req=\
     {0}\n\
     required: {2}\n\
@@ -3190,14 +3190,14 @@ compiler.err.override.incompatible.ret=\
 
 # 0: message segment, 1: type, 2: type
 # lint: unchecked
-# flags: aggregate
+# flags: aggregate, mandatory
 compiler.warn.override.unchecked.ret=\
     {0}\n\
     return type requires unchecked conversion from {1} to {2}
 
 # 0: message segment, 1: type
 # lint: unchecked
-# flags: aggregate
+# flags: aggregate, mandatory
 compiler.warn.override.unchecked.thrown=\
     {0}\n\
     overridden method does not throw {1}
@@ -3301,18 +3301,19 @@ compiler.err.preview.feature.disabled.classfile=\
 
 # 0: message segment (feature)
 # lint: preview
-# flags: aggregate
+# flags: aggregate, mandatory
 compiler.warn.preview.feature.use=\
    {0} is a preview feature and may be removed in a future release.
 
 # 0: message segment (feature)
 # lint: preview
-# flags: aggregate
+# flags: aggregate, mandatory
 compiler.warn.preview.feature.use.plural=\
    {0} are a preview feature and may be removed in a future release.
 
 # 0: file object (classfile), 1: string (expected version)
 # lint: preview
+# flags: mandatory
 compiler.warn.preview.feature.use.classfile=\
    class file for {0} uses preview features of Java SE {1}.
 
@@ -4270,7 +4271,7 @@ compiler.err.incorrect.number.of.nested.patterns=\
 
 # 0: kind name, 1: symbol
 # lint: preview
-# flags: aggregate
+# flags: aggregate, mandatory
 compiler.warn.declared.using.preview=\
     {0} {1} is declared using a preview feature, which may be removed in a future release.
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
@@ -1676,6 +1676,7 @@ compiler.warn.output.file.clash=\
 ## The following string will appear before all messages keyed as:
 ## "compiler.note".
 
+# flags: mandatory
 compiler.note.compressed.diags=\
     Some messages have been simplified; recompile with -Xdiags:verbose to get full output
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/AbstractLog.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/AbstractLog.java
@@ -161,7 +161,7 @@ public abstract class AbstractLog {
      * @param warningKey The key for the localized warning message.
      */
     public void warning(Warning warningKey) {
-        report(diags.warning(source, null, warningKey));
+        report(diags.warning(null, source, null, warningKey));
     }
 
     /** Report a warning, unless suppressed by the  -nowarn option or the
@@ -170,7 +170,17 @@ public abstract class AbstractLog {
      *  @param warningKey    The key for the localized warning message.
      */
     public void warning(DiagnosticPosition pos, Warning warningKey) {
-        report(diags.warning(source, pos, warningKey));
+        report(diags.warning(null, source, pos, warningKey));
+    }
+
+    /** Report a warning, unless suppressed by the  -nowarn option or the
+     *  maximum number of warnings has been reached.
+     *  @param flag   A flag to set on the diagnostic
+     *  @param pos    The source position at which to report the warning.
+     *  @param warningKey    The key for the localized warning message.
+     */
+    public void warning(DiagnosticFlag flag, DiagnosticPosition pos, Warning warningKey) {
+        report(diags.warning(flag, source, pos, warningKey));
     }
 
     /** Report a warning, unless suppressed by the  -nowarn option or the
@@ -179,15 +189,7 @@ public abstract class AbstractLog {
      *  @param warningKey    The key for the localized warning message.
      */
     public void warning(int pos, Warning warningKey) {
-        report(diags.warning(source, wrap(pos), warningKey));
-    }
-
-    /** Report a warning.
-     *  @param pos    The source position at which to report the warning.
-     *  @param warningKey    The key for the localized warning message.
-     */
-    public void mandatoryWarning(DiagnosticPosition pos, Warning warningKey) {
-        report(diags.mandatoryWarning(source, pos, warningKey));
+        report(diags.warning(null, source, wrap(pos), warningKey));
     }
 
     /** Provide a non-fatal notification, unless suppressed by the -nowarn option.

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/AbstractLog.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/AbstractLog.java
@@ -196,35 +196,36 @@ public abstract class AbstractLog {
      *  @param noteKey    The key for the localized notification message.
      */
     public void note(Note noteKey) {
-        report(diags.note(source, null, noteKey));
+        report(diags.note(null, source, null, noteKey));
     }
 
     /** Provide a non-fatal notification, unless suppressed by the -nowarn option.
      *  @param noteKey    The key for the localized notification message.
      */
     public void note(DiagnosticPosition pos, Note noteKey) {
-        report(diags.note(source, pos, noteKey));
+        report(diags.note(null, source, pos, noteKey));
+    }
+
+    /** Provide a non-fatal notification, unless suppressed by the -nowarn option.
+     *  @param flag       A flag to set on the diagnostic
+     *  @param noteKey    The key for the localized notification message.
+     */
+    public void note(DiagnosticFlag flag, DiagnosticPosition pos, Note noteKey) {
+        report(diags.note(flag, source, pos, noteKey));
     }
 
     /** Provide a non-fatal notification, unless suppressed by the -nowarn option.
      *  @param noteKey    The key for the localized notification message.
      */
     public void note(int pos, Note noteKey) {
-        report(diags.note(source, wrap(pos), noteKey));
+        report(diags.note(null, source, wrap(pos), noteKey));
     }
 
     /** Provide a non-fatal notification, unless suppressed by the -nowarn option.
      *  @param noteKey    The key for the localized notification message.
      */
     public void note(JavaFileObject file, Note noteKey) {
-        report(diags.note(getSource(file), null, noteKey));
-    }
-
-    /** Provide a non-fatal notification, unless suppressed by the -nowarn option.
-     *  @param noteKey    The key for the localized notification message.
-     */
-    public void mandatoryNote(final JavaFileObject file, Note noteKey) {
-        report(diags.mandatoryNote(getSource(file), noteKey));
+        report(diags.note(null, getSource(file), null, noteKey));
     }
 
     protected abstract void report(JCDiagnostic diagnostic);

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/JCDiagnostic.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/JCDiagnostic.java
@@ -458,7 +458,9 @@ public class JCDiagnostic implements Diagnostic<JavaFileObject> {
         API,
         /** Flag for not-supported-in-source-X errors.
          */
-        SOURCE_LEVEL;
+        SOURCE_LEVEL,
+        /** Flag for warnings that cannot be disabled */
+        STRICT;
     }
 
     private final DiagnosticSource source;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/JCDiagnostic.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/JCDiagnostic.java
@@ -144,44 +144,25 @@ public class JCDiagnostic implements Diagnostic<JavaFileObject> {
         }
 
         /**
-         * Create a note diagnostic that will not be hidden by the -nowarn or -Xlint:none options.
-         *  @param source The source of the compilation unit, if any, in which to report the warning.
-         *  @param key    The key for the localized warning message.
-         *  @param args   Fields of the warning message.
-         *  @see MandatoryWarningHandler
-         */
-        public JCDiagnostic mandatoryNote(DiagnosticSource source, String key, Object... args) {
-            return mandatoryNote(source, noteKey(key, args));
-        }
-
-        /**
-         * Create a note diagnostic that will not be hidden by the -nowarn or -Xlint:none options.
-         *  @param noteKey    The key for the localized note message.
-         *  @see MandatoryWarningHandler
-         */
-        public JCDiagnostic mandatoryNote(DiagnosticSource source, Note noteKey) {
-            return create(EnumSet.of(DiagnosticFlag.MANDATORY), source, null, noteKey);
-        }
-
-        /**
          * Create a note diagnostic.
          *  @param key    The key for the localized error message.
          *  @param args   Fields of the message.
          */
         public JCDiagnostic note(
                 DiagnosticSource source, DiagnosticPosition pos, String key, Object... args) {
-            return note(source, pos, noteKey(key, args));
+            return note(null, source, pos, noteKey(key, args));
         }
 
         /**
          * Create a note diagnostic.
+         *  @param flag   A flag to add to the diagnostic.
          *  @param source The source of the compilation unit, if any, in which to report the note.
          *  @param pos    The source position at which to report the note.
          *  @param noteKey    The key for the localized note message.
          */
         public JCDiagnostic note(
-                DiagnosticSource source, DiagnosticPosition pos, Note noteKey) {
-            return create(EnumSet.noneOf(DiagnosticFlag.class), source, pos, noteKey);
+                DiagnosticFlag flag, DiagnosticSource source, DiagnosticPosition pos, Note noteKey) {
+            return create(flag != null ? EnumSet.of(flag) : EnumSet.noneOf(DiagnosticFlag.class), source, pos, noteKey);
         }
 
         /**

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/JCDiagnostic.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/JCDiagnostic.java
@@ -117,33 +117,6 @@ public class JCDiagnostic implements Diagnostic<JavaFileObject> {
         }
 
         /**
-         * Create a warning diagnostic that will not be hidden by the -nowarn or -Xlint:none options.
-         *  @param lc     The lint category for the diagnostic
-         *  @param source The source of the compilation unit, if any, in which to report the warning.
-         *  @param pos    The source position at which to report the warning.
-         *  @param key    The key for the localized warning message.
-         *  @param args   Fields of the warning message.
-         *  @see MandatoryWarningHandler
-         */
-        public JCDiagnostic mandatoryWarning(
-                LintCategory lc,
-                DiagnosticSource source, DiagnosticPosition pos, String key, Object... args) {
-            return mandatoryWarning(source, pos, warningKey(lc, key, args));
-        }
-
-        /**
-         * Create a warning diagnostic that will not be hidden by the -nowarn or -Xlint:none options.
-         *  @param source The source of the compilation unit, if any, in which to report the warning.
-         *  @param pos    The source position at which to report the warning.
-         *  @param warningKey    The key for the localized warning message.
-         *  @see MandatoryWarningHandler
-         */
-        public JCDiagnostic mandatoryWarning(
-                DiagnosticSource source, DiagnosticPosition pos, Warning warningKey) {
-            return create(EnumSet.of(DiagnosticFlag.MANDATORY), source, pos, warningKey);
-        }
-
-        /**
          * Create a warning diagnostic.
          *  @param lc     The lint category for the diagnostic
          *  @param source The source of the compilation unit, if any, in which to report the warning.
@@ -154,19 +127,20 @@ public class JCDiagnostic implements Diagnostic<JavaFileObject> {
          */
         public JCDiagnostic warning(
                 LintCategory lc, DiagnosticSource source, DiagnosticPosition pos, String key, Object... args) {
-            return warning(source, pos, warningKey(lc, key, args));
+            return warning(null, source, pos, warningKey(lc, key, args));
         }
 
         /**
          * Create a warning diagnostic.
+         *  @param flag   A flag to add to the diagnostic.
          *  @param source The source of the compilation unit, if any, in which to report the warning.
          *  @param pos    The source position at which to report the warning.
          *  @param warningKey    The key for the localized warning message.
          *  @see MandatoryWarningHandler
          */
         public JCDiagnostic warning(
-                DiagnosticSource source, DiagnosticPosition pos, Warning warningKey) {
-            return create(EnumSet.noneOf(DiagnosticFlag.class), source, pos, warningKey);
+                DiagnosticFlag flag, DiagnosticSource source, DiagnosticPosition pos, Warning warningKey) {
+            return create(flag != null ? EnumSet.of(flag) : EnumSet.noneOf(DiagnosticFlag.class), source, pos, warningKey);
         }
 
         /**

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Log.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Log.java
@@ -798,7 +798,8 @@ public class Log extends AbstractLog {
                 }
 
                 // Emit warning unless not mandatory and warnings are disabled
-                if (emitWarnings || diagnostic.isMandatory()) {
+                if (emitWarnings || diagnostic.isMandatory() ||
+                        diagnostic.isFlagSet(DiagnosticFlag.STRICT)) {
                     if (nwarnings < MaxWarnings) {
                         writeDiagnostic(diagnostic);
                         nwarnings++;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Log.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Log.java
@@ -680,16 +680,6 @@ public class Log extends AbstractLog {
         errWriter.flush();
     }
 
-    /** Report a warning that cannot be suppressed.
-     *  @param pos    The source position at which to report the warning.
-     *  @param key    The key for the localized warning message.
-     *  @param args   Fields of the warning message.
-     */
-    public void strictWarning(DiagnosticPosition pos, String key, Object ... args) {
-        writeDiagnostic(diags.warning(null, source, pos, key, args));
-        nwarnings++;
-    }
-
     /**
      * Primary method to report a diagnostic.
      * @param diagnostic

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Log.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Log.java
@@ -48,6 +48,7 @@ import com.sun.tools.javac.code.Source;
 import com.sun.tools.javac.main.Main;
 import com.sun.tools.javac.main.Option;
 import com.sun.tools.javac.tree.EndPosTable;
+import com.sun.tools.javac.util.JCDiagnostic.DiagnosticFlag;
 import com.sun.tools.javac.util.JCDiagnostic.DiagnosticInfo;
 import com.sun.tools.javac.util.JCDiagnostic.DiagnosticPosition;
 import com.sun.tools.javac.util.JCDiagnostic.DiagnosticType;
@@ -797,9 +798,15 @@ public class Log extends AbstractLog {
                         return;
                 }
 
-                // Emit warning unless not mandatory and warnings are disabled
-                if (emitWarnings || diagnostic.isMandatory() ||
-                        diagnostic.isFlagSet(DiagnosticFlag.STRICT)) {
+                // Strict warnings are always emitted
+                if (diagnostic.isFlagSet(DiagnosticFlag.STRICT)) {
+                    writeDiagnostic(diagnostic);
+                    nwarnings++;
+                    return;
+                }
+
+                // Emit other warning unless not mandatory and warnings are disabled
+                if (emitWarnings || diagnostic.isMandatory()) {
                     if (nwarnings < MaxWarnings) {
                         writeDiagnostic(diagnostic);
                         nwarnings++;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/WarningAggregator.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/WarningAggregator.java
@@ -35,6 +35,7 @@ import javax.tools.JavaFileObject;
 import com.sun.tools.javac.code.Lint;
 import com.sun.tools.javac.code.Lint.LintCategory;
 import com.sun.tools.javac.code.Source;
+import com.sun.tools.javac.util.JCDiagnostic.DiagnosticFlag;
 import com.sun.tools.javac.util.JCDiagnostic.DiagnosticPosition;
 import com.sun.tools.javac.util.JCDiagnostic.LintWarning;
 import com.sun.tools.javac.util.JCDiagnostic.Note;
@@ -205,7 +206,7 @@ class WarningAggregator {
     }
 
     private void addNote(List<JCDiagnostic> list, JavaFileObject file, String msg, Object... args) {
-        list.add(log.diags.mandatoryNote(log.getSource(file), new Note(null, "compiler", msg, args)));
+        list.add(log.diags.note(DiagnosticFlag.MANDATORY, log.getSource(file), null, new Note(null, "compiler", msg, args)));
     }
 
     /**

--- a/test/langtools/tools/lib/toolbox/JavacTask.java
+++ b/test/langtools/tools/lib/toolbox/JavacTask.java
@@ -37,6 +37,7 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.processing.Processor;
+import javax.tools.DiagnosticListener;
 import javax.tools.JavaCompiler;
 import javax.tools.JavaFileManager;
 import javax.tools.JavaFileObject;
@@ -62,6 +63,7 @@ public class JavacTask extends AbstractTask<JavacTask> {
     private JavaFileManager fileManager;
     private Consumer<com.sun.source.util.JavacTask> callback;
     private List<Processor> procs;
+    private DiagnosticListener<? super JavaFileObject> diagnosticListener;
 
     private JavaCompiler compiler;
     private StandardJavaFileManager internalFileManager;
@@ -286,6 +288,14 @@ public class JavacTask extends AbstractTask<JavacTask> {
     }
 
     /**
+     * Sets the diagnostic listener to be used.
+     */
+    public JavacTask diagnosticListener(DiagnosticListener<? super JavaFileObject> diagnosticListener) {
+        this.diagnosticListener = diagnosticListener;
+        return this;
+    }
+
+    /**
      * Sets the file manager to be used by this task.
      * @param fileManager the file manager
      * @return this task object
@@ -406,7 +416,7 @@ public class JavacTask extends AbstractTask<JavacTask> {
             Iterable<? extends JavaFileObject> allFiles = joinFiles(files, fileObjects);
             JavaCompiler.CompilationTask task = compiler.getTask(pw,
                     fileManager,
-                    null,  // diagnostic listener; should optionally collect diags
+                    diagnosticListener,  // diagnostic listener; should optionally collect diags
                     allOpts,
                     classes,
                     allFiles);


### PR DESCRIPTION
The fix for [JDK-8359493](https://bugs.openjdk.org/browse/JDK-8359493) added the ability to associate `DiagnosticFlag`'s to specific warnings defined in `compiler.properties`. In cases where the flag is an inherent property of the warning itself, `compiler.properties` is a more appropriate place to declare the flag, instead having to add it at all the points in the codebase where that particular warning is used.

In particular, the Log API methods `mandatoryWarning()` and `mandatoryNote()` can be removed, as they serve only to add the `MANDATORY` flag to warnings and notes for which "mandatoryness" is inherent. Doing so will help decomplexify the code a bit.

This PR depends on (i.e., includes):
* #26129