### PR TITLE
8358696: Assert with extreme values for -XX:BciProfileWidth

### DIFF
--- a/src/hotspot/cpu/ppc/interp_masm_ppc.hpp
+++ b/src/hotspot/cpu/ppc/interp_masm_ppc.hpp
@@ -228,7 +228,7 @@ class InterpreterMacroAssembler: public MacroAssembler {
 
   // Interpreter profiling operations
   void set_method_data_pointer_for_bcp();
-  void test_method_data_pointer(Label& zero_continue);
+  void test_method_data_pointer(Label& zero_continue, bool may_be_far = false);
   void verify_method_data_pointer();
 
   void set_mdp_data_at(int constant, Register value);

--- a/src/hotspot/cpu/ppc/interp_masm_ppc_64.cpp
+++ b/src/hotspot/cpu/ppc/interp_masm_ppc_64.cpp
@@ -1249,7 +1249,7 @@ void InterpreterMacroAssembler::set_method_data_pointer_for_bcp() {
 }
 
 // Test ImethodDataPtr. If it is null, continue at the specified label.
-  void InterpreterMacroAssembler::test_method_data_pointer(Label& zero_continue, bool may_be_far) {
+void InterpreterMacroAssembler::test_method_data_pointer(Label& zero_continue, bool may_be_far) {
   assert(ProfileInterpreter, "must be profiling interpreter");
   cmpdi(CR0, R28_mdx, 0);
   if (may_be_far) {
@@ -1257,7 +1257,6 @@ void InterpreterMacroAssembler::set_method_data_pointer_for_bcp() {
   } else {
     beq(CR0, zero_continue);
   }
-
 }
 
 void InterpreterMacroAssembler::verify_method_data_pointer() {

--- a/src/hotspot/cpu/ppc/interp_masm_ppc_64.cpp
+++ b/src/hotspot/cpu/ppc/interp_masm_ppc_64.cpp
@@ -1249,10 +1249,15 @@ void InterpreterMacroAssembler::set_method_data_pointer_for_bcp() {
 }
 
 // Test ImethodDataPtr. If it is null, continue at the specified label.
-void InterpreterMacroAssembler::test_method_data_pointer(Label& zero_continue) {
+  void InterpreterMacroAssembler::test_method_data_pointer(Label& zero_continue, bool may_be_far) {
   assert(ProfileInterpreter, "must be profiling interpreter");
   cmpdi(CR0, R28_mdx, 0);
-  beq(CR0, zero_continue);
+  if (may_be_far) {
+    bc_far_optimized(Assembler::bcondCRbiIs1, bi0(CR0, Assembler::equal), zero_continue);
+  } else {
+    beq(CR0, zero_continue);
+  }
+
 }
 
 void InterpreterMacroAssembler::verify_method_data_pointer() {
@@ -1555,7 +1560,7 @@ void InterpreterMacroAssembler::profile_ret(TosState state, Register return_bci,
     uint row;
 
     // If no method data exists, go to profile_continue.
-    test_method_data_pointer(profile_continue);
+    test_method_data_pointer(profile_continue, true);
 
     // Update the total ret count.
     increment_mdp_data_at(in_bytes(CounterData::count_offset()), scratch1, scratch2 );

--- a/src/hotspot/cpu/riscv/interp_masm_riscv.cpp
+++ b/src/hotspot/cpu/riscv/interp_masm_riscv.cpp
@@ -888,7 +888,7 @@ void InterpreterMacroAssembler::test_method_data_pointer(Register mdp,
                                                          Label& zero_continue) {
   assert(ProfileInterpreter, "must be profiling interpreter");
   ld(mdp, Address(fp, frame::interpreter_frame_mdp_offset * wordSize));
-  beqz(mdp, zero_continue);
+  beqz(mdp, zero_continue, /* is_far */ true);
 }
 
 // Set the method data pointer for the current bcp.
@@ -964,15 +964,12 @@ void InterpreterMacroAssembler::increment_mdp_data_at(Register mdp_in,
                                                       int constant) {
   assert(ProfileInterpreter, "must be profiling interpreter");
 
-  assert_different_registers(t1, t0, mdp_in, index);
+  assert_different_registers(t0, t1, mdp_in, index);
 
-  Address addr1(mdp_in, constant);
-  Address addr2(t1, 0);
-  Address &addr = addr1;
+  Address addr(t1);
+  la(t1, Address(mdp_in, constant));
   if (index != noreg) {
-    la(t1, addr1);
     add(t1, t1, index);
-    addr = addr2;
   }
 
   ld(t0, addr);

--- a/src/hotspot/share/cds/filemap.cpp
+++ b/src/hotspot/share/cds/filemap.cpp
@@ -1985,7 +1985,7 @@ bool FileMapHeader::validate() {
     if (_bci_profile_width != BciProfileWidth) {
       MetaspaceShared::report_loading_error("The %s's BciProfileWidth setting (%d)"
                                             " does not equal the current BciProfileWidth setting (%d).", file_type,
-                                            (int)_bci_profile_width, (int)BciProfileWidth);
+                                            _bci_profile_width, BciProfileWidth);
       return false;
     }
     if (_type_profile_casts != TypeProfileCasts) {

--- a/src/hotspot/share/cds/filemap.hpp
+++ b/src/hotspot/share/cds/filemap.hpp
@@ -152,7 +152,7 @@ private:
   int     _type_profile_args_limit;
   int     _type_profile_parms_limit;
   intx    _type_profile_width;
-  intx    _bci_profile_width;
+  int     _bci_profile_width;
   bool    _profile_traps;
   bool    _type_profile_casts;
   int     _spec_trap_limit_extra_entries;

--- a/src/hotspot/share/jvmci/jvmciCompilerToVMInit.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVMInit.cpp
@@ -350,7 +350,7 @@ JVMCIObjectArray CompilerToVM::initialize_intrinsics(JVMCI_TRAPS) {
   do_int_flag(AllocatePrefetchLines)                                       \
   do_int_flag(AllocatePrefetchStepSize)                                    \
   do_int_flag(AllocatePrefetchStyle)                                       \
-  do_intx_flag(BciProfileWidth)                                            \
+  do_int_flag(BciProfileWidth)                                            \
   do_bool_flag(BootstrapJVMCI)                                             \
   do_bool_flag(CITime)                                                     \
   do_bool_flag(CITimeEach)                                                 \

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -1351,10 +1351,9 @@ const int ObjectAlignmentInBytes = 8;
           "Number of receiver types to record in call/cast profile")        \
           range(0, 8)                                                       \
                                                                             \
-  develop(intx, BciProfileWidth, 2,                                         \
+  develop(int, BciProfileWidth, 2,                                          \
           "Number of return bci's to record in ret profile")                \
           range(0, AARCH64_ONLY(1000) NOT_AARCH64(5000))                    \
-                                                                            \
                                                                             \
   product(intx, PerMethodRecompilationCutoff, 400,                          \
           "After recompiling N times, stay in the interpreter (-1=>'Inf')") \

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -1353,7 +1353,7 @@ const int ObjectAlignmentInBytes = 8;
                                                                             \
   develop(int, BciProfileWidth, 2,                                          \
           "Number of return bci's to record in ret profile")                \
-          range(0, AARCH64_ONLY(1000) NOT_AARCH64(5000))                    \
+          range(0, 1000)                                                    \
                                                                             \
   product(intx, PerMethodRecompilationCutoff, 400,                          \
           "After recompiling N times, stay in the interpreter (-1=>'Inf')") \

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -1351,9 +1351,9 @@ const int ObjectAlignmentInBytes = 8;
           "Number of receiver types to record in call/cast profile")        \
           range(0, 8)                                                       \
                                                                             \
-  develop(intx, BciProfileWidth,      2,                                    \
+  develop(intx, BciProfileWidth, 2,                                         \
           "Number of return bci's to record in ret profile")                \
-          range(0, 8000)                                                   \
+          range(0, AARCH64_ONLY(1000) NOT_AARCH64(5000))                    \
                                                                             \
                                                                             \
   product(intx, PerMethodRecompilationCutoff, 400,                          \

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -1353,6 +1353,8 @@ const int ObjectAlignmentInBytes = 8;
                                                                             \
   develop(intx, BciProfileWidth,      2,                                    \
           "Number of return bci's to record in ret profile")                \
+          range(0, 10000)                                                   \
+                                                                            \
                                                                             \
   product(intx, PerMethodRecompilationCutoff, 400,                          \
           "After recompiling N times, stay in the interpreter (-1=>'Inf')") \

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -1353,7 +1353,7 @@ const int ObjectAlignmentInBytes = 8;
                                                                             \
   develop(intx, BciProfileWidth,      2,                                    \
           "Number of return bci's to record in ret profile")                \
-          range(0, 10000)                                                   \
+          range(0, 8000)                                                   \
                                                                             \
                                                                             \
   product(intx, PerMethodRecompilationCutoff, 400,                          \

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/MethodData.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/MethodData.java
@@ -143,7 +143,7 @@ public class MethodData extends Metadata implements MethodDataInterface<Klass,Me
       if (flag.getName().equals("TypeProfileWidth")) {
         TypeProfileWidth = (int)flag.getIntx();
       } else if (flag.getName().equals("BciProfileWidth")) {
-        BciProfileWidth = (int)flag.getIntx();
+        BciProfileWidth = (int)flag.getInt();
       } else if (flag.getName().equals("CompileThreshold")) {
         CompileThreshold = (int)flag.getIntx();
       }

--- a/test/hotspot/jtreg/compiler/arguments/TestBciProfileWidth.java
+++ b/test/hotspot/jtreg/compiler/arguments/TestBciProfileWidth.java
@@ -25,6 +25,7 @@
  * @test
  * @summary Test the range defined in globals.hpp for BciProfileWidth
  * @bug 8358696
+ * @requires vm.debug
  * @run main/othervm -XX:BciProfileWidth=0
  *      compiler.arguments.TestBciProfileWidth
  * @run main/othervm -XX:BciProfileWidth=1000

--- a/test/hotspot/jtreg/compiler/arguments/TestBciProfileWidth.java
+++ b/test/hotspot/jtreg/compiler/arguments/TestBciProfileWidth.java
@@ -26,17 +26,33 @@
  * @summary Test the range defined in globals.hpp for BciProfileWidth
  * @bug 8358696
  * @requires vm.debug
- * @run main/othervm -XX:BciProfileWidth=0
- *      compiler.arguments.TestBciProfileWidth
- * @run main/othervm -XX:BciProfileWidth=1000
- *      compiler.arguments.TestBciProfileWidth
+ * @library /test/lib
+ * @run main/othervm compiler.arguments.TestBciProfileWidth
  */
 
 package compiler.arguments;
 
+import jdk.test.lib.process.ProcessTools;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.Asserts;
+
 public class TestBciProfileWidth {
 
-    static public void main(String[] args) {
-        System.out.println("Passed");
+    public static void main(String args[]) throws Throwable {
+        checkBciProfileWidth(-1, true);
+        checkBciProfileWidth(10000, true);
+        checkBciProfileWidth(0, false);
+        checkBciProfileWidth(1000, false);
+    }
+
+    static void checkBciProfileWidth(int value, boolean fail) throws Throwable {
+        OutputAnalyzer out = ProcessTools.executeTestJava("-XX:BciProfileWidth=" + value);
+        String output = out.getOutput();
+        if (fail) {
+            String pattern = "int BciProfileWidth=" + value + " is outside the allowed range [ 0 ... 1000 ]";
+            Asserts.assertTrue(output.contains(pattern));
+        } else {
+            System.out.println("Passed");
+        }
     }
 }

--- a/test/hotspot/jtreg/compiler/arguments/TestBciProfileWidth.java
+++ b/test/hotspot/jtreg/compiler/arguments/TestBciProfileWidth.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @summary Test the range defined in globals.hpp for BciProfileWidth
+ * @bug 8358696
+ * @run main/othervm -XX:BciProfileWidth=0
+ *      compiler.arguments.TestBciProfileWidth
+ * @run main/othervm -XX:BciProfileWidth=1000
+ *      compiler.arguments.TestBciProfileWidth
+ */
+
+package compiler.arguments;
+
+public class TestBciProfileWidth {
+
+    static public void main(String[] args) {
+        System.out.println("Passed");
+    }
+}

--- a/test/lib-test/jdk/test/whitebox/vm_flags/IntxTest.java
+++ b/test/lib-test/jdk/test/whitebox/vm_flags/IntxTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/lib-test/jdk/test/whitebox/vm_flags/IntxTest.java
+++ b/test/lib-test/jdk/test/whitebox/vm_flags/IntxTest.java
@@ -39,7 +39,8 @@ public class IntxTest {
     private static final String FLAG_DEBUG_NAME = "BinarySwitchThreshold";
     private static final long COMPILE_THRESHOLD = VmFlagTest.WHITE_BOX.getIntxVMFlag("CompileThreshold");
     private static final Long[] TESTS = {0L, 100L, (long)(Integer.MAX_VALUE>>3)*100L};
-    public static void main(String[] args) throws Exception {
+
+     public static void main(String[] args) throws Exception {
         find_and_set_max_osrp();
         VmFlagTest.runTest(FLAG_NAME, TESTS,
             VmFlagTest.WHITE_BOX::setIntxVMFlag,

--- a/test/lib-test/jdk/test/whitebox/vm_flags/IntxTest.java
+++ b/test/lib-test/jdk/test/whitebox/vm_flags/IntxTest.java
@@ -38,12 +38,14 @@ public class IntxTest {
     private static final String FLAG_NAME = "OnStackReplacePercentage";
     private static final long COMPILE_THRESHOLD = VmFlagTest.WHITE_BOX.getIntxVMFlag("CompileThreshold");
     private static final Long[] TESTS = {0L, 100L, (long)(Integer.MAX_VALUE>>3)*100L};
+    private static final String FLAG_DEBUG_NAME = "BinarySwitchThreshold";
 
     public static void main(String[] args) throws Exception {
         find_and_set_max_osrp();
         VmFlagTest.runTest(FLAG_NAME, TESTS,
             VmFlagTest.WHITE_BOX::setIntxVMFlag,
             VmFlagTest.WHITE_BOX::getIntxVMFlag);
+        VmFlagTest.runTest(FLAG_DEBUG_NAME, VmFlagTest.WHITE_BOX::getIntxVMFlag);
     }
 
     static void find_and_set_max_osrp() {

--- a/test/lib-test/jdk/test/whitebox/vm_flags/IntxTest.java
+++ b/test/lib-test/jdk/test/whitebox/vm_flags/IntxTest.java
@@ -36,10 +36,9 @@
 import jdk.test.lib.Platform;
 public class IntxTest {
     private static final String FLAG_NAME = "OnStackReplacePercentage";
+    private static final String FLAG_DEBUG_NAME = "BinarySwitchThreshold";
     private static final long COMPILE_THRESHOLD = VmFlagTest.WHITE_BOX.getIntxVMFlag("CompileThreshold");
     private static final Long[] TESTS = {0L, 100L, (long)(Integer.MAX_VALUE>>3)*100L};
-    private static final String FLAG_DEBUG_NAME = "BinarySwitchThreshold";
-
     public static void main(String[] args) throws Exception {
         find_and_set_max_osrp();
         VmFlagTest.runTest(FLAG_NAME, TESTS,

--- a/test/lib-test/jdk/test/whitebox/vm_flags/IntxTest.java
+++ b/test/lib-test/jdk/test/whitebox/vm_flags/IntxTest.java
@@ -40,7 +40,7 @@ public class IntxTest {
     private static final long COMPILE_THRESHOLD = VmFlagTest.WHITE_BOX.getIntxVMFlag("CompileThreshold");
     private static final Long[] TESTS = {0L, 100L, (long)(Integer.MAX_VALUE>>3)*100L};
 
-     public static void main(String[] args) throws Exception {
+    public static void main(String[] args) throws Exception {
         find_and_set_max_osrp();
         VmFlagTest.runTest(FLAG_NAME, TESTS,
             VmFlagTest.WHITE_BOX::setIntxVMFlag,

--- a/test/lib-test/jdk/test/whitebox/vm_flags/IntxTest.java
+++ b/test/lib-test/jdk/test/whitebox/vm_flags/IntxTest.java
@@ -36,7 +36,6 @@
 import jdk.test.lib.Platform;
 public class IntxTest {
     private static final String FLAG_NAME = "OnStackReplacePercentage";
-    private static final String FLAG_DEBUG_NAME = "BciProfileWidth";
     private static final long COMPILE_THRESHOLD = VmFlagTest.WHITE_BOX.getIntxVMFlag("CompileThreshold");
     private static final Long[] TESTS = {0L, 100L, (long)(Integer.MAX_VALUE>>3)*100L};
 
@@ -45,7 +44,6 @@ public class IntxTest {
         VmFlagTest.runTest(FLAG_NAME, TESTS,
             VmFlagTest.WHITE_BOX::setIntxVMFlag,
             VmFlagTest.WHITE_BOX::getIntxVMFlag);
-        VmFlagTest.runTest(FLAG_DEBUG_NAME, VmFlagTest.WHITE_BOX::getIntxVMFlag);
     }
 
     static void find_and_set_max_osrp() {


### PR DESCRIPTION
**Issue**
Extreme values for BciProfileWidth flag such as `java -XX:BciProfileWidth=-1 -version` and `java -XX:BciProfileWidth=100000 -version `results in assert failure `assert(allocates2(pc)) failed: not in CodeBuffer memory: 0x0000772b63a7a3a0 <= 0x0000772b63b75159 <= 0x0000772b63b75158 `. This is observed in a x86 machine.

**Analysis** 
 On debugging the issue, I found that increasing the size of the interpreter using the `InterpreterCodeSize` variable in `src/hotspot/cpu/x86/templateInterpreterGenerator_x86.cpp` prevented the above mentioned assert from failing for large values of BciProfileWidth.  

**Proposal** 
Considering the fact that larger BciProfileWidth results in slower profiling, I have proposed a range between 0 to 5000 to restrict the value for BciProfileWidth for x86 machines. This maximum value is based on modifying the `InterpreterCodeSize` variable in `src/hotspot/cpu/x86/templateInterpreterGenerator_x86.cpp` using the smallest `InterpreterCodeSize` for all the architectures.  As for the lower bound, a value of -1 would be the same as 0, as this simply means  no  return bci's will be recorded in ret profile. 

**Issue in AArch64**
Additionally running the command `java -XX:BciProfileWidth= 10000 -version` (or larger values) results in a different failure  `assert(offset_ok_for_immed(offset(), size)) failed: must be, was: 32768, 3` on an AArch64 machine.This is an issue of maximum offset for `ldr/str` in AArch64 which can be fixed using `form_address`  as mentioned in [JDK-8342736](https://bugs.openjdk.org/browse/JDK-8342736). In my preliminary fix using `form_address` on AArch64 machine. I had to modify 3 `ldr` and 1 `str` instruction (in file `src/hotspot/cpu/aarch64/interp_masm_aarch64.cpp` at line number 926, 983, and 997). With this fix  using `form_address`, `BciProfileWidth` works for maximum of 5000 after which it crashes with`assert(allocates2(pc)) failed: not in CodeBuffer memory: 0x0000772b63a7a3a0 <= 0x0000772b63b75159 <= 0x0000772b63b75158 `.  Without this fix `BciProfileWidth` works for a maximum value of 1300.   Currently, I have suggested to restrict the upper bound on AArch64 to 1000 instead of fixing it with `form_address`. 

**Question to reviewers**
Do you think this is a reasonable fix ?  For AArch64 do you suggest fixing using `form_address` ? If yes, do I fix it under this PR or create another one ?

**Request to port maintainers**
@dafedafe suggested that we keep the upper bound of `BciProfileWidth` to 1000 provided it works on all the other architectures (PPC, ARM32, RISCV, S390) or change the upper bound to lowest value supported in these architectures. Would it possible to test if upper bound of 1000 works on these architectures ? @TheRealMDoerr, @RealFYang @offamitkumar @bulasevich . Thank you.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Error
&nbsp;⚠️ Pull request body is missing required line: `- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).`

### Warnings
&nbsp;⚠️ Patch contains a binary file (src/java.base/share/classes/jdk/internal/icu/impl/data/icudt76b/nfc.nrm)
&nbsp;⚠️ Patch contains a binary file (src/java.base/share/classes/jdk/internal/icu/impl/data/icudt76b/nfkc.nrm)
&nbsp;⚠️ Patch contains a binary file (src/java.base/share/classes/jdk/internal/icu/impl/data/icudt76b/ubidi.icu)
&nbsp;⚠️ Patch contains a binary file (src/java.base/share/classes/jdk/internal/icu/impl/data/icudt76b/uprops.icu)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/javax/swing/beaninfo/images/JAppletColor16.gif)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/javax/swing/beaninfo/images/JAppletColor32.gif)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/javax/swing/beaninfo/images/JAppletMono16.gif)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/javax/swing/beaninfo/images/JAppletMono32.gif)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/javax/swing/doc-files/JRootPane-1.gif)
&nbsp;⚠️ Patch contains a binary file (test/jdk/java/util/jar/JarEntry/test.jar)
&nbsp;⚠️ Patch contains a binary file (test/jdk/javax/net/ssl/HttpsURLConnection/crisubn.jks)
&nbsp;⚠️ Patch contains a binary file (test/jdk/javax/net/ssl/HttpsURLConnection/trusted.jks)
&nbsp;⚠️ Patch contains a binary file (test/jdk/javax/rmi/ssl/keystore)
&nbsp;⚠️ Patch contains a binary file (test/jdk/javax/rmi/ssl/truststore)
&nbsp;⚠️ Patch contains a binary file (test/jdk/sun/net/www/protocol/https/HttpsClient/dnsstore)
&nbsp;⚠️ Patch contains a binary file (test/jdk/sun/net/www/protocol/https/HttpsClient/ipstore)

### Issue
 * [JDK-8358696](https://bugs.openjdk.org/browse/JDK-8358696): Assert with extreme values for -XX:BciProfileWidth (**Bug** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**) 🔄 Re-review required (review applies to [60da70c6](https://git.openjdk.org/jdk/pull/26139/files/60da70c69f897756f9a2b00d94ee796e614f486f))
 * [Boris Ulasevich](https://openjdk.org/census#bulasevich) (@bulasevich - Committer) 🔄 Re-review required (review applies to [60da70c6](https://git.openjdk.org/jdk/pull/26139/files/60da70c69f897756f9a2b00d94ee796e614f486f))
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**) 🔄 Re-review required (review applies to [2f511dbf](https://git.openjdk.org/jdk/pull/26139/files/2f511dbfc43d3fbec7621ddc4a491e7cdcfe177f))

### Contributors
 * Fei Yang `<fyang@openjdk.org>`
 * Martin Doerr `<mdoerr@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26139/head:pull/26139` \
`$ git checkout pull/26139`

Update a local copy of the PR: \
`$ git checkout pull/26139` \
`$ git pull https://git.openjdk.org/jdk.git pull/26139/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26139`

View PR using the GUI difftool: \
`$ git pr show -t 26139`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26139.diff">https://git.openjdk.org/jdk/pull/26139.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26139#issuecomment-3096743635)
</details>
