### PR TITLE
8362898

### DIFF
--- a/src/java.desktop/share/classes/com/sun/imageio/plugins/tiff/TIFFBaseJPEGCompressor.java
+++ b/src/java.desktop/share/classes/com/sun/imageio/plugins/tiff/TIFFBaseJPEGCompressor.java
@@ -55,6 +55,8 @@ import javax.imageio.plugins.jpeg.JPEGImageWriteParam;
 import javax.imageio.stream.ImageOutputStream;
 import javax.imageio.stream.MemoryCacheImageOutputStream;
 import org.w3c.dom.Node;
+import sun.java2d.Disposer;
+import sun.java2d.DisposerRecord;
 
 /**
  * Base class for all possible forms of JPEG compression in TIFF.
@@ -219,12 +221,14 @@ public abstract class TIFFBaseJPEGCompressor extends TIFFCompressor {
             if(supportsStreamMetadata) {
                 String smName = spi.getNativeStreamMetadataFormatName();
                 if(smName == null || !smName.equals(STREAM_METADATA_NAME)) {
+                    this.JPEGWriter.dispose();
                     this.JPEGWriter = null;
                 }
             }
             if(this.JPEGWriter != null && supportsImageMetadata) {
                 String imName = spi.getNativeImageMetadataFormatName();
                 if(imName == null || !imName.equals(IMAGE_METADATA_NAME)) {
+                    this.JPEGWriter.dispose();
                     this.JPEGWriter = null;
                 }
             }
@@ -263,6 +267,12 @@ public abstract class TIFFBaseJPEGCompressor extends TIFFCompressor {
 
                 // Set the writer.
                 this.JPEGWriter = writer;
+                // The JDK built-in JPEGImageWriter will self-dispose.
+                // So a Disposer is only needed here if it is an unknown reader.
+                // This is not common, so likely this will rarely be needed.
+                if (!(this.JPEGWriter instanceof com.sun.imageio.plugins.jpeg.JPEGImageWriter)) {
+                    Disposer.addRecord(this, new ImageWriterDisposerRecord(this.JPEGWriter));
+                }
                 break;
             }
 
@@ -435,11 +445,16 @@ public abstract class TIFFBaseJPEGCompressor extends TIFFCompressor {
         return compDataLength;
     }
 
-    @SuppressWarnings("removal")
-    protected void finalize() throws Throwable {
-        super.finalize();
-        if(JPEGWriter != null) {
-            JPEGWriter.dispose();
-        }
+    private static class ImageWriterDisposerRecord implements DisposerRecord {
+        private final ImageWriter writer;
+            
+        public ImageWriterDisposerRecord(ImageWriter writer) {
+            this.writer = writer;
+        }   
+            
+        @Override
+        public void dispose() {
+            writer.dispose();
+        }   
     }
 }

--- a/src/java.desktop/share/classes/com/sun/imageio/plugins/tiff/TIFFOldJPEGDecompressor.java
+++ b/src/java.desktop/share/classes/com/sun/imageio/plugins/tiff/TIFFOldJPEGDecompressor.java
@@ -610,8 +610,4 @@ public class TIFFOldJPEGDecompressor extends TIFFJPEGDecompressor {
         JPEGReader.read(0, JPEGParam);
     }
 
-    protected void finalize() throws Throwable {
-        super.finalize();
-        JPEGReader.dispose();
-    }
 }


### PR DESCRIPTION
Remove finalize from TIFF ImageIO implementatation classes.

Following copied from the bug description 
The TIFF image (de)compressors can make use of a JPEG reader / writer
Like all ImageIO readers and writers, once done, the owner should call their dispose() method.
This is currently done with finalize() to ensure it isn't missed.

This can be migrated to a Disposer.

However, the most common case is that it is the ImageIO built-in JPEGImageReader and JPEGImageWriter
that is located and that already implements a Disposer. So there is no need to add a Disposer for that.
We only need to add it if we find some other reader/writer.

With enough work, it might be possible for the TIFF compressor/decompressor classes to work out when
they are really done and avoid a Disposer at all. But it could also be that they instead need to discard
them when a specific task is done and then obtain a new one.
That would be much more overhead than just adding a Disposer for the rare case and regardless
of what is done in the TIFF code, the built in JPEG classes will install their own Disposer so I don't
think I want to pursue that route.

I also noticed that TIFFBaseJPEGCompressor.java can replace the current writer if it doesn't satisfy a need.
In that case it just nulls it out and doesn't call dispose() and of course finalize() will then refer to the replacement.
So I added direct calls to dispose() in such a case. That was definitely necessary with the finalize() code
but the Disposer would have taken care of it anyway, so it isn't strictly needed with the new code but
it is still good to do it early if you can. 