### PR TITLE
8362582: GHA: Increase bundle retention time to deal with infra overload better

### DIFF
--- a/.github/actions/build-jtreg/action.yml
+++ b/.github/actions/build-jtreg/action.yml
@@ -65,4 +65,4 @@ runs:
       with:
         name: bundles-jtreg-${{ steps.version.outputs.value }}
         path: jtreg/installed
-        retention-days: 1
+        retention-days: 5

--- a/.github/actions/upload-bundles/action.yml
+++ b/.github/actions/upload-bundles/action.yml
@@ -91,5 +91,5 @@ runs:
       with:
         name: bundles-${{ inputs.platform }}${{ inputs.debug-suffix }}${{ inputs.static-suffix }}${{ inputs.bundle-suffix }}
         path: bundles
-        retention-days: 1
+        retention-days: 5
       if: steps.bundles.outputs.bundles-found == 'true'


### PR DESCRIPTION
I have now seen GHA runs where we spend more than 24 hours for a testing workflow. The practical effect of this is that bundles that we current carry with `retention-days: 1` gets purged before jobs can use them. This then fails the test jobs that e.g. unable to pull jtreg.

This seems to happen in openjdk-bots -driven backports quite a bit (the run a lots of GHA runs, so they are often at capacity) and with Mac jobs (where the compute capacity is not great).

We can bump the retention time a bit to handle this a bit better. 

Additional testing:
 - [ ] GHA