### PR TITLE
8361959: [GCC static analyzer] java_props_md.c  leak of 'temp'  variable is reported

### DIFF
--- a/src/java.base/unix/native/libjava/java_props_md.c
+++ b/src/java.base/unix/native/libjava/java_props_md.c
@@ -253,6 +253,7 @@ static int ParseLocale(JNIEnv* env, int cat, char ** std_language, char ** std_s
         if (mapLookup(country_names, country, std_country) == 0) {
             *std_country = malloc(strlen(country)+1);
             if (*std_country == NULL) {
+                free(temp);
                 free(encoding_variant);
                 JNU_ThrowOutOfMemoryError(env, NULL);
                 return 0;

--- a/src/java.base/unix/native/libjava/java_props_md.c
+++ b/src/java.base/unix/native/libjava/java_props_md.c
@@ -239,6 +239,7 @@ static int ParseLocale(JNIEnv* env, int cat, char ** std_language, char ** std_s
         if (language != NULL && mapLookup(language_names, language, std_language) == 0) {
             *std_language = malloc(strlen(language)+1);
             if (*std_language == NULL) {
+                free(temp);
                 free(encoding_variant);
                 JNU_ThrowOutOfMemoryError(env, NULL);
                 return 0;


### PR DESCRIPTION
The following is reported when building with the gcc static analyzer (-fanalyzer) :

```
/jdk/src/java.base/unix/native/libjava/java_props_md.c:244:17: warning: leak of 'temp' [CWE-401] [-Wanalyzer-malloc-leak]
  244 | return 0;
```

Seems we have to free temp in an early return.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8361959](https://bugs.openjdk.org/browse/JDK-8361959): [GCC static analyzer] java_props_md.c  leak of 'temp'  variable is reported (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26264/head:pull/26264` \
`$ git checkout pull/26264`

Update a local copy of the PR: \
`$ git checkout pull/26264` \
`$ git pull https://git.openjdk.org/jdk.git pull/26264/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26264`

View PR using the GUI difftool: \
`$ git pr show -t 26264`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26264.diff">https://git.openjdk.org/jdk/pull/26264.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26264#issuecomment-3062221742)
</details>
