### PR TITLE
8361844: Build without C1 or C2 fails after 8360707

### DIFF
--- a/src/hotspot/share/runtime/stubInfo.cpp
+++ b/src/hotspot/share/runtime/stubInfo.cpp
@@ -156,17 +156,33 @@ int StubInfo::span(EntryId second, EntryId first) {
 }
 
 int StubInfo::span(StubId second, StubId first) {
+  // normally when the two ids are equal the entry span is 1 but we
+  // have a special case when the base and max are both NO_STUBID in
+  // which case the entry count is 0. n.b. that only happens in the
+  // case where a stub group is empty e.g. when either C1 or C2 is
+  // omitted from the build
   int idx1 = static_cast<int>(first);
   int idx2 = static_cast<int>(second);
-  assert(idx2 >= 0 && idx2 >= idx1, "bad stub ids first %d and second %d", idx1, idx2);
+  assert((idx1 < 0 && idx2  < 0) || (idx1 >= 0 && idx2 >= idx1), "bad stub ids first %d and second %d", idx1, idx2);
+  if (idx1 < 0) {
+    return 0;
+  }
   // span is inclusive of first and second
   return idx2 + 1 - idx1;
 }
 
 int StubInfo::span(BlobId second, BlobId first) {
+  // normally when the two ids are equal the entry span is 1 but we
+  // have a special case when the base and max are both NO_BLOBID in
+  // which case the entry count is 0. n.b. that only happens in the
+  // case where a stub group is empty e.g. when either C1 or C2 is
+  // omitted from the build
   int idx1 = static_cast<int>(first);
   int idx2 = static_cast<int>(second);
-  assert(idx2 >= 0 && idx2 >= idx1, "bad blob ids first %d and second %d", idx1, idx2);
+  assert((idx1 < 0 && idx2  < 0) || (idx1 >= 0 && idx2 >= idx1), "bad blob ids first %d and second %d", idx1, idx2);
+  if (idx1 < 0) {
+    return 0;
+  }
   // span is inclusive of first and second
   return idx2 + 1 - idx1;
 }
@@ -905,13 +921,13 @@ int StubInfo::blob_count(StubGroup stub_group) {
 }
 
 StubId StubInfo::stub_base(StubGroup stub_group) {
-  // delegate
-  return stub_base(blob_base(stub_group));
+  BlobId base = blob_base(stub_group);
+  return (base == BlobId::NO_BLOBID ? StubId::NO_STUBID : stub_base(base));
 }
 
 StubId StubInfo::stub_max(StubGroup stub_group) {
-  // delegate
-  return stub_max(blob_max(stub_group));
+  BlobId base = blob_max(stub_group);
+  return (base == BlobId::NO_BLOBID ? StubId::NO_STUBID : stub_max(base));
 }
 
 int StubInfo::stub_count(StubGroup stub_group) {

--- a/src/hotspot/share/runtime/stubInfo.cpp
+++ b/src/hotspot/share/runtime/stubInfo.cpp
@@ -793,9 +793,16 @@ void StubInfo::dump_group_table(LogStream& ls) {
     GroupDetails& g = _group_table[i];
     ls.print_cr("%1d: %-8s", i, g._name);
     if (g._base == g._max) {
-      ls.print_cr("  blobs: %s(%d)",
-                  blob_details(g._base)._name,
-                  static_cast<int>(g._base));
+      // some groups don't have a blob
+      if (g._base == BlobId::NO_BLOBID) {
+        ls.print_cr("  blobs: %s(%d)",
+                    "no_blobs",
+                    static_cast<int>(g._base));
+      } else {
+        ls.print_cr("  blobs: %s(%d)",
+                    blob_details(g._base)._name,
+                    static_cast<int>(g._base));
+      }
     } else {
       ls.print_cr(" blobs: %s(%d) ... %s(%d)",
                   blob_details(g._base)._name,
@@ -812,9 +819,16 @@ void StubInfo::dump_blob_table(LogStream& ls) {
     BlobDetails& b = _blob_table[i];
     ls.print_cr("%-3d: %s", i, b._name);
     if (b._base == b._max) {
-      ls.print_cr("  stubs: %s(%d)",
-                  stub_details(b._base)._name,
-                  static_cast<int>(b._base));
+      // some blobs don't have a stub
+      if (b._base == StubId::NO_STUBID) {
+        ls.print_cr("  stubs: %s(%d)",
+                    "no_stubs",
+                    static_cast<int>(b._base));
+      } else {
+        ls.print_cr("  stubs: %s(%d)",
+                    stub_details(b._base)._name,
+                    static_cast<int>(b._base));
+      }
     } else {
       ls.print_cr("  stubs: %s(%d) ... %s(%d)",
                   stub_details(b._base)._name,


### PR DESCRIPTION
After [JDK-8360707](https://bugs.openjdk.org/browse/JDK-8360707) builds which omit C1 or C2 can generate an exploded jdk which fails on startup with an assert:

    assert(idx2 >= 0 && idx2 >= idx1) failed: bad blob ids first -1 and second -1

The problem is that the blob and stub id verification expects the blob, stub and entry ranges in the C1 and C2 stub groups to be positive. However, when C1 or C2 is omitted the associated range starts and ends are NO_BLOBID, NO_STUBID and NO_ENTRYID (all -1) and this breaks some of the internal consistency checks that test the span of blob, stub and entry ranges.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8361844](https://bugs.openjdk.org/browse/JDK-8361844): Build without C1 or C2 fails after 8360707 (**Bug** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26242/head:pull/26242` \
`$ git checkout pull/26242`

Update a local copy of the PR: \
`$ git checkout pull/26242` \
`$ git pull https://git.openjdk.org/jdk.git pull/26242/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26242`

View PR using the GUI difftool: \
`$ git pr show -t 26242`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26242.diff">https://git.openjdk.org/jdk/pull/26242.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26242#issuecomment-3057207451)
</details>
