### PR TITLE
8361520: Stabilize SystemGC benchmarks

### DIFF
--- a/test/micro/org/openjdk/bench/vm/gc/systemgc/AllDead.java
+++ b/test/micro/org/openjdk/bench/vm/gc/systemgc/AllDead.java
@@ -26,16 +26,20 @@ import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.ArrayList;
 import java.util.concurrent.TimeUnit;
 
 @BenchmarkMode(Mode.SingleShotTime)
+@Warmup(iterations = 5)
+@Measurement(iterations = 5)
 @Fork(value=25, jvmArgs={"-Xmx5g", "-Xms5g", "-Xmn3g", "-XX:+AlwaysPreTouch"})
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Benchmark)
@@ -52,6 +56,9 @@ public class AllDead {
     @Setup(Level.Iteration)
     public void generateGarbage() {
         holder = GarbageGenerator.generateObjectArrays();
+        // Compact right now, kicking out all unrelated objects
+        System.gc();
+        // Make the holder dead
         holder = null;
     }
 

--- a/test/micro/org/openjdk/bench/vm/gc/systemgc/AllDead.java
+++ b/test/micro/org/openjdk/bench/vm/gc/systemgc/AllDead.java
@@ -53,12 +53,15 @@ public class AllDead {
 
     static ArrayList<Object[]> holder;
 
+    @Setup(Level.Trial)
+    public void preRun() {
+        // Compact right now, kicking out all unrelated objects
+        System.gc();
+    }
+
     @Setup(Level.Iteration)
     public void generateGarbage() {
         holder = GarbageGenerator.generateObjectArrays();
-        // Compact right now, kicking out all unrelated objects
-        System.gc();
-        // Make the holder dead
         holder = null;
     }
 

--- a/test/micro/org/openjdk/bench/vm/gc/systemgc/AllLive.java
+++ b/test/micro/org/openjdk/bench/vm/gc/systemgc/AllLive.java
@@ -47,6 +47,8 @@ public class AllLive {
 
     /*
      * Test the System GC when all allocated objects are live.
+     *
+     * The jvmArgs are provided to avoid GCs during object creation.
      */
 
     static ArrayList<Object[]> holder;

--- a/test/micro/org/openjdk/bench/vm/gc/systemgc/AllLive.java
+++ b/test/micro/org/openjdk/bench/vm/gc/systemgc/AllLive.java
@@ -53,11 +53,15 @@ public class AllLive {
 
     static ArrayList<Object[]> holder;
 
+    @Setup(Level.Trial)
+    public void preRun() {
+        // Compact right now, kicking out all unrelated objects
+        System.gc();
+    }
+
     @Setup(Level.Iteration)
     public void generateGarbage() {
         holder = GarbageGenerator.generateObjectArrays();
-        // Compact right now, kicking out all unrelated objects
-        System.gc();
     }
 
     @Benchmark

--- a/test/micro/org/openjdk/bench/vm/gc/systemgc/AllLive.java
+++ b/test/micro/org/openjdk/bench/vm/gc/systemgc/AllLive.java
@@ -26,16 +26,20 @@ import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.ArrayList;
 import java.util.concurrent.TimeUnit;
 
 @BenchmarkMode(Mode.SingleShotTime)
+@Warmup(iterations = 5)
+@Measurement(iterations = 5)
 @Fork(value=25, jvmArgs={"-Xmx5g", "-Xms5g", "-Xmn3g", "-XX:+AlwaysPreTouch"})
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Benchmark)
@@ -43,8 +47,6 @@ public class AllLive {
 
     /*
      * Test the System GC when all allocated objects are live.
-     *
-     * The jvmArgs are provided to avoid GCs during object creation.
      */
 
     static ArrayList<Object[]> holder;
@@ -52,6 +54,8 @@ public class AllLive {
     @Setup(Level.Iteration)
     public void generateGarbage() {
         holder = GarbageGenerator.generateObjectArrays();
+        // Compact right now, kicking out all unrelated objects
+        System.gc();
     }
 
     @Benchmark

--- a/test/micro/org/openjdk/bench/vm/gc/systemgc/DifferentObjectSizesArray.java
+++ b/test/micro/org/openjdk/bench/vm/gc/systemgc/DifferentObjectSizesArray.java
@@ -26,15 +26,19 @@ import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.concurrent.TimeUnit;
 
 @BenchmarkMode(Mode.SingleShotTime)
+@Warmup(iterations = 5)
+@Measurement(iterations = 5)
 @Fork(value=25, jvmArgs={"-Xmx5g", "-Xms5g", "-Xmn3g", "-XX:+AlwaysPreTouch"})
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Benchmark)
@@ -52,6 +56,8 @@ public class DifferentObjectSizesArray {
     @Setup(Level.Iteration)
     public void generateGarbage() {
         largeObjArray = GarbageGenerator.generateAndFillLargeObjArray(false);
+        // Compact right now, kicking out all unrelated objects
+        System.gc();
         // Removing a third of the objects and keeping a good
         // distribution of sizes.
         for (int i = 0; i < largeObjArray.length; i++) {

--- a/test/micro/org/openjdk/bench/vm/gc/systemgc/DifferentObjectSizesArray.java
+++ b/test/micro/org/openjdk/bench/vm/gc/systemgc/DifferentObjectSizesArray.java
@@ -53,11 +53,15 @@ public class DifferentObjectSizesArray {
 
     static Object[] largeObjArray;
 
+    @Setup(Level.Trial)
+    public void preRun() {
+        // Compact right now, kicking out all unrelated objects
+        System.gc();
+    }
+
     @Setup(Level.Iteration)
     public void generateGarbage() {
         largeObjArray = GarbageGenerator.generateAndFillLargeObjArray(false);
-        // Compact right now, kicking out all unrelated objects
-        System.gc();
         // Removing a third of the objects and keeping a good
         // distribution of sizes.
         for (int i = 0; i < largeObjArray.length; i++) {

--- a/test/micro/org/openjdk/bench/vm/gc/systemgc/DifferentObjectSizesHashMap.java
+++ b/test/micro/org/openjdk/bench/vm/gc/systemgc/DifferentObjectSizesHashMap.java
@@ -54,11 +54,15 @@ public class DifferentObjectSizesHashMap {
 
     static HashMap<Integer, byte[]> largeMap;
 
+    @Setup(Level.Trial)
+    public void preRun() {
+        // Compact right now, kicking out all unrelated objects
+        System.gc();
+    }
+
     @Setup(Level.Iteration)
     public void generateGarbage() {
         largeMap = GarbageGenerator.generateAndFillHashMap(false);
-        // Compact right now, kicking out all unrelated objects
-        System.gc();
         int numberOfObjects = largeMap.size();
         // Removing a third of the objects and keeping a good
         // distribution of sizes.

--- a/test/micro/org/openjdk/bench/vm/gc/systemgc/DifferentObjectSizesHashMap.java
+++ b/test/micro/org/openjdk/bench/vm/gc/systemgc/DifferentObjectSizesHashMap.java
@@ -26,16 +26,20 @@ import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.HashMap;
 import java.util.concurrent.TimeUnit;
 
 @BenchmarkMode(Mode.SingleShotTime)
+@Warmup(iterations = 5)
+@Measurement(iterations = 5)
 @Fork(value=25, jvmArgs={"-Xmx5g", "-Xms5g", "-Xmn3g", "-XX:+AlwaysPreTouch"})
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Benchmark)
@@ -53,6 +57,8 @@ public class DifferentObjectSizesHashMap {
     @Setup(Level.Iteration)
     public void generateGarbage() {
         largeMap = GarbageGenerator.generateAndFillHashMap(false);
+        // Compact right now, kicking out all unrelated objects
+        System.gc();
         int numberOfObjects = largeMap.size();
         // Removing a third of the objects and keeping a good
         // distribution of sizes.

--- a/test/micro/org/openjdk/bench/vm/gc/systemgc/DifferentObjectSizesTreeMap.java
+++ b/test/micro/org/openjdk/bench/vm/gc/systemgc/DifferentObjectSizesTreeMap.java
@@ -53,11 +53,15 @@ public class DifferentObjectSizesTreeMap {
      */
     static TreeMap<Integer, byte[]> largeMap;
 
+    @Setup(Level.Trial)
+    public void preRun() {
+        // Compact right now, kicking out all unrelated objects
+        System.gc();
+    }
+
     @Setup(Level.Iteration)
     public void generateGarbage() {
         largeMap = GarbageGenerator.generateAndFillTreeMap(false);
-        // Compact right now, kicking out all unrelated objects
-        System.gc();
         int numberOfObjects = largeMap.size();
         // Removing a third of the objects and keeping a good
         // distribution of sizes.

--- a/test/micro/org/openjdk/bench/vm/gc/systemgc/DifferentObjectSizesTreeMap.java
+++ b/test/micro/org/openjdk/bench/vm/gc/systemgc/DifferentObjectSizesTreeMap.java
@@ -26,16 +26,20 @@ import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
 
 @BenchmarkMode(Mode.SingleShotTime)
+@Warmup(iterations = 5)
+@Measurement(iterations = 5)
 @Fork(value=25, jvmArgs={"-Xmx5g", "-Xms5g", "-Xmn3g", "-XX:+AlwaysPreTouch"})
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Benchmark)
@@ -52,6 +56,8 @@ public class DifferentObjectSizesTreeMap {
     @Setup(Level.Iteration)
     public void generateGarbage() {
         largeMap = GarbageGenerator.generateAndFillTreeMap(false);
+        // Compact right now, kicking out all unrelated objects
+        System.gc();
         int numberOfObjects = largeMap.size();
         // Removing a third of the objects and keeping a good
         // distribution of sizes.

--- a/test/micro/org/openjdk/bench/vm/gc/systemgc/HalfDeadFirstPart.java
+++ b/test/micro/org/openjdk/bench/vm/gc/systemgc/HalfDeadFirstPart.java
@@ -54,11 +54,15 @@ public class HalfDeadFirstPart {
 
     static ArrayList<Object[]> holder;
 
+    @Setup(Level.Trial)
+    public void preRun() {
+        // Compact right now, kicking out all unrelated objects
+        System.gc();
+    }
+
     @Setup(Level.Iteration)
     public void generateGarbage() {
         holder = GarbageGenerator.generateObjectArrays();
-        // Compact right now, kicking out all unrelated objects
-        System.gc();
         // Clearing every other object array in the holder
         for (int i = 0; i < holder.size() / 2; i++) {
             holder.set(i, null);

--- a/test/micro/org/openjdk/bench/vm/gc/systemgc/HalfDeadFirstPart.java
+++ b/test/micro/org/openjdk/bench/vm/gc/systemgc/HalfDeadFirstPart.java
@@ -26,16 +26,20 @@ import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.ArrayList;
 import java.util.concurrent.TimeUnit;
 
 @BenchmarkMode(Mode.SingleShotTime)
+@Warmup(iterations = 5)
+@Measurement(iterations = 5)
 @Fork(value=25, jvmArgs={"-Xmx5g", "-Xms5g", "-Xmn3g", "-XX:+AlwaysPreTouch"})
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Benchmark)
@@ -53,6 +57,8 @@ public class HalfDeadFirstPart {
     @Setup(Level.Iteration)
     public void generateGarbage() {
         holder = GarbageGenerator.generateObjectArrays();
+        // Compact right now, kicking out all unrelated objects
+        System.gc();
         // Clearing every other object array in the holder
         for (int i = 0; i < holder.size() / 2; i++) {
             holder.set(i, null);

--- a/test/micro/org/openjdk/bench/vm/gc/systemgc/HalfDeadInterleaved.java
+++ b/test/micro/org/openjdk/bench/vm/gc/systemgc/HalfDeadInterleaved.java
@@ -26,16 +26,20 @@ import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.ArrayList;
 import java.util.concurrent.TimeUnit;
 
 @BenchmarkMode(Mode.SingleShotTime)
+@Warmup(iterations = 5)
+@Measurement(iterations = 5)
 @Fork(value=25, jvmArgs={"-Xmx5g", "-Xms5g", "-Xmn3g", "-XX:+AlwaysPreTouch"})
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Benchmark)
@@ -53,6 +57,8 @@ public class HalfDeadInterleaved {
     @Setup(Level.Iteration)
     public void generateGarbage() {
         holder = GarbageGenerator.generateObjectArrays();
+        // Compact right now, kicking out all unrelated objects
+        System.gc();
         for (Object[] objArray : holder) {
             for (int i=0; i < objArray.length; i++) {
                 if ((i & 1) == 1) {

--- a/test/micro/org/openjdk/bench/vm/gc/systemgc/HalfDeadInterleaved.java
+++ b/test/micro/org/openjdk/bench/vm/gc/systemgc/HalfDeadInterleaved.java
@@ -54,11 +54,15 @@ public class HalfDeadInterleaved {
 
     static ArrayList<Object[]> holder;
 
+    @Setup(Level.Trial)
+    public void preRun() {
+        // Compact right now, kicking out all unrelated objects
+        System.gc();
+    }
+
     @Setup(Level.Iteration)
     public void generateGarbage() {
         holder = GarbageGenerator.generateObjectArrays();
-        // Compact right now, kicking out all unrelated objects
-        System.gc();
         for (Object[] objArray : holder) {
             for (int i=0; i < objArray.length; i++) {
                 if ((i & 1) == 1) {

--- a/test/micro/org/openjdk/bench/vm/gc/systemgc/HalfDeadInterleavedChunks.java
+++ b/test/micro/org/openjdk/bench/vm/gc/systemgc/HalfDeadInterleavedChunks.java
@@ -26,16 +26,20 @@ import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.ArrayList;
 import java.util.concurrent.TimeUnit;
 
 @BenchmarkMode(Mode.SingleShotTime)
+@Warmup(iterations = 5)
+@Measurement(iterations = 5)
 @Fork(value=25, jvmArgs={"-Xmx5g", "-Xms5g", "-Xmn3g", "-XX:+AlwaysPreTouch"})
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Benchmark)
@@ -53,6 +57,8 @@ public class HalfDeadInterleavedChunks {
     @Setup(Level.Iteration)
     public void generateGarbage() {
         holder = GarbageGenerator.generateObjectArrays();
+        // Compact right now, kicking out all unrelated objects
+        System.gc();
         // Clearing every other object array in the holder
         for (int i = 0; i < holder.size(); i++) {
             if ((i & 1) == 1) {

--- a/test/micro/org/openjdk/bench/vm/gc/systemgc/HalfDeadInterleavedChunks.java
+++ b/test/micro/org/openjdk/bench/vm/gc/systemgc/HalfDeadInterleavedChunks.java
@@ -54,11 +54,15 @@ public class HalfDeadInterleavedChunks {
 
     static ArrayList<Object[]> holder;
 
+    @Setup(Level.Trial)
+    public void preRun() {
+        // Compact right now, kicking out all unrelated objects
+        System.gc();
+    }
+
     @Setup(Level.Iteration)
     public void generateGarbage() {
         holder = GarbageGenerator.generateObjectArrays();
-        // Compact right now, kicking out all unrelated objects
-        System.gc();
         // Clearing every other object array in the holder
         for (int i = 0; i < holder.size(); i++) {
             if ((i & 1) == 1) {

--- a/test/micro/org/openjdk/bench/vm/gc/systemgc/HalfDeadSecondPart.java
+++ b/test/micro/org/openjdk/bench/vm/gc/systemgc/HalfDeadSecondPart.java
@@ -54,11 +54,15 @@ public class HalfDeadSecondPart {
 
     ArrayList<Object[]> holder;
 
+    @Setup(Level.Trial)
+    public void preRun() {
+        // Compact right now, kicking out all unrelated objects
+        System.gc();
+    }
+
     @Setup(Level.Iteration)
     public void generateGarbage() {
         holder = GarbageGenerator.generateObjectArrays();
-        // Compact right now, kicking out all unrelated objects
-        System.gc();
         // Clearing every other object array in the holder
         for (int i = holder.size() / 2; i < holder.size(); i++) {
             holder.set(i, null);

--- a/test/micro/org/openjdk/bench/vm/gc/systemgc/HalfDeadSecondPart.java
+++ b/test/micro/org/openjdk/bench/vm/gc/systemgc/HalfDeadSecondPart.java
@@ -26,16 +26,20 @@ import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.ArrayList;
 import java.util.concurrent.TimeUnit;
 
 @BenchmarkMode(Mode.SingleShotTime)
+@Warmup(iterations = 5)
+@Measurement(iterations = 5)
 @Fork(value=25, jvmArgs={"-Xmx5g", "-Xms5g", "-Xmn3g", "-XX:+AlwaysPreTouch"})
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Benchmark)
@@ -48,11 +52,13 @@ public class HalfDeadSecondPart {
      * The jvmArgs are provided to avoid GCs during object creation.
      */
 
-    static ArrayList<Object[]> holder;
+    ArrayList<Object[]> holder;
 
     @Setup(Level.Iteration)
     public void generateGarbage() {
         holder = GarbageGenerator.generateObjectArrays();
+        // Compact right now, kicking out all unrelated objects
+        System.gc();
         // Clearing every other object array in the holder
         for (int i = holder.size() / 2; i < holder.size(); i++) {
             holder.set(i, null);

--- a/test/micro/org/openjdk/bench/vm/gc/systemgc/HalfDeadSecondPart.java
+++ b/test/micro/org/openjdk/bench/vm/gc/systemgc/HalfDeadSecondPart.java
@@ -52,7 +52,7 @@ public class HalfDeadSecondPart {
      * The jvmArgs are provided to avoid GCs during object creation.
      */
 
-    ArrayList<Object[]> holder;
+    static ArrayList<Object[]> holder;
 
     @Setup(Level.Trial)
     public void preRun() {

--- a/test/micro/org/openjdk/bench/vm/gc/systemgc/HalfHashedHalfDead.java
+++ b/test/micro/org/openjdk/bench/vm/gc/systemgc/HalfHashedHalfDead.java
@@ -26,16 +26,20 @@ import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.ArrayList;
 import java.util.concurrent.TimeUnit;
 
 @BenchmarkMode(Mode.SingleShotTime)
+@Warmup(iterations = 5)
+@Measurement(iterations = 5)
 @Fork(value=25, jvmArgs={"-Xmx5g", "-Xms5g", "-Xmn3g", "-XX:+AlwaysPreTouch"})
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Benchmark)
@@ -53,6 +57,8 @@ public class HalfHashedHalfDead {
     @Setup(Level.Iteration)
     public void generateGarbage() {
         holder = GarbageGenerator.generateObjectArrays();
+        // Compact right now, kicking out all unrelated objects
+        System.gc();
         // Keeping half the objects and calculating the hash code to
         // force some GCs to preserve marks.
         for (Object[] objectArray: holder) {

--- a/test/micro/org/openjdk/bench/vm/gc/systemgc/HalfHashedHalfDead.java
+++ b/test/micro/org/openjdk/bench/vm/gc/systemgc/HalfHashedHalfDead.java
@@ -54,11 +54,15 @@ public class HalfHashedHalfDead {
 
     static ArrayList<Object[]> holder;
 
+    @Setup(Level.Trial)
+    public void preRun() {
+        // Compact right now, kicking out all unrelated objects
+        System.gc();
+    }
+
     @Setup(Level.Iteration)
     public void generateGarbage() {
         holder = GarbageGenerator.generateObjectArrays();
-        // Compact right now, kicking out all unrelated objects
-        System.gc();
         // Keeping half the objects and calculating the hash code to
         // force some GCs to preserve marks.
         for (Object[] objectArray: holder) {

--- a/test/micro/org/openjdk/bench/vm/gc/systemgc/NoObjects.java
+++ b/test/micro/org/openjdk/bench/vm/gc/systemgc/NoObjects.java
@@ -52,8 +52,8 @@ public class NoObjects {
      * test for consistency.
      */
 
-    @Setup(Level.Iteration)
-    public void generateGarbage() {
+    @Setup(Level.Trial)
+    public void preRun() {
         // Compact right now, kicking out all unrelated objects
         System.gc();
     }

--- a/test/micro/org/openjdk/bench/vm/gc/systemgc/NoObjects.java
+++ b/test/micro/org/openjdk/bench/vm/gc/systemgc/NoObjects.java
@@ -25,14 +25,23 @@ package org.openjdk.bench.vm.gc.systemgc;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.concurrent.TimeUnit;
 
 @BenchmarkMode(Mode.SingleShotTime)
+@Warmup(iterations = 5)
+@Measurement(iterations = 5)
 @Fork(value=25, jvmArgs={"-Xmx5g", "-Xms5g", "-Xmn3g", "-XX:+AlwaysPreTouch"})
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
 public class NoObjects {
 
     /*
@@ -42,6 +51,12 @@ public class NoObjects {
      * The heap settings provided are the same as for the other
      * test for consistency.
      */
+
+    @Setup(Level.Iteration)
+    public void generateGarbage() {
+        // Compact right now, kicking out all unrelated objects
+        System.gc();
+    }
 
     @Benchmark
     public void gc() {

--- a/test/micro/org/openjdk/bench/vm/gc/systemgc/OneBigObject.java
+++ b/test/micro/org/openjdk/bench/vm/gc/systemgc/OneBigObject.java
@@ -26,15 +26,19 @@ import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.concurrent.TimeUnit;
 
 @BenchmarkMode(Mode.SingleShotTime)
+@Warmup(iterations = 5)
+@Measurement(iterations = 5)
 @Fork(value=25, jvmArgs={"-Xmx5g", "-Xms5g", "-Xmn3g", "-XX:+AlwaysPreTouch"})
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Benchmark)
@@ -52,6 +56,8 @@ public class OneBigObject {
     @Setup(Level.Iteration)
     public void generateGarbage() {
         holder = new Object[1024*1024*128];
+        // Compact right now, kicking out all unrelated objects
+        System.gc();
     }
 
     @Benchmark

--- a/test/micro/org/openjdk/bench/vm/gc/systemgc/OneBigObject.java
+++ b/test/micro/org/openjdk/bench/vm/gc/systemgc/OneBigObject.java
@@ -53,11 +53,15 @@ public class OneBigObject {
 
     static Object[] holder;
 
+    @Setup(Level.Trial)
+    public void preRun() {
+        // Compact right now, kicking out all unrelated objects
+        System.gc();
+    }
+
     @Setup(Level.Iteration)
     public void generateGarbage() {
         holder = new Object[1024*1024*128];
-        // Compact right now, kicking out all unrelated objects
-        System.gc();
     }
 
     @Benchmark


### PR DESCRIPTION
Noticed this while working on a related bug ([JDK-8359960](https://bugs.openjdk.org/browse/JDK-8359960)):

First, I see the benchmark executes a single shot per fork. As such, I believe the benchmark really tests the cost of initial GC, that probably drags a lot of (potentially non-benchmark-related) objects through new (possibly awkwardly wired, despite +AlwaysPreTouch) memory. The first iteration is 80 ms/op for me here, and the second one is -- whoosh -- only 3 ms/op! Second, the benchmark is really, really noisy. Part of it is due to first iteration being noisy, but also we want more samples to shrink the estimated errors.

Additional testing:
 - [x] Linux x86_64 server fastdebug, `gc.systemgc` benchmark runs

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8361520](https://bugs.openjdk.org/browse/JDK-8361520): Stabilize SystemGC benchmarks (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26182/head:pull/26182` \
`$ git checkout pull/26182`

Update a local copy of the PR: \
`$ git checkout pull/26182` \
`$ git pull https://git.openjdk.org/jdk.git pull/26182/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26182`

View PR using the GUI difftool: \
`$ git pr show -t 26182`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26182.diff">https://git.openjdk.org/jdk/pull/26182.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26182#issuecomment-3048127145)
</details>
