### PR TITLE
8364541: Parallel: Support allocation in old generation when heap is almost full

### DIFF
--- a/src/hotspot/share/gc/parallel/parallelScavengeHeap.cpp
+++ b/src/hotspot/share/gc/parallel/parallelScavengeHeap.cpp
@@ -310,11 +310,13 @@ HeapWord* ParallelScavengeHeap::mem_allocate_work(size_t size,
         return result;
       }
 
-      // If certain conditions hold, try allocating from the old gen.
-      if (!is_tlab && !should_alloc_in_eden(size)) {
-        result = old_gen()->cas_allocate_noexpand(size);
-        if (result != nullptr) {
-          return result;
+      // Try allocating from the old gen for non-TLAB in certain scenarios.
+      if (!is_tlab) {
+        if (!should_alloc_in_eden(size) || _is_heap_almost_full) {
+          result = old_gen()->cas_allocate_noexpand(size);
+          if (result != nullptr) {
+            return result;
+          }
         }
       }
     }


### PR DESCRIPTION
Adding old-gen allocation support in heap-almost-full scenario. This can make tests that cause OOM deliberately more resilient to timeout and help runaway apps to exit/fail faster.

Test: tier1-3

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8364541](https://bugs.openjdk.org/browse/JDK-8364541): Parallel: Support allocation in old generation when heap is almost full (**Enhancement** - P4)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26599/head:pull/26599` \
`$ git checkout pull/26599`

Update a local copy of the PR: \
`$ git checkout pull/26599` \
`$ git pull https://git.openjdk.org/jdk.git pull/26599/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26599`

View PR using the GUI difftool: \
`$ git pr show -t 26599`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26599.diff">https://git.openjdk.org/jdk/pull/26599.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26599#issuecomment-3144999921)
</details>
