### PR TITLE
8361521 : BogusFocusableWindowState.java fails with StackOverflowError on Linux

### DIFF
--- a/src/java.desktop/unix/classes/sun/awt/X11/XWindowPeer.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11/XWindowPeer.java
@@ -1083,9 +1083,6 @@ class XWindowPeer extends XPanelPeer implements WindowPeer,
 
     @Override
     public void setVisible(boolean vis) {
-        if(isVisible() == vis) {
-            return;
-        }
         if (!isVisible() && vis) {
             isBeforeFirstMapNotify = true;
             winAttr.initialFocus = isAutoRequestFocus();
@@ -1101,7 +1098,10 @@ class XWindowPeer extends XPanelPeer implements WindowPeer,
                 suppressWmTakeFocus(true);
             }
         }
-        updateFocusability();
+        if(isVisible() != vis )
+        {
+            updateFocusability();
+        }
         promoteDefaultPosition();
         boolean refreshChildsTransientFor = isVisible() != vis;
         super.setVisible(vis);

--- a/src/java.desktop/unix/classes/sun/awt/X11/XWindowPeer.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11/XWindowPeer.java
@@ -1098,11 +1098,11 @@ class XWindowPeer extends XPanelPeer implements WindowPeer,
                 suppressWmTakeFocus(true);
             }
         }
-        if (isVisible() != vis) {
+        boolean refreshChildsTransientFor = isVisible() != vis;
+        if (refreshChildsTransientFor) {
             updateFocusability();
         }
         promoteDefaultPosition();
-        boolean refreshChildsTransientFor = isVisible() != vis;
         super.setVisible(vis);
         if (refreshChildsTransientFor) {
             for (Window child : ((Window) target).getOwnedWindows()) {

--- a/src/java.desktop/unix/classes/sun/awt/X11/XWindowPeer.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11/XWindowPeer.java
@@ -1098,8 +1098,7 @@ class XWindowPeer extends XPanelPeer implements WindowPeer,
                 suppressWmTakeFocus(true);
             }
         }
-        if(isVisible() != vis)
-        {
+        if(isVisible() != vis) {
             updateFocusability();
         }
         promoteDefaultPosition();

--- a/src/java.desktop/unix/classes/sun/awt/X11/XWindowPeer.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11/XWindowPeer.java
@@ -1098,7 +1098,7 @@ class XWindowPeer extends XPanelPeer implements WindowPeer,
                 suppressWmTakeFocus(true);
             }
         }
-        if(isVisible() != vis) {
+        if (isVisible() != vis) {
             updateFocusability();
         }
         promoteDefaultPosition();

--- a/src/java.desktop/unix/classes/sun/awt/X11/XWindowPeer.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11/XWindowPeer.java
@@ -1083,6 +1083,9 @@ class XWindowPeer extends XPanelPeer implements WindowPeer,
 
     @Override
     public void setVisible(boolean vis) {
+        if(isVisible() == vis) {
+            return;
+        }
         if (!isVisible() && vis) {
             isBeforeFirstMapNotify = true;
             winAttr.initialFocus = isAutoRequestFocus();

--- a/src/java.desktop/unix/classes/sun/awt/X11/XWindowPeer.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11/XWindowPeer.java
@@ -1098,7 +1098,7 @@ class XWindowPeer extends XPanelPeer implements WindowPeer,
                 suppressWmTakeFocus(true);
             }
         }
-        if(isVisible() != vis )
+        if(isVisible() != vis)
         {
             updateFocusability();
         }

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -119,7 +119,6 @@ java/awt/Focus/FocusOwnerFrameOnClick/FocusOwnerFrameOnClick.java 8081489 generi
 java/awt/Focus/IconifiedFrameFocusChangeTest/IconifiedFrameFocusChangeTest.java 6849364 generic-all
 java/awt/Focus/AutoRequestFocusTest/AutoRequestFocusToFrontTest.java 6848406 generic-all
 java/awt/Focus/AutoRequestFocusTest/AutoRequestFocusSetVisibleTest.java 6848407 generic-all
-java/awt/Frame/BogusFocusableWindowState/BogusFocusableWindowState.java 8361521 linux-all
 java/awt/Frame/MaximizedToMaximized/MaximizedToMaximized.java 8340374 macosx-all
 java/awt/Frame/MaximizedUndecorated/MaximizedUndecorated.java 8022302 generic-all
 java/awt/Frame/RestoreToOppositeScreen/RestoreToOppositeScreen.java 8286840 linux-all

--- a/test/jdk/java/awt/Frame/BogusFocusableWindowState/BogusFocusableWindowState.java
+++ b/test/jdk/java/awt/Frame/BogusFocusableWindowState/BogusFocusableWindowState.java
@@ -25,7 +25,7 @@ import java.awt.Window;
 
 /**
  * @test
- * @bug 8346952
+ * @bug 8346952 8361521
  * @summary Verifies no exception occurs when triggering updateCG()
  * for an ownerless window.
  * @key headful

--- a/test/jdk/java/awt/Frame/BogusFocusableWindowState/BogusFocusableWindowState.java
+++ b/test/jdk/java/awt/Frame/BogusFocusableWindowState/BogusFocusableWindowState.java
@@ -31,23 +31,12 @@ import java.awt.Window;
  * @key headful
  */
 public final class BogusFocusableWindowState {
-    private static boolean isRunning = false;
 
     public static void main(String[] args) {
         Window frame = new Window(null) {
             @Override
             public boolean getFocusableWindowState() {
-                if (isRunning) {
-                    return false;
-                }
-
-                isRunning = true;
-                try {
-                    removeNotify();
-                } finally {
-                    isRunning = false;
-                }
-
+                removeNotify();
                 return true;
             }
         };

--- a/test/jdk/java/awt/Frame/BogusFocusableWindowState/BogusFocusableWindowState.java
+++ b/test/jdk/java/awt/Frame/BogusFocusableWindowState/BogusFocusableWindowState.java
@@ -31,12 +31,23 @@ import java.awt.Window;
  * @key headful
  */
 public final class BogusFocusableWindowState {
+    private static boolean isRunning = false;
 
     public static void main(String[] args) {
         Window frame = new Window(null) {
             @Override
             public boolean getFocusableWindowState() {
-                removeNotify();
+                if (isRunning) {
+                    return false;
+                }
+
+                isRunning = true;
+                try {
+                    removeNotify();
+                } finally {
+                    isRunning = false;
+                }
+
                 return true;
             }
         };


### PR DESCRIPTION
**Analysis:**
The getFocusableWindowState() method is not intended to modify the configuration; doing so can cause recursive re-entry on Linux.

**Proposed Fix:**
We are intentionally overriding getFocusableWindowState() to allow it to change the configuration, in order to verify that calling getScreenImOn() for ownerless windows does not throw any exceptions.
To prevent recursive re-entry, we use a flag to ensure that getFocusableWindowState() is executed only once

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8361521](https://bugs.openjdk.org/browse/JDK-8361521): BogusFocusableWindowState.java fails with StackOverflowError on Linux (**Bug** - P4)


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**) Review applies to [3e893a08](https://git.openjdk.org/jdk/pull/26298/files/3e893a08c5d2ce47cc47671300f857a7986766c2)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26298/head:pull/26298` \
`$ git checkout pull/26298`

Update a local copy of the PR: \
`$ git checkout pull/26298` \
`$ git pull https://git.openjdk.org/jdk.git pull/26298/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26298`

View PR using the GUI difftool: \
`$ git pr show -t 26298`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26298.diff">https://git.openjdk.org/jdk/pull/26298.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26298#issuecomment-3070315509)
</details>
