### PR TITLE
8362429: AssertionError in File.listFiles(FileFilter | FilenameFilter)

### DIFF
--- a/src/java.base/share/classes/java/io/File.java
+++ b/src/java.base/share/classes/java/io/File.java
@@ -1134,15 +1134,9 @@ public class File
         if (ss == null) return null;
         int n = ss.length;
         File[] fs = new File[n];
-        if (path.isEmpty()) {
-            for (int i = 0; i < n; i++) {
-                fs[i] = new File(ss[i]);
-            }
-        } else {
-            for (int i = 0; i < n; i++) {
-                fs[i] = new File(ss[i], this);
-            }
-        }
+        boolean isEmpty = path.isEmpty();
+        for (int i = 0; i < n; i++)
+            fs[i] = isEmpty ? new File(ss[i]) : new File(ss[i], this);
         return fs;
     }
 
@@ -1175,9 +1169,10 @@ public class File
         String[] ss = normalizedList();
         if (ss == null) return null;
         ArrayList<File> files = new ArrayList<>();
+        boolean isEmpty = path.isEmpty();
         for (String s : ss)
             if ((filter == null) || filter.accept(this, s))
-                files.add(new File(s, this));
+                files.add(isEmpty ? new File(s) : new File(s, this));
         return files.toArray(new File[files.size()]);
     }
 
@@ -1208,8 +1203,9 @@ public class File
         String[] ss = normalizedList();
         if (ss == null) return null;
         ArrayList<File> files = new ArrayList<>();
+        boolean isEmpty = path.isEmpty();
         for (String s : ss) {
-            File f = new File(s, this);
+            File f = isEmpty ? new File(s) : new File(s, this);
             if ((filter == null) || filter.accept(f))
                 files.add(f);
         }


### PR DESCRIPTION
Hi all,

    This pull request contains a backport of commit [be0161a8](https://github.com/openjdk/jdk/commit/be0161a8e63096f3a21ce6ea1e055ee1c4ed63ad) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

    The commit being backported was authored by Brian Burkhalter on 17 Jul 2025 and was reviewed by Alan Bateman.

    Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8362429](https://bugs.openjdk.org/browse/JDK-8362429): AssertionError in File.listFiles(FileFilter | FilenameFilter) (**Bug** - P2)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26361/head:pull/26361` \
`$ git checkout pull/26361`

Update a local copy of the PR: \
`$ git checkout pull/26361` \
`$ git pull https://git.openjdk.org/jdk.git pull/26361/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26361`

View PR using the GUI difftool: \
`$ git pr show -t 26361`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26361.diff">https://git.openjdk.org/jdk/pull/26361.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26361#issuecomment-3082775352)
</details>
