### PR TITLE
JDK-8364611: (process) Child process SIGPIPE signal disposition should be default

### DIFF
--- a/make/test/JtregNativeJdk.gmk
+++ b/make/test/JtregNativeJdk.gmk
@@ -62,7 +62,8 @@ BUILD_JDK_JTREG_LIBRARIES_JDK_LIBS_libGetXSpace := java.base:libjava
 ifeq ($(call isTargetOs, windows), true)
   BUILD_JDK_JTREG_EXCLUDE += libDirectIO.c libInheritedChannel.c \
       libExplicitAttach.c libImplicitAttach.c \
-      exelauncher.c libFDLeaker.c exeFDLeakTester.c
+      exelauncher.c libFDLeaker.c exeFDLeakTester.c \
+      libChangeSignalDisposition.c exePrintSignalDisposition.c
 
   BUILD_JDK_JTREG_EXECUTABLES_LIBS_exeNullCallerTest := $(LIBCXX)
   BUILD_JDK_JTREG_EXECUTABLES_LIBS_exerevokeall := advapi32.lib

--- a/src/java.base/unix/native/libjava/childproc.c
+++ b/src/java.base/unix/native/libjava/childproc.c
@@ -426,6 +426,11 @@ childProcess(void *arg)
         sigprocmask(SIG_SETMASK, &unblock_signals, NULL);
     }
 
+    // Childs should be started with default signal disposition for SIGPIPE
+    if (signal(SIGPIPE, SIG_DFL) == SIG_ERR) {
+        goto WhyCantJohnnyExec;
+    }
+
     JDK_execvpe(p->mode, p->argv[0], p->argv, p->envv);
 
  WhyCantJohnnyExec:

--- a/test/jdk/java/lang/ProcessBuilder/childSignalDisposition/TestChildSignalDisposition.java
+++ b/test/jdk/java/lang/ProcessBuilder/childSignalDisposition/TestChildSignalDisposition.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test id=posix_spawn
+ * @bug 8364611
+ * @summary Check that childs start with SIG_DFL as SIGPIPE disposition
+ * @requires os.family != "windows"
+ * @library /test/lib
+ * @run main/othervm/native -Djdk.lang.Process.launchMechanism=posix_spawn -agentlib:ChangeSignalDisposition TestChildSignalDisposition
+ */
+
+/**
+ * @test id=fork
+ * @bug 8364611
+ * @summary Check that childs start with SIG_DFL as SIGPIPE disposition
+ * @requires os.family != "windows"
+ * @library /test/lib
+ * @run main/othervm/native -Djdk.lang.Process.launchMechanism=fork -agentlib:ChangeSignalDisposition TestChildSignalDisposition
+ */
+
+/**
+ * @test id=vfork
+ * @bug 8364611
+ * @summary Check that childs start with SIG_DFL as SIGPIPE disposition
+ * @requires os.family == "linux"
+ * @library /test/lib
+ * @run main/othervm/native -Djdk.lang.Process.launchMechanism=vfork -agentlib:ChangeSignalDisposition TestChildSignalDisposition
+ */
+
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+public class TestChildSignalDisposition {
+    // This test has two native parts:
+    // - a library injected into the JVM with -agentlib changes signal disposition of the VM process for SIGPIPE to
+    //   SIG_IGN
+    // - a small native executable that prints out, in its main function, all signal handler dispositions, to be executed
+    //   as a child process.
+    //
+    // What should happen: In child process, SIGPIPE should be set to default.
+    public static void main(String[] args) throws Exception {
+        ProcessBuilder pb = ProcessTools.createNativeTestProcessBuilder("PrintSignalDisposition");
+        OutputAnalyzer output = ProcessTools.executeProcess(pb);
+        output.shouldHaveExitValue(0);
+        output.shouldNotMatch("SIGPIPE: +ignore");
+        output.shouldNotMatch("SIGPIPE: +block");
+        output.shouldMatch("SIGPIPE: +default");
+        output.reportDiagnosticSummary();
+    }
+}

--- a/test/jdk/java/lang/ProcessBuilder/childSignalDisposition/exePrintSignalDisposition.c
+++ b/test/jdk/java/lang/ProcessBuilder/childSignalDisposition/exePrintSignalDisposition.c
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include <errno.h>
+#include "jvmti.h"
+#include <signal.h>
+#include <stdio.h>
+#include <unistd.h>
+
+#define SIGNALS(XX) \
+    XX(SIGABRT) \
+    XX(SIGALRM) \
+    XX(SIGBUS) \
+    XX(SIGCHLD) \
+    XX(SIGCONT) \
+    XX(SIGFPE) \
+    XX(SIGHUP) \
+    XX(SIGILL) \
+    XX(SIGINT) \
+    XX(SIGKILL) \
+    XX(SIGPIPE) \
+    XX(SIGQUIT) \
+    XX(SIGSEGV) \
+    XX(SIGSTOP) \
+    XX(SIGTERM) \
+    XX(SIGTSTP) \
+    XX(SIGTTIN) \
+    XX(SIGTTOU) \
+    XX(SIGUSR1) \
+    XX(SIGUSR2) \
+    XX(SIGPOLL) \
+    XX(SIGPROF) \
+    XX(SIGSYS) \
+    XX(SIGTRAP) \
+    XX(SIGURG) \
+    XX(SIGVTALRM) \
+    XX(SIGXCPU) \
+    XX(SIGXFSZ)
+
+#define DEF_SIGNALS(name) { name, #name },
+static const struct { int sig; const char* name; } signals[] = {
+    SIGNALS(DEF_SIGNALS)
+    { -1, NULL }
+};
+
+int main(int argc, char** argv) {
+    printf("PID: %d\n", getpid());
+    sigset_t current_mask;
+    sigemptyset(&current_mask);
+    if (sigprocmask(SIG_BLOCK /* ignored */, NULL, &current_mask) != 0) {
+        perror("sigprocmask");
+        return -1;
+    }
+
+    for (int n = 0; signals[n].sig != -1; n++) {
+        printf("%s: ", signals[n].name);
+        if (sigismember(&current_mask, signals[n].sig)) {
+            printf("blocked ");
+        }
+        struct sigaction act;
+        const void* handler;
+        if (sigaction(signals[n].sig, NULL, &act) != 0) {
+            perror("sigaction");
+            return -1;
+        }
+        if (act.sa_flags & SA_SIGINFO) {
+            handler = (void*)act.sa_sigaction;
+        } else {
+            handler = (void*)act.sa_handler;
+        }
+        if (handler == (void*)SIG_DFL) {
+            printf("default ");
+        } else if (handler == (void*)SIG_IGN) {
+            printf("ignore ");
+        } else if (handler == (void*)SIG_HOLD) {
+            printf("hold ");
+        } else {
+            printf("%p ", handler);
+        }
+        printf("%X %X\n", act.sa_flags, act.sa_mask);
+    }
+
+    return 0;
+}

--- a/test/jdk/java/lang/ProcessBuilder/childSignalDisposition/libChangeSignalDisposition.c
+++ b/test/jdk/java/lang/ProcessBuilder/childSignalDisposition/libChangeSignalDisposition.c
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include <errno.h>
+#include "jvmti.h"
+#include <signal.h>
+#include <stdio.h>
+
+JNIEXPORT jint JNICALL
+Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
+
+  if (signal(SIGPIPE, SIG_IGN) != SIG_ERR) {
+    printf("pid %d: changed signal disposition for SIGPIPE to SIG_IGN\n");
+  } else {
+    printf("pid %d: FAILED to change signal disposition for SIGPIPE to SIG_IGN (%d)\n", errno);
+    return JNI_ERR;
+  }
+
+  return JNI_OK;
+}


### PR DESCRIPTION
A customer reported an error where a well-known system library, upon loading into the JVM process (via a longish indirect dependency chain), changed the signal disposition of the process for SIGPIPE to SIG_IGN. This gets inherited down to child processes, where it caused child processes to not react to SIGPIPE.

The system library is clearly at fault here, but the current workaround we recommend (pre-loading libjsig to interpose incorrect signal handling requests) is impractical for many customers. It is an okay solution when customers themselves have uncommon signal handling requirements; but for cases like these, where some version of system library does that, we should have a more pragmatic solution.

See further details and arguments for the fix in this mail thread: https://mail.openjdk.org/pipermail/core-libs-dev/2025-April/144077.html .

The behavior is changed changed such that we set SIGPIPE to SIG_DFL in the child processes, and a regression test is added. Note: Regression test deliberately prints outs details for other POSIX signals too; this can be both a good ad-hoc analysis tool as well as a point where we add more tests for other signals, should we ever need to.
