### PR TITLE
8364166: Parallel: Remove the use of soft_ref_policy in Full GC

### DIFF
--- a/src/hotspot/share/gc/parallel/psParallelCompact.cpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.cpp
@@ -958,18 +958,10 @@ void PSParallelCompact::summary_phase()
   }
 }
 
-// This method should contain all heap-specific policy for invoking a full
-// collection.  invoke_no_policy() will only attempt to compact the heap; it
-// will do nothing further.  If we need to bail out for policy reasons, scavenge
-// before full gc, or any other specialized behavior, it needs to be added here.
-//
+// This method invokes a full collection. The argument controls whether
+// soft-refs should be cleared or not.
 // Note that this method should only be called from the vm_thread while at a
 // safepoint.
-//
-// Note that the all_soft_refs_clear flag in the soft ref policy
-// may be true because this method can be called without intervening
-// activity.  For example when the heap space is tight and full measure
-// are being taken to free space.
 bool PSParallelCompact::invoke(bool clear_all_soft_refs) {
   assert(SafepointSynchronize::is_at_safepoint(), "should be at safepoint");
   assert(Thread::current() == (Thread*)VMThread::vm_thread(),

--- a/src/hotspot/share/gc/parallel/psParallelCompact.hpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.hpp
@@ -761,8 +761,8 @@ private:
 public:
   static void fill_dead_objs_in_dense_prefix(uint worker_id, uint num_workers);
 
-  static bool invoke(bool maximum_heap_compaction);
-  static bool invoke_no_policy(bool maximum_heap_compaction);
+  static bool invoke(bool clear_all_soft_refs);
+  static bool invoke_no_policy(bool clear_all_soft_refs);
 
   template<typename Func>
   static void adjust_in_space_helper(SpaceId id, volatile uint* claim_counter, Func&& on_stripe);


### PR DESCRIPTION
Simple removing redundant soft-ref-clearing checking in full-gc, because Parallel already reacts to this particular gc-cause, `_wb_full_gc`.

Test: tier1-3

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8364166](https://bugs.openjdk.org/browse/JDK-8364166): Parallel: Remove the use of soft_ref_policy in Full GC (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Sangheon Kim](https://openjdk.org/census#sangheki) (@sangheon - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26496/head:pull/26496` \
`$ git checkout pull/26496`

Update a local copy of the PR: \
`$ git checkout pull/26496` \
`$ git pull https://git.openjdk.org/jdk.git pull/26496/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26496`

View PR using the GUI difftool: \
`$ git pr show -t 26496`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26496.diff">https://git.openjdk.org/jdk/pull/26496.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26496#issuecomment-3126034557)
</details>
