### PR TITLE
8362291: [macOS] Remove finalize method in CGraphicsEnvironment.java

### DIFF
--- a/src/java.desktop/macosx/classes/sun/awt/CGraphicsEnvironment.java
+++ b/src/java.desktop/macosx/classes/sun/awt/CGraphicsEnvironment.java
@@ -150,13 +150,11 @@ public final class CGraphicsEnvironment extends SunGraphicsEnvironment {
             displayReconfigContext = ptr;
         }
 
-        public synchronized void dispose() {
-            if (displayReconfigContext != 0L) {
-                try {
-                    deregisterDisplayReconfiguration(displayReconfigContext);
-                } catch (Throwable t) {
-                    // Runs on disposer thread, can't allow an exception to escape.
-                }
+        public void dispose() {
+            try {
+                deregisterDisplayReconfiguration(displayReconfigContext);
+            } catch (Throwable t) {
+                // Runs on disposer thread, can't allow an exception to escape.
             }
         }
     }

--- a/src/java.desktop/macosx/classes/sun/awt/CGraphicsEnvironment.java
+++ b/src/java.desktop/macosx/classes/sun/awt/CGraphicsEnvironment.java
@@ -151,11 +151,7 @@ public final class CGraphicsEnvironment extends SunGraphicsEnvironment {
         }
 
         public void dispose() {
-            try {
-                deregisterDisplayReconfiguration(displayReconfigContext);
-            } catch (Throwable t) {
-                // Runs on disposer thread, can't allow an exception to escape.
-            }
+            deregisterDisplayReconfiguration(displayReconfigContext);
         }
     }
 

--- a/src/java.desktop/macosx/classes/sun/awt/CGraphicsEnvironment.java
+++ b/src/java.desktop/macosx/classes/sun/awt/CGraphicsEnvironment.java
@@ -37,6 +37,8 @@ import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
 
+import sun.java2d.Disposer;
+import sun.java2d.DisposerRecord;
 import sun.java2d.SunGraphicsEnvironment;
 
 /**
@@ -82,7 +84,7 @@ public final class CGraphicsEnvironment extends SunGraphicsEnvironment {
     /**
      * Remove the instance's registration with CGDisplayRemoveReconfigurationCallback()
      */
-    private native void deregisterDisplayReconfiguration(long context);
+    private static native void deregisterDisplayReconfiguration(long context);
 
     /** Available CoreGraphics displays. */
     private final Map<Integer, CGraphicsDevice> devices = new HashMap<>(5);
@@ -93,6 +95,7 @@ public final class CGraphicsEnvironment extends SunGraphicsEnvironment {
 
     /** Reference to the display reconfiguration callback context. */
     private final long displayReconfigContext;
+    private Object disposerReferent = new Object();
 
     // list of invalidated graphics devices (those which were removed)
     private List<WeakReference<CGraphicsDevice>> oldDevices = new ArrayList<>();
@@ -114,6 +117,7 @@ public final class CGraphicsEnvironment extends SunGraphicsEnvironment {
         if (displayReconfigContext == 0L) {
             throw new RuntimeException("Could not register CoreGraphics display reconfiguration callback");
         }
+        Disposer.addRecord(disposerReferent, new CGEDisposerRecord(displayReconfigContext));
     }
 
     /**
@@ -139,13 +143,21 @@ public final class CGraphicsEnvironment extends SunGraphicsEnvironment {
         rebuildDevices();
     }
 
-    @Override
-    @SuppressWarnings("removal")
-    protected void finalize() throws Throwable {
-        try {
-            super.finalize();
-        } finally {
-            deregisterDisplayReconfiguration(displayReconfigContext);
+    private static class CGEDisposerRecord implements DisposerRecord {
+        private long displayReconfigContext;
+
+        CGEDisposerRecord(long ptr) {
+            displayReconfigContext = ptr;
+        }
+
+        public synchronized void dispose() {
+            if (displayReconfigContext != 0L) {
+                try {
+                    deregisterDisplayReconfiguration(displayReconfigContext);
+                } catch (Throwable t) {
+                    // Runs on disposer thread, can't allow an exception to escape.
+                }
+            }
         }
     }
 

--- a/src/java.desktop/macosx/classes/sun/awt/CGraphicsEnvironment.java
+++ b/src/java.desktop/macosx/classes/sun/awt/CGraphicsEnvironment.java
@@ -95,7 +95,7 @@ public final class CGraphicsEnvironment extends SunGraphicsEnvironment {
 
     /** Reference to the display reconfiguration callback context. */
     private final long displayReconfigContext;
-    private Object disposerReferent = new Object();
+    private final Object disposerReferent = new Object();
 
     // list of invalidated graphics devices (those which were removed)
     private List<WeakReference<CGraphicsDevice>> oldDevices = new ArrayList<>();
@@ -144,7 +144,7 @@ public final class CGraphicsEnvironment extends SunGraphicsEnvironment {
     }
 
     private static class CGEDisposerRecord implements DisposerRecord {
-        private long displayReconfigContext;
+        private final long displayReconfigContext;
 
         CGEDisposerRecord(long ptr) {
             displayReconfigContext = ptr;

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CGraphicsEnv.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CGraphicsEnv.m
@@ -162,7 +162,7 @@ JNI_COCOA_EXIT(env);
  */
 JNIEXPORT void JNICALL
 Java_sun_awt_CGraphicsEnvironment_deregisterDisplayReconfiguration
-(JNIEnv *env, jobject this, jlong p)
+(JNIEnv *env, jclass clazz, jlong p)
 {
 JNI_COCOA_ENTER(env);
 

--- a/src/java.desktop/share/classes/sun/java2d/Disposer.java
+++ b/src/java.desktop/share/classes/sun/java2d/Disposer.java
@@ -137,7 +137,7 @@ public class Disposer implements Runnable {
                 obj = null;
                 rec = null;
                 clearDeferredRecords();
-            } catch (Exception e) {
+            } catch (Throwable t) {
                 System.out.println("Exception while removing reference.");
             }
         }
@@ -157,7 +157,7 @@ public class Disposer implements Runnable {
     private static void safeDispose(DisposerRecord rec) {
         try {
             rec.dispose();
-        } catch (final Exception e) {
+        } catch (final Throwable t) {
             System.out.println("Exception while disposing deferred rec.");
         }
     }
@@ -212,7 +212,7 @@ public class Disposer implements Runnable {
                     deferredRecords.offerLast(rec);
                 }
             }
-        } catch (Exception e) {
+        } catch (Throwable t) {
             System.out.println("Exception while removing reference.");
         } finally {
             pollingQueue = false;


### PR DESCRIPTION
Remove a finalize() method in CGraphicsEnvironment, replacing it with Disposer.

I don't see a way to add a test to verify this clean up.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8362291](https://bugs.openjdk.org/browse/JDK-8362291): [macOS] Remove finalize method in CGraphicsEnvironment.java (**Bug** - P4)


### Reviewers
 * [Brent Christian](https://openjdk.org/census#bchristi) (@bchristi-git - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)
 * [Alexander Zuev](https://openjdk.org/census#kizune) (@azuev-java - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26332/head:pull/26332` \
`$ git checkout pull/26332`

Update a local copy of the PR: \
`$ git checkout pull/26332` \
`$ git pull https://git.openjdk.org/jdk.git pull/26332/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26332`

View PR using the GUI difftool: \
`$ git pr show -t 26332`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26332.diff">https://git.openjdk.org/jdk/pull/26332.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26332#issuecomment-3075563195)
</details>
