### PR TITLE
8361445: javac crashes on unresolvable constant in @SuppressWarnings

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Lint.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Lint.java
@@ -530,7 +530,9 @@ public class Lint {
         EnumSet<LintCategory> result = LintCategory.newEmptySet();
         Attribute.Array values = (Attribute.Array)suppressWarnings.member(names.value);
         for (Attribute value : values.values) {
-            Optional.of((String)((Attribute.Constant)value).value)
+            Optional.of(value)
+              .filter(val -> val instanceof Attribute.Constant)
+              .map(val -> (String) ((Attribute.Constant) val).value)
               .flatMap(LintCategory::get)
               .filter(lc -> lc.annotationSuppression)
               .ifPresent(result::add);


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [0bd2f9cb](https://github.com/openjdk/jdk/commit/0bd2f9cba2118ed5a112b4c70b8ff4a1a58f21dd) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Jan Lahoda on 8 Jul 2025 and was reviewed by Adam Sotona and Chen Liang.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8361445: javac crashes on unresolvable constant in @SuppressWarnings`

### Issue
 * [JDK-8361445](https://bugs.openjdk.org/browse/JDK-8361445): javac crashes on unresolvable constant in @<!---->SuppressWarnings (**Bug** - P3)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)
 * [Adam Sotona](https://openjdk.org/census#asotona) (@asotona - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26183/head:pull/26183` \
`$ git checkout pull/26183`

Update a local copy of the PR: \
`$ git checkout pull/26183` \
`$ git pull https://git.openjdk.org/jdk.git pull/26183/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26183`

View PR using the GUI difftool: \
`$ git pr show -t 26183`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26183.diff">https://git.openjdk.org/jdk/pull/26183.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26183#issuecomment-3048968715)
</details>
