### PR TITLE
8361570: Incorrect 'sealed is not allowed here' compile-time error

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Flags.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Flags.java
@@ -250,7 +250,7 @@ public class Flags {
     /**
      * Flag that marks either a default method or an interface containing default methods.
      */
-    public static final long DEFAULT = 1L<<43;
+    public static final long DEFAULT = 1L<<43; // part of ExtendedStandardFlags, cannot be reused
 
     /**
      * Flag that marks class as auxiliary, ie a non-public class following
@@ -278,9 +278,10 @@ public class Flags {
      */
     public static final long THROWS = 1L<<47;
 
-    /*
-     * Currently available: Bit 48.
+    /**
+     * Flag to indicate sealed class/interface declaration.
      */
+    public static final long SEALED = 1L<<48; // part of ExtendedStandardFlags, cannot be reused
 
     /**
      * Flag that marks a synthetic method body for a lambda expression
@@ -390,11 +391,6 @@ public class Flags {
     public static final int GENERATED_MEMBER = 1<<24; // MethodSymbols and VarSymbols
 
     /**
-     * Flag to indicate sealed class/interface declaration.
-     */
-    public static final long SEALED = 1L<<62; // ClassSymbols
-
-    /**
      * Flag to indicate restricted method declaration.
      */
     public static final long RESTRICTED = 1L<<62; // MethodSymbols
@@ -412,7 +408,7 @@ public class Flags {
     /**
      * Flag to indicate that the class/interface was declared with the non-sealed modifier.
      */
-    public static final long NON_SEALED = 1L<<63; // ClassSymbols
+    public static final long NON_SEALED = 1L<<63;  // part of ExtendedStandardFlags, cannot be reused
 
     /**
      * Describe modifier flags as they might appear in source code, i.e.,
@@ -443,6 +439,7 @@ public class Flags {
         RecordMethodFlags                 = AccessFlags | ABSTRACT | STATIC |
                                             SYNCHRONIZED | FINAL | STRICTFP;
     public static final long
+        //NOTE: flags in ExtendedStandardFlags cannot be overlayed across Symbol kinds:
         ExtendedStandardFlags             = (long)StandardFlags | DEFAULT | SEALED | NON_SEALED,
         ExtendedMemberClassFlags          = (long)MemberClassFlags | SEALED | NON_SEALED,
         ExtendedMemberStaticClassFlags    = (long) MemberStaticClassFlags | SEALED | NON_SEALED,
@@ -550,7 +547,7 @@ public class Flags {
         DEPRECATED_ANNOTATION(Flags.DEPRECATED_ANNOTATION),
         DEPRECATED_REMOVAL(Flags.DEPRECATED_REMOVAL),
         HAS_RESOURCE(Flags.HAS_RESOURCE),
-        // Bit 48 is currently available
+        SEALED(Flags.SEALED),
         ANONCONSTR_BASED(Flags.ANONCONSTR_BASED),
         NAME_FILLED(Flags.NAME_FILLED),
         PREVIEW_API(Flags.PREVIEW_API),
@@ -559,7 +556,7 @@ public class Flags {
         MATCH_BINDING_TO_OUTER(Flags.MATCH_BINDING_TO_OUTER),
         RECORD(Flags.RECORD),
         RECOVERABLE(Flags.RECOVERABLE),
-        SEALED(Flags.SEALED),
+        RESTRICTED(Flags.RESTRICTED),
         NON_SEALED(Flags.NON_SEALED) {
             @Override
             public String toString() {

--- a/test/langtools/tools/javac/flags/ExtendedStandardFlagsOverlayFlagsConflict.java
+++ b/test/langtools/tools/javac/flags/ExtendedStandardFlagsOverlayFlagsConflict.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8361570
+ * @summary Verify no flags in ExtendedStandardFlags have overlays for different
+ *          Symbol kinds.
+ * @library /tools/lib
+ * @modules jdk.compiler/com.sun.tools.javac.code
+ * @compile ExtendedStandardFlagsOverlayFlagsConflict.java
+ * @run main ExtendedStandardFlagsOverlayFlagsConflict
+ */
+
+import com.sun.tools.javac.code.Flags;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/* Flags in ExtendedStandardFlags are checked using masks, and if they have
+ * Symbol-kind specific meaning, they can lead to confusing errors. Hence,
+ * Flags in ExtendedStandardFlags should have the same meaning for all Symbols.
+ */
+public class ExtendedStandardFlagsOverlayFlagsConflict {
+
+    public static void main(String... args) throws Exception {
+        ExtendedStandardFlagsOverlayFlagsConflict t =
+                new ExtendedStandardFlagsOverlayFlagsConflict();
+        t.run();
+    }
+
+    public void run() throws Exception {
+        Map<Long, List<Field>> value2FlagFields = new HashMap<>();
+
+        for (Field f : Flags.class.getFields()) {
+            if (!Modifier.isStatic(f.getModifiers())) {
+                continue;
+            }
+            if (f.getName().startsWith("ACC_")) {
+                continue;
+            }
+            long flag = ((Number) f.get(null)).longValue();
+            value2FlagFields.computeIfAbsent(flag, _ -> new ArrayList<>())
+                            .add(f);
+        }
+
+        long pendingFlags2Check = Flags.ExtendedStandardFlags;
+
+        while (pendingFlags2Check != 0) {
+            long flag = Long.highestOneBit(pendingFlags2Check);
+            List<Field> flagFields = value2FlagFields.get(flag);
+            if (flagFields.size() != 1) {
+                throw new AssertionError("Flag: " + flag +
+                                         " has more than one flag field: " + flagFields);
+            }
+            pendingFlags2Check &= ~flag;
+        }
+    }
+}

--- a/test/langtools/tools/javac/flags/NoFalseSealedError.java
+++ b/test/langtools/tools/javac/flags/NoFalseSealedError.java
@@ -1,0 +1,21 @@
+/**
+ * @test /nodynamiccopyright/
+ * @bug 8361570
+ * @summary Verify there's no fake sealed not allowed here error when sealed
+ *          and requires-identity Flags clash
+ * @modules java.base/jdk.internal
+ * @compile NoFalseSealedError.java
+ */
+
+import java.lang.ref.WeakReference;
+import java.util.WeakHashMap;
+
+void main(String[] args) {
+    new RequiresIdentity(null) {};
+    new WeakReference<>(null) {};
+    new WeakHashMap<>() {};
+}
+
+static class RequiresIdentity {
+    RequiresIdentity(@jdk.internal.RequiresIdentity Object o) {}
+}

--- a/test/langtools/tools/javac/platform/RequiresIdentityTest.java
+++ b/test/langtools/tools/javac/platform/RequiresIdentityTest.java
@@ -132,7 +132,7 @@ public class RequiresIdentityTest extends TestRunner {
 
             List<String> expected = List.of(
                 "public class WeakHashMap<@jdk.internal.RequiresIdentity K, V> extends java.util.AbstractMap<K,V> implements java.util.Map<K,V> {",
-                "  public V put(@jdk.internal.RequiresIdentity sealed K key,"
+                "  public V put(@jdk.internal.RequiresIdentity K key,"
             );
             if (!expected.equals(printed)) {
                 throw new AssertionError("Expected: " + expected +
@@ -154,7 +154,7 @@ public class RequiresIdentityTest extends TestRunner {
 
             List<String> expected = List.of(
                 "public class WeakHashMap<K, V> extends java.util.AbstractMap<K,V> implements java.util.Map<K,V> {",
-                "  public V put(sealed K arg0,"
+                "  public V put(K arg0,"
             );
             if (!expected.equals(printed)) {
                 throw new AssertionError("Expected: " + expected +


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [85331943](https://github.com/openjdk/jdk/commit/853319439e7887ddd54f8c4a3d79aa62ec51fd64) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Jan Lahoda on 8 Jul 2025 and was reviewed by Maurizio Cimadamore and Vicente Romero.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8361570](https://bugs.openjdk.org/browse/JDK-8361570): Incorrect 'sealed is not allowed here' compile-time error (**Bug** - P2)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26188/head:pull/26188` \
`$ git checkout pull/26188`

Update a local copy of the PR: \
`$ git checkout pull/26188` \
`$ git pull https://git.openjdk.org/jdk.git pull/26188/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26188`

View PR using the GUI difftool: \
`$ git pr show -t 26188`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26188.diff">https://git.openjdk.org/jdk/pull/26188.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26188#issuecomment-3049241223)
</details>
