### PR TITLE
8364767: G1: Remove use of CollectedHeap::_soft_ref_policy

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -848,12 +848,9 @@ void G1CollectedHeap::do_full_collection(bool clear_all_soft_refs,
                                          size_t allocation_word_size) {
   assert_at_safepoint_on_vm_thread();
 
-  const bool do_clear_all_soft_refs = clear_all_soft_refs ||
-      soft_ref_policy()->should_clear_all_soft_refs();
-
   G1FullGCMark gc_mark;
   GCTraceTime(Info, gc) tm("Pause Full", nullptr, gc_cause(), true);
-  G1FullCollector collector(this, do_clear_all_soft_refs, do_maximal_compaction, gc_mark.tracer());
+  G1FullCollector collector(this, clear_all_soft_refs, do_maximal_compaction, gc_mark.tracer());
 
   collector.prepare_collection();
   collector.collect();
@@ -985,9 +982,6 @@ HeapWord* G1CollectedHeap::satisfy_failed_allocation(size_t word_size) {
   if (result != nullptr) {
     return result;
   }
-
-  assert(!soft_ref_policy()->should_clear_all_soft_refs(),
-         "Flag should have been handled and cleared prior to this point");
 
   // What else?  We might try synchronous finalization later.  If the total
   // space available is large enough for the allocation, then a more

--- a/src/hotspot/share/gc/g1/g1FullGCScope.cpp
+++ b/src/hotspot/share/gc/g1/g1FullGCScope.cpp
@@ -40,6 +40,7 @@ G1FullGCScope::G1FullGCScope(G1MonitoringSupport* monitoring_support,
                              bool do_maximal_compaction,
                              G1FullGCTracer* tracer) :
     _rm(),
+    _should_clear_soft_refs(clear_soft),
     _do_maximal_compaction(do_maximal_compaction),
     _g1h(G1CollectedHeap::heap()),
     _svc_marker(SvcGCMarker::FULL),
@@ -47,16 +48,11 @@ G1FullGCScope::G1FullGCScope(G1MonitoringSupport* monitoring_support,
     _tracer(tracer),
     _active(),
     _tracer_mark(&_timer, _tracer),
-    _soft_refs(clear_soft, _g1h->soft_ref_policy()),
     _monitoring_scope(monitoring_support),
     _heap_printer(_g1h),
     _region_compaction_threshold(do_maximal_compaction ?
                                  G1HeapRegion::GrainWords :
                                  (1 - MarkSweepDeadRatio / 100.0) * G1HeapRegion::GrainWords) { }
-
-bool G1FullGCScope::should_clear_soft_refs() {
-  return _soft_refs.should_clear();
-}
 
 STWGCTimer* G1FullGCScope::timer() {
   return &_timer;

--- a/src/hotspot/share/gc/g1/g1FullGCScope.hpp
+++ b/src/hotspot/share/gc/g1/g1FullGCScope.hpp
@@ -47,6 +47,7 @@ public:
 // Class used to group scoped objects used in the Full GC together.
 class G1FullGCScope : public StackObj {
   ResourceMark            _rm;
+  bool                    _should_clear_soft_refs;
   bool                    _do_maximal_compaction;
   G1CollectedHeap*        _g1h;
   SvcGCMarker             _svc_marker;
@@ -54,7 +55,6 @@ class G1FullGCScope : public StackObj {
   G1FullGCTracer*         _tracer;
   IsSTWGCActiveMark       _active;
   G1FullGCJFRTracerMark   _tracer_mark;
-  ClearedAllSoftRefs      _soft_refs;
   G1FullGCMonitoringScope _monitoring_scope;
   G1HeapPrinterMark       _heap_printer;
   size_t                  _region_compaction_threshold;
@@ -65,7 +65,7 @@ public:
                 bool do_maximal_compaction,
                 G1FullGCTracer* tracer);
 
-  bool should_clear_soft_refs();
+  bool should_clear_soft_refs() const { return _should_clear_soft_refs; }
   bool do_maximal_compaction() { return _do_maximal_compaction; }
 
   STWGCTimer* timer();

--- a/src/hotspot/share/gc/g1/g1VMOperations.cpp
+++ b/src/hotspot/share/gc/g1/g1VMOperations.cpp
@@ -50,7 +50,9 @@ bool VM_G1CollectFull::skip_operation() const {
 void VM_G1CollectFull::doit() {
   G1CollectedHeap* g1h = G1CollectedHeap::heap();
   GCCauseSetter x(g1h, _gc_cause);
-  g1h->do_full_collection(false /* clear_all_soft_refs */,
+  bool clear_all_soft_refs = _gc_cause == GCCause::_metadata_GC_clear_soft_refs ||
+                             _gc_cause == GCCause::_wb_full_gc;
+  g1h->do_full_collection(clear_all_soft_refs /* clear_all_soft_refs */,
                           false /* do_maximal_compaction */,
                           size_t(0) /* allocation_word_size */);
 }

--- a/src/hotspot/share/gc/shared/softRefPolicy.hpp
+++ b/src/hotspot/share/gc/shared/softRefPolicy.hpp
@@ -58,21 +58,4 @@ class SoftRefPolicy {
   }
 };
 
-class ClearedAllSoftRefs : public StackObj {
-  bool           _clear_all_soft_refs;
-  SoftRefPolicy* _soft_ref_policy;
- public:
-  ClearedAllSoftRefs(bool clear_all_soft_refs, SoftRefPolicy* soft_ref_policy) :
-    _clear_all_soft_refs(clear_all_soft_refs),
-    _soft_ref_policy(soft_ref_policy) {}
-
-  ~ClearedAllSoftRefs() {
-    if (_clear_all_soft_refs) {
-      _soft_ref_policy->cleared_all_soft_refs();
-    }
-  }
-
-  bool should_clear() { return _clear_all_soft_refs; }
-};
-
 #endif // SHARE_GC_SHARED_SOFTREFPOLICY_HPP

--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -1502,12 +1502,6 @@ WB_END
 WB_ENTRY(void, WB_FullGC(JNIEnv* env, jobject o))
   Universe::heap()->soft_ref_policy()->set_should_clear_all_soft_refs(true);
   Universe::heap()->collect(GCCause::_wb_full_gc);
-#if INCLUDE_G1GC
-  if (UseG1GC) {
-    // Needs to be cleared explicitly for G1 GC.
-    Universe::heap()->soft_ref_policy()->set_should_clear_all_soft_refs(false);
-  }
-#endif // INCLUDE_G1GC
 WB_END
 
 WB_ENTRY(void, WB_YoungGC(JNIEnv* env, jobject o))


### PR DESCRIPTION
Use gc-cause checking in `VM_G1CollectFull` to decide soft-ref policy.

Test: tier1-3

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8364767](https://bugs.openjdk.org/browse/JDK-8364767): G1: Remove use of CollectedHeap::_soft_ref_policy (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Sangheon Kim](https://openjdk.org/census#sangheki) (@sangheon - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26648/head:pull/26648` \
`$ git checkout pull/26648`

Update a local copy of the PR: \
`$ git checkout pull/26648` \
`$ git pull https://git.openjdk.org/jdk.git pull/26648/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26648`

View PR using the GUI difftool: \
`$ git pr show -t 26648`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26648.diff">https://git.openjdk.org/jdk/pull/26648.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26648#issuecomment-3156167939)
</details>
