### PR TITLE
8364282: ZGC: Improve ZPageAllocation JFR event sending

### DIFF
--- a/src/hotspot/share/gc/z/zPageAllocator.cpp
+++ b/src/hotspot/share/gc/z/zPageAllocator.cpp
@@ -547,21 +547,24 @@ public:
   }
 
   void send_event(bool successful) {
-    EventZPageAllocation event;
+    if (!EventZPageAllocation::is_enabled()) {
+      // Event not enabled, exit early
+      return;
+    }
 
     Ticks end_timestamp = Ticks::now();
     const ZPageAllocationStats st = stats();
 
-    event.commit(_start_timestamp,
-                 end_timestamp,
-                 (u8)_type,
-                 size(),
-                 st._total_harvested,
-                 st._total_committed_capacity,
-                 (unsigned)st._num_harvested_vmems,
-                 _is_multi_partition,
-                 successful,
-                 _flags.non_blocking());
+    EventZPageAllocation::commit(_start_timestamp,
+                                 end_timestamp,
+                                 (u8)_type,
+                                 size(),
+                                 st._total_harvested,
+                                 st._total_committed_capacity,
+                                 (unsigned)st._num_harvested_vmems,
+                                 _is_multi_partition,
+                                 successful,
+                                 _flags.non_blocking());
   }
 };
 


### PR DESCRIPTION
Hello,

This is a follow up to [JDK-8350441](https://bugs.openjdk.org/browse/JDK-8350441), improving on how the ZPageAllocation JFR event is sent. 

The starting time for the event is measured separately from creating a local event varaible (EventZPageAllocation). This means it is better to use the anonymous EventZPageAllocation::commit rather than creating an event and sending that event, which would record the starting time again, unnecessarily.

Additionally, if the event is not enabled (either specifically or if JFR is disabled), we should not waste time sampling statistics for the event.

Testing:
* Oracle's tier1-4