### PR TITLE
8363920: JVMTI Documentation for GetLocalDouble is wrong: refers to long

### DIFF
--- a/src/hotspot/share/prims/jvmti.xml
+++ b/src/hotspot/share/prims/jvmti.xml
@@ -6127,7 +6127,7 @@ class C2 extends C1 implements I2 {
       <synopsis>Get Local Variable - Double</synopsis>
       <description>
         This function can be used to retrieve the value of a local
-        variable whose type is <code>long</code>.
+        variable whose type is <code>double</code>.
         <p/>
         The specified thread must be suspended or must be the current thread.
       </description>


### PR DESCRIPTION
Hi all,

Fixed type errors in documentation, minor changes.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8363920](https://bugs.openjdk.org/browse/JDK-8363920): JVMTI Documentation for GetLocalDouble is wrong: refers to long (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26521/head:pull/26521` \
`$ git checkout pull/26521`

Update a local copy of the PR: \
`$ git checkout pull/26521` \
`$ git pull https://git.openjdk.org/jdk.git pull/26521/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26521`

View PR using the GUI difftool: \
`$ git pr show -t 26521`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26521.diff">https://git.openjdk.org/jdk/pull/26521.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26521#issuecomment-3130353184)
</details>
