### PR TITLE
8309400

### DIFF
--- a/src/jdk.jdi/share/classes/com/sun/jdi/ThreadReference.java
+++ b/src/jdk.jdi/share/classes/com/sun/jdi/ThreadReference.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -402,8 +402,8 @@ public interface ThreadReference extends ObjectReference {
      * @throws java.lang.IllegalArgumentException if <CODE>frame</CODE>
      * is not on this thread's call stack.
      *
-     * @throws OpaqueFrameException if this thread is a suspended virtual thread and the
-     * target VM was unable to pop the frames.
+     * @throws OpaqueFrameException if target VM is unable to pop this frame
+     * (e.g. a virtual thread is not suspended at an event).
      *
      * @throws NativeMethodException if one of the frames that would be
      * popped is that of a native method or if the frame previous to
@@ -484,8 +484,8 @@ public interface ThreadReference extends ObjectReference {
      * @throws IncompatibleThreadStateException if this
      * thread is not suspended.
      *
-     * @throws OpaqueFrameException if this thread is a suspended virtual thread and the
-     * target VM is unable to force the method to return.
+     * @throws OpaqueFrameException if target VM is unable to pop this frame
+     * (e.g. a virtual thread is not suspended at an event).
      *
      * @throws NativeMethodException if the frame to be returned from
      * is that of a native method.

--- a/src/jdk.jdi/share/classes/com/sun/tools/jdi/StackFrameImpl.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/jdi/StackFrameImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -395,29 +395,25 @@ public class StackFrameImpl extends MirrorImpl
         } catch (JDWPException exc) {
             switch (exc.errorCode()) {
             case JDWP.Error.OPAQUE_FRAME:
-                if (thread.isVirtual()) {
-                    // We first need to find out if the current frame is native, or if the
-                    // previous frame is native, in which case we throw NativeMethodException
-                    for (int i = 0; i < 2; i++) {
-                        StackFrameImpl sf;
-                        try {
-                            sf = (StackFrameImpl)thread.frame(i);
-                        } catch (IndexOutOfBoundsException e) {
-                            // This should never happen, but we need to check for it.
-                            break;
-                        }
-                        sf.validateStackFrame();
-                        MethodImpl meth = (MethodImpl)sf.location().method();
-                        if (meth.isNative()) {
-                            throw new NativeMethodException();
-                        }
+                // We first need to find out if the current frame is native, or if the
+                // previous frame is native, in which case we throw NativeMethodException
+                for (int i = 0; i < 2; i++) {
+                    StackFrameImpl sf;
+                    try {
+                        sf = (StackFrameImpl)thread.frame(i);
+                    } catch (IndexOutOfBoundsException e) {
+                        // This should never happen, but we need to check for it.
+                        break;
                     }
-                    // No native frames involved. Must have been due to thread
-                    // not being mounted.
-                    throw new OpaqueFrameException();
-                } else {
-                    throw new NativeMethodException();
+                    sf.validateStackFrame();
+                    MethodImpl meth = (MethodImpl)sf.location().method();
+                    if (meth.isNative()) {
+                        throw new NativeMethodException();
+                    }
                 }
+                // No native frames involved. Must have been due to virtual thread
+                // not being mounted or some other reason such as failure to deopt.
+                throw new OpaqueFrameException();
             case JDWP.Error.THREAD_NOT_SUSPENDED:
                 throw new IncompatibleThreadStateException(
                          "Thread not current or suspended");

--- a/src/jdk.jdi/share/classes/com/sun/tools/jdi/ThreadReferenceImpl.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/jdi/ThreadReferenceImpl.java
@@ -597,10 +597,10 @@ public class ThreadReferenceImpl extends ObjectReferenceImpl
         } catch (JDWPException exc) {
             switch (exc.errorCode()) {
             case JDWP.Error.OPAQUE_FRAME:
-                if (isVirtual() && !meth.isNative()) {
-                    throw new OpaqueFrameException();
-                } else {
+                if (meth.isNative()) {
                     throw new NativeMethodException();
+                } else {
+                    throw new OpaqueFrameException();
                 }
             case JDWP.Error.THREAD_NOT_SUSPENDED:
                 throw new IncompatibleThreadStateException(


### PR DESCRIPTION
Fix how ThreadReference.popFrame() and ThreadReference.forceEarlyReturn deal with JDWP OPAQUE_FRAME error.

Before virtual threads, OpaqueFrameException did not exist and these API always threw NativeMethodException when JDWP OPAQUE_FRAME error was returned. For virtual threads OpaqueFrameException was added to handle the case where a virtual thread was not suspended at an event, so the JDI implementation was updated to throw OpaqueFrameException if it detected that a native method was not the cause. It turns out however that JVMTI (and therefore JDWP) can return OPAQUE_FRAME error for reasons other than a native method or the special virtual thread case, and for platform threads we were incorrectly throwing NativeMethodException in these cases. This PR fixes that. For platform threads we now only throw NativeMethodException if a native method is detected, and otherwise throw OpaqueFrameException.

The spec language is also being cleaned up to better align with JVMTI. Rather than calling out all the reasons for OpaqueFrameException, a more generic explanation is given.

This is somewhat of a preliminary PR so I can get some feedback. I still need to do a CR and complete testing.