### PR TITLE
8361909: ConstantPoolBuilder::loadableConstantEntry and constantValueEntry should throw NPE

### DIFF
--- a/src/java.base/share/classes/java/lang/classfile/constantpool/ConstantPoolBuilder.java
+++ b/src/java.base/share/classes/java/lang/classfile/constantpool/ConstantPoolBuilder.java
@@ -540,7 +540,7 @@ public sealed interface ConstantPoolBuilder
         if (c instanceof Long l) return longEntry(l);
         if (c instanceof Float f) return floatEntry(f);
         if (c instanceof Double d) return doubleEntry(d);
-        throw new IllegalArgumentException("Illegal type: " + (c == null ? null : c.getClass()));
+        throw new IllegalArgumentException("Illegal type: " + c.getClass()); // implicit null check
     }
 
     /**
@@ -559,7 +559,8 @@ public sealed interface ConstantPoolBuilder
         if (c instanceof MethodTypeDesc mtd) return methodTypeEntry(mtd);
         if (c instanceof DirectMethodHandleDesc dmhd) return methodHandleEntry(dmhd);
         if (c instanceof DynamicConstantDesc<?> dcd) return constantDynamicEntry(dcd);
-        throw new IllegalArgumentException("Illegal type: " + (c == null ? null : c.getClass()));
+        // Shouldn't reach here
+        throw new IllegalArgumentException("Illegal type: " + c.getClass()); // implicit null check
     }
 
     /**

--- a/test/jdk/jdk/classfile/ConstantDescSymbolsTest.java
+++ b/test/jdk/jdk/classfile/ConstantDescSymbolsTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8304031 8338406 8338546
+ * @bug 8304031 8338406 8338546 8361909
  * @summary Testing handling of various constant descriptors in ClassFile API.
  * @modules java.base/jdk.internal.constant
  *          java.base/jdk.internal.classfile.impl
@@ -57,6 +57,13 @@ import static java.lang.constant.ConstantDescs.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 final class ConstantDescSymbolsTest {
+
+    @Test
+    void testNulls() {
+        var cpb = ConstantPoolBuilder.of();
+        assertThrows(NullPointerException.class, () -> cpb.loadableConstantEntry(null));
+        assertThrows(NullPointerException.class, () -> cpb.constantValueEntry(null));
+    }
 
     // Testing that primitive class descs are encoded properly as loadable constants.
     @Test


### PR DESCRIPTION
Currently, the aforementioned two methods do not throw NPE upon null input, but throw IAE.

This behavior is bad for composition: `bsmEntry` actually throws IAE for nested null in the argument list/array, and other APIs are similarly affected.

Given this domino effect, I think the best way is to fix the API itself to correctly throw NPE instead. A small CSR is opened to record this change.