### PR TITLE
8361615: CodeBuilder::parameterSlot throws undocumented IOOBE

### DIFF
--- a/src/java.base/share/classes/java/lang/classfile/CodeBuilder.java
+++ b/src/java.base/share/classes/java/lang/classfile/CodeBuilder.java
@@ -132,6 +132,7 @@ public sealed interface CodeBuilder
      * values require two slots.
      *
      * @param paramNo the index of the parameter
+     * @throws IndexOutOfBoundsException if the parameter index is out of bounds
      */
     int parameterSlot(int paramNo);
 

--- a/test/jdk/jdk/classfile/BuilderParamTest.java
+++ b/test/jdk/jdk/classfile/BuilderParamTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @bug 8361615
  * @summary Testing ClassFile builder parameters.
  * @run junit BuilderParamTest
  */
@@ -46,19 +47,26 @@ class BuilderParamTest {
         cc.build(ClassDesc.of("Foo"), cb -> {
             cb.withMethod("foo", MethodTypeDesc.ofDescriptor("(IJI)V"), 0,
                           mb -> mb.withCode(xb -> {
+                assertThrows(IndexOutOfBoundsException.class, () -> xb.parameterSlot(-1));
                 assertEquals(xb.receiverSlot(), 0);
                 assertEquals(xb.parameterSlot(0), 1);
                 assertEquals(xb.parameterSlot(1), 2);
                 assertEquals(xb.parameterSlot(2), 4);
+                assertThrows(IndexOutOfBoundsException.class, () -> xb.parameterSlot(3));
+                assertThrows(IndexOutOfBoundsException.class, () -> xb.parameterSlot(Integer.MAX_VALUE));
                 xb.return_();
             }));
         });
         cc.build(ClassDesc.of("Foo"), cb -> {
             cb.withMethod("foo", MethodTypeDesc.ofDescriptor("(IJI)V"), ACC_STATIC,
                           mb -> mb.withCode(xb -> {
+                              assertThrows(IndexOutOfBoundsException.class, () -> xb.parameterSlot(Integer.MIN_VALUE));
+                              assertThrows(IndexOutOfBoundsException.class, () -> xb.parameterSlot(-1));
+                              assertThrows(IllegalStateException.class, () -> xb.receiverSlot());
                               assertEquals(xb.parameterSlot(0), 0);
                               assertEquals(xb.parameterSlot(1), 1);
                               assertEquals(xb.parameterSlot(2), 3);
+                              assertThrows(IndexOutOfBoundsException.class, () -> xb.parameterSlot(3));
                               xb.return_();
                           }));
         });


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [c9bea773](https://github.com/openjdk/jdk/commit/c9bea77342672715f8f720d7311d66c2b3ac9f8a) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository. #26200

The commit being backported was authored by Chen Liang on 9 Jul 2025 and was reviewed by Adam Sotona. This is doc and test only, so eligible for RDP backports.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Change requires CSR request [JDK-8361617](https://bugs.openjdk.org/browse/JDK-8361617) to be approved
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8361615](https://bugs.openjdk.org/browse/JDK-8361615): CodeBuilder::parameterSlot throws undocumented IOOBE (**Bug** - P4)
 * [JDK-8361617](https://bugs.openjdk.org/browse/JDK-8361617): CodeBuilder::parameterSlot throws undocumented IOOBE (**CSR**)


### Reviewers
 * [Adam Sotona](https://openjdk.org/census#asotona) (@asotona - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26226/head:pull/26226` \
`$ git checkout pull/26226`

Update a local copy of the PR: \
`$ git checkout pull/26226` \
`$ git pull https://git.openjdk.org/jdk.git pull/26226/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26226`

View PR using the GUI difftool: \
`$ git pr show -t 26226`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26226.diff">https://git.openjdk.org/jdk/pull/26226.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26226#issuecomment-3053787246)
</details>
