### PR TITLE
8361328: cds/appcds/dynamicArchive/TestAutoCreateSharedArchive.java archive timestamps comparison failed

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/TestAutoCreateSharedArchive.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/TestAutoCreateSharedArchive.java
@@ -556,10 +556,10 @@ public class TestAutoCreateSharedArchive extends DynamicArchiveTestBase {
                        .shouldContain(HELLO_WORLD)
                        .shouldContain("Dumping shared data to file:");
              });
-        ft2 = Files.getLastModifiedTime(Paths.get(versionB));
+        ft2 = Files.getLastModifiedTime(Paths.get(versionF));
         fileModified = !ft1.equals(ft2);
         if (!fileModified) {
-            throw new RuntimeException("Shared archive " + versionB + " should be created at exit");
+            throw new RuntimeException("Shared archive " + versionF + " should be created at exit");
         }
 
         // 22 create an archive with dynamic magic number only


### PR DESCRIPTION
This test failure is intermittent and only seen with Windows non-debug build in 21u testing. It is due to the test is comparing the timestamp of a CDS archive with the timestamp of an archive which was generated in a previous test scenario.

Fixing it in mainline and then backport to 25 and 21u.

Testing: tested on Windows non-debug build with JDK 21u.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8361328](https://bugs.openjdk.org/browse/JDK-8361328): cds/appcds/dynamicArchive/TestAutoCreateSharedArchive.java archive timestamps comparison failed (**Bug** - P4)


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)
 * [Matias Saavedra Silva](https://openjdk.org/census#matsaave) (@matias9927 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26250/head:pull/26250` \
`$ git checkout pull/26250`

Update a local copy of the PR: \
`$ git checkout pull/26250` \
`$ git pull https://git.openjdk.org/jdk.git pull/26250/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26250`

View PR using the GUI difftool: \
`$ git pr show -t 26250`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26250.diff">https://git.openjdk.org/jdk/pull/26250.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26250#issuecomment-3058869354)
</details>
