### PR TITLE
8361868: [GCC static analyzer] complains about missing calloc - NULL checks in p11_util.c

### DIFF
--- a/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_util.c
+++ b/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_util.c
@@ -481,6 +481,10 @@ CK_MECHANISM_PTR updateGCMParams(JNIEnv *env, CK_MECHANISM_PTR mechPtr) {
             // CK_GCM_PARAMS => CK_GCM_PARAMS_NO_IVBITS
             pParams = (CK_GCM_PARAMS*) mechPtr->pParameter;
             pParamsNoIvBits = calloc(1, sizeof(CK_GCM_PARAMS_NO_IVBITS));
+            if (pParamsNoIvBits == NULL) {
+                p11ThrowOutOfMemoryError(env, 0);
+                return NULL;
+            }
             pParamsNoIvBits->pIv = pParams->pIv;
             pParamsNoIvBits->ulIvLen = pParams->ulIvLen;
             pParamsNoIvBits->pAAD = pParams->pAAD;
@@ -495,6 +499,10 @@ CK_MECHANISM_PTR updateGCMParams(JNIEnv *env, CK_MECHANISM_PTR mechPtr) {
             // CK_GCM_PARAMS_NO_IVBITS => CK_GCM_PARAMS
             pParamsNoIvBits = (CK_GCM_PARAMS_NO_IVBITS*) mechPtr->pParameter;
             pParams = calloc(1, sizeof(CK_GCM_PARAMS));
+            if (pParams == NULL) {
+                p11ThrowOutOfMemoryError(env, 0);
+                return NULL;
+            }
             pParams->pIv = pParamsNoIvBits->pIv;
             pParams->ulIvLen = pParamsNoIvBits->ulIvLen;
             pParams->ulIvBits = pParamsNoIvBits->ulIvLen << 3;


### PR DESCRIPTION
When using the GCC -fanalyzer flag (see https://developers.redhat.com/articles/2022/04/12/state-static-analysis-gcc-12-compiler# ) , we get some complaints about missing calloc return value checks for NULL (we check at some code locations but in p11_util.c we do not do it).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8361868](https://bugs.openjdk.org/browse/JDK-8361868): [GCC static analyzer] complains about missing calloc - NULL checks in p11_util.c (**Bug** - P4)


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26319/head:pull/26319` \
`$ git checkout pull/26319`

Update a local copy of the PR: \
`$ git checkout pull/26319` \
`$ git pull https://git.openjdk.org/jdk.git pull/26319/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26319`

View PR using the GUI difftool: \
`$ git pr show -t 26319`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26319.diff">https://git.openjdk.org/jdk/pull/26319.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26319#issuecomment-3073862327)
</details>
