### PR TITLE
8361481: Flexible Constructor Bodies generates a compilation error when compiling a user supplied java.lang.Object class

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -1236,8 +1236,8 @@ public class Attr extends JCTree.Visitor {
                 annotate.queueScanTreeAndTypeAnnotate(tree.body, localEnv, m, null);
                 annotate.flush();
 
-                // Start of constructor prologue
-                localEnv.info.ctorPrologue = isConstructor;
+                // Start of constructor prologue (if not in java.lang.Object constructor)
+                localEnv.info.ctorPrologue = isConstructor && owner.type != syms.objectType;
 
                 // Attribute method body.
                 attribStat(tree.body, localEnv);

--- a/test/langtools/tools/javac/ObjectEarlyContext/T8361481.java
+++ b/test/langtools/tools/javac/ObjectEarlyContext/T8361481.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+
+
+/*
+ * @test
+ * @bug 8361481
+ * @modules jdk.compiler
+ * @summary Flexible Constructor Bodies generates a compilation error when compiling a user supplied java.lang.Object class
+ */
+
+import java.io.*;
+import java.util.*;
+
+public class T8361481 {
+    static String testSrc = System.getProperty("test.src", ".");
+
+    public static void main(String... args) throws Exception {
+        new T8361481().run();
+    }
+
+    public void run() throws Exception {
+        // compile modified Object.java, using patch-module to avoid errors
+        File x = new File(testSrc, "x");
+        String[] jcArgs = { "-d", ".", "--patch-module", "java.base=" + x.getAbsolutePath(),
+                new File(new File(new File(x, "java"), "lang"), "Object.java").getPath()};
+        compile(jcArgs);
+    }
+
+    void compile(String... args) {
+        int rc = com.sun.tools.javac.Main.compile(args);
+        if (rc != 0)
+            throw new Error("javac failed: " + Arrays.asList(args) + ": " + rc);
+    }
+}
+

--- a/test/langtools/tools/javac/ObjectEarlyContext/java/lang/Object.java
+++ b/test/langtools/tools/javac/ObjectEarlyContext/java/lang/Object.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8361481
+ * @summary Flexible Constructor Bodies generates a compilation error when compiling a user supplied java.lang.Object class
+ * @compile -source 8 Object.java
+ */
+
+package java.lang;
+
+public class Object {
+    int x;
+
+    public Object() {
+        x = 2;
+    }
+}

--- a/test/langtools/tools/javac/ObjectEarlyContext/x/java/lang/Object.java
+++ b/test/langtools/tools/javac/ObjectEarlyContext/x/java/lang/Object.java
@@ -21,19 +21,12 @@
  * questions.
  */
 
-/*
- * @test
- * @bug 8361481
- * @summary Flexible Constructor Bodies generates a compilation error when compiling a user supplied java.lang.Object class
- * @compile -source 8 Object.java
- */
-
 package java.lang;
 
 public class Object {
-    int x;
-
     public Object() {
-        x = 2;
+        foo(); // valid, not in early constructor context
     }
+
+    void foo() { }
 }


### PR DESCRIPTION
The JLS says:

> IF a constructor body contains an explicit constructor invocation, the BlockStatements preceding the explicit constructor invocation are called the prologue of the constructor body."

Note the "IF". Only constructors that contain an explicit constructor invocation have a prologue.

But a constructor in `Object` doesn't contain an explicit constructor invocation:

> If a constructor body does not begin with an explicit constructor invocation **and the constructor being declared is not part of the primordial class Object**, then the constructor body implicitly begins with a superclass constructor invocation "super();", an invocation of the constructor of its direct superclass that takes no arguments.

In other words, a constructor in the Object class has no prologue.

Unfortunately javac misses this, and sets the `env.info.ctorPrologue` at the start of all constructors (even those in `Object`). However, since no implicit `super` call is added to `Object` constructors, this flag remains set for the entire body of the `Object` constructor -- that is, it's as if the whole constructor body was one big prologue.

This results in spurious errors being generated (and referring to preview features), as demonstrated in the issue linked to this PR.

The fix is not to set the `ctorPrologue` flag if we're in a constructor of the `Object` class.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8361481](https://bugs.openjdk.org/browse/JDK-8361481): Flexible Constructor Bodies generates a compilation error when compiling a user supplied java.lang.Object class (**Bug** - P4)


### Reviewers
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**) Review applies to [2bd99e00](https://git.openjdk.org/jdk/pull/26158/files/2bd99e00d242d7c1a2943a55f47b56de12d1a7dc)
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26158/head:pull/26158` \
`$ git checkout pull/26158`

Update a local copy of the PR: \
`$ git checkout pull/26158` \
`$ git pull https://git.openjdk.org/jdk.git pull/26158/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26158`

View PR using the GUI difftool: \
`$ git pr show -t 26158`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26158.diff">https://git.openjdk.org/jdk/pull/26158.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26158#issuecomment-3044569536)
</details>
