### PR TITLE
8362250: ARM32: forward_exception_entry missing return address

### DIFF
--- a/src/hotspot/cpu/arm/arm.ad
+++ b/src/hotspot/cpu/arm/arm.ad
@@ -8888,13 +8888,8 @@ instruct TailCalljmpInd(IPRegP jump_target, inline_cache_regP method_ptr) %{
   match(TailCall jump_target method_ptr);
 
   ins_cost(CALL_COST);
-  format %{ "MOV    Rexception_pc, LR\n\t"
-            "jump   $jump_target  \t! $method_ptr holds method" %}
+  format %{ "jump   $jump_target  \t! $method_ptr holds method" %}
   ins_encode %{
-    __ mov(Rexception_pc, LR);   // this is used only to call
-                                 // StubRoutines::forward_exception_entry()
-                                 // which expects PC of exception in
-                                 // R5. FIXME?
     __ jump($jump_target$$Register);
   %}
   ins_pipe(tail_call);
@@ -8939,8 +8934,10 @@ instruct ForwardExceptionjmp()
   match(ForwardException);
   ins_cost(CALL_COST);
 
-  format %{ "b    forward_exception_stub" %}
+  format %{ "MOV  Rexception_pc, LR\n\t"
+            "b    forward_exception_entry" %}
   ins_encode %{
+    __ mov(Rexception_pc, LR);
     // OK to trash Rtemp, because Rtemp is used by stub
     __ jump(StubRoutines::forward_exception_entry(), relocInfo::runtime_call_type, Rtemp);
   %}


### PR DESCRIPTION
This pull request contains a backport of commit [6ed81641](https://github.com/openjdk/jdk/commit/6ed81641b101658fbbd35445b6dd74ec17fc20f3) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The ARM32 ForwardExceptionNode code generation has been updated to set the exception address. This is a minimal, ARM32-specific change, it fixes a couple of failing hotspot jtreg tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8362250](https://bugs.openjdk.org/browse/JDK-8362250): ARM32: forward_exception_entry missing return address (**Bug** - P3)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26352/head:pull/26352` \
`$ git checkout pull/26352`

Update a local copy of the PR: \
`$ git checkout pull/26352` \
`$ git pull https://git.openjdk.org/jdk.git pull/26352/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26352`

View PR using the GUI difftool: \
`$ git pr show -t 26352`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26352.diff">https://git.openjdk.org/jdk/pull/26352.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26352#issuecomment-3079385782)
</details>
