### PR TITLE
8349191: Test compiler/ciReplay/TestIncrementalInlining.java failed

### DIFF
--- a/src/hotspot/share/opto/printinlining.cpp
+++ b/src/hotspot/share/opto/printinlining.cpp
@@ -46,7 +46,10 @@ void InlinePrinter::print_on(outputStream* tty) const {
   if (!is_enabled()) {
     return;
   }
-  _root.dump(tty, -1);
+  // using stringStream prevents interleaving with multiple compile threads
+  stringStream ss;
+  _root.dump(&ss, -1);
+  tty->print_raw(ss.freeze());
 }
 
 InlinePrinter::IPInlineSite* InlinePrinter::locate(JVMState* state, ciMethod* callee) {

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -75,9 +75,6 @@ compiler/codecache/CodeCacheFullCountTest.java 8332954 generic-all
 
 compiler/interpreter/Test6833129.java 8335266 generic-i586
 
-compiler/ciReplay/TestInliningProtectionDomain.java 8349191 generic-all
-compiler/ciReplay/TestIncrementalInlining.java 8349191 generic-all
-
 compiler/c2/TestVerifyConstraintCasts.java 8355574 generic-all
 
 compiler/c2/aarch64/TestStaticCallStub.java 8359963 linux-aarch64,macosx-aarch64


### PR DESCRIPTION
This PR fixes a bug caused by synchronization issues in the print inlining system. Individual segments of a single line of output are interleaved with output from other commpile threads, causing tests that parse replay files to fail.

A snippet of a problematic replay file is shown below:
```
<writer thread='55214'/>
                            @ 0   compiler.ciReplay.IncrementalInliningTest::level0 (4 bytes)   force inline by annotation
                              @ 0   compiler.ciReplay.IncrementalInliningTest::level1 (4 bytes)   inline (hot)
                                @ 0   compiler.ciReplay.IncrementalInliningTest::level2 (4 bytes)
<writer thread='55217'/>
<make_not_compilable thread='55217' osr='0' level='4' reason='excluded by CompileCommand' method='java.lang.Class isPrimitive ()Z' bytes='5' count='1536' iicount='1536' stamp='0.110'/>
<writer thread='55214'/>
   force inline by annotation
                                  @ 0   compiler.ciReplay.IncrementalInliningTest::late (4 bytes)   force inline by annotation   late inline succeeded
                                    @ 0   compiler.ciReplay.IncrementalInliningTest::level4 (6 bytes)   failed to inline: inlining too deep
```

This makes the output impossible to parse for tests like `compiler/ciReplay/TestIncrementalInlining.java`, as they rely on regular expressions to parse individual lines. Because it is a synchronization issue, the bug quite intermittent and I was only able to reproduce it with mach5 in tier 7.

This bug was caused by [JDK-8319850](https://bugs.openjdk.org/browse/JDK-8319850), as it introduced important changes in the print inlining system. With these changes,  individual segments of the output are printed directly to tty, and this risks causing problematic interleavings with multiple compile threads. 

My proposed solution is to simply print everything to a `stringStream` first, and then dump it to `tty`. The PR also removes the relevant tests from `ProblemList.txt`.

### Testing
- [x] [GitHub Actions](https://github.com/benoitmaillard/jdk/actions?query=branch%3AJDK-8349191)
- [x] tier1-3, plus some internal testing
- [x] tier7 for the relevant tests (`TestIncrementalInlining.java` and `TestInliningProtectionDomain.java`)

Thanks for reviewing!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8349191](https://bugs.openjdk.org/browse/JDK-8349191): Test compiler/ciReplay/TestIncrementalInlining.java failed (**Bug** - P4)


### Reviewers
 * [Manuel Hässig](https://openjdk.org/census#mhaessig) (@mhaessig - Committer)
 * [Damon Fenacci](https://openjdk.org/census#dfenacci) (@dafedafe - Committer)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26654/head:pull/26654` \
`$ git checkout pull/26654`

Update a local copy of the PR: \
`$ git checkout pull/26654` \
`$ git pull https://git.openjdk.org/jdk.git pull/26654/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26654`

View PR using the GUI difftool: \
`$ git pr show -t 26654`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26654.diff">https://git.openjdk.org/jdk/pull/26654.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26654#issuecomment-3160674923)
</details>
