### PR TITLE
8360164: AOT cache creation crashes in ~ThreadTotalCPUTimeClosure()

### DIFF
--- a/src/hotspot/share/cds/metaspaceShared.cpp
+++ b/src/hotspot/share/cds/metaspaceShared.cpp
@@ -837,11 +837,10 @@ void MetaspaceShared::preload_and_dump(TRAPS) {
       struct stat st;
       if (os::stat(AOTCache, &st) != 0) {
         tty->print_cr("AOTCache creation failed: %s", AOTCache);
-        vm_exit(0);
       } else {
         tty->print_cr("AOTCache creation is complete: %s " INT64_FORMAT " bytes", AOTCache, (int64_t)(st.st_size));
-        vm_exit(0);
       }
+      vm_direct_exit(0);
     }
   }
 }


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [7d7e60c8](https://github.com/openjdk/jdk/commit/7d7e60c8aebc4b4c1e7121be702393e5bc46e9ce) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Ioi Lam on 1 Jul 2025 and was reviewed by Calvin Cheung, Vladimir Kozlov and David Holmes.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8360164](https://bugs.openjdk.org/browse/JDK-8360164): AOT cache creation crashes in ~ThreadTotalCPUTimeClosure() (**Bug** - P3)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26149/head:pull/26149` \
`$ git checkout pull/26149`

Update a local copy of the PR: \
`$ git checkout pull/26149` \
`$ git pull https://git.openjdk.org/jdk.git pull/26149/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26149`

View PR using the GUI difftool: \
`$ git pr show -t 26149`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26149.diff">https://git.openjdk.org/jdk/pull/26149.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26149#issuecomment-3043045331)
</details>
