### PR TITLE
8364580: Test compiler/vectorization/TestSubwordTruncation.java fails on platforms without RoundF/RoundD

### DIFF
--- a/test/hotspot/jtreg/compiler/vectorization/TestSubwordTruncation.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestSubwordTruncation.java
@@ -403,7 +403,7 @@ public class TestSubwordTruncation {
     }
 
     @Test
-    @IR(counts = { IRNode.ROUND_F, ">0" })
+    @IR(applyIfPlatformOr = {"x64", "true", "aarch64", "true", "riscv64", "true"}, counts = { IRNode.ROUND_F, ">0" })
     @Arguments(setup = "setupByteArray")
     public Object[] testRoundF(byte[] in) {
         short[] res = new short[SIZE];
@@ -416,7 +416,7 @@ public class TestSubwordTruncation {
     }
 
     @Test
-    @IR(counts = { IRNode.ROUND_D, ">0" })
+    @IR(applyIfPlatformOr = {"x64", "true", "aarch64", "true", "riscv64", "true"}, counts = { IRNode.ROUND_D, ">0" })
     @Arguments(setup = "setupByteArray")
     public Object[] testRoundD(byte[] in) {
         short[] res = new short[SIZE];


### PR DESCRIPTION
Hi all,
This is a quick patch to fix the test bug where TestSubwordTruncation fails on platforms that don't implement RoundF and RoundD. Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8364580](https://bugs.openjdk.org/browse/JDK-8364580): Test compiler/vectorization/TestSubwordTruncation.java fails on platforms without RoundF/RoundD (**Bug** - P4)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26611/head:pull/26611` \
`$ git checkout pull/26611`

Update a local copy of the PR: \
`$ git checkout pull/26611` \
`$ git pull https://git.openjdk.org/jdk.git pull/26611/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26611`

View PR using the GUI difftool: \
`$ git pr show -t 26611`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26611.diff">https://git.openjdk.org/jdk/pull/26611.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26611#issuecomment-3148987994)
</details>
