### PR TITLE
Fix compilation with clang 20

### DIFF
--- a/src/hotspot/share/oops/resolvedFieldEntry.hpp
+++ b/src/hotspot/share/oops/resolvedFieldEntry.hpp
@@ -55,17 +55,6 @@ class ResolvedFieldEntry {
   u1 _flags;                    // Flags: [0000|00|is_final|is_volatile]
   u1 _get_code, _put_code;      // Get and Put bytecodes of the field
 
-  void copy_from(const ResolvedFieldEntry& other) {
-    _field_holder = other._field_holder;
-    _field_offset = other._field_offset;
-    _field_index = other._field_index;
-    _cpool_index = other._cpool_index;
-    _tos_state = other._tos_state;
-    _flags = other._flags;
-    _get_code = other._get_code;
-    _put_code = other._put_code;
-  }
-
 public:
   ResolvedFieldEntry(u2 cpi) :
     _field_holder(nullptr),
@@ -80,14 +69,9 @@ public:
   ResolvedFieldEntry() :
     ResolvedFieldEntry(0) {}
 
-  ResolvedFieldEntry(const ResolvedFieldEntry& other) {
-    copy_from(other);
-  }
+  ResolvedFieldEntry(const ResolvedFieldEntry& other) = default;
 
-  ResolvedFieldEntry& operator=(const ResolvedFieldEntry& other) {
-    copy_from(other);
-    return *this;
-  }
+  ResolvedFieldEntry& operator=(const ResolvedFieldEntry& other) = default;
 
   // Bit shift to get flags
   // Note: Only two flags exists at the moment but more could be added

--- a/src/hotspot/share/oops/resolvedMethodEntry.hpp
+++ b/src/hotspot/share/oops/resolvedMethodEntry.hpp
@@ -82,21 +82,6 @@ class ResolvedMethodEntry {
   bool _has_table_index;
 #endif
 
-  void copy_from(const ResolvedMethodEntry& other) {
-    _method = other._method;
-    _entry_specific = other._entry_specific;
-    _cpool_index = other._cpool_index;
-    _number_of_parameters = other._number_of_parameters;
-    _tos_state = other._tos_state;
-    _flags = other._flags;
-    _bytecode1 = other._bytecode1;
-    _bytecode2 = other._bytecode2;
-#ifdef ASSERT
-    _has_interface_klass = other._has_interface_klass;
-    _has_table_index = other._has_table_index;
-#endif
-  }
-
   // Constructors
   public:
     ResolvedMethodEntry(u2 cpi) :
@@ -114,14 +99,9 @@ class ResolvedMethodEntry {
     ResolvedMethodEntry() :
       ResolvedMethodEntry(0) {}
 
-    ResolvedMethodEntry(const ResolvedMethodEntry& other) {
-      copy_from(other);
-    }
+    ResolvedMethodEntry(const ResolvedMethodEntry& other) = default;
 
-    ResolvedMethodEntry& operator=(const ResolvedMethodEntry& other) {
-      copy_from(other);
-      return *this;
-    }
+    ResolvedMethodEntry& operator=(const ResolvedMethodEntry& other) = default;
 
 
   // Bit shift to get flags


### PR DESCRIPTION
Clang 20 refuses to compile resolvedFieldEntry.cpp and resolvedMethodEntry.cpp because of applying memset to a non trivially copyable class.

Both classes seem to be defined with the intent to be trivially copyable except with pre-C++11 notation.

This patch makes copy constructors and copy assignment notations explicitly defaulted, thus satisfying the TriviallyCopyable named requirement.

With this patch, I can compile with clang 20 in CentOS Stream 10.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Warnings
&nbsp;⚠️ Patch contains a binary file (test/jdk/javax/rmi/ssl/keystore)
&nbsp;⚠️ Patch contains a binary file (test/jdk/javax/rmi/ssl/truststore)
&nbsp;⚠️ Patch contains a binary file (test/jdk/sun/net/www/protocol/https/HttpsClient/dnsstore)
&nbsp;⚠️ Patch contains a binary file (test/jdk/sun/net/www/protocol/https/HttpsClient/ipstore)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26391/head:pull/26391` \
`$ git checkout pull/26391`

Update a local copy of the PR: \
`$ git checkout pull/26391` \
`$ git pull https://git.openjdk.org/jdk.git pull/26391/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26391`

View PR using the GUI difftool: \
`$ git pr show -t 26391`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26391.diff">https://git.openjdk.org/jdk/pull/26391.diff</a>

</details>
