### PR TITLE
Backport 272e66d017a3497d9af4df6f042c741ad8a59dd6

### DIFF
--- a/src/hotspot/share/oops/methodData.cpp
+++ b/src/hotspot/share/oops/methodData.cpp
@@ -1860,7 +1860,7 @@ public:
 };
 
 Mutex* MethodData::extra_data_lock() {
-  Mutex* lock = Atomic::load(&_extra_data_lock);
+  Mutex* lock = Atomic::load_acquire(&_extra_data_lock);
   if (lock == nullptr) {
     // This lock could be acquired while we are holding DumpTimeTable_lock/nosafepoint
     lock = new Mutex(Mutex::nosafepoint-1, "MDOExtraData_lock");


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [272e66d0](https://github.com/openjdk/jdk/commit/272e66d017a3497d9af4df6f042c741ad8a59dd6) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Thomas Schatzl on 14 Jul 2025 and was reviewed by Aleksey Shipilev, Coleen Phillimore and David Holmes.

Thanks!