### PR TITLE
8364106: Include java.runtime.version in thread dump output

### DIFF
--- a/src/hotspot/share/runtime/threads.cpp
+++ b/src/hotspot/share/runtime/threads.cpp
@@ -1363,7 +1363,7 @@ public:
 void Threads::print_on(outputStream* st, bool print_stacks,
                        bool internal_format, bool print_concurrent_locks,
                        bool print_extended_info) {
-  char buf[256];
+  char buf[32];
   st->print_raw_cr(os::local_time_string(buf, sizeof(buf)));
 
   st->print_cr("Full thread dump %s (%s %s)",
@@ -1372,13 +1372,13 @@ void Threads::print_on(outputStream* st, bool print_stacks,
                VM_Version::vm_info_string());
   JDK_Version::current().to_string(buf, sizeof(buf));
   const char* runtime_name = JDK_Version::runtime_name() != nullptr ?
-    JDK_Version::runtime_name() : "";
+                             JDK_Version::runtime_name() : "";
   const char* runtime_version = JDK_Version::runtime_version() != nullptr ?
-    JDK_Version::runtime_version() : "";
+                                JDK_Version::runtime_version() : "";
   const char* vendor_version = JDK_Version::runtime_vendor_version() != nullptr ?
-    JDK_Version::runtime_vendor_version() : "";
+                               JDK_Version::runtime_vendor_version() : "";
   const char* jdk_debug_level = VM_Version::printable_jdk_debug_level() != nullptr ?
-    VM_Version::printable_jdk_debug_level() : "";
+                                VM_Version::printable_jdk_debug_level() : "";
 
   st->print_cr("                 JRE version: %s%s%s (%s) (%sbuild %s)", runtime_name,
                 (*vendor_version != '\0') ? " " : "", vendor_version,

--- a/src/hotspot/share/runtime/threads.cpp
+++ b/src/hotspot/share/runtime/threads.cpp
@@ -1380,7 +1380,7 @@ void Threads::print_on(outputStream* st, bool print_stacks,
   const char* jdk_debug_level = VM_Version::printable_jdk_debug_level() != nullptr ?
                                 VM_Version::printable_jdk_debug_level() : "";
 
-  st->print_cr("                 JRE version: %s%s%s (%s) (%sbuild %s)", runtime_name,
+  st->print_cr("                 JDK version: %s%s%s (%s) (%sbuild %s)", runtime_name,
                 (*vendor_version != '\0') ? " " : "", vendor_version,
                 buf, jdk_debug_level, runtime_version);
 

--- a/src/hotspot/share/runtime/threads.cpp
+++ b/src/hotspot/share/runtime/threads.cpp
@@ -1363,13 +1363,27 @@ public:
 void Threads::print_on(outputStream* st, bool print_stacks,
                        bool internal_format, bool print_concurrent_locks,
                        bool print_extended_info) {
-  char buf[32];
+  char buf[256];
   st->print_raw_cr(os::local_time_string(buf, sizeof(buf)));
 
-  st->print_cr("Full thread dump %s (%s %s):",
+  st->print_cr("Full thread dump %s (%s %s)",
                VM_Version::vm_name(),
                VM_Version::vm_release(),
                VM_Version::vm_info_string());
+  JDK_Version::current().to_string(buf, sizeof(buf));
+  const char* runtime_name = JDK_Version::runtime_name() != nullptr ?
+    JDK_Version::runtime_name() : "";
+  const char* runtime_version = JDK_Version::runtime_version() != nullptr ?
+    JDK_Version::runtime_version() : "";
+  const char* vendor_version = JDK_Version::runtime_vendor_version() != nullptr ?
+    JDK_Version::runtime_vendor_version() : "";
+  const char* jdk_debug_level = VM_Version::printable_jdk_debug_level() != nullptr ?
+    VM_Version::printable_jdk_debug_level() : "";
+
+  st->print_cr("                 JRE version: %s%s%s (%s) (%sbuild %s)", runtime_name,
+                (*vendor_version != '\0') ? " " : "", vendor_version,
+                buf, jdk_debug_level, runtime_version);
+
   st->cr();
 
 #if INCLUDE_SERVICES

--- a/test/hotspot/jtreg/serviceability/dcmd/thread/PrintTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/thread/PrintTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -168,6 +168,9 @@ public class PrintTest {
             output.shouldNotMatch(jucLockPattern1);
             output.shouldNotMatch(jucLockPattern2);
         }
+
+        /* Check for presence of version string */
+        output.shouldContain("JDK version:");
     }
 
     @Test


### PR DESCRIPTION
Proposed output (similar to that produced for hs_err log):

```
Full thread dump Java HotSpot(TM) 64-Bit Server VM (26-internal-2025-07-28-0739549.daholme... mixed mode, sharing)
                 JRE version: Java(TM) SE Runtime Environment (26.0) (fastdebug build 26-internal-2025-07-28-0739549.daholme...)

Threads class SMR info:
... 
```
Testing:
 - manual thread dump production via ctrl-\
 -  tiers 1-3 (sanity)

Potentially the null checks are not needed in this case as we should not be able to generate a thread dump until after things are initialized, but it doesn't really hurt.

Thanks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8364106](https://bugs.openjdk.org/browse/JDK-8364106): Include java.runtime.version in thread dump output (**Enhancement** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Sean Coffey](https://openjdk.org/census#coffeys) (@coffeys - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26520/head:pull/26520` \
`$ git checkout pull/26520`

Update a local copy of the PR: \
`$ git checkout pull/26520` \
`$ git pull https://git.openjdk.org/jdk.git pull/26520/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26520`

View PR using the GUI difftool: \
`$ git pr show -t 26520`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26520.diff">https://git.openjdk.org/jdk/pull/26520.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26520#issuecomment-3130158352)
</details>
