### PR TITLE
8340312: sun.security.ssl.SSLLogger uses incorrect log level ALL for `finest` log events

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/SSLLogger.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLLogger.java
@@ -179,7 +179,7 @@ public final class SSLLogger {
     }
 
     public static void finest(String msg, Object... params) {
-        SSLLogger.log(Level.ALL, msg, params);
+        SSLLogger.log(Level.TRACE, msg, params);
     }
 
     private static void log(Level level, String msg, Object... params) {

--- a/test/jdk/sun/security/ssl/SSLLogger/DebugPropertyValuesTest.java
+++ b/test/jdk/sun/security/ssl/SSLLogger/DebugPropertyValuesTest.java
@@ -23,7 +23,7 @@
 
 /**
  * @test
- * @bug 8350582
+ * @bug 8350582 8340312
  * @library /test/lib /javax/net/ssl/templates
  * @summary Correct the parsing of the ssl value in javax.net.debug
  * @run junit DebugPropertyValuesTest
@@ -80,6 +80,8 @@ public class DebugPropertyValuesTest extends SSLSocketTemplate {
         debugMessages.put("java.security.debug",
                 List.of("properties\\[.*\\|main\\|.*" + DATE_REGEX + ".*\\]:",
                         "certpath\\[.*\\|main\\|.*" + DATE_REGEX + ".*\\]:"));
+        // "ALL" shouldn't be seen as a valid Level
+        debugMessages.put("javax.net.debug.logger.ALL", List.of("ALL:"));
         debugMessages.put("javax.net.debug.logger",
                 List.of("FINE: adding as trusted certificates",
                         "FINE: WRITE: TLSv1.3 application_data"));


### PR DESCRIPTION
SSLLogger shouldn't be logging at the `ALL` level. 

Trivial enough edit so that both the SSLLogger `finer `and `finest `methods log at the `System.Logger.Level.TRACE` value
DebugPropertyValuesTest.java edited to cover this change

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340312](https://bugs.openjdk.org/browse/JDK-8340312): sun.security.ssl.SSLLogger uses incorrect log level ALL for `finest` log events (**Bug** - P4)


### Reviewers
 * [Bradford Wetmore](https://openjdk.org/census#wetmore) (@bradfordwetmore - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26390/head:pull/26390` \
`$ git checkout pull/26390`

Update a local copy of the PR: \
`$ git checkout pull/26390` \
`$ git pull https://git.openjdk.org/jdk.git pull/26390/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26390`

View PR using the GUI difftool: \
`$ git pr show -t 26390`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26390.diff">https://git.openjdk.org/jdk/pull/26390.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26390#issuecomment-3089829818)
</details>
