### PR TITLE
8362122: Problem list TestStressBailout until JDK-8361752 is fixed

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -82,6 +82,8 @@ compiler/c2/TestVerifyConstraintCasts.java 8355574 generic-all
 
 compiler/c2/aarch64/TestStaticCallStub.java 8359963 linux-aarch64,macosx-aarch64
 
+compiler/debug/TestStressBailout.java 8361752 generic-all
+
 #############################################################################
 
 # :hotspot_gc


### PR DESCRIPTION
Let's problem list the test until [JDK-8361752](https://bugs.openjdk.org/browse/JDK-8361752) is fixed. The failure seems to be triggered by [JDK-8357473](https://bugs.openjdk.org/browse/JDK-8357473).

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8362122](https://bugs.openjdk.org/browse/JDK-8362122): Problem list TestStressBailout until JDK-8361752 is fixed (**Sub-task** - P4)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26288/head:pull/26288` \
`$ git checkout pull/26288`

Update a local copy of the PR: \
`$ git checkout pull/26288` \
`$ git pull https://git.openjdk.org/jdk.git pull/26288/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26288`

View PR using the GUI difftool: \
`$ git pr show -t 26288`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26288.diff">https://git.openjdk.org/jdk/pull/26288.diff</a>

</details>
