### PR TITLE
8361869: Tests which call ThreadController should mark as /native

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/monitoring/stress/thread/strace010/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/monitoring/stress/thread/strace010/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,5 +47,5 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run main/othervm nsk.monitoring.stress.thread.strace010 -depth=100 -threadCount=30
+ * @run main/othervm/native nsk.monitoring.stress.thread.strace010 -depth=100 -threadCount=30
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/monitoring/stress/thread/strace011/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/monitoring/stress/thread/strace011/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,7 +44,7 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run main/othervm
+ * @run main/othervm/native
  *      nsk.monitoring.stress.thread.strace010
  *      -testMode=server
  *      -depth=100

--- a/test/hotspot/jtreg/vmTestbase/nsk/monitoring/stress/thread/strace012/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/monitoring/stress/thread/strace012/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,7 +44,7 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run main/othervm
+ * @run main/othervm/native
  *      nsk.monitoring.stress.thread.strace010
  *      -testMode=server
  *      -MBeanServer=custom

--- a/test/hotspot/jtreg/vmTestbase/nsk/monitoring/stress/thread/strace013/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/monitoring/stress/thread/strace013/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,7 +44,7 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run main/othervm
+ * @run main/othervm/native
  *      nsk.monitoring.stress.thread.strace010
  *      -depth=100
  *      -threadCount=30

--- a/test/hotspot/jtreg/vmTestbase/nsk/monitoring/stress/thread/strace014/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/monitoring/stress/thread/strace014/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,7 +44,7 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run main/othervm
+ * @run main/othervm/native
  *      nsk.monitoring.stress.thread.strace010
  *      -testMode=server
  *      -depth=100

--- a/test/hotspot/jtreg/vmTestbase/nsk/monitoring/stress/thread/strace015/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/monitoring/stress/thread/strace015/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,7 +44,7 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run main/othervm
+ * @run main/othervm/native
  *      nsk.monitoring.stress.thread.strace010
  *      -testMode=server
  *      -MBeanServer=custom

--- a/test/hotspot/jtreg/vmTestbase/nsk/monitoring/stress/thread/strace016/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/monitoring/stress/thread/strace016/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,7 +44,7 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run main/othervm
+ * @run main/othervm/native
  *      nsk.monitoring.stress.thread.strace010
  *      -depth=100
  *      -threadCount=30

--- a/test/hotspot/jtreg/vmTestbase/nsk/monitoring/stress/thread/strace017/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/monitoring/stress/thread/strace017/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,7 +44,7 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run main/othervm
+ * @run main/othervm/native
  *      nsk.monitoring.stress.thread.strace010
  *      -testMode=server
  *      -depth=100

--- a/test/hotspot/jtreg/vmTestbase/nsk/monitoring/stress/thread/strace018/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/monitoring/stress/thread/strace018/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,7 +44,7 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run main/othervm
+ * @run main/othervm/native
  *      nsk.monitoring.stress.thread.strace010
  *      -testMode=server
  *      -MBeanServer=custom


### PR DESCRIPTION
Hi all,

Several tests which call `ThreadController` native libary missing `/native` jtreg directive. This PR add `/native` directive will make test more friendly. The analysis process of how to find which tests missing show as [JDK-8361869](https://bugs.openjdk.org/browse/JDK-8361869)
Test-fix only, change has been verified locally, no risk.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8361869](https://bugs.openjdk.org/browse/JDK-8361869): Tests which call ThreadController should mark as /native (**Bug** - P4)


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26244/head:pull/26244` \
`$ git checkout pull/26244`

Update a local copy of the PR: \
`$ git checkout pull/26244` \
`$ git pull https://git.openjdk.org/jdk.git pull/26244/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26244`

View PR using the GUI difftool: \
`$ git pr show -t 26244`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26244.diff">https://git.openjdk.org/jdk/pull/26244.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26244#issuecomment-3057637547)
</details>
