### PR TITLE
8363965: GHA: Switch cross-compiling sysroots to Debian bookworm

### DIFF
--- a/.github/workflows/build-cross-compile.yml
+++ b/.github/workflows/build-cross-compile.yml
@@ -89,7 +89,7 @@ jobs:
             gnu-arch: riscv64
             debian-arch: riscv64
             debian-repository: https://httpredir.debian.org/debian/
-            debian-version: bookworm
+            debian-version: sid
             tolerate-sysroot-errors: true
 
     steps:

--- a/.github/workflows/build-cross-compile.yml
+++ b/.github/workflows/build-cross-compile.yml
@@ -64,32 +64,32 @@ jobs:
             gnu-arch: aarch64
             debian-arch: arm64
             debian-repository: https://httpredir.debian.org/debian/
-            debian-version: bullseye
+            debian-version: bookworm
             tolerate-sysroot-errors: false
           - target-cpu: arm
             gnu-arch: arm
             debian-arch: armhf
             debian-repository: https://httpredir.debian.org/debian/
-            debian-version: bullseye
+            debian-version: bookworm
             tolerate-sysroot-errors: false
             gnu-abi: eabihf
           - target-cpu: s390x
             gnu-arch: s390x
             debian-arch: s390x
             debian-repository: https://httpredir.debian.org/debian/
-            debian-version: bullseye
+            debian-version: bookworm
             tolerate-sysroot-errors: false
           - target-cpu: ppc64le
             gnu-arch: powerpc64le
             debian-arch: ppc64el
             debian-repository: https://httpredir.debian.org/debian/
-            debian-version: bullseye
+            debian-version: bookworm
             tolerate-sysroot-errors: false
           - target-cpu: riscv64
             gnu-arch: riscv64
             debian-arch: riscv64
             debian-repository: https://httpredir.debian.org/debian/
-            debian-version: sid
+            debian-version: bookworm
             tolerate-sysroot-errors: true
 
     steps:


### PR DESCRIPTION
I have noticed that GHA jobs started to fail when creating ppc64el sysroot. We are using Debian bullseye as the base for sysroots. Debian bullseye is LTS release. Perhaps counter-intuitively, LTS platform support shrinks over the LTS lifetime. Debian wiki: https://wiki.debian.org/LTS/Using -- says:

"Important: The current LTS version is Debian 11 ("bullseye") and will be supported until August 31st, 2026. Supported architectures in Debian 11 LTS are limited to amd64, i386, arm64 and armhf. Users of other architectures are especially encouraged to upgrade to Debian 12 (''bookworm''). "

We should consider switching to Debian bookworm for GHA cross-compiling sysroots. Again, Debian wiki: https://wiki.debian.org/DebianBookworm#Architectures -- says all architectures we need are supported. But actually, RISC-V is still only supported with sid. So, we need to be switching only current bullseye to bookworm, leaving sid as sid. This should change as Debian trixie releases in a few weeks, but we cannot wait for this long. Debian trixie update would be handled in [JDK-8363966](https://bugs.openjdk.org/browse/JDK-8363966).

Additional testing:
 - [x] GHA cross-compilation jobs

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8363965](https://bugs.openjdk.org/browse/JDK-8363965): GHA: Switch cross-compiling sysroots to Debian bookworm (**Enhancement** - P4)


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26447/head:pull/26447` \
`$ git checkout pull/26447`

Update a local copy of the PR: \
`$ git checkout pull/26447` \
`$ git pull https://git.openjdk.org/jdk.git pull/26447/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26447`

View PR using the GUI difftool: \
`$ git pr show -t 26447`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26447.diff">https://git.openjdk.org/jdk/pull/26447.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26447#issuecomment-3109331037)
</details>
