### PR TITLE
8361827: [TESTBUG] serviceability/HeapDump/UnmountedVThreadNativeMethodAtTop.java throws OutOfMemoryError

### DIFF
--- a/test/hotspot/jtreg/serviceability/HeapDump/UnmountedVThreadNativeMethodAtTop.java
+++ b/test/hotspot/jtreg/serviceability/HeapDump/UnmountedVThreadNativeMethodAtTop.java
@@ -38,6 +38,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import com.sun.management.HotSpotDiagnosticMXBean;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -48,6 +49,15 @@ import jdk.test.lib.hprof.parser.Reader;
 public class UnmountedVThreadNativeMethodAtTop {
 
     boolean done;
+
+    /**
+     * The tests accumulate previous heap dumps. Trigger GC before each test to get rid of them.
+     * This makes dumps smaller, processing faster, and avoids OOMs
+     */
+    @BeforeEach
+    void doGC() {
+        System.gc();
+    }
 
     /**
      * Test dumping the heap while a virtual thread is blocked entering a synchronized native method.


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [cbb3d23e](https://github.com/openjdk/jdk/commit/cbb3d23e19a8a893bf2fbda03e7bda4f4b7a59a6) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository to jdk25.


Test-fix only to improves test performance and stability. Change has been verified locally, no risk.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8361827](https://bugs.openjdk.org/browse/JDK-8361827): [TESTBUG] serviceability/HeapDump/UnmountedVThreadNativeMethodAtTop.java throws OutOfMemoryError (**Bug** - P4)


### Reviewers
 * [Richard Reingruber](https://openjdk.org/census#rrich) (@reinrich - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26343/head:pull/26343` \
`$ git checkout pull/26343`

Update a local copy of the PR: \
`$ git checkout pull/26343` \
`$ git pull https://git.openjdk.org/jdk.git pull/26343/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26343`

View PR using the GUI difftool: \
`$ git pr show -t 26343`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26343.diff">https://git.openjdk.org/jdk/pull/26343.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26343#issuecomment-3077072573)
</details>
