### PR TITLE
8364877: G1: Inline G1CollectedHeap::set_region_short_lived_locked

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -1214,7 +1214,6 @@ public:
     return named_heap<G1CollectedHeap>(CollectedHeap::G1);
   }
 
-  void set_region_short_lived_locked(G1HeapRegion* hr);
   // add appropriate methods for any other surv rate groups
 
   G1SurvivorRegions* survivor() { return &_survivor; }

--- a/src/hotspot/share/gc/g1/g1EdenRegions.hpp
+++ b/src/hotspot/share/gc/g1/g1EdenRegions.hpp
@@ -42,7 +42,7 @@ public:
   G1EdenRegions() : _length(0), _used_bytes(0), _regions_on_node() { }
 
   uint add(G1HeapRegion* hr) {
-    assert(!hr->is_eden(), "should not already be set");
+    assert(hr->is_eden(), "should not already be set");
     _length++;
     return _regions_on_node.add(hr);
   }

--- a/src/hotspot/share/gc/g1/g1EdenRegions.hpp
+++ b/src/hotspot/share/gc/g1/g1EdenRegions.hpp
@@ -42,7 +42,7 @@ public:
   G1EdenRegions() : _length(0), _used_bytes(0), _regions_on_node() { }
 
   uint add(G1HeapRegion* hr) {
-    assert(hr->is_eden(), "should not already be set");
+    assert(hr->is_eden(), "must be");
     _length++;
     return _regions_on_node.add(hr);
   }

--- a/src/hotspot/share/gc/g1/g1Policy.hpp
+++ b/src/hotspot/share/gc/g1/g1Policy.hpp
@@ -121,7 +121,6 @@ public:
   G1OldGenAllocationTracker* old_gen_alloc_tracker() { return &_old_gen_alloc_tracker; }
 
   void set_region_eden(G1HeapRegion* hr) {
-    hr->set_eden();
     hr->install_surv_rate_group(_eden_surv_rate_group);
   }
 


### PR DESCRIPTION
Hi all,

  please review this change that inlines `G1CollectedHeap::set_region_short_lived_locked` - it's very small, and used only once in the same class, and has a very unusual name.

Testing: gha

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8364877](https://bugs.openjdk.org/browse/JDK-8364877): G1: Inline G1CollectedHeap::set_region_short_lived_locked (**Enhancement** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Sangheon Kim](https://openjdk.org/census#sangheki) (@sangheon - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26663/head:pull/26663` \
`$ git checkout pull/26663`

Update a local copy of the PR: \
`$ git checkout pull/26663` \
`$ git pull https://git.openjdk.org/jdk.git pull/26663/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26663`

View PR using the GUI difftool: \
`$ git pr show -t 26663`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26663.diff">https://git.openjdk.org/jdk/pull/26663.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26663#issuecomment-3163142416)
</details>
