### PR TITLE
8363898: RISC-V: TestRangeCheckHoistingScaledIV.java fails after JDK-8355293 when running without RVV

### DIFF
--- a/test/hotspot/jtreg/compiler/rangechecks/TestRangeCheckHoistingScaledIV.java
+++ b/test/hotspot/jtreg/compiler/rangechecks/TestRangeCheckHoistingScaledIV.java
@@ -28,7 +28,8 @@
  * @summary Test range check hoisting for some scaled iv at array index
  * @library /test/lib /
  * @requires vm.flagless
- * @requires vm.debug & vm.compiler2.enabled & (os.simpleArch == "x64" | os.arch == "aarch64" | os.arch == "riscv64")
+ * @requires vm.debug & vm.compiler2.enabled
+ * @requires os.simpleArch == "x64" | os.arch == "aarch64" | (os.arch == "riscv64" & vm.cpu.features ~= ".*rvv.*")
  * @modules jdk.incubator.vector
  * @run main/othervm compiler.rangechecks.TestRangeCheckHoistingScaledIV
  */


### PR DESCRIPTION
Hi all,
Please take a look and review this PR, thanks!

test/hotspot/jtreg/compiler/rangechecks/TestRangeCheckHoistingScaledIV.java fails without RVV after [JDK-8355293](https://bugs.openjdk.org/browse/JDK-8355293) in fastdebug mode.

In [JDK-8291669](https://bugs.openjdk.org/browse/JDK-8291669), which introduced this case, it is mentioned:
>Previously attached jtreg case fails on ppc64 because VectorAPI has no
>vector intrinsics on ppc64 so there's no long range check to hoist. In
>this patch, we limit the test architecture to x64 and AArch64.

So we need RVV to use vector intrinsics on RISC-V.

### Test (fastdebug)
- [x] Run test/hotspot/jtreg/compiler/rangechecks/TestRangeCheckHoistingScaledIV.java on k1 and sg2042
- [x] Run test/hotspot/jtreg/compiler/rangechecks/TestRangeCheckHoistingScaledIV.java on qemu-system w/ and w/o RVV

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8363898](https://bugs.openjdk.org/browse/JDK-8363898): RISC-V: TestRangeCheckHoistingScaledIV.java fails after JDK-8355293 when running without RVV (**Bug** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Hamlin Li](https://openjdk.org/census#mli) (@Hamlin-Li - **Reviewer**)
 * [SendaoYan](https://openjdk.org/census#syan) (@sendaoYan - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26437/head:pull/26437` \
`$ git checkout pull/26437`

Update a local copy of the PR: \
`$ git checkout pull/26437` \
`$ git pull https://git.openjdk.org/jdk.git pull/26437/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26437`

View PR using the GUI difftool: \
`$ git pr show -t 26437`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26437.diff">https://git.openjdk.org/jdk/pull/26437.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26437#issuecomment-3105555843)
</details>
