### PR TITLE
8362257: (process) Remove aliveness-ping-workaround for older glibcs in POSIX_SPAWN mode

### DIFF
--- a/src/java.base/unix/native/libjava/childproc.c
+++ b/src/java.base/unix/native/libjava/childproc.c
@@ -359,15 +359,6 @@ childProcess(void *arg)
     const ChildStuff* p = (const ChildStuff*) arg;
     int fail_pipe_fd = p->fail[1];
 
-    if (p->sendAlivePing) {
-        /* Child shall signal aliveness to parent at the very first
-         * moment. */
-        int code = CHILD_IS_ALIVE;
-        if (writeFully(fail_pipe_fd, &code, sizeof(code)) != sizeof(code)) {
-            goto WhyCantJohnnyExec;
-        }
-    }
-
 #ifdef DEBUG
     jtregSimulateCrash(0, 6);
 #endif

--- a/src/java.base/unix/native/libjava/childproc.h
+++ b/src/java.base/unix/native/libjava/childproc.h
@@ -93,7 +93,6 @@ typedef struct _ChildStuff
     const char **envv;
     const char *pdir;
     int redirectErrorStream;
-    int sendAlivePing;
 } ChildStuff;
 
 /* following used in addition when mode is SPAWN */
@@ -106,13 +105,6 @@ typedef struct _SpawnInfo {
     int nparentPathv; /* number of elements in parentPathv array */
     int parentPathvBytes; /* total number of bytes in parentPathv array */
 } SpawnInfo;
-
-/* If ChildStuff.sendAlivePing is true, child shall signal aliveness to
- * the parent the moment it gains consciousness, before any subsequent
- * pre-exec errors could happen.
- * This code must fit into an int and not be a valid errno value on any of
- * our platforms. */
-#define CHILD_IS_ALIVE      65535
 
 /**
  * The cached and split version of the JDK's effective PATH.


### PR DESCRIPTION
Removes the liveness ping since it is not needed anymore for newer versions of glibc.

See JBS issue description for more details, and also for analysis of the major Linux distros wrt glibc version. 

Patch also removes `throwExitCause()`, introduced with https://bugs.openjdk.org/browse/JDK-8226242 to analyze pre-exec abnormal abortions in jspawnhelper (see discussion about that removal at https://mail.openjdk.org/pipermail/core-libs-dev/2025-July/148908.html).

We then can also remove the definitions for the waitpid status macros (WIFSIGNALED and so forth). These were remnants from the initial checkin, back at that time used for Java_java_lang_UNIXProcess_waitForProcessExit. That one has long been moved.

In `Java_java_lang_ProcessImpl_forkAndExec`, I modified the error-number-printout to preserve the specialized printout for jspawnhelper error codes introduced by Aleksey with [JDK-8352533](https://bugs.openjdk.org/browse/JDK-8352533).

Note: removing this code also fixes a path that would have caused Zombie processes to appear (see https://bugs.openjdk.org/browse/JDK-8362267 , which is a separate issue).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8362257](https://bugs.openjdk.org/browse/JDK-8362257): (process) Remove aliveness-ping-workaround for older glibcs in POSIX_SPAWN mode (**Enhancement** - P4) ⚠️ Issue is not open.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26342/head:pull/26342` \
`$ git checkout pull/26342`

Update a local copy of the PR: \
`$ git checkout pull/26342` \
`$ git pull https://git.openjdk.org/jdk.git pull/26342/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26342`

View PR using the GUI difftool: \
`$ git pr show -t 26342`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26342.diff">https://git.openjdk.org/jdk/pull/26342.diff</a>

</details>
