### PR TITLE
8364722: Parallel: Move CLDG mark clearing to the end of full GC

### DIFF
--- a/src/hotspot/share/gc/parallel/psParallelCompact.cpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.cpp
@@ -685,6 +685,9 @@ void PSParallelCompact::post_compact()
   CodeCache::on_gc_marking_cycle_finish();
   CodeCache::arm_all_nmethods();
 
+  // Need to clear claim bits for the next full-gc (marking and adjust-pointers).
+  ClassLoaderDataGraph::clear_claimed_marks();
+
   for (unsigned int id = old_space_id; id < last_space_id; ++id) {
     // Clear the marking bitmap, summary data and split info.
     clear_data_covering_space(SpaceId(id));
@@ -1288,9 +1291,6 @@ void PSParallelCompact::marking_phase(ParallelOldTracer *gc_tracer) {
       ClassLoaderDataGraph::purge(true /* at_safepoint */);
       DEBUG_ONLY(MetaspaceUtils::verify();)
     }
-
-    // Need to clear claim bits for the next mark.
-    ClassLoaderDataGraph::clear_claimed_marks();
   }
 
   {


### PR DESCRIPTION
Move ClassLoaderDataGraph claim-mark clearing to `post_compact` (the end of full-gc), to be more aligned with other GCs.

Test: tier1-3

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8364722](https://bugs.openjdk.org/browse/JDK-8364722): Parallel: Move CLDG mark clearing to the end of full GC (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Zhengyu Gu](https://openjdk.org/census#zgu) (@zhengyu123 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26637/head:pull/26637` \
`$ git checkout pull/26637`

Update a local copy of the PR: \
`$ git checkout pull/26637` \
`$ git pull https://git.openjdk.org/jdk.git pull/26637/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26637`

View PR using the GUI difftool: \
`$ git pr show -t 26637`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26637.diff">https://git.openjdk.org/jdk/pull/26637.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26637#issuecomment-3154599485)
</details>
