### PR TITLE
8364111: InstanceMirrorKlass iterators should handle CDS and hidden classes consistently

### DIFF
--- a/src/hotspot/share/oops/instanceMirrorKlass.hpp
+++ b/src/hotspot/share/oops/instanceMirrorKlass.hpp
@@ -52,6 +52,9 @@ class InstanceMirrorKlass: public InstanceKlass {
 
   InstanceMirrorKlass(const ClassFileParser& parser) : InstanceKlass(parser, Kind) {}
 
+  template <class OopClosureType>
+  void do_metadata(oop obj, OopClosureType* closure);
+
  public:
   InstanceMirrorKlass();
 

--- a/src/hotspot/share/oops/instanceMirrorKlass.hpp
+++ b/src/hotspot/share/oops/instanceMirrorKlass.hpp
@@ -53,7 +53,7 @@ class InstanceMirrorKlass: public InstanceKlass {
   InstanceMirrorKlass(const ClassFileParser& parser) : InstanceKlass(parser, Kind) {}
 
   template <class OopClosureType>
-  void do_metadata(oop obj, OopClosureType* closure);
+  inline void do_metadata(oop obj, OopClosureType* closure);
 
  public:
   InstanceMirrorKlass();

--- a/src/hotspot/share/oops/instanceMirrorKlass.inline.hpp
+++ b/src/hotspot/share/oops/instanceMirrorKlass.inline.hpp
@@ -64,9 +64,14 @@ void InstanceMirrorKlass::do_metadata(oop obj, OopClosureType* closure) {
       Devirtualizer::do_klass(closure, klass);
     }
   } else {
-    // Klass is null means this has been a mirror for a primitive type
-    // that we do not need to follow as they are always strong roots.
-    assert(java_lang_Class::is_primitive(obj), "Sanity");
+    // Java mirror -> Klass* "nullptr" backlink means either:
+    // 1. obj is a Java mirror for a primitive class, we do not need to follow it,
+    //    these mirrors are always strong roots.
+    // 2. obj is a Java mirror for a newly allocated non-primitive class, and we
+    //    somehow managed to reach the newly allocated Java mirror with not yet
+    //    installed backlink. This case should be made benign by GC itself for
+    //    this and any other Java mirror usage path, we cannot do anything here.
+    // Unfortunately, the existence of corner case (2) precludes asserting (1).
   }
 }
 

--- a/src/hotspot/share/oops/instanceMirrorKlass.inline.hpp
+++ b/src/hotspot/share/oops/instanceMirrorKlass.inline.hpp
@@ -46,38 +46,36 @@ void InstanceMirrorKlass::oop_oop_iterate_statics(oop obj, OopClosureType* closu
   }
 }
 
+template <class OopClosureType>
+void InstanceMirrorKlass::do_metadata(oop obj, OopClosureType* closure) {
+  Klass* klass = java_lang_Class::as_Klass(obj);
+  if (klass != nullptr) {
+    if (klass->class_loader_data() == nullptr) {
+      // This is a mirror that belongs to a shared class that has not been loaded yet.
+      assert(klass->is_shared(), "must be");
+    } else if (klass->is_instance_klass() && klass->class_loader_data()->has_class_mirror_holder()) {
+      // A non-strong hidden class doesn't have its own class loader,
+      // so when handling the java mirror for the class we need to make sure its class
+      // loader data is claimed, this is done by calling do_cld explicitly.
+      // For non-strong hidden classes the call to do_cld is made when the class
+      // loader itself is handled.
+      Devirtualizer::do_cld(closure, klass->class_loader_data());
+    } else {
+      Devirtualizer::do_klass(closure, klass);
+    }
+  } else {
+    // Klass is null means this has been a mirror for a primitive type
+    // that we do not need to follow as they are always strong roots.
+    assert(java_lang_Class::is_primitive(obj), "Sanity check");
+  }
+}
+
 template <typename T, class OopClosureType>
 void InstanceMirrorKlass::oop_oop_iterate(oop obj, OopClosureType* closure) {
   InstanceKlass::oop_oop_iterate<T>(obj, closure);
 
   if (Devirtualizer::do_metadata(closure)) {
-    Klass* klass = java_lang_Class::as_Klass(obj);
-    // We'll get null for primitive mirrors.
-    if (klass != nullptr) {
-      if (klass->class_loader_data() == nullptr) {
-        // This is a mirror that belongs to a shared class that has not be loaded yet.
-        assert(klass->is_shared(), "must be");
-      } else if (klass->is_instance_klass() && klass->class_loader_data()->has_class_mirror_holder()) {
-        // A non-strong hidden class doesn't have its own class loader,
-        // so when handling the java mirror for the class we need to make sure its class
-        // loader data is claimed, this is done by calling do_cld explicitly.
-        // For non-strong hidden classes the call to do_cld is made when the class
-        // loader itself is handled.
-        Devirtualizer::do_cld(closure, klass->class_loader_data());
-      } else {
-        Devirtualizer::do_klass(closure, klass);
-      }
-    } else {
-      // We would like to assert here (as below) that if klass has been null, then
-      // this has been a mirror for a primitive type that we do not need to follow
-      // as they are always strong roots.
-      // However, we might get across a klass that just changed during CMS concurrent
-      // marking if allocation occurred in the old generation.
-      // This is benign here, as we keep alive all CLDs that were loaded during the
-      // CMS concurrent phase in the class loading, i.e. they will be iterated over
-      // and kept alive during remark.
-      // assert(java_lang_Class::is_primitive(obj), "Sanity check");
-    }
+    do_metadata<OopClosureType>(obj, closure);
   }
 
   oop_oop_iterate_statics<T>(obj, closure);
@@ -121,11 +119,7 @@ void InstanceMirrorKlass::oop_oop_iterate_bounded(oop obj, OopClosureType* closu
 
   if (Devirtualizer::do_metadata(closure)) {
     if (mr.contains(obj)) {
-      Klass* klass = java_lang_Class::as_Klass(obj);
-      // We'll get null for primitive mirrors.
-      if (klass != nullptr) {
-        Devirtualizer::do_klass(closure, klass);
-      }
+      do_metadata<OopClosureType>(obj, closure);
     }
   }
 

--- a/src/hotspot/share/oops/instanceMirrorKlass.inline.hpp
+++ b/src/hotspot/share/oops/instanceMirrorKlass.inline.hpp
@@ -52,7 +52,7 @@ void InstanceMirrorKlass::do_metadata(oop obj, OopClosureType* closure) {
   if (klass != nullptr) {
     if (klass->class_loader_data() == nullptr) {
       // This is a mirror that belongs to a shared class that has not been loaded yet.
-      assert(klass->is_shared(), "must be");
+      assert(klass->is_shared(), "Must be");
     } else if (klass->is_instance_klass() && klass->class_loader_data()->has_class_mirror_holder()) {
       // A non-strong hidden class doesn't have its own class loader,
       // so when handling the java mirror for the class we need to make sure its class
@@ -66,7 +66,7 @@ void InstanceMirrorKlass::do_metadata(oop obj, OopClosureType* closure) {
   } else {
     // Klass is null means this has been a mirror for a primitive type
     // that we do not need to follow as they are always strong roots.
-    assert(java_lang_Class::is_primitive(obj), "Sanity check");
+    assert(java_lang_Class::is_primitive(obj), "Sanity");
   }
 }
 

--- a/src/hotspot/share/oops/instanceMirrorKlass.inline.hpp
+++ b/src/hotspot/share/oops/instanceMirrorKlass.inline.hpp
@@ -65,13 +65,13 @@ void InstanceMirrorKlass::do_metadata(oop obj, OopClosureType* closure) {
     }
   } else {
     // Java mirror -> Klass* "nullptr" backlink means either:
-    // 1. obj is a Java mirror for a primitive class, we do not need to follow it,
+    // 1. This is a Java mirror for a primitive class. We do not need to follow it,
     //    these mirrors are always strong roots.
-    // 2. obj is a Java mirror for a newly allocated non-primitive class, and we
+    // 2. This is a Java mirror for a newly allocated non-primitive class, and we
     //    somehow managed to reach the newly allocated Java mirror with not yet
-    //    installed backlink. This case should be made benign by GC itself for
-    //    this and any other Java mirror usage path, we cannot do anything here.
-    // Unfortunately, the existence of corner case (2) precludes asserting (1).
+    //    installed backlink. We cannot do anything here, this case would be handled
+    //    separately by GC, e.g. by keeping the relevant metadata alive during the GC.
+    // Unfortunately, the existence of corner case (2) prevents us from asserting (1).
   }
 }
 


### PR DESCRIPTION
See the bug for more investigation. I think the root cause is already fixed in one of the `InstanceMirrorKlass` iterators, but not in the other one. Additionally, only one iterator handles the hidden classes. Also, there is a stale comment about CMS that apparently prevents us from asserting `is_primitive`, which is not relevant anymore.

So this PR commons out the metadata handling on both iterators, which fixes the GenShen+CDS bug, likely fixes hidden classes bug somewhere, and prevents the omission like this from happening again.

Additional testing:
 - [x] Linux x86_64 server fastdebug, Generational Shenandoah + CDS bugs are not reproducing now
 - [x] Linux x86_64 server fastdebug, `tier1`
 - [x] Linux x86_64 server fastdebug, `all`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8364111](https://bugs.openjdk.org/browse/JDK-8364111): InstanceMirrorKlass iterators should handle CDS and hidden classes consistently (**Bug** - P4)


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**) Review applies to [5e4153ae](https://git.openjdk.org/jdk/pull/26477/files/5e4153ae0d3556d41182f1987ec28c28668a3539)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26477/head:pull/26477` \
`$ git checkout pull/26477`

Update a local copy of the PR: \
`$ git checkout pull/26477` \
`$ git pull https://git.openjdk.org/jdk.git pull/26477/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26477`

View PR using the GUI difftool: \
`$ git pr show -t 26477`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26477.diff">https://git.openjdk.org/jdk/pull/26477.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26477#issuecomment-3117713441)
</details>
