### PR TITLE
8362846: Windows error reporting for dll_load doesn't check for a null buffer

### DIFF
--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -1110,7 +1110,10 @@ void * os::dll_load(const char *filename, char *ebuf, int ebuflen) {
   if (result != nullptr) {
     return result;
   }
-
+  if (ebuf == nullptr || ebuflen < 1) {
+    // no error reporting requested
+    return nullptr;
+  }
   Events::log_dll_message(nullptr, "Loading shared library %s failed, %s", filename, error_report);
   log_info(os)("shared library load of %s failed, %s", filename, error_report);
   int diag_msg_max_length=ebuflen-strlen(ebuf);

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -1685,6 +1685,11 @@ void * os::dll_load(const char *filename, char *ebuf, int ebuflen) {
     return result;
   }
 
+  if (ebuf == nullptr || ebuflen < 1) {
+    // no error reporting requested
+    return nullptr;
+  }
+
   Elf32_Ehdr elf_head;
   size_t prefix_len = strlen(ebuf);
   ssize_t diag_msg_max_length = ebuflen - prefix_len;

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -1729,6 +1729,12 @@ void * os::dll_load(const char *name, char *ebuf, int ebuflen) {
     log_info(os)("shared library load of %s was successful", name);
     return result;
   }
+
+  if (ebuf == nullptr || ebuflen < 1) {
+    // no error reporting requested
+    return nullptr;
+  }
+
   DWORD errcode = GetLastError();
   // Read system error message into ebuf
   // It may or may not be overwritten below (in the for loop and just above)
@@ -2261,6 +2267,8 @@ void os::jvm_path(char *buf, jint buflen) {
 // from src/windows/hpi/src/system_md.c
 
 size_t os::lasterror(char* buf, size_t len) {
+  assert(buf != nullptr && len > 0, "invalid buffer passed");
+
   DWORD errval;
 
   if ((errval = GetLastError()) != 0) {

--- a/test/hotspot/gtest/runtime/test_os.cpp
+++ b/test/hotspot/gtest/runtime/test_os.cpp
@@ -1181,3 +1181,9 @@ TEST_VM(os, map_memory_to_file_aligned) {
 }
 
 #endif // !defined(_AIX)
+
+TEST_VM(os, dll_load_null_error_buf) {
+  // This should not crash.
+  void* lib = os::dll_load("NoSuchLib", nullptr, 0);
+  ASSERT_NULL(lib);
+}


### PR DESCRIPTION
Please review this simple fix for some missing null checks in `os::dll_load`. The primary issue handles Windows, while the additional is for Linux/BSD.

Testing:
- new gtest
- tiers 1-3

Thanks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8362846](https://bugs.openjdk.org/browse/JDK-8362846): Windows error reporting for dll_load doesn't check for a null buffer (**Bug** - P3)
 * [JDK-8362954](https://bugs.openjdk.org/browse/JDK-8362954): Missing error buffer null check in os::dll_load on Linux/BSD (**Bug** - P4)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26420/head:pull/26420` \
`$ git checkout pull/26420`

Update a local copy of the PR: \
`$ git checkout pull/26420` \
`$ git pull https://git.openjdk.org/jdk.git pull/26420/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26420`

View PR using the GUI difftool: \
`$ git pr show -t 26420`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26420.diff">https://git.openjdk.org/jdk/pull/26420.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26420#issuecomment-3100150389)
</details>
