### PR TITLE
8364114: Test TestHugePageDecisionsAtVMStartup.java#LP_enabled fails when no free hugepage

### DIFF
--- a/test/hotspot/jtreg/runtime/os/TestHugePageDecisionsAtVMStartup.java
+++ b/test/hotspot/jtreg/runtime/os/TestHugePageDecisionsAtVMStartup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2023, 2024, Red Hat Inc.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -29,6 +29,7 @@
  * @requires os.family == "linux"
  * @modules java.base/jdk.internal.misc
  *          java.management
+ * @build jtreg.SkippedException
  * @run driver TestHugePageDecisionsAtVMStartup
  */
 
@@ -39,6 +40,7 @@
  * @requires os.family == "linux"
  * @modules java.base/jdk.internal.misc
  *          java.management
+ * @build jtreg.SkippedException
  * @run driver TestHugePageDecisionsAtVMStartup -XX:+UseLargePages
  */
 
@@ -50,12 +52,14 @@
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management
+ * @build jtreg.SkippedException
  * @run driver TestHugePageDecisionsAtVMStartup -XX:+UseTransparentHugePages
  */
 
 import jdk.test.lib.os.linux.HugePageConfiguration;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
+import jtreg.SkippedException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -123,6 +127,9 @@ public class TestHugePageDecisionsAtVMStartup {
             out.shouldContain(warningNoTHP);
         } else if (useLP && !useTHP &&
                  configuration.supportsExplicitHugePages() && haveUsableExplicitHugePages) {
+            if (configuration.readAvailableHugePageNumberFromOS() == 0) {
+                throw new SkippedException("No usable explicit hugepages configured on the system, skipping test");
+            }
             out.shouldContain("[info][pagesize] Using the default large page size: " + buildSizeString(configuration.getExplicitDefaultHugePageSize()));
             out.shouldContain("[info][pagesize] UseLargePages=1, UseTransparentHugePages=0");
             out.shouldContain("[info][pagesize] Large page support enabled");

--- a/test/hotspot/jtreg/runtime/os/TestHugePageDecisionsAtVMStartup.java
+++ b/test/hotspot/jtreg/runtime/os/TestHugePageDecisionsAtVMStartup.java
@@ -29,7 +29,6 @@
  * @requires os.family == "linux"
  * @modules java.base/jdk.internal.misc
  *          java.management
- * @build jtreg.SkippedException
  * @run driver TestHugePageDecisionsAtVMStartup
  */
 
@@ -40,7 +39,6 @@
  * @requires os.family == "linux"
  * @modules java.base/jdk.internal.misc
  *          java.management
- * @build jtreg.SkippedException
  * @run driver TestHugePageDecisionsAtVMStartup -XX:+UseLargePages
  */
 
@@ -52,7 +50,6 @@
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management
- * @build jtreg.SkippedException
  * @run driver TestHugePageDecisionsAtVMStartup -XX:+UseTransparentHugePages
  */
 

--- a/test/hotspot/jtreg/runtime/os/TestHugePageDecisionsAtVMStartup.java
+++ b/test/hotspot/jtreg/runtime/os/TestHugePageDecisionsAtVMStartup.java
@@ -124,7 +124,7 @@ public class TestHugePageDecisionsAtVMStartup {
             out.shouldContain(warningNoTHP);
         } else if (useLP && !useTHP &&
                  configuration.supportsExplicitHugePages() && haveUsableExplicitHugePages) {
-            if (configuration.readAvailableHugePageNumberFromOS() == 0) {
+            if (configuration.getExplicitAvailableHugePageNumber() == 0) {
                 throw new SkippedException("No usable explicit hugepages configured on the system, skipping test");
             }
             out.shouldContain("[info][pagesize] Using the default large page size: " + buildSizeString(configuration.getExplicitDefaultHugePageSize()));

--- a/test/lib/jdk/test/lib/os/linux/HugePageConfiguration.java
+++ b/test/lib/jdk/test/lib/os/linux/HugePageConfiguration.java
@@ -64,6 +64,7 @@ public class HugePageConfiguration {
 
     Set<ExplicitHugePageConfig> _explicitHugePageConfigurations;
     long _explicitDefaultHugePageSize = -1;
+    long _explicitAvailableHugePageNumber = -1;
 
     public enum THPMode {always, never, madvise}
     THPMode _thpMode;
@@ -78,6 +79,10 @@ public class HugePageConfiguration {
 
     public long getExplicitDefaultHugePageSize() {
         return _explicitDefaultHugePageSize;
+    }
+
+    public long getExplicitAvailableHugePageNumber() {
+        return _explicitAvailableHugePageNumber;
     }
 
     public THPMode getThpMode() {
@@ -116,9 +121,10 @@ public class HugePageConfiguration {
         return _explicitDefaultHugePageSize > 0 && _explicitHugePageConfigurations.size() > 0;
     }
 
-    public HugePageConfiguration(Set<ExplicitHugePageConfig> explicitHugePageConfigurations, long explicitDefaultHugePageSize, THPMode _thpMode, long _thpPageSize, ShmemTHPMode _shmemThpMode) {
+    public HugePageConfiguration(Set<ExplicitHugePageConfig> explicitHugePageConfigurations, long explicitDefaultHugePageSize, long explicitAvailableHugePageNumber, THPMode _thpMode, long _thpPageSize, ShmemTHPMode _shmemThpMode) {
         this._explicitHugePageConfigurations = explicitHugePageConfigurations;
         this._explicitDefaultHugePageSize = explicitDefaultHugePageSize;
+        this._explicitAvailableHugePageNumber = explicitAvailableHugePageNumber;
         this._thpMode = _thpMode;
         this._thpPageSize = _thpPageSize;
         this._shmemThpMode = _shmemThpMode;
@@ -129,6 +135,7 @@ public class HugePageConfiguration {
         return "Configuration{" +
                 "_explicitHugePageConfigurations=" + _explicitHugePageConfigurations +
                 ", _explicitDefaultHugePageSize=" + _explicitDefaultHugePageSize +
+                ", _explicitAvailableHugePageNumber=" + _explicitAvailableHugePageNumber +
                 ", _thpMode=" + _thpMode +
                 ", _thpPageSize=" + _thpPageSize +
                 ", _shmemThpMode=" + _shmemThpMode +
@@ -138,6 +145,7 @@ public class HugePageConfiguration {
     @Override
     public int hashCode() {
         return Objects.hash(_explicitDefaultHugePageSize,
+                            _explicitAvailableHugePageNumber,
                             _thpPageSize,
                             _explicitHugePageConfigurations,
                             _thpMode,
@@ -149,6 +157,7 @@ public class HugePageConfiguration {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         HugePageConfiguration that = (HugePageConfiguration) o;
+        // _explicitAvailableHugePageNumber is not compared here, because there is no direct counterpart on the JVM-side log.
         return _explicitDefaultHugePageSize == that._explicitDefaultHugePageSize && _thpPageSize == that._thpPageSize &&
                 Objects.equals(_explicitHugePageConfigurations, that._explicitHugePageConfigurations) && _thpMode == that._thpMode &&
                 _shmemThpMode == that._shmemThpMode;
@@ -169,7 +178,7 @@ public class HugePageConfiguration {
         return 0;
     }
 
-    public static long readAvailableHugePageNumberFromOS() {
+    private static long readAvailableHugePageNumberFromOS() {
         Pattern pat = Pattern.compile("HugePages_Free: *(\\d+)$");
         try (Scanner scanner = new Scanner(new File("/proc/meminfo"))) {
             while (scanner.hasNextLine()) {
@@ -278,6 +287,7 @@ public class HugePageConfiguration {
     public static HugePageConfiguration readFromOS() throws IOException {
         return new HugePageConfiguration(readSupportedHugePagesFromOS(),
                 readDefaultHugePageSizeFromOS(),
+                readAvailableHugePageNumberFromOS(),
                 readTHPModeFromOS(),
                 readTHPPageSizeFromOS(),
                 readShmemTHPModeFromOS());
@@ -348,7 +358,7 @@ public class HugePageConfiguration {
             }
         }
 
-        return new HugePageConfiguration(explicitHugePageConfigs, defaultHugepageSize, thpMode, thpPageSize, shmemThpMode);
+        return new HugePageConfiguration(explicitHugePageConfigs, defaultHugepageSize, -1, thpMode, thpPageSize, shmemThpMode);
     }
 
 }

--- a/test/lib/jdk/test/lib/os/linux/HugePageConfiguration.java
+++ b/test/lib/jdk/test/lib/os/linux/HugePageConfiguration.java
@@ -169,6 +169,21 @@ public class HugePageConfiguration {
         return 0;
     }
 
+    public static long readAvailableHugePageNumberFromOS() {
+        Pattern pat = Pattern.compile("HugePages_Free: *(\\d+)$");
+        try (Scanner scanner = new Scanner(new File("/proc/meminfo"))) {
+            while (scanner.hasNextLine()) {
+                Matcher mat = pat.matcher(scanner.nextLine());
+                if (mat.matches()) {
+                    return Long.parseLong(mat.group(1));
+                }
+            }
+        } catch (FileNotFoundException e) {
+            System.out.println("Could not open /proc/meminfo");
+        }
+        return 0;
+    }
+
     private static Set<ExplicitHugePageConfig> readSupportedHugePagesFromOS() throws IOException {
         TreeSet<ExplicitHugePageConfig> hugePageConfigs = new TreeSet<>();
         Pattern pat = Pattern.compile("hugepages-(\\d+)kB");


### PR DESCRIPTION
Hi all,

The test runtime/os/TestHugePageDecisionsAtVMStartup.java#LP_enabled will fails when there is no free hugepases.
The /proc/meminfo and /sys/kernel/mm/hugepages/hugepages-*/free_hugepages says there is no free hugepage, and the JVM output also say there is available large page.

```
> cat /proc/meminfo | grep -i HugePages
AnonHugePages:         0 kB
ShmemHugePages:        0 kB
FileHugePages:         0 kB
HugePages_Total:       2
HugePages_Free:        0
HugePages_Rsvd:        0
HugePages_Surp:        2
Hugepagesize:       2048 kB

> ( set -x ; cat /sys/kernel/mm/hugepages/hugepages-*/free_hugepages )
+ cat /sys/kernel/mm/hugepages/hugepages-1048576kB/free_hugepages /sys/kernel/mm/hugepages/hugepages-2048kB/free_hugepages
0
0

JVM output snippet from java -XX:+UseLargePages -Xlog:pagesize -version
[0.001s][info][pagesize] Large page size (2M) failed sanity check, checking if smaller large page sizes are usable
[0.001s][warning][pagesize] UseLargePages disabled, no large pages configured and available on the system.
```

The JVM can not use large page when there is no available large page on system, it's not a JVM bug. So I think it's not suitable to report test failure, but report SkippedException.

Change has been verified locally, test report SkippedException on the system without free hugepage, the test passes on the system with free hugepage. Test-fix only, risk is low.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8364114](https://bugs.openjdk.org/browse/JDK-8364114): Test TestHugePageDecisionsAtVMStartup.java#LP_enabled fails when no free hugepage (**Enhancement** - P4)


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26480/head:pull/26480` \
`$ git checkout pull/26480`

Update a local copy of the PR: \
`$ git checkout pull/26480` \
`$ git pull https://git.openjdk.org/jdk.git pull/26480/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26480`

View PR using the GUI difftool: \
`$ git pr show -t 26480`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26480.diff">https://git.openjdk.org/jdk/pull/26480.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26480#issuecomment-3117704286)
</details>
