### PR TITLE
8363676: [GCC static analyzer] missing return value check of malloc in OGLContext_SetTransform

### DIFF
--- a/src/java.desktop/share/native/common/java2d/opengl/OGLContext.c
+++ b/src/java.desktop/share/native/common/java2d/opengl/OGLContext.c
@@ -484,6 +484,7 @@ OGLContext_SetTransform(OGLContext *oglc,
     if (oglc->xformMatrix == NULL) {
         size_t arrsize = 16 * sizeof(GLdouble);
         oglc->xformMatrix = (GLdouble *)malloc(arrsize);
+        RETURN_IF_NULL(oglc->xformMatrix);
         memset(oglc->xformMatrix, 0, arrsize);
         oglc->xformMatrix[10] = 1.0;
         oglc->xformMatrix[15] = 1.0;


### PR DESCRIPTION
When using the GCC static analyzer (-fanalyzer) the following issue is reported :
`src/java.desktop/share/native/common/java2d/opengl/OGLContext.c:487:9: warning: use of possibly-NULL '*oglc.xformMatrix' where non-null expected [CWE-690] [-Wanalyzer-possible-null-argument]`

Seems we miss a NULL check of the return value of malloc (at most other places in the coding we do it).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8363676](https://bugs.openjdk.org/browse/JDK-8363676): [GCC static analyzer] missing return value check of malloc in OGLContext_SetTransform (**Bug** - P4)


### Reviewers
 * [Prasanta Sadhukhan](https://openjdk.org/census#psadhukhan) (@prsadhuk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26443/head:pull/26443` \
`$ git checkout pull/26443`

Update a local copy of the PR: \
`$ git checkout pull/26443` \
`$ git pull https://git.openjdk.org/jdk.git pull/26443/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26443`

View PR using the GUI difftool: \
`$ git pr show -t 26443`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26443.diff">https://git.openjdk.org/jdk/pull/26443.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26443#issuecomment-3108753120)
</details>
