### PR TITLE
8364666: Tier1 builds broken by JDK-8360559

### DIFF
--- a/src/hotspot/cpu/x86/stubGenerator_x86_64_sinh.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64_sinh.cpp
@@ -289,7 +289,7 @@ ATTRIBUTE_ALIGNED(16) static const juint _T2_neg_f[] =
 #define __ _masm->
 
 address StubGenerator::generate_libmSinh() {
-  StubGenStubId stub_id = StubGenStubId::dsinh_id;
+  StubId stub_id = StubId::stubgen_dsinh_id;
   StubCodeMark mark(this, stub_id);
   address start = __ pc();
 


### PR DESCRIPTION
This change corrects the stub id type declaration for x86_64 sinh that wasn't properly matched with the other intrinsic udpates.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8364666](https://bugs.openjdk.org/browse/JDK-8364666): Tier1 builds broken by JDK-8360559 (**Bug** - P1)


### Reviewers
 * [Sandhya Viswanathan](https://openjdk.org/census#sviswanathan) (@sviswa7 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26629/head:pull/26629` \
`$ git checkout pull/26629`

Update a local copy of the PR: \
`$ git checkout pull/26629` \
`$ git pull https://git.openjdk.org/jdk.git pull/26629/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26629`

View PR using the GUI difftool: \
`$ git pr show -t 26629`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26629.diff">https://git.openjdk.org/jdk/pull/26629.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26629#issuecomment-3152340851)
</details>
