### PR TITLE
8363928: Specifying AOTCacheOutput with a blank path causes the JVM to crash

### DIFF
--- a/src/hotspot/share/cds/cds_globals.hpp
+++ b/src/hotspot/share/cds/cds_globals.hpp
@@ -121,6 +121,7 @@
                                                                             \
   product(ccstr, AOTCacheOutput, nullptr,                                   \
           "Specifies the file name for writing the AOT cache")              \
+          constraint(AOTCacheOutputConstraintFunc, AtParse)                 \
                                                                             \
   product(bool, AOTInvokeDynamicLinking, false, DIAGNOSTIC,                 \
           "AOT-link JVM_CONSTANT_InvokeDynamic entries in cached "          \

--- a/src/hotspot/share/runtime/flags/jvmFlagConstraintsRuntime.cpp
+++ b/src/hotspot/share/runtime/flags/jvmFlagConstraintsRuntime.cpp
@@ -39,6 +39,14 @@ JVMFlag::Error AOTCacheConstraintFunc(ccstr value, bool verbose) {
   return JVMFlag::SUCCESS;
 }
 
+JVMFlag::Error AOTCacheOutputConstraintFunc(ccstr value, bool verbose) {
+  if (value == nullptr) {
+    JVMFlag::printError(verbose, "AOTCacheOutput cannot be empty\n");
+    return JVMFlag::VIOLATES_CONSTRAINT;
+  }
+  return JVMFlag::SUCCESS;
+}
+
 JVMFlag::Error AOTConfigurationConstraintFunc(ccstr value, bool verbose) {
   if (value == nullptr) {
     JVMFlag::printError(verbose, "AOTConfiguration cannot be empty\n");

--- a/src/hotspot/share/runtime/flags/jvmFlagConstraintsRuntime.hpp
+++ b/src/hotspot/share/runtime/flags/jvmFlagConstraintsRuntime.hpp
@@ -35,6 +35,7 @@
 
 #define RUNTIME_CONSTRAINTS(f)                        \
   f(ccstr,  AOTCacheConstraintFunc)                   \
+  f(ccstr,  AOTCacheOutputConstraintFunc)             \
   f(ccstr,  AOTConfigurationConstraintFunc)           \
   f(ccstr,  AOTModeConstraintFunc)                    \
   f(int,    ObjectAlignmentInBytesConstraintFunc)     \

--- a/test/hotspot/jtreg/runtime/cds/appcds/aotFlags/AOTFlags.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotFlags/AOTFlags.java
@@ -484,6 +484,7 @@ public class AOTFlags {
         testEmptyValue("AOTCache");
         testEmptyValue("AOTConfiguration");
         testEmptyValue("AOTMode");
+        testEmptyValue("AOTCacheOutput");
     }
 
     static void testEmptyValue(String option) throws Exception {


### PR DESCRIPTION
Added a constraint check for the `AOTCacheOutput` option in order to avoid VM crash in case an empty value is specified.
Update `aotFlags/AOTFlags.java` to test this scenario.

Testing: ran test locally on linux-x64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8363928](https://bugs.openjdk.org/browse/JDK-8363928): Specifying AOTCacheOutput with a blank path causes the JVM to crash (**Bug** - P3)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26518/head:pull/26518` \
`$ git checkout pull/26518`

Update a local copy of the PR: \
`$ git checkout pull/26518` \
`$ git pull https://git.openjdk.org/jdk.git pull/26518/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26518`

View PR using the GUI difftool: \
`$ git pr show -t 26518`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26518.diff">https://git.openjdk.org/jdk/pull/26518.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26518#issuecomment-3130040049)
</details>
