### PR TITLE
8362284: RISC-V: cleanup NativeMovRegMem

### DIFF
--- a/src/hotspot/cpu/riscv/nativeInst_riscv.cpp
+++ b/src/hotspot/cpu/riscv/nativeInst_riscv.cpp
@@ -339,19 +339,6 @@ void NativeMovConstReg::print() {
                 p2i(instruction_address()), data());
 }
 
-//-------------------------------------------------------------------
-
-int NativeMovRegMem::offset() const  {
-  Unimplemented();
-  return 0;
-}
-
-void NativeMovRegMem::set_offset(int x) { Unimplemented(); }
-
-void NativeMovRegMem::verify() {
-  Unimplemented();
-}
-
 //--------------------------------------------------------------------------------
 
 void NativeJump::verify() { }

--- a/src/hotspot/cpu/riscv/nativeInst_riscv.hpp
+++ b/src/hotspot/cpu/riscv/nativeInst_riscv.hpp
@@ -229,7 +229,7 @@ class NativeMovRegMem: public NativeInstruction {
 
 inline NativeMovRegMem* nativeMovRegMem_at(address addr) {
   Unimplemented();
-  return (NativeMovRegMem*)0;
+  return (NativeMovRegMem*)nullptr;
 }
 
 class NativeJump: public NativeInstruction {

--- a/src/hotspot/cpu/riscv/nativeInst_riscv.hpp
+++ b/src/hotspot/cpu/riscv/nativeInst_riscv.hpp
@@ -37,7 +37,7 @@
 // - NativeInstruction
 // - - NativeCall
 // - - NativeMovConstReg
-// - - NativeMovRegMem
+// - - NativeMovRegMem - Unimplemented
 // - - NativeJump
 // - - NativeGeneralJump
 // - - NativeIllegalInstruction
@@ -218,38 +218,18 @@ inline NativeMovConstReg* nativeMovConstReg_before(address addr) {
 // NativeMovRegMem to keep some compilers happy.
 class NativeMovRegMem: public NativeInstruction {
  public:
-  enum RISCV_specific_constants {
-    instruction_size            =    NativeInstruction::instruction_size,
-    instruction_offset          =    0,
-    data_offset                 =    0,
-    next_instruction_offset     =    NativeInstruction::instruction_size
-  };
+  int num_bytes_to_end_of_patch() const { Unimplemented(); return 0; }
 
-  int instruction_start() const { return instruction_offset; }
+  int offset() const { Unimplemented(); return 0; }
 
-  address instruction_address() const { return addr_at(instruction_offset); }
+  void set_offset(int x) { Unimplemented(); }
 
-  int num_bytes_to_end_of_patch() const { return instruction_offset + instruction_size; }
-
-  int offset() const;
-
-  void set_offset(int x);
-
-  void add_offset_in_bytes(int add_offset) {
-    set_offset(offset() + add_offset);
-  }
-
-  void verify();
-  void print();
-
- private:
-  inline friend NativeMovRegMem* nativeMovRegMem_at(address addr);
+  void add_offset_in_bytes(int add_offset) { Unimplemented(); }
 };
 
 inline NativeMovRegMem* nativeMovRegMem_at(address addr) {
-  NativeMovRegMem* test = (NativeMovRegMem*)(addr - NativeMovRegMem::instruction_offset);
-  DEBUG_ONLY(test->verify());
-  return test;
+  Unimplemented();
+  return (NativeMovRegMem*)0;
 }
 
 class NativeJump: public NativeInstruction {


### PR DESCRIPTION
Hi,
Can you help to review this simple patch?

NativeMovRegMem on riscv is actually dead code, but still needed in case of compilation of C1.
So make the code as simple as possible to avoid any reading and maintainance effort.

No tests, as `offset()` and `set_offset()` were Unimplemented and used in C1 and never triggered before.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8362284](https://bugs.openjdk.org/browse/JDK-8362284): RISC-V: cleanup NativeMovRegMem (**Enhancement** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Ludovic Henry](https://openjdk.org/census#luhenry) (@luhenry - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26328/head:pull/26328` \
`$ git checkout pull/26328`

Update a local copy of the PR: \
`$ git checkout pull/26328` \
`$ git pull https://git.openjdk.org/jdk.git pull/26328/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26328`

View PR using the GUI difftool: \
`$ git pr show -t 26328`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26328.diff">https://git.openjdk.org/jdk/pull/26328.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26328#issuecomment-3075001111)
</details>
