### PR TITLE
8361752: Double free in CompileQueue::delete_all after JDK-8357473

### DIFF
--- a/src/hotspot/share/compiler/compileBroker.cpp
+++ b/src/hotspot/share/compiler/compileBroker.cpp
@@ -377,7 +377,7 @@ void CompileQueue::delete_all() {
     } else {
       // Blocking task. By convention, it is the waiters responsibility
       // to delete the task. We cannot delete it here, because we do not
-      // coordinate with waiters. We will notify them later.
+      // coordinate with waiters. We will notify the waiters later.
     }
     current = current->next();
   }

--- a/src/hotspot/share/compiler/compileTask.cpp
+++ b/src/hotspot/share/compiler/compileTask.cpp
@@ -56,8 +56,6 @@ CompileTask::CompileTask(int compile_id,
   _comp_level = comp_level;
   _num_inlined_bytecodes = 0;
 
-  _waiting_count = 0;
-
   _is_complete = false;
   _is_success = false;
 

--- a/src/hotspot/share/compiler/compileTask.hpp
+++ b/src/hotspot/share/compiler/compileTask.hpp
@@ -99,7 +99,6 @@ class CompileTask : public CHeapObj<mtCompiler> {
   // Compilation state for a blocking JVMCI compilation
   JVMCICompileState*   _blocking_jvmci_compile_state;
 #endif
-  int                  _waiting_count;  // See waiting_for_completion_count()
   int                  _comp_level;
   int                  _num_inlined_bytecodes;
   CompileTask*         _next, *_prev;
@@ -163,23 +162,6 @@ class CompileTask : public CHeapObj<mtCompiler> {
     _blocking_jvmci_compile_state = state;
   }
 #endif
-
-  // See how many threads are waiting for this task. Must have lock to read this.
-  int waiting_for_completion_count() {
-    assert(CompileTaskWait_lock->owned_by_self(), "must have lock to use waiting_for_completion_count()");
-    return _waiting_count;
-  }
-  // Indicates that a thread is waiting for this task to complete. Must have lock to use this.
-  void inc_waiting_for_completion() {
-    assert(CompileTaskWait_lock->owned_by_self(), "must have lock to use inc_waiting_for_completion()");
-    _waiting_count++;
-  }
-  // Indicates that a thread stopped waiting for this task to complete. Must have lock to use this.
-  void dec_waiting_for_completion() {
-    assert(CompileTaskWait_lock->owned_by_self(), "must have lock to use dec_waiting_for_completion()");
-    assert(_waiting_count > 0, "waiting count is not positive");
-    _waiting_count--;
-  }
 
   void         mark_complete()                   { _is_complete = true; }
   void         mark_success()                    { _is_success = true; }

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -82,8 +82,6 @@ compiler/c2/TestVerifyConstraintCasts.java 8355574 generic-all
 
 compiler/c2/aarch64/TestStaticCallStub.java 8359963 linux-aarch64,macosx-aarch64
 
-compiler/debug/TestStressBailout.java 8361752 generic-all
-
 #############################################################################
 
 # :hotspot_gc


### PR DESCRIPTION
See the bug for more analysis. 

The short summary is that `CompileQueue::delete_all` walks the entire compile queue and deletes the tasks. It normally goes simple, unless there are blocking tasks. Then, the actual waiters have to delete the task. Full deletion and blocking waits coordinate with `waiting_for_completion_count` counter. This mechanism _almost_ works, but there is a subtle race window, where blocking waiter could have already unparked, dropped `waiting_for_completion_count` to `0` and proceeded to delete the task, see `CompileBroker::wait_for_completion()`.

...then the queue deletion code could assume there are _no actual waiters_ on the blocking task, and proceeded to delete the task _again_, thus getting us a double-free.

I suspect we can fix that by complicating the coordination protocol even further, e.g. by tracking the counters wider. 

But recognizing `CompileQueue::delete_all()` is basically only called from the compiler shutdown code, and it looks completely opportunistic (= missing deletes / minor memory leaks are not a big deal), we should strive to simplify it.  This PR summarily delegates _all_ blocking task cleanups to waiters. I think it stands to reason and from my examination of the code, that if a blocking task is in queue, then there _is_ a waiter that would eventually call `CompileBroker::wait_for_completion()` on it.

Additional testing:
 - [x] Linux AArch64 server fastdebug, `tier1`
 - [ ] Linux AArch64 server fastdebug, `all`