### PR TITLE
8362855: Test java/net/ipv6tests/TcpTest.java should report SkippedException when there no ia4addr  or ia6addr

### DIFF
--- a/test/jdk/java/net/ipv6tests/TcpTest.java
+++ b/test/jdk/java/net/ipv6tests/TcpTest.java
@@ -31,12 +31,15 @@
  * @library /test/lib
  * @build jdk.test.lib.NetworkConfiguration
  *        jdk.test.lib.Platform
+ *        jtreg.SkippedException
  * @run main TcpTest -d
  */
 
 import java.net.*;
 import java.io.*;
 import java.util.concurrent.TimeUnit;
+
+import jtreg.SkippedException;
 
 public class TcpTest extends Tests {
     static ServerSocket server, server1, server2;
@@ -62,12 +65,10 @@ public class TcpTest extends Tests {
     public static void main (String[] args) throws Exception {
         checkDebug(args);
         if (ia4addr == null) {
-            System.out.println ("No IPV4 addresses: exiting test");
-            return;
+            throw new SkippedException("No IPV4 addresses: exiting test");
         }
         if (ia6addr == null) {
-            System.out.println ("No IPV6 addresses: exiting test");
-            return;
+            throw new SkippedException("No IPV6 addresses: exiting test");
         }
         dprintln ("Local Addresses");
         dprintln (ia4addr.toString());


### PR DESCRIPTION
Hi all,

I think the test java/net/ipv6tests/TcpTest.java should report jtreg.SkippedException when there no IPV4 addresses or no IPV6 addresses, rather than just print a messge and then report test run passes.

Change has been verified locally, both enable ipv6 and disable ipv6 on linux. When enable ipv6, test run passes; when disable ipv6, test report jtreg.SkippedException as expected. Test-fix only, no risk.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8362855](https://bugs.openjdk.org/browse/JDK-8362855): Test java/net/ipv6tests/TcpTest.java should report SkippedException when there no ia4addr  or ia6addr (**Enhancement** - P4)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26459/head:pull/26459` \
`$ git checkout pull/26459`

Update a local copy of the PR: \
`$ git checkout pull/26459` \
`$ git pull https://git.openjdk.org/jdk.git pull/26459/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26459`

View PR using the GUI difftool: \
`$ git pr show -t 26459`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26459.diff">https://git.openjdk.org/jdk/pull/26459.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26459#issuecomment-3113413087)
</details>
