### PR TITLE
8364227: MBeanServer registerMBean throws NPE

### DIFF
--- a/src/java.management/share/classes/com/sun/jmx/interceptor/DefaultMBeanServerInterceptor.java
+++ b/src/java.management/share/classes/com/sun/jmx/interceptor/DefaultMBeanServerInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -291,8 +291,13 @@ public class DefaultMBeanServerInterceptor implements MBeanServerInterceptor {
         throws InstanceAlreadyExistsException, MBeanRegistrationException,
         NotCompliantMBeanException  {
 
-        // ------------------------------
-        // ------------------------------
+        if (object == null) {
+            final RuntimeException wrapped =
+                new IllegalArgumentException("Object cannot be null");
+            throw new RuntimeOperationsException(wrapped,
+                      "Exception occurred trying to register the MBean");
+        }
+
         Class<?> theClass = object.getClass();
 
         Introspector.checkCompliance(theClass);


### PR DESCRIPTION
A long-standing omission where MBeanServer.registerMBean documents exception behaviour, but we actually throw an NPE.  We should recognise a null object and return the wrapped exception we document.

This wrapping behaviour is common elsewhere in this area, e.g. unregisterMBean which checks for a null name and throws RuntimeOperationsException.

Docs:
https://docs.oracle.com/en/java/javase/24/docs/api/java.management/javax/management/MBeanServer.html#registerMBean(java.lang.Object,javax.management.ObjectName)

Throws:
RuntimeOperationsException - Wraps a java.lang.IllegalArgumentException: The object passed in parameter is null or no object name is specified.


Current behaviour:

```
$ java MBS_NPE.java
Exception in thread "main" java.lang.NullPointerException: Cannot invoke "Object.getClass()" because "object" is null
        at java.management/com.sun.jmx.interceptor.DefaultMBeanServerInterceptor.registerMBean(DefaultMBeanServerInterceptor.java:296)
        at java.management/com.sun.jmx.mbeanserver.JmxMBeanServer.registerMBean(JmxMBeanServer.java:511)
        at MBS_NPE.main(MBS_NPE.java:11)
```

Should be changed to:

```
$ java MBS_NPE.java
javax.management.RuntimeOperationsException: Exception occurred trying to register the MBean
        at java.management/com.sun.jmx.interceptor.DefaultMBeanServerInterceptor.registerMBean(DefaultMBeanServerInterceptor.java:297)
        at java.management/com.sun.jmx.mbeanserver.JmxMBeanServer.registerMBean(JmxMBeanServer.java:511)
        at MBS_NPE.main(MBS_NPE.java:11)
        at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
        at java.base/java.lang.reflect.Method.invoke(Method.java:565)
        at jdk.compiler/com.sun.tools.javac.launcher.SourceLauncher.execute(SourceLauncher.java:258)
        at jdk.compiler/com.sun.tools.javac.launcher.SourceLauncher.run(SourceLauncher.java:138)
        at jdk.compiler/com.sun.tools.javac.launcher.SourceLauncher.main(SourceLauncher.java:76)
Caused by: java.lang.IllegalArgumentException: Object cannot be null
        at java.management/com.sun.jmx.interceptor.DefaultMBeanServerInterceptor.registerMBean(DefaultMBeanServerInterceptor.java:295)
        ... 7 more
```


