### PR TITLE
8362390: AIX make fails in awt_GraphicsEnv.c

### DIFF
--- a/src/java.desktop/unix/native/libawt_xawt/awt/awt_GraphicsEnv.c
+++ b/src/java.desktop/unix/native/libawt_xawt/awt/awt_GraphicsEnv.c
@@ -1747,7 +1747,7 @@ Java_sun_awt_X11GraphicsDevice_initXrandrExtension
 // ---------------------------------------------------
 // display mode change via XRRSetCrtcConfig
 // ---------------------------------------------------
-
+#if !defined(NO_XRANDR)
 static jint refreshRateFromModeInfo(const XRRModeInfo *modeInfo) {
     if (!modeInfo->hTotal || !modeInfo->vTotal) {
         return 0;
@@ -2031,6 +2031,7 @@ static void xrrChangeDisplayMode(jint screen, jint width, jint height, jint refr
         }
         awt_XRRFreeScreenResources(res);
 }
+#endif
 
 // ---------------------------------------------------
 // display mode change via XRRSetCrtcConfig


### PR DESCRIPTION
We have build errors on AIX , seems related to [JDK-8354415](https://bugs.openjdk.org/browse/JDK-8354415) :

```
=== Output from failing command(s) repeated here ===
* For target support_native_java.desktop_libawt_xawt_awt_GraphicsEnv.o:
/priv/jenkins/client-home/workspace/openjdk-jdk-aix_ppc64-opt/jdk/src/java.desktop/unix/native/libawt_xawt/awt/awt_GraphicsEnv.c:1751:43: error: unknown type name 'XRRModeInfo'
1751 | static jint refreshRateFromModeInfo(const XRRModeInfo *modeInfo) {
      | ^
/priv/jenkins/client-home/workspace/openjdk-jdk-aix_ppc64-opt/jdk/src/java.desktop/unix/native/libawt_xawt/awt/awt_GraphicsEnv.c:1758:31: error: use of undeclared identifier 'RR_Interlace'
1758 | if (modeInfo->modeFlags & RR_Interlace) {
      | ^
/priv/jenkins/client-home/workspace/openjdk-jdk-aix_ppc64-opt/jdk/src/java.desktop/unix/native/libawt_xawt/awt/awt_GraphicsEnv.c:1762:31: error: use of undeclared identifier 'RR_DoubleScan'
1762 | if (modeInfo->modeFlags & RR_DoubleScan) {
      | ^
/priv/jenkins/client-home/workspace/openjdk-jdk-aix_ppc64-opt/jdk/src/java.desktop/unix/native/libawt_xawt/awt/awt_GraphicsEnv.c:1769:43: error: unknown type name 'XRRCrtcInfo'
1769 | static inline Bool isLandscapeOrientation(XRRCrtcInfo* info) {
      | ^
/priv/jenkins/client-home/workspace/openjdk-jdk-aix_ppc64-opt/jdk/src/java.desktop/unix/native/libawt_xawt/awt/awt_GraphicsEnv.c:1773:30: error: use of undeclared identifier 'RR_Rotate_0'
1773 | return info->rotation == RR_Rotate_0 || info->rotation == RR_Rotate_180;
      | ^
   ... (rest of output omitted)
```

Seems we miss some checks for the NO_XRANDR macro.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8362390](https://bugs.openjdk.org/browse/JDK-8362390): AIX make fails in awt_GraphicsEnv.c (**Bug** - P3)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26348/head:pull/26348` \
`$ git checkout pull/26348`

Update a local copy of the PR: \
`$ git checkout pull/26348` \
`$ git pull https://git.openjdk.org/jdk.git pull/26348/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26348`

View PR using the GUI difftool: \
`$ git pr show -t 26348`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26348.diff">https://git.openjdk.org/jdk/pull/26348.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26348#issuecomment-3078442322)
</details>
