### PR TITLE
8364212: Shenandoah: Rework archived objects loading

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahAllocRequest.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahAllocRequest.hpp
@@ -34,6 +34,7 @@ public:
   enum Type {
     _alloc_shared,      // Allocate common, outside of TLAB
     _alloc_shared_gc,   // Allocate common, outside of GCLAB/PLAB
+    _alloc_cds,         // Allocate for CDS
     _alloc_tlab,        // Allocate TLAB
     _alloc_gclab,       // Allocate GCLAB
     _alloc_plab,        // Allocate PLAB
@@ -46,6 +47,8 @@ public:
         return "Shared";
       case _alloc_shared_gc:
         return "Shared GC";
+      case _alloc_cds:
+        return "CDS";
       case _alloc_tlab:
         return "TLAB";
       case _alloc_gclab:
@@ -121,6 +124,10 @@ public:
     return ShenandoahAllocRequest(0, requested_size, _alloc_shared, ShenandoahAffiliation::YOUNG_GENERATION);
   }
 
+  static inline ShenandoahAllocRequest for_cds(size_t requested_size) {
+    return ShenandoahAllocRequest(0, requested_size, _alloc_cds, ShenandoahAffiliation::YOUNG_GENERATION);
+  }
+
   inline size_t size() const {
     return _requested_size;
   }
@@ -163,6 +170,7 @@ public:
     switch (_alloc_type) {
       case _alloc_tlab:
       case _alloc_shared:
+      case _alloc_cds:
         return true;
       case _alloc_gclab:
       case _alloc_plab:
@@ -178,6 +186,7 @@ public:
     switch (_alloc_type) {
       case _alloc_tlab:
       case _alloc_shared:
+      case _alloc_cds:
         return false;
       case _alloc_gclab:
       case _alloc_plab:
@@ -197,6 +206,7 @@ public:
         return true;
       case _alloc_shared:
       case _alloc_shared_gc:
+      case _alloc_cds:
         return false;
       default:
         ShouldNotReachHere();

--- a/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
@@ -816,6 +816,7 @@ HeapWord* ShenandoahFreeSet::allocate_single(ShenandoahAllocRequest& req, bool& 
   switch (req.type()) {
     case ShenandoahAllocRequest::_alloc_tlab:
     case ShenandoahAllocRequest::_alloc_shared:
+    case ShenandoahAllocRequest::_alloc_cds:
       return allocate_for_mutator(req, in_new_region);
     case ShenandoahAllocRequest::_alloc_gclab:
     case ShenandoahAllocRequest::_alloc_plab:
@@ -1169,8 +1170,8 @@ HeapWord* ShenandoahFreeSet::try_allocate_in(ShenandoahHeapRegion* r, Shenandoah
   return result;
 }
 
-HeapWord* ShenandoahFreeSet::allocate_contiguous(ShenandoahAllocRequest& req) {
-  assert(req.is_mutator_alloc(), "All humongous allocations are performed by mutator");
+HeapWord* ShenandoahFreeSet::allocate_contiguous(ShenandoahAllocRequest& req, bool is_humongous) {
+  assert(req.is_mutator_alloc(), "All contiguous allocations are performed by mutator");
   shenandoah_assert_heaplocked();
 
   size_t words_size = req.size();
@@ -1244,10 +1245,16 @@ HeapWord* ShenandoahFreeSet::allocate_contiguous(ShenandoahAllocRequest& req) {
     assert(i == beg || _heap->get_region(i - 1)->index() + 1 == r->index(), "Should be contiguous");
     assert(r->is_empty(), "Should be empty");
 
-    if (i == beg) {
-      r->make_humongous_start();
+    r->set_affiliation(req.affiliation());
+
+    if (is_humongous) {
+      if (i == beg) {
+        r->make_humongous_start();
+      } else {
+        r->make_humongous_cont();
+      }
     } else {
-      r->make_humongous_cont();
+      r->make_regular_allocation(req.affiliation());
     }
 
     // Trailing region may be non-full, record the remainder there
@@ -1257,21 +1264,19 @@ HeapWord* ShenandoahFreeSet::allocate_contiguous(ShenandoahAllocRequest& req) {
     } else {
       used_words = ShenandoahHeapRegion::region_size_words();
     }
-
-    r->set_affiliation(req.affiliation());
-    r->set_update_watermark(r->bottom());
     r->set_top(r->bottom() + used_words);
+    r->set_update_watermark(r->bottom());
   }
   generation->increase_affiliated_region_count(num);
 
   // retire_range_from_partition() will adjust bounds on Mutator free set if appropriate
   _partitions.retire_range_from_partition(ShenandoahFreeSetPartitionId::Mutator, beg, end);
 
-  size_t total_humongous_size = ShenandoahHeapRegion::region_size_bytes() * num;
-  _partitions.increase_used(ShenandoahFreeSetPartitionId::Mutator, total_humongous_size);
+  size_t size = is_humongous ? ShenandoahHeapRegion::region_size_bytes() * num : words_size;
+  _partitions.increase_used(ShenandoahFreeSetPartitionId::Mutator, size);
   _partitions.assert_bounds();
   req.set_actual_size(words_size);
-  if (remainder != 0) {
+  if (remainder != 0 && is_humongous) {
     req.set_waste(ShenandoahHeapRegion::region_size_words() - remainder);
   }
   return _heap->get_region(beg)->bottom();
@@ -2060,7 +2065,10 @@ HeapWord* ShenandoahFreeSet::allocate(ShenandoahAllocRequest& req, bool& in_new_
       case ShenandoahAllocRequest::_alloc_shared:
       case ShenandoahAllocRequest::_alloc_shared_gc:
         in_new_region = true;
-        return allocate_contiguous(req);
+        return allocate_contiguous(req, /* is_humongous = */ true);
+      case ShenandoahAllocRequest::_alloc_cds:
+        in_new_region = true;
+        return allocate_contiguous(req, /* is_humongous = */ false);
       case ShenandoahAllocRequest::_alloc_plab:
       case ShenandoahAllocRequest::_alloc_gclab:
       case ShenandoahAllocRequest::_alloc_tlab:

--- a/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
@@ -1264,19 +1264,19 @@ HeapWord* ShenandoahFreeSet::allocate_contiguous(ShenandoahAllocRequest& req, bo
     } else {
       used_words = ShenandoahHeapRegion::region_size_words();
     }
-    r->set_top(r->bottom() + used_words);
     r->set_update_watermark(r->bottom());
+    r->set_top(r->bottom() + used_words);
   }
   generation->increase_affiliated_region_count(num);
 
   // retire_range_from_partition() will adjust bounds on Mutator free set if appropriate
   _partitions.retire_range_from_partition(ShenandoahFreeSetPartitionId::Mutator, beg, end);
 
-  size_t size = is_humongous ? ShenandoahHeapRegion::region_size_bytes() * num : words_size;
-  _partitions.increase_used(ShenandoahFreeSetPartitionId::Mutator, size);
+  size_t total_contiguous_size = ShenandoahHeapRegion::region_size_bytes() * num;
+  _partitions.increase_used(ShenandoahFreeSetPartitionId::Mutator, total_contiguous_size);
   _partitions.assert_bounds();
   req.set_actual_size(words_size);
-  if (remainder != 0 && is_humongous) {
+  if (remainder != 0) {
     req.set_waste(ShenandoahHeapRegion::region_size_words() - remainder);
   }
   return _heap->get_region(beg)->bottom();

--- a/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.hpp
@@ -345,7 +345,7 @@ private:
   // object.  No other objects are packed into these regions.
   //
   // Precondition: ShenandoahHeapRegion::requires_humongous(req.size())
-  HeapWord* allocate_contiguous(ShenandoahAllocRequest& req);
+  HeapWord* allocate_contiguous(ShenandoahAllocRequest& req, bool is_humongous);
 
   // Change region r from the Mutator partition to the GC's Collector or OldCollector partition.  This requires that the
   // region is entirely empty.

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
@@ -147,22 +147,13 @@ void ShenandoahHeapRegion::make_regular_bypass() {
           ShenandoahHeap::heap()->is_degenerated_gc_in_progress(),
           "Only for STW GC or when Universe is initializing (CDS)");
   reset_age();
-  auto cur_state = state();
-  switch (cur_state) {
+  switch (state()) {
     case _empty_uncommitted:
       do_commit();
     case _empty_committed:
     case _cset:
     case _humongous_start:
     case _humongous_cont:
-      if (cur_state == _humongous_start || cur_state == _humongous_cont) {
-        // CDS allocates chunks of the heap to fill with regular objects. The allocator
-        // will dutifully track any waste in the unused portion of the last region. Once
-        // CDS has finished initializing the objects, it will convert these regions to
-        // regular regions. The 'waste' in the last region is no longer wasted at this point,
-        // so we must stop treating it as such.
-        decrement_humongous_waste();
-      }
       set_state(_regular);
       return;
     case _pinned_cset:

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
@@ -142,10 +142,9 @@ void ShenandoahHeapRegion::make_affiliated_maybe() {
 
 void ShenandoahHeapRegion::make_regular_bypass() {
   shenandoah_assert_heaplocked();
-  assert (!Universe::is_fully_initialized() ||
-          ShenandoahHeap::heap()->is_full_gc_in_progress() ||
+  assert (ShenandoahHeap::heap()->is_full_gc_in_progress() ||
           ShenandoahHeap::heap()->is_degenerated_gc_in_progress(),
-          "Only for STW GC or when Universe is initializing (CDS)");
+          "Only for STW GC");
   reset_age();
   switch (state()) {
     case _empty_uncommitted:

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.hpp
@@ -491,8 +491,9 @@ public:
     _needs_bitmap_reset = false;
   }
 
-private:
   void decrement_humongous_waste() const;
+
+private:
   void do_commit();
   void do_uncommit();
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.hpp
@@ -491,9 +491,8 @@ public:
     _needs_bitmap_reset = false;
   }
 
-  void decrement_humongous_waste() const;
-
 private:
+  void decrement_humongous_waste() const;
   void do_commit();
   void do_uncommit();
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.inline.hpp
@@ -112,6 +112,7 @@ inline void ShenandoahHeapRegion::adjust_alloc_metadata(ShenandoahAllocRequest::
   switch (type) {
     case ShenandoahAllocRequest::_alloc_shared:
     case ShenandoahAllocRequest::_alloc_shared_gc:
+    case ShenandoahAllocRequest::_alloc_cds:
       // Counted implicitly by tlab/gclab allocs
       break;
     case ShenandoahAllocRequest::_alloc_tlab:


### PR DESCRIPTION
As continuation of [JDK-8293650](https://bugs.openjdk.org/browse/JDK-8293650), we would want to avoid allocating CDS archives as humongous regions and then flipping them back to regular state. This already complicates the region accounting significantly, and was a source a few bugs. We can rework the CDS archive load to cleanly ask collector for a contiguous set of regular regions.

Additional testing:
 - [x] Linux x86_64 server fastdebug, `hotspot_gc_shenandoah`
 - [x] Linux x86_64 server fastdebug, `runtime/cds`
 - [x] Linux x86_64 server fastdebug, `runtime/cds` with `-XX:+UseShenandoahGC`
 - [ ] Linux x86_64 server fastdebug, `all`