### PR TITLE
8361836: RISC-V: Relax min vector length to 32-bit for short vectors

### DIFF
--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -1994,6 +1994,9 @@ int Matcher::min_vector_size(const BasicType bt) {
   } else if (bt == T_BOOLEAN) {
     // To support vector api load/store mask.
     size = 2;
+    // To support vector type conversions between short and wider types.
+  } else if (bt == T_SHORT) {
+    size = 2;
   }
   if (size < 2) size = 2;
   return MIN2(size, max_size);

--- a/test/hotspot/jtreg/compiler/vectorapi/reshape/utils/TestCastMethods.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/reshape/utils/TestCastMethods.java
@@ -127,11 +127,17 @@ public class TestCastMethods {
         // from S 64
             // to X 64
             makePair(SSPEC64, BSPEC64),
+            makePair(SSPEC64, ISPEC64),
+            makePair(SSPEC64, ISPEC64, true),
+            makePair(SSPEC64, FSPEC64),
             // to X 128
             makePair(SSPEC64, BSPEC128),
             makePair(SSPEC64, ISPEC128),
             makePair(SSPEC64, ISPEC128, true),
+            makePair(SSPEC64, LSPEC128),
+            makePair(SSPEC64, LSPEC128, true),
             makePair(SSPEC64, FSPEC128),
+            makePair(SSPEC64, DSPEC128),
             // to X 256
             makePair(SSPEC64, BSPEC256),
             makePair(SSPEC64, ISPEC256),
@@ -156,7 +162,10 @@ public class TestCastMethods {
             makePair(SSPEC128, BSPEC128),
             makePair(SSPEC128, ISPEC128),
             makePair(SSPEC128, ISPEC128, true),
+            makePair(SSPEC128, LSPEC128),
+            makePair(SSPEC128, LSPEC128, true),
             makePair(SSPEC128, FSPEC128),
+            makePair(SSPEC128, DSPEC128),
             // to X 256
             makePair(SSPEC128, BSPEC256),
             makePair(SSPEC128, ISPEC256),
@@ -228,6 +237,7 @@ public class TestCastMethods {
         // ====== from I ======
         // from I 64
             // to X 64
+            makePair(ISPEC64, SSPEC64),
             makePair(ISPEC64, FSPEC64),
             // to X 128
             makePair(ISPEC64, LSPEC128),
@@ -299,10 +309,12 @@ public class TestCastMethods {
         // ====== from L ======
         // from L 128
             // to X 64
+            makePair(LSPEC128, SSPEC64),
             makePair(LSPEC128, ISPEC64),
             makePair(LSPEC128, FSPEC64),
             makePair(LSPEC128, DSPEC64),
             // to X 128
+            makePair(LSPEC128, SSPEC128),
             makePair(LSPEC128, ISPEC128),
             makePair(LSPEC128, FSPEC128),
             makePair(LSPEC128, DSPEC128),
@@ -369,6 +381,7 @@ public class TestCastMethods {
         // ====== from F ======
         // from F 64
             // to X 64
+            makePair(FSPEC64, SSPEC64),
             makePair(FSPEC64, ISPEC64),
             // to X 128
             makePair(FSPEC64, ISPEC128),
@@ -433,10 +446,12 @@ public class TestCastMethods {
         // ====== from D ======
         // from D 128
             // to X 64
+            makePair(DSPEC128, SSPEC64),
             makePair(DSPEC128, ISPEC64),
             makePair(DSPEC128, LSPEC64),
             makePair(DSPEC128, FSPEC64),
             // to X 128
+            makePair(DSPEC128, SSPEC128),
             makePair(DSPEC128, ISPEC128),
             makePair(DSPEC128, LSPEC128),
             makePair(DSPEC128, FSPEC128),


### PR DESCRIPTION
Follow up JDK-8359419, RVV supports all vector type conversion APIs in the Vector API.
So we only need to relax the length limit of the short type to achieve a significant improvement in JMH performance for converting between short and wider types.

### Test
qemu-system UseRVV:
* [x]  Run jdk_vector (fastdebug)
* [x]  Run compiler/vectorapi (fastdebug)

### Performance
Following shows the performance improvement of relative VectorAPI JMHs on k1 (256-bit RVV):

```
Benchmark                                             (SIZE)   Mode   Units   Before     After    Gain
VectorFPtoIntCastOperations.microDouble128ToShort128     512  thrpt  ops/ms   52.280   840.112   16.07
VectorFPtoIntCastOperations.microDouble128ToShort128    1024  thrpt  ops/ms   28.156   429.322   15.25
VectorFPtoIntCastOperations.microFloat64ToShort64        512  thrpt  ops/ms   14.242   479.509   33.67
VectorFPtoIntCastOperations.microFloat64ToShort64       1024  thrpt  ops/ms    6.906   242.690   35.14
```
PS: VectorFPtoIntCastOperations.microFloat64ToShort64 is added by JDK-8359419