### PR TITLE
8364319: Move java.lang.constant.AsTypeMethodHandleDesc to jdk.internal

### DIFF
--- a/src/java.base/share/classes/java/lang/constant/ConstantDescs.java
+++ b/src/java.base/share/classes/java/lang/constant/ConstantDescs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,7 +43,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static java.lang.constant.DirectMethodHandleDesc.*;
 import static java.lang.constant.DirectMethodHandleDesc.Kind.STATIC;
 
 /**
@@ -336,9 +335,6 @@ public final class ConstantDescs {
      */
     public static final MethodTypeDesc MTD_void = MethodTypeDesc.of(CD_void);
 
-    static final DirectMethodHandleDesc MHD_METHODHANDLE_ASTYPE
-            = MethodHandleDesc.ofMethod(Kind.VIRTUAL, CD_MethodHandle, "asType",
-                                        MethodTypeDesc.of(CD_MethodHandle, CD_MethodType));
     /**
      * Returns a {@link MethodHandleDesc} corresponding to a bootstrap method for
      * an {@code invokedynamic} callsite, which is a static method whose leading

--- a/src/java.base/share/classes/java/lang/constant/MethodHandleDesc.java
+++ b/src/java.base/share/classes/java/lang/constant/MethodHandleDesc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,7 @@ import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
 
+import jdk.internal.constant.AsTypeMethodHandleDesc;
 import jdk.internal.constant.DirectMethodHandleDescImpl;
 
 import static java.lang.constant.ConstantDescs.CD_void;

--- a/src/java.base/share/classes/jdk/internal/constant/AsTypeMethodHandleDesc.java
+++ b/src/java.base/share/classes/jdk/internal/constant/AsTypeMethodHandleDesc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,8 +22,13 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package java.lang.constant;
+package jdk.internal.constant;
 
+import java.lang.constant.ConstantDescs;
+import java.lang.constant.DirectMethodHandleDesc;
+import java.lang.constant.DynamicConstantDesc;
+import java.lang.constant.MethodHandleDesc;
+import java.lang.constant.MethodTypeDesc;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
@@ -37,15 +42,19 @@ import static java.util.Objects.requireNonNull;
  * {@link MethodHandle} constant that performs a {@link MethodHandle#asType(MethodType)}
  * adaptation on another {@link MethodHandle}.
  */
-final class AsTypeMethodHandleDesc extends DynamicConstantDesc<MethodHandle>
+public final class AsTypeMethodHandleDesc extends DynamicConstantDesc<MethodHandle>
         implements MethodHandleDesc {
+
+    private static final DirectMethodHandleDesc MHD_METHODHANDLE_ASTYPE
+            = MethodHandleDesc.ofMethod(DirectMethodHandleDesc.Kind.VIRTUAL, CD_MethodHandle, "asType",
+                                        MethodTypeDesc.of(CD_MethodHandle, ConstantDescs.CD_MethodType));
 
     private final MethodHandleDesc underlying;
     private final MethodTypeDesc type;
 
-    AsTypeMethodHandleDesc(MethodHandleDesc underlying, MethodTypeDesc type) {
+    public AsTypeMethodHandleDesc(MethodHandleDesc underlying, MethodTypeDesc type) {
         super(BSM_INVOKE, ConstantDescs.DEFAULT_NAME, CD_MethodHandle,
-              ConstantDescs.MHD_METHODHANDLE_ASTYPE, underlying, type);
+              MHD_METHODHANDLE_ASTYPE, underlying, type);
         this.underlying = requireNonNull(underlying);
         this.type = requireNonNull(type);
     }


### PR DESCRIPTION
java.lang.constant.AsTypeMethodHandleDesc is an implementation class for the Constant API. It was omitted in the move probably because its name does not end with Impl. We should move it to the implementation package instead.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8364319](https://bugs.openjdk.org/browse/JDK-8364319): Move java.lang.constant.AsTypeMethodHandleDesc to jdk.internal (**Enhancement** - P4)


### Reviewers
 * [Claes Redestad](https://openjdk.org/census#redestad) (@cl4es - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26542/head:pull/26542` \
`$ git checkout pull/26542`

Update a local copy of the PR: \
`$ git checkout pull/26542` \
`$ git pull https://git.openjdk.org/jdk.git pull/26542/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26542`

View PR using the GUI difftool: \
`$ git pr show -t 26542`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26542.diff">https://git.openjdk.org/jdk/pull/26542.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26542#issuecomment-3134168736)
</details>
