### PR TITLE
8361892: AArch64: Incorrect matching rule leading to improper oop instruction encoding

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -3450,10 +3450,6 @@ encode %{
     __ mov(dst_reg, (uint64_t)1);
   %}
 
-  enc_class aarch64_enc_mov_byte_map_base(iRegP dst, immByteMapBase src) %{
-    __ load_byte_map_base($dst$$Register);
-  %}
-
   enc_class aarch64_enc_mov_n(iRegN dst, immN src) %{
     Register dst_reg = as_Register($dst$$reg);
     address con = (address)$src$$constant;
@@ -4547,21 +4543,6 @@ operand immP0()
 operand immP_1()
 %{
   predicate(n->get_ptr() == 1);
-  match(ConP);
-
-  op_cost(0);
-  format %{ %}
-  interface(CONST_INTER);
-%}
-
-// Card Table Byte Map Base
-operand immByteMapBase()
-%{
-  // Get base of card map
-  predicate(BarrierSet::barrier_set()->is_a(BarrierSet::CardTableBarrierSet) &&
-            SHENANDOAHGC_ONLY(!BarrierSet::barrier_set()->is_a(BarrierSet::ShenandoahBarrierSet) &&)
-            n->get_ptr_type()->isa_rawptr() != NULL &&
-            (CardTable::CardValue*)n->get_ptr() == ((CardTableBarrierSet*)(BarrierSet::barrier_set()))->card_table()->byte_map_base());
   match(ConP);
 
   op_cost(0);
@@ -6851,20 +6832,6 @@ instruct loadConP1(iRegPNoSp dst, immP_1 con)
   format %{ "mov  $dst, $con\t# nullptr ptr" %}
 
   ins_encode(aarch64_enc_mov_p1(dst, con));
-
-  ins_pipe(ialu_imm);
-%}
-
-// Load Byte Map Base Constant
-
-instruct loadByteMapBase(iRegPNoSp dst, immByteMapBase con)
-%{
-  match(Set dst con);
-
-  ins_cost(INSN_COST);
-  format %{ "adr  $dst, $con\t# Byte Map Base" %}
-
-  ins_encode(aarch64_enc_mov_byte_map_base(dst, con));
 
   ins_pipe(ialu_imm);
 %}

--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -4560,6 +4560,7 @@ operand immByteMapBase()
   // Get base of card map
   predicate(BarrierSet::barrier_set()->is_a(BarrierSet::CardTableBarrierSet) &&
             SHENANDOAHGC_ONLY(!BarrierSet::barrier_set()->is_a(BarrierSet::ShenandoahBarrierSet) &&)
+            n->get_ptr_type()->isa_rawptr() != NULL &&
             (CardTable::CardValue*)n->get_ptr() == ((CardTableBarrierSet*)(BarrierSet::barrier_set()))->card_table()->byte_map_base());
   match(ConP);
 


### PR DESCRIPTION
The bug is that the predicate rule of immByteMapBase would cause a ConP Node for oop incorrect matching with byte_map_base when the placeholder jni handle address was just allocated to the address of byte_map_base.

C2 uses JNI handles as placeholders to encoding constant oops, and one of some handle maybe locate at the address of byte_map_base, which is not memory reserved by CardTable. It's possible because JNIHandleBlocks are allocated by malloc.

  // The assembler store_check code will do an unsigned shift of the oop,
  // then add it to _byte_map_base, i.e.
  //
  //   _byte_map = _byte_map_base + (uintptr_t(low_bound) >> card_shift)
  _byte_map = (CardValue*) rs.base();
  _byte_map_base = _byte_map - (uintptr_t(low_bound) >> _card_shift);

In aarch64 port, C2 will incorrectly match ConP for oop to ConP for byte_map_base by the immByteMapBase operand.

// Card Table Byte Map Base
operand immByteMapBase()
%{
  // Get base of card map
  predicate((jbyte*)n->get_ptr() ==
        ((CardTableModRefBS*)(Universe::heap()->barrier_set()))->byte_map_base);
  match(ConP);

  op_cost(0);
  format %{ %}
  interface(CONST_INTER);
%}

// Load Byte Map Base Constant
instruct loadByteMapBase(iRegPNoSp dst, immByteMapBase con)
%{
  match(Set dst con);

  ins_cost(INSN_COST);
  format %{ "adr  $dst, $con\t# Byte Map Base" %}

  ins_encode(aarch64_enc_mov_byte_map_base(dst, con));

  ins_pipe(ialu_imm);
%}

As below, a typical incorrect instructions generated by C2 for java.lang.ref.Finalizer.register(Ljava/lang/Object;)V (10 bytes) @ 0x0000ffff25caf0bc [0x0000ffff25caee80+0x23c], where 0xffff21730000 is the byte_map_base address mistakenly used as an object address:
   0xffff25caf08c:	ldaxr	x8, [x11]
   0xffff25caf090:	cmp	x10, x8
   0xffff25caf094:	b.ne	0xffff25caf0a0  // b.any
   0xffff25caf098:	stlxr	w8, x28, [x11]
   0xffff25caf09c:	cbnz	w8, 0xffff25caf08c
   0xffff25caf0a0:	orr	x11, xzr, #0x3
   0xffff25caf0a4:	str	x11, [x13]
   0xffff25caf0a8:	b.eq	0xffff25caef80  // b.none
   0xffff25caf0ac:	str	x14, [sp]
   0xffff25caf0b0:	add	x2, sp, #0x20
   0xffff25caf0b4:	adrp	x1, 0xffff21730000
   0xffff25caf0b8:	bl	0xffff256fffc0
   0xffff25caf0bc:	ldr	x14, [sp]
   0xffff25caf0c0:	b	0xffff25caef80
   0xffff25caf0c4:	add	x13, sp, #0x20
   0xffff25caf0c8:	adrp	x12, 0xffff21730000
   0xffff25caf0cc:	ldr	x10, [x13]
   0xffff25caf0d0:	cmp	x10, xzr
   0xffff25caf0d4:	b.eq	0xffff25caf130  // b.none
   0xffff25caf0d8:	ldr	x11, [x12]
   0xffff25caf0dc:	tbnz	w10, #1, 0xffff25caf0f8
   0xffff25caf0e0:	ldxr	x11, [x12]
   0xffff25caf0e4:	cmp	x13, x11
   0xffff25caf0e8:	b.ne	0xffff25caf130  // b.any
   0xffff25caf0ec:	stlxr	w11, x10, [x12]
   0xffff25caf0f0:	cbz	w11, 0xffff25caf130
   0xffff25caf0f4:	b	0xffff25caf0e0

Details see https://mail.openjdk.org/pipermail/aarch64-port-dev/2025-July/016021.html.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8361892](https://bugs.openjdk.org/browse/JDK-8361892): AArch64: Incorrect matching rule leading to improper oop instruction encoding (**Bug** - P3)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Andrew Dinn](https://openjdk.org/census#adinn) (@adinn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26249/head:pull/26249` \
`$ git checkout pull/26249`

Update a local copy of the PR: \
`$ git checkout pull/26249` \
`$ git pull https://git.openjdk.org/jdk.git pull/26249/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26249`

View PR using the GUI difftool: \
`$ git pr show -t 26249`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26249.diff">https://git.openjdk.org/jdk/pull/26249.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26249#issuecomment-3058508902)
</details>
