### PR TITLE
8361463: Render method of javax.swing.text.AbstractDocument uses 'currency' instead of 'concurrency'

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/text/AbstractDocument.java
+++ b/src/java.desktop/share/classes/javax/swing/text/AbstractDocument.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -408,7 +408,7 @@ public abstract class AbstractDocument implements Document, Serializable {
 
     /**
      * This allows the model to be safely rendered in the presence
-     * of currency, if the model supports being updated asynchronously.
+     * of concurrency, if the model supports being updated asynchronously.
      * The given runnable will be executed in a way that allows it
      * to safely read the model with no changes while the runnable
      * is being executed.  The runnable itself may <em>not</em>


### PR DESCRIPTION
Hello,
This is a trivial change in the documentation of render method of AbstractDocument class.
Changed currency to concurrency

Kindly review.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8361463](https://bugs.openjdk.org/browse/JDK-8361463): Render method of javax.swing.text.AbstractDocument uses 'currency' instead of 'concurrency' (**Bug** - P4)


### Reviewers
 * [Prasanta Sadhukhan](https://openjdk.org/census#psadhukhan) (@prsadhuk - **Reviewer**)
 * [Tejesh R](https://openjdk.org/census#tr) (@TejeshR13 - **Reviewer**)
 * [Abhishek Kumar](https://openjdk.org/census#abhiscxk) (@kumarabhi006 - **Reviewer**)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26154/head:pull/26154` \
`$ git checkout pull/26154`

Update a local copy of the PR: \
`$ git checkout pull/26154` \
`$ git pull https://git.openjdk.org/jdk.git pull/26154/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26154`

View PR using the GUI difftool: \
`$ git pr show -t 26154`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26154.diff">https://git.openjdk.org/jdk/pull/26154.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26154#issuecomment-3043527350)
</details>
