### PR TITLE
8362533: Tests sun/management/jmxremote/bootstrap/* duplicate VM flags

### DIFF
--- a/test/jdk/sun/management/jmxremote/bootstrap/AbstractFilePermissionTest.java
+++ b/test/jdk/sun/management/jmxremote/bootstrap/AbstractFilePermissionTest.java
@@ -169,8 +169,6 @@ public abstract class AbstractFilePermissionTest {
             List<String> command = new ArrayList<>();
             command.add(mp);
             command.add(pp);
-            command.add("-cp");
-            command.add(TEST_CLASSES);
             command.add(className);
 
             ProcessBuilder processBuilder = ProcessTools.createTestJavaProcessBuilder(command);

--- a/test/jdk/sun/management/jmxremote/bootstrap/LocalManagementTest.java
+++ b/test/jdk/sun/management/jmxremote/bootstrap/LocalManagementTest.java
@@ -46,7 +46,6 @@ import jdk.test.lib.process.ProcessTools;
  * @run main/othervm/timeout=300 LocalManagementTest
  */
 public class LocalManagementTest {
-    private static final String TEST_CLASSPATH = System.getProperty("test.class.path");
 
     public static void main(String[] args) throws Exception {
         int failures = 0;
@@ -97,8 +96,6 @@ public class LocalManagementTest {
     private static boolean doTest(String testId, String arg) throws Exception {
         List<String> args = new ArrayList<>();
         args.add("-XX:+UsePerfData");
-        args.add("-cp");
-        args.add(TEST_CLASSPATH);
 
         if (arg != null) {
             args.add(arg);
@@ -131,8 +128,6 @@ public class LocalManagementTest {
             System.out.println("  shutdown port : " + port.get());
 
             ProcessBuilder client = ProcessTools.createTestJavaProcessBuilder(
-                "-cp",
-                TEST_CLASSPATH,
                 "--add-exports", "jdk.management.agent/jdk.internal.agent=ALL-UNNAMED",
                 "TestManager",
                 String.valueOf(serverPrc.pid()),

--- a/test/jdk/sun/management/jmxremote/bootstrap/RmiRegistrySslTest.java
+++ b/test/jdk/sun/management/jmxremote/bootstrap/RmiRegistrySslTest.java
@@ -182,8 +182,6 @@ public class RmiRegistrySslTest {
             command.add("-Dtest.src=" + TEST_SRC);
             command.add("-Dtest.rmi.port=" + port);
             command.addAll(Arrays.asList(args));
-            command.add("-cp");
-            command.add(TEST_CLASS_PATH);
             command.add(className);
 
             ProcessBuilder processBuilder = ProcessTools.createTestJavaProcessBuilder(command);


### PR DESCRIPTION
Hi all,

`ProcessTools.createTestJavaProcessBuilder(String... command)` will call `jdk.test.lib.Utils#getTestJavaOpts`, so remove the duplicate vm flags. Trivial fix.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8362533](https://bugs.openjdk.org/browse/JDK-8362533): Tests sun/management/jmxremote/bootstrap/* duplicate VM flags (**Bug** - P4)


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26555/head:pull/26555` \
`$ git checkout pull/26555`

Update a local copy of the PR: \
`$ git checkout pull/26555` \
`$ git pull https://git.openjdk.org/jdk.git pull/26555/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26555`

View PR using the GUI difftool: \
`$ git pr show -t 26555`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26555.diff">https://git.openjdk.org/jdk/pull/26555.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26555#issuecomment-3136708093)
</details>
