### PR TITLE
8361587: AssertionError in File.listFiles() when path is empty and -esa is enabled

### DIFF
--- a/src/java.base/share/classes/java/io/File.java
+++ b/src/java.base/share/classes/java/io/File.java
@@ -264,7 +264,6 @@ public class File
      */
     private File(String child, File parent) {
         assert parent.path != null;
-        assert (!parent.path.isEmpty());
         this.path = FS.resolve(parent.path, child);
         this.prefixLength = parent.prefixLength;
     }

--- a/src/java.base/share/classes/java/io/File.java
+++ b/src/java.base/share/classes/java/io/File.java
@@ -264,6 +264,7 @@ public class File
      */
     private File(String child, File parent) {
         assert parent.path != null;
+        assert (!parent.path.isEmpty());
         this.path = FS.resolve(parent.path, child);
         this.prefixLength = parent.prefixLength;
     }

--- a/src/java.base/share/classes/java/io/File.java
+++ b/src/java.base/share/classes/java/io/File.java
@@ -1134,8 +1134,16 @@ public class File
         if (ss == null) return null;
         int n = ss.length;
         File[] fs = new File[n];
+        boolean isEmpty = path.isEmpty();
+        // replace empty parent with "." to avoid assertion in private ctor
+        File parent = isEmpty ? new File(".") : this;
         for (int i = 0; i < n; i++) {
-            fs[i] = new File(ss[i], this);
+            fs[i] = new File(ss[i], parent);
+        }
+        if (isEmpty) {
+            for (int i = 0; i < n; i++) {
+                fs[i] = new File(fs[i].getName());
+            }
         }
         return fs;
     }

--- a/src/java.base/share/classes/java/io/File.java
+++ b/src/java.base/share/classes/java/io/File.java
@@ -1134,15 +1134,13 @@ public class File
         if (ss == null) return null;
         int n = ss.length;
         File[] fs = new File[n];
-        boolean isEmpty = path.isEmpty();
-        // replace empty parent with "." to avoid assertion in private ctor
-        File parent = isEmpty ? new File(".") : this;
-        for (int i = 0; i < n; i++) {
-            fs[i] = new File(ss[i], parent);
-        }
-        if (isEmpty) {
+        if (path.isEmpty()) {
             for (int i = 0; i < n; i++) {
-                fs[i] = new File(fs[i].getName());
+                fs[i] = new File(ss[i]);
+            }
+        } else {
+            for (int i = 0; i < n; i++) {
+                fs[i] = new File(ss[i], this);
             }
         }
         return fs;

--- a/src/java.base/unix/classes/java/io/UnixFileSystem.java
+++ b/src/java.base/unix/classes/java/io/UnixFileSystem.java
@@ -117,7 +117,6 @@ final class UnixFileSystem extends FileSystem {
     @Override
     public String resolve(String parent, String child) {
         if (child.isEmpty()) return parent;
-        if (parent.isEmpty()) return child;
         if (child.charAt(0) == '/') {
             if (parent.equals("/")) return child;
             return trimSeparator(parent + child);

--- a/src/java.base/unix/classes/java/io/UnixFileSystem.java
+++ b/src/java.base/unix/classes/java/io/UnixFileSystem.java
@@ -117,6 +117,7 @@ final class UnixFileSystem extends FileSystem {
     @Override
     public String resolve(String parent, String child) {
         if (child.isEmpty()) return parent;
+        if (parent.isEmpty()) return child;
         if (child.charAt(0) == '/') {
             if (parent.equals("/")) return child;
             return trimSeparator(parent + child);

--- a/test/jdk/java/io/File/EmptyPath.java
+++ b/test/jdk/java/io/File/EmptyPath.java
@@ -38,6 +38,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -209,13 +210,15 @@ public class EmptyPath {
 
         File[] files = f.listFiles();
         for (File file : files)
-            assertTrue(f.toString().indexOf(File.separatorChar) == -1);
+            assertEquals(-1, f.toString().indexOf(File.separatorChar));
 
-        List<String> ioNames =
-            Arrays.asList(files).stream().map(f -> f.toString()).toList();
-        Set<String> ioSet = new HashSet(ioNames);
-        Set<String> nioSet = new HashSet();
-        Files.list(p).forEach((x) -> nioSet.add(x.toString()));
+        Set<String> ioSet = Arrays.stream(files)
+            .map(File::getName)
+            .collect(Collectors.toSet());
+        Set<String> nioSet = Files.list(p)
+            .map(Path::getFileName)
+            .map(Path::toString)
+            .collect(Collectors.toSet());
         assertEquals(nioSet, ioSet);
     }
 

--- a/test/jdk/java/io/File/EmptyPath.java
+++ b/test/jdk/java/io/File/EmptyPath.java
@@ -44,7 +44,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -260,27 +259,8 @@ public class EmptyPath {
     }
 
     @Test
-    @DisabledOnOs({OS.WINDOWS})
-    public void mkdirsNotWindows() {
-        // The empty parent causes the child to be resolved against the
-        // system-dependent directory, the Unix default for which is "/"
-        File child = new File(f, "child");
-        assertEquals("/child", child.toString());
-        assertFalse(child.mkdirs());
-    }
-
-    @Test
-    @EnabledOnOs({OS.WINDOWS})
-    public void mkdirsWindows() {
-        // The empty parent causes the child to be resolved against the
-        // system-dependent directory, the Windows default for which is "\\"
-        String childName = "child" + System.nanoTime();
-        File child = new File(f, childName);
-        assertEquals("\\" + childName, child.toString());
-        if (!child.exists()) {
-            assertTrue(child.mkdirs());
-            assertTrue(child.delete());
-        }
+    public void mkdirs() {
+        assertFalse(f.mkdirs());
     }
 
     @Test

--- a/test/jdk/java/io/File/EmptyPath.java
+++ b/test/jdk/java/io/File/EmptyPath.java
@@ -260,9 +260,27 @@ public class EmptyPath {
     }
 
     @Test
-    public void mkdirs() {
+    @DisabledOnOs({OS.WINDOWS})
+    public void mkdirsNotWindows() {
+        // The empty parent causes the child to be resolved against the
+        // system-dependent directory, the Unix default for which is "/"
         File child = new File(f, "child");
+        assertEquals("/child", child.toString());
         assertFalse(child.mkdirs());
+    }
+
+    @Test
+    @EnabledOnOs({OS.WINDOWS})
+    public void mkdirsWindows() {
+        // The empty parent causes the child to be resolved against the
+        // system-dependent directory, the Windows default for which is "\\"
+        String childName = "child" + System.nanoTime();
+        File child = new File(f, childName);
+        assertEquals("\\" + childName, child.toString());
+        if (!child.exists()) {
+            assertTrue(child.mkdirs());
+            assertTrue(child.delete());
+        }
     }
 
     @Test

--- a/test/jdk/java/io/File/EmptyPath.java
+++ b/test/jdk/java/io/File/EmptyPath.java
@@ -121,7 +121,7 @@ public class EmptyPath {
 
     @Test
     public void getCanonicalFile() throws IOException {
-        assertEquals(p.toRealPath(), f.getCanonicalFile().toPath());
+        assertEquals(p.toRealPath().toFile(), f.getCanonicalFile());
     }
 
     @Test

--- a/test/jdk/java/io/File/EmptyPath.java
+++ b/test/jdk/java/io/File/EmptyPath.java
@@ -22,7 +22,7 @@
  */
 
 /* @test
- * @bug 4842706 8024695
+ * @bug 4842706 8024695 8361587
  * @summary Test some file operations with empty path
  * @run junit EmptyPath
  */
@@ -36,6 +36,7 @@ import java.nio.file.FileStore;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import org.junit.jupiter.api.BeforeAll;
@@ -193,6 +194,26 @@ public class EmptyPath {
         String[] files = f.list();
         assertNotNull(files);
         Set<String> ioSet = new HashSet(Arrays.asList(files));
+        Set<String> nioSet = new HashSet();
+        Files.list(p).forEach((x) -> nioSet.add(x.toString()));
+        assertEquals(nioSet, ioSet);
+    }
+
+    @Test
+    public void listFiles() throws IOException {
+        File child = new File(f.getAbsoluteFile(), "child");
+        assertTrue(child.createNewFile());
+        child.deleteOnExit();
+
+        assertTrue(Arrays.asList(f.list()).contains(child.getName()));
+
+        File[] files = f.listFiles();
+        for (File file : files)
+            assertTrue(f.toString().indexOf(File.separatorChar) == -1);
+
+        List<String> ioNames =
+            Arrays.asList(files).stream().map(f -> f.toString()).toList();
+        Set<String> ioSet = new HashSet(ioNames);
         Set<String> nioSet = new HashSet();
         Files.list(p).forEach((x) -> nioSet.add(x.toString()));
         assertEquals(nioSet, ioSet);

--- a/test/jdk/java/io/File/EmptyPath.java
+++ b/test/jdk/java/io/File/EmptyPath.java
@@ -108,10 +108,25 @@ public class EmptyPath {
     }
 
     @Test
+    public void getAbsoluteFile() {
+        assertEquals(p.toAbsolutePath(), f.getAbsoluteFile().toPath());
+    }
+
+    @Test
     public void getAbsolutePath() {
         System.out.println(p.toAbsolutePath().toString() + "\n" +
                            f.getAbsolutePath());
         assertEquals(p.toAbsolutePath().toString(), f.getAbsolutePath());
+    }
+
+    @Test
+    public void getCanonicalFile() throws IOException {
+        assertEquals(p.toRealPath(), f.getCanonicalFile().toPath());
+    }
+
+    @Test
+    public void getCanonicalPath() throws IOException {
+        assertEquals(p.toRealPath().toString(), f.getCanonicalPath());
     }
 
     private void checkSpace(long expected, long actual) {
@@ -136,6 +151,11 @@ public class EmptyPath {
     @Test
     public void getParent() {
         assertNull(f.getParent());
+    }
+
+    @Test
+    public void getParentFile() {
+        assertNull(f.getParentFile());
     }
 
     @Test
@@ -223,8 +243,32 @@ public class EmptyPath {
     }
 
     @Test
+    public void listRoots() {
+        Set<String> expected = Arrays.stream(f.getAbsoluteFile().listRoots())
+            .map(File::toString)
+            .collect(Collectors.toSet());
+        Set<String> actual = Arrays.stream(f.listRoots())
+            .map(File::toString)
+            .collect(Collectors.toSet());
+        assertEquals(expected, actual);
+    }
+
+    @Test
     public void mkdir() {
         assertFalse(f.mkdir());
+    }
+
+    @Test
+    public void mkdirs() {
+        File child = new File(f, "child");
+        assertFalse(child.mkdirs());
+    }
+
+    @Test
+    public void renameTo() throws IOException {
+        File tmp = File.createTempFile("foo", "bar", f.getAbsoluteFile());
+        assertTrue(tmp.exists());
+        assertFalse(f.renameTo(tmp));
     }
 
     @Test
@@ -293,6 +337,12 @@ public class EmptyPath {
     @Test
     public void toPath() {
         assertEquals(p, f.toPath());
+    }
+
+    @Test
+    public String toString() {
+        assertEquals(EMPTY_STRING, f.toString());
+        return EMPTY_STRING;
     }
 
     @Test

--- a/test/jdk/java/io/File/EmptyPath.java
+++ b/test/jdk/java/io/File/EmptyPath.java
@@ -109,7 +109,7 @@ public class EmptyPath {
 
     @Test
     public void getAbsoluteFile() {
-        assertEquals(p.toAbsolutePath(), f.getAbsoluteFile().toPath());
+        assertEquals(p.toAbsolutePath().toFile(), f.getAbsoluteFile());
     }
 
     @Test
@@ -226,8 +226,6 @@ public class EmptyPath {
         assertTrue(child.createNewFile());
         child.deleteOnExit();
 
-        assertTrue(Arrays.asList(f.list()).contains(child.getName()));
-
         File[] files = f.listFiles();
         for (File file : files)
             assertEquals(-1, f.toString().indexOf(File.separatorChar));
@@ -235,6 +233,9 @@ public class EmptyPath {
         Set<String> ioSet = Arrays.stream(files)
             .map(File::getName)
             .collect(Collectors.toSet());
+
+        assertTrue(ioSet.contains(child.getName()));
+
         Set<String> nioSet = Files.list(p)
             .map(Path::getFileName)
             .map(Path::toString)


### PR DESCRIPTION
Changes to address `File.listFiles` invoked on an empty path. This fixes an oversight in #22821.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8361587](https://bugs.openjdk.org/browse/JDK-8361587): AssertionError in File.listFiles() when path is empty and -esa is enabled (**Bug** - P2)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26224/head:pull/26224` \
`$ git checkout pull/26224`

Update a local copy of the PR: \
`$ git checkout pull/26224` \
`$ git pull https://git.openjdk.org/jdk.git pull/26224/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26224`

View PR using the GUI difftool: \
`$ git pr show -t 26224`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26224.diff">https://git.openjdk.org/jdk/pull/26224.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26224#issuecomment-3053562171)
</details>
