### PR TITLE
8360507: JPKG002-006: SigningPackageTest: appOutput.txt cannot be found in user home directory and output doesn't contain: origin=Developer ID Application: jpackage.openjdk.java.net

### DIFF
--- a/test/jdk/tools/jpackage/macosx/SigningPackageTest.java
+++ b/test/jdk/tools/jpackage/macosx/SigningPackageTest.java
@@ -55,6 +55,25 @@ import jdk.jpackage.test.Annotations.Parameter;
  * @build jdk.jpackage.test.*
  * @build SigningPackageTest
  * @requires (jpackage.test.MacSignTests == "run")
+ * @requires (jpackage.test.SQETest != null)
+ * @run main/othervm/timeout=720 -Xmx512m jdk.jpackage.test.Main
+ * --jpt-run=SigningPackageTest
+ * --jpt-space-subst=*
+ * --jpt-include=SigningPackageTest.test(true,*true,*true,*ASCII_INDEX)
+ * --jpt-before-run=SigningBase.verifySignTestEnvReady
+ */
+
+/*
+ * @test
+ * @summary jpackage with --type pkg,dmg --mac-sign
+ * @library /test/jdk/tools/jpackage/helpers
+ * @library base
+ * @key jpackagePlatformPackage
+ * @build SigningBase
+ * @build jdk.jpackage.test.*
+ * @build SigningPackageTest
+ * @requires (jpackage.test.MacSignTests == "run")
+ * @requires (jpackage.test.SQETest == null)
  * @run main/othervm/timeout=720 -Xmx512m jdk.jpackage.test.Main
  *  --jpt-run=SigningPackageTest
  *  --jpt-before-run=SigningBase.verifySignTestEnvReady


### PR DESCRIPTION
- Wrong package was generated for SQE. Fixed by generating correct package for SQE.
- Issue with appOutput.txt is not created will be fixed with https://bugs.openjdk.org/browse/JDK-8358723.