### PR TITLE
8361191: Test java/awt/Mixing/AWT_Mixing/JPopupMenuOverlapping.java fails on MacOS X

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -156,7 +156,6 @@ java/awt/Mixing/AWT_Mixing/JMenuBarOverlapping.java 8159451 macosx-all
 java/awt/Mixing/AWT_Mixing/JSplitPaneOverlapping.java 6986109 generic-all
 java/awt/Mixing/AWT_Mixing/JInternalFrameMoveOverlapping.java 6986109 windows-all
 java/awt/Mixing/AWT_Mixing/MixingPanelsResizing.java 8049405 macosx-all
-java/awt/Mixing/AWT_Mixing/JPopupMenuOverlapping.java 8049405 macosx-all
 java/awt/Mixing/NonOpaqueInternalFrame.java 7124549 macosx-all
 java/awt/Mouse/EnterExitEvents/DragWindowTest.java 8298823 macosx-all
 java/awt/Focus/ActualFocusedWindowTest/ActualFocusedWindowRetaining.java 6829264 generic-all

--- a/test/jdk/java/awt/Mixing/AWT_Mixing/JPopupMenuOverlapping.java
+++ b/test/jdk/java/awt/Mixing/AWT_Mixing/JPopupMenuOverlapping.java
@@ -74,6 +74,7 @@ public class JPopupMenuOverlapping extends OverlappingTestBase {
 
             public void actionPerformed(ActionEvent event) {
                 lwClicked = true;
+                frame.setVisible(false);
             }
         };
         JMenuItem item;


### PR DESCRIPTION
Fixes failed test by disabling heavyweight component in ItemListener.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Dependency #26162 must be integrated first

### Issue
 * [JDK-8361191](https://bugs.openjdk.org/browse/JDK-8361191): Test java/awt/Mixing/AWT_Mixing/JPopupMenuOverlapping.java fails on MacOS X (**Sub-task** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26190/head:pull/26190` \
`$ git checkout pull/26190`

Update a local copy of the PR: \
`$ git checkout pull/26190` \
`$ git pull https://git.openjdk.org/jdk.git pull/26190/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26190`

View PR using the GUI difftool: \
`$ git pr show -t 26190`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26190.diff">https://git.openjdk.org/jdk/pull/26190.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26190#issuecomment-3049406797)
</details>
