### PR TITLE
8361209: (bf) Use CharSequence::getChars for StringCharBuffer bulk get methods

### DIFF
--- a/src/java.base/share/classes/java/nio/StringCharBuffer.java
+++ b/src/java.base/share/classes/java/nio/StringCharBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -97,7 +97,33 @@ final class StringCharBuffer                                  // package-private
         return str.charAt(index + offset);
     }
 
-    // ## Override bulk get methods for better performance
+    // Override bulk get methods for better performance
+
+    @Override
+    public CharBuffer get(int index, char[] dst, int offset, int length) {
+        Objects.checkFromIndexSize(index, length, limit());
+        Objects.checkFromIndexSize(offset, length, dst.length);
+        str.getChars(index, index + length, dst, offset);
+        return this;
+    }
+
+    @Override
+    public CharBuffer get(char[] dst, int offset, int length) {
+        int pos = position();
+        get(pos, dst, offset, length);
+        position(pos + length);
+        return this;
+    }
+
+    @Override
+    public void getChars(int srcBegin, int srcEnd, char[] dst, int dstBegin) {
+        // Check [srcBegin,srcEnd) is a subset of [0, limit() - position())
+        int pos = position();
+        int lim = limit();
+        Objects.checkFromToIndex(srcBegin, srcEnd, lim - pos);
+
+        get(pos + srcBegin, dst, dstBegin, srcEnd - srcBegin);
+    }
 
     public final CharBuffer put(char c) {
         throw new ReadOnlyBufferException();

--- a/test/micro/org/openjdk/bench/java/nio/StringCharBufferBulkGet.java
+++ b/test/micro/org/openjdk/bench/java/nio/StringCharBufferBulkGet.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.java.nio;
+
+import java.nio.CharBuffer;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+/**
+ * Benchmark for bulk get methods of a {@code CharBuffer} created from a
+ * {@code CharSequence}.
+ */
+
+@Warmup(iterations = 5, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+@Fork(1)
+public class StringCharBufferBulkGet {
+    private static final int LENGTH = 16384;
+
+    char[] buf = new char[LENGTH];
+    CharBuffer cb = CharBuffer.wrap(new String(buf));
+    char[] dst = new char[LENGTH];
+
+    @Benchmark
+    public void absoluteBulkGet() {
+        cb.get(0, dst, 0, dst.length);
+    }
+
+    @Benchmark
+    public void relativeBulkGet() {
+        cb.get(dst, 0, dst.length);
+        cb.position(0);
+    }
+
+    @Benchmark
+    public void getChars() {
+        cb.getChars(0, LENGTH, dst, 0);
+    }
+}


### PR DESCRIPTION
For `CharBuffer`s created from a `CharSequence`, use `CharSequence.getChars` to perform bulk gets instead of successively copying single characters.