### PR TITLE
8361536: [s390x] Saving return_pc at wrong offset

### DIFF
--- a/src/hotspot/cpu/s390/stubGenerator_s390.cpp
+++ b/src/hotspot/cpu/s390/stubGenerator_s390.cpp
@@ -166,14 +166,14 @@ class StubGenerator: public StubCodeGenerator {
       BLOCK_COMMENT("save registers, push frame {");
       __ save_return_pc();
       __ z_stmg(Z_R6, Z_R13, 16, Z_SP);
-      __ z_std(Z_F8, 88, Z_SP);
-      __ z_std(Z_F9, 96, Z_SP);
-      __ z_std(Z_F10, 104, Z_SP);
-      __ z_std(Z_F11, 112, Z_SP);
-      __ z_std(Z_F12, 120, Z_SP);
-      __ z_std(Z_F13, 128, Z_SP);
-      __ z_std(Z_F14, 136, Z_SP);
-      __ z_std(Z_F15, 144, Z_SP);
+      __ z_std(Z_F8, 80, Z_SP);
+      __ z_std(Z_F9, 88, Z_SP);
+      __ z_std(Z_F10, 96, Z_SP);
+      __ z_std(Z_F11, 104, Z_SP);
+      __ z_std(Z_F12, 112, Z_SP);
+      __ z_std(Z_F13, 120, Z_SP);
+      __ z_std(Z_F14, 128, Z_SP);
+      __ z_std(Z_F15, 136, Z_SP);
 
       //
       // Push ENTRY_FRAME including arguments:
@@ -340,14 +340,14 @@ class StubGenerator: public StubCodeGenerator {
       // Restore non-volatiles.
       __ restore_return_pc();
       __ z_lmg(Z_R6, Z_R13, 16, Z_SP);
-      __ z_ld(Z_F8, 88, Z_SP);
-      __ z_ld(Z_F9, 96, Z_SP);
-      __ z_ld(Z_F10, 104, Z_SP);
-      __ z_ld(Z_F11, 112, Z_SP);
-      __ z_ld(Z_F12, 120, Z_SP);
-      __ z_ld(Z_F13, 128, Z_SP);
-      __ z_ld(Z_F14, 136, Z_SP);
-      __ z_ld(Z_F15, 144, Z_SP);
+      __ z_ld(Z_F8, 80, Z_SP);
+      __ z_ld(Z_F9, 88, Z_SP);
+      __ z_ld(Z_F10, 96, Z_SP);
+      __ z_ld(Z_F11, 104, Z_SP);
+      __ z_ld(Z_F12, 112, Z_SP);
+      __ z_ld(Z_F13, 120, Z_SP);
+      __ z_ld(Z_F14, 128, Z_SP);
+      __ z_ld(Z_F15, 136, Z_SP);
       BLOCK_COMMENT("} restore");
 
       //


### PR DESCRIPTION
Fixes the bug where return pc was stored at a wrong offset, which causes issue with java abi. 

Issue appeared in #26004, see the comment: https://github.com/openjdk/jdk/pull/26004#issuecomment-3017928879.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8361536](https://bugs.openjdk.org/browse/JDK-8361536): [s390x] Saving return_pc at wrong offset (**Enhancement** - P3)


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26209/head:pull/26209` \
`$ git checkout pull/26209`

Update a local copy of the PR: \
`$ git checkout pull/26209` \
`$ git pull https://git.openjdk.org/jdk.git pull/26209/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26209`

View PR using the GUI difftool: \
`$ git pr show -t 26209`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26209.diff">https://git.openjdk.org/jdk/pull/26209.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26209#issuecomment-3055196247)
</details>
