### PR TITLE
8361193: Test java/awt/Mixing/AWT_Mixing/MixingPanelsResizing.java fails on MacOS X

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -155,7 +155,6 @@ java/awt/Mixing/AWT_Mixing/OpaqueOverlappingChoice.java 8048171 generic-all
 java/awt/Mixing/AWT_Mixing/JMenuBarOverlapping.java 8159451 macosx-all
 java/awt/Mixing/AWT_Mixing/JSplitPaneOverlapping.java 6986109 generic-all
 java/awt/Mixing/AWT_Mixing/JInternalFrameMoveOverlapping.java 6986109 windows-all
-java/awt/Mixing/AWT_Mixing/MixingPanelsResizing.java 8049405 macosx-all
 java/awt/Mixing/AWT_Mixing/JComboBoxOverlapping.java 8049405 macosx-all
 java/awt/Mixing/AWT_Mixing/JPopupMenuOverlapping.java 8049405 macosx-all
 java/awt/Mixing/NonOpaqueInternalFrame.java 7124549 macosx-all

--- a/test/jdk/java/awt/Mixing/AWT_Mixing/MixingPanelsResizing.java
+++ b/test/jdk/java/awt/Mixing/AWT_Mixing/MixingPanelsResizing.java
@@ -114,12 +114,14 @@ public class MixingPanelsResizing {
                 awtPanel.add(jbutton);
                 jbutton.setForeground(jbColor);
                 jbutton.setBackground(jbColor);
+                jbutton.setOpaque(true);
 
                 JPanel jPanel = new JPanel();
                 jbutton2 = new JButton("SwingButton2");
                 jPanel.add(jbutton2);
                 jbutton2.setForeground(jb2Color);
                 jbutton2.setBackground(jb2Color);
+                jbutton2.setOpaque(true);
                 awtButton2 = new Button("AWT Button2");
                 jPanel.add(awtButton2);
                 awtButton2.setForeground(awt2Color);
@@ -163,19 +165,19 @@ public class MixingPanelsResizing {
 
                 btnLoc = awtButton.getLocationOnScreen();
                 c = robot.getPixelColor(btnLoc.x + 5, btnLoc.y + 5);
-                if (!c.equals(awtColor)) {
+                if (!isAlmostEqualColor(c, awtColor)) {
                     fail("AWT Button was not redrawn properly on AWT Panel during move");
                 }
 
                 btnLoc = jbutton2.getLocationOnScreen();
                 c = robot.getPixelColor(btnLoc.x + 5, btnLoc.y + 5);
-                if (!c.equals(jb2Color)) {
+                if (!isAlmostEqualColor(c, jb2Color)) {
                     fail("JButton was not redrawn properly on JPanel during move");
                 }
 
                 btnLoc = awtButton2.getLocationOnScreen();
                 c = robot.getPixelColor(btnLoc.x + 5, btnLoc.y + 5);
-                if (!c.equals(awt2Color)) {
+                if (!isAlmostEqualColor(c, awt2Color)) {
                     fail("ATW Button was not redrawn properly on JPanel during move");
                 }
             }
@@ -298,6 +300,19 @@ public class MixingPanelsResizing {
         failureMessage = whyFailed;
         mainThread.interrupt();
     }//fail()
+    private static boolean isAlmostEqualColor(Color color, Color refColor) {
+        final int COLOR_TOLERANCE_MACOSX = 10;
+        if(color.equals(refColor)){
+            return true;
+        } else {
+            return Math.abs(color.getRed() - refColor.getRed()) <
+                    COLOR_TOLERANCE_MACOSX &&
+                    Math.abs(color.getGreen() - refColor.getGreen()) <
+                            COLOR_TOLERANCE_MACOSX &&
+                    Math.abs(color.getBlue() - refColor.getBlue()) <
+                            COLOR_TOLERANCE_MACOSX;
+        }
+    }
 }// class JButtonInGlassPane
 class TestPassedException extends RuntimeException {
 }

--- a/test/jdk/java/awt/Mixing/AWT_Mixing/MixingPanelsResizing.java
+++ b/test/jdk/java/awt/Mixing/AWT_Mixing/MixingPanelsResizing.java
@@ -302,7 +302,7 @@ public class MixingPanelsResizing {
     }//fail()
     private static boolean isAlmostEqualColor(Color color, Color refColor) {
         final int COLOR_TOLERANCE_MACOSX = 10;
-        if(color.equals(refColor)){
+        if (color.equals(refColor)){
             return true;
         } else {
             return Math.abs(color.getRed() - refColor.getRed()) <


### PR DESCRIPTION
Sets setOpaque for lightweight, and uses a compares colors with tolerance in MacOS X machines.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Dependency #25971 must be integrated first

### Warnings
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/javax/swing/beaninfo/images/JAppletColor16.gif)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/javax/swing/beaninfo/images/JAppletColor32.gif)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/javax/swing/beaninfo/images/JAppletMono16.gif)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/javax/swing/beaninfo/images/JAppletMono32.gif)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/javax/swing/doc-files/JRootPane-1.gif)
&nbsp;⚠️ Patch contains a binary file (test/jdk/javax/rmi/ssl/keystore)
&nbsp;⚠️ Patch contains a binary file (test/jdk/javax/rmi/ssl/truststore)
&nbsp;⚠️ Patch contains a binary file (test/jdk/sun/net/www/protocol/https/HttpsClient/dnsstore)
&nbsp;⚠️ Patch contains a binary file (test/jdk/sun/net/www/protocol/https/HttpsClient/ipstore)

### Issue
 * [JDK-8361193](https://bugs.openjdk.org/browse/JDK-8361193): Test java/awt/Mixing/AWT_Mixing/MixingPanelsResizing.java fails on MacOS X (**Sub-task** - P4) ⚠️ Issue is not open.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26166/head:pull/26166` \
`$ git checkout pull/26166`

Update a local copy of the PR: \
`$ git checkout pull/26166` \
`$ git pull https://git.openjdk.org/jdk.git pull/26166/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26166`

View PR using the GUI difftool: \
`$ git pr show -t 26166`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26166.diff">https://git.openjdk.org/jdk/pull/26166.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26166#issuecomment-3046037680)
</details>
