### PR TITLE
8360562: sun/security/tools/keytool/i18n.java add an ability to add comment for failures

### DIFF
--- a/test/jdk/sun/security/tools/keytool/i18n.java
+++ b/test/jdk/sun/security/tools/keytool/i18n.java
@@ -385,13 +385,8 @@ public class i18n {
         okButton.addActionListener(_ -> dialogWindow.setVisible(false));
 
         final JPanel okayBtnPanel = new JPanel(
-                new FlowLayout(FlowLayout.CENTER,
-                        4,
-                        0));
-        okayBtnPanel.setBorder(createEmptyBorder(4,
-                0,
-                0,
-                0));
+                new FlowLayout(FlowLayout.CENTER, 4, 0));
+        okayBtnPanel.setBorder(createEmptyBorder(4, 0, 0, 0));
         okayBtnPanel.add(okButton);
 
         final JPanel mainPanel = new JPanel(new BorderLayout());

--- a/test/jdk/sun/security/tools/keytool/i18n.java
+++ b/test/jdk/sun/security/tools/keytool/i18n.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -63,10 +63,20 @@
 
 import jdk.test.lib.UIBuilder;
 
-import javax.swing.*;
+import javax.swing.JDialog;
+import javax.swing.SwingUtilities;
+import javax.swing.JTextArea;
+import javax.swing.JButton;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JFrame;
+import java.awt.FlowLayout;
+import java.awt.BorderLayout;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.util.Locale;
+
+import static javax.swing.BorderFactory.createEmptyBorder;
 
 public class i18n {
     private static final String[][] TABLE = new String[][]{
@@ -238,11 +248,12 @@ public class i18n {
                     "Output in ${LANG}. Check keytool error: java.lang"
                             + ".IllegalArgumentException: if -protected is "
                             + "specified, then -storepass, -keypass, and -new "
-                            + "must not be specified."},
+                            + "must not be specified."}
     };
     private static String TEST_SRC = System.getProperty("test.src");
     private static int TIMEOUT_MS = 120000;
     private volatile boolean failed = false;
+    private volatile String failureReason = "";
     private volatile boolean aborted = false;
     private Thread currentThread = null;
 
@@ -334,6 +345,7 @@ public class i18n {
 
             if (failed) {
                 System.out.println(command + ": TEST FAILED");
+                System.out.println("REASON: " + failureReason);
                 System.out.println(message);
             } else {
                 System.out.println(command + ": TEST PASSED");
@@ -352,11 +364,46 @@ public class i18n {
 
     public void fail() {
         failed = true;
+        failureReason = requestFailDescription();
         currentThread.interrupt();
     }
 
     public void abort() {
         aborted = true;
         currentThread.interrupt();
+    }
+
+    /**
+     * Opens a prompt to enter a failure reason to be filled by the tester
+     */
+     public static String requestFailDescription() {
+
+        final JDialog dialogWindow = new JDialog(new JFrame(), "Failure Description", true);
+        final JTextArea reasonTextArea = new JTextArea(5, 20);
+
+        final JButton okButton = new JButton("OK");
+        okButton.addActionListener(_ -> dialogWindow.setVisible(false));
+
+        final JPanel okayBtnPanel = new JPanel(
+                new FlowLayout(FlowLayout.CENTER,
+                        4,
+                        0));
+        okayBtnPanel.setBorder(createEmptyBorder(4,
+                0,
+                0,
+                0));
+        okayBtnPanel.add(okButton);
+
+        final JPanel mainPanel = new JPanel(new BorderLayout());
+        mainPanel.add(new JScrollPane(reasonTextArea), BorderLayout.CENTER);
+        mainPanel.add(okayBtnPanel, BorderLayout.SOUTH);
+
+        dialogWindow.add(mainPanel);
+        dialogWindow.pack();
+        dialogWindow.setVisible(true);
+
+        dialogWindow.dispose();
+
+        return reasonTextArea.getText();
     }
 }


### PR DESCRIPTION
When the test is run now the reason for the failure will be requested providing further feedback.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8360562](https://bugs.openjdk.org/browse/JDK-8360562): sun/security/tools/keytool/i18n.java add an ability to add comment for failures (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26412/head:pull/26412` \
`$ git checkout pull/26412`

Update a local copy of the PR: \
`$ git checkout pull/26412` \
`$ git pull https://git.openjdk.org/jdk.git pull/26412/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26412`

View PR using the GUI difftool: \
`$ git pr show -t 26412`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26412.diff">https://git.openjdk.org/jdk/pull/26412.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26412#issuecomment-3096201681)
</details>
