### PR TITLE
8361433: [Big Endian] assert(verify_guards()) failed: Expected valid memory guards after 8357601

### DIFF
--- a/src/hotspot/share/memory/guardedMemory.hpp
+++ b/src/hotspot/share/memory/guardedMemory.hpp
@@ -119,7 +119,7 @@ protected:
         // We may not be able to dereference directly so use
         // SafeFetch. It doesn't matter if the value read happens
         // to be 0xFF as that is not what we expect anyway.
-        u_char val = (u_char) SafeFetch32((int*)c, 0xFF);
+        u_char val = (u_char) (SafeFetch32((int*)c, 0xFF) BIG_ENDIAN_ONLY(>> 24));
         if (val != badResourceValue) {
           return false;
         }

--- a/src/hotspot/share/memory/guardedMemory.hpp
+++ b/src/hotspot/share/memory/guardedMemory.hpp
@@ -26,6 +26,7 @@
 #define SHARE_MEMORY_GUARDEDMEMORY_HPP
 
 #include "memory/allocation.hpp"
+#include "runtime/os.hpp"
 #include "runtime/safefetch.hpp"
 #include "utilities/globalDefinitions.hpp"
 
@@ -113,14 +114,14 @@ protected:
     }
 
     bool verify() const {
+      // We may not be able to dereference directly.
+      if (!os::is_readable_range((const void*) _guard, (const void*) (_guard + GUARD_SIZE))) {
+        return false;
+      }
       u_char* c = (u_char*) _guard;
       u_char* end = c + GUARD_SIZE;
       while (c < end) {
-        // We may not be able to dereference directly so use
-        // SafeFetch. It doesn't matter if the value read happens
-        // to be 0xFF as that is not what we expect anyway.
-        u_char val = (u_char) (SafeFetch32((int*)c, 0xFF) BIG_ENDIAN_ONLY(>> 24));
-        if (val != badResourceValue) {
+        if (*c != badResourceValue) {
           return false;
         }
         c++;


### PR DESCRIPTION
Big Endian fix for [JDK-8357601](https://bugs.openjdk.org/browse/JDK-8357601).

Note: The first commit is only a Big Endian fix. The code looks still wrong for platforms which don't support unaligned accesses. Also see `UseUnalignedAccesses`.
The second commit changes to check `os::is_readable_range()`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8361433](https://bugs.openjdk.org/browse/JDK-8361433): [Big Endian] assert(verify_guards()) failed: Expected valid memory guards after 8357601 (**Bug** - P2)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26140/head:pull/26140` \
`$ git checkout pull/26140`

Update a local copy of the PR: \
`$ git checkout pull/26140` \
`$ git pull https://git.openjdk.org/jdk.git pull/26140/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26140`

View PR using the GUI difftool: \
`$ git pr show -t 26140`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26140.diff">https://git.openjdk.org/jdk/pull/26140.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26140#issuecomment-3037356934)
</details>
