### PR TITLE
8364198: NMT should have a better corruption message

### DIFF
--- a/src/hotspot/share/nmt/mallocHeader.inline.hpp
+++ b/src/hotspot/share/nmt/mallocHeader.inline.hpp
@@ -104,7 +104,7 @@ inline OutTypeParam MallocHeader::resolve_checked_impl(InTypeParam memblock) {
   OutTypeParam header_pointer = (OutTypeParam)memblock - 1;
   if (!header_pointer->check_block_integrity(msg, sizeof(msg), &corruption)) {
     header_pointer->print_block_on_error(tty, corruption != nullptr ? corruption : (address)header_pointer);
-    fatal("NMT corruption: Block at " PTR_FORMAT ": %s", p2i(memblock), msg);
+    fatal("NMT has detected a memory corruption bug. Block at " PTR_FORMAT ": %s", p2i(memblock), msg);
   }
   return header_pointer;
 }

--- a/test/hotspot/gtest/nmt/test_nmt_buffer_overflow_detection.cpp
+++ b/test/hotspot/gtest/nmt/test_nmt_buffer_overflow_detection.cpp
@@ -35,7 +35,7 @@
 
 // This prefix shows up on any c heap corruption NMT detects. If unsure which assert will
 // come, just use this one.
-#define COMMON_NMT_HEAP_CORRUPTION_MESSAGE_PREFIX "NMT corruption"
+#define COMMON_NMT_HEAP_CORRUPTION_MESSAGE_PREFIX "NMT has detected a memory corruption bug."
 
 #define DEFINE_TEST(test_function, expected_assertion_message)                            \
   TEST_VM_FATAL_ERROR_MSG(NMT, test_function, ".*" expected_assertion_message ".*") {     \


### PR DESCRIPTION
Hi,

When NMT detects a memory corruption it outputs "NMT corruption" and some helpful metadata. I'd like to change the prefix to "NMT has detected a memory corruption bug.". I want to do this because the old message sounds like it is NMT itself that has become corrupted, which is not what's happened. Instead, it should be clear that NMT has helped detect a bug stemming from somewhere else. This is meant to help avoid someone misunderstanding the message.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8364198](https://bugs.openjdk.org/browse/JDK-8364198): NMT should have a better corruption message (**Enhancement** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26507/head:pull/26507` \
`$ git checkout pull/26507`

Update a local copy of the PR: \
`$ git checkout pull/26507` \
`$ git pull https://git.openjdk.org/jdk.git pull/26507/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26507`

View PR using the GUI difftool: \
`$ git pr show -t 26507`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26507.diff">https://git.openjdk.org/jdk/pull/26507.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26507#issuecomment-3127465457)
</details>
