### PR TITLE
8325482: Test that distinct seeds produce distinct traces for compiler stress flags

### DIFF
--- a/test/hotspot/jtreg/compiler/debug/TestStress.java
+++ b/test/hotspot/jtreg/compiler/debug/TestStress.java
@@ -77,7 +77,17 @@ public class TestStress {
 
     static void sum(int n) {
         int acc = 0;
-        for (int i = 0; i < n; i++) acc += i;
+        int[] arr1 = new int[n];
+        int[] arr2 = new int[n];
+        int[] arr3 = new int[n];
+        int[] arr4 = new int[n];
+        for (int i = 0; i < n; i++) {
+            acc += i;
+            arr1[i] = i;
+            arr2[i] = acc;
+            arr3[i] = i * n;
+            arr4[i] = acc * n;
+        }
         System.out.println(acc);
     }
 

--- a/test/hotspot/jtreg/compiler/debug/TestStressDistinctSeed.java
+++ b/test/hotspot/jtreg/compiler/debug/TestStressDistinctSeed.java
@@ -1,0 +1,116 @@
+/* Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+* DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+*
+* This code is free software; you can redistribute it and/or modify it
+* under the terms of the GNU General Public License version 2 only, as
+* published by the Free Software Foundation.
+*
+* This code is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+* version 2 for more details (a copy is included in the LICENSE file that
+* accompanied this code).
+*
+* You should have received a copy of the GNU General Public License version
+* 2 along with this work; if not, write to the Free Software Foundation,
+* Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+*
+* Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+* or visit www.oracle.com if you need additional information or have any
+* questions.
+*/
+
+package compiler.debug;
+
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+import jdk.test.lib.Asserts;
+import java.util.Set;
+import java.util.HashSet;
+import java.util.Arrays;
+
+/*
+ * @test
+ * @key stress randomness
+ * @requires vm.debug == true & vm.compiler2.enabled
+ * @requires vm.flagless
+ * @summary Tests that stress compilations with the N different seed yield different
+ *          IGVN, CCP, macro elimination, and macro expansion traces.
+ * @library /test/lib /
+ * @run driver compiler.debug.TestStressDistinctSeed
+ */
+
+public class TestStressDistinctSeed {
+
+    private static int counter = 0;
+
+    static String phaseTrace(String stressOption, String traceOption,
+            int stressSeed) throws Exception {
+        String className = TestStressDistinctSeed.class.getName();
+        String[] procArgs = {
+                "-Xcomp", "-XX:-TieredCompilation", "-XX:-Inline", "-XX:+CICountNative",
+                "-XX:CompileOnly=" + className + "::sum", "-XX:" + traceOption,
+                "-XX:+" + stressOption, "-XX:StressSeed=" + stressSeed,
+                className, "10" };
+        ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(procArgs);
+        OutputAnalyzer out = new OutputAnalyzer(pb.start());
+        out.shouldHaveExitValue(0);
+        return out.getStdout();
+    }
+
+    static String igvnTrace(int stressSeed) throws Exception {
+        return phaseTrace("StressIGVN", "+TraceIterativeGVN", stressSeed);
+    }
+
+    static String ccpTrace(int stressSeed) throws Exception {
+        return phaseTrace("StressCCP", "+TracePhaseCCP", stressSeed);
+    }
+
+    static String macroExpansionTrace(int stressSeed) throws Exception {
+        return phaseTrace("StressMacroExpansion",
+                "CompileCommand=PrintIdealPhase,*::*,AFTER_MACRO_EXPANSION_STEP",
+                stressSeed);
+    }
+
+    static String macroEliminationTrace(int stressSeed) throws Exception {
+        return phaseTrace("StressMacroElimination",
+                "CompileCommand=PrintIdealPhase,*::*,AFTER_MACRO_ELIMINATION_STEP",
+                stressSeed);
+    }
+
+    static void sum(int n) {
+        int[] arr1 = new int[n];
+        for (int i = 0; i < n; i++) {
+            synchronized (TestStressDistinctSeed.class) {
+                counter += i;
+                arr1[i] = counter;
+            }
+        }
+        System.out.println(counter);
+    }
+
+    public static void main(String[] args) throws Exception {
+        Set<String> igvnTraceSet = new HashSet<>();
+        Set<String> ccpTraceSet = new HashSet<>();
+        Set<String> macroExpansionTraceSet = new HashSet<>();
+        Set<String> macroEliminationTraceSet = new HashSet<>();
+        if (args.length == 0) {
+            for (int s = 0; s < 10; s++) {
+                igvnTraceSet.add(igvnTrace(s));
+                ccpTraceSet.add(ccpTrace(s));
+                macroExpansionTraceSet.add(macroExpansionTrace(s));
+                macroEliminationTraceSet.add(macroEliminationTrace(s));
+            }
+            Asserts.assertGT(igvnTraceSet.size(), 1,
+                    "got same IGVN traces for 10 different seeds");
+            Asserts.assertGT(ccpTraceSet.size(), 1,
+                    "got same CCP traces for 10 different seeds");
+            Asserts.assertGT(macroExpansionTraceSet.size(), 1,
+                    "got same macro expansion traces for 10 different seeds");
+            Asserts.assertGT(macroEliminationTraceSet.size(), 1,
+                    "got same macro elimination traces for 10 different seeds");
+        } else if (args.length > 0) {
+            sum(Integer.parseInt(args[0]));
+        }
+    }
+}

--- a/test/hotspot/jtreg/compiler/debug/TestStressDistinctSeed.java
+++ b/test/hotspot/jtreg/compiler/debug/TestStressDistinctSeed.java
@@ -50,7 +50,7 @@ public class TestStressDistinctSeed {
                 "-Xcomp", "-XX:-TieredCompilation", "-XX:-Inline", "-XX:+CICountNative",
                 "-XX:CompileOnly=" + className + "::sum", "-XX:" + traceOption,
                 "-XX:+" + stressOption, "-XX:StressSeed=" + stressSeed,
-                className, "10" };
+                className, "5" };
         ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(procArgs);
         OutputAnalyzer out = new OutputAnalyzer(pb.start());
         out.shouldHaveExitValue(0);
@@ -95,7 +95,7 @@ public class TestStressDistinctSeed {
         Set<String> macroEliminationTraceSet = new HashSet<>();
         String igvntrace, ccptrace, macroexpansiontrace, macroeliminationtrace;
         if (args.length == 0) {
-            for (int s = 0; s < 10; s++) {
+            for (int s = 0; s < 5; s++) {
                 igvntrace = igvnTrace(s);
                 ccptrace = ccpTrace(s);
                 macroexpansiontrace = macroExpansionTrace(s);
@@ -117,13 +117,13 @@ public class TestStressDistinctSeed {
                 macroEliminationTraceSet.add(macroeliminationtrace);
             }
             Asserts.assertGT(igvnTraceSet.size(), 1,
-                    "got same IGVN traces for 10 different seeds");
+                    "got same IGVN traces for 5 different seeds");
             Asserts.assertGT(ccpTraceSet.size(), 1,
-                    "got same CCP traces for 10 different seeds");
+                    "got same CCP traces for 5 different seeds");
             Asserts.assertGT(macroExpansionTraceSet.size(), 1,
-                    "got same macro expansion traces for 10 different seeds");
+                    "got same macro expansion traces for 5 different seeds");
             Asserts.assertGT(macroEliminationTraceSet.size(), 1,
-                    "got same macro elimination traces for 10 different seeds");
+                    "got same macro elimination traces for 5 different seeds");
         } else if (args.length > 0) {
             sum(Integer.parseInt(args[0]));
         }

--- a/test/hotspot/jtreg/compiler/debug/TestStressDistinctSeed.java
+++ b/test/hotspot/jtreg/compiler/debug/TestStressDistinctSeed.java
@@ -32,9 +32,8 @@ import java.util.Arrays;
 /*
  * @test
  * @key stress randomness
- * @requires vm.debug == true & vm.compiler2.enabled
- * @requires vm.flagless
- * @summary Tests that stress compilations with the N different seed yield different
+ * @requires vm.debug == true & vm.compiler2.enabled & vm.flagless
+ * @summary Tests that stress compilations with the N different seeds yield different
  *          IGVN, CCP, macro elimination, and macro expansion traces.
  * @library /test/lib /
  * @run driver compiler.debug.TestStressDistinctSeed
@@ -94,12 +93,28 @@ public class TestStressDistinctSeed {
         Set<String> ccpTraceSet = new HashSet<>();
         Set<String> macroExpansionTraceSet = new HashSet<>();
         Set<String> macroEliminationTraceSet = new HashSet<>();
+        String igvntrace, ccptrace, macroexpansiontrace, macroeliminationtrace;
         if (args.length == 0) {
             for (int s = 0; s < 10; s++) {
-                igvnTraceSet.add(igvnTrace(s));
-                ccpTraceSet.add(ccpTrace(s));
-                macroExpansionTraceSet.add(macroExpansionTrace(s));
-                macroEliminationTraceSet.add(macroEliminationTrace(s));
+                igvntrace = igvnTrace(s);
+                ccptrace = ccpTrace(s);
+                macroexpansiontrace = macroExpansionTrace(s);
+                macroeliminationtrace = macroEliminationTrace(s);
+                // Test same seed produce same result to test that different traces come from different seed and
+                // not indeterminism with the test.
+                Asserts.assertEQ(igvntrace, igvnTrace(s),
+                        "got different IGVN traces for the same seed");
+                Asserts.assertEQ(ccptrace, ccpTrace(s),
+                        "got different CCP traces for the same seed");
+                Asserts.assertEQ(macroexpansiontrace, macroExpansionTrace(s),
+                        "got different macro expansion traces for the same seed");
+                Asserts.assertEQ(macroeliminationtrace, macroEliminationTrace(s),
+                        "got different macro elimination traces for the same seed");
+
+                igvnTraceSet.add(igvntrace);
+                ccpTraceSet.add(ccptrace);
+                macroExpansionTraceSet.add(macroexpansiontrace);
+                macroEliminationTraceSet.add(macroeliminationtrace);
             }
             Asserts.assertGT(igvnTraceSet.size(), 1,
                     "got same IGVN traces for 10 different seeds");

--- a/test/hotspot/jtreg/compiler/debug/TestStressDistinctSeed.java
+++ b/test/hotspot/jtreg/compiler/debug/TestStressDistinctSeed.java
@@ -93,28 +93,28 @@ public class TestStressDistinctSeed {
         Set<String> ccpTraceSet = new HashSet<>();
         Set<String> macroExpansionTraceSet = new HashSet<>();
         Set<String> macroEliminationTraceSet = new HashSet<>();
-        String igvntrace, ccptrace, macroexpansiontrace, macroeliminationtrace;
+        String igvnTraceOutput, ccpTraceOutput, macroExpansionTraceOutput, macroEliminationTraceOutput;
         if (args.length == 0) {
             for (int s = 0; s < 5; s++) {
-                igvntrace = igvnTrace(s);
-                ccptrace = ccpTrace(s);
-                macroexpansiontrace = macroExpansionTrace(s);
-                macroeliminationtrace = macroEliminationTrace(s);
+                igvnTraceOutput = igvnTrace(s);
+                ccpTraceOutput = ccpTrace(s);
+                macroExpansionTraceOutput = macroExpansionTrace(s);
+                macroEliminationTraceOutput = macroEliminationTrace(s);
                 // Test same seed produce same result to test that different traces come from different seed and
                 // not indeterminism with the test.
-                Asserts.assertEQ(igvntrace, igvnTrace(s),
+                Asserts.assertEQ(igvnTraceOutput, igvnTrace(s),
                         "got different IGVN traces for the same seed");
-                Asserts.assertEQ(ccptrace, ccpTrace(s),
+                Asserts.assertEQ(ccpTraceOutput, ccpTrace(s),
                         "got different CCP traces for the same seed");
-                Asserts.assertEQ(macroexpansiontrace, macroExpansionTrace(s),
+                Asserts.assertEQ(macroExpansionTraceOutput, macroExpansionTrace(s),
                         "got different macro expansion traces for the same seed");
-                Asserts.assertEQ(macroeliminationtrace, macroEliminationTrace(s),
+                Asserts.assertEQ(macroEliminationTraceOutput, macroEliminationTrace(s),
                         "got different macro elimination traces for the same seed");
 
-                igvnTraceSet.add(igvntrace);
-                ccpTraceSet.add(ccptrace);
-                macroExpansionTraceSet.add(macroexpansiontrace);
-                macroEliminationTraceSet.add(macroeliminationtrace);
+                igvnTraceSet.add(igvnTraceOutput);
+                ccpTraceSet.add(ccpTraceOutput);
+                macroExpansionTraceSet.add(macroExpansionTraceOutput);
+                macroEliminationTraceSet.add(macroEliminationTraceOutput);
             }
             Asserts.assertGT(igvnTraceSet.size(), 1,
                     "got same IGVN traces for 5 different seeds");


### PR DESCRIPTION
### Issue 
The existing test (`compiler/debug/TestStress.java`) verifies that compiler stress options produce consistent traces when using the same seed. However, there is currently no test to ensure that different seeds result in different traces.

### Solution
Added a test case to assess the distinctness of traces generated from different seeds. This fix addresses the fragility concern highlighted in [JDK-8325482](https://bugs.openjdk.org/browse/JDK-8325482) by verifying that traces produced using N (in this case 10) distinct seeds are all not identical.

### Changes to `compiler/debug/TestStress.java`
While investigating this issue, I observed that in `compiler/debug/TestStress.java`, the stress options for macro expansion and macro elimination were not being triggered because there were fewer than 2 macro nodes. Note that the  `shuffle_macro_nodes()` in` compile.cpp` is only meaningful when there are more than two macro nodes. The generated traces for macro expansion and macro elimination in `TestStress.java` were empty. I have proposed changes to address this problem.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325482](https://bugs.openjdk.org/browse/JDK-8325482): Test that distinct seeds produce distinct traces for compiler stress flags (**Enhancement** - P4)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Damon Fenacci](https://openjdk.org/census#dfenacci) (@dafedafe - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26554/head:pull/26554` \
`$ git checkout pull/26554`

Update a local copy of the PR: \
`$ git checkout pull/26554` \
`$ git pull https://git.openjdk.org/jdk.git pull/26554/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26554`

View PR using the GUI difftool: \
`$ git pr show -t 26554`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26554.diff">https://git.openjdk.org/jdk/pull/26554.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26554#issuecomment-3138835272)
</details>
