### PR TITLE
8360647: [XWayland] [OL10] NumPad keys are not triggered

### DIFF
--- a/src/java.desktop/unix/native/libawt_xawt/awt/screencast_pipewire.c
+++ b/src/java.desktop/unix/native/libawt_xawt/awt/screencast_pipewire.c
@@ -33,6 +33,7 @@
 
 #ifndef _AIX
 #include "screencast_pipewire.h"
+#include "java_awt_event_KeyEvent.h"
 
 struct pw_buffer *(*fp_pw_stream_dequeue_buffer)(struct pw_stream *stream);
 const char * (*fp_pw_stream_state_as_string)(enum pw_stream_state state);
@@ -1197,6 +1198,24 @@ JNIEXPORT jint JNICALL Java_sun_awt_screencast_ScreencastHelper_remoteDesktopMou
     return result ? RESULT_OK : pw.pwFd;
 }
 
+static int getNumpadKey(jint jkey) {
+    switch (jkey) {
+        case java_awt_event_KeyEvent_VK_NUMPAD0: return XK_KP_Insert;
+        case java_awt_event_KeyEvent_VK_NUMPAD1: return XK_KP_End;
+        case java_awt_event_KeyEvent_VK_NUMPAD2: return XK_KP_Down;
+        case java_awt_event_KeyEvent_VK_NUMPAD3: return XK_KP_Page_Down;
+        case java_awt_event_KeyEvent_VK_NUMPAD4: return XK_KP_Left;
+        case java_awt_event_KeyEvent_VK_NUMPAD5: return XK_KP_Begin;
+        case java_awt_event_KeyEvent_VK_NUMPAD6: return XK_KP_Right;
+        case java_awt_event_KeyEvent_VK_NUMPAD7: return XK_KP_Home;
+        case java_awt_event_KeyEvent_VK_NUMPAD8: return XK_KP_Up;
+        case java_awt_event_KeyEvent_VK_NUMPAD9: return XK_KP_Prior;
+        case java_awt_event_KeyEvent_VK_DECIMAL:
+        case java_awt_event_KeyEvent_VK_SEPARATOR: return XK_KP_Delete;
+        default: return 0;
+    }
+}
+
 /*
  * Class:     sun_awt_screencast_ScreencastHelper
  * Method:    remoteDesktopKeyImpl
@@ -1205,9 +1224,12 @@ JNIEXPORT jint JNICALL Java_sun_awt_screencast_ScreencastHelper_remoteDesktopMou
 JNIEXPORT jint JNICALL Java_sun_awt_screencast_ScreencastHelper_remoteDesktopKeyImpl
         (JNIEnv *env, jclass cls, jboolean isPress, jint jkey, jstring jtoken) {
 
-    AWT_LOCK();
-    int key = awt_getX11KeySym(jkey);
-    AWT_UNLOCK();
+    int key = getNumpadKey(jkey);
+    if (!key) {
+        AWT_LOCK();
+        key = awt_getX11KeySym(jkey);
+        AWT_UNLOCK();
+    }
 
     if (key == NoSymbol || (*env)->ExceptionCheck(env)) {
         return RESULT_ERROR;

--- a/test/jdk/java/awt/event/KeyEvent/KeyCharTest/KeyCharTest.java
+++ b/test/jdk/java/awt/event/KeyEvent/KeyCharTest/KeyCharTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
   @test
-  @bug 5013984
+  @bug 5013984 8360647
   @summary Tests KEY_PRESSED has the same KeyChar as KEY_RELEASED
   @key headful
   @run main KeyCharTest
@@ -37,7 +37,7 @@ import java.awt.event.MouseEvent;
 import java.util.HashMap;
 
 public class KeyCharTest extends Frame implements KeyListener {
-    HashMap<Integer, Character> transMap = new HashMap();
+    HashMap<Integer, Character> transMap = new HashMap<>();
 
     public void keyTyped(KeyEvent e){
     }
@@ -47,14 +47,27 @@ public class KeyCharTest extends Frame implements KeyListener {
     }
 
     public void keyReleased(KeyEvent e){
-        Object value = transMap.get(e.getKeyCode());
-        if (value != null && e.getKeyChar() != ((Character)value).charValue()) {
+        Character value = transMap.get(e.getKeyCode());
+        if (value != null && e.getKeyChar() != value) {
             throw new RuntimeException("Wrong KeyChar on KEY_RELEASED "+
                 KeyEvent.getKeyText(e.getKeyCode()));
         }
     }
 
-    public void start () {
+    private void testKeyRange(Robot robot, int start, int end) {
+        System.out.printf("\nTesting range on %d to %d\n", start, end);
+        for(int vkey = start; vkey <= end; vkey++) {
+            try {
+                robot.keyPress(vkey);
+                robot.keyRelease(vkey);
+                System.out.println(KeyEvent.getKeyText(vkey) + " " + vkey);
+            } catch (RuntimeException ignored) {}
+        }
+        robot.delay(100);
+    }
+
+    public void start() throws Exception {
+        Robot robot = new Robot();
         addKeyListener(this);
         setLocationRelativeTo(null);
         setSize(200, 200);
@@ -62,7 +75,6 @@ public class KeyCharTest extends Frame implements KeyListener {
         requestFocus();
 
         try {
-            Robot robot = new Robot();
             robot.setAutoDelay(10);
             robot.setAutoWaitForIdle(true);
             robot.delay(100);
@@ -72,22 +84,22 @@ public class KeyCharTest extends Frame implements KeyListener {
             robot.mousePress(MouseEvent.BUTTON1_DOWN_MASK);
             robot.mouseRelease(MouseEvent.BUTTON1_DOWN_MASK);
 
-            for(int vkey = 0x20; vkey < 0x7F; vkey++) {
-                try {
-                    robot.keyPress(vkey);
-                    robot.keyRelease(vkey);
-                    System.out.println(KeyEvent.getKeyText(vkey) + " " + vkey);
-                } catch (RuntimeException e) {
-                }
-            }
-            robot.delay(100);
+            testKeyRange(robot, 0x20, 0x7E);
+
+            // Try again with a different numpad state.
+            robot.keyPress(KeyEvent.VK_NUM_LOCK);
+            robot.keyRelease(KeyEvent.VK_NUM_LOCK);
+
+            testKeyRange(robot, KeyEvent.VK_NUMPAD0, KeyEvent.VK_DIVIDE);
         } catch(Exception e){
-            e.printStackTrace();
             throw new RuntimeException("Exception while performing Robot actions.");
+        } finally {
+            robot.keyPress(KeyEvent.VK_NUM_LOCK);
+            robot.keyRelease(KeyEvent.VK_NUM_LOCK);
         }
    }
 
-    public static void main(String[] args) {
+    public static void main(String[] args) throws Exception {
         KeyCharTest test = new KeyCharTest();
         try {
             test.start();

--- a/test/jdk/java/awt/event/KeyEvent/KeyCharTest/KeyCharTest.java
+++ b/test/jdk/java/awt/event/KeyEvent/KeyCharTest/KeyCharTest.java
@@ -74,6 +74,7 @@ public class KeyCharTest extends Frame implements KeyListener {
         setVisible(true);
         requestFocus();
 
+        boolean wasNumlockPressed = false;
         try {
             robot.setAutoDelay(10);
             robot.setAutoWaitForIdle(true);
@@ -89,13 +90,16 @@ public class KeyCharTest extends Frame implements KeyListener {
             // Try again with a different numpad state.
             robot.keyPress(KeyEvent.VK_NUM_LOCK);
             robot.keyRelease(KeyEvent.VK_NUM_LOCK);
+            wasNumlockPressed = true;
 
             testKeyRange(robot, KeyEvent.VK_NUMPAD0, KeyEvent.VK_DIVIDE);
         } catch(Exception e){
             throw new RuntimeException("Exception while performing Robot actions.");
         } finally {
-            robot.keyPress(KeyEvent.VK_NUM_LOCK);
-            robot.keyRelease(KeyEvent.VK_NUM_LOCK);
+            if (wasNumlockPressed) {
+                robot.keyPress(KeyEvent.VK_NUM_LOCK);
+                robot.keyRelease(KeyEvent.VK_NUM_LOCK);
+            }
         }
    }
 


### PR DESCRIPTION
When we try to pass `XK_KP_0` to [`NotifyKeyboardKeysym`](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.RemoteDesktop.html#org-freedesktop-portal-remotedesktop-notifykeyboardkeysym) in Remote Desktop API, it presses/releases `SHIFT` + `XK_KP_Insert`.

To get the same result as XTest api when using `NotifyKeyboardKeysym` we should use `XK_KP_Insert` instead of `XK_KP_0` regardless of NumLock state. Similarly for other Numpad keys.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8360647](https://bugs.openjdk.org/browse/JDK-8360647): [XWayland] [OL10] NumPad keys are not triggered (**Bug** - P3)


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**) Review applies to [7096b725](https://git.openjdk.org/jdk/pull/26170/files/7096b725b0a611250874292eca302bd3578828d1)
 * [Harshitha Onkar](https://openjdk.org/census#honkar) (@honkar-jdk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26170/head:pull/26170` \
`$ git checkout pull/26170`

Update a local copy of the PR: \
`$ git checkout pull/26170` \
`$ git pull https://git.openjdk.org/jdk.git pull/26170/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26170`

View PR using the GUI difftool: \
`$ git pr show -t 26170`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26170.diff">https://git.openjdk.org/jdk/pull/26170.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26170#issuecomment-3046296308)
</details>
