### PR TITLE
8362889: [GCC static analyzer] leak in libstringPlatformChars.c

### DIFF
--- a/test/jdk/java/lang/String/nativeEncoding/libstringPlatformChars.c
+++ b/test/jdk/java/lang/String/nativeEncoding/libstringPlatformChars.c
@@ -64,6 +64,7 @@ Java_StringPlatformChars_newString(JNIEnv *env, jclass unused, jbyteArray bytes)
     }
     str = (char*)malloc(len + 1);
     if (str == NULL) {
+        (*env)->ReleasePrimitiveArrayCritical(env, bytes, (void*)jbytes, 0);
         return NULL;
     }
     for (i = 0; i < len; i++) {


### PR DESCRIPTION
This is reported by the gcc static analyzer (-fanalyzer); it is just test coding so not very critical but probably should still be adjusted .

```
/jdk/test/jdk/java/lang/String/nativeEncoding/libstringPlatformChars.c:74:12: warning: leak of 'str' [CWE-401] [-Wanalyzer-malloc-leak]
   74 | return JNU_NewStringPlatform(env, str);
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8362889](https://bugs.openjdk.org/browse/JDK-8362889): [GCC static analyzer] leak in libstringPlatformChars.c (**Bug** - P4)


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26415/head:pull/26415` \
`$ git checkout pull/26415`

Update a local copy of the PR: \
`$ git checkout pull/26415` \
`$ git pull https://git.openjdk.org/jdk.git pull/26415/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26415`

View PR using the GUI difftool: \
`$ git pr show -t 26415`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26415.diff">https://git.openjdk.org/jdk/pull/26415.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26415#issuecomment-3096986473)
</details>
