### PR TITLE
8340870: [WIN] Checkbox is not sized according to uiScale

### DIFF
--- a/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/XPStyle.java
+++ b/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/XPStyle.java
@@ -722,7 +722,7 @@ final class XPStyle {
             ThemeReader.paintBackground(SunWritableRaster.stealData(dbi, 0),
                                         part.getControlName(c), part.getValue(),
                                         State.getValue(part, state),
-                                        0, 0, w, h, w, dpi);
+                                        w, h, w, dpi);
 
             SunWritableRaster.markDirty(dbi);
         }

--- a/src/java.desktop/windows/classes/sun/awt/windows/ThemeReader.java
+++ b/src/java.desktop/windows/classes/sun/awt/windows/ThemeReader.java
@@ -180,22 +180,18 @@ public final class ThemeReader {
 
     private static native void paintBackground(int[] buffer, long theme,
                                                int part, int state,
-                                               int rectRight, int rectBottom,
                                                int w, int h, int stride);
 
     public static void paintBackground(int[] buffer, String widget,
-           int part, int state, int x, int y, int w, int h, int stride, int dpi) {
+           int part, int state, int w, int h, int stride, int dpi) {
         readLock.lock();
         try {
-            /* For widgets and parts in the lists, we get the part size
-            for the current screen DPI to scale them better. */
-            Dimension d = (partSizeWidgets.contains(widget)
-                          && partSizeWidgetParts.contains(Integer.valueOf(part)))
-                          ? getPartSize(getTheme(widget, dpi), part, state)
-                          : new Dimension(w, h);
-
-            paintBackground(buffer, getTheme(widget, dpi), part, state,
-                            d.width, d.height, w, h, stride);
+            // getTheme is not guaranteed to retrieve the theme handle for the desired DPI
+            // if assets for it aren't already loaded by the theming system. In that case,
+            // the closest loaded asset will be used and scaled to fit the provided height
+            // and width by paintBackground. The resulting image won't be as crisp as the
+            // native resolution asset, but it will be the correct size.
+            paintBackground(buffer, getTheme(widget, dpi), part, state, w, h, stride);
         } finally {
             readLock.unlock();
         }

--- a/src/java.desktop/windows/native/libawt/windows/ThemeReader.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/ThemeReader.cpp
@@ -442,7 +442,7 @@ JNIEXPORT void JNICALL Java_sun_awt_windows_ThemeReader_paintBackground
     rect.top = 0;
     rect.bottom = h;
     rect.right = w;
-    
+
     ZeroMemory(pSrcBits,(BITS_PER_PIXEL>>3)*w*h);
 
     HRESULT hres = DrawThemeBackgroundFunc(hTheme, memDC, part, state, &rect, NULL);

--- a/src/java.desktop/windows/native/libawt/windows/ThemeReader.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/ThemeReader.cpp
@@ -393,7 +393,7 @@ static void copyDIBToBufferedImage(int *pDstBits, int *pSrcBits,
  */
 JNIEXPORT void JNICALL Java_sun_awt_windows_ThemeReader_paintBackground
   (JNIEnv *env, jclass klass, jintArray array, jlong theme, jint part, jint state,
-    jint rectRight, jint rectBottom, jint w, jint h, jint stride) {
+    jint w, jint h, jint stride) {
 
     int *pDstBits=NULL;
     int *pSrcBits=NULL;
@@ -440,14 +440,9 @@ JNIEXPORT void JNICALL Java_sun_awt_windows_ThemeReader_paintBackground
 
     rect.left = 0;
     rect.top = 0;
-
-    if (OpenThemeDataForDpiFunc) {
-        rect.bottom = rectBottom;
-        rect.right = rectRight;
-    } else {
-        rect.bottom = h;
-        rect.right = w;
-    }
+    rect.bottom = h;
+    rect.right = w;
+    
     ZeroMemory(pSrcBits,(BITS_PER_PIXEL>>3)*w*h);
 
     HRESULT hres = DrawThemeBackgroundFunc(hTheme, memDC, part, state, &rect, NULL);


### PR DESCRIPTION
[JDK-8294427](https://bugs.openjdk.org/browse/JDK-8294427) introduced code to solve the rendering quality of the graphic portions of checkboxes and radio buttons, by loading the graphics for the desired DPI directly via the native Windows theming system instead of having to resort to scaling.
For that, it uses the `OpenThemeDataForDpi` API, and while I couldn't fault the actual logic it applies when using the API, it unfortunately ignores a significant limitation of this api [1]:
_"The behavior of the returned theme handle will be undermined if the requested DPI value does not correspond to a currently connected display. The theming system only loads theme assets for the set of DPI values corresponding to the currently connected displays."_

In practice, this means that when setting uiScale to a value that results a DPI value not matching any if the connected screens, the api call will always return a graphic asset for the control, but it most likely won't be the one for the requested resolution, which results in the size of the graphic asset not matching the rest of the UI. 
Even more confusingly, if you had a switched to that particular display scale recently on any of the connected screen, then the theme may still be loaded and the api call may yet return the right asset, even if there are no longer any screen set to this scale (which made for a fair amount of confusion and frustration while trying to reproduce and understand the issue!)
![image](https://github.com/user-attachments/assets/16d38e81-1d99-4d22-9e75-f2b28acc7028)
![image](https://github.com/user-attachments/assets/3a3dbc82-4bb2-443f-87ab-a426631a8db5)

While I don't believe there is a way to solve this problem in an entirely satisfying way, I nevertheless it's worth considering a different trade off which would result in the controls being rendered at the correct size, at the cost of crispness and image quality just for the boxes (not the whole app).  In  the absence of a perfect solution, I think that rendering the control in the right size is more valuable than having it looking  pixel perfect (but too small), as this might otherwise affect accessibility for users with visual impairments  or motor disabilities.
![image](https://github.com/user-attachments/assets/be32d40b-bb03-4234-a9f6-eb97f62c82c0)

Since the `DrawThemeBackground` used to draw the picture already supports re-scaling to a desired size [2], the PR attempts to achieve this by simply removing the logic that does a first theme look-up to determine the effective size of the control and instead use the computed size, forcing `paintBackground` to re-scaled it if it doesn't match.


[1] https://learn.microsoft.com/en-us/windows/win32/api/uxtheme/nf-uxtheme-openthemedatafordpi

[2] https://learn.microsoft.com/en-us/windows/win32/api/uxtheme/nf-uxtheme-drawthemebackground#remarks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Error
&nbsp;⚠️ 8340870 is used in problem lists: [test/jdk/ProblemList.txt]

### Issue
 * [JDK-8340870](https://bugs.openjdk.org/browse/JDK-8340870): [WIN] Checkbox is not sized according to uiScale (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26221/head:pull/26221` \
`$ git checkout pull/26221`

Update a local copy of the PR: \
`$ git checkout pull/26221` \
`$ git pull https://git.openjdk.org/jdk.git pull/26221/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26221`

View PR using the GUI difftool: \
`$ git pr show -t 26221`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26221.diff">https://git.openjdk.org/jdk/pull/26221.diff</a>

</details>
