### PR TITLE
8360979: Remove use of Thread.stop in krb5/auto/KDC.java

### DIFF
--- a/test/jdk/sun/security/krb5/auto/KDC.java
+++ b/test/jdk/sun/security/krb5/auto/KDC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1646,9 +1646,9 @@ public class KDC {
             System.out.println("Done");
         } else {
             try {
-                thread1.stop();
-                thread2.stop();
-                thread3.stop();
+                thread1.interrupt();
+                thread2.interrupt();
+                thread3.interrupt();
                 u1.close();
                 t1.close();
             } catch (Exception e) {

--- a/test/jdk/sun/security/krb5/auto/KDC.java
+++ b/test/jdk/sun/security/krb5/auto/KDC.java
@@ -1547,65 +1547,65 @@ public class KDC {
         this.port = port;
 
         // The UDP consumer
-        thread1 = new Thread() {
-            public void run() {
-                udpConsumerReady = true;
-                while (true) {
-                    try {
-                        byte[] inbuf = new byte[8192];
-                        DatagramPacket p = new DatagramPacket(inbuf, inbuf.length);
-                        udp.receive(p);
-                        System.out.println("-----------------------------------------------");
-                        System.out.println(">>>>> UDP packet received");
-                        q.put(new Job(processMessage(Arrays.copyOf(inbuf, p.getLength())), udp, p));
-                    } catch (Exception e) {
-                        e.printStackTrace();
-                    }
+        thread1 = new Thread(() -> {
+            udpConsumerReady = true;
+            while (true) {
+                try {
+                    byte[] inbuf = new byte[8192];
+                    DatagramPacket p = new DatagramPacket(inbuf, inbuf.length);
+                    udp.receive(p);
+                    System.out.println("-----------------------------------------------");
+                    System.out.println(">>>>> UDP packet received");
+                    q.put(new Job(processMessage(Arrays.copyOf(inbuf, p.getLength())), udp, p));
+                } catch (InterruptedException e){
+                    break; // Thread was stopped, so stopping the loop
+                } catch (Exception e) {
+                    e.printStackTrace();
                 }
             }
-        };
+        });
         thread1.setDaemon(asDaemon);
         thread1.start();
 
         // The TCP consumer
-        thread2 = new Thread() {
-            public void run() {
-                tcpConsumerReady = true;
-                while (true) {
-                    try {
-                        Socket socket = tcp.accept();
-                        System.out.println("-----------------------------------------------");
-                        System.out.println(">>>>> TCP connection established");
-                        DataInputStream in = new DataInputStream(socket.getInputStream());
-                        DataOutputStream out = new DataOutputStream(socket.getOutputStream());
-                        int len = in.readInt();
-                        if (len > 65535) {
-                            throw new Exception("Huge request not supported");
-                        }
-                        byte[] token = new byte[len];
-                        in.readFully(token);
-                        q.put(new Job(processMessage(token), socket, out));
-                    } catch (Exception e) {
-                        e.printStackTrace();
+        thread2 = new Thread(() -> {
+            tcpConsumerReady = true;
+            while (true) {
+                try {
+                    Socket socket = tcp.accept();
+                    System.out.println("-----------------------------------------------");
+                    System.out.println(">>>>> TCP connection established");
+                    DataInputStream in = new DataInputStream(socket.getInputStream());
+                    DataOutputStream out = new DataOutputStream(socket.getOutputStream());
+                    int len = in.readInt();
+                    if (len > 65535) {
+                        throw new Exception("Huge request not supported");
                     }
+                    byte[] token = new byte[len];
+                    in.readFully(token);
+                    q.put(new Job(processMessage(token), socket, out));
+                } catch (InterruptedException e){
+                    break; // Thread was stopped, so stopping the loop
+                } catch (Exception e) {
+                    e.printStackTrace();
                 }
             }
-        };
+        });
         thread2.setDaemon(asDaemon);
         thread2.start();
 
         // The dispatcher
-        thread3 = new Thread() {
-            public void run() {
-                dispatcherReady = true;
-                while (true) {
-                    try {
-                        q.take().send();
-                    } catch (Exception e) {
-                    }
+        thread3 = new Thread(() -> {
+            dispatcherReady = true;
+            while (true) {
+                try {
+                    q.take().send();
+                } catch (InterruptedException e){
+                    break; // Thread was stopped, so stopping the loop
+                } catch (Exception e) {
                 }
             }
-        };
+        });
         thread3.setDaemon(true);
         thread3.start();
 


### PR DESCRIPTION
Replaced Thread::stop to Thread::interrupt

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8360979](https://bugs.openjdk.org/browse/JDK-8360979): Remove use of Thread.stop in krb5/auto/KDC.java (**Bug** - P4)


### Reviewers
 * [Weijun Wang](https://openjdk.org/census#weijun) (@wangweij - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26247/head:pull/26247` \
`$ git checkout pull/26247`

Update a local copy of the PR: \
`$ git checkout pull/26247` \
`$ git pull https://git.openjdk.org/jdk.git pull/26247/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26247`

View PR using the GUI difftool: \
`$ git pr show -t 26247`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26247.diff">https://git.openjdk.org/jdk/pull/26247.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26247#issuecomment-3058079893)
</details>
