### PR TITLE
8361693: Remove Klass::clean_subklass_tree()

### DIFF
--- a/src/hotspot/share/gc/shared/parallelCleaning.cpp
+++ b/src/hotspot/share/gc/shared/parallelCleaning.cpp
@@ -122,7 +122,7 @@ void KlassCleaningTask::work() {
 
   // One worker will clean the subklass/sibling klass tree.
   if (claim_clean_klass_tree_task()) {
-    Klass::clean_subklass_tree();
+    Klass::clean_weak_klass_links(true /* class_unloading_occurred */, false /* clean_alive_klasses */);
   }
 
   // All workers will help cleaning the classes,

--- a/src/hotspot/share/oops/klass.hpp
+++ b/src/hotspot/share/oops/klass.hpp
@@ -735,9 +735,6 @@ public:
   void clean_subklass();
 
   static void clean_weak_klass_links(bool unloading_occurred, bool clean_alive_klasses = true);
-  static void clean_subklass_tree() {
-    clean_weak_klass_links(/*unloading_occurred*/ true , /* clean_alive_klasses */ false);
-  }
 
   // Return self, except for abstract classes with exactly 1
   // implementor.  Then return the 1 concrete implementation.


### PR DESCRIPTION
Hi all,

  please review this inlining of Klass::clean_subklass_tree because it's only used in one place and replaces only one call. There does not seem to be any advantage having the extra method.

Testing: local compilation, gha

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8361693](https://bugs.openjdk.org/browse/JDK-8361693): Remove Klass::clean_subklass_tree() (**Enhancement** - P4)


### Reviewers
 * [Zhengyu Gu](https://openjdk.org/census#zgu) (@zhengyu123 - **Reviewer**)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26220/head:pull/26220` \
`$ git checkout pull/26220`

Update a local copy of the PR: \
`$ git checkout pull/26220` \
`$ git pull https://git.openjdk.org/jdk.git pull/26220/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26220`

View PR using the GUI difftool: \
`$ git pr show -t 26220`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26220.diff">https://git.openjdk.org/jdk/pull/26220.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26220#issuecomment-3052835415)
</details>
