### PR TITLE
8361349

### DIFF
--- a/src/hotspot/share/gc/epsilon/epsilonHeap.hpp
+++ b/src/hotspot/share/gc/epsilon/epsilonHeap.hpp
@@ -49,6 +49,10 @@ private:
   volatile size_t _last_counter_update;
   volatile size_t _last_heap_print;
 
+protected:
+  void print_tracing_info() const override;
+  void stop() override {};
+
 public:
   static EpsilonHeap* heap();
 
@@ -66,8 +70,6 @@ public:
 
   jint initialize() override;
   void initialize_serviceability() override;
-
-  void stop() override {};
 
   GrowableArray<GCMemoryManager*> memory_managers() override;
   GrowableArray<MemoryPool*> memory_pools() override;
@@ -130,7 +132,6 @@ public:
 
   void print_heap_on(outputStream* st) const override;
   void print_gc_on(outputStream* st) const override {}
-  void print_tracing_info() const override;
   bool print_location(outputStream* st, void* addr) const override;
 
 private:

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -882,6 +882,11 @@ public:
 private:
   jint initialize_concurrent_refinement();
   jint initialize_service_thread();
+
+protected:
+  void print_tracing_info() const override;
+  void stop() override;
+
 public:
   // Initialize the G1CollectedHeap to have the initial and
   // maximum sizes and remembered and barrier sets
@@ -891,7 +896,6 @@ public:
   // Returns whether concurrent mark threads (and the VM) are about to terminate.
   bool concurrent_mark_is_terminating() const;
 
-  void stop() override;
   void safepoint_synchronize_begin() override;
   void safepoint_synchronize_end() override;
 
@@ -1308,9 +1312,6 @@ public:
   void print_gc_on(outputStream* st) const override;
 
   void gc_threads_do(ThreadClosure* tc) const override;
-
-  // Override
-  void print_tracing_info() const override;
 
   // Used to print information about locations in the hs_err file.
   bool print_location(outputStream* st, void* addr) const override;

--- a/src/hotspot/share/gc/parallel/parallelScavengeHeap.hpp
+++ b/src/hotspot/share/gc/parallel/parallelScavengeHeap.hpp
@@ -111,6 +111,10 @@ class ParallelScavengeHeap : public CollectedHeap {
 
   void do_full_collection(bool clear_all_soft_refs) override;
 
+protected:
+  void print_tracing_info() const override;
+  void stop() override {};
+
 public:
   ParallelScavengeHeap() :
     CollectedHeap(),
@@ -154,8 +158,6 @@ public:
 
   void post_initialize() override;
   void update_counters();
-
-  void stop() override {};
 
   size_t capacity() const override;
   size_t used() const override;
@@ -214,7 +216,6 @@ public:
   void print_heap_on(outputStream* st) const override;
   void print_gc_on(outputStream* st) const override;
   void gc_threads_do(ThreadClosure* tc) const override;
-  void print_tracing_info() const override;
 
   WorkerThreads* safepoint_workers() override { return &_workers; }
 

--- a/src/hotspot/share/gc/serial/serialHeap.hpp
+++ b/src/hotspot/share/gc/serial/serialHeap.hpp
@@ -118,14 +118,16 @@ private:
   void gc_prologue();
   void gc_epilogue(bool full);
 
+protected:
+  void print_tracing_info() const override;
+  void stop() override {};
+
 public:
   // Returns JNI_OK on success
   jint initialize() override;
 
   // Does operations required after initialization has been done.
   void post_initialize() override;
-
-  void stop() override {};
 
   bool is_in_reserved(const void* addr) const { return _reserved.contains(addr); }
 
@@ -211,7 +213,6 @@ public:
   void print_heap_on(outputStream* st) const override;
   void print_gc_on(outputStream* st) const override;
   void gc_threads_do(ThreadClosure* tc) const override;
-  void print_tracing_info() const override;
 
   // Used to print information about locations in the hs_err file.
   bool print_location(outputStream* st, void* addr) const override;

--- a/src/hotspot/share/gc/shared/collectedHeap.hpp
+++ b/src/hotspot/share/gc/shared/collectedHeap.hpp
@@ -208,6 +208,10 @@ protected:
     return static_cast<T*>(heap);
   }
 
+  // Print any relevant tracing info that flags imply.
+  // Default implementation does nothing.
+  virtual void print_tracing_info() const = 0;
+
   // Stop any onging concurrent work and prepare for exit.
   virtual void stop() = 0;
 
@@ -458,10 +462,6 @@ protected:
 
   // Iterator for all GC threads (other than VM thread)
   virtual void gc_threads_do(ThreadClosure* tc) const = 0;
-
-  // Print any relevant tracing info that flags imply.
-  // Default implementation does nothing.
-  virtual void print_tracing_info() const = 0;
 
   double elapsed_gc_cpu_time() const;
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.hpp
@@ -36,6 +36,10 @@ class ShenandoahGenerationalControlThread;
 class ShenandoahAgeCensus;
 
 class ShenandoahGenerationalHeap : public ShenandoahHeap {
+protected:
+  void print_tracing_info() const override;
+  void stop() override;
+
 public:
   explicit ShenandoahGenerationalHeap(ShenandoahCollectorPolicy* policy);
   void post_initialize() override;
@@ -53,7 +57,6 @@ public:
   }
 
   void print_init_logger() const override;
-  void print_tracing_info() const override;
 
   size_t unsafe_max_tlab_alloc(Thread *thread) const override;
 
@@ -125,8 +128,6 @@ public:
   ShenandoahRegulatorThread* regulator_thread() const { return _regulator_thread;  }
 
   void gc_threads_do(ThreadClosure* tcl) const override;
-
-  void stop() override;
 
   bool requires_barriers(stackChunkOop obj) const override;
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
@@ -159,6 +159,10 @@ private:
   // updated at each STW pause associated with a ShenandoahVMOp.
   ShenandoahGeneration* _active_generation;
 
+protected:
+  void print_tracing_info() const override;
+  void stop() override;
+
 public:
   ShenandoahHeapLock* lock() {
     return &_lock;
@@ -204,10 +208,7 @@ public:
 
   void print_heap_on(outputStream* st)         const override;
   void print_gc_on(outputStream *st)           const override;
-  void print_tracing_info()                    const override;
   void print_heap_regions_on(outputStream* st) const;
-
-  void stop() override;
 
   void prepare_for_verify() override;
   void verify(VerifyOption vo) override;

--- a/src/hotspot/share/gc/z/zCollectedHeap.hpp
+++ b/src/hotspot/share/gc/z/zCollectedHeap.hpp
@@ -55,6 +55,10 @@ private:
                               size_t requested_size,
                               size_t* actual_size) override;
 
+protected:
+  void print_tracing_info() const override;
+  void stop() override;
+
 public:
   static ZCollectedHeap* heap();
 
@@ -63,7 +67,6 @@ public:
   const char* name() const override;
   jint initialize() override;
   void initialize_serviceability() override;
-  void stop() override;
 
   size_t max_capacity() const override;
   size_t capacity() const override;
@@ -116,7 +119,6 @@ public:
 
   void print_heap_on(outputStream* st) const override;
   void print_gc_on(outputStream* st) const override;
-  void print_tracing_info() const override;
   bool print_location(outputStream* st, void* addr) const override;
 
   void prepare_for_verify() override;


### PR DESCRIPTION
Hi all,

  please review this refactoring to improve the visibility of `CollectedHeap::stop()` and `CH::print_tracing_info()`.

The change moves these methods to `protected` visibility.

Testing: gha

Thanks,
  Thomas