### PR TITLE
8361190: Test java/awt/Mixing/AWT_Mixing/JMenuBarOverlapping.java fails on MacOS X

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -152,7 +152,6 @@ java/awt/event/InputEvent/EventWhenTest/EventWhenTest.java 8168646 generic-all
 java/awt/List/KeyEventsTest/KeyEventsTest.java 8201307 linux-all
 java/awt/Paint/ListRepaint.java 8201307 linux-all
 java/awt/Mixing/AWT_Mixing/OpaqueOverlappingChoice.java 8048171 generic-all
-java/awt/Mixing/AWT_Mixing/JMenuBarOverlapping.java 8159451 macosx-all
 java/awt/Mixing/AWT_Mixing/JSplitPaneOverlapping.java 6986109 generic-all
 java/awt/Mixing/AWT_Mixing/JInternalFrameMoveOverlapping.java 6986109 windows-all
 java/awt/Mixing/AWT_Mixing/MixingPanelsResizing.java 8049405 macosx-all

--- a/test/jdk/java/awt/Mixing/AWT_Mixing/JMenuBarOverlapping.java
+++ b/test/jdk/java/awt/Mixing/AWT_Mixing/JMenuBarOverlapping.java
@@ -53,7 +53,7 @@ import test.java.awt.regtesthelpers.Util;
  *          java.desktop/java.awt.peer
  * @build java.desktop/java.awt.Helper
  * @build Util
- * @run main JMenuBarOverlapping
+ * @run main/timeout=180 JMenuBarOverlapping
  */
 public class JMenuBarOverlapping extends OverlappingTestBase {
 


### PR DESCRIPTION
Add more timeout for the test to pass.