### PR TITLE
8361524: [XWayland] possible JavaFX interop hang

### DIFF
--- a/src/java.desktop/unix/native/libawt_xawt/awt/screencast_portal.c
+++ b/src/java.desktop/unix/native/libawt_xawt/awt/screencast_portal.c
@@ -716,6 +716,7 @@ static void callbackScreenCastStart(
         DEBUG_SCREENCAST("Failed to start screencast: %u\n", status);
         startHelper->result = RESULT_DENIED;
         helper->isDone = TRUE;
+        callbackEnd();
         return;
     }
 
@@ -731,6 +732,7 @@ static void callbackScreenCastStart(
         DEBUG_SCREENCAST("No streams available with current token\n",  NULL);
         startHelper->result = RESULT_NO_STREAMS;
         helper->isDone = TRUE;
+        callbackEnd();
         return;
     }
 


### PR DESCRIPTION
Callbacks in the `src/java.desktop/unix/native/libawt_xawt/awt/screencast_portal.c` file normally have the following pattern:

```c
helper->isDone = TRUE;
callbackEnd();
// return;
```

Failing to call `callbackEnd()` could result in a hang if another GTK loop is running (e.g., JavaFX see https://github.com/openjdk/jdk/pull/22131#issue-2660482472).

This fix corrects this flaw.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8361524](https://bugs.openjdk.org/browse/JDK-8361524): [XWayland] possible JavaFX interop hang (**Bug** - P4)


### Reviewers
 * [Prasanta Sadhukhan](https://openjdk.org/census#psadhukhan) (@prsadhuk - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)
 * [Alexander Zuev](https://openjdk.org/census#kizune) (@azuev-java - **Reviewer**)
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - Author)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26172/head:pull/26172` \
`$ git checkout pull/26172`

Update a local copy of the PR: \
`$ git checkout pull/26172` \
`$ git pull https://git.openjdk.org/jdk.git pull/26172/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26172`

View PR using the GUI difftool: \
`$ git pr show -t 26172`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26172.diff">https://git.openjdk.org/jdk/pull/26172.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26172#issuecomment-3046605245)
</details>
