### PR TITLE
8364004: Expose VMError::controlledCrash via Whitebox

### DIFF
--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -102,6 +102,7 @@
 #include "utilities/macros.hpp"
 #include "utilities/nativeCallStack.hpp"
 #include "utilities/ostream.hpp"
+#include "utilities/vmError.hpp"
 #if INCLUDE_G1GC
 #include "gc/g1/g1Arguments.hpp"
 #include "gc/g1/g1CollectedHeap.inline.hpp"
@@ -2728,6 +2729,14 @@ WB_ENTRY(jlong, WB_Rss(JNIEnv* env, jobject o))
   return os::rss();
 WB_END
 
+WB_ENTRY(void, WB_ControlledCrash(JNIEnv* env, jobject o, jint how))
+#ifdef ASSERT
+  DEBUG_ONLY(VMError::controlled_crash(how);)
+#else
+  THROW_MSG_0(vmSymbols::java_lang_UnsupportedOperationException(), "Only available in debug builds");
+#endif
+WB_END
+
 #define CC (char*)
 
 static JNINativeMethod methods[] = {
@@ -3019,9 +3028,9 @@ static JNINativeMethod methods[] = {
   {CC"lockAndStuckInSafepoint", CC"()V", (void*)&WB_TakeLockAndHangInSafepoint},
   {CC"wordSize", CC"()J",                             (void*)&WB_WordSize},
   {CC"rootChunkWordSize", CC"()J",                    (void*)&WB_RootChunkWordSize},
-  {CC"isStatic", CC"()Z",                             (void*)&WB_IsStaticallyLinked}
+  {CC"isStatic", CC"()Z",                             (void*)&WB_IsStaticallyLinked},
+  {CC"controlledCrash",CC"(I)V",                      (void*)&WB_ControlledCrash},
 };
-
 
 #undef CC
 

--- a/test/lib/jdk/test/whitebox/WhiteBox.java
+++ b/test/lib/jdk/test/whitebox/WhiteBox.java
@@ -560,6 +560,9 @@ public class WhiteBox {
   // Force Full GC
   public native void fullGC();
 
+  // Force a controlled crash (debug builds only)
+  public native void controlledCrash(int how);
+
   // Infrastructure for waitForReferenceProcessing()
   private static volatile Method waitForReferenceProcessingMethod = null;
 


### PR DESCRIPTION
Small addition to the circle of WhiteBox functions to allow more controlled crashes triggered from jtreg tests.