### PR TITLE
8350709: [JMH] test ProtectionDomainBench failed for 2 threads config

### DIFF
--- a/test/micro/org/openjdk/bench/java/security/ProtectionDomainBench.java
+++ b/test/micro/org/openjdk/bench/java/security/ProtectionDomainBench.java
@@ -109,7 +109,7 @@ public class ProtectionDomainBench {
         protected Class<?> findClass(MyState state, String name)
                 throws ClassNotFoundException {
             if (name.equals(state.classNames[state.index] /* "B" + index */)) {
-                assert state.compiledClasses[state.index]  != null;
+                assert state.compiledClasses[state.index] != null;
                 return defineClass(name, state.compiledClasses[state.index], 0,
                         (state.compiledClasses[state.index]).length,
                         state.cs[state.index % state.cs.length] );
@@ -132,7 +132,7 @@ public class ProtectionDomainBench {
 
     @Benchmark
     @Fork(value = 3)
-    public void noSecurityManager(MyState state)  throws ClassNotFoundException {
+    public void noSecurityManager(MyState state) throws ClassNotFoundException {
         work(state);
     }
 }


### PR DESCRIPTION
[JDK-8350709](https://bugs.openjdk.org/browse/JDK-8350709)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350709](https://bugs.openjdk.org/browse/JDK-8350709): [JMH] test ProtectionDomainBench failed for 2 threads config (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26301/head:pull/26301` \
`$ git checkout pull/26301`

Update a local copy of the PR: \
`$ git checkout pull/26301` \
`$ git pull https://git.openjdk.org/jdk.git pull/26301/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26301`

View PR using the GUI difftool: \
`$ git pr show -t 26301`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26301.diff">https://git.openjdk.org/jdk/pull/26301.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26301#issuecomment-3070718369)
</details>
