### PR TITLE
8358183: [JVMCI] crash accessing nmethod::jvmci_name in CodeCache::aggregate

### DIFF
--- a/src/hotspot/share/code/codeBlob.cpp
+++ b/src/hotspot/share/code/codeBlob.cpp
@@ -210,6 +210,8 @@ void CodeBlob::purge() {
   if (_mutable_data != blob_end()) {
     os::free(_mutable_data);
     _mutable_data = blob_end(); // Valid not null address
+    _mutable_data_size = 0;
+    _relocation_size = 0;
   }
   if (_oop_maps != nullptr) {
     delete _oop_maps;

--- a/src/hotspot/share/code/nmethod.cpp
+++ b/src/hotspot/share/code/nmethod.cpp
@@ -2166,6 +2166,7 @@ void nmethod::purge(bool unregister_nmethod) {
   }
   CodeCache::unregister_old_nmethod(this);
 
+  JVMCI_ONLY( _metadata_size = 0; )
   CodeBlob::purge();
 }
 


### PR DESCRIPTION
This is the backport of the JVMCI metadata crash fix.

Issue:
When flushing nmethods via CodeBlob::purge(), the JVMCI metadata was freed (mutable_data) but its size fields remained non-zero. As a result, invoking heap analytics via jcmd Compiler.CodeHeap_Analytics still walks the purged metadata and calls jvmci_name() on arbitrary memory, leading to intermittent crashes

Fix:
Extend CodeBlob::purge() to zero out the _mutable_data_size, _relocation_size, and _metadata_size fields so that after a purge jvmci_data_size() returns 0 and CompileBroker::print_heapinfo() skips any JVMCI metadata

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8358183](https://bugs.openjdk.org/browse/JDK-8358183): [JVMCI] crash accessing nmethod::jvmci_name in CodeCache::aggregate (**Bug** - P3)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26248/head:pull/26248` \
`$ git checkout pull/26248`

Update a local copy of the PR: \
`$ git checkout pull/26248` \
`$ git pull https://git.openjdk.org/jdk.git pull/26248/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26248`

View PR using the GUI difftool: \
`$ git pr show -t 26248`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26248.diff">https://git.openjdk.org/jdk/pull/26248.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26248#issuecomment-3058371900)
</details>
