### PR TITLE
8361952

### DIFF
--- a/src/hotspot/share/oops/methodData.cpp
+++ b/src/hotspot/share/oops/methodData.cpp
@@ -1860,7 +1860,7 @@ public:
 };
 
 Mutex* MethodData::extra_data_lock() {
-  Mutex* lock = Atomic::load(&_extra_data_lock);
+  Mutex* lock = Atomic::load_acquire(&_extra_data_lock);
   if (lock == nullptr) {
     // This lock could be acquired while we are holding DumpTimeTable_lock/nosafepoint
     lock = new Mutex(Mutex::nosafepoint-1, "MDOExtraData_lock");


### PR DESCRIPTION
Hi all,

  please review this change that fixes some recently introduced double-checked locking missing the memory barrier (`load_acquire`) on the reader side. Without it the reader might get a valid pointer to the `Mutex` created on the fly, without it being initialized properly.

Found during code inspection for https://bugs.openjdk.org/browse/JDK-8361706 ; due to some suspicious hangs in the `MutexLocker` while cleaning klasses during class unloading in parallel (multiple threads hanging in `MethodData::clean_method_data`), executing the `vmTestbase/nsk/jvmti/RedefineClasses/StressRedefine/TestDescription.java` test.

Testing: gha

Thanks,
  Thomas