### PR TITLE
8361754: New test runtime/jni/checked/TestCharArrayReleasing.java can cause disk full errors

### DIFF
--- a/test/hotspot/jtreg/runtime/jni/checked/TestCharArrayReleasing.java
+++ b/test/hotspot/jtreg/runtime/jni/checked/TestCharArrayReleasing.java
@@ -84,7 +84,7 @@ public class TestCharArrayReleasing {
     }
 
     public static void main(String[] args) throws Throwable {
-        int ABRT = Platform.isWindows() ? 1 : 134;
+        int ABRT = 1;
         int[][] errorCodes = new int[][] {
             { ABRT, 0, ABRT, ABRT, ABRT },
             { ABRT, ABRT, 0, ABRT, ABRT },
@@ -118,6 +118,7 @@ public class TestCharArrayReleasing {
         ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(
              "-Djava.library.path=" + System.getProperty("test.nativepath"),
              "--enable-native-access=ALL-UNNAMED",
+             "-XX:-CreateCoredumpOnCrash",
              "-Xcheck:jni",
              "TestCharArrayReleasing$Driver",
              args[0], args[1]);


### PR DESCRIPTION
Please review this trivial fix to the test, which needed to set `-XX:-CreateCoredumpsOnCrash`, after which the exit code is 1 on all platforms.

The test now runs a lot faster too.

Thanks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8361754](https://bugs.openjdk.org/browse/JDK-8361754): New test runtime/jni/checked/TestCharArrayReleasing.java can cause disk full errors (**Bug** - P2)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26235/head:pull/26235` \
`$ git checkout pull/26235`

Update a local copy of the PR: \
`$ git checkout pull/26235` \
`$ git pull https://git.openjdk.org/jdk.git pull/26235/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26235`

View PR using the GUI difftool: \
`$ git pr show -t 26235`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26235.diff">https://git.openjdk.org/jdk/pull/26235.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26235#issuecomment-3055563159)
</details>
