### PR TITLE
8364540: Apply @Stable to Shared Secrets

### DIFF
--- a/src/java.base/share/classes/jdk/internal/access/SharedSecrets.java
+++ b/src/java.base/share/classes/jdk/internal/access/SharedSecrets.java
@@ -25,6 +25,8 @@
 
 package jdk.internal.access;
 
+import jdk.internal.vm.annotation.Stable;
+
 import javax.crypto.SealedObject;
 import javax.crypto.spec.SecretKeySpec;
 import java.io.ObjectInputFilter;
@@ -59,37 +61,38 @@ import javax.security.auth.x500.X500Principal;
  */
 
 public class SharedSecrets {
+    // This field is not necessarily stable
     private static JavaAWTFontAccess javaAWTFontAccess;
-    private static JavaBeansAccess javaBeansAccess;
-    private static JavaLangAccess javaLangAccess;
-    private static JavaLangInvokeAccess javaLangInvokeAccess;
-    private static JavaLangModuleAccess javaLangModuleAccess;
-    private static JavaLangRefAccess javaLangRefAccess;
-    private static JavaLangReflectAccess javaLangReflectAccess;
-    private static JavaIOAccess javaIOAccess;
-    private static JavaIOFileDescriptorAccess javaIOFileDescriptorAccess;
-    private static JavaIORandomAccessFileAccess javaIORandomAccessFileAccess;
-    private static JavaObjectInputStreamReadString javaObjectInputStreamReadString;
-    private static JavaObjectInputStreamAccess javaObjectInputStreamAccess;
-    private static JavaObjectInputFilterAccess javaObjectInputFilterAccess;
-    private static JavaObjectStreamReflectionAccess javaObjectStreamReflectionAccess;
-    private static JavaNetInetAddressAccess javaNetInetAddressAccess;
-    private static JavaNetHttpCookieAccess javaNetHttpCookieAccess;
-    private static JavaNetUriAccess javaNetUriAccess;
-    private static JavaNetURLAccess javaNetURLAccess;
-    private static JavaNioAccess javaNioAccess;
-    private static JavaUtilCollectionAccess javaUtilCollectionAccess;
-    private static JavaUtilConcurrentTLRAccess javaUtilConcurrentTLRAccess;
-    private static JavaUtilConcurrentFJPAccess javaUtilConcurrentFJPAccess;
-    private static JavaUtilJarAccess javaUtilJarAccess;
-    private static JavaUtilZipFileAccess javaUtilZipFileAccess;
-    private static JavaUtilResourceBundleAccess javaUtilResourceBundleAccess;
-    private static JavaSecurityPropertiesAccess javaSecurityPropertiesAccess;
-    private static JavaSecuritySignatureAccess javaSecuritySignatureAccess;
-    private static JavaSecuritySpecAccess javaSecuritySpecAccess;
-    private static JavaxCryptoSealedObjectAccess javaxCryptoSealedObjectAccess;
-    private static JavaxCryptoSpecAccess javaxCryptoSpecAccess;
-    private static JavaxSecurityAccess javaxSecurityAccess;
+    @Stable private static JavaBeansAccess javaBeansAccess;
+    @Stable private static JavaLangAccess javaLangAccess;
+    @Stable private static JavaLangInvokeAccess javaLangInvokeAccess;
+    @Stable private static JavaLangModuleAccess javaLangModuleAccess;
+    @Stable private static JavaLangRefAccess javaLangRefAccess;
+    @Stable private static JavaLangReflectAccess javaLangReflectAccess;
+    @Stable private static JavaIOAccess javaIOAccess;
+    @Stable private static JavaIOFileDescriptorAccess javaIOFileDescriptorAccess;
+    @Stable private static JavaIORandomAccessFileAccess javaIORandomAccessFileAccess;
+    @Stable private static JavaObjectInputStreamReadString javaObjectInputStreamReadString;
+    @Stable private static JavaObjectInputStreamAccess javaObjectInputStreamAccess;
+    @Stable private static JavaObjectInputFilterAccess javaObjectInputFilterAccess;
+    @Stable private static JavaObjectStreamReflectionAccess javaObjectStreamReflectionAccess;
+    @Stable private static JavaNetInetAddressAccess javaNetInetAddressAccess;
+    @Stable private static JavaNetHttpCookieAccess javaNetHttpCookieAccess;
+    @Stable private static JavaNetUriAccess javaNetUriAccess;
+    @Stable private static JavaNetURLAccess javaNetURLAccess;
+    @Stable private static JavaNioAccess javaNioAccess;
+    @Stable private static JavaUtilCollectionAccess javaUtilCollectionAccess;
+    @Stable private static JavaUtilConcurrentTLRAccess javaUtilConcurrentTLRAccess;
+    @Stable private static JavaUtilConcurrentFJPAccess javaUtilConcurrentFJPAccess;
+    @Stable private static JavaUtilJarAccess javaUtilJarAccess;
+    @Stable private static JavaUtilZipFileAccess javaUtilZipFileAccess;
+    @Stable private static JavaUtilResourceBundleAccess javaUtilResourceBundleAccess;
+    @Stable private static JavaSecurityPropertiesAccess javaSecurityPropertiesAccess;
+    @Stable private static JavaSecuritySignatureAccess javaSecuritySignatureAccess;
+    @Stable private static JavaSecuritySpecAccess javaSecuritySpecAccess;
+    @Stable private static JavaxCryptoSealedObjectAccess javaxCryptoSealedObjectAccess;
+    @Stable private static JavaxCryptoSpecAccess javaxCryptoSpecAccess;
+    @Stable private static JavaxSecurityAccess javaxSecurityAccess;
 
     public static void setJavaUtilCollectionAccess(JavaUtilCollectionAccess juca) {
         javaUtilCollectionAccess = juca;


### PR DESCRIPTION
This PR proposes to update the `SharedSecrets` class in `jdk.internal.access` to annotate all but one static field with the `@Stable` annotation.

The `@Stable` annotation was added to all static fields except for `javaAWTFontAccess`, which remains unannotated. This is because it can be set using several code paths.

No tests were changed or added, as this is an internal annotation adjustment with no expected behavioral impact.

This PR passes `tier1`, `tier2`, and `tier3` testing on multiple platforms.

In a future follow-up issue, we could identify fields in the implementations of the access classes that, in turn, are stable themselves. When this PR is integrated, it might be possible to remove local copies of access in classes to reduce bytecode size with little or no performance impact.