### PR TITLE
8364516

### DIFF
--- a/src/hotspot/share/gc/serial/serialFullGC.cpp
+++ b/src/hotspot/share/gc/serial/serialFullGC.cpp
@@ -705,6 +705,16 @@ void SerialFullGC::invoke_at_safepoint(bool clear_all_softrefs) {
 
   allocate_stacks();
 
+  // Usually, all classunloading works occurs at the end of phase 1, but Serial
+  // full-gc accesses dead-objs' klass to find out the start of next live-obj
+  // during phase 2. This requires klasses of dead-objs to be kept loaded.
+  // Therefore, we declare classunloading context in the same level as various
+  // phases, and purge dead classes (invoking ClassLoaderDataGraph::purge)
+  // after all phases of full-gc.
+  ClassUnloadingContext ctx(1 /* num_nmethod_unlink_workers */,
+                          false /* unregister_nmethods_during_purge */,
+                          false /* lock_nmethod_free_separately */);
+
   phase1_mark(clear_all_softrefs);
 
   Compacter compacter{gch};
@@ -754,6 +764,13 @@ void SerialFullGC::invoke_at_safepoint(bool clear_all_softrefs) {
 
     compacter.phase4_compact();
   }
+
+  // Delete metaspaces for unloaded class loaders and clean up loader_data graph
+  ClassLoaderDataGraph::purge(true /* at_safepoint */);
+  DEBUG_ONLY(MetaspaceUtils::verify();)
+
+  // Need to clear claim bits for the next full-gc (specifically phase 1 and 3).
+  ClassLoaderDataGraph::clear_claimed_marks();
 
   restore_marks();
 

--- a/src/hotspot/share/gc/serial/serialHeap.cpp
+++ b/src/hotspot/share/gc/serial/serialHeap.cpp
@@ -603,9 +603,6 @@ void SerialHeap::do_full_collection(bool clear_all_soft_refs) {
   gc_prologue();
   COMPILER2_OR_JVMCI_PRESENT(DerivedPointerTable::clear());
   CodeCache::on_gc_marking_cycle_start();
-  ClassUnloadingContext ctx(1 /* num_nmethod_unlink_workers */,
-                            false /* unregister_nmethods_during_purge */,
-                            false /* lock_nmethod_free_separately */);
 
   STWGCTimer* gc_timer = SerialFullGC::gc_timer();
   gc_timer->register_gc_start();
@@ -629,13 +626,6 @@ void SerialHeap::do_full_collection(bool clear_all_soft_refs) {
   // Adjust generation sizes.
   _old_gen->compute_new_size();
   _young_gen->compute_new_size();
-
-  // Delete metaspaces for unloaded class loaders and clean up loader_data graph
-  ClassLoaderDataGraph::purge(/*at_safepoint*/true);
-  DEBUG_ONLY(MetaspaceUtils::verify();)
-
-  // Need to clear claim bits for the next mark.
-  ClassLoaderDataGraph::clear_claimed_marks();
 
   _old_gen->update_promote_stats();
 


### PR DESCRIPTION
Encapsulating classunloading logic inside `invoke_at_safepoint` and adding doc explaining why the classunloading logic can't be placed at the end of marking during full-gc, like other STW collectors.

Test: tier1-3