### PR TITLE
8358048: java/net/httpclient/HttpsTunnelAuthTest.java incorrectly calls Thread::stop

### DIFF
--- a/test/jdk/java/net/httpclient/HttpsTunnelAuthTest.java
+++ b/test/jdk/java/net/httpclient/HttpsTunnelAuthTest.java
@@ -37,12 +37,11 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.net.ssl.SSLContext;
 import jdk.httpclient.test.lib.common.HttpServerAdapters;
-import jdk.httpclient.test.lib.http2.Http2TestServer;
 import jdk.test.lib.net.SimpleSSLContext;
 
 import static java.lang.System.out;
 
-/**
+/*
  * @test
  * @bug 8262027
  * @summary Verify that it's possible to handle proxy authentication manually
@@ -62,7 +61,7 @@ import static java.lang.System.out;
 //-Djdk.internal.httpclient.debug=true -Dtest.debug=true
 public class HttpsTunnelAuthTest implements HttpServerAdapters, AutoCloseable {
 
-    static final String data[] = {
+    static final String[] data = {
         "Lorem ipsum",
         "dolor sit amet",
         "consectetur adipiscing elit, sed do eiusmod tempor",
@@ -150,7 +149,7 @@ public class HttpsTunnelAuthTest implements HttpServerAdapters, AutoCloseable {
 
     @Override
     public void close() throws Exception {
-        if (proxy != null) close(proxy::stop);
+        if (proxy != null) close(proxy);
         if (http1Server != null) close(http1Server::stop);
         if (https1Server != null) close(https1Server::stop);
         if (https2Server != null) close(https2Server::stop);
@@ -160,7 +159,8 @@ public class HttpsTunnelAuthTest implements HttpServerAdapters, AutoCloseable {
         try {
             closeable.close();
         } catch (Exception x) {
-            // OK.
+            // OK to ignore and just log
+            System.err.println("ignoring failure during close() of " + closeable + " due to: " + x);
         }
     }
 


### PR DESCRIPTION
Can I please get a review of this test-only change which fixes an accidental use of `Thread.stop()`? This addresses https://bugs.openjdk.org/browse/JDK-8358048.

The test during it's termination attempts to close the `ProxyServer` and invokes `ProxyServer.stop()`. The `ProxyServer` does not have a `stop()` method of its own but since the `ProxyServer` is a `java.lang.Thread`, calling `stop()` on the `ProxyServer` ends up calling the `Thread.stop()`. The use of `stop()` in this test is accidental and the test should have used `ProxyServer.close()`.

The commit in this PR fixes the issue by removing the use of `ProxyServer.stop()`. The test continues to pass with this change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8358048](https://bugs.openjdk.org/browse/JDK-8358048): java/net/httpclient/HttpsTunnelAuthTest.java incorrectly calls Thread::stop (**Bug** - P3)


### Reviewers
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Volkan Yazici](https://openjdk.org/census#vyazici) (@vy - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26473/head:pull/26473` \
`$ git checkout pull/26473`

Update a local copy of the PR: \
`$ git checkout pull/26473` \
`$ git pull https://git.openjdk.org/jdk.git pull/26473/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26473`

View PR using the GUI difftool: \
`$ git pr show -t 26473`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26473.diff">https://git.openjdk.org/jdk/pull/26473.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26473#issuecomment-3116813958)
</details>
