### PR TITLE
8363949: Incorrect jtreg header in MonitorWithDeadObjectTest.java

### DIFF
--- a/test/hotspot/jtreg/runtime/Monitor/MonitorWithDeadObjectTest.java
+++ b/test/hotspot/jtreg/runtime/Monitor/MonitorWithDeadObjectTest.java
@@ -32,20 +32,20 @@
  */
 
 /*
- * @requires os.family != "windows" & os.family != "aix"
  * @test id=DetachThread
+ * @requires os.family != "windows" & os.family != "aix"
  * @run main/othervm/native MonitorWithDeadObjectTest 0
  */
 
 /*
- * @requires os.family != "windows" & os.family != "aix"
  * @test id=DumpThreadsBeforeDetach
+ * @requires os.family != "windows" & os.family != "aix"
  * @run main/othervm/native MonitorWithDeadObjectTest 1
  */
 
 /*
- * @requires os.family != "windows" & os.family != "aix"
  * @test id=DumpThreadsAfterDetach
+ * @requires os.family != "windows" & os.family != "aix"
  * @run main/othervm/native MonitorWithDeadObjectTest 2
  */
 


### PR DESCRIPTION
Hi, please consider the following changes:

the mentioned test fails if run standalone with the following error: 
Error: Not a test or directory containing tests: runtime/Monitor/MonitorWithDeadObjectTest.java

The order of jtreg tags is not correct, to make it pass standalone it is sufficient to put @test first in each test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8363949](https://bugs.openjdk.org/browse/JDK-8363949): Incorrect jtreg header in MonitorWithDeadObjectTest.java (**Bug** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26527/head:pull/26527` \
`$ git checkout pull/26527`

Update a local copy of the PR: \
`$ git checkout pull/26527` \
`$ git pull https://git.openjdk.org/jdk.git pull/26527/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26527`

View PR using the GUI difftool: \
`$ git pr show -t 26527`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26527.diff">https://git.openjdk.org/jdk/pull/26527.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26527#issuecomment-3131608142)
</details>
