### PR TITLE
4870789: RFE: UIDefaults.getUIError() hides real error

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/MultiUIDefaults.java
+++ b/src/java.desktop/share/classes/javax/swing/MultiUIDefaults.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -139,11 +139,11 @@ class MultiUIDefaults extends UIDefaults
     }
 
     @Override
-    protected void getUIError(String msg) {
+    protected void getUIError(String msg, Throwable cause) {
         if (tables != null && tables.length > 0 && tables[0] != null) {
-            tables[0].getUIError(msg);
+            tables[0].getUIError(msg, cause);
         } else {
-            super.getUIError(msg);
+            super.getUIError(msg, cause);
         }
     }
 

--- a/src/java.desktop/share/classes/javax/swing/UIDefaults.java
+++ b/src/java.desktop/share/classes/javax/swing/UIDefaults.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -745,11 +745,12 @@ public class UIDefaults extends Hashtable<Object,Object>
      * Subclasses may choose to do more or less here.
      *
      * @param msg message string to print
+     * @param cause cause of the failure
      * @see #getUI
      */
-    protected void getUIError(String msg) {
+    protected void getUIError(String msg, Throwable cause) {
         try {
-            throw new Error(msg);
+            throw new Error(msg, cause);
         }
         catch (Throwable e) {
             e.printStackTrace();
@@ -779,7 +780,7 @@ public class UIDefaults extends Hashtable<Object,Object>
         Object uiObject = null;
 
         if (uiClass == null) {
-            getUIError("no ComponentUI class for: " + target);
+            getUIError("no ComponentUI class for: " + target, null);
         }
         else {
             try {
@@ -797,14 +798,14 @@ public class UIDefaults extends Hashtable<Object,Object>
                 }
             }
             catch (NoSuchMethodException e) {
-                getUIError("static createUI() method not found in " + uiClass);
+                getUIError("static createUI() method not found in " + uiClass, e);
             }
             catch (Exception e) {
                 StringWriter w = new StringWriter();
                 PrintWriter pw = new PrintWriter(w);
                 e.printStackTrace(pw);
                 pw.flush();
-                getUIError("createUI() failed for " + target + "\n" + w);
+                getUIError("createUI() failed for " + target + "\n" + w, e);
             }
         }
 

--- a/src/java.desktop/share/classes/javax/swing/plaf/multi/MultiLookAndFeel.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/multi/MultiLookAndFeel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -303,7 +303,7 @@ class MultiUIDefaults extends UIDefaults {
     MultiUIDefaults(int initialCapacity, float loadFactor) {
         super(initialCapacity, loadFactor);
     }
-    protected void getUIError(String msg) {
-        System.err.println("Multiplexing LAF:  " + msg);
+    protected void getUIError(String msg, Throwable cause) {
+        System.err.println("Multiplexing LAF:  " + msg + "\n" + cause);
     }
 }


### PR DESCRIPTION
`UIDefaults.getUIError` method is invoked when an exception occurred in UI code but this method hides the underlying exception, this method could be more useful if the original exception is passed as argument and used as the cause of the Error thrown from `getUIError` body

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-4870789](https://bugs.openjdk.org/browse/JDK-4870789): RFE: UIDefaults.getUIError() hides real error (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26567/head:pull/26567` \
`$ git checkout pull/26567`

Update a local copy of the PR: \
`$ git checkout pull/26567` \
`$ git pull https://git.openjdk.org/jdk.git pull/26567/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26567`

View PR using the GUI difftool: \
`$ git pr show -t 26567`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26567.diff">https://git.openjdk.org/jdk/pull/26567.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26567#issuecomment-3138601069)
</details>
