### PR TITLE
8355742: G1: Move Rebuild Free List phase into Post Evacuate 2

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -2718,12 +2718,6 @@ void G1CollectedHeap::clear_collection_set() {
   collection_set()->clear();
 }
 
-void G1CollectedHeap::rebuild_free_region_list() {
-  Ticks start = Ticks::now();
-  _hrm.rebuild_free_list(workers());
-  phase_times()->record_total_rebuild_freelist_time_ms((Ticks::now() - start).seconds() * 1000.0);
-}
-
 class G1AbandonCollectionSetClosure : public G1HeapRegionClosure {
 public:
   virtual bool do_heap_region(G1HeapRegion* r) {
@@ -2740,6 +2734,10 @@ void G1CollectedHeap::abandon_collection_set(G1CollectionSet* collection_set) {
 
   collection_set->clear();
   collection_set->stop_incremental_building();
+}
+
+G1AbstractSubTask* G1CollectedHeap::rebuild_free_list_task(G1HeapRegionBoolClosure* will_be_free) {
+  return _hrm.rebuild_free_list_task(will_be_free);
 }
 
 bool G1CollectedHeap::is_old_gc_alloc_region(G1HeapRegion* hr) {

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -193,7 +193,6 @@ private:
   G1BlockOffsetTable* _bot;
 
 public:
-  void rebuild_free_region_list();
   // Start a new incremental collection set for the next pause.
   void start_new_collection_set();
 
@@ -1003,6 +1002,7 @@ public:
     return _hrm.is_free(hr);
   }
 #endif // ASSERT
+  G1AbstractSubTask* rebuild_free_list_task(G1HeapRegionBoolClosure* will_be_free);
 
   inline void old_set_add(G1HeapRegion* hr);
   inline void old_set_remove(G1HeapRegion* hr);

--- a/src/hotspot/share/gc/g1/g1GCPhaseTimes.hpp
+++ b/src/hotspot/share/gc/g1/g1GCPhaseTimes.hpp
@@ -75,8 +75,8 @@ class G1GCPhaseTimes : public CHeapObj<mtGC> {
     FreeCollectionSet,
     YoungFreeCSet,
     NonYoungFreeCSet,
-    ResizeThreadLABs,
     RebuildFreeList,
+    ResizeThreadLABs,
     SampleCollectionSetCandidates,
     MergePSS,
     RestoreEvacuationFailedRegions,
@@ -205,10 +205,6 @@ class G1GCPhaseTimes : public CHeapObj<mtGC> {
 
   double _recorded_serial_free_cset_time_ms;
 
-  double _recorded_total_rebuild_freelist_time_ms;
-
-  double _recorded_serial_rebuild_freelist_time_ms;
-
   double _cur_region_register_time;
 
   // Not included in _gc_pause_time_ms
@@ -334,14 +330,6 @@ class G1GCPhaseTimes : public CHeapObj<mtGC> {
     _recorded_serial_free_cset_time_ms = time_ms;
   }
 
-  void record_total_rebuild_freelist_time_ms(double time_ms) {
-    _recorded_total_rebuild_freelist_time_ms = time_ms;
-  }
-
-  void record_serial_rebuild_freelist_time_ms(double time_ms) {
-    _recorded_serial_rebuild_freelist_time_ms = time_ms;
-  }
-
   void record_register_regions(double time_ms) {
     _cur_region_register_time = time_ms;
   }
@@ -406,10 +394,6 @@ class G1GCPhaseTimes : public CHeapObj<mtGC> {
 
   double young_cset_choice_time_ms() {
     return _recorded_young_cset_choice_time_ms;
-  }
-
-  double total_rebuild_freelist_time_ms() {
-    return _recorded_total_rebuild_freelist_time_ms;
   }
 
   double non_young_cset_choice_time_ms() {

--- a/src/hotspot/share/gc/g1/g1HeapRegion.hpp
+++ b/src/hotspot/share/gc/g1/g1HeapRegion.hpp
@@ -562,6 +562,13 @@ public:
   bool verify(VerifyOption vo) const;
 };
 
+// Closure that returns true or false for a given G1HeapRegion.
+class G1HeapRegionBoolClosure : public StackObj {
+public:
+
+  virtual bool do_heap_region(G1HeapRegion* r) const = 0;
+};
+
 // G1HeapRegionClosure is used for iterating over regions.
 // Terminates the iteration when the "do_heap_region" method returns "true".
 class G1HeapRegionClosure : public StackObj {

--- a/src/hotspot/share/gc/g1/g1HeapRegionManager.hpp
+++ b/src/hotspot/share/gc/g1/g1HeapRegionManager.hpp
@@ -32,8 +32,10 @@
 #include "memory/allocation.hpp"
 #include "services/memoryUsage.hpp"
 
+class G1AbstractSubTask;
 class G1HeapRegion;
 class G1HeapRegionClaimer;
+class G1HeapRegionBoolClosure;
 class G1HeapRegionClosure;
 class G1FreeRegionList;
 class WorkerThreads;
@@ -72,6 +74,7 @@ class G1HeapRegionTable : public G1BiasedMappedArray<G1HeapRegion*> {
 class G1HeapRegionManager: public CHeapObj<mtGC> {
   friend class VMStructs;
   friend class G1HeapRegionClaimer;
+  friend class G1RebuildFreeListTask;
 
   G1RegionToSpaceMapper* _bot_mapper;
   G1RegionToSpaceMapper* _cardtable_mapper;
@@ -191,8 +194,7 @@ public:
   // Insert the given region into the free region list.
   inline void insert_into_free_list(G1HeapRegion* hr);
 
-  // Rebuild the free region list from scratch.
-  void rebuild_free_list(WorkerThreads* workers);
+  G1AbstractSubTask* rebuild_free_list_task(G1HeapRegionBoolClosure* will_be_free);
 
   // Insert the given region list into the global free region list.
   void insert_list_into_free_list(G1FreeRegionList* list) {

--- a/src/hotspot/share/gc/g1/g1HeapRegionSet.cpp
+++ b/src/hotspot/share/gc/g1/g1HeapRegionSet.cpp
@@ -32,11 +32,9 @@ uint G1FreeRegionList::_unrealistically_long_length = 0;
 #ifndef PRODUCT
 void G1HeapRegionSetBase::verify_region(G1HeapRegion* hr) {
   assert(hr->containing_set() == this, "Inconsistent containing set for %u", hr->hrm_index());
-  assert(!hr->is_young(), "Adding young region %u", hr->hrm_index()); // currently we don't use these sets for young regions
   assert(_checker == nullptr || _checker->is_correct_type(hr), "Wrong type of region %u (%s) and set %s",
          hr->hrm_index(), hr->get_type_str(), name());
   assert(!hr->is_free() || hr->is_empty(), "Free region %u is not empty for set %s", hr->hrm_index(), name());
-  assert(!hr->is_empty() || hr->is_free(), "Empty region %u is not free or old for set %s", hr->hrm_index(), name());
 }
 #endif
 

--- a/src/hotspot/share/gc/g1/g1YoungCollector.cpp
+++ b/src/hotspot/share/gc/g1/g1YoungCollector.cpp
@@ -1049,8 +1049,6 @@ void G1YoungCollector::post_evacuate_collection_set(G1EvacInfo* evacuation_info,
 
   assert_used_and_recalculate_used_equal(_g1h);
 
-  _g1h->rebuild_free_region_list();
-
   _g1h->record_obj_copy_mem_stats();
 
   evacuation_info->set_bytes_used(_g1h->bytes_used_during_gc());

--- a/src/hotspot/share/gc/g1/g1YoungGCPostEvacuateTasks.hpp
+++ b/src/hotspot/share/gc/g1/g1YoungGCPostEvacuateTasks.hpp
@@ -26,6 +26,7 @@
 #define SHARE_GC_G1_G1YOUNGGCPOSTEVACUATETASKS_HPP
 
 #include "gc/g1/g1BatchedTask.hpp"
+#include "gc/g1/g1HeapRegion.hpp"
 
 class FreeCSetStats;
 
@@ -54,6 +55,7 @@ public:
 // Second set of post evacuate collection set tasks containing (s means serial):
 // - Eagerly Reclaim Humongous Objects (s)
 // - Update Derived Pointers (s)
+// - Rebuild the Master Free List
 // - Clear Retained Region Data (on evacuation failure)
 // - Redirty Logged Cards
 // - Free Collection Set
@@ -70,6 +72,14 @@ class G1PostEvacuateCollectionSetCleanupTask2 : public G1BatchedTask {
   class FreeCollectionSetTask;
   class ResizeTLABsTask;
   class ResetPartialArrayStateManagerTask;
+
+  class WillBeFreeHeapRegionClosure : public G1HeapRegionBoolClosure {
+    G1EvacFailureRegions* _evac_failure_regions;
+  public:
+    WillBeFreeHeapRegionClosure(G1EvacFailureRegions* evac_failure_regions);
+
+    bool do_heap_region(G1HeapRegion* r) const;
+  } _will_be_free_cl;
 
 public:
   G1PostEvacuateCollectionSetCleanupTask2(G1ParScanThreadStateSet* per_thread_states,

--- a/test/hotspot/jtreg/gc/g1/TestGCLogMessages.java
+++ b/test/hotspot/jtreg/gc/g1/TestGCLogMessages.java
@@ -182,6 +182,7 @@ public class TestGCLogMessages {
         new LogMessageWithLevelC2OrJVMCIOnly("Update Derived Pointers", Level.DEBUG),
         new LogMessageWithLevel("Redirty Logged Cards \\(ms\\):", Level.DEBUG),
         new LogMessageWithLevel("Redirtied Cards:", Level.DEBUG),
+        new LogMessageWithLevel("Rebuild Free List:", Level.DEBUG),
         new LogMessageWithLevel("Resize TLABs \\(ms\\):", Level.DEBUG),
         new LogMessageWithLevel("Free Collection Set \\(ms\\):", Level.DEBUG),
         new LogMessageWithLevel("Serial Free Collection Set:", Level.TRACE),
@@ -190,9 +191,6 @@ public class TestGCLogMessages {
         new LogMessageWithLevel("Reset Partial Array State Manager \\(ms\\)", Level.TRACE),
 
         // Misc Top-level
-        new LogMessageWithLevel("Rebuild Free List:", Level.DEBUG),
-        new LogMessageWithLevel("Serial Rebuild Free List:", Level.TRACE),
-        new LogMessageWithLevel("Parallel Rebuild Free List \\(ms\\):", Level.TRACE),
         new LogMessageWithLevel("Prepare For Mutator:", Level.DEBUG),
         new LogMessageWithLevel("Resize Heap After Collection:", Level.DEBUG),
     };

--- a/test/jdk/jdk/jfr/event/gc/collection/TestG1ParallelPhases.java
+++ b/test/jdk/jdk/jfr/event/gc/collection/TestG1ParallelPhases.java
@@ -107,6 +107,7 @@ public class TestG1ParallelPhases {
             "Termination",
             "RedirtyCards",
             "RecalculateUsed",
+            "RebuildFreeList"
             "ResizeTLABs",
             "FreeCSet",
             "UpdateDerivedPointers",


### PR DESCRIPTION
Hi all,

  please review this change that moves the entire "Rebuild Free List" phase into the post evacuation phase 2.

The spin-up and tear-down of the extra workers was in the range of the actual work, so making this phase very inefficent.

Instead this task has been added as subtask of Post Evacuation Phase 2.

Testing: tier1-5

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8355742](https://bugs.openjdk.org/browse/JDK-8355742): G1: Move Rebuild Free List phase into Post Evacuate 2 (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26448/head:pull/26448` \
`$ git checkout pull/26448`

Update a local copy of the PR: \
`$ git checkout pull/26448` \
`$ git pull https://git.openjdk.org/jdk.git pull/26448/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26448`

View PR using the GUI difftool: \
`$ git pr show -t 26448`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26448.diff">https://git.openjdk.org/jdk/pull/26448.diff</a>

</details>
