### PR TITLE
8362882: Update SubmissionPublisher() specification to reflect use of ForkJoinPool.asyncCommonPool()

### DIFF
--- a/src/java.base/share/classes/java/util/concurrent/SubmissionPublisher.java
+++ b/src/java.base/share/classes/java/util/concurrent/SubmissionPublisher.java
@@ -292,9 +292,7 @@ public class SubmissionPublisher<T> implements Publisher<T>,
 
     /**
      * Creates a new SubmissionPublisher using the {@link
-     * ForkJoinPool#commonPool()} for async delivery to subscribers
-     * (unless it does not support a parallelism level of at least two,
-     * in which case, a new Thread is created to run each task), with
+     * ForkJoinPool#commonPool()} for async delivery to subscribers, with
      * maximum buffer capacity of {@link Flow#defaultBufferSize}, and no
      * handler for Subscriber exceptions in method {@link
      * Flow.Subscriber#onNext(Object) onNext}.


### PR DESCRIPTION
The changes in JDK-8319447 to improve the performance of delayed task handling updated CompletableFuture and SubmissionPublisher to use the ForkJoinPool commonPool in all cases. These APIs previously created a Thread for each task when parallelism was less than 2. We missed the update to SubmissionPublisher's no-arg constructor in that update.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8363552](https://bugs.openjdk.org/browse/JDK-8363552) to be approved

### Issues
 * [JDK-8362882](https://bugs.openjdk.org/browse/JDK-8362882): Update SubmissionPublisher() specification to reflect use of ForkJoinPool.asyncCommonPool() (**Bug** - P3)
 * [JDK-8363552](https://bugs.openjdk.org/browse/JDK-8363552): Update SubmissionPublisher() specification to reflect use of ForkJoinPool.asyncCommonPool() (**CSR**)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Doug Lea](https://openjdk.org/census#dl) (@DougLea - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26426/head:pull/26426` \
`$ git checkout pull/26426`

Update a local copy of the PR: \
`$ git checkout pull/26426` \
`$ git pull https://git.openjdk.org/jdk.git pull/26426/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26426`

View PR using the GUI difftool: \
`$ git pr show -t 26426`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26426.diff">https://git.openjdk.org/jdk/pull/26426.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26426#issuecomment-3106849977)
</details>
