### PR TITLE
8363929: G1: Add G1 prefix to various G1 specific global locks

### DIFF
--- a/src/hotspot/share/gc/g1/g1Allocator.cpp
+++ b/src/hotspot/share/gc/g1/g1Allocator.cpp
@@ -249,7 +249,7 @@ HeapWord* G1Allocator::survivor_attempt_allocation(uint node_index,
                                                                               desired_word_size,
                                                                               actual_word_size);
   if (result == nullptr && !survivor_is_full()) {
-    MutexLocker x(FreeList_lock, Mutex::_no_safepoint_check_flag);
+    MutexLocker x(G1FreeList_lock, Mutex::_no_safepoint_check_flag);
     // Multiple threads may have queued at the FreeList_lock above after checking whether there
     // actually is still memory available. Redo the check under the lock to avoid unnecessary work;
     // the memory may have been used up as the threads waited to acquire the lock.
@@ -278,7 +278,7 @@ HeapWord* G1Allocator::old_attempt_allocation(size_t min_word_size,
                                                                desired_word_size,
                                                                actual_word_size);
   if (result == nullptr && !old_is_full()) {
-    MutexLocker x(FreeList_lock, Mutex::_no_safepoint_check_flag);
+    MutexLocker x(G1FreeList_lock, Mutex::_no_safepoint_check_flag);
     // Multiple threads may have queued at the FreeList_lock above after checking whether there
     // actually is still memory available. Redo the check under the lock to avoid unnecessary work;
     // the memory may have been used up as the threads waited to acquire the lock.

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -1134,7 +1134,7 @@ public:
 
     if (SafepointSynchronize::is_at_safepoint()) {
       guarantee(Thread::current()->is_VM_thread() ||
-                FreeList_lock->owned_by_self() || OldSets_lock->owned_by_self(),
+                G1FreeList_lock->owned_by_self() || G1OldSets_lock->owned_by_self(),
                 "master old set MT safety protocol at a safepoint");
     } else {
       guarantee(Heap_lock->owned_by_self(), "master old set MT safety protocol outside a safepoint");
@@ -1157,7 +1157,7 @@ public:
 
     if (SafepointSynchronize::is_at_safepoint()) {
       guarantee(Thread::current()->is_VM_thread() ||
-                OldSets_lock->owned_by_self(),
+                G1OldSets_lock->owned_by_self(),
                 "master humongous set MT safety protocol at a safepoint");
     } else {
       guarantee(Heap_lock->owned_by_self(),
@@ -2329,7 +2329,7 @@ HeapWord* G1CollectedHeap::do_collection_pause(size_t word_size,
 void G1CollectedHeap::start_concurrent_cycle(bool concurrent_operation_is_full_mark) {
   assert(!_cm_thread->in_progress(), "Can not start concurrent operation while in progress");
 
-  MutexLocker x(CGC_lock, Mutex::_no_safepoint_check_flag);
+  MutexLocker x(G1CGC_lock, Mutex::_no_safepoint_check_flag);
   if (concurrent_operation_is_full_mark) {
     _cm->post_concurrent_mark_start();
     _cm_thread->start_full_mark();
@@ -2337,7 +2337,7 @@ void G1CollectedHeap::start_concurrent_cycle(bool concurrent_operation_is_full_m
     _cm->post_concurrent_undo_start();
     _cm_thread->start_undo_mark();
   }
-  CGC_lock->notify();
+  G1CGC_lock->notify();
 }
 
 bool G1CollectedHeap::is_potential_eager_reclaim_candidate(G1HeapRegion* r) const {
@@ -2691,7 +2691,7 @@ void G1CollectedHeap::free_humongous_region(G1HeapRegion* hr,
 void G1CollectedHeap::remove_from_old_gen_sets(const uint old_regions_removed,
                                                const uint humongous_regions_removed) {
   if (old_regions_removed > 0 || humongous_regions_removed > 0) {
-    MutexLocker x(OldSets_lock, Mutex::_no_safepoint_check_flag);
+    MutexLocker x(G1OldSets_lock, Mutex::_no_safepoint_check_flag);
     _old_set.bulk_remove(old_regions_removed);
     _humongous_set.bulk_remove(humongous_regions_removed);
   }
@@ -2701,7 +2701,7 @@ void G1CollectedHeap::remove_from_old_gen_sets(const uint old_regions_removed,
 void G1CollectedHeap::prepend_to_freelist(G1FreeRegionList* list) {
   assert(list != nullptr, "list can't be null");
   if (!list->is_empty()) {
-    MutexLocker x(FreeList_lock, Mutex::_no_safepoint_check_flag);
+    MutexLocker x(G1FreeList_lock, Mutex::_no_safepoint_check_flag);
     _hrm.insert_list_into_free_list(list);
   }
 }
@@ -2936,7 +2936,7 @@ bool G1CollectedHeap::has_more_regions(G1HeapRegionAttr dest) {
 }
 
 G1HeapRegion* G1CollectedHeap::new_gc_alloc_region(size_t word_size, G1HeapRegionAttr dest, uint node_index) {
-  assert(FreeList_lock->owned_by_self(), "pre-condition");
+  assert(G1FreeList_lock->owned_by_self(), "pre-condition");
 
   if (!has_more_regions(dest)) {
     return nullptr;

--- a/src/hotspot/share/gc/g1/g1CommittedRegionMap.cpp
+++ b/src/hotspot/share/gc/g1/g1CommittedRegionMap.cpp
@@ -183,7 +183,7 @@ void G1CommittedRegionMap::guarantee_mt_safety_active() const {
 
   if (SafepointSynchronize::is_at_safepoint()) {
     guarantee(Thread::current()->is_VM_thread() ||
-              FreeList_lock->owned_by_self(),
+              G1FreeList_lock->owned_by_self(),
               "G1CommittedRegionMap _active-map MT safety protocol at a safepoint");
   } else {
     guarantee(Heap_lock->owned_by_self(),
@@ -204,10 +204,10 @@ void G1CommittedRegionMap::guarantee_mt_safety_inactive() const {
 
   if (SafepointSynchronize::is_at_safepoint()) {
     guarantee(Thread::current()->is_VM_thread() ||
-              FreeList_lock->owned_by_self(),
+              G1FreeList_lock->owned_by_self(),
               "G1CommittedRegionMap MT safety protocol at a safepoint");
   } else {
-    guarantee(Uncommit_lock->owned_by_self(),
+    guarantee(G1Uncommit_lock->owned_by_self(),
               "G1CommittedRegionMap MT safety protocol outside a safepoint");
   }
 }

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -164,7 +164,7 @@ G1CMMarkStack::TaskQueueEntryChunk* G1CMMarkStack::ChunkAllocator::allocate_new_
       return nullptr;
     }
 
-    MutexLocker x(MarkStackChunkList_lock, Mutex::_no_safepoint_check_flag);
+    MutexLocker x(G1MarkStackChunkList_lock, Mutex::_no_safepoint_check_flag);
     if (Atomic::load_acquire(&_buckets[bucket]) == nullptr) {
       size_t desired_capacity = bucket_size(bucket) * 2;
       if (!try_expand_to(desired_capacity)) {
@@ -293,13 +293,13 @@ void G1CMMarkStack::add_chunk_to_list(TaskQueueEntryChunk* volatile* list, TaskQ
 }
 
 void G1CMMarkStack::add_chunk_to_chunk_list(TaskQueueEntryChunk* elem) {
-  MutexLocker x(MarkStackChunkList_lock, Mutex::_no_safepoint_check_flag);
+  MutexLocker x(G1MarkStackChunkList_lock, Mutex::_no_safepoint_check_flag);
   add_chunk_to_list(&_chunk_list, elem);
   _chunks_in_chunk_list++;
 }
 
 void G1CMMarkStack::add_chunk_to_free_list(TaskQueueEntryChunk* elem) {
-  MutexLocker x(MarkStackFreeList_lock, Mutex::_no_safepoint_check_flag);
+  MutexLocker x(G1MarkStackFreeList_lock, Mutex::_no_safepoint_check_flag);
   add_chunk_to_list(&_free_list, elem);
 }
 
@@ -312,7 +312,7 @@ G1CMMarkStack::TaskQueueEntryChunk* G1CMMarkStack::remove_chunk_from_list(TaskQu
 }
 
 G1CMMarkStack::TaskQueueEntryChunk* G1CMMarkStack::remove_chunk_from_chunk_list() {
-  MutexLocker x(MarkStackChunkList_lock, Mutex::_no_safepoint_check_flag);
+  MutexLocker x(G1MarkStackChunkList_lock, Mutex::_no_safepoint_check_flag);
   TaskQueueEntryChunk* result = remove_chunk_from_list(&_chunk_list);
   if (result != nullptr) {
     _chunks_in_chunk_list--;
@@ -321,7 +321,7 @@ G1CMMarkStack::TaskQueueEntryChunk* G1CMMarkStack::remove_chunk_from_chunk_list(
 }
 
 G1CMMarkStack::TaskQueueEntryChunk* G1CMMarkStack::remove_chunk_from_free_list() {
-  MutexLocker x(MarkStackFreeList_lock, Mutex::_no_safepoint_check_flag);
+  MutexLocker x(G1MarkStackFreeList_lock, Mutex::_no_safepoint_check_flag);
   return remove_chunk_from_list(&_free_list);
 }
 
@@ -432,9 +432,9 @@ bool G1CMRootMemRegions::contains(const MemRegion mr) const {
 }
 
 void G1CMRootMemRegions::notify_scan_done() {
-  MutexLocker x(RootRegionScan_lock, Mutex::_no_safepoint_check_flag);
+  MutexLocker x(G1RootRegionScan_lock, Mutex::_no_safepoint_check_flag);
   _scan_in_progress = false;
-  RootRegionScan_lock->notify_all();
+  G1RootRegionScan_lock->notify_all();
 }
 
 void G1CMRootMemRegions::cancel_scan() {
@@ -459,7 +459,7 @@ bool G1CMRootMemRegions::wait_until_scan_finished() {
   }
 
   {
-    MonitorLocker ml(RootRegionScan_lock, Mutex::_no_safepoint_check_flag);
+    MonitorLocker ml(G1RootRegionScan_lock, Mutex::_no_safepoint_check_flag);
     while (scan_in_progress()) {
       ml.wait();
     }
@@ -517,7 +517,7 @@ G1ConcurrentMark::G1ConcurrentMark(G1CollectedHeap* g1h,
   _top_at_rebuild_starts(NEW_C_HEAP_ARRAY(HeapWord*, _g1h->max_num_regions(), mtGC)),
   _needs_remembered_set_rebuild(false)
 {
-  assert(CGC_lock != nullptr, "CGC_lock must be initialized");
+  assert(G1CGC_lock != nullptr, "CGC_lock must be initialized");
 
   _mark_bitmap.initialize(g1h->reserved(), bitmap_storage);
 

--- a/src/hotspot/share/gc/g1/g1ConcurrentMarkThread.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMarkThread.cpp
@@ -80,7 +80,7 @@ void G1ConcurrentMarkThread::delay_to_keep_mmu(bool remark) {
   if (policy->use_adaptive_young_list_length()) {
     double delay_end_sec = mmu_delay_end(policy, remark);
     // Wait for timeout or thread termination request.
-    MonitorLocker ml(CGC_lock, Monitor::_no_safepoint_check_flag);
+    MonitorLocker ml(G1CGC_lock, Monitor::_no_safepoint_check_flag);
     while (!_cm->has_aborted() && !should_terminate()) {
       double sleep_time_sec = (delay_end_sec - os::elapsedTime());
       jlong sleep_time_ms = ceil(sleep_time_sec * MILLIUNITS);
@@ -143,12 +143,12 @@ void G1ConcurrentMarkThread::stop_service() {
     _cm->abort_marking_threads();
   }
 
-  MutexLocker ml(CGC_lock, Mutex::_no_safepoint_check_flag);
-  CGC_lock->notify_all();
+  MutexLocker ml(G1CGC_lock, Mutex::_no_safepoint_check_flag);
+  G1CGC_lock->notify_all();
 }
 
 bool G1ConcurrentMarkThread::wait_for_next_cycle() {
-  MonitorLocker ml(CGC_lock, Mutex::_no_safepoint_check_flag);
+  MonitorLocker ml(G1CGC_lock, Mutex::_no_safepoint_check_flag);
   while (!in_progress() && !should_terminate()) {
     ml.wait();
   }

--- a/src/hotspot/share/gc/g1/g1HeapRegionManager.cpp
+++ b/src/hotspot/share/gc/g1/g1HeapRegionManager.cpp
@@ -52,7 +52,7 @@ public:
 
     if (SafepointSynchronize::is_at_safepoint()) {
       guarantee(Thread::current()->is_VM_thread() ||
-                FreeList_lock->owned_by_self(), "master free list MT safety protocol at a safepoint");
+                G1FreeList_lock->owned_by_self(), "master free list MT safety protocol at a safepoint");
     } else {
       guarantee(Heap_lock->owned_by_self(), "master free list MT safety protocol outside a safepoint");
     }
@@ -288,7 +288,7 @@ uint G1HeapRegionManager::uncommit_inactive_regions(uint limit) {
   uint uncommitted = 0;
   uint offset = 0;
   do {
-    MutexLocker uc(Uncommit_lock, Mutex::_no_safepoint_check_flag);
+    MutexLocker uc(G1Uncommit_lock, Mutex::_no_safepoint_check_flag);
     G1HeapRegionRange range = _committed_map.next_inactive_range(offset);
     // No more regions available for uncommit. Return the number of regions
     // already uncommitted or 0 if there were no longer any inactive regions.
@@ -374,7 +374,7 @@ void G1HeapRegionManager::expand_exact(uint start, uint num_regions, WorkerThrea
     if (_committed_map.inactive(i)) {
       // Need to grab the lock since this can be called by a java thread
       // doing humongous allocations.
-      MutexLocker uc(Uncommit_lock, Mutex::_no_safepoint_check_flag);
+      MutexLocker uc(G1Uncommit_lock, Mutex::_no_safepoint_check_flag);
       // State might change while getting the lock.
       if (_committed_map.inactive(i)) {
         reactivate_regions(i, 1);

--- a/src/hotspot/share/gc/g1/g1YoungGCPostEvacuateTasks.cpp
+++ b/src/hotspot/share/gc/g1/g1YoungGCPostEvacuateTasks.cpp
@@ -765,7 +765,7 @@ class FreeCSetClosure : public G1HeapRegionClosure {
     assert(retain_region == r->rem_set()->is_tracked(), "When retaining a region, remembered set should be kept.");
 
     // Add region to old set, need to hold lock.
-    MutexLocker x(OldSets_lock, Mutex::_no_safepoint_check_flag);
+    MutexLocker x(G1OldSets_lock, Mutex::_no_safepoint_check_flag);
     _g1h->old_set_add(r);
   }
 

--- a/src/hotspot/share/runtime/mutexLocker.cpp
+++ b/src/hotspot/share/runtime/mutexLocker.cpp
@@ -70,13 +70,7 @@ Monitor* ThreadsLockThrottle_lock     = nullptr;
 Monitor* Threads_lock                 = nullptr;
 Mutex*   NonJavaThreadsList_lock      = nullptr;
 Mutex*   NonJavaThreadsListSync_lock  = nullptr;
-Monitor* CGC_lock                     = nullptr;
 Monitor* STS_lock                     = nullptr;
-Monitor* G1OldGCCount_lock            = nullptr;
-Mutex*   G1RareEvent_lock             = nullptr;
-Mutex*   G1DetachedRefinementStats_lock = nullptr;
-Mutex*   MarkStackFreeList_lock       = nullptr;
-Mutex*   MarkStackChunkList_lock      = nullptr;
 Mutex*   MonitoringSupport_lock       = nullptr;
 Monitor* ConcurrentGCBreakpoints_lock = nullptr;
 Mutex*   Compile_lock                 = nullptr;
@@ -103,10 +97,16 @@ Mutex*   RawMonitor_lock              = nullptr;
 Mutex*   PerfDataMemAlloc_lock        = nullptr;
 Mutex*   PerfDataManager_lock         = nullptr;
 
-Mutex*   FreeList_lock                = nullptr;
-Mutex*   OldSets_lock                 = nullptr;
-Mutex*   Uncommit_lock                = nullptr;
-Monitor* RootRegionScan_lock          = nullptr;
+Monitor* G1CGC_lock                   = nullptr;
+Mutex*   G1FreeList_lock              = nullptr;
+Mutex*   G1OldSets_lock               = nullptr;
+Mutex*   G1Uncommit_lock              = nullptr;
+Monitor* G1RootRegionScan_lock        = nullptr;
+Monitor* G1OldGCCount_lock            = nullptr;
+Mutex*   G1RareEvent_lock             = nullptr;
+Mutex*   G1DetachedRefinementStats_lock = nullptr;
+Mutex*   G1MarkStackFreeList_lock     = nullptr;
+Mutex*   G1MarkStackChunkList_lock    = nullptr;
 
 Mutex*   Management_lock              = nullptr;
 Monitor* MonitorDeflation_lock        = nullptr;
@@ -210,17 +210,17 @@ void mutex_init() {
   MUTEX_DEFN(STS_lock                        , PaddedMonitor, nosafepoint);
 
   if (UseG1GC) {
-    MUTEX_DEFN(CGC_lock                      , PaddedMonitor, nosafepoint);
+    MUTEX_DEFN(G1CGC_lock                    , PaddedMonitor, nosafepoint);
 
     MUTEX_DEFN(G1DetachedRefinementStats_lock, PaddedMutex  , nosafepoint-2);
 
-    MUTEX_DEFN(FreeList_lock                 , PaddedMutex  , service-1);
-    MUTEX_DEFN(OldSets_lock                  , PaddedMutex  , nosafepoint);
-    MUTEX_DEFN(Uncommit_lock                 , PaddedMutex  , service-2);
-    MUTEX_DEFN(RootRegionScan_lock           , PaddedMonitor, nosafepoint-1);
+    MUTEX_DEFN(G1FreeList_lock               , PaddedMutex  , service-1);
+    MUTEX_DEFN(G1OldSets_lock                , PaddedMutex  , nosafepoint);
+    MUTEX_DEFN(G1Uncommit_lock               , PaddedMutex  , service-2);
+    MUTEX_DEFN(G1RootRegionScan_lock         , PaddedMonitor, nosafepoint-1);
 
-    MUTEX_DEFN(MarkStackFreeList_lock        , PaddedMutex  , nosafepoint);
-    MUTEX_DEFN(MarkStackChunkList_lock       , PaddedMutex  , nosafepoint);
+    MUTEX_DEFN(G1MarkStackFreeList_lock      , PaddedMutex  , nosafepoint);
+    MUTEX_DEFN(G1MarkStackChunkList_lock     , PaddedMutex  , nosafepoint);
   }
   MUTEX_DEFN(MonitoringSupport_lock          , PaddedMutex  , service-1);        // used for serviceability monitoring support
 

--- a/src/hotspot/share/runtime/mutexLocker.hpp
+++ b/src/hotspot/share/runtime/mutexLocker.hpp
@@ -70,14 +70,13 @@ extern Monitor* Threads_lock;                    // a lock on the Threads table 
                                                  // (also used by Safepoints too to block threads creation/destruction)
 extern Mutex*   NonJavaThreadsList_lock;         // a lock on the NonJavaThreads list
 extern Mutex*   NonJavaThreadsListSync_lock;     // a lock for NonJavaThreads list synchronization
-extern Monitor* G1CGC_lock;                        // used for coordination between
-                                                 // fore- & background GC threads.
+extern Monitor* G1CGC_lock;                      // used for coordination between fore- & background G1 concurrent GC threads.
 extern Monitor* STS_lock;                        // used for joining/leaving SuspendibleThreadSet.
 extern Monitor* G1OldGCCount_lock;               // in support of "concurrent" full gc
 extern Mutex*   G1RareEvent_lock;                // Synchronizes (rare) parallel GC operations.
-extern Mutex*   G1DetachedRefinementStats_lock;  // Lock protecting detached refinement stats
-extern Mutex*   G1MarkStackFreeList_lock;          // Protects access to the global mark stack free list.
-extern Mutex*   G1MarkStackChunkList_lock;         // Protects access to the global mark stack chunk list.
+extern Mutex*   G1DetachedRefinementStats_lock;  // Lock protecting detached refinement stats for G1.
+extern Mutex*   G1MarkStackFreeList_lock;        // Protects access to the G1 global mark stack free list.
+extern Mutex*   G1MarkStackChunkList_lock;       // Protects access to the G1 global mark stack chunk list.
 extern Mutex*   MonitoringSupport_lock;          // Protects updates to the serviceability memory pools and allocated memory high water mark.
 extern Monitor* ConcurrentGCBreakpoints_lock;    // Protects concurrent GC breakpoint management
 extern Mutex*   Compile_lock;                    // a lock held when Compilation is updating code (used to block CodeCache traversal, CHA updates, etc)
@@ -103,10 +102,10 @@ extern Mutex*   RawMonitor_lock;
 extern Mutex*   PerfDataMemAlloc_lock;           // a lock on the allocator for PerfData memory for performance data
 extern Mutex*   PerfDataManager_lock;            // a long on access to PerfDataManager resources
 
-extern Mutex*   G1FreeList_lock;                   // protects the free region list during safepoints
-extern Mutex*   G1OldSets_lock;                    // protects the old region sets
-extern Mutex*   G1Uncommit_lock;                   // protects the uncommit list when not at safepoints
-extern Monitor* G1RootRegionScan_lock;             // used to notify that the CM threads have finished scanning the IM snapshot regions
+extern Mutex*   G1FreeList_lock;                 // protects the G1 free region list during safepoints
+extern Mutex*   G1OldSets_lock;                  // protects the G1 old region sets
+extern Mutex*   G1Uncommit_lock;                 // protects the G1 uncommit list when not at safepoints
+extern Monitor* G1RootRegionScan_lock;           // used to notify that the G1 CM threads have finished scanning the root regions
 
 extern Mutex*   Management_lock;                 // a lock used to serialize JVM management
 extern Monitor* MonitorDeflation_lock;           // a lock used for monitor deflation thread operation

--- a/src/hotspot/share/runtime/mutexLocker.hpp
+++ b/src/hotspot/share/runtime/mutexLocker.hpp
@@ -70,14 +70,14 @@ extern Monitor* Threads_lock;                    // a lock on the Threads table 
                                                  // (also used by Safepoints too to block threads creation/destruction)
 extern Mutex*   NonJavaThreadsList_lock;         // a lock on the NonJavaThreads list
 extern Mutex*   NonJavaThreadsListSync_lock;     // a lock for NonJavaThreads list synchronization
-extern Monitor* CGC_lock;                        // used for coordination between
+extern Monitor* G1CGC_lock;                        // used for coordination between
                                                  // fore- & background GC threads.
 extern Monitor* STS_lock;                        // used for joining/leaving SuspendibleThreadSet.
 extern Monitor* G1OldGCCount_lock;               // in support of "concurrent" full gc
 extern Mutex*   G1RareEvent_lock;                // Synchronizes (rare) parallel GC operations.
 extern Mutex*   G1DetachedRefinementStats_lock;  // Lock protecting detached refinement stats
-extern Mutex*   MarkStackFreeList_lock;          // Protects access to the global mark stack free list.
-extern Mutex*   MarkStackChunkList_lock;         // Protects access to the global mark stack chunk list.
+extern Mutex*   G1MarkStackFreeList_lock;          // Protects access to the global mark stack free list.
+extern Mutex*   G1MarkStackChunkList_lock;         // Protects access to the global mark stack chunk list.
 extern Mutex*   MonitoringSupport_lock;          // Protects updates to the serviceability memory pools and allocated memory high water mark.
 extern Monitor* ConcurrentGCBreakpoints_lock;    // Protects concurrent GC breakpoint management
 extern Mutex*   Compile_lock;                    // a lock held when Compilation is updating code (used to block CodeCache traversal, CHA updates, etc)
@@ -103,10 +103,10 @@ extern Mutex*   RawMonitor_lock;
 extern Mutex*   PerfDataMemAlloc_lock;           // a lock on the allocator for PerfData memory for performance data
 extern Mutex*   PerfDataManager_lock;            // a long on access to PerfDataManager resources
 
-extern Mutex*   FreeList_lock;                   // protects the free region list during safepoints
-extern Mutex*   OldSets_lock;                    // protects the old region sets
-extern Mutex*   Uncommit_lock;                   // protects the uncommit list when not at safepoints
-extern Monitor* RootRegionScan_lock;             // used to notify that the CM threads have finished scanning the IM snapshot regions
+extern Mutex*   G1FreeList_lock;                   // protects the free region list during safepoints
+extern Mutex*   G1OldSets_lock;                    // protects the old region sets
+extern Mutex*   G1Uncommit_lock;                   // protects the uncommit list when not at safepoints
+extern Monitor* G1RootRegionScan_lock;             // used to notify that the CM threads have finished scanning the IM snapshot regions
 
 extern Mutex*   Management_lock;                 // a lock used to serialize JVM management
 extern Monitor* MonitorDeflation_lock;           // a lock used for monitor deflation thread operation


### PR DESCRIPTION
Hi all,

  please review this renaming of a few G1 specific locks to have a G1 prefix to make it clear that they should not be used elsewhere.

Testing: local compilation, gha

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8363929](https://bugs.openjdk.org/browse/JDK-8363929): G1: Add G1 prefix to various G1 specific global locks (**Enhancement** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**) Review applies to [27c8ad42](https://git.openjdk.org/jdk/pull/26444/files/27c8ad42522f24e17ff65ba2bf2bd53398cb77b5)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26444/head:pull/26444` \
`$ git checkout pull/26444`

Update a local copy of the PR: \
`$ git checkout pull/26444` \
`$ git pull https://git.openjdk.org/jdk.git pull/26444/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26444`

View PR using the GUI difftool: \
`$ git pr show -t 26444`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26444.diff">https://git.openjdk.org/jdk/pull/26444.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26444#issuecomment-3108833453)
</details>
