### PR TITLE
8362556: New test jdk/jfr/event/io/TestIOTopFrame.java is failing on all platforms

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/PlatformEventType.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/PlatformEventType.java
@@ -107,9 +107,9 @@ public final class PlatformEventType extends Type {
             return switch (getName()) {
                 case Type.EVENT_NAME_PREFIX + "SocketRead",
                      Type.EVENT_NAME_PREFIX + "SocketWrite",
-                     Type.EVENT_NAME_PREFIX + "FileRead",
                      Type.EVENT_NAME_PREFIX + "FileWrite" -> 6;
-                case Type.EVENT_NAME_PREFIX + "FileForce" -> 5;
+                case Type.EVENT_NAME_PREFIX + "FileRead",
+                     Type.EVENT_NAME_PREFIX + "FileForce" -> 5;
                 default -> 3;
             };
         }


### PR DESCRIPTION
Could I have a review of a PR that adjusts the number of frames to skip for the FileRead event? The problem was that an intermediary frame was removed during review, but the offset was not updated.

Testing: jdk/jdk/jfr

Thanks
Erik