### PR TITLE
8360312: Serviceability Agent tests fail with JFR enabled due to unknown thread type JfrRecorderThread

### DIFF
--- a/src/hotspot/share/jfr/recorder/service/jfrRecorderThread.cpp
+++ b/src/hotspot/share/jfr/recorder/service/jfrRecorderThread.cpp
@@ -36,14 +36,6 @@
 #include "utilities/preserveException.hpp"
 #include "utilities/macros.hpp"
 
-class JfrRecorderThread : public JavaThread {
- public:
-  JfrRecorderThread(ThreadFunction entry_point) : JavaThread(entry_point) {}
-  virtual ~JfrRecorderThread() {}
-
-  virtual bool is_JfrRecorder_thread() const { return true; }
-};
-
 static Thread* start_thread(instanceHandle thread_oop, ThreadFunction proc, TRAPS) {
   assert(thread_oop.not_null(), "invariant");
   assert(proc != nullptr, "invariant");

--- a/src/hotspot/share/jfr/recorder/service/jfrRecorderThread.hpp
+++ b/src/hotspot/share/jfr/recorder/service/jfrRecorderThread.hpp
@@ -26,9 +26,9 @@
 #define SHARE_JFR_RECORDER_SERVICE_JFRRECORDERTHREAD_HPP
 
 #include "memory/allStatic.hpp"
+#include "runtime/javaThread.hpp"
 #include "utilities/debug.hpp"
 
-class JavaThread;
 class JfrCheckpointManager;
 class JfrPostBox;
 class Thread;
@@ -40,6 +40,14 @@ class JfrRecorderThreadEntry : AllStatic {
  public:
   static JfrPostBox& post_box();
   static bool start(JfrCheckpointManager* cp_manager, JfrPostBox* post_box, TRAPS);
+};
+
+class JfrRecorderThread : public JavaThread {
+ public:
+  JfrRecorderThread(ThreadFunction entry_point) : JavaThread(entry_point) {}
+  virtual ~JfrRecorderThread() {}
+
+  virtual bool is_JfrRecorder_thread() const { return true; }
 };
 
 #endif // SHARE_JFR_RECORDER_SERVICE_JFRRECORDERTHREAD_HPP

--- a/src/hotspot/share/runtime/vmStructs.cpp
+++ b/src/hotspot/share/runtime/vmStructs.cpp
@@ -44,6 +44,7 @@
 #include "gc/shared/vmStructs_gc.hpp"
 #include "interpreter/bytecodes.hpp"
 #include "interpreter/interpreter.hpp"
+#include "jfr/recorder/service/jfrRecorderThread.hpp"
 #include "logging/logAsyncWriter.hpp"
 #include "memory/allocation.hpp"
 #include "memory/allocation.inline.hpp"
@@ -1027,6 +1028,7 @@
         declare_type(TrainingReplayThread, JavaThread)                    \
         declare_type(StringDedupThread, JavaThread)                       \
         declare_type(AttachListenerThread, JavaThread)                    \
+        declare_type(JfrRecorderThread, JavaThread)                       \
         DEBUG_ONLY(COMPILER2_OR_JVMCI_PRESENT(                            \
           declare_type(DeoptimizeObjectsALotThread, JavaThread)))         \
   declare_toplevel_type(OSThread)                                         \

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/Threads.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/Threads.java
@@ -158,6 +158,7 @@ public class Threads {
         virtualConstructor.addMapping("JvmtiAgentThread", JavaThread.class);
         virtualConstructor.addMapping("NotificationThread", JavaThread.class);
         virtualConstructor.addMapping("AttachListenerThread", JavaThread.class);
+        virtualConstructor.addMapping("JfrRecorderThread", JavaThread.class);
 
         // These are all the hidden JavaThread subclasses that don't execute java code.
         virtualConstructor.addMapping("StringDedupThread", HiddenJavaThread.class);
@@ -195,7 +196,8 @@ public class Threads {
         } catch (Exception e) {
             throw new RuntimeException("Unable to deduce type of thread from address " + threadAddr +
             " (expected type JavaThread, CompilerThread, MonitorDeflationThread, AttachListenerThread," +
-            " DeoptimizeObjectsALotThread, StringDedupThread, NotificationThread, ServiceThread or JvmtiAgentThread)", e);
+            " DeoptimizeObjectsALotThread, StringDedupThread, NotificationThread, ServiceThread," +
+            " JfrRecorderThread, or JvmtiAgentThread)", e);
         }
     }
 

--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbJstackWithConcurrentLock.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbJstackWithConcurrentLock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,7 +46,7 @@ public class ClhsdbJstackWithConcurrentLock {
 
             theApp = new LingeredAppWithConcurrentLock();
             // Use a small heap so the scan is quick.
-            LingeredApp.startApp(theApp, "-Xmx4m");
+            LingeredApp.startApp(theApp, "-Xmx8m");
             System.out.println("Started LingeredApp with pid " + theApp.getPid());
 
             // Run the 'jstack -l' command to get the stack and have java.util.concurrent


### PR DESCRIPTION
Clean backport of [JDK-8360312](https://bugs.openjdk.org/browse/JDK-8360312). The bug was introduced in JDK25 and fixed in JDK26, so should be backported to JDK25.

Tier5 ci testing in progress.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8360312](https://bugs.openjdk.org/browse/JDK-8360312): Serviceability Agent tests fail with JFR enabled due to unknown thread type JfrRecorderThread (**Bug** - P3)


### Reviewers
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26198/head:pull/26198` \
`$ git checkout pull/26198`

Update a local copy of the PR: \
`$ git checkout pull/26198` \
`$ git pull https://git.openjdk.org/jdk.git pull/26198/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26198`

View PR using the GUI difftool: \
`$ git pr show -t 26198`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26198.diff">https://git.openjdk.org/jdk/pull/26198.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26198#issuecomment-3049845759)
</details>
