### PR TITLE
8361705: Clean up KlassCleaningTask

### DIFF
--- a/src/hotspot/share/gc/shared/parallelCleaning.hpp
+++ b/src/hotspot/share/gc/shared/parallelCleaning.hpp
@@ -52,19 +52,16 @@ public:
   void work(uint worker_id);
 };
 
-
+// Cleans out the Klass tree from stale data.
 class KlassCleaningTask : public StackObj {
-  volatile int                            _clean_klass_tree_claimed;
+  volatile bool _clean_klass_tree_claimed;
   ClassLoaderDataGraphKlassIteratorAtomic _klass_iterator;
 
-public:
-  KlassCleaningTask();
-
-private:
   bool claim_clean_klass_tree_task();
   InstanceKlass* claim_next_klass();
 
 public:
+  KlassCleaningTask();
 
   void work();
 };


### PR DESCRIPTION
Hi all,

  please review this cleanup of `KlassCleaningTask`, fixing some style issues.

Testing: gha

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8361705](https://bugs.openjdk.org/browse/JDK-8361705): Clean up KlassCleaningTask (**Enhancement** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26289/head:pull/26289` \
`$ git checkout pull/26289`

Update a local copy of the PR: \
`$ git checkout pull/26289` \
`$ git pull https://git.openjdk.org/jdk.git pull/26289/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26289`

View PR using the GUI difftool: \
`$ git pr show -t 26289`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26289.diff">https://git.openjdk.org/jdk/pull/26289.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26289#issuecomment-3068797881)
</details>
