### PR TITLE
8362203: assert(state == nullptr || state->get_thread_oop() != nullptr) failed: incomplete state

### DIFF
--- a/src/hotspot/share/prims/jvmtiExport.cpp
+++ b/src/hotspot/share/prims/jvmtiExport.cpp
@@ -675,6 +675,11 @@ void JvmtiExport::post_early_vm_start() {
 void JvmtiExport::post_vm_start() {
   EVT_TRIG_TRACE(JVMTI_EVENT_VM_START, ("Trg VM start event triggered" ));
 
+  // The thread state might be incomplete if initialized in post_early_vm_start
+  // before classes are initialized. It should be updated now.
+  JavaThread *thread  = JavaThread::current();
+  thread->jvmti_thread_state()->update_thread_oop(thread);
+
   // can now enable some events
   JvmtiEventController::vm_start();
 
@@ -684,7 +689,6 @@ void JvmtiExport::post_vm_start() {
     if (!env->early_vmstart_env() && env->is_enabled(JVMTI_EVENT_VM_START)) {
       EVT_TRACE(JVMTI_EVENT_VM_START, ("Evt VM start event sent" ));
 
-      JavaThread *thread  = JavaThread::current();
       JvmtiThreadEventMark jem(thread);
       JvmtiJavaThreadEventTransition jet(thread);
       jvmtiEventVMStart callback = env->callbacks()->VMStart;

--- a/src/hotspot/share/prims/jvmtiThreadState.cpp
+++ b/src/hotspot/share/prims/jvmtiThreadState.cpp
@@ -1041,6 +1041,15 @@ oop JvmtiThreadState::get_thread_oop() {
   return _thread_oop_h.resolve();
 }
 
+void JvmtiThreadState::update_thread_oop(JavaThread* thread) {
+  assert(thread->threadObj() != nullptr, "Should threadObj be already initialized");
+  if (thread->jvmti_thread_state() != nullptr
+         && thread->jvmti_thread_state()->get_thread_oop() == nullptr) {
+    _thread_oop_h.release(JvmtiExport::jvmti_oop_storage());
+    _thread_oop_h = OopHandle(JvmtiExport::jvmti_oop_storage(), thread->threadObj());
+  }
+}
+
 void JvmtiThreadState::set_thread(JavaThread* thread) {
   _thread_saved = nullptr;  // Common case.
   if (!_is_virtual && thread == nullptr) {

--- a/src/hotspot/share/prims/jvmtiThreadState.hpp
+++ b/src/hotspot/share/prims/jvmtiThreadState.hpp
@@ -311,6 +311,7 @@ class JvmtiThreadState : public CHeapObj<mtInternal> {
   // Also used for carrier threads to clear/restore _thread.
   void set_thread(JavaThread* thread);
   oop get_thread_oop();
+  void update_thread_oop(JavaThread* thread);
 
   inline bool is_virtual() { return _is_virtual; } // the _thread is virtual
 

--- a/test/hotspot/jtreg/serviceability/jvmti/StartPhase/AllowedFunctions/AllowedFunctions.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/StartPhase/AllowedFunctions/AllowedFunctions.java
@@ -29,6 +29,7 @@
  * @requires vm.jvmti
  * @run main/othervm/native -agentlib:AllowedFunctions AllowedFunctions
  * @run main/othervm/native -agentlib:AllowedFunctions=with_early_vmstart AllowedFunctions
+ * @run main/othervm/native -agentlib:AllowedFunctions=with_early_vmstart  -Xrunjdwp:transport=dt_socket,address=8000,server=y,suspend=n AllowedFunctions
  */
 
 public class AllowedFunctions {


### PR DESCRIPTION
The problem happens if post_early_vm_start is triggered.
The fix is to complete initialization once threadObj become available.

 