### PR TITLE
8362306: HotSpotJVMCIRuntime.getMirror can crash

### DIFF
--- a/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
@@ -3016,7 +3016,7 @@ C2V_END
 
 static jbyteArray get_encoded_annotation_data(InstanceKlass* holder, AnnotationArray* annotations_array, bool for_class,
                                               jint filter_length, jlong filter_klass_pointers,
-                                              JavaThread* THREAD, JVMCIEnv* JVMCIENV) {
+                                              JavaThread* THREAD, JVMCI_TRAPS) {
   // Get a ConstantPool object for annotation parsing
   Handle jcp = reflect_ConstantPool::create(CHECK_NULL);
   reflect_ConstantPool::set_cp(jcp(), holder->constants());
@@ -3081,14 +3081,14 @@ C2V_VMENTRY_NULL(jbyteArray, getEncodedClassAnnotationData, (JNIEnv* env, jobjec
                  jobject filter, jint filter_length, jlong filter_klass_pointers))
   CompilerThreadCanCallJava canCallJava(thread, true); // Requires Java support
   InstanceKlass* holder = InstanceKlass::cast(UNPACK_PAIR(Klass, klass));
-  return get_encoded_annotation_data(holder, holder->class_annotations(), true, filter_length, filter_klass_pointers, THREAD, JVMCI_CHECK_NULL);
+  return get_encoded_annotation_data(holder, holder->class_annotations(), true, filter_length, filter_klass_pointers, THREAD, JVMCIENV);
 C2V_END
 
 C2V_VMENTRY_NULL(jbyteArray, getEncodedExecutableAnnotationData, (JNIEnv* env, jobject, ARGUMENT_PAIR(method),
                  jobject filter, jint filter_length, jlong filter_klass_pointers))
   CompilerThreadCanCallJava canCallJava(thread, true); // Requires Java support
   methodHandle method(THREAD, UNPACK_PAIR(Method, method));
-  return get_encoded_annotation_data(method->method_holder(), method->annotations(), false, filter_length, filter_klass_pointers, THREAD, JVMCI_CHECK_NULL);
+  return get_encoded_annotation_data(method->method_holder(), method->annotations(), false, filter_length, filter_klass_pointers, THREAD, JVMCIENV);
 C2V_END
 
 C2V_VMENTRY_NULL(jbyteArray, getEncodedFieldAnnotationData, (JNIEnv* env, jobject, ARGUMENT_PAIR(klass), jint index,
@@ -3096,7 +3096,7 @@ C2V_VMENTRY_NULL(jbyteArray, getEncodedFieldAnnotationData, (JNIEnv* env, jobjec
   CompilerThreadCanCallJava canCallJava(thread, true); // Requires Java support
   InstanceKlass* holder = check_field(InstanceKlass::cast(UNPACK_PAIR(Klass, klass)), index, JVMCI_CHECK_NULL);
   fieldDescriptor fd(holder, index);
-  return get_encoded_annotation_data(holder, fd.annotations(), false, filter_length, filter_klass_pointers, THREAD, JVMCI_CHECK_NULL);
+  return get_encoded_annotation_data(holder, fd.annotations(), false, filter_length, filter_klass_pointers, THREAD, JVMCIENV);
 C2V_END
 
 C2V_VMENTRY_NULL(jobjectArray, getFailedSpeculations, (JNIEnv* env, jobject, jlong failed_speculations_address, jobjectArray current))

--- a/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
@@ -3081,22 +3081,22 @@ C2V_VMENTRY_NULL(jbyteArray, getEncodedClassAnnotationData, (JNIEnv* env, jobjec
                  jobject filter, jint filter_length, jlong filter_klass_pointers))
   CompilerThreadCanCallJava canCallJava(thread, true); // Requires Java support
   InstanceKlass* holder = InstanceKlass::cast(UNPACK_PAIR(Klass, klass));
-  return get_encoded_annotation_data(holder, holder->class_annotations(), true, filter_length, filter_klass_pointers, THREAD, JVMCIENV);
+  return get_encoded_annotation_data(holder, holder->class_annotations(), true, filter_length, filter_klass_pointers, THREAD, JVMCI_CHECK_NULL);
 C2V_END
 
 C2V_VMENTRY_NULL(jbyteArray, getEncodedExecutableAnnotationData, (JNIEnv* env, jobject, ARGUMENT_PAIR(method),
                  jobject filter, jint filter_length, jlong filter_klass_pointers))
   CompilerThreadCanCallJava canCallJava(thread, true); // Requires Java support
   methodHandle method(THREAD, UNPACK_PAIR(Method, method));
-  return get_encoded_annotation_data(method->method_holder(), method->annotations(), false, filter_length, filter_klass_pointers, THREAD, JVMCIENV);
+  return get_encoded_annotation_data(method->method_holder(), method->annotations(), false, filter_length, filter_klass_pointers, THREAD, JVMCI_CHECK_NULL);
 C2V_END
 
 C2V_VMENTRY_NULL(jbyteArray, getEncodedFieldAnnotationData, (JNIEnv* env, jobject, ARGUMENT_PAIR(klass), jint index,
                  jobject filter, jint filter_length, jlong filter_klass_pointers))
   CompilerThreadCanCallJava canCallJava(thread, true); // Requires Java support
-  InstanceKlass* holder = check_field(InstanceKlass::cast(UNPACK_PAIR(Klass, klass)), index, JVMCIENV);
+  InstanceKlass* holder = check_field(InstanceKlass::cast(UNPACK_PAIR(Klass, klass)), index, JVMCI_CHECK_NULL);
   fieldDescriptor fd(holder, index);
-  return get_encoded_annotation_data(holder, fd.annotations(), false, filter_length, filter_klass_pointers, THREAD, JVMCIENV);
+  return get_encoded_annotation_data(holder, fd.annotations(), false, filter_length, filter_klass_pointers, THREAD, JVMCI_CHECK_NULL);
 C2V_END
 
 C2V_VMENTRY_NULL(jobjectArray, getFailedSpeculations, (JNIEnv* env, jobject, jlong failed_speculations_address, jobjectArray current))

--- a/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
@@ -2277,7 +2277,7 @@ C2V_VMENTRY_NULL(jobjectArray, getDeclaredFieldsInfo, (JNIEnv* env, jobject, ARG
   InstanceKlass* iklass = InstanceKlass::cast(klass);
   int java_fields, injected_fields;
   GrowableArray<FieldInfo>* fields = FieldInfoStream::create_FieldInfoArray(iklass->fieldinfo_stream(), &java_fields, &injected_fields);
-  JVMCIObjectArray array = JVMCIENV->new_FieldInfo_array(fields->length(), JVMCIENV);
+  JVMCIObjectArray array = JVMCIENV->new_FieldInfo_array(fields->length(), JVMCI_CHECK_NULL);
   for (int i = 0; i < fields->length(); i++) {
     JVMCIObject field_info = JVMCIENV->new_FieldInfo(fields->adr_at(i), JVMCI_CHECK_NULL);
     JVMCIENV->put_object_at(array, i, field_info);

--- a/src/hotspot/share/runtime/fieldDescriptor.hpp
+++ b/src/hotspot/share/runtime/fieldDescriptor.hpp
@@ -84,6 +84,7 @@ class fieldDescriptor {
   bool is_static()                const    { return access_flags().is_static(); }
   bool is_final()                 const    { return access_flags().is_final(); }
   bool is_stable()                const    { return field_flags().is_stable(); }
+  bool is_injected()              const    { return field_flags().is_injected(); }
   bool is_volatile()              const    { return access_flags().is_volatile(); }
   bool is_transient()             const    { return access_flags().is_transient(); }
 

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotJVMCIRuntime.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotJVMCIRuntime.java
@@ -775,8 +775,8 @@ public final class HotSpotJVMCIRuntime implements JVMCIRuntime {
      *         instances
      */
     public Class<?> getMirror(ResolvedJavaType type) {
-        if (type instanceof HotSpotResolvedJavaType && reflection instanceof HotSpotJDKReflection) {
-            return ((HotSpotJDKReflection) reflection).getMirror((HotSpotResolvedJavaType) type);
+        if (type instanceof HotSpotResolvedJavaType hType && reflection instanceof HotSpotJDKReflection) {
+            return ((HotSpotJDKReflection) reflection).getMirror(hType);
         }
         return null;
     }
@@ -790,8 +790,8 @@ public final class HotSpotJVMCIRuntime implements JVMCIRuntime {
      *         instances to {@link Executable} instances
      */
     public Executable getMirror(ResolvedJavaMethod method) {
-        if (method instanceof HotSpotResolvedJavaMethodImpl && reflection instanceof HotSpotJDKReflection) {
-            return HotSpotJDKReflection.getMethod((HotSpotResolvedJavaMethodImpl) method);
+        if (!method.isClassInitializer() && method instanceof HotSpotResolvedJavaMethodImpl hMethod && reflection instanceof HotSpotJDKReflection) {
+            return HotSpotJDKReflection.getMethod(hMethod);
         }
         return null;
     }
@@ -805,8 +805,8 @@ public final class HotSpotJVMCIRuntime implements JVMCIRuntime {
      *         instances
      */
     public Field getMirror(ResolvedJavaField field) {
-        if (field instanceof HotSpotResolvedJavaFieldImpl && reflection instanceof HotSpotJDKReflection) {
-            return HotSpotJDKReflection.getField((HotSpotResolvedJavaFieldImpl) field);
+        if (!field.isInternal() && field instanceof HotSpotResolvedJavaFieldImpl hField && reflection instanceof HotSpotJDKReflection) {
+            return HotSpotJDKReflection.getField(hField);
         }
         return null;
     }

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotResolvedPrimitiveType.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotResolvedPrimitiveType.java
@@ -298,6 +298,16 @@ public final class HotSpotResolvedPrimitiveType extends HotSpotResolvedJavaType 
     }
 
     @Override
+    public ResolvedJavaMethod[] getDeclaredConstructors(boolean forceLink) {
+        return new ResolvedJavaMethod[0];
+    }
+
+    @Override
+    public ResolvedJavaMethod[] getDeclaredMethods(boolean forceLink) {
+        return new ResolvedJavaMethod[0];
+    }
+
+    @Override
     public ResolvedJavaMethod[] getDeclaredMethods() {
         return new ResolvedJavaMethod[0];
     }

--- a/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.runtime.test/src/jdk/vm/ci/runtime/test/TestResolvedJavaField.java
+++ b/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.runtime.test/src/jdk/vm/ci/runtime/test/TestResolvedJavaField.java
@@ -33,6 +33,7 @@
  * @compile ../../../../../../../../../../../jdk/jdk/internal/vm/AnnotationEncodingDecoding/alt/MemberDeleted.java
  *          ../../../../../../../../../../../jdk/jdk/internal/vm/AnnotationEncodingDecoding/alt/MemberTypeChanged.java
  * @modules jdk.internal.vm.ci/jdk.vm.ci.meta
+ *          jdk.internal.vm.ci/jdk.vm.ci.hotspot
  *          jdk.internal.vm.ci/jdk.vm.ci.runtime
  *          jdk.internal.vm.ci/jdk.vm.ci.common
  *          java.base/jdk.internal.reflect

--- a/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.runtime.test/src/jdk/vm/ci/runtime/test/TestResolvedJavaType.java
+++ b/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.runtime.test/src/jdk/vm/ci/runtime/test/TestResolvedJavaType.java
@@ -1110,6 +1110,7 @@ public class TestResolvedJavaType extends TypeUniverse {
         if (clinit != null) {
             assertEquals(0, clinit.getAnnotations().length);
             assertEquals(0, clinit.getDeclaredAnnotations().length);
+            assertNull(runtime.getMirror(clinit));
         }
         return clinit;
     }

--- a/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.runtime.test/src/jdk/vm/ci/runtime/test/TestResolvedJavaType.java
+++ b/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.runtime.test/src/jdk/vm/ci/runtime/test/TestResolvedJavaType.java
@@ -34,6 +34,7 @@
  *          ../../../../../../../../../../../jdk/jdk/internal/vm/AnnotationEncodingDecoding/alt/MemberTypeChanged.java
  * @modules java.base/jdk.internal.reflect
  *          jdk.internal.vm.ci/jdk.vm.ci.meta
+ *          jdk.internal.vm.ci/jdk.vm.ci.hotspot
  *          jdk.internal.vm.ci/jdk.vm.ci.runtime
  *          jdk.internal.vm.ci/jdk.vm.ci.common
  *          java.base/jdk.internal.misc
@@ -104,14 +105,23 @@ import jdk.vm.ci.meta.ResolvedJavaMethod;
 import jdk.vm.ci.meta.ResolvedJavaType;
 import jdk.vm.ci.meta.UnresolvedJavaType;
 import sun.reflect.annotation.AnnotationSupport;
+import jdk.vm.ci.hotspot.HotSpotJVMCIRuntime;
 
 /**
  * Tests for {@link ResolvedJavaType}.
  */
 public class TestResolvedJavaType extends TypeUniverse {
     private static final Class<? extends Annotation> SIGNATURE_POLYMORPHIC_CLASS = findPolymorphicSignatureClass();
+    private static final HotSpotJVMCIRuntime runtime = HotSpotJVMCIRuntime.runtime();
 
     public TestResolvedJavaType() {
+    }
+
+    @Test
+    public void getMirrorTest() {
+        for (ResolvedJavaType type : javaTypes) {
+            assertEquals(type.toClassName(), runtime.getMirror(type).getName());
+        }
     }
 
     @Test
@@ -935,6 +945,9 @@ public class TestResolvedJavaType extends TypeUniverse {
         return null;
     }
 
+    /**
+     * Replicates the semantics of jdk.internal.reflect.Reflection#fieldFilterMap.
+     */
     private static boolean isHiddenFromReflection(ResolvedJavaField f) {
         if (f.getDeclaringClass().equals(metaAccess.lookupJavaType(ConstantPool.class)) && f.getName().equals("constantPoolOop")) {
             return true;
@@ -971,7 +984,13 @@ public class TestResolvedJavaType extends TypeUniverse {
                 int reflectFieldIndex = 0;
                 for (int i = 0; i < fields.length; i++) {
                     ResolvedJavaField field = fields[i];
-                    if (field.isInternal() || isHiddenFromReflection(field)) {
+                    var mirror = runtime.getMirror(field);
+                    if (field.isInternal()) {
+                        assertNull(field.toString(), mirror);
+                        continue;
+                    }
+                    assertNotNull(field.toString(), mirror);
+                    if (isHiddenFromReflection(field)) {
                         continue;
                     }
                     Field reflectField = reflectFields.get(reflectFieldIndex++);
@@ -1002,6 +1021,8 @@ public class TestResolvedJavaType extends TypeUniverse {
                 assertNotNull(lookupField(actual, f));
             }
             for (ResolvedJavaField rf : actual) {
+                var mirror = runtime.getMirror(rf);
+                assertNotNull(rf.toString(), mirror);
                 if (!isHiddenFromReflection(rf)) {
                     assertEquals(lookupField(expected, rf) != null, !rf.isInternal());
                 }
@@ -1025,6 +1046,28 @@ public class TestResolvedJavaType extends TypeUniverse {
                 expected.add(resolvedMethod);
             }
             Set<ResolvedJavaMethod> actual = new HashSet<>(Arrays.asList(type.getDeclaredMethods()));
+            for (ResolvedJavaMethod method : actual) {
+                assertNotNull(method.toString(), runtime.getMirror(method));
+            }
+            assertEquals(expected, actual);
+        }
+    }
+
+    @Test
+    public void getDeclaredConstructorsTest() {
+        for (Class<?> c : classes) {
+            ResolvedJavaType type = metaAccess.lookupJavaType(c);
+            Constructor<?>[] raw = c.getDeclaredConstructors();
+            Set<ResolvedJavaMethod> expected = new HashSet<>();
+            for (Constructor<?> m : raw) {
+                ResolvedJavaMethod resolvedMethod = metaAccess.lookupJavaMethod(m);
+                assertNotNull(resolvedMethod);
+                expected.add(resolvedMethod);
+            }
+            Set<ResolvedJavaMethod> actual = new HashSet<>(Arrays.asList(type.getDeclaredConstructors()));
+            for (ResolvedJavaMethod method : actual) {
+                assertNotNull(runtime.getMirror(method));
+            }
             assertEquals(expected, actual);
         }
     }
@@ -1238,7 +1281,6 @@ public class TestResolvedJavaType extends TypeUniverse {
         "initialize",
         "isPrimitive",
         "newArray",
-        "getDeclaredConstructors",
         "isInitialized",
         "isLinked",
         "getJavaClass",


### PR DESCRIPTION
This PR fixes `HotSpotJVMCIRuntime.getMirror(ResolvedJavaMethod method)` and `HotSpotJVMCIRuntime.getMirror(ResolvedJavaField field)` so that they return null for `<clinit>` and an injected field respectively instead of crashing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8362306](https://bugs.openjdk.org/browse/JDK-8362306): HotSpotJVMCIRuntime.getMirror can crash (**Bug** - P4)


### Reviewers
 * [Gilles Duboscq](https://openjdk.org/census#gdub) (@gilles-duboscq - Committer)
 * [Cesar Soares Lucas](https://openjdk.org/census#cslucas) (@JohnTortugo - Committer) Review applies to [fd44d95c](https://git.openjdk.org/jdk/pull/26346/files/fd44d95c83bb9160395b5fe94298f1a300233001)
 * [Tom Rodriguez](https://openjdk.org/census#never) (@tkrodriguez - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26346/head:pull/26346` \
`$ git checkout pull/26346`

Update a local copy of the PR: \
`$ git checkout pull/26346` \
`$ git pull https://git.openjdk.org/jdk.git pull/26346/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26346`

View PR using the GUI difftool: \
`$ git pr show -t 26346`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26346.diff">https://git.openjdk.org/jdk/pull/26346.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26346#issuecomment-3077577277)
</details>
