### PR TITLE
8339791: Refactor MiscUndecorated/ActiveAWTWindowTest.java

### DIFF
--- a/test/jdk/java/awt/Frame/MiscUndecorated/ActiveAWTWindowTest.java
+++ b/test/jdk/java/awt/Frame/MiscUndecorated/ActiveAWTWindowTest.java
@@ -112,12 +112,7 @@ public class ActiveAWTWindowTest {
 
         textField = new TextField("TextField");
         button = new Button("Click me");
-        button.addActionListener(new ActionListener() {
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                textField.setText("Focus gained");
-            }
-        });
+        button.addActionListener(e -> textField.setText("Focus gained"));
 
         frame.setBackground(Color.green);
         frame.add(button);
@@ -132,12 +127,7 @@ public class ActiveAWTWindowTest {
 
         button2 = new Button("Click me");
         textField2 = new TextField("TextField");
-        button2.addActionListener(new ActionListener() {
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                textField2.setText("Got the focus");
-            }
-        });
+        button2.addActionListener(e -> textField2.setText("Got the focus"));
 
         frame2.add(button2, BorderLayout.SOUTH);
         frame2.add(textField2, BorderLayout.NORTH);

--- a/test/jdk/java/awt/Frame/MiscUndecorated/ActiveAWTWindowTest.java
+++ b/test/jdk/java/awt/Frame/MiscUndecorated/ActiveAWTWindowTest.java
@@ -29,6 +29,7 @@
  * @run main ActiveAWTWindowTest
  */
 
+import java.awt.AWTException;
 import java.awt.BorderLayout;
 import java.awt.Button;
 import java.awt.Color;
@@ -59,23 +60,18 @@ public class ActiveAWTWindowTest {
     private static boolean passed = true;
 
     public static void main(String[] args) throws Exception {
-        try {
-            EventQueue.invokeAndWait(() -> {
-                initializeGUI();
-            });
-            doTest();
-        } catch (Exception e) {
-            throw new RuntimeException("Unexpected Exception encountered.");
-        } finally {
-            EventQueue.invokeAndWait(() -> {
-                if (frame != null) {
-                    frame.dispose();
-                }
-                if (frame2 != null) {
-                    frame2.dispose();
-                }
-            });
-        }
+        EventQueue.invokeAndWait(() -> {
+            initializeGUI();
+        });
+        doTest();
+        EventQueue.invokeAndWait(() -> {
+            if (frame != null) {
+                frame.dispose();
+            }
+            if (frame2 != null) {
+                frame2.dispose();
+            }
+        });
     }
 
     private static void initializeGUI() {
@@ -148,24 +144,13 @@ public class ActiveAWTWindowTest {
         frame2.setVisible(true);
     }
 
-    private static void doTest() {
-        Robot robot;
-        try {
-            robot = new Robot();
-        } catch (Exception e) {
-            throw new RuntimeException("Cannot create robot");
-        }
+    private static void doTest() throws AWTException, InterruptedException  {
+        Robot robot = new Robot();
         robot.setAutoDelay(150);
         robot.setAutoWaitForIdle(true);
-        try {
-            if (!windowFocusGainedLatch.await(1500, TimeUnit.MILLISECONDS)) {
+        if (!windowFocusGainedLatch.await(1500, TimeUnit.MILLISECONDS)) {
                 passed = false;
-            }
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new RuntimeException("Interrupted while waiting for focus");
         }
-
         robot.mouseMove(
             button.getLocationOnScreen().x + button.getSize().width / 2,
             button.getLocationOnScreen().y + button.getSize().height / 2);
@@ -173,12 +158,7 @@ public class ActiveAWTWindowTest {
         robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
 
         if (eventType != WindowEvent.WINDOW_ACTIVATED) {
-            try {
-                windowActivatedLatch.await(1500, TimeUnit.MILLISECONDS);
-            } catch (Exception e) {
-                throw new RuntimeException("Unexpected Exception: "
-                    + "waiting on WINDOW_ACTIVATED event");
-            }
+            windowActivatedLatch.await(1500, TimeUnit.MILLISECONDS);
         }
         if (eventType != WindowEvent.WINDOW_ACTIVATED) {
             passed = false;
@@ -192,12 +172,7 @@ public class ActiveAWTWindowTest {
         robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
 
         if (eventType != WindowEvent.WINDOW_DEACTIVATED) {
-            try {
-                windowDeactivatedLatch.await(1500, TimeUnit.MILLISECONDS);
-            } catch (Exception e) {
-                throw new RuntimeException("Unexpected Exception: "
-                    + "waiting on WINDOW_DEACTIVATED event");
-            }
+            windowDeactivatedLatch.await(1500, TimeUnit.MILLISECONDS);
         }
         if (eventType != WindowEvent.WINDOW_DEACTIVATED) {
             passed = false;

--- a/test/jdk/java/awt/Frame/MiscUndecorated/ActiveAWTWindowTest.java
+++ b/test/jdk/java/awt/Frame/MiscUndecorated/ActiveAWTWindowTest.java
@@ -153,6 +153,9 @@ public class ActiveAWTWindowTest {
         if (!windowDeactivatedLatch.await(2000, TimeUnit.MILLISECONDS)) {
             throw new RuntimeException("Frame was not deactivated");
         }
+        if (frame.hasFocus()) {
+            throw new RuntimeException("Frame did not lose focus");
+        }
     }
 
     private static void clickButtonCenter(Robot robot, Component button) {

--- a/test/jdk/java/awt/Frame/MiscUndecorated/ActiveAWTWindowTest.java
+++ b/test/jdk/java/awt/Frame/MiscUndecorated/ActiveAWTWindowTest.java
@@ -25,7 +25,7 @@
  * @test
  * @key headful
  * @summary To check proper WINDOW_EVENTS are triggered when Frame gains
- * or looses the focus
+ * or loses the focus
  * @run main ActiveAWTWindowTest
  */
 


### PR DESCRIPTION
The java/awt/Frame/MiscUndecorated/ActiveAWTWindowTest.java test uses object monitors and wait/notify to synchronise actions in the test.

Using CountDownLatch could make the test simpler, shorter, clearer.
Tested the code on a windows-x64, macos-x64 and lnux-x64 machines and the test is working as expected.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339791](https://bugs.openjdk.org/browse/JDK-8339791): Refactor MiscUndecorated/ActiveAWTWindowTest.java (**Bug** - P4)


### Reviewers
 * [Prasanta Sadhukhan](https://openjdk.org/census#psadhukhan) (@prsadhuk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26471/head:pull/26471` \
`$ git checkout pull/26471`

Update a local copy of the PR: \
`$ git checkout pull/26471` \
`$ git pull https://git.openjdk.org/jdk.git pull/26471/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26471`

View PR using the GUI difftool: \
`$ git pr show -t 26471`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26471.diff">https://git.openjdk.org/jdk/pull/26471.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26471#issuecomment-3116468520)
</details>
