### PR TITLE
8364506: javax/swing/Popup/TaskbarPositionTest.java can fail subsequent tests on MacOS

### DIFF
--- a/test/jdk/javax/swing/Popup/TaskbarPositionTest.java
+++ b/test/jdk/javax/swing/Popup/TaskbarPositionTest.java
@@ -101,14 +101,14 @@ public class TaskbarPositionTest implements ActionListener {
     };
 
     public TaskbarPositionTest() {
-        frame = new JFrame("Use CTRL-down to show a JPopupMenu");
+        frame = new JFrame("Use SHIFT-down to show a JPopupMenu");
         frame.setContentPane(panel = createContentPane());
         frame.setJMenuBar(createMenuBar());
-        frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+        frame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
 
         // CTRL-down will show the popup.
         panel.getInputMap().put(KeyStroke.getKeyStroke(
-                KeyEvent.VK_DOWN, InputEvent.CTRL_DOWN_MASK), "OPEN_POPUP");
+                KeyEvent.VK_DOWN, InputEvent.SHIFT_DOWN_MASK), "OPEN_POPUP");
         panel.getActionMap().put("OPEN_POPUP", new PopupHandler());
 
         frame.pack();
@@ -253,10 +253,10 @@ public class TaskbarPositionTest implements ActionListener {
             item.addActionListener(this);
         }
 
-        JTextField field = new JTextField("CTRL+down for Popup");
-        // CTRL-down will show the popup.
+        JTextField field = new JTextField("SHIFT+down for Popup");
+        // SHIFT-down will show the popup.
         field.getInputMap().put(KeyStroke.getKeyStroke(
-                KeyEvent.VK_DOWN, InputEvent.CTRL_DOWN_MASK), "OPEN_POPUP");
+                KeyEvent.VK_DOWN, InputEvent.SHIFT_DOWN_MASK), "OPEN_POPUP");
         field.getActionMap().put("OPEN_POPUP", new PopupHandler());
 
         JPanel panel = new JPanel();
@@ -406,10 +406,10 @@ public class TaskbarPositionTest implements ActionListener {
             robot.waitForIdle();
 
             // Open its popup
-            robot.keyPress(KeyEvent.VK_CONTROL);
+            robot.keyPress(KeyEvent.VK_SHIFT);
             robot.keyPress(KeyEvent.VK_DOWN);
             robot.keyRelease(KeyEvent.VK_DOWN);
-            robot.keyRelease(KeyEvent.VK_CONTROL);
+            robot.keyRelease(KeyEvent.VK_SHIFT);
 
             robot.waitForIdle();
             SwingUtilities.invokeAndWait(() -> isPopupOnScreen(popupMenu, fullScreenBounds));


### PR DESCRIPTION
Issue:
javax/swing/Popup/TaskbarPositionTest.java can fail subsequent tests on MacOS because of using 'Cntrl+Down Arrow' as this acts as a shortcut in MacOS to show all windows related to the focused one.

Fix:
Change the 'Cntrl' key to 'Shift'

Testing:
Tested in all supported platforms using mach5 and got all PASS.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8364506](https://bugs.openjdk.org/browse/JDK-8364506): javax/swing/Popup/TaskbarPositionTest.java can fail subsequent tests on MacOS (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26623/head:pull/26623` \
`$ git checkout pull/26623`

Update a local copy of the PR: \
`$ git checkout pull/26623` \
`$ git pull https://git.openjdk.org/jdk.git pull/26623/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26623`

View PR using the GUI difftool: \
`$ git pr show -t 26623`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26623.diff">https://git.openjdk.org/jdk/pull/26623.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26623#issuecomment-3151215972)
</details>
