### PR TITLE
8362097: JFR: Active Settings view broken

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/query/view.ini
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/query/view.ini
@@ -39,8 +39,7 @@ label = "Active Settings"
 table = "COLUMN 'Event Type', 'Enabled', 'Threshold',
                 'Stack Trace','Period','Cutoff', 'Throttle'
          FORMAT none, missing:whitespace, missing:whitespace, missing:whitespace,
-                missing:whitespace, missing:whitespace, missing:whitespace,
-                missing:whitespace
+                missing:whitespace, missing:whitespace, missing:whitespace
          SELECT E.id, LAST_BATCH(E.value), LAST_BATCH(T.value),
                 LAST_BATCH(S.value), LAST_BATCH(P.value),
                 LAST_BATCH(C.value), LAST_BATCH(U.value)


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8362097](https://bugs.openjdk.org/browse/JDK-8362097): JFR: Active Settings view broken (**Bug** - P2)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26329/head:pull/26329` \
`$ git checkout pull/26329`

Update a local copy of the PR: \
`$ git checkout pull/26329` \
`$ git pull https://git.openjdk.org/jdk.git pull/26329/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26329`

View PR using the GUI difftool: \
`$ git pr show -t 26329`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26329.diff">https://git.openjdk.org/jdk/pull/26329.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26329#issuecomment-3075135628)
</details>
