### PR TITLE
8351487: [ubsan] jvmti.h runtime error: load of value which is not a valid value

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetErrorName/geterrname002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetErrorName/geterrname002/TestDescription.java
@@ -36,6 +36,8 @@
  * COMMENTS
  *
  * @requires !vm.ubsan
+ * @comment We test with arguments out of scope of the jvmti enums, this causes
+ *          ubsan issues.
  * @library /vmTestbase
  *          /test/lib
  * @run main/othervm/native

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetErrorName/geterrname002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetErrorName/geterrname002/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,6 +35,7 @@
  *         JVMTI_ERROR_NULL_POINTER        if name_ptr is NULL.
  * COMMENTS
  *
+ * @requires !vm.ubsan
  * @library /vmTestbase
  *          /test/lib
  * @run main/othervm/native

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetErrorName/geterrname002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetErrorName/geterrname002/TestDescription.java
@@ -35,9 +35,9 @@
  *         JVMTI_ERROR_NULL_POINTER        if name_ptr is NULL.
  * COMMENTS
  *
- * @requires !vm.ubsan
- * @comment We test with arguments out of scope of the jvmti enums, this causes
+ * @comment We test with arguments out of scope of the jvmti enums, which causes
  *          ubsan issues.
+ * @requires !vm.ubsan
  * @library /vmTestbase
  *          /test/lib
  * @run main/othervm/native

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetVerboseFlag/setvrbflag002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetVerboseFlag/setvrbflag002/TestDescription.java
@@ -34,9 +34,9 @@
  *     if flag is not a jvmtiVerboseFlag.
  * COMMENTS
  *
- * @requires !vm.ubsan
- * @comment We test with arguments out of scope of the jvmti enums, this causes
+ * @comment We test with arguments out of scope of the jvmti enums, which causes
  *          ubsan issues.
+ * @requires !vm.ubsan
  * @library /vmTestbase
  *          /test/lib
  * @run main/othervm/native

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetVerboseFlag/setvrbflag002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetVerboseFlag/setvrbflag002/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,6 +34,7 @@
  *     if flag is not a jvmtiVerboseFlag.
  * COMMENTS
  *
+ * @requires !vm.ubsan
  * @library /vmTestbase
  *          /test/lib
  * @run main/othervm/native

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetVerboseFlag/setvrbflag002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetVerboseFlag/setvrbflag002/TestDescription.java
@@ -35,6 +35,8 @@
  * COMMENTS
  *
  * @requires !vm.ubsan
+ * @comment We test with arguments out of scope of the jvmti enums, this causes
+ *          ubsan issues.
  * @library /vmTestbase
  *          /test/lib
  * @run main/othervm/native


### PR DESCRIPTION
When running with ubsan - enabled binaries, the following 2 issues are observed in jvmti.h (on macOS aarch64).

```
jtreg test vmTestbase/nsk/jvmti/SetVerboseFlag/setvrbflag002/TestDescription.java 

/priv/jenkins/client-home/workspace/openjdk-jdk-weekly-macos_aarch64-opt/build/support/modules_include/java.base/jvmti.h:2645:44: runtime error: load of value 4294967295, which is not a valid value for type 'jvmtiVerboseFlag'
    #0 0x104453540 in _jvmtiEnv::SetVerboseFlag(jvmtiVerboseFlag, unsigned char) jvmti.h:2645
    #1 0x10444ed5c in agentProc(_jvmtiEnv*, JNIEnv_*, void*) setvrbflag002.cpp:49
    #2 0x10444f1c8 in agentThreadWrapper(_jvmtiEnv*, JNIEnv_*, void*) agent_tools.cpp:151
    #3 0x10914895c in JvmtiAgentThread::call_start_function() jvmtiImpl.cpp:89
    #4 0x108ebd7f0 in JavaThread::thread_main_inner() javaThread.cpp:776
    #5 0x1096f6094 in Thread::call_run() thread.cpp:231
    #6 0x10941c37c in thread_native_entry(Thread*) os_bsd.cpp:601
    #7 0x1936fef90 in _pthread_start+0x84 (libsystem_pthread.dylib:arm64e+0x6f90)
    #8 0x1936f9d30 in thread_start+0x4 (libsystem_pthread.dylib:arm64e+0x1d30)

vmTestbase/nsk/jvmti/GetErrorName/geterrname002/TestDescription.java

/priv/jenkins/client-home/workspace/openjdk-jdk-weekly-macos_aarch64-opt/build/support/modules_include/java.base/jvmti.h:2640:42: runtime error: load of value 4294967295, which is not a valid value for type 'jvmtiError'
    #0 0x1002b3504 in _jvmtiEnv::GetErrorName(jvmtiError, char**) jvmti.h:2640
    #1 0x1002aec9c in agentProc(_jvmtiEnv*, JNIEnv_*, void*) geterrname002.cpp:50
    #2 0x1002af198 in agentThreadWrapper(_jvmtiEnv*, JNIEnv_*, void*) agent_tools.cpp:151
    #3 0x104f4895c in JvmtiAgentThread::call_start_function() jvmtiImpl.cpp:89
    #4 0x104cbd7f0 in JavaThread::thread_main_inner() javaThread.cpp:776
    #5 0x1054f6094 in Thread::call_run() thread.cpp:231
    #6 0x10521c37c in thread_native_entry(Thread*) os_bsd.cpp:601
    #7 0x1936fef90 in _pthread_start+0x84 (libsystem_pthread.dylib:arm64e+0x6f90)
    #8 0x1936f9d30 in thread_start+0x4 (libsystem_pthread.dylib:arm64e+0x1d30)
```

So the problem reported is SetVerboseFlag method (which is part of the VM) calls SetVerboseFlag function with that bad argument ;  but the test code seems to intentionally use 'bad' arguments . But this does not work well with ubsan ;  so better exclude those tests from ubsan checking .
Please note that jvmti.h is shipped so adding some macros/attributes to methods for avoiding ubsan  is probably not the best thing to do in this case.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8351487](https://bugs.openjdk.org/browse/JDK-8351487): [ubsan] jvmti.h runtime error: load of value which is not a valid value (**Bug** - P4)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26159/head:pull/26159` \
`$ git checkout pull/26159`

Update a local copy of the PR: \
`$ git checkout pull/26159` \
`$ git pull https://git.openjdk.org/jdk.git pull/26159/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26159`

View PR using the GUI difftool: \
`$ git pr show -t 26159`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26159.diff">https://git.openjdk.org/jdk/pull/26159.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26159#issuecomment-3044838954)
</details>
