### PR TITLE
8363357: Remove unused flag VerifyAdapterCalls

### DIFF
--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -618,9 +618,6 @@ const int ObjectAlignmentInBytes = 8;
   product(bool, PrintAdapterHandlers, false, DIAGNOSTIC,                    \
           "Print code generated for i2c/c2i adapters")                      \
                                                                             \
-  product(bool, VerifyAdapterCalls, trueInDebug, DIAGNOSTIC,                \
-          "Verify that i2c/c2i adapters are called properly")               \
-                                                                            \
   develop(bool, VerifyAdapterSharing, false,                                \
           "Verify that the code for shared adapters is the equivalent")     \
                                                                             \


### PR DESCRIPTION
It seems that the flag VerifyAdapterCalls is unused since [JDK-8350209](https://bugs.openjdk.org/browse/JDK-8350209), so pretty recently.

Let's remove it, very direct, no trick.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8363357](https://bugs.openjdk.org/browse/JDK-8363357): Remove unused flag VerifyAdapterCalls (**Enhancement** - P4)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26440/head:pull/26440` \
`$ git checkout pull/26440`

Update a local copy of the PR: \
`$ git checkout pull/26440` \
`$ git pull https://git.openjdk.org/jdk.git pull/26440/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26440`

View PR using the GUI difftool: \
`$ git pr show -t 26440`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26440.diff">https://git.openjdk.org/jdk/pull/26440.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26440#issuecomment-3106839810)
</details>
