### PR TITLE
8362591: Wrong argument warning when heap size larger than coops threshold

### DIFF
--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -1576,7 +1576,7 @@ void Arguments::set_heap_size() {
       // was not specified.
       if (reasonable_max > max_coop_heap) {
         if (FLAG_IS_ERGO(UseCompressedOops) && override_coop_limit) {
-          aot_log_info(aot)("UseCompressedOops and UseCompressedClassPointers have been disabled due to"
+          aot_log_info(aot)("UseCompressedOops disabled due to"
             " max heap %zu > compressed oop heap %zu. "
             "Please check the setting of MaxRAMPercentage %5.2f."
             ,(size_t)reasonable_max, (size_t)max_coop_heap, MaxRAMPercentage);

--- a/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/SysDictCrash.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/SysDictCrash.java
@@ -58,7 +58,7 @@ public class SysDictCrash {
         try {
             TestCommon.checkDump(output);
         } catch (java.lang.RuntimeException re) {
-            if (!output.getStdout().contains("UseCompressedOops and UseCompressedClassPointers have been disabled due to")) {
+            if (!output.getStdout().contains("UseCompressedOops disabled due to")) {
                 throw re;
             } else {
                 System.out.println("Shared archive was not created due to UseCompressedOops and UseCompressedClassPointers have been disabled.");


### PR DESCRIPTION
Trivial fix to an argument warning that was incorrect. UseCompressedClassPointers has long been separated from UseCompressedOops (since JDK 15).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8362591](https://bugs.openjdk.org/browse/JDK-8362591): Wrong argument warning when heap size larger than coops threshold (**Enhancement** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26439/head:pull/26439` \
`$ git checkout pull/26439`

Update a local copy of the PR: \
`$ git checkout pull/26439` \
`$ git pull https://git.openjdk.org/jdk.git pull/26439/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26439`

View PR using the GUI difftool: \
`$ git pr show -t 26439`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26439.diff">https://git.openjdk.org/jdk/pull/26439.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26439#issuecomment-3106645172)
</details>
