### PR TITLE
8364558: Failure to generate compiler stubs from compiler thread should not crash VM when compilation disabled due to full CodeCache

### DIFF
--- a/src/hotspot/share/opto/c2compiler.cpp
+++ b/src/hotspot/share/opto/c2compiler.cpp
@@ -92,16 +92,16 @@ bool C2Compiler::init_c2_runtime() {
 
   // If there was an error generating the blob then UseCompiler will
   // have been unset and we need to skip the remaining initialization
-  if (UseCompiler) {
-    Compile::pd_compiler2_init();
-
-    CompilerThread* thread = CompilerThread::current();
-
-    HandleMark handle_mark(thread);
-    return OptoRuntime::generate(thread->env());
-  } else {
+  if (!UseCompiler) {
     return false;
   }
+
+  Compile::pd_compiler2_init();
+
+  CompilerThread* thread = CompilerThread::current();
+
+  HandleMark handle_mark(thread);
+  return OptoRuntime::generate(thread->env());
 }
 
 void C2Compiler::initialize() {

--- a/src/hotspot/share/opto/c2compiler.cpp
+++ b/src/hotspot/share/opto/c2compiler.cpp
@@ -90,12 +90,18 @@ bool C2Compiler::init_c2_runtime() {
 
   compiler_stubs_init(true /* in_compiler_thread */); // generate compiler's intrinsics stubs
 
-  Compile::pd_compiler2_init();
+  // If there was an error generating the blob then UseCompiler will
+  // have been unset and we need to skip the remaining initialization
+  if (UseCompiler) {
+    Compile::pd_compiler2_init();
 
-  CompilerThread* thread = CompilerThread::current();
+    CompilerThread* thread = CompilerThread::current();
 
-  HandleMark handle_mark(thread);
-  return OptoRuntime::generate(thread->env());
+    HandleMark handle_mark(thread);
+    return OptoRuntime::generate(thread->env());
+  } else {
+    return false;
+  }
 }
 
 void C2Compiler::initialize() {

--- a/src/hotspot/share/runtime/stubRoutines.cpp
+++ b/src/hotspot/share/runtime/stubRoutines.cpp
@@ -181,6 +181,17 @@ static BufferBlob* initialize_stubs(BlobId blob_id,
   int size = code_size + CodeEntryAlignment * max_aligned_stubs;
   BufferBlob* stubs_code = BufferBlob::create(buffer_name, size);
   if (stubs_code == nullptr) {
+    // The compiler blob may be created late by a C2 compiler thread
+    // rather than during normal initialization by the initial thread.
+    // In that case we can tolerate an allocation failure because the
+    // compiler will have been shut down and we have no need of the
+    // blob.
+    if (Thread::current()->is_Compiler_thread()) {
+      assert(blob_id == BlobId::stubgen_compiler_id, "sanity");
+      assert(DelayCompilerStubsGeneration, "sanity");
+      log_warning(stubs)("Ignoring failed allocation of blob %s under compiler thread", StubInfo::name(blob_id));
+      return nullptr;
+    }
     vm_exit_out_of_memory(code_size, OOM_MALLOC_ERROR, "CodeCache: no room for %s", buffer_name);
   }
   CodeBuffer buffer(stubs_code);

--- a/src/hotspot/share/runtime/stubRoutines.cpp
+++ b/src/hotspot/share/runtime/stubRoutines.cpp
@@ -189,7 +189,7 @@ static BufferBlob* initialize_stubs(BlobId blob_id,
     if (Thread::current()->is_Compiler_thread()) {
       assert(blob_id == BlobId::stubgen_compiler_id, "sanity");
       assert(DelayCompilerStubsGeneration, "sanity");
-      log_warning(stubs)("Ignoring failed allocation of blob %s under compiler thread", StubInfo::name(blob_id));
+      log_warning(stubs)("%s\t not generated:\t no space left in CodeCache", buffer_name);
       return nullptr;
     }
     vm_exit_out_of_memory(code_size, OOM_MALLOC_ERROR, "CodeCache: no room for %s", buffer_name);


### PR DESCRIPTION
This PR avoids bringing down the VM when a code cache allocation for the stubgen compiler blob is requested by the compiler thread and fails because the code cache is full. Instead the VM is allowed to carry on with the compiler disabled.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8364558](https://bugs.openjdk.org/browse/JDK-8364558): Failure to generate compiler stubs from compiler thread should not crash VM when compilation disabled due to full CodeCache (**Bug** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26642/head:pull/26642` \
`$ git checkout pull/26642`

Update a local copy of the PR: \
`$ git checkout pull/26642` \
`$ git pull https://git.openjdk.org/jdk.git pull/26642/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26642`

View PR using the GUI difftool: \
`$ git pr show -t 26642`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26642.diff">https://git.openjdk.org/jdk/pull/26642.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26642#issuecomment-3155219517)
</details>
