### PR TITLE
8364545: tools/javac/launcher/SourceLauncherTest.java fails frequently

### DIFF
--- a/test/langtools/tools/javac/launcher/SourceLauncherStackTraceTest.java
+++ b/test/langtools/tools/javac/launcher/SourceLauncherStackTraceTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8362237
+ * @summary Test source launcher with specific VM behaviors
+ * @library /tools/lib
+ * @modules jdk.compiler/com.sun.tools.javac.api
+ *          jdk.compiler/com.sun.tools.javac.launcher
+ *          jdk.compiler/com.sun.tools.javac.main
+ *          java.base/jdk.internal.module
+ * @build toolbox.JavaTask toolbox.JavacTask toolbox.TestRunner toolbox.ToolBox
+ * @run main/othervm -XX:-StackTraceInThrowable SourceLauncherStackTraceTest
+ */
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+
+import toolbox.TestRunner;
+
+/// SourceLauncherTest runs the source launcher in the same VM, so we must
+/// use another test to run specific tests with specific VM flags
+public class SourceLauncherStackTraceTest extends TestRunner {
+
+    // Inheritance will shadow all parent tests
+    SourceLauncherTest parent = new SourceLauncherTest();
+
+    SourceLauncherStackTraceTest() {
+        super(System.err);
+    }
+
+    public static void main(String... args) throws Exception {
+        SourceLauncherStackTraceTest t = new SourceLauncherStackTraceTest();
+        t.runTests(m -> new Object[] { Paths.get(m.getName()) });
+    }
+
+    /*
+     * Tests in which main throws an exception without a stacktrace.
+     */
+    @Test
+    public void testTargetException2(Path base) throws IOException {
+        parent.tb.writeJavaFiles(base, """
+                public class TestLauncher {
+                    public static TestLauncher test() {
+                        throw new RuntimeException("No trace");
+                    }
+
+                    public static void main(String[] args) {
+                        // This will throw a RuntimeException without
+                        // a stack trace due to VM options
+                        test();
+                    }
+                }
+                """);
+        Path file = base.resolve("TestLauncher.java");
+        SourceLauncherTest.Result r = parent.run(file, List.of(), List.of("3"));
+        parent.checkEmpty("stdout", r.stdOut());
+        parent.checkEmpty("stderr", r.stdErr());
+        parent.checkTrace("exception", r.exception(), "java.lang.RuntimeException: No trace");
+    }
+}

--- a/test/langtools/tools/javac/launcher/SourceLauncherTest.java
+++ b/test/langtools/tools/javac/launcher/SourceLauncherTest.java
@@ -24,7 +24,6 @@
 /*
  * @test
  * @bug 8192920 8204588 8246774 8248843 8268869 8235876 8328339 8335896 8344706
- *      8362237
  * @summary Test source launcher
  * @library /tools/lib
  * @modules jdk.compiler/com.sun.tools.javac.api
@@ -77,7 +76,7 @@ public class SourceLauncherTest extends TestRunner {
         System.err.println("version: " + thisVersion);
     }
 
-    private final ToolBox tb;
+    final ToolBox tb;
     private static final String thisVersion = System.getProperty("java.specification.version");
 
     /*
@@ -713,42 +712,6 @@ public class SourceLauncherTest extends TestRunner {
                 "at Thrower.throwWhenZero(Thrower.java:8)",
                 "at Thrower.throwWhenZero(Thrower.java:8)",
                 "at Thrower.main(Thrower.java:4)");
-    }
-
-    /*
-     * Tests in which main throws an exception without a stacktrace.
-     */
-    @Test
-    public void testTargetException2(Path base) throws IOException {
-        tb.writeJavaFiles(base, """
-                public class TestLauncher {
-                    public static TestLauncher testCheckcast(Object arg) {
-                        return (TestLauncher)arg;
-                    }
-
-                    public static void main(String[] args) {
-                        // Warmup to trigger C2 compilation
-                        TestLauncher t = new TestLauncher();
-                        for (int i = 0; i < 10_000; ++i) {
-                            testCheckcast(t);
-                            try {
-                                testCheckcast(42);
-                            } catch (Exception e) {
-                                // Expected
-                            }
-                        }
-                        // This will throw a ClassCastException without
-                        // a stack trace if OmitStackTraceInFastThrow
-                        // is enabled (default)
-                        testCheckcast(42);
-                    }
-                }
-                """);
-        Path file = base.resolve("TestLauncher.java");
-        Result r = run(file, Collections.emptyList(), List.of("3"));
-        checkEmpty("stdout", r.stdOut);
-        checkEmpty("stderr", r.stdErr);
-        checkTrace("exception", r.exception, "java.lang.ClassCastException");
     }
 
     @Test


### PR DESCRIPTION
SourceLauncherTest is placing arbitrary assumptions on the hotspot compiler. Since this test is running the source launcher in the same JVM, we have to create separate jtreg tests to allow running the test and the in-JVM source launcher with another set of VM flags.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8364545](https://bugs.openjdk.org/browse/JDK-8364545): tools/javac/launcher/SourceLauncherTest.java fails frequently (**Bug** - P2)


### Reviewers
 * [Christian Stein](https://openjdk.org/census#cstein) (@sormuras - Committer)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26601/head:pull/26601` \
`$ git checkout pull/26601`

Update a local copy of the PR: \
`$ git checkout pull/26601` \
`$ git pull https://git.openjdk.org/jdk.git pull/26601/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26601`

View PR using the GUI difftool: \
`$ git pr show -t 26601`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26601.diff">https://git.openjdk.org/jdk/pull/26601.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26601#issuecomment-3145290880)
</details>
