### PR TITLE
8362244: Devkit's Oracle Linux base OS keyword is incorrectly documented

### DIFF
--- a/doc/building.html
+++ b/doc/building.html
@@ -1491,12 +1491,12 @@ following targets are known to work:</p>
 </tr>
 </tbody>
 </table>
-<p><code>BASE_OS</code> must be one of "OEL6" for Oracle Enterprise
-Linux 6 or "Fedora" (if not specified "OEL6" will be the default). If
-the base OS is "Fedora" the corresponding Fedora release can be
-specified with the help of the <code>BASE_OS_VERSION</code> option (with
-"27" as default version). If the build is successful, the new devkits
-can be found in the <code>build/devkit/result</code> subdirectory:</p>
+<p><code>BASE_OS</code> must be one of <code>OL</code> for Oracle
+Enterprise Linux or <code>Fedora</code>. If the base OS is
+<code>Fedora</code> the corresponding Fedora release can be specified
+with the help of the <code>BASE_OS_VERSION</code> option. If the build
+is successful, the new devkits can be found in the
+<code>build/devkit/result</code> subdirectory:</p>
 <pre><code>cd make/devkit
 make TARGETS=&quot;ppc64le-linux-gnu aarch64-linux-gnu&quot; BASE_OS=Fedora BASE_OS_VERSION=21
 ls -1 ../../build/devkit/result/

--- a/doc/building.md
+++ b/doc/building.md
@@ -1285,10 +1285,10 @@ at least the following targets are known to work:
 | ppc64le-linux-gnu        |
 | s390x-linux-gnu          |
 
-`BASE_OS` must be one of "OEL6" for Oracle Enterprise Linux 6 or "Fedora" (if
-not specified "OEL6" will be the default). If the base OS is "Fedora" the
+`BASE_OS` must be one of `OL` for Oracle Enterprise Linux or `Fedora` (if
+not specified `OL` will be the default). If the base OS is `Fedora` the
 corresponding Fedora release can be specified with the help of the
-`BASE_OS_VERSION` option (with "27" as default version). If the build is
+`BASE_OS_VERSION` option (with `27` as default version). If the build is
 successful, the new devkits can be found in the `build/devkit/result`
 subdirectory:
 

--- a/doc/building.md
+++ b/doc/building.md
@@ -1285,12 +1285,10 @@ at least the following targets are known to work:
 | ppc64le-linux-gnu        |
 | s390x-linux-gnu          |
 
-`BASE_OS` must be one of `OL` for Oracle Enterprise Linux or `Fedora` (if
-not specified `OL` will be the default). If the base OS is `Fedora` the
-corresponding Fedora release can be specified with the help of the
-`BASE_OS_VERSION` option (with `27` as default version). If the build is
-successful, the new devkits can be found in the `build/devkit/result`
-subdirectory:
+`BASE_OS` must be one of `OL` for Oracle Enterprise Linux or `Fedora`. If the
+base OS is `Fedora` the corresponding Fedora release can be specified with the
+help of the `BASE_OS_VERSION` option. If the build is successful, the new
+devkits can be found in the `build/devkit/result` subdirectory:
 
 ```
 cd make/devkit


### PR DESCRIPTION
`open/doc/building.md` uses the incorrect `OEL6` keyword to denote the Oracle Enterprise Linux base OS distribution for Devkit – replaced it with the correct one instead, i.e., `OL`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8362244](https://bugs.openjdk.org/browse/JDK-8362244): Devkit's Oracle Linux base OS keyword is incorrectly documented (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26311/head:pull/26311` \
`$ git checkout pull/26311`

Update a local copy of the PR: \
`$ git checkout pull/26311` \
`$ git pull https://git.openjdk.org/jdk.git pull/26311/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26311`

View PR using the GUI difftool: \
`$ git pr show -t 26311`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26311.diff">https://git.openjdk.org/jdk/pull/26311.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26311#issuecomment-3072989744)
</details>
