### PR TITLE
8362968: [JVMCI] support modifying locals in StackIntrospection on virtual threads

### DIFF
--- a/src/hotspot/cpu/aarch64/frame_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/frame_aarch64.cpp
@@ -301,7 +301,7 @@ void frame::patch_pc(Thread* thread, address pc) {
   DEBUG_ONLY(address old_pc = _pc;)
   *pc_addr = signed_pc;
   _pc = pc; // must be set before call to get_deopt_original_pc
-  address original_pc = get_deopt_original_pc();
+  address original_pc = get_deopt_original_pc(nullptr);
   if (original_pc != nullptr) {
     assert(original_pc == old_pc, "expected original PC to be stored before patching");
     _deopt_state = is_deoptimized;
@@ -461,14 +461,9 @@ JavaThread** frame::saved_thread_address(const frame& f) {
 // given unextended SP.
 #ifdef ASSERT
 void frame::verify_deopt_original_pc(nmethod* nm, intptr_t* unextended_sp) {
-  frame fr;
+  assert(unextended_sp == _unextended_sp, "expected to be the same frame");
 
-  // This is ugly but it's better than to change {get,set}_original_pc
-  // to take an SP value as argument.  And it's only a debugging
-  // method anyway.
-  fr._unextended_sp = unextended_sp;
-
-  address original_pc = nm->get_original_pc(&fr);
+  address original_pc = get_original_pc(nullptr, nm);
   assert(nm->insts_contains_inclusive(original_pc),
          "original PC must be in the main code section of the compiled method (or must be immediately following it)");
 }

--- a/src/hotspot/cpu/aarch64/frame_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/frame_aarch64.hpp
@@ -154,7 +154,7 @@
 
 #ifdef ASSERT
   // Used in frame::sender_for_{interpreter,compiled}_frame
-  static void verify_deopt_original_pc(nmethod* nm, intptr_t* unextended_sp);
+  void verify_deopt_original_pc(nmethod* nm, intptr_t* unextended_sp);
 #endif
 
  public:

--- a/src/hotspot/cpu/aarch64/frame_aarch64.inline.hpp
+++ b/src/hotspot/cpu/aarch64/frame_aarch64.inline.hpp
@@ -118,7 +118,8 @@ inline void frame::init(intptr_t* sp, intptr_t* fp, address pc) {
 inline void frame::setup(address pc) {
   adjust_unextended_sp();
 
-  address original_pc = get_deopt_original_pc();
+  assert(_pc == pc, "must have been set");
+  address original_pc = get_deopt_original_pc(nullptr);
   if (original_pc != nullptr) {
     _pc = original_pc;
     _deopt_state = is_deoptimized;
@@ -225,7 +226,7 @@ inline frame::frame(intptr_t* sp, intptr_t* fp) {
   _cb = CodeCache::find_blob(_pc);
   adjust_unextended_sp();
 
-  address original_pc = get_deopt_original_pc();
+  address original_pc = get_deopt_original_pc(nullptr);
   if (original_pc != nullptr) {
     _pc = original_pc;
     _deopt_state = is_deoptimized;

--- a/src/hotspot/cpu/arm/frame_arm.cpp
+++ b/src/hotspot/cpu/arm/frame_arm.cpp
@@ -228,7 +228,7 @@ void frame::patch_pc(Thread* thread, address pc) {
   DEBUG_ONLY(address old_pc = _pc;)
   *pc_addr = pc;
   _pc = pc; // must be set before call to get_deopt_original_pc
-  address original_pc = get_deopt_original_pc();
+  address original_pc = get_deopt_original_pc(nullptr);
   if (original_pc != nullptr) {
     assert(original_pc == old_pc, "expected original PC to be stored before patching");
     _deopt_state = is_deoptimized;
@@ -337,14 +337,9 @@ JavaThread** frame::saved_thread_address(const frame& f) {
 // for MethodHandle call sites.
 #ifdef ASSERT
 void frame::verify_deopt_original_pc(nmethod* nm, intptr_t* unextended_sp, bool is_method_handle_return) {
-  frame fr;
+  assert(unextended_sp == _unextended_sp, "expected to be the same frame");
 
-  // This is ugly but it's better than to change {get,set}_original_pc
-  // to take an SP value as argument.  And it's only a debugging
-  // method anyway.
-  fr._unextended_sp = unextended_sp;
-
-  address original_pc = nm->get_original_pc(&fr);
+  address original_pc = get_original_pc(nullptr, nm);
   assert(nm->insts_contains_inclusive(original_pc),
          "original PC must be in the main code section of the compiled method (or must be immediately following it)");
   assert(nm->is_method_handle_return(original_pc) == is_method_handle_return, "must be");

--- a/src/hotspot/cpu/arm/frame_arm.hpp
+++ b/src/hotspot/cpu/arm/frame_arm.hpp
@@ -93,8 +93,8 @@
 
 #ifdef ASSERT
   // Used in frame::sender_for_{interpreter,compiled}_frame
-  static void verify_deopt_original_pc(nmethod* nm, intptr_t* unextended_sp, bool is_method_handle_return = false);
-  static void verify_deopt_mh_original_pc(nmethod* nm, intptr_t* unextended_sp) {
+  void verify_deopt_original_pc(nmethod* nm, intptr_t* unextended_sp, bool is_method_handle_return = false);
+  void verify_deopt_mh_original_pc(nmethod* nm, intptr_t* unextended_sp) {
     verify_deopt_original_pc(nm, unextended_sp, true);
   }
 #endif

--- a/src/hotspot/cpu/arm/frame_arm.inline.hpp
+++ b/src/hotspot/cpu/arm/frame_arm.inline.hpp
@@ -114,7 +114,7 @@ inline void frame::init(intptr_t* sp, intptr_t* unextended_sp, intptr_t* fp, add
 inline void frame::setup(address pc) {
   adjust_unextended_sp();
 
-  address original_pc = get_deopt_original_pc();
+  address original_pc = get_deopt_original_pc(nullptr);
   if (original_pc != nullptr) {
     _pc = original_pc;
     _deopt_state = is_deoptimized;

--- a/src/hotspot/cpu/ppc/frame_ppc.cpp
+++ b/src/hotspot/cpu/ppc/frame_ppc.cpp
@@ -307,7 +307,7 @@ void frame::patch_pc(Thread* thread, address pc) {
   DEBUG_ONLY(address old_pc = _pc;)
   own_abi()->lr = (uint64_t)pc;
   _pc = pc; // must be set before call to get_deopt_original_pc
-  address original_pc = get_deopt_original_pc();
+  address original_pc = get_deopt_original_pc(nullptr);
   if (original_pc != nullptr) {
     assert(original_pc == old_pc, "expected original PC to be stored before patching");
     _deopt_state = is_deoptimized;

--- a/src/hotspot/cpu/ppc/frame_ppc.inline.hpp
+++ b/src/hotspot/cpu/ppc/frame_ppc.inline.hpp
@@ -64,7 +64,7 @@ inline void frame::setup(kind knd) {
     }
   }
 
-  address original_pc = get_deopt_original_pc();
+  address original_pc = get_deopt_original_pc(nullptr);
   if (original_pc != nullptr) {
     _pc = original_pc;
     _deopt_state = is_deoptimized;

--- a/src/hotspot/cpu/riscv/frame_riscv.cpp
+++ b/src/hotspot/cpu/riscv/frame_riscv.cpp
@@ -277,7 +277,7 @@ void frame::patch_pc(Thread* thread, address pc) {
   DEBUG_ONLY(address old_pc = _pc;)
   *pc_addr = pc;
   _pc = pc; // must be set before call to get_deopt_original_pc
-  address original_pc = get_deopt_original_pc();
+  address original_pc = get_deopt_original_pc(nullptr);
   if (original_pc != nullptr) {
     assert(original_pc == old_pc, "expected original PC to be stored before patching");
     _deopt_state = is_deoptimized;
@@ -434,15 +434,10 @@ JavaThread** frame::saved_thread_address(const frame& f) {
 // given unextended SP.
 #ifdef ASSERT
 void frame::verify_deopt_original_pc(nmethod* nm, intptr_t* unextended_sp) {
-  frame fr;
-
-  // This is ugly but it's better than to change {get,set}_original_pc
-  // to take an SP value as argument.  And it's only a debugging
-  // method anyway.
-  fr._unextended_sp = unextended_sp;
+  assert(unextended_sp == _unextended_sp, "expected to be the same frame");
 
   assert_cond(nm != nullptr);
-  address original_pc = nm->get_original_pc(&fr);
+  address original_pc = get_original_pc(nullptr, nm);
   assert(nm->insts_contains_inclusive(original_pc),
          "original PC must be in the main code section of the compiled method (or must be immediately following it)");
 }

--- a/src/hotspot/cpu/riscv/frame_riscv.hpp
+++ b/src/hotspot/cpu/riscv/frame_riscv.hpp
@@ -187,7 +187,7 @@
 
 #ifdef ASSERT
   // Used in frame::sender_for_{interpreter,compiled}_frame
-  static void verify_deopt_original_pc(nmethod* nm, intptr_t* unextended_sp);
+  void verify_deopt_original_pc(nmethod* nm, intptr_t* unextended_sp);
 #endif
 
  public:

--- a/src/hotspot/cpu/riscv/frame_riscv.inline.hpp
+++ b/src/hotspot/cpu/riscv/frame_riscv.inline.hpp
@@ -116,7 +116,7 @@ inline void frame::init(intptr_t* ptr_sp, intptr_t* ptr_fp, address pc) {
 inline void frame::setup(address pc) {
   adjust_unextended_sp();
 
-  address original_pc = get_deopt_original_pc();
+  address original_pc = get_deopt_original_pc(nullptr);
   if (original_pc != nullptr) {
     _pc = original_pc;
     _deopt_state = is_deoptimized;
@@ -217,7 +217,7 @@ inline frame::frame(intptr_t* ptr_sp, intptr_t* ptr_fp) {
   _cb = CodeCache::find_blob(_pc);
   adjust_unextended_sp();
 
-  address original_pc = get_deopt_original_pc();
+  address original_pc = get_deopt_original_pc(nullptr);
   if (original_pc != nullptr) {
     _pc = original_pc;
     _deopt_state = is_deoptimized;

--- a/src/hotspot/cpu/s390/frame_s390.cpp
+++ b/src/hotspot/cpu/s390/frame_s390.cpp
@@ -272,7 +272,7 @@ void frame::patch_pc(Thread* thread, address pc) {
   DEBUG_ONLY(address old_pc = _pc;)
   own_abi()->return_pc = (uint64_t)pc;
   _pc = pc; // must be set before call to get_deopt_original_pc
-  address original_pc = get_deopt_original_pc();
+  address original_pc = get_deopt_original_pc(nullptr);
   if (original_pc != nullptr) {
     // assert(original_pc == _pc, "expected original to be stored before patching");
     _deopt_state = is_deoptimized;

--- a/src/hotspot/cpu/s390/frame_s390.inline.hpp
+++ b/src/hotspot/cpu/s390/frame_s390.inline.hpp
@@ -56,7 +56,7 @@ inline void frame::setup() {
   assert(_on_heap || (is_aligned(_sp, alignment_in_bytes) && is_aligned(_fp, alignment_in_bytes)),
          "invalid alignment sp:" PTR_FORMAT " unextended_sp:" PTR_FORMAT " fp:" PTR_FORMAT, p2i(_sp), p2i(_unextended_sp), p2i(_fp));
 
-  address original_pc = get_deopt_original_pc();
+  address original_pc = get_deopt_original_pc(nullptr);
   if (original_pc != nullptr) {
     _pc = original_pc;
     _deopt_state = is_deoptimized;

--- a/src/hotspot/cpu/x86/frame_x86.cpp
+++ b/src/hotspot/cpu/x86/frame_x86.cpp
@@ -287,7 +287,7 @@ void frame::patch_pc(Thread* thread, address pc) {
   DEBUG_ONLY(address old_pc = _pc;)
   *pc_addr = pc;
   _pc = pc; // must be set before call to get_deopt_original_pc
-  address original_pc = get_deopt_original_pc();
+  address original_pc = get_deopt_original_pc(nullptr);
   if (original_pc != nullptr) {
     assert(original_pc == old_pc, "expected original PC to be stored before patching");
     _deopt_state = is_deoptimized;
@@ -450,14 +450,9 @@ JavaThread** frame::saved_thread_address(const frame& f) {
 // given unextended SP.
 #ifdef ASSERT
 void frame::verify_deopt_original_pc(nmethod* nm, intptr_t* unextended_sp) {
-  frame fr;
+  assert(unextended_sp == _unextended_sp, "expected to be the same frame");
 
-  // This is ugly but it's better than to change {get,set}_original_pc
-  // to take an SP value as argument.  And it's only a debugging
-  // method anyway.
-  fr._unextended_sp = unextended_sp;
-
-  address original_pc = nm->get_original_pc(&fr);
+  address original_pc = get_original_pc(nullptr, nm);
   assert(nm->insts_contains_inclusive(original_pc),
          "original PC must be in the main code section of the compiled method (or must be immediately following it) original_pc: " INTPTR_FORMAT " unextended_sp: " INTPTR_FORMAT " name: %s", p2i(original_pc), p2i(unextended_sp), nm->name());
 }

--- a/src/hotspot/cpu/x86/frame_x86.hpp
+++ b/src/hotspot/cpu/x86/frame_x86.hpp
@@ -146,7 +146,7 @@
 
 #ifdef ASSERT
   // Used in frame::sender_for_{interpreter,compiled}_frame
-  static void verify_deopt_original_pc(nmethod* nm, intptr_t* unextended_sp);
+  void verify_deopt_original_pc(nmethod* nm, intptr_t* unextended_sp);
 #endif
 
  public:

--- a/src/hotspot/cpu/x86/frame_x86.inline.hpp
+++ b/src/hotspot/cpu/x86/frame_x86.inline.hpp
@@ -113,7 +113,8 @@ inline void frame::init(intptr_t* sp, intptr_t* fp, address pc) {
 inline void frame::setup(address pc) {
   adjust_unextended_sp();
 
-  address original_pc = get_deopt_original_pc();
+  assert(_pc == pc, "must have been set");
+  address original_pc = get_deopt_original_pc(nullptr);
   if (original_pc != nullptr) {
     _pc = original_pc;
     _deopt_state = is_deoptimized;
@@ -211,7 +212,7 @@ inline frame::frame(intptr_t* sp, intptr_t* fp) {
   _cb = CodeCache::find_blob(_pc);
   adjust_unextended_sp();
 
-  address original_pc = get_deopt_original_pc();
+  address original_pc = get_deopt_original_pc(nullptr);
   if (original_pc != nullptr) {
     _pc = original_pc;
     _deopt_state = is_deoptimized;

--- a/src/hotspot/os/posix/signals_posix.cpp
+++ b/src/hotspot/os/posix/signals_posix.cpp
@@ -627,7 +627,7 @@ int JVM_HANDLE_XXX_SIGNAL(int sig, siginfo_t* info,
         assert(deopt != nullptr, "");
 
         frame fr = os::fetch_frame_from_context(uc);
-        nm->set_original_pc(&fr, pc);
+        fr.set_original_pc(nullptr, nm, pc);
 
         os::Posix::ucontext_set_pc(uc, deopt);
         signal_was_handled = true;

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -2797,7 +2797,7 @@ LONG WINAPI topLevelExceptionFilter(struct _EXCEPTION_POINTERS* exceptionInfo) {
             nm->deopt_mh_handler_begin() :
             nm->deopt_handler_begin();
           assert(nm->insts_contains_inclusive(pc), "");
-          nm->set_original_pc(&fr, pc);
+          fr.set_original_pc(nullptr, nm, pc);
           // Set pc to handler
           exceptionInfo->ContextRecord->PC_NAME = (DWORD64)deopt;
           return EXCEPTION_CONTINUE_EXECUTION;

--- a/src/hotspot/share/code/nmethod.cpp
+++ b/src/hotspot/share/code/nmethod.cpp
@@ -854,10 +854,6 @@ void nmethod::cleanup_inline_caches_whitebox() {
   cleanup_inline_caches_impl(false /* unloading_occurred */, true /* clean_all */);
 }
 
-address* nmethod::orig_pc_addr(const frame* fr) {
-  return (address*) ((address)fr->unextended_sp() + orig_pc_offset());
-}
-
 // Called to clean up after class unloading for live nmethods
 void nmethod::cleanup_inline_caches_impl(bool unloading_occurred, bool clean_all) {
   assert(CompiledICLocker::is_safe(this), "mt unsafe call");

--- a/src/hotspot/share/code/nmethod.hpp
+++ b/src/hotspot/share/code/nmethod.hpp
@@ -827,9 +827,9 @@ public:
   inline bool is_deopt_mh_entry(address pc);
   inline bool is_deopt_entry(address pc);
 
-  // Accessor/mutator for the original pc of a frame before a frame was deopted.
-  address get_original_pc(const frame* fr) { return *orig_pc_addr(fr); }
-  void    set_original_pc(const frame* fr, address pc) { *orig_pc_addr(fr) = pc; }
+  int orig_pc_offset() const {
+    return _orig_pc_offset;
+  }
 
   const char* state() const;
 
@@ -951,8 +951,6 @@ public:
 
  private:
   ScopeDesc* scope_desc_in(address begin, address end);
-
-  address* orig_pc_addr(const frame* fr);
 
   // used by jvmti to track if the load events has been reported
   bool  load_reported() const                     { return _load_reported; }

--- a/src/hotspot/share/jfr/leakprofiler/checkpoint/rootResolver.cpp
+++ b/src/hotspot/share/jfr/leakprofiler/checkpoint/rootResolver.cpp
@@ -262,17 +262,6 @@ bool ReferenceToThreadRootClosure::do_thread_stack_detailed(JavaThread* jt) {
     return true;
   }
 
-  GrowableArrayView<jvmtiDeferredLocalVariableSet*>* const list = JvmtiDeferredUpdates::deferred_locals(jt);
-  if (list != nullptr) {
-    for (int i = 0; i < list->length(); i++) {
-      list->at(i)->oops_do(&rcl);
-    }
-  }
-
-  if (rcl.complete()) {
-    return true;
-  }
-
   // Traverse instance variables at the end since the GC may be moving things
   // around using this function
   /*

--- a/src/hotspot/share/jvmci/jvmciEnv.cpp
+++ b/src/hotspot/share/jvmci/jvmciEnv.cpp
@@ -445,7 +445,7 @@ class ExceptionTranslation: public StackObj {
       } else {
         decode(THREAD, _encoded_ok, buffer);
         if (!_to_env->has_pending_exception()) {
-          _to_env->throw_InternalError("decodeAndThrowThrowable should have thrown an exception");
+          _to_env->throw_InternalError("decodeAndThrowThrowable should have thrown an exception", __FILE__, __LINE__);
         }
         return;
       }
@@ -905,15 +905,15 @@ const char* JVMCIEnv::as_utf8_string(JVMCIObject str) {
   }
 }
 
-#define DO_THROW(name)                             \
-void JVMCIEnv::throw_##name(const char* msg) {     \
-  if (is_hotspot()) {                              \
-    JavaThread* THREAD = JavaThread::current();    \
-    THROW_MSG(HotSpotJVMCI::name::symbol(), msg);  \
-  } else {                                         \
-    JNIAccessMark jni(this);                       \
-    jni()->ThrowNew(JNIJVMCI::name::clazz(), msg); \
-  }                                                \
+#define DO_THROW(name)                                                             \
+void JVMCIEnv::throw_##name(const char* msg, const char* file, int line) {         \
+  if (is_hotspot()) {                                                              \
+    JavaThread* THREAD = JavaThread::current();                                    \
+    Exceptions::_throw_msg(THREAD, file, line, HotSpotJVMCI::name::symbol(), msg); \
+  } else {                                                                         \
+    JNIAccessMark jni(this);                                                       \
+    jni()->ThrowNew(JNIJVMCI::name::clazz(), msg);                                 \
+  }                                                                                \
 }
 
 DO_THROW(InternalError)

--- a/src/hotspot/share/jvmci/jvmciEnv.hpp
+++ b/src/hotspot/share/jvmci/jvmciEnv.hpp
@@ -370,7 +370,7 @@ public:
   BasicType kindToBasicType(JVMCIObject kind, JVMCI_TRAPS);
 
 #define DO_THROW(name) \
-  void throw_##name(const char* msg = nullptr);
+  void throw_##name(const char* msg, const char* file, int line);
 
   DO_THROW(InternalError)
   DO_THROW(ArrayIndexOutOfBoundsException)

--- a/src/hotspot/share/jvmci/jvmciExceptions.hpp
+++ b/src/hotspot/share/jvmci/jvmciExceptions.hpp
@@ -67,14 +67,14 @@ class JVMCIEnv;
 #define JVMCI_ERROR_NULL(...) JVMCI_ERROR_(nullptr, __VA_ARGS__)
 #define JVMCI_ERROR_OK(...)   JVMCI_ERROR_(JVMCI::ok, __VA_ARGS__)
 
-#define JVMCI_THROW(name) { JVMCIENV->throw_##name(); return; }
-#define JVMCI_THROW_NULL(name) { JVMCIENV->throw_##name(); return nullptr; }
-#define JVMCI_THROW_0(name) { JVMCIENV->throw_##name(); return 0; }
-#define JVMCI_THROW_MSG_NULL(name, msg) { JVMCIENV->throw_##name(msg); return nullptr; }
-#define JVMCI_THROW_MSG_(name, msg, value) { JVMCIENV->throw_##name(msg); return (value); }
-#define JVMCI_THROW_MSG_0(name, msg) { JVMCIENV->throw_##name(msg); return 0; }
-#define JVMCI_THROW_MSG(name, msg) { JVMCIENV->throw_##name(msg); return; }
-#define JVMCI_THROW_(name, value) { JVMCIENV->throw_##name(); return (value); }
+#define JVMCI_THROW(name)                  { JVMCIENV->throw_##name(nullptr, __FILE__, __LINE__); return; }
+#define JVMCI_THROW_NULL(name)             { JVMCIENV->throw_##name(nullptr, __FILE__, __LINE__); return nullptr; }
+#define JVMCI_THROW_0(name)                { JVMCIENV->throw_##name(nullptr, __FILE__, __LINE__); return 0; }
+#define JVMCI_THROW_MSG_NULL(name, msg)    { JVMCIENV->throw_##name(msg,     __FILE__, __LINE__); return nullptr; }
+#define JVMCI_THROW_MSG_(name, msg, value) { JVMCIENV->throw_##name(msg,     __FILE__, __LINE__); return (value); }
+#define JVMCI_THROW_MSG_0(name, msg)       { JVMCIENV->throw_##name(msg,     __FILE__, __LINE__); return 0; }
+#define JVMCI_THROW_MSG(name, msg)         { JVMCIENV->throw_##name(msg,     __FILE__, __LINE__); return; }
+#define JVMCI_THROW_(name, value)          { JVMCIENV->throw_##name(nullptr, __FILE__, __LINE__); return (value); }
 
 #define JVMCI_CATCH                              \
   JVMCIENV); if (JVMCI_HAS_PENDING_EXCEPTION) {  \

--- a/src/hotspot/share/jvmci/jvmciJavaClasses.hpp
+++ b/src/hotspot/share/jvmci/jvmciJavaClasses.hpp
@@ -188,10 +188,10 @@
     object_field(ValueKind, platformKind, "Ljdk/vm/ci/meta/PlatformKind;")                                    \
   end_class                                                                                                   \
   start_class(HotSpotStackFrameReference, jdk_vm_ci_hotspot_HotSpotStackFrameReference)                       \
-    object_field(HotSpotStackFrameReference, compilerToVM, "Ljdk/vm/ci/hotspot/CompilerToVM;")                \
     boolean_field(HotSpotStackFrameReference, objectsMaterialized)                                            \
-    long_field(HotSpotStackFrameReference, stackPointer)                                                      \
+    long_field(HotSpotStackFrameReference, startingFrameId)                                                   \
     int_field(HotSpotStackFrameReference, frameNumber)                                                        \
+    int_field(HotSpotStackFrameReference, vframeId)                                                           \
     int_field(HotSpotStackFrameReference, bci)                                                                \
     object_field(HotSpotStackFrameReference, method, "Ljdk/vm/ci/hotspot/HotSpotResolvedJavaMethod;")         \
     objectarray_field(HotSpotStackFrameReference, locals, "[Ljava/lang/Object;")                              \

--- a/src/hotspot/share/prims/jvmtiDeferredUpdates.cpp
+++ b/src/hotspot/share/prims/jvmtiDeferredUpdates.cpp
@@ -25,62 +25,10 @@
 
 #include "prims/jvmtiDeferredUpdates.hpp"
 
-void JvmtiDeferredUpdates::create_for(JavaThread* thread) {
-  assert(thread->deferred_updates() == nullptr, "already allocated");
-  thread->set_deferred_updates(new JvmtiDeferredUpdates());
-}
-
 JvmtiDeferredUpdates::~JvmtiDeferredUpdates() {
   while (_deferred_locals_updates.length() != 0) {
     jvmtiDeferredLocalVariableSet* dlv = _deferred_locals_updates.pop();
     // individual jvmtiDeferredLocalVariableSet are CHeapObj's
     delete dlv;
-  }
-}
-
-void JvmtiDeferredUpdates::inc_relock_count_after_wait(JavaThread* thread) {
-  if (thread->deferred_updates() == nullptr) {
-    create_for(thread);
-  }
-  thread->deferred_updates()->inc_relock_count_after_wait();
-}
-
-int JvmtiDeferredUpdates::get_and_reset_relock_count_after_wait(JavaThread* jt) {
-  JvmtiDeferredUpdates* updates = jt->deferred_updates();
-  int result = 0;
-  if (updates != nullptr) {
-    result = updates->get_and_reset_relock_count_after_wait();
-    if (updates->count() == 0) {
-      delete updates;
-      jt->set_deferred_updates(nullptr);
-    }
-  }
-  return result;
-}
-
-void JvmtiDeferredUpdates::delete_updates_for_frame(JavaThread* jt, intptr_t* frame_id) {
-  JvmtiDeferredUpdates* updates = jt->deferred_updates();
-  if (updates != nullptr) {
-    GrowableArray<jvmtiDeferredLocalVariableSet*>* list = updates->deferred_locals();
-    assert(list->length() > 0, "Updates holder not deleted");
-    int i = 0;
-    do {
-      // Because of inlining we could have multiple vframes for a single frame
-      // and several of the vframes could have deferred writes. Find them all.
-      jvmtiDeferredLocalVariableSet* dlv = list->at(i);
-      if (dlv->id() == frame_id) {
-        list->remove_at(i);
-        // individual jvmtiDeferredLocalVariableSet are CHeapObj's
-        delete dlv;
-      } else {
-        i++;
-      }
-    } while ( i < list->length() );
-    if (updates->count() == 0) {
-      jt->set_deferred_updates(nullptr);
-      // Free deferred updates.
-      // Note, the 'list' of local variable updates is embedded in 'updates'.
-      delete updates;
-    }
   }
 }

--- a/src/hotspot/share/prims/jvmtiDeferredUpdates.hpp
+++ b/src/hotspot/share/prims/jvmtiDeferredUpdates.hpp
@@ -70,7 +70,6 @@ private:
 
   Method*   _method;
   int       _bci;
-  intptr_t* _id;
   int       _vframe_id;
   GrowableArray<jvmtiDeferredLocalVariable*>* _locals;
   bool      _objects_are_deoptimized;
@@ -83,7 +82,6 @@ private:
   // JVM state
   Method*   method()                  const { return _method; }
   int       bci()                     const { return _bci; }
-  intptr_t* id()                      const { return _id; }
   int       vframe_id()               const { return _vframe_id; }
   bool      objects_are_deoptimized() const { return _objects_are_deoptimized; }
 
@@ -95,14 +93,11 @@ private:
   // Does the vframe match this jvmtiDeferredLocalVariableSet
   bool      matches(const vframe* vf);
 
-  // Does the underlying physical frame match this jvmtiDeferredLocalVariableSet
-  bool      matches(intptr_t* fr_id)        { return id() == fr_id; }
-
   // GC
   void      oops_do(OopClosure* f);
 
   // constructor
-  jvmtiDeferredLocalVariableSet(Method* method, int bci, intptr_t* id, int vframe_id);
+  jvmtiDeferredLocalVariableSet(Method* method, int bci, int vframe_id);
 
   // destructor
   ~jvmtiDeferredLocalVariableSet();
@@ -112,51 +107,21 @@ private:
 
 class JvmtiDeferredUpdates : public CHeapObj<mtCompiler> {
 
-  // Relocking has to be deferred if the lock owning thread is currently waiting on the monitor.
-  int _relock_count_after_wait;
+  address _original_pc;
 
   // Deferred updates of locals, expressions, and monitors
   GrowableArray<jvmtiDeferredLocalVariableSet*> _deferred_locals_updates;
 
-  void inc_relock_count_after_wait() {
-    _relock_count_after_wait++;
-  }
-
-  int get_and_reset_relock_count_after_wait() {
-    int result = _relock_count_after_wait;
-    _relock_count_after_wait = 0;
-    return result;
-  }
-
-  GrowableArray<jvmtiDeferredLocalVariableSet*>* deferred_locals() { return &_deferred_locals_updates; }
-
-  JvmtiDeferredUpdates() :
-    _relock_count_after_wait(0),
-    _deferred_locals_updates((AnyObj::set_allocation_type((address) &_deferred_locals_updates,
-                             AnyObj::C_HEAP), 1), mtCompiler) { }
-
 public:
+  JvmtiDeferredUpdates(address original_pc) :
+    _original_pc(original_pc),
+    _deferred_locals_updates((AnyObj::set_allocation_type((address) &_deferred_locals_updates,
+                                                          AnyObj::C_HEAP), 1), mtCompiler) { }
+
   ~JvmtiDeferredUpdates();
 
-  static void create_for(JavaThread* thread);
-
-  static GrowableArray<jvmtiDeferredLocalVariableSet*>* deferred_locals(JavaThread* jt) {
-    return jt->deferred_updates() == nullptr ? nullptr : jt->deferred_updates()->deferred_locals();
-  }
-
-  // Relocking has to be deferred if the lock owning thread is currently waiting on the monitor.
-  static int  get_and_reset_relock_count_after_wait(JavaThread* jt);
-  static void inc_relock_count_after_wait(JavaThread* thread);
-
-  // Delete deferred updates for the compiled frame with id 'frame_id' on the
-  // given thread's stack. The thread's JvmtiDeferredUpdates instance will be
-  // deleted too if no updates remain.
-  static void delete_updates_for_frame(JavaThread* jt, intptr_t* frame_id);
-
-  // Number of deferred updates
-  int count() const {
-    return _deferred_locals_updates.length() + (_relock_count_after_wait > 0 ? 1 : 0);
-  }
+  address original_pc() const { return _original_pc; }
+  GrowableArray<jvmtiDeferredLocalVariableSet*>* deferred_locals() { return &_deferred_locals_updates; }
 };
 
 #endif // SHARE_PRIMS_JVMTIDEFERREDUPDATES_HPP

--- a/src/hotspot/share/prims/jvmtiEnvBase.cpp
+++ b/src/hotspot/share/prims/jvmtiEnvBase.cpp
@@ -2426,7 +2426,7 @@ UpdateForPopTopFrameClosure::doit(Thread *target) {
       return;
     }
     is_interpreted[frame_count] = vfs.is_interpreted_frame();
-    frame_sp[frame_count] = vfs.frame_id();
+    frame_sp[frame_count] = vfs.current()->id();
     if (++frame_count > 1) break;
   }
   if (frame_count < 2)  {

--- a/src/hotspot/share/prims/jvmtiEventController.cpp
+++ b/src/hotspot/share/prims/jvmtiEventController.cpp
@@ -239,7 +239,7 @@ class EnterInterpOnlyModeClosure : public HandshakeClosure {
       ResourceMark resMark;
       for (StackFrameStream fst(jt, false /* update */, false /* process_frames */); !fst.is_done(); fst.next()) {
         if (fst.current()->can_be_deoptimized()) {
-          Deoptimization::deoptimize(jt, *fst.current());
+          Deoptimization::deoptimize(jt, *fst.current(), fst.register_map());
         }
       }
     }

--- a/src/hotspot/share/prims/scopedMemoryAccess.cpp
+++ b/src/hotspot/share/prims/scopedMemoryAccess.cpp
@@ -198,7 +198,7 @@ public:
           // We would like to deoptimize here only if last_frame::oops_do
           // reports the session oop being live at this safepoint, but this
           // currently isn't possible due to JDK-8290892
-          Deoptimization::deoptimize(jt, last_frame);
+          Deoptimization::deoptimize(jt, last_frame, nullptr);
         }
       }
     }

--- a/src/hotspot/share/prims/vectorSupport.cpp
+++ b/src/hotspot/share/prims/vectorSupport.cpp
@@ -104,7 +104,7 @@ void VectorSupport::init_payload_element(typeArrayOop arr, BasicType elem_bt, in
   }
 }
 
-Handle VectorSupport::allocate_vector_payload_helper(InstanceKlass* ik, frame* fr, RegisterMap* reg_map, Location location, TRAPS) {
+Handle VectorSupport::allocate_vector_payload_helper(InstanceKlass* ik, frame* fr, const RegisterMap* reg_map, Location location, TRAPS) {
   int num_elem = klass2length(ik);
   BasicType elem_bt = klass2bt(ik);
   int elem_size = type2aelembytes(elem_bt);
@@ -133,7 +133,7 @@ Handle VectorSupport::allocate_vector_payload_helper(InstanceKlass* ik, frame* f
   return Handle(THREAD, arr);
 }
 
-Handle VectorSupport::allocate_vector_payload(InstanceKlass* ik, frame* fr, RegisterMap* reg_map, ScopeValue* payload, TRAPS) {
+Handle VectorSupport::allocate_vector_payload(InstanceKlass* ik, frame* fr, const RegisterMap* reg_map, ScopeValue* payload, TRAPS) {
   if (payload->is_location()) {
     Location location = payload->as_LocationValue()->location();
     if (location.type() == Location::vector) {
@@ -157,7 +157,7 @@ Handle VectorSupport::allocate_vector_payload(InstanceKlass* ik, frame* fr, Regi
   return Handle(THREAD, nullptr);
 }
 
-instanceOop VectorSupport::allocate_vector(InstanceKlass* ik, frame* fr, RegisterMap* reg_map, ObjectValue* ov, TRAPS) {
+instanceOop VectorSupport::allocate_vector(InstanceKlass* ik, frame* fr, const RegisterMap* reg_map, ObjectValue* ov, TRAPS) {
   assert(is_vector(ik), "%s not a vector", ik->name()->as_C_string());
   assert(ov->field_size() == 1, "%s not a vector", ik->name()->as_C_string());
 

--- a/src/hotspot/share/prims/vectorSupport.hpp
+++ b/src/hotspot/share/prims/vectorSupport.hpp
@@ -38,8 +38,8 @@ extern "C" {
 
 class VectorSupport : AllStatic {
  private:
-  static Handle allocate_vector_payload(InstanceKlass* ik, frame* fr, RegisterMap* reg_map, ScopeValue* payload, TRAPS);
-  static Handle allocate_vector_payload_helper(InstanceKlass* ik, frame* fr, RegisterMap* reg_map, Location location, TRAPS);
+  static Handle allocate_vector_payload(InstanceKlass* ik, frame* fr, const RegisterMap* reg_map, ScopeValue* payload, TRAPS);
+  static Handle allocate_vector_payload_helper(InstanceKlass* ik, frame* fr, const RegisterMap* reg_map, Location location, TRAPS);
 
   static void init_payload_element(typeArrayOop arr, BasicType elem_bt, int index, address addr);
 
@@ -127,7 +127,7 @@ class VectorSupport : AllStatic {
   static bool has_scalar_op(jint id);
   static bool is_unsigned_op(jint id);
 
-  static instanceOop allocate_vector(InstanceKlass* holder, frame* fr, RegisterMap* reg_map, ObjectValue* sv, TRAPS);
+  static instanceOop allocate_vector(InstanceKlass* holder, frame* fr, const RegisterMap* reg_map, ObjectValue* sv, TRAPS);
 
   static bool is_vector(Klass* klass);
   static bool is_vector_mask(Klass* klass);

--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -769,7 +769,7 @@ class VM_WhiteBoxDeoptimizeFrames : public VM_WhiteBoxOperation {
         for (StackFrameStream fst(t, false /* update */, true /* process_frames */); !fst.is_done(); fst.next()) {
           frame* f = fst.current();
           if (f->can_be_deoptimized() && !f->is_deoptimized_frame()) {
-            Deoptimization::deoptimize(t, *f);
+            Deoptimization::deoptimize(t, *f, fst.register_map());
             if (_make_not_entrant) {
                 nmethod* nm = CodeCache::find_nmethod(f->pc());
                 assert(nm != nullptr, "did not find nmethod");

--- a/src/hotspot/share/runtime/continuationFreezeThaw.cpp
+++ b/src/hotspot/share/runtime/continuationFreezeThaw.cpp
@@ -2076,7 +2076,7 @@ int ThawBase::remove_top_compiled_frame_from_chunk(stackChunkOop chunk, int &arg
       // The caller of the runtime stub when the continuation is preempted is not at a
       // Java call instruction, and so cannot rely on nmethod patching for deopt.
       log_develop_trace(continuations)("Deoptimizing runtime stub caller");
-      f.to_frame().deoptimize(nullptr); // the null thread simply avoids the assertion in deoptimize which we're not set up for
+      f.to_frame().deoptimize(nullptr, nullptr); // the null thread simply avoids the assertion in deoptimize which we're not set up for
     }
   }
 
@@ -2632,7 +2632,7 @@ void ThawBase::recurse_thaw_compiled_frame(const frame& hf, frame& caller, int n
     log_develop_trace(continuations)("Deoptimizing thawed frame");
     DEBUG_ONLY(ContinuationHelper::Frame::patch_pc(f, nullptr));
 
-    f.deoptimize(nullptr); // the null thread simply avoids the assertion in deoptimize which we're not set up for
+    f.deoptimize(nullptr, nullptr); // the null thread simply avoids the assertion in deoptimize which we're not set up for
     assert(f.is_deoptimized_frame(), "");
     assert(ContinuationHelper::Frame::is_deopt_return(f.raw_pc(), f), "");
     maybe_set_fastpath(f.sp());
@@ -2905,7 +2905,7 @@ static bool do_verify_after_thaw(JavaThread* thread, stackChunkOop chunk, output
   for (; !fst.is_done() && !Continuation::is_continuation_enterSpecial(*fst.current()); fst.next()) {
     if (fst.current()->cb()->is_nmethod() && fst.current()->cb()->as_nmethod()->is_marked_for_deoptimization()) {
       st->print_cr(">>> do_verify_after_thaw deopt");
-      fst.current()->deoptimize(nullptr);
+      fst.current()->deoptimize(nullptr, nullptr);
       fst.current()->print_on(st);
     }
 

--- a/src/hotspot/share/runtime/deoptimization.hpp
+++ b/src/hotspot/share/runtime/deoptimization.hpp
@@ -181,16 +181,16 @@ class Deoptimization : AllStatic {
 
  public:
   // Deoptimizes a frame lazily. Deopt happens on return to the frame.
-  static void deoptimize(JavaThread* thread, frame fr, DeoptReason reason = Reason_constraint);
+  static void deoptimize(JavaThread* thread, frame fr, const RegisterMap* reg_map, DeoptReason reason = Reason_constraint);
 
 #if INCLUDE_JVMCI
   static address deoptimize_for_missing_exception_handler(nmethod* nm);
-  static oop get_cached_box(AutoBoxObjectValue* bv, frame* fr, RegisterMap* reg_map, bool& cache_init_error, TRAPS);
+  static oop get_cached_box(AutoBoxObjectValue* bv, frame* fr, const RegisterMap* reg_map, bool& cache_init_error, TRAPS);
 #endif
 
   private:
   // Does the actual work for deoptimizing a single frame
-  static void deoptimize_single_frame(JavaThread* thread, frame fr, DeoptReason reason);
+  static void deoptimize_single_frame(JavaThread* thread, frame fr, const RegisterMap* reg_map, DeoptReason reason);
 
 #if COMPILER2_OR_JVMCI
   // Deoptimize objects, that is reallocate and relock them, just before they
@@ -201,10 +201,10 @@ class Deoptimization : AllStatic {
  public:
 
   // Support for restoring non-escaping objects
-  static bool realloc_objects(JavaThread* thread, frame* fr, RegisterMap* reg_map, GrowableArray<ScopeValue*>* objects, TRAPS);
-  static void reassign_type_array_elements(frame* fr, RegisterMap* reg_map, ObjectValue* sv, typeArrayOop obj, BasicType type);
-  static void reassign_object_array_elements(frame* fr, RegisterMap* reg_map, ObjectValue* sv, objArrayOop obj);
-  static void reassign_fields(frame* fr, RegisterMap* reg_map, GrowableArray<ScopeValue*>* objects, bool realloc_failures, bool skip_internal);
+  static bool realloc_objects(JavaThread* thread, frame* fr, const RegisterMap* reg_map, GrowableArray<ScopeValue*>* objects, TRAPS);
+  static void reassign_type_array_elements(frame* fr, const RegisterMap* reg_map, ObjectValue* sv, typeArrayOop obj, BasicType type);
+  static void reassign_object_array_elements(frame* fr, const RegisterMap* reg_map, ObjectValue* sv, objArrayOop obj);
+  static void reassign_fields(frame* fr, const RegisterMap* reg_map, GrowableArray<ScopeValue*>* objects, bool realloc_failures, bool skip_internal);
   static bool relock_objects(JavaThread* thread, GrowableArray<MonitorInfo*>* monitors,
                              JavaThread* deoptee_thread, frame& fr, int exec_mode, bool realloc_failures);
   static void pop_frames_failed_reallocs(JavaThread* thread, vframeArray* array);
@@ -324,6 +324,7 @@ class Deoptimization : AllStatic {
   // VM_DeoptimizeFrame otherwise deoptimize directly.
   static void deoptimize_frame(JavaThread* thread, intptr_t* id, DeoptReason reason);
   static void deoptimize_frame(JavaThread* thread, intptr_t* id);
+  static void deoptimize_frame(JavaThread* thread, compiledVFrame* cvf);
 
   // Statistics
   static void gather_statistics(DeoptReason reason, DeoptAction action,

--- a/src/hotspot/share/runtime/escapeBarrier.hpp
+++ b/src/hotspot/share/runtime/escapeBarrier.hpp
@@ -31,6 +31,7 @@
 #include "utilities/macros.hpp"
 
 class JavaThread;
+class compiledVFrame;
 
 // EscapeBarriers should be put on execution paths where JVMTI agents can access object
 // references held by java threads.
@@ -59,12 +60,12 @@ class EscapeBarrier : StackObj {
   void resume_all();
 
   // Deoptimize the given frame and deoptimize objects with optimizations based on escape analysis.
-  bool deoptimize_objects_internal(JavaThread* deoptee, intptr_t* fr_id);
+  bool deoptimize_objects_internal(JavaThread* deoptee, compiledVFrame* cvf);
 
   // Deoptimize objects, i.e. reallocate and relock them. The target frames are deoptimized.
   // The methods return false iff at least one reallocation failed.
-  bool deoptimize_objects(intptr_t* fr_id) {
-    return deoptimize_objects_internal(deoptee_thread(), fr_id);
+  bool deoptimize_objects(compiledVFrame* cvf) {
+    return deoptimize_objects_internal(deoptee_thread(), cvf);
   }
 
 public:
@@ -118,7 +119,7 @@ public:
 
 #if COMPILER2_OR_JVMCI
   // Returns true iff objects were reallocated and relocked because of access through JVMTI.
-  static bool objs_are_deoptimized(JavaThread* thread, intptr_t* fr_id);
+  static bool objs_are_deoptimized(JavaThread* thread, compiledVFrame* cvf);
 
   ~EscapeBarrier() {
     if (!barrier_active()) return;

--- a/src/hotspot/share/runtime/frame.inline.hpp
+++ b/src/hotspot/share/runtime/frame.inline.hpp
@@ -71,12 +71,12 @@ inline bool frame::is_compiled_frame() const {
   return false;
 }
 
-inline address frame::get_deopt_original_pc() const {
+inline address frame::get_deopt_original_pc(stackChunkOop chunk) const {
   if (_cb == nullptr)  return nullptr;
 
   nmethod* nm = _cb->as_nmethod_or_null();
   if (nm != nullptr && nm->is_deopt_pc(_pc)) {
-    return nm->get_original_pc(this);
+    return get_original_pc(chunk, nm);
   }
   return nullptr;
 }

--- a/src/hotspot/share/runtime/javaThread.hpp
+++ b/src/hotspot/share/runtime/javaThread.hpp
@@ -59,7 +59,6 @@ class InternalOOMEMark;
 class JNIHandleBlock;
 class JVMCIRuntime;
 
-class JvmtiDeferredUpdates;
 class JvmtiSampledObjectAllocEventCollector;
 class JvmtiThreadState;
 
@@ -130,10 +129,9 @@ class JavaThread: public Thread {
   nmethod*      _deopt_nmethod;                  // nmethod that is currently being deoptimized
   vframeArray*  _vframe_array_head;              // Holds the heap of the active vframeArrays
   vframeArray*  _vframe_array_last;              // Holds last vFrameArray we popped
-  // Holds updates by JVMTI agents for compiled frames that cannot be performed immediately. They
-  // will be carried out as soon as possible which, in most cases, is just before deoptimization of
-  // the frame, when control returns to it.
-  JvmtiDeferredUpdates* _jvmti_deferred_updates;
+
+  // Relocking has to be deferred if the lock owning thread is currently waiting on the monitor.
+  int _relock_count_after_wait;
 
   // Handshake value for fixing 6243940. We need a place for the i2c
   // adapter to store the callee Method*. This value is NEVER live
@@ -764,9 +762,15 @@ public:
   void set_vframe_array_head(vframeArray* value) { _vframe_array_head = value; }
   vframeArray* vframe_array_head() const         { return _vframe_array_head;  }
 
-  // Side structure for deferring update of java frame locals until deopt occurs
-  JvmtiDeferredUpdates* deferred_updates() const      { return _jvmti_deferred_updates; }
-  void set_deferred_updates(JvmtiDeferredUpdates* du) { _jvmti_deferred_updates = du; }
+  void inc_relock_count_after_wait() {
+    _relock_count_after_wait++;
+  }
+
+  int get_and_reset_relock_count_after_wait() {
+    int result = _relock_count_after_wait;
+    _relock_count_after_wait = 0;
+    return result;
+  }
 
   // These only really exist to make debugging deopt problems simpler
 

--- a/src/hotspot/share/runtime/objectMonitor.cpp
+++ b/src/hotspot/share/runtime/objectMonitor.cpp
@@ -1949,7 +1949,7 @@ void ObjectMonitor::wait(jlong millis, bool interruptible, TRAPS) {
   current->set_current_waiting_monitor(nullptr);
 
   guarantee(_recursions == 0, "invariant");
-  int relock_count = JvmtiDeferredUpdates::get_and_reset_relock_count_after_wait(current);
+  int relock_count = current->get_and_reset_relock_count_after_wait();
   _recursions =   save          // restore the old recursion count
                 + relock_count; //  increased by the deferred relock count
   current->inc_held_monitor_count(relock_count); // Deopt never entered these counts.

--- a/src/hotspot/share/runtime/stackChunkFrameStream.inline.hpp
+++ b/src/hotspot/share/runtime/stackChunkFrameStream.inline.hpp
@@ -35,6 +35,7 @@
 #include "oops/oop.hpp"
 #include "oops/stackChunkOop.inline.hpp"
 #include "oops/instanceStackChunkKlass.inline.hpp"
+#include "prims/jvmtiDeferredUpdates.hpp"
 #include "runtime/frame.inline.hpp"
 #include "utilities/debug.hpp"
 #include "utilities/devirtualizer.inline.hpp"
@@ -326,9 +327,7 @@ inline address StackChunkFrameStream<frame_kind>::orig_pc() const {
     return pc1;
   }
   nmethod* nm = cb()->as_nmethod();
-  if (nm->is_deopt_pc(pc1)) {
-    pc1 = *(address*)((address)unextended_sp() + nm->orig_pc_offset());
-  }
+  pc1 = frame::get_deopt_original_pc(nm, pc1, (address)unextended_sp());
 
   assert(pc1 != nullptr, "");
   assert(!nm->is_deopt_pc(pc1), "");

--- a/src/hotspot/share/runtime/vframe.hpp
+++ b/src/hotspot/share/runtime/vframe.hpp
@@ -30,6 +30,7 @@
 #include "code/location.hpp"
 #include "oops/oop.hpp"
 #include "runtime/frame.hpp"
+#include "runtime/frame.inline.hpp"
 #include "runtime/handles.hpp"
 #include "runtime/registerMap.hpp"
 #include "runtime/stackValue.hpp"
@@ -300,11 +301,12 @@ class vframeStreamCommon : StackObj {
   }
 
   const RegisterMap* reg_map() { return &_reg_map; }
+  frame* current() { return &_frame; }
 
   javaVFrame* asJavaVFrame();
-
   // Frame type
   inline bool is_interpreted_frame() const;
+  inline bool is_compiled_frame() const;
 
   // Iteration
   inline void next();

--- a/src/hotspot/share/runtime/vframe.inline.hpp
+++ b/src/hotspot/share/runtime/vframe.inline.hpp
@@ -73,6 +73,7 @@ inline int vframeStreamCommon::decode_offset() const {
 }
 
 inline bool vframeStreamCommon::is_interpreted_frame() const { return _frame.is_interpreted_frame(); }
+inline bool vframeStreamCommon::is_compiled_frame() const { return _frame.is_compiled_frame(); }
 
 inline void vframeStreamCommon::next() {
   // handle frames with inlining

--- a/src/hotspot/share/runtime/vframe_hp.cpp
+++ b/src/hotspot/share/runtime/vframe_hp.cpp
@@ -64,7 +64,7 @@ StackValueCollection* compiledVFrame::locals() const {
   // Replace the original values with any stores that have been
   // performed through compiledVFrame::update_locals.
   if (!register_map()->in_cont()) { // LOOM TODO
-    GrowableArray<jvmtiDeferredLocalVariableSet*>* list = JvmtiDeferredUpdates::deferred_locals(thread());
+    GrowableArray<jvmtiDeferredLocalVariableSet*>* list = get_deferred_locals();
     if (list != nullptr ) {
       // In real life this never happens or is typically a single element search
       for (int i = 0; i < list->length(); i++) {
@@ -104,8 +104,7 @@ void compiledVFrame::update_monitor(int index, MonitorInfo* val) {
 
 void compiledVFrame::update_deferred_value(BasicType type, int index, jvalue value) {
   assert(fr().is_deoptimized_frame(), "frame must be scheduled for deoptimization");
-  assert(!Continuation::is_frame_in_continuation(thread(), fr()), "No support for deferred values in continuations");
-  GrowableArray<jvmtiDeferredLocalVariableSet*>* deferred = JvmtiDeferredUpdates::deferred_locals(thread());
+  GrowableArray<jvmtiDeferredLocalVariableSet*>* deferred = get_deferred_locals();
   jvmtiDeferredLocalVariableSet* locals = nullptr;
   if (deferred != nullptr ) {
     // See if this vframe has already had locals with deferred writes
@@ -119,13 +118,12 @@ void compiledVFrame::update_deferred_value(BasicType type, int index, jvalue val
   } else {
     // No deferred updates pending for this thread.
     // allocate in C heap
-    JvmtiDeferredUpdates::create_for(thread());
-    deferred = JvmtiDeferredUpdates::deferred_locals(thread());
+
+    deferred = fr().create_deferred_locals(_chunk());
   }
   if (locals == nullptr) {
-    locals = new jvmtiDeferredLocalVariableSet(method(), bci(), fr().id(), vframe_id());
+    locals = new jvmtiDeferredLocalVariableSet(method(), bci(), vframe_id());
     deferred->push(locals);
-    assert(locals->id() == fr().id(), "Huh? Must match");
   }
   locals->set_value_at(index, type, value);
 }
@@ -197,7 +195,7 @@ StackValueCollection* compiledVFrame::expressions() const {
   if (!register_map()->in_cont()) { // LOOM TODO
     // Replace the original values with any stores that have been
     // performed through compiledVFrame::update_stack.
-    GrowableArray<jvmtiDeferredLocalVariableSet*>* list = JvmtiDeferredUpdates::deferred_locals(thread());
+    GrowableArray<jvmtiDeferredLocalVariableSet*>* list = get_deferred_locals();
     if (list != nullptr ) {
       // In real life this never happens or is typically a single element search
       for (int i = 0; i < list->length(); i++) {
@@ -280,7 +278,7 @@ GrowableArray<MonitorInfo*>* compiledVFrame::monitors() const {
   // Replace the original values with any stores that have been
   // performed through compiledVFrame::update_monitors.
   if (thread() == nullptr) return result; // Unmounted continuations have no thread so nothing to do.
-  GrowableArrayView<jvmtiDeferredLocalVariableSet*>* list = JvmtiDeferredUpdates::deferred_locals(thread());
+  GrowableArrayView<jvmtiDeferredLocalVariableSet*>* list = get_deferred_locals();
   if (list != nullptr ) {
     // In real life this never happens or is typically a single element search
     for (int i = 0; i < list->length(); i++) {
@@ -312,6 +310,7 @@ compiledVFrame::compiledVFrame(const frame* fr, const RegisterMap* reg_map, Java
   _vframe_id = vframe_id;
   guarantee(_scope != nullptr, "scope must be present");
 }
+
 
 compiledVFrame* compiledVFrame::at_scope(int decode_offset, int vframe_id) {
   if (scope()->decode_offset() != decode_offset) {
@@ -403,10 +402,13 @@ vframe* compiledVFrame::sender() const {
   }
 }
 
-jvmtiDeferredLocalVariableSet::jvmtiDeferredLocalVariableSet(Method* method, int bci, intptr_t* id, int vframe_id) {
+GrowableArray<jvmtiDeferredLocalVariableSet*>* compiledVFrame::get_deferred_locals() const {
+  return fr().deferred_locals(_chunk());
+}
+
+jvmtiDeferredLocalVariableSet::jvmtiDeferredLocalVariableSet(Method* method, int bci, int vframe_id) {
   _method = method;
   _bci = bci;
-  _id = id;
   _vframe_id = vframe_id;
   // Always will need at least one, must be on C heap
   _locals = new(mtCompiler) GrowableArray<jvmtiDeferredLocalVariable*> (1, mtCompiler);
@@ -424,7 +426,7 @@ jvmtiDeferredLocalVariableSet::~jvmtiDeferredLocalVariableSet() {
 bool jvmtiDeferredLocalVariableSet::matches(const vframe* vf) {
   if (!vf->is_compiled_frame()) return false;
   compiledVFrame* cvf = (compiledVFrame*)vf;
-  if (cvf->fr().id() == id() && cvf->vframe_id() == vframe_id()) {
+  if (cvf->vframe_id() == vframe_id()) {
     assert(cvf->method() == method() && cvf->bci() == bci(), "must agree");
     return true;
   }

--- a/src/hotspot/share/runtime/vframe_hp.hpp
+++ b/src/hotspot/share/runtime/vframe_hp.hpp
@@ -56,6 +56,8 @@ class compiledVFrame: public javaVFrame {
     return (compiledVFrame*) vf;
   }
 
+  GrowableArray<jvmtiDeferredLocalVariableSet*>* get_deferred_locals() const;
+
   void update_deferred_value(BasicType type, int index, jvalue value);
 
   // After object deoptimization, that is object reallocation and relocking, we
@@ -66,6 +68,8 @@ class compiledVFrame: public javaVFrame {
  public:
   // Constructors
   compiledVFrame(const frame* fr, const RegisterMap* reg_map, JavaThread* thread, nmethod* nm);
+
+  bool is_deoptimized_frame() const { return _fr.is_deoptimized_frame(); }
 
   // Update a local in a compiled frame. Update happens when deopt occurs
   void update_local(BasicType type, int index, jvalue value);

--- a/src/hotspot/share/runtime/vmOperations.cpp
+++ b/src/hotspot/share/runtime/vmOperations.cpp
@@ -152,7 +152,7 @@ void VM_DeoptimizeAll::doit() {
             if (fst.current()->can_be_deoptimized()) {
               if (fcount++ == fnum) {
                 fcount = 0;
-                Deoptimization::deoptimize(thread, *fst.current());
+                Deoptimization::deoptimize(thread, *fst.current(), fst.register_map());
               }
             }
           }

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotStackFrameReference.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotStackFrameReference.java
@@ -29,27 +29,19 @@ import jdk.vm.ci.meta.ResolvedJavaMethod;
 
 public class HotSpotStackFrameReference implements InspectedFrame {
 
-    private CompilerToVM compilerToVM;
     // set in the VM when materializeVirtualObjects is called
     @SuppressWarnings("unused") private boolean objectsMaterialized;
 
     // information used to find the stack frame
-    private long stackPointer;
+    private long startingFrameId;
     private int frameNumber;
+    private int vframeId;
 
     // information about the stack frame's contents
     private int bci;
     private HotSpotResolvedJavaMethod method;
     private Object[] locals;
     private boolean[] localIsVirtual;
-
-    public long getStackPointer() {
-        return stackPointer;
-    }
-
-    public int getFrameNumber() {
-        return frameNumber;
-    }
 
     @Override
     public Object getLocal(int index) {
@@ -63,10 +55,7 @@ public class HotSpotStackFrameReference implements InspectedFrame {
 
     @Override
     public void materializeVirtualObjects(boolean invalidateCode) {
-        if (Thread.currentThread().isVirtual()) {
-            throw new IllegalArgumentException("cannot materialize frames of a virtual thread");
-        }
-        compilerToVM.materializeVirtualObjects(this, invalidateCode);
+        CompilerToVM.compilerToVM().materializeVirtualObjects(this, invalidateCode);
     }
 
     @Override
@@ -91,7 +80,7 @@ public class HotSpotStackFrameReference implements InspectedFrame {
 
     @Override
     public String toString() {
-        return "HotSpotStackFrameReference [stackPointer=" + stackPointer + ", frameNumber=" + frameNumber + ", bci=" + bci + ", method=" + getMethod() + ", locals=" + Arrays.toString(locals) +
-                        ", localIsVirtual=" + Arrays.toString(localIsVirtual) + "]";
+        return "HotSpotStackFrameReference [startingFrameId=" + startingFrameId + ", frameNumber=" + frameNumber + ", vframeId=" + vframeId + ", bci=" + bci + ", method=" + getMethod() + ", locals=" + Arrays.toString(locals) +
+                        ", localIsVirtual=" + Arrays.toString(localIsVirtual) + ", objectsMaterialized=" + objectsMaterialized + "]";
     }
 }

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotStackIntrospection.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotStackIntrospection.java
@@ -42,7 +42,6 @@ public class HotSpotStackIntrospection implements StackIntrospection {
 
     @Override
     public boolean canMaterializeVirtualObjects() {
-        // Virtual threads do not support materializing locals (JDK-8307125)
-        return !Thread.currentThread().isVirtual();
+        return true;
     }
 }


### PR DESCRIPTION
This a draft of adding support for JVMTI deferred locals on virtual threads.  The JDK issue has a more full description but basically I'd like some feedback on whether the strategy seems ok and whether full JVMTI support for deferred locals would be a desired outcome.  If it's not then I might be able to recast this in a way that is more JVMCI specific so it requires fewer changes to the core JVMTI deferred locals support which is probably the scariest looking part.  Maybe @AlanBateman and @kevinjwalls could offer some opinions here?

For the deopt/loom interactions I tried to make the use of the chunk for heap frames fairly explicit as the absolutized heap frames make me nervous.  But maybe I'm just making it too complicated?