### PR TITLE
8361298: SwingUtilities/bug4967768.java fails where character P is not underline

### DIFF
--- a/test/jdk/javax/swing/SwingUtilities/bug4967768.java
+++ b/test/jdk/javax/swing/SwingUtilities/bug4967768.java
@@ -37,13 +37,19 @@ import javax.swing.JPanel;
 
 public class bug4967768 {
     private static final String INSTRUCTIONS = """
-            When the test starts you'll see a button "Oops"
-            with the "p" letter underlined at the bottom
-            of the instruction frame.
+            When the test starts you'll see a button "Oops".
+
+            For Windows and GTK Look and Feel, you need to press
+            ALT key to activate the mnemonic to be visible.
+            Once ALT key is pressed, the "p" letter
+            is underlined at the bottom of the instruction frame.
 
             Ensure the underline cuts through the descender
             of letter "p", i.e. the underline is painted
             not below the letter but below the baseline.
+
+            Press Pass if you see the expected behaviour else
+            press Fail.
             """;
 
     public static void main(String[] args) throws Exception {

--- a/test/jdk/javax/swing/SwingUtilities/bug4967768.java
+++ b/test/jdk/javax/swing/SwingUtilities/bug4967768.java
@@ -39,10 +39,10 @@ public class bug4967768 {
     private static final String INSTRUCTIONS = """
             When the test starts you'll see a button "Oops".
 
-            For Windows and GTK Look and Feel, you need to press
-            ALT key to activate the mnemonic to be visible.
-            Once ALT key is pressed, the "p" letter
-            is underlined at the bottom of the instruction frame.
+            For Windows and GTK Look and Feel, you will need to
+            press the ALT key to make the mnemonic visible.
+            Once the ALT key is pressed, the letter "p" will be
+            underlined at the bottom of the instruction frame.
 
             Ensure the underline cuts through the descender
             of letter "p", i.e. the underline is painted


### PR DESCRIPTION
For Windows and GTK L&F, mnemonic is visible when ALT key is pressed.
Test instruction updated to reflect the desired behaviour .

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8361298](https://bugs.openjdk.org/browse/JDK-8361298): SwingUtilities/bug4967768.java fails where character P is not underline (**Bug** - P4)


### Reviewers
 * [Damon Nguyen](https://openjdk.org/census#dnguyen) (@DamonGuy - Committer)
 * [Prasanta Sadhukhan](https://openjdk.org/census#psadhukhan) (@prsadhuk - **Reviewer**)
 * [Alisen Chung](https://openjdk.org/census#achung) (@alisenchung - Committer)
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26546/head:pull/26546` \
`$ git checkout pull/26546`

Update a local copy of the PR: \
`$ git checkout pull/26546` \
`$ git pull https://git.openjdk.org/jdk.git pull/26546/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26546`

View PR using the GUI difftool: \
`$ git pr show -t 26546`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26546.diff">https://git.openjdk.org/jdk/pull/26546.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26546#issuecomment-3135014447)
</details>
