### PR TITLE
8363720: Follow up to JDK-8360411 with post review comments

### DIFF
--- a/test/jdk/java/io/File/MaxPathLength.java
+++ b/test/jdk/java/io/File/MaxPathLength.java
@@ -34,7 +34,7 @@ import java.nio.file.DirectoryNotEmptyException;
 public class MaxPathLength {
     private static String sep = File.separator;
     private static String pathComponent = sep +
-            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
     private static String fileName =
             "areallylongfilenamethatsforsur";
     private static boolean isWindows = false;
@@ -75,7 +75,7 @@ public class MaxPathLength {
 
     private static String getNextName(String fName) {
         return (fName.length() < MAX_LENGTH/2) ? fName + fName
-                : fName + "A";
+                                               : fName + "A";
     }
 
     static void testLongPath(int max, String fn,
@@ -150,7 +150,7 @@ public class MaxPathLength {
                 throw new RuntimeException ("File.listFiles() failed");
 
             if (isWindows &&
-                    !fu.getCanonicalPath().equals(f.getCanonicalPath()))
+                !fu.getCanonicalPath().equals(f.getCanonicalPath()))
                 throw new RuntimeException ("getCanonicalPath() failed");
 
             char[] cc = tPath.toCharArray();
@@ -164,7 +164,7 @@ public class MaxPathLength {
                 */
                 String abPath = f.getAbsolutePath();
                 if (!abPath.startsWith("\\\\") ||
-                        abPath.length() < 1093) {
+                    abPath.length() < 1093) {
                     throw new RuntimeException ("File.renameTo() failed for length="
                             + abPath.length());
                 }
@@ -212,4 +212,5 @@ public class MaxPathLength {
         }
     }
 }
+
 

--- a/test/jdk/java/io/File/MaxPathLength.java
+++ b/test/jdk/java/io/File/MaxPathLength.java
@@ -36,7 +36,7 @@ public class MaxPathLength {
     private static String pathComponent = sep +
         "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
     private static String fileName =
-            "areallylongfilenamethatsforsur";
+                "areallylongfilenamethatsforsur";
     private static boolean isWindows = false;
 
     private static final int MAX_LENGTH = 256;
@@ -166,7 +166,7 @@ public class MaxPathLength {
                 if (!abPath.startsWith("\\\\") ||
                     abPath.length() < 1093) {
                     throw new RuntimeException ("File.renameTo() failed for length="
-                            + abPath.length());
+                                                + abPath.length());
                 }
             } else {
                 if (!nf.canRead())

--- a/test/jdk/java/io/File/MaxPathLength.java
+++ b/test/jdk/java/io/File/MaxPathLength.java
@@ -205,5 +205,3 @@ public class MaxPathLength {
         }
     }
 }
-
-

--- a/test/jdk/java/io/File/MaxPathLength.java
+++ b/test/jdk/java/io/File/MaxPathLength.java
@@ -24,20 +24,21 @@
 /* @test
    @bug 4759207 4403166 4165006 4403166 6182812 6274272 7160013
    @summary Test to see if win32 path length can be greater than 260
+   @library .. /test/lib
  */
 
 import java.io.*;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.DirectoryNotEmptyException;
+import jdk.test.lib.Platform;
 
 public class MaxPathLength {
     private static String sep = File.separator;
     private static String pathComponent = sep +
         "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
     private static String fileName =
-                "areallylongfilenamethatsforsur";
-    private static boolean isWindows = false;
+            "areallylongfilenamethatsforsur";
 
     private static final int MAX_LENGTH = 256;
 
@@ -48,7 +49,6 @@ public class MaxPathLength {
     private static int counter = 0;
 
     public static void main(String[] args) throws Exception {
-        setIsWindows();
 
         for (int i = 4; i < 7; i++) {
             String name = fileName;
@@ -61,15 +61,8 @@ public class MaxPathLength {
 
         // test long paths on windows
         // And these long paths cannot be handled on Linux and Mac platforms
-        if (isWindows) {
+        if (Platform.isWindows()) {
             testLongPath();
-        }
-    }
-
-    private static void setIsWindows() {
-        String osName = System.getProperty("os.name");
-        if (osName.startsWith("Windows")) {
-            isWindows = true;
         }
     }
 
@@ -149,7 +142,7 @@ public class MaxPathLength {
             if (flist == null || !fn.equals(flist[0].getName()))
                 throw new RuntimeException ("File.listFiles() failed");
 
-            if (isWindows &&
+            if (Platform.isWindows() &&
                 !fu.getCanonicalPath().equals(f.getCanonicalPath()))
                 throw new RuntimeException ("getCanonicalPath() failed");
 


### PR DESCRIPTION
There were a couple of post review comments for PR: https://github.com/openjdk/jdk/pull/26193 after the /integrate command was submitted. This issue will address those comments. Also created constants for hardcoded values and tests. Fixed some typos.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8363720](https://bugs.openjdk.org/browse/JDK-8363720): Follow up to JDK-8360411 with post review comments (**Enhancement** - P4)


### Reviewers
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26445/head:pull/26445` \
`$ git checkout pull/26445`

Update a local copy of the PR: \
`$ git checkout pull/26445` \
`$ git pull https://git.openjdk.org/jdk.git pull/26445/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26445`

View PR using the GUI difftool: \
`$ git pr show -t 26445`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26445.diff">https://git.openjdk.org/jdk/pull/26445.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26445#issuecomment-3108847719)
</details>
