### PR TITLE
8363996: Remove UseCompressedClassPointers

### DIFF
--- a/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
@@ -76,23 +76,6 @@ const Register SHIFT_count = rcx;   // where count for shift operations must be
 
 #define __ _masm->
 
-
-static void select_different_registers(Register preserve,
-                                       Register extra,
-                                       Register &tmp1,
-                                       Register &tmp2) {
-  if (tmp1 == preserve) {
-    assert_different_registers(tmp1, tmp2, extra);
-    tmp1 = extra;
-  } else if (tmp2 == preserve) {
-    assert_different_registers(tmp1, tmp2, extra);
-    tmp2 = extra;
-  }
-  assert_different_registers(preserve, tmp1, tmp2);
-}
-
-
-
 static void select_different_registers(Register preserve,
                                        Register extra,
                                        Register &tmp1,
@@ -1315,12 +1298,8 @@ void LIR_Assembler::emit_typecheck_helper(LIR_OpTypeCheck *op, Label* success, L
   } else if (obj == klass_RInfo) {
     klass_RInfo = dst;
   }
-  if (k->is_loaded() && !UseCompressedClassPointers) {
-    select_different_registers(obj, dst, k_RInfo, klass_RInfo);
-  } else {
-    Rtmp1 = op->tmp3()->as_register();
-    select_different_registers(obj, dst, k_RInfo, klass_RInfo, Rtmp1);
-  }
+  Rtmp1 = op->tmp3()->as_register();
+  select_different_registers(obj, dst, k_RInfo, klass_RInfo, Rtmp1);
 
   assert_different_registers(obj, k_RInfo, klass_RInfo);
 
@@ -1360,12 +1339,8 @@ void LIR_Assembler::emit_typecheck_helper(LIR_OpTypeCheck *op, Label* success, L
   if (op->fast_check()) {
     // get object class
     // not a safepoint as obj null check happens earlier
-    if (UseCompressedClassPointers) {
-      __ load_klass(Rtmp1, obj, tmp_load_klass);
-      __ cmpptr(k_RInfo, Rtmp1);
-    } else {
-      __ cmpptr(k_RInfo, Address(obj, oopDesc::klass_offset_in_bytes()));
-    }
+    __ load_klass(Rtmp1, obj, tmp_load_klass);
+    __ cmpptr(k_RInfo, Rtmp1);
     __ jcc(Assembler::notEqual, *failure_target);
     // successful cast, fall through to profile or jump
   } else {
@@ -2668,9 +2643,7 @@ void LIR_Assembler::emit_arraycopy(LIR_OpArrayCopy* op) {
     // but not necessarily exactly of type default_type.
     Label known_ok, halt;
     __ mov_metadata(tmp, default_type->constant_encoding());
-    if (UseCompressedClassPointers) {
-      __ encode_klass_not_null(tmp, rscratch1);
-    }
+    __ encode_klass_not_null(tmp, rscratch1);
 
     if (basic_type != T_OBJECT) {
       __ cmp_klass(tmp, dst, tmp2);

--- a/src/hotspot/cpu/x86/c1_LIRGenerator_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_LIRGenerator_x86.cpp
@@ -1285,9 +1285,7 @@ void LIRGenerator::do_CheckCast(CheckCast* x) {
   }
   LIR_Opr reg = rlock_result(x);
   LIR_Opr tmp3 = LIR_OprFact::illegalOpr;
-  if (!x->klass()->is_loaded() || UseCompressedClassPointers) {
-    tmp3 = new_register(objectType);
-  }
+  tmp3 = new_register(objectType);
   __ checkcast(reg, obj.result(), x->klass(),
                new_register(objectType), new_register(objectType), tmp3,
                x->direct_compare(), info_for_exception, patching_info, stub,
@@ -1307,9 +1305,7 @@ void LIRGenerator::do_InstanceOf(InstanceOf* x) {
   }
   obj.load_item();
   LIR_Opr tmp3 = LIR_OprFact::illegalOpr;
-  if (!x->klass()->is_loaded() || UseCompressedClassPointers) {
-    tmp3 = new_register(objectType);
-  }
+  tmp3 = new_register(objectType);
   __ instanceof(reg, obj.result(), x->klass(),
                 new_register(objectType), new_register(objectType), tmp3,
                 x->direct_compare(), patching_info, x->profiled_method(), x->profiled_bci());

--- a/src/hotspot/cpu/x86/c1_MacroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_MacroAssembler_x86.cpp
@@ -160,14 +160,11 @@ void C1_MacroAssembler::initialize_header(Register obj, Register klass, Register
   if (UseCompactObjectHeaders) {
     movptr(t1, Address(klass, Klass::prototype_header_offset()));
     movptr(Address(obj, oopDesc::mark_offset_in_bytes()), t1);
-  } else if (UseCompressedClassPointers) { // Take care not to kill klass
+  } else { // compressed klass pointer: Take care not to kill klass
     movptr(Address(obj, oopDesc::mark_offset_in_bytes()), checked_cast<int32_t>(markWord::prototype().value()));
     movptr(t1, klass);
     encode_klass_not_null(t1, rscratch1);
     movl(Address(obj, oopDesc::klass_offset_in_bytes()), t1);
-  } else {
-    movptr(Address(obj, oopDesc::mark_offset_in_bytes()), checked_cast<int32_t>(markWord::prototype().value()));
-    movptr(Address(obj, oopDesc::klass_offset_in_bytes()), klass);
   }
 
   if (len->is_valid()) {
@@ -179,7 +176,7 @@ void C1_MacroAssembler::initialize_header(Register obj, Register klass, Register
       xorl(t1, t1);
       movl(Address(obj, base_offset), t1);
     }
-  } else if (UseCompressedClassPointers && !UseCompactObjectHeaders) {
+  } else if (!UseCompactObjectHeaders) {
     xorptr(t1, t1);
     store_klass_gap(obj, t1);
   }

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -985,12 +985,9 @@ int MacroAssembler::ic_check(int end_alignment) {
   if (UseCompactObjectHeaders) {
     load_narrow_klass_compact(temp, receiver);
     cmpl(temp, Address(data, CompiledICData::speculated_klass_offset()));
-  } else if (UseCompressedClassPointers) {
+  } else {
     movl(temp, Address(receiver, oopDesc::klass_offset_in_bytes()));
     cmpl(temp, Address(data, CompiledICData::speculated_klass_offset()));
-  } else {
-    movptr(temp, Address(receiver, oopDesc::klass_offset_in_bytes()));
-    cmpptr(temp, Address(data, CompiledICData::speculated_klass_offset()));
   }
 
   // if inline cache check fails, then jump to runtime routine
@@ -5163,11 +5160,9 @@ void MacroAssembler::load_klass(Register dst, Register src, Register tmp) {
   if (UseCompactObjectHeaders) {
     load_narrow_klass_compact(dst, src);
     decode_klass_not_null(dst, tmp);
-  } else if (UseCompressedClassPointers) {
+  } else {
     movl(dst, Address(src, oopDesc::klass_offset_in_bytes()));
     decode_klass_not_null(dst, tmp);
-  } else {
-    movptr(dst, Address(src, oopDesc::klass_offset_in_bytes()));
   }
 }
 
@@ -5175,12 +5170,8 @@ void MacroAssembler::store_klass(Register dst, Register src, Register tmp) {
   assert(!UseCompactObjectHeaders, "not with compact headers");
   assert_different_registers(src, tmp);
   assert_different_registers(dst, tmp);
-  if (UseCompressedClassPointers) {
-    encode_klass_not_null(src, tmp);
-    movl(Address(dst, oopDesc::klass_offset_in_bytes()), src);
-  } else {
-    movptr(Address(dst, oopDesc::klass_offset_in_bytes()), src);
-  }
+  encode_klass_not_null(src, tmp);
+  movl(Address(dst, oopDesc::klass_offset_in_bytes()), src);
 }
 
 void MacroAssembler::cmp_klass(Register klass, Register obj, Register tmp) {
@@ -5189,10 +5180,8 @@ void MacroAssembler::cmp_klass(Register klass, Register obj, Register tmp) {
     assert_different_registers(klass, obj, tmp);
     load_narrow_klass_compact(tmp, obj);
     cmpl(klass, tmp);
-  } else if (UseCompressedClassPointers) {
-    cmpl(klass, Address(obj, oopDesc::klass_offset_in_bytes()));
   } else {
-    cmpptr(klass, Address(obj, oopDesc::klass_offset_in_bytes()));
+    cmpl(klass, Address(obj, oopDesc::klass_offset_in_bytes()));
   }
 }
 
@@ -5203,12 +5192,9 @@ void MacroAssembler::cmp_klasses_from_objects(Register obj1, Register obj2, Regi
     load_narrow_klass_compact(tmp1, obj1);
     load_narrow_klass_compact(tmp2, obj2);
     cmpl(tmp1, tmp2);
-  } else if (UseCompressedClassPointers) {
+  } else {
     movl(tmp1, Address(obj1, oopDesc::klass_offset_in_bytes()));
     cmpl(tmp1, Address(obj2, oopDesc::klass_offset_in_bytes()));
-  } else {
-    movptr(tmp1, Address(obj1, oopDesc::klass_offset_in_bytes()));
-    cmpptr(tmp1, Address(obj2, oopDesc::klass_offset_in_bytes()));
   }
 }
 
@@ -5257,10 +5243,8 @@ void MacroAssembler::store_heap_oop_null(Address dst) {
 
 void MacroAssembler::store_klass_gap(Register dst, Register src) {
   assert(!UseCompactObjectHeaders, "Don't use with compact headers");
-  if (UseCompressedClassPointers) {
-    // Store to klass gap in destination
-    movl(Address(dst, oopDesc::klass_gap_offset_in_bytes()), src);
-  }
+  // Store to klass gap in destination
+  movl(Address(dst, oopDesc::klass_gap_offset_in_bytes()), src);
 }
 
 #ifdef ASSERT
@@ -5450,7 +5434,6 @@ void  MacroAssembler::decode_klass_not_null(Register r, Register tmp) {
   BLOCK_COMMENT("decode_klass_not_null {");
   assert_different_registers(r, tmp);
   // Note: it will change flags
-  assert(UseCompressedClassPointers, "should only be used for compressed headers");
   // Cannot assert, unverified entry point counts instructions (see .ad file)
   // vtableStubs also counts instructions in pd_code_size_limit.
   // Also do not verify_oop as this is called by verify_oop.
@@ -5472,7 +5455,6 @@ void  MacroAssembler::decode_and_move_klass_not_null(Register dst, Register src)
   BLOCK_COMMENT("decode_and_move_klass_not_null {");
   assert_different_registers(src, dst);
   // Note: it will change flags
-  assert (UseCompressedClassPointers, "should only be used for compressed headers");
   // Cannot assert, unverified entry point counts instructions (see .ad file)
   // vtableStubs also counts instructions in pd_code_size_limit.
   // Also do not verify_oop as this is called by verify_oop.
@@ -5529,7 +5511,6 @@ void  MacroAssembler::set_narrow_oop(Address dst, jobject obj) {
 }
 
 void  MacroAssembler::set_narrow_klass(Register dst, Klass* k) {
-  assert (UseCompressedClassPointers, "should only be used for compressed headers");
   assert (oop_recorder() != nullptr, "this assembler needs an OopRecorder");
   int klass_index = oop_recorder()->find_index(k);
   RelocationHolder rspec = metadata_Relocation::spec(klass_index);
@@ -5537,7 +5518,6 @@ void  MacroAssembler::set_narrow_klass(Register dst, Klass* k) {
 }
 
 void  MacroAssembler::set_narrow_klass(Address dst, Klass* k) {
-  assert (UseCompressedClassPointers, "should only be used for compressed headers");
   assert (oop_recorder() != nullptr, "this assembler needs an OopRecorder");
   int klass_index = oop_recorder()->find_index(k);
   RelocationHolder rspec = metadata_Relocation::spec(klass_index);
@@ -5563,7 +5543,6 @@ void  MacroAssembler::cmp_narrow_oop(Address dst, jobject obj) {
 }
 
 void  MacroAssembler::cmp_narrow_klass(Register dst, Klass* k) {
-  assert (UseCompressedClassPointers, "should only be used for compressed headers");
   assert (oop_recorder() != nullptr, "this assembler needs an OopRecorder");
   int klass_index = oop_recorder()->find_index(k);
   RelocationHolder rspec = metadata_Relocation::spec(klass_index);
@@ -5571,7 +5550,6 @@ void  MacroAssembler::cmp_narrow_klass(Register dst, Klass* k) {
 }
 
 void  MacroAssembler::cmp_narrow_klass(Address dst, Klass* k) {
-  assert (UseCompressedClassPointers, "should only be used for compressed headers");
   assert (oop_recorder() != nullptr, "this assembler needs an OopRecorder");
   int klass_index = oop_recorder()->find_index(k);
   RelocationHolder rspec = metadata_Relocation::spec(klass_index);

--- a/src/hotspot/cpu/x86/macroAssembler_x86.hpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.hpp
@@ -351,8 +351,7 @@ class MacroAssembler: public Assembler {
   void load_klass(Register dst, Register src, Register tmp);
   void store_klass(Register dst, Register src, Register tmp);
 
-  // Compares the Klass pointer of an object to a given Klass (which might be narrow,
-  // depending on UseCompressedClassPointers).
+  // Compares the narrow Klass pointer of an object to a given Klass
   void cmp_klass(Register klass, Register obj, Register tmp);
 
   // Compares the Klass pointer of two objects obj1 and obj2. Result is in the condition flags.

--- a/src/hotspot/cpu/x86/matcher_x86.hpp
+++ b/src/hotspot/cpu/x86/matcher_x86.hpp
@@ -75,7 +75,6 @@
   }
 
   static bool narrow_klass_use_complex_address() {
-    assert(UseCompressedClassPointers, "only for compressed klass code");
     return (CompressedKlassPointers::shift() <= 3);
   }
 

--- a/src/hotspot/cpu/x86/x86_64.ad
+++ b/src/hotspot/cpu/x86/x86_64.ad
@@ -1570,13 +1570,8 @@ uint BoxLockNode::size(PhaseRegAlloc *ra_) const
 #ifndef PRODUCT
 void MachUEPNode::format(PhaseRegAlloc* ra_, outputStream* st) const
 {
-  if (UseCompressedClassPointers) {
-    st->print_cr("movl    rscratch1, [j_rarg0 + oopDesc::klass_offset_in_bytes()]\t# compressed klass");
-    st->print_cr("\tcmpl    rscratch1, [rax + CompiledICData::speculated_klass_offset()]\t # Inline cache check");
-  } else {
-    st->print_cr("movq    rscratch1, [j_rarg0 + oopDesc::klass_offset_in_bytes()]\t# compressed klass");
-    st->print_cr("\tcmpq    rscratch1, [rax + CompiledICData::speculated_klass_offset()]\t # Inline cache check");
-  }
+  st->print_cr("movl    rscratch1, [j_rarg0 + oopDesc::klass_offset_in_bytes()]\t# compressed klass");
+  st->print_cr("\tcmpl    rscratch1, [rax + CompiledICData::speculated_klass_offset()]\t # Inline cache check");
   st->print_cr("\tjne     SharedRuntime::_ic_miss_stub");
 }
 #endif

--- a/src/hotspot/share/cds/archiveHeapLoader.hpp
+++ b/src/hotspot/share/cds/archiveHeapLoader.hpp
@@ -49,7 +49,7 @@ public:
 
   // Can this VM map archived heap region? Currently only G1+compressed{oops,cp}
   static bool can_map() {
-    CDS_JAVA_HEAP_ONLY(return (UseG1GC && UseCompressedClassPointers);)
+    CDS_JAVA_HEAP_ONLY(return (UseG1GC && USES_COMPRESSED_KLASS_POINTERS);)
     NOT_CDS_JAVA_HEAP(return false;)
   }
 

--- a/src/hotspot/share/cds/archiveHeapWriter.cpp
+++ b/src/hotspot/share/cds/archiveHeapWriter.cpp
@@ -357,7 +357,7 @@ int ArchiveHeapWriter::filler_array_length(size_t fill_bytes) {
 }
 
 HeapWord* ArchiveHeapWriter::init_filler_array_at_buffer_top(int array_length, size_t fill_bytes) {
-  assert(UseCompressedClassPointers, "Archived heap only supported for compressed klasses");
+  assert(USES_COMPRESSED_KLASS_POINTERS, "Archived heap only supported for compressed klasses");
   Klass* oak = Universe::objectArrayKlass(); // already relocated to point to archived klass
   HeapWord* mem = offset_to_buffered_address<HeapWord*>(_buffer_used);
   memset(mem, 0, fill_bytes);
@@ -577,7 +577,7 @@ template <typename T> void ArchiveHeapWriter::mark_oop_pointer(T* buffered_addr,
 }
 
 void ArchiveHeapWriter::update_header_for_requested_obj(oop requested_obj, oop src_obj,  Klass* src_klass) {
-  assert(UseCompressedClassPointers, "Archived heap only supported for compressed klasses");
+  assert(USES_COMPRESSED_KLASS_POINTERS, "Archived heap only supported for compressed klasses");
   narrowKlass nk = ArchiveBuilder::current()->get_requested_narrow_klass(src_klass);
   address buffered_addr = requested_addr_to_buffered_addr(cast_from_oop<address>(requested_obj));
 

--- a/src/hotspot/share/cds/cdsConfig.cpp
+++ b/src/hotspot/share/cds/cdsConfig.cpp
@@ -875,8 +875,8 @@ const char* CDSConfig::type_of_archive_being_written() {
 // If an incompatible VM options is found, return a text message that explains why
 static const char* check_options_incompatible_with_dumping_heap() {
 #if INCLUDE_CDS_JAVA_HEAP
-  if (!UseCompressedClassPointers) {
-    return "UseCompressedClassPointers must be true";
+  if (!USES_COMPRESSED_KLASS_POINTERS) {
+    return "USES_COMPRESSED_KLASS_POINTERS must be true";
   }
 
   // Almost all GCs support heap region dump, except ZGC (so far).

--- a/src/hotspot/share/cds/filemap.hpp
+++ b/src/hotspot/share/cds/filemap.hpp
@@ -115,7 +115,7 @@ private:
   uintx  _max_heap_size;                          // java max heap size during dumping
   CompressedOops::Mode _narrow_oop_mode;          // compressed oop encoding mode
   bool    _compressed_oops;                       // save the flag UseCompressedOops
-  bool    _compressed_class_ptrs;                 // save the flag UseCompressedClassPointers
+  bool    _compressed_class_ptrs;                 // save the USES_COMPRESSED_KLASS_POINTERS mode
   int     _narrow_klass_pointer_bits;             // save number of bits in narrowKlass
   int     _narrow_klass_shift;                    // save shift width used to pre-compute narrowKlass IDs in archived heap objects
   size_t  _cloned_vtables_offset;                 // The address of the first cloned vtable

--- a/src/hotspot/share/utilities/macros.hpp
+++ b/src/hotspot/share/utilities/macros.hpp
@@ -643,7 +643,7 @@
 #define INCLUDE_ASAN 0
 #endif
 
-#if _LP64
+#ifdef _LP64
 #define USES_COMPRESSED_KLASS_POINTERS 1
 #else
 // 32-bit still uses uncompressed class pointers

--- a/src/hotspot/share/utilities/macros.hpp
+++ b/src/hotspot/share/utilities/macros.hpp
@@ -643,4 +643,19 @@
 #define INCLUDE_ASAN 0
 #endif
 
+#if _LP64
+#define USES_COMPRESSED_KLASS_POINTERS 1
+#else
+// 32-bit still uses uncompressed class pointers
+#define USES_COMPRESSED_KLASS_POINTERS 0
+#endif
+
+#if USES_COMPRESSED_KLASS_POINTERS
+#define COMPRESSED_KLASS_POINTERS_ONLY(code) code
+#define NOT_COMPRESSED_KLASS_POINTERS(code)
+#else
+#define COMPRESSED_KLASS_POINTERS_ONLY(code)
+#define NOT_COMPRESSED_KLASS_POINTERS(code) code
+#endif
+
 #endif // SHARE_UTILITIES_MACROS_HPP

--- a/test/hotspot/gtest/oops/test_arrayOop.cpp
+++ b/test/hotspot/gtest/oops/test_arrayOop.cpp
@@ -97,7 +97,8 @@ TEST_VM(arrayOopDesc, base_offset) {
       EXPECT_EQ(arrayOopDesc::base_offset_in_bytes(T_OBJECT), 16);
       EXPECT_EQ(arrayOopDesc::base_offset_in_bytes(T_ARRAY),  16);
     }
-  } else if (UseCompressedClassPointers) {
+  } else {
+    // Compressed Class Pointers, -COH
     EXPECT_EQ(arrayOopDesc::base_offset_in_bytes(T_BOOLEAN), 16);
     EXPECT_EQ(arrayOopDesc::base_offset_in_bytes(T_BYTE),    16);
     EXPECT_EQ(arrayOopDesc::base_offset_in_bytes(T_SHORT),   16);
@@ -108,24 +109,9 @@ TEST_VM(arrayOopDesc, base_offset) {
     EXPECT_EQ(arrayOopDesc::base_offset_in_bytes(T_DOUBLE),  16);
     EXPECT_EQ(arrayOopDesc::base_offset_in_bytes(T_OBJECT),  16);
     EXPECT_EQ(arrayOopDesc::base_offset_in_bytes(T_ARRAY),   16);
-  } else {
-    EXPECT_EQ(arrayOopDesc::base_offset_in_bytes(T_BOOLEAN), 20);
-    EXPECT_EQ(arrayOopDesc::base_offset_in_bytes(T_BYTE),    20);
-    EXPECT_EQ(arrayOopDesc::base_offset_in_bytes(T_SHORT),   20);
-    EXPECT_EQ(arrayOopDesc::base_offset_in_bytes(T_CHAR),    20);
-    EXPECT_EQ(arrayOopDesc::base_offset_in_bytes(T_INT),     20);
-    EXPECT_EQ(arrayOopDesc::base_offset_in_bytes(T_FLOAT),   20);
-    EXPECT_EQ(arrayOopDesc::base_offset_in_bytes(T_LONG),    24);
-    EXPECT_EQ(arrayOopDesc::base_offset_in_bytes(T_DOUBLE),  24);
-    if (UseCompressedOops) {
-      EXPECT_EQ(arrayOopDesc::base_offset_in_bytes(T_OBJECT), 20);
-      EXPECT_EQ(arrayOopDesc::base_offset_in_bytes(T_ARRAY),  20);
-    } else {
-      EXPECT_EQ(arrayOopDesc::base_offset_in_bytes(T_OBJECT), 24);
-      EXPECT_EQ(arrayOopDesc::base_offset_in_bytes(T_ARRAY),  24);
-    }
   }
 #else
+  // Uncompressed Class Pointers
   EXPECT_EQ(arrayOopDesc::base_offset_in_bytes(T_BOOLEAN), 12);
   EXPECT_EQ(arrayOopDesc::base_offset_in_bytes(T_BYTE),    12);
   EXPECT_EQ(arrayOopDesc::base_offset_in_bytes(T_SHORT),   12);

--- a/test/hotspot/gtest/oops/test_compressedKlass.cpp
+++ b/test/hotspot/gtest/oops/test_compressedKlass.cpp
@@ -27,10 +27,8 @@
 
 #include "unittest.hpp"
 
+#if USES_COMPRESSED_KLASS_POINTERS
 TEST_VM(CompressedKlass, basics) {
-  if (!UseCompressedClassPointers) {
-    return;
-  }
   ASSERT_LE((address)0, CompressedKlassPointers::base());
   ASSERT_LE(CompressedKlassPointers::base(), CompressedKlassPointers::klass_range_start());
   ASSERT_LT(CompressedKlassPointers::klass_range_start(), CompressedKlassPointers::klass_range_end());
@@ -49,22 +47,7 @@ TEST_VM(CompressedKlass, basics) {
   }
 }
 
-TEST_VM(CompressedKlass, ccp_off) {
-  if (UseCompressedClassPointers) {
-    return;
-  }
-  ASSERT_EQ(CompressedKlassPointers::klass_range_start(), (address)nullptr);
-  ASSERT_EQ(CompressedKlassPointers::klass_range_end(), (address)nullptr);
-  // We should be able to call CompressedKlassPointers::is_encodable, and it should
-  // always return false
-  ASSERT_FALSE(CompressedKlassPointers::is_encodable((address)0x12345));
-}
-
-
 TEST_VM(CompressedKlass, test_too_low_address) {
-  if (!UseCompressedClassPointers) {
-    return;
-  }
   address really_low = (address) 32;
   ASSERT_FALSE(CompressedKlassPointers::is_encodable(really_low));
   address low = CompressedKlassPointers::klass_range_start() - 1;
@@ -72,9 +55,6 @@ TEST_VM(CompressedKlass, test_too_low_address) {
 }
 
 TEST_VM(CompressedKlass, test_too_high_address) {
-  if (!UseCompressedClassPointers) {
-    return;
-  }
   address really_high = (address) UINTPTR_MAX;
   ASSERT_FALSE(CompressedKlassPointers::is_encodable(really_high));
   address high = CompressedKlassPointers::klass_range_end();
@@ -82,9 +62,6 @@ TEST_VM(CompressedKlass, test_too_high_address) {
 }
 
 TEST_VM(CompressedKlass, test_unaligned_address) {
-  if (!UseCompressedClassPointers) {
-    return;
-  }
   const size_t alignment = CompressedKlassPointers::klass_alignment_in_bytes();
   address addr = CompressedKlassPointers::klass_range_start() + alignment - 1;
   ASSERT_FALSE(CompressedKlassPointers::is_encodable(addr));
@@ -98,12 +75,20 @@ TEST_VM(CompressedKlass, test_unaligned_address) {
 }
 
 TEST_VM(CompressedKlass, test_good_address) {
-  if (!UseCompressedClassPointers) {
-    return;
-  }
   const size_t alignment = CompressedKlassPointers::klass_alignment_in_bytes();
   address addr = CompressedKlassPointers::klass_range_start();
   ASSERT_TRUE(CompressedKlassPointers::is_encodable(addr));
   addr = CompressedKlassPointers::klass_range_end() - alignment;
   ASSERT_TRUE(CompressedKlassPointers::is_encodable(addr));
 }
+
+#else
+
+TEST_VM(CompressedKlass, ccp_off) {
+  ASSERT_EQ(CompressedKlassPointers::klass_range_start(), (address)nullptr);
+  ASSERT_EQ(CompressedKlassPointers::klass_range_end(), (address)nullptr);
+  // We should be able to call CompressedKlassPointers::is_encodable, and it should
+  // always return false
+  ASSERT_FALSE(CompressedKlassPointers::is_encodable((address)0x12345));
+}
+#endif // USES_COMPRESSED_KLASS_POINTERS

--- a/test/hotspot/gtest/oops/test_objArrayOop.cpp
+++ b/test/hotspot/gtest/oops/test_objArrayOop.cpp
@@ -31,20 +31,14 @@ TEST_VM(objArrayOop, osize) {
   } x[] = {
 //    ObjAligInB, UseCCP, UseCoops, UseCOH, object size in heap words
 #ifdef _LP64
-    { 8,          false,  false, false,   4 },  // 20 byte header, 8 byte oops
-    { 8,          false,  true,  false,   3 },  // 20 byte header, 4 byte oops
     { 8,          true,   false, false,   3 },  // 16 byte header, 8 byte oops
     { 8,          true,   true,  false,   3 },  // 16 byte header, 4 byte oops
     { 8,          true,   false, true,    3 },  // 12 byte header, 8 byte oops
     { 8,          true,   true,  true,    2 },  // 12 byte header, 4 byte oops
-    { 16,         false,  false, false,   4 },  // 20 byte header, 8 byte oops, 16-byte align
-    { 16,         false,  true,  false,   4 },  // 20 byte header, 4 byte oops, 16-byte align
     { 16,         true,   false, false,   4 },  // 16 byte header, 8 byte oops, 16-byte align
     { 16,         true,   true,  false,   4 },  // 16 byte header, 4 byte oops, 16-byte align
     { 16,         true,   false, true,    4 },  // 12 byte header, 8 byte oops, 16-byte align
     { 16,         true,   true,  true,    2 },  // 12 byte header, 4 byte oops, 16-byte align
-    { 256,        false,  false, false,  32 }, // 20 byte header, 8 byte oops, 256-byte align
-    { 256,        false,  true,  false,  32 }, // 20 byte header, 4 byte oops, 256-byte align
     { 256,        true,   false, false,  32 }, // 16 byte header, 8 byte oops, 256-byte align
     { 256,        true,   true,  false,  32 }, // 16 byte header, 4 byte oops, 256-byte align
     { 256,        true,   false, true,   32 }, // 12 byte header, 8 byte oops, 256-byte align
@@ -55,7 +49,7 @@ TEST_VM(objArrayOop, osize) {
     { -1,         false,  false, false,  -1 }
   };
   for (int i = 0; x[i].result != -1; i++) {
-    if (x[i].objal == (int)ObjectAlignmentInBytes && x[i].ccp == UseCompressedClassPointers && x[i].coops == UseCompressedOops &&
+    if (x[i].objal == (int)ObjectAlignmentInBytes && x[i].ccp == (bool)USES_COMPRESSED_KLASS_POINTERS && x[i].coops == UseCompressedOops &&
         x[i].coh == UseCompactObjectHeaders) {
       EXPECT_EQ(objArrayOopDesc::object_size(1), (size_t)x[i].result);
     }


### PR DESCRIPTION
Work in progress, please ignore.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8363996](https://bugs.openjdk.org/browse/JDK-8363996)

### Warnings
&nbsp;⚠️ Patch contains a binary file (test/jdk/javax/rmi/ssl/keystore)
&nbsp;⚠️ Patch contains a binary file (test/jdk/javax/rmi/ssl/truststore)
&nbsp;⚠️ Patch contains a binary file (test/jdk/sun/net/www/protocol/https/HttpsClient/dnsstore)
&nbsp;⚠️ Patch contains a binary file (test/jdk/sun/net/www/protocol/https/HttpsClient/ipstore)

### Issue
 * [JDK-8363996](https://bugs.openjdk.org/browse/JDK-8363996): Obsolete UseCompressedClassPointers (**Enhancement** - P4) ⚠️ Title mismatch between PR and JBS.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26482/head:pull/26482` \
`$ git checkout pull/26482`

Update a local copy of the PR: \
`$ git checkout pull/26482` \
`$ git pull https://git.openjdk.org/jdk.git pull/26482/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26482`

View PR using the GUI difftool: \
`$ git pr show -t 26482`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26482.diff">https://git.openjdk.org/jdk/pull/26482.diff</a>

</details>
