### PR TITLE
8362611: [GCC static analyzer] memory leak in ps_core.c core_handle_note

### DIFF
--- a/src/jdk.hotspot.agent/linux/native/libsaproc/ps_core.c
+++ b/src/jdk.hotspot.agent/linux/native/libsaproc/ps_core.c
@@ -286,8 +286,7 @@ static bool core_handle_note(struct ps_prochandle* ph, ELF_PHDR* note_phdr) {
       if (notep->n_type == NT_PRSTATUS) {
         if (core_handle_prstatus(ph, descdata, notep->n_descsz) != true) {
           print_error("failed to handle NT_PRSTATUS note\n");
-          free(buf);
-          return false;
+          goto err;
         }
       } else if (notep->n_type == NT_AUXV) {
         // Get first segment from entry point

--- a/src/jdk.hotspot.agent/linux/native/libsaproc/ps_core.c
+++ b/src/jdk.hotspot.agent/linux/native/libsaproc/ps_core.c
@@ -286,6 +286,7 @@ static bool core_handle_note(struct ps_prochandle* ph, ELF_PHDR* note_phdr) {
       if (notep->n_type == NT_PRSTATUS) {
         if (core_handle_prstatus(ph, descdata, notep->n_descsz) != true) {
           print_error("failed to handle NT_PRSTATUS note\n");
+          free(buf);
           return false;
         }
       } else if (notep->n_type == NT_AUXV) {


### PR DESCRIPTION
Free the `buf` before the early return.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8362611](https://bugs.openjdk.org/browse/JDK-8362611): [GCC static analyzer] memory leak in ps_core.c core_handle_note (**Bug** - P4)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**) Review applies to [bf535406](https://git.openjdk.org/jdk/pull/26403/files/bf535406fc8d8d79cc8632b136ec843cd9e2c626)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26403/head:pull/26403` \
`$ git checkout pull/26403`

Update a local copy of the PR: \
`$ git checkout pull/26403` \
`$ git pull https://git.openjdk.org/jdk.git pull/26403/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26403`

View PR using the GUI difftool: \
`$ git pr show -t 26403`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26403.diff">https://git.openjdk.org/jdk/pull/26403.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26403#issuecomment-3092494037)
</details>
