### PR TITLE
8361948: Shenandoah: region free capacity unit mismatch

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
@@ -880,7 +880,7 @@ HeapWord* ShenandoahFreeSet::allocate_from_regions(Iter& iterator, ShenandoahAll
   for (idx_t idx = iterator.current(); iterator.has_next(); idx = iterator.next()) {
     ShenandoahHeapRegion* r = _heap->get_region(idx);
     size_t min_size = (req.type() == ShenandoahAllocRequest::_alloc_tlab) ? req.min_size() : req.size();
-    if (alloc_capacity(r) >= min_size) {
+    if (alloc_capacity(r) >= min_size * HeapWordSize) {
       HeapWord* result = try_allocate_in(r, req, in_new_region);
       if (result != nullptr) {
         return result;


### PR DESCRIPTION
In the code path of [mutator allocation](https://github.com/openjdk/jdk/blob/master/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp#L883
), looks like we assume that ShenandoahAllocRequest::size/min_size and region free capacity have same unit, which is apparently not right, unit used in ShenandoahAllocRequest is word but region free capacity is in bytes.

It should be just one line change like:
```
if (alloc_capacity(r) >= min_size * HeapWordSize) {
   ...
}

```

### Test
- [x] make test TEST=hotspot_gc_shenandoah

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8361948](https://bugs.openjdk.org/browse/JDK-8361948): Shenandoah: region free capacity unit mismatch (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26259/head:pull/26259` \
`$ git checkout pull/26259`

Update a local copy of the PR: \
`$ git checkout pull/26259` \
`$ git pull https://git.openjdk.org/jdk.git pull/26259/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26259`

View PR using the GUI difftool: \
`$ git pr show -t 26259`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26259.diff">https://git.openjdk.org/jdk/pull/26259.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26259#issuecomment-3063227785)
</details>
