### PR TITLE
8347052: Update java man page documentation to reflect current state of the UseNUMA flag

### DIFF
--- a/src/java.base/share/man/java.md
+++ b/src/java.base/share/man/java.md
@@ -2809,9 +2809,8 @@ Java HotSpot VM.
 `-XX:+UseNUMA`
 :   Enables performance optimization of an application on a machine with
     nonuniform memory architecture (NUMA) by increasing the application's use
-    of lower latency memory. By default, this option is disabled and no
-    optimization for NUMA is made. The option is available only when the
-    parallel garbage collector is used (`-XX:+UseParallelGC`).
+    of lower latency memory. The default value for this option depends on the
+    garbage collector.
 
 `-XX:+UseParallelGC`
 :   Enables the use of the parallel scavenge garbage collector (also known as


### PR DESCRIPTION
Hi all,

  please review this small fix to the man pages that previously stated that `UseNUMA` is only available with Parallel GC. To minimize future update problems, the text has been modified to just say that the default value is dependent on the collector.

Testing: local compilation

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347052](https://bugs.openjdk.org/browse/JDK-8347052): Update java man page documentation to reflect current state of the UseNUMA flag (**Bug** - P4)(⚠️ The fixVersion in this issue is [25] but the fixVersion in .jcheck/conf is 26, a new backport will be created when this pr is integrated.)


### Reviewers
 * [Derek White](https://openjdk.org/census#drwhite) (@dwhite-intel - Committer)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26321/head:pull/26321` \
`$ git checkout pull/26321`

Update a local copy of the PR: \
`$ git checkout pull/26321` \
`$ git pull https://git.openjdk.org/jdk.git pull/26321/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26321`

View PR using the GUI difftool: \
`$ git pr show -t 26321`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26321.diff">https://git.openjdk.org/jdk/pull/26321.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26321#issuecomment-3074111904)
</details>
