### PR TITLE
8362493: Cleanup CodeBuffer::copy_relocations_to

### DIFF
--- a/src/hotspot/share/asm/codeBuffer.cpp
+++ b/src/hotspot/share/asm/codeBuffer.cpp
@@ -626,7 +626,7 @@ csize_t CodeBuffer::total_relocation_size() const {
   return (csize_t) align_up(total, HeapWordSize);
 }
 
-csize_t CodeBuffer::copy_relocations_to(address buf, csize_t buf_limit, bool only_inst) const {
+csize_t CodeBuffer::copy_relocations_to(address buf, csize_t buf_limit) const {
   csize_t buf_offset = 0;
   csize_t code_end_so_far = 0;
   csize_t code_point_so_far = 0;
@@ -635,10 +635,6 @@ csize_t CodeBuffer::copy_relocations_to(address buf, csize_t buf_limit, bool onl
   assert(buf_limit % HeapWordSize == 0, "buf must be evenly sized");
 
   for (int n = (int) SECT_FIRST; n < (int)SECT_LIMIT; n++) {
-    if (only_inst && (n != (int)SECT_INSTS)) {
-      // Need only relocation info for code.
-      continue;
-    }
     // pull relocs out of each section
     const CodeSection* cs = code_section(n);
     assert(!(cs->is_empty() && cs->locs_count() > 0), "sanity");
@@ -705,7 +701,7 @@ csize_t CodeBuffer::copy_relocations_to(address buf, csize_t buf_limit, bool onl
     buf_offset += sizeof(relocInfo);
   }
 
-  assert(only_inst || code_end_so_far == total_content_size(), "sanity");
+  assert(code_end_so_far == total_content_size(), "sanity");
 
   return buf_offset;
 }
@@ -721,7 +717,7 @@ csize_t CodeBuffer::copy_relocations_to(CodeBlob* dest) const {
   }
   // if dest is null, this is just the sizing pass
   //
-  buf_offset = copy_relocations_to(buf, buf_limit, false);
+  buf_offset = copy_relocations_to(buf, buf_limit);
 
   return buf_offset;
 }

--- a/src/hotspot/share/asm/codeBuffer.hpp
+++ b/src/hotspot/share/asm/codeBuffer.hpp
@@ -641,6 +641,7 @@ class CodeBuffer: public StackObj DEBUG_ONLY(COMMA private Scrubber) {
   // copies combined relocations to the blob, returns bytes copied
   // (if target is null, it is a dry run only, just for sizing)
   csize_t copy_relocations_to(CodeBlob* blob) const;
+  csize_t copy_relocations_to(address buf, csize_t buf_limit) const;
 
   // copies combined code to the blob (assumes relocs are already in there)
   void copy_code_to(CodeBlob* blob);
@@ -790,8 +791,6 @@ class CodeBuffer: public StackObj DEBUG_ONLY(COMMA private Scrubber) {
   csize_t total_relocation_size() const;
 
   int total_skipped_instructions_size() const;
-
-  csize_t copy_relocations_to(address buf, csize_t buf_limit, bool only_inst) const;
 
   // allocated size of any and all recorded oops
   csize_t total_oop_size() const {


### PR DESCRIPTION
Hi,
Can you help to review this simple patch?

`CodeBuffer::copy_relocations_to(address buf, csize_t buf_limit, bool only_inst)` is only used in `copy_relocations_to(CodeBlob* dest)` which passes false to only_inst, so the former one should be able to be simplified.

Thank you!