### PR TITLE
8362829: Exclude CDS test cases after JDK-8361725

### DIFF
--- a/test/hotspot/jtreg/TEST.groups
+++ b/test/hotspot/jtreg/TEST.groups
@@ -542,6 +542,7 @@ hotspot_aot_classlinking = \
  -runtime/cds/appcds/dynamicArchive/OldClassInBaseArchive.java \
  -runtime/cds/appcds/dynamicArchive/OldClassVerifierTrouble.java \
  -runtime/cds/appcds/HelloExtTest.java \
+ -runtime/cds/appcds/javaldr/ExceptionDuringDumpAtObjectsInitPhase.java \
  -runtime/cds/appcds/javaldr/GCDuringDump.java \
  -runtime/cds/appcds/javaldr/LockDuringDump.java \
  -runtime/cds/appcds/jigsaw/classpathtests/EmptyClassInBootClassPath.java \
@@ -559,6 +560,7 @@ hotspot_aot_classlinking = \
  -runtime/cds/appcds/JvmtiAddPath.java \
  -runtime/cds/appcds/jvmti \
  -runtime/cds/appcds/LambdaProxyClasslist.java \
+ -runtime/cds/appcds/LambdaWithJavaAgent.java \
  -runtime/cds/appcds/loaderConstraints/LoaderConstraintsTest.java \
  -runtime/cds/appcds/methodHandles \
  -runtime/cds/appcds/NestHostOldInf.java \


### PR DESCRIPTION
These two test cases uses Java agents. Since [JDK-8361725](https://bugs.openjdk.org/browse/JDK-8361725) disallows Java agents with `-XX:+AOTClassLinking`, these two tests be excluded from the test group `test/hotspot/jtreg:hotspot_aot_classlinking`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8362829](https://bugs.openjdk.org/browse/JDK-8362829): Exclude CDS test cases after JDK-8361725 (**Bug** - P3)


### Reviewers
 * [Calvin Cheung](https://openjdk.org/census#ccheung) (@calvinccheung - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26400/head:pull/26400` \
`$ git checkout pull/26400`

Update a local copy of the PR: \
`$ git checkout pull/26400` \
`$ git pull https://git.openjdk.org/jdk.git pull/26400/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26400`

View PR using the GUI difftool: \
`$ git pr show -t 26400`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26400.diff">https://git.openjdk.org/jdk/pull/26400.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26400#issuecomment-3091379881)
</details>
