### PR TITLE
8363910: Avoid tuning for Power10 CPUs on Linux ppc64le when gcc < 10 is used

### DIFF
--- a/make/autoconf/flags-cflags.m4
+++ b/make/autoconf/flags-cflags.m4
@@ -736,8 +736,15 @@ AC_DEFUN([FLAGS_SETUP_CFLAGS_CPU_DEP],
         $1_CFLAGS_CPU_JVM="${$1_CFLAGS_CPU_JVM} -mminimal-toc"
       elif test "x$FLAGS_CPU" = xppc64le; then
         # Little endian machine uses ELFv2 ABI.
-        # Use Power8, this is the first CPU to support PPC64 LE with ELFv2 ABI.
-        $1_CFLAGS_CPU="-mcpu=power8 -mtune=power10"
+        # Use Power8 for target cpu, this is the first CPU to support PPC64 LE with ELFv2 ABI.
+        # Use Power10 for tuning target, this is supported by gcc >= 10
+        POWER_TUNE_VERSION="-mtune=power10"
+        FLAGS_COMPILER_CHECK_ARGUMENTS(ARGUMENT: [${POWER_TUNE_VERSION}],
+          IF_FALSE: [
+              POWER_TUNE_VERSION="-mtune=power8"
+          ]
+        )
+        $1_CFLAGS_CPU="-mcpu=power8 ${POWER_TUNE_VERSION}"
         $1_CFLAGS_CPU_JVM="${$1_CFLAGS_CPU_JVM} -DABI_ELFv2"
       fi
     elif test "x$FLAGS_CPU" = xs390x; then


### PR DESCRIPTION
Older gcc version (8, 9) do not support the -mtune=power10 flag. We should set this only when recent gcc versions are used.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8363910](https://bugs.openjdk.org/browse/JDK-8363910): Avoid tuning for Power10 CPUs on Linux ppc64le when gcc &lt; 10 is used (**Bug** - P4)


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26442/head:pull/26442` \
`$ git checkout pull/26442`

Update a local copy of the PR: \
`$ git checkout pull/26442` \
`$ git pull https://git.openjdk.org/jdk.git pull/26442/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26442`

View PR using the GUI difftool: \
`$ git pr show -t 26442`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26442.diff">https://git.openjdk.org/jdk/pull/26442.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26442#issuecomment-3107822824)
</details>
