### PR TITLE
8358618: UnsupportedOperationException constructors javadoc is not clear

### DIFF
--- a/src/java.base/share/classes/java/lang/RuntimeException.java
+++ b/src/java.base/share/classes/java/lang/RuntimeException.java
@@ -52,7 +52,7 @@ public class RuntimeException extends Exception {
         super();
     }
 
-    /** Constructs a new runtime exception with the specified detail message.
+    /** Constructs a new {@code RuntimeException} with the specified detail message.
      * The cause is not initialized, and may subsequently be initialized by a
      * call to {@link #initCause}.
      *
@@ -64,7 +64,7 @@ public class RuntimeException extends Exception {
     }
 
     /**
-     * Constructs a new runtime exception with the specified detail message and
+     * Constructs a new {@code RuntimeException} with the specified detail message and
      * cause.  <p>Note that the detail message associated with
      * {@code cause} is <i>not</i> automatically incorporated in
      * this runtime exception's detail message.
@@ -81,7 +81,7 @@ public class RuntimeException extends Exception {
         super(message, cause);
     }
 
-    /** Constructs a new runtime exception with the specified cause and a
+    /** Constructs a new {@code RuntimeException} with the specified cause and a
      * detail message of {@code (cause==null ? null : cause.toString())}
      * (which typically contains the class and detail message of
      * {@code cause}).  This constructor is useful for runtime exceptions
@@ -98,7 +98,7 @@ public class RuntimeException extends Exception {
     }
 
     /**
-     * Constructs a new runtime exception with the specified detail
+     * Constructs a new {@code RuntimeException} with the specified detail
      * message, cause, suppression enabled or disabled, and writable
      * stack trace enabled or disabled.
      *

--- a/src/java.base/share/classes/java/lang/RuntimeException.java
+++ b/src/java.base/share/classes/java/lang/RuntimeException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,7 +44,7 @@ public class RuntimeException extends Exception {
     @java.io.Serial
     static final long serialVersionUID = -7034897190745766939L;
 
-    /** Constructs a new {@code RuntimeException} with {@code null} as its
+    /** Constructs a new runtime exception with {@code null} as its
      * detail message.  The cause is not initialized, and may subsequently be
      * initialized by a call to {@link #initCause}.
      */
@@ -52,7 +52,7 @@ public class RuntimeException extends Exception {
         super();
     }
 
-    /** Constructs a new {@code RuntimeException} with the specified detail message.
+    /** Constructs a new runtime exception with the specified detail message.
      * The cause is not initialized, and may subsequently be initialized by a
      * call to {@link #initCause}.
      *
@@ -64,7 +64,7 @@ public class RuntimeException extends Exception {
     }
 
     /**
-     * Constructs a new {@code RuntimeException} with the specified detail message and
+     * Constructs a new runtime exception with the specified detail message and
      * cause.  <p>Note that the detail message associated with
      * {@code cause} is <i>not</i> automatically incorporated in
      * this runtime exception's detail message.
@@ -81,7 +81,7 @@ public class RuntimeException extends Exception {
         super(message, cause);
     }
 
-    /** Constructs a new {@code RuntimeException} with the specified cause and a
+    /** Constructs a new runtime exception with the specified cause and a
      * detail message of {@code (cause==null ? null : cause.toString())}
      * (which typically contains the class and detail message of
      * {@code cause}).  This constructor is useful for runtime exceptions
@@ -98,7 +98,7 @@ public class RuntimeException extends Exception {
     }
 
     /**
-     * Constructs a new {@code RuntimeException} with the specified detail
+     * Constructs a new runtime exception with the specified detail
      * message, cause, suppression enabled or disabled, and writable
      * stack trace enabled or disabled.
      *

--- a/src/java.base/share/classes/java/lang/RuntimeException.java
+++ b/src/java.base/share/classes/java/lang/RuntimeException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,7 +44,7 @@ public class RuntimeException extends Exception {
     @java.io.Serial
     static final long serialVersionUID = -7034897190745766939L;
 
-    /** Constructs a new runtime exception with {@code null} as its
+    /** Constructs a new {@code RuntimeException} with {@code null} as its
      * detail message.  The cause is not initialized, and may subsequently be
      * initialized by a call to {@link #initCause}.
      */

--- a/src/java.base/share/classes/java/lang/UnsupportedOperationException.java
+++ b/src/java.base/share/classes/java/lang/UnsupportedOperationException.java
@@ -45,7 +45,7 @@ public class UnsupportedOperationException extends RuntimeException {
     }
 
     /**
-     * Constructs an UnsupportedOperationException with the specified
+     * Constructs a new {@code UnsupportedOperationException} with the specified
      * detail message.
      *
      * @param message the detail message
@@ -55,7 +55,7 @@ public class UnsupportedOperationException extends RuntimeException {
     }
 
     /**
-     * Constructs a new exception with the specified detail message and
+     * Constructs a new {@code UnsupportedOperationException} with the specified detail message and
      * cause.
      *
      * <p>Note that the detail message associated with {@code cause} is
@@ -75,7 +75,7 @@ public class UnsupportedOperationException extends RuntimeException {
     }
 
     /**
-     * Constructs a new exception with the specified cause and a detail
+     * Constructs a new {@code UnsupportedOperationException} with the specified cause and a detail
      * message of {@code (cause==null ? null : cause.toString())} (which
      * typically contains the class and detail message of {@code cause}).
      * This constructor is useful for exceptions that are little more than

--- a/src/java.base/share/classes/java/lang/UnsupportedOperationException.java
+++ b/src/java.base/share/classes/java/lang/UnsupportedOperationException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,9 @@ package java.lang;
  */
 public class UnsupportedOperationException extends RuntimeException {
     /**
-     * Constructs an UnsupportedOperationException with no detail message.
+     * Constructs a new {@code UnsupportedOperationException} with {@code null} as its
+     * detail message. The cause is not initialized, and may subsequently be
+     * initialized by a call to {@link #initCause(Throwable)}.
      */
     public UnsupportedOperationException() {
     }

--- a/src/java.base/share/classes/java/lang/UnsupportedOperationException.java
+++ b/src/java.base/share/classes/java/lang/UnsupportedOperationException.java
@@ -46,7 +46,8 @@ public class UnsupportedOperationException extends RuntimeException {
 
     /**
      * Constructs a new {@code UnsupportedOperationException} with the specified
-     * detail message.
+     * detail message. The cause is not initialized, and may subsequently be
+     * initialized by a call to {@link #initCause(Throwable)}.
      *
      * @param message the detail message
      */

--- a/src/java.base/share/classes/java/lang/UnsupportedOperationException.java
+++ b/src/java.base/share/classes/java/lang/UnsupportedOperationException.java
@@ -37,9 +37,9 @@ package java.lang;
  */
 public class UnsupportedOperationException extends RuntimeException {
     /**
-     * Constructs a new {@code UnsupportedOperationException} with {@code null} as its
-     * detail message. The cause is not initialized, and may subsequently be
-     * initialized by a call to {@link #initCause(Throwable)}.
+     * Constructs a new {@code UnsupportedOperationException} with {@code null}
+     * as its detail message. The cause is not initialized, and may subsequently
+     * be initialized by a call to {@link #initCause(Throwable)}.
      */
     public UnsupportedOperationException() {
     }
@@ -56,8 +56,8 @@ public class UnsupportedOperationException extends RuntimeException {
     }
 
     /**
-     * Constructs a new {@code UnsupportedOperationException} with the specified detail message and
-     * cause.
+     * Constructs a new {@code UnsupportedOperationException} with the specified
+     * detail message and cause.
      *
      * <p>Note that the detail message associated with {@code cause} is
      * <i>not</i> automatically incorporated in this exception's detail
@@ -76,8 +76,9 @@ public class UnsupportedOperationException extends RuntimeException {
     }
 
     /**
-     * Constructs a new {@code UnsupportedOperationException} with the specified cause and a detail
-     * message of {@code (cause==null ? null : cause.toString())} (which
+     * Constructs a new {@code UnsupportedOperationException} with the specified
+     * cause and a detail message of
+     * {@code (cause==null ? null : cause.toString())} (which
      * typically contains the class and detail message of {@code cause}).
      * This constructor is useful for exceptions that are little more than
      * wrappers for other throwables (for example, {@link


### PR DESCRIPTION
Please review this patch that extends the javadoc of `UnsupportedOperationException` no-arg constructor, to clear up that the detail message is null.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8364278](https://bugs.openjdk.org/browse/JDK-8364278) to be approved

### Issues
 * [JDK-8358618](https://bugs.openjdk.org/browse/JDK-8358618): UnsupportedOperationException constructors javadoc is not clear (**Bug** - P4)
 * [JDK-8364278](https://bugs.openjdk.org/browse/JDK-8364278): UnsupportedOperationException constructors javadoc is not clear (**CSR**)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26533/head:pull/26533` \
`$ git checkout pull/26533`

Update a local copy of the PR: \
`$ git checkout pull/26533` \
`$ git pull https://git.openjdk.org/jdk.git pull/26533/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26533`

View PR using the GUI difftool: \
`$ git pr show -t 26533`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26533.diff">https://git.openjdk.org/jdk/pull/26533.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26533#issuecomment-3132577791)
</details>
