### PR TITLE
8361829: [TESTBUG] RISC-V: compiler/vectorization/runner/BasicIntOpTest.java fails with RVV but not Zvbb

### DIFF
--- a/test/hotspot/jtreg/compiler/vectorization/runner/BasicIntOpTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/BasicIntOpTest.java
@@ -141,7 +141,7 @@ public class BasicIntOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx2", "true", "rvv", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx2", "true", "zvbb", "true"},
         counts = {IRNode.POPCOUNT_VI, ">0"})
     public int[] vectorPopCount() {
         int[] res = new int[SIZE];


### PR DESCRIPTION
Hi all,
Please take a look and review this PR, thanks!

After [JDK-8355293](https://bugs.openjdk.org/browse/JDK-8355293) , compiler/vectorization/runner/BasicIntOpTest.java fails with RVV but not Zvbb.
The reason for the error is that `PopCountVI` on RISC-V requires `Zvbb`, not just `RVV`.

### Test
- [x] Run compiler/vectorization/runner/BasicIntOpTest.java on k1
- [x] Run compiler/vectorization/runner/BasicIntOpTest.java on qemu-system (enable RVV) w/ and w/o zvbb

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8361829](https://bugs.openjdk.org/browse/JDK-8361829): [TESTBUG] RISC-V: compiler/vectorization/runner/BasicIntOpTest.java fails with RVV but not Zvbb (**Bug** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Feilong Jiang](https://openjdk.org/census#fjiang) (@feilongjiang - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26238/head:pull/26238` \
`$ git checkout pull/26238`

Update a local copy of the PR: \
`$ git checkout pull/26238` \
`$ git pull https://git.openjdk.org/jdk.git pull/26238/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26238`

View PR using the GUI difftool: \
`$ git pr show -t 26238`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26238.diff">https://git.openjdk.org/jdk/pull/26238.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26238#issuecomment-3056333020)
</details>
