### PR TITLE
8360941: [ubsan] MemRegion::end() shows runtime error: applying non-zero offset 8388608 to null pointer

### DIFF
--- a/src/hotspot/share/memory/memRegion.hpp
+++ b/src/hotspot/share/memory/memRegion.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -63,8 +63,7 @@ public:
   MemRegion minus(const MemRegion mr2) const;
 
   HeapWord* start() const { return _start; }
-  // in the gtests we call end() with a _start == nullptr so adjust the addition to avoid ub
-  HeapWord* end() const   { return reinterpret_cast<HeapWord*>(reinterpret_cast<uintptr_t>(_start) + (_word_size * sizeof(HeapWord))); }
+  HeapWord* end() const { return _start + _word_size; }
   HeapWord* last() const  { return _start + _word_size - 1; }
 
   void set_start(HeapWord* start) { _start = start; }

--- a/src/hotspot/share/memory/memRegion.hpp
+++ b/src/hotspot/share/memory/memRegion.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -63,7 +63,8 @@ public:
   MemRegion minus(const MemRegion mr2) const;
 
   HeapWord* start() const { return _start; }
-  HeapWord* end() const   { return _start + _word_size; }
+  // in the gtests we call end() with a _start == nullptr so adjust the addition to avoid ub
+  HeapWord* end() const   { return reinterpret_cast<HeapWord*>(reinterpret_cast<uintptr_t>(_start) + (_word_size * sizeof(HeapWord))); }
   HeapWord* last() const  { return _start + _word_size - 1; }
 
   void set_start(HeapWord* start) { _start = start; }

--- a/src/hotspot/share/memory/memRegion.hpp
+++ b/src/hotspot/share/memory/memRegion.hpp
@@ -63,7 +63,7 @@ public:
   MemRegion minus(const MemRegion mr2) const;
 
   HeapWord* start() const { return _start; }
-  HeapWord* end() const  { return _start + _word_size; }
+  HeapWord* end() const   { return _start + _word_size; }
   HeapWord* last() const  { return _start + _word_size - 1; }
 
   void set_start(HeapWord* start) { _start = start; }

--- a/src/hotspot/share/memory/memRegion.hpp
+++ b/src/hotspot/share/memory/memRegion.hpp
@@ -63,7 +63,7 @@ public:
   MemRegion minus(const MemRegion mr2) const;
 
   HeapWord* start() const { return _start; }
-  HeapWord* end() const { return _start + _word_size; }
+  HeapWord* end() const  { return _start + _word_size; }
   HeapWord* last() const  { return _start + _word_size - 1; }
 
   void set_start(HeapWord* start) { _start = start; }

--- a/test/hotspot/gtest/gc/g1/test_freeRegionList.cpp
+++ b/test/hotspot/gtest/gc/g1/test_freeRegionList.cpp
@@ -46,7 +46,8 @@ TEST_OTHER_VM(G1FreeRegionList, length) {
   // does not access it.
   const size_t szw = num_regions_in_test * G1HeapRegion::GrainWords;
   const size_t sz = szw * BytesPerWord;
-  char* addr = os::reserve_memory(sz, mtTest);
+  const size_t lpsz = os::large_page_size();
+  char* addr = os::reserve_memory_aligned(sz, lpsz, mtTest);
   MemRegion heap((HeapWord*)addr, szw);
 
   // Allocate a fake BOT because the G1HeapRegion constructor initializes

--- a/test/hotspot/gtest/gc/g1/test_freeRegionList.cpp
+++ b/test/hotspot/gtest/gc/g1/test_freeRegionList.cpp
@@ -44,10 +44,10 @@ TEST_OTHER_VM(G1FreeRegionList, length) {
 
   // Create a fake heap. It does not need to be valid, as the G1HeapRegion constructor
   // does not access it.
-  HeapWord val{};
-  HeapWord* ptr = align_up(&val, os::vm_page_size());
-
-  MemRegion heap(ptr, num_regions_in_test * G1HeapRegion::GrainWords);
+  const size_t szw = num_regions_in_test * G1HeapRegion::GrainWords;
+  const size_t sz = szw * BytesPerWord;
+  char* addr = os::reserve_memory(sz, mtTest);
+  MemRegion heap((HeapWord*)addr, szw);
 
   // Allocate a fake BOT because the G1HeapRegion constructor initializes
   // the BOT.
@@ -90,5 +90,6 @@ TEST_OTHER_VM(G1FreeRegionList, length) {
 
   bot_storage->uncommit_regions(0, num_regions_in_test);
   delete bot_storage;
+  os::release_memory(addr, szw);
   FREE_C_HEAP_ARRAY(HeapWord, bot_data);
 }

--- a/test/hotspot/gtest/gc/g1/test_freeRegionList.cpp
+++ b/test/hotspot/gtest/gc/g1/test_freeRegionList.cpp
@@ -46,8 +46,7 @@ TEST_OTHER_VM(G1FreeRegionList, length) {
   // does not access it.
   const size_t szw = num_regions_in_test * G1HeapRegion::GrainWords;
   const size_t sz = szw * BytesPerWord;
-  const size_t lpsz = os::large_page_size();
-  char* addr = os::reserve_memory_aligned(sz, lpsz, mtTest);
+  char* addr = os::reserve_memory_aligned(sz, G1HeapRegion::GrainBytes, mtTest);
   MemRegion heap((HeapWord*)addr, szw);
 
   // Allocate a fake BOT because the G1HeapRegion constructor initializes
@@ -91,6 +90,6 @@ TEST_OTHER_VM(G1FreeRegionList, length) {
 
   bot_storage->uncommit_regions(0, num_regions_in_test);
   delete bot_storage;
-  os::release_memory(addr, szw);
+  os::release_memory(addr, sz);
   FREE_C_HEAP_ARRAY(HeapWord, bot_data);
 }

--- a/test/hotspot/gtest/gc/g1/test_freeRegionList.cpp
+++ b/test/hotspot/gtest/gc/g1/test_freeRegionList.cpp
@@ -44,9 +44,8 @@ TEST_OTHER_VM(G1FreeRegionList, length) {
 
   // Create a fake heap. It does not need to be valid, as the G1HeapRegion constructor
   // does not access it.
-  int val = 1;
-  HeapWord* ptr = reinterpret_cast<HeapWord*>(&val);
-  ptr = align_up(ptr, os::vm_page_size());
+  HeapWord val{};
+  HeapWord* ptr = align_up(&val, os::vm_page_size());
 
   MemRegion heap(ptr, num_regions_in_test * G1HeapRegion::GrainWords);
 

--- a/test/hotspot/gtest/gc/g1/test_freeRegionList.cpp
+++ b/test/hotspot/gtest/gc/g1/test_freeRegionList.cpp
@@ -46,6 +46,8 @@ TEST_OTHER_VM(G1FreeRegionList, length) {
   // does not access it.
   int val = 1;
   HeapWord* ptr = reinterpret_cast<HeapWord*>(&val);
+  ptr = align_up(ptr, os::vm_page_size());
+
   MemRegion heap(ptr, num_regions_in_test * G1HeapRegion::GrainWords);
 
   // Allocate a fake BOT because the G1HeapRegion constructor initializes

--- a/test/hotspot/gtest/gc/g1/test_freeRegionList.cpp
+++ b/test/hotspot/gtest/gc/g1/test_freeRegionList.cpp
@@ -44,7 +44,9 @@ TEST_OTHER_VM(G1FreeRegionList, length) {
 
   // Create a fake heap. It does not need to be valid, as the G1HeapRegion constructor
   // does not access it.
-  MemRegion heap(nullptr, num_regions_in_test * G1HeapRegion::GrainWords);
+  int val = 1;
+  HeapWord* ptr = reinterpret_cast<HeapWord*>(&val);
+  MemRegion heap(ptr, num_regions_in_test * G1HeapRegion::GrainWords);
 
   // Allocate a fake BOT because the G1HeapRegion constructor initializes
   // the BOT.


### PR DESCRIPTION
When running HS test
gtest/GTestWrapper.java
with ubsan-enabled binaries on macOS aarch64, the following error is reported (did not see this so far on Linux but there we use gcc and it seems the gcc/ubsan checks are a bit more limited).

test/hotspot/gtest/gc/g1/test_freeRegionList.cpp:37: Failure
Death test: child_G1FreeRegionList_length_()
    Result: died but not with expected exit code:
            Terminated by signal 6 (core dumped)
Actual msg:
```
[  DEATH   ] /jdk/src/hotspot/share/memory/memRegion.hpp:66:43: runtime error: applying non-zero offset 8388608 to null pointer
[  DEATH   ]     #0 0x108afd6f4 in MemRegion::end() const+0x84 (libjvm.dylib:arm64+0x16556f4)
[  DEATH   ]     #1 0x1075c68a0 in G1FreeRegionList_length_other_vm_Test::TestBody()+0x380 (libjvm.dylib:arm64+0x11e8a0)
[  DEATH   ]     #2 0x1090f3bb0 in testing::Test::Run()+0xc0 (libjvm.dylib:arm64+0x1c4bbb0)
[  DEATH   ]     #3 0x1090f4d94 in testing::TestInfo::Run()+0x1e4 (libjvm.dylib:arm64+0x1c4cd94)
[  DEATH   ]     #4 0x1090f6754 in testing::TestSuite::Run()+0x43c (libjvm.dylib:arm64+0x1c4e754)
[  DEATH   ]     #5 0x109103ca0 in testing::internal::UnitTestImpl::RunAllTests()+0x48c (libjvm.dylib:arm64+0x1c5bca0)
[  DEATH   ]     #6 0x109103588 in testing::UnitTest::Run()+0x78 (libjvm.dylib:arm64+0x1c5b588)
[  DEATH   ]     #7 0x1074a9ac0 in runUnitTestsInner(int, char**)+0x724 (libjvm.dylib:arm64+0x1ac0)
[  DEATH   ]     #8 0x102dc3f18 in main+0x2c (gtestLauncher:arm64+0x100003f18)
[  DEATH   ]     #9 0x196fea0dc  (<unknown module>)
[  DEATH   ] 
[  DEATH   ] SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /jdk/src/hotspot/share/memory/memRegion.hpp:66:43 in 
[  DEATH   ] 

```

Seems the test_freeRegionList.cpp uses a special MemRegion starting at nullptr ; but this causes a bit of trouble when adding to start == nullptr .
So far I see this issue just in the gtest, seems other MemRegion objects do not start at nullptr .

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8360941](https://bugs.openjdk.org/browse/JDK-8360941): [ubsan] MemRegion::end() shows runtime error: applying non-zero offset 8388608 to null pointer (**Bug** - P4)


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**) Review applies to [e2407fd4](https://git.openjdk.org/jdk/pull/26216/files/e2407fd47e21b46473cbc1822c1cb67a28742bbd)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)

### Contributors
 * Kim Barrett `<kbarrett@openjdk.org>`
 * Thomas Stuefe `<stuefe@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26216/head:pull/26216` \
`$ git checkout pull/26216`

Update a local copy of the PR: \
`$ git checkout pull/26216` \
`$ git pull https://git.openjdk.org/jdk.git pull/26216/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26216`

View PR using the GUI difftool: \
`$ git pr show -t 26216`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26216.diff">https://git.openjdk.org/jdk/pull/26216.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26216#issuecomment-3052147303)
</details>
