### PR TITLE
8379044: [macos] javadoc for setOpenURIHandler refers to wrong type

### DIFF
--- a/src/java.desktop/share/classes/java/awt/Desktop.java
+++ b/src/java.desktop/share/classes/java/awt/Desktop.java
@@ -652,7 +652,7 @@ public class Desktop {
      *
      * @implNote Please note that for macOS, notifications
      * are only sent if the Java app is a bundled application,
-     * with a {@code CFBundleDocumentTypes} array present in its
+     * with a {@code CFBundleURLTypes} array present in its
      * {@code Info.plist}. Check the
      * <a href="https://developer.apple.com/documentation">
      * Apple Developer Documentation</a> for more information about


### PR DESCRIPTION
The javadoc for setOpenURIHandler should refer to CFBundleURLTypes which is what the code looks for as seen here:

https://github.com/openjdk/jdk/blob/dc4d9b4849f6557f290338643910f0b05751d748/src/java.desktop/macosx/native/libawt_lwawt/awt/ApplicationDelegate.m#L245

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8379044](https://bugs.openjdk.org/browse/JDK-8379044): [macos] javadoc for setOpenURIHandler refers to wrong type (**Bug** - P4)


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26630/head:pull/26630` \
`$ git checkout pull/26630`

Update a local copy of the PR: \
`$ git checkout pull/26630` \
`$ git pull https://git.openjdk.org/jdk.git pull/26630/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26630`

View PR using the GUI difftool: \
`$ git pr show -t 26630`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26630.diff">https://git.openjdk.org/jdk/pull/26630.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26630#issuecomment-4405345468)
</details>
