### PR TITLE
8357694: RISC-V: Several IR verification tests fail when vlen=128

### DIFF
--- a/test/hotspot/jtreg/compiler/c2/irTests/TestIfMinMax.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestIfMinMax.java
@@ -295,8 +295,12 @@ public class TestIfMinMax {
     }
 
     @Test
-    @IR(applyIfAnd = { "SuperWordReductions", "true", "MaxVectorSize", ">=32" },
-        applyIfCPUFeatureOr = { "avx512", "true", "rvv", "true" },
+    @IR(applyIf = { "SuperWordReductions", "true" },
+        applyIfCPUFeature = { "avx512", "true" },
+        counts = { IRNode.MAX_REDUCTION_V, "> 0" })
+    @IR(applyIfPlatform = {"riscv64", "true"},
+        applyIfAnd = { "SuperWordReductions", "true", "MaxVectorSize", ">=32" },
+        applyIfCPUFeature = { "rvv", "true" },
         counts = { IRNode.MAX_REDUCTION_V, "> 0" })
     @Arguments(setup = "setupLongArrays")
     public Object[] testMaxLongReduction(long[] a, long[] b) {
@@ -330,8 +334,12 @@ public class TestIfMinMax {
     }
 
     @Test
-    @IR(applyIfAnd = { "SuperWordReductions", "true", "MaxVectorSize", ">=32" },
-        applyIfCPUFeatureOr = { "avx512", "true", "rvv", "true" },
+    @IR(applyIf = { "SuperWordReductions", "true" },
+        applyIfCPUFeature = { "avx512", "true" },
+        counts = { IRNode.MIN_REDUCTION_V, "> 0" })
+    @IR(applyIfPlatform = {"riscv64", "true"},
+        applyIfAnd = { "SuperWordReductions", "true", "MaxVectorSize", ">=32" },
+        applyIfCPUFeature = { "rvv", "true" },
         counts = { IRNode.MIN_REDUCTION_V, "> 0" })
     @Arguments(setup = "setupLongArrays")
     public Object[] testMinLongReduction(long[] a, long[] b) {

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestIfMinMax.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestIfMinMax.java
@@ -295,7 +295,7 @@ public class TestIfMinMax {
     }
 
     @Test
-    @IR(applyIf = { "SuperWordReductions", "true" },
+    @IR(applyIfAnd = { "SuperWordReductions", "true", "MaxVectorSize", ">=32" },
         applyIfCPUFeatureOr = { "avx512", "true", "rvv", "true" },
         counts = { IRNode.MAX_REDUCTION_V, "> 0" })
     @Arguments(setup = "setupLongArrays")
@@ -330,7 +330,7 @@ public class TestIfMinMax {
     }
 
     @Test
-    @IR(applyIf = { "SuperWordReductions", "true" },
+    @IR(applyIfAnd = { "SuperWordReductions", "true", "MaxVectorSize", ">=32" },
         applyIfCPUFeatureOr = { "avx512", "true", "rvv", "true" },
         counts = { IRNode.MIN_REDUCTION_V, "> 0" })
     @Arguments(setup = "setupLongArrays")

--- a/test/hotspot/jtreg/compiler/loopopts/superword/RedTest_long.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/RedTest_long.java
@@ -140,7 +140,7 @@ public class RedTest_long {
         counts = {IRNode.ADD_REDUCTION_VL, ">= 1", IRNode.ADD_REDUCTION_VL, "<= 2"}) // one for main-loop, one for vector-post-loop
     @IR(applyIfPlatform = {"riscv64", "true"},
         applyIfCPUFeature = {"rvv", "true"},
-        applyIfAnd = {"SuperWordReductions", "true", "LoopMaxUnroll", ">= 8"},
+        applyIfAnd = {"SuperWordReductions", "true", "LoopMaxUnroll", ">= 8", "MaxVectorSize", ">=32"},
         counts = {IRNode.ADD_REDUCTION_VL, ">= 1", IRNode.ADD_REDUCTION_VL, "<= 2"}) // one for main-loop, one for vector-post-loop
     public static long sumReductionImplement(
             long[] a,
@@ -162,7 +162,7 @@ public class RedTest_long {
         counts = {IRNode.OR_REDUCTION_V, ">= 1", IRNode.OR_REDUCTION_V, "<= 2"}) // one for main-loop, one for vector-post-loop
     @IR(applyIfPlatform = {"riscv64", "true"},
         applyIfCPUFeature = {"rvv", "true"},
-        applyIfAnd = {"SuperWordReductions", "true", "LoopMaxUnroll", ">= 8"},
+        applyIfAnd = {"SuperWordReductions", "true", "LoopMaxUnroll", ">= 8", "MaxVectorSize", ">=32"},
         counts = {IRNode.OR_REDUCTION_V, ">= 1", IRNode.OR_REDUCTION_V, "<= 2"}) // one for main-loop, one for vector-post-loop
     public static long orReductionImplement(
             long[] a,
@@ -184,7 +184,7 @@ public class RedTest_long {
         counts = {IRNode.AND_REDUCTION_V, ">= 1", IRNode.AND_REDUCTION_V, "<= 2"}) // one for main-loop, one for vector-post-loop
     @IR(applyIfPlatform = {"riscv64", "true"},
         applyIfCPUFeature = {"rvv", "true"},
-        applyIfAnd = {"SuperWordReductions", "true", "LoopMaxUnroll", ">= 8"},
+        applyIfAnd = {"SuperWordReductions", "true", "LoopMaxUnroll", ">= 8", "MaxVectorSize", ">=32"},
         counts = {IRNode.AND_REDUCTION_V, ">= 1", IRNode.AND_REDUCTION_V, "<= 2"}) // one for main-loop, one for vector-post-loop
     public static long andReductionImplement(
             long[] a,
@@ -206,7 +206,7 @@ public class RedTest_long {
         counts = {IRNode.XOR_REDUCTION_V, ">= 1", IRNode.XOR_REDUCTION_V, "<= 2"}) // one for main-loop, one for vector-post-loop
     @IR(applyIfPlatform = {"riscv64", "true"},
         applyIfCPUFeature = {"rvv", "true"},
-        applyIfAnd = {"SuperWordReductions", "true", "LoopMaxUnroll", ">= 8"},
+        applyIfAnd = {"SuperWordReductions", "true", "LoopMaxUnroll", ">= 8", "MaxVectorSize", ">=32"},
         counts = {IRNode.XOR_REDUCTION_V, ">= 1", IRNode.XOR_REDUCTION_V, "<= 2"}) // one for main-loop, one for vector-post-loop
     public static long xorReductionImplement(
             long[] a,
@@ -228,7 +228,7 @@ public class RedTest_long {
         counts = {IRNode.MUL_REDUCTION_VL, ">= 1", IRNode.MUL_REDUCTION_VL, "<= 2"}) // one for main-loop, one for vector-post-loop
     @IR(applyIfPlatform = {"riscv64", "true"},
         applyIfCPUFeature = {"rvv", "true"},
-        applyIfAnd = {"SuperWordReductions", "true", "LoopMaxUnroll", ">= 8"},
+        applyIfAnd = {"SuperWordReductions", "true", "LoopMaxUnroll", ">= 8", "MaxVectorSize", ">=32"},
         counts = {IRNode.MUL_REDUCTION_VL, ">= 1", IRNode.MUL_REDUCTION_VL, "<= 2"}) // one for main-loop, one for vector-post-loop
     public static long mulReductionImplement(
             long[] a,

--- a/test/hotspot/jtreg/compiler/loopopts/superword/SumRed_Long.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/SumRed_Long.java
@@ -98,7 +98,7 @@ public class SumRed_Long {
         counts = {IRNode.ADD_REDUCTION_VL, ">= 1", IRNode.ADD_REDUCTION_VL, "<= 2"}) // one for main-loop, one for vector-post-loop
     @IR(applyIfPlatform = {"riscv64", "true"},
         applyIfCPUFeature = {"rvv", "true"},
-        applyIfAnd = {"SuperWordReductions", "true", "LoopMaxUnroll", ">= 8"},
+        applyIfAnd = {"SuperWordReductions", "true", "LoopMaxUnroll", ">= 8", "MaxVectorSize", ">=32"},
         counts = {IRNode.ADD_REDUCTION_VL, ">= 1", IRNode.ADD_REDUCTION_VL, "<= 2"}) // one for main-loop, one for vector-post-loop
     public static long sumReductionImplement(
             long[] a,

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestGeneralizedReductions.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestGeneralizedReductions.java
@@ -81,9 +81,13 @@ public class TestGeneralizedReductions {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"avx2", "true", "rvv", "true"},
-        applyIfAnd = {"SuperWordReductions", "true", "MaxVectorSize", ">=32"},
+    @IR(applyIfCPUFeature = {"avx2", "true"},
+        applyIf = {"SuperWordReductions", "true"},
         applyIfPlatform = {"64-bit", "true"},
+        counts = {IRNode.ADD_REDUCTION_VI, ">= 1"})
+    @IR(applyIfPlatform = {"riscv64", "true"},
+        applyIfCPUFeature = {"rvv", "true"},
+        applyIfAnd = {"SuperWordReductions", "true", "MaxVectorSize", ">=32"},
         counts = {IRNode.ADD_REDUCTION_VI, ">= 1"})
     private static long testReductionOnGlobalAccumulator(long[] array) {
         acc = 0;
@@ -94,9 +98,13 @@ public class TestGeneralizedReductions {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"avx2", "true", "rvv", "true"},
-        applyIfAnd = {"SuperWordReductions", "true", "MaxVectorSize", ">=32"},
+    @IR(applyIfCPUFeature = {"avx2", "true"},
+        applyIf = {"SuperWordReductions", "true"},
         applyIfPlatform = {"64-bit", "true"},
+        counts = {IRNode.ADD_REDUCTION_VI, ">= 1"})
+    @IR(applyIfPlatform = {"riscv64", "true"},
+        applyIfCPUFeature = {"rvv", "true"},
+        applyIfAnd = {"SuperWordReductions", "true", "MaxVectorSize", ">=32"},
         counts = {IRNode.ADD_REDUCTION_VI, ">= 1"})
     private static long testReductionOnPartiallyUnrolledLoop(long[] array) {
         int sum = 0;
@@ -108,9 +116,13 @@ public class TestGeneralizedReductions {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"avx2", "true", "rvv", "true"},
-        applyIfAnd = {"SuperWordReductions", "true", "MaxVectorSize", ">=32"},
+    @IR(applyIfCPUFeature = {"avx2", "true"},
+        applyIf = {"SuperWordReductions", "true"},
         applyIfPlatform = {"64-bit", "true"},
+        counts = {IRNode.ADD_REDUCTION_VI, ">= 1"})
+    @IR(applyIfPlatform = {"riscv64", "true"},
+        applyIfCPUFeature = {"rvv", "true"},
+        applyIfAnd = {"SuperWordReductions", "true", "MaxVectorSize", ">=32"},
         counts = {IRNode.ADD_REDUCTION_VI, ">= 1"})
     private static long testReductionOnLargePartiallyUnrolledLoop(long[] array) {
         int sum = 0;

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestGeneralizedReductions.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestGeneralizedReductions.java
@@ -82,7 +82,7 @@ public class TestGeneralizedReductions {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"avx2", "true", "rvv", "true"},
-        applyIf = {"SuperWordReductions", "true"},
+        applyIfAnd = {"SuperWordReductions", "true", "MaxVectorSize", ">=32"},
         applyIfPlatform = {"64-bit", "true"},
         counts = {IRNode.ADD_REDUCTION_VI, ">= 1"})
     private static long testReductionOnGlobalAccumulator(long[] array) {
@@ -95,7 +95,7 @@ public class TestGeneralizedReductions {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"avx2", "true", "rvv", "true"},
-        applyIf = {"SuperWordReductions", "true"},
+        applyIfAnd = {"SuperWordReductions", "true", "MaxVectorSize", ">=32"},
         applyIfPlatform = {"64-bit", "true"},
         counts = {IRNode.ADD_REDUCTION_VI, ">= 1"})
     private static long testReductionOnPartiallyUnrolledLoop(long[] array) {
@@ -109,7 +109,7 @@ public class TestGeneralizedReductions {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"avx2", "true", "rvv", "true"},
-        applyIf = {"SuperWordReductions", "true"},
+        applyIfAnd = {"SuperWordReductions", "true", "MaxVectorSize", ">=32"},
         applyIfPlatform = {"64-bit", "true"},
         counts = {IRNode.ADD_REDUCTION_VI, ">= 1"})
     private static long testReductionOnLargePartiallyUnrolledLoop(long[] array) {

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestUnorderedReductionPartialVectorization.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestUnorderedReductionPartialVectorization.java
@@ -64,15 +64,21 @@ public class TestUnorderedReductionPartialVectorization {
     @IR(counts = {IRNode.LOAD_VECTOR_I,   IRNode.VECTOR_SIZE + "min(max_int, max_long)", "> 0",
                   IRNode.VECTOR_CAST_I2L, IRNode.VECTOR_SIZE + "min(max_int, max_long)", "> 0",
                   IRNode.OR_REDUCTION_V,                                                 "> 0",},
-        applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">=32"},
+        applyIfOr = {"AlignVector", "false", "UseCompactObjectHeaders", "false"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"avx2", "true", "rvv", "true"})
+        applyIfCPUFeature = {"avx2", "true"})
+    @IR(counts = {IRNode.LOAD_VECTOR_I,   IRNode.VECTOR_SIZE + "min(max_int, max_long)", "> 0",
+                  IRNode.VECTOR_CAST_I2L, IRNode.VECTOR_SIZE + "min(max_int, max_long)", "> 0",
+                  IRNode.OR_REDUCTION_V,                                                 "> 0",},
+        applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">=32"},
+        applyIfPlatform = {"riscv64", "true"},
+        applyIfCPUFeature = {"rvv", "true"})
     @IR(counts = {IRNode.LOAD_VECTOR_I,   IRNode.VECTOR_SIZE + "min(max_int, max_long)", "> 0",
                   IRNode.VECTOR_CAST_I2L, IRNode.VECTOR_SIZE + "min(max_int, max_long)", "> 0",
                   IRNode.OR_REDUCTION_V,                                                 "> 0",},
         applyIfAnd = {"UseCompactObjectHeaders", "false", "MaxVectorSize", ">=32"},
-        applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"avx2", "true", "rvv", "true"})
+        applyIfPlatform = {"riscv64", "true"},
+        applyIfCPUFeature = {"rvv", "true"})
     static long test1(int[] data, long sum) {
         for (int i = 0; i < data.length; i+=2) {
             // Mixing int and long ops means we only end up allowing half of the int

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestUnorderedReductionPartialVectorization.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestUnorderedReductionPartialVectorization.java
@@ -64,7 +64,13 @@ public class TestUnorderedReductionPartialVectorization {
     @IR(counts = {IRNode.LOAD_VECTOR_I,   IRNode.VECTOR_SIZE + "min(max_int, max_long)", "> 0",
                   IRNode.VECTOR_CAST_I2L, IRNode.VECTOR_SIZE + "min(max_int, max_long)", "> 0",
                   IRNode.OR_REDUCTION_V,                                                 "> 0",},
-        applyIfOr = {"AlignVector", "false", "UseCompactObjectHeaders", "false"},
+        applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">=32"},
+        applyIfPlatform = {"64-bit", "true"},
+        applyIfCPUFeatureOr = {"avx2", "true", "rvv", "true"})
+    @IR(counts = {IRNode.LOAD_VECTOR_I,   IRNode.VECTOR_SIZE + "min(max_int, max_long)", "> 0",
+                  IRNode.VECTOR_CAST_I2L, IRNode.VECTOR_SIZE + "min(max_int, max_long)", "> 0",
+                  IRNode.OR_REDUCTION_V,                                                 "> 0",},
+        applyIfAnd = {"UseCompactObjectHeaders", "false", "MaxVectorSize", ">=32"},
         applyIfPlatform = {"64-bit", "true"},
         applyIfCPUFeatureOr = {"avx2", "true", "rvv", "true"})
     static long test1(int[] data, long sum) {

--- a/test/hotspot/jtreg/compiler/vectorization/runner/LoopReductionOpTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/LoopReductionOpTest.java
@@ -178,6 +178,7 @@ public class LoopReductionOpTest extends VectorizationTestRunner {
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.STORE_VECTOR, ">0"})
     @IR(applyIfCPUFeatureOr = {"avx2", "true", "rvv", "true"},
+        applyIf = {"MaxVectorSize", ">=32" },
         counts = {IRNode.ADD_REDUCTION_V, ">0"})
     public long reductionWithNonReductionDifferentSizes() {
         long res = 0L;

--- a/test/hotspot/jtreg/compiler/vectorization/runner/LoopReductionOpTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/LoopReductionOpTest.java
@@ -177,7 +177,10 @@ public class LoopReductionOpTest extends VectorizationTestRunner {
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.STORE_VECTOR, ">0"})
-    @IR(applyIfCPUFeatureOr = {"avx2", "true", "rvv", "true"},
+    @IR(applyIfCPUFeature = {"avx2", "true"},
+        counts = {IRNode.ADD_REDUCTION_V, ">0"})
+    @IR(applyIfPlatform = {"riscv64", "true"},
+        applyIfCPUFeature = {"rvv", "true"},
         applyIf = {"MaxVectorSize", ">=32" },
         counts = {IRNode.ADD_REDUCTION_V, ">0"})
     public long reductionWithNonReductionDifferentSizes() {


### PR DESCRIPTION
Hi,
Can you help to review this patch? Thanks!

These tests failed because with a vlen of 128, these tests generate vectors containing only two elements. However, ​​2-element reductions for INT/LONG are not profitable​​, so the compiler won't generate the corresponding reductions IR.

We can refer to here:
https://github.com/openjdk/jdk/blob/441dbde2c3c915ffd916e39a5b4a91df5620d7f3/src/hotspot/share/opto/superword.cpp#L1606-L1633

According to the explanation above, when I use `-XX:+UnlockDiagnosticVMOptions -XX:AutoVectorizationOverrideProfitability=2`, these cases passed with vlen=128.

We can fix this problem by adding the restriction of `MaxVectorSize` greater than or equal to 32 (256 bits) to these test cases.

## Test (fastdebug)
### Test on k1 and qemu (w/ RVV, vlen=128)
- compiler/vectorization/runner/LoopReductionOpTest.java
- compiler/c2/irTests/TestIfMinMax.java
- compiler/loopopts/superword/RedTest_long.java
- compiler/loopopts/superword/SumRed_Long.java
- compiler/loopopts/superword/TestGeneralizedReductions.java
- compiler/loopopts/superword/TestUnorderedReductionPartialVectorization.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8357694](https://bugs.openjdk.org/browse/JDK-8357694): RISC-V: Several IR verification tests fail when vlen=128 (**Bug** - P4)


### Reviewers
 * [Manuel Hässig](https://openjdk.org/census#mhaessig) (@mhaessig - Committer)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Hamlin Li](https://openjdk.org/census#mli) (@Hamlin-Li - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26408/head:pull/26408` \
`$ git checkout pull/26408`

Update a local copy of the PR: \
`$ git checkout pull/26408` \
`$ git pull https://git.openjdk.org/jdk.git pull/26408/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26408`

View PR using the GUI difftool: \
`$ git pr show -t 26408`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26408.diff">https://git.openjdk.org/jdk/pull/26408.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26408#issuecomment-3095060499)
</details>
