### PR TITLE
8364503

### DIFF
--- a/test/hotspot/jtreg/gc/g1/TestCodeCacheUnloadDuringConcCycle.java
+++ b/test/hotspot/jtreg/gc/g1/TestCodeCacheUnloadDuringConcCycle.java
@@ -147,6 +147,7 @@ class TestCodeCacheUnloadDuringConcCycleRunner {
     }
 
     public static void main(String[] args) throws Exception {
+        System.out.println("Running to breakpoint: " + args[0]);
         try {
             WB.concurrentGCAcquireControl();
             WB.concurrentGCRunTo(args[0]);
@@ -157,9 +158,13 @@ class TestCodeCacheUnloadDuringConcCycleRunner {
 
             WB.concurrentGCRunToIdle();
         } finally {
+            // Make sure that the marker we use to find the expected log message is printed
+            // before we release whitebox control, i.e. before the expected garbage collection
+            // can start.
+            System.out.println(TestCodeCacheUnloadDuringConcCycle.AFTER_FIRST_CYCLE_MARKER);
+            System.out.flush();
             WB.concurrentGCReleaseControl();
         }
-        System.out.println(TestCodeCacheUnloadDuringConcCycle.AFTER_FIRST_CYCLE_MARKER);
         Thread.sleep(1000);
         triggerCodeCacheGC();
     }


### PR DESCRIPTION
Hi all,

  please review this change to the `gc/g1/TestCodeCacheUnloadDuringConcCycle.java` test - previously, the GC that we were waiting for in the test could occur between releasing whitebox control and the marker we use to distinguish before/after test setup.

The change makes sure the marker is printed before releasing Whitebox control.

Testing:

Thanks,
  Thomas