### PR TITLE
8209992: Align SSLSocket and SSLEngine Javadocs

### DIFF
--- a/src/java.base/share/classes/javax/net/ssl/SSLEngine.java
+++ b/src/java.base/share/classes/javax/net/ssl/SSLEngine.java
@@ -1088,11 +1088,16 @@ public abstract class SSLEngine {
 
 
     /**
-     * Initiates handshaking (initial or renegotiation) on this SSLEngine.
+     * Initiates handshaking on this SSLEngine. Common reasons include a need
+     * to initiate a new session, to use new encryption keys or to change
+     * cipher suites. To force complete reauthentication, the current session
+     * could be invalidated before starting this handshake.
      * <P>
-     * For TLSv1.3 and later versions calling this method after the connection
-     * has been established will force producing a KeyUpdate message. For prior
-     * TLS versions it will force a renegotiation (re-handshake).
+     * The behavior of this method is protocol (and possibly implementation)
+     * dependent. For example, in TLSv1.3 and later versions calling this
+     * method after the connection has been established will force producing
+     * a KeyUpdate message. For prior TLS versions it will force a
+     * renegotiation (re-handshake).
      * <P>
      * This method is not needed for the initial handshake, as the
      * {@code wrap()} and {@code unwrap()} methods will

--- a/src/java.base/share/classes/javax/net/ssl/SSLEngine.java
+++ b/src/java.base/share/classes/javax/net/ssl/SSLEngine.java
@@ -1090,6 +1090,10 @@ public abstract class SSLEngine {
     /**
      * Initiates handshaking (initial or renegotiation) on this SSLEngine.
      * <P>
+     * For TLSv1.3 and later versions calling this method after the connection
+     * has been established will force producing a KeyUpdate message. For prior
+     * TLS versions it will force a renegotiation (re-handshake).
+     * <P>
      * This method is not needed for the initial handshake, as the
      * {@code wrap()} and {@code unwrap()} methods will
      * implicitly call this method if handshaking has not already begun.

--- a/src/java.base/share/classes/javax/net/ssl/SSLEngine.java
+++ b/src/java.base/share/classes/javax/net/ssl/SSLEngine.java
@@ -1112,9 +1112,6 @@ public abstract class SSLEngine {
      * SSLSocket#startHandshake()} method, this method does not block
      * until handshaking is completed.
      * <P>
-     * To force a complete SSL/TLS/DTLS session renegotiation, the current
-     * session should be invalidated prior to calling this method.
-     * <P>
      * Some protocols may not support multiple handshakes on an existing
      * engine and may throw an {@code SSLException}.
      *

--- a/src/java.base/share/classes/javax/net/ssl/SSLEngine.java
+++ b/src/java.base/share/classes/javax/net/ssl/SSLEngine.java
@@ -1088,16 +1088,17 @@ public abstract class SSLEngine {
 
 
     /**
-     * Initiates handshaking on this SSLEngine. Common reasons include a need
-     * to initiate a new session, to use new encryption keys or to change
-     * cipher suites. To force complete reauthentication, the current session
-     * could be invalidated before starting this handshake.
+     * Begins handshaking on this {@code SSLEngine}.
+     * <P>
+     * Common reasons include a need to initiate a new protected session,
+     * create new encryption keys, or to change cipher suites. To force
+     * complete reauthentication, the current session should be invalidated
+     * before starting this handshake.
      * <P>
      * The behavior of this method is protocol (and possibly implementation)
-     * dependent. For example, in TLSv1.3 and later versions calling this
-     * method after the connection has been established will force producing
-     * a KeyUpdate message. For prior TLS versions it will force a
-     * renegotiation (re-handshake).
+     * dependent. For example, in TLSv1.3 calling this method after the
+     * connection has been established will force a key update. For prior TLS
+     * versions it will force a renegotiation (re-handshake).
      * <P>
      * This method is not needed for the initial handshake, as the
      * {@code wrap()} and {@code unwrap()} methods will

--- a/src/java.base/share/classes/javax/net/ssl/SSLSocket.java
+++ b/src/java.base/share/classes/javax/net/ssl/SSLSocket.java
@@ -502,16 +502,17 @@ public abstract class SSLSocket extends Socket
 
 
     /**
-     * Initiates handshaking on this connection. Common reasons include a need
-     * to initiate a new session, to use new encryption keys or to change
-     * cipher suites. To force complete reauthentication, the current session
-     * could be invalidated before starting this handshake.
+     * Starts handshaking on this {@code SSLSocket}.
+     * <P>
+     * Common reasons include a need to initiate a new protected session,
+     * create new encryption keys, or to change cipher suites. To force
+     * complete reauthentication, the current session should be invalidated
+     * before starting this handshake.
      * <P>
      * The behavior of this method is protocol (and possibly implementation)
-     * dependent. For example, in TLSv1.3 and later versions calling this
-     * method after the connection has been established will force producing
-     * a KeyUpdate message. For prior TLS versions it will force a
-     * renegotiation (re-handshake).
+     * dependent. For example, in TLSv1.3 calling this method after the
+     * connection has been established will force a key update. For prior TLS
+     * versions it will force a renegotiation (re-handshake).
      * <P>
      * If data has already been sent on the connection, it continues
      * to flow during this handshake.  When the handshake completes, this

--- a/src/java.base/share/classes/javax/net/ssl/SSLSocket.java
+++ b/src/java.base/share/classes/javax/net/ssl/SSLSocket.java
@@ -521,7 +521,7 @@ public abstract class SSLSocket extends Socket
      * This method is synchronous for the initial handshake on a connection
      * and returns when the negotiated handshake is complete. Some
      * protocols may not support multiple handshakes on an existing socket
-     * and may throw an IOException.
+     * and may throw an {@code IOException}.
      *
      * @throws IOException on a network level error
      * @see #addHandshakeCompletedListener(HandshakeCompletedListener)

--- a/src/java.base/share/classes/javax/net/ssl/SSLSocket.java
+++ b/src/java.base/share/classes/javax/net/ssl/SSLSocket.java
@@ -506,11 +506,15 @@ public abstract class SSLSocket extends Socket
      * a need to use new encryption keys, to change cipher suites, or to
      * initiate a new session.  To force complete reauthentication, the
      * current session could be invalidated before starting this handshake.
-     *
-     * <P> If data has already been sent on the connection, it continues
+     * <P>
+     * For TLSv1.3 and later versions calling this method after the connection
+     * has been established will force producing a KeyUpdate message. For prior
+     * TLS versions it will force a renegotiation (re-handshake).
+     * <P>
+     * If data has already been sent on the connection, it continues
      * to flow during this handshake.  When the handshake completes, this
      * will be signaled with an event.
-     *
+     * <P>
      * This method is synchronous for the initial handshake on a connection
      * and returns when the negotiated handshake is complete. Some
      * protocols may not support multiple handshakes on an existing socket

--- a/src/java.base/share/classes/javax/net/ssl/SSLSocket.java
+++ b/src/java.base/share/classes/javax/net/ssl/SSLSocket.java
@@ -502,14 +502,16 @@ public abstract class SSLSocket extends Socket
 
 
     /**
-     * Starts an SSL handshake on this connection.  Common reasons include
-     * a need to use new encryption keys, to change cipher suites, or to
-     * initiate a new session.  To force complete reauthentication, the
-     * current session could be invalidated before starting this handshake.
+     * Initiates handshaking on this connection. Common reasons include a need
+     * to initiate a new session, to use new encryption keys or to change
+     * cipher suites. To force complete reauthentication, the current session
+     * could be invalidated before starting this handshake.
      * <P>
-     * For TLSv1.3 and later versions calling this method after the connection
-     * has been established will force producing a KeyUpdate message. For prior
-     * TLS versions it will force a renegotiation (re-handshake).
+     * The behavior of this method is protocol (and possibly implementation)
+     * dependent. For example, in TLSv1.3 and later versions calling this
+     * method after the connection has been established will force producing
+     * a KeyUpdate message. For prior TLS versions it will force a
+     * renegotiation (re-handshake).
      * <P>
      * If data has already been sent on the connection, it continues
      * to flow during this handshake.  When the handshake completes, this


### PR DESCRIPTION
Add a javadoc paragraph to SSLSocket.startHandshake() and SSLEngine.beginHandshake() methods explaining behavioral differences between TLSv1.3+ and TLSv1.2- versions.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8364223](https://bugs.openjdk.org/browse/JDK-8364223) to be approved

### Issues
 * [JDK-8209992](https://bugs.openjdk.org/browse/JDK-8209992): Align SSLSocket and SSLEngine Javadocs (**Bug** - P4)
 * [JDK-8364223](https://bugs.openjdk.org/browse/JDK-8364223): Align SSLSocket and SSLEngine Javadocs (**CSR**)


### Reviewers
 * [Bradford Wetmore](https://openjdk.org/census#wetmore) (@bradfordwetmore - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26484/head:pull/26484` \
`$ git checkout pull/26484`

Update a local copy of the PR: \
`$ git checkout pull/26484` \
`$ git pull https://git.openjdk.org/jdk.git pull/26484/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26484`

View PR using the GUI difftool: \
`$ git pr show -t 26484`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26484.diff">https://git.openjdk.org/jdk/pull/26484.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26484#issuecomment-3119263059)
</details>
