### PR TITLE
8362659: Remove sun.print.PrintJob2D.finalize()

### DIFF
--- a/src/java.desktop/share/classes/sun/print/PrintJob2D.java
+++ b/src/java.desktop/share/classes/sun/print/PrintJob2D.java
@@ -913,15 +913,6 @@ public class PrintJob2D extends PrintJob implements Printable, Runnable {
     }
 
     /**
-     * Ends this print job once it is no longer referenced.
-     * @see #end
-     */
-    @SuppressWarnings("removal")
-    public void finalize() {
-        end();
-    }
-
-    /**
      * Prints the page at the specified index into the specified
      * {@link Graphics} context in the specified
      * format.  A {@code PrinterJob} calls the


### PR DESCRIPTION
Remove sun.print.PrintJob2D.finalize() - it duplicates the super class finalize()
See the bug report for additional info.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8362659](https://bugs.openjdk.org/browse/JDK-8362659): Remove sun.print.PrintJob2D.finalize() (**Bug** - P4)


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26398/head:pull/26398` \
`$ git checkout pull/26398`

Update a local copy of the PR: \
`$ git checkout pull/26398` \
`$ git pull https://git.openjdk.org/jdk.git pull/26398/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26398`

View PR using the GUI difftool: \
`$ git pr show -t 26398`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26398.diff">https://git.openjdk.org/jdk/pull/26398.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26398#issuecomment-3090734943)
</details>
