### PR TITLE
8210765: Remove finalize method in CStrike.java

### DIFF
--- a/src/java.desktop/macosx/classes/sun/font/CStrike.java
+++ b/src/java.desktop/macosx/classes/sun/font/CStrike.java
@@ -75,10 +75,6 @@ public final class CStrike extends PhysicalStrike {
     CStrike(final CFont font, final FontStrikeDesc inDesc) {
         nativeFont = font;
         desc = inDesc;
-        nativeStrikePtr = initNativeStrikePtr();
-        glyphInfoCache = new GlyphInfoCache(font, desc, nativeStrikePtr);
-        glyphAdvanceCache = new GlyphAdvanceCache();
-        disposer = glyphInfoCache;
 
         // Normally the device transform should be the identity transform
         // for screen operations.  The device transform only becomes
@@ -93,6 +89,10 @@ public final class CStrike extends PhysicalStrike {
                 // so we won't worry about it.
             }
         }
+        nativeStrikePtr = initNativeStrikePtr(); // after setting up invDevTx
+        glyphInfoCache = new GlyphInfoCache(font, desc, nativeStrikePtr);
+        glyphAdvanceCache = new GlyphAdvanceCache();
+        disposer = glyphInfoCache;
     }
 
     public long getNativeStrikePtr() {

--- a/src/java.desktop/macosx/classes/sun/font/CStrikeDisposer.java
+++ b/src/java.desktop/macosx/classes/sun/font/CStrikeDisposer.java
@@ -48,7 +48,7 @@ package sun.font;
  */
 class CStrikeDisposer extends FontStrikeDisposer {
 
-    long pNativeScalerContext;
+    private final long pNativeScalerContext;
 
     public CStrikeDisposer(Font2D font2D, FontStrikeDesc desc,
                                long pContext, int[] images)
@@ -73,19 +73,18 @@ class CStrikeDisposer extends FontStrikeDisposer {
 
     public CStrikeDisposer(Font2D font2D, FontStrikeDesc desc) {
         super(font2D, desc);
+        pNativeScalerContext = 0L;
     }
 
     @Override
     public synchronized void dispose() {
         if (!disposed) {
             if (pNativeScalerContext != 0L) {
-                freeNativeScalerContext(pNativeScalerContext);
+                CStrike.disposeNativeStrikePtr(pNativeScalerContext);
             }
             super.dispose();
         }
     }
-
-    private native void freeNativeScalerContext(long pContext);
 
     protected static native void removeGlyphInfoFromCache(long glyphInfo);
 }


### PR DESCRIPTION
Remove finalize method from CStrike.java

This one is a bit odd in that there's already a Disposer used - and in fact it involves two classes
CStrikeDisposer.java and its subclass - the nested class CStrike.GlyphInfoCache
CStrike.GlyphInfoCache is tracking all the glyph image references.

CStrikeDisposer has the full set of constructors of its superclass - FontStrikeDisposer including support
for the native context

And if supplied, CStrikeDisposer will call the native method freeNativeScalerContext(long) to free the native context
but that native method does not exist !
And there's no CStrike.GlyphInfoCache constructor which allows it to be specified

So the fix is to add that and call the disposeNativeStrikePtr method instead.

I also rejigged things a little so nativeStrikePtr could be final which is supposed to help with the thread visibility.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8210765](https://bugs.openjdk.org/browse/JDK-8210765): Remove finalize method in CStrike.java (**Bug** - P4)


### Reviewers
 * [Prasanta Sadhukhan](https://openjdk.org/census#psadhukhan) (@prsadhuk - **Reviewer**)
 * [Alisen Chung](https://openjdk.org/census#achung) (@alisenchung - Committer)
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26397/head:pull/26397` \
`$ git checkout pull/26397`

Update a local copy of the PR: \
`$ git checkout pull/26397` \
`$ git pull https://git.openjdk.org/jdk.git pull/26397/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26397`

View PR using the GUI difftool: \
`$ git pr show -t 26397`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26397.diff">https://git.openjdk.org/jdk/pull/26397.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26397#issuecomment-3090706324)
</details>
