### PR TITLE
8364351: ZGC: Replace usages of ZPageAgeRange() with ZPageAgeRangeAll

### DIFF
--- a/src/hotspot/share/gc/z/zGeneration.cpp
+++ b/src/hotspot/share/gc/z/zGeneration.cpp
@@ -704,7 +704,7 @@ uint ZGenerationYoung::compute_tenuring_threshold(ZRelocationSetSelectorStats st
   uint last_populated_age = 0;
   size_t last_populated_live = 0;
 
-  for (ZPageAge age : ZPageAgeRange()) {
+  for (ZPageAge age : ZPageAgeRangeAll) {
     const size_t young_live = stats.small(age).live() + stats.medium(age).live() + stats.large(age).live();
     if (young_live > 0) {
       last_populated_age = untype(age);

--- a/src/hotspot/share/gc/z/zObjectAllocator.cpp
+++ b/src/hotspot/share/gc/z/zObjectAllocator.cpp
@@ -204,7 +204,7 @@ void ZObjectAllocator::PerAge::retire_pages() {
 ZObjectAllocator::ZObjectAllocator()
   : _allocators() {
 
-  for (ZPageAge age : ZPageAgeRange()) {
+  for (ZPageAge age : ZPageAgeRangeAll) {
     _allocators[untype(age)].initialize(age);
   }
 }

--- a/src/hotspot/share/gc/z/zPageAge.hpp
+++ b/src/hotspot/share/gc/z/zPageAge.hpp
@@ -62,5 +62,6 @@ constexpr ZPageAgeRange ZPageAgeRangeYoung = ZPageAgeRange::create<ZPageAge::ede
 constexpr ZPageAgeRange ZPageAgeRangeSurvivor = ZPageAgeRange::create<ZPageAge::survivor1, ZPageAge::old>();
 constexpr ZPageAgeRange ZPageAgeRangeRelocation = ZPageAgeRange::create<ZPageAge::survivor1, ZPageAgeLastPlusOne>();
 constexpr ZPageAgeRange ZPageAgeRangeOld = ZPageAgeRange::create<ZPageAge::old, ZPageAgeLastPlusOne>();
+constexpr ZPageAgeRange ZPageAgeRangeAll = ZPageAgeRange();
 
 #endif // SHARE_GC_Z_ZPAGEAGE_HPP

--- a/src/hotspot/share/gc/z/zRelocationSetSelector.cpp
+++ b/src/hotspot/share/gc/z/zRelocationSetSelector.cpp
@@ -240,7 +240,7 @@ void ZRelocationSetSelector::select() {
 ZRelocationSetSelectorStats ZRelocationSetSelector::stats() const {
   ZRelocationSetSelectorStats stats;
 
-  for (ZPageAge age : ZPageAgeRange()) {
+  for (ZPageAge age : ZPageAgeRangeAll) {
     const uint i = untype(age);
     stats._small[i] = _small.stats(age);
     stats._medium[i] = _medium.stats(age);

--- a/src/hotspot/share/gc/z/zRelocationSetSelector.inline.hpp
+++ b/src/hotspot/share/gc/z/zRelocationSetSelector.inline.hpp
@@ -189,7 +189,7 @@ inline void ZRelocationSetSelector::clear_empty_pages() {
 
 inline size_t ZRelocationSetSelector::total() const {
   size_t sum = 0;
-  for (ZPageAge age : ZPageAgeRange()) {
+  for (ZPageAge age : ZPageAgeRangeAll) {
     sum += _small.stats(age).total() + _medium.stats(age).total() + _large.stats(age).total();
   }
   return sum;
@@ -197,7 +197,7 @@ inline size_t ZRelocationSetSelector::total() const {
 
 inline size_t ZRelocationSetSelector::empty() const {
   size_t sum = 0;
-  for (ZPageAge age : ZPageAgeRange()) {
+  for (ZPageAge age : ZPageAgeRangeAll) {
     sum += _small.stats(age).empty() + _medium.stats(age).empty() + _large.stats(age).empty();
   }
   return sum;
@@ -205,7 +205,7 @@ inline size_t ZRelocationSetSelector::empty() const {
 
 inline size_t ZRelocationSetSelector::relocate() const {
   size_t sum = 0;
-  for (ZPageAge age : ZPageAgeRange()) {
+  for (ZPageAge age : ZPageAgeRangeAll) {
     sum += _small.stats(age).relocate() + _medium.stats(age).relocate() + _large.stats(age).relocate();
   }
   return sum;

--- a/src/hotspot/share/gc/z/zStat.cpp
+++ b/src/hotspot/share/gc/z/zStat.cpp
@@ -1500,7 +1500,7 @@ void ZStatRelocation::print_page_summary() {
     summary.relocate += stats.relocate();
   };
 
-  for (ZPageAge age : ZPageAgeRange()) {
+  for (ZPageAge age : ZPageAgeRangeAll) {
     account_page_size(small_summary, _selector_stats.small(age));
     account_page_size(medium_summary, _selector_stats.medium(age));
     account_page_size(large_summary, _selector_stats.large(age));
@@ -1561,7 +1561,7 @@ void ZStatRelocation::print_age_table() {
 
   uint oldest_none_empty_age = 0;
 
-  for (ZPageAge age : ZPageAgeRange()) {
+  for (ZPageAge age : ZPageAgeRangeAll) {
     uint i = untype(age);
     auto summarize_pages = [&](const ZRelocationSetSelectorGroupStats& stats) {
       live[i] += stats.live();
@@ -1790,7 +1790,7 @@ void ZStatHeap::at_select_relocation_set(const ZRelocationSetSelectorStats& stat
   ZLocker<ZLock> locker(&_stat_lock);
 
   size_t live = 0;
-  for (ZPageAge age : ZPageAgeRange()) {
+  for (ZPageAge age : ZPageAgeRangeAll) {
     live += stats.small(age).live() + stats.medium(age).live() + stats.large(age).live();
   }
   _at_mark_end.live = live;

--- a/test/hotspot/gtest/gc/z/test_zPageAge.cpp
+++ b/test/hotspot/gtest/gc/z/test_zPageAge.cpp
@@ -44,4 +44,8 @@ TEST(ZPageAgeRangeTest, test) {
   ZPageAgeRange rangeOld = ZPageAgeRangeOld;
   EXPECT_EQ(rangeOld.first(), ZPageAge::old);
   EXPECT_EQ(rangeOld.last(), ZPageAge::old);
+
+  ZPageAgeRange rangeAll = ZPageAgeRangeAll;
+  EXPECT_EQ(rangeAll.first(), ZPageAge::eden);
+  EXPECT_EQ(rangeAll.last(), ZPageAge::old);
 }


### PR DESCRIPTION
Hello,

Following up on [JDK-8357053](https://bugs.openjdk.org/browse/JDK-8357053) and [JDK-8358586](https://bugs.openjdk.org/browse/JDK-8358586), this RFE adds a new pre-defined ZPageAge iterator called ZPageAgeRangeAll to iterate over all ages. ZPageAgeRangeAll replaces the usage of `ZPageAgeRange()`, and the ZPageAge gtest is expanded to cover this.

Testing:
* Oracle's tier 1-4

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8364351](https://bugs.openjdk.org/browse/JDK-8364351): ZGC: Replace usages of ZPageAgeRange() with ZPageAgeRangeAll (**Enhancement** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26549/head:pull/26549` \
`$ git checkout pull/26549`

Update a local copy of the PR: \
`$ git checkout pull/26549` \
`$ git pull https://git.openjdk.org/jdk.git pull/26549/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26549`

View PR using the GUI difftool: \
`$ git pr show -t 26549`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26549.diff">https://git.openjdk.org/jdk/pull/26549.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26549#issuecomment-3136055514)
</details>
