### PR TITLE
8364819: Post-integration cleanups for JDK-8359820

### DIFF
--- a/src/hotspot/share/runtime/handshake.cpp
+++ b/src/hotspot/share/runtime/handshake.cpp
@@ -202,7 +202,7 @@ static void handle_timeout(HandshakeOperation* op, JavaThread* target) {
   }
 
   if (target != nullptr) {
-    VMError::set_handshake_timed_out_thread(p2i(target));
+    VMError::set_handshake_timed_out_thread(target);
     if (os::signal_thread(target, SIGILL, "cannot be handshaked")) {
       // Give target a chance to report the error and terminate the VM.
       os::naked_sleep(3000);

--- a/src/hotspot/share/runtime/safepoint.cpp
+++ b/src/hotspot/share/runtime/safepoint.cpp
@@ -651,7 +651,7 @@ void SafepointSynchronize::print_safepoint_timeout() {
     // Send the blocking thread a signal to terminate and write an error file.
     for (JavaThreadIteratorWithHandle jtiwh; JavaThread *cur_thread = jtiwh.next(); ) {
       if (cur_thread->safepoint_state()->is_running()) {
-        VMError::set_safepoint_timed_out_thread(p2i(cur_thread));
+        VMError::set_safepoint_timed_out_thread(cur_thread);
         if (!os::signal_thread(cur_thread, SIGILL, "blocking a safepoint")) {
           break; // Could not send signal. Report fatal error.
         }

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -104,8 +104,8 @@ int               VMError::_lineno;
 size_t            VMError::_size;
 const size_t      VMError::_reattempt_required_stack_headroom = 64 * K;
 const intptr_t    VMError::segfault_address = pd_segfault_address;
-Thread* volatile VMError::_handshake_timed_out_thread = nullptr;
-Thread* volatile VMError::_safepoint_timed_out_thread = nullptr;
+Thread* VMError::_handshake_timed_out_thread = nullptr;
+Thread* VMError::_safepoint_timed_out_thread = nullptr;
 
 // List of environment variables that should be reported in error log file.
 static const char* env_list[] = {
@@ -1339,19 +1339,21 @@ void VMError::report(outputStream* st, bool _verbose) {
 }
 
 void VMError::set_handshake_timed_out_thread(Thread* thread) {
-  Atomic::release_store(&_handshake_timed_out_thread, thread);
+  _handshake_timed_out_thread = thread;
+  OrderAccess::fence();
 }
 
 void VMError::set_safepoint_timed_out_thread(Thread* thread) {
-  Atomic::release_store(&_safepoint_timed_out_thread, thread);
+  _safepoint_timed_out_thread = thread;
+  OrderAccess::fence();
 }
 
 Thread* VMError::get_handshake_timed_out_thread() {
-  return Atomic::load_acquire(&_handshake_timed_out_thread);
+  return _handshake_timed_out_thread;
 }
 
 Thread* VMError::get_safepoint_timed_out_thread() {
-  return Atomic::load_acquire(&_safepoint_timed_out_thread);
+  return _safepoint_timed_out_thread;
 }
 
 // Report for the vm_info_cmd. This prints out the information above omitting

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -104,8 +104,8 @@ int               VMError::_lineno;
 size_t            VMError::_size;
 const size_t      VMError::_reattempt_required_stack_headroom = 64 * K;
 const intptr_t    VMError::segfault_address = pd_segfault_address;
-volatile intptr_t VMError::_handshake_timed_out_thread = p2i(nullptr);
-volatile intptr_t VMError::_safepoint_timed_out_thread = p2i(nullptr);
+volatile Thread* VMError::_handshake_timed_out_thread = nullptr;
+volatile Thread* VMError::_safepoint_timed_out_thread = nullptr;
 
 // List of environment variables that should be reported in error log file.
 static const char* env_list[] = {
@@ -821,10 +821,10 @@ void VMError::report(outputStream* st, bool _verbose) {
       st->print(" (0x%x)", _id);                // signal number
       st->print(" at pc=" PTR_FORMAT, p2i(_pc));
       if (_siginfo != nullptr && os::signal_sent_by_kill(_siginfo)) {
-        if (_handshake_timed_out_thread == p2i(_thread)) {
-          st->print(" (sent by handshake timeout handler");
-        } else if (_safepoint_timed_out_thread == p2i(_thread)) {
-          st->print(" (sent by safepoint timeout handler");
+        if (_handshake_timed_out_thread == _thread) {
+          st->print(" (sent by handshake timeout handler)");
+        } else if (_safepoint_timed_out_thread == _thread) {
+          st->print(" (sent by safepoint timeout handler)");
         } else {
           st->print(" (sent by kill)");
         }
@@ -1338,12 +1338,12 @@ void VMError::report(outputStream* st, bool _verbose) {
 # undef END
 }
 
-void VMError::set_handshake_timed_out_thread(intptr_t thread_addr) {
-  _handshake_timed_out_thread = thread_addr;
+void VMError::set_handshake_timed_out_thread(Thread* thread) {
+  _handshake_timed_out_thread = thread;
 }
 
-void VMError::set_safepoint_timed_out_thread(intptr_t thread_addr) {
-  _safepoint_timed_out_thread = thread_addr;
+void VMError::set_safepoint_timed_out_thread(Thread* thread) {
+  _safepoint_timed_out_thread = thread;
 }
 
 // Report for the vm_info_cmd. This prints out the information above omitting

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -1351,11 +1351,11 @@ void VMError::set_safepoint_timed_out_thread(Thread* thread) {
 }
 
 Thread* VMError::get_handshake_timed_out_thread() {
-  return _handshake_timed_out_thread;
+  return Atomic::load(&_handshake_timed_out_thread);
 }
 
 Thread* VMError::get_safepoint_timed_out_thread() {
-  return _safepoint_timed_out_thread;
+  return Atomic::load(&_safepoint_timed_out_thread);
 }
 
 // Report for the vm_info_cmd. This prints out the information above omitting

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -1339,9 +1339,9 @@ void VMError::report(outputStream* st, bool _verbose) {
 }
 
 void VMError::set_handshake_timed_out_thread(Thread* thread) {
-  // Atomic::replace_if_null() operation is used to discard all possible 
+  // Atomic::replace_if_null() operation is used to discard all possible
   // updates except the 1st one. Those can hypothetically happen
-  // if more than one thread times out. 
+  // if more than one thread times out.
   // The default memory ordering guarantees visibility to other threads.
   Atomic::replace_if_null(&_handshake_timed_out_thread, thread);
 }

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -104,8 +104,8 @@ int               VMError::_lineno;
 size_t            VMError::_size;
 const size_t      VMError::_reattempt_required_stack_headroom = 64 * K;
 const intptr_t    VMError::segfault_address = pd_segfault_address;
-volatile Thread* VMError::_handshake_timed_out_thread = nullptr;
-volatile Thread* VMError::_safepoint_timed_out_thread = nullptr;
+Thread* volatile VMError::_handshake_timed_out_thread = nullptr;
+Thread* volatile VMError::_safepoint_timed_out_thread = nullptr;
 
 // List of environment variables that should be reported in error log file.
 static const char* env_list[] = {
@@ -1346,11 +1346,11 @@ void VMError::set_safepoint_timed_out_thread(Thread* thread) {
   Atomic::release_store(&_safepoint_timed_out_thread, thread);
 }
 
-volatile Thread* VMError::get_handshake_timed_out_thread() {
+Thread* VMError::get_handshake_timed_out_thread() {
   return Atomic::load_acquire(&_handshake_timed_out_thread);
 }
 
-volatile Thread* VMError::get_safepoint_timed_out_thread() {
+Thread* VMError::get_safepoint_timed_out_thread() {
   return Atomic::load_acquire(&_safepoint_timed_out_thread);
 }
 

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -1339,14 +1339,14 @@ void VMError::report(outputStream* st, bool _verbose) {
 }
 
 void VMError::set_handshake_timed_out_thread(Thread* thread) {
-  // Atomic::replace_if_null() operation is used to discard all possible
-  // updates except the 1st one. Those can hypothetically happen
-  // if more than one thread times out.
-  // The default memory ordering guarantees visibility to other threads.
+  // Only preserve the first thread to time-out this way. The atomic operation ensures
+  // visibility to the target thread.
   Atomic::replace_if_null(&_handshake_timed_out_thread, thread);
 }
 
 void VMError::set_safepoint_timed_out_thread(Thread* thread) {
+  // Only preserve the first thread to time-out this way. The atomic operation ensures
+  // visibility to the target thread.
   Atomic::replace_if_null(&_safepoint_timed_out_thread, thread);
 }
 

--- a/src/hotspot/share/utilities/vmError.hpp
+++ b/src/hotspot/share/utilities/vmError.hpp
@@ -143,8 +143,8 @@ class VMError : public AllStatic {
   static void clear_step_start_time();
 
   // Handshake/safepoint timed out threads
-  static volatile Thread* _handshake_timed_out_thread;
-  static volatile Thread* _safepoint_timed_out_thread;
+  static Thread* volatile _handshake_timed_out_thread;
+  static Thread* volatile _safepoint_timed_out_thread;
 
   WINDOWS_ONLY([[noreturn]] static void raise_fail_fast(const void* exrecord, const void* context);)
 
@@ -225,8 +225,8 @@ public:
 
   static void set_handshake_timed_out_thread(Thread* thread);
   static void set_safepoint_timed_out_thread(Thread* thread);
-  static volatile Thread* get_handshake_timed_out_thread();
-  static volatile Thread* get_safepoint_timed_out_thread();
+  static Thread* get_handshake_timed_out_thread();
+  static Thread* get_safepoint_timed_out_thread();
 };
 
 class VMErrorCallback {

--- a/src/hotspot/share/utilities/vmError.hpp
+++ b/src/hotspot/share/utilities/vmError.hpp
@@ -225,6 +225,8 @@ public:
 
   static void set_handshake_timed_out_thread(Thread* thread);
   static void set_safepoint_timed_out_thread(Thread* thread);
+  static volatile Thread* get_handshake_timed_out_thread();
+  static volatile Thread* get_safepoint_timed_out_thread();
 };
 
 class VMErrorCallback {

--- a/src/hotspot/share/utilities/vmError.hpp
+++ b/src/hotspot/share/utilities/vmError.hpp
@@ -143,8 +143,8 @@ class VMError : public AllStatic {
   static void clear_step_start_time();
 
   // Handshake/safepoint timed out threads
-  static Thread* _handshake_timed_out_thread;
-  static Thread* _safepoint_timed_out_thread;
+  static Thread* volatile _handshake_timed_out_thread;
+  static Thread* volatile _safepoint_timed_out_thread;
 
   WINDOWS_ONLY([[noreturn]] static void raise_fail_fast(const void* exrecord, const void* context);)
 

--- a/src/hotspot/share/utilities/vmError.hpp
+++ b/src/hotspot/share/utilities/vmError.hpp
@@ -143,8 +143,8 @@ class VMError : public AllStatic {
   static void clear_step_start_time();
 
   // Handshake/safepoint timed out threads
-  static volatile intptr_t _handshake_timed_out_thread;
-  static volatile intptr_t _safepoint_timed_out_thread;
+  static volatile Thread* _handshake_timed_out_thread;
+  static volatile Thread* _safepoint_timed_out_thread;
 
   WINDOWS_ONLY([[noreturn]] static void raise_fail_fast(const void* exrecord, const void* context);)
 
@@ -223,8 +223,8 @@ public:
 
   static bool was_assert_poison_crash(const void* sigInfo);
 
-  static void set_handshake_timed_out_thread(intptr_t thread_addr);
-  static void set_safepoint_timed_out_thread(intptr_t thread_addr);
+  static void set_handshake_timed_out_thread(Thread* thread);
+  static void set_safepoint_timed_out_thread(Thread* thread);
 };
 
 class VMErrorCallback {

--- a/src/hotspot/share/utilities/vmError.hpp
+++ b/src/hotspot/share/utilities/vmError.hpp
@@ -143,8 +143,8 @@ class VMError : public AllStatic {
   static void clear_step_start_time();
 
   // Handshake/safepoint timed out threads
-  static Thread* volatile _handshake_timed_out_thread;
-  static Thread* volatile _safepoint_timed_out_thread;
+  static Thread* _handshake_timed_out_thread;
+  static Thread* _safepoint_timed_out_thread;
 
   WINDOWS_ONLY([[noreturn]] static void raise_fail_fast(const void* exrecord, const void* context);)
 

--- a/test/hotspot/jtreg/runtime/Safepoint/TestAbortVMOnSafepointTimeout.java
+++ b/test/hotspot/jtreg/runtime/Safepoint/TestAbortVMOnSafepointTimeout.java
@@ -88,7 +88,7 @@ public class TestAbortVMOnSafepointTimeout {
         } else {
             output.shouldContain("SIGILL");
             if (Platform.isLinux()) {
-                output.shouldContain("(sent by safepoint timeout handler");
+                output.shouldContain("(sent by safepoint timeout handler)");
             }
         }
         output.shouldNotHaveExitValue(0);


### PR DESCRIPTION
Hi, please consider the following changes:

This is a cleanup after https://github.com/openjdk/jdk/pull/26309

1) `_handshake_timed_out_thread `and `_safepoint_timed_out_thread` are now `Thread*` and not `intptr_t`, no conversions `p2i <-> i2p` needed.

2) Added a missed brace in the error message. 

3) Updates are done with `Atomic::replace_if_null()` to address possible multiple updates and visibility among all threads. 

Trivial change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8364819](https://bugs.openjdk.org/browse/JDK-8364819): Post-integration cleanups for JDK-8359820 (**Enhancement** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**) Review applies to [b833bf5d](https://git.openjdk.org/jdk/pull/26656/files/b833bf5de027d45e55bae7eee1dd65184719b3d5)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26656/head:pull/26656` \
`$ git checkout pull/26656`

Update a local copy of the PR: \
`$ git checkout pull/26656` \
`$ git pull https://git.openjdk.org/jdk.git pull/26656/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26656`

View PR using the GUI difftool: \
`$ git pr show -t 26656`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26656.diff">https://git.openjdk.org/jdk/pull/26656.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26656#issuecomment-3159080816)
</details>
