### PR TITLE
8362581: Timeouts in java/nio/channels/SocketChannel/OpenLeak.java on UNIX

### DIFF
--- a/src/java.base/share/classes/jdk/internal/util/Exceptions.java
+++ b/src/java.base/share/classes/jdk/internal/util/Exceptions.java
@@ -274,11 +274,8 @@ public final class Exceptions {
      */
     public static IOException ioException(IOException e, SocketAddress addr) {
         setup();
-        if (addr == null) {
+        if (!enhancedSocketExceptionText || addr == null) {
             return e;
-        }
-        if (!enhancedSocketExceptionText) {
-            return create(e, e.getMessage());
         }
         if (addr instanceof UnixDomainSocketAddress) {
             return ofUnixDomain(e, (UnixDomainSocketAddress)addr);

--- a/test/jdk/java/nio/channels/SocketChannel/OpenLeak.java
+++ b/test/jdk/java/nio/channels/SocketChannel/OpenLeak.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,7 +22,7 @@
  */
 
 /* @test
- * @bug 6548464 8362581
+ * @bug 6548464
  * @summary SocketChannel.open(SocketAddress) leaks file descriptor if
  *     connection cannot be established
  * @requires vm.flagless

--- a/test/jdk/java/nio/channels/SocketChannel/OpenLeak.java
+++ b/test/jdk/java/nio/channels/SocketChannel/OpenLeak.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,7 +22,7 @@
  */
 
 /* @test
- * @bug 6548464
+ * @bug 6548464 8362581
  * @summary SocketChannel.open(SocketAddress) leaks file descriptor if
  *     connection cannot be established
  * @requires vm.flagless


### PR DESCRIPTION
Hi,

This is a fix for 8362581 caused by the implementation for https://bugs.openjdk.org/browse/JDK-8348986
An incorrect check was added to the method Exceptions.ioException() which wasn't noticed partly
because that file was renamed, and webrev doesn't show the diffs side by side.
The effect of this change is to restore the method to pretty much what it was before, but taking account
of the changed categorisation of exceptions.

A test is not included since this was caught by an existing regression test.

Thanks,
Michael

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8362581](https://bugs.openjdk.org/browse/JDK-8362581): Timeouts in java/nio/channels/SocketChannel/OpenLeak.java on UNIX (**Bug** - P4)


### Reviewers
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - **Reviewer**) Review applies to [45cb3a46](https://git.openjdk.org/jdk/pull/26478/files/45cb3a461d192db5b5a7e2464f42487fe9fc74a1)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26478/head:pull/26478` \
`$ git checkout pull/26478`

Update a local copy of the PR: \
`$ git checkout pull/26478` \
`$ git pull https://git.openjdk.org/jdk.git pull/26478/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26478`

View PR using the GUI difftool: \
`$ git pr show -t 26478`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26478.diff">https://git.openjdk.org/jdk/pull/26478.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26478#issuecomment-3117563693)
</details>
