### PR TITLE
7191877: TEST_BUG: java/rmi/transport/checkLeaseInfoLeak/CheckLeaseLeak.java failing intermittently

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -615,8 +615,6 @@ java/rmi/server/Unreferenced/finiteGCLatency/FiniteGCLatency.java 7140992 generi
 
 java/rmi/transport/rapidExportUnexport/RapidExportUnexport.java 7146541 linux-all
 
-java/rmi/transport/checkLeaseInfoLeak/CheckLeaseLeak.java       7191877 generic-all
-
 java/rmi/registry/readTest/CodebaseTest.java                    8173324 windows-all
 java/rmi/registry/multipleRegistries/MultipleRegistries.java    8268182 macosx-all
 

--- a/test/jdk/java/rmi/transport/checkLeaseInfoLeak/LeaseLeakClient.java
+++ b/test/jdk/java/rmi/transport/checkLeaseInfoLeak/LeaseLeakClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,6 @@ import java.rmi.registry.*;
 
 public class LeaseLeakClient {
     public static void main(String args[]) {
-        TestLibrary.suggestSecurityManager("java.rmi.RMISecurityManager");
 
         try {
             LeaseLeak leaseLeak = null;


### PR DESCRIPTION
The test was problem listed since jdk8 as intermittent failures were observed. For all the failed scenarios, number of objects left in leaseTable were less than or equal to 4. Though for most of the runs the number of objects left is less than 2, at times the tests are failing when the remaining objects are 3 or 4 (observed only on mac os). As per the code, the leak should be fixed if the number of objects left in the table is less than 11. I have updated the acceptable number of objects to 4 from 2, and is still at lower end compared to 11.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-7191877](https://bugs.openjdk.org/browse/JDK-7191877): TEST_BUG: java/rmi/transport/checkLeaseInfoLeak/CheckLeaseLeak.java failing intermittently (**Bug** - P4)


### Reviewers
 * [Stuart Marks](https://openjdk.org/census#smarks) (@stuart-marks - **Reviewer**)
 * [Sean Coffey](https://openjdk.org/census#coffeys) (@coffeys - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26657/head:pull/26657` \
`$ git checkout pull/26657`

Update a local copy of the PR: \
`$ git checkout pull/26657` \
`$ git pull https://git.openjdk.org/jdk.git pull/26657/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26657`

View PR using the GUI difftool: \
`$ git pr show -t 26657`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26657.diff">https://git.openjdk.org/jdk/pull/26657.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26657#issuecomment-3159407548)
</details>
