### PR TITLE
8361423: Add IPSupport::printPlatformSupport to java/net/NetworkInterface/IPv4Only.java

### DIFF
--- a/test/jdk/java/net/NetworkInterface/IPv4Only.java
+++ b/test/jdk/java/net/NetworkInterface/IPv4Only.java
@@ -49,7 +49,7 @@ public class IPv4Only {
                 Enumeration<InetAddress> addrs = nif.getInetAddresses();
                 while (addrs.hasMoreElements()) {
                    InetAddress hostAddr = addrs.nextElement();
-                   if ( hostAddr instanceof Inet6Address){
+                   if (hostAddr instanceof Inet6Address){
                         throw new RuntimeException( "NetworkInterfaceV6List failed - found v6 address " + hostAddr.getHostAddress() );
                    }
                 }


### PR DESCRIPTION
This is part of a series of diagnostic output updates to java.net tests to assist in the analysis of failures in IPv6 only environments
for Linux there is not IPv4 configuration but the IPv4 stack remains enabled
For macOS, and windows the IPv4 stacks are disabled, and IPv4 configuration removed

add IPSupport::printPlatformSupport(System.out);

to the start of main

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8361423](https://bugs.openjdk.org/browse/JDK-8361423): Add IPSupport::printPlatformSupport to java/net/NetworkInterface/IPv4Only.java (**Enhancement** - P4)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26265/head:pull/26265` \
`$ git checkout pull/26265`

Update a local copy of the PR: \
`$ git checkout pull/26265` \
`$ git pull https://git.openjdk.org/jdk.git pull/26265/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26265`

View PR using the GUI difftool: \
`$ git pr show -t 26265`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26265.diff">https://git.openjdk.org/jdk/pull/26265.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26265#issuecomment-3073387082)
</details>
