### PR TITLE
8364954: (bf) CleaningThread should be InnocuousThread

### DIFF
--- a/src/java.base/share/classes/java/nio/BufferCleaner.java
+++ b/src/java.base/share/classes/java/nio/BufferCleaner.java
@@ -236,7 +236,7 @@ class BufferCleaner {
 
     private static final CleanerList cleanerList = new CleanerList();
     private static final ReferenceQueue<Object> queue = new ReferenceQueue<Object>();
-    private static Thread cleaningThread = null;
+    private static Thread cleaningThread;
 
     private static void startCleaningThreadIfNeeded() {
         synchronized (cleanerList) {

--- a/src/java.base/share/classes/java/nio/BufferCleaner.java
+++ b/src/java.base/share/classes/java/nio/BufferCleaner.java
@@ -29,6 +29,7 @@ import java.lang.ref.PhantomReference;
 import java.lang.ref.Reference;
 import java.lang.ref.ReferenceQueue;
 import java.util.Objects;
+import jdk.internal.misc.InnocuousThread;
 import sun.nio.Cleaner;
 
 /**
@@ -200,8 +201,9 @@ class BufferCleaner {
         }
     }
 
-    private static final class CleaningThread extends Thread {
-        public CleaningThread() {}
+
+    private static final class CleaningRunnable implements Runnable {
+        public CleaningRunnable() {}
 
         @Override
         public void run() {
@@ -234,14 +236,14 @@ class BufferCleaner {
 
     private static final CleanerList cleanerList = new CleanerList();
     private static final ReferenceQueue<Object> queue = new ReferenceQueue<Object>();
-    private static CleaningThread cleaningThread = null;
+    private static Thread cleaningThread = null;
 
     private static void startCleaningThreadIfNeeded() {
         synchronized (cleanerList) {
             if (cleaningThread != null) {
                 return;
             }
-            cleaningThread = new CleaningThread();
+            cleaningThread = InnocuousThread.newThread(new CleaningRunnable());
         }
         cleaningThread.setDaemon(true);
         cleaningThread.start();


### PR DESCRIPTION
This migrates a `Thread` introduced in [JDK-8344332](https://bugs.openjdk.org/browse/JDK-8344332) to use `InnocuousThread`, similar to the changes in [JDK-8345432](https://bugs.openjdk.org/browse/JDK-8345432) to migrate other uses of `Thread` in `java.nio` to `InnocuousThread`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8364954](https://bugs.openjdk.org/browse/JDK-8364954): (bf) CleaningThread should be InnocuousThread (**Enhancement** - P3)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**) Review applies to [89394ce2](https://git.openjdk.org/jdk/pull/26665/files/89394ce2826ed8c15588ca22602ca28caf24caa5)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26665/head:pull/26665` \
`$ git checkout pull/26665`

Update a local copy of the PR: \
`$ git checkout pull/26665` \
`$ git pull https://git.openjdk.org/jdk.git pull/26665/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26665`

View PR using the GUI difftool: \
`$ git pr show -t 26665`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26665.diff">https://git.openjdk.org/jdk/pull/26665.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26665#issuecomment-3161901071)
</details>
