### PR TITLE
8362379: Test serviceability/HeapDump/UnmountedVThreadNativeMethodAtTop.java should mark as /native

### DIFF
--- a/test/hotspot/jtreg/serviceability/HeapDump/UnmountedVThreadNativeMethodAtTop.java
+++ b/test/hotspot/jtreg/serviceability/HeapDump/UnmountedVThreadNativeMethodAtTop.java
@@ -27,7 +27,7 @@
  * @requires vm.continuations
  * @modules jdk.management
  * @library /test/lib
- * @run junit/othervm --enable-native-access=ALL-UNNAMED UnmountedVThreadNativeMethodAtTop
+ * @run junit/othervm/native --enable-native-access=ALL-UNNAMED UnmountedVThreadNativeMethodAtTop
  */
 
 import java.lang.management.ManagementFactory;


### PR DESCRIPTION
Hi all,

  Test serviceability/HeapDump/UnmountedVThreadNativeMethodAtTop.java call native libary 'UnmountedVThreadNativeMethodAtTop' with System.loadLibrary. If run this test without jtreg option '-nativepath', jtreg will report 'JUnit test failure'. After this PR, we add jtreg directive `/native` to test header, run this test without jtreg option '-nativepath', jtreg will report 'Error. Use -nativepath to specify the location of native code'. So add `/native` directive will make this test more friendly.

Change has been verified locally, test-fix only, no risk.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8362379](https://bugs.openjdk.org/browse/JDK-8362379): Test serviceability/HeapDump/UnmountedVThreadNativeMethodAtTop.java should mark as /native (**Enhancement** - P4)


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26384/head:pull/26384` \
`$ git checkout pull/26384`

Update a local copy of the PR: \
`$ git checkout pull/26384` \
`$ git pull https://git.openjdk.org/jdk.git pull/26384/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26384`

View PR using the GUI difftool: \
`$ git pr show -t 26384`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26384.diff">https://git.openjdk.org/jdk/pull/26384.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26384#issuecomment-3088610461)
</details>
