### PR TITLE
8361587: AssertionError in File.listFiles() when path is empty and -esa is enabled

### DIFF
--- a/src/java.base/share/classes/java/io/File.java
+++ b/src/java.base/share/classes/java/io/File.java
@@ -1134,8 +1134,14 @@ public class File
         if (ss == null) return null;
         int n = ss.length;
         File[] fs = new File[n];
-        for (int i = 0; i < n; i++) {
-            fs[i] = new File(ss[i], this);
+        if (path.isEmpty()) {
+            for (int i = 0; i < n; i++) {
+                fs[i] = new File(ss[i]);
+            }
+        } else {
+            for (int i = 0; i < n; i++) {
+                fs[i] = new File(ss[i], this);
+            }
         }
         return fs;
     }

--- a/test/jdk/java/io/File/EmptyPath.java
+++ b/test/jdk/java/io/File/EmptyPath.java
@@ -22,7 +22,7 @@
  */
 
 /* @test
- * @bug 4842706 8024695
+ * @bug 4842706 8024695 8361587
  * @summary Test some file operations with empty path
  * @run junit EmptyPath
  */
@@ -36,13 +36,14 @@ import java.nio.file.FileStore;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -106,10 +107,25 @@ public class EmptyPath {
     }
 
     @Test
+    public void getAbsoluteFile() {
+        assertEquals(p.toAbsolutePath().toFile(), f.getAbsoluteFile());
+    }
+
+    @Test
     public void getAbsolutePath() {
         System.out.println(p.toAbsolutePath().toString() + "\n" +
                            f.getAbsolutePath());
         assertEquals(p.toAbsolutePath().toString(), f.getAbsolutePath());
+    }
+
+    @Test
+    public void getCanonicalFile() throws IOException {
+        assertEquals(p.toRealPath().toFile(), f.getCanonicalFile());
+    }
+
+    @Test
+    public void getCanonicalPath() throws IOException {
+        assertEquals(p.toRealPath().toString(), f.getCanonicalPath());
     }
 
     private void checkSpace(long expected, long actual) {
@@ -134,6 +150,11 @@ public class EmptyPath {
     @Test
     public void getParent() {
         assertNull(f.getParent());
+    }
+
+    @Test
+    public void getParentFile() {
+        assertNull(f.getParentFile());
     }
 
     @Test
@@ -199,8 +220,54 @@ public class EmptyPath {
     }
 
     @Test
+    public void listFiles() throws IOException {
+        File child = new File(f.getAbsoluteFile(), "child");
+        assertTrue(child.createNewFile());
+        child.deleteOnExit();
+
+        File[] files = f.listFiles();
+        for (File file : files)
+            assertEquals(-1, f.toString().indexOf(File.separatorChar));
+
+        Set<String> ioSet = Arrays.stream(files)
+            .map(File::getName)
+            .collect(Collectors.toSet());
+
+        assertTrue(ioSet.contains(child.getName()));
+
+        Set<String> nioSet = Files.list(p)
+            .map(Path::getFileName)
+            .map(Path::toString)
+            .collect(Collectors.toSet());
+        assertEquals(nioSet, ioSet);
+    }
+
+    @Test
+    public void listRoots() {
+        Set<String> expected = Arrays.stream(f.getAbsoluteFile().listRoots())
+            .map(File::toString)
+            .collect(Collectors.toSet());
+        Set<String> actual = Arrays.stream(f.listRoots())
+            .map(File::toString)
+            .collect(Collectors.toSet());
+        assertEquals(expected, actual);
+    }
+
+    @Test
     public void mkdir() {
         assertFalse(f.mkdir());
+    }
+
+    @Test
+    public void mkdirs() {
+        assertFalse(f.mkdirs());
+    }
+
+    @Test
+    public void renameTo() throws IOException {
+        File tmp = File.createTempFile("foo", "bar", f.getAbsoluteFile());
+        assertTrue(tmp.exists());
+        assertFalse(f.renameTo(tmp));
     }
 
     @Test
@@ -269,6 +336,12 @@ public class EmptyPath {
     @Test
     public void toPath() {
         assertEquals(p, f.toPath());
+    }
+
+    @Test
+    public String toString() {
+        assertEquals(EMPTY_STRING, f.toString());
+        return EMPTY_STRING;
     }
 
     @Test


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [eefbfdce](https://github.com/openjdk/jdk/commit/eefbfdce315237eeec4aceceb476d86314304e81) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Brian Burkhalter on 15 Jul 2025 and was reviewed by Alan Bateman.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8361587](https://bugs.openjdk.org/browse/JDK-8361587): AssertionError in File.listFiles() when path is empty and -esa is enabled (**Bug** - P2)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26327/head:pull/26327` \
`$ git checkout pull/26327`

Update a local copy of the PR: \
`$ git checkout pull/26327` \
`$ git pull https://git.openjdk.org/jdk.git pull/26327/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26327`

View PR using the GUI difftool: \
`$ git pr show -t 26327`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26327.diff">https://git.openjdk.org/jdk/pull/26327.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26327#issuecomment-3074913411)
</details>
