### PR TITLE
8361908: Mix and match of dead and valid exception handler leads to malformed class file

### DIFF
--- a/src/java.base/share/classes/jdk/internal/classfile/impl/DirectCodeBuilder.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/DirectCodeBuilder.java
@@ -206,7 +206,6 @@ public final class DirectCodeBuilder
             } else {
                 buf.writeU2U2U2(startPc, endPc, handlerPc);
                 buf.writeIndexOrZero(h.catchTypeEntry());
-                handlersSize++;
             }
         }
         if (handlersSize < handlers.size())


### PR DESCRIPTION
Noticed this error when I was verifying all sizes are u2 compatible and verified with a test that fails on mainline with ConstantPoolException (because we write a size of 2 with 1-length list content) and works in this patch. Problem wasn't discovered before because we use the `handlersSize < handlers.size()` instead of `handlersSize != handlers.size()` check.

Testing: jdk/jdk/classfile

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8361908](https://bugs.openjdk.org/browse/JDK-8361908): Mix and match of dead and valid exception handler leads to malformed class file (**Bug** - P4)


### Reviewers
 * [Adam Sotona](https://openjdk.org/census#asotona) (@asotona - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26255/head:pull/26255` \
`$ git checkout pull/26255`

Update a local copy of the PR: \
`$ git checkout pull/26255` \
`$ git pull https://git.openjdk.org/jdk.git pull/26255/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26255`

View PR using the GUI difftool: \
`$ git pr show -t 26255`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26255.diff">https://git.openjdk.org/jdk/pull/26255.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26255#issuecomment-3059219271)
</details>
