### PR TITLE
8361316: javadoc tool fails with an exception for an inheritdoc on throws clause of a constructor

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/taglets/ThrowsTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/taglets/ThrowsTaglet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -247,6 +247,7 @@ public class ThrowsTaglet extends BaseTaglet implements InheritableTaglet {
         Set<TypeMirror> alreadyDocumentedExceptions = new HashSet<>();
         List<ThrowsTree> exceptionTags = utils.getThrowsTrees(executable);
         for (ThrowsTree t : exceptionTags) {
+            config.tagletManager.checkTags(holder, t.getDescription());
             Element exceptionElement = getExceptionType(t, executable);
             outputAnExceptionTagDeeply(exceptionSection, exceptionElement, t, executable, alreadyDocumentedExceptions, typeSubstitutions);
         }
@@ -364,9 +365,10 @@ public class ThrowsTaglet extends BaseTaglet implements InheritableTaglet {
         alreadyDocumentedExceptions.add(exceptionType);
         var description = tag.getDescription();
         int i = indexOfInheritDoc(tag, holder);
-        if (i == -1) {
-            // Since the description does not contain {@inheritDoc}, we either add a new entry, or
-            // append to the current one. Here's an example of when we add a new entry:
+        // Constructors do not support {@inheritDoc}, but we still want to render the remaining tag.
+        if (i == -1 || holder.getKind() != ElementKind.METHOD) {
+            // Since the description does not contain or support {@inheritDoc}, we either add a new entry,
+            // or append to the current one. Here's an example of when we add a new entry:
             //
             //     ... -> {@inheritDoc} -> <text>
             //
@@ -387,7 +389,6 @@ public class ThrowsTaglet extends BaseTaglet implements InheritableTaglet {
                 exceptionSection.endEntry();
             }
         } else { // expand a single {@inheritDoc}
-            assert holder.getKind() == ElementKind.METHOD : holder.getKind(); // only methods can use {@inheritDoc}
             // Is the {@inheritDoc} that we found standalone (i.e. without preceding and following text)?
             boolean loneInheritDoc = description.size() == 1;
             assert !loneInheritDoc || i == 0 : i;

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/resources/doclets.properties
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/resources/doclets.properties
@@ -124,7 +124,7 @@ doclet.inheritDocNoDoc=overridden methods do not document exception type {0}
 doclet.throwsInheritDocUnsupported=@inheritDoc is not supported for exception-type type parameters \
   that are not declared by a method; document such exception types directly
 doclet.noInheritedDoc=@inheritDoc used but {0} does not override or implement any method.
-doclet.tag_misuse=Tag {0} cannot be used in {1} documentation.  It can only be used in the following types of documentation: {2}.
+doclet.tag_misuse=Tag {0} cannot be used in {1} documentation. It can only be used in the following types of documentation: {2}.
 doclet.Package_Summary=Package Summary
 doclet.Requires_Summary=Requires
 doclet.Indirect_Requires_Summary=Indirect Requires


### PR DESCRIPTION
Please review a simple fix for a javadoc failure when `{@inheritDoc}` is placed in the `@throws` tag of a constructor. 

`{@inheritDoc}` tags in invalid locations are treated as warnings, so we add a check for the warning and ignore the `{@inheritDoc}` when rendering the `@throws` tag.

The test also checks `{@inheritDoc}` tags in a few other locations, such as field descriptions, constructor descriptions, and `@param` tags of constructors. The patch also includes some whitespace cleanup in the warning message and the existing tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8361316: javadoc tool fails with an exception for an inheritdoc on throws clause of a constructor`

### Issue
 * [JDK-8361316](https://bugs.openjdk.org/browse/JDK-8361316): javadoc tool fails with an exception for an inheritdoc on throws clause of a constructor (**Bug** - P4)


### Reviewers
 * [Nizar Benalla](https://openjdk.org/census#nbenalla) (@nizarbenalla - Committer)
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26557/head:pull/26557` \
`$ git checkout pull/26557`

Update a local copy of the PR: \
`$ git checkout pull/26557` \
`$ git pull https://git.openjdk.org/jdk.git pull/26557/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26557`

View PR using the GUI difftool: \
`$ git pr show -t 26557`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26557.diff">https://git.openjdk.org/jdk/pull/26557.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26557#issuecomment-3136881695)
</details>
