### PR TITLE
8361961: Typo in ProtectionDomain.implies

### DIFF
--- a/src/java.base/share/classes/java/security/ProtectionDomain.java
+++ b/src/java.base/share/classes/java/security/ProtectionDomain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -224,7 +224,7 @@ public class ProtectionDomain {
      * no longer supported. The {@linkplain Policy#getPolicy current policy}
      * is always a {@code Policy} object that grants no permissions.
      *
-     * @param perm the {code Permission} object to check.
+     * @param perm the {@code Permission} object to check.
      *
      * @return {@code true} if {@code perm} is implied by this
      * {@code ProtectionDomain}.


### PR DESCRIPTION
Missing Javadoc meta character for ProtectionDomain.implies.  Fix adds missing meta character.

No regression tests related to change, but did validate that Javadoc does now render the code element.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8361961](https://bugs.openjdk.org/browse/JDK-8361961): Typo in ProtectionDomain.implies (**Bug** - P4)


### Reviewers
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Hai-May Chao](https://openjdk.org/census#hchao) (@haimaychao - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26281/head:pull/26281` \
`$ git checkout pull/26281`

Update a local copy of the PR: \
`$ git checkout pull/26281` \
`$ git pull https://git.openjdk.org/jdk.git pull/26281/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26281`

View PR using the GUI difftool: \
`$ git pr show -t 26281`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26281.diff">https://git.openjdk.org/jdk/pull/26281.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26281#issuecomment-3079861860)
</details>
