### PR TITLE
8361342: Shenandoah: Evacuation may assert on invalid mirror object after JDK-8340297

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahAsserts.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahAsserts.cpp
@@ -77,6 +77,10 @@ void ShenandoahAsserts::print_obj(ShenandoahMessageBuffer& msg, oop obj) {
   }
   msg.append("  mark:%s\n", mw_ss.freeze());
   msg.append("  region: %s", ss.freeze());
+  if (obj_klass == vmClasses::Class_klass()) {
+    msg.append("  mirrored klass:       " PTR_FORMAT "\n", p2i(obj->metadata_field(java_lang_Class::klass_offset())));
+    msg.append("  mirrored array klass: " PTR_FORMAT "\n", p2i(obj->metadata_field(java_lang_Class::array_klass_offset())));
+  }
 }
 
 void ShenandoahAsserts::print_non_obj(ShenandoahMessageBuffer& msg, void* loc) {
@@ -268,17 +272,11 @@ void ShenandoahAsserts::assert_correct(void* interior_loc, oop obj, const char* 
   }
 
   // Do additional checks for special objects: their fields can hold metadata as well.
-  // We want to check class loading/unloading did not corrupt them.
+  // We want to check class loading/unloading did not corrupt them. We can only reasonably
+  // trust the forwarded objects, as the from-space object can have the klasses effectively
+  // dead.
 
   if (Universe::is_fully_initialized() && (obj_klass == vmClasses::Class_klass())) {
-    // During class redefinition the old Klass gets reclaimed and the old mirror oop's Klass reference
-    // nulled out (hence the "klass != nullptr" condition below). However, the mirror oop may have been
-    // forwarded if we are in the mids of an evacuation. In that case, the forwardee's Klass reference
-    // is nulled out. The old, forwarded, still still carries the old invalid Klass pointer. It will be
-    // eventually collected.
-    // This checking code may encounter the old copy of the mirror, and its referee Klass pointer may
-    // already be reclaimed and therefore be invalid. We must therefore check the forwardee's Klass
-    // reference.
     const Metadata* klass = fwd->metadata_field(java_lang_Class::klass_offset());
     if (klass != nullptr && !Metaspace::contains(klass)) {
       print_failure(_safe_all, obj, interior_loc, nullptr, "Shenandoah assert_correct failed",


### PR DESCRIPTION
Hi Shenandoah devs, may I please have thoughts and reviews for this fix. 

This is a fix for a problem that was uncovered during my ongoing work on Metaspace use-after-free recognition (JDK-8340297). I would like to get this fix into the codebase before eventually pushing JDK-8340297, since I want the fixes to be separate from the patch that introduces stricter testing.

For details about this issue, please see the Jira description and comment. The short version is:
- class gets redefined, and therefore its Klass is discarded and its mirror oop left to be eventually collected. Mirror oop's Klass field is nulled out before.
- but we may be in the middle of an evacuation. So the mirror oop may be forwarded. In that case, class redefinition (correctly) nulls out the forwardee's Klass reference.
- But that leaves the old forwarded mirror oop untouched, and that still carries the now invalid Klass pointer in its Klass field. That we now notice with JDK-8340297. So, `ShenandoaAsserts::assert_correct` complains about an invalid Klass reference when processing the old mirror oop.

I thought hard about this, but I believe this is benign, since no code should be accessing the old mirror oop's Klass field, it should always resolve the forwardee first. Class redefinition itself gets the oop address to null out from an OopHandle in Klass, which should contain the forwardee's address if the mirror was forwarded, which should ensure that only the forwardee is nulled out, never the forwarded.

Therefore I just changed the assertions.

But I would like to hear other people's opinion on this.

Note why we never saw this before: Before JDK-8340297 (as in, now), the only check ShenandoaAssert makes for Klass validity is `Metaspace::contains`, which is weak. A reclaimed Klass pointer will still point to Metaspace, so ShenandoaAssert does not complain. Metadata::is_valid() is similarly weak now, since it basically just checks a byte in the object for not null; pretty much any non-null garbage will satisfy this condition.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8361342](https://bugs.openjdk.org/browse/JDK-8361342): Shenandoah: Evacuation may assert on invalid mirror object after JDK-8340297 (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Roman Kennke](https://openjdk.org/census#rkennke) (@rkennke - **Reviewer**)

### Contributors
 * Aleksey Shipilev `<shade@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26187/head:pull/26187` \
`$ git checkout pull/26187`

Update a local copy of the PR: \
`$ git checkout pull/26187` \
`$ git pull https://git.openjdk.org/jdk.git pull/26187/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26187`

View PR using the GUI difftool: \
`$ git pr show -t 26187`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26187.diff">https://git.openjdk.org/jdk/pull/26187.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26187#issuecomment-3049303597)
</details>
