### PR TITLE
8361449: RISC-V: Code cleanup for native call

### DIFF
--- a/src/hotspot/cpu/riscv/nativeInst_riscv.hpp
+++ b/src/hotspot/cpu/riscv/nativeInst_riscv.hpp
@@ -134,7 +134,7 @@ class NativeCall: private NativeInstruction {
   address next_instruction_address() const;
   address return_address() const;
   address destination() const;
-  address reloc_destination(address orig_address);
+  address reloc_destination();
 
   void verify_alignment() {} // do nothing on riscv
   void verify();

--- a/src/hotspot/cpu/riscv/relocInfo_riscv.cpp
+++ b/src/hotspot/cpu/riscv/relocInfo_riscv.cpp
@@ -72,12 +72,12 @@ void Relocation::pd_set_data_value(address x, bool verify_only) {
 }
 
 address Relocation::pd_call_destination(address orig_addr) {
-  assert(is_call(), "should be an address instruction here");
-  if (NativeCall::is_at(addr())) {
-    return nativeCall_at(addr())->reloc_destination(orig_addr);
-  }
-  // Non call reloc
-  if (orig_addr != nullptr) {
+  assert(is_call(), "should be a call here");
+  if (orig_addr == nullptr) {
+    if (NativeCall::is_at(addr())) {
+      return nativeCall_at(addr())->reloc_destination();
+    }
+  } else {
     // the extracted address from the instructions in address orig_addr
     address new_addr = MacroAssembler::pd_call_destination(orig_addr);
     // If call is branch to self, don't try to relocate it, just leave it
@@ -91,16 +91,14 @@ address Relocation::pd_call_destination(address orig_addr) {
 }
 
 void Relocation::pd_set_call_destination(address x) {
-  assert(is_call(), "should be an address instruction here");
+  assert(is_call(), "should be a call here");
   if (NativeCall::is_at(addr())) {
-    NativeCall* nc = nativeCall_at(addr());
-    if (nc->reloc_set_destination(x)) {
-      return;
-    }
+    NativeCall* call = nativeCall_at(addr());
+    call->reloc_set_destination(x);
+  } else {
+    MacroAssembler::pd_patch_instruction_size(addr(), x);
+    assert(pd_call_destination(addr()) == x, "fail in reloc");
   }
-  MacroAssembler::pd_patch_instruction_size(addr(), x);
-  address pd_call = pd_call_destination(addr());
-  assert(pd_call == x, "fail in reloc");
 }
 
 address* Relocation::pd_address_in_code() {


### PR DESCRIPTION
Hi, please consider this code cleanup change for native call.

This removes the address parameter for NativeCall::reloc_destination and NativeFarCall::reloc_destination.
This also removes several unnecessary code blob related runtime checks turning them into assertions.

### Testing
* [x]  hs:tier1 - hs:tier3 tested with linux-riscv64 fastdebug build