### PR TITLE
8366844: Update and automate MouseDraggedOriginatedByScrollBarTest.java

### DIFF
--- a/test/jdk/java/awt/List/MouseDraggedOriginatedByScrollBarTest.java
+++ b/test/jdk/java/awt/List/MouseDraggedOriginatedByScrollBarTest.java
@@ -44,13 +44,13 @@ import java.awt.event.MouseMotionAdapter;
 public class MouseDraggedOriginatedByScrollBarTest {
     private static Frame frame;
     private static volatile Point loc;
-    private static volatile List list;
+    private static List list;
     private static final int XOFFSET = 10;
     private static final int YOFFSET = 20;
 
     public static void main(String[] args) throws Exception {
         try {
-            createUI();
+            EventQueue.invokeAndWait(() -> createUI());
             test();
         } finally {
             EventQueue.invokeAndWait(() -> {
@@ -82,7 +82,7 @@ public class MouseDraggedOriginatedByScrollBarTest {
             new MouseMotionAdapter(){
                 @Override
                 public void mouseDragged(MouseEvent me){
-                    System.out.println(me.toString());
+                    System.out.println(me);
                     throw new RuntimeException("Mouse dragged event detected.");
                 }
             });
@@ -90,17 +90,17 @@ public class MouseDraggedOriginatedByScrollBarTest {
         list.addMouseListener(
             new MouseAdapter() {
                 public void mousePressed(MouseEvent me) {
-                    System.out.println(me.toString());
+                    System.out.println(me);
                     throw new RuntimeException("Mouse pressed event detected.");
                 }
 
                 public void mouseReleased(MouseEvent me) {
-                    System.out.println(me.toString());
+                    System.out.println(me);
                     throw new RuntimeException("Mouse released event detected.");
                 }
 
                 public void mouseClicked(MouseEvent me){
-                    System.out.println(me.toString());
+                    System.out.println(me);
                     throw new RuntimeException("Mouse clicked event detected.");
                 }
             });


### PR DESCRIPTION
When testing jtreg manual tests, some tests were out of date. This PR is an attempt at updating the test and automating it. 

`MouseDraggedOriginatedByScrollBarTest.java` works as expected when compared to native apps and outputs drag events even when the mouse pointer is dragged off of the scrollbar and window altogether. Events should still fire, but the previous instructions may make this confusing since it reads as if no events should be output to the textarea at all.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8366844](https://bugs.openjdk.org/browse/JDK-8366844): Update and automate MouseDraggedOriginatedByScrollBarTest.java (**Bug** - P4)


### Reviewers
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Harshitha Onkar](https://openjdk.org/census#honkar) (@honkar-jdk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26636/head:pull/26636` \
`$ git checkout pull/26636`

Update a local copy of the PR: \
`$ git checkout pull/26636` \
`$ git pull https://git.openjdk.org/jdk.git pull/26636/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26636`

View PR using the GUI difftool: \
`$ git pr show -t 26636`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26636.diff">https://git.openjdk.org/jdk/pull/26636.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26636#issuecomment-3154347446)
</details>
