### PR TITLE
8357818: Shenandoah doesn't use shared API for printing heap before/after GC

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
@@ -150,6 +150,7 @@ void ShenandoahControlThread::run_service() {
       // If GC was requested, we better dump freeset data for performance debugging
       heap->free_set()->log_status_under_lock();
 
+      heap->print_before_gc();
       switch (mode) {
         case concurrent_normal:
           service_concurrent_normal_cycle(cause);
@@ -163,6 +164,7 @@ void ShenandoahControlThread::run_service() {
         default:
           ShouldNotReachHere();
       }
+      heap->print_after_gc();
 
       // If this was the requested GC cycle, notify waiters about it
       if (is_gc_requested) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalControlThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalControlThread.cpp
@@ -250,6 +250,7 @@ void ShenandoahGenerationalControlThread::run_gc_cycle(const ShenandoahGCRequest
     // Cannot uncommit bitmap slices during concurrent reset
     ShenandoahNoUncommitMark forbid_region_uncommit(_heap);
 
+    _heap->print_before_gc();
     switch (gc_mode()) {
       case concurrent_normal: {
         service_concurrent_normal_cycle(request);
@@ -271,6 +272,7 @@ void ShenandoahGenerationalControlThread::run_gc_cycle(const ShenandoahGCRequest
       default:
         ShouldNotReachHere();
     }
+    _heap->print_after_gc();
   }
 
   // If this cycle completed successfully, notify threads waiting for gc


### PR DESCRIPTION
Add logging for Shenandoah as well as Generational Shenandoah. 

Log samples:

```
######################################
Before gc
######################################
[0.231s][debug][gc,heap      ] GC(0) Heap Before GC invocations=0 (full 0):
[0.231s][debug][gc,heap      ] GC(0)  Shenandoah Heap
[0.231s][debug][gc,heap      ] GC(0)   100M max, 100M soft max, 100M committed, 39686K used
[0.231s][debug][gc,heap      ] GC(0)   400 x 256 K regions
[0.231s][debug][gc,heap      ] GC(0)  Status: not cancelled
[0.231s][debug][gc,heap      ] GC(0)  Reserved region:
[0.231s][debug][gc,heap      ] GC(0)   - [0x00000000f9c00000, 0x0000000100000000) 
[0.231s][debug][gc,heap      ] GC(0)  Collection set:
[0.231s][debug][gc,heap      ] GC(0)   - map (vanilla): 0x0000000000004e70
[0.231s][debug][gc,heap      ] GC(0)   - map (biased):  0x0000000000001000
[0.231s][debug][gc,heap      ] GC(0) 
[0.231s][debug][gc,metaspace ] GC(0) Metaspace Before GC invocations=0 (full 0):
[0.231s][debug][gc,metaspace ] GC(0)  Metaspace       used 153K, committed 384K, reserved 1114112K
[0.231s][debug][gc,metaspace ] GC(0)   class space    used 3K, committed 128K, reserved 1048576K




######################################
After gc
######################################
[2.067s][debug][gc,heap        ] GC(11) Heap After GC invocations=0 (full 0):
[2.067s][debug][gc,heap        ] GC(11)  Shenandoah Heap
[2.067s][debug][gc,heap        ] GC(11)   100M max, 100M soft max, 100M committed, 101356K used
[2.067s][debug][gc,heap        ] GC(11)   400 x 256 K regions
[2.067s][debug][gc,heap        ] GC(11)  Status: not cancelled
[2.067s][debug][gc,heap        ] GC(11)  Reserved region:
[2.067s][debug][gc,heap        ] GC(11)   - [0x00000000f9c00000, 0x0000000100000000) 
[2.067s][debug][gc,heap        ] GC(11)  Collection set:
[2.067s][debug][gc,heap        ] GC(11)   - map (vanilla): 0x0000000000004e70
[2.067s][debug][gc,heap        ] GC(11)   - map (biased):  0x0000000000001000
[2.067s][debug][gc,heap        ] GC(11) 
[2.067s][debug][gc,metaspace   ] GC(11) Metaspace After GC invocations=0 (full 0):
[2.067s][debug][gc,metaspace   ] GC(11)  Metaspace       used 190K, committed 384K, reserved 1114112K
[2.067s][debug][gc,metaspace   ] GC(11)   class space    used 4K, committed 128K, reserved 1048576K
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8357818](https://bugs.openjdk.org/browse/JDK-8357818): Shenandoah doesn't use shared API for printing heap before/after GC (**Enhancement** - P4)


### Reviewers
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - **Reviewer**)
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26272/head:pull/26272` \
`$ git checkout pull/26272`

Update a local copy of the PR: \
`$ git checkout pull/26272` \
`$ git pull https://git.openjdk.org/jdk.git pull/26272/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26272`

View PR using the GUI difftool: \
`$ git pr show -t 26272`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26272.diff">https://git.openjdk.org/jdk/pull/26272.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26272#issuecomment-3063353488)
</details>
