### PR TITLE
8361730: The CodeBuilder.trying(BlockCodeBuilder,CatchBuilder) method generates corrupted bytecode in certain cases

### DIFF
--- a/src/java.base/share/classes/java/lang/classfile/CodeBuilder.java
+++ b/src/java.base/share/classes/java/lang/classfile/CodeBuilder.java
@@ -175,6 +175,11 @@ public sealed interface CodeBuilder
      * A builder for blocks of code.  Its {@link #startLabel()} and {@link
      * #endLabel()} do not enclose the entire method body, but from the start to
      * the end of the block.
+     * <p>
+     * The location where a block of code merges back to its parent block, as
+     * represented by the {@link #breakLabel()}, is expected to be reachable,
+     * either from this block or the parent block.  The built code may be
+     * malformed if there is no executable code at that location.
      *
      * @since 24
      */


### PR DESCRIPTION
Explicitly document that BlockCodeBuilder expects control flow to continue after it merges back to the parent block, so failure to do that by the users can lead to malformed code. This is better than introducing complex and costly analysis.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8364553](https://bugs.openjdk.org/browse/JDK-8364553) to be approved

### Issues
 * [JDK-8361730](https://bugs.openjdk.org/browse/JDK-8361730): The CodeBuilder.trying(BlockCodeBuilder,CatchBuilder) method generates corrupted bytecode in certain cases (**Bug** - P3)
 * [JDK-8364553](https://bugs.openjdk.org/browse/JDK-8364553): BlockCodeBuilder may generate corrupted bytecode if its break has no subsequent code (**CSR**)


### Reviewers
 * [Adam Sotona](https://openjdk.org/census#asotona) (@asotona - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26602/head:pull/26602` \
`$ git checkout pull/26602`

Update a local copy of the PR: \
`$ git checkout pull/26602` \
`$ git pull https://git.openjdk.org/jdk.git pull/26602/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26602`

View PR using the GUI difftool: \
`$ git pr show -t 26602`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26602.diff">https://git.openjdk.org/jdk/pull/26602.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26602#issuecomment-3145380063)
</details>
