### PR TITLE
8364090: Dump JFR recording on CrashOnOutOfMemoryError

### DIFF
--- a/src/hotspot/share/jfr/jfr.cpp
+++ b/src/hotspot/share/jfr/jfr.cpp
@@ -152,9 +152,9 @@ void Jfr::on_resolution(const Method* caller, const Method* target, TRAPS) {
 }
 #endif
 
-void Jfr::on_vm_shutdown(bool emit_old_object_samples, bool halt) {
+void Jfr::on_vm_shutdown(bool emit_old_object_samples, bool emit_event_shutdown, bool halt) {
   if (!halt && JfrRecorder::is_recording()) {
-    JfrEmergencyDump::on_vm_shutdown(emit_old_object_samples);
+    JfrEmergencyDump::on_vm_shutdown(emit_old_object_samples, emit_event_shutdown);
   }
 }
 

--- a/src/hotspot/share/jfr/jfr.cpp
+++ b/src/hotspot/share/jfr/jfr.cpp
@@ -152,9 +152,9 @@ void Jfr::on_resolution(const Method* caller, const Method* target, TRAPS) {
 }
 #endif
 
-void Jfr::on_vm_shutdown(bool exception_handler, bool halt) {
+void Jfr::on_vm_shutdown(bool is_oom, bool halt) {
   if (!halt && JfrRecorder::is_recording()) {
-    JfrEmergencyDump::on_vm_shutdown(exception_handler);
+    JfrEmergencyDump::on_vm_shutdown(is_oom);
   }
 }
 

--- a/src/hotspot/share/jfr/jfr.cpp
+++ b/src/hotspot/share/jfr/jfr.cpp
@@ -152,9 +152,9 @@ void Jfr::on_resolution(const Method* caller, const Method* target, TRAPS) {
 }
 #endif
 
-void Jfr::on_vm_shutdown(bool is_oom, bool halt) {
+void Jfr::on_vm_shutdown(bool emit_old_object_samples, bool halt) {
   if (!halt && JfrRecorder::is_recording()) {
-    JfrEmergencyDump::on_vm_shutdown(is_oom);
+    JfrEmergencyDump::on_vm_shutdown(emit_old_object_samples);
   }
 }
 

--- a/src/hotspot/share/jfr/jfr.hpp
+++ b/src/hotspot/share/jfr/jfr.hpp
@@ -70,7 +70,7 @@ class Jfr : AllStatic {
   static void on_resolution(const Method* caller, const Method* target, TRAPS);
   static void on_java_thread_start(JavaThread* starter, JavaThread* startee);
   static void on_set_current_thread(JavaThread* jt, oop thread);
-  static void on_vm_shutdown(bool is_oom = true, bool halt = false);
+  static void on_vm_shutdown(bool emit_old_object_samples = true, bool halt = false);
   static void on_vm_error_report(outputStream* st);
   static bool on_flight_recorder_option(const JavaVMOption** option, char* delimiter);
   static bool on_start_flight_recording_option(const JavaVMOption** option, char* delimiter);

--- a/src/hotspot/share/jfr/jfr.hpp
+++ b/src/hotspot/share/jfr/jfr.hpp
@@ -70,7 +70,7 @@ class Jfr : AllStatic {
   static void on_resolution(const Method* caller, const Method* target, TRAPS);
   static void on_java_thread_start(JavaThread* starter, JavaThread* startee);
   static void on_set_current_thread(JavaThread* jt, oop thread);
-  static void on_vm_shutdown(bool emit_old_object_samples = true, bool halt = false);
+  static void on_vm_shutdown(bool emit_old_object_samples, bool emit_event_shutdown, bool halt = false);
   static void on_vm_error_report(outputStream* st);
   static bool on_flight_recorder_option(const JavaVMOption** option, char* delimiter);
   static bool on_start_flight_recording_option(const JavaVMOption** option, char* delimiter);

--- a/src/hotspot/share/jfr/jfr.hpp
+++ b/src/hotspot/share/jfr/jfr.hpp
@@ -70,7 +70,7 @@ class Jfr : AllStatic {
   static void on_resolution(const Method* caller, const Method* target, TRAPS);
   static void on_java_thread_start(JavaThread* starter, JavaThread* startee);
   static void on_set_current_thread(JavaThread* jt, oop thread);
-  static void on_vm_shutdown(bool exception_handler = false, bool halt = false);
+  static void on_vm_shutdown(bool is_oom = true, bool halt = false);
   static void on_vm_error_report(outputStream* st);
   static bool on_flight_recorder_option(const JavaVMOption** option, char* delimiter);
   static bool on_start_flight_recording_option(const JavaVMOption** option, char* delimiter);

--- a/src/hotspot/share/jfr/recorder/repository/jfrEmergencyDump.cpp
+++ b/src/hotspot/share/jfr/recorder/repository/jfrEmergencyDump.cpp
@@ -556,10 +556,11 @@ class JavaThreadInVMAndNative : public StackObj {
   }
 };
 
-static void post_events(bool emit_old_object_samples, Thread* thread) {
+static void post_events(bool emit_old_object_samples, bool emit_event_shutdown, Thread* thread) {
   if (emit_old_object_samples) {
     LeakProfiler::emit_events(max_jlong, false, false);
-  } else {
+  }
+  if (emit_event_shutdown) {
     EventShutdown e;
     e.set_reason("VM Error");
     e.commit();
@@ -570,7 +571,7 @@ static void post_events(bool emit_old_object_samples, Thread* thread) {
   event.commit();
 }
 
-void JfrEmergencyDump::on_vm_shutdown(bool emit_old_object_samples) {
+void JfrEmergencyDump::on_vm_shutdown(bool emit_old_object_samples, bool emit_event_shutdown) {
   if (!guard_reentrancy()) {
     return;
   }
@@ -583,7 +584,7 @@ void JfrEmergencyDump::on_vm_shutdown(bool emit_old_object_samples) {
   if (!prepare_for_emergency_dump(thread)) {
     return;
   }
-  post_events(emit_old_object_samples, thread);
+  post_events(emit_old_object_samples, emit_event_shutdown, thread);
   // if JavaThread, transition to _thread_in_native to issue a final flushpoint
   NoHandleMark nhm;
   jtivm.transition_to_native();

--- a/src/hotspot/share/jfr/recorder/repository/jfrEmergencyDump.hpp
+++ b/src/hotspot/share/jfr/recorder/repository/jfrEmergencyDump.hpp
@@ -39,7 +39,7 @@ class JfrEmergencyDump : AllStatic {
   static const char* chunk_path(const char* repository_path);
   static void on_vm_error(const char* repository_path);
   static void on_vm_error_report(outputStream* st, const char* repository_path);
-  static void on_vm_shutdown(bool is_oom);
+  static void on_vm_shutdown(bool emit_old_object_samples);
 };
 
 #endif // SHARE_JFR_RECORDER_REPOSITORY_JFREMERGENCYDUMP_HPP

--- a/src/hotspot/share/jfr/recorder/repository/jfrEmergencyDump.hpp
+++ b/src/hotspot/share/jfr/recorder/repository/jfrEmergencyDump.hpp
@@ -39,7 +39,7 @@ class JfrEmergencyDump : AllStatic {
   static const char* chunk_path(const char* repository_path);
   static void on_vm_error(const char* repository_path);
   static void on_vm_error_report(outputStream* st, const char* repository_path);
-  static void on_vm_shutdown(bool emit_old_object_samples);
+  static void on_vm_shutdown(bool emit_old_object_samples, bool emit_event_shutdown);
 };
 
 #endif // SHARE_JFR_RECORDER_REPOSITORY_JFREMERGENCYDUMP_HPP

--- a/src/hotspot/share/jfr/recorder/repository/jfrEmergencyDump.hpp
+++ b/src/hotspot/share/jfr/recorder/repository/jfrEmergencyDump.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,7 +39,7 @@ class JfrEmergencyDump : AllStatic {
   static const char* chunk_path(const char* repository_path);
   static void on_vm_error(const char* repository_path);
   static void on_vm_error_report(outputStream* st, const char* repository_path);
-  static void on_vm_shutdown(bool exception_handler);
+  static void on_vm_shutdown(bool is_oom);
 };
 
 #endif // SHARE_JFR_RECORDER_REPOSITORY_JFREMERGENCYDUMP_HPP

--- a/src/hotspot/share/runtime/java.cpp
+++ b/src/hotspot/share/runtime/java.cpp
@@ -463,7 +463,10 @@ void before_exit(JavaThread* thread, bool halt) {
     event.commit();
   }
 
-  JFR_ONLY(Jfr::on_vm_shutdown(true, halt);)
+  // 2nd argument (emit_event_shutdown) should be set to false
+  // because EventShutdown would be emitted at Threads::destroy_vm().
+  // (one of the callers of before_exit())
+  JFR_ONLY(Jfr::on_vm_shutdown(true, false, halt);)
 
   // Stop the WatcherThread. We do this before disenrolling various
   // PeriodicTasks to reduce the likelihood of races.

--- a/src/hotspot/share/runtime/java.cpp
+++ b/src/hotspot/share/runtime/java.cpp
@@ -463,7 +463,7 @@ void before_exit(JavaThread* thread, bool halt) {
     event.commit();
   }
 
-  JFR_ONLY(Jfr::on_vm_shutdown(false, halt);)
+  JFR_ONLY(Jfr::on_vm_shutdown(true, halt);)
 
   // Stop the WatcherThread. We do this before disenrolling various
   // PeriodicTasks to reduce the likelihood of races.

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -1856,7 +1856,7 @@ void VMError::report_and_die(int id, const char* message, const char* detail_fmt
     log.set_fd(-1);
   }
 
-  JFR_ONLY(Jfr::on_vm_shutdown(static_cast<VMErrorType>(_id) == OOM_JAVA_HEAP_FATAL);)
+  JFR_ONLY(Jfr::on_vm_shutdown(static_cast<VMErrorType>(_id) == OOM_JAVA_HEAP_FATAL, true);)
 
   if (PrintNMTStatistics) {
     fdStream fds(fd_out);

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -1856,7 +1856,7 @@ void VMError::report_and_die(int id, const char* message, const char* detail_fmt
     log.set_fd(-1);
   }
 
-  JFR_ONLY(Jfr::on_vm_shutdown(true);)
+  JFR_ONLY(Jfr::on_vm_shutdown(static_cast<VMErrorType>(_id) == OOM_JAVA_HEAP_FATAL);)
 
   if (PrintNMTStatistics) {
     fdStream fds(fd_out);

--- a/test/jdk/jdk/jfr/event/oldobject/TestEmergencyDumpAtOOM.java
+++ b/test/jdk/jdk/jfr/event/oldobject/TestEmergencyDumpAtOOM.java
@@ -96,17 +96,12 @@ public class TestEmergencyDumpAtOOM {
 
             // Check OldObjectSample events
             if (oldObjects.get() > 0L) {
-                // Check shutdown reason
-                String expectedShutdownReason = shouldCrash
-                    ? "VM Error"
-                    : "No remaining non-daemon Java threads";
-                Asserts.assertEquals(expectedShutdownReason, shutdownReason.get());
-
-                // Check dump reason - it would appear on emergency dump only
                 if (shouldCrash) {
+                    Asserts.assertEquals("VM Error", shutdownReason.get());
                     Asserts.assertEquals("Out of Memory", dumpReason.get());
+                } else {
+                    Asserts.assertEquals("No remaining non-daemon Java threads", shutdownReason.get());
                 }
-
                 // Passed this test
                 return;
             }

--- a/test/jdk/jdk/jfr/event/oldobject/TestEmergencyDumpAtOOM.java
+++ b/test/jdk/jdk/jfr/event/oldobject/TestEmergencyDumpAtOOM.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, NTT DATA.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.jfr.event.oldobject;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import jdk.jfr.consumer.RecordingFile;
+
+import jdk.test.lib.Asserts;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+/**
+* @test
+* @bug 8364090
+* @summary Tests Dump reason and OldObjectSample events at OOME.
+* @requires vm.flagless
+* @requires vm.hasJFR
+* @library /test/lib
+* @run main/othervm jdk.jfr.event.oldobject.TestEmergencyDumpAtOOM
+*/
+public class TestEmergencyDumpAtOOM {
+
+    public static List<String> DEFAULT_LEAKER_ARGS = List.of(
+        "-Xmx32m",
+        "-XX:StartFlightRecording:path-to-gc-roots=true,dumponexit=true,filename=oom.jfr",
+        Leaker.class.getName()
+    );
+
+    public static class Leaker {
+        public static void main(String... args) {
+            List<byte[]> list = new ArrayList<>();
+            while (true) {
+                list.add(new byte[1024]);
+            }
+        }
+    }
+
+    private static void test(boolean shouldCrash) throws Exception {
+        var args = new ArrayList<String>(DEFAULT_LEAKER_ARGS);
+        if (shouldCrash) {
+            args.add(0, "-XX:+CrashOnOutOfMemoryError");
+        }
+        var p = ProcessTools.createTestJavaProcessBuilder(args).start();
+        p.waitFor();
+        var output = new OutputAnalyzer(p);
+        if (!output.contains("java.lang.OutOfMemoryError")) {
+            throw new RuntimeException("OutOfMemoryError did not happen.");
+        }
+
+        // Check recording file, and load all of events
+        var jfrFileName = shouldCrash ? String.format("hs_err_pid%d.jfr", p.pid()) : "oom.jfr";
+        var jfrPath = Path.of(jfrFileName);
+        Asserts.assertTrue(Files.exists(jfrPath), "No jfr recording file " + jfrFileName + " exists");
+        var events = RecordingFile.readAllEvents(jfrPath);
+
+        // Check shutdown reason
+        var shutdownEvent = events.stream()
+                                  .filter(e -> e.getEventType().getName().equals("jdk.Shutdown"))
+                                  .findAny()
+                                  .get();
+        String shutdownReason = shouldCrash
+            ? "VM Error"
+            : "No remaining non-daemon Java threads";
+        Asserts.assertEquals(shutdownReason, shutdownEvent.getString("reason"));
+
+        // Check dump reason
+        if (shouldCrash) {
+            var dumpReasonEvent = events.stream()
+                                        .filter(e -> e.getEventType().getName().equals("jdk.DumpReason"))
+                                        .findAny()
+                                        .get();
+            Asserts.assertEquals("Out of Memory", dumpReasonEvent.getString("reason"));
+        }
+
+        // Check OldObjectSample events
+        var numEvents = events.stream()
+                              .filter(e -> e.getEventType().getName().equals("jdk.OldObjectSample"))
+                              .count();
+        Asserts.assertGreaterThan(numEvents, 0L);
+    }
+
+    public static void main(String... args) throws Exception {
+        test(true);
+        test(false);
+    }
+}


### PR DESCRIPTION
JFR emergency dump would happen when OOM was thrown. However it would not contain most recent `OldObjectSample` events emitted by LeakProfiler.

I [reported this issue in past](https://mail.openjdk.org/pipermail/hotspot-jfr-dev/2019-January/000381.html), and it seems to be difficult to fix soon, and also JDK codebase has been updated in several years. It brings us to fix this issue easier than past.

So I propose again to emit the events from LeakProfiler when OOM happened.
This change passed `jdk_jfr` tests on Linux x64 (excepts TestHeapSummaryEventPSParOld.java reported in [JDK-8364082](https://bugs.openjdk.org/browse/JDK-8364082))

Related email thread: https://mail.openjdk.org/pipermail/hotspot-jfr-dev/2025-July/008007.html

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8364090](https://bugs.openjdk.org/browse/JDK-8364090): Dump JFR recording on CrashOnOutOfMemoryError (**Bug** - P4)


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**) Review applies to [5ecd4e43](https://git.openjdk.org/jdk/pull/26468/files/5ecd4e43bf35ebc66d08b56b24b0e48f79a24864)
 * [Erik Gahlin](https://openjdk.org/census#egahlin) (@egahlin - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26468/head:pull/26468` \
`$ git checkout pull/26468`

Update a local copy of the PR: \
`$ git checkout pull/26468` \
`$ git pull https://git.openjdk.org/jdk.git pull/26468/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26468`

View PR using the GUI difftool: \
`$ git pr show -t 26468`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26468.diff">https://git.openjdk.org/jdk/pull/26468.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26468#issuecomment-3115449025)
</details>
