### PR TITLE
8361871: [GCC static analyzer] complains about use of uninitialized value ckpObject in p11_util.c

### DIFF
--- a/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_util.c
+++ b/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_util.c
@@ -1209,7 +1209,7 @@ CK_VOID_PTR jObjectToPrimitiveCKObjectPtr(JNIEnv *env, jobject jObject, CK_ULONG
     jclass jBooleanArrayClass, jIntArrayClass, jLongArrayClass;
     jclass jStringClass;
     jclass jObjectClass, jClassClass;
-    CK_VOID_PTR ckpObject;
+    CK_VOID_PTR ckpObject = NULL;
     jmethodID jMethod;
     jobject jClassObject;
     jstring jClassNameString;


### PR DESCRIPTION
Seems the used j*ToCKByteArray helper functions have a potential code path where ckpObject is not written/initialized .
(we see this when using the gcc flag -fanalyzer)

```
/jdk/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_util.c:1239:16: error: use of uninitialized value 'ckpObject' [CWE-457] [-Werror=analyzer-use-of-uninitialized-value]
 1239 | return ckpObject;
      | ^~~~~~~~~

/jdk/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_util.c:1246:16: error: use of uninitialized value 'ckpObject' [CWE-457] [-Werror=analyzer-use-of-uninitialized-value]
 1246 | return ckpObject;
 
 
/jdk/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_util.c:1290:16: error: use of uninitialized value 'ckpObject' [CWE-457] [-Werror=analyzer-use-of-uninitialized-value]
 1290 | return ckpObject;
      | ^~~~~~~~~

/jdk/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_util.c:1297:16: error: use of uninitialized value 'ckpObject' [CWE-457] [-Werror=analyzer-use-of-uninitialized-value]
 1297 | return ckpObject;
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8361871](https://bugs.openjdk.org/browse/JDK-8361871): [GCC static analyzer] complains about use of uninitialized value ckpObject in p11_util.c (**Bug** - P4)


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26427/head:pull/26427` \
`$ git checkout pull/26427`

Update a local copy of the PR: \
`$ git checkout pull/26427` \
`$ git pull https://git.openjdk.org/jdk.git pull/26427/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26427`

View PR using the GUI difftool: \
`$ git pr show -t 26427`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26427.diff">https://git.openjdk.org/jdk/pull/26427.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26427#issuecomment-3102764997)
</details>
