### PR TITLE
8364277: (fs) BasicFileAttributes.isDirectory and isOther return true for NTFS directory junctions when links not followed

### DIFF
--- a/src/java.base/windows/classes/sun/nio/fs/WindowsFileAttributes.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsFileAttributes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -426,7 +426,8 @@ class WindowsFileAttributes
         // ignore FILE_ATTRIBUTE_DIRECTORY attribute if file is a sym link
         if (isSymbolicLink())
             return false;
-        return ((fileAttrs & FILE_ATTRIBUTE_DIRECTORY) != 0);
+        return ((fileAttrs & FILE_ATTRIBUTE_DIRECTORY) != 0 &&
+                (fileAttrs & FILE_ATTRIBUTE_REPARSE_POINT) == 0);
     }
 
     @Override

--- a/test/jdk/java/nio/file/attribute/BasicFileAttributeView/Basic.java
+++ b/test/jdk/java/nio/file/attribute/BasicFileAttributeView/Basic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,9 +22,12 @@
  */
 
 /* @test
- * @bug 4313887 6838333
+ * @bug 4313887 6838333 8364277
  * @summary Unit test for java.nio.file.attribute.BasicFileAttributeView
- * @library ../..
+ * @library ../.. /test/lib
+ * @build jdk.test.lib.Platform
+ *        jdk.test.lib.util.FileUtils
+ * @run main/othervm --enable-native-access=ALL-UNNAMED Basic
  */
 
 import java.nio.file.*;
@@ -32,6 +35,9 @@ import java.nio.file.attribute.*;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.io.*;
+
+import jdk.test.lib.Platform;
+import jdk.test.lib.util.FileUtils;
 
 public class Basic {
 
@@ -97,6 +103,17 @@ public class Basic {
         check(!attrs.isOther(), "is not other");
     }
 
+    static void checkAttributesOfJunction(Path junction)
+        throws IOException
+    {
+        BasicFileAttributes attrs =
+            Files.readAttributes(junction, BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
+        check(!attrs.isSymbolicLink(), "is a link");
+        check(!attrs.isDirectory(), "is a directory");
+        check(!attrs.isRegularFile(), "is not a regular file");
+        check(attrs.isOther(), "is other");
+    }
+
     static void attributeReadWriteTests(Path dir)
         throws IOException
     {
@@ -114,12 +131,22 @@ public class Basic {
         Path link = dir.resolve("link");
         try {
             Files.createSymbolicLink(link, file);
-        } catch (UnsupportedOperationException x) {
-            return;
-        } catch (IOException x) {
-            return;
+            checkAttributesOfLink(link);
+        } catch (IOException | UnsupportedOperationException x) {
+            if (!Platform.isWindows())
+                return;
         }
-        checkAttributesOfLink(link);
+
+        // NTFS junctions are Windows-only
+        if (Platform.isWindows()) {
+            Path junction = dir.resolve("junction");
+            FileUtils.createDirectoryJunction(junction.toString(),
+                                              dir.toString());
+            checkAttributesOfJunction(junction);
+            // TestUtil::removeAll will not delete the directory junction,
+            // so it must be deleted manually
+            junction.toFile().delete();
+        }
     }
 
     public static void main(String[] args) throws IOException {

--- a/test/lib/jdk/test/lib/util/FileUtils.java
+++ b/test/lib/jdk/test/lib/util/FileUtils.java
@@ -24,6 +24,7 @@
 package jdk.test.lib.util;
 
 import java.io.BufferedReader;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.PrintStream;
@@ -33,6 +34,7 @@ import java.lang.management.ManagementFactory;
 import java.nio.file.DirectoryNotEmptyException;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
+import java.nio.file.LinkOption;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.SimpleFileVisitor;
@@ -443,7 +445,29 @@ public final class FileUtils {
         Files.write(path, lines);
     }
 
+    // Create a link from "junction" to the real path of "target"
+    public static boolean createDirectoryJunction(String junction, String target)
+        throws IOException
+    {
+        // Convert "target" to its real path
+        target = new File(target).getAbsolutePath().toString();
+
+        // Create a directory junction or a symbolic link
+        if (IS_WINDOWS) {
+            if (!nativeLibLoaded) {
+                System.loadLibrary("FileUtils");
+                nativeLibLoaded = true;
+            }
+            return createWinDirectoryJunction(junction, target);
+        } else {
+            Files.createSymbolicLink(Path.of(junction), Path.of(target));
+            return Files.exists(Path.of(junction), LinkOption.NOFOLLOW_LINKS);
+        }
+    }
+
     private static native long getWinProcessHandleCount();
+    private static native boolean createWinDirectoryJunction(String junction,
+        String target) throws IOException;
 
     // Possible command locations and arguments
     static String[][] lsCommands = new String[][] {

--- a/test/lib/jdk/test/lib/util/libFileUtils.c
+++ b/test/lib/jdk/test/lib/util/libFileUtils.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,9 +27,49 @@
 #ifdef _WIN32
 
 #include "jni.h"
+#include "jni_util.h"
+#include <string.h>
 #include <windows.h>
+#include <fileapi.h>
+#include <handleapi.h>
+#include <ioapiset.h>
+#include <winioctl.h>
+#include <errhandlingapi.h>
 
-JNIEXPORT jlong JNICALL Java_jdk_test_lib_util_FileUtils_getWinProcessHandleCount(JNIEnv *env)
+// Based on Microsoft documentation
+#define MAX_REPARSE_BUFFER_SIZE 16384
+
+// Unavailable in standard header files:
+// copied from Microsoft documentation
+typedef struct _REPARSE_DATA_BUFFER {
+    ULONG  ReparseTag;
+    USHORT ReparseDataLength;
+    USHORT Reserved;
+    union {
+        struct {
+            USHORT SubstituteNameOffset;
+            USHORT SubstituteNameLength;
+            USHORT PrintNameOffset;
+            USHORT PrintNameLength;
+            ULONG  Flags;
+            WCHAR  PathBuffer[1];
+        } SymbolicLinkReparseBuffer;
+        struct {
+            USHORT SubstituteNameOffset;
+            USHORT SubstituteNameLength;
+            USHORT PrintNameOffset;
+            USHORT PrintNameLength;
+            WCHAR  PathBuffer[1];
+        } MountPointReparseBuffer;
+        struct {
+            UCHAR DataBuffer[1];
+        } GenericReparseBuffer;
+    } DUMMYUNIONNAME;
+} REPARSE_DATA_BUFFER, * PREPARSE_DATA_BUFFER;
+
+JNIEXPORT jlong JNICALL
+Java_jdk_test_lib_util_FileUtils_getWinProcessHandleCount
+    (JNIEnv* env)
 {
     DWORD handleCount;
     HANDLE handle = GetCurrentProcess();
@@ -38,6 +78,119 @@ JNIEXPORT jlong JNICALL Java_jdk_test_lib_util_FileUtils_getWinProcessHandleCoun
     } else {
         return -1L;
     }
+}
+
+void throwIOExceptionWithLastError(JNIEnv* env) {
+#define BUFSIZE 256
+    DWORD errval;
+    WCHAR buf[BUFSIZE];
+
+    if ((errval = GetLastError()) != 0) {
+        jsize n = FormatMessageW(
+            FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+            NULL, errval, 0, buf, BUFSIZE, NULL);
+
+        jclass ioExceptionClass = (*env)->FindClass(env, "java/io/IOException");
+        (*env)->ThrowNew(env, ioExceptionClass, (const char*) buf);
+    }
+}
+
+JNIEXPORT jboolean JNICALL
+Java_jdk_test_lib_util_FileUtils_createWinDirectoryJunction
+    (JNIEnv* env, jclass unused, jstring sjunction, jstring starget)
+{
+    const jshort bpc = sizeof(wchar_t); // bytes per character
+    HANDLE hJunction = INVALID_HANDLE_VALUE;
+
+    const jchar* junction = (*env)->GetStringChars(env, sjunction, NULL);
+    const jchar* target   = (*env)->GetStringChars(env, starget, NULL);
+    if (junction == NULL || target == NULL) {
+        jclass npeClass = (*env)->FindClass(env, "java/lang/NullPointerException");
+        (*env)->ThrowNew(env, npeClass, NULL);
+        goto err;
+    }
+
+    USHORT wlen = (USHORT)wcslen(target);
+    USHORT blen = (USHORT)(wlen * sizeof(wchar_t));
+
+    void* lpInBuffer = calloc(MAX_REPARSE_BUFFER_SIZE, sizeof(char));
+    if (lpInBuffer == NULL) {
+        jclass oomeClass = (*env)->FindClass(env, "java/lang/OutOfMemoryError");
+        (*env)->ThrowNew(env, oomeClass, NULL);
+        goto err;
+    }
+
+    if (CreateDirectoryW(junction, NULL) == 0) {
+        throwIOExceptionWithLastError(env);
+        goto err;
+    }
+
+    hJunction = CreateFileW(junction, GENERIC_READ | GENERIC_WRITE,
+        FILE_SHARE_READ | FILE_SHARE_WRITE, NULL, OPEN_EXISTING,
+        FILE_FLAG_OPEN_REPARSE_POINT | FILE_FLAG_BACKUP_SEMANTICS, NULL);
+    if (hJunction == INVALID_HANDLE_VALUE) {
+        throwIOExceptionWithLastError(env);
+        goto err;
+    }
+
+    PREPARSE_DATA_BUFFER reparseBuffer = (PREPARSE_DATA_BUFFER)lpInBuffer;
+    reparseBuffer->ReparseTag = IO_REPARSE_TAG_MOUNT_POINT;
+    reparseBuffer->Reserved = 0;
+    WCHAR* prefix = L"\\??\\";
+    USHORT prefixLength = (USHORT)(bpc * wcslen(prefix));
+    reparseBuffer->MountPointReparseBuffer.SubstituteNameOffset = 0;
+    reparseBuffer->MountPointReparseBuffer.SubstituteNameLength =
+        prefixLength + blen;
+    reparseBuffer->MountPointReparseBuffer.PrintNameOffset =
+        prefixLength + blen + sizeof(WCHAR);
+    reparseBuffer->MountPointReparseBuffer.PrintNameLength = blen;
+    memcpy(&reparseBuffer->MountPointReparseBuffer.PathBuffer,
+        prefix, prefixLength);
+    memcpy(&reparseBuffer->MountPointReparseBuffer.PathBuffer[prefixLength/bpc],
+        target, blen);
+    memcpy(&reparseBuffer->MountPointReparseBuffer.PathBuffer[prefixLength/bpc + blen/bpc + 1],
+        target, blen);
+    reparseBuffer->ReparseDataLength =
+        (USHORT)(sizeof(reparseBuffer->MountPointReparseBuffer) +
+        prefixLength + bpc*blen + bpc);
+    DWORD nInBufferSize = FIELD_OFFSET(REPARSE_DATA_BUFFER,
+        MountPointReparseBuffer) + reparseBuffer->ReparseDataLength;
+    BOOL result = DeviceIoControl(hJunction, FSCTL_SET_REPARSE_POINT,
+                                  lpInBuffer, nInBufferSize,
+                                  NULL, 0, NULL, NULL);
+
+    (*env)->ReleaseStringChars(env, sjunction, junction);
+    (*env)->ReleaseStringChars(env, starget, target);
+    free(lpInBuffer);
+    lpInBuffer = NULL;
+
+    if (result == 0) {
+        throwIOExceptionWithLastError(env);
+        goto err;
+    }
+
+    if (CloseHandle(hJunction) == 0) {
+        throwIOExceptionWithLastError(env);
+        goto err;
+    }
+
+    return JNI_TRUE;
+
+err:
+    if (junction != NULL) {
+        (*env)->ReleaseStringChars(env, sjunction, junction);
+        if (target != NULL) {
+            (*env)->ReleaseStringChars(env, starget, target);
+            if (lpInBuffer != NULL) {
+                free(lpInBuffer);
+                if (hJunction != INVALID_HANDLE_VALUE) {
+                    // Ignore any error in CloseHandle
+                    CloseHandle(hJunction);
+                }
+            }
+        }
+    }
+    return JNI_FALSE;
 }
 
 #endif  /*  _WIN32 */


### PR DESCRIPTION
Change `BasicFileAttributes` for Windows such that for a directory junction `isOther` returns `true` but all other `is*` methods return `false`. Without this change, `isDirectory` also returns false.