### PR TITLE
8361717: Refactor Collections.emptyList() in Locale related classes

### DIFF
--- a/src/java.base/share/classes/sun/util/locale/LanguageTag.java
+++ b/src/java.base/share/classes/sun/util/locale/LanguageTag.java
@@ -51,7 +51,7 @@ public record LanguageTag(String language, String script, String region, String 
     public static final String UNDETERMINED = "und";
     public static final String PRIVUSE_VARIANT_PREFIX = "lvariant";
     private static final String EMPTY_SUBTAG = "";
-    private static final List<String> EMPTY_SUBTAGS = Collections.emptyList();
+    private static final List<String> EMPTY_SUBTAGS = List.of();
 
     // Map contains legacy language tags and its preferred mappings from
     // http://www.ietf.org/rfc/rfc5646.txt

--- a/src/java.base/share/classes/sun/util/locale/provider/LocaleServiceProviderPool.java
+++ b/src/java.base/share/classes/sun/util/locale/provider/LocaleServiceProviderPool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,6 @@ package sun.util.locale.provider;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.IllformedLocaleException;
 import java.util.List;
@@ -388,8 +387,7 @@ public final class LocaleServiceProviderPool {
      * A dummy locale service provider list that indicates there is no
      * provider available
      */
-    private static final List<LocaleServiceProvider> NULL_LIST =
-        Collections.emptyList();
+    private static final List<LocaleServiceProvider> NULL_LIST = List.of();
 
     /**
      * An interface to get a localized object for each locale sensitive


### PR DESCRIPTION
Replaced Collections.emptyList() with List.of() as part of refactoring. This was discussed in the context of investigating a CDS-related issue (https://bugs.openjdk.org/browse/JDK-8357281?focusedId=14796714&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-14796714). Although the root cause was ultimately determined to be user error, modernizing the code by using List.of() is still a desirable improvement

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8361717](https://bugs.openjdk.org/browse/JDK-8361717): Refactor Collections.emptyList() in Locale related classes (**Bug** - P4)


### Reviewers
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)
 * [Justin Lu](https://openjdk.org/census#jlu) (@justin-curtis-lu - Committer)
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)
 * [Christian Stein](https://openjdk.org/census#cstein) (@sormuras - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26225/head:pull/26225` \
`$ git checkout pull/26225`

Update a local copy of the PR: \
`$ git checkout pull/26225` \
`$ git pull https://git.openjdk.org/jdk.git pull/26225/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26225`

View PR using the GUI difftool: \
`$ git pr show -t 26225`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26225.diff">https://git.openjdk.org/jdk/pull/26225.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26225#issuecomment-3053642959)
</details>
