### PR TITLE
8360679: Shenandoah: AOT saved adapter calls into broken GC barrier stub

### DIFF
--- a/src/hotspot/cpu/aarch64/gc/shenandoah/shenandoahBarrierSetAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/gc/shenandoah/shenandoahBarrierSetAssembler_aarch64.cpp
@@ -23,6 +23,7 @@
  *
  */
 
+#include "code/aotCodeCache.hpp"
 #include "gc/shenandoah/heuristics/shenandoahHeuristics.hpp"
 #include "gc/shenandoah/mode/shenandoahMode.hpp"
 #include "gc/shenandoah/shenandoahBarrierSet.hpp"
@@ -292,7 +293,12 @@ void ShenandoahBarrierSetAssembler::load_reference_barrier(MacroAssembler* masm,
   } else {
     assert(is_phantom, "only remaining strength");
     assert(!is_narrow, "phantom access cannot be narrow");
-    __ lea(lr, RuntimeAddress(CAST_FROM_FN_PTR(address, ShenandoahRuntime::load_reference_barrier_phantom)));
+    if (AOTCodeCache::is_on_for_dump()) {
+      // AOT needs relocation for this stub to save adapters.
+      __ lea(lr, RuntimeAddress(CAST_FROM_FN_PTR(address, ShenandoahRuntime::load_reference_barrier_phantom)));
+    } else {
+      __ mov(lr, CAST_FROM_FN_PTR(address, ShenandoahRuntime::load_reference_barrier_phantom));
+    }
   }
   __ blr(lr);
   __ mov(rscratch1, r0);

--- a/src/hotspot/cpu/aarch64/gc/shenandoah/shenandoahBarrierSetAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/gc/shenandoah/shenandoahBarrierSetAssembler_aarch64.cpp
@@ -292,7 +292,7 @@ void ShenandoahBarrierSetAssembler::load_reference_barrier(MacroAssembler* masm,
   } else {
     assert(is_phantom, "only remaining strength");
     assert(!is_narrow, "phantom access cannot be narrow");
-    __ mov(lr, CAST_FROM_FN_PTR(address, ShenandoahRuntime::load_reference_barrier_phantom));
+    __ lea(lr, RuntimeAddress(CAST_FROM_FN_PTR(address, ShenandoahRuntime::load_reference_barrier_phantom)));
   }
   __ blr(lr);
   __ mov(rscratch1, r0);


### PR DESCRIPTION
See the bug for more analysis. This is AOT-, AArch64-, Shenandoah-specific problem. The fix is simple, the failure is catastrophic, and it is very reproducible. So it makes the issue P2, and would like to get it into JDK 25 under RDP 2 rules.

Additional testing:
 - [x] Linux AArch64 server fastdebug, mainline, `runtime/cds` with `-XX:+UseShenandoahGC` (now passes)
 - [ ] Linux AArch64 server fastdebug, mainline, `hotspot_gc_shenandoah` (still passes)
 - [ ] Linux AArch64 server fastdebug, JDK 25, `runtime/cds` with `-XX:+UseShenandoahGC` (now passes)
 - [ ] Linux AArch64 server fastdebug, JDK 25, `hotspot_gc_shenandoah` (still passes)