### PR TITLE
8364081: Shenandoah & GenShen logging improvement

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
@@ -285,6 +285,7 @@ void ShenandoahControlThread::service_concurrent_normal_cycle(GCCause::Cause cau
     log_info(gc)("Cancelled");
     return;
   }
+  heap->increment_total_collections(false);
 
   ShenandoahGCSession session(cause, heap->global_generation());
 
@@ -331,6 +332,8 @@ void ShenandoahControlThread::service_stw_full_cycle(GCCause::Cause cause) {
   ShenandoahHeap* const heap = ShenandoahHeap::heap();
   ShenandoahGCSession session(cause, heap->global_generation());
 
+  heap->increment_total_collections(true);
+
   ShenandoahFullGC gc;
   gc.collect(cause);
 }
@@ -339,6 +342,8 @@ void ShenandoahControlThread::service_stw_degenerated_cycle(GCCause::Cause cause
   assert (point != ShenandoahGC::_degenerated_unset, "Degenerated point should be set");
   ShenandoahHeap* const heap = ShenandoahHeap::heap();
   ShenandoahGCSession session(cause, heap->global_generation());
+
+  heap->increment_total_collections(false);
 
   ShenandoahDegenGC gc(point, heap->global_generation());
   gc.collect(cause);

--- a/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.cpp
@@ -482,7 +482,9 @@ const char* ShenandoahDegenGC::degen_event_message(ShenandoahDegenPoint point) c
 
 void ShenandoahDegenGC::upgrade_to_full() {
   log_info(gc)("Degenerated GC upgrading to Full GC");
-  ShenandoahHeap::heap()->shenandoah_policy()->record_degenerated_upgrade_to_full();
+  ShenandoahHeap* heap = ShenandoahHeap::heap();
+  heap->increment_total_collections(true);
+  heap->shenandoah_policy()->record_degenerated_upgrade_to_full();
   ShenandoahFullGC full_gc;
   full_gc.op_full(GCCause::_shenandoah_upgrade_to_full_gc);
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalControlThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalControlThread.cpp
@@ -379,6 +379,8 @@ void ShenandoahGenerationalControlThread::service_concurrent_old_cycle(const She
 
   TraceCollectorStats tcs(_heap->monitoring_support()->concurrent_collection_counters());
 
+  _heap->increment_total_collections(false);
+
   switch (original_state) {
     case ShenandoahOldGeneration::FILLING: {
       ShenandoahGCSession session(request.cause, old_generation);
@@ -528,6 +530,7 @@ void ShenandoahGenerationalControlThread::service_concurrent_cycle(ShenandoahGen
   assert(!generation->is_old(), "Old GC takes a different control path");
 
   ShenandoahConcurrentGC gc(generation, do_old_gc_bootstrap);
+  _heap->increment_total_collections(false);
   if (gc.collect(cause)) {
     // Cycle is complete
     _heap->notify_gc_progress();
@@ -595,6 +598,7 @@ bool ShenandoahGenerationalControlThread::check_cancellation_or_degen(Shenandoah
 }
 
 void ShenandoahGenerationalControlThread::service_stw_full_cycle(GCCause::Cause cause) {
+  _heap->increment_total_collections(true);
   ShenandoahGCSession session(cause, _heap->global_generation());
   maybe_set_aging_cycle();
   ShenandoahFullGC gc;
@@ -604,6 +608,7 @@ void ShenandoahGenerationalControlThread::service_stw_full_cycle(GCCause::Cause 
 
 void ShenandoahGenerationalControlThread::service_stw_degenerated_cycle(const ShenandoahGCRequest& request) {
   assert(_degen_point != ShenandoahGC::_degenerated_unset, "Degenerated point should be set");
+  _heap->increment_total_collections(false);
 
   ShenandoahGCSession session(request.cause, request.generation);
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -579,20 +579,32 @@ ShenandoahHeap::ShenandoahHeap(ShenandoahCollectorPolicy* policy) :
 #endif
 
 void ShenandoahHeap::print_heap_on(outputStream* st) const {
-  st->print_cr("Shenandoah Heap");
-  st->print_cr(" %zu%s max, %zu%s soft max, %zu%s committed, %zu%s used",
-               byte_size_in_proper_unit(max_capacity()), proper_unit_for_byte_size(max_capacity()),
-               byte_size_in_proper_unit(soft_max_capacity()), proper_unit_for_byte_size(soft_max_capacity()),
-               byte_size_in_proper_unit(committed()),    proper_unit_for_byte_size(committed()),
-               byte_size_in_proper_unit(used()),         proper_unit_for_byte_size(used()));
-  st->print_cr(" %zu x %zu %s regions",
-               num_regions(),
-               byte_size_in_proper_unit(ShenandoahHeapRegion::region_size_bytes()),
-               proper_unit_for_byte_size(ShenandoahHeapRegion::region_size_bytes()));
+  bool is_generational = mode()->is_generational();
+  if (is_generational) {
+    st->print_cr("Generational Shenandoah Heap");
+    st->print_cr(" Young:");
+    st->print_cr("  " PROPERFMT " max, " PROPERFMT " used", PROPERFMTARGS(young_generation()->max_capacity()), PROPERFMTARGS(young_generation()->used()));
+    st->print_cr(" Old:");
+    st->print_cr("  " PROPERFMT " max, " PROPERFMT " used", PROPERFMTARGS(old_generation()->max_capacity()), PROPERFMTARGS(old_generation()->used()));
+    st->print_cr(" Entire heap:");
+    st->print_cr("  " PROPERFMT " soft max, " PROPERFMT " committed",
+                PROPERFMTARGS(soft_max_capacity()), PROPERFMTARGS(committed()));
+  } else {
+    st->print_cr("Shenandoah Heap");
+    st->print_cr("  " PROPERFMT " max, " PROPERFMT " soft max, " PROPERFMT " committed, " PROPERFMT " used",
+      PROPERFMTARGS(max_capacity()),
+      PROPERFMTARGS(soft_max_capacity()),
+      PROPERFMTARGS(committed()),
+      PROPERFMTARGS(used())
+    );
+    st->print_cr(" %zu x " PROPERFMT " regions",
+                num_regions(),
+                PROPERFMTARGS(ShenandoahHeapRegion::region_size_bytes()));
+  }
 
   st->print("Status: ");
   if (has_forwarded_objects())                 st->print("has forwarded objects, ");
-  if (!mode()->is_generational()) {
+  if (!is_generational) {
     if (is_concurrent_mark_in_progress())      st->print("marking,");
   } else {
     if (is_concurrent_old_mark_in_progress())    st->print("old marking, ");

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -579,7 +579,8 @@ ShenandoahHeap::ShenandoahHeap(ShenandoahCollectorPolicy* policy) :
 #endif
 
 void ShenandoahHeap::print_heap_on(outputStream* st) const {
-  bool is_generational = mode()->is_generational();
+  const bool is_generational = mode()->is_generational();
+  const char* front_spacing = "";
   if (is_generational) {
     st->print_cr("Generational Shenandoah Heap");
     st->print_cr(" Young:");
@@ -589,6 +590,7 @@ void ShenandoahHeap::print_heap_on(outputStream* st) const {
     st->print_cr(" Entire heap:");
     st->print_cr("  " PROPERFMT " soft max, " PROPERFMT " committed",
                 PROPERFMTARGS(soft_max_capacity()), PROPERFMTARGS(committed()));
+    front_spacing = " ";
   } else {
     st->print_cr("Shenandoah Heap");
     st->print_cr("  " PROPERFMT " max, " PROPERFMT " soft max, " PROPERFMT " committed, " PROPERFMT " used",
@@ -597,10 +599,11 @@ void ShenandoahHeap::print_heap_on(outputStream* st) const {
       PROPERFMTARGS(committed()),
       PROPERFMTARGS(used())
     );
-    st->print_cr(" %zu x " PROPERFMT " regions",
-                num_regions(),
-                PROPERFMTARGS(ShenandoahHeapRegion::region_size_bytes()));
   }
+  st->print_cr("%s %zu x " PROPERFMT " regions",
+          front_spacing,
+          num_regions(),
+          PROPERFMTARGS(ShenandoahHeapRegion::region_size_bytes()));
 
   st->print("Status: ");
   if (has_forwarded_objects())                 st->print("has forwarded objects, ");


### PR DESCRIPTION
Fix missing `increment_total_collections` usages in Shenandoah (otherwise, the invocation count is always 0 as shown in https://github.com/openjdk/jdk/pull/26272 overview). 

Also added some generational information for generational shenandoah logging.

Shenandoah logging samples:

```
######################
Shenandoah - Before GC
######################
[0.161s][debug][gc,heap      ] GC(0) Heap Before GC invocations=0 (full 0):
[0.161s][debug][gc,heap      ] GC(0)  Shenandoah Heap
[0.161s][debug][gc,heap      ] GC(0)    100M max, 100M soft max, 100M committed, 40312K used
[0.161s][debug][gc,heap      ] GC(0)   400 x 256K regions
[0.161s][debug][gc,heap      ] GC(0)  Status: not cancelled
[0.161s][debug][gc,heap      ] GC(0)  Reserved region:
[0.161s][debug][gc,heap      ] GC(0)   - [0x00000000f9c00000, 0x0000000100000000) 
[0.161s][debug][gc,heap      ] GC(0)  Collection set:
[0.161s][debug][gc,heap      ] GC(0)   - map (vanilla): 0x0000000000004e70
[0.161s][debug][gc,heap      ] GC(0)   - map (biased):  0x0000000000001000
[0.161s][debug][gc,heap      ] GC(0) 
[0.161s][debug][gc,metaspace ] GC(0) Metaspace Before GC invocations=0 (full 0):
[0.161s][debug][gc,metaspace ] GC(0)  Metaspace       used 86K, committed 320K, reserved 1114112K
[0.161s][debug][gc,metaspace ] GC(0)   class space    used 3K, committed 128K, reserved 1048576K

######################
Shenandoah - After GC
######################
[2.179s][debug][gc,heap        ] GC(9) Heap After GC invocations=17 (full 7):
[2.179s][debug][gc,heap        ] GC(9)  Shenandoah Heap
[2.179s][debug][gc,heap        ] GC(9)    100M max, 100M soft max, 100M committed, 97113K used
[2.179s][debug][gc,heap        ] GC(9)   400 x 256K regions
[2.179s][debug][gc,heap        ] GC(9)  Status: not cancelled
[2.179s][debug][gc,heap        ] GC(9)  Reserved region:
[2.179s][debug][gc,heap        ] GC(9)   - [0x00000000f9c00000, 0x0000000100000000) 
[2.179s][debug][gc,heap        ] GC(9)  Collection set:
[2.179s][debug][gc,heap        ] GC(9)   - map (vanilla): 0x0000000000004e70
[2.179s][debug][gc,heap        ] GC(9)   - map (biased):  0x0000000000001000
[2.179s][debug][gc,heap        ] GC(9) 
[2.179s][debug][gc,metaspace   ] GC(9) Metaspace After GC invocations=17 (full 7):
[2.179s][debug][gc,metaspace   ] GC(9)  Metaspace       used 125K, committed 320K, reserved 1114112K
[2.179s][debug][gc,metaspace   ] GC(9)   class space    used 4K, committed 128K, reserved 1048576K
```

Generational Shenandoah logging samples
```
######################
Generational Shenandoah - Before GC
######################
[0.210s][debug][gc,heap      ] GC(0) Heap Before GC invocations=0 (full 0):
[0.210s][debug][gc,heap      ] GC(0)  Generational Shenandoah Heap
[0.210s][debug][gc,heap      ] GC(0)   Young:
[0.210s][debug][gc,heap      ] GC(0)    100M max, 39686K used
[0.210s][debug][gc,heap      ] GC(0)   Old:
[0.210s][debug][gc,heap      ] GC(0)    0B max, 0B used
[0.210s][debug][gc,heap      ] GC(0)   Entire heap:
[0.210s][debug][gc,heap      ] GC(0)    100M soft max, 100M committed
[0.210s][debug][gc,heap      ] GC(0)    400 x 256K regions
[0.210s][debug][gc,heap      ] GC(0)  Status: not cancelled
[0.210s][debug][gc,heap      ] GC(0)  Reserved region:
[0.210s][debug][gc,heap      ] GC(0)   - [0x00000000f9c00000, 0x0000000100000000) 
[0.210s][debug][gc,heap      ] GC(0)  Collection set:
[0.210s][debug][gc,heap      ] GC(0)   - map (vanilla): 0x0000000000004e70
[0.210s][debug][gc,heap      ] GC(0)   - map (biased):  0x0000000000001000
[0.210s][debug][gc,heap      ] GC(0) 
[0.210s][debug][gc,metaspace ] GC(0) Metaspace Before GC invocations=0 (full 0):
[0.210s][debug][gc,metaspace ] GC(0)  Metaspace       used 153K, committed 384K, reserved 1114112K
[0.210s][debug][gc,metaspace ] GC(0)   class space    used 3K, committed 128K, reserved 1048576K

######################
Generational Shenandoah - After GC
######################
[1.339s][debug][gc,heap        ] GC(13) Heap After GC invocations=14 (full 2):
[1.339s][debug][gc,heap        ] GC(13)  Generational Shenandoah Heap
[1.339s][debug][gc,heap        ] GC(13)   Young:
[1.339s][debug][gc,heap        ] GC(13)    2816K max, 2813K used
[1.339s][debug][gc,heap        ] GC(13)   Old:
[1.339s][debug][gc,heap        ] GC(13)    99584K max, 97492K used
[1.339s][debug][gc,heap        ] GC(13)   Entire heap:
[1.339s][debug][gc,heap        ] GC(13)    100M soft max, 100M committed
[1.339s][debug][gc,heap        ] GC(13)    400 x 256K regions
[1.339s][debug][gc,heap        ] GC(13)  Status: not cancelled
[1.339s][debug][gc,heap        ] GC(13)  Reserved region:
[1.339s][debug][gc,heap        ] GC(13)   - [0x00000000f9c00000, 0x0000000100000000) 
[1.339s][debug][gc,heap        ] GC(13)  Collection set:
[1.339s][debug][gc,heap        ] GC(13)   - map (vanilla): 0x0000000000004e70
[1.339s][debug][gc,heap        ] GC(13)   - map (biased):  0x0000000000001000
[1.339s][debug][gc,heap        ] GC(13) 
[1.339s][debug][gc,metaspace   ] GC(13) Metaspace After GC invocations=14 (full 2):
[1.339s][debug][gc,metaspace   ] GC(13)  Metaspace       used 190K, committed 384K, reserved 1114112K
[1.339s][debug][gc,metaspace   ] GC(13)   class space    used 4K, committed 128K, reserved 1048576K
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8364081](https://bugs.openjdk.org/browse/JDK-8364081): Shenandoah &amp; GenShen logging improvement (**Enhancement** - P4)


### Reviewers
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - **Reviewer**) Review applies to [1d51fcff](https://git.openjdk.org/jdk/pull/26469/files/1d51fcff9efa2eda61f5907fcc2ff5ba0f78d7e4)
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26469/head:pull/26469` \
`$ git checkout pull/26469`

Update a local copy of the PR: \
`$ git checkout pull/26469` \
`$ git pull https://git.openjdk.org/jdk.git pull/26469/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26469`

View PR using the GUI difftool: \
`$ git pr show -t 26469`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26469.diff">https://git.openjdk.org/jdk/pull/26469.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26469#issuecomment-3117967576)
</details>
