### PR TITLE
8365186: Reduce size of j.t.f.DateTimePrintContext::adjust

### DIFF
--- a/src/java.base/share/classes/java/time/format/DateTimePrintContext.java
+++ b/src/java.base/share/classes/java/time/format/DateTimePrintContext.java
@@ -141,8 +141,7 @@ final class DateTimePrintContext {
             return temporal;
         }
 
-        // The chronology and zone fields of Formatter are usually null,
-        // so the non-null processing code is placed in a separate method
+        // Placing the non-null cases in a separate method allows more flexible code optimizations
         return adjustWithOverride(temporal, overrideChrono, overrideZone);
     }
 
@@ -233,12 +232,8 @@ final class DateTimePrintContext {
      */
     private static TemporalAccessor adjustSlow(
             TemporalAccessor temporal,
-            ZoneId overrideZone,
-            ZoneId temporalZone,
-            Chronology overrideChrono,
-            Chronology effectiveChrono,
-            Chronology temporalChrono
-    ) {
+            ZoneId overrideZone, ZoneId temporalZone,
+            Chronology overrideChrono, Chronology effectiveChrono, Chronology temporalChrono) {
         if (overrideZone != null) {
             // block changing zone on OffsetTime, and similar problem cases
             if (overrideZone.normalized() instanceof ZoneOffset && temporal.isSupported(OFFSET_SECONDS) &&


### PR DESCRIPTION
By adding the JVM startup parameters `-XX:+UnlockDiagnosticVMOptions -XX:+PrintInlining` and analyzing the printed log information, and found that the code size of the j.t.f.DateTimePrintContext::adjust method is 382, which is greater than 325, causing inlining failure.

```
@ 7   java.time.format.DateTimePrintContext::adjust (382 bytes)   failed to inline: hot method too big
```

By splitting the code into `common/uncommon`, and moving the uncommon code into adjust0, the adjust method is kept small and can be inlined by the C2 optimizer.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8365186](https://bugs.openjdk.org/browse/JDK-8365186): Reduce size of j.t.f.DateTimePrintContext::adjust (**Enhancement** - P4)


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26633/head:pull/26633` \
`$ git checkout pull/26633`

Update a local copy of the PR: \
`$ git checkout pull/26633` \
`$ git pull https://git.openjdk.org/jdk.git pull/26633/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26633`

View PR using the GUI difftool: \
`$ git pr show -t 26633`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26633.diff">https://git.openjdk.org/jdk/pull/26633.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26633#issuecomment-3170322910)
</details>
