### PR TITLE
8362972: C2 fails with unexpected node in SuperWord truncation: IsFiniteF, IsFiniteD

### DIFF
--- a/src/hotspot/share/opto/superword.cpp
+++ b/src/hotspot/share/opto/superword.cpp
@@ -2593,6 +2593,8 @@ static bool can_subword_truncate(Node* in, const Type* type) {
   case Op_ReverseI:
   case Op_CountLeadingZerosI:
   case Op_CountTrailingZerosI:
+  case Op_IsFiniteF:
+  case Op_IsFiniteD:
   case Op_IsInfiniteF:
   case Op_IsInfiniteD:
   case Op_ExtractS:


### PR DESCRIPTION
Same as  https://bugs.openjdk.org/browse/JDK-8362171 , so  I've added `IsFiniteF`, `IsFiniteD` to the assert switch.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8362972](https://bugs.openjdk.org/browse/JDK-8362972): C2 fails with unexpected node in SuperWord truncation: IsFiniteF, IsFiniteD (**Bug** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Jasmine Karthikeyan](https://openjdk.org/census#jkarthikeyan) (@jaskarth - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26423/head:pull/26423` \
`$ git checkout pull/26423`

Update a local copy of the PR: \
`$ git checkout pull/26423` \
`$ git pull https://git.openjdk.org/jdk.git pull/26423/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26423`

View PR using the GUI difftool: \
`$ git pr show -t 26423`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26423.diff">https://git.openjdk.org/jdk/pull/26423.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26423#issuecomment-3101424579)
</details>
