### PR TITLE
[BACKOUT] AArch64: [VectorAPI] sve vector math operations are not supported after JDK-8353217

### DIFF
--- a/make/autoconf/flags-cflags.m4
+++ b/make/autoconf/flags-cflags.m4
@@ -940,7 +940,7 @@ AC_DEFUN([FLAGS_SETUP_CFLAGS_CPU_DEP],
   # ACLE and this flag are required to build the aarch64 SVE related functions in
   # libvectormath. Apple Silicon does not support SVE; use macOS as a proxy for
   # that check.
-  if test "x$OPENJDK_TARGET_CPU" = "xaarch64" && test "x$OPENJDK_TARGET_OS" = "xlinux"; then
+  if test "x$OPENJDK_TARGET_CPU" = "xaarch64" && test "x$OPENJDK_TARGET_CPU" = "xlinux"; then
     if test "x$TOOLCHAIN_TYPE" = xgcc || test "x$TOOLCHAIN_TYPE" = xclang; then
       AC_LANG_PUSH(C)
       OLD_CFLAGS="$CFLAGS"


### PR DESCRIPTION
Can I please get a review of this change which backs out the changes done in https://bugs.openjdk.org/browse/JDK-8363063? The linux-aarch64 builds in our CI started failing after the changes in JDK-8363063 were integrated. 

The description in the backout issue https://bugs.openjdk.org/browse/JDK-8364185 has the details about the build failure errors.

The commit in this PR backs out the change (`git revert 011de4c894ed827ee8e15a7cfe400788175e5b2c`). CI jobs are currently in progress to verify that this backout fixes the build failures.

A new REDO issue has been created https://bugs.openjdk.org/browse/JDK-8364184 to redo the original change and address these linux-aarch64 build issues.