### PR TITLE
8357277: Update OpenSSL library for interop tests

### DIFF
--- a/test/lib/jdk/test/lib/security/OpensslArtifactFetcher.java
+++ b/test/lib/jdk/test/lib/security/OpensslArtifactFetcher.java
@@ -32,7 +32,7 @@ import jtreg.SkippedException;
 
 public class OpensslArtifactFetcher {
 
-    private static final String OPENSSL_BUNDLE_VERSION = "3.0.14";
+    private static final String OPENSSL_BUNDLE_VERSION = "3.5.1";
     private static final String OPENSSL_ORG = "jpg.tests.jdk.openssl";
 
     /**


### PR DESCRIPTION
This simple PR updates the version of OpenSSL to the latest TLS version, 3.5.1