### PR TITLE
8362336: Revert changes in metaspaceShared.cpp done via JDK-8356807

### DIFF
--- a/src/hotspot/share/cds/metaspaceShared.cpp
+++ b/src/hotspot/share/cds/metaspaceShared.cpp
@@ -1428,7 +1428,7 @@ FileMapInfo* MetaspaceShared::open_dynamic_archive() {
 MapArchiveResult MetaspaceShared::map_archives(FileMapInfo* static_mapinfo, FileMapInfo* dynamic_mapinfo,
                                                bool use_requested_addr) {
   if (use_requested_addr && static_mapinfo->requested_base_address() == nullptr) {
-    report_loading_error("Archive(s) were created with -XX:SharedBaseAddress=0. Always map at os-selected address.");
+    aot_log_info(aot)("Archive(s) were created with -XX:SharedBaseAddress=0. Always map at os-selected address.");
     return MAP_ARCHIVE_MMAP_FAILURE;
   }
 
@@ -1436,12 +1436,12 @@ MapArchiveResult MetaspaceShared::map_archives(FileMapInfo* static_mapinfo, File
       // For product build only -- this is for benchmarking the cost of doing relocation.
       // For debug builds, the check is done below, after reserving the space, for better test coverage
       // (see comment below).
-      report_loading_error("ArchiveRelocationMode == 1: always map archive(s) at an alternative address");
+      aot_log_info(aot)("ArchiveRelocationMode == 1: always map archive(s) at an alternative address");
       return MAP_ARCHIVE_MMAP_FAILURE;
     });
 
   if (ArchiveRelocationMode == 2 && !use_requested_addr) {
-    report_loading_error("ArchiveRelocationMode == 2: never map archive(s) at an alternative address");
+    aot_log_info(aot)("ArchiveRelocationMode == 2: never map archive(s) at an alternative address");
     return MAP_ARCHIVE_MMAP_FAILURE;
   };
 


### PR DESCRIPTION
The changes in `metaspaceShared.cpp` for JDK-8356807 is causing bootcycle prebuilt failures. Therefore, reverting those changes.

Testing: tiers 1 - 3, builds-tier4.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8362336](https://bugs.openjdk.org/browse/JDK-8362336): Revert changes in metaspaceShared.cpp done via JDK-8356807 (**Bug** - P4)


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26344/head:pull/26344` \
`$ git checkout pull/26344`

Update a local copy of the PR: \
`$ git checkout pull/26344` \
`$ git pull https://git.openjdk.org/jdk.git pull/26344/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26344`

View PR using the GUI difftool: \
`$ git pr show -t 26344`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26344.diff">https://git.openjdk.org/jdk/pull/26344.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26344#issuecomment-3077074690)
</details>
