### PR TITLE
8336147: Clarify CDS documentation about static vs dynamic archive

### DIFF
--- a/src/java.base/share/man/java.md
+++ b/src/java.base/share/man/java.md
@@ -3816,9 +3816,10 @@ general form:
     be loaded on top of those in the `<static_archive>`.
 -   On Windows, the above path delimiter `:` should be replaced with `;`
 
-(The names "static" and "dynamic" are used for historical reasons.
-The only significance is that the "static" archive is loaded first and
-the "dynamic" archive is loaded second).
+The names "static" and "dynamic" are used for historical reasons. The dynamic
+archive, while still useful, supports fewer optimizations than
+available for the static CDS archive. If the full set of CDS/AOT
+optimizations are desired, consider using the AOT cache described below.
 
 The JVM can use up to two archives. To use only a single `<static_archive>`,
 you can omit the `<dynamic_archive>` portion:


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [854de8c9](https://github.com/openjdk/jdk/commit/854de8c9c6a1d851c1788e5f2250fe0928c51ca4) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Ioi Lam on 3 Jul 2025 and was reviewed by Calvin Cheung and Aleksey Shipilev.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336147](https://bugs.openjdk.org/browse/JDK-8336147): Clarify CDS documentation about static vs dynamic archive (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewers without OpenJDK IDs
 * @abdelhak-zaaim (no known openjdk.org user name / role)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26148/head:pull/26148` \
`$ git checkout pull/26148`

Update a local copy of the PR: \
`$ git checkout pull/26148` \
`$ git pull https://git.openjdk.org/jdk.git pull/26148/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26148`

View PR using the GUI difftool: \
`$ git pr show -t 26148`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26148.diff">https://git.openjdk.org/jdk/pull/26148.diff</a>

</details>
