### PR TITLE
8363063: AArch64: [VectorAPI] sve vector math operations are not supported after JDK-8353217

### DIFF
--- a/make/autoconf/flags-cflags.m4
+++ b/make/autoconf/flags-cflags.m4
@@ -933,7 +933,7 @@ AC_DEFUN([FLAGS_SETUP_CFLAGS_CPU_DEP],
   # ACLE and this flag are required to build the aarch64 SVE related functions in
   # libvectormath. Apple Silicon does not support SVE; use macOS as a proxy for
   # that check.
-  if test "x$OPENJDK_TARGET_CPU" = "xaarch64" && test "x$OPENJDK_TARGET_CPU" = "xlinux"; then
+  if test "x$OPENJDK_TARGET_CPU" = "xaarch64" && test "x$OPENJDK_TARGET_OS" = "xlinux"; then
     if test "x$TOOLCHAIN_TYPE" = xgcc || test "x$TOOLCHAIN_TYPE" = xclang; then
       AC_LANG_PUSH(C)
       OLD_CFLAGS="$CFLAGS"


### PR DESCRIPTION
This patch fixes a typo introduced in [JDK-8353217](https://github.com/openjdk/jdk/commit/130b0cdaa6604da47a893e5425547acf3d5253f4), which incorrectly disabled SVE vector math symbols. As a result, some vector math test cases such as `jdk/incubator/vector/Double256VectorTests.java` threw exceptions on 256-bit SVE machines with errors like:
`java.lang.InternalError: not supported: ACOS Species[double, 4, S_256_BIT] acosdx_u10sve`.

`test/jdk/jdk/incubator/vector` passed on `256-bit sve` machine, `macos` and `neon` machine.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8363063](https://bugs.openjdk.org/browse/JDK-8363063): AArch64: [VectorAPI] sve vector math operations are not supported after JDK-8353217 (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26465/head:pull/26465` \
`$ git checkout pull/26465`

Update a local copy of the PR: \
`$ git checkout pull/26465` \
`$ git pull https://git.openjdk.org/jdk.git pull/26465/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26465`

View PR using the GUI difftool: \
`$ git pr show -t 26465`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26465.diff">https://git.openjdk.org/jdk/pull/26465.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26465#issuecomment-3114045583)
</details>
