### PR TITLE
8361529: GenShen: Fix bad assert in swap card tables

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.cpp
@@ -624,7 +624,7 @@ void ShenandoahDirectCardMarkRememberedSet::swap_card_tables() {
 
 #ifdef ASSERT
   CardValue* start_bp = &(_card_table->write_byte_map())[0];
-  CardValue* end_bp = &(new_ptr)[_card_table->last_valid_index()];
+  CardValue* end_bp = &(start_bp[_card_table->last_valid_index()]);
 
   while (start_bp <= end_bp) {
     assert(*start_bp == CardTable::clean_card_val(), "Should be clean: " PTR_FORMAT, p2i(start_bp));


### PR DESCRIPTION
Clean backport. Fixes bad pointer in assert.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8361529](https://bugs.openjdk.org/browse/JDK-8361529): GenShen: Fix bad assert in swap card tables (**Bug** - P3)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26228/head:pull/26228` \
`$ git checkout pull/26228`

Update a local copy of the PR: \
`$ git checkout pull/26228` \
`$ git pull https://git.openjdk.org/jdk.git pull/26228/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26228`

View PR using the GUI difftool: \
`$ git pr show -t 26228`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26228.diff">https://git.openjdk.org/jdk/pull/26228.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26228#issuecomment-3054055852)
</details>
