### PR TITLE
8361905: Problem list serviceability/sa/ClhsdbThreadContext.java on Windows due to JDK-8356704

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -138,6 +138,8 @@ serviceability/sa/ClhsdbPstack.java#core          8318754 macosx-aarch64
 serviceability/sa/TestJmapCore.java               8318754 macosx-aarch64
 serviceability/sa/TestJmapCoreMetaspace.java      8318754 macosx-aarch64
 
+serviceability/sa/ClhsdbThreadContext.java        8356704 windows-x64
+
 serviceability/jvmti/stress/StackTrace/NotSuspended/GetStackTraceNotSuspendedStressTest.java 8315980 linux-all,windows-x64
 
 #############################################################################


### PR DESCRIPTION
This issue is somewhat noisy on JDK 25 also, so warrants a backport. Backport is clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8361905](https://bugs.openjdk.org/browse/JDK-8361905): Problem list serviceability/sa/ClhsdbThreadContext.java on Windows due to JDK-8356704 (**Sub-task** - P4)


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26297/head:pull/26297` \
`$ git checkout pull/26297`

Update a local copy of the PR: \
`$ git checkout pull/26297` \
`$ git pull https://git.openjdk.org/jdk.git pull/26297/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26297`

View PR using the GUI difftool: \
`$ git pr show -t 26297`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26297.diff">https://git.openjdk.org/jdk/pull/26297.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26297#issuecomment-3070258977)
</details>
