### PR TITLE
8356942: invokeinterface Throws AbstractMethodError Instead of IncompatibleClassChangeError

### DIFF
--- a/src/hotspot/share/oops/klassVtable.cpp
+++ b/src/hotspot/share/oops/klassVtable.cpp
@@ -1180,38 +1180,42 @@ void klassItable::check_constraints(GrowableArray<Method*>* supers, TRAPS) {
     Method* interface_method = supers->at(i); // method overridden
 
     if (target != nullptr && interface_method != nullptr) {
-      InstanceKlass* method_holder = target->method_holder();
-      InstanceKlass* interf = interface_method->method_holder();
-      HandleMark hm(THREAD);
-      Handle method_holder_loader(THREAD, method_holder->class_loader());
-      Handle interface_loader(THREAD, interf->class_loader());
+      // Do not check loader constraints for overpass methods because overpass
+      // methods are created by the jvm to throw exceptions.
+      if (!target->is_overpass()) {
+        InstanceKlass* method_holder = target->method_holder();
+        InstanceKlass* interf = interface_method->method_holder();
+        HandleMark hm(THREAD);
+        Handle method_holder_loader(THREAD, method_holder->class_loader());
+        Handle interface_loader(THREAD, interf->class_loader());
 
-      if (method_holder_loader() != interface_loader()) {
-        ResourceMark rm(THREAD);
-        Symbol* failed_type_symbol =
-          SystemDictionary::check_signature_loaders(target->signature(),
-                                                    _klass,
-                                                    method_holder_loader,
-                                                    interface_loader,
-                                                    true);
-        if (failed_type_symbol != nullptr) {
-          stringStream ss;
-          ss.print("loader constraint violation in interface itable"
-                   " initialization for class %s: when selecting method '",
-                   _klass->external_name());
-          interface_method->print_external_name(&ss),
-          ss.print("' the class loader %s for super interface %s, and the class"
-                   " loader %s of the selected method's %s, %s have"
-                   " different Class objects for the type %s used in the signature (%s; %s)",
-                   interf->class_loader_data()->loader_name_and_id(),
-                   interf->external_name(),
-                   method_holder->class_loader_data()->loader_name_and_id(),
-                   method_holder->external_kind(),
-                   method_holder->external_name(),
-                   failed_type_symbol->as_klass_external_name(),
-                   interf->class_in_module_of_loader(false, true),
-                   method_holder->class_in_module_of_loader(false, true));
-          THROW_MSG(vmSymbols::java_lang_LinkageError(), ss.as_string());
+        if (method_holder_loader() != interface_loader()) {
+          ResourceMark rm(THREAD);
+          Symbol* failed_type_symbol =
+            SystemDictionary::check_signature_loaders(target->signature(),
+                                                      _klass,
+                                                      method_holder_loader,
+                                                      interface_loader,
+                                                      true);
+          if (failed_type_symbol != nullptr) {
+            stringStream ss;
+            ss.print("loader constraint violation in interface itable"
+                     " initialization for class %s: when selecting method '",
+                     _klass->external_name());
+            interface_method->print_external_name(&ss),
+              ss.print("' the class loader %s for super interface %s, and the class"
+                       " loader %s of the selected method's %s, %s have"
+                       " different Class objects for the type %s used in the signature (%s; %s)",
+                       interf->class_loader_data()->loader_name_and_id(),
+                       interf->external_name(),
+                       method_holder->class_loader_data()->loader_name_and_id(),
+                       method_holder->external_kind(),
+                       method_holder->external_name(),
+                       failed_type_symbol->as_klass_external_name(),
+                       interf->class_in_module_of_loader(false, true),
+                       method_holder->class_in_module_of_loader(false, true));
+            THROW_MSG(vmSymbols::java_lang_LinkageError(), ss.as_string());
+          }
         }
       }
     }
@@ -1333,11 +1337,9 @@ void klassItable::initialize_itable_for_interface(int method_table_offset, Insta
       target = LinkResolver::lookup_instance_method_in_klasses(_klass, m->name(), m->signature(),
                                                                Klass::PrivateLookupMode::skip);
     }
-    if (target == nullptr || !target->is_public() || target->is_abstract() || target->is_overpass()) {
-      assert(target == nullptr || !target->is_overpass() || target->is_public(),
-             "Non-public overpass method!");
+    if (target == nullptr || !target->is_public() || target->is_abstract()) {
       // Entry does not resolve. Leave it empty for AbstractMethodError or other error.
-      if (!(target == nullptr) && !target->is_public()) {
+      if (target != nullptr && !target->is_public()) {
         // Stuff an IllegalAccessError throwing method in there instead.
         itableOffsetEntry::method_entry(_klass, method_table_offset)[m->itable_index()].
             initialize(_klass, Universe::throw_illegal_access_error());

--- a/test/hotspot/jtreg/vmTestbase/vm/runtime/defmeth/ConflictingDefaultsTest.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/runtime/defmeth/ConflictingDefaultsTest.java
@@ -82,6 +82,8 @@ public class ConflictingDefaultsTest extends DefMethTest {
      * class C implements I, J {}
      *
      * TEST: C c = new C(); c.m() ==> ICCE
+     * TEST: I c = new C(); c.m() ==> ICCE
+     * TEST: J c = new C(); c.m() ==> ICCE
      */
     public void testConflict(TestBuilder b) {
         Interface I = b.intf("I")
@@ -95,7 +97,13 @@ public class ConflictingDefaultsTest extends DefMethTest {
         ConcreteClass C = b.clazz("C").implement(I,J).build();
 
         b.test().callSite(C, C, "m","()I")
-                .throws_(IncompatibleClassChangeError.class)
+                .throwsExact(IncompatibleClassChangeError.class)
+            .done()
+         .test().callSite(I, C, "m","()I")
+                .throwsExact(IncompatibleClassChangeError.class)
+            .done()
+         .test().callSite(J, C, "m","()I")
+                .throwsExact(IncompatibleClassChangeError.class)
             .done();
     }
 
@@ -145,7 +153,7 @@ public class ConflictingDefaultsTest extends DefMethTest {
         ConcreteClass C = b.clazz("C").implement(J).build();
 
         b.test().callSite(C, C, "m","()I")
-                .throws_(AbstractMethodError.class)
+                .throwsExact(AbstractMethodError.class)
             .done();
     }
 
@@ -177,16 +185,16 @@ public class ConflictingDefaultsTest extends DefMethTest {
             .build();
 
         b.test().callSite(C, C, "m","()I")
-                .throws_(AbstractMethodError.class)
+                .throwsExact(AbstractMethodError.class)
             .done()
          .test().callSite(J, C, "m","()I")
-                .throws_(AbstractMethodError.class)
+                .throwsExact(AbstractMethodError.class)
             .done()
          .test().callSite(I, C, "m","()I")
-                .throws_(AbstractMethodError.class)
+                .throwsExact(AbstractMethodError.class)
             .done()
          .test().callSite(D, D, "m","()I")
-                .throws_(AbstractMethodError.class)
+                .throwsExact(AbstractMethodError.class)
             .done();
     }
 
@@ -218,7 +226,7 @@ public class ConflictingDefaultsTest extends DefMethTest {
         ConcreteClass C = b.clazz("C").extend(A).implement(K).build();
 
         b.test().callSite(A, C, "m","()I")
-                .throws_(AbstractMethodError.class)
+                .throwsExact(AbstractMethodError.class)
             .done();
     }
 
@@ -259,13 +267,13 @@ public class ConflictingDefaultsTest extends DefMethTest {
         ConcreteClass D = b.clazz("D").extend(C).implement(L).build();
 
         b.test().callSite(I, A, "m","()I")
-                .throws_(IncompatibleClassChangeError.class)
+                .throwsExact(IncompatibleClassChangeError.class)
             .done()
          .test().callSite(K, C, "m","()I")
-                .throws_(AbstractMethodError.class)
+                .throwsExact(AbstractMethodError.class)
             .done()
          .test().callSite(L, D, "m","()I")
-                .throws_(AbstractMethodError.class)
+                .throwsExact(AbstractMethodError.class)
             .done();
     }
 
@@ -307,10 +315,10 @@ public class ConflictingDefaultsTest extends DefMethTest {
             .build();
 
         b.test().callSite(I, A, "m","()I")
-                .throws_(IncompatibleClassChangeError.class)
+                .throwsExact(IncompatibleClassChangeError.class)
             .done()
          .test().callSite(L, D, "m","()I")
-                .throws_(AbstractMethodError.class)
+                .throwsExact(AbstractMethodError.class)
             .done();
     }
 
@@ -370,22 +378,22 @@ public class ConflictingDefaultsTest extends DefMethTest {
         }
 
          b.test().callSite(A, C, "m", "()I")
-                 .throws_(expectedError2)
+                 .throwsExact(expectedError2)
              .done()
           .test().callSite(C, C, "m", "()I")
-                 .throws_(expectedError2)
+                 .throwsExact(expectedError2)
              .done()
           .test().callSite(J, C, "m", "()I")
-                 .throws_(expectedError1)
+                 .throwsExact(expectedError1)
              .done()
           .test().callSite(I, C, "m", "()I")
-                 .throws_(expectedError1)
+                 .throwsExact(expectedError1)
              .done()
           .test().callSite(C, C, "test_Cmethod_ISMR", "()V")
-                 .throws_(expectedError2)
+                 .throwsExact(expectedError2)
              .done()
           .test().callSite(A, C, "test_Amethod_ISIMR", "()V")
-                 .throws_(expectedError2)
+                 .throwsExact(expectedError2)
              .done();
     }
 
@@ -486,13 +494,13 @@ public class ConflictingDefaultsTest extends DefMethTest {
         .test()
                 .callSite(I, C, "m","(I)I")
                 .params(0)
-                .throws_(NoSuchMethodError.class)
+                .throwsExact(NoSuchMethodError.class)
             .done()
 
         // J j = new C(); ...
         .test()
                 .callSite(J, C, "m","()I")
-                .throws_(NoSuchMethodError.class)
+                .throwsExact(NoSuchMethodError.class)
             .done()
         .test()
                 .callSite(J, C, "m","(I)I")
@@ -539,19 +547,19 @@ public class ConflictingDefaultsTest extends DefMethTest {
         // I i = new C(); ...
         b.test()
                 .callSite(I, C, "m","()I")
-                .throws_(IncompatibleClassChangeError.class)
+                .throwsExact(IncompatibleClassChangeError.class)
             .done()
 
         // J j = new C(); ...
         .test()
                 .callSite(J, C, "m","()I")
-                .throws_(IncompatibleClassChangeError.class)
+                .throwsExact(IncompatibleClassChangeError.class)
             .done()
 
         // C c = new C(); ...
         .test()
                 .callSite(C, C, "m","()I")
-                .throws_(IncompatibleClassChangeError.class)
+                .throwsExact(IncompatibleClassChangeError.class)
             .done()
         .test()
                 .callSite(C, C, "m","(I)I")


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [f36147b3](https://github.com/openjdk/jdk/commit/f36147b3263662229e9a0ec712b9748711d2d85d) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by David Holmes on 14 Jul 2025 and was reviewed by Coleen Phillimore and Ioi Lam.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8356942: invokeinterface Throws AbstractMethodError Instead of IncompatibleClassChangeError`

### Issue
 * [JDK-8356942](https://bugs.openjdk.org/browse/JDK-8356942): invokeinterface Throws AbstractMethodError Instead of IncompatibleClassChangeError (**Bug** - P3)


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26304/head:pull/26304` \
`$ git checkout pull/26304`

Update a local copy of the PR: \
`$ git checkout pull/26304` \
`$ git pull https://git.openjdk.org/jdk.git pull/26304/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26304`

View PR using the GUI difftool: \
`$ git pr show -t 26304`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26304.diff">https://git.openjdk.org/jdk/pull/26304.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26304#issuecomment-3071507221)
</details>
