### PR TITLE
8361890: Aarch64: Removal of redundant dmb from C1 AtomicLong methods

### DIFF
--- a/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
@@ -3133,7 +3133,9 @@ void LIR_Assembler::atomic_op(LIR_Code code, LIR_Opr src, LIR_Opr data, LIR_Opr 
   default:
     ShouldNotReachHere();
   }
-  __ membar(__ AnyAny);
+  if(!UseLSE) {
+    __ membar(__ AnyAny);
+  }
 }
 
 #undef __


### PR DESCRIPTION
The current C1 implementation of AtomicLong methods
which either adds or exchanges (such as getAndAdd)
emit one of a ldaddal and swpal respectively when using
LSE as well as an immediately proceeding dmb. Since
ldaddal/swpal have both acquire and release semantics,
this provides similar ordering guarantees to a dmb.full
so the dmb here is redundant and can be removed.

This is due to both clause 7 and clause 11 of the
definition of Barrier-ordered-before in B2.3.7 of the
DDI0487 L.a Arm Architecture Reference Manual for A-profile
architecture being satisfied by the existence of a
ldaddal/swpal which ensures such memory ordering guarantees.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8361890](https://bugs.openjdk.org/browse/JDK-8361890): Aarch64: Removal of redundant dmb from C1 AtomicLong methods (**Enhancement** - P4) ⚠️ Issue is not open.


### Reviewers
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26245/head:pull/26245` \
`$ git checkout pull/26245`

Update a local copy of the PR: \
`$ git checkout pull/26245` \
`$ git pull https://git.openjdk.org/jdk.git pull/26245/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26245`

View PR using the GUI difftool: \
`$ git pr show -t 26245`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26245.diff">https://git.openjdk.org/jdk/pull/26245.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26245#issuecomment-3058049911)
</details>
