### PR TITLE
8360775: Fix Shenandoah GC test failures when APX is enabled

### DIFF
--- a/src/hotspot/cpu/x86/assembler_x86.cpp
+++ b/src/hotspot/cpu/x86/assembler_x86.cpp
@@ -15681,6 +15681,8 @@ void Assembler::pusha_uncached() { // 64bit
     // Push pair of original stack pointer along with remaining registers
     // at 16B aligned boundary.
     push2p(rax, r31);
+    // Restore the original contents of RAX register.
+    movq(rax, Address(rax));
     push2p(r30, r29);
     push2p(r28, r27);
     push2p(r26, r25);

--- a/src/hotspot/cpu/x86/gc/shenandoah/shenandoahBarrierSetAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/gc/shenandoah/shenandoahBarrierSetAssembler_x86.cpp
@@ -353,7 +353,7 @@ void ShenandoahBarrierSetAssembler::load_reference_barrier(MacroAssembler* masm,
 
   // The rest is saved with the optimized path
 
-  uint num_saved_regs = 4 + (dst != rax ? 1 : 0) + 4;
+  uint num_saved_regs = 4 + (dst != rax ? 1 : 0) + 4 + (UseAPX ? 16 : 0);
   __ subptr(rsp, num_saved_regs * wordSize);
   uint slot = num_saved_regs;
   if (dst != rax) {
@@ -367,6 +367,25 @@ void ShenandoahBarrierSetAssembler::load_reference_barrier(MacroAssembler* masm,
   __ movptr(Address(rsp, (--slot) * wordSize), r9);
   __ movptr(Address(rsp, (--slot) * wordSize), r10);
   __ movptr(Address(rsp, (--slot) * wordSize), r11);
+  // Save APX extended registers r16–r31 if enabled
+  if (UseAPX) {
+    __ movptr(Address(rsp, (--slot) * wordSize), r16);
+    __ movptr(Address(rsp, (--slot) * wordSize), r17);
+    __ movptr(Address(rsp, (--slot) * wordSize), r18);
+    __ movptr(Address(rsp, (--slot) * wordSize), r19);
+    __ movptr(Address(rsp, (--slot) * wordSize), r20);
+    __ movptr(Address(rsp, (--slot) * wordSize), r21);
+    __ movptr(Address(rsp, (--slot) * wordSize), r22);
+    __ movptr(Address(rsp, (--slot) * wordSize), r23);
+    __ movptr(Address(rsp, (--slot) * wordSize), r24);
+    __ movptr(Address(rsp, (--slot) * wordSize), r25);
+    __ movptr(Address(rsp, (--slot) * wordSize), r26);
+    __ movptr(Address(rsp, (--slot) * wordSize), r27);
+    __ movptr(Address(rsp, (--slot) * wordSize), r28);
+    __ movptr(Address(rsp, (--slot) * wordSize), r29);
+    __ movptr(Address(rsp, (--slot) * wordSize), r30);
+    __ movptr(Address(rsp, (--slot) * wordSize), r31);
+  }
   // r12-r15 are callee saved in all calling conventions
   assert(slot == 0, "must use all slots");
 
@@ -398,6 +417,25 @@ void ShenandoahBarrierSetAssembler::load_reference_barrier(MacroAssembler* masm,
     __ super_call_VM_leaf(CAST_FROM_FN_PTR(address, ShenandoahRuntime::load_reference_barrier_phantom), arg0, arg1);
   }
 
+  // Restore APX extended registers r31–r16 if previously saved
+  if (UseAPX) {
+    __ movptr(r31, Address(rsp, (slot++) * wordSize));
+    __ movptr(r30, Address(rsp, (slot++) * wordSize));
+    __ movptr(r29, Address(rsp, (slot++) * wordSize));
+    __ movptr(r28, Address(rsp, (slot++) * wordSize));
+    __ movptr(r27, Address(rsp, (slot++) * wordSize));
+    __ movptr(r26, Address(rsp, (slot++) * wordSize));
+    __ movptr(r25, Address(rsp, (slot++) * wordSize));
+    __ movptr(r24, Address(rsp, (slot++) * wordSize));
+    __ movptr(r23, Address(rsp, (slot++) * wordSize));
+    __ movptr(r22, Address(rsp, (slot++) * wordSize));
+    __ movptr(r21, Address(rsp, (slot++) * wordSize));
+    __ movptr(r20, Address(rsp, (slot++) * wordSize));
+    __ movptr(r19, Address(rsp, (slot++) * wordSize));
+    __ movptr(r18, Address(rsp, (slot++) * wordSize));
+    __ movptr(r17, Address(rsp, (slot++) * wordSize));
+    __ movptr(r16, Address(rsp, (slot++) * wordSize));
+  }
   __ movptr(r11, Address(rsp, (slot++) * wordSize));
   __ movptr(r10, Address(rsp, (slot++) * wordSize));
   __ movptr(r9,  Address(rsp, (slot++) * wordSize));


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [1c560727](https://github.com/openjdk/jdk/commit/1c560727b850593561982ccc3ed37b0e98b3bbee) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Srinivas Vamsi Parasa on 4 Jul 2025 and was reviewed by Sandhya Viswanathan, Jatin Bhateja and Emanuel Peter.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8360775](https://bugs.openjdk.org/browse/JDK-8360775): Fix Shenandoah GC test failures when APX is enabled (**Bug** - P3)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Sandhya Viswanathan](https://openjdk.org/census#sviswanathan) (@sviswa7 - **Reviewer**)
 * [Jatin Bhateja](https://openjdk.org/census#jbhateja) (@jatin-bhateja - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26271/head:pull/26271` \
`$ git checkout pull/26271`

Update a local copy of the PR: \
`$ git checkout pull/26271` \
`$ git pull https://git.openjdk.org/jdk.git pull/26271/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26271`

View PR using the GUI difftool: \
`$ git pr show -t 26271`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26271.diff">https://git.openjdk.org/jdk/pull/26271.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26271#issuecomment-3063092498)
</details>
