### PR TITLE
8361697: Remove duplicate message  in MainResources.properties

### DIFF
--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/resources/MainResources.properties
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/resources/MainResources.properties
@@ -87,7 +87,6 @@ MSG_BundlerConfigException=Bundler {0} skipped because of a configuration proble
 Advice to fix: {2}
 MSG_BundlerConfigExceptionNoAdvice=Bundler {0} skipped because of a configuration problem: {1}
 MSG_BundlerRuntimeException=Bundler {0} failed because of {1}
-MSG_BundlerFailed=Error: Bundler "{1}" ({0}) failed to produce a package
 
 ERR_NoMainClass=Error: Main application class is missing
 ERR_UnsupportedOption=Error: Option [{0}] is not valid on this platform


### PR DESCRIPTION
Bug reference: https://bugs.openjdk.org/browse/JDK-8361697

The following message is removed:

`
MSG_BundlerFailed=Error: Bundler "{1}" ({0}) failed to produce a package`

Signed-off-by: Pooja.D.P1 <Pooja.D.P1@ibm.com>

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8361697](https://bugs.openjdk.org/browse/JDK-8361697): Remove duplicate message  in MainResources.properties (**Bug** - P4)


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Alexey Semenyuk](https://openjdk.org/census#asemenyuk) (@alexeysemenyukoracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26215/head:pull/26215` \
`$ git checkout pull/26215`

Update a local copy of the PR: \
`$ git checkout pull/26215` \
`$ git pull https://git.openjdk.org/jdk.git pull/26215/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26215`

View PR using the GUI difftool: \
`$ git pr show -t 26215`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26215.diff">https://git.openjdk.org/jdk/pull/26215.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26215#issuecomment-3061576992)
</details>
