### PR TITLE
8362979: C2 fails with unexpected node in SuperWord truncation: CmpLTMask, RoundF

### DIFF
--- a/src/hotspot/share/opto/superword.cpp
+++ b/src/hotspot/share/opto/superword.cpp
@@ -2597,6 +2597,9 @@ static bool can_subword_truncate(Node* in, const Type* type) {
   case Op_IsFiniteD:
   case Op_IsInfiniteF:
   case Op_IsInfiniteD:
+  case Op_CmpLTMask:
+  case Op_RoundF:
+  case Op_RoundD:
   case Op_ExtractS:
   case Op_ExtractC:
   case Op_ExtractB:

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
@@ -585,6 +585,21 @@ public class IRNode {
         beforeMatchingNameRegex(CMP_P, "CmpP");
     }
 
+    public static final String CMP_LT_MASK = PREFIX + "CMP_LT_MASK" + POSTFIX;
+    static {
+        beforeMatchingNameRegex(CMP_LT_MASK, "CmpLTMask");
+    }
+
+    public static final String ROUND_F = PREFIX + "ROUND_F" + POSTFIX;
+    static {
+        beforeMatchingNameRegex(ROUND_F, "RoundF");
+    }
+
+    public static final String ROUND_D = PREFIX + "ROUND_D" + POSTFIX;
+    static {
+        beforeMatchingNameRegex(ROUND_D, "RoundD");
+    }
+
     public static final String COMPRESS_BITS = PREFIX + "COMPRESS_BITS" + POSTFIX;
     static {
         beforeMatchingNameRegex(COMPRESS_BITS, "CompressBits");

--- a/test/hotspot/jtreg/compiler/vectorization/TestSubwordTruncation.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestSubwordTruncation.java
@@ -389,6 +389,45 @@ public class TestSubwordTruncation {
         }
     }
 
+    @Test
+    @IR(counts = { IRNode.CMP_LT_MASK, ">0" })
+    @Arguments(setup = "setupByteArray")
+    public Object[] testCmpLTMask(byte[] in) {
+        char[] res = new char[SIZE];
+
+        for (int i = 0; i < SIZE; i++) {
+            res[i] = (char) (in[i] >= 0 ? in[i] : 256 + in[i]);
+        }
+
+        return new Object[] { in, res };
+    }
+
+    @Test
+    @IR(counts = { IRNode.ROUND_F, ">0" })
+    @Arguments(setup = "setupByteArray")
+    public Object[] testRoundF(byte[] in) {
+        short[] res = new short[SIZE];
+
+        for (int i = 0; i < SIZE; i++) {
+            res[i] = (short) Math.round(in[i] * 10.F);
+        }
+
+        return new Object[] { in, res };
+    }
+
+    @Test
+    @IR(counts = { IRNode.ROUND_D, ">0" })
+    @Arguments(setup = "setupByteArray")
+    public Object[] testRoundD(byte[] in) {
+        short[] res = new short[SIZE];
+
+        for (int i = 0; i < SIZE; i++) {
+            res[i] = (short) Math.round(in[i] * 10.0);
+        }
+
+        return new Object[] { in, res };
+    }
+
     public static void main(String[] args) {
         TestFramework.run();
     }


### PR DESCRIPTION
Hi all,
This is a fix for a debug assert failure in SuperWord truncation for `CmpLTMask` and `RoundF` nodes, as discovered by CTW in the linked JBS report. I've added the nodes to the switch, and added reduced test cases. I've made a similar fix for `RoundD` nodes as well. Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8362979](https://bugs.openjdk.org/browse/JDK-8362979): C2 fails with unexpected node in SuperWord truncation: CmpLTMask, RoundF (**Bug** - P3)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26494/head:pull/26494` \
`$ git checkout pull/26494`

Update a local copy of the PR: \
`$ git checkout pull/26494` \
`$ git pull https://git.openjdk.org/jdk.git pull/26494/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26494`

View PR using the GUI difftool: \
`$ git pr show -t 26494`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26494.diff">https://git.openjdk.org/jdk/pull/26494.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26494#issuecomment-3125087098)
</details>
