### PR TITLE
4938801: The popup does not go when the component is removed

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/JPopupMenu.java
+++ b/src/java.desktop/share/classes/javax/swing/JPopupMenu.java
@@ -126,20 +126,15 @@ public class JPopupMenu extends JComponent implements Accessible,MenuElement {
     transient  Popup popup;
     transient  Frame frame;
     private    int desiredLocationX,desiredLocationY;
-    transient private PropertyChangeListener propListener =
-        new PropertyChangeListener() {
-            public void propertyChange(PropertyChangeEvent e) {
-                String propertyName = e.getPropertyName();
-                if (propertyName == "ancestor") {
-                    if (e.getOldValue() != null &&
-                            e.getNewValue() == null) {
-                        if (isVisible()) {
-                            setVisible(false);
-                        }
-                    }
+
+    private transient PropertyChangeListener propListener =
+            (e) -> {
+                if (e.getOldValue() != null
+                    && e.getNewValue() == null
+                    && isVisible()) {
+                    setVisible(false);
                 }
-            }
-        };
+            };
 
     private    String     label                   = null;
     private    boolean   paintBorder              = true;
@@ -955,14 +950,13 @@ public class JPopupMenu extends JComponent implements Accessible,MenuElement {
     public void setInvoker(Component invoker) {
         Component oldInvoker = this.invoker;
         this.invoker = invoker;
-        PropertyChangeListener oldPropListener = propListener;
 
         if ((oldInvoker != this.invoker) && (ui != null)) {
             ui.uninstallUI(this);
             if (oldInvoker != null) {
-                oldInvoker.removePropertyChangeListener(oldPropListener);
+                oldInvoker.removePropertyChangeListener("ancestor", propListener);
             }
-            invoker.addPropertyChangeListener(propListener);
+            invoker.addPropertyChangeListener("ancestor", propListener);
             ui.installUI(this);
         }
         invalidate();
@@ -1426,7 +1420,7 @@ public class JPopupMenu extends JComponent implements Accessible,MenuElement {
             indexCounter++;
         }
         if(indexCounter < maxCounter && values.elementAt(indexCounter).
-                equals("propListener")) {
+           equals("propListener")) {
             propListener = (PropertyChangeListener) values.elementAt(++indexCounter);
             indexCounter++;
         }

--- a/src/java.desktop/share/classes/javax/swing/JPopupMenu.java
+++ b/src/java.desktop/share/classes/javax/swing/JPopupMenu.java
@@ -127,14 +127,7 @@ public class JPopupMenu extends JComponent implements Accessible,MenuElement {
     transient  Frame frame;
     private    int desiredLocationX,desiredLocationY;
 
-    private transient PropertyChangeListener propListener =
-            (e) -> {
-                if (e.getOldValue() != null
-                    && e.getNewValue() == null
-                    && isVisible()) {
-                    setVisible(false);
-                }
-            };
+    private PropertyChangeListener propListener = new Listener();
 
     private    String     label                   = null;
     private    boolean   paintBorder              = true;
@@ -936,6 +929,16 @@ public class JPopupMenu extends JComponent implements Accessible,MenuElement {
      */
     public Component getInvoker() {
         return this.invoker;
+    }
+
+    private class Listener implements PropertyChangeListener,Serializable {
+        public void propertyChange(PropertyChangeEvent e) {
+            if (e.getOldValue() != null
+                    && e.getNewValue() == null
+                    && isVisible()) {
+                setVisible(false);
+            }
+        }
     }
 
     /**

--- a/src/java.desktop/share/classes/javax/swing/JPopupMenu.java
+++ b/src/java.desktop/share/classes/javax/swing/JPopupMenu.java
@@ -127,7 +127,7 @@ public class JPopupMenu extends JComponent implements Accessible,MenuElement {
     transient  Frame frame;
     private    int desiredLocationX,desiredLocationY;
 
-    private PropertyChangeListener propListener = new Listener();
+    private PropertyChangeListener propListener = new AncestorListener();
 
     private    String     label                   = null;
     private    boolean   paintBorder              = true;
@@ -931,7 +931,8 @@ public class JPopupMenu extends JComponent implements Accessible,MenuElement {
         return this.invoker;
     }
 
-    private class Listener implements PropertyChangeListener,Serializable {
+    private final class AncestorListener implements PropertyChangeListener, Serializable {
+        @Override
         public void propertyChange(PropertyChangeEvent e) {
             if (e.getOldValue() != null
                     && e.getNewValue() == null

--- a/src/java.desktop/share/classes/javax/swing/JPopupMenu.java
+++ b/src/java.desktop/share/classes/javax/swing/JPopupMenu.java
@@ -126,7 +126,20 @@ public class JPopupMenu extends JComponent implements Accessible,MenuElement {
     transient  Popup popup;
     transient  Frame frame;
     private    int desiredLocationX,desiredLocationY;
-    transient private PropertyChangeListener propListener;
+    transient private PropertyChangeListener propListener =
+        new PropertyChangeListener() {
+            public void propertyChange(PropertyChangeEvent e) {
+                String propertyName = e.getPropertyName();
+                if (propertyName == "ancestor") {
+                    if (e.getOldValue() != null &&
+                            e.getNewValue() == null) {
+                        if (isVisible()) {
+                            setVisible(false);
+                        }
+                    }
+                }
+            }
+        };
 
     private    String     label                   = null;
     private    boolean   paintBorder              = true;
@@ -949,21 +962,6 @@ public class JPopupMenu extends JComponent implements Accessible,MenuElement {
             if (oldInvoker != null) {
                 oldInvoker.removePropertyChangeListener(oldPropListener);
             }
-            propListener = new PropertyChangeListener() {
-                public void propertyChange(PropertyChangeEvent e) {
-                    String propertyName = e.getPropertyName();
-                    if (propertyName == "ancestor") {
-                        if (e.getOldValue() != null &&
-                                e.getNewValue() == null) {
-                            if (popup != null) {
-                                popup.dispose();
-                                popup = null;
-                            }
-
-                        }
-                    }
-                }
-            };
             invoker.addPropertyChangeListener(propListener);
             ui.installUI(this);
         }

--- a/src/java.desktop/share/classes/javax/swing/JPopupMenu.java
+++ b/src/java.desktop/share/classes/javax/swing/JPopupMenu.java
@@ -941,10 +941,6 @@ public class JPopupMenu extends JComponent implements Accessible,MenuElement {
     public void setInvoker(Component invoker) {
         Component oldInvoker = this.invoker;
         this.invoker = invoker;
-        if ((oldInvoker != this.invoker) && (ui != null)) {
-            ui.uninstallUI(this);
-            ui.installUI(this);
-        }
         PropertyChangeListener propListener = new PropertyChangeListener() {
             public void propertyChange(PropertyChangeEvent e) {
                 String propertyName = e.getPropertyName();
@@ -960,6 +956,13 @@ public class JPopupMenu extends JComponent implements Accessible,MenuElement {
                 }
             }
         };
+        if ((oldInvoker != this.invoker) && (ui != null)) {
+            ui.uninstallUI(this);
+            if (oldInvoker != null) {
+                oldInvoker.removePropertyChangeListener(propListener);
+            }
+            ui.installUI(this);
+        }
         invoker.addPropertyChangeListener(propListener);
         invalidate();
     }

--- a/src/java.desktop/share/classes/javax/swing/JPopupMenu.java
+++ b/src/java.desktop/share/classes/javax/swing/JPopupMenu.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -945,6 +945,22 @@ public class JPopupMenu extends JComponent implements Accessible,MenuElement {
             ui.uninstallUI(this);
             ui.installUI(this);
         }
+        PropertyChangeListener propListener = new PropertyChangeListener() {
+            public void propertyChange(PropertyChangeEvent e) {
+                String propertyName = e.getPropertyName();
+                if (propertyName == "ancestor") {
+                    if (e.getOldValue() != null &&
+                            e.getNewValue() == null) {
+                        if (popup != null) {
+                            popup.dispose();
+                            popup = null;
+                        }
+
+                    }
+                }
+            }
+        };
+        invoker.addPropertyChangeListener(propListener);
         invalidate();
     }
 

--- a/test/jdk/javax/swing/JPopupMenu/TestPopupInvoker.java
+++ b/test/jdk/javax/swing/JPopupMenu/TestPopupInvoker.java
@@ -45,8 +45,6 @@ public class TestPopupInvoker {
     static JFrame frame;
     static JLabel label;
     static Container pane;
-    static volatile Point pt;
-    static volatile Rectangle size;
     static volatile boolean isVisible;
 
     private static void createUI() {
@@ -60,23 +58,23 @@ public class TestPopupInvoker {
         frame.setVisible(true);
     }
 
-    public static void main(String args[]) throws Exception {
+    public static void main(String[] args) throws Exception {
         try {
             Robot robot = new Robot();
-            SwingUtilities.invokeAndWait(() -> createUI());
+            SwingUtilities.invokeAndWait(TestPopupInvoker::createUI);
             robot.waitForIdle();
             robot.delay(1000);
+
             SwingUtilities.invokeAndWait(() -> {
                 jpm = new JPopupMenu("Popup");
                 jpm.add("One");
                 jpm.add("Two");
                 jpm.add("Three");
                 jpm.show(label, 0, 0);
-                pt = label.getLocationOnScreen();
-                size = label.getBounds();
             });
             robot.waitForIdle();
-            robot.delay(2000);
+            robot.delay(1000);
+
             SwingUtilities.invokeAndWait(() -> {
                 pane.remove(label);
                 pane.repaint();

--- a/test/jdk/javax/swing/JPopupMenu/TestPopupInvoker.java
+++ b/test/jdk/javax/swing/JPopupMenu/TestPopupInvoker.java
@@ -83,7 +83,7 @@ public class TestPopupInvoker {
                 isVisible = jpm.isVisible();
             });
             if (isVisible) {
-                throw new RuntimeException("poup is visible after component is removed");
+                throw new RuntimeException("popup is visible after component is removed");
             }
         } finally {
             SwingUtilities.invokeAndWait(() -> {

--- a/test/jdk/javax/swing/JPopupMenu/TestPopupInvoker.java
+++ b/test/jdk/javax/swing/JPopupMenu/TestPopupInvoker.java
@@ -21,6 +21,14 @@
  * questions.
  */
 
+/*
+ * @test
+ * @bug 4938801
+ * @key headful
+ * @summary Verifies popup is removed when the component is removed
+ * @run main TestPopupInvoker
+ */
+
 import java.awt.Container;
 import java.awt.Component;
 import java.awt.event.ActionEvent;

--- a/test/jdk/javax/swing/JPopupMenu/TestPopupInvoker.java
+++ b/test/jdk/javax/swing/JPopupMenu/TestPopupInvoker.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Container;
+import java.awt.Component;
+import java.awt.event.ActionEvent;
+import java.awt.event.InputEvent;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.Robot;
+import java.awt.BorderLayout;
+import javax.swing.JPopupMenu;
+import javax.swing.JButton;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JTextField;
+import javax.swing.SwingUtilities;
+
+public class TestPopupInvoker {
+    static JPopupMenu jpm;
+    static JFrame frame;
+    static JLabel label;
+    static volatile Point pt;
+    static volatile Rectangle size;
+
+    public static class MyThread implements Runnable {
+        static Container box;
+        static Component invo;
+
+        public MyThread(Container cont, Component comp) {
+            this.invo = comp;
+            this.box = cont;
+        }
+
+        public void run() {
+            System.out.println("Starting 3 second countdown...");
+            try{
+                Thread.currentThread().sleep(3000);
+            } catch (Exception e) {}
+            System.out.println("Removing popup invoker from the container.");
+            box.remove(invo);
+            box.repaint();
+            if (jpm.isVisible()) {
+                throw new RuntimeException("poup is visible after component is removed");
+            }
+        }
+    }
+
+    private static void createUI() {
+        frame = new JFrame("My frame");
+        final Container pane = frame.getContentPane();
+        pane.setLayout(new BorderLayout());
+        label = new JLabel("Click here to invoke popup");
+        label.addMouseListener(new MouseAdapter() {
+            public void mouseReleased(MouseEvent e) {
+                if (jpm == null) {
+                    jpm = new JPopupMenu("Popup");
+                    jpm.add("One");
+                    jpm.add("Two");
+                    jpm.add("Three");
+                }
+                jpm.show(label, 0, 0);
+            }
+
+            public void mousePressed(MouseEvent e) {
+                Thread thr = new Thread(new MyThread(pane, label));
+                thr.start();
+            }
+        });
+        pane.add(label, BorderLayout.CENTER);
+        frame.pack();
+        frame.setLocationRelativeTo(null);
+        frame.setVisible(true);
+    }
+
+    public static void main(String args[]) throws Exception {
+        try {
+            Robot robot = new Robot();
+            SwingUtilities.invokeAndWait(() -> createUI());
+            robot.waitForIdle();
+            robot.delay(1000);
+            SwingUtilities.invokeAndWait(() -> {
+                pt = label.getLocationOnScreen();
+                size = label.getBounds();
+            });
+            robot.mouseMove(pt.x + size.width / 2, pt.y + size.height / 2);
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+            robot.waitForIdle();
+            robot.delay(1000);
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+    }
+}


### PR DESCRIPTION
Issue is seen that a popup doesn't get closed when the component that invokes it, gets removed from the parent container.
This is because the JPopupMenu does not listen to its invoker liefecycle thereby behaving as a standalone entity after creation.
Fix is made to make sure popup listens to its invoker lifecycle by registering its PropertyChangeListener to the invoker and listens to the ["ancestor" property name ], https://github.com/openjdk/jdk/blob/441dbde2c3c915ffd916e39a5b4a91df5620d7f3/src/java.desktop/share/classes/javax/swing/JComponent.java#L4853-L4858 which will become null when removed, wherein we should dispose of the popup

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-4938801](https://bugs.openjdk.org/browse/JDK-4938801): The popup does not go when the component is removed (**Bug** - P4)


### Reviewers
 * [Damon Nguyen](https://openjdk.org/census#dnguyen) (@DamonGuy - Committer)
 * [Abhishek Kumar](https://openjdk.org/census#abhiscxk) (@kumarabhi006 - **Reviewer**)

### Contributors
 * Alexey Ivanov `<aivanov@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26407/head:pull/26407` \
`$ git checkout pull/26407`

Update a local copy of the PR: \
`$ git checkout pull/26407` \
`$ git pull https://git.openjdk.org/jdk.git pull/26407/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26407`

View PR using the GUI difftool: \
`$ git pr show -t 26407`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26407.diff">https://git.openjdk.org/jdk/pull/26407.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26407#issuecomment-3095048130)
</details>
