### PR TITLE
8361912: ThreadsListHandle::cv_internal_thread_to_JavaThread  does not deal with a virtual thread's carrier thread

### DIFF
--- a/src/hotspot/share/prims/jvmtiExport.cpp
+++ b/src/hotspot/share/prims/jvmtiExport.cpp
@@ -859,47 +859,6 @@ JvmtiExport::cv_external_thread_to_JavaThread(ThreadsList * t_list,
   return JVMTI_ERROR_NONE;
 }
 
-// Convert an oop to a JavaThread found on the specified ThreadsList.
-// The ThreadsListHandle in the caller "protects" the returned
-// JavaThread *.
-//
-// On success, *jt_pp is set to the converted JavaThread * and
-// JVMTI_ERROR_NONE is returned. On error, returns various
-// JVMTI_ERROR_* values.
-//
-jvmtiError
-JvmtiExport::cv_oop_to_JavaThread(ThreadsList * t_list, oop thread_oop,
-                                  JavaThread ** jt_pp) {
-  assert(t_list != nullptr, "must have a ThreadsList");
-  assert(thread_oop != nullptr, "must have an oop");
-  assert(jt_pp != nullptr, "must have a return JavaThread pointer");
-
-  if (!thread_oop->is_a(vmClasses::Thread_klass())) {
-    // The oop is not a java.lang.Thread.
-    return JVMTI_ERROR_INVALID_THREAD;
-  }
-  // Looks like a java.lang.Thread oop at this point.
-
-  JavaThread * java_thread = java_lang_Thread::thread(thread_oop);
-  if (java_thread == nullptr) {
-    // The java.lang.Thread does not contain a JavaThread * so it has
-    // not yet run or it has died.
-    return JVMTI_ERROR_THREAD_NOT_ALIVE;
-  }
-  // Looks like a live JavaThread at this point.
-
-  if (!t_list->includes(java_thread)) {
-    // Not on the JavaThreads list so it is not alive.
-    return JVMTI_ERROR_THREAD_NOT_ALIVE;
-  }
-
-  // Return a live JavaThread that is "protected" by the
-  // ThreadsListHandle in the caller.
-  *jt_pp = java_thread;
-
-  return JVMTI_ERROR_NONE;
-}
-
 class JvmtiClassFileLoadHookPoster : public StackObj {
  private:
   Symbol*            _h_name;

--- a/src/hotspot/share/prims/jvmtiExport.hpp
+++ b/src/hotspot/share/prims/jvmtiExport.hpp
@@ -454,8 +454,6 @@ class JvmtiExport : public AllStatic {
                                                      jthread thread,
                                                      JavaThread ** jt_pp,
                                                      oop * thread_oop_p);
-  static jvmtiError cv_oop_to_JavaThread(ThreadsList * t_list, oop thread_oop,
-                                         JavaThread ** jt_pp);
 };
 
 // Support class used by JvmtiDynamicCodeEventCollector and others. It

--- a/src/hotspot/share/runtime/threadSMR.cpp
+++ b/src/hotspot/share/runtime/threadSMR.cpp
@@ -830,7 +830,7 @@ bool ThreadsListHandle::cv_internal_thread_to_JavaThread(jobject jthread,
       // make it past ensure_join() where the JavaThread* is cleared.
       return false;
     } else {
-      // For virtual thread's we need to extract the carrier's JavaThread - if any.
+      // For virtual threads we need to extract the carrier's JavaThread - if any.
        oop carrier_thread = java_lang_VirtualThread::carrier_thread(thread_oop);
        if (carrier_thread != nullptr) {
          java_thread = java_lang_Thread::thread(carrier_thread);

--- a/src/hotspot/share/runtime/threadSMR.cpp
+++ b/src/hotspot/share/runtime/threadSMR.cpp
@@ -789,9 +789,13 @@ ThreadsListHandle::~ThreadsListHandle() {
 
 // Convert an internal thread reference to a JavaThread found on the
 // associated ThreadsList. This ThreadsListHandle "protects" the
-// returned JavaThread *. If the jthread resolves to a virtual thread
-// then the JavaThread * for its current carrier thread (if any) is
-// returned via *jt_pp.
+// returned JavaThread *.
+//
+// If the jthread resolves to a virtual thread then the JavaThread *
+// for its current carrier thread (if any) is returned via *jt_pp.
+// It is up to the caller to prevent the virtual thread from changing
+// its mounted status, or else account for it when acting on the carrier
+// JavaThread.
 //
 // If thread_oop_p is not null, then the caller wants to use the oop
 // after this call so the oop is always returned. On success, *jt_pp is set

--- a/src/hotspot/share/runtime/threadSMR.cpp
+++ b/src/hotspot/share/runtime/threadSMR.cpp
@@ -817,24 +817,8 @@ bool ThreadsListHandle::cv_internal_thread_to_JavaThread(jobject jthread,
     // the oop even if this function returns false.
     *thread_oop_p = thread_oop;
   }
-  return cv_thread_oop_to_JavaThread(thread_oop, jt_pp);
-}
 
-// Convert a thread oop to a JavaThread found on the associated ThreadsList.
-// This ThreadsListHandle "protects" the returned JavaThread *.  If the oop
-// is a virtual thread then the JavaThread * for its current carrier thread
-// (if any) is returned via *jt_pp.
-// On success, *jt_pp is set to the converted JavaThread * and true is returned.
-// On error, returns false, and *jt_pp is unchanged.
-//
-bool ThreadsListHandle::cv_thread_oop_to_JavaThread(oop thread_oop,
-                                                    JavaThread ** jt_pp) {
-
-  assert(this->list() != nullptr, "must have a ThreadsList");
-  assert(jt_pp != nullptr, "must have a return JavaThread pointer");
-  assert(thread_oop->is_a(vmClasses::Thread_klass()), "must be a valid j.l.Thread oop");
-
-  JavaThread* java_thread = java_lang_Thread::thread_acquire(thread_oop);
+  JavaThread *java_thread = java_lang_Thread::thread_acquire(thread_oop);
   if (java_thread == nullptr) {
     if (!java_lang_VirtualThread::is_instance(thread_oop)) {
       // The java.lang.Thread does not contain a JavaThread* so it has not
@@ -848,7 +832,7 @@ bool ThreadsListHandle::cv_thread_oop_to_JavaThread(oop thread_oop,
          java_thread = java_lang_Thread::thread(carrier_thread);
        }
        if (java_thread == nullptr) {
-         // Virtual thread was unbound, or else carrier has now terminated.
+         // Virtual thread was unmounted, or else carrier has now terminated.
          return false;
        }
     }

--- a/src/hotspot/share/runtime/threadSMR.hpp
+++ b/src/hotspot/share/runtime/threadSMR.hpp
@@ -75,11 +75,6 @@ class ThreadsList;
 // but that target JavaThread* will not be deleted until it is no
 // longer protected by a ThreadsListHandle.
 //
-// Note that for virtual threads, we obtain a reference to the carrier JavaThread
-// on which it is mounted (if any). It is up to the caller to prevent the virtual
-// thread from changing its mounted status, or else account for it when acting on
-// the carrier JavaThread.
-//
 // SMR Support for the Threads class.
 //
 class ThreadsSMRSupport : AllStatic {

--- a/src/hotspot/share/runtime/threadSMR.hpp
+++ b/src/hotspot/share/runtime/threadSMR.hpp
@@ -45,7 +45,7 @@ class ThreadsList;
 // operation. It is no longer necessary to hold the Threads_lock to safely
 // perform an operation on a target thread.
 //
-// There two ways to refer to java.lang.Thread objects so we have two ways
+// There are two ways to refer to java.lang.Thread objects so we have two ways
 // to get a protected JavaThread*:
 //
 // JNI jobject example:
@@ -69,7 +69,7 @@ class ThreadsList;
 //   }
 //   :  // do stuff with 'jt'...
 //
-// A JavaThread* that is included in the ThreadsList that is held by
+// A JavaThread * that is included in the ThreadsList that is held by
 // a ThreadsListHandle is protected as long as the ThreadsListHandle
 // remains in scope. The target JavaThread* may have logically exited,
 // but that target JavaThread* will not be deleted until it is no

--- a/src/hotspot/share/runtime/threadSMR.hpp
+++ b/src/hotspot/share/runtime/threadSMR.hpp
@@ -45,8 +45,8 @@ class ThreadsList;
 // operation. It is no longer necessary to hold the Threads_lock to safely
 // perform an operation on a target thread.
 //
-// There are several different ways to refer to java.lang.Thread objects
-// so we have a few ways to get a protected JavaThread*:
+// There two ways to refer to java.lang.Thread objects so we have two ways
+// to get a protected JavaThread*:
 //
 // JNI jobject example:
 //   jobject jthread = ...;
@@ -68,16 +68,6 @@ class ThreadsList;
 //     return err;
 //   }
 //   :  // do stuff with 'jt'...
-//
-// Java oop example
-//   oop thread_obj = ...;
-//   :
-//   JavaThread *jt = nullptr;
-//   ThreadsListHandle tlh;
-//   bool is_alive = tlh.cv_thread_oop_to_JavaThread(thread_oop, &jt);
-//   if (is_alive) {
-//     :  // do stuff with 'jt'...
-//   }
 //
 // A JavaThread* that is included in the ThreadsList that is held by
 // a ThreadsListHandle is protected as long as the ThreadsListHandle
@@ -323,7 +313,6 @@ public:
   inline Iterator end();
 
   bool cv_internal_thread_to_JavaThread(jobject jthread, JavaThread** jt_pp, oop* thread_oop_p);
-  bool cv_thread_oop_to_JavaThread(oop thread_oop, JavaThread** jt_pp);
 
   bool includes(JavaThread* p) {
     return list()->includes(p);

--- a/src/hotspot/share/runtime/threadSMR.hpp
+++ b/src/hotspot/share/runtime/threadSMR.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,7 +46,7 @@ class ThreadsList;
 // perform an operation on a target thread.
 //
 // There are several different ways to refer to java.lang.Thread objects
-// so we have a few ways to get a protected JavaThread *:
+// so we have a few ways to get a protected JavaThread*:
 //
 // JNI jobject example:
 //   jobject jthread = ...;
@@ -69,22 +69,26 @@ class ThreadsList;
 //   }
 //   :  // do stuff with 'jt'...
 //
-// JVM/TI oop example (this one should be very rare):
+// Java oop example
 //   oop thread_obj = ...;
 //   :
 //   JavaThread *jt = nullptr;
 //   ThreadsListHandle tlh;
-//   jvmtiError err = JvmtiExport::cv_oop_to_JavaThread(tlh.list(), thread_obj, &jt);
-//   if (err != JVMTI_ERROR_NONE) {
-//     return err;
+//   bool is_alive = tlh.cv_thread_oop_to_JavaThread(thread_oop, &jt);
+//   if (is_alive) {
+//     :  // do stuff with 'jt'...
 //   }
-//   :  // do stuff with 'jt'...
 //
-// A JavaThread * that is included in the ThreadsList that is held by
+// A JavaThread* that is included in the ThreadsList that is held by
 // a ThreadsListHandle is protected as long as the ThreadsListHandle
-// remains in scope. The target JavaThread * may have logically exited,
-// but that target JavaThread * will not be deleted until it is no
+// remains in scope. The target JavaThread* may have logically exited,
+// but that target JavaThread* will not be deleted until it is no
 // longer protected by a ThreadsListHandle.
+//
+// Note that for virtual threads, we obtain a reference to the carrier JavaThread
+// on which it is mounted (if any). It is up to the caller to prevent the virtual
+// thread from changing its mounted status, or else account for it when acting on
+// the carrier JavaThread.
 //
 // SMR Support for the Threads class.
 //
@@ -318,7 +322,8 @@ public:
   inline Iterator begin();
   inline Iterator end();
 
-  bool cv_internal_thread_to_JavaThread(jobject jthread, JavaThread ** jt_pp, oop * thread_oop_p);
+  bool cv_internal_thread_to_JavaThread(jobject jthread, JavaThread** jt_pp, oop* thread_oop_p);
+  bool cv_thread_oop_to_JavaThread(oop thread_oop, JavaThread** jt_pp);
 
   bool includes(JavaThread* p) {
     return list()->includes(p);

--- a/src/hotspot/share/services/threadService.cpp
+++ b/src/hotspot/share/services/threadService.cpp
@@ -1434,6 +1434,27 @@ int jdk_internal_vm_ThreadSnapshot::_locks_offset;
 int jdk_internal_vm_ThreadSnapshot::_blockerTypeOrdinal_offset;
 int jdk_internal_vm_ThreadSnapshot::_blockerObject_offset;
 
+// wrapper to auto delete JvmtiVTMSTransitionDisabler
+class TransitionDisabler {
+  JvmtiVTMSTransitionDisabler* _transition_disabler;
+ public:
+  TransitionDisabler(): _transition_disabler(nullptr) {}
+  ~TransitionDisabler() {
+    reset();
+  }
+  // Invoke this when you know you have a virtual thread.
+  void init(jobject jthread) {
+    _transition_disabler = new (mtInternal) JvmtiVTMSTransitionDisabler(jthread);
+  }
+  // Manually re-enable transitions.
+  void reset() {
+    if (_transition_disabler != nullptr) {
+      delete _transition_disabler;
+      _transition_disabler = nullptr;
+    }
+  }
+};
+
 oop ThreadSnapshotFactory::get_thread_snapshot(jobject jthread, TRAPS) {
   ThreadsListHandle tlh(THREAD);
 
@@ -1441,46 +1462,22 @@ oop ThreadSnapshotFactory::get_thread_snapshot(jobject jthread, TRAPS) {
   HandleMark   hm(THREAD);
 
   JavaThread* java_thread = nullptr;
-  oop thread_oop;
-  bool has_javathread = tlh.cv_internal_thread_to_JavaThread(jthread, &java_thread, &thread_oop);
-  assert((has_javathread && thread_oop != nullptr) || !has_javathread, "Missing Thread oop");
+  oop thread_oop = JNIHandles::resolve_non_null(jthread);
   Handle thread_h(THREAD, thread_oop);
   bool is_virtual = java_lang_VirtualThread::is_instance(thread_h());  // Deals with null
 
-  if (!has_javathread && !is_virtual) {
-    return nullptr; // thread terminated so not of interest
+  TransitionDisabler transition_disabler;
+
+  if (is_virtual) {
+    // We must disable mount/unmount transitions
+    transition_disabler.init(jthread);
   }
 
-  // wrapper to auto delete JvmtiVTMSTransitionDisabler
-  class TransitionDisabler {
-    JvmtiVTMSTransitionDisabler* _transition_disabler;
-  public:
-    TransitionDisabler(): _transition_disabler(nullptr) {}
-    ~TransitionDisabler() {
-      reset();
-    }
-    void init(jobject jthread) {
-      _transition_disabler = new (mtInternal) JvmtiVTMSTransitionDisabler(jthread);
-    }
-    void reset() {
-      if (_transition_disabler != nullptr) {
-        delete _transition_disabler;
-        _transition_disabler = nullptr;
-      }
-    }
-  } transition_disabler;
+  bool has_javathread = tlh.cv_thread_oop_to_JavaThread(thread_oop, &java_thread);
+  assert((has_javathread && thread_oop != nullptr) || !has_javathread, "Missing Thread oop");
 
-  Handle carrier_thread;
-  if (is_virtual) {
-    // 1st need to disable mount/unmount transitions
-    transition_disabler.init(jthread);
-
-    carrier_thread = Handle(THREAD, java_lang_VirtualThread::carrier_thread(thread_h()));
-    if (carrier_thread != nullptr) {
-      java_thread = java_lang_Thread::thread(carrier_thread());
-    }
-  } else {
-    java_thread = java_lang_Thread::thread(thread_h());
+  if (!has_javathread && !is_virtual) {
+    return nullptr; // thread terminated so not of interest
   }
 
   // Handshake with target
@@ -1544,7 +1541,10 @@ oop ThreadSnapshotFactory::get_thread_snapshot(jobject jthread, TRAPS) {
   Handle snapshot = jdk_internal_vm_ThreadSnapshot::allocate(InstanceKlass::cast(snapshot_klass), CHECK_NULL);
   jdk_internal_vm_ThreadSnapshot::set_name(snapshot(), cl._thread_name.resolve());
   jdk_internal_vm_ThreadSnapshot::set_thread_status(snapshot(), (int)cl._thread_status);
-  jdk_internal_vm_ThreadSnapshot::set_carrier_thread(snapshot(), carrier_thread());
+  if (is_virtual) {
+    Handle carrier_thread = Handle(THREAD, java_lang_VirtualThread::carrier_thread(thread_h()));
+    jdk_internal_vm_ThreadSnapshot::set_carrier_thread(snapshot(), carrier_thread());
+  }
   jdk_internal_vm_ThreadSnapshot::set_stack_trace(snapshot(), trace());
   jdk_internal_vm_ThreadSnapshot::set_locks(snapshot(), locks());
   if (!cl._blocker.is_empty()) {
@@ -1554,4 +1554,3 @@ oop ThreadSnapshotFactory::get_thread_snapshot(jobject jthread, TRAPS) {
 }
 
 #endif // INCLUDE_JVMTI
-


### PR DESCRIPTION
The `cv_internal_thread_to_JavaThread` method will now check if the thread is a mounted virtual thread, and if so protect the carrier thread. User's of the API that need to deal with virtual threads must still check the carrier themselves as it could change asynchronously, but it is now guaranteed that the carrier JavaThread returned via this method cannot terminate whilst being used (the same as regular platform JavaThreads).

It was noticed whilst updating the documentation that the `JvmtiExport` variant `cv_oop_to_JavaThread` is unused and so can be removed.

Testing:
- tiers 1-4

Thanks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8361912](https://bugs.openjdk.org/browse/JDK-8361912): ThreadsListHandle::cv_internal_thread_to_JavaThread  does not deal with a virtual thread's carrier thread (**Bug** - P3)


### Reviewers
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**) Review applies to [820f26e4](https://git.openjdk.org/jdk/pull/26287/files/820f26e4b93673c0d0b68f4dd816addb5c6f723e)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**) Review applies to [820f26e4](https://git.openjdk.org/jdk/pull/26287/files/820f26e4b93673c0d0b68f4dd816addb5c6f723e)
 * [Patricio Chilano Mateo](https://openjdk.org/census#pchilanomate) (@pchilano - **Reviewer**)
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26287/head:pull/26287` \
`$ git checkout pull/26287`

Update a local copy of the PR: \
`$ git checkout pull/26287` \
`$ git pull https://git.openjdk.org/jdk.git pull/26287/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26287`

View PR using the GUI difftool: \
`$ git pr show -t 26287`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26287.diff">https://git.openjdk.org/jdk/pull/26287.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26287#issuecomment-3095725662)
</details>
