### PR TITLE
8361704: Parallel: Simplify logic condition in MutableNUMASpace::initialize

### DIFF
--- a/src/hotspot/share/gc/parallel/mutableNUMASpace.cpp
+++ b/src/hotspot/share/gc/parallel/mutableNUMASpace.cpp
@@ -412,8 +412,8 @@ void MutableNUMASpace::initialize(MemRegion mr,
 
     size_t chunk_byte_size = 0;
     if (i < lgrp_spaces()->length() - 1) {
-      if (!UseAdaptiveNUMAChunkSizing                                ||
-          (UseAdaptiveNUMAChunkSizing && NUMAChunkResizeWeight == 0) ||
+      if (!UseAdaptiveNUMAChunkSizing ||
+           NUMAChunkResizeWeight == 0 ||
            samples_count() < AdaptiveSizePolicyReadyThreshold) {
         // No adaptation. Divide the space equally.
         chunk_byte_size = default_chunk_size();


### PR DESCRIPTION
Trivial simplification via logical equivalence reduction.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8361704](https://bugs.openjdk.org/browse/JDK-8361704): Parallel: Simplify logic condition in MutableNUMASpace::initialize (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26218/head:pull/26218` \
`$ git checkout pull/26218`

Update a local copy of the PR: \
`$ git checkout pull/26218` \
`$ git pull https://git.openjdk.org/jdk.git pull/26218/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26218`

View PR using the GUI difftool: \
`$ git pr show -t 26218`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26218.diff">https://git.openjdk.org/jdk/pull/26218.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26218#issuecomment-3052454703)
</details>
