### PR TITLE
8313395: LotsUnloadTest.java fails with OOME transiently with libgraal

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/LotsUnloadTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/LotsUnloadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -65,7 +65,7 @@ public class LotsUnloadTest extends DynamicArchiveTestBase {
 
         dump(topArchiveName,
              logging,
-             "-Xmx64m", "-Xms32m",
+             "-Xmx256m", "-Xms32m",
              "-cp", appJar, mainClass)
           .assertNormalExit(output -> {
                 output.shouldHaveExitValue(0);
@@ -73,7 +73,7 @@ public class LotsUnloadTest extends DynamicArchiveTestBase {
 
         run(topArchiveName,
             logging,
-            "-Xmx64m", "-Xms32m",
+            "-Xmx256m", "-Xms32m",
             "-cp", appJar, mainClass)
           .assertNormalExit(output -> {
               output.shouldHaveExitValue(0);


### PR DESCRIPTION
It seems like when libgraal is used as the JIT, more heap space is allocated in the Java heap to support JIT compilation. This causes OOM in the test when the heap is very small.

The test allocates 1024 * 2 MB of heap objects but at any time keeps only 8 MB of them alive. The test expects class unloading would happen when the heap is filled with garbage. By increasing the heap size from 64MB to 256MB, we can still accomplish what the test wants to do but will be more friendly to libgraal.

The fact that libgraal uses more memory is still a concern, but that should be tested elsewhere, and is not the responsibility of this test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313395](https://bugs.openjdk.org/browse/JDK-8313395): LotsUnloadTest.java fails with OOME transiently with libgraal (**Bug** - P3)


### Reviewers
 * [Doug Simon](https://openjdk.org/census#dnsimon) (@dougxc - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26230/head:pull/26230` \
`$ git checkout pull/26230`

Update a local copy of the PR: \
`$ git checkout pull/26230` \
`$ git pull https://git.openjdk.org/jdk.git pull/26230/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26230`

View PR using the GUI difftool: \
`$ git pr show -t 26230`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26230.diff">https://git.openjdk.org/jdk/pull/26230.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26230#issuecomment-3054487058)
</details>
