### PR TITLE
8360175: C2 crash:  assert(edge_from_to(prior_use,n)) failed: before block local scheduling

### DIFF
--- a/src/hotspot/cpu/x86/peephole_x86_64.cpp
+++ b/src/hotspot/cpu/x86/peephole_x86_64.cpp
@@ -346,7 +346,7 @@ bool Peephole::lea_remove_redundant(Block* block, int block_index, PhaseCFG* cfg
   for (DUIterator_Fast imax, i = decode->fast_outs(imax); i < imax; i++) {
     Node* dependant_lea = decode->fast_out(i);
     if (dependant_lea->is_Mach() && dependant_lea->as_Mach()->ideal_Opcode() == Op_AddP) {
-      dependant_lea->set_req(AddPNode::Base, decode_address);
+      dependant_lea->set_req(AddPNode::Base, lea_derived_oop->in(AddPNode::Address));
       // This deleted something in the out array, hence adjust i, imax.
       --i;
       --imax;


### PR DESCRIPTION
The triggered assert is part of the schedule verification code that runs just before machine code is emitted. The debug output showed that a `leaPCompressedOopOffset` node was causing the assert, which suggested the peephole optimization introduced in #25471 as the cause. The failure proved quite difficult to reproduce. It failed more often on Windows and required `-XX:+UseKNLSetting` (forces code generation for Intel's Knights Landing platform), which forces `-XX:+OptoScheduling`.

The root-cause is a subtle bug in the rewiring of the base edge of `leaP*` nodes in the `remove_redundant_lea` peephole. When the peephole removed a `decodeHeapOop_not_null` including a spill, it did not set the base edge of the `leaP*` node to the same node as the address edge, which is the intent of the peephole, but to the parent node of the spill. That is not catastrophic in most cases, but might reference another register slot, which causes this assert. Concretely, we see the following graph
```
    MemToRegSpillCopy
     |             |
     |    MemToRegSpillCopy
     |             |    
DefiniinoSpillCopy |
     |             |
     |  decodeHeapOop_not_null
     |             |
   leaPCompressedHeapOop
```
gets rewired to
```
     MemToRegSpillCopy
       |            |    
DefinitionSpillCopy |
       |            |
   leaPCompressedHeapOop
```
instead of
```
  MemToRegSpillCopy
         |
 DefinitionSpillCopy
        / \     
leaPCompressedHeapOop
```

This PR fixes this by always setting the base edge of the `leaP*` node to the same node as the address edge. Unfortunately, I was not able to construct a regression test because of the difficulty of reproducing the bug.

# Testing

- [x] Github Actions
- [x] tier1,tier2 plus internal testing on all Oracle supported platforms
- [x] tier3,tier4,tier5 plus internal testing on Linux and Windows x64
- [x] Runthese8H on `windows-x64-debug` (test that reliably produced the failure addressed in this PR)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8360175](https://bugs.openjdk.org/browse/JDK-8360175): C2 crash:  assert(edge_from_to(prior_use,n)) failed: before block local scheduling (**Bug** - P3)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26157/head:pull/26157` \
`$ git checkout pull/26157`

Update a local copy of the PR: \
`$ git checkout pull/26157` \
`$ git pull https://git.openjdk.org/jdk.git pull/26157/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26157`

View PR using the GUI difftool: \
`$ git pr show -t 26157`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26157.diff">https://git.openjdk.org/jdk/pull/26157.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26157#issuecomment-3044373765)
</details>
