### PR TITLE
8364365: HKSCS encoder does not properly set the replacement character

### DIFF
--- a/src/java.base/share/classes/sun/nio/cs/HKSCS.java
+++ b/src/java.base/share/classes/sun/nio/cs/HKSCS.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,12 +28,9 @@ package sun.nio.cs;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.nio.charset.Charset;
-import java.nio.charset.CharsetDecoder;
-import java.nio.charset.CharsetEncoder;
 import java.nio.charset.CoderResult;
 import java.util.Arrays;
-import sun.nio.cs.DoubleByte;
-import sun.nio.cs.Surrogate;
+
 import static sun.nio.cs.CharsetMapping.*;
 
 public class HKSCS {
@@ -353,12 +350,6 @@ public class HKSCS {
                 return encodeArrayLoop(src, dst);
             else
                 return encodeBufferLoop(src, dst);
-        }
-
-        @SuppressWarnings("this-escape")
-        private byte[] repl = replacement();
-        protected void implReplaceWith(byte[] newReplacement) {
-            repl = newReplacement;
         }
 
         public int encode(char[] src, int sp, int len, byte[] dst) {

--- a/test/jdk/sun/nio/cs/TestEncoderReplaceLatin1.java
+++ b/test/jdk/sun/nio/cs/TestEncoderReplaceLatin1.java
@@ -1,0 +1,263 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import sun.nio.cs.ArrayEncoder;
+import sun.nio.cs.DoubleByte;
+import sun.nio.cs.SingleByte;
+
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.Charset;
+import java.nio.charset.CharsetEncoder;
+import java.nio.charset.CoderResult;
+import java.nio.charset.CodingErrorAction;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Map;
+import java.util.function.Predicate;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static sun.nio.cs.CharsetMapping.UNMAPPABLE_ENCODING;
+
+/*
+ * @test
+ * @bug 8364365
+ * @summary Verifies `CodingErrorAction.REPLACE` behaviour of all available
+ *          character set encoders while encoding a Latin-1 character
+ * @modules java.base/jdk.internal.access
+ *          java.base/sun.nio.cs
+ * @run junit TestEncoderReplaceLatin1
+ */
+
+class TestEncoderReplaceLatin1 {
+
+    static Collection<Charset> charsets() {
+        return Charset.availableCharsets().values();
+    }
+
+    @ParameterizedTest
+    @MethodSource("charsets")
+    void testEncoderReplace(Charset charset) {
+
+        // Create an encoder
+        CharsetEncoder encoder = createEncoder(charset);
+        if (encoder == null) {
+            return;
+        }
+
+        // Find an unmappable character to test the `REPLACE` action.
+        char[] unmappable = findUnmappable(encoder);
+        if (unmappable == null) {
+            return;
+        }
+
+        // Configure the `REPLACE` action
+        byte[] replacement = findCustomReplacement(encoder, new byte[]{(byte) unmappable[0]});
+        if (replacement == null) {
+            return;
+        }
+        encoder.onUnmappableCharacter(CodingErrorAction.REPLACE).replaceWith(replacement);
+
+        // Verify the replacement
+        System.err.println("Verifying replacement... " + Map.of(
+                "unmappable", TestEncoderReplaceLatin1.prettyPrintChars(unmappable),
+                "replacement", TestEncoderReplaceLatin1.prettyPrintBytes(replacement)));
+        testCharsetEncoderReplace(encoder, unmappable, replacement);
+        testArrayEncoderLatin1Replace(encoder, unmappable[0], replacement);
+
+    }
+
+    private static CharsetEncoder createEncoder(Charset charset) {
+        try {
+            return charset.newEncoder();
+        } catch (UnsupportedOperationException _) {
+            System.err.println("Could not create the character encoder!");
+        }
+        return null;
+    }
+
+    private static char[] findUnmappable(CharsetEncoder encoder) {
+
+        // Try to find a single-byte unmappable
+        Predicate<char[]> isUnmappable1 = createUnmappableSingleCharPredicate(encoder);
+        char[] unmappable1 = {0};
+        for (int i = 0; i < 0xFF; i++) {
+            unmappable1[0] = (char) i;
+            boolean unmappable = isUnmappable1.test(unmappable1);
+            if (unmappable) {
+                return unmappable1;
+            }
+        }
+
+        System.err.println("Could not find an unmappable character!");
+        return null;
+
+    }
+
+    static Predicate<char[]> createUnmappableSingleCharPredicate(CharsetEncoder encoder) {
+        return switch (encoder) {
+            case SingleByte.Encoder sbEncoder -> c -> sbEncoder.encode(c[0]) == UNMAPPABLE_ENCODING;
+            case DoubleByte.Encoder dbEncoder -> c -> dbEncoder.encodeChar(c[0]) == UNMAPPABLE_ENCODING;
+            default -> createUnmappableDoubleCharPredicate(encoder);
+        };
+    }
+
+    static Predicate<char[]> createUnmappableDoubleCharPredicate(CharsetEncoder encoder) {
+        assertEquals(encoder.unmappableCharacterAction(), CodingErrorAction.REPORT);
+        CharBuffer charBuffer = CharBuffer.allocate(2);
+        ByteBuffer byteBuffer = ByteBuffer.allocate(4);
+        return unmappable -> {
+            charBuffer.clear().put(unmappable).flip();
+            byteBuffer.clear();
+            CoderResult coderResult = encoder.encode(charBuffer, byteBuffer, true);
+            return coderResult.isUnmappable();
+        };
+    }
+
+    /**
+     * Finds a {@linkplain CharsetEncoder#replacement() replacement} which is
+     * different from the given unmappable and the default one.
+     */
+    static byte[] findCustomReplacement(CharsetEncoder encoder, byte[] unmappable) {
+
+        // Obtain the default replacement
+        byte[] replacementD = encoder.replacement();
+
+        // Try to find a single-byte replacement
+        byte[] replacement1 = {0};
+        for (int i = 0; i < 0xFF; i++) {
+            // Skip if the replacement is equal to the unmappable.
+            // They need to be distinct to be able to determine whether the replacement has occurred.
+            if (unmappable[0] == i) {
+                continue;
+            }
+            replacement1[0] = (byte) i;
+            // Skip the default value, since we're verifying if a custom one works
+            if (replacement1[0] == replacementD[0]) {
+                continue;
+            }
+            if (encoder.isLegalReplacement(replacement1)) {
+                return replacement1;
+            }
+        }
+
+        // Try to find a double-byte replacement
+        byte[] replacement2 = {0, 0};
+        for (int i = 0; i < 0xFF; i++) {
+            // Skip if the replacement is equal to the unmappable.
+            // They need to be distinct to be able to determine whether the replacement has occurred.
+            if (unmappable[0] == i) {
+                continue;
+            }
+            replacement2[0] = (byte) i;
+            for (int j = 0; j < 0xFF; j++) {
+                // Skip if the replacement is equal to the unmappable.
+                // They need to be distinct to be able to determine whether the replacement has occurred.
+                if (unmappable.length > 1 && unmappable[1] == j) {
+                    continue;
+                }
+                replacement2[1] = (byte) j;
+                // Skip the default value, since we're verifying if a custom one works
+                if (replacementD.length > 1 && replacement2[1] == replacementD[1]) {
+                    continue;
+                }
+                if (encoder.isLegalReplacement(replacement2)) {
+                    return replacement2;
+                }
+            }
+        }
+
+        System.err.println("Could not find a replacement!");
+        return null;
+
+    }
+
+    /**
+     * Verifies {@linkplain CoderResult#isUnmappable() unmappable} character
+     * {@linkplain CodingErrorAction#REPLACE replacement} using {@link
+     * CharsetEncoder#encode(CharBuffer, ByteBuffer, boolean)
+     * CharsetEncoder::encode}.
+     */
+    static void testCharsetEncoderReplace(CharsetEncoder encoder, char[] unmappable, byte[] replacement) {
+        CharBuffer charBuffer = CharBuffer.wrap(unmappable);
+        ByteBuffer byteBuffer = ByteBuffer.allocate(replacement.length);
+        CoderResult coderResult = encoder.encode(charBuffer, byteBuffer, true);
+        assertArrayEquals(replacement, byteBuffer.array(), () -> {
+            Object context = Map.of(
+                    "coderResult", coderResult,
+                    "byteBuffer.position()", byteBuffer.position(),
+                    "byteBuffer.array()", prettyPrintBytes(byteBuffer.array()),
+                    "unmappable", prettyPrintChars(unmappable),
+                    "replacement", prettyPrintBytes(replacement));
+            return "Unexpected `CharsetEncoder::encode` output! " + context;
+        });
+    }
+
+    /**
+     * Verifies {@linkplain CoderResult#isUnmappable() unmappable} character
+     * {@linkplain CodingErrorAction#REPLACE replacement} using {@link
+     * ArrayEncoder#encodeFromLatin1(byte[], int, int, byte[])
+     * ArrayEncoder::encodeFromLatin1}.
+     */
+    private static void testArrayEncoderLatin1Replace(CharsetEncoder encoder, char unmappable, byte[] replacement) {
+        if (!(encoder instanceof ArrayEncoder arrayEncoder)) {
+            System.err.println("Encoder is not of type `ArrayEncoder`, skipping the `ArrayEncoder::encodeFromLatin1` test.");
+            return;
+        }
+        byte[] sa = {(byte) unmappable};
+        byte[] da = new byte[replacement.length];
+        int dp = arrayEncoder.encodeFromLatin1(sa, 0, 1, da);
+        assertTrue(dp == replacement.length && Arrays.equals(da, replacement), () -> {
+            Object context = Map.of(
+                    "dp", dp,
+                    "da", prettyPrintBytes(da),
+                    "sa", prettyPrintBytes(sa),
+                    "unmappable", prettyPrintChars(new char[]{unmappable}),
+                    "replacement", prettyPrintBytes(replacement));
+            return "Unexpected `ArrayEncoder::encodeFromLatin1` output! " + context;
+        });
+    }
+
+    static String prettyPrintChars(char[] cs) {
+        StringBuilder sb = new StringBuilder("[");
+        for (int i = 0; i < cs.length; i++) {
+            char c = cs[i];
+            sb.append("%sU+%04X".formatted(i > 0 ? ", " : "", (int) c));
+        }
+        return sb.append(']').toString();
+    }
+
+    static String prettyPrintBytes(byte[] bs) {
+        StringBuilder sb = new StringBuilder("[");
+        for (int i = 0; i < bs.length; i++) {
+            byte b = bs[i];
+            sb.append("%s0x%02X".formatted(i > 0 ? ", " : "", b & 0xFF));
+        }
+        return sb.append(']').toString();
+    }
+
+}

--- a/test/jdk/sun/nio/cs/TestEncoderReplaceLatin1.java
+++ b/test/jdk/sun/nio/cs/TestEncoderReplaceLatin1.java
@@ -34,6 +34,8 @@ import java.nio.charset.CodingErrorAction;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -213,21 +215,15 @@ class TestEncoderReplaceLatin1 {
     }
 
     static String prettyPrintChars(char[] cs) {
-        StringBuilder sb = new StringBuilder("[");
-        for (int i = 0; i < cs.length; i++) {
-            char c = cs[i];
-            sb.append("%sU+%04X".formatted(i > 0 ? ", " : "", (int) c));
-        }
-        return sb.append(']').toString();
+        return IntStream.range(0, cs.length)
+                .mapToObj(i -> String.format("U+%04X", (int) cs[i]))
+                .collect(Collectors.joining(", ", "[", "]"));
     }
 
     static String prettyPrintBytes(byte[] bs) {
-        StringBuilder sb = new StringBuilder("[");
-        for (int i = 0; i < bs.length; i++) {
-            byte b = bs[i];
-            sb.append("%s0x%02X".formatted(i > 0 ? ", " : "", b & 0xFF));
-        }
-        return sb.append(']').toString();
+        return IntStream.range(0, bs.length)
+                .mapToObj(i -> String.format("0x%02X", bs[i] & 0xFF))
+                .collect(Collectors.joining(", ", "[", "]"));
     }
 
 }

--- a/test/jdk/sun/nio/cs/TestEncoderReplaceUTF16.java
+++ b/test/jdk/sun/nio/cs/TestEncoderReplaceUTF16.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import jdk.internal.access.JavaLangAccess;
+import jdk.internal.access.SharedSecrets;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import sun.nio.cs.ArrayEncoder;
+
+import java.nio.charset.Charset;
+import java.nio.charset.CharsetEncoder;
+import java.nio.charset.CoderResult;
+import java.nio.charset.CodingErrorAction;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Predicate;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/*
+ * @test
+ * @bug 8364365
+ * @summary Verifies `CodingErrorAction.REPLACE` behaviour of all available
+ *          character set encoders while encoding a UTF-16 character
+ * @modules java.base/jdk.internal.access
+ *          java.base/sun.nio.cs
+ * @build TestEncoderReplaceLatin1
+ * @run junit/timeout=10 TestEncoderReplaceUTF16
+ * @run junit/timeout=10/othervm -XX:-CompactStrings TestEncoderReplaceUTF16
+ */
+
+class TestEncoderReplaceUTF16 {
+
+    private static final JavaLangAccess JLA = SharedSecrets.getJavaLangAccess();
+
+    /**
+     * Character sets known to be absent of non-Latin-1 {@linkplain CoderResult#isUnmappable() unmappable} characters.
+     */
+    private static final Set<String> CHARSETS_WITHOUT_UNMAPPABLE = Set.of(
+            "CESU-8",
+            "EUC-JP",
+            "GB18030",
+            "ISO-2022-JP",
+            "ISO-2022-JP-2",
+            "ISO-2022-KR",
+            "ISO-8859-1",
+            "US-ASCII",
+            "UTF-16",
+            "UTF-16BE",
+            "UTF-16LE",
+            "UTF-32",
+            "UTF-32BE",
+            "UTF-32LE",
+            "UTF-8",
+            "x-euc-jp-linux",
+            "x-EUC-TW",
+            "x-eucJP-Open",
+            "x-IBM29626C",
+            "x-IBM33722",
+            "x-IBM964",
+            "x-ISCII91",
+            "x-ISO-2022-CN-CNS",
+            "x-ISO-2022-CN-GB",
+            "x-MS932_0213",
+            "x-SJIS_0213",
+            "x-UTF-16LE-BOM",
+            "X-UTF-32BE-BOM",
+            "X-UTF-32LE-BOM",
+            "x-windows-50220",
+            "x-windows-50221",
+            "x-windows-iso2022jp");
+
+    @ParameterizedTest
+    @MethodSource("TestEncoderReplaceLatin1#charsets")
+    void testEncoderReplace(Charset charset) {
+
+        // Create an encoder
+        CharsetEncoder encoder = createEncoder(charset);
+        if (encoder == null) {
+            return;
+        }
+
+        // Find an unmappable character to test the `REPLACE` action.
+        char[] unmappable = findUnmappableNonLatin1(encoder);
+        if (unmappable == null) {
+            return;
+        }
+
+        // Configure the `REPLACE` action
+        byte[] unmappableUTF16Bytes = utf16Bytes(unmappable);
+        byte[] replacement = TestEncoderReplaceLatin1.findCustomReplacement(encoder, unmappableUTF16Bytes);
+        if (replacement == null) {
+            return;
+        }
+        encoder.onUnmappableCharacter(CodingErrorAction.REPLACE).replaceWith(replacement);
+
+        // Verify the replacement
+        System.err.println("Verifying replacement... " + Map.of(
+                "unmappable", TestEncoderReplaceLatin1.prettyPrintChars(unmappable),
+                "unmappableUTF16Bytes", TestEncoderReplaceLatin1.prettyPrintBytes(unmappableUTF16Bytes),
+                "replacement", TestEncoderReplaceLatin1.prettyPrintBytes(replacement)));
+        TestEncoderReplaceLatin1.testCharsetEncoderReplace(encoder, unmappable, replacement);
+        testArrayEncoderUTF16Replace(encoder, unmappableUTF16Bytes, replacement);
+
+    }
+
+    private static CharsetEncoder createEncoder(Charset charset) {
+        try {
+            return charset.newEncoder();
+        } catch (UnsupportedOperationException _) {
+            System.err.println("Could not create the character encoder!");
+        }
+        return null;
+    }
+
+    /**
+     * Finds an {@linkplain CoderResult#isUnmappable() unmappable} non-Latin-1 {@code char[]} for the given encoder.
+     */
+    private static char[] findUnmappableNonLatin1(CharsetEncoder encoder) {
+
+        // Fast-path for characters sets known to be absent of unmappable non-Latin-1 characters
+        if (CHARSETS_WITHOUT_UNMAPPABLE.contains(encoder.charset().name())) {
+            System.err.println("Character set is known to be absent of unmappable non-Latin-1 characters!");
+            return null;
+        }
+
+        // Try to find a single-`char` unmappable
+        Predicate<char[]> isUnmappable1 = TestEncoderReplaceLatin1.createUnmappableSingleCharPredicate(encoder);
+        char[] unmappable1 = {0};
+        for (int i = 0xFF; i < 0xFFFF; i++) {
+            unmappable1[0] = (char) i;
+            boolean unmappable = isUnmappable1.test(unmappable1);
+            if (unmappable) {
+                return unmappable1;
+            }
+        }
+
+        // Try to find a double-`char` unmappable
+        Predicate<char[]> isUnmappable2 = TestEncoderReplaceLatin1.createUnmappableDoubleCharPredicate(encoder);
+        char[] unmappable2 = {0, 0};
+        for (int i = 0xFF; i < 0xFFFF; i++) {
+            unmappable2[0] = (char) i;
+            for (int j = 0xFF; j < 0xFFFF; j++) {
+                unmappable2[1] = (char) j;
+                boolean unmappable = isUnmappable2.test(unmappable2);
+                if (unmappable) {
+                    return unmappable2;
+                }
+            }
+        }
+
+        System.err.println("Could not find an unmappable character!");
+        return null;
+    }
+
+    private static byte[] utf16Bytes(char[] cs) {
+        int sl = cs.length;
+        byte[] sa = new byte[sl << 1];
+        for (int i = 0; i < sl; i++) {
+            JLA.uncheckedPutCharUTF16(sa, i, cs[i]);
+        }
+        return sa;
+    }
+
+    /**
+     * Verifies {@linkplain CoderResult#isUnmappable() unmappable} character
+     * {@linkplain CodingErrorAction#REPLACE replacement} using {@link
+     * ArrayEncoder#encodeFromUTF16(byte[], int, int, byte[])
+     * ArrayEncoder::encodeFromUTF16}.
+     */
+    private static void testArrayEncoderUTF16Replace(CharsetEncoder encoder, byte[] unmappableUTF16Bytes, byte[] replacement) {
+        if (!(encoder instanceof ArrayEncoder arrayEncoder)) {
+            System.err.println("Encoder is not of type `ArrayEncoder`, skipping the `ArrayEncoder::encodeFromUTF16` test.");
+            return;
+        }
+        byte[] da = new byte[replacement.length];
+        int dp = arrayEncoder.encodeFromUTF16(unmappableUTF16Bytes, 0, unmappableUTF16Bytes.length >>> 1, da);
+        assertTrue(dp == replacement.length && Arrays.equals(da, replacement), () -> {
+            Object context = Map.of(
+                    "dp", dp,
+                    "da", TestEncoderReplaceLatin1.prettyPrintBytes(da),
+                    "unmappableUTF16Bytes", TestEncoderReplaceLatin1.prettyPrintBytes(unmappableUTF16Bytes),
+                    "replacement", TestEncoderReplaceLatin1.prettyPrintBytes(replacement));
+            return "Unexpected `ArrayEncoder::encodeFromUTF16` output! " + context;
+        });
+    }
+
+}


### PR DESCRIPTION
Fix `HKSCS` encoder to correctly set the replacement character, and add tests to verify the `CodingErrorAction.REPLACE` behavior of all available encoders.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8364365](https://bugs.openjdk.org/browse/JDK-8364365): HKSCS encoder does not properly set the replacement character (**Task** - P4)


### Reviewers
 * [Xueming Shen](https://openjdk.org/census#sherman) (@xuemingshen-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26635/head:pull/26635` \
`$ git checkout pull/26635`

Update a local copy of the PR: \
`$ git checkout pull/26635` \
`$ git pull https://git.openjdk.org/jdk.git pull/26635/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26635`

View PR using the GUI difftool: \
`$ git pr show -t 26635`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26635.diff">https://git.openjdk.org/jdk/pull/26635.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26635#issuecomment-3154117296)
</details>
