### PR TITLE
8361224: [macos] MacSignTest.testMultipleCertificates failed

### DIFF
--- a/test/jdk/tools/jpackage/macosx/MacSignTest.java
+++ b/test/jdk/tools/jpackage/macosx/MacSignTest.java
@@ -133,14 +133,20 @@ public class MacSignTest {
     }
 
     @Test
-    @Parameter({"IMAGE", "GOOD_SIGNING_KEY_USER_NAME"})
-    @Parameter({"MAC_DMG", "GOOD_SIGNING_KEY_USER_NAME"})
-    @Parameter({"MAC_PKG", "GOOD_SIGNING_KEY_USER_NAME_PKG", "GOOD_SIGNING_KEY_USER_NAME"})
+    // Case "--mac-signing-key-user-name": jpackage selects first certificate
+    // found with warning message. Certificate hash is pass to "codesign" in this
+    // case.
+    @Parameter({"IMAGE", "0", "GOOD_SIGNING_KEY_USER_NAME"})
+    @Parameter({"MAC_DMG", "0", "GOOD_SIGNING_KEY_USER_NAME"})
+    @Parameter({"MAC_PKG", "0", "GOOD_SIGNING_KEY_USER_NAME_PKG", "GOOD_SIGNING_KEY_USER_NAME"})
 
-    @Parameter({"IMAGE", "GOOD_CODESIGN_SIGN_IDENTITY"})
-    @Parameter({"MAC_PKG", "GOOD_CODESIGN_SIGN_IDENTITY", "GOOD_PKG_SIGN_IDENTITY"})
-    @Parameter({"MAC_PKG", "GOOD_PKG_SIGN_IDENTITY"})
-    public static void testMultipleCertificates(PackageType type, SignOption... options) {
+    // Case "--mac-app-image-sign-identity": sign identity will be pass to
+    // "codesign" and "codesign" should fail due to multiple certificates with
+    // same common name found.
+    @Parameter({"IMAGE", "1", "GOOD_CODESIGN_SIGN_IDENTITY"})
+    @Parameter({"MAC_PKG", "1", "GOOD_CODESIGN_SIGN_IDENTITY", "GOOD_PKG_SIGN_IDENTITY"})
+    @Parameter({"MAC_PKG", "1", "GOOD_PKG_SIGN_IDENTITY"})
+    public static void testMultipleCertificates(PackageType type, int jpackageExitCode, SignOption... options) {
 
         final var keychain = SigningBase.StandardKeychain.DUPLICATE.spec().keychain();
 
@@ -154,7 +160,7 @@ public class MacSignTest {
 
             SignOption.configureOutputValidation(cmd, List.of(options), opt -> {
                 return JPackageStringBundle.MAIN.cannedFormattedString("error.multiple.certs.found", opt.identityName(), keychain.name());
-            }).execute(1);
+            }).execute(jpackageExitCode);
         });
     }
 


### PR DESCRIPTION
Test updated to expect `jpackage` to PASS in case of `--mac-signing-key-user-name` and FAIL in case of `-mac-app-image-sign-identity`. See explanation below.

Case 1: Only common name of certificate is used (PASS):
jpackage --type dmg -i input -n Test --main-class components.DynamicTreeDemo --main-jar DynamicTreeDemo.jar --mac-sign --mac-signing-keychain jpackagerTest-duplicate.keychain --mac-signing-key-user-name jpackage.openjdk.java.net
[10:02:37.545] WARNING: Multiple certificates found matching [Developer ID Application: jpackage.openjdk.java.net] using keychain [jpackagerTest-duplicate.keychain], using first one

Actual codesign command in PASS case:
/usr/bin/codesign -s CBDE500D7ED18E08F6DF852A5D23D8C7113EB30C -vvvv --timestamp --options runtime --prefix components. --keychain jpackagerTest-duplicate.keychain --force /var/folders/dr/65dj5x3j0296mqtsn9z27xc80000gn/T/jdk.jpackage3439321874841533317/image/Test.app

CBDE500D7ED18E08F6DF852A5D23D8C7113EB30C is hash of certificate which exist in both jpackagerTest.keychain and jpackagerTest-duplicate.keychain. Based on man page documentation it is allowed. When hash is used codesign will not perform any search of certificates based on man page. So codesign will not fail which is expected.

Case 2: Full name of certificate is used (FAIL):
jpackage --type dmg -i input -n Test --main-class components.DynamicTreeDemo --main-jar DynamicTreeDemo.jar --mac-sign --mac-signing-keychain jpackagerTest-duplicate.keychain --mac-app-image-sign-identity "Developer ID Application: jpackage.openjdk.java.net"
Error: "codesign" failed with following output:
Developer ID Application: jpackage.openjdk.java.net: found in both /Users/alexander/Library/Keychains/jpackagerTest.keychain-db and /Users/alexander/Library/Keychains/jpackagerTest-duplicate.keychain-db (this is all right)
Developer ID Application: jpackage.openjdk.java.net: ambiguous (matches "Developer ID Application: jpackage.openjdk.java.net" in /Users/alexander/Library/Keychains/jpackagerTest.keychain-db and "Developer ID Application: jpackage.openjdk.java.net" in /Users/alexander/Library/Keychains/jpackagerTest-duplicate.keychain-db)

Actual codesign command in FAIL case:
/usr/bin/codesign -s Developer ID Application: jpackage.openjdk.java.net -vvvv --timestamp --options runtime --prefix components. --keychain jpackagerTest-duplicate.keychain /var/folders/dr/65dj5x3j0296mqtsn9z27xc80000gn/T/jdk.jpackage12899615926124631029/image/Test.app/Contents/runtime/Contents/Home/lib/libnet.dylib
[11:20:45.113] Output:
    Developer ID Application: jpackage.openjdk.java.net: found in both /Users/alexander/Library/Keychains/jpackagerTest.keychain-db and /Users/alexander/Library/Keychains/jpackagerTest-duplicate.keychain-db (this is all right)
    Developer ID Application: jpackage.openjdk.java.net: ambiguous (matches "Developer ID Application: jpackage.openjdk.java.net" in /Users/alexander/Library/Keychains/jpackagerTest.keychain-db and "Developer ID Application: jpackage.openjdk.java.net" in /Users/alexander/Library/Keychains/jpackagerTest-duplicate.keychain-db)

Full certificate name is being passed since --mac-app-image-sign-identity is used which is pass through. In this case codesign will perform search and finds duplicated certificate and fails, since it does not know which one to use. Based on man page it is expected.

Suggested fix:
Case when --mac-signing-key-user-name is used. jpackage should PASS, since jpackage performs certificate search and selects first one with warning by design.

Case when --mac-app-image-sign-identity is used. jpackage should FAIL, since codesign selects certificate based on --mac-app-image-sign-identity.