### PR TITLE
8364248: Separate memory limit detection

### DIFF
--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -905,6 +905,11 @@ bool os::has_allocatable_memory_limit(size_t* limit) {
   return true;
 }
 
+bool os::has_limited_virtual_address_space(size_t* limit) {
+  // Virtual address space cannot be limited on Windows.
+  return false;
+}
+
 int os::active_processor_count() {
   // User has overridden the number of active processors
   if (ActiveProcessorCount > 0) {

--- a/src/hotspot/share/gc/z/zAddressSpaceLimit.cpp
+++ b/src/hotspot/share/gc/z/zAddressSpaceLimit.cpp
@@ -33,7 +33,7 @@
 static size_t address_space_limit() {
   size_t limit = 0;
 
-  if (os::has_allocatable_memory_limit(&limit)) {
+  if (os::has_limited_virtual_address_space(&limit)) {
     return limit;
   }
 

--- a/src/hotspot/share/runtime/os.hpp
+++ b/src/hotspot/share/runtime/os.hpp
@@ -449,6 +449,8 @@ class os: AllStatic {
   // Returns the lowest address the process is allowed to map against.
   static size_t vm_min_address();
 
+  static bool has_limited_virtual_address_space(size_t* limit);
+
   inline static size_t cds_core_region_alignment();
 
   // Reserves virtual memory.


### PR DESCRIPTION
The function os::has_allocatable_memory() is intended to determine whether there is a system-imposed limit on how much memory can be committed, and if so, what that limit is. On POSIX systems, limiting committable memory is typically enforced by restricting the available virtual address space, such as via RLIMIT_AS. As a result, os::has_allocatable_memory() tells us both how much memory can be committed and how much virtual address space is available. On Windows however, os::has_allocatable_memory() always returns true, along with the size of the available virtual address space. This is misleading because it is not possible to limit how much memory can be committed via virtual address space, and also the virtual address space cannot be limited.

ZGC currently uses os::has_allocatable_memory() to check if the virtual address space is limited. To make it clear that the virtual address space cannot be limited on Windows, I propose that we create a new function called os::has_limited_virtual_address_space() which simply returns false on Windows, since the virtual address space cannot be limited there.

As a follow-up, I think it is reasonable to re-visit the implementation of os::has_allocatable_memory() on Windows, since it doesn't follow any user-set limits, apart from how much virtual memory is available. Perhaps looking at limit(s) set by Job Objects could be more fruitful, and would improve the support for native Windows containers (Hyper-V). 