### PR TITLE
8360942: [ubsan] aotCache tests trigger runtime error: applying non-zero offset 16 to null pointer in CodeBlob::relocation_end()

### DIFF
--- a/src/hotspot/share/code/codeBlob.cpp
+++ b/src/hotspot/share/code/codeBlob.cpp
@@ -160,7 +160,7 @@ CodeBlob::CodeBlob(const char* name, CodeBlobKind kind, CodeBuffer* cb, int size
     }
   } else {
     // We need unique and valid not null address
-    assert(_mutable_data = blob_end(), "sanity");
+    assert(_mutable_data == blob_end(), "sanity");
   }
 
   set_oop_maps(oop_maps);
@@ -177,6 +177,7 @@ CodeBlob::CodeBlob(const char* name, CodeBlobKind kind, int size, uint16_t heade
   _code_offset(_content_offset),
   _data_offset(size),
   _frame_size(0),
+  _mutable_data_size(0),
   S390_ONLY(_ctable_offset(0) COMMA)
   _header_size(header_size),
   _frame_complete_offset(CodeOffsets::frame_never_safe),
@@ -185,7 +186,7 @@ CodeBlob::CodeBlob(const char* name, CodeBlobKind kind, int size, uint16_t heade
 {
   assert(is_aligned(size,            oopSize), "unaligned size");
   assert(is_aligned(header_size,     oopSize), "unaligned size");
-  assert(_mutable_data = blob_end(), "sanity");
+  assert(_mutable_data == blob_end(), "sanity");
 }
 
 void CodeBlob::restore_mutable_data(address reloc_data) {
@@ -195,8 +196,11 @@ void CodeBlob::restore_mutable_data(address reloc_data) {
     if (_mutable_data == nullptr) {
       vm_exit_out_of_memory(_mutable_data_size, OOM_MALLOC_ERROR, "codebuffer: no space for mutable data");
     }
+  } else {
+    _mutable_data = blob_end(); // default value
   }
   if (_relocation_size > 0) {
+    assert(_mutable_data_size > 0, "relocation is part of mutable data section");
     memcpy((address)relocation_begin(), reloc_data, relocation_size());
   }
 }

--- a/src/hotspot/share/code/codeBlob.hpp
+++ b/src/hotspot/share/code/codeBlob.hpp
@@ -247,7 +247,7 @@ public:
   // Sizes
   int size() const               { return _size; }
   int header_size() const        { return _header_size; }
-  int relocation_size() const    { return pointer_delta_as_int((address) relocation_end(), (address) relocation_begin()); }
+  int relocation_size() const    { return _relocation_size; }
   int content_size() const       { return pointer_delta_as_int(content_end(), content_begin()); }
   int code_size() const          { return pointer_delta_as_int(code_end(), code_begin()); }
 


### PR DESCRIPTION
`CodeBlob::relocation_size()` is calculated as `(_mutable_data + _relocation_size - _mutable_data)`. `CodeBlob::relocation_size()` is called during AOT code loading before we allocate space for mutable data (the size is used to find how big space should be allocated). The expression at that point is `(NULL + _relocation_size - NULL)` which returns correct result. But we should just return `_relocation_size` which is recorded anyway in AOT data.

Added missing  `_mutable_data = blob_end();` initialization when we restore AOT code blob.

Fixed embarrassing typo in asserts.

Tested: tier1-6,8,10,xcomp,stress

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8360942](https://bugs.openjdk.org/browse/JDK-8360942): [ubsan] aotCache tests trigger runtime error: applying non-zero offset 16 to null pointer in CodeBlob::relocation_end() (**Bug** - P4)


### Reviewers
 * [Andrew Dinn](https://openjdk.org/census#adinn) (@adinn - **Reviewer**)
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26175/head:pull/26175` \
`$ git checkout pull/26175`

Update a local copy of the PR: \
`$ git checkout pull/26175` \
`$ git pull https://git.openjdk.org/jdk.git pull/26175/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26175`

View PR using the GUI difftool: \
`$ git pr show -t 26175`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26175.diff">https://git.openjdk.org/jdk/pull/26175.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26175#issuecomment-3046864132)
</details>
