### PR TITLE
8361964: Remove outdated algorithms from requirements and add PBES2 algorithms

### DIFF
--- a/src/java.base/share/classes/java/security/AlgorithmParameters.java
+++ b/src/java.base/share/classes/java/security/AlgorithmParameters.java
@@ -55,10 +55,11 @@ import java.util.Objects;
  * <ul>
  * <li>{@code AES}</li>
  * <li>{@code ChaCha20-Poly1305}</li>
- * <li>{@code DESede}</li>
  * <li>{@code DiffieHellman}</li>
  * <li>{@code DSA}</li>
  * <li>{@code EC} (secp256r1, secp384r1)</li>
+ * <li>{@code PBEWithHmacSHA256AndAES_128}</li>
+ * <li>{@code PBEWithHmacSHA256AndAES_256}</li>
  * <li>{@code RSASSA-PSS} (MGF1 mask generation function and SHA-256 or SHA-384
  *     hash algorithms)</li>
  * </ul>

--- a/src/java.base/share/classes/javax/crypto/Cipher.java
+++ b/src/java.base/share/classes/javax/crypto/Cipher.java
@@ -150,11 +150,8 @@ import sun.security.util.KnownOIDs;
  * <li>{@code AES/ECB/PKCS5Padding} (128)</li>
  * <li>{@code AES/GCM/NoPadding} (128, 256)</li>
  * <li>{@code ChaCha20-Poly1305}</li>
- * <li>{@code DESede/CBC/NoPadding} (168)</li>
- * <li>{@code DESede/CBC/PKCS5Padding} (168)</li>
- * <li>{@code DESede/ECB/NoPadding} (168)</li>
- * <li>{@code DESede/ECB/PKCS5Padding} (168)</li>
- * <li>{@code RSA/ECB/PKCS1Padding} (1024, 2048)</li>
+ * <li>{@code PBEWithHmacSHA256AndAES_128}</li>
+ * <li>{@code PBEWithHmacSHA256AndAES_256}</li>
  * <li>{@code RSA/ECB/OAEPWithSHA-1AndMGF1Padding} (1024, 2048)</li>
  * <li>{@code RSA/ECB/OAEPWithSHA-256AndMGF1Padding} (1024, 2048)</li>
  * </ul>

--- a/src/java.base/share/classes/javax/crypto/KeyGenerator.java
+++ b/src/java.base/share/classes/javax/crypto/KeyGenerator.java
@@ -98,7 +98,6 @@ import sun.security.util.Debug;
  * <ul>
  * <li>{@code AES} (128, 256)</li>
  * <li>{@code ChaCha20}</li>
- * <li>{@code DESede} (168)</li>
  * <li>{@code HmacSHA1}</li>
  * <li>{@code HmacSHA256}</li>
  * </ul>

--- a/src/java.base/share/classes/javax/crypto/Mac.java
+++ b/src/java.base/share/classes/javax/crypto/Mac.java
@@ -58,6 +58,7 @@ import sun.security.jca.GetInstance.Instance;
  * <ul>
  * <li>{@code HmacSHA1}</li>
  * <li>{@code HmacSHA256}</li>
+ * <li>{@code PBEWithHmacSHA256}</li>
  * </ul>
  * These algorithms are described in the
  * <a href="{@docRoot}/../specs/security/standard-names.html#mac-algorithms">

--- a/src/java.base/share/classes/javax/crypto/SecretKeyFactory.java
+++ b/src/java.base/share/classes/javax/crypto/SecretKeyFactory.java
@@ -59,7 +59,9 @@ import sun.security.jca.GetInstance.Instance;
  * <p> Every implementation of the Java platform is required to support the
  * following standard {@code SecretKeyFactory} algorithms:
  * <ul>
- * <li>{@code DESede}</li>
+ * <li>{@code PBEWithHmacSHA256AndAES_128}</li>
+ * <li>{@code PBEWithHmacSHA256AndAES_256}</li>
+ * <li>{@code PBKDF2WithHmacSHA256}</li>
  * </ul>
  * These algorithms are described in the <a href=
  * "{@docRoot}/../specs/security/standard-names.html#secretkeyfactory-algorithms">


### PR DESCRIPTION
The Security Algorithm Implementation Requirements will be updated as follows:

The following algorithms will be removed from the list of required algorithms as they are no longer recommended, and should not be in wide usage anymore:

    AlgorithmParameters: DESede
    Cipher:
        DESede/CBC/NoPadding
        DESede/CBC/PKCS5Padding
        DESede/ECB/NoPadding
        DESede/ECB/PKCS5Padding
        RSA/ECB/PKCS1Padding
    KeyGenerator: DESede
    SecretKeyFactory: DESede

The following PBES2 algorithms will be added as new requirements. These are modern password-based encryption, mac and key derivation algorithms defined in PKCS #5 version 2.1 ([RFC 8018](https://www.rfc-editor.org/rfc/rfc8018)):

    AlgorithmParameters:
        PBEWithHmacSHA256AndAES_128
        PBEWithHmacSHA256AndAES_256
    Cipher:
        PBEWithHmacSHA256AndAES_128
        PBEWithHmacSHA256AndAES_256
    Mac:
        PBEWithHmacSHA256
    SecretKeyFactory:
        PBEWithHmacSHA256AndAES_128
        PBEWithHmacSHA256AndAES_256
        PBKDF2WithHmacSHA256

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8362549](https://bugs.openjdk.org/browse/JDK-8362549) to be approved

### Issues
 * [JDK-8361964](https://bugs.openjdk.org/browse/JDK-8361964): Remove outdated algorithms from requirements and add PBES2 algorithms (**Enhancement** - P3)
 * [JDK-8362549](https://bugs.openjdk.org/browse/JDK-8362549): Remove outdated algorithms from requirements and add PBES2 algorithms (**CSR**)


### Reviewers
 * [Hai-May Chao](https://openjdk.org/census#hchao) (@haimaychao - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26392/head:pull/26392` \
`$ git checkout pull/26392`

Update a local copy of the PR: \
`$ git checkout pull/26392` \
`$ git pull https://git.openjdk.org/jdk.git pull/26392/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26392`

View PR using the GUI difftool: \
`$ git pr show -t 26392`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26392.diff">https://git.openjdk.org/jdk/pull/26392.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26392#issuecomment-3090101163)
</details>
