### PR TITLE
8364235: Fix for JDK-8361447 breaks the alignment requirements for GuardedMemory

### DIFF
--- a/src/hotspot/share/memory/guardedMemory.hpp
+++ b/src/hotspot/share/memory/guardedMemory.hpp
@@ -45,6 +45,7 @@
  * |+GUARD_SIZE        | <size_t:user_size>   | User data size |
  * |+sizeof(size_t)    | <tag>                | Tag word       |
  * |+sizeof(void*)     | <tag2>               | Tag word       |
+ * |+sizeof(void*)     | <pad bytes>          | Padding        |
  * |+sizeof(void*)     | 0xF1 <user_data> (   | User data      |
  * |+user_size         | 0xABABABABABABABAB   | Tail guard     |
  * -------------------------------------------------------------
@@ -52,6 +53,8 @@
  * Where:
  *  - guard padding uses "badResourceValue" (0xAB)
  *  - tag word and tag2 word are general purpose
+ *  - padding is inserted as-needed by the compiler to ensure
+ *    the user data is aligned on a 16-byte boundary
  *  - user data
  *    -- initially padded with "uninitBlockPad" (0xF1),
  *    -- to "freeBlockPad" (0xBA), when freed


### PR DESCRIPTION
The fix for [JDK-8361447](https://bugs.openjdk.org/browse/JDK-8361447) added a new field to the `GuardHeader`, not realizing that the size of the `GuardHeader` must be such that the address of the user-data has the strictest necessary alignment (16-byte).

We need to add a padding field to restore the alignment.

A static assert is added to check the alignment.

Testing:
 - tiers 1-3 (in progress)

Thanks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8364235](https://bugs.openjdk.org/browse/JDK-8364235): Fix for JDK-8361447 breaks the alignment requirements for GuardedMemory (**Bug** - P2)


### Reviewers
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@jdksjolen - **Reviewer**) Review applies to [a7502d8c](https://git.openjdk.org/jdk/pull/26524/files/a7502d8ca8c1e77c49c427d02bdaa70a4bb9548b)
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - **Reviewer**) Review applies to [ab19a75d](https://git.openjdk.org/jdk/pull/26524/files/ab19a75de58289b8ead7f7e1d98b987bda952186)
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**)

### Contributors
 * Johan Sjölen `<jsjolen@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26524/head:pull/26524` \
`$ git checkout pull/26524`

Update a local copy of the PR: \
`$ git checkout pull/26524` \
`$ git pull https://git.openjdk.org/jdk.git pull/26524/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26524`

View PR using the GUI difftool: \
`$ git pr show -t 26524`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26524.diff">https://git.openjdk.org/jdk/pull/26524.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26524#issuecomment-3130895522)
</details>
