### PR TITLE
8362592: Remove unused argument in nmethod::oops_do

### DIFF
--- a/src/hotspot/share/code/nmethod.cpp
+++ b/src/hotspot/share/code/nmethod.cpp
@@ -2446,7 +2446,7 @@ void nmethod::do_unloading(bool unloading_occurred) {
   }
 }
 
-void nmethod::oops_do(OopClosure* f, bool allow_dead) {
+void nmethod::oops_do(OopClosure* f) {
   // Prevent extra code cache walk for platforms that don't have immediate oops.
   if (relocInfo::mustIterateImmediateOopsInCode()) {
     RelocIterator iter(this, oops_reloc_begin());

--- a/src/hotspot/share/code/nmethod.hpp
+++ b/src/hotspot/share/code/nmethod.hpp
@@ -919,8 +919,7 @@ public:
   bool jvmci_skip_profile_deopt() const;
 #endif
 
-  void oops_do(OopClosure* f) { oops_do(f, false); }
-  void oops_do(OopClosure* f, bool allow_dead);
+  void oops_do(OopClosure* f);
 
   // All-in-one claiming of nmethods: returns true if the caller successfully claimed that
   // nmethod.

--- a/src/hotspot/share/gc/shared/gcBehaviours.cpp
+++ b/src/hotspot/share/gc/shared/gcBehaviours.cpp
@@ -70,6 +70,6 @@ public:
 
 bool ClosureIsUnloadingBehaviour::has_dead_oop(nmethod* nm) const {
   IsCompiledMethodUnloadingOopClosure cl(_cl);
-  nm->oops_do(&cl, true /* allow_dead */);
+  nm->oops_do(&cl);
   return cl.is_unloading();
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahNMethod.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahNMethod.cpp
@@ -178,9 +178,9 @@ public:
   }
 };
 
-void ShenandoahNMethod::assert_same_oops(bool allow_dead) {
+void ShenandoahNMethod::assert_same_oops() {
   ShenandoahNMethodOopDetector detector;
-  nm()->oops_do(&detector, allow_dead);
+  nm()->oops_do(&detector);
 
   GrowableArray<oop*>* oops = detector.oops();
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahNMethod.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahNMethod.hpp
@@ -71,7 +71,7 @@ public:
   static inline void attach_gc_data(nmethod* nm, ShenandoahNMethod* gc_data);
 
   void assert_correct() NOT_DEBUG_RETURN;
-  void assert_same_oops(bool allow_dead = false) NOT_DEBUG_RETURN;
+  void assert_same_oops() NOT_DEBUG_RETURN;
 
 private:
   static void detect_reloc_oops(nmethod* nm, GrowableArray<oop*>& oops, bool& _has_non_immed_oops);


### PR DESCRIPTION
Trivial removing dead code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8362592](https://bugs.openjdk.org/browse/JDK-8362592): Remove unused argument in nmethod::oops_do (**Enhancement** - P4)


### Reviewers
 * [Zhengyu Gu](https://openjdk.org/census#zgu) (@zhengyu123 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26385/head:pull/26385` \
`$ git checkout pull/26385`

Update a local copy of the PR: \
`$ git checkout pull/26385` \
`$ git pull https://git.openjdk.org/jdk.git pull/26385/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26385`

View PR using the GUI difftool: \
`$ git pr show -t 26385`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26385.diff">https://git.openjdk.org/jdk/pull/26385.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26385#issuecomment-3088951849)
</details>
