### PR TITLE
8359596: Behavior change when both -Xlint:options and -Xlint:-options flags are given

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Lint.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Lint.java
@@ -183,9 +183,9 @@ public class Lint {
 
         // Look for specific overrides
         for (LintCategory lc : LintCategory.values()) {
-            if (options.isExplicitlyEnabled(Option.XLINT, lc)) {
+            if (options.isLintExplicitlyEnabled(lc)) {
                 values.add(lc);
-            } else if (options.isExplicitlyDisabled(Option.XLINT, lc)) {
+            } else if (options.isLintExplicitlyDisabled(lc)) {
                 values.remove(lc);
             }
         }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Modules.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Modules.java
@@ -205,7 +205,7 @@ public class Modules extends JCTree.Visitor {
 
         allowAccessIntoSystem = options.isUnset(Option.RELEASE);
 
-        lintOptions = !options.isExplicitlyDisabled(Option.XLINT, LintCategory.OPTIONS);
+        lintOptions = !options.isLintDisabled(LintCategory.OPTIONS);
 
         multiModuleMode = fileManager.hasLocation(StandardLocation.MODULE_SOURCE_PATH);
         ClassWriter classWriter = ClassWriter.instance(context);

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/main/Arguments.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/main/Arguments.java
@@ -503,7 +503,7 @@ public class Arguments {
                     }
                 } else {
                     // single-module or legacy mode
-                    boolean lintPaths = !options.isExplicitlyDisabled(Option.XLINT, LintCategory.PATH);
+                    boolean lintPaths = !options.isLintDisabled(LintCategory.PATH);
                     if (lintPaths) {
                         Path outDirParent = outDir.getParent();
                         if (outDirParent != null && Files.exists(outDirParent.resolve("module-info.class"))) {
@@ -576,7 +576,7 @@ public class Arguments {
             reportDiag(Errors.SourcepathModulesourcepathConflict);
         }
 
-        boolean lintOptions = !options.isExplicitlyDisabled(Option.XLINT, LintCategory.OPTIONS);
+        boolean lintOptions = !options.isLintDisabled(LintCategory.OPTIONS);
         if (lintOptions && source.compareTo(Source.DEFAULT) < 0 && !options.isSet(Option.RELEASE)) {
             if (fm instanceof BaseFileManager baseFileManager) {
                 if (source.compareTo(Source.JDK8) <= 0) {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Options.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Options.java
@@ -172,55 +172,67 @@ public class Options {
     }
 
     /**
-     * Check whether the given lint category is explicitly enabled or disabled.
+     * Determine if a specific {@link LintCategory} is enabled via a custom
+     * option flag of the form {@code -Xlint}, {@code -Xlint:all}, or {@code -Xlint:key}.
      *
      * <p>
-     * If the category is neither enabled nor disabled, return the given default value.
+     * Note: It's possible the category was also disabled; this method does not check that.
      *
-     * @param option the plain (non-custom) option
      * @param lc the {@link LintCategory} in question
-     * @param defaultValue presumed default value
-     * @return true if {@code lc} would be included
+     * @return true if {@code lc} has been enabled
      */
-    public boolean isSet(Option option, LintCategory lc, boolean defaultValue) {
-        Option customOption = option.getCustom();
-        if (lc.optionList.stream().anyMatch(alias -> isSet(customOption, alias))) {
-            return true;
-        }
-        if (lc.optionList.stream().anyMatch(alias -> isSet(customOption, "-" + alias))) {
-            return false;
-        }
-        if (isSet(option) || isSet(customOption, Option.LINT_CUSTOM_ALL)) {
-            return true;
-        }
-        if (isSet(customOption, Option.LINT_CUSTOM_NONE)) {
-            return false;
-        }
-        return defaultValue;
+    public boolean isLintEnabled(LintCategory lc) {
+        return isLintExplicitlyEnabled(lc) ||
+            isSet(Option.XLINT_CUSTOM) ||
+            isSet(Option.XLINT_CUSTOM, Option.LINT_CUSTOM_ALL);
     }
 
     /**
-     * Determine if a specific {@link LintCategory} was explicitly enabled via a custom option flag
-     * of the form {@code -Flag:all} or {@code -Flag:key}.
+     * Determine if a specific {@link LintCategory} is disabled via a custom
+     * option flag of the form {@code -Xlint:none} or {@code -Xlint:-key}.
      *
-     * @param option the option
+     * <p>
+     * Note: It's possible the category was also enabled; this method does not check that.
+     *
+     * @param lc the {@link LintCategory} in question
+     * @return true if {@code lc} has been disabled
+     */
+    public boolean isLintDisabled(LintCategory lc) {
+        return isLintExplicitlyDisabled(lc) || isSet(Option.XLINT_CUSTOM, Option.LINT_CUSTOM_NONE);
+    }
+
+    /**
+     * Determine if a specific {@link LintCategory} is explicitly enabled via a custom
+     * option flag of the form {@code -Xlint:key}.
+     *
+     * <p>
+     * Note: This does not check for option flags of the form {@code -Xlint} or {@code -Xlint:all}.
+     *
+     * <p>
+     * Note: It's possible the category was also disabled; this method does not check that.
+     *
      * @param lc the {@link LintCategory} in question
      * @return true if {@code lc} has been explicitly enabled
      */
-    public boolean isExplicitlyEnabled(Option option, LintCategory lc) {
-        return isSet(option, lc, false);
+    public boolean isLintExplicitlyEnabled(LintCategory lc) {
+        return lc.optionList.stream().anyMatch(alias -> isSet(Option.XLINT_CUSTOM, alias));
     }
 
     /**
-     * Determine if a specific {@link LintCategory} was explicitly disabled via a custom option flag
-     * of the form {@code -Flag:none} or {@code -Flag:-key}.
+     * Determine if a specific {@link LintCategory} is explicitly disabled via a custom
+     * option flag of the form {@code -Xlint:-key}.
      *
-     * @param option the option
+     * <p>
+     * Note: This does not check for an option flag of the form {@code -Xlint:none}.
+     *
+     * <p>
+     * Note: It's possible the category was also enabled; this method does not check that.
+     *
      * @param lc the {@link LintCategory} in question
      * @return true if {@code lc} has been explicitly disabled
      */
-    public boolean isExplicitlyDisabled(Option option, LintCategory lc) {
-        return !isSet(option, lc, true);
+    public boolean isLintExplicitlyDisabled(LintCategory lc) {
+        return lc.optionList.stream().anyMatch(alias -> isSet(Option.XLINT_CUSTOM, "-" + alias));
     }
 
     public void put(String name, String value) {

--- a/test/langtools/tools/javac/lint/LintOptions.java
+++ b/test/langtools/tools/javac/lint/LintOptions.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8359596
+ * @summary Verify behavior when both "-Xlint:options" and "-Xlint:-options" are given
+ * @compile/fail/ref=LintOptions.out -Werror -XDrawDiagnostics -source 21 -target 21                                LintOptions.java
+ * @compile/fail/ref=LintOptions.out -Werror -XDrawDiagnostics -source 21 -target 21 -Xlint:options                 LintOptions.java
+ * @compile                          -Werror -XDrawDiagnostics -source 21 -target 21                -Xlint:-options LintOptions.java
+ * @compile                          -Werror -XDrawDiagnostics -source 21 -target 21 -Xlint:options -Xlint:-options LintOptions.java
+ * @compile                          -Werror -XDrawDiagnostics -source 21 -target 21                -Xlint:none     LintOptions.java
+ * @compile                          -Werror -XDrawDiagnostics -source 21 -target 21 -Xlint:options -Xlint:none     LintOptions.java
+ */
+class LintOptions {
+}

--- a/test/langtools/tools/javac/lint/LintOptions.out
+++ b/test/langtools/tools/javac/lint/LintOptions.out
@@ -1,0 +1,4 @@
+- compiler.warn.source.no.system.modules.path: 21, (compiler.misc.source.no.system.modules.path.with.target: 21, 21)
+- compiler.err.warnings.and.werror
+1 error
+1 warning


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [3525a40f](https://github.com/openjdk/jdk/commit/3525a40f39a966b8592f694a9b3cd4c5dc449266) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Archie Cobbs on 27 Jun 2025 and was reviewed by Maurizio Cimadamore and Uwe Schindler.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8359844](https://bugs.openjdk.org/browse/JDK-8359844) to be approved

### Issues
 * [JDK-8359596](https://bugs.openjdk.org/browse/JDK-8359596): Behavior change when both -Xlint:options and -Xlint:-options flags are given (**Bug** - P2)
 * [JDK-8359844](https://bugs.openjdk.org/browse/JDK-8359844): Behavior change when both -Xlint:options and -Xlint:-options flags are given (**CSR**)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26163/head:pull/26163` \
`$ git checkout pull/26163`

Update a local copy of the PR: \
`$ git checkout pull/26163` \
`$ git pull https://git.openjdk.org/jdk.git pull/26163/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26163`

View PR using the GUI difftool: \
`$ git pr show -t 26163`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26163.diff">https://git.openjdk.org/jdk/pull/26163.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26163#issuecomment-3045751929)
</details>
