### PR TITLE
8361499: Intersection type cast causes javac crash with -Xjcov

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransTypes.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransTypes.java
@@ -1142,7 +1142,7 @@ public class TransTypes extends TreeTranslator {
     }
 
     public void visitTypeIntersection(JCTypeIntersection tree) {
-        result = translate(tree.bounds, null).head;
+        result = translate(tree.bounds.head, null);
     }
 
 /* ************************************************************************

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransTypes.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransTypes.java
@@ -1142,9 +1142,7 @@ public class TransTypes extends TreeTranslator {
     }
 
     public void visitTypeIntersection(JCTypeIntersection tree) {
-        tree.bounds = translate(tree.bounds, null);
-        tree.type = erasure(tree.type);
-        result = tree;
+        result = translate(tree.bounds, null).head;
     }
 
 /* ************************************************************************

--- a/test/langtools/tools/javac/NoTypeIntersectionASTAfterTransTypesTest.java
+++ b/test/langtools/tools/javac/NoTypeIntersectionASTAfterTransTypesTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8361499
+ * @summary intersection type cast causes javac crash with -Xjcov
+ * @library /tools/lib
+ * @modules jdk.compiler/com.sun.tools.javac.api
+ *          jdk.compiler/com.sun.tools.javac.comp
+ *          jdk.compiler/com.sun.tools.javac.main
+ *          jdk.compiler/com.sun.tools.javac.tree
+ *          jdk.compiler/com.sun.tools.javac.util
+ * @build toolbox.ToolBox toolbox.JavacTask NoTypeIntersectionASTAfterTransTypesTest
+ * @run main NoTypeIntersectionASTAfterTransTypesTest
+ */
+
+import java.util.List;
+import com.sun.source.util.JavacTask;
+import com.sun.tools.javac.api.JavacTool;
+import com.sun.tools.javac.comp.TransTypes;
+import com.sun.tools.javac.tree.JCTree;
+import com.sun.tools.javac.tree.JCTree.JCTypeIntersection;
+import com.sun.tools.javac.util.Context;
+import com.sun.tools.javac.util.Context.Factory;
+
+import toolbox.ToolBox;
+
+public class NoTypeIntersectionASTAfterTransTypesTest {
+    public static void main(String... args) {
+        new NoTypeIntersectionASTAfterTransTypesTest().run();
+    }
+
+    void run() {
+        String code =
+                """
+                class Test {
+                    interface I {}
+                    void test() {
+                        Runnable r1 = (Runnable & I)() -> {};
+                        Runnable r2 = (I & Runnable)() -> {};
+                    }
+                }
+                """;
+        Context ctx = new Context();
+        MyTransTypes.preRegister(ctx);
+        JavacTask task = JavacTool.create().getTask(null, null, null, null, null, List.of(new ToolBox.JavaSource(code)), ctx);
+        if (!task.call()) {
+            throw new AssertionError("test failed due to a compilation error");
+        }
+    }
+
+    static class MyTransTypes extends TransTypes {
+        public static void preRegister(Context ctx) {
+            ctx.put(transTypesKey, new Factory<TransTypes>() {
+                @Override
+                public TransTypes make(Context c) {
+                    return new MyTransTypes(c);
+                }
+            });
+        }
+        public MyTransTypes(Context context) {
+            super(context);
+        }
+        @Override
+        public void visitTypeIntersection(JCTypeIntersection tree) {
+            super.visitTypeIntersection(tree);
+            // after the invocation to the method in the super class the JCTypeIntersection should have been lowered
+            if (result instanceof JCTypeIntersection) {
+                throw new AssertionError("there are unexpected type intersection ASTs");
+            }
+        }
+    }
+}


### PR DESCRIPTION
After TransTypes decomposes an intersection type in its components, there is no point keeping the intersection AST around. This could lead to errors in the backend. This PR is proposing lowering the intersection AST to it's first component,

TIA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8361499](https://bugs.openjdk.org/browse/JDK-8361499): Intersection type cast causes javac crash with -Xjcov (**Bug** - P4)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26203/head:pull/26203` \
`$ git checkout pull/26203`

Update a local copy of the PR: \
`$ git checkout pull/26203` \
`$ git pull https://git.openjdk.org/jdk.git pull/26203/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26203`

View PR using the GUI difftool: \
`$ git pr show -t 26203`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26203.diff">https://git.openjdk.org/jdk/pull/26203.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26203#issuecomment-3050318166)
</details>
