### PR TITLE
8361725: Do not load Java agent with "-Xshare:dump -XX:+AOTClassLinking"

### DIFF
--- a/src/hotspot/share/cds/cdsConfig.cpp
+++ b/src/hotspot/share/cds/cdsConfig.cpp
@@ -598,6 +598,7 @@ void CDSConfig::check_aotmode_create() {
   //
   // Since application is not executed in the assembly phase, there's no need to load
   // the agents anyway -- no one will notice that the agents are not loaded.
+  log_info(aot)("Disabled all JVMTI agents during -XX:AOTMode=create");
   JvmtiAgentList::disable_agent_list();
 }
 
@@ -699,6 +700,13 @@ bool CDSConfig::check_vm_args_consistency(bool patch_mod_javabase, bool mode_fla
     if (!BytecodeVerificationRemote) {
       BytecodeVerificationRemote = true;
       aot_log_info(aot)("All non-system classes will be verified (-Xverify:remote) during CDS dump time.");
+    }
+  }
+
+  if (is_dumping_classic_static_archive() && AOTClassLinking) {
+    if (JvmtiAgentList::disable_agent_list()) {
+      FLAG_SET_ERGO(AllowArchivingWithJavaAgent, false);
+      log_warning(cds)("Disabled all JVMTI agents with -Xshare:dump -XX:+AOTClassLinking");
     }
   }
 

--- a/src/hotspot/share/prims/jvmtiAgentList.cpp
+++ b/src/hotspot/share/prims/jvmtiAgentList.cpp
@@ -273,11 +273,13 @@ JvmtiAgent* JvmtiAgentList::lookup(JvmtiEnv* env, void* f_ptr) {
   return nullptr;
 }
 
-void JvmtiAgentList::disable_agent_list() {
+bool JvmtiAgentList::disable_agent_list() {
 #if INCLUDE_CDS
-  assert(CDSConfig::is_dumping_final_static_archive(), "use this only for -XX:AOTMode=create!");
   assert(!Universe::is_bootstrapping() && !Universe::is_fully_initialized(), "must do this very early");
-  log_info(aot)("Disabled all JVMTI agents during -XX:AOTMode=create");
-  _head = nullptr; // Pretend that no agents have been added.
+  if (_head != nullptr) {
+    _head = nullptr; // Pretend that no agents have been added.
+    return true;
+  }
 #endif
+  return false;
 }

--- a/src/hotspot/share/prims/jvmtiAgentList.hpp
+++ b/src/hotspot/share/prims/jvmtiAgentList.hpp
@@ -83,7 +83,7 @@ class JvmtiAgentList : AllStatic {
   static Iterator java_agents();
   static Iterator native_agents();
   static Iterator xrun_agents();
-  static void disable_agent_list() NOT_JVMTI_RETURN;
+  static bool disable_agent_list() NOT_JVMTI_RETURN_(false);
 };
 
 #endif // SHARE_PRIMS_JVMTIAGENTLIST_HPP

--- a/test/hotspot/jtreg/runtime/cds/appcds/aotCache/JavaAgentTransformer.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotCache/JavaAgentTransformer.java
@@ -22,6 +22,7 @@
  *
  */
 
+import java.lang.System.Logger.Level;
 import java.lang.instrument.ClassFileTransformer;
 import java.lang.instrument.IllegalClassFormatException;
 import java.lang.instrument.Instrumentation;
@@ -30,11 +31,14 @@ import java.security.ProtectionDomain;
 // This class is available on the classpath so it can be accessed by JavaAgentApp
 public class JavaAgentTransformer  implements ClassFileTransformer {
     private static Instrumentation savedInstrumentation;
+    private static final System.Logger LOGGER = System.getLogger(JavaAgentTransformer.class.getName());
 
     public static void premain(String agentArguments, Instrumentation instrumentation) {
         System.out.println("JavaAgentTransformer.premain() is called");
         instrumentation.addTransformer(new JavaAgentTransformer(), /*canRetransform=*/true);
         savedInstrumentation = instrumentation;
+
+        LOGGER.log(Level.WARNING, "JavaAgentTransformer::premain() is finished");
     }
 
     public static Instrumentation getInstrumentation() {


### PR DESCRIPTION
When `-XX:+AOTClassLinking` is enabled when dumping CDS archives with `java -Xshare:dump`, we have more stringent restriction of what Java code can be executed -- if arbitrary Java code is executed, it may produce side effects that cannot be handled when archiving Java heap objects. This usually leads to cdsHeapVerifier.cpp reporting suspicious references to static fields that are not known to be safe.

We already avoid loading Java agents when dumping AOT caches (which are just enhanced CDS archives with more optimizations), we should do the same thing for `java -Xshare:dump -XX:+AOTClassLinking`.

After this PR, we still allow Java agents for `java -Xshare:dump -XX:-AOTClassLinking`, as that is required by some CDS tests. In a subsequent RFE, we will fix these CDS tests so Java agents are always disabled for `java -Xshare:dump`. See [JDK-8362561](https://bugs.openjdk.org/browse/JDK-8362561)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8361725](https://bugs.openjdk.org/browse/JDK-8361725): Do not load Java agent with "-Xshare:dump -XX:+AOTClassLinking" (**Bug** - P4)


### Reviewers
 * [Matias Saavedra Silva](https://openjdk.org/census#matsaave) (@matias9927 - **Reviewer**)
 * [Calvin Cheung](https://openjdk.org/census#ccheung) (@calvinccheung - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26374/head:pull/26374` \
`$ git checkout pull/26374`

Update a local copy of the PR: \
`$ git checkout pull/26374` \
`$ git pull https://git.openjdk.org/jdk.git pull/26374/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26374`

View PR using the GUI difftool: \
`$ git pr show -t 26374`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26374.diff">https://git.openjdk.org/jdk/pull/26374.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26374#issuecomment-3085695027)
</details>
