### PR TITLE
8357682 : sun.security.provider.certpath.Builder#getMatchingPolicies always returns null

### DIFF
--- a/src/java.base/share/classes/sun/security/provider/certpath/Builder.java
+++ b/src/java.base/share/classes/sun/security/provider/certpath/Builder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/sun/security/provider/certpath/Builder.java
+++ b/src/java.base/share/classes/sun/security/provider/certpath/Builder.java
@@ -139,7 +139,7 @@ abstract class Builder {
      * cert's certificate policies extension in order for a cert to be selected.
      */
     Set<String> getMatchingPolicies() {
-        if (matchingPolicies != null) {
+        if (matchingPolicies == null) {
             Set<String> initialPolicies = buildParams.initialPolicies();
             if ((!initialPolicies.isEmpty()) &&
                 (!initialPolicies.contains(PolicyChecker.ANY_POLICY)) &&


### PR DESCRIPTION
The method sun.security.provider.certpath.Builder#getMatchingPolicies appears to have been intended as a lazy initialization of the matchingPolicies field of the Builder class. However it checks for "matchingPolicies != null" (presumably it should be "matchingPolicies == null") at the start, which is always false. Therefore the method always returns null and the intended optimization goes unused.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8357682](https://bugs.openjdk.org/browse/JDK-8357682): sun.security.provider.certpath.Builder#getMatchingPolicies always returns null (**Bug** - P4)


### Reviewers
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26418/head:pull/26418` \
`$ git checkout pull/26418`

Update a local copy of the PR: \
`$ git checkout pull/26418` \
`$ git pull https://git.openjdk.org/jdk.git pull/26418/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26418`

View PR using the GUI difftool: \
`$ git pr show -t 26418`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26418.diff">https://git.openjdk.org/jdk/pull/26418.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26418#issuecomment-3104383466)
</details>
