### PR TITLE
8360416: Incorrect l10n test case in sun/security/tools/keytool/i18n.java

### DIFF
--- a/test/jdk/sun/security/tools/keytool/i18n.java
+++ b/test/jdk/sun/security/tools/keytool/i18n.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 4348369 8076069 8294994
+ * @bug 4348369 8076069 8294994 8360400
  * @summary keytool i18n compliant
  * @author charlie lai
  * @modules java.base/sun.security.tools.keytool
@@ -33,7 +33,7 @@
 
 /*
  * @test
- * @bug 4348369 8076069 8294994
+ * @bug 4348369 8076069 8294994 8360400
  * @summary keytool i18n compliant
  * @author charlie lai
  * @modules java.base/sun.security.tools.keytool
@@ -43,7 +43,7 @@
 
 /*
  * @test
- * @bug 4348369 8076069 8294994
+ * @bug 4348369 8076069 8294994 8360400
  * @summary keytool i18n compliant
  * @author charlie lai
  * @modules java.base/sun.security.tools.keytool
@@ -53,7 +53,7 @@
 
 /*
  * @test
- * @bug 4348369 8076069 8294994
+ * @bug 4348369 8076069 8294994 8360400
  * @summary keytool i18n compliant
  * @author charlie lai
  * @modules java.base/sun.security.tools.keytool
@@ -94,10 +94,6 @@ public class i18n {
                     "Output in ${LANG}. Check: contains 1 keystore entry with "
                             + "512-bit DSA key algorithm for CN=Name, OU=Java, "
                             + "O=Oracle, L=City, ST=State C=Country."},
-
-            {"-list -v -storepass a -keystore ./i18n.keystore",
-                    "Output in ${LANG}. Check keytool error:java.io.IOException: "
-                            + "keystore password was incorrect."},
 
             {"-genkey -keyalg DSA -v -keysize 512 "
                     + "-storepass password "


### PR DESCRIPTION
Please review this PR which is a backport of commit [5540a785](https://github.com/openjdk/jdk/commit/5540a7859b3ae0faf6b6c7f50e53ff611b253a9f) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

This is a test-only issue which removes an incorrect l10n test case.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8360416](https://bugs.openjdk.org/browse/JDK-8360416): Incorrect l10n test case in sun/security/tools/keytool/i18n.java (**Bug** - P4)


### Reviewers
 * [Hai-May Chao](https://openjdk.org/census#hchao) (@haimaychao - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26431/head:pull/26431` \
`$ git checkout pull/26431`

Update a local copy of the PR: \
`$ git checkout pull/26431` \
`$ git pull https://git.openjdk.org/jdk.git pull/26431/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26431`

View PR using the GUI difftool: \
`$ git pr show -t 26431`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26431.diff">https://git.openjdk.org/jdk/pull/26431.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26431#issuecomment-3104793504)
</details>
