### PR TITLE
8364556: JFR: Disable SymbolTableStatistics and StringTableStatistics in default.jfc

### DIFF
--- a/src/jdk.jfr/share/conf/jfr/default.jfc
+++ b/src/jdk.jfr/share/conf/jfr/default.jfc
@@ -33,12 +33,12 @@
     </event>
 
     <event name="jdk.SymbolTableStatistics">
-      <setting name="enabled">true</setting>
+      <setting name="enabled">false</setting>
       <setting name="period">10 s</setting>
     </event>
 
     <event name="jdk.StringTableStatistics">
-      <setting name="enabled">true</setting>
+      <setting name="enabled">false</setting>
       <setting name="period">10 s</setting>
     </event>
 


### PR DESCRIPTION
Could I have a review of PR that disabled two events in the default configuration due to much impact on applications performance.

Testing: jdk/jdk/jfr

Thanks
Erik