### PR TITLE
8362171: C2 fails with unexpected node in SuperWord truncation: ModI

### DIFF
--- a/src/hotspot/share/opto/superword.cpp
+++ b/src/hotspot/share/opto/superword.cpp
@@ -2581,6 +2581,7 @@ static bool can_subword_truncate(Node* in, const Type* type) {
   switch (opc) {
   case Op_AbsI:
   case Op_DivI:
+  case Op_ModI:
   case Op_MinI:
   case Op_MaxI:
   case Op_CMoveI:

--- a/test/hotspot/jtreg/compiler/vectorization/TestSubwordTruncation.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestSubwordTruncation.java
@@ -29,7 +29,7 @@ import compiler.lib.generators.*;
 
 /*
  * @test
- * @bug 8350177
+ * @bug 8350177 8362171
  * @summary Ensure that truncation of subword vectors produces correct results
  * @library /test/lib /
  * @run driver compiler.vectorization.TestSubwordTruncation
@@ -376,6 +376,18 @@ public class TestSubwordTruncation {
         }
     }
 
+    int intField;
+    short shortField;
+
+    @Test
+    @IR(counts = { IRNode.MOD_I, ">0" })
+    public void testMod() {
+        for (int i = 1; i < SIZE; i++) {
+            for (int j = 1; j < 204; j++) {
+                shortField %= intField | 1;
+            }
+        }
+    }
 
     public static void main(String[] args) {
         TestFramework.run();


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [70c1ff7e](https://github.com/openjdk/jdk/commit/70c1ff7e1505eee11b2a9acd9e94a39cd2c9a932) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Jasmine Karthikeyan on 16 Jul 2025 and was reviewed by Tobias Hartmann and Christian Hagedorn.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8362171](https://bugs.openjdk.org/browse/JDK-8362171): C2 fails with unexpected node in SuperWord truncation: ModI (**Bug** - P2)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26350/head:pull/26350` \
`$ git checkout pull/26350`

Update a local copy of the PR: \
`$ git checkout pull/26350` \
`$ git pull https://git.openjdk.org/jdk.git pull/26350/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26350`

View PR using the GUI difftool: \
`$ git pr show -t 26350`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26350.diff">https://git.openjdk.org/jdk/pull/26350.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26350#issuecomment-3078681289)
</details>
