### PR TITLE
8361615: CodeBuilder::parameterSlot throws undocumented IOOBE

### DIFF
--- a/src/java.base/share/classes/java/lang/classfile/CodeBuilder.java
+++ b/src/java.base/share/classes/java/lang/classfile/CodeBuilder.java
@@ -132,6 +132,7 @@ public sealed interface CodeBuilder
      * values require two slots.
      *
      * @param paramNo the index of the parameter
+     * @throws IndexOutOfBoundsException if the parameter index is out of bounds
      */
     int parameterSlot(int paramNo);
 

--- a/test/jdk/jdk/classfile/BuilderParamTest.java
+++ b/test/jdk/jdk/classfile/BuilderParamTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @bug 8361615
  * @summary Testing ClassFile builder parameters.
  * @run junit BuilderParamTest
  */
@@ -46,19 +47,26 @@ class BuilderParamTest {
         cc.build(ClassDesc.of("Foo"), cb -> {
             cb.withMethod("foo", MethodTypeDesc.ofDescriptor("(IJI)V"), 0,
                           mb -> mb.withCode(xb -> {
+                assertThrows(IndexOutOfBoundsException.class, () -> xb.parameterSlot(-1));
                 assertEquals(xb.receiverSlot(), 0);
                 assertEquals(xb.parameterSlot(0), 1);
                 assertEquals(xb.parameterSlot(1), 2);
                 assertEquals(xb.parameterSlot(2), 4);
+                assertThrows(IndexOutOfBoundsException.class, () -> xb.parameterSlot(3));
+                assertThrows(IndexOutOfBoundsException.class, () -> xb.parameterSlot(Integer.MAX_VALUE));
                 xb.return_();
             }));
         });
         cc.build(ClassDesc.of("Foo"), cb -> {
             cb.withMethod("foo", MethodTypeDesc.ofDescriptor("(IJI)V"), ACC_STATIC,
                           mb -> mb.withCode(xb -> {
+                              assertThrows(IndexOutOfBoundsException.class, () -> xb.parameterSlot(Integer.MIN_VALUE));
+                              assertThrows(IndexOutOfBoundsException.class, () -> xb.parameterSlot(-1));
+                              assertThrows(IllegalStateException.class, () -> xb.receiverSlot());
                               assertEquals(xb.parameterSlot(0), 0);
                               assertEquals(xb.parameterSlot(1), 1);
                               assertEquals(xb.parameterSlot(2), 3);
+                              assertThrows(IndexOutOfBoundsException.class, () -> xb.parameterSlot(3));
                               xb.return_();
                           }));
         });


### PR DESCRIPTION
In a recent inspection of all methods that accept an `int` argument in the Class-File API, I noticed this method that validates its argument but did not document the validation. The behavior is to throw IOOBE. We can simply document this behavior and enhance existing tests to verify exceptional behaviors in addition to anticipated outputs.

This is doc plus test only, so should be eligible for backport regardless of priority. A CSR will be created to track this new assertion in the spec.

Testing: jdk/jdk/classfile/BuilderParamTest.java