### PR TITLE
8360408: [TEST] Use @requires tag instead of exiting based on "os.name" property value for sun/net/www/protocol/file/FileURLTest.java

### DIFF
--- a/test/jdk/sun/net/www/protocol/file/FileURLTest.java
+++ b/test/jdk/sun/net/www/protocol/file/FileURLTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
  * @test
  * @bug 4474391
  * @summary url: file:///D|/Projects/tmp/test.html: urlConnection.getInputStream() broken.
+ * @requires os.family == "windows"
  */
 import java.io.*;
 import java.net.*;
@@ -33,10 +34,7 @@ public class FileURLTest {
 
     public static void main(String [] args)
     {
-        String name = System.getProperty("os.name");
-        if (name.startsWith("Windows")) {
             String urlStr = "file:///C|/nonexisted.txt";
-
             try {
                 URL url = new URL(urlStr);
                 URLConnection urlConnection = url.openConnection();
@@ -49,6 +47,5 @@ public class FileURLTest {
                     throw new RuntimeException("Can't handle '|' in place of ':' in file urls");
                 }
             }
-        }
     }
 }


### PR DESCRIPTION
Refactor remove the test logic for Windows OS and replace with jtreg check for os

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8360408](https://bugs.openjdk.org/browse/JDK-8360408): [TEST] Use @<!---->requires tag instead of exiting based on "os.name" property value for sun/net/www/protocol/file/FileURLTest.java (**Enhancement** - P4)


### Reviewers
 * [Volkan Yazici](https://openjdk.org/census#vyazici) (@vy - Committer)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26537/head:pull/26537` \
`$ git checkout pull/26537`

Update a local copy of the PR: \
`$ git checkout pull/26537` \
`$ git pull https://git.openjdk.org/jdk.git pull/26537/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26537`

View PR using the GUI difftool: \
`$ git pr show -t 26537`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26537.diff">https://git.openjdk.org/jdk/pull/26537.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26537#issuecomment-3133411792)
</details>
