### PR TITLE
8364230: javax/swing/text/StringContent can be migrated away from using finalize

### DIFF
--- a/test/jdk/javax/swing/text/AbstractDocument/StringContentPositionTest.java
+++ b/test/jdk/javax/swing/text/AbstractDocument/StringContentPositionTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import javax.swing.text.BadLocationException;
+import javax.swing.text.Position;
+import javax.swing.text.StringContent;
+
+/*
+ * @test
+ * @summary test that StringContent Position APIs behave as expected.
+ */
+
+public class StringContentPositionTest {
+
+    static final int SIZE = 20;
+    static final String text = "hello";
+    static final int LEN = text.length();
+    static final StringContent st = new StringContent();
+
+    public static void main(String[] args) throws BadLocationException {
+
+        for (int i = 0; i < 1000; i++) {
+            test();
+            System.gc();
+        }
+    }
+
+    static void test() throws BadLocationException {
+
+        Position[] positions = new Position[SIZE];
+
+        for (int i = 0; i < SIZE; i++) {
+            st.insertString(0, "hello");
+            positions[i] = st.createPosition(5);
+        }
+        for (int i=0; i<SIZE; i++) {
+           int expected = ((SIZE - i) * LEN);
+           if (positions[i].getOffset() != expected) {
+               System.err.println("insert: Bad offset i=" + i + " off=" + positions[i].getOffset());
+           }
+        }
+        st.remove(0,  SIZE * LEN);
+        for (int i=0; i<SIZE; i++) {
+            if (positions[i].getOffset() != 0) {
+               System.err.println("remove: Bad offset i=" + i + " off=" + positions[i].getOffset());
+            }
+        }
+     }
+}

--- a/test/jdk/javax/swing/text/AbstractDocument/StringContentPositionTest.java
+++ b/test/jdk/javax/swing/text/AbstractDocument/StringContentPositionTest.java
@@ -33,9 +33,9 @@ import javax.swing.text.StringContent;
 public class StringContentPositionTest {
 
     static final int SIZE = 20;
-    static final String text = "hello";
-    static final int LEN = text.length();
-    static final StringContent st = new StringContent();
+    static final String TEXT = "hello";
+    static final int LEN = TEXT.length();
+    static final StringContent SC = new StringContent();
 
     public static void main(String[] args) throws BadLocationException {
 
@@ -50,19 +50,19 @@ public class StringContentPositionTest {
         Position[] positions = new Position[SIZE];
 
         for (int i = 0; i < SIZE; i++) {
-            st.insertString(0, "hello");
-            positions[i] = st.createPosition(5);
+            SC.insertString(0, TEXT);
+            positions[i] = SC.createPosition(5);
         }
-        for (int i=0; i<SIZE; i++) {
+        for (int i = 0; i < SIZE; i++) {
            int expected = ((SIZE - i) * LEN);
            if (positions[i].getOffset() != expected) {
-               System.err.println("insert: Bad offset i=" + i + " off=" + positions[i].getOffset());
+               throw new RuntimeException("insert: Bad offset i=" + i + " off=" + positions[i].getOffset());
            }
         }
-        st.remove(0,  SIZE * LEN);
-        for (int i=0; i<SIZE; i++) {
+        SC.remove(0, SIZE * LEN);
+        for (int i = 0; i < SIZE; i++) {
             if (positions[i].getOffset() != 0) {
-               System.err.println("remove: Bad offset i=" + i + " off=" + positions[i].getOffset());
+               throw new RuntimeException("remove: Bad offset i=" + i + " off=" + positions[i].getOffset());
             }
         }
      }

--- a/test/jdk/javax/swing/text/AbstractDocument/StringContentPositionTest.java
+++ b/test/jdk/javax/swing/text/AbstractDocument/StringContentPositionTest.java
@@ -51,7 +51,7 @@ public class StringContentPositionTest {
 
         for (int i = 0; i < SIZE; i++) {
             SC.insertString(0, TEXT);
-            positions[i] = SC.createPosition(5);
+            positions[i] = SC.createPosition(LEN);
         }
         for (int i = 0; i < SIZE; i++) {
            int expected = ((SIZE - i) * LEN);


### PR DESCRIPTION
Convert StringContent's Position usage tracking to use a WeakReference

The test that is added only implicitly tests this but I added it because of a complete lack of any test for this code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8364230](https://bugs.openjdk.org/browse/JDK-8364230): javax/swing/text/StringContent can be migrated away from using finalize (**Bug** - P4)


### Reviewers
 * [Alexander Zuev](https://openjdk.org/census#kizune) (@azuev-java - **Reviewer**) Review applies to [e37e57c2](https://git.openjdk.org/jdk/pull/26519/files/e37e57c2b268f80cd16b6985aa9a2218596b0dd9)
 * [Prasanta Sadhukhan](https://openjdk.org/census#psadhukhan) (@prsadhuk - **Reviewer**)
 * [Abhishek Kumar](https://openjdk.org/census#abhiscxk) (@kumarabhi006 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26519/head:pull/26519` \
`$ git checkout pull/26519`

Update a local copy of the PR: \
`$ git checkout pull/26519` \
`$ git pull https://git.openjdk.org/jdk.git pull/26519/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26519`

View PR using the GUI difftool: \
`$ git pr show -t 26519`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26519.diff">https://git.openjdk.org/jdk/pull/26519.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26519#issuecomment-3130098584)
</details>
