### PR TITLE
8294074: Make other specs more discoverable from the API docs

### DIFF
--- a/make/Docs.gmk
+++ b/make/Docs.gmk
@@ -237,18 +237,18 @@ define create_overview_file
   ifneq ($$($1_GROUPS), )
     $1_OVERVIEW_TEXT += \
       <p>This document specifies the following Java APIs:</p> \
-            <blockquote><dl> \
-            #
-          $1_OVERVIEW_TEXT += $$(foreach g, $$($1_GROUPS), \
-              <dt style="margin-top: 8px;">$$($$g_GROUP_NAME)</dt> \
-              <dd style="margin-top: 8px;">$$($$g_GROUP_DESCRIPTION)</dd> \
-          )
-          $1_OVERVIEW_TEXT += \
-              </dl></blockquote> \
-      <p><a href="../specs/index.html">Related documents</a> specify the Java language, \
-      the Java virtual machine, and various tools, protocols, and file formats pertaining \
-      to the Java platform.</p> \
+      <blockquote><dl> \
       #
+    $1_OVERVIEW_TEXT += $$(foreach g, $$($1_GROUPS), \
+        <dt style="margin-top: 8px;">$$($$g_GROUP_NAME)</dt> \
+        <dd style="margin-top: 8px;">$$($$g_GROUP_DESCRIPTION)</dd> \
+    )
+    $1_OVERVIEW_TEXT += \
+        </dl></blockquote> \
+    <p><a href="../specs/index.html">Related documents</a> specify the Java language, \
+    the Java virtual machine, and various tools, protocols, and file formats pertaining \
+    to the Java platform.</p> \
+    #
   endif
   $1_OVERVIEW_TEXT += \
       </body></html> \

--- a/make/Docs.gmk
+++ b/make/Docs.gmk
@@ -246,9 +246,9 @@ define create_overview_file
     )
     $1_OVERVIEW_TEXT += \
         </dl></blockquote> \
-    <p><a href="../specs/index.html">Related documents</a> specify the Java language, \
-    the Java virtual machine, various protocols and file formats pertaining to the \
-    Java platform, and tools included in the JDK.</p> \
+    <p><a href="../specs/index.html">Related documents</a> specify the Java \
+    programming language, the Java Virtual Machine, various protocols and file \
+    formats pertaining to the Java platform, and tools included in the JDK.</p> \
     #
   endif
   $1_OVERVIEW_TEXT += \

--- a/make/Docs.gmk
+++ b/make/Docs.gmk
@@ -236,7 +236,8 @@ define create_overview_file
       #
   ifneq ($$($1_GROUPS), )
     $1_OVERVIEW_TEXT += \
-      <p>This document specifies the following Java APIs:</p> \
+      <p>This document has \
+      $$(subst 2,two,$$(subst 3,three,$$(words $$($1_GROUPS)))) major sections:</p> \
       <blockquote><dl> \
       #
     $1_OVERVIEW_TEXT += $$(foreach g, $$($1_GROUPS), \
@@ -246,8 +247,8 @@ define create_overview_file
     $1_OVERVIEW_TEXT += \
         </dl></blockquote> \
     <p><a href="../specs/index.html">Related documents</a> specify the Java language, \
-    the Java virtual machine, and various tools, protocols, and file formats pertaining \
-    to the Java platform.</p> \
+    the Java virtual machine, various protocols and file formats pertaining to the \
+    Java platform, and tools included in the JDK.</p> \
     #
   endif
   $1_OVERVIEW_TEXT += \

--- a/make/Docs.gmk
+++ b/make/Docs.gmk
@@ -236,17 +236,19 @@ define create_overview_file
       #
   ifneq ($$($1_GROUPS), )
     $1_OVERVIEW_TEXT += \
-      <p>This document is divided into \
-      $$(subst 2,two,$$(subst 3,three,$$(words $$($1_GROUPS)))) sections:</p> \
-      <blockquote><dl> \
+      <p>This document specifies the following Java APIs:</p> \
+            <blockquote><dl> \
+            #
+          $1_OVERVIEW_TEXT += $$(foreach g, $$($1_GROUPS), \
+              <dt style="margin-top: 8px;">$$($$g_GROUP_NAME)</dt> \
+              <dd style="margin-top: 8px;">$$($$g_GROUP_DESCRIPTION)</dd> \
+          )
+          $1_OVERVIEW_TEXT += \
+              </dl></blockquote> \
+      <p><a href="../specs/index.html">Related documents</a> specify the Java language, \
+      the Java virtual machine, and various tools, protocols, and file formats pertaining \
+      to the Java platform.</p> \
       #
-    $1_OVERVIEW_TEXT += $$(foreach g, $$($1_GROUPS), \
-        <dt style="margin-top: 8px;">$$($$g_GROUP_NAME)</dt> \
-        <dd style="margin-top: 8px;">$$($$g_GROUP_DESCRIPTION)</dd> \
-    )
-    $1_OVERVIEW_TEXT += \
-        </dl></blockquote> \
-        #
   endif
   $1_OVERVIEW_TEXT += \
       </body></html> \


### PR DESCRIPTION
Please review a doc-only change to the API overview page to make other specs more discoverable. The following sentence is added at the end of the overview text:

> [Related documents](https://cr.openjdk.org/~hannesw/8294074/docs.00/specs/index.html) specify the Java language, the Java virtual machine, various protocols and file formats pertaining to the Java platform, and tools included in the JDK.

The first sentence of the overview text is also rephrased.

The new API overview page [can be viewed here](https://cr.openjdk.org/~hannesw/8294074/docs.00/api/index.html).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294074](https://bugs.openjdk.org/browse/JDK-8294074): Make other specs more discoverable from the API docs (**Enhancement** - P3)


### Reviewers
 * [Mark Reinhold](https://openjdk.org/census#mr) (@mbreinhold - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26547/head:pull/26547` \
`$ git checkout pull/26547`

Update a local copy of the PR: \
`$ git checkout pull/26547` \
`$ git pull https://git.openjdk.org/jdk.git pull/26547/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26547`

View PR using the GUI difftool: \
`$ git pr show -t 26547`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26547.diff">https://git.openjdk.org/jdk/pull/26547.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26547#issuecomment-3135805237)
</details>
