### PR TITLE
8362564: hotspot/jtreg/compiler/c2/TestLWLockingCodeGen.java fails on static JDK on x86_64 with AVX instruction extensions

### DIFF
--- a/src/hotspot/cpu/x86/stubDeclarations_x86.hpp
+++ b/src/hotspot/cpu/x86/stubDeclarations_x86.hpp
@@ -30,7 +30,7 @@
                                       do_arch_blob,                     \
                                       do_arch_entry,                    \
                                       do_arch_entry_init)               \
-  do_arch_blob(initial, 20000 WINDOWS_ONLY(+1000))                      \
+  do_arch_blob(initial, PRODUCT_ONLY(20000) NOT_PRODUCT(21000) WINDOWS_ONLY(+1000))                      \
   do_stub(initial, verify_mxcsr)                                        \
   do_arch_entry(x86, initial, verify_mxcsr, verify_mxcsr_entry,         \
                 verify_mxcsr_entry)                                     \

--- a/src/hotspot/share/runtime/stubRoutines.cpp
+++ b/src/hotspot/share/runtime/stubRoutines.cpp
@@ -231,7 +231,9 @@ static BufferBlob* initialize_stubs(StubGenBlobId blob_id,
   StubGenerator_generate(&buffer, blob_id);
   // When new stubs added we need to make sure there is some space left
   // to catch situation when we should increase size again.
-  assert(code_size == 0 || buffer.insts_remaining() > 200, "increase %s", assert_msg);
+  assert(code_size == 0 || buffer.insts_remaining() > 200,
+         "increase %s, code_size: %d, used: %d, free: %d",
+         assert_msg, code_size, buffer.total_content_size(), buffer.insts_remaining());
 
   LogTarget(Info, stubs) lt;
   if (lt.is_enabled()) {
@@ -240,6 +242,7 @@ static BufferBlob* initialize_stubs(StubGenBlobId blob_id,
                 buffer_name, p2i(stubs_code->content_begin()), p2i(stubs_code->content_end()),
                 buffer.total_content_size(), buffer.insts_remaining());
   }
+
   return stubs_code;
 }
 


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [c239c0ab](https://github.com/openjdk/jdk/commit/c239c0ab00196da8c7c5f6099c8189a778874588) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Jiangli Zhou on 29 Jul 2025 and was reviewed by Chuck Rasbold.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8362564](https://bugs.openjdk.org/browse/JDK-8362564): hotspot/jtreg/compiler/c2/TestLWLockingCodeGen.java fails on static JDK on x86_64 with AVX instruction extensions (**Bug** - P2)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26565/head:pull/26565` \
`$ git checkout pull/26565`

Update a local copy of the PR: \
`$ git checkout pull/26565` \
`$ git pull https://git.openjdk.org/jdk.git pull/26565/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26565`

View PR using the GUI difftool: \
`$ git pr show -t 26565`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26565.diff">https://git.openjdk.org/jdk/pull/26565.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26565#issuecomment-3137584914)
</details>
