### PR TITLE
8361569: [JVMCI] Further refine JVMCI-compiled nmethod that should not collect deoptimiztaion profile

### DIFF
--- a/src/hotspot/share/code/nmethod.cpp
+++ b/src/hotspot/share/code/nmethod.cpp
@@ -1936,10 +1936,7 @@ void nmethod::inc_decompile_count() {
   if (!is_compiled_by_c2() && !is_compiled_by_jvmci()) return;
   // Could be gated by ProfileTraps, but do not bother...
 #if INCLUDE_JVMCI
-  // Deoptimization count is used by the CompileBroker to reason about compilations
-  // it requests so do not pollute the count for deoptimizations in non-default (i.e.
-  // non-CompilerBroker) compilations.
-  if (is_jvmci_hosted()) {
+  if (jvmci_skip_profile_deopt()) {
     return;
   }
 #endif
@@ -4066,7 +4063,7 @@ const char* nmethod::jvmci_name() {
   return nullptr;
 }
 
-bool nmethod::is_jvmci_hosted() const {
-  return jvmci_nmethod_data() != nullptr && !jvmci_nmethod_data()->is_default();
+bool nmethod::jvmci_skip_profile_deopt() const {
+  return jvmci_nmethod_data() != nullptr && !jvmci_nmethod_data()->profile_deopt();
 }
 #endif

--- a/src/hotspot/share/code/nmethod.hpp
+++ b/src/hotspot/share/code/nmethod.hpp
@@ -914,9 +914,9 @@ public:
     return jvmci_data_size() == 0 ? nullptr : (JVMCINMethodData*) jvmci_data_begin();
   }
 
-  // Returns true if a JVMCI compiled method is non-default,
-  // i.e., not triggered by CompilerBroker
-  bool is_jvmci_hosted() const;
+  // Returns true if the runtime should NOT collect deoptimization profile for a JVMCI
+  // compiled method
+  bool jvmci_skip_profile_deopt() const;
 #endif
 
   void oops_do(OopClosure* f) { oops_do(f, false); }

--- a/src/hotspot/share/jvmci/jvmciJavaClasses.hpp
+++ b/src/hotspot/share/jvmci/jvmciJavaClasses.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -100,10 +100,11 @@
   end_class                                                                                                   \
   start_class(HotSpotNmethod, jdk_vm_ci_hotspot_HotSpotNmethod)                                               \
     boolean_field(HotSpotNmethod, isDefault)                                                                  \
+    boolean_field(HotSpotNmethod, profileDeopt)                                                               \
     long_field(HotSpotNmethod, compileIdSnapshot)                                                             \
     object_field(HotSpotNmethod, method, "Ljdk/vm/ci/hotspot/HotSpotResolvedJavaMethodImpl;")                 \
     int_field(HotSpotNmethod, invalidationReason)                                                             \
-    jvmci_constructor(HotSpotNmethod, "(Ljdk/vm/ci/hotspot/HotSpotResolvedJavaMethodImpl;Ljava/lang/String;ZJ)V") \
+    jvmci_constructor(HotSpotNmethod, "(Ljdk/vm/ci/hotspot/HotSpotResolvedJavaMethodImpl;Ljava/lang/String;ZZJ)V") \
   end_class                                                                                                   \
   start_class(HotSpotCompiledCode, jdk_vm_ci_hotspot_HotSpotCompiledCode)                                     \
     primarray_field(HotSpotCompiledCode, targetCode, "[B")                                                    \

--- a/src/hotspot/share/jvmci/jvmciRuntime.hpp
+++ b/src/hotspot/share/jvmci/jvmciRuntime.hpp
@@ -53,10 +53,12 @@ class JVMCINMethodData : public ResourceObj {
     struct {
       // Is HotSpotNmethod.name non-null? If so, the value is
       // embedded in the end of this object.
-      uint8_t _has_name   : 1,
+      uint8_t _has_name      : 1,
       // HotSpotNmethod.isDefault (e.g., compilation scheduled by CompileBroker)
-              _is_default : 1,
-                          : 6;
+              _is_default    : 1,
+      // HotSpotNmethod.profileDeopt
+              _profile_deopt : 1,
+                             : 5;
     } bits;
   };
 
@@ -87,6 +89,7 @@ class JVMCINMethodData : public ResourceObj {
                    int nmethod_entry_patch_offset,
                    const char* nmethod_mirror_name,
                    bool is_default,
+                   bool profile_deopt,
                    FailedSpeculation** failed_speculations);
 
   void* operator new(size_t size, const char* nmethod_mirror_name) {
@@ -100,12 +103,14 @@ public:
                                   int nmethod_entry_patch_offset,
                                   const char* nmethod_mirror_name,
                                   bool is_default,
+                                  bool profile_deopt,
                                   FailedSpeculation** failed_speculations) {
     JVMCINMethodData* result = new (nmethod_mirror_name) JVMCINMethodData();
     result->initialize(nmethod_mirror_index,
                        nmethod_entry_patch_offset,
                        nmethod_mirror_name,
                        is_default,
+                       profile_deopt,
                        failed_speculations);
     return result;
   }
@@ -152,6 +157,10 @@ public:
 
   bool is_default() {
     return _properties.bits._is_default;
+  }
+
+  bool profile_deopt() {
+    return _properties.bits._profile_deopt;
   }
 };
 

--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -2367,7 +2367,7 @@ JRT_ENTRY(void, Deoptimization::uncommon_trap_inner(JavaThread* current, jint tr
     // Deoptimization count is used by the CompileBroker to reason about compilations
     // it requests so do not pollute the count for deoptimizations in non-default (i.e.
     // non-CompilerBroker) compilations.
-    if (nm->is_jvmci_hosted()) {
+    if (nm->jvmci_skip_profile_deopt()) {
       update_trap_state = false;
     }
 #endif

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/code/CodeCacheProvider.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/code/CodeCacheProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,13 +42,15 @@ public interface CodeCacheProvider {
      * @param installedCode a predefined {@link InstalledCode} object to use as a reference to the
      *            installed code. If {@code null}, a new {@link InstalledCode} object will be
      *            created.
+     * @param profileDeopt specifies if HotSpot should profile deoptimizations for the
+     *            {@code nmethod} associated with this object.
      * @return a reference to the ready-to-run code
      * @throws BailoutException if the code installation failed
      * @throws IllegalArgumentException if {@code installedCode != null} and this object does not
      *             support a predefined {@link InstalledCode} object
      */
-    default InstalledCode addCode(ResolvedJavaMethod method, CompiledCode compiledCode, SpeculationLog log, InstalledCode installedCode) {
-        return installCode(method, compiledCode, installedCode, log, false);
+    default InstalledCode addCode(ResolvedJavaMethod method, CompiledCode compiledCode, SpeculationLog log, InstalledCode installedCode, boolean profileDeopt) {
+        return installCode(method, compiledCode, installedCode, log, false, profileDeopt);
     }
 
     /**
@@ -64,7 +66,7 @@ public interface CodeCacheProvider {
      *             support a predefined {@link InstalledCode} object
      */
     default InstalledCode setDefaultCode(ResolvedJavaMethod method, CompiledCode compiledCode) {
-        return installCode(method, compiledCode, null, null, true);
+        return installCode(method, compiledCode, null, null, true, true);
     }
 
     /**
@@ -81,10 +83,12 @@ public interface CodeCacheProvider {
      *            {@code compRequest.getMethod()}. The default implementation for a method is the
      *            code executed for standard calls to the method. This argument is ignored if
      *            {@code compRequest == null}.
+     * @param profileDeopt specifies if HotSpot should profile deoptimizations for the
+     *            {@code nmethod} associated with this object.
      * @return a reference to the compiled and ready-to-run installed code
      * @throws BailoutException if the code installation failed
      */
-    InstalledCode installCode(ResolvedJavaMethod method, CompiledCode compiledCode, InstalledCode installedCode, SpeculationLog log, boolean isDefault);
+    InstalledCode installCode(ResolvedJavaMethod method, CompiledCode compiledCode, InstalledCode installedCode, SpeculationLog log, boolean isDefault, boolean profileDeopt);
 
     /**
      * Invalidates {@code installedCode} such that {@link InvalidInstalledCodeException} will be

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/code/package-info.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/code/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,8 +23,6 @@
 /**
  * Package that defines the interface between a Java application that wants to install code and the
  * runtime. The runtime provides in implementation of the {@link jdk.vm.ci.code.CodeCacheProvider}
- * interface. The method
- * {@link jdk.vm.ci.code.CodeCacheProvider#addCode(jdk.vm.ci.meta.ResolvedJavaMethod, CompiledCode, jdk.vm.ci.meta.SpeculationLog, InstalledCode)}
- * can be used to install code.
+ * interface. The method {@link jdk.vm.ci.code.CodeCacheProvider#addCode} can be used to install code.
  */
 package jdk.vm.ci.code;

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotCodeCacheProvider.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotCodeCacheProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -101,7 +101,7 @@ public class HotSpotCodeCacheProvider implements CodeCacheProvider {
     }
 
     @Override
-    public InstalledCode installCode(ResolvedJavaMethod method, CompiledCode compiledCode, InstalledCode installedCode, SpeculationLog log, boolean isDefault) {
+    public InstalledCode installCode(ResolvedJavaMethod method, CompiledCode compiledCode, InstalledCode installedCode, SpeculationLog log, boolean isDefault, boolean profileDeopt) {
         InstalledCode resultInstalledCode;
         if (installedCode != null) {
             throw new IllegalArgumentException("InstalledCode argument must be null");
@@ -131,7 +131,7 @@ public class HotSpotCodeCacheProvider implements CodeCacheProvider {
         } else {
             hsCompiledNmethod = (HotSpotCompiledNmethod) hsCompiledCode;
             HotSpotResolvedJavaMethodImpl hsMethod = (HotSpotResolvedJavaMethodImpl) method;
-            HotSpotNmethod nmethod = new HotSpotNmethod(hsMethod, name, isDefault, hsCompiledNmethod.id);
+            HotSpotNmethod nmethod = new HotSpotNmethod(hsMethod, name, isDefault, profileDeopt, hsCompiledNmethod.id);
             nmethod.setSpeculationLog(speculationLog);
             resultInstalledCode = nmethod;
         }

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotNmethod.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotNmethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -55,6 +55,13 @@ public class HotSpotNmethod extends HotSpotInstalledCode {
     private final boolean isDefault;
 
     /**
+     * Specifies whether HotSpot should profile deoptimizations for the {@code nmethod} associated
+     * with this object. This is particularly useful for whitebox testing scenarios that involve
+     * deoptimization.
+     */
+    private final boolean profileDeopt;
+
+    /**
      * Determines whether this object is in the oops table of the nmethod.
      * <p>
      * If this object is in the oops table, the VM uses the oops table entry to update this object's
@@ -83,10 +90,11 @@ public class HotSpotNmethod extends HotSpotInstalledCode {
      */
     private int invalidationReason;
 
-    HotSpotNmethod(HotSpotResolvedJavaMethodImpl method, String name, boolean isDefault, long compileId) {
+    HotSpotNmethod(HotSpotResolvedJavaMethodImpl method, String name, boolean isDefault, boolean profileDeopt, long compileId) {
         super(name);
         this.method = method;
         this.isDefault = isDefault;
+        this.profileDeopt = profileDeopt;
         boolean inOopsTable = !IS_IN_NATIVE_IMAGE && !isDefault;
         this.compileIdSnapshot = inOopsTable ? 0L : compileId;
         this.invalidationReason = -1;
@@ -116,6 +124,14 @@ public class HotSpotNmethod extends HotSpotInstalledCode {
      */
     public boolean isDefault() {
         return isDefault;
+    }
+
+    /**
+     * Determines if HotSpot should profile deoptimization for the {@code nmethod} associated
+     * with this object.
+     */
+    public boolean profileDeopt() {
+        return profileDeopt;
     }
 
     @Override


### PR DESCRIPTION
In https://github.com/openjdk/jdk/pull/25356 we prevent all non-CompilerBroker JVMCI compilations from collecting deoptimiztaion profiles. This causes some regression in Graal's whitebox unit tests, some of which employ non-CompilerBroker compilations to test deoptimiztaions.