### PR TITLE
8361894: sun/security/krb5/config/native/TestDynamicStore.java ensure that the test is run with sudo

### DIFF
--- a/test/jdk/sun/security/krb5/config/native/TestDynamicStore.java
+++ b/test/jdk/sun/security/krb5/config/native/TestDynamicStore.java
@@ -60,13 +60,13 @@ public class TestDynamicStore {
 
         // Show a popup to remind to run this test as sudo user
         // this will only trigger if sudo (root) user is not detected
-        if ("root".equals(System.getProperty("user.name"))) {
+        if (!"root".equals(System.getProperty("user.name"))) {
 
             JOptionPane.showMessageDialog(null, """
-                            This test MUST be run with SUDO user.\s
+                            This test MUST be run as ROOT.\s
                             Please close and RESTART the test.""");
 
-            Asserts.assertFalse(true, "Test must be run with SUDO");
+            Asserts.assertFalse(true, "This test must be run as ROOT");
         }
 
         System.loadLibrary("TestDynamicStore");

--- a/test/jdk/sun/security/krb5/config/native/TestDynamicStore.java
+++ b/test/jdk/sun/security/krb5/config/native/TestDynamicStore.java
@@ -57,14 +57,17 @@ public class TestDynamicStore {
     public static void main(String[] args) throws Exception {
 
         // Show a popup to remind to run this test as sudo user
-        PassFailJFrame.builder()
-                .instructions("""
-                        This test MUST be run with SUDO user.\s
+        // this will only trigger if sudo (root) user is not detected
+        if (!"root".equals(System.getProperty("user.name"))) {
+            PassFailJFrame.builder()
+                    .instructions("""
+                            This test MUST be run with SUDO user.\s
 
-                        Please press FAIL and RESTART the test if it is not,\s
-                        else press PASS and the test will be executed automatically""")
-                .build()
-                .awaitAndCheck();
+                            Please press FAIL and RESTART the test if it is not,\s
+                            else press PASS and the test will be executed automatically""")
+                    .build()
+                    .awaitAndCheck();
+        }
 
         System.loadLibrary("TestDynamicStore");
 

--- a/test/jdk/sun/security/krb5/config/native/TestDynamicStore.java
+++ b/test/jdk/sun/security/krb5/config/native/TestDynamicStore.java
@@ -26,13 +26,15 @@
  * @bug 8257860
  * @summary SCDynamicStoreConfig works
  * @modules java.security.jgss/sun.security.krb5
- * @library /test/lib /java/awt/regtesthelpers
- * @run main/manual/native TestDynamicStore
+ * @library /test/lib
+ * @run main/manual/native/timeout=180 TestDynamicStore
  * @requires (os.family == "mac")
  */
 
 import jdk.test.lib.Asserts;
 import sun.security.krb5.Config;
+
+import javax.swing.JOptionPane;
 
 // =================== Attention ===================
 // This test calls a native method implemented in libTestDynamicStore.m
@@ -58,15 +60,13 @@ public class TestDynamicStore {
 
         // Show a popup to remind to run this test as sudo user
         // this will only trigger if sudo (root) user is not detected
-        if (!"root".equals(System.getProperty("user.name"))) {
-            PassFailJFrame.builder()
-                    .instructions("""
-                            This test MUST be run with SUDO user.\s
+        if ("root".equals(System.getProperty("user.name"))) {
 
-                            Please press FAIL and RESTART the test if it is not,\s
-                            else press PASS and the test will be executed automatically""")
-                    .build()
-                    .awaitAndCheck();
+            JOptionPane.showMessageDialog(null, """
+                            This test MUST be run with SUDO user.\s
+                            Please close and RESTART the test.""");
+
+            Asserts.assertFalse(true, "Test must be run with SUDO");
         }
 
         System.loadLibrary("TestDynamicStore");

--- a/test/jdk/sun/security/krb5/config/native/TestDynamicStore.java
+++ b/test/jdk/sun/security/krb5/config/native/TestDynamicStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
  * @bug 8257860
  * @summary SCDynamicStoreConfig works
  * @modules java.security.jgss/sun.security.krb5
- * @library /test/lib
+ * @library /test/lib /java/awt/regtesthelpers
  * @run main/manual/native TestDynamicStore
  * @requires (os.family == "mac")
  */
@@ -55,6 +55,16 @@ public class TestDynamicStore {
     }
 
     public static void main(String[] args) throws Exception {
+
+        // Show a popup to remind to run this test as sudo user
+        PassFailJFrame.builder()
+                .instructions("""
+                        This test MUST be run with SUDO user.\s
+
+                        Please press FAIL and RESTART the test if it is not,\s
+                        else press PASS and the test will be executed automatically""")
+                .build()
+                .awaitAndCheck();
 
         System.loadLibrary("TestDynamicStore");
 


### PR DESCRIPTION
sun/security/krb5/config/native/TestDynamicStore.java is commonly run without sudo, which leads to the access related failure. 
Added a ui popup reminding to run the test with sudo, making instructions clearer and more noticeable

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8361894](https://bugs.openjdk.org/browse/JDK-8361894): sun/security/krb5/config/native/TestDynamicStore.java ensure that the test is run with sudo (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26293/head:pull/26293` \
`$ git checkout pull/26293`

Update a local copy of the PR: \
`$ git checkout pull/26293` \
`$ git pull https://git.openjdk.org/jdk.git pull/26293/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26293`

View PR using the GUI difftool: \
`$ git pr show -t 26293`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26293.diff">https://git.openjdk.org/jdk/pull/26293.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26293#issuecomment-3069529406)
</details>
