### PR TITLE
8364461: JFR: Default constructor may not be first in setting control

### DIFF
--- a/test/jdk/jdk/jfr/api/settings/RegExpControl.java
+++ b/test/jdk/jdk/jfr/api/settings/RegExpControl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,14 @@ import jdk.jfr.SettingControl;
 
 public final class RegExpControl extends SettingControl {
     private Pattern pattern = Pattern.compile(".*");
+
+    // Purpose of this constructor is to ensure that the correct
+    // constructor is picked when the event class is registered
+    public RegExpControl(String dummy) {
+    }
+
+    public RegExpControl() {
+    }
 
     public void setValue(String value) {
         this.pattern = Pattern.compile(value);


### PR DESCRIPTION
Could I have a review of a PR that fixes a bug occurring when a user-defined setting does not have the default constructor first?

Test: test/jdk/jdk/jfr

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8364461](https://bugs.openjdk.org/browse/JDK-8364461): JFR: Default constructor may not be first in setting control (**Bug** - P4)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26582/head:pull/26582` \
`$ git checkout pull/26582`

Update a local copy of the PR: \
`$ git checkout pull/26582` \
`$ git pull https://git.openjdk.org/jdk.git pull/26582/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26582`

View PR using the GUI difftool: \
`$ git pr show -t 26582`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26582.diff">https://git.openjdk.org/jdk/pull/26582.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26582#issuecomment-3141120377)
</details>
