### PR TITLE
8362602: Add test.timeout.factor to CompileFactory to avoid test timeouts

### DIFF
--- a/test/hotspot/jtreg/compiler/lib/compile_framework/Compile.java
+++ b/test/hotspot/jtreg/compiler/lib/compile_framework/Compile.java
@@ -40,6 +40,7 @@ import jdk.test.lib.JDKToolFinder;
  */
 class Compile {
     private static final int COMPILE_TIMEOUT = 60;
+    private static final float timeoutFactor = Float.parseFloat(System.getProperty("test.timeout.factor", "1.0"));
 
     private static final String JAVA_PATH = JDKToolFinder.getJDKTool("java");
     private static final String JAVAC_PATH = JDKToolFinder.getJDKTool("javac");
@@ -182,7 +183,8 @@ class Compile {
         int exitCode;
         try {
             Process process = builder.start();
-            boolean exited = process.waitFor(COMPILE_TIMEOUT, TimeUnit.SECONDS);
+            long timeout = COMPILE_TIMEOUT * (long)Math.pow(2, timeoutFactor-1);
+            boolean exited = process.waitFor(timeout, TimeUnit.SECONDS);
             if (!exited) {
                 process.destroyForcibly();
                 System.out.println("Timeout: compile command: " + String.join(" ", command));


### PR DESCRIPTION
Add the TimeoutFactor property to the CompileFramework to avoid timeouts on different systems.