### PR TITLE
8362461: Deproblemlist javax/swing/SwingUtilities/TestBadBreak/TestBadBreak.java

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -691,7 +691,6 @@ javax/swing/JFileChooser/6396844/TwentyThousandTest.java 8198003 generic-all
 javax/swing/JFileChooser/8194044/FileSystemRootTest.java 8327236 windows-all
 javax/swing/JPopupMenu/6800513/bug6800513.java 7184956 macosx-all
 javax/swing/JTabbedPane/4624207/bug4624207.java 8064922 macosx-all
-javax/swing/SwingUtilities/TestBadBreak/TestBadBreak.java 8160720 generic-all
 javax/swing/JFileChooser/bug6798062.java 8146446 windows-all
 javax/swing/JPopupMenu/4870644/bug4870644.java 8194130 macosx-all,linux-all
 javax/swing/dnd/8139050/NativeErrorsInTableDnD.java 8202765  macosx-all,linux-all


### PR DESCRIPTION
javax/swing/SwingUtilities/TestBadBreak/TestBadBreak.java is passing now in mainline. Hence, de-problemlisting it and monitoring the results on CI.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8362461](https://bugs.openjdk.org/browse/JDK-8362461): Deproblemlist javax/swing/SwingUtilities/TestBadBreak/TestBadBreak.java (**Sub-task** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26381/head:pull/26381` \
`$ git checkout pull/26381`

Update a local copy of the PR: \
`$ git checkout pull/26381` \
`$ git pull https://git.openjdk.org/jdk.git pull/26381/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26381`

View PR using the GUI difftool: \
`$ git pr show -t 26381`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26381.diff">https://git.openjdk.org/jdk/pull/26381.diff</a>

</details>
