### PR TITLE
8361445: javac crashes on unresolvable constant in @SuppressWarnings

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Lint.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Lint.java
@@ -530,7 +530,9 @@ public class Lint {
         EnumSet<LintCategory> result = LintCategory.newEmptySet();
         Attribute.Array values = (Attribute.Array)suppressWarnings.member(names.value);
         for (Attribute value : values.values) {
-            Optional.of((String)((Attribute.Constant)value).value)
+            Optional.of(value)
+              .filter(val -> val instanceof Attribute.Constant)
+              .map(val -> (String) ((Attribute.Constant) val).value)
               .flatMap(LintCategory::get)
               .filter(lc -> lc.annotationSuppression)
               .ifPresent(result::add);


### PR DESCRIPTION
Consider this code:
```
@SuppressWarnings(CONST)
public class Ann {
    public static final String CONST = "";
}
```

javac will crash attempting to compile it:
```
$ javac -XDdev /tmp/Ann.java
/tmp/Ann.java:1: error: cannot find symbol
@SuppressWarnings(CONST)
                  ^
  symbol: variable CONST
1 error
An exception has occurred in the compiler (26-internal). Please file a bug against the Java compiler via the Java bug reporting page (https://bugreport.java.com/) after checking the Bug Database (https://bugs.java.com/) for duplicates. Include your program, the following diagnostic, and the parameters passed to the Java compiler in your report. Thank you.
java.lang.ClassCastException: class com.sun.tools.javac.code.Attribute$Error cannot be cast to class com.sun.tools.javac.code.Attribute$Constant (com.sun.tools.javac.code.Attribute$Error and com.sun.tools.javac.code.Attribute$Constant are in module jdk.compiler of loader 'app')
        at jdk.compiler/com.sun.tools.javac.code.Lint.suppressionsFrom(Lint.java:533)
...
```

The reason is that the unresolvable constant will be `Attribute.Error`, not `Attribute.Constant`, and there's an unguarded cast. The proposal herein is to improve error recovery by ignoring non-constant annotation attributes in `Lint.suppressionsFrom`. Such erroneous cases should have already been reported as compile-time errors anyway.
