### PR TITLE
8359339: applications/jcstress tests should report SkippedException when can not resolve jcstress.jar

### DIFF
--- a/test/hotspot/jtreg/applications/jcstress/JcstressRunner.java
+++ b/test/hotspot/jtreg/applications/jcstress/JcstressRunner.java
@@ -29,6 +29,7 @@ import jdk.test.lib.artifacts.ArtifactResolver;
 import jdk.test.lib.artifacts.ArtifactResolverException;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
+import jtreg.SkippedException;
 
 import java.io.File;
 import java.nio.file.Files;
@@ -56,7 +57,7 @@ public class JcstressRunner {
         try {
             artifacts = ArtifactResolver.resolve(JcstressRunner.class);
         } catch (ArtifactResolverException e) {
-            throw new Error("TESTBUG: Can not resolve artifacts for "
+            throw new SkippedException("TESTBUG: Can not resolve artifacts for "
                             + JcstressRunner.class.getName(), e);
         }
         return artifacts.get("org.openjdk.jcstress.jcstress-tests-all-" + VERSION)


### PR DESCRIPTION
Hi all,

I think it's more elegant that applications/jcstress tests report SkippedException when can not resolve jcstress.jar, rather than report  test failure. Change has been verified locally, test-fix only, no risk.

Tests:

- [ ] Run test test/hotspot/jtreg/applications/jcstress/countdownlatch.java with -Djdk.test.lib.artifacts.applications.jcstress.JcstressRunner=jcstress-tests-all.jar, test run success as expected.
- [ ] Run test test/hotspot/jtreg/applications/jcstress/countdownlatch.java without -Djdk.test.lib.artifacts.applications.jcstress.JcstressRunner=jcstress-tests-all.jar, test report shipped as expected.