### PR TITLE
8360599: [TESTBUG] DumpThreadsWithEliminatedLock.java fails because of unstable inlining

### DIFF
--- a/test/jdk/com/sun/management/HotSpotDiagnosticMXBean/DumpThreadsWithEliminatedLock.java
+++ b/test/jdk/com/sun/management/HotSpotDiagnosticMXBean/DumpThreadsWithEliminatedLock.java
@@ -26,14 +26,14 @@
  * @bug 8356870
  * @summary Test HotSpotDiagnosticMXBean.dumpThreads with a thread owning a monitor for
  *     an object that is scalar replaced
- * @requires !vm.debug & (vm.compMode != "Xcomp")
+ * @requires vm.compMode != "Xcomp"
  * @requires (vm.opt.TieredStopAtLevel == null | vm.opt.TieredStopAtLevel == 4)
  * @modules jdk.management
  * @library /test/lib
- * @run main/othervm DumpThreadsWithEliminatedLock plain platform
- * @run main/othervm DumpThreadsWithEliminatedLock plain virtual
- * @run main/othervm DumpThreadsWithEliminatedLock json platform
- * @run main/othervm DumpThreadsWithEliminatedLock json virtual
+ * @run main/othervm -XX:CompileCommand=inline,java/lang/String*.* DumpThreadsWithEliminatedLock plain platform
+ * @run main/othervm -XX:CompileCommand=inline,java/lang/String*.* DumpThreadsWithEliminatedLock plain virtual
+ * @run main/othervm -XX:CompileCommand=inline,java/lang/String*.* DumpThreadsWithEliminatedLock json platform
+ * @run main/othervm -XX:CompileCommand=inline,java/lang/String*.* DumpThreadsWithEliminatedLock json virtual
  */
 
 import java.io.IOException;


### PR DESCRIPTION
This pull request contains a backport of commit [fea73c1d](https://github.com/openjdk/jdk/commit/fea73c1d40441561a246f2a09a739367cfc197ea) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Richard Reingruber on 7 Jul 2025 and was reviewed by Alan Bateman, Martin Doerr and Leonid Mesnik.

Testing was done with fastdebug and release builds on the main platforms and also on Linux/PPC64le and AIX.

Thanks, Richard.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8360599](https://bugs.openjdk.org/browse/JDK-8360599): [TESTBUG] DumpThreadsWithEliminatedLock.java fails because of unstable inlining (**Bug** - P4)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26180/head:pull/26180` \
`$ git checkout pull/26180`

Update a local copy of the PR: \
`$ git checkout pull/26180` \
`$ git pull https://git.openjdk.org/jdk.git pull/26180/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26180`

View PR using the GUI difftool: \
`$ git pr show -t 26180`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26180.diff">https://git.openjdk.org/jdk/pull/26180.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26180#issuecomment-3051558746)
</details>
