### PR TITLE
8364504: [BACKOUT] JDK-8364176 Serial: Group all class unloading logic at the end of marking phase

### DIFF
--- a/src/hotspot/share/gc/serial/serialFullGC.cpp
+++ b/src/hotspot/share/gc/serial/serialFullGC.cpp
@@ -525,9 +525,7 @@ void SerialFullGC::phase1_mark(bool clear_all_softrefs) {
   {
     GCTraceTime(Debug, gc, phases) tm_m("Class Unloading", gc_timer());
 
-    ClassUnloadingContext ctx(1 /* num_nmethod_unlink_workers */,
-                              false /* unregister_nmethods_during_purge */,
-                              false /* lock_nmethod_free_separately */);
+    ClassUnloadingContext* ctx = ClassUnloadingContext::context();
 
     bool unloading_occurred;
     {
@@ -543,7 +541,7 @@ void SerialFullGC::phase1_mark(bool clear_all_softrefs) {
     {
       GCTraceTime(Debug, gc, phases) t("Purge Unlinked NMethods", gc_timer());
       // Release unloaded nmethod's memory.
-      ctx.purge_nmethods();
+      ctx->purge_nmethods();
     }
     {
       GCTraceTime(Debug, gc, phases) ur("Unregister NMethods", gc_timer());
@@ -551,7 +549,7 @@ void SerialFullGC::phase1_mark(bool clear_all_softrefs) {
     }
     {
       GCTraceTime(Debug, gc, phases) t("Free Code Blobs", gc_timer());
-      ctx.free_nmethods();
+      ctx->free_nmethods();
     }
 
     // Prune dead klasses from subklass/sibling/implementor lists.
@@ -559,13 +557,6 @@ void SerialFullGC::phase1_mark(bool clear_all_softrefs) {
 
     // Clean JVMCI metadata handles.
     JVMCI_ONLY(JVMCI::do_unloading(unloading_occurred));
-
-    // Delete metaspaces for unloaded class loaders and clean up loader_data graph
-    ClassLoaderDataGraph::purge(true /* at_safepoint */);
-    DEBUG_ONLY(MetaspaceUtils::verify();)
-
-    // Need to clear claim bits for the next mark.
-    ClassLoaderDataGraph::clear_claimed_marks();
   }
 
   {

--- a/src/hotspot/share/gc/serial/serialHeap.cpp
+++ b/src/hotspot/share/gc/serial/serialHeap.cpp
@@ -603,6 +603,9 @@ void SerialHeap::do_full_collection(bool clear_all_soft_refs) {
   gc_prologue();
   COMPILER2_OR_JVMCI_PRESENT(DerivedPointerTable::clear());
   CodeCache::on_gc_marking_cycle_start();
+  ClassUnloadingContext ctx(1 /* num_nmethod_unlink_workers */,
+                            false /* unregister_nmethods_during_purge */,
+                            false /* lock_nmethod_free_separately */);
 
   STWGCTimer* gc_timer = SerialFullGC::gc_timer();
   gc_timer->register_gc_start();
@@ -626,6 +629,13 @@ void SerialHeap::do_full_collection(bool clear_all_soft_refs) {
   // Adjust generation sizes.
   _old_gen->compute_new_size();
   _young_gen->compute_new_size();
+
+  // Delete metaspaces for unloaded class loaders and clean up loader_data graph
+  ClassLoaderDataGraph::purge(/*at_safepoint*/true);
+  DEBUG_ONLY(MetaspaceUtils::verify();)
+
+  // Need to clear claim bits for the next mark.
+  ClassLoaderDataGraph::clear_claimed_marks();
 
   _old_gen->update_promote_stats();
 


### PR DESCRIPTION
A clean revert of  "JDK-8364176 Serial: Group all class unloading logic at the end of marking phase".

Test: Used `jdk/jfr/event/gc/stacktrace/TestMetaspaceSerialGCAllocationPendingStackTrace.java` to verify that it fails before the revert and passes after the revert.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8364504](https://bugs.openjdk.org/browse/JDK-8364504): [BACKOUT] JDK-8364176 Serial: Group all class unloading logic at the end of marking phase (**Sub-task** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26587/head:pull/26587` \
`$ git checkout pull/26587`

Update a local copy of the PR: \
`$ git checkout pull/26587` \
`$ git pull https://git.openjdk.org/jdk.git pull/26587/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26587`

View PR using the GUI difftool: \
`$ git pr show -t 26587`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26587.diff">https://git.openjdk.org/jdk/pull/26587.diff</a>

</details>
