### PR TITLE
8347707: Standardise the use of os::snprintf and os::snprintf_checked

### DIFF
--- a/src/hotspot/cpu/aarch64/frame_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/frame_aarch64.cpp
@@ -702,10 +702,10 @@ static void printbc(Method *m, intptr_t bcx) {
   if (m->validate_bci_from_bcp((address)bcx) < 0
       || !m->contains((address)bcx)) {
     name = "???";
-    snprintf(buf, sizeof buf, "(bad)");
+    os::snprintf_checked(buf, sizeof buf, "(bad)");
   } else {
     int bci = m->bci_from((address)bcx);
-    snprintf(buf, sizeof buf, "%d", bci);
+    os::snprintf_checked(buf, sizeof buf, "%d", bci);
     name = Bytecodes::name(m->code_at(bci));
   }
   ResourceMark rm;

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -2259,7 +2259,7 @@ void MacroAssembler::movptr(Register r, uintptr_t imm64) {
 #ifndef PRODUCT
   {
     char buffer[64];
-    snprintf(buffer, sizeof(buffer), "0x%" PRIX64, (uint64_t)imm64);
+    os::snprintf_checked(buffer, sizeof(buffer), "0x%" PRIX64, (uint64_t)imm64);
     block_comment(buffer);
   }
 #endif
@@ -2317,7 +2317,7 @@ void MacroAssembler::mov_immediate64(Register dst, uint64_t imm64)
 #ifndef PRODUCT
   {
     char buffer[64];
-    snprintf(buffer, sizeof(buffer), "0x%" PRIX64, imm64);
+    os::snprintf_checked(buffer, sizeof(buffer), "0x%" PRIX64, imm64);
     block_comment(buffer);
   }
 #endif
@@ -2430,7 +2430,7 @@ void MacroAssembler::mov_immediate32(Register dst, uint32_t imm32)
 #ifndef PRODUCT
     {
       char buffer[64];
-      snprintf(buffer, sizeof(buffer), "0x%" PRIX32, imm32);
+      os::snprintf_checked(buffer, sizeof(buffer), "0x%" PRIX32, imm32);
       block_comment(buffer);
     }
 #endif
@@ -2902,11 +2902,11 @@ int MacroAssembler::push_fp(unsigned int bitset, Register stack, FpPushPopMode m
   {
     char buffer[48];
     if (mode == PushPopSVE) {
-      snprintf(buffer, sizeof(buffer), "push_fp: %d SVE registers", count);
+      os::snprintf_checked(buffer, sizeof(buffer), "push_fp: %d SVE registers", count);
     } else if (mode == PushPopNeon) {
-      snprintf(buffer, sizeof(buffer), "push_fp: %d Neon registers", count);
+      os::snprintf_checked(buffer, sizeof(buffer), "push_fp: %d Neon registers", count);
     } else {
-      snprintf(buffer, sizeof(buffer), "push_fp: %d fp registers", count);
+      os::snprintf_checked(buffer, sizeof(buffer), "push_fp: %d fp registers", count);
     }
     block_comment(buffer);
   }
@@ -3014,11 +3014,11 @@ int MacroAssembler::pop_fp(unsigned int bitset, Register stack, FpPushPopMode mo
   {
     char buffer[48];
     if (mode == PushPopSVE) {
-      snprintf(buffer, sizeof(buffer), "pop_fp: %d SVE registers", count);
+      os::snprintf_checked(buffer, sizeof(buffer), "pop_fp: %d SVE registers", count);
     } else if (mode == PushPopNeon) {
-      snprintf(buffer, sizeof(buffer), "pop_fp: %d Neon registers", count);
+      os::snprintf_checked(buffer, sizeof(buffer), "pop_fp: %d Neon registers", count);
     } else {
-      snprintf(buffer, sizeof(buffer), "pop_fp: %d fp registers", count);
+      os::snprintf_checked(buffer, sizeof(buffer), "pop_fp: %d fp registers", count);
     }
     block_comment(buffer);
   }
@@ -5920,7 +5920,7 @@ address MacroAssembler::arrays_equals(Register a1, Register a2, Register tmp3,
   {
     const char kind = (elem_size == 2) ? 'U' : 'L';
     char comment[64];
-    snprintf(comment, sizeof comment, "array_equals%c{", kind);
+    os::snprintf_checked(comment, sizeof comment, "array_equals%c{", kind);
     BLOCK_COMMENT(comment);
   }
 #endif
@@ -6118,7 +6118,7 @@ void MacroAssembler::string_equals(Register a1, Register a2,
 #ifndef PRODUCT
   {
     char comment[64];
-    snprintf(comment, sizeof comment, "{string_equalsL");
+    os::snprintf_checked(comment, sizeof comment, "{string_equalsL");
     BLOCK_COMMENT(comment);
   }
 #endif
@@ -6266,7 +6266,7 @@ address MacroAssembler::zero_words(Register base, uint64_t cnt)
 #ifndef PRODUCT
     {
       char buf[64];
-      snprintf(buf, sizeof buf, "zero_words (count = %" PRIu64 ") {", cnt);
+      os::snprintf_checked(buf, sizeof buf, "zero_words (count = %" PRIu64 ") {", cnt);
       BLOCK_COMMENT(buf);
     }
 #endif

--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -724,7 +724,7 @@ void VM_Version::initialize_cpu_information(void) {
   _no_of_sockets = _no_of_cores;
   os::snprintf_checked(_cpu_name, CPU_TYPE_DESC_BUF_SIZE - 1, "AArch64");
 
-  int desc_len = snprintf(_cpu_desc, CPU_DETAILED_DESC_BUF_SIZE, "AArch64 ");
+  int desc_len = os::snprintf(_cpu_desc, CPU_DETAILED_DESC_BUF_SIZE, "AArch64 ");
   get_compatible_board(_cpu_desc + desc_len, CPU_DETAILED_DESC_BUF_SIZE - desc_len);
   desc_len = (int)strlen(_cpu_desc);
   os::snprintf_checked(_cpu_desc + desc_len, CPU_DETAILED_DESC_BUF_SIZE - desc_len, " %s", _cpu_info_string);

--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -643,7 +643,8 @@ void VM_Version::initialize() {
 
   // Construct the "features" string
   char buf[512];
-  int buf_used_len = os::snprintf_checked(buf, sizeof(buf), "0x%02x:0x%x:0x%03x:%d", _cpu, _variant, _model, _revision);
+  int buf_used_len = os::snprintf(buf, sizeof(buf), "0x%02x:0x%x:0x%03x:%d", _cpu, _variant, _model, _revision);
+  assert(buf_used_len < (int)sizeof(buf), "unexpected os::snprintf error - return value: %d", buf_used_len);
   if (_model2) {
     os::snprintf_checked(buf + buf_used_len, sizeof(buf) - buf_used_len, "(0x%03x)", _model2);
   }

--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -722,12 +722,12 @@ void VM_Version::initialize_cpu_information(void) {
   _no_of_cores  = os::processor_count();
   _no_of_threads = _no_of_cores;
   _no_of_sockets = _no_of_cores;
-  snprintf(_cpu_name, CPU_TYPE_DESC_BUF_SIZE - 1, "AArch64");
+  os::snprintf_checked(_cpu_name, CPU_TYPE_DESC_BUF_SIZE - 1, "AArch64");
 
   int desc_len = snprintf(_cpu_desc, CPU_DETAILED_DESC_BUF_SIZE, "AArch64 ");
   get_compatible_board(_cpu_desc + desc_len, CPU_DETAILED_DESC_BUF_SIZE - desc_len);
   desc_len = (int)strlen(_cpu_desc);
-  snprintf(_cpu_desc + desc_len, CPU_DETAILED_DESC_BUF_SIZE - desc_len, " %s", _cpu_info_string);
+  os::snprintf_checked(_cpu_desc + desc_len, CPU_DETAILED_DESC_BUF_SIZE - desc_len, " %s", _cpu_info_string);
 
   _initialized = true;
 }

--- a/src/hotspot/cpu/arm/macroAssembler_arm.cpp
+++ b/src/hotspot/cpu/arm/macroAssembler_arm.cpp
@@ -839,7 +839,7 @@ void MacroAssembler::_verify_oop(Register reg, const char* s, const char* file, 
   char buffer[64];
 #ifdef COMPILER1
   if (CommentedAssembly) {
-    snprintf(buffer, sizeof(buffer), "verify_oop at %d", offset());
+    os::snprintf_checked(buffer, sizeof(buffer), "verify_oop at %d", offset());
     block_comment(buffer);
   }
 #endif

--- a/src/hotspot/cpu/arm/vm_version_arm_32.cpp
+++ b/src/hotspot/cpu/arm/vm_version_arm_32.cpp
@@ -362,7 +362,7 @@ void VM_Version::initialize_cpu_information(void) {
   _no_of_cores  = os::processor_count();
   _no_of_threads = _no_of_cores;
   _no_of_sockets = _no_of_cores;
-  snprintf(_cpu_name, CPU_TYPE_DESC_BUF_SIZE - 1, "ARM%d", _arm_arch);
-  snprintf(_cpu_desc, CPU_DETAILED_DESC_BUF_SIZE, "%s", _cpu_info_string);
+  os::snprintf_checked(_cpu_name, CPU_TYPE_DESC_BUF_SIZE - 1, "ARM%d", _arm_arch);
+  os::snprintf_checked(_cpu_desc, CPU_DETAILED_DESC_BUF_SIZE, "%s", _cpu_info_string);
   _initialized = true;
 }

--- a/src/hotspot/cpu/ppc/vm_version_ppc.cpp
+++ b/src/hotspot/cpu/ppc/vm_version_ppc.cpp
@@ -625,7 +625,7 @@ void VM_Version::initialize_cpu_information(void) {
   _no_of_cores  = os::processor_count();
   _no_of_threads = _no_of_cores;
   _no_of_sockets = _no_of_cores;
-  snprintf(_cpu_name, CPU_TYPE_DESC_BUF_SIZE, "PowerPC POWER%lu", PowerArchitecturePPC64);
-  snprintf(_cpu_desc, CPU_DETAILED_DESC_BUF_SIZE, "PPC %s", cpu_info_string());
+  os::snprintf_checked(_cpu_name, CPU_TYPE_DESC_BUF_SIZE, "PowerPC POWER%lu", PowerArchitecturePPC64);
+  os::snprintf_checked(_cpu_desc, CPU_DETAILED_DESC_BUF_SIZE, "PPC %s", cpu_info_string());
   _initialized = true;
 }

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -2679,7 +2679,7 @@ void MacroAssembler::movptr(Register Rd, address addr, int32_t &offset, Register
 #ifndef PRODUCT
   {
     char buffer[64];
-    snprintf(buffer, sizeof(buffer), "0x%" PRIx64, uimm64);
+    os::snprintf_checked(buffer, sizeof(buffer), "0x%" PRIx64, uimm64);
     block_comment(buffer);
   }
 #endif

--- a/src/hotspot/cpu/riscv/vm_version_riscv.cpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.cpp
@@ -493,8 +493,8 @@ void VM_Version::initialize_cpu_information(void) {
   _no_of_cores  = os::processor_count();
   _no_of_threads = _no_of_cores;
   _no_of_sockets = _no_of_cores;
-  snprintf(_cpu_name, CPU_TYPE_DESC_BUF_SIZE - 1, "RISCV64");
-  snprintf(_cpu_desc, CPU_DETAILED_DESC_BUF_SIZE, "RISCV64 %s", cpu_info_string());
+  os::snprintf_checked(_cpu_name, CPU_TYPE_DESC_BUF_SIZE - 1, "RISCV64");
+  os::snprintf_checked(_cpu_desc, CPU_DETAILED_DESC_BUF_SIZE, "RISCV64 %s", cpu_info_string());
   _initialized = true;
 }
 

--- a/src/hotspot/cpu/s390/vm_version_s390.cpp
+++ b/src/hotspot/cpu/s390/vm_version_s390.cpp
@@ -1541,7 +1541,7 @@ void VM_Version::initialize_cpu_information(void) {
   _no_of_cores  = os::processor_count();
   _no_of_threads = _no_of_cores;
   _no_of_sockets = _no_of_cores;
-  snprintf(_cpu_name, CPU_TYPE_DESC_BUF_SIZE, "s390 %s", VM_Version::get_model_string());
-  snprintf(_cpu_desc, CPU_DETAILED_DESC_BUF_SIZE, "s390 %s", cpu_info_string());
+  os::snprintf_checked(_cpu_name, CPU_TYPE_DESC_BUF_SIZE, "s390 %s", VM_Version::get_model_string());
+  os::snprintf_checked(_cpu_desc, CPU_DETAILED_DESC_BUF_SIZE, "s390 %s", cpu_info_string());
   _initialized = true;
 }

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
@@ -4332,10 +4332,10 @@ void StubGenerator::generate_compiler_stubs() {
     if (libsimdsort != nullptr) {
       log_info(library)("Loaded library %s, handle " INTPTR_FORMAT, JNI_LIB_PREFIX "simdsort" JNI_LIB_SUFFIX, p2i(libsimdsort));
 
-      snprintf(ebuf_, sizeof(ebuf_), VM_Version::supports_avx512_simd_sort() ? "avx512_sort" : "avx2_sort");
+      os::snprintf_checked(ebuf_, sizeof(ebuf_), VM_Version::supports_avx512_simd_sort() ? "avx512_sort" : "avx2_sort");
       StubRoutines::_array_sort = (address)os::dll_lookup(libsimdsort, ebuf_);
 
-      snprintf(ebuf_, sizeof(ebuf_), VM_Version::supports_avx512_simd_sort() ? "avx512_partition" : "avx2_partition");
+      os::snprintf_checked(ebuf_, sizeof(ebuf_), VM_Version::supports_avx512_simd_sort() ? "avx512_partition" : "avx2_partition");
       StubRoutines::_array_partition = (address)os::dll_lookup(libsimdsort, ebuf_);
     }
   }

--- a/src/hotspot/cpu/zero/frame_zero.cpp
+++ b/src/hotspot/cpu/zero/frame_zero.cpp
@@ -242,8 +242,8 @@ void frame::zero_print_on_error(int           frame_index,
     int offset = fp() - addr;
 
     // Fill in default values, then try and improve them
-    snprintf(fieldbuf, buflen, "word[%d]", offset);
-    snprintf(valuebuf, buflen, PTR_FORMAT, *addr);
+    os::snprintf_checked(fieldbuf, buflen, "word[%d]", offset);
+    os::snprintf_checked(valuebuf, buflen, PTR_FORMAT, *addr);
     zeroframe()->identify_word(frame_index, offset, fieldbuf, valuebuf, buflen);
     fieldbuf[buflen - 1] = '\0';
     valuebuf[buflen - 1] = '\0';
@@ -300,7 +300,7 @@ void EntryFrame::identify_word(int   frame_index,
     break;
 
   default:
-    snprintf(fieldbuf, buflen, "local[%d]", offset - 3);
+    os::snprintf_checked(fieldbuf, buflen, "local[%d]", offset - 3);
   }
 }
 
@@ -321,12 +321,12 @@ void InterpreterFrame::identify_word(int   frame_index,
         istate->method()->name_and_sig_as_C_string(valuebuf, buflen);
       }
       else if (is_valid && !strcmp(field, "_bcp") && istate->bcp()) {
-        snprintf(valuebuf, buflen, PTR_FORMAT " (bci %d)",
-                 (intptr_t) istate->bcp(),
-                 istate->method()->bci_from(istate->bcp()));
+        os::snprintf_checked(valuebuf, buflen, PTR_FORMAT " (bci %d)",
+                             (intptr_t) istate->bcp(),
+                             istate->method()->bci_from(istate->bcp()));
       }
-      snprintf(fieldbuf, buflen, "%sistate->%s",
-               field[strlen(field) - 1] == ')' ? "(": "", field);
+      os::snprintf_checked(fieldbuf, buflen, "%sistate->%s",
+                           field[strlen(field) - 1] == ')' ? "(": "", field);
     }
     else if (addr == (intptr_t *) istate) {
       strncpy(fieldbuf, "(vtable for istate)", buflen);
@@ -358,13 +358,13 @@ void InterpreterFrame::identify_word(int   frame_index,
             else
               desc = " (this)";
           }
-          snprintf(fieldbuf, buflen, "parameter[%d]%s", param, desc);
+          os::snprintf_checked(fieldbuf, buflen, "parameter[%d]%s", param, desc);
           return;
         }
 
         for (int i = 0; i < handler->argument_count(); i++) {
           if (params[i] == (intptr_t) addr) {
-            snprintf(fieldbuf, buflen, "unboxed parameter[%d]", i);
+            os::snprintf_checked(fieldbuf, buflen, "unboxed parameter[%d]", i);
             return;
           }
         }
@@ -396,18 +396,18 @@ void ZeroFrame::identify_vp_word(int       frame_index,
     intptr_t offset = (intptr_t) addr - monitor;
 
     if (offset == in_bytes(BasicObjectLock::obj_offset()))
-      snprintf(fieldbuf, buflen, "monitor[%d]->_obj", index);
+      os::snprintf_checked(fieldbuf, buflen, "monitor[%d]->_obj", index);
     else if (offset == in_bytes(BasicObjectLock::lock_offset()))
-      snprintf(fieldbuf, buflen, "monitor[%d]->_lock", index);
+      os::snprintf_checked(fieldbuf, buflen, "monitor[%d]->_lock", index);
 
     return;
   }
 
   // Expression stack
   if (addr < stack_base) {
-    snprintf(fieldbuf, buflen, "%s[%d]",
-             frame_index == 0 ? "stack_word" : "local",
-             (int) (stack_base - addr - 1));
+    os::snprintf_checked(fieldbuf, buflen, "%s[%d]",
+                         frame_index == 0 ? "stack_word" : "local",
+                         (int) (stack_base - addr - 1));
     return;
   }
 }

--- a/src/hotspot/cpu/zero/vm_version_zero.cpp
+++ b/src/hotspot/cpu/zero/vm_version_zero.cpp
@@ -150,7 +150,7 @@ void VM_Version::initialize_cpu_information(void) {
   _no_of_cores  = os::processor_count();
   _no_of_threads = _no_of_cores;
   _no_of_sockets = _no_of_cores;
-  snprintf(_cpu_name, CPU_TYPE_DESC_BUF_SIZE - 1, "Zero VM");
-  snprintf(_cpu_desc, CPU_DETAILED_DESC_BUF_SIZE, "%s", _cpu_info_string);
+  os::snprintf_checked(_cpu_name, CPU_TYPE_DESC_BUF_SIZE - 1, "Zero VM");
+  os::snprintf_checked(_cpu_desc, CPU_DETAILED_DESC_BUF_SIZE, "%s", _cpu_info_string);
   _initialized = true;
 }

--- a/src/hotspot/os/aix/attachListener_aix.cpp
+++ b/src/hotspot/os/aix/attachListener_aix.cpp
@@ -209,10 +209,10 @@ int AixAttachListener::init() {
     ::atexit(listener_cleanup);
   }
 
-  int n = snprintf(path, UNIX_PATH_MAX, "%s/.java_pid%d",
-                   os::get_temp_directory(), os::current_process_id());
+  int n = os::snprintf(path, UNIX_PATH_MAX, "%s/.java_pid%d",
+                       os::get_temp_directory(), os::current_process_id());
   if (n < (int)UNIX_PATH_MAX) {
-    n = snprintf(initial_path, UNIX_PATH_MAX, "%s.tmp", path);
+    n = os::snprintf(initial_path, UNIX_PATH_MAX, "%s.tmp", path);
   }
   if (n >= (int)UNIX_PATH_MAX) {
     return -1;
@@ -349,8 +349,8 @@ void AttachListener::vm_start() {
   struct stat st;
   int ret;
 
-  int n = snprintf(fn, UNIX_PATH_MAX, "%s/.java_pid%d",
-           os::get_temp_directory(), os::current_process_id());
+  int n = os::snprintf(fn, UNIX_PATH_MAX, "%s/.java_pid%d",
+                       os::get_temp_directory(), os::current_process_id());
   assert(n < (int)UNIX_PATH_MAX, "java_pid file name buffer overflow");
 
   RESTARTABLE(::stat(fn, &st), ret);

--- a/src/hotspot/os/aix/attachListener_aix.cpp
+++ b/src/hotspot/os/aix/attachListener_aix.cpp
@@ -419,8 +419,8 @@ bool AttachListener::is_init_trigger() {
   RESTARTABLE(::stat(fn, &st), ret);
   if (ret == -1) {
     log_trace(attach)("Failed to find attach file: %s, trying alternate", fn);
-    snprintf(fn, sizeof(fn), "%s/.attach_pid%d",
-             os::get_temp_directory(), os::current_process_id());
+    os::snprintf_checked(fn, sizeof(fn), "%s/.attach_pid%d",
+                         os::get_temp_directory(), os::current_process_id());
     RESTARTABLE(::stat(fn, &st), ret);
     if (ret == -1) {
       log_debug(attach)("Failed to find attach file: %s", fn);

--- a/src/hotspot/os/aix/os_aix.cpp
+++ b/src/hotspot/os/aix/os_aix.cpp
@@ -1051,8 +1051,8 @@ static void* dll_load_library(const char *filename, int *eno, char *ebuf, int eb
       error_report = "dlerror returned no error description";
     }
     if (ebuf != nullptr && ebuflen > 0) {
-      snprintf(ebuf, ebuflen - 1, "%s, LIBPATH=%s, LD_LIBRARY_PATH=%s : %s",
-               filename, ::getenv("LIBPATH"), ::getenv("LD_LIBRARY_PATH"), error_report);
+      os::snprintf_checked(ebuf, ebuflen - 1, "%s, LIBPATH=%s, LD_LIBRARY_PATH=%s : %s",
+                           filename, ::getenv("LIBPATH"), ::getenv("LD_LIBRARY_PATH"), error_report);
     }
     Events::log_dll_message(nullptr, "Loading shared library %s failed, %s", filename, error_report);
     log_info(os)("shared library load of %s failed, %s", filename, error_report);
@@ -1094,7 +1094,7 @@ void os::get_summary_os_info(char* buf, size_t buflen) {
   // There might be something more readable than uname results for AIX.
   struct utsname name;
   uname(&name);
-  snprintf(buf, buflen, "%s %s", name.release, name.version);
+  os::snprintf_checked(buf, buflen, "%s %s", name.release, name.version);
 }
 
 int os::get_loaded_modules_info(os::LoadedModulesCallbackFunc callback, void *param) {

--- a/src/hotspot/os/aix/os_aix.cpp
+++ b/src/hotspot/os/aix/os_aix.cpp
@@ -1077,7 +1077,7 @@ void *os::dll_load(const char *filename, char *ebuf, int ebuflen) {
       STATIC_ASSERT(sizeof(old_extension) >= sizeof(new_extension));
       char* tmp_path = os::strdup(filename);
       size_t prefix_size = pointer_delta(pointer_to_dot, filename, 1);
-      os::snprintf(tmp_path + prefix_size, sizeof(old_extension), "%s", new_extension);
+      os::snprintf_checked(tmp_path + prefix_size, sizeof(old_extension), "%s", new_extension);
       result = dll_load_library(tmp_path, &eno, ebuf, ebuflen);
       os::free(tmp_path);
     }

--- a/src/hotspot/os/aix/porting_aix.cpp
+++ b/src/hotspot/os/aix/porting_aix.cpp
@@ -936,7 +936,7 @@ static const char* rtv_linkedin_libpath() {
 
   // retrieve the path to the currently running executable binary
   // to open it
-  snprintf(buffer, 100, "/proc/%ld/object/a.out", (long)getpid());
+  os::snprintf_checked(buffer, 100, "/proc/%ld/object/a.out", (long)getpid());
   FILE* f = nullptr;
   struct xcoffhdr the_xcoff;
   struct scnhdr the_scn;
@@ -1154,7 +1154,7 @@ bool os::pd_dll_unload(void* libhandle, char* ebuf, int ebuflen) {
         error_report = "dlerror returned no error description";
       }
       if (ebuf != nullptr && ebuflen > 0) {
-        snprintf(ebuf, ebuflen - 1, "%s", error_report);
+        os::snprintf_checked(ebuf, ebuflen - 1, "%s", error_report);
       }
       assert(false, "os::pd_dll_unload() ::dlclose() failed");
     }
@@ -1189,4 +1189,3 @@ bool os::pd_dll_unload(void* libhandle, char* ebuf, int ebuflen) {
 
   return res;
 } // end: os::pd_dll_unload()
-

--- a/src/hotspot/os/bsd/memMapPrinter_macosx.cpp
+++ b/src/hotspot/os/bsd/memMapPrinter_macosx.cpp
@@ -177,7 +177,7 @@ public:
       X1(GENEALOGY, genealogy);
       default:
         static char buffer[30];
-        snprintf(buffer, sizeof(buffer), "user_tag=0x%x(%d)", user_tag, user_tag);
+        os::snprintf_checked(buffer, sizeof(buffer), "user_tag=0x%x(%d)", user_tag, user_tag);
         return buffer;
     }
   }

--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -2156,7 +2156,7 @@ void os::set_native_thread_name(const char *name) {
   if (name != nullptr) {
     // Add a "Java: " prefix to the name
     char buf[MAXTHREADNAMESIZE];
-    snprintf(buf, sizeof(buf), "Java: %s", name);
+    (void) os::snprintf(buf, sizeof(buf), "Java: %s", name);
     pthread_setname_np(buf);
   }
 #endif

--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -522,7 +522,7 @@ void os::init_system_properties_values() {
   // by the nulls included by the sizeof operator (so actually one byte more
   // than necessary is allocated).
   os::snprintf_checked(buf, bufsize, "%s" SYS_EXTENSIONS_DIR ":%s" EXTENSIONS_DIR ":" SYS_EXTENSIONS_DIRS,
-          user_home_dir, Arguments::get_java_home());
+                       user_home_dir, Arguments::get_java_home());
   Arguments::set_ext_dirs(buf);
 
   FREE_C_HEAP_ARRAY(char, buf);
@@ -1242,27 +1242,27 @@ void * os::dll_load(const char *filename, char *ebuf, int ebuflen) {
   }
 
   if (lib_arch.endianess != arch_array[running_arch_index].endianess) {
-    ::snprintf(diag_msg_buf, diag_msg_max_length-1," (Possible cause: endianness mismatch)");
+    os::snprintf_checked(diag_msg_buf, diag_msg_max_length-1," (Possible cause: endianness mismatch)");
     return nullptr;
   }
 
 #ifndef S390
   if (lib_arch.elf_class != arch_array[running_arch_index].elf_class) {
-    ::snprintf(diag_msg_buf, diag_msg_max_length-1," (Possible cause: architecture word width mismatch)");
+    os::snprintf_checked(diag_msg_buf, diag_msg_max_length-1," (Possible cause: architecture word width mismatch)");
     return nullptr;
   }
 #endif // !S390
 
   if (lib_arch.compat_class != arch_array[running_arch_index].compat_class) {
     if (lib_arch.name!=nullptr) {
-      ::snprintf(diag_msg_buf, diag_msg_max_length-1,
-                 " (Possible cause: can't load %s-bit .so on a %s-bit platform)",
-                 lib_arch.name, arch_array[running_arch_index].name);
+      os::snprintf_checked(diag_msg_buf, diag_msg_max_length-1,
+                           " (Possible cause: can't load %s-bit .so on a %s-bit platform)",
+                           lib_arch.name, arch_array[running_arch_index].name);
     } else {
-      ::snprintf(diag_msg_buf, diag_msg_max_length-1,
-                 " (Possible cause: can't load this .so (machine code=0x%x) on a %s-bit platform)",
-                 lib_arch.code,
-                 arch_array[running_arch_index].name);
+      os::snprintf_checked(diag_msg_buf, diag_msg_max_length-1,
+                           " (Possible cause: can't load this .so (machine code=0x%x) on a %s-bit platform)",
+                           lib_arch.code,
+                           arch_array[running_arch_index].name);
     }
   }
 
@@ -1364,13 +1364,13 @@ void os::get_summary_os_info(char* buf, size_t buflen) {
     size = sizeof(build);
     int mib_build[] = { CTL_KERN, KERN_OSVERSION };
     if (sysctl(mib_build, 2, build, &size, nullptr, 0) < 0) {
-      snprintf(buf, buflen, "%s %s, macOS %s", os, release, osproductversion);
+      os::snprintf_checked(buf, buflen, "%s %s, macOS %s", os, release, osproductversion);
     } else {
-      snprintf(buf, buflen, "%s %s, macOS %s (%s)", os, release, osproductversion, build);
+      os::snprintf_checked(buf, buflen, "%s %s, macOS %s (%s)", os, release, osproductversion, build);
     }
   } else
 #endif
-  snprintf(buf, buflen, "%s %s", os, release);
+  os::snprintf_checked(buf, buflen, "%s %s", os, release);
 }
 
 void os::print_os_info_brief(outputStream* st) {
@@ -1447,14 +1447,14 @@ void os::get_summary_cpu_info(char* buf, size_t buflen) {
 
 #if defined(__APPLE__) && !defined(ZERO)
   if (VM_Version::is_cpu_emulated()) {
-    snprintf(buf, buflen, "\"%s\" %s (EMULATED) %d MHz", model, machine, mhz);
+    os::snprintf_checked(buf, buflen, "\"%s\" %s (EMULATED) %d MHz", model, machine, mhz);
   } else {
-    NOT_AARCH64(snprintf(buf, buflen, "\"%s\" %s %d MHz", model, machine, mhz));
+    NOT_AARCH64(os::snprintf_checked(buf, buflen, "\"%s\" %s %d MHz", model, machine, mhz));
     // aarch64 CPU doesn't report its speed
-    AARCH64_ONLY(snprintf(buf, buflen, "\"%s\" %s", model, machine));
+    AARCH64_ONLY(os::snprintf_checked(buf, buflen, "\"%s\" %s", model, machine));
   }
 #else
-  snprintf(buf, buflen, "\"%s\" %s %d MHz", model, machine, mhz);
+  os::snprintf_checked(buf, buflen, "\"%s\" %s %d MHz", model, machine, mhz);
 #endif
 }
 
@@ -2491,7 +2491,7 @@ bool os::pd_dll_unload(void* libhandle, char* ebuf, int ebuflen) {
       error_report = "dlerror returned no error description";
     }
     if (ebuf != nullptr && ebuflen > 0) {
-      snprintf(ebuf, ebuflen - 1, "%s", error_report);
+      os::snprintf_checked(ebuf, ebuflen - 1, "%s", error_report);
     }
   }
 

--- a/src/hotspot/os/linux/gc/z/zPhysicalMemoryBacking_linux.cpp
+++ b/src/hotspot/os/linux/gc/z/zPhysicalMemoryBacking_linux.cpp
@@ -204,7 +204,7 @@ int ZPhysicalMemoryBacking::create_mem_fd(const char* name) const {
 
   // Create file name
   char filename[PATH_MAX];
-  snprintf(filename, sizeof(filename), "%s%s", name, ZLargePages::is_explicit() ? ".hugetlb" : "");
+  os::snprintf_checked(filename, sizeof(filename), "%s%s", name, ZLargePages::is_explicit() ? ".hugetlb" : "");
 
   // Create file
   const int extra_flags = ZLargePages::is_explicit() ? (MFD_HUGETLB | MFD_HUGE_2MB) : 0;
@@ -262,7 +262,7 @@ int ZPhysicalMemoryBacking::create_file_fd(const char* name) const {
 
   // Create file name
   char filename[PATH_MAX];
-  snprintf(filename, sizeof(filename), "%s/%s.%d", mountpoint.get(), name, os::current_process_id());
+  os::snprintf_checked(filename, sizeof(filename), "%s/%s.%d", mountpoint.get(), name, os::current_process_id());
 
   // Create file
   const int fd = os::open(filename, O_CREAT|O_EXCL|O_RDWR|O_CLOEXEC, S_IRUSR|S_IWUSR);

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -4797,7 +4797,7 @@ uint os::processor_id() {
 void os::set_native_thread_name(const char *name) {
   if (Linux::_pthread_setname_np) {
     char buf [16]; // according to glibc manpage, 16 chars incl. '/0'
-    snprintf(buf, sizeof(buf), "%s", name);
+    (void) os::snprintf(buf, sizeof(buf), "%s", name);
     buf[sizeof(buf) - 1] = '\0';
     const int rc = Linux::_pthread_setname_np(pthread_self(), buf);
     // ERANGE should not happen; all other errors should just be ignored.
@@ -5395,7 +5395,7 @@ bool os::pd_dll_unload(void* libhandle, char* ebuf, int ebuflen) {
       error_report = "dlerror returned no error description";
     }
     if (ebuf != nullptr && ebuflen > 0) {
-      snprintf(ebuf, ebuflen - 1, "%s", error_report);
+      os::snprintf_checked(ebuf, ebuflen - 1, "%s", error_report);
     }
   }
 

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -1848,32 +1848,32 @@ void * os::dll_load(const char *filename, char *ebuf, int ebuflen) {
 
   if (lib_arch.compat_class != arch_array[running_arch_index].compat_class) {
     if (lib_arch.name != nullptr) {
-      ::snprintf(diag_msg_buf, diag_msg_max_length-1,
-                 " (Possible cause: can't load %s .so on a %s platform)",
-                 lib_arch.name, arch_array[running_arch_index].name);
+      os::snprintf_checked(diag_msg_buf, diag_msg_max_length-1,
+                           " (Possible cause: can't load %s .so on a %s platform)",
+                           lib_arch.name, arch_array[running_arch_index].name);
     } else {
-      ::snprintf(diag_msg_buf, diag_msg_max_length-1,
-                 " (Possible cause: can't load this .so (machine code=0x%x) on a %s platform)",
-                 lib_arch.code, arch_array[running_arch_index].name);
+      os::snprintf_checked(diag_msg_buf, diag_msg_max_length-1,
+                           " (Possible cause: can't load this .so (machine code=0x%x) on a %s platform)",
+                           lib_arch.code, arch_array[running_arch_index].name);
     }
     return nullptr;
   }
 
   if (lib_arch.endianness != arch_array[running_arch_index].endianness) {
-    ::snprintf(diag_msg_buf, diag_msg_max_length-1, " (Possible cause: endianness mismatch)");
+    os::snprintf_checked(diag_msg_buf, diag_msg_max_length-1, " (Possible cause: endianness mismatch)");
     return nullptr;
   }
 
   // ELF file class/capacity : 0 - invalid, 1 - 32bit, 2 - 64bit
   if (lib_arch.elf_class > 2 || lib_arch.elf_class < 1) {
-    ::snprintf(diag_msg_buf, diag_msg_max_length-1, " (Possible cause: invalid ELF file class)");
+    os::snprintf_checked(diag_msg_buf, diag_msg_max_length-1, " (Possible cause: invalid ELF file class)");
     return nullptr;
   }
 
   if (lib_arch.elf_class != arch_array[running_arch_index].elf_class) {
-    ::snprintf(diag_msg_buf, diag_msg_max_length-1,
-               " (Possible cause: architecture word width mismatch, can't load %d-bit .so on a %d-bit platform)",
-               (int) lib_arch.elf_class * 32, arch_array[running_arch_index].elf_class * 32);
+    os::snprintf_checked(diag_msg_buf, diag_msg_max_length-1,
+                         " (Possible cause: architecture word width mismatch, can't load %d-bit .so on a %d-bit platform)",
+                         (int) lib_arch.elf_class * 32, arch_array[running_arch_index].elf_class * 32);
     return nullptr;
   }
 
@@ -2613,10 +2613,10 @@ static void print_sys_devices_cpu_info(outputStream* st) {
       char hbuf_type[60];
       char hbuf_size[60];
       char hbuf_coherency_line_size[80];
-      snprintf(hbuf_level, 60, "/sys/devices/system/cpu/cpu0/cache/index%u/level", i);
-      snprintf(hbuf_type, 60, "/sys/devices/system/cpu/cpu0/cache/index%u/type", i);
-      snprintf(hbuf_size, 60, "/sys/devices/system/cpu/cpu0/cache/index%u/size", i);
-      snprintf(hbuf_coherency_line_size, 80, "/sys/devices/system/cpu/cpu0/cache/index%u/coherency_line_size", i);
+      os::snprintf_checked(hbuf_level, 60, "/sys/devices/system/cpu/cpu0/cache/index%u/level", i);
+      os::snprintf_checked(hbuf_type, 60, "/sys/devices/system/cpu/cpu0/cache/index%u/type", i);
+      os::snprintf_checked(hbuf_size, 60, "/sys/devices/system/cpu/cpu0/cache/index%u/size", i);
+      os::snprintf_checked(hbuf_coherency_line_size, 80, "/sys/devices/system/cpu/cpu0/cache/index%u/coherency_line_size", i);
       if (os::file_exists(hbuf_level)) {
         _print_ascii_file_h("cache level", hbuf_level, st);
         _print_ascii_file_h("cache type", hbuf_type, st);
@@ -4217,7 +4217,7 @@ int os::Linux::get_namespace_pid(int vmid) {
   char fname[24];
   int retpid = -1;
 
-  snprintf(fname, sizeof(fname), "/proc/%d/status", vmid);
+  os::snprintf_checked(fname, sizeof(fname), "/proc/%d/status", vmid);
   FILE *fp = os::fopen(fname, "r");
 
   if (fp) {
@@ -5009,7 +5009,7 @@ static jlong slow_thread_cpu_time(Thread *thread, bool user_sys_cpu_time) {
   long ldummy;
   FILE *fp;
 
-  snprintf(proc_name, 64, "/proc/self/task/%d/stat", tid);
+  os::snprintf_checked(proc_name, 64, "/proc/self/task/%d/stat", tid);
   fp = os::fopen(proc_name, "r");
   if (fp == nullptr) return -1;
   statlen = fread(stat, 1, 2047, fp);

--- a/src/hotspot/os/linux/os_perf_linux.cpp
+++ b/src/hotspot/os/linux/os_perf_linux.cpp
@@ -988,7 +988,7 @@ NetworkPerformanceInterface::NetworkPerformance::~NetworkPerformance() {
 int64_t NetworkPerformanceInterface::NetworkPerformance::read_counter(const char* iface, const char* counter) const {
   char buf[128];
 
-  snprintf(buf, sizeof(buf), "/sys/class/net/%s/statistics/%s", iface, counter);
+  os::snprintf_checked(buf, sizeof(buf), "/sys/class/net/%s/statistics/%s", iface, counter);
 
   int fd = os::open(buf, O_RDONLY, 0);
   if (fd == -1) {

--- a/src/hotspot/os/posix/attachListener_posix.cpp
+++ b/src/hotspot/os/posix/attachListener_posix.cpp
@@ -418,8 +418,8 @@ bool AttachListener::is_init_trigger() {
   RESTARTABLE(::stat(fn, &st), ret);
   if (ret == -1) {
     log_trace(attach)("Failed to find attach file: %s, trying alternate", fn);
-    snprintf(fn, sizeof(fn), "%s/.attach_pid%d", os::get_temp_directory(),
-             os::current_process_id());
+    os::snprintf_checked(fn, sizeof(fn), "%s/.attach_pid%d", os::get_temp_directory(),
+                         os::current_process_id());
     RESTARTABLE(::stat(fn, &st), ret);
     if (ret == -1) {
       log_debug(attach)("Failed to find attach file: %s", fn);

--- a/src/hotspot/os/posix/attachListener_posix.cpp
+++ b/src/hotspot/os/posix/attachListener_posix.cpp
@@ -195,10 +195,10 @@ int PosixAttachListener::init() {
     ::atexit(listener_cleanup);
   }
 
-  int n = snprintf(path, UNIX_PATH_MAX, "%s/.java_pid%d",
-                   os::get_temp_directory(), os::current_process_id());
+  int n = os::snprintf(path, UNIX_PATH_MAX, "%s/.java_pid%d",
+                       os::get_temp_directory(), os::current_process_id());
   if (n < (int)UNIX_PATH_MAX) {
-    n = snprintf(initial_path, UNIX_PATH_MAX, "%s.tmp", path);
+    n = os::snprintf(initial_path, UNIX_PATH_MAX, "%s.tmp", path);
   }
   if (n >= (int)UNIX_PATH_MAX) {
     return -1;
@@ -346,8 +346,8 @@ void AttachListener::vm_start() {
   struct stat st;
   int ret;
 
-  int n = snprintf(fn, UNIX_PATH_MAX, "%s/.java_pid%d",
-           os::get_temp_directory(), os::current_process_id());
+  int n = os::snprintf(fn, UNIX_PATH_MAX, "%s/.java_pid%d",
+                       os::get_temp_directory(), os::current_process_id());
   assert(n < (int)UNIX_PATH_MAX, "java_pid file name buffer overflow");
 
   RESTARTABLE(::stat(fn, &st), ret);

--- a/src/hotspot/os/posix/os_posix.cpp
+++ b/src/hotspot/os/posix/os_posix.cpp
@@ -323,7 +323,7 @@ int os::create_file_for_heap(const char* dir) {
       vm_exit_during_initialization(err_msg("Malloc failed during creation of backing file for heap (%s)", os::strerror(errno)));
       return -1;
     }
-    int n = snprintf(fullname, fullname_len + 1, "%s%s", dir, name_template);
+    int n = os::snprintf(fullname, fullname_len + 1, "%s%s", dir, name_template);
     assert((size_t)n == fullname_len, "Unexpected number of characters in string");
 
     os::native_path(fullname);

--- a/src/hotspot/os/posix/perfMemory_posix.cpp
+++ b/src/hotspot/os/posix/perfMemory_posix.cpp
@@ -150,7 +150,7 @@ static char* get_user_tmp_dir(const char* user, int vmid, int nspid) {
   char* dirname = NEW_C_HEAP_ARRAY(char, nbytes, mtInternal);
 
   // construct the path name to user specific tmp directory
-  snprintf(dirname, nbytes, "%s/%s_%s", tmpdir, perfdir, user);
+  os::snprintf_checked(dirname, nbytes, "%s/%s_%s", tmpdir, perfdir, user);
 
   return dirname;
 }
@@ -661,7 +661,7 @@ static char* get_sharedmem_filename(const char* dirname, int vmid, int nspid) {
   size_t nbytes = strlen(dirname) + UINT_CHARS + 2;
 
   char* name = NEW_C_HEAP_ARRAY(char, nbytes, mtInternal);
-  snprintf(name, nbytes, "%s/%d", dirname, pid);
+  os::snprintf_checked(name, nbytes, "%s/%d", dirname, pid);
 
   return name;
 }

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -3205,7 +3205,7 @@ int os::create_file_for_heap(const char* dir) {
     vm_exit_during_initialization(err_msg("Malloc failed during creation of backing file for heap (%s)", os::strerror(errno)));
     return -1;
   }
-  int n = snprintf(fullname, fullname_len + 1, "%s%s", dir, name_template);
+  int n = os::snprintf(fullname, fullname_len + 1, "%s%s", dir, name_template);
   assert((size_t)n == fullname_len, "Unexpected number of characters in string");
 
   os::native_path(fullname);

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -1434,7 +1434,7 @@ void  os::dll_unload(void *lib) {
     Events::log_dll_message(nullptr, "Attempt to unload dll \"%s\" [" INTPTR_FORMAT "] failed (error code %d)", name, p2i(lib), errcode);
     log_info(os)("Attempt to unload dll \"%s\" [" INTPTR_FORMAT "] failed (error code %d)", name, p2i(lib), errcode);
     if (tl == 0) {
-      os::snprintf(buf, sizeof(buf), "Attempt to unload dll failed (error code %d)", (int) errcode);
+      os::snprintf_checked(buf, sizeof(buf), "Attempt to unload dll failed (error code %d)", (int) errcode);
     }
     JFR_ONLY(unload_event.set_error_msg(buf);)
   }
@@ -1831,14 +1831,14 @@ void * os::dll_load(const char *name, char *ebuf, int ebuflen) {
   }
 
   if (lib_arch_str != nullptr) {
-    os::snprintf(ebuf, ebuflen - 1,
-                 "Can't load %s-bit .dll on a %s-bit platform",
-                 lib_arch_str, running_arch_str);
+    os::snprintf_checked(ebuf, ebuflen - 1,
+                         "Can't load %s-bit .dll on a %s-bit platform",
+                         lib_arch_str, running_arch_str);
   } else {
     // don't know what architecture this dll was build for
-    os::snprintf(ebuf, ebuflen - 1,
-                 "Can't load this .dll (machine code=0x%x) on a %s-bit platform",
-                 lib_arch, running_arch_str);
+    os::snprintf_checked(ebuf, ebuflen - 1,
+                         "Can't load this .dll (machine code=0x%x) on a %s-bit platform",
+                         lib_arch, running_arch_str);
   }
   JFR_ONLY(load_event.set_error_msg(ebuf);)
   return nullptr;

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -1418,7 +1418,7 @@ void os::die() {
 void  os::dll_unload(void *lib) {
   char name[MAX_PATH];
   if (::GetModuleFileName((HMODULE)lib, name, sizeof(name)) == 0) {
-    snprintf(name, MAX_PATH, "<not available>");
+    os::snprintf_checked(name, MAX_PATH, "<not available>");
   }
 
   JFR_ONLY(NativeLibraryUnloadEvent unload_event(name);)

--- a/src/hotspot/os/windows/perfMemory_windows.cpp
+++ b/src/hotspot/os/windows/perfMemory_windows.cpp
@@ -164,7 +164,7 @@ static char* get_user_tmp_dir(const char* user) {
   char* dirname = NEW_C_HEAP_ARRAY(char, nbytes, mtInternal);
 
   // construct the path name to user specific tmp directory
-  os::snprintf(dirname, nbytes, "%s\\%s_%s", tmpdir, perfdir, user);
+  os::snprintf_checked(dirname, nbytes, "%s\\%s_%s", tmpdir, perfdir, user);
 
   return dirname;
 }
@@ -454,7 +454,7 @@ static char *get_sharedmem_objectname(const char* user, int vmid) {
   //
   nbytes += UINT_CHARS;
   char* name = NEW_C_HEAP_ARRAY(char, nbytes, mtInternal);
-  os::snprintf(name, nbytes, "%s_%s_%u", PERFDATA_NAME, user, vmid);
+  os::snprintf_checked(name, nbytes, "%s_%s_%u", PERFDATA_NAME, user, vmid);
 
   return name;
 }
@@ -470,7 +470,7 @@ static char* get_sharedmem_filename(const char* dirname, int vmid) {
   size_t nbytes = strlen(dirname) + UINT_CHARS + 2;
 
   char* name = NEW_C_HEAP_ARRAY(char, nbytes, mtInternal);
-  os::snprintf(name, nbytes, "%s\\%d", dirname, vmid);
+  os::snprintf_checked(name, nbytes, "%s\\%d", dirname, vmid);
 
   return name;
 }

--- a/src/hotspot/os_cpu/linux_riscv/vm_version_linux_riscv.cpp
+++ b/src/hotspot/os_cpu/linux_riscv/vm_version_linux_riscv.cpp
@@ -126,7 +126,7 @@ void VM_Version::setup_cpu_available_features() {
   char buf[1024] = {};
   if (uarch != nullptr && strcmp(uarch, "") != 0) {
     // Use at max half the buffer.
-    snprintf(buf, sizeof(buf)/2, "%s ", uarch);
+    os::snprintf_checked(buf, sizeof(buf)/2, "%s ", uarch);
   }
   os::free((void*) uarch);
 

--- a/src/hotspot/share/ci/ciEnv.cpp
+++ b/src/hotspot/share/ci/ciEnv.cpp
@@ -217,7 +217,7 @@ public:
   void push_va(ciEnv* ci, const char* fmt, va_list args) {
     char *e = ci->_dyno_name + strlen(ci->_dyno_name);
     char *m = ci->_dyno_name + ARRAY_SIZE(ci->_dyno_name) - 1;
-    os::vsnprintf(e, m - e, fmt, args);
+    (void) os::vsnprintf(e, m - e, fmt, args);
     assert(strlen(ci->_dyno_name) < (ARRAY_SIZE(ci->_dyno_name) - 1), "overflow");
   }
 

--- a/src/hotspot/share/classfile/javaClasses.cpp
+++ b/src/hotspot/share/classfile/javaClasses.cpp
@@ -2604,14 +2604,16 @@ static void print_stack_element_to_stream(outputStream* st, Handle mirror, int m
   char* buf = NEW_RESOURCE_ARRAY(char, buf_size);
 
   // Print stack trace line in buffer
-  size_t buf_off = os::snprintf_checked(buf, buf_size, "\tat %s.%s(", klass_name, method_name);
-
+  int buf_off = os::snprintf(buf, buf_size, "\tat %s.%s(", klass_name, method_name);
+  assert(static_cast<size_t>(buf_off) < buf_size, "buffer is wrong size");
   // Print module information
   if (module_name != nullptr) {
     if (module_version != nullptr) {
-      buf_off += os::snprintf_checked(buf + buf_off, buf_size - buf_off, "%s@%s/", module_name, module_version);
+      buf_off += os::snprintf(buf + buf_off, buf_size - buf_off, "%s@%s/", module_name, module_version);
+      assert(static_cast<size_t>(buf_off) < buf_size, "buffer is wrong size");
     } else {
-      buf_off += os::snprintf_checked(buf + buf_off, buf_size - buf_off, "%s/", module_name);
+      buf_off += os::snprintf(buf + buf_off, buf_size - buf_off, "%s/", module_name);
+      assert(static_cast<size_t>(buf_off) < buf_size, "buffer is wrong size");
     }
   }
 
@@ -2626,13 +2628,16 @@ static void print_stack_element_to_stream(outputStream* st, Handle mirror, int m
     } else {
       if (source_file_name != nullptr && (line_number != -1)) {
         // Sourcename and linenumber
-        buf_off += os::snprintf_checked(buf + buf_off, buf_size - buf_off, "%s:%d)", source_file_name, line_number);
+        buf_off += os::snprintf(buf + buf_off, buf_size - buf_off, "%s:%d)", source_file_name, line_number);
+        assert(static_cast<size_t>(buf_off) < buf_size, "buffer is wrong size");
       } else if (source_file_name != nullptr) {
         // Just sourcename
-        buf_off += os::snprintf_checked(buf + buf_off, buf_size - buf_off, "%s)", source_file_name);
+        buf_off += os::snprintf(buf + buf_off, buf_size - buf_off, "%s)", source_file_name);
+        assert(static_cast<size_t>(buf_off) < buf_size, "buffer is wrong size");
       } else {
         // Neither sourcename nor linenumber
-        buf_off += os::snprintf_checked(buf + buf_off, buf_size - buf_off, "Unknown Source)");
+        buf_off += os::snprintf(buf + buf_off, buf_size - buf_off, "Unknown Source)");
+        assert(static_cast<size_t>(buf_off) < buf_size, "buffer is wrong size");
       }
       nmethod* nm = method->code();
       if (WizardMode && nm != nullptr) {

--- a/src/hotspot/share/code/codeHeapState.cpp
+++ b/src/hotspot/share/code/codeHeapState.cpp
@@ -739,7 +739,7 @@ void CodeHeapState::aggregate(outputStream* out, CodeHeap* heap, size_t granular
             if (jvmci_name != nullptr) {
               size_t size = ::strlen(blob_name) + ::strlen(" jvmci_name=") + ::strlen(jvmci_name) + 1;
               char* new_blob_name = (char*)os::malloc(size, mtInternal);
-              os::snprintf(new_blob_name, size, "%s jvmci_name=%s", blob_name, jvmci_name);
+              os::snprintf_checked(new_blob_name, size, "%s jvmci_name=%s", blob_name, jvmci_name);
               os::free((void*)blob_name);
               blob_name = new_blob_name;
             }

--- a/src/hotspot/share/compiler/compilationMemoryStatistic.cpp
+++ b/src/hotspot/share/compiler/compilationMemoryStatistic.cpp
@@ -158,10 +158,10 @@ void FootprintTimeline::print_on(outputStream* st) const {
       st->print("%24s", e.info.text);
       col += 25; st->fill_to(col);
       char tmp[64];
-      os::snprintf(tmp, sizeof(tmp), "%9zu (%+zd)", e._bytes.cur, e._bytes.end_delta());
+      os::snprintf_checked(tmp, sizeof(tmp), "%9zu (%+zd)", e._bytes.cur, e._bytes.end_delta());
       st->print("%s ", tmp); // end
       col += 21; st->fill_to(col);
-      os::snprintf(tmp, sizeof(tmp), "%6u (%+d)", e._live_nodes.cur, e._live_nodes.end_delta());
+      os::snprintf_checked(tmp, sizeof(tmp), "%6u (%+d)", e._live_nodes.cur, e._live_nodes.end_delta());
       st->print("%s ", tmp); // end
       if (e._bytes.temporary_peak_size() > significant_peak_threshold) {
         col += 20; st->fill_to(col);

--- a/src/hotspot/share/gc/g1/g1YoungCollector.cpp
+++ b/src/hotspot/share/gc/g1/g1YoungCollector.cpp
@@ -81,19 +81,19 @@ class G1YoungGCTraceTime {
     evacuation_failed_string[0] = '\0';
 
     if (_collector->evacuation_failed()) {
-      snprintf(evacuation_failed_string,
-               ARRAY_SIZE(evacuation_failed_string),
-               " (Evacuation Failure: %s%s%s)",
-               _collector->evacuation_alloc_failed() ? "Allocation" : "",
-               _collector->evacuation_alloc_failed() && _collector->evacuation_pinned() ? " / " : "",
-               _collector->evacuation_pinned() ? "Pinned" : "");
+      os::snprintf_checked(evacuation_failed_string,
+                           ARRAY_SIZE(evacuation_failed_string),
+                           " (Evacuation Failure: %s%s%s)",
+                           _collector->evacuation_alloc_failed() ? "Allocation" : "",
+                           _collector->evacuation_alloc_failed() && _collector->evacuation_pinned() ? " / " : "",
+                           _collector->evacuation_pinned() ? "Pinned" : "");
     }
-    snprintf(_young_gc_name_data,
-             MaxYoungGCNameLength,
-             "Pause Young (%s) (%s)%s",
-             G1GCPauseTypeHelper::to_string(_pause_type),
-             GCCause::to_string(_pause_cause),
-             evacuation_failed_string);
+    os::snprintf_checked(_young_gc_name_data,
+                         MaxYoungGCNameLength,
+                         "Pause Young (%s) (%s)%s",
+                         G1GCPauseTypeHelper::to_string(_pause_type),
+                         GCCause::to_string(_pause_cause),
+                         evacuation_failed_string);
     return _young_gc_name_data;
   }
 

--- a/src/hotspot/share/gc/shared/oopStorage.cpp
+++ b/src/hotspot/share/gc/shared/oopStorage.cpp
@@ -820,7 +820,7 @@ static Mutex* make_oopstorage_mutex(const char* storage_name,
                                     const char* kind,
                                     Mutex::Rank rank) {
   char name[256];
-  os::snprintf(name, sizeof(name), "%s %s lock", storage_name, kind);
+  os::snprintf_checked(name, sizeof(name), "%s %s lock", storage_name, kind);
   return new PaddedMutex(rank, name);
 }
 

--- a/src/hotspot/share/gc/shared/satbMarkQueue.cpp
+++ b/src/hotspot/share/gc/shared/satbMarkQueue.cpp
@@ -306,7 +306,7 @@ void SATBMarkQueueSet::print_all(const char* msg) {
   int i = 0;
   while (nd != nullptr) {
     void** buf = BufferNode::make_buffer_from_node(nd);
-    os::snprintf(buffer, SATB_PRINTER_BUFFER_SIZE, "Enqueued: %d", i);
+    os::snprintf_checked(buffer, SATB_PRINTER_BUFFER_SIZE, "Enqueued: %d", i);
     print_satb_buffer(buffer, buf, nd->index(), nd->capacity());
     nd = nd->next();
     i += 1;
@@ -321,7 +321,7 @@ void SATBMarkQueueSet::print_all(const char* msg) {
       _qset(qset), _buffer(buffer) {}
 
     virtual void do_thread(Thread* t) {
-      os::snprintf(_buffer, SATB_PRINTER_BUFFER_SIZE, "Thread: %s", t->name());
+      os::snprintf_checked(_buffer, SATB_PRINTER_BUFFER_SIZE, "Thread: %s", t->name());
       _qset->satb_queue_for_thread(t).print(_buffer);
     }
   } closure(this, buffer);

--- a/src/hotspot/share/jvmci/jvmciEnv.cpp
+++ b/src/hotspot/share/jvmci/jvmciEnv.cpp
@@ -934,7 +934,7 @@ void JVMCIEnv::fthrow_error(const char* file, int line, const char* format, ...)
   va_list ap;
   va_start(ap, format);
   char msg[max_msg_size];
-  os::vsnprintf(msg, max_msg_size, format, ap);
+  (void) os::vsnprintf(msg, max_msg_size, format, ap);
   va_end(ap);
   JavaThread* THREAD = JavaThread::current();
   if (is_hotspot()) {

--- a/src/hotspot/share/oops/compressedKlass.cpp
+++ b/src/hotspot/share/oops/compressedKlass.cpp
@@ -69,10 +69,10 @@ void CompressedKlassPointers::pre_initialize() {
 void CompressedKlassPointers::sanity_check_after_initialization() {
   // In expectation of an assert, prepare condensed info to be printed with the assert.
   char tmp[256];
-  os::snprintf(tmp, sizeof(tmp), "klass range: " RANGE2FMT ","
-      " base " PTR_FORMAT ", shift %d, lowest/highest valid narrowKlass %u/%u",
-      RANGE2FMTARGS(_klass_range_start, _klass_range_end),
-      p2i(_base), _shift, _lowest_valid_narrow_klass_id, _highest_valid_narrow_klass_id);
+  os::snprintf_checked(tmp, sizeof(tmp), "klass range: " RANGE2FMT ","
+                       " base " PTR_FORMAT ", shift %d, lowest/highest valid narrowKlass %u/%u",
+                       RANGE2FMTARGS(_klass_range_start, _klass_range_end),
+                       p2i(_base), _shift, _lowest_valid_narrow_klass_id, _highest_valid_narrow_klass_id);
 #define ASSERT_HERE(cond) assert(cond, " (%s)", tmp);
 #define ASSERT_HERE_2(cond, msg) assert(cond, msg " (%s)", tmp);
 

--- a/src/hotspot/share/oops/generateOopMap.cpp
+++ b/src/hotspot/share/oops/generateOopMap.cpp
@@ -2150,7 +2150,7 @@ bool GenerateOopMap::compute_map(Thread* current) {
 void GenerateOopMap::error_work(const char *format, va_list ap) {
   _got_error = true;
   char msg_buffer[512];
-  os::vsnprintf(msg_buffer, sizeof(msg_buffer), format, ap);
+  (void) os::vsnprintf(msg_buffer, sizeof(msg_buffer), format, ap);
   // Append method name
   char msg_buffer2[512];
   os::snprintf(msg_buffer2, sizeof(msg_buffer2), "%s in method %s", msg_buffer, method()->name()->as_C_string());

--- a/src/hotspot/share/oops/generateOopMap.cpp
+++ b/src/hotspot/share/oops/generateOopMap.cpp
@@ -2153,7 +2153,7 @@ void GenerateOopMap::error_work(const char *format, va_list ap) {
   (void) os::vsnprintf(msg_buffer, sizeof(msg_buffer), format, ap);
   // Append method name
   char msg_buffer2[512];
-  os::snprintf(msg_buffer2, sizeof(msg_buffer2), "%s in method %s", msg_buffer, method()->name()->as_C_string());
+  (void) os::snprintf(msg_buffer2, sizeof(msg_buffer2), "%s in method %s", msg_buffer, method()->name()->as_C_string());
   Thread* current = Thread::current();
   if (current->can_call_java()) {
     _exception = Exceptions::new_exception(JavaThread::cast(current),

--- a/src/hotspot/share/opto/idealGraphPrinter.cpp
+++ b/src/hotspot/share/opto/idealGraphPrinter.cpp
@@ -640,8 +640,8 @@ void IdealGraphPrinter::visit_node(Node* n, bool edges) {
         jint value = typeInt->get_con();
 
         // Only use up to 4 chars and fall back to a generic "I" to keep it short.
-        int written_chars = os::snprintf_checked(buffer, sizeof(buffer), "%d", value);
-        if (written_chars <= 4) {
+        int written_chars = os::snprintf(buffer, sizeof(buffer), "%d", value);
+        if (written_chars > 0 && written_chars <= 4) {
           print_prop(short_name, buffer);
         } else {
           print_prop(short_name, "I");
@@ -654,8 +654,8 @@ void IdealGraphPrinter::visit_node(Node* n, bool edges) {
         jlong value = typeLong->get_con();
 
         // Only use up to 4 chars and fall back to a generic "L" to keep it short.
-        int written_chars = os::snprintf_checked(buffer, sizeof(buffer), JLONG_FORMAT, value);
-        if (written_chars <= 4) {
+        int written_chars = os::snprintf(buffer, sizeof(buffer), JLONG_FORMAT, value);
+        if (written_chars > 0 && written_chars <= 4) {
           print_prop(short_name, buffer);
         } else {
           print_prop(short_name, "L");

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -113,18 +113,20 @@ int os::snprintf_checked(char* buf, size_t len, const char* fmt, ...) {
   va_start(args, fmt);
   int result = os::vsnprintf(buf, len, fmt, args);
   va_end(args);
-  assert(result >= 0, "os::snprintf error");
   assert(static_cast<size_t>(result) < len, "os::snprintf truncated");
   return result;
 }
 
 int os::vsnprintf(char* buf, size_t len, const char* fmt, va_list args) {
+  assert(buf != nullptr || len == 0, "Valid buffer and length must be given");
+  assert(fmt != nullptr, "Missing format string");
   int result = permit_forbidden_function::vsnprintf(buf, len, fmt, args);
-  // If an encoding error occurred (result < 0) then it's not clear
+  // If an error occurred (result < 0) then it's not clear
   // whether the buffer is NUL terminated, so ensure it is.
-  if ((result < 0) && (len > 0)) {
+  if ((result < 0) && (len > 0) && (buf != nullptr)) {
     buf[len - 1] = '\0';
   }
+  assert(result >= 0, "os::vsnprintf error: %s", strerror(errno));
   return result;
 }
 

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -108,13 +108,12 @@ int os::snprintf(char* buf, size_t len, const char* fmt, ...) {
   return result;
 }
 
-int os::snprintf_checked(char* buf, size_t len, const char* fmt, ...) {
+void os::snprintf_checked(char* buf, size_t len, const char* fmt, ...) {
   va_list args;
   va_start(args, fmt);
   int result = os::vsnprintf(buf, len, fmt, args);
   va_end(args);
   assert(static_cast<size_t>(result) < len, "os::snprintf truncated");
-  return result;
 }
 
 int os::vsnprintf(char* buf, size_t len, const char* fmt, va_list args) {

--- a/src/hotspot/share/runtime/os.hpp
+++ b/src/hotspot/share/runtime/os.hpp
@@ -800,7 +800,7 @@ class os: AllStatic {
   // an encoding error or any other kind of usage error).
   [[nodiscard]] static int vsnprintf(char* buf, size_t len, const char* fmt, va_list args) ATTRIBUTE_PRINTF(3, 0);
   // Delegates to vsnprintf.
-  static int snprintf(char* buf, size_t len, const char* fmt, ...) ATTRIBUTE_PRINTF(3, 4);
+  [[nodiscard]] static int snprintf(char* buf, size_t len, const char* fmt, ...) ATTRIBUTE_PRINTF(3, 4);
 
   // Delegates to snprintf and asserts that the output was not truncated.
   static void snprintf_checked(char* buf, size_t len, const char* fmt, ...) ATTRIBUTE_PRINTF(3, 4);

--- a/src/hotspot/share/runtime/os.hpp
+++ b/src/hotspot/share/runtime/os.hpp
@@ -803,7 +803,7 @@ class os: AllStatic {
   static int snprintf(char* buf, size_t len, const char* fmt, ...) ATTRIBUTE_PRINTF(3, 4);
 
   // Delegates to snprintf and asserts that the output was not truncated.
-  static int snprintf_checked(char* buf, size_t len, const char* fmt, ...) ATTRIBUTE_PRINTF(3, 4);
+  static void snprintf_checked(char* buf, size_t len, const char* fmt, ...) ATTRIBUTE_PRINTF(3, 4);
 
   // Get host name in buffer provided
   static bool get_host_name(char* buf, size_t buflen);

--- a/src/hotspot/share/runtime/os.hpp
+++ b/src/hotspot/share/runtime/os.hpp
@@ -795,11 +795,14 @@ class os: AllStatic {
 
   // Provide wrapper versions of these functions to guarantee NUL-termination
   // in all cases.
-  static int vsnprintf(char* buf, size_t len, const char* fmt, va_list args) ATTRIBUTE_PRINTF(3, 0);
+
+  // Performs vsnprintf and asserts the result is non-negative (so there was not
+  // an encoding error or any other kind of usage error).
+  [[nodiscard]] static int vsnprintf(char* buf, size_t len, const char* fmt, va_list args) ATTRIBUTE_PRINTF(3, 0);
+  // Delegates to vsnprintf.
   static int snprintf(char* buf, size_t len, const char* fmt, ...) ATTRIBUTE_PRINTF(3, 4);
 
-  // Performs snprintf and asserts the result is non-negative (so there was not
-  // an encoding error) and that the output was not truncated.
+  // Delegates to snprintf and asserts that the output was not truncated.
   static int snprintf_checked(char* buf, size_t len, const char* fmt, ...) ATTRIBUTE_PRINTF(3, 4);
 
   // Get host name in buffer provided

--- a/src/hotspot/share/services/heapDumper.cpp
+++ b/src/hotspot/share/services/heapDumper.cpp
@@ -2113,7 +2113,7 @@ char* DumpMerger::get_writer_path(const char* base_path, int seq) {
   char* path = NEW_RESOURCE_ARRAY(char, buf_size);
   memset(path, 0, buf_size);
 
-  os::snprintf(path, buf_size, "%s.p%d", base_path, seq);
+  os::snprintf_checked(path, buf_size, "%s.p%d", base_path, seq);
 
   return path;
 }

--- a/src/hotspot/share/utilities/forbiddenFunctions.hpp
+++ b/src/hotspot/share/utilities/forbiddenFunctions.hpp
@@ -59,6 +59,7 @@ FORBID_IMPORTED_C_FUNCTION(char* strerror(int), "use os::strerror");
 FORBID_IMPORTED_C_FUNCTION(char* strtok(char*, const char*), "use strtok_r");
 
 FORBID_C_FUNCTION(int sprintf(char*, const char*, ...), "use os::snprintf");
+FORBID_C_FUNCTION(int snprintf(char*, size_t, const char*, ...), "use os::snprintf");
 
 PRAGMA_DIAG_PUSH
 FORBIDDEN_FUNCTION_IGNORE_CLANG_FORTIFY_WARNING

--- a/src/hotspot/share/utilities/virtualizationSupport.cpp
+++ b/src/hotspot/share/utilities/virtualizationSupport.cpp
@@ -67,13 +67,13 @@ void VirtualizationSupport::initialize() {
     VMGuestLibError sg_error = GuestLib_StatGet("text", "resources", &result_info, &result_size);
     if (sg_error == VMGUESTLIB_ERROR_SUCCESS) {
       has_resource_information = true;
-      os::snprintf(extended_resource_info_at_startup, sizeof(extended_resource_info_at_startup), "%s", result_info);
+      os::snprintf_checked(extended_resource_info_at_startup, sizeof(extended_resource_info_at_startup), "%s", result_info);
       GuestLib_StatFree(result_info, result_size);
     }
     sg_error = GuestLib_StatGet("text", "host", &result_info, &result_size);
     if (sg_error == VMGUESTLIB_ERROR_SUCCESS) {
       has_host_information = true;
-      os::snprintf(host_information, sizeof(host_information), "%s", result_info);
+      os::snprintf_checked(host_information, sizeof(host_information), "%s", result_info);
       GuestLib_StatFree(result_info, result_size);
     }
   }

--- a/test/hotspot/gtest/classfile/test_symbolTable.cpp
+++ b/test/hotspot/gtest/classfile/test_symbolTable.cpp
@@ -105,7 +105,7 @@ TEST_VM(SymbolTable, test_symbol_refcount_parallel) {
   char symbol_name[symbol_name_length];
   // Find a symbol where there will probably be only one instance.
   for (int i = 0; i < 100; i++) {
-    os::snprintf(symbol_name, symbol_name_length, "some_symbol%d", i);
+    os::snprintf_checked(symbol_name, symbol_name_length, "some_symbol%d", i);
     TempNewSymbol ts = SymbolTable::new_symbol(symbol_name);
     if (ts->refcount() == 1) {
       EXPECT_TRUE(ts->refcount() == 1) << "Symbol is just created";
@@ -158,7 +158,7 @@ TEST_VM(SymbolTable, test_cleanup_delay) {
   constexpr int symbol_name_length = 30;
   char symbol_name[symbol_name_length];
   for (uint i = 1; i < TempSymbolCleanupDelayer::QueueSize; i++) {
-    os::snprintf(symbol_name, symbol_name_length, "temp-filler-%d", i);
+    os::snprintf_checked(symbol_name, symbol_name_length, "temp-filler-%d", i);
     TempNewSymbol s = SymbolTable::new_symbol(symbol_name);
     ASSERT_EQ(s->refcount(), 2) << "TempNewSymbol refcount just created is 2";
   }
@@ -177,7 +177,7 @@ TEST_VM(SymbolTable, test_cleanup_delay_drain) {
   char symbol_name[symbol_name_length];
   TempNewSymbol symbols[TempSymbolCleanupDelayer::QueueSize] = {};
   for (uint i = 0; i < TempSymbolCleanupDelayer::QueueSize; i++) {
-    os::snprintf(symbol_name, symbol_name_length, "temp-%d", i);
+    os::snprintf_checked(symbol_name, symbol_name_length, "temp-%d", i);
     TempNewSymbol s = SymbolTable::new_symbol(symbol_name);
     symbols[i] = s;
   }

--- a/test/hotspot/gtest/gtestMain.cpp
+++ b/test/hotspot/gtest/gtestMain.cpp
@@ -256,7 +256,7 @@ static void runUnitTestsInner(int argc, char** argv) {
 #ifdef __APPLE__
   size_t len = strlen(java_home) + strlen("/lib/jli/libjli.dylib") + 1;
   char* path = new char[len];
-  snprintf(path, len, "%s/lib/jli/libjli.dylib", java_home);
+  os::snprintf_checked(path, len, "%s/lib/jli/libjli.dylib", java_home);
   dlopen(path, RTLD_NOW | RTLD_GLOBAL);
 #endif // __APPLE__
 

--- a/test/hotspot/gtest/logging/test_asynclog.cpp
+++ b/test/hotspot/gtest/logging/test_asynclog.cpp
@@ -163,7 +163,7 @@ TEST_VM_F(AsyncLogTest, logBuffer) {
                                       LogDecorators());
   size_t len = strlen(TestLogFileName) + strlen(LogFileOutput::Prefix) + 1;
   char* name = NEW_C_HEAP_ARRAY(char, len, mtLogging);
-  snprintf(name, len, "%s%s", LogFileOutput::Prefix, TestLogFileName);
+  os::snprintf_checked(name, len, "%s%s", LogFileOutput::Prefix, TestLogFileName);
 
   LogFileStreamOutput* output = new LogFileOutput(name);
   output->initialize(nullptr, nullptr);

--- a/test/hotspot/gtest/runtime/test_os_windows.cpp
+++ b/test/hotspot/gtest/runtime/test_os_windows.cpp
@@ -376,7 +376,7 @@ static void record_path(char const* name, char const* len_name, wchar_t* path) {
 
   if (convert_to_cstring(buf, JVM_MAXPATHLEN, path)) {
     ::testing::Test::RecordProperty(name, buf);
-    os::snprintf(buf, JVM_MAXPATHLEN, "%d", (int) wcslen(path));
+    os::snprintf_checked(buf, JVM_MAXPATHLEN, "%d", (int) wcslen(path));
     ::testing::Test::RecordProperty(len_name, buf);
   }
 }


### PR DESCRIPTION
EDIT: I've just realized that the `[[nodiscard]]` attribute is not currently permitted. So I may have to revise this aspect of the changes.

This is a proposal to standardize on the use of os::snprintf and os::snprintf_checked across the hotspot code base, and to disallow use of the C library variants. (It does not touch use of jio_printf at all.)

From: https://bugs.openjdk.org/browse/JDK-8347707

The platform `snprintf/vsnprintf` returns -1 on error, else if the buffer is large enough returns the number of bytes written (excluding the null byte), else (buffer is too small) the number of characters (excluding the terminating null byte) which would have been written to the final string if enough space had been available. Thus, a return value of size or more means that the output was truncated.

To provide a consistent approach to error handling and truncation management, we provide `os::xxx` wrapper functions as described below and forbid the use of the library `::vsnprintf` and `::snprintf`.

The potential errors are, generally speaking, not something we should encounter in our own well-written code:

- encoding error: not applicable as we are not using extended character sets
- invalid parameters (null buffers, specifying a limit > size of the buffer [Windows], things of this nature)
- mal-formed formatting directives
- overflow error (POSIX) if the required buffer size exceeds INT_MAX (as we return `int`).

As these should simply never occur, we handle the checks for -1 at the lowest-level (`os::vsnprintf`) with an assertion, and accompanying precondition assertions.

The potential clients of this API then fall into a number of camps:

1. Those who have sized their buffer correctly, don't need the return value for subsequent use, and for whom truncation (if it were possible) would be a programming error.

For these clients we have `void os::snprintf_checked` - which returns nothing and asserts on truncation.

2. Those who have sized their buffer correctly, but do need the return value for subsequent operations (e.g. chains of `snprintf` where you advance the buffer pointer based on previous writes), but again for whom truncation should never happen.

For these clients we have `os::snprintf`, but they have to add their own assertion for no truncation.

3. Those who present a buffer but know that truncation is a possibility, but don't need to do anything about it themselves, and for whom the return value is of no use.

These clients also use `os::snprintf_checked`. The truncation assertion can be useful for guiding buffer sizing decisions, but in product mode truncation is not an error.

4. Those who present a buffer but know that truncation is a possibility, and either need to handle it themselves, or else need to use the return value in subsequent operations.

These clients are also directed to use `os::snprintf`.

In summary we provide the following API:
- `[[nodiscard]] int os::vsnprintf` is the building block for the other methods, it:
  - asserts on precondition failures
  - asserts on error
  - guarantees null-termination in the case of unexpected errors (as the standards are still unclear on that point
  - is declared `[[nodiscard[]]` so that callers cannot ignore the return value (they can explicitly cast to `void` to indicate they don't need it)
- `void os::snprintf_checked`
  - calls `os::vnsprintf`` so asserts on errors
  - asserts on truncation
- `[[nodiscard]] int os::snprintf`
  - calls `os::vnsprintf` so asserts on errors

In terms of the effects on the existing code we:
- Change callers of `::snprintf`/`os::snprintf` that ignore the return value and ensure the buffer is large enough to use `os::snprintf_checked`
  - those that allow truncation to happen must use `os::snprintf`.
- Change all callers of `::snprintf`/`os::snprintf` that use the return value to use `os::snprintf`, plus any additional assertions needed
- Change the 9 callers of `os::snprintf_checked` that do use the return value, to use `os::snprintf` with their own assertions added
- Callers of `os::vnsprintf` are adjusted as needed

The PR  is comprising multiple dependent commits so that you can view things in stages.  There are 46 modified files. The bulk of the changes replace calls to `snprintf`/`os::snprintf` with calls to `os::snprintf_checked`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347707](https://bugs.openjdk.org/browse/JDK-8347707): Standardise the use of os::snprintf and os::snprintf_checked (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26470/head:pull/26470` \
`$ git checkout pull/26470`

Update a local copy of the PR: \
`$ git checkout pull/26470` \
`$ git pull https://git.openjdk.org/jdk.git pull/26470/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26470`

View PR using the GUI difftool: \
`$ git pr show -t 26470`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26470.diff">https://git.openjdk.org/jdk/pull/26470.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26470#issuecomment-3148939644)
</details>
