### PR TITLE
8364184: [REDO] AArch64: [VectorAPI] sve vector math operations are not supported after JDK-8353217

### DIFF
--- a/make/autoconf/flags-cflags.m4
+++ b/make/autoconf/flags-cflags.m4
@@ -940,7 +940,7 @@ AC_DEFUN([FLAGS_SETUP_CFLAGS_CPU_DEP],
   # ACLE and this flag are required to build the aarch64 SVE related functions in
   # libvectormath. Apple Silicon does not support SVE; use macOS as a proxy for
   # that check.
-  if test "x$OPENJDK_TARGET_CPU" = "xaarch64" && test "x$OPENJDK_TARGET_CPU" = "xlinux"; then
+  if test "x$OPENJDK_TARGET_CPU" = "xaarch64" && test "x$OPENJDK_TARGET_OS" = "xlinux"; then
     if test "x$TOOLCHAIN_TYPE" = xgcc || test "x$TOOLCHAIN_TYPE" = xclang; then
       AC_LANG_PUSH(C)
       OLD_CFLAGS="$CFLAGS"

--- a/make/modules/jdk.incubator.vector/Lib.gmk
+++ b/make/modules/jdk.incubator.vector/Lib.gmk
@@ -50,7 +50,9 @@ ifeq ($(INCLUDE_COMPILER2), true)
     ifeq ($(call isTargetCpu, riscv64), true)
       LIBSLEEF_CFLAGS := -march=rv64gcv
     endif
-
+    ifeq ($(TOOLCHAIN_TYPE), gcc)
+      SVE_CFLAGS += -ftrivial-auto-var-init=zero
+    endif
     $(eval $(call SetupJdkLibrary, BUILD_LIBSLEEF, \
         NAME := sleef, \
         OPTIMIZATION := HIGH, \


### PR DESCRIPTION
`-ftrivial-auto-var-init=pattern` [1] supported by gcc-12 was added recently to help detect uses of uninitialized memory. [2] Under this extension mode, `__builtin_clear_padding` is called to clear the padding bits in object representation. But the builtin function does not support variable length aggregates [3].

`vfloat2_sve_sleef` is a typedef of `svfloat32x2_t`, which is defined as an opaque sizeless type in ARM C Language Extensions (ACLE) [4]. When `__builtin_clear_padding` is applied to such a type, it triggers the unsupported code path and results in build failures when compiling libsleef on Linux-AArch64, as reported in [JDK-8364185](https://bugs.openjdk.org/browse/JDK-8364185) [5].

Switching the initialization mode with gcc-12 from `pattern` to `zero` avoids the use of this unsupported `__builtin_clear_padding` and resolves the issue.

I did not encounter similar problems when building with Clang-16 [6].

This patch:
1. Keeps the libsleef SVE support enabled
2. Changes the initialization mode from `pattern` to `zero` when compiling libsleef SVE component on Linux-AArch64 with gcc-12 to fix the build failure and help avoid potential security issues related to uninitialized padding

Testing:
1. Release and fastdebug build with gcc-12 and Clang-16
2. `test/jdk/jdk/incubator/vector` passed on both 256-bit SVE and NEON machines

[1] https://gcc.gnu.org/onlinedocs/gcc-12.1.0/gcc/Optimize-Options.html#index-ftrivial-auto-var-init
[2] https://github.com/openjdk/jdk/commit/fae37aaae8b36fd74309b84fa1fdf017c7d932ed
[3] https://gcc.gnu.org/pipermail/gcc-patches/2020-November/559214.html
[4] https://arm-software.github.io/acle/main/acle.html#arm_sveh
[5] https://bugs.openjdk.org/browse/JDK-8364185
[6] https://releases.llvm.org/16.0.0/tools/clang/docs/ReleaseNotes.html