### PR TITLE
8357380: java/lang/StringBuilder/RacingSBThreads.java times out with C1

### DIFF
--- a/test/jdk/java/lang/StringBuilder/RacingSBThreads.java
+++ b/test/jdk/java/lang/StringBuilder/RacingSBThreads.java
@@ -46,7 +46,7 @@ import java.util.function.BiConsumer;
 public class RacingSBThreads {
 
     private static final int TIMEOUT_SEC = 1;   // Duration to run each test case
-    private static final int N = 10_000_000;    // static number of iterations for writes and modifies
+    private static final int N = 1_000_000;     // static number of iterations for writes and modifies
     private static final int LEN = 100_000;     // Length of initial SB
 
     // Strings available to be used as the initial contents of a StringBuilder


### PR DESCRIPTION
Reduced number of iterations from 10 million to 1 million to reduce cpu time

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8357380](https://bugs.openjdk.org/browse/JDK-8357380): java/lang/StringBuilder/RacingSBThreads.java times out with C1 (**Bug** - P4)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26389/head:pull/26389` \
`$ git checkout pull/26389`

Update a local copy of the PR: \
`$ git checkout pull/26389` \
`$ git pull https://git.openjdk.org/jdk.git pull/26389/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26389`

View PR using the GUI difftool: \
`$ git pr show -t 26389`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26389.diff">https://git.openjdk.org/jdk/pull/26389.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26389#issuecomment-3089829140)
</details>
