### PR TITLE
8362957: Fix jdk/javadoc/doccheck/checks/jdkCheckHtml.java (docs) failure

### DIFF
--- a/src/java.base/share/classes/javax/crypto/Cipher.java
+++ b/src/java.base/share/classes/javax/crypto/Cipher.java
@@ -116,10 +116,6 @@ import sun.security.util.KnownOIDs;
  * <p> An {@link IllegalStateException} will be thrown when calling {@code update}
  * or {@code doFinal} methods if a reset did not occur. A call to {@code init} will
  * re-initialize the {@code Cipher} object with new parameters.
- *
- *  @see javax.crypto.Cipher
- *  @see javax.crypto.spec.GCMParameterSpec
- *
  * <p>
  * Every implementation of the Java platform is required to support
  * the following standard {@code Cipher} object transformations with


### PR DESCRIPTION
Test jdk/javadoc/doccheck/checks/jdkCheckHtml.java (docs) fails due to this PR https://github.com/openjdk/jdk/pull/25399.

Removing the block tags as it's no longer necessary.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8362957](https://bugs.openjdk.org/browse/JDK-8362957): Fix jdk/javadoc/doccheck/checks/jdkCheckHtml.java (docs) failure (**Bug** - P4)


### Reviewers
 * [Anthony Scarpino](https://openjdk.org/census#ascarpino) (@ascarpino - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26421/head:pull/26421` \
`$ git checkout pull/26421`

Update a local copy of the PR: \
`$ git checkout pull/26421` \
`$ git pull https://git.openjdk.org/jdk.git pull/26421/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26421`

View PR using the GUI difftool: \
`$ git pr show -t 26421`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26421.diff">https://git.openjdk.org/jdk/pull/26421.diff</a>

</details>
