### PR TITLE
8356557: Update CodeSource::implies API documentation and deprecate java.net.SocketPermission class for removal

### DIFF
--- a/src/java.base/share/classes/java/net/SocketPermission.java
+++ b/src/java.base/share/classes/java/net/SocketPermission.java
@@ -111,14 +111,13 @@ import static jdk.internal.util.Exceptions.formatMsg;
  * <P>
  * The actions string is converted to lowercase before processing.
  *
- * @apiNote
+ * @deprecated
  * This permission cannot be used for controlling access to resources
  * as the Security Manager is no longer supported.
  *
  * @spec https://www.rfc-editor.org/info/rfc2732
  *      RFC 2732: Format for Literal IPv6 Addresses in URL's
  * @see java.security.Permissions
- * @see SocketPermission
  *
  *
  * @author Marianne Mueller
@@ -128,6 +127,7 @@ import static jdk.internal.util.Exceptions.formatMsg;
  * @serial exclude
  */
 
+@Deprecated(since = "26", forRemoval = true)
 public final class SocketPermission extends Permission
     implements java.io.Serializable
 {

--- a/src/java.base/share/classes/java/net/SocketPermission.java
+++ b/src/java.base/share/classes/java/net/SocketPermission.java
@@ -1307,6 +1307,7 @@ else its the cname?
  * @serial include
  */
 
+@SuppressWarnings("removal")
 final class SocketPermissionCollection extends PermissionCollection
     implements Serializable
 {

--- a/src/java.base/share/classes/java/security/CodeSource.java
+++ b/src/java.base/share/classes/java/security/CodeSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -73,6 +73,7 @@ public class CodeSource implements java.io.Serializable {
     private transient java.security.cert.Certificate[] certs = null;
 
     // cached SocketPermission used for matchLocation
+    @SuppressWarnings("removal")
     private transient SocketPermission sp;
 
     // for generating cert paths
@@ -269,9 +270,22 @@ public class CodeSource implements java.io.Serializable {
      *           equal to <i>codesource</i>'s protocol, ignoring case.
      *
      *     <li>  If this object's host (getLocation().getHost()) is not null,
-     *           then the SocketPermission
-     *           constructed with this object's host must imply the
-     *           SocketPermission constructed with <i>codesource</i>'s host.
+     *           then the following checks are made in order:
+     *           <ul>
+     *           <li> If this object's host was initialized with a single IP
+     *           address then one of <i>codesource</i>'s IP addresses must be
+     *           equal to this object's IP address.
+     *           <li> If this object's host is a wildcard domain (such as
+     *           *.example.com), then <i>codesource</i>'s canonical host name
+     *           (the name without any preceding *) must end with this object's
+     *           canonical host name. For example, *.example.com implies
+     *           *.foo.example.com.
+     *           <li> If this object's host was not initialized with a single
+     *           IP address, then one of this object's IP addresses must equal
+     *           one of <i>codesource</i>'s IP addresses or this object's
+     *           canonical host name must equal <i>codesource</i>'s canonical
+     *           host name.
+     *           </ul>
      *
      *     <li>  If this object's port (getLocation().getPort()) is not
      *           equal to -1 (that is, if a port is specified), it must equal
@@ -387,6 +401,7 @@ public class CodeSource implements java.io.Serializable {
      *
      * @param that {@code CodeSource} to compare against
      */
+    @SuppressWarnings("removal")
     private boolean matchLocation(CodeSource that) {
         if (location == null)
             return true;

--- a/test/jdk/java/security/CodeSource/Implies.java
+++ b/test/jdk/java/security/CodeSource/Implies.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,11 +23,12 @@
 
 /*
  * @test
- * @bug 4866847 7152564 7155693
+ * @bug 4866847 7152564 7155693 8356557
  * @summary various CodeSource.implies tests
  */
 
 import java.security.CodeSource;
+import java.net.InetAddress;
 import java.net.URL;
 
 public class Implies {
@@ -46,6 +47,40 @@ public class Implies {
         thisURL = new URL("http", "localhost", 80, "dir/-");
         thatURL = new URL("HTTP", "localhost", "dir/file");
         // port check should match default port of thatURL
+        testImplies(thisURL, thatURL, true);
+
+        thisURL = new URL("http", "204.160.241.0", "file");
+        thatURL = new URL("http", "localhost", "file");
+        // ip address should not imply localhost's IP address
+        testImplies(thisURL, thatURL, false);
+
+        thisURL = new URL("http", "204.160.241.0", "file");
+        thatURL = new URL("http", "*.example.com", "file");
+        // ip address should not imply wildcarded host
+        testImplies(thisURL, thatURL, false);
+
+        InetAddress ia = InetAddress.getLocalHost();
+        thisURL = new URL("http", ia.getHostAddress(), "file");
+        thatURL = new URL("http", ia.getHostName(), "file");
+        // ip address should imply host name with same ip address
+        testImplies(thisURL, thatURL, true);
+
+        thisURL = new URL("http", "*.example.com", "file");
+        thatURL = new URL("http", "*.foo.example.com", "file");
+        // wildcarded host name should imply wildcarded host name ending with
+        // same canonical host name
+        testImplies(thisURL, thatURL, true);
+
+        thisURL = new URL("http", "example.com", "file");
+        thatURL = new URL("http", "*.foo.example.com", "file");
+        // host name should not imply wildcarded host name ending with same
+        // canonical host name
+        testImplies(thisURL, thatURL, false);
+
+        thisURL = new URL("http", "*.example.com", "file");
+        thatURL = new URL("http", "foo.example.com", "file");
+        // wildcarded host name should imply host name ending with same
+        // canonical host name
         testImplies(thisURL, thatURL, true);
 
         System.out.println("test passed");


### PR DESCRIPTION
`SocketPermission` should be deprecated for removal as has already been done for many other `Permission` subclasses. However, `CodeSource.implies()` has specification dependencies on `SocketPermission` which requires additional changes to decouple those dependencies. 

This change deprecates `SocketPermission`for removal and removes the dependency on `SocketPermission` from `CodeSource.implies` by copying the relevant conditions from `SocketPermission.implies`. Additional test cases for `CodeSource.implies` were also added to check that the behavior is consistent.

Note that we may also eventually deprecate `CodeSource.implies` for removal but that requires more investigation.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Change requires CSR request [JDK-8362175](https://bugs.openjdk.org/browse/JDK-8362175) to be approved
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8356557](https://bugs.openjdk.org/browse/JDK-8356557): Update CodeSource::implies API documentation and deprecate java.net.SocketPermission class for removal (**Enhancement** - P3)
 * [JDK-8362175](https://bugs.openjdk.org/browse/JDK-8362175): Update CodeSource::implies API documentation and deprecate java.net.SocketPermission class for removal (**CSR**)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26300/head:pull/26300` \
`$ git checkout pull/26300`

Update a local copy of the PR: \
`$ git checkout pull/26300` \
`$ git pull https://git.openjdk.org/jdk.git pull/26300/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26300`

View PR using the GUI difftool: \
`$ git pr show -t 26300`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26300.diff">https://git.openjdk.org/jdk/pull/26300.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26300#issuecomment-3070704228)
</details>
