### PR TITLE
8361492: [IR Framework] Has too restrictive regex for load and store

### DIFF
--- a/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
@@ -102,8 +102,6 @@ public class IRNode {
     public static final String START = "(\\d+(\\s){2}(";
     public static final String MID = ".*)+(\\s){2}===.*";
     public static final String END = ")";
-    private static final String STORE_OF_CLASS_POSTFIX = "(:|\\+)\\S* \\*" + END;
-    private static final String LOAD_OF_CLASS_POSTFIX = "(:|\\+)\\S* \\*" + END;
 
     public static final String IS_REPLACED = "#IS_REPLACED#"; // Is replaced by an additional user-defined string.
 
@@ -2969,13 +2967,25 @@ public class IRNode {
                                                                           CompilePhase.AFTER_LOOP_OPTS));
     }
 
+    // Typename in load/store have the structure:
+    // @fully/qualified/package/name/to/TheClass+12 *
+    // And variation:
+    // - after @, we can have "stable:" or other labels, with optional space after ':'
+    // - the class can actually be a subclass, with $ separator (and it must be ok to give only the deepest one
+    // - after the class name, we can have a comma-separated list of implemented interfaces enclosed in parentheses
+    // - before the offset, we can have something like ":NotNull", either way, seeing "+" or ":" means the end of the type
+    // Worst case, it can be something like:
+    // @bla: bli:a/b/c$d$e (f/g,h/i/j):NotNull+24 *
+    private static final String LOAD_STORE_PREFIX = "@(\\w+: ?)*[\\w/\\$]*\\b";
+    private static final String LOAD_STORE_SUFFIX = "( \\([^\\)]+\\))?(:|\\+)\\S* \\*";
+
     private static void loadOfNodes(String irNodePlaceholder, String irNodeRegex) {
-        String regex = START + irNodeRegex + MID + "@\\S*" + IS_REPLACED + LOAD_OF_CLASS_POSTFIX;
+        String regex = START + irNodeRegex + MID + LOAD_STORE_PREFIX + IS_REPLACED + LOAD_STORE_SUFFIX + END;
         beforeMatching(irNodePlaceholder, regex);
     }
 
     private static void storeOfNodes(String irNodePlaceholder, String irNodeRegex) {
-        String regex = START + irNodeRegex + MID + "@\\S*" + IS_REPLACED + STORE_OF_CLASS_POSTFIX;
+        String regex = START + irNodeRegex + MID + LOAD_STORE_PREFIX + IS_REPLACED + LOAD_STORE_SUFFIX + END;
         beforeMatching(irNodePlaceholder, regex);
     }
 

--- a/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestPhaseIRMatching.java
+++ b/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestPhaseIRMatching.java
@@ -572,7 +572,7 @@ class LoadStore {
         }
     }
 
-    SingleNest.DoubleNest double_nest = new SingleNest.DoubleNest();
+    SingleNest.DoubleNest doubleNest = new SingleNest.DoubleNest();
 
 
     @Test
@@ -760,7 +760,7 @@ class LoadStore {
     )
     // @ir_framework/tests/LoadStore$SingleNest$DoubleNest+12 *
     public int loadDoubleNested() {
-        return double_nest.i;
+        return doubleNest.i;
     }
 
     @Test
@@ -783,6 +783,6 @@ class LoadStore {
     )
     // @ir_framework/tests/LoadStore$SingleNest$DoubleNest+12 *
     public void storeDoubleNested() {
-        double_nest.i = 1;
+        doubleNest.i = 1;
     }
 }

--- a/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestPhaseIRMatching.java
+++ b/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestPhaseIRMatching.java
@@ -60,6 +60,7 @@ public class TestPhaseIRMatching {
     public static void main(String[] args) {
         run(Basics.class);
         run(NoCompilationOutput.class);
+        run(LoadStore.class);
     }
 
     private static void run(Class<?> testClass) {
@@ -547,5 +548,241 @@ record Failure(String methodName, int irRuleId, CompilePhase compilePhase, Check
                                                   .thenComparing(Failure::compilePhase)
                                                   .thenComparing(Failure::checkAttributeType)
                                                   .thenComparing(Failure::constraintId)).collect(Collectors.toList());
+    }
+}
+
+// Test load and store regexes
+class LoadStore {
+    int i;
+    float f;
+    interface I1{}
+    static class Base implements I1 {
+        int i;
+    }
+    interface I2{}
+    static class Derived extends Base implements I2 {
+        long l;
+    }
+    Base Lb = new Base();
+    Derived Ld = new Derived();
+
+    static class SingleNest{
+        static class DoubleNest{
+            int i;
+        }
+    }
+
+    SingleNest.DoubleNest Ldn = new SingleNest.DoubleNest();
+
+
+    @Test
+    @IR(failOn = {IRNode.LOAD_OF_CLASS, ".*", IRNode.STORE_OF_CLASS, ".*"})
+    public void triviallyFailBoth() {
+    }
+
+    @Test
+    @IR(counts = {
+            IRNode.LOAD_OF_CLASS, "LoadS[a-z]+", "1",
+            IRNode.LOAD_OF_CLASS, "Load.tore", "1",
+            IRNode.LOAD_OF_CLASS, "LoadStore", "1",
+            IRNode.LOAD_OF_CLASS, "/LoadStore", "1",
+            IRNode.LOAD_OF_CLASS, "tests/LoadStore", "1",
+            IRNode.LOAD_OF_CLASS, "/tests/LoadStore", "1",
+            IRNode.LOAD_OF_CLASS, "ir_framework/tests/LoadStore", "1",
+            IRNode.LOAD_OF_CLASS, "(?<=[@: ])ir_framework/tests/LoadStore", "1",  // To assert it's the whole qualification
+            IRNode.LOAD_OF_CLASS, "(?<=[@: ])[\\w\\$/]*tests[\\w\\$/]*", "1",
+        },
+        failOn = {
+            IRNode.LOAD_OF_CLASS, "oadStore",
+            IRNode.LOAD_OF_CLASS, "LoadStor",
+            IRNode.LOAD_OF_CLASS, "/ir_framework/tests/LoadStore",
+            IRNode.LOAD_OF_CLASS, "(?<=[@: ])[\\w\\$]*tests[\\w\\$]*",
+        }
+    )
+    // @ir_framework/tests/LoadStore+12 *
+    public float simpleLoad() {
+        return f;
+    }
+
+    @Test
+    @IR(counts = {
+            IRNode.STORE_OF_CLASS, "LoadS[a-z]+", "1",
+            IRNode.STORE_OF_CLASS, "Load.tore", "1",
+            IRNode.STORE_OF_CLASS, "LoadStore", "1",
+            IRNode.STORE_OF_CLASS, "/LoadStore", "1",
+            IRNode.STORE_OF_CLASS, "tests/LoadStore", "1",
+            IRNode.STORE_OF_CLASS, "/tests/LoadStore", "1",
+            IRNode.STORE_OF_CLASS, "ir_framework/tests/LoadStore", "1",
+            IRNode.STORE_OF_CLASS, "(?<=[@: ])ir_framework/tests/LoadStore", "1",
+            IRNode.STORE_OF_CLASS, "(?<=[@: ])[\\w\\$/]*tests[\\w\\$/]*", "1",
+        },
+        failOn = {
+            IRNode.STORE_OF_CLASS, "oadStore",
+            IRNode.STORE_OF_CLASS, "LoadStor",
+            IRNode.STORE_OF_CLASS, "/ir_framework/tests/LoadStore",
+            IRNode.STORE_OF_CLASS, "(?<=[@: ])[\\w\\$]*tests[\\w\\$]*",
+        }
+    )
+    // @ir_framework/tests/LoadStore+12 *
+    public void simpleStore() {
+        i = 1;
+    }
+
+    @Test
+    @IR(counts = {
+            IRNode.LOAD_I_OF_CLASS, "Base", "1",
+            IRNode.LOAD_I_OF_CLASS, "\\$Base", "1",
+            IRNode.LOAD_I_OF_CLASS, "LoadS[a-z]+\\$Base", "1",
+            IRNode.LOAD_I_OF_CLASS, "Load.tore\\$Base", "1",
+            IRNode.LOAD_I_OF_CLASS, "LoadStore\\$Base", "1",
+            IRNode.LOAD_I_OF_CLASS, "/LoadStore\\$Base", "1",
+            IRNode.LOAD_I_OF_CLASS, "tests/LoadStore\\$Base", "1",
+            IRNode.LOAD_I_OF_CLASS, "/tests/LoadStore\\$Base", "1",
+            IRNode.LOAD_I_OF_CLASS, "ir_framework/tests/LoadStore\\$Base", "1",
+            IRNode.LOAD_I_OF_CLASS, "(?<=[@: ])ir_framework/tests/LoadStore\\$Base", "1",
+            IRNode.LOAD_I_OF_CLASS, "(?<=[@: ])[\\w\\$/]*tests[\\w\\$/]*", "1",
+        },
+        failOn = {
+            IRNode.LOAD_I_OF_CLASS, "/Base",
+            IRNode.LOAD_I_OF_CLASS, "oadStore\\$Base",
+            IRNode.LOAD_I_OF_CLASS, "LoadStore\\$Bas",
+            IRNode.LOAD_I_OF_CLASS, "LoadStore",
+            IRNode.LOAD_I_OF_CLASS, "/ir_framework/tests/LoadStore\\$Base",
+            IRNode.LOAD_I_OF_CLASS, "(?<=[@: ])[\\w\\$]*tests[\\w\\$]*",
+        }
+    )
+    // @ir_framework/tests/LoadStore$Base (ir_framework/tests/LoadStore$I1)+12 *
+    public int loadWithInterface() {
+        return Lb.i;
+    }
+
+    @Test
+    @IR(counts = {
+            IRNode.STORE_I_OF_CLASS, "Base", "1",
+            IRNode.STORE_I_OF_CLASS, "\\$Base", "1",
+            IRNode.STORE_I_OF_CLASS, "LoadS[a-z]+\\$Base", "1",
+            IRNode.STORE_I_OF_CLASS, "Load.tore\\$Base", "1",
+            IRNode.STORE_I_OF_CLASS, "LoadStore\\$Base", "1",
+            IRNode.STORE_I_OF_CLASS, "/LoadStore\\$Base", "1",
+            IRNode.STORE_I_OF_CLASS, "tests/LoadStore\\$Base", "1",
+            IRNode.STORE_I_OF_CLASS, "/tests/LoadStore\\$Base", "1",
+            IRNode.STORE_I_OF_CLASS, "ir_framework/tests/LoadStore\\$Base", "1",
+            IRNode.STORE_I_OF_CLASS, "(?<=[@: ])ir_framework/tests/LoadStore\\$Base", "1",
+            IRNode.STORE_I_OF_CLASS, "(?<=[@: ])[\\w\\$/]*tests[\\w\\$/]*", "1",
+        },
+        failOn = {
+            IRNode.STORE_I_OF_CLASS, "/Base",
+            IRNode.STORE_I_OF_CLASS, "oadStore\\$Base",
+            IRNode.STORE_I_OF_CLASS, "LoadStore\\$Bas",
+            IRNode.STORE_I_OF_CLASS, "LoadStore",
+            IRNode.STORE_I_OF_CLASS, "/ir_framework/tests/LoadStore\\$Base",
+            IRNode.STORE_I_OF_CLASS, "(?<=[@: ])[\\w\\$]*tests[\\w\\$]*",
+        }
+    )
+    // @ir_framework/tests/LoadStore$Base (ir_framework/tests/LoadStore$I1)+12 *
+    public void storeWithInterface() {
+        Lb.i = 1;
+    }
+
+    @Test
+    @IR(counts = {
+            IRNode.LOAD_L_OF_CLASS, "Derived", "1",
+            IRNode.LOAD_L_OF_CLASS, "\\$Derived", "1",
+            IRNode.LOAD_L_OF_CLASS, "LoadS[a-z]+\\$Derived", "1",
+            IRNode.LOAD_L_OF_CLASS, "Load.tore\\$Derived", "1",
+            IRNode.LOAD_L_OF_CLASS, "LoadStore\\$Derived", "1",
+            IRNode.LOAD_L_OF_CLASS, "/LoadStore\\$Derived", "1",
+            IRNode.LOAD_L_OF_CLASS, "tests/LoadStore\\$Derived", "1",
+            IRNode.LOAD_L_OF_CLASS, "/tests/LoadStore\\$Derived", "1",
+            IRNode.LOAD_L_OF_CLASS, "ir_framework/tests/LoadStore\\$Derived", "1",
+            IRNode.LOAD_L_OF_CLASS, "(?<=[@: ])ir_framework/tests/LoadStore\\$Derived", "1",
+            IRNode.LOAD_L_OF_CLASS, "(?<=[@: ])[\\w\\$/]*tests[\\w\\$/]*", "1",
+        },
+        failOn = {
+            IRNode.LOAD_L_OF_CLASS, "/Derived",
+            IRNode.LOAD_L_OF_CLASS, "oadStore\\$Derived",
+            IRNode.LOAD_L_OF_CLASS, "LoadStore\\$Derive",
+            IRNode.LOAD_L_OF_CLASS, "LoadStore",
+            IRNode.LOAD_L_OF_CLASS, "/ir_framework/tests/LoadStore\\$Derived",
+            IRNode.LOAD_L_OF_CLASS, "(?<=[@: ])[\\w\\$]*tests[\\w\\$]*",
+        }
+    )
+    // @ir_framework/tests/LoadStore$Derived (ir_framework/tests/LoadStore$I1,ir_framework/tests/LoadStore$I2)+24 *
+    public long loadWithInterfaces() {
+        return Ld.l;
+    }
+
+    @Test
+    @IR(counts = {
+            IRNode.STORE_L_OF_CLASS, "Derived", "1",
+            IRNode.STORE_L_OF_CLASS, "\\$Derived", "1",
+            IRNode.STORE_L_OF_CLASS, "LoadS[a-z]+\\$Derived", "1",
+            IRNode.STORE_L_OF_CLASS, "Load.tore\\$Derived", "1",
+            IRNode.STORE_L_OF_CLASS, "LoadStore\\$Derived", "1",
+            IRNode.STORE_L_OF_CLASS, "/LoadStore\\$Derived", "1",
+            IRNode.STORE_L_OF_CLASS, "tests/LoadStore\\$Derived", "1",
+            IRNode.STORE_L_OF_CLASS, "/tests/LoadStore\\$Derived", "1",
+            IRNode.STORE_L_OF_CLASS, "ir_framework/tests/LoadStore\\$Derived", "1",
+            IRNode.STORE_L_OF_CLASS, "(?<=[@: ])ir_framework/tests/LoadStore\\$Derived", "1",
+            IRNode.STORE_L_OF_CLASS, "(?<=[@: ])[\\w\\$/]*tests[\\w\\$/]*", "1",
+        },
+        failOn = {
+            IRNode.STORE_L_OF_CLASS, "/Derived",
+            IRNode.STORE_L_OF_CLASS, "oadStore\\$Derived",
+            IRNode.STORE_L_OF_CLASS, "LoadStore\\$Derive",
+            IRNode.STORE_L_OF_CLASS, "LoadStore",
+            IRNode.STORE_L_OF_CLASS, "/ir_framework/tests/LoadStore\\$Derived",
+            IRNode.STORE_L_OF_CLASS, "(?<=[@: ])[\\w\\$]*tests[\\w\\$]*",
+        }
+    )
+    // @ir_framework/tests/LoadStore$Derived (ir_framework/tests/LoadStore$I1,ir_framework/tests/LoadStore$I2)+24 *
+    public void storeWithInterfaces() {
+        Ld.l = 1;
+    }
+
+    @Test
+    @IR(counts = {
+            IRNode.LOAD_I_OF_CLASS, "DoubleNest", "1",
+            IRNode.LOAD_I_OF_CLASS, "\\$DoubleNest", "1",
+            IRNode.LOAD_I_OF_CLASS, "SingleNest\\$DoubleNest", "1",
+            IRNode.LOAD_I_OF_CLASS, "\\$SingleNest\\$DoubleNest", "1",
+            IRNode.LOAD_I_OF_CLASS, "LoadStore\\$SingleNest\\$DoubleNest", "1",
+            IRNode.LOAD_I_OF_CLASS, "/LoadStore\\$SingleNest\\$DoubleNest", "1",
+            IRNode.LOAD_I_OF_CLASS, "tests/LoadStore\\$SingleNest\\$DoubleNest", "1",
+            IRNode.LOAD_I_OF_CLASS, "/tests/LoadStore\\$SingleNest\\$DoubleNest", "1",
+            IRNode.LOAD_I_OF_CLASS, "ir_framework/tests/LoadStore\\$SingleNest\\$DoubleNest", "1",
+        },
+        failOn = {
+            IRNode.LOAD_I_OF_CLASS, "SingleNest",
+            IRNode.LOAD_I_OF_CLASS, "LoadStore",
+            IRNode.LOAD_I_OF_CLASS, "LoadStore\\$SingleNest",
+        }
+    )
+    // @ir_framework/tests/LoadStore$SingleNest$DoubleNest+12 *
+    public int loadDoubleNested() {
+        return Ldn.i;
+    }
+
+    @Test
+    @IR(counts = {
+            IRNode.STORE_I_OF_CLASS, "DoubleNest", "1",
+            IRNode.STORE_I_OF_CLASS, "\\$DoubleNest", "1",
+            IRNode.STORE_I_OF_CLASS, "SingleNest\\$DoubleNest", "1",
+            IRNode.STORE_I_OF_CLASS, "\\$SingleNest\\$DoubleNest", "1",
+            IRNode.STORE_I_OF_CLASS, "LoadStore\\$SingleNest\\$DoubleNest", "1",
+            IRNode.STORE_I_OF_CLASS, "/LoadStore\\$SingleNest\\$DoubleNest", "1",
+            IRNode.STORE_I_OF_CLASS, "tests/LoadStore\\$SingleNest\\$DoubleNest", "1",
+            IRNode.STORE_I_OF_CLASS, "/tests/LoadStore\\$SingleNest\\$DoubleNest", "1",
+            IRNode.STORE_I_OF_CLASS, "ir_framework/tests/LoadStore\\$SingleNest\\$DoubleNest", "1",
+        },
+        failOn = {
+            IRNode.STORE_I_OF_CLASS, "SingleNest",
+            IRNode.STORE_I_OF_CLASS, "LoadStore",
+            IRNode.STORE_I_OF_CLASS, "LoadStore\\$SingleNest",
+        }
+    )
+    // @ir_framework/tests/LoadStore$SingleNest$DoubleNest+12 *
+    public void storeDoubleNested() {
+        Ldn.i = 1;
     }
 }

--- a/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestPhaseIRMatching.java
+++ b/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestPhaseIRMatching.java
@@ -555,24 +555,24 @@ record Failure(String methodName, int irRuleId, CompilePhase compilePhase, Check
 class LoadStore {
     int i;
     float f;
-    interface I1{}
+    interface I1 {}
     static class Base implements I1 {
         int i;
     }
-    interface I2{}
+    interface I2 {}
     static class Derived extends Base implements I2 {
         long l;
     }
-    Base Lb = new Base();
-    Derived Ld = new Derived();
+    Base base = new Base();
+    Derived derived = new Derived();
 
-    static class SingleNest{
-        static class DoubleNest{
+    static class SingleNest {
+        static class DoubleNest {
             int i;
         }
     }
 
-    SingleNest.DoubleNest Ldn = new SingleNest.DoubleNest();
+    SingleNest.DoubleNest double_nest = new SingleNest.DoubleNest();
 
 
     @Test
@@ -653,7 +653,7 @@ class LoadStore {
     )
     // @ir_framework/tests/LoadStore$Base (ir_framework/tests/LoadStore$I1)+12 *
     public int loadWithInterface() {
-        return Lb.i;
+        return base.i;
     }
 
     @Test
@@ -681,7 +681,7 @@ class LoadStore {
     )
     // @ir_framework/tests/LoadStore$Base (ir_framework/tests/LoadStore$I1)+12 *
     public void storeWithInterface() {
-        Lb.i = 1;
+        base.i = 1;
     }
 
     @Test
@@ -709,7 +709,7 @@ class LoadStore {
     )
     // @ir_framework/tests/LoadStore$Derived (ir_framework/tests/LoadStore$I1,ir_framework/tests/LoadStore$I2)+24 *
     public long loadWithInterfaces() {
-        return Ld.l;
+        return derived.l;
     }
 
     @Test
@@ -737,7 +737,7 @@ class LoadStore {
     )
     // @ir_framework/tests/LoadStore$Derived (ir_framework/tests/LoadStore$I1,ir_framework/tests/LoadStore$I2)+24 *
     public void storeWithInterfaces() {
-        Ld.l = 1;
+        derived.l = 1;
     }
 
     @Test
@@ -760,7 +760,7 @@ class LoadStore {
     )
     // @ir_framework/tests/LoadStore$SingleNest$DoubleNest+12 *
     public int loadDoubleNested() {
-        return Ldn.i;
+        return double_nest.i;
     }
 
     @Test
@@ -783,6 +783,6 @@ class LoadStore {
     )
     // @ir_framework/tests/LoadStore$SingleNest$DoubleNest+12 *
     public void storeDoubleNested() {
-        Ldn.i = 1;
+        double_nest.i = 1;
     }
 }


### PR DESCRIPTION
Improving store and load regexes + adding test. It's mostly an improve version of a fix I had to do in Valhalla where it was blocking (part of JDK-8361250, blocking JDK-8357785).

The new regex takes into account that classes can implement interfaces, nested classes, and various labels after the `@`. It should be more robust.

Thanks,
Marc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8361492](https://bugs.openjdk.org/browse/JDK-8361492): [IR Framework] Has too restrictive regex for load and store (**Bug** - P4)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Damon Fenacci](https://openjdk.org/census#dfenacci) (@dafedafe - Committer) Review applies to [3dc823cb](https://git.openjdk.org/jdk/pull/26269/files/3dc823cb040b30536177778e7cfff305ae0351cf)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26269/head:pull/26269` \
`$ git checkout pull/26269`

Update a local copy of the PR: \
`$ git checkout pull/26269` \
`$ git pull https://git.openjdk.org/jdk.git pull/26269/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26269`

View PR using the GUI difftool: \
`$ git pr show -t 26269`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26269.diff">https://git.openjdk.org/jdk/pull/26269.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26269#issuecomment-3063062108)
</details>
