### PR TITLE
8362123: ClassLoader Leak via Executors.newSingleThreadExecutor(...)

### DIFF
--- a/src/java.base/share/classes/java/util/concurrent/Executors.java
+++ b/src/java.base/share/classes/java/util/concurrent/Executors.java
@@ -755,6 +755,13 @@ public final class Executors {
             super.shutdown();
             cleanable.clean();  // unregisters the cleanable
         }
+
+        @Override
+        public List<Runnable> shutdownNow() {
+            List<Runnable> unexecuted = super.shutdownNow();
+            cleanable.clean();  // unregisters the cleanable
+            return unexecuted;
+        }
     }
 
     /**


### PR DESCRIPTION
Executors shutdown via `shutdownNow()` should have their cleanables cleaned to prevent a classloader leak. This can happen if a classloader exists that both references the wrapped executor and is referenced by the delegate executor.

To quote @Martin-Buchholz:
> BTW: I find Cleaners much harder to use than old finalize, and it looks like I'm not the only one!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8362123](https://bugs.openjdk.org/browse/JDK-8362123): ClassLoader Leak via Executors.newSingleThreadExecutor(...) (**Bug** - P4)


### Reviewers
 * [Viktor Klang](https://openjdk.org/census#vklang) (@viktorklang-ora - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26296/head:pull/26296` \
`$ git checkout pull/26296`

Update a local copy of the PR: \
`$ git checkout pull/26296` \
`$ git pull https://git.openjdk.org/jdk.git pull/26296/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26296`

View PR using the GUI difftool: \
`$ git pr show -t 26296`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26296.diff">https://git.openjdk.org/jdk/pull/26296.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26296#issuecomment-3339077819)
</details>
