### PR TITLE
8364087: Amend comment in globalDefinitions.hpp on "classfile_constants.h" include

### DIFF
--- a/src/hotspot/share/utilities/globalDefinitions.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions.hpp
@@ -25,7 +25,6 @@
 #ifndef SHARE_UTILITIES_GLOBALDEFINITIONS_HPP
 #define SHARE_UTILITIES_GLOBALDEFINITIONS_HPP
 
-// Get constants like JVM_T_CHAR and JVM_SIGNATURE_INT.
 #include "classfile_constants.h"
 #include "utilities/compilerWarnings.hpp"
 #include "utilities/debug.hpp"

--- a/src/hotspot/share/utilities/globalDefinitions.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions.hpp
@@ -25,7 +25,7 @@
 #ifndef SHARE_UTILITIES_GLOBALDEFINITIONS_HPP
 #define SHARE_UTILITIES_GLOBALDEFINITIONS_HPP
 
-// Get constants like JVM_T_CHAR and JVM_SIGNATURE_INT, before pulling in <jvm.h>.
+// Get constants like JVM_T_CHAR and JVM_SIGNATURE_INT.
 #include "classfile_constants.h"
 #include "utilities/compilerWarnings.hpp"
 #include "utilities/debug.hpp"


### PR DESCRIPTION
The comment was introduced in [8231844](https://github.com/fandreuz/jdk/commit/fce43203699336e9513d06cd54b66735e93234a4). I looked around, and `<jvm.h>` is not included in any of the headers included by `globalDefinitions.hpp`, neither now nor in the original commit. Thus, I propose to amend the comment, as it [turned out to be confusing](https://github.com/openjdk/jdk/pull/26428/files#r2229575525) during an header clean up. 

Including `classfile_constants.h` is needed for e.g. `JVM_T_CHAR`, as stated by the comment, thus I'm going to leave that part intact.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8364087](https://bugs.openjdk.org/browse/JDK-8364087): Amend comment in globalDefinitions.hpp on "classfile_constants.h" include (**Enhancement** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26573/head:pull/26573` \
`$ git checkout pull/26573`

Update a local copy of the PR: \
`$ git checkout pull/26573` \
`$ git pull https://git.openjdk.org/jdk.git pull/26573/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26573`

View PR using the GUI difftool: \
`$ git pr show -t 26573`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26573.diff">https://git.openjdk.org/jdk/pull/26573.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26573#issuecomment-3139499663)
</details>
