### PR TITLE
8360679: Shenandoah: AOT saved adapter calls into broken GC barrier stub

### DIFF
--- a/src/hotspot/cpu/aarch64/gc/shenandoah/shenandoahBarrierSetAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/gc/shenandoah/shenandoahBarrierSetAssembler_aarch64.cpp
@@ -292,7 +292,8 @@ void ShenandoahBarrierSetAssembler::load_reference_barrier(MacroAssembler* masm,
   } else {
     assert(is_phantom, "only remaining strength");
     assert(!is_narrow, "phantom access cannot be narrow");
-    __ mov(lr, CAST_FROM_FN_PTR(address, ShenandoahRuntime::load_reference_barrier_phantom));
+    // AOT saved adapters need relocation for this call.
+    __ lea(lr, RuntimeAddress(CAST_FROM_FN_PTR(address, ShenandoahRuntime::load_reference_barrier_phantom)));
   }
   __ blr(lr);
   __ mov(rscratch1, r0);


### PR DESCRIPTION
Backports the AOT- Shenandoah- AArch64- specific bugfix for JDK 25 regression. JDK 25 RDP2 approval is pending.

Additional testing:
 - [x] Linux AArch64 server fastdebug, `runtime/cds` with `-XX:+UseShenandoahGC` (now passes)
 - [x] Linux AArch64 server fastdebug, `hotspot_gc_shenandoah` (still passes)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8360679](https://bugs.openjdk.org/browse/JDK-8360679): Shenandoah: AOT saved adapter calls into broken GC barrier stub (**Bug** - P2)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26464/head:pull/26464` \
`$ git checkout pull/26464`

Update a local copy of the PR: \
`$ git checkout pull/26464` \
`$ git pull https://git.openjdk.org/jdk.git pull/26464/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26464`

View PR using the GUI difftool: \
`$ git pr show -t 26464`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26464.diff">https://git.openjdk.org/jdk/pull/26464.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26464#issuecomment-3114036827)
</details>
