### PR TITLE
8360817: [ubsan] zDirector select_worker_threads - outside the range of representable values issue

### DIFF
--- a/src/hotspot/share/gc/z/zDirector.cpp
+++ b/src/hotspot/share/gc/z/zDirector.cpp
@@ -711,7 +711,7 @@ static ZWorkerCounts select_worker_threads(const ZDirectorStats& stats, uint you
     return {active_young_workers, active_old_workers};
   }
 
-  double young_to_old_ratio = calculate_young_to_old_worker_ratio(stats);
+  const double young_to_old_ratio = calculate_young_to_old_worker_ratio(stats);
   uint old_workers = clamp(uint(young_workers * young_to_old_ratio), 1u, ZOldGCThreads);
 
   if (type != ZWorkerSelectionType::normal && old_workers + young_workers > ConcGCThreads) {


### PR DESCRIPTION
When running the jtreg test
gc/z/TestMappedCacheHarvest.java
with ubsan-enabled binaries on macOS aarch64, the following ubsan error is reported :

```
 stderr: [/jdk/src/hotspot/share/gc/z/zDirector.cpp:715:33: runtime error: 6.1962e+10 is outside the range of representable values of type 'unsigned int'
    #0 0x109e368fc in select_worker_threads(ZDirectorStats const&, unsigned int, ZWorkerSelectionType) zDirector.cpp:715
    #1 0x109e3658c in initial_workers(ZDirectorStats const&, ZWorkerSelectionType) zDirector.cpp:804
    #2 0x109e35df0 in ZDirector::run_thread() zDirector.cpp:932
    #3 0x109ecd5f4 in ZThread::run_service() zThread.cpp:28
    #4 0x108cd1e50 in ConcurrentGCThread::run() concurrentGCThread.cpp:47
    #5 0x109ce770c in Thread::call_run() thread.cpp:243
    #6 0x10985be28 in thread_native_entry(Thread*) os_bsd.cpp:599
    #7 0x19fa8ef90 in _pthread_start+0x84 (libsystem_pthread.dylib:arm64e+0x6f90)
    #8 0x19fa89d30 in thread_start+0x4 (libsystem_pthread.dylib:arm64e+0x1d30)
```

After I added a bit of tracing to `select_worker_threads` it seems we get WAY too high young_to_old_ratio values; in my locally failing example
young_to_old_ratio:27561965412.478878
this leads to values out of range of uint and that makes ubsan complain about the uint cast 
`uint(young_workers * young_to_old_ratio)` .
We clamp the value anyway to the range 1u to ZOldGCThreads ; so it probably makes sense to avoid such high factors for young_to_old_ratio .

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8360817](https://bugs.openjdk.org/browse/JDK-8360817): [ubsan] zDirector select_worker_threads - outside the range of representable values issue (**Bug** - P4)


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**) Review applies to [1cdc7b9f](https://git.openjdk.org/jdk/pull/26186/files/1cdc7b9febfea6ccf324706dd6702a191df86419)
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26186/head:pull/26186` \
`$ git checkout pull/26186`

Update a local copy of the PR: \
`$ git checkout pull/26186` \
`$ git pull https://git.openjdk.org/jdk.git pull/26186/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26186`

View PR using the GUI difftool: \
`$ git pr show -t 26186`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26186.diff">https://git.openjdk.org/jdk/pull/26186.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26186#issuecomment-3049006858)
</details>
