### PR TITLE
8361698: Fix obsolete comments in Klass::clean_weak_klass_links()

### DIFF
--- a/src/hotspot/share/oops/klass.cpp
+++ b/src/hotspot/share/oops/klass.cpp
@@ -732,14 +732,14 @@ void Klass::clean_weak_klass_links(bool unloading_occurred, bool clean_alive_kla
 
     assert(current->is_loader_alive(), "just checking, this should be live");
 
-    // Find and set the first alive subklass
+    // Find and set the first subklass.
     Klass* sub = current->subklass(true);
     current->clean_subklass();
     if (sub != nullptr) {
       stack.push(sub);
     }
 
-    // Find and set the first alive sibling
+    // Find and set the first sibling.
     Klass* sibling = current->next_sibling(true);
     current->set_next_sibling(sibling);
     if (sibling != nullptr) {


### PR DESCRIPTION
Hi all,

  please review this fix to some comments in the Klass::clean_weak_klass_links() after the changes in JDK-8213209. I believe this is a trivial change.

Testing: local compilation

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8361698](https://bugs.openjdk.org/browse/JDK-8361698): Fix obsolete comments in Klass::clean_weak_klass_links() (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26219/head:pull/26219` \
`$ git checkout pull/26219`

Update a local copy of the PR: \
`$ git checkout pull/26219` \
`$ git pull https://git.openjdk.org/jdk.git pull/26219/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26219`

View PR using the GUI difftool: \
`$ git pr show -t 26219`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26219.diff">https://git.openjdk.org/jdk/pull/26219.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26219#issuecomment-3052833252)
</details>
