### PR TITLE
8364296: Set IntelJccErratumMitigation flag ergonomically

### DIFF
--- a/src/hotspot/cpu/x86/vm_version_x86.cpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.cpp
@@ -1069,6 +1069,7 @@ void VM_Version::get_processor_features() {
 
   if (FLAG_IS_DEFAULT(IntelJccErratumMitigation)) {
     _has_intel_jcc_erratum = compute_has_intel_jcc_erratum();
+    FLAG_SET_ERGO(IntelJccErratumMitigation, _has_intel_jcc_erratum);
   } else {
     _has_intel_jcc_erratum = IntelJccErratumMitigation;
   }


### PR DESCRIPTION
We should update the flag if we are using a computed value. Nobody else reads IntelJccErratumMitigation specifically, but we want it to be correctly shown in PrintFlagsFinal and anywhere else these flags are inspected.

```
Intel(R) Xeon(R) Platinum 8259CL
java -XX:+UnlockDiagnosticVMOptions -XX:+PrintFlagsFinal -version | grep IntelJcc
Before:
     bool IntelJccErratumMitigation  = true   {ARCH diagnostic} {default}
After:
     bool IntelJccErratumMitigation  = true   {ARCH diagnostic} {ergonomic}
```

Even worse when it's actually false, but shows as true:

```
AMD EPYC 7R13
java -XX:+UnlockDiagnosticVMOptions -XX:+PrintFlagsFinal -version | grep IntelJcc
Before:
     bool IntelJccErratumMitigation  = true   {ARCH diagnostic} {default}
After:
     bool IntelJccErratumMitigation  = false  {ARCH diagnostic} {ergonomic}
```