### PR TITLE
8364320: String encodeUTF8 latin1 with negatives

### DIFF
--- a/src/java.base/share/classes/java/lang/String.java
+++ b/src/java.base/share/classes/java/lang/String.java
@@ -1294,7 +1294,7 @@ public final class String
             System.arraycopy(val, 0, dst, 0, positives);
         }
         int dp = positives;
-        for (int i=dp; i<val.length; ++i) {
+        for (int i = dp; i < val.length; i++) {
             byte c = val[i];
             if (c < 0) {
                 dst[dp++] = (byte) (0xc0 | ((c & 0xff) >> 6));


### PR DESCRIPTION
As suggested on mailing list, when encoding latin1 bytes to utf-8, we can count the leading positive bytes and in the case where there is a negative, we can copy all the positive values to the target byte[] prior to processing the remaining data 1 byte at a time.

https://mail.openjdk.org/pipermail/core-libs-dev/2025-July/149417.html

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8364320](https://bugs.openjdk.org/browse/JDK-8364320): String encodeUTF8 latin1 with negatives (**Enhancement** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26597/head:pull/26597` \
`$ git checkout pull/26597`

Update a local copy of the PR: \
`$ git checkout pull/26597` \
`$ git pull https://git.openjdk.org/jdk.git pull/26597/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26597`

View PR using the GUI difftool: \
`$ git pr show -t 26597`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26597.diff">https://git.openjdk.org/jdk/pull/26597.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26597#issuecomment-3144448576)
</details>
