### PR TITLE
8364667: JFR: Throttle doesn't work with dynamic events

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/ClassInspector.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/ClassInspector.java
@@ -140,7 +140,7 @@ final class ClassInspector {
         return true;
     }
 
-    boolean isThrottled() {
+    boolean isThrottled(MethodDesc staticThrottleMethod) {
         String result = annotationValue(ANNOTATION_THROTTLE, String.class, "off");
         if (result != null) {
             return true;
@@ -150,6 +150,9 @@ final class ClassInspector {
             if (t != null) {
                 return true;
             }
+        }
+        if (isJDK()) {
+            return hasStaticMethod(staticThrottleMethod);
         }
         return false;
     }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/EventInstrumentation.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/EventInstrumentation.java
@@ -124,11 +124,7 @@ public final class EventInstrumentation {
         this.eventClassDesc = inspector.getClassDesc();
         this.staticCommitMethod = inspector.findStaticCommitMethod();
         this.untypedEventConfiguration = hasUntypedConfiguration();
-        if (inspector.isJDK()) {
-            this.throttled = inspector.hasStaticMethod(METHOD_EVENT_SHOULD_THROTTLE_COMMIT_LONG_LONG);
-        } else {
-            this.throttled = inspector.isThrottled();
-        }
+        this.throttled = inspector.isThrottled(METHOD_EVENT_SHOULD_THROTTLE_COMMIT_LONG_LONG);
     }
 
     byte[] buildInstrumented() {

--- a/test/jdk/jdk/jfr/api/metadata/annotations/TestThrottle.java
+++ b/test/jdk/jdk/jfr/api/metadata/annotations/TestThrottle.java
@@ -29,11 +29,17 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import jdk.jfr.AnnotationElement;
 import jdk.jfr.Enabled;
 import jdk.jfr.Event;
+import jdk.jfr.EventFactory;
+import jdk.jfr.Name;
 import jdk.jfr.Recording;
 import jdk.jfr.SettingControl;
 import jdk.jfr.SettingDefinition;
@@ -132,6 +138,41 @@ public class TestThrottle {
         testThrottleThresholded();
         testThrottleNormalRate();
         testThrottleUserdefined();
+        testThrottleDynamic();
+    }
+
+    private static void testThrottleDynamic() throws Exception {
+        List<AnnotationElement> offAnnotations = new ArrayList<>();
+        offAnnotations.add(new AnnotationElement(Name.class, "DynamicZero"));
+        offAnnotations.add(new AnnotationElement(Throttle.class, "0/s"));
+        EventFactory offFactory = EventFactory.create(offAnnotations, List.of());
+
+        List<AnnotationElement> highRateAnnotations = new ArrayList<>();
+        highRateAnnotations.add(new AnnotationElement(Name.class, "DynamicHighRate"));
+        highRateAnnotations.add(new AnnotationElement(Throttle.class, "1000/s"));
+        EventFactory highRateFactory = EventFactory.create(highRateAnnotations, List.of());
+
+        List<RecordedEvent> events = new CopyOnWriteArrayList<>();
+        try (RecordingStream r = new RecordingStream()) {
+            r.enable("DynamicZero");
+            r.enable("DynamicHighRate");
+            r.onEvent(events::add);
+            r.startAsync();
+            Event offEvent = offFactory.newEvent();
+            offEvent.commit();
+            Event highRateEvent = highRateFactory.newEvent();
+            highRateEvent.begin();
+            highRateEvent.commit();
+            r.stop();
+            if (events.size() != 1) {
+                System.out.println(events);
+                throw new Exception("Expected one dynamic event");
+            }
+            if (!events.get(0).getEventType().getName().equals("DynamicHighRate")) {
+                System.out.println(events);
+                throw new Exception("Expected DynamicHighRate");
+            }
+        }
     }
 
     private static void testUnthrottled() throws Exception {
@@ -272,6 +313,8 @@ public class TestThrottle {
             }
             if (shouldCommit) {
                 assertEvents(r, eventClass.getName(), 17 + 50 + 11);
+            } else {
+                assertEvents(r, eventClass.getName(), 0);
             }
         }
     }

--- a/test/jdk/jdk/jfr/api/metadata/annotations/TestThrottle.java
+++ b/test/jdk/jdk/jfr/api/metadata/annotations/TestThrottle.java
@@ -141,40 +141,6 @@ public class TestThrottle {
         testThrottleDynamic();
     }
 
-    private static void testThrottleDynamic() throws Exception {
-        List<AnnotationElement> offAnnotations = new ArrayList<>();
-        offAnnotations.add(new AnnotationElement(Name.class, "DynamicZero"));
-        offAnnotations.add(new AnnotationElement(Throttle.class, "0/s"));
-        EventFactory offFactory = EventFactory.create(offAnnotations, List.of());
-
-        List<AnnotationElement> highRateAnnotations = new ArrayList<>();
-        highRateAnnotations.add(new AnnotationElement(Name.class, "DynamicHighRate"));
-        highRateAnnotations.add(new AnnotationElement(Throttle.class, "1000/s"));
-        EventFactory highRateFactory = EventFactory.create(highRateAnnotations, List.of());
-
-        List<RecordedEvent> events = new CopyOnWriteArrayList<>();
-        try (RecordingStream r = new RecordingStream()) {
-            r.enable("DynamicZero");
-            r.enable("DynamicHighRate");
-            r.onEvent(events::add);
-            r.startAsync();
-            Event offEvent = offFactory.newEvent();
-            offEvent.commit();
-            Event highRateEvent = highRateFactory.newEvent();
-            highRateEvent.begin();
-            highRateEvent.commit();
-            r.stop();
-            if (events.size() != 1) {
-                System.out.println(events);
-                throw new Exception("Expected one dynamic event");
-            }
-            if (!events.get(0).getEventType().getName().equals("DynamicHighRate")) {
-                System.out.println(events);
-                throw new Exception("Expected DynamicHighRate");
-            }
-        }
-    }
-
     private static void testUnthrottled() throws Exception {
         testEvent(UnthrottledEvent.class, true);
     }
@@ -270,6 +236,40 @@ public class TestThrottle {
                 e5.commit();
             }
             assertEvents(r, eventName, emit ? 5 : 0);
+        }
+    }
+
+    private static void testThrottleDynamic() throws Exception {
+        List<AnnotationElement> offAnnotations = new ArrayList<>();
+        offAnnotations.add(new AnnotationElement(Name.class, "DynamicZero"));
+        offAnnotations.add(new AnnotationElement(Throttle.class, "0/s"));
+        EventFactory offFactory = EventFactory.create(offAnnotations, List.of());
+
+        List<AnnotationElement> highRateAnnotations = new ArrayList<>();
+        highRateAnnotations.add(new AnnotationElement(Name.class, "DynamicHighRate"));
+        highRateAnnotations.add(new AnnotationElement(Throttle.class, "1000/s"));
+        EventFactory highRateFactory = EventFactory.create(highRateAnnotations, List.of());
+
+        List<RecordedEvent> events = new CopyOnWriteArrayList<>();
+        try (RecordingStream r = new RecordingStream()) {
+            r.enable("DynamicZero");
+            r.enable("DynamicHighRate");
+            r.onEvent(events::add);
+            r.startAsync();
+            Event offEvent = offFactory.newEvent();
+            offEvent.commit();
+            Event highRateEvent = highRateFactory.newEvent();
+            highRateEvent.begin();
+            highRateEvent.commit();
+            r.stop();
+            if (events.size() != 1) {
+                System.out.println(events);
+                throw new Exception("Expected one dynamic event");
+            }
+            if (!events.get(0).getEventType().getName().equals("DynamicHighRate")) {
+                System.out.println(events);
+                throw new Exception("Expected DynamicHighRate");
+            }
         }
     }
 


### PR DESCRIPTION
Could I have a review of a PR that fixes a bug with dynamic events and the new `@Throttle` annotation?

If a class is in the boot class loader (isJDK), it only checks for a static commit method and does not check if the `@Throttle` annotation exists (which it does  for dynamic events).

I added a test, and I also noticed that there is no check to see if there are zero events when shouldCommit is false, so I added that as well.

Testing: jdk/jdk/jfr

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8364667](https://bugs.openjdk.org/browse/JDK-8364667): JFR: Throttle doesn't work with dynamic events (**Bug** - P3)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26632/head:pull/26632` \
`$ git checkout pull/26632`

Update a local copy of the PR: \
`$ git checkout pull/26632` \
`$ git pull https://git.openjdk.org/jdk.git pull/26632/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26632`

View PR using the GUI difftool: \
`$ git pr show -t 26632`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26632.diff">https://git.openjdk.org/jdk/pull/26632.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26632#issuecomment-3152623891)
</details>
