### PR TITLE
8349732: Add support for JARs signed with ML-DSA

### DIFF
--- a/src/java.base/share/classes/sun/security/pkcs/SignerInfo.java
+++ b/src/java.base/share/classes/sun/security/pkcs/SignerInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -303,15 +303,20 @@ public class SignerInfo implements DerEncoder {
         return certList;
     }
 
-    /* Returns null if verify fails, this signerInfo if
-       verify succeeds. */
-    SignerInfo verify(PKCS7 block, byte[] data)
-    throws NoSuchAlgorithmException, SignatureException {
+    /**
+     * Verify this signerInfo in a PKCS7 block.
+     *
+     * @param block the PKCS7 object
+     * @param data the content to verify against; read from block if null
+     * @param cert certificate to verify with; read from block if null
+     * @return null if verify fails, this signerInfo if verify succeeds.
+     */
+    SignerInfo verify(PKCS7 block, byte[] data, X509Certificate cert)
+            throws NoSuchAlgorithmException, SignatureException {
 
         try {
-            Timestamp timestamp = null;
             try {
-                timestamp = getTimestamp();
+                getTimestamp();
             } catch (Exception e) {
                 // Log exception and continue. This allows for the case
                 // where, if there are no other errors, the code is
@@ -356,22 +361,19 @@ public class SignerInfo implements DerEncoder {
                     return null;
 
                 byte[] computedMessageDigest;
-                if (digestAlgName.equals("SHAKE256")
-                        || digestAlgName.equals("SHAKE256-LEN")) {
-                    if (digestAlgName.equals("SHAKE256-LEN")) {
-                        // RFC8419: for EdDSA in CMS, the id-shake256-len
-                        // algorithm id must contain parameter value 512
-                        // encoded as a positive integer value
-                        byte[] params = digestAlgorithmId.getEncodedParams();
-                        if (params == null) {
-                            throw new SignatureException(
-                                    "id-shake256-len oid missing length");
-                        }
-                        int v = new DerValue(params).getInteger();
-                        if (v != 512) {
-                            throw new SignatureException(
-                                    "Unsupported id-shake256-" + v);
-                        }
+                if (digestAlgName.equals("SHAKE256-LEN")) {
+                    // RFC8419: for EdDSA in CMS, the id-shake256-len
+                    // algorithm id must contain parameter value 512
+                    // encoded as a positive integer value
+                    byte[] params = digestAlgorithmId.getEncodedParams();
+                    if (params == null) {
+                        throw new SignatureException(
+                                "id-shake256-len oid missing length");
+                    }
+                    int v = new DerValue(params).getInteger();
+                    if (v != 512) {
+                        throw new SignatureException(
+                                "Unsupported id-shake256-" + v);
                     }
                     var md = new SHAKE256(64);
                     md.update(data, 0, data.length);
@@ -410,9 +412,11 @@ public class SignerInfo implements DerEncoder {
                         "SignerInfo digestEncryptionAlgorithm field", true));
             }
 
-            X509Certificate cert = getCertificate(block);
             if (cert == null) {
-                return null;
+                cert = getCertificate(block);
+                if (cert == null) {
+                    return null;
+                }
             }
             PublicKey key = cert.getPublicKey();
 
@@ -507,24 +511,54 @@ public class SignerInfo implements DerEncoder {
                 }
                 break;
             case "Ed25519":
-                if (!digAlgId.equals(SignatureUtil.EdDSADigestAlgHolder.sha512)) {
+                if (!digAlgId.equalsOID(AlgorithmId.SHA512_oid)) {
                     throw new NoSuchAlgorithmException("Incompatible digest algorithm");
                 }
                 break;
             case "Ed448":
                 if (directSign) {
-                    if (!digAlgId.equals(SignatureUtil.EdDSADigestAlgHolder.shake256)) {
+                    if (!digAlgId.equalsOID(AlgorithmId.SHAKE256_512_oid)) {
                         throw new NoSuchAlgorithmException("Incompatible digest algorithm");
                     }
                 } else {
-                    if (!digAlgId.equals(SignatureUtil.EdDSADigestAlgHolder.shake256$512)) {
+                    if (!digAlgId.equals(SignatureUtil.DigestAlgHolder.shake256$512)) {
                         throw new NoSuchAlgorithmException("Incompatible digest algorithm");
                     }
                 }
                 break;
             case "HSS/LMS":
                 // RFC 8708 requires the same hash algorithm used as in the HSS/LMS algorithm
-                if (!digAlgId.equals(AlgorithmId.get(KeyUtil.hashAlgFromHSS(key)))) {
+                if (!digAlgId.equalsOID(KeyUtil.hashAlgFromHSS(key))) {
+                    throw new NoSuchAlgorithmException("Incompatible digest algorithm");
+                }
+                break;
+            case "ML-DSA-44":
+                // Following 3 from Table 1 inside
+                // https://datatracker.ietf.org/doc/html/draft-ietf-lamps-cms-ml-dsa-06#name-signerinfo-content
+                if (!digAlgId.equalsOID(AlgorithmId.SHA256_oid)
+                        && !digAlgId.equalsOID(AlgorithmId.SHA384_oid)
+                        && !digAlgId.equalsOID(AlgorithmId.SHA512_oid)
+                        && !digAlgId.equalsOID(AlgorithmId.SHA3_256_oid)
+                        && !digAlgId.equalsOID(AlgorithmId.SHA3_384_oid)
+                        && !digAlgId.equalsOID(AlgorithmId.SHA3_512_oid)
+                        && !digAlgId.equalsOID(AlgorithmId.SHAKE128_256_oid)
+                        && !digAlgId.equalsOID(AlgorithmId.SHAKE256_512_oid)) {
+                    throw new NoSuchAlgorithmException("Incompatible digest algorithm" + digAlgId);
+                }
+                break;
+            case "ML-DSA-65":
+                if (!digAlgId.equalsOID(AlgorithmId.SHA384_oid)
+                        && !digAlgId.equalsOID(AlgorithmId.SHA512_oid)
+                        && !digAlgId.equalsOID(AlgorithmId.SHA3_384_oid)
+                        && !digAlgId.equalsOID(AlgorithmId.SHA3_512_oid)
+                        && !digAlgId.equalsOID(AlgorithmId.SHAKE256_512_oid)) {
+                    throw new NoSuchAlgorithmException("Incompatible digest algorithm");
+                }
+                break;
+            case "ML-DSA-87":
+                if (!digAlgId.equalsOID(AlgorithmId.SHA512_oid)
+                        && !digAlgId.equalsOID(AlgorithmId.SHA3_512_oid)
+                        && !digAlgId.equalsOID(AlgorithmId.SHAKE256_512_oid)) {
                     throw new NoSuchAlgorithmException("Incompatible digest algorithm");
                 }
                 break;
@@ -538,9 +572,9 @@ public class SignerInfo implements DerEncoder {
      * The digest algorithm is in the form "DIG", and the encryption
      * algorithm can be in any of the 3 forms:
      *
-     * 1. Old style key algorithm like RSA, DSA, EC, this method returns
+     * 1. Simply key algorithm like RSA, DSA, EC, this method returns
      *    DIGwithKEY.
-     * 2. New style signature algorithm in the form of HASHwithKEY, this
+     * 2. Traditional signature algorithm in the form of HASHwithKEY, this
      *    method returns DIGwithKEY. Please note this is not HASHwithKEY.
      * 3. Modern signature algorithm like RSASSA-PSS and EdDSA, this method
      *    returns the signature algorithm itself.
@@ -550,40 +584,26 @@ public class SignerInfo implements DerEncoder {
      */
     public static String makeSigAlg(AlgorithmId digAlgId, AlgorithmId encAlgId) {
         String encAlg = encAlgId.getName();
-        switch (encAlg) {
-            case "RSASSA-PSS":
-            case "Ed25519":
-            case "Ed448":
-            case "HSS/LMS":
-                return encAlg;
-            default:
-                String digAlg = digAlgId.getName();
-                String keyAlg = SignatureUtil.extractKeyAlgFromDwithE(encAlg);
-                if (keyAlg == null) {
-                    // The encAlg used to be only the key alg
-                    keyAlg = encAlg;
-                }
-                if (digAlg.startsWith("SHA-")) {
-                    digAlg = "SHA" + digAlg.substring(4);
-                }
-                if (keyAlg.equals("EC")) keyAlg = "ECDSA";
-                String sigAlg = digAlg + "with" + keyAlg;
-                try {
-                    Signature.getInstance(sigAlg);
-                    return sigAlg;
-                } catch (NoSuchAlgorithmException e) {
-                    // Possibly an unknown modern signature algorithm,
-                    // in this case, encAlg should already be a signature
-                    // algorithm.
-                    return encAlg;
-                }
+        String keyAlg = SignatureUtil.extractKeyAlgFromDwithE(encAlg);
+        if (keyAlg == null) { // No "WITH" inside
+            if (encAlg.equals("RSA") || encAlg.equals("DSA") || encAlg.equals("EC")) {
+                keyAlg = encAlg; // Sometimes encAlgId is just the enc alg
+            } else {
+                return encAlg; // Must be a modern algorithm like EdDSA or ML-DSA
+            }
         }
+        String digAlg = digAlgId.getName();
+        if (digAlg.startsWith("SHA-")) {
+            digAlg = "SHA" + digAlg.substring(4);
+        }
+        if (keyAlg.equals("EC")) keyAlg = "ECDSA";
+        return digAlg + "with" + keyAlg;
     }
 
     /* Verify the content of the pkcs7 block. */
     SignerInfo verify(PKCS7 block)
         throws NoSuchAlgorithmException, SignatureException {
-        return verify(block, null);
+        return verify(block, null, null);
     }
 
     public BigInteger getVersion() {

--- a/src/java.base/share/classes/sun/security/util/KeyUtil.java
+++ b/src/java.base/share/classes/sun/security/util/KeyUtil.java
@@ -430,7 +430,7 @@ public final class KeyUtil {
      * @return the hash algorithm
      * @throws NoSuchAlgorithmException if key is from an unknown configuration
      */
-    public static String hashAlgFromHSS(PublicKey publicKey)
+    public static ObjectIdentifier hashAlgFromHSS(PublicKey publicKey)
             throws NoSuchAlgorithmException {
         try {
             DerValue val = new DerValue(publicKey.getEncoded());
@@ -449,7 +449,7 @@ public final class KeyUtil {
                     + ((rawKey[6] & 0xff) << 8) + (rawKey[7] & 0xff);
             return switch (num) {
                 // RFC 8554 only supports SHA_256 hash algorithm
-                case 5, 6, 7, 8, 9 -> "SHA-256";
+                case 5, 6, 7, 8, 9 -> AlgorithmId.SHA256_oid;
                 default -> throw new NoSuchAlgorithmException("Unknown LMS type: " + num);
             };
         } catch (IOException e) {

--- a/src/java.base/share/classes/sun/security/util/SignatureUtil.java
+++ b/src/java.base/share/classes/sun/security/util/SignatureUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -190,15 +190,15 @@ public class SignatureUtil {
         SharedSecrets.getJavaSecuritySignatureAccess().initSign(s, key, params, sr);
     }
 
-    public static class EdDSADigestAlgHolder {
+    public static class DigestAlgHolder {
         public static final AlgorithmId sha512;
         public static final AlgorithmId shake256;
         public static final AlgorithmId shake256$512;
 
         static {
             try {
-                sha512 = new AlgorithmId(ObjectIdentifier.of(KnownOIDs.SHA_512));
-                shake256 = new AlgorithmId(ObjectIdentifier.of(KnownOIDs.SHAKE256_512));
+                sha512 = new AlgorithmId(AlgorithmId.SHA512_oid);
+                shake256 = new AlgorithmId(AlgorithmId.SHAKE256_512_oid);
                 shake256$512 = new AlgorithmId(
                         ObjectIdentifier.of(KnownOIDs.SHAKE256_LEN),
                         new DerValue((byte) 2, new byte[]{2, 0})); // int 512
@@ -233,18 +233,22 @@ public class SignatureUtil {
             // https://www.rfc-editor.org/rfc/rfc8419.html#section-3
             switch (kAlg.toUpperCase(Locale.ENGLISH)) {
                 case "ED25519":
-                    digAlgID = EdDSADigestAlgHolder.sha512;
+                    digAlgID = DigestAlgHolder.sha512;
                     break;
                 case "ED448":
                     if (directsign) {
-                        digAlgID = EdDSADigestAlgHolder.shake256;
+                        digAlgID = DigestAlgHolder.shake256;
                     } else {
-                        digAlgID = EdDSADigestAlgHolder.shake256$512;
+                        digAlgID = DigestAlgHolder.shake256$512;
                     }
                     break;
                 default:
                     throw new AssertionError("Unknown curve name: " + kAlg);
             }
+        } else if (kAlg.toUpperCase(Locale.ENGLISH).startsWith("ML-DSA")) {
+            // https://datatracker.ietf.org/doc/html/draft-ietf-lamps-cms-ml-dsa-06#name-signerinfo-content
+            // Just use SHA-512
+            digAlgID = DigestAlgHolder.sha512;
         } else if (sigalg.equalsIgnoreCase("RSASSA-PSS")) {
             try {
                 digAlgID = AlgorithmId.get(signer.getParameters()
@@ -254,7 +258,7 @@ public class SignatureUtil {
                 throw new AssertionError("Should not happen", e);
             }
         } else if (sigalg.equalsIgnoreCase("HSS/LMS")) {
-            digAlgID = AlgorithmId.get(KeyUtil.hashAlgFromHSS(publicKey));
+            digAlgID = new AlgorithmId(KeyUtil.hashAlgFromHSS(publicKey));
         } else {
             digAlgID = AlgorithmId.get(extractDigestAlgFromDwithE(sigalg));
         }

--- a/src/java.base/share/classes/sun/security/x509/AlgorithmId.java
+++ b/src/java.base/share/classes/sun/security/x509/AlgorithmId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -308,6 +308,14 @@ public class AlgorithmId implements Serializable, DerEncoder {
     public boolean equals(AlgorithmId other) {
         return algid.equals(other.algid) &&
             Arrays.equals(encodedParams, other.encodedParams);
+    }
+
+    /**
+     * Returns true if this AlgorithmID only has the specified ObjectIdentifier
+     * and a NULL params. Note the encoded params might be ASN.1 NULL or absent.
+     */
+    public boolean equalsOID(ObjectIdentifier oid) {
+        return algid.equals(oid) && encodedParams == null;
     }
 
     /**
@@ -672,4 +680,9 @@ public class AlgorithmId implements Serializable, DerEncoder {
             ObjectIdentifier.of(KnownOIDs.SHA3_384withRSA);
     public static final ObjectIdentifier SHA3_512withRSA_oid =
             ObjectIdentifier.of(KnownOIDs.SHA3_512withRSA);
+
+    public static final ObjectIdentifier SHAKE128_256_oid =
+            ObjectIdentifier.of(KnownOIDs.SHAKE128_256);
+    public static final ObjectIdentifier SHAKE256_512_oid =
+            ObjectIdentifier.of(KnownOIDs.SHAKE256_512);
 }

--- a/test/jdk/sun/security/pkcs/pkcs7/DigestConformance.java
+++ b/test/jdk/sun/security/pkcs/pkcs7/DigestConformance.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8349732
+ * @summary ML-DSA digest alg conformance check
+ * @modules java.base/sun.security.pkcs
+ *          java.base/sun.security.tools.keytool
+ *          java.base/sun.security.x509
+ * @library /test/lib
+ */
+
+import jdk.test.lib.Asserts;
+import sun.security.pkcs.PKCS7;
+import sun.security.tools.keytool.CertAndKeyGen;
+import sun.security.x509.AlgorithmId;
+import sun.security.x509.X500Name;
+
+import java.nio.charset.StandardCharsets;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.cert.X509Certificate;
+import java.util.List;
+import java.util.Map;
+
+public class DigestConformance {
+
+    static String[] ALL_KEY_ALGS = {"ML-DSA-44", "ML-DSA-65", "ML-DSA-87"};
+    static String[] ALL_DIGEST_ALGS = {
+            "SHA-1", "SHA-224", "SHA-256", "SHA-384", "SHA-512",
+            "SHA3-224", "SHA3-256", "SHA3-384", "SHA3-512",
+            "SHAKE128-256", "SHAKE256-512"};
+    static Map<String, List<String>> SUPPORTED = Map.of(
+            "ML-DSA-44", List.of("SHA-256", "SHA-384", "SHA-512",
+                    "SHA3-256", "SHA3-384", "SHA3-512",
+                    "SHAKE128-256", "SHAKE256-512"),
+            "ML-DSA-65", List.of("SHA-384", "SHA-512",
+                    "SHA3-384", "SHA3-512", "SHAKE256-512"),
+            "ML-DSA-87", List.of("SHA-512", "SHA3-512", "SHAKE256-512")
+    );
+
+    public static void main(String[] args) throws Exception {
+        testSig("ML-DSA-44");
+        testSig("ML-DSA-65");
+        testSig("ML-DSA-87");
+    }
+
+    static void testSig(String keyAlg) throws Exception {
+        System.out.println("Testing " + keyAlg);
+        var cag = new CertAndKeyGen(keyAlg, keyAlg);
+        cag.generate(keyAlg);
+        var sk = cag.getPrivateKey();
+        var certs = new X509Certificate[] {
+                cag.getSelfCertificate(new X500Name("CN=Me"), 1000)
+        };
+        var count = testDigest(keyAlg, sk, certs, null);
+        System.out.println("   digestAlg default: " + count);
+        Asserts.assertEQ(count, 1);
+        for (var da : ALL_DIGEST_ALGS) {
+            count = testDigest(keyAlg, sk, certs, da);
+            System.out.println("   digestAlg " + da + ": " + count);
+            if (SUPPORTED.get(keyAlg).contains(da)) {
+                Asserts.assertEQ(count, 1);
+            } else {
+                Asserts.assertEQ(count, 0);
+            }
+        }
+    }
+
+    static int testDigest(String keyAlg, PrivateKey sk,
+            X509Certificate[] certs, String digestAlg) throws Exception {
+        var content = "hello".getBytes(StandardCharsets.UTF_8);
+        var p7 = PKCS7.generateSignedData(keyAlg, null,
+                sk, certs,
+                content, true, false,
+                digestAlg == null ? null : AlgorithmId.get(digestAlg),
+                null);
+        try {
+            return new PKCS7(p7).verify(null).length;
+        } catch (NoSuchAlgorithmException e) {
+            return 0;
+        }
+    }
+}

--- a/test/jdk/sun/security/tools/jarsigner/ML_DSA.java
+++ b/test/jdk/sun/security/tools/jarsigner/ML_DSA.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8298387
+ * @summary signing with ML-DSA
+ * @library /test/lib
+ * @modules java.base/sun.security.util
+ */
+
+import jdk.test.lib.Asserts;
+import jdk.test.lib.SecurityTools;
+import jdk.test.lib.security.DerUtils;
+import jdk.test.lib.util.JarUtils;
+import sun.security.util.KnownOIDs;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.jar.JarFile;
+
+public class ML_DSA {
+    public static void main(String[] args) throws Exception {
+
+        JarUtils.createJarFile(Path.of("a.jar"), Path.of("."),
+                Files.write(Path.of("a"), new byte[10]));
+
+        genKeyAndSign("ML-DSA-44", "M4");
+        genKeyAndSign("ML-DSA-65", "M6");
+        genKeyAndSign("ML-DSA-87", "M8");
+
+        SecurityTools.jarsigner("-verify a.jar -verbose -certs")
+                .shouldHaveExitValue(0)
+                .shouldContain("jar verified");
+
+        try (var jf = new JarFile("a.jar")) {
+
+            var je = jf.getJarEntry("a");
+            jf.getInputStream(je).readAllBytes();
+            Asserts.assertEquals(3, je.getCertificates().length);
+
+            checkDigestAlgorithm(jf, "M4", KnownOIDs.SHA_512);
+            checkDigestAlgorithm(jf, "M6", KnownOIDs.SHA_512);
+            checkDigestAlgorithm(jf, "M8", KnownOIDs.SHA_512);
+        }
+    }
+
+    static void genKeyAndSign(String alg, String alias) throws Exception {
+        SecurityTools.keytool("-keystore ks -storepass changeit -genkeypair -alias "
+                        + alias + " -keyalg " + alg + " -dname CN=" + alias)
+                .shouldHaveExitValue(0);
+        SecurityTools.jarsigner("-keystore ks -storepass changeit a.jar " + alias)
+                .shouldHaveExitValue(0);
+    }
+
+    static void checkDigestAlgorithm(JarFile jf, String alias, KnownOIDs expectAlg)
+            throws Exception {
+        var p7 = jf.getInputStream(jf.getEntry("META-INF/" + alias + ".DSA"))
+                .readAllBytes();
+        // SignedData - digestAlgorithms
+        DerUtils.checkAlg(p7, "10100", expectAlg);
+        // SignedData - signerInfos - digestAlgorithm
+        DerUtils.checkAlg(p7, "104020", expectAlg);
+        // SignedData - signerInfos - signedAttrs - CMSAlgorithmProtection - digestAlgorithm
+        DerUtils.checkAlg(p7, "1040321000", expectAlg);
+    }
+}


### PR DESCRIPTION
Add support for ML-DSA signing of JAR files.

This is a draft PR since https://datatracker.ietf.org/doc/draft-ietf-lamps-cms-ml-dsa/ is not finalized.