### PR TITLE
8361376: Regressions 1-6% in several Renaissance in 26-b4 only MacOSX aarch64

### DIFF
--- a/src/hotspot/cpu/aarch64/gc/shared/barrierSetNMethod_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/gc/shared/barrierSetNMethod_aarch64.cpp
@@ -117,8 +117,15 @@ public:
     return Atomic::load_acquire(guard_addr());
   }
 
-  void set_value(int value) {
-    Atomic::release_store(guard_addr(), value);
+  void set_value(int value, int bit_mask) {
+    assert((value & ~bit_mask) == 0, "trying to set bits outside the mask");
+    while (true) {
+      int old = Atomic::load(guard_addr());
+      // Only bits in the mask are changed
+      int new_value = value | (old & ~bit_mask);
+      int v = Atomic::cmpxchg(guard_addr(), old, new_value, memory_order_release);
+      if (v == old) break;
+    }
   }
 
   bool check_barrier(err_msg& msg) const;
@@ -181,7 +188,7 @@ void BarrierSetNMethod::deoptimize(nmethod* nm, address* return_address_ptr) {
   new_frame->pc = SharedRuntime::get_handle_wrong_method_stub();
 }
 
-void BarrierSetNMethod::set_guard_value(nmethod* nm, int value) {
+void BarrierSetNMethod::set_guard_value(nmethod* nm, int value, int bit_mask) {
   if (!supports_entry_barrier(nm)) {
     return;
   }
@@ -198,7 +205,7 @@ void BarrierSetNMethod::set_guard_value(nmethod* nm, int value) {
   }
 
   NativeNMethodBarrier barrier(nm);
-  barrier.set_value(value);
+  barrier.set_value(value, bit_mask);
 }
 
 int BarrierSetNMethod::guard_value(nmethod* nm) {

--- a/src/hotspot/cpu/ppc/nativeInst_ppc.hpp
+++ b/src/hotspot/cpu/ppc/nativeInst_ppc.hpp
@@ -462,7 +462,7 @@ class NativeMovRegMem: public NativeInstruction {
     return ((*hi_ptr) << 16) | ((*lo_ptr) & 0xFFFF);
   }
 
-  void set_offset(intptr_t x) {
+  void set_offset(intptr_t x, bool flush_icash = true) {
 #ifdef VM_LITTLE_ENDIAN
     short *hi_ptr = (short*)(addr_at(0));
     short *lo_ptr = (short*)(addr_at(4));
@@ -472,7 +472,9 @@ class NativeMovRegMem: public NativeInstruction {
 #endif
     *hi_ptr = x >> 16;
     *lo_ptr = x & 0xFFFF;
-    ICache::ppc64_flush_icache_bytes(addr_at(0), NativeMovRegMem::instruction_size);
+    if (flush_icashe) {
+      ICache::ppc64_flush_icache_bytes(addr_at(0), NativeMovRegMem::instruction_size);
+    }
   }
 
   void add_offset_in_bytes(intptr_t radd_offset) {

--- a/src/hotspot/cpu/riscv/gc/shared/barrierSetNMethod_riscv.cpp
+++ b/src/hotspot/cpu/riscv/gc/shared/barrierSetNMethod_riscv.cpp
@@ -111,8 +111,15 @@ public:
     return Atomic::load_acquire(guard_addr());
   }
 
-  void set_value(int value) {
-    Atomic::release_store(guard_addr(), value);
+  void set_value(int value, int bit_mask) {
+    assert((value & ~bit_mask) == 0, "trying to set bits outside the mask");
+    while (true) {
+      int old = Atomic::load(guard_addr());
+      // Only bits in the mask are changed
+      int new_value = value | (old & ~bit_mask);
+      int v = Atomic::cmpxchg(guard_addr(), old, new_value, memory_order_release);
+      if (v == old) break;
+    }
   }
 
   bool check_barrier(err_msg& msg) const;
@@ -194,7 +201,7 @@ void BarrierSetNMethod::deoptimize(nmethod* nm, address* return_address_ptr) {
   new_frame->pc = SharedRuntime::get_handle_wrong_method_stub();
 }
 
-void BarrierSetNMethod::set_guard_value(nmethod* nm, int value) {
+void BarrierSetNMethod::set_guard_value(nmethod* nm, int value, int bit_mask) {
   if (!supports_entry_barrier(nm)) {
     return;
   }
@@ -211,7 +218,7 @@ void BarrierSetNMethod::set_guard_value(nmethod* nm, int value) {
   }
 
   NativeNMethodBarrier barrier(nm);
-  barrier.set_value(value);
+  barrier.set_value(value, bit_mask);
 }
 
 int BarrierSetNMethod::guard_value(nmethod* nm) {

--- a/src/hotspot/cpu/s390/gc/shared/barrierSetNMethod_s390.cpp
+++ b/src/hotspot/cpu/s390/gc/shared/barrierSetNMethod_s390.cpp
@@ -53,11 +53,16 @@ class NativeMethodBarrier: public NativeInstruction {
       return *((int32_t*)data_addr);
     }
 
-    void set_guard_value(int value) {
+    void set_guard_value(int value, int bit_mask) {
+      assert((value & ~bit_mask) == 0, "trying to set bits outside the mask");
       int32_t* data_addr = (int32_t*)get_patchable_data_address();
-
-      // Set guard instruction value
-      *data_addr = value;
+      while (true) {
+        int old = Atomic::load(data_addr);
+        // Only bits in the mask are changed
+        int new_value = value | (old & ~bit_mask);
+        int v = Atomic::cmpxchg(data_addr, old, new_value, memory_order_release);
+        if (v == old) break;
+      }
     }
 
     #ifdef ASSERT
@@ -100,13 +105,13 @@ void BarrierSetNMethod::deoptimize(nmethod* nm, address* return_address_ptr) {
   return;
 }
 
-void BarrierSetNMethod::set_guard_value(nmethod* nm, int value) {
+void BarrierSetNMethod::set_guard_value(nmethod* nm, int value, int bit_mask) {
   if (!supports_entry_barrier(nm)) {
     return;
   }
 
   NativeMethodBarrier* barrier = get_nmethod_barrier(nm);
-  barrier->set_guard_value(value);
+  barrier->set_guard_value(value, bit_mask);
 }
 
 int BarrierSetNMethod::guard_value(nmethod* nm) {

--- a/src/hotspot/share/gc/shared/barrierSetNMethod.cpp
+++ b/src/hotspot/share/gc/shared/barrierSetNMethod.cpp
@@ -72,21 +72,12 @@ bool BarrierSetNMethod::supports_entry_barrier(nmethod* nm) {
 }
 
 void BarrierSetNMethod::disarm(nmethod* nm) {
-  guard_with(nm, disarmed_guard_value());
+  set_guard_value(nm, disarmed_guard_value());
 }
 
 void BarrierSetNMethod::guard_with(nmethod* nm, int value) {
   assert((value & not_entrant) == 0, "not_entrant bit is reserved");
-  // Enter critical section.  Does not block for safepoint.
-  ConditionalMutexLocker ml(NMethodEntryBarrier_lock, !NMethodEntryBarrier_lock->owned_by_self(), Mutex::_no_safepoint_check_flag);
-  // Do not undo sticky bit
-  if (is_not_entrant(nm)) {
-    value |= not_entrant;
-  }
-  if (guard_value(nm) != value) {
-    // Patch the code only if needed.
-    set_guard_value(nm, value);
-  }
+  set_guard_value(nm, value);
 }
 
 bool BarrierSetNMethod::is_armed(nmethod* nm) {
@@ -118,6 +109,8 @@ bool BarrierSetNMethod::nmethod_entry_barrier(nmethod* nm) {
     // and disarmed the nmethod. No need to continue.
     return true;
   }
+
+  MACOS_AARCH64_ONLY(ThreadWXEnable wx(WXWrite, Thread::current()));
 
   // If the nmethod is the only thing pointing to the oops, and we are using a
   // SATB GC, then it is important that this code marks them live.
@@ -179,10 +172,6 @@ void BarrierSetNMethod::arm_all_nmethods() {
 }
 
 int BarrierSetNMethod::nmethod_stub_entry_barrier(address* return_address_ptr) {
-  // Enable WXWrite: the function is called directly from nmethod_entry_barrier
-  // stub.
-  MACOS_AARCH64_ONLY(ThreadWXEnable wx(WXWrite, Thread::current()));
-
   address return_address = *return_address_ptr;
   AARCH64_PORT_ONLY(return_address = pauth_strip_pointer(return_address));
   CodeBlob* cb = CodeCache::find_blob(return_address);
@@ -243,13 +232,7 @@ oop BarrierSetNMethod::oop_load_phantom(const nmethod* nm, int index) {
 // nmethod_stub_entry_barrier() may appear to be spurious, because is_armed() still returns
 // false and nmethod_entry_barrier() is not called.
 void BarrierSetNMethod::make_not_entrant(nmethod* nm) {
-  // Enter critical section.  Does not block for safepoint.
-  ConditionalMutexLocker ml(NMethodEntryBarrier_lock, !NMethodEntryBarrier_lock->owned_by_self(), Mutex::_no_safepoint_check_flag);
-  int value = guard_value(nm) | not_entrant;
-  if (guard_value(nm) != value) {
-    // Patch the code only if needed.
-    set_guard_value(nm, value);
-  }
+  set_guard_value(nm, not_entrant, not_entrant);
 }
 
 bool BarrierSetNMethod::is_not_entrant(nmethod* nm) {

--- a/src/hotspot/share/gc/shared/barrierSetNMethod.hpp
+++ b/src/hotspot/share/gc/shared/barrierSetNMethod.hpp
@@ -36,17 +36,18 @@ class nmethod;
 class BarrierSetNMethod: public CHeapObj<mtGC> {
 private:
   int _current_phase;
+
+  void deoptimize(nmethod* nm, address* return_addr_ptr);
+
+protected:
   enum {
     not_entrant = 1 << 31, // armed sticky bit, see make_not_entrant
     armed = 0,
     initial = 1,
   };
 
-  void deoptimize(nmethod* nm, address* return_addr_ptr);
-
-protected:
-  virtual int guard_value(nmethod* nm);
-  void set_guard_value(nmethod* nm, int value);
+  int guard_value(nmethod* nm);
+  void set_guard_value(nmethod* nm, int value, int bit_mask = ~not_entrant);
 
 public:
   BarrierSetNMethod() : _current_phase(initial) {}
@@ -60,13 +61,13 @@ public:
 
   static int nmethod_stub_entry_barrier(address* return_address_ptr);
   bool nmethod_osr_entry_barrier(nmethod* nm);
-  virtual bool is_armed(nmethod* nm);
+  bool is_armed(nmethod* nm);
   void arm(nmethod* nm) { guard_with(nm, armed); }
   void disarm(nmethod* nm);
-  virtual void make_not_entrant(nmethod* nm);
-  virtual bool is_not_entrant(nmethod* nm);
+  void make_not_entrant(nmethod* nm);
+  bool is_not_entrant(nmethod* nm);
 
-  virtual void guard_with(nmethod* nm, int value);
+  void guard_with(nmethod* nm, int value);
 
   virtual void arm_all_nmethods();
 

--- a/src/hotspot/share/gc/z/zBarrierSetNMethod.cpp
+++ b/src/hotspot/share/gc/z/zBarrierSetNMethod.cpp
@@ -106,34 +106,6 @@ oop ZBarrierSetNMethod::oop_load_phantom(const nmethod* nm, int index) {
   return ZNMethod::oop_load_phantom(nm, index);
 }
 
-void ZBarrierSetNMethod::guard_with(nmethod* nm, int value) {
-  assert((value & not_entrant) == 0, "not_entrant bit is reserved");
-  ZLocker<ZReentrantLock> locker(ZNMethod::lock_for_nmethod(nm));
-  // Preserve the sticky bit
-  if (is_not_entrant(nm)) {
-    value |= not_entrant;
-  }
-  if (guard_value(nm) != value) {
-    // Patch the code only if needed.
-    set_guard_value(nm, value);
-  }
-}
-
-bool ZBarrierSetNMethod::is_armed(nmethod* nm) {
-  int value = guard_value(nm) & ~not_entrant;
-  return value != disarmed_guard_value();
-}
-
-void ZBarrierSetNMethod::make_not_entrant(nmethod* nm) {
-  ZLocker<ZReentrantLock> locker(ZNMethod::lock_for_nmethod(nm));
-  int value = guard_value(nm) | not_entrant; // permanent sticky value
-  set_guard_value(nm, value);
-}
-
-bool ZBarrierSetNMethod::is_not_entrant(nmethod* nm) {
-  return (guard_value(nm) & not_entrant) != 0;
-}
-
 uintptr_t ZBarrierSetNMethod::color(nmethod* nm) {
   // color is stored at low order bits of int; conversion to uintptr_t is fine
   return uintptr_t(guard_value(nm) & ~not_entrant);

--- a/src/hotspot/share/gc/z/zBarrierSetNMethod.hpp
+++ b/src/hotspot/share/gc/z/zBarrierSetNMethod.hpp
@@ -30,10 +30,6 @@
 class nmethod;
 
 class ZBarrierSetNMethod : public BarrierSetNMethod {
-  enum : int {
-    not_entrant = 1 << 31, // armed sticky bit, see make_not_entrant
-  };
-
 protected:
   virtual bool nmethod_entry_barrier(nmethod* nm);
 
@@ -46,10 +42,6 @@ public:
   virtual oop oop_load_no_keepalive(const nmethod* nm, int index);
   virtual oop oop_load_phantom(const nmethod* nm, int index);
 
-  virtual void make_not_entrant(nmethod* nm);
-  virtual bool is_not_entrant(nmethod* nm);
-  virtual void guard_with(nmethod* nm, int value);
-  virtual bool is_armed(nmethod* nm);
   virtual void arm_all_nmethods() { ShouldNotCallThis(); }
 };
 


### PR DESCRIPTION
Replace the lock around set_guard_value with Atomic::cmpxchg.