### PR TITLE
8356807: Change log_info(cds) to `MetaspaceShared::report_loading_error()`

### DIFF
--- a/src/hotspot/share/cds/filemap.cpp
+++ b/src/hotspot/share/cds/filemap.cpp
@@ -2019,7 +2019,8 @@ bool FileMapHeader::validate() {
   if (prop != nullptr) {
     if (has_aot_linked_classes()) {
       MetaspaceShared::report_loading_error("%s has aot-linked classes. It cannot be used when the "
-                     "java.system.class.loader property is specified.", CDSConfig::type_of_archive_being_loaded());
+                                            "java.system.class.loader property is specified.",
+                                            CDSConfig::type_of_archive_being_loaded());
       return false;
     }
     aot_log_warning(aot)("Archived non-system classes are disabled because the "

--- a/src/hotspot/share/cds/filemap.cpp
+++ b/src/hotspot/share/cds/filemap.cpp
@@ -409,7 +409,7 @@ public:
     assert(_archive_name != nullptr, "Archive name is null");
     _fd = os::open(_archive_name, O_RDONLY | O_BINARY, 0);
     if (_fd < 0) {
-      aot_log_info(aot)("Specified %s not found (%s)", CDSConfig::type_of_archive_being_loaded(), _archive_name);
+      MetaspaceShared::report_loading_error("Specified %s not found (%s)", CDSConfig::type_of_archive_being_loaded(), _archive_name);
       return false;
     }
     return initialize(_fd);
@@ -1218,8 +1218,8 @@ MapArchiveResult FileMapInfo::map_region(int i, intx addr_delta, char* mapped_ba
     // can't mmap into a ReservedSpace, so we just ::read() the data. We're going to patch all the
     // regions anyway, so there's no benefit for mmap anyway.
     if (!read_region(i, requested_addr, size, /* do_commit = */ true)) {
-      aot_log_info(aot)("Failed to read %s shared space into reserved space at " INTPTR_FORMAT,
-                    shared_region_name[i], p2i(requested_addr));
+      MetaspaceShared::report_loading_error("Failed to read %s shared space into reserved space at " INTPTR_FORMAT,
+                                            shared_region_name[i], p2i(requested_addr));
       return MAP_ARCHIVE_OTHER_FAILURE; // oom or I/O error.
     } else {
       assert(r->mapped_base() != nullptr, "must be initialized");
@@ -1232,8 +1232,8 @@ MapArchiveResult FileMapInfo::map_region(int i, intx addr_delta, char* mapped_ba
                             requested_addr, size, r->read_only(),
                             r->allow_exec(), mtClassShared);
     if (base != requested_addr) {
-      aot_log_info(aot)("Unable to map %s shared space at " INTPTR_FORMAT,
-                    shared_region_name[i], p2i(requested_addr));
+      MetaspaceShared::report_loading_error("Unable to map %s shared space at " INTPTR_FORMAT,
+                                            shared_region_name[i], p2i(requested_addr));
       _memory_mapping_failed = true;
       return MAP_ARCHIVE_MMAP_FAILURE;
     }
@@ -1298,8 +1298,8 @@ bool FileMapInfo::map_aot_code_region(ReservedSpace rs) {
   char* mapped_base;
   if (MetaspaceShared::use_windows_memory_mapping()) {
     if (!read_region(MetaspaceShared::ac, requested_base, r->used_aligned(), /* do_commit = */ true)) {
-      aot_log_info(aot)("Failed to read aot code shared space into reserved space at " INTPTR_FORMAT,
-                    p2i(requested_base));
+      MetaspaceShared::report_loading_error("Failed to read aot code shared space into reserved space at " INTPTR_FORMAT,
+                                            p2i(requested_base));
       return false;
     }
     mapped_base = requested_base;
@@ -1311,7 +1311,7 @@ bool FileMapInfo::map_aot_code_region(ReservedSpace rs) {
                              requested_base, r->used_aligned(), read_only, allow_exec, mtClassShared);
   }
   if (mapped_base == nullptr) {
-    aot_log_info(aot)("failed to map aot code region");
+    MetaspaceShared::report_loading_error("failed to map aot code region");
     return false;
   } else {
     assert(mapped_base == requested_base, "must be");
@@ -1687,9 +1687,9 @@ bool FileMapInfo::map_heap_region_impl() {
                       r->allow_exec(), mtJavaHeap);
     if (base == nullptr || base != addr) {
       dealloc_heap_region();
-      aot_log_info(aot)("UseSharedSpaces: Unable to map at required address in java heap. "
-                    INTPTR_FORMAT ", size = %zu bytes",
-                    p2i(addr), _mapped_heap_memregion.byte_size());
+      MetaspaceShared::report_loading_error("UseSharedSpaces: Unable to map at required address in java heap. "
+                                            INTPTR_FORMAT ", size = %zu bytes",
+                                            p2i(addr), _mapped_heap_memregion.byte_size());
       return false;
     }
 
@@ -1925,16 +1925,16 @@ int FileMapHeader::compute_crc() {
 bool FileMapHeader::validate() {
   const char* file_type = CDSConfig::type_of_archive_being_loaded();
   if (_obj_alignment != ObjectAlignmentInBytes) {
-    aot_log_info(aot)("The %s's ObjectAlignmentInBytes of %d"
-                  " does not equal the current ObjectAlignmentInBytes of %d.",
-                  file_type, _obj_alignment, ObjectAlignmentInBytes);
+    MetaspaceShared::report_loading_error("The %s's ObjectAlignmentInBytes of %d"
+                                          " does not equal the current ObjectAlignmentInBytes of %d.",
+                                          file_type, _obj_alignment, ObjectAlignmentInBytes);
     return false;
   }
   if (_compact_strings != CompactStrings) {
-    aot_log_info(aot)("The %s's CompactStrings setting (%s)"
-                  " does not equal the current CompactStrings setting (%s).", file_type,
-                  _compact_strings ? "enabled" : "disabled",
-                  CompactStrings   ? "enabled" : "disabled");
+    MetaspaceShared::report_loading_error("The %s's CompactStrings setting (%s)"
+                                          " does not equal the current CompactStrings setting (%s).", file_type,
+                                          _compact_strings ? "enabled" : "disabled",
+                                          CompactStrings   ? "enabled" : "disabled");
     return false;
   }
   bool jvmci_compiler_is_enabled = CompilerConfig::is_jvmci_compiler_enabled();
@@ -2018,7 +2018,7 @@ bool FileMapHeader::validate() {
   const char* prop = Arguments::get_property("java.system.class.loader");
   if (prop != nullptr) {
     if (has_aot_linked_classes()) {
-      aot_log_error(aot)("%s has aot-linked classes. It cannot be used when the "
+      MetaspaceShared::report_loading_error("%s has aot-linked classes. It cannot be used when the "
                      "java.system.class.loader property is specified.", CDSConfig::type_of_archive_being_loaded());
       return false;
     }
@@ -2031,10 +2031,10 @@ bool FileMapHeader::validate() {
 
   if (!_verify_local && BytecodeVerificationLocal) {
     //  we cannot load boot classes, so there's no point of using the CDS archive
-    aot_log_info(aot)("The %s's BytecodeVerificationLocal setting (%s)"
-                               " does not equal the current BytecodeVerificationLocal setting (%s).", file_type,
-                               _verify_local ? "enabled" : "disabled",
-                               BytecodeVerificationLocal ? "enabled" : "disabled");
+    MetaspaceShared::report_loading_error("The %s's BytecodeVerificationLocal setting (%s)"
+                                          " does not equal the current BytecodeVerificationLocal setting (%s).", file_type,
+                                          _verify_local ? "enabled" : "disabled",
+                                          BytecodeVerificationLocal ? "enabled" : "disabled");
     return false;
   }
 
@@ -2055,8 +2055,8 @@ bool FileMapHeader::validate() {
   // Note: _allow_archiving_with_java_agent is set in the shared archive during dump time
   // while AllowArchivingWithJavaAgent is set during the current run.
   if (_allow_archiving_with_java_agent && !AllowArchivingWithJavaAgent) {
-    aot_log_warning(aot)("The setting of the AllowArchivingWithJavaAgent is different "
-                               "from the setting in the %s.", file_type);
+    MetaspaceShared::report_loading_error("The setting of the AllowArchivingWithJavaAgent is different "
+                                          "from the setting in the %s.", file_type);
     return false;
   }
 

--- a/src/hotspot/share/cds/metaspaceShared.cpp
+++ b/src/hotspot/share/cds/metaspaceShared.cpp
@@ -1428,7 +1428,7 @@ FileMapInfo* MetaspaceShared::open_dynamic_archive() {
 MapArchiveResult MetaspaceShared::map_archives(FileMapInfo* static_mapinfo, FileMapInfo* dynamic_mapinfo,
                                                bool use_requested_addr) {
   if (use_requested_addr && static_mapinfo->requested_base_address() == nullptr) {
-    aot_log_info(aot)("Archive(s) were created with -XX:SharedBaseAddress=0. Always map at os-selected address.");
+    report_loading_error("Archive(s) were created with -XX:SharedBaseAddress=0. Always map at os-selected address.");
     return MAP_ARCHIVE_MMAP_FAILURE;
   }
 
@@ -1436,12 +1436,12 @@ MapArchiveResult MetaspaceShared::map_archives(FileMapInfo* static_mapinfo, File
       // For product build only -- this is for benchmarking the cost of doing relocation.
       // For debug builds, the check is done below, after reserving the space, for better test coverage
       // (see comment below).
-      aot_log_info(aot)("ArchiveRelocationMode == 1: always map archive(s) at an alternative address");
+      report_loading_error("ArchiveRelocationMode == 1: always map archive(s) at an alternative address");
       return MAP_ARCHIVE_MMAP_FAILURE;
     });
 
   if (ArchiveRelocationMode == 2 && !use_requested_addr) {
-    aot_log_info(aot)("ArchiveRelocationMode == 2: never map archive(s) at an alternative address");
+    report_loading_error("ArchiveRelocationMode == 2: never map archive(s) at an alternative address");
     return MAP_ARCHIVE_MMAP_FAILURE;
   };
 

--- a/test/hotspot/jtreg/runtime/cds/ServiceLoaderTest.java
+++ b/test/hotspot/jtreg/runtime/cds/ServiceLoaderTest.java
@@ -49,9 +49,10 @@ public class ServiceLoaderTest {
         CDSTestUtils.createArchiveAndCheck(opts);
 
         // Some mach5 tiers run with -vmoptions:-Xlog:cds=debug. This would cause the outputs to mismatch.
-        // Force the log level to warning for all tags to supressed the CDS logs. Also disable the timestamp.
+        // Force the log level to warning for all tags to suppress the CDS logs. Also disable the timestamp.
+        // Disable CDS error by turing off CDS logging.
         opts.setUseVersion(false);
-        opts.addSuffix("-showversion", "-Xlog:all=warning::level,tags", "ServiceLoaderApp");
+        opts.addSuffix("-showversion", "-Xlog:all=warning::level,tags", "-Xlog:cds=off", "ServiceLoaderApp");
         OutputAnalyzer out1 = CDSTestUtils.runWithArchive(opts);
 
         opts.setXShareMode("off");

--- a/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/ArchivedModuleWithCustomImageTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/ArchivedModuleWithCustomImageTest.java
@@ -133,6 +133,7 @@ public class ArchivedModuleWithCustomImageTest {
             customJava.toString(),
             "-XX:SharedArchiveFile=./ArchivedModuleWithCustomImageTest.jsa",
             "-Xshare:on",
+            "-Xlog:cds=off",
             "--show-module-resolution",
             "-version"};
         printCommand(showModuleCmd2);


### PR DESCRIPTION
The patch changes some of the `aot_log_info(aot)()` to `MetaspaceShared::report_loading_error()` for those referring to an error condition during loading of AOT cache or CDS archive.

Passed tiers 1 - 4 testing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8356807](https://bugs.openjdk.org/browse/JDK-8356807): Change log_info(cds) to `MetaspaceShared::report_loading_error()` (**Enhancement** - P4)


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**) Review applies to [1b55f8a4](https://git.openjdk.org/jdk/pull/26253/files/1b55f8a4ca28722dea414d74ca411f62f593a7a7)
 * [Matias Saavedra Silva](https://openjdk.org/census#matsaave) (@matias9927 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26253/head:pull/26253` \
`$ git checkout pull/26253`

Update a local copy of the PR: \
`$ git checkout pull/26253` \
`$ git pull https://git.openjdk.org/jdk.git pull/26253/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26253`

View PR using the GUI difftool: \
`$ git pr show -t 26253`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26253.diff">https://git.openjdk.org/jdk/pull/26253.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26253#issuecomment-3059151315)
</details>
