### PR TITLE
8263476

### DIFF
--- a/src/hotspot/os/aix/os_aix.inline.hpp
+++ b/src/hotspot/os/aix/os_aix.inline.hpp
@@ -43,7 +43,7 @@ inline bool os::uses_stack_guard_pages() {
 // Whether or not calling code should/can commit/uncommit stack pages
 // before guarding them. Answer for AIX is definitely no, because memory
 // is automatically committed on touch.
-inline bool os::must_commit_stack_guard_pages() {
+inline bool os::must_allocate_stack_guard_pages() {
   assert(uses_stack_guard_pages(), "sanity check");
   return false;
 }

--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -1676,13 +1676,15 @@ bool os::pd_uncommit_memory(char* addr, size_t size, bool exec) {
 }
 
 bool os::pd_create_stack_guard_pages(char* addr, size_t size) {
-  return os::commit_memory(addr, size, !ExecMem);
+  ShouldNotReachHere();
+  return true;
 }
 
 // If this is a growable mapping, remove the guard pages entirely by
 // munmap()ping them.  If not, just call uncommit_memory().
 bool os::remove_stack_guard_pages(char* addr, size_t size) {
-  return os::uncommit_memory(addr, size);
+  ShouldNotReachHere();
+  return true;
 }
 
 // 'requested_addr' is only treated as a hint, the return value may or

--- a/src/hotspot/os/bsd/os_bsd.inline.hpp
+++ b/src/hotspot/os/bsd/os_bsd.inline.hpp
@@ -38,17 +38,9 @@ inline bool os::uses_stack_guard_pages() {
   return true;
 }
 
-inline bool os::must_commit_stack_guard_pages() {
+inline bool os::must_allocate_stack_guard_pages() {
   assert(uses_stack_guard_pages(), "sanity check");
-#if !defined(__FreeBSD__) || __FreeBSD__ < 5
-  // Since FreeBSD 4 uses malloc() for allocating the thread stack
-  // there is no need to do anything extra to allocate the guard pages
   return false;
-#else
-  // FreeBSD 5+ uses mmap MAP_STACK for allocating the thread stacks.
-  // Must 'allocate' them or guard pages are ignored.
-  return true;
-#endif
 }
 
 // Bang the shadow pages if they need to be touched to be mapped.

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -3451,12 +3451,13 @@ bool os::pd_create_stack_guard_pages(char* addr, size_t size) {
                                                            (size_t)addr - stack_extent);
     }
 
-    if (stack_extent < (uintptr_t)addr) {
-      ::munmap((void*)stack_extent, (uintptr_t)(addr - stack_extent));
+    if (stack_extent < (uintptr_t)addr + size) {
+      ::munmap((void*)stack_extent, (uintptr_t)(addr + size - stack_extent));
     }
+    return os::pd_attempt_reserve_memory_at(addr, size, !ExecMem) != nullptr;
   }
 
-  return os::commit_memory(addr, size, !ExecMem);
+  return true;
 }
 
 // If this is a growable mapping, remove the guard pages entirely by
@@ -3472,7 +3473,7 @@ bool os::remove_stack_guard_pages(char* addr, size_t size) {
     return ::munmap(addr, size) == 0;
   }
 
-  return os::uncommit_memory(addr, size);
+  return true;
 }
 
 // 'requested_addr' is only treated as a hint, the return value may or

--- a/src/hotspot/os/linux/os_linux.inline.hpp
+++ b/src/hotspot/os/linux/os_linux.inline.hpp
@@ -38,7 +38,7 @@ inline bool os::uses_stack_guard_pages() {
   return true;
 }
 
-inline bool os::must_commit_stack_guard_pages() {
+inline bool os::must_allocate_stack_guard_pages() {
   assert(uses_stack_guard_pages(), "sanity check");
   return true;
 }

--- a/src/hotspot/os/windows/os_windows.inline.hpp
+++ b/src/hotspot/os/windows/os_windows.inline.hpp
@@ -39,7 +39,7 @@ inline bool os::uses_stack_guard_pages() {
   return true;
 }
 
-inline bool os::must_commit_stack_guard_pages() {
+inline bool os::must_allocate_stack_guard_pages() {
   return true;
 }
 

--- a/src/hotspot/share/runtime/os.hpp
+++ b/src/hotspot/share/runtime/os.hpp
@@ -372,7 +372,7 @@ class os: AllStatic {
   // exception processing)  There are guard pages, and above that shadow
   // pages for stack overflow checking.
   inline static bool uses_stack_guard_pages();
-  inline static bool must_commit_stack_guard_pages();
+  inline static bool must_allocate_stack_guard_pages();
   inline static void map_stack_shadow_pages(address sp);
   static bool stack_shadow_pages_available(Thread *thread, const methodHandle& method, address sp);
 

--- a/src/hotspot/share/runtime/stackOverflow.cpp
+++ b/src/hotspot/share/runtime/stackOverflow.cpp
@@ -89,10 +89,10 @@ void StackOverflow::create_stack_guard_pages() {
   assert(is_aligned(low_addr, os::vm_page_size()), "Stack base should be the start of a page");
   assert(is_aligned(len, os::vm_page_size()), "Stack size should be a multiple of page size");
 
-  bool must_commit = os::must_commit_stack_guard_pages();
+  bool must_allocate = os::must_allocate_stack_guard_pages();
   // warning("Guarding at " PTR_FORMAT " for len %zu\n", low_addr, len);
 
-  if (must_commit && !os::create_stack_guard_pages((char *) low_addr, len)) {
+  if (must_allocate && !os::create_stack_guard_pages((char *) low_addr, len)) {
     log_warning(os, thread)("Attempt to allocate stack guard pages failed.");
     return;
   }
@@ -115,7 +115,7 @@ void StackOverflow::remove_stack_guard_pages() {
   address low_addr = stack_end();
   size_t len = stack_guard_zone_size();
 
-  if (os::must_commit_stack_guard_pages()) {
+  if (os::must_allocate_stack_guard_pages()) {
     if (os::remove_stack_guard_pages((char *) low_addr, len)) {
       _stack_guard_state = stack_guard_unused;
     } else {


### PR DESCRIPTION
Use reserved (instead of committed) memory for stack-guard-pages on linux like systems.

`os::must_commit_stack_guard_pages` uses `commit` in its name, but `commit` usually has specific meanings in OS memory context. The actual question the caller is asking is whether the caller needs to do some preparation work before marking the guard-pages as inaccessible. To avoid confusion, I changed it to "allocate". Other suggestions are welcome.

Test: tier1-3