### PR TITLE
8363229: Parallel: Remove develop flag GCExpandToAllocateDelayMillis

### DIFF
--- a/src/hotspot/share/gc/parallel/psOldGen.cpp
+++ b/src/hotspot/share/gc/parallel/psOldGen.cpp
@@ -172,9 +172,6 @@ bool PSOldGen::expand_for_allocate(size_t word_size) {
       result = expand(word_size*HeapWordSize);
     }
   }
-  if (GCExpandToAllocateDelayMillis > 0) {
-    os::naked_sleep(GCExpandToAllocateDelayMillis);
-  }
   return result;
 }
 

--- a/src/hotspot/share/gc/shared/gc_globals.hpp
+++ b/src/hotspot/share/gc/shared/gc_globals.hpp
@@ -602,9 +602,6 @@
           "space parameters)")                                              \
           range(1, UINT_MAX)                                                \
                                                                             \
-  develop(uintx, GCExpandToAllocateDelayMillis, 0,                          \
-          "Delay between expansion and allocation (in milliseconds)")       \
-                                                                            \
   product(uint, GCDrainStackTargetSize, 64,                                 \
           "Number of entries we will try to leave on the stack "            \
           "during parallel gc")                                             \


### PR DESCRIPTION
Simple removing a develop flag that is rarely (or even never) used.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8363229](https://bugs.openjdk.org/browse/JDK-8363229): Parallel: Remove develop flag GCExpandToAllocateDelayMillis (**Enhancement** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26425/head:pull/26425` \
`$ git checkout pull/26425`

Update a local copy of the PR: \
`$ git checkout pull/26425` \
`$ git pull https://git.openjdk.org/jdk.git pull/26425/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26425`

View PR using the GUI difftool: \
`$ git pr show -t 26425`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26425.diff">https://git.openjdk.org/jdk/pull/26425.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26425#issuecomment-3102056592)
</details>
