### PR TITLE
8315131: Clarify VarHandle set/get access on 32-bit platforms

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
@@ -276,10 +276,10 @@ import java.util.stream.Stream;
  * if {@code A >= S}. An aligned var handle is guaranteed to support the following
  * access modes:
  * <ul>
- * <li>read write access modes for all {@code T}. On 32-bit platforms, access modes
- *     {@code get} and {@code set} for {@code long}, {@code double} and {@code MemorySegment}
- *     are supported but might lead to word tearing, as described in Section {@jls 17.7}.
- *     of <cite>The Java Language Specification</cite>.
+ * <li>read write access modes for all {@code T}.  Access modes {@code get} and
+ *     {@code set} for {@code long}, {@code double} and {@code MemorySegment}
+ *     are supported but have no atomicity guarantee, as described in Section
+ *     {@jls 17.7} of <cite>The Java Language Specification</cite>.
  * <li>atomic update access modes for {@code int}, {@code long},
  *     {@code float}, {@code double} and {@link MemorySegment}.
  *     (Future major platform releases of the JDK may support additional

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -4305,9 +4305,10 @@ return mh1;
      * If access is aligned then following access modes are supported and are
      * guaranteed to support atomic access:
      * <ul>
-     * <li>read write access modes for all {@code T}, with the exception of
-     *     access modes {@code get} and {@code set} for {@code long} and
-     *     {@code double} on 32-bit platforms.
+     * <li>read write access modes for all {@code T}.  Access modes {@code get}
+     *     and {@code set} for {@code long} and {@code double} are supported but
+     *     have no atomicity guarantee, as described in Section {@jls 17.7} of
+     *     <cite>The Java Language Specification</cite>.
      * <li>atomic update access modes for {@code int}, {@code long},
      *     {@code float} or {@code double}.
      *     (Future major platform releases of the JDK may support additional


### PR DESCRIPTION
JDK-8315131 addresses a doc-only mistake present on release 25. Since this is doc-only, this is eligible for backport, and its CSR is approved for release 25 too. See #26258 for the original PR review.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8361935](https://bugs.openjdk.org/browse/JDK-8361935) to be approved

### Issues
 * [JDK-8315131](https://bugs.openjdk.org/browse/JDK-8315131): Clarify VarHandle set/get access on 32-bit platforms (**Bug** - P4)
 * [JDK-8361935](https://bugs.openjdk.org/browse/JDK-8361935): Clarify VarHandle set/get access on 32-bit platforms (**CSR**)


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26438/head:pull/26438` \
`$ git checkout pull/26438`

Update a local copy of the PR: \
`$ git checkout pull/26438` \
`$ git pull https://git.openjdk.org/jdk.git pull/26438/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26438`

View PR using the GUI difftool: \
`$ git pr show -t 26438`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26438.diff">https://git.openjdk.org/jdk/pull/26438.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26438#issuecomment-3105614416)
</details>
