### PR TITLE
8364760: G1: Remove obsolete code in G1MergeCardSetClosure

### DIFF
--- a/src/hotspot/share/gc/g1/g1RemSet.cpp
+++ b/src/hotspot/share/gc/g1/g1RemSet.cpp
@@ -986,13 +986,12 @@ class G1MergeHeapRootsTask : public WorkerTask {
 
   // Visitor for remembered sets. Several methods of it are called by a region's
   // card set iterator to drop card set remembered set entries onto the card.
-  // table. This is in addition to being the HG1eapRegionClosure to iterate over
-  // all region's remembered sets.
+  // table.
   //
   // We add a small prefetching cache in front of the actual work as dropping
   // onto the card table is basically random memory access. This improves
   // performance of this operation significantly.
-  class G1MergeCardSetClosure : public G1HeapRegionClosure {
+  class G1MergeCardSetClosure {
     friend class G1MergeCardSetCache;
 
     G1RemSetScanState* _scan_state;
@@ -1039,7 +1038,6 @@ class G1MergeHeapRootsTask : public WorkerTask {
     }
 
   public:
-
     G1MergeCardSetClosure(G1RemSetScanState* scan_state) :
       _scan_state(scan_state),
       _ct(G1CollectedHeap::heap()->card_table()),
@@ -1069,38 +1067,6 @@ class G1MergeHeapRootsTask : public WorkerTask {
       _ct->mark_range_dirty(_region_base_idx + start_card_idx, length);
       _stats.inc_remset_cards(length);
       _scan_state->set_chunk_range_dirty(_region_base_idx + start_card_idx, length);
-    }
-
-    // Helper to merge the cards in the card set for the given region onto the card
-    // table.
-    //
-    // Called directly for humongous starts regions because we should not add
-    // humongous eager reclaim candidates to the "all" list of regions to
-    // clear the card table by default as we do not know yet whether this region
-    // will be reclaimed (and reused).
-    // If the humongous region contains dirty cards, g1 will scan them
-    // because dumping the remembered set entries onto the card table will add
-    // the humongous region to the "dirty" region list to scan. Then scanning
-    // either clears the card during scan (if there is only an initial evacuation
-    // pass) or the "dirty" list will be merged with the "all" list later otherwise.
-    // (And there is no problem either way if the region does not contain dirty
-    // cards).
-    void merge_card_set_for_region(G1HeapRegion* r) {
-      assert(r->in_collection_set() || r->is_starts_humongous(), "must be");
-
-      G1HeapRegionRemSet* rem_set = r->rem_set();
-      if (!rem_set->is_empty()) {
-        rem_set->iterate_for_merge(*this);
-      }
-    }
-
-    virtual bool do_heap_region(G1HeapRegion* r) {
-      assert(r->in_collection_set(), "must be");
-
-      _scan_state->add_all_dirty_region(r->hrm_index());
-      merge_card_set_for_region(r);
-
-      return false;
     }
 
     G1MergeCardSetStats stats() {
@@ -1189,8 +1155,7 @@ class G1MergeHeapRootsTask : public WorkerTask {
                 "Found a not-small remembered set here. This is inconsistent with previous assumptions.");
 
       if (!r->rem_set()->is_empty()) {
-        _cl.merge_card_set_for_region(r);
-
+        r->rem_set()->iterate_for_merge(_cl);
         // We should only clear the card based remembered set here as we will not
         // implicitly rebuild anything else during eager reclaim. Note that at the moment
         // (and probably never) we do not enter this path if there are other kind of


### PR DESCRIPTION
Hi all,

  please review this removal of some obsolete code.

Before JDK-8343782 G1 iterated remsets for humongous eager reclaim candidates by region, as there has been a 1:1 mapping between regions and (card-based) remembered sets.

With that change, all remembered set iteration should go via the group remsets (`G1CSetCandidateGroup`), and the code does, except for humongous eager reclaim candidates which handle their group remsets on the side (which is a separate issue).

This obsoleted some code in `G1MergeCardSetClosure` - it does not need to be a `G1HeapRegionClosure` any more, and for humongous regions we can directly do the iteration via the group rem set attached to the humongous starts region. I.e. inline that `merge_card_set_for_region()` method.

Testing: gha

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8364760](https://bugs.openjdk.org/browse/JDK-8364760): G1: Remove obsolete code in G1MergeCardSetClosure (**Enhancement** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Sangheon Kim](https://openjdk.org/census#sangheki) (@sangheon - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26645/head:pull/26645` \
`$ git checkout pull/26645`

Update a local copy of the PR: \
`$ git checkout pull/26645` \
`$ git pull https://git.openjdk.org/jdk.git pull/26645/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26645`

View PR using the GUI difftool: \
`$ git pr show -t 26645`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26645.diff">https://git.openjdk.org/jdk/pull/26645.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26645#issuecomment-3155794929)
</details>
