### PR TITLE
8364082: jdk/jfr/event/gc/heapsummary/TestHeapSummaryEventPSParOld.java Eden should be placed first in young

### DIFF
--- a/test/jdk/jdk/jfr/event/gc/heapsummary/HeapSummaryEventAllGcs.java
+++ b/test/jdk/jdk/jfr/event/gc/heapsummary/HeapSummaryEventAllGcs.java
@@ -161,18 +161,18 @@ public class HeapSummaryEventAllGcs {
         long toStart = Events.assertField(event, "toSpace.start").getValue();
         long toEnd = Events.assertField(event, "toSpace.end").getValue();
         Asserts.assertEquals(oldEnd, youngStart, "Young should start where old ends");
-        Asserts.assertEquals(youngStart, edenStart, "Eden should be placed first in young");
         if (fromStart < toStart) {
-            // [eden][from][to]
-            Asserts.assertGreaterThanOrEqual(fromStart, edenEnd, "From should start after eden");
+            // [from][to][eden]
+            Asserts.assertEquals(youngStart, fromStart, "From should be placed first in young");
             Asserts.assertLessThanOrEqual(fromEnd, toStart, "To should start after From");
-            Asserts.assertLessThanOrEqual(toEnd, youngEnd, "To should start after From");
+            Asserts.assertLessThanOrEqual(toEnd, edenStart, "Eden should start after To");
         } else {
-            // [eden][to][from]
-            Asserts.assertGreaterThanOrEqual(toStart, edenEnd, "From should start after eden");
-            Asserts.assertLessThanOrEqual(toEnd, fromStart, "To should start after From");
-            Asserts.assertLessThanOrEqual(fromEnd, youngEnd, "To should start after From");
+            // [to][from][eden]
+            Asserts.assertEquals(youngStart, toStart, "To should be placed first in young");
+            Asserts.assertLessThanOrEqual(toEnd, fromStart, "From should start after to");
+            Asserts.assertLessThanOrEqual(fromEnd, edenStart, "Eden should start after From");
         }
+        Asserts.assertEquals(edenEnd, youngEnd, "Eden should be last of young");
     }
 
     private static void checkVirtualSpace(RecordedEvent event, String structName) {


### PR DESCRIPTION
Update the test to reflect the new young-gen layout `from/to, eden` after [JDK-8338977](https://bugs.openjdk.org/browse/JDK-8338977).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8364082](https://bugs.openjdk.org/browse/JDK-8364082): jdk/jfr/event/gc/heapsummary/TestHeapSummaryEventPSParOld.java Eden should be placed first in young (**Bug** - P2)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26466/head:pull/26466` \
`$ git checkout pull/26466`

Update a local copy of the PR: \
`$ git checkout pull/26466` \
`$ git pull https://git.openjdk.org/jdk.git pull/26466/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26466`

View PR using the GUI difftool: \
`$ git pr show -t 26466`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26466.diff">https://git.openjdk.org/jdk/pull/26466.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26466#issuecomment-3114561837)
</details>
