### PR TITLE
8361532: RISC-V: Several vector tests fail after JDK-8354383

### DIFF
--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -8426,6 +8426,17 @@ instruct castVV(vReg dst)
   ins_pipe(pipe_class_empty);
 %}
 
+instruct castVVMask(vRegMask dst)
+%{
+  match(Set dst (CastVV dst));
+
+  size(0);
+  format %{ "# castVV of $dst" %}
+  ins_encode(/* empty encoding */);
+  ins_cost(0);
+  ins_pipe(pipe_class_empty);
+%}
+
 // ============================================================================
 // Convert Instructions
 


### PR DESCRIPTION
Hi all,
Please take a look and review this PR, thanks!

After [JDK-8354383](https://bugs.openjdk.org/browse/JDK-8354383) , several test cases fail when fastdebug with RVV.
The reason for the error is that riscv lacks CastVV with dst as the mask register. 
This PR adds the corresponding matching rules.

### Testing
qemu-system with RVV:
* [x]  Run jdk_vector (fastdebug)
* [x]  Run compiler/vectorapi (fastdebug)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8361532](https://bugs.openjdk.org/browse/JDK-8361532): RISC-V: Several vector tests fail after JDK-8354383 (**Bug** - P3)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Feilong Jiang](https://openjdk.org/census#fjiang) (@feilongjiang - Committer)
 * [Gui Cao](https://openjdk.org/census#gcao) (@zifeihan - Author)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26178/head:pull/26178` \
`$ git checkout pull/26178`

Update a local copy of the PR: \
`$ git checkout pull/26178` \
`$ git pull https://git.openjdk.org/jdk.git pull/26178/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26178`

View PR using the GUI difftool: \
`$ git pr show -t 26178`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26178.diff">https://git.openjdk.org/jdk/pull/26178.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26178#issuecomment-3047160213)
</details>
