### PR TITLE
8358679: [asan] vmTestbase/nsk/jvmti tests show memory issues

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RawMonitorEnter/rawmonenter003/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RawMonitorEnter/rawmonenter003/TestDescription.java
@@ -37,8 +37,8 @@
  *         4431533: TEST_BUG: destroyed raw monitor can be occasionally valid
  *     Ported from JVMDI.
  *
- * @comment the test intentionally passes bad argument to the function to verify the functionality,
-            it causes false positive from ASAN lib
+ * @comment The test intentionally passes a bad argument to the function to verify error checking,
+            which causes a false positive from the ASAN lib
  * @requires !vm.asan
  * @library /vmTestbase
  *          /test/lib

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RawMonitorEnter/rawmonenter003/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RawMonitorEnter/rawmonenter003/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,6 +37,9 @@
  *         4431533: TEST_BUG: destroyed raw monitor can be occasionally valid
  *     Ported from JVMDI.
  *
+ * @comment the test intentionally passes bad argument to the function to verify the functionality,
+            it causes false positive from ASAN lib
+ * @requires !vm.asan
  * @library /vmTestbase
  *          /test/lib
  * @run main/othervm/native -agentlib:rawmonenter003 nsk.jvmti.RawMonitorEnter.rawmonenter003

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RawMonitorExit/rawmonexit003/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RawMonitorExit/rawmonexit003/TestDescription.java
@@ -37,8 +37,8 @@
  *         4431533: TEST_BUG: destroyed raw monitor can be occasionally valid
  *     Ported from JVMDI.
  *
- * @comment the test intentionally passes bad argument to the function to verify the functionality,
-            it causes false positive from ASAN lib
+ * @comment The test intentionally passes a bad argument to the function to verify error checking,
+            which causes a false positive from the ASAN lib
  * @requires !vm.asan
  * @library /vmTestbase
  *          /test/lib

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RawMonitorExit/rawmonexit003/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RawMonitorExit/rawmonexit003/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,6 +37,9 @@
  *         4431533: TEST_BUG: destroyed raw monitor can be occasionally valid
  *     Ported from JVMDI.
  *
+ * @comment the test intentionally passes bad argument to the function to verify the functionality,
+            it causes false positive from ASAN lib
+ * @requires !vm.asan
  * @library /vmTestbase
  *          /test/lib
  * @run main/othervm/native -agentlib:rawmonexit003 nsk.jvmti.RawMonitorExit.rawmonexit003

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RawMonitorNotify/rawmnntfy003/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RawMonitorNotify/rawmnntfy003/TestDescription.java
@@ -37,8 +37,8 @@
  *         4431533: TEST_BUG: destroyed raw monitor can be occasionally valid
  *     Ported from JVMDI.
  *
- * @comment the test intentionally passes bad argument to the function to verify the functionality,
-            it causes false positive from ASAN lib
+ * @comment The test intentionally passes a bad argument to the function to verify error checking,
+            which causes a false positive from the ASAN lib
  * @requires !vm.asan
  * @library /vmTestbase
  *          /test/lib

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RawMonitorNotify/rawmnntfy003/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RawMonitorNotify/rawmnntfy003/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,6 +37,9 @@
  *         4431533: TEST_BUG: destroyed raw monitor can be occasionally valid
  *     Ported from JVMDI.
  *
+ * @comment the test intentionally passes bad argument to the function to verify the functionality,
+            it causes false positive from ASAN lib
+ * @requires !vm.asan
  * @library /vmTestbase
  *          /test/lib
  * @run main/othervm/native -agentlib:rawmnntfy003 nsk.jvmti.RawMonitorNotify.rawmnntfy003

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RawMonitorNotifyAll/rawmnntfyall003/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RawMonitorNotifyAll/rawmnntfyall003/TestDescription.java
@@ -37,8 +37,8 @@
  *         4431533: TEST_BUG: destroyed raw monitor can be occasionally valid
  *     Ported from JVMDI.
  *
- * @comment the test intentionally passes bad argument to the function to verify the functionality,
-            it causes false positive from ASAN lib
+ * @comment The test intentionally passes a bad argument to the function to verify error checking,
+            which causes a false positive from the ASAN lib
  * @requires !vm.asan
  * @library /vmTestbase
  *          /test/lib

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RawMonitorNotifyAll/rawmnntfyall003/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RawMonitorNotifyAll/rawmnntfyall003/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,6 +37,9 @@
  *         4431533: TEST_BUG: destroyed raw monitor can be occasionally valid
  *     Ported from JVMDI.
  *
+ * @comment the test intentionally passes bad argument to the function to verify the functionality,
+            it causes false positive from ASAN lib
+ * @requires !vm.asan
  * @library /vmTestbase
  *          /test/lib
  * @run main/othervm/native -agentlib:rawmnntfyall003 nsk.jvmti.RawMonitorNotifyAll.rawmnntfyall003

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RawMonitorWait/rawmnwait003/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RawMonitorWait/rawmnwait003/TestDescription.java
@@ -37,8 +37,8 @@
  *         4431533: TEST_BUG: destroyed raw monitor can be occasionally valid
  *     Ported from JVMDI.
  *
- * @comment the test intentionally passes bad argument to the function to verify the functionality,
-            it causes false positive from ASAN lib
+ * @comment The test intentionally passes a bad argument to the function to verify error checking,
+            which causes a false positive from the ASAN lib
  * @requires !vm.asan
  * @library /vmTestbase
  *          /test/lib

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RawMonitorWait/rawmnwait003/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RawMonitorWait/rawmnwait003/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,6 +37,9 @@
  *         4431533: TEST_BUG: destroyed raw monitor can be occasionally valid
  *     Ported from JVMDI.
  *
+ * @comment the test intentionally passes bad argument to the function to verify the functionality,
+            it causes false positive from ASAN lib
+ * @requires !vm.asan
  * @library /vmTestbase
  *          /test/lib
  * @run main/othervm/native -agentlib:rawmnwait003 nsk.jvmti.RawMonitorWait.rawmnwait003

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM07/em07t002/em07t002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM07/em07t002/em07t002.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -237,10 +237,6 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* agentJNI, void* arg) {
     }
 
     jvmti->RawMonitorExit(syncLock);
-
-    if (!NSK_JVMTI_VERIFY(jvmti->DestroyRawMonitor(syncLock)))
-        nsk_jvmti_setFailStatus();
-
 }
 
 /* ============================================================================= */


### PR DESCRIPTION
The fix updates several tests ASAN complains about.
Tests for RawMonitors intentionally passes bad pointer to tested function, they should not be run with ASAN.
Test vmTestbase/nsk/jvmti/scenarios/events/EM07/em07t002 verifies COMPILED_METHOD_LOAD/COMPILED_METHOD_UNLOAD event and uses RawMonitor for synchronization. It destroys the monitor, but some events may arrive later (before VM exits). Usually JVMTI tests do not destroy synchronization monitors, removed destruction here.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8358679](https://bugs.openjdk.org/browse/JDK-8358679): [asan] vmTestbase/nsk/jvmti tests show memory issues (**Bug** - P4)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26176/head:pull/26176` \
`$ git checkout pull/26176`

Update a local copy of the PR: \
`$ git checkout pull/26176` \
`$ git pull https://git.openjdk.org/jdk.git pull/26176/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26176`

View PR using the GUI difftool: \
`$ git pr show -t 26176`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26176.diff">https://git.openjdk.org/jdk/pull/26176.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26176#issuecomment-3046915116)
</details>
