### PR TITLE
8362268 : NPE thrown from SASL GSSAPI impl on Java 11+ when TLS is used with QOP auth-int against Active Directory

### DIFF
--- a/src/java.security.sasl/share/classes/com/sun/security/sasl/util/AbstractSaslImpl.java
+++ b/src/java.security.sasl/share/classes/com/sun/security/sasl/util/AbstractSaslImpl.java
@@ -56,7 +56,11 @@ public abstract class AbstractSaslImpl {
 
     // These are relevant only when privacy or integray have been negotiated
     protected int sendMaxBufSize = 0;     // specified by peer but can override
-    protected int recvMaxBufSize = 65536; // optionally specified by self
+
+    // optionally specified by self
+    protected int recvMaxBufSize = System.getProperty("javax.security.sasl.maxbuffer") == null ?
+            65536 : Integer.valueOf(System.getProperty("javax.security.sasl.maxbuffer"));
+
     protected int rawSendSize;            // derived from sendMaxBufSize
 
     protected String myClassName;

--- a/src/jdk.security.jgss/share/classes/com/sun/security/sasl/gsskerb/GssKrb5Base.java
+++ b/src/jdk.security.jgss/share/classes/com/sun/security/sasl/gsskerb/GssKrb5Base.java
@@ -134,6 +134,12 @@ abstract class GssKrb5Base extends AbstractSaslImpl {
             throw new IllegalStateException("No security layer negotiated");
         }
 
+        // Connection::cleanup is called. Context might be set to null already
+        // before this method is completed.
+        if (secCtx == null) {
+            throw new SaslException("GSSContext is null");
+        }
+
         // Generate GSS token
         try {
             MessageProp msgProp = new MessageProp(JGSS_QOP, privacy);


### PR DESCRIPTION
NPE thrown from SASL GSSAPI impl on Java 11+ when TLS is used with QOP auth-int against Active Directory.

When the exception was triggered, LDAP will do "clean-up" operation and output stream got flushed and closed while GssKrb5Client is still wrapping the message and SaslOuput Stream to try write content of the buffer; and at the time GSSContext was disposed and it is null. That's the reason to throw NPE.

1) Check if the context is null or not; then wrap the NPE. The change was done in GssKrb5Base.java
2) Max buffer size is set as 65536 forever; it can not be changed by the property. Inside SaslInputStream.java, max buffer size was set by constructor code although it is hard coded as field variable, which is always set by the variable in AbstractSaslImpl.java. See the change in AbstractSaslImpl.java

Not test file was attache for this MR since it needs Sasl LDAP with security setup.