### PR TITLE
8364089: JDK 25 RDP2 L10n resource files update

### DIFF
--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/msg/XMLMessages_de.properties
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/msg/XMLMessages_de.properties
@@ -328,4 +328,4 @@
         CatalogException=JAXP00090001: CatalogResolver ist mit dem Katalog "{0}" aktiviert, eine CatalogException wird jedoch zurückgegeben.
 
 # Implementation Property DTD
-        JDK_DTD_DENY = JAXP00010008: DOCTYPE ist nicht zulässig, wenn die DTD-Eigenschaft auf Ablehnen gesetzt wurde. Weitere Informationen: Eigenschaft jdk.xml.dtd.support in java.xml/module-summary.
+        JDK_DTD_DENY = JAXP00010008: DOCTYPE ist nicht zulässig, wenn die DTD-Eigenschaft auf "Ablehnen" gesetzt wurde. Weitere Informationen: Eigenschaft jdk.xml.dtd.support in java.xml/module-summary.

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler_de.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler_de.properties
@@ -1378,14 +1378,17 @@ compiler.warn.incubating.modules=Inkubatormodul(e) verwendet: {0}
 
 # 0: symbol, 1: symbol
 # lint: deprecation
+# flags: aggregate
 compiler.warn.has.been.deprecated={0} in {1} ist veraltet
 
 # 0: symbol, 1: symbol
 # lint: removal
+# flags: aggregate
 compiler.warn.has.been.deprecated.for.removal={0} in {1} ist veraltet und wurde zum Entfernen markiert
 
 # 0: symbol
 # lint: preview
+# flags: aggregate
 compiler.warn.is.preview={0} ist eine Vorschau-API, die in einem zukünftigen Release entfernt werden kann.
 
 # 0: symbol
@@ -1393,6 +1396,7 @@ compiler.err.is.preview={0} ist eine Vorschau-API, die standardmäßig deaktivie
 
 # 0: symbol
 # lint: preview
+# flags: aggregate
 compiler.warn.is.preview.reflective={0} ist eine reflektive Vorschau-API, die in einem zukünftigen Release entfernt werden kann.
 
 # 0: symbol, 1: symbol
@@ -1401,13 +1405,16 @@ compiler.warn.restricted.method={0}.{1} ist eine eingeschränkte Methode.\n(Eing
 
 # 0: symbol
 # lint: deprecation
+# flags: aggregate
 compiler.warn.has.been.deprecated.module=Modul {0} ist veraltet
 
 # 0: symbol
 # lint: removal
+# flags: aggregate
 compiler.warn.has.been.deprecated.for.removal.module=Modul {0} ist veraltet und wurde zum Entfernen markiert
 
 # 0: symbol
+# flags: strict
 compiler.warn.sun.proprietary={0} ist eine interne proprietäre API, die in einem zukünftigen Release entfernt werden kann
 
 compiler.warn.illegal.char.for.encoding=Nicht zuordenbares Zeichen für Codierung {0}
@@ -1704,10 +1711,12 @@ compiler.warn.unchecked.assign=Nicht geprüfte Zuweisung: {0} zu {1}
 
 # 0: symbol, 1: type
 # lint: unchecked
+# flags: aggregate
 compiler.warn.unchecked.assign.to.var=Nicht geprüfte Zuweisung zu Variable {0} als Mitglied des Raw-Typs {1}
 
 # 0: symbol, 1: type
 # lint: unchecked
+# flags: aggregate
 compiler.warn.unchecked.call.mbr.of.raw.type=Nicht geprüfter Aufruf von {0} als Mitglied des Raw-Typs {1}
 
 # lint: unchecked
@@ -1715,14 +1724,17 @@ compiler.warn.unchecked.cast.to.type=Nicht geprüftes Casting zu Typ {0}
 
 # 0: kind name, 1: name, 2: object, 3: object, 4: kind name, 5: symbol
 # lint: unchecked
+# flags: aggregate
 compiler.warn.unchecked.meth.invocation.applied=Nicht geprüfter Methodenaufruf: {0} {1} in {4} {5} wird auf die angegebenen Typen angewendet\nErforderlich: {2}\nErmittelt:    {3}
 
 # 0: type
 # lint: unchecked
+# flags: aggregate
 compiler.warn.unchecked.generic.array.creation=Nicht geprüfte Erstellung eines generischen Arrays für varargs-Parameter des Typs {0}
 
 # 0: type
 # lint: unchecked
+# flags: aggregate
 compiler.warn.unchecked.varargs.non.reifiable.type=Möglich Heap-Beschädigung aus parametrisiertem vararg-Typ {0}
 
 # 0: symbol
@@ -2011,6 +2023,7 @@ compiler.misc.prob.found.req=Inkompatible Typen: {0}
 
 # 0: message segment, 1: type, 2: type
 # lint: unchecked
+# flags: aggregate
 compiler.warn.prob.found.req={0}\nErforderlich: {2}\nErmittelt:    {1}
 
 # 0: type, 1: type
@@ -2284,10 +2297,12 @@ compiler.err.override.incompatible.ret={0}\nRückgabetyp {1} ist nicht mit {2} k
 
 # 0: message segment, 1: type, 2: type
 # lint: unchecked
+# flags: aggregate
 compiler.warn.override.unchecked.ret={0}\nRückgabetyp erfordert eine nicht geprüfte Konvertierung von {1} in {2}
 
 # 0: message segment, 1: type
 # lint: unchecked
+# flags: aggregate
 compiler.warn.override.unchecked.thrown={0}\nAußer Kraft gesetzte Methode löst nicht {1} aus
 
 # 0: symbol
@@ -2336,9 +2351,11 @@ compiler.misc.inapplicable.method={0} {1}.{2} ist nicht anwendbar\n({3})
 ########################################
 
 # 0: message segment (feature), 1: string (found version), 2: string (expected version)
+# flags: source-level
 compiler.err.feature.not.supported.in.source={0} wird in -source {1} nicht unterstützt\n(Verwenden Sie -source {2} oder höher, um {0} zu aktivieren)
 
 # 0: message segment (feature), 1: string (found version), 2: string (expected version)
+# flags: source-level
 compiler.err.feature.not.supported.in.source.plural={0} werden in -source {1} nicht unterstützt\n(Verwenden Sie -source {2} oder höher, um {0} zu aktivieren)
 
 # 0: message segment (feature), 1: string (found version), 2: string (expected version)
@@ -2348,9 +2365,11 @@ compiler.misc.feature.not.supported.in.source={0} wird in -source {1} nicht unte
 compiler.misc.feature.not.supported.in.source.plural={0} werden in -source {1} nicht unterstützt\n(Verwenden Sie -source {2} oder höher, um {0} zu aktivieren)
 
 # 0: message segment (feature)
+# flags: source-level
 compiler.err.preview.feature.disabled={0} ist ein Vorschaufeature, das standardmäßig deaktiviert ist.\n(Verwenden Sie --enable-preview, um {0} zu aktivieren)
 
 # 0: message segment (feature)
+# flags: source-level
 compiler.err.preview.feature.disabled.plural={0} sind ein Vorschaufeature, das standardmäßig deaktiviert ist.\n(Verwenden Sie --enable-preview, um {0} zu aktivieren)
 
 # 0: file object (classfile), 1: string (expected version)
@@ -2358,10 +2377,12 @@ compiler.err.preview.feature.disabled.classfile=Klassendatei für {0} verwendet 
 
 # 0: message segment (feature)
 # lint: preview
+# flags: aggregate
 compiler.warn.preview.feature.use={0} ist ein Vorschaufeature, das in einem zukünftigen Release entfernt werden kann.
 
 # 0: message segment (feature)
 # lint: preview
+# flags: aggregate
 compiler.warn.preview.feature.use.plural={0} sind ein Vorschaufeature, das in einem zukünftigen Release entfernt werden kann.
 
 # 0: file object (classfile), 1: string (expected version)
@@ -3039,6 +3060,7 @@ compiler.err.incorrect.number.of.nested.patterns=Falsche Anzahl verschachtelter 
 
 # 0: kind name, 1: symbol
 # lint: preview
+# flags: aggregate
 compiler.warn.declared.using.preview={0} {1} ist mit einem Vorschaufeature deklariert, das in einem zukünftigen Release entfernt werden kann.
 
 # lint: identity

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler_ja.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler_ja.properties
@@ -1378,14 +1378,17 @@ compiler.warn.incubating.modules=実験的なモジュールを使用してい�
 
 # 0: symbol, 1: symbol
 # lint: deprecation
+# flags: aggregate
 compiler.warn.has.been.deprecated={1}の{0}は推奨されません
 
 # 0: symbol, 1: symbol
 # lint: removal
+# flags: aggregate
 compiler.warn.has.been.deprecated.for.removal={1}の{0}は推奨されておらず、削除用にマークされています
 
 # 0: symbol
 # lint: preview
+# flags: aggregate
 compiler.warn.is.preview={0}はプレビューAPIであり、今後のリリースで削除される可能性があります。
 
 # 0: symbol
@@ -1393,6 +1396,7 @@ compiler.err.is.preview={0}はプレビューAPIであり、デフォルトで�
 
 # 0: symbol
 # lint: preview
+# flags: aggregate
 compiler.warn.is.preview.reflective={0}はリフレクティブ・プレビューAPIであり、今後のリリースで削除される可能性があります。
 
 # 0: symbol, 1: symbol
@@ -1401,13 +1405,16 @@ compiler.warn.restricted.method={0}.{1}は制限されたメソッドです。\n
 
 # 0: symbol
 # lint: deprecation
+# flags: aggregate
 compiler.warn.has.been.deprecated.module=モジュール{0}は推奨されません
 
 # 0: symbol
 # lint: removal
+# flags: aggregate
 compiler.warn.has.been.deprecated.for.removal.module=モジュール{0}は推奨されておらず、削除用にマークされています
 
 # 0: symbol
+# flags: strict
 compiler.warn.sun.proprietary={0}は内部所有のAPIであり、今後のリリースで削除される可能性があります
 
 compiler.warn.illegal.char.for.encoding=この文字は、エンコーディング{0}にマップできません
@@ -1704,10 +1711,12 @@ compiler.warn.unchecked.assign={0}から{1}への無検査代入です
 
 # 0: symbol, 1: type
 # lint: unchecked
+# flags: aggregate
 compiler.warn.unchecked.assign.to.var=raw型{1}のメンバーとして変数{0}への無検査代入です
 
 # 0: symbol, 1: type
 # lint: unchecked
+# flags: aggregate
 compiler.warn.unchecked.call.mbr.of.raw.type=raw型{1}のメンバーとしての{0}への無検査呼出しです
 
 # lint: unchecked
@@ -1715,14 +1724,17 @@ compiler.warn.unchecked.cast.to.type=型{0}への無検査キャストです
 
 # 0: kind name, 1: name, 2: object, 3: object, 4: kind name, 5: symbol
 # lint: unchecked
+# flags: aggregate
 compiler.warn.unchecked.meth.invocation.applied=無検査メソッド呼出し: {4} {5}の{0} {1}は指定された型に適用されます\n期待値: {2}\n検出値:    {3}
 
 # 0: type
 # lint: unchecked
+# flags: aggregate
 compiler.warn.unchecked.generic.array.creation=型{0}の可変引数パラメータに対する総称型配列の無検査作成です
 
 # 0: type
 # lint: unchecked
+# flags: aggregate
 compiler.warn.unchecked.varargs.non.reifiable.type=パラメータ化された可変引数型{0}からのヒープ汚染の可能性があります
 
 # 0: symbol
@@ -2011,6 +2023,7 @@ compiler.misc.prob.found.req=不適合な型: {0}
 
 # 0: message segment, 1: type, 2: type
 # lint: unchecked
+# flags: aggregate
 compiler.warn.prob.found.req={0}\n期待値: {2}\n検出値:    {1}
 
 # 0: type, 1: type
@@ -2284,10 +2297,12 @@ compiler.err.override.incompatible.ret={0}\n戻り値の型{1}は{2}と互換性
 
 # 0: message segment, 1: type, 2: type
 # lint: unchecked
+# flags: aggregate
 compiler.warn.override.unchecked.ret={0}\n戻り値の型は{1}から{2}への無検査変換が必要です
 
 # 0: message segment, 1: type
 # lint: unchecked
+# flags: aggregate
 compiler.warn.override.unchecked.thrown={0}\nオーバーライドされたメソッドは{1}をスローしません
 
 # 0: symbol
@@ -2336,9 +2351,11 @@ compiler.misc.inapplicable.method={0} {1}.{2}は使用できません\n({3})
 ########################################
 
 # 0: message segment (feature), 1: string (found version), 2: string (expected version)
+# flags: source-level
 compiler.err.feature.not.supported.in.source={0}は-source {1}でサポートされていません\n({0}を有効にするには-source {2}以上を使用してください)
 
 # 0: message segment (feature), 1: string (found version), 2: string (expected version)
+# flags: source-level
 compiler.err.feature.not.supported.in.source.plural={0}は-source {1}でサポートされていません\n({0}を有効にするには-source {2}以上を使用してください)
 
 # 0: message segment (feature), 1: string (found version), 2: string (expected version)
@@ -2348,9 +2365,11 @@ compiler.misc.feature.not.supported.in.source={0}は-source {1}でサポート�
 compiler.misc.feature.not.supported.in.source.plural={0}は-source {1}でサポートされていません\n({0}を有効にするには-source {2}以上を使用してください)
 
 # 0: message segment (feature)
+# flags: source-level
 compiler.err.preview.feature.disabled={0}はプレビュー機能であり、デフォルトで無効になっています。\n({0}を有効にするには--enable-previewを使用します)
 
 # 0: message segment (feature)
+# flags: source-level
 compiler.err.preview.feature.disabled.plural={0}はプレビュー機能であり、デフォルトで無効になっています。\n({0}を有効にするには--enable-previewを使用します)
 
 # 0: file object (classfile), 1: string (expected version)
@@ -2358,10 +2377,12 @@ compiler.err.preview.feature.disabled.classfile={0}のクラス・ファイル�
 
 # 0: message segment (feature)
 # lint: preview
+# flags: aggregate
 compiler.warn.preview.feature.use={0}はプレビュー機能であり、今後のリリースで削除される可能性があります。
 
 # 0: message segment (feature)
 # lint: preview
+# flags: aggregate
 compiler.warn.preview.feature.use.plural={0}はプレビュー機能であり、今後のリリースで削除される可能性があります。
 
 # 0: file object (classfile), 1: string (expected version)
@@ -3039,6 +3060,7 @@ compiler.err.incorrect.number.of.nested.patterns=ネスト・パターンの数�
 
 # 0: kind name, 1: symbol
 # lint: preview
+# flags: aggregate
 compiler.warn.declared.using.preview={0} {1}はプレビュー機能を使用して宣言されており、今後のリリースで削除される可能性があります。
 
 # lint: identity

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler_zh_CN.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler_zh_CN.properties
@@ -1378,14 +1378,17 @@ compiler.warn.incubating.modules=使用 incubating 模块: {0}
 
 # 0: symbol, 1: symbol
 # lint: deprecation
+# flags: aggregate
 compiler.warn.has.been.deprecated={1}中的{0}已过时
 
 # 0: symbol, 1: symbol
 # lint: removal
+# flags: aggregate
 compiler.warn.has.been.deprecated.for.removal={1} 中的 {0} 已过时, 且标记为待删除
 
 # 0: symbol
 # lint: preview
+# flags: aggregate
 compiler.warn.is.preview={0} 是预览 API，可能会在未来发行版中删除。
 
 # 0: symbol
@@ -1393,6 +1396,7 @@ compiler.err.is.preview={0} 是预览 API，默认情况下处于禁用状态。
 
 # 0: symbol
 # lint: preview
+# flags: aggregate
 compiler.warn.is.preview.reflective={0} 是反射预览 API，可能会在未来发行版中删除。
 
 # 0: symbol, 1: symbol
@@ -1401,13 +1405,16 @@ compiler.warn.restricted.method={0}.{1} 是受限制的方法。\n（受限制�
 
 # 0: symbol
 # lint: deprecation
+# flags: aggregate
 compiler.warn.has.been.deprecated.module=模块 {0} 已过时
 
 # 0: symbol
 # lint: removal
+# flags: aggregate
 compiler.warn.has.been.deprecated.for.removal.module=模块 {0} 已过时, 且标记为待删除
 
 # 0: symbol
+# flags: strict
 compiler.warn.sun.proprietary={0}是内部专用 API, 可能会在未来发行版中删除
 
 compiler.warn.illegal.char.for.encoding=编码{0}的不可映射字符
@@ -1704,10 +1711,12 @@ compiler.warn.unchecked.assign=未经检查的分配: 将{0}分配给{1}
 
 # 0: symbol, 1: type
 # lint: unchecked
+# flags: aggregate
 compiler.warn.unchecked.assign.to.var=对作为原始类型{1}的成员的变量{0}的分配未经过检查
 
 # 0: symbol, 1: type
 # lint: unchecked
+# flags: aggregate
 compiler.warn.unchecked.call.mbr.of.raw.type=对作为原始类型{1}的成员的{0}的调用未经过检查
 
 # lint: unchecked
@@ -1715,14 +1724,17 @@ compiler.warn.unchecked.cast.to.type=向类型{0}的转换未经过检查
 
 # 0: kind name, 1: name, 2: object, 3: object, 4: kind name, 5: symbol
 # lint: unchecked
+# flags: aggregate
 compiler.warn.unchecked.meth.invocation.applied=方法调用未经过检查: 将{4} {5}中的{0} {1}应用到给定的类型\n需要: {2}\n找到:    {3}
 
 # 0: type
 # lint: unchecked
+# flags: aggregate
 compiler.warn.unchecked.generic.array.creation=对于类型为{0}的 varargs 参数, 泛型数组创建未经过检查
 
 # 0: type
 # lint: unchecked
+# flags: aggregate
 compiler.warn.unchecked.varargs.non.reifiable.type=参数化 vararg 类型{0}的堆可能已受污染
 
 # 0: symbol
@@ -2011,6 +2023,7 @@ compiler.misc.prob.found.req=不兼容的类型: {0}
 
 # 0: message segment, 1: type, 2: type
 # lint: unchecked
+# flags: aggregate
 compiler.warn.prob.found.req={0}\n需要: {2}\n找到:    {1}
 
 # 0: type, 1: type
@@ -2284,10 +2297,12 @@ compiler.err.override.incompatible.ret={0}\n返回类型{1}与{2}不兼容
 
 # 0: message segment, 1: type, 2: type
 # lint: unchecked
+# flags: aggregate
 compiler.warn.override.unchecked.ret={0}\n返回类型需要从{1}到{2}的未经检查的转换
 
 # 0: message segment, 1: type
 # lint: unchecked
+# flags: aggregate
 compiler.warn.override.unchecked.thrown={0}\n被覆盖的方法未抛出{1}
 
 # 0: symbol
@@ -2336,9 +2351,11 @@ compiler.misc.inapplicable.method={0} {1}.{2}不适用\n({3})
 ########################################
 
 # 0: message segment (feature), 1: string (found version), 2: string (expected version)
+# flags: source-level
 compiler.err.feature.not.supported.in.source=-source {1} 中不支持 {0}\n(请使用 -source {2} 或更高版本以启用 {0})
 
 # 0: message segment (feature), 1: string (found version), 2: string (expected version)
+# flags: source-level
 compiler.err.feature.not.supported.in.source.plural=-source {1} 中不支持 {0}\n(请使用 -source {2} 或更高版本以启用 {0})
 
 # 0: message segment (feature), 1: string (found version), 2: string (expected version)
@@ -2348,9 +2365,11 @@ compiler.misc.feature.not.supported.in.source=-source {1} 中不支持 {0}\n(请
 compiler.misc.feature.not.supported.in.source.plural=-source {1} 中不支持 {0}\n(请使用 -source {2} 或更高版本以启用 {0})
 
 # 0: message segment (feature)
+# flags: source-level
 compiler.err.preview.feature.disabled={0} 是预览功能，默认情况下禁用。\n（请使用 --enable-preview 以启用 {0}）
 
 # 0: message segment (feature)
+# flags: source-level
 compiler.err.preview.feature.disabled.plural={0} 是预览功能，默认情况下禁用。\n（请使用 --enable-preview 以启用 {0}）
 
 # 0: file object (classfile), 1: string (expected version)
@@ -2358,10 +2377,12 @@ compiler.err.preview.feature.disabled.classfile={0} 的类文件使用 Java SE {
 
 # 0: message segment (feature)
 # lint: preview
+# flags: aggregate
 compiler.warn.preview.feature.use={0} 是预览功能，可能会在未来发行版中删除。
 
 # 0: message segment (feature)
 # lint: preview
+# flags: aggregate
 compiler.warn.preview.feature.use.plural={0} 是预览功能，可能会在未来发行版中删除。
 
 # 0: file object (classfile), 1: string (expected version)
@@ -3039,6 +3060,7 @@ compiler.err.incorrect.number.of.nested.patterns=嵌套模式数不正确\n需�
 
 # 0: kind name, 1: symbol
 # lint: preview
+# flags: aggregate
 compiler.warn.declared.using.preview={0} {1} 是使用预览功能声明的，可能会在未来发行版中删除。
 
 # lint: identity

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/javac_de.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/javac_de.properties
@@ -175,11 +175,8 @@ javac.opt.Xlint.desc.preview=Warnt vor Verwendung von Vorschausprachfeatures.
 
 javac.opt.Xlint.desc.restricted=Warnt vor der Verwendung eingeschränkter Methoden.
 
-javac.opt.Xlint.desc.synchronization=\
-    Warnt vor Synchronisierungsversuchen mit Instanzen wertbasierter Klassen.\n\
-\                         Dieser Schlüssel ist ein veralteter Alias für die Kategorie ''identity'', die dieselben Verwendungen und\n\
-\                         Effekte hat. Benutzern wird empfohlen, die Kategorie ''identity'' für alle zukünftigen\n\
-\                         und vorhandenen Verwendungen von ''synchronization'' zu verwenden.
+# L10N: do not localize: identity synchronization
+javac.opt.Xlint.desc.synchronization=Warnt vor Synchronisierungsversuchen mit Instanzen wertbasierter Klassen.\n                         Dieser Schlüssel ist ein veralteter Alias für die Kategorie "identity", die dieselben Verwendungen und\n                         Effekte hat. Benutzern wird empfohlen, die Kategorie "identity" für alle zukünftigen\n                         und vorhandenen Verwendungen von "synchronization" zu verwenden.
 
 javac.opt.Xlint.desc.identity=Warnt vor Verwendungen wertbasierter Klassen, wenn eine Identitätsklasse erwartet wird.
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/javac_ja.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/javac_ja.properties
@@ -175,6 +175,7 @@ javac.opt.Xlint.desc.preview=プレビュー言語機能の使用について警
 
 javac.opt.Xlint.desc.restricted=制限されたメソッドの使用について警告します。
 
+# L10N: do not localize: identity synchronization
 javac.opt.Xlint.desc.synchronization=値ベース・クラスのインスタンスでの同期の試行について警告します。\n                         このキーは、''identity''の非推奨のエイリアスであり、同じ使用方法と効果を\n                         持ちます。ユーザーには、今後および既存の''synchronization''の使用に対して''identity''カテゴリを\n                         使用することをお薦めします。
 
 javac.opt.Xlint.desc.identity=アイデンティティ・クラスが必要な場所での値ベース・クラスの使用について警告します。

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/javac_zh_CN.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/javac_zh_CN.properties
@@ -175,6 +175,7 @@ javac.opt.Xlint.desc.preview=有关使用预览语言功能的警告。
 
 javac.opt.Xlint.desc.restricted=有关使用受限制方法的警告。
 
+# L10N: do not localize: identity synchronization
 javac.opt.Xlint.desc.synchronization=有关尝试在基于值的类的实例上同步的警告。\n                         此密钥是 ''identity'' 的已过时别名，具有相同的用法和\n                         效果。建议用户在 ''synchronization'' 的所有未来和现有\n                         用法中使用 ''identity'' 类别。
 
 javac.opt.Xlint.desc.identity=有关在需要身份类的情况下使用基于值的类的警告。

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/launcher_de.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/launcher_de.properties
@@ -100,7 +100,7 @@ launcher.err.main.not.void=Methode "main" ist nicht mit Rückgabetyp "void" dekl
 launcher.err.cant.find.class=Klasse nicht gefunden: {0}
 
 # 0: string
-launcher.err.cant.find.main.method=Konnte keine main(String[])- oder main()-Methode in der Klasse: {0} finden.
+launcher.err.cant.find.main.method=main(String[])- oder main()-Methode nicht gefunden in Klasse: {0}
 
 # 0: string
 launcher.err.cant.instantiate=Abstrakte Klasse: {0} kann nicht instanziiert werden

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/standard_de.properties
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/standard_de.properties
@@ -136,8 +136,7 @@ doclet.Preview_API_Checkbox_Toggle_All=Alle umschalten
 doclet.Preview_JEP_URL=https://openjdk.org/jeps/{0}
 doclet.Preview_Label=Vorschau
 doclet.Preview_Mark=PREVIEW
-doclet.Preview_Notes=Hinweise zur Vorschau-API
-doclet.Preview_Notes_Elements=Elemente mit Vorschauhinweisen
+doclet.Preview_Notes=Von Vorschaufeatures betroffene permanente APIs
 doclet.Restricted_Methods=Eingeschränkte Methoden
 doclet.Restricted_Mark=RESTRICTED
 doclet.searchTag=Suchtag
@@ -345,6 +344,7 @@ doclet.UsesDeclaredUsingPreview={0} bezieht sich auf mindestens einen Typ, der m
 doclet.PreviewTrailingNote1=Programme können {0} nur verwenden, wenn Vorschaufeatures aktiviert sind.
 doclet.PreviewTrailingNote2=Vorschaufeatures können in künftigen Releases entfernt oder zu permanenten Features der Java-Plattform hochgestuft werden.
 doclet.PreviewJavaSERequiresTransitiveJavaBase=Indirekte Exporte aus dem Modul <code>java.base</code> sind mit der Direktive <code>requires transitive java.base</code> verknüpft. Das ist ein Vorschaufeature der Java-Sprache.<br>Programme können <code>requires transitive java.base</code> nur verwenden, wenn Vorschaufeatures aktiviert sind.<br>Vorschaufeatures können in einem zukünftigen Release entfernt oder zu permanenten Features der Java-Plattform hochgestuft werden.<br>
+doclet.PreviewMultipleNotes=Mehrere Vorschauhinweise in {0}.
 doclet.RestrictedMethod=eingeschränkte Methode
 doclet.RestrictedLeadingNote={0} ist eine {1} der Java-Plattform.
 doclet.RestrictedTrailingNote1=Programme können {0} nur verwenden, wenn der Zugriff auf eingeschränkte Methoden aktiviert ist.
@@ -432,7 +432,7 @@ doclet.usage.excludedocfilessubdir.parameters=<name>,<name>,...
 doclet.usage.excludedocfilessubdir.description=Schließen Sie alle "doc-files"-Unterverzeichnisse mit einem angegebenen Namen aus.\n":" kann überall im Argument als Trennzeichen verwendet werden.
 
 doclet.usage.group.parameters=<name> <g1>,<g2>...
-doclet.usage.group.description=Angegebene Elemente auf Überblickseite gruppieren.\n":" kann überall im Argument als Trennzeichen verwendet werden.
+doclet.usage.group.description=Angegebene Packages oder Module auf Überblickseite gruppieren.\n":" kann überall im Argument als Trennzeichen verwendet werden.
 
 doclet.usage.legal-notices.parameters='default' | 'none' | <Verzeichnis>
 doclet.usage.legal-notices.description=Steuert die rechtlichen Hinweise in der generierten Ausgabe

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/standard_ja.properties
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/standard_ja.properties
@@ -136,8 +136,7 @@ doclet.Preview_API_Checkbox_Toggle_All=すべて設定
 doclet.Preview_JEP_URL=https://openjdk.org/jeps/{0}
 doclet.Preview_Label=プレビュー
 doclet.Preview_Mark=PREVIEW
-doclet.Preview_Notes=プレビューAPIのノート
-doclet.Preview_Notes_Elements=プレビュー・ノートを含む要素
+doclet.Preview_Notes=プレビュー機能によって影響を受ける永続的なAPI
 doclet.Restricted_Methods=制限されたメソッド
 doclet.Restricted_Mark=RESTRICTED
 doclet.searchTag=検索タグ
@@ -345,6 +344,7 @@ doclet.UsesDeclaredUsingPreview={0}は、Java言語のプレビュー機能を�
 doclet.PreviewTrailingNote1=プログラムは、プレビュー機能が有効になっている場合にのみ{0}を使用できます。
 doclet.PreviewTrailingNote2=プレビュー機能は将来のリリースで削除されるか、Javaプラットフォームの永続的な機能にアップグレードされる可能性があります。
 doclet.PreviewJavaSERequiresTransitiveJavaBase=<code>java.base</code>モジュールからの間接的エクスポートは、Java言語のプレビュー機能である<code>requires transitive java.base</code>ディレクティブに関連付けられています。<br>プログラムは、プレビュー機能が有効になっている場合にのみ<code>requires transitive java.base</code>を使用できます。<br>プレビュー機能は将来のリリースで削除されるか、Javaプラットフォームの永続的な機能にアップグレードされる可能性があります。<br>
+doclet.PreviewMultipleNotes={0}の複数のプレビュー・ノート。
 doclet.RestrictedMethod=制限されたメソッド
 doclet.RestrictedLeadingNote={0}は、Javaプラットフォームの{1}です。
 doclet.RestrictedTrailingNote1=プログラムは、制限されたメソッドへのアクセスが有効になっている場合にのみ{0}を使用できます。
@@ -432,7 +432,7 @@ doclet.usage.excludedocfilessubdir.parameters=<name>,<name>,...
 doclet.usage.excludedocfilessubdir.description=指定された名前の'doc-files'サブディレクトリをすべて除外します。\n':'も、セパレータとして引数の任意の場所に使用できます。
 
 doclet.usage.group.parameters=<name> <g1>,<g2>...
-doclet.usage.group.description=指定する要素を概要ページにおいてグループ化します。\n':'も、セパレータとして引数の任意の場所に使用できます。
+doclet.usage.group.description=指定するパッケージまたはモジュールを概要ページにおいてグループ化します。\n':'も、セパレータとして引数の任意の場所に使用できます。
 
 doclet.usage.legal-notices.parameters='default' | 'none' | <directory>
 doclet.usage.legal-notices.description=生成された出力の法律上の注意点を制御します

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/standard_zh_CN.properties
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/standard_zh_CN.properties
@@ -136,8 +136,7 @@ doclet.Preview_API_Checkbox_Toggle_All=全部切换
 doclet.Preview_JEP_URL=https://openjdk.org/jeps/{0}
 doclet.Preview_Label=预览
 doclet.Preview_Mark=PREVIEW
-doclet.Preview_Notes=预览 API 注释
-doclet.Preview_Notes_Elements=包含预览注释的元素
+doclet.Preview_Notes=受预览功能影响的永久 API
 doclet.Restricted_Methods=受限制的方法
 doclet.Restricted_Mark=RESTRICTED
 doclet.searchTag=搜索标记
@@ -345,6 +344,7 @@ doclet.UsesDeclaredUsingPreview={0} 引用一个或多个类型，这些类型�
 doclet.PreviewTrailingNote1=只有在启用了预览功能时，程序才能使用 {0}。
 doclet.PreviewTrailingNote2=预览功能可能会在未来发行版中删除，也可能会升级为 Java 平台的永久功能。
 doclet.PreviewJavaSERequiresTransitiveJavaBase=来自 <code>java.base</code> 模块的间接导出项与 <code>requires transitive java.base</code> 指令关联，这是 Java 语言的预览功能。<br>仅在启用了预览功能时，程序才能使用 <code>requires transitive java.base</code>。<br>预览功能可能会在未来发行版中删除，也可能会升级为 Java 平台的永久功能。<br>
+doclet.PreviewMultipleNotes={0} 中有多个预览注释。
 doclet.RestrictedMethod=受限制方法
 doclet.RestrictedLeadingNote={0} 是 Java 平台的 {1}。
 doclet.RestrictedTrailingNote1=只有在启用了对受限制方法的访问时，程序才能使用 {0}。
@@ -432,7 +432,7 @@ doclet.usage.excludedocfilessubdir.parameters=<name>,<name>,...
 doclet.usage.excludedocfilessubdir.description=排除包含给定名称的所有 'doc-files' 子目录。\n还可以将 ':' 作为分隔符用于参数中的任何位置。
 
 doclet.usage.group.parameters=<name> <g1>,<g2>...
-doclet.usage.group.description=在概览页面上将指定元素归到一组。\n还可以将 ':' 作为分隔符用于参数中的任何位置。
+doclet.usage.group.description=在概览页面中将指定程序包或模块归到一组。\n还可以将 ':' 作为分隔符用于参数中的任何位置。
 
 doclet.usage.legal-notices.parameters='default' | 'none' | <directory>
 doclet.usage.legal-notices.description=控制所生成输出中的法律声明

--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/resources/MainResources_de.properties
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/resources/MainResources_de.properties
@@ -86,7 +86,6 @@ MSG_BundlerFailed=Fehler: Bundler "{1}" ({0}) konnte kein Package generieren
 MSG_BundlerConfigException=Bundler {0} aufgrund eines Konfigurationsproblems übersprungen: {1} \nEmpfehlung zur Behebung: {2}
 MSG_BundlerConfigExceptionNoAdvice=Bundler {0} aufgrund eines Konfigurationsproblems übersprungen: {1}
 MSG_BundlerRuntimeException=Bundler {0} nicht erfolgreich. Grund: {1}
-MSG_BundlerFailed=Fehler: Bundler "{1}" ({0}) konnte kein Package generieren
 
 ERR_NoMainClass=Fehler: Hauptanwendungsklasse fehlt
 ERR_UnsupportedOption=Fehler: Option [{0}] ist auf dieser Plattform ungültig

--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/resources/MainResources_ja.properties
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/resources/MainResources_ja.properties
@@ -86,7 +86,6 @@ MSG_BundlerFailed=エラー: バンドラ"{1}" ({0})がパッケージの生成�
 MSG_BundlerConfigException=構成の問題のため、バンドラ{0}がスキップされました: {1} \n次の修正を行ってください: {2}
 MSG_BundlerConfigExceptionNoAdvice=構成の問題のため、バンドラ{0}がスキップされました: {1}
 MSG_BundlerRuntimeException={1}のため、バンドラ{0}が失敗しました
-MSG_BundlerFailed=エラー: バンドラ"{1}" ({0})がパッケージの生成に失敗しました
 
 ERR_NoMainClass=エラー: メイン・アプリケーション・クラスがありません
 ERR_UnsupportedOption=エラー: オプション[{0}]は、このプラットフォームでは無効です

--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/resources/MainResources_zh_CN.properties
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/resources/MainResources_zh_CN.properties
@@ -86,7 +86,6 @@ MSG_BundlerFailed=错误：打包程序 "{1}" ({0}) 无法生成程序包
 MSG_BundlerConfigException=由于配置问题, 跳过了打包程序{0}: {1} \n修复建议: {2}
 MSG_BundlerConfigExceptionNoAdvice=由于配置问题, 跳过了打包程序{0}: {1}
 MSG_BundlerRuntimeException=由于{1}, 打包程序{0}失败
-MSG_BundlerFailed=错误：打包程序 "{1}" ({0}) 无法生成程序包
 
 ERR_NoMainClass=错误：缺少主应用程序类
 ERR_UnsupportedOption=错误：选项 [{0}] 在此平台上无效


### PR DESCRIPTION
This issue is responsible for updating the translations of all the localize(able) resources in the JDK since the previous L10n drop.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8364089](https://bugs.openjdk.org/browse/JDK-8364089): JDK 25 RDP2 L10n resource files update (**Bug** - P2)


### Reviewers
 * [Justin Lu](https://openjdk.org/census#jlu) (@justin-curtis-lu - Committer)
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)
 * [Damon Nguyen](https://openjdk.org/census#dnguyen) (@DamonGuy - Committer)
 * [Alexey Semenyuk](https://openjdk.org/census#asemenyuk) (@alexeysemenyukoracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26467/head:pull/26467` \
`$ git checkout pull/26467`

Update a local copy of the PR: \
`$ git checkout pull/26467` \
`$ git pull https://git.openjdk.org/jdk.git pull/26467/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26467`

View PR using the GUI difftool: \
`$ git pr show -t 26467`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26467.diff">https://git.openjdk.org/jdk/pull/26467.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26467#issuecomment-3115406268)
</details>
