### PR TITLE
8364317: Explicitly document some assumptions of StringUTF16

### DIFF
--- a/src/java.base/share/classes/java/lang/StringUTF16.java
+++ b/src/java.base/share/classes/java/lang/StringUTF16.java
@@ -42,6 +42,11 @@ import static java.lang.String.UTF16;
 
 /// UTF16 String operations.
 ///
+/// UTF16 byte arrays have the identical layout as char arrays. They share the
+/// same base offset and scale, and for each two-byte unit interpreted as a char,
+/// it has the same endianness as a char, which is the platform endianness.
+/// This is ensured in the static initializer of StringUTF16.
+///
 /// All indices and sizes for byte arrays carrying UTF16 data are in number of
 /// chars instead of  number of bytes.
 final class StringUTF16 {

--- a/src/java.base/share/classes/java/lang/StringUTF16.java
+++ b/src/java.base/share/classes/java/lang/StringUTF16.java
@@ -40,6 +40,10 @@ import jdk.internal.vm.annotation.IntrinsicCandidate;
 
 import static java.lang.String.UTF16;
 
+/// UTF16 String operations.
+///
+/// All indices and sizes for byte arrays carrying UTF16 data are in number of
+/// chars instead of  number of bytes.
 final class StringUTF16 {
 
     // Return a new byte array for a UTF16-coded string for len chars
@@ -1635,6 +1639,9 @@ final class StringUTF16 {
     private static final int HI_BYTE_SHIFT;
     private static final int LO_BYTE_SHIFT;
     static {
+        // Assumptions for StringUTF16 operations. Present in `LibraryCallKit::inline_string_char_access` too.
+        assert Unsafe.ARRAY_CHAR_BASE_OFFSET == Unsafe.ARRAY_BYTE_BASE_OFFSET : "sanity: byte[] and char[] bases agree";
+        assert Unsafe.ARRAY_CHAR_INDEX_SCALE == Unsafe.ARRAY_BYTE_INDEX_SCALE * 2 : "sanity: byte[] and char[] scales agree";
         if (Unsafe.getUnsafe().isBigEndian()) {
             HI_BYTE_SHIFT = 8;
             LO_BYTE_SHIFT = 0;


### PR DESCRIPTION
In #24773, people were concerned that the layout of a UTF16 byte array and a char array may be incompatible. In fact, they are - they are asserted in a corner in `LibraryCallKit::inline_string_char_access` in `library_call.cpp`.

In addition, another frequent error I see is that contributors have confused the meaning of indices in StringUTF16 - the indices are always in char array indices. I think we should make these explicit to help future maintenance.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8364317](https://bugs.openjdk.org/browse/JDK-8364317): Explicitly document some assumptions of StringUTF16 (**Enhancement** - P5)


### Reviewers
 * [Raffaello Giulietti](https://openjdk.org/census#rgiulietti) (@rgiulietti - **Reviewer**)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Volkan Yazici](https://openjdk.org/census#vyazici) (@vy - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26541/head:pull/26541` \
`$ git checkout pull/26541`

Update a local copy of the PR: \
`$ git checkout pull/26541` \
`$ git pull https://git.openjdk.org/jdk.git pull/26541/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26541`

View PR using the GUI difftool: \
`$ git pr show -t 26541`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26541.diff">https://git.openjdk.org/jdk/pull/26541.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26541#issuecomment-3134099454)
</details>
