### PR TITLE
8361192: Test java/awt/Mixing/AWT_Mixing/JSplitPaneOverlapping.java fails on all platforms

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -153,7 +153,6 @@ java/awt/List/KeyEventsTest/KeyEventsTest.java 8201307 linux-all
 java/awt/Paint/ListRepaint.java 8201307 linux-all
 java/awt/Mixing/AWT_Mixing/OpaqueOverlappingChoice.java 8048171 generic-all
 java/awt/Mixing/AWT_Mixing/JMenuBarOverlapping.java 8159451 macosx-all
-java/awt/Mixing/AWT_Mixing/JSplitPaneOverlapping.java 6986109 generic-all
 java/awt/Mixing/AWT_Mixing/JInternalFrameMoveOverlapping.java 6986109 windows-all
 java/awt/Mixing/AWT_Mixing/MixingPanelsResizing.java 8049405 macosx-all
 java/awt/Mixing/AWT_Mixing/JComboBoxOverlapping.java 8049405 macosx-all

--- a/test/jdk/java/awt/Mixing/AWT_Mixing/JSplitPaneOverlapping.java
+++ b/test/jdk/java/awt/Mixing/AWT_Mixing/JSplitPaneOverlapping.java
@@ -70,6 +70,8 @@ public class JSplitPaneOverlapping extends OverlappingTestBase {
         p.setPreferredSize(new Dimension(500, 500));
         propagateAWTControls(p);
         sp1 = new JScrollPane(p);
+        currentAwtControl.setForeground(Color.white);
+        currentAwtControl.setBackground(Color.white);
 
         JButton button = new JButton("JButton");
         button.setBackground(Color.RED);


### PR DESCRIPTION
Changes heavyweight color to white, for the test to pass.