### PR TITLE
8361751: Test sun/tools/jcmd/TestJcmdSanity.java timed out on Windows

### DIFF
--- a/test/jdk/sun/tools/jcmd/JcmdBase.java
+++ b/test/jdk/sun/tools/jcmd/JcmdBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -102,6 +102,8 @@ public final class JcmdBase {
                 launcher.addVMArg(vmArg);
             }
         }
+        // Some command output may be lengthy, disable streaming output to avoid deadlocks
+        launcher.addVMArg("-Djdk.attach.allowStreamingOutput=false");
         if (requestToCurrentProcess) {
             launcher.addToolArg(Long.toString(ProcessTools.getProcessId()));
         }


### PR DESCRIPTION
Tests which run serviceability tools to attach to the main test process can get deadlock with streaming output (see #24672 )
The fix disables attach streaming output for tests in jdk/sun/tools/jcmd

Testing: tier6, tier7

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8361751](https://bugs.openjdk.org/browse/JDK-8361751): Test sun/tools/jcmd/TestJcmdSanity.java timed out on Windows (**Bug** - P3)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26358/head:pull/26358` \
`$ git checkout pull/26358`

Update a local copy of the PR: \
`$ git checkout pull/26358` \
`$ git pull https://git.openjdk.org/jdk.git pull/26358/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26358`

View PR using the GUI difftool: \
`$ git pr show -t 26358`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26358.diff">https://git.openjdk.org/jdk/pull/26358.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26358#issuecomment-3081424402)
</details>
