### PR TITLE
8362237: IllegalArgumentException in the launcher when exception without stack trace is thrown

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/launcher/SourceLauncher.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/launcher/SourceLauncher.java
@@ -261,12 +261,15 @@ public final class SourceLauncher {
             throw new Fault(Errors.CantAccessMainMethod(mainClassName));
         } catch (InvocationTargetException exception) {
             // remove stack frames for source launcher
+            StackTraceElement[] invocationElements = exception.getStackTrace();
+            if (invocationElements == null) throw exception;
             Throwable cause = exception.getCause();
             if (cause == null) throw exception;
-            StackTraceElement[] elements = cause.getStackTrace();
-            int range = elements.length - exception.getStackTrace().length;
+            StackTraceElement[] causeElements = cause.getStackTrace();
+            if (causeElements == null) throw exception;
+            int range = causeElements.length - invocationElements.length;
             if (range >= 0) {
-                cause.setStackTrace(Arrays.copyOfRange(elements, 0, range));
+                cause.setStackTrace(Arrays.copyOfRange(causeElements, 0, range));
             }
             throw exception;
         }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/launcher/SourceLauncher.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/launcher/SourceLauncher.java
@@ -259,13 +259,16 @@ public final class SourceLauncher {
             }
         } catch (IllegalAccessException e) {
             throw new Fault(Errors.CantAccessMainMethod(mainClassName));
-        } catch (InvocationTargetException e) {
+        } catch (InvocationTargetException exception) {
             // remove stack frames for source launcher
-            int invocationFrames = e.getStackTrace().length;
-            Throwable target = e.getCause();
-            StackTraceElement[] targetTrace = target.getStackTrace();
-            target.setStackTrace(Arrays.copyOfRange(targetTrace, 0, targetTrace.length - invocationFrames));
-            throw e;
+            Throwable cause = exception.getCause();
+            if (cause == null) throw exception;
+            StackTraceElement[] elements = cause.getStackTrace();
+            int range = elements.length - exception.getStackTrace().length;
+            if (range >= 0) {
+                cause.setStackTrace(Arrays.copyOfRange(elements, 0, range));
+            }
+            throw exception;
         }
 
         return mainClass;


### PR DESCRIPTION
Please review this change introducing a range check before pruning
stacktrace elements in source launch mode. Additional `null`-checks
are also added to this change set.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8362237](https://bugs.openjdk.org/browse/JDK-8362237): IllegalArgumentException in the launcher when exception without stack trace is thrown (**Bug** - P4)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - Author)
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26315/head:pull/26315` \
`$ git checkout pull/26315`

Update a local copy of the PR: \
`$ git checkout pull/26315` \
`$ git pull https://git.openjdk.org/jdk.git pull/26315/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26315`

View PR using the GUI difftool: \
`$ git pr show -t 26315`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26315.diff">https://git.openjdk.org/jdk/pull/26315.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26315#issuecomment-3073408214)
</details>
