### PR TITLE
8361888: [GCC static analyzer] ProcessImpl_md.c Java_java_lang_ProcessImpl_forkAndExec error: use of uninitialized value '*(ChildStuff *)p.mode

### DIFF
--- a/src/java.base/unix/native/libjava/ProcessImpl_md.c
+++ b/src/java.base/unix/native/libjava/ProcessImpl_md.c
@@ -732,7 +732,7 @@ Java_java_lang_ProcessImpl_forkAndExec(JNIEnv *env,
         (fds[2] == -1 && pipe(err) < 0) ||
         (pipe(childenv) < 0) ||
         (pipe(fail) < 0)) {
-        throwInternalIOException(env, errno, "Bad file descriptor", c->mode);
+        throwInternalIOException(env, errno, "Bad file descriptor", mode);
         goto Catch;
     }
     c->fds[0] = fds[0];


### PR DESCRIPTION
When using GCC static analyzer (-fanalyzer), the following issue is reported.
Seems `c->mode` is initialized later in the method, but we use it already in the exception, this looks wrong.

```
/jdk/src/java.base/unix/native/libjava/ProcessImpl_md.c: In function 'Java_java_lang_ProcessImpl_forkAndExec':
/jdk/src/java.base/unix/native/libjava/ProcessImpl_md.c:735:9: error: use of uninitialized value '*(ChildStuff *)p.mode' [CWE-457] [-Werror=analyzer-use-of-uninitialized-value]
  735 | throwInternalIOException(env, errno, "Bad file descriptor", c->mode);
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8361888](https://bugs.openjdk.org/browse/JDK-8361888): [GCC static analyzer] ProcessImpl_md.c Java_java_lang_ProcessImpl_forkAndExec error: use of uninitialized value '*(ChildStuff *)p.mode (**Bug** - P4)


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [SendaoYan](https://openjdk.org/census#syan) (@sendaoYan - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26316/head:pull/26316` \
`$ git checkout pull/26316`

Update a local copy of the PR: \
`$ git checkout pull/26316` \
`$ git pull https://git.openjdk.org/jdk.git pull/26316/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26316`

View PR using the GUI difftool: \
`$ git pr show -t 26316`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26316.diff">https://git.openjdk.org/jdk/pull/26316.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26316#issuecomment-3073493261)
</details>
