### PR TITLE
8320836: jtreg gtest runs should limit heap size

### DIFF
--- a/test/hotspot/jtreg/gtest/GTestWrapper.java
+++ b/test/hotspot/jtreg/gtest/GTestWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
Trivial fix to limit Java heap size when running the gtests. Otherwise, we run with an unknown malloc load (since GC structures, preallocated, may be very large), and not all tests like that.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8320836: jtreg gtest runs should limit heap size`

### Issue
 * [JDK-8320836](https://bugs.openjdk.org/browse/JDK-8320836): jtreg gtest runs should limit heap size (**Enhancement** - P4)


### Reviewers
 * [Cesar Soares Lucas](https://openjdk.org/census#cslucas) (@JohnTortugo - Committer) Review applies to [65ae1a5c](https://git.openjdk.org/jdk/pull/26454/files/65ae1a5c95014e7e1394e79252bb32e7efe182a2)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26454/head:pull/26454` \
`$ git checkout pull/26454`

Update a local copy of the PR: \
`$ git checkout pull/26454` \
`$ git pull https://git.openjdk.org/jdk.git pull/26454/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26454`

View PR using the GUI difftool: \
`$ git pr show -t 26454`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26454.diff">https://git.openjdk.org/jdk/pull/26454.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26454#issuecomment-3113137415)
</details>
