### PR TITLE
JDK-8362088: CompressedKlassPointers::encode should be const correct

### DIFF
--- a/src/hotspot/share/oops/compressedKlass.hpp
+++ b/src/hotspot/share/oops/compressedKlass.hpp
@@ -231,8 +231,8 @@ public:
   // Returns the highest possible narrowKlass value given the current Klass range
   static narrowKlass highest_valid_narrow_klass_id() { return _highest_valid_narrow_klass_id; }
 
-  static bool is_null(Klass* v)      { return v == nullptr; }
-  static bool is_null(narrowKlass v) { return v == 0; }
+  static bool is_null(const Klass* v)  { return v == nullptr; }
+  static bool is_null(narrowKlass v)   { return v == 0; }
 
   // Versions without asserts
   static inline Klass* decode_not_null_without_asserts(narrowKlass v);
@@ -240,9 +240,9 @@ public:
   static inline Klass* decode_not_null(narrowKlass v);
   static inline Klass* decode(narrowKlass v);
 
-  static inline narrowKlass encode_not_null_without_asserts(Klass* k, address narrow_base, int shift);
-  static inline narrowKlass encode_not_null(Klass* v);
-  static inline narrowKlass encode(Klass* v);
+  static inline narrowKlass encode_not_null_without_asserts(const Klass* k, address narrow_base, int shift);
+  static inline narrowKlass encode_not_null(const Klass* v);
+  static inline narrowKlass encode(const Klass* v);
 
 #ifdef ASSERT
   // Given an address, check that it can be encoded with the current encoding

--- a/src/hotspot/share/oops/compressedKlass.inline.hpp
+++ b/src/hotspot/share/oops/compressedKlass.inline.hpp
@@ -36,7 +36,7 @@ inline Klass* CompressedKlassPointers::decode_not_null_without_asserts(narrowKla
   return (Klass*)((uintptr_t)narrow_base_base +((uintptr_t)v << shift));
 }
 
-inline narrowKlass CompressedKlassPointers::encode_not_null_without_asserts(Klass* k, address narrow_base, int shift) {
+inline narrowKlass CompressedKlassPointers::encode_not_null_without_asserts(const Klass* k, address narrow_base, int shift) {
   return (narrowKlass)(pointer_delta(k, narrow_base, 1) >> shift);
 }
 
@@ -60,7 +60,7 @@ inline Klass* CompressedKlassPointers::decode(narrowKlass v) {
   return is_null(v) ? nullptr : decode_not_null(v);
 }
 
-inline narrowKlass CompressedKlassPointers::encode_not_null(Klass* v) {
+inline narrowKlass CompressedKlassPointers::encode_not_null(const Klass* v) {
   assert(!is_null(v), "klass value can never be zero");
   DEBUG_ONLY(check_encodable(v);)
   const narrowKlass nk = encode_not_null_without_asserts(v, base(), shift());
@@ -69,7 +69,7 @@ inline narrowKlass CompressedKlassPointers::encode_not_null(Klass* v) {
   return nk;
 }
 
-inline narrowKlass CompressedKlassPointers::encode(Klass* v) {
+inline narrowKlass CompressedKlassPointers::encode(const Klass* v) {
   return is_null(v) ? (narrowKlass)0 : encode_not_null(v);
 }
 


### PR DESCRIPTION
Trivial change. CompressedKlassPointers::encode It should accept a const Klass* .