### PR TITLE
JDK-8361711: Add library name configurability to PKCS11Test.java

### DIFF
--- a/test/jdk/java/security/KeyAgreement/Generic.java
+++ b/test/jdk/java/security/KeyAgreement/Generic.java
@@ -28,7 +28,7 @@
  * @summary make sure Generic is accepted by all KeyAgreement implementations
  * @run main Generic builtin
  * @run main/othervm Generic nss
- * @run main/othervm -DCUSTOM_P11_CONFIG_NAME=p11-nss-sensitive.txt Generic nss
+ * @run main/othervm -DCUSTOM_P11_CONFIG_VARIANT=sensitive Generic nss
  */
 import jdk.test.lib.Asserts;
 

--- a/test/jdk/sun/security/pkcs11/Mac/TestLargeSecretKeys.java
+++ b/test/jdk/sun/security/pkcs11/Mac/TestLargeSecretKeys.java
@@ -31,7 +31,7 @@ import java.security.Provider;
  * @test
  * @bug 8328556
  * @library /test/lib ..
- * @run main/othervm/timeout=30 -DCUSTOM_P11_CONFIG_NAME=p11-nss-sensitive.txt TestLargeSecretKeys
+ * @run main/othervm/timeout=30 -DCUSTOM_P11_CONFIG_VARIANT=sensitive TestLargeSecretKeys
  */
 
 public final class TestLargeSecretKeys extends PKCS11Test {

--- a/test/jdk/sun/security/pkcs11/PKCS11Test.java
+++ b/test/jdk/sun/security/pkcs11/PKCS11Test.java
@@ -455,6 +455,7 @@ public abstract class PKCS11Test {
     }
 
     public static String getNssConfig() throws Exception {
+        nss_library = System.getProperty("CUSTOM_P11_LIBRARY_NAME", nss_library);
         String libdir = getNSSLibDir();
         if (libdir == null) {
             return null;
@@ -478,9 +479,17 @@ public abstract class PKCS11Test {
         String customConfigName = System.getProperty("CUSTOM_P11_CONFIG_NAME", "p11-nss.txt");
         System.setProperty("pkcs11test.nss.lib", libfile);
         System.setProperty("pkcs11test.nss.db", dbdir);
-        return (customConfig != null) ?
+        String configFilePath = (customConfig != null) ?
                 customConfig :
                 nssConfigDir + SEP + customConfigName;
+        String customConfigVariant = System.getProperty("CUSTOM_P11_CONFIG_VARIANT");
+        if (customConfigVariant != null) {
+            // Change, e.g., .../p11-nss.txt to .../p11-nss-sensitive.txt.
+            configFilePath = configFilePath.replaceFirst(
+                    "(\\.[^\\.]*)?$", "-" + customConfigVariant + "$1");
+        }
+        System.out.println("Configuration file: " + configFilePath);
+        return configFilePath;
     }
 
     // Generate a vector of supported elliptic curves of a given provider

--- a/test/jdk/sun/security/pkcs11/rsa/TestP11KeyFactoryGetRSAKeySpec.java
+++ b/test/jdk/sun/security/pkcs11/rsa/TestP11KeyFactoryGetRSAKeySpec.java
@@ -38,14 +38,14 @@ import java.security.spec.*;
  * @summary Also checks to ensure that sensitive RSA keys are correctly not exposed
  * @library /test/lib ..
  * @run main/othervm TestP11KeyFactoryGetRSAKeySpec
- * @run main/othervm -DCUSTOM_P11_CONFIG_NAME=p11-nss-sensitive.txt TestP11KeyFactoryGetRSAKeySpec
+ * @run main/othervm -DCUSTOM_P11_CONFIG_VARIANT=sensitive TestP11KeyFactoryGetRSAKeySpec
  * @modules jdk.crypto.cryptoki
  */
 
 public class TestP11KeyFactoryGetRSAKeySpec extends PKCS11Test {
     private static boolean testingSensitiveKeys = false;
     public static void main(String[] args) throws Exception {
-        testingSensitiveKeys = "p11-nss-sensitive.txt".equals(System.getProperty("CUSTOM_P11_CONFIG_NAME"));
+        testingSensitiveKeys = "sensitive".equals(System.getProperty("CUSTOM_P11_CONFIG_VARIANT"));
         main(new TestP11KeyFactoryGetRSAKeySpec(), args);
     }
 


### PR DESCRIPTION
This patch adds configurability to `PKCS11Test.java`.

Specifically, it adds two new system properties:

- `CUSTOM_P11_LIBRARY_NAME`: Allow overriding the value assigned to the `nss_library` field.  Prior to this patch, `nss_library` was set to either `"softokn3"` or `"nss3"`.

- `CUSTOM_P11_CONFIG_VARIANT`: Abstract the configuration file type to load.  Prior to this patch, test cases that wanted to run `NSS` in sensitive mode would hard-code `p11-nss-sensitive.txt` on their command lines.

The patch updates the three `p11-nss-sensitive.txt`-using test cases to use the new `CUSTOM_P11_CONFIG_VARIANT` property:

```
test/jdk/java/security/KeyAgreement/Generic.java
test/jdk/sun/security/pkcs11/Mac/TestLargeSecretKeys.java
test/jdk/sun/security/pkcs11/rsa/TestP11KeyFactoryGetRSAKeySpec.java
```

I have been using this change to run `PKCS11Test.java` against the [Kryoptic](https://github.com/latchset/kryoptic) PKCS11 soft token, using this invocation:

```
make test \
    JTREG="JAVA_OPTIONS=-DCUSTOM_P11_CONFIG=/tmp/kryoptic-configuration/p11-kryoptic.txt \
                        -DCUSTOM_P11_LIBRARY_NAME=kryoptic_pkcs11 \
                        -Djdk.test.lib.artifacts.nsslib-linux_x64=/tmp/kryoptic-configuration \
                        -DCUSTOM_DB_DIR=/tmp/kryoptic-configuration"
```

`/tmp/kryoptic-configuration` contains (among other files):

```
libkryoptic_pkcs11.so
p11-kryoptic.txt
p11-kryoptic-sensitive.txt
```

With `CUSTOM_P11_LIBRARY_NAME` set, `PKCS11Test.java` can find `libkryoptic_pkcs11.so`.

And setting `CUSTOM_P11_CONFIG` causes the sensitive tests to use `p11-kryoptic-sensitive.txt` via the new `CUSTOM_P11_CONFIG_VARIANT` property.

On my `Fedora 42` `x86-64` machine, I tested for regressions with:
```
$ time make test JOBS=4 JTREG="JAVA_OPTIONS=-Djdk.test.lib.artifacts.nsslib-linux_x64=/usr/lib64" TEST="test/jdk/sun/security/pkcs11"
```
and:
```
$ time make test JOBS=4 TEST="test/jdk/sun/security/pkcs11"
```