### PR TITLE
8364514: [asan] runtime/jni/checked/TestCharArrayReleasing.java heap-buffer-overflow

### DIFF
--- a/test/hotspot/jtreg/runtime/jni/checked/TestCharArrayReleasing.java
+++ b/test/hotspot/jtreg/runtime/jni/checked/TestCharArrayReleasing.java
@@ -25,7 +25,7 @@
  * @test
  * @bug 8357601
  * @requires vm.flagless
- * @comment array was allocated with raw malloc, this causes expected heap buffer issues and triggers asan
+ * @comment The check of the array allocated with raw malloc triggers ASAN as we peek into the malloc header space.
  * @requires !vm.asan
  * @library /test/lib
  * @run main/othervm/native TestCharArrayReleasing 0 0


### PR DESCRIPTION
When running with ASAN enabled binaries , the test runtime/jni/checked/TestCharArrayReleasing.java fails with a  heap-buffer-overflow . This is expected because the test checks API usage errors and this way triggers ASAN.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8364514](https://bugs.openjdk.org/browse/JDK-8364514): [asan] runtime/jni/checked/TestCharArrayReleasing.java heap-buffer-overflow (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26598/head:pull/26598` \
`$ git checkout pull/26598`

Update a local copy of the PR: \
`$ git checkout pull/26598` \
`$ git pull https://git.openjdk.org/jdk.git pull/26598/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26598`

View PR using the GUI difftool: \
`$ git pr show -t 26598`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26598.diff">https://git.openjdk.org/jdk/pull/26598.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26598#issuecomment-3144582109)
</details>
