### PR TITLE
8363895: Minimal build fails with slowdebug builds after JDK-8354887

### DIFF
--- a/src/hotspot/share/code/aotCodeCache.hpp
+++ b/src/hotspot/share/code/aotCodeCache.hpp
@@ -379,7 +379,7 @@ public:
   static void init2() NOT_CDS_RETURN;
   static void close() NOT_CDS_RETURN;
   static bool is_on() CDS_ONLY({ return cache() != nullptr && !_cache->closing(); }) NOT_CDS_RETURN_(false);
-  static bool is_on_for_use() { return is_on() && _cache->for_use(); }
+  static bool is_on_for_use()  CDS_ONLY({ return is_on() && _cache->for_use(); }) NOT_CDS_RETURN_(false);
   static bool is_on_for_dump() CDS_ONLY({ return is_on() && _cache->for_dump(); }) NOT_CDS_RETURN_(false);
   static bool is_dumping_stub() NOT_CDS_RETURN_(false);
   static bool is_dumping_adapter() NOT_CDS_RETURN_(false);

--- a/src/hotspot/share/code/aotCodeCache.hpp
+++ b/src/hotspot/share/code/aotCodeCache.hpp
@@ -379,8 +379,8 @@ public:
   static void init2() NOT_CDS_RETURN;
   static void close() NOT_CDS_RETURN;
   static bool is_on() CDS_ONLY({ return cache() != nullptr && !_cache->closing(); }) NOT_CDS_RETURN_(false);
-  static bool is_on_for_use()  { return is_on() && _cache->for_use(); }
-  static bool is_on_for_dump() { return is_on() && _cache->for_dump(); }
+  static bool is_on_for_use() { return is_on() && _cache->for_use(); }
+  static bool is_on_for_dump() CDS_ONLY({ return is_on() && _cache->for_dump(); }) NOT_CDS_RETURN_(false);
   static bool is_dumping_stub() NOT_CDS_RETURN_(false);
   static bool is_dumping_adapter() NOT_CDS_RETURN_(false);
   static bool is_using_stub() NOT_CDS_RETURN_(false);


### PR DESCRIPTION
Configure with `--with-jvm-variants=minimal --with-debug-level=slowdebug`.

Error message:
```
...
Compiling up to 136 files for BUILD_java.compiler.interim
Creating support/modules_libs/java.base/minimal/libjvm.so from 628 file(s)
/opt/rh/devtoolset-11/root/usr/libexec/gcc/x86_64-redhat-linux/11/ld: /home/aoqi/work/openjdk/jdk/build/linux-x86_64-minimal-slowdebug/hotspot/variant-minimal/libjvm/objs/macroAssembler_x86.o: in function `AOTCodeCache::is_on_for_dump()':
/home/aoqi/work/openjdk/jdk/src/hotspot/share/code/aotCodeCache.hpp:383: undefined reference to `AOTCodeCache::_cache'
collect2: error: ld returned 1 exit status
gmake[3]: *** [lib/CompileJvm.gmk:175: /home/aoqi/work/openjdk/jdk/build/linux-x86_64-minimal-slowdebug/support/modules_libs/java.base/minimal/libjvm.so] Error 1
gmake[2]: *** [make/Main.gmk:242: hotspot-minimal-libs] Error 1
gmake[2]: *** Waiting for unfinished jobs....
```

`AOTCodeCache::is_on_for_dump()` is used in `macroAssembler_x86.cpp` but not defined when cds is disabled.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8363895](https://bugs.openjdk.org/browse/JDK-8363895): Minimal build fails with slowdebug builds after JDK-8354887 (**Bug** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26436/head:pull/26436` \
`$ git checkout pull/26436`

Update a local copy of the PR: \
`$ git checkout pull/26436` \
`$ git pull https://git.openjdk.org/jdk.git pull/26436/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26436`

View PR using the GUI difftool: \
`$ git pr show -t 26436`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26436.diff">https://git.openjdk.org/jdk/pull/26436.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26436#issuecomment-3105499611)
</details>
