### PR TITLE
8361602: [TESTBUG] serviceability/HeapDump/UnmountedVThreadNativeMethodAtTop.java deadlocks on exception

### DIFF
--- a/test/hotspot/jtreg/serviceability/HeapDump/UnmountedVThreadNativeMethodAtTop.java
+++ b/test/hotspot/jtreg/serviceability/HeapDump/UnmountedVThreadNativeMethodAtTop.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,6 +46,8 @@ import jdk.test.lib.hprof.model.ThreadObject;
 import jdk.test.lib.hprof.parser.Reader;
 
 public class UnmountedVThreadNativeMethodAtTop {
+
+    boolean done;
 
     /**
      * Test dumping the heap while a virtual thread is blocked entering a synchronized native method.
@@ -96,7 +98,9 @@ public class UnmountedVThreadNativeMethodAtTop {
             started.countDown();
             try {
                 synchronized (lock) {
-                    lock.wait();
+                    while (!done) {
+                        lock.wait();
+                    }
                 }
             } catch (InterruptedException e) { }
         });
@@ -109,11 +113,11 @@ public class UnmountedVThreadNativeMethodAtTop {
 
             Path dumpFile = dumpHeap();
             verifyHeapDump(dumpFile);
-
+        } finally {
             synchronized (lock) {
+                done = true;
                 lock.notify();
             }
-        } finally {
             vthread.join();
         }
     }


### PR DESCRIPTION
This pull request contains a backport of commit [917d0182](https://github.com/openjdk/jdk/commit/917d0182cb5ea6066afd396381ca4650371e64b0) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

It moves the notify() call to the finally block to avoid the deadlock in join() if verifyHeapDump(dumpFile) throws an exception. It also wraps the wait into a loop to protect against spurious wake up.

The commit being backported was authored by Richard Reingruber on 12 Jul 2025 and was reviewed by Chris Plummer, Christoph Langer and David Holmes.

Testing was done with fastdebug and release builds on the main platforms and also on Linux/PPC64le and AIX.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8361602](https://bugs.openjdk.org/browse/JDK-8361602): [TESTBUG] serviceability/HeapDump/UnmountedVThreadNativeMethodAtTop.java deadlocks on exception (**Bug** - P4)


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26279/head:pull/26279` \
`$ git checkout pull/26279`

Update a local copy of the PR: \
`$ git checkout pull/26279` \
`$ git pull https://git.openjdk.org/jdk.git pull/26279/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26279`

View PR using the GUI difftool: \
`$ git pr show -t 26279`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26279.diff">https://git.openjdk.org/jdk/pull/26279.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26279#issuecomment-3068161005)
</details>
