### PR TITLE
8361827: [TESTBUG] serviceability/HeapDump/UnmountedVThreadNativeMethodAtTop.java throws OutOfMemoryError

### DIFF
--- a/test/hotspot/jtreg/serviceability/HeapDump/UnmountedVThreadNativeMethodAtTop.java
+++ b/test/hotspot/jtreg/serviceability/HeapDump/UnmountedVThreadNativeMethodAtTop.java
@@ -132,41 +132,6 @@ public class UnmountedVThreadNativeMethodAtTop {
         }
     }
 
-    /**
-     * Duplicate of VThreadBlockedAtOjectWait supposed to throw OOM
-     */
-    @Test
-    void VThreadBlockedAtOjectWait_DUP_FOR_OOM() throws Exception {
-        var lock = this;
-        var started = new CountDownLatch(1);
-        var vthread = Thread.ofVirtual().unstarted(() -> {
-            started.countDown();
-            try {
-                synchronized (lock) {
-                    while (!done) {
-                        lock.wait();
-                    }
-                }
-            } catch (InterruptedException e) { }
-        });
-        try {
-            vthread.start();
-
-            // wait for thread to start and wait
-            started.await();
-            await(vthread, Thread.State.WAITING);
-
-            Path dumpFile = dumpHeap();
-            verifyHeapDump(dumpFile);
-        } finally {
-            synchronized (lock) {
-                done = true;
-                lock.notify();
-            }
-            vthread.join();
-        }
-    }
-
     private Path dumpHeap() throws Exception {
         Path df = Files.createTempFile(Path.of("."), "dump", ".hprof");
         Files.delete(df);


### PR DESCRIPTION
This pr makes sure to call System.gc() before each test in UnmountedVThreadNativeMethodAtTop.java

The intention is to get rid of unreachable objects representing loaded heap dumps from previous tests.

This prevents OutOfMemoryErrors. Parsing the smaller dumps is faster too.

The PR also includes a reproducer for convenient testing of the pr.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8361827](https://bugs.openjdk.org/browse/JDK-8361827): [TESTBUG] serviceability/HeapDump/UnmountedVThreadNativeMethodAtTop.java throws OutOfMemoryError (**Bug** - P4)


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)
 * [SendaoYan](https://openjdk.org/census#syan) (@sendaoYan - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26278/head:pull/26278` \
`$ git checkout pull/26278`

Update a local copy of the PR: \
`$ git checkout pull/26278` \
`$ git pull https://git.openjdk.org/jdk.git pull/26278/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26278`

View PR using the GUI difftool: \
`$ git pr show -t 26278`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26278.diff">https://git.openjdk.org/jdk/pull/26278.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26278#issuecomment-3068152768)
</details>
