### PR TITLE
8364970: Redo JDK-8327381 by updating the CmpU type instead of the Bool type

### DIFF
--- a/src/hotspot/share/opto/phaseX.cpp
+++ b/src/hotspot/share/opto/phaseX.cpp
@@ -2878,7 +2878,6 @@ void PhaseCCP::push_more_uses(Unique_Node_List& worklist, Node* parent, const No
   push_and(worklist, parent, use);
   push_cast_ii(worklist, parent, use);
   push_opaque_zero_trip_guard(worklist, use);
-  push_bool_with_cmpu_and_mask(worklist, use);
 }
 
 
@@ -2921,57 +2920,6 @@ void PhaseCCP::push_cmpu(Unique_Node_List& worklist, const Node* use) const {
         // Got a CmpU or CmpU3 which might need the new type information from node n.
         push_if_not_bottom_type(worklist, cmpu);
       }
-    }
-  }
-}
-
-// Look for the following shape, which can be optimized by BoolNode::Value_cmpu_and_mask() (i.e. corresponds to case
-// (1b): "(m & x) <u (m + 1))".
-// If any of the inputs on the level (%%) change, we need to revisit Bool because we could have prematurely found that
-// the Bool is constant (i.e. case (1b) can be applied) which could become invalid with new type information during CCP.
-//
-//  m    x  m    1  (%%)
-//   \  /    \  /
-//   AndI    AddI
-//      \    /
-//       CmpU
-//        |
-//       Bool
-//
-void PhaseCCP::push_bool_with_cmpu_and_mask(Unique_Node_List& worklist, const Node* use) const {
-  uint use_op = use->Opcode();
-  if (use_op != Op_AndI && (use_op != Op_AddI || use->in(2)->find_int_con(0) != 1)) {
-    // Not "m & x" or "m + 1"
-    return;
-  }
-  for (DUIterator_Fast imax, i = use->fast_outs(imax); i < imax; i++) {
-    Node* cmpu = use->fast_out(i);
-    if (cmpu->Opcode() == Op_CmpU) {
-      push_bool_matching_case1b(worklist, cmpu);
-    }
-  }
-}
-
-// Push any Bool below 'cmpu' that matches case (1b) of BoolNode::Value_cmpu_and_mask().
-void PhaseCCP::push_bool_matching_case1b(Unique_Node_List& worklist, const Node* cmpu) const {
-  assert(cmpu->Opcode() == Op_CmpU, "must be");
-  for (DUIterator_Fast imax, i = cmpu->fast_outs(imax); i < imax; i++) {
-    Node* bol = cmpu->fast_out(i);
-    if (!bol->is_Bool() || bol->as_Bool()->_test._test != BoolTest::lt) {
-      // Not a Bool with "<u"
-      continue;
-    }
-    Node* andI = cmpu->in(1);
-    Node* addI = cmpu->in(2);
-    if (andI->Opcode() != Op_AndI || addI->Opcode() != Op_AddI || addI->in(2)->find_int_con(0) != 1) {
-      // Not "m & x" and "m + 1"
-      continue;
-    }
-
-    Node* m = addI->in(1);
-    if (m == andI->in(1) || m == andI->in(2)) {
-      // Is "m" shared? Matched (1b) and thus we revisit Bool.
-      push_if_not_bottom_type(worklist, bol);
     }
   }
 }

--- a/src/hotspot/share/opto/phaseX.hpp
+++ b/src/hotspot/share/opto/phaseX.hpp
@@ -638,8 +638,6 @@ class PhaseCCP : public PhaseIterGVN {
   void push_and(Unique_Node_List& worklist, const Node* parent, const Node* use) const;
   void push_cast_ii(Unique_Node_List& worklist, const Node* parent, const Node* use) const;
   void push_opaque_zero_trip_guard(Unique_Node_List& worklist, const Node* use) const;
-  void push_bool_with_cmpu_and_mask(Unique_Node_List& worklist, const Node* use) const;
-  void push_bool_matching_case1b(Unique_Node_List& worklist, const Node* cmpu) const;
 
  public:
   PhaseCCP( PhaseIterGVN *igvn ); // Compute conditional constants

--- a/src/hotspot/share/opto/subnode.cpp
+++ b/src/hotspot/share/opto/subnode.cpp
@@ -801,6 +801,81 @@ const Type *CmpUNode::sub( const Type *t1, const Type *t2 ) const {
   return TypeInt::CC;                   // else use worst case results
 }
 
+// We use the following Lemmas/insights for the following two transformations (1) and (2):
+//   x & y <=u y, for any x and y           (Lemma 1, masking always results in a smaller unsigned number)
+//   y <u y + 1 is always true if y != -1   (Lemma 2, (uint)(-1 + 1) == (uint)(UINT_MAX + 1) which overflows)
+//   y <u 0 is always false for any y       (Lemma 3, 0 == UINT_MIN and nothing can be smaller than that)
+//
+// (1a) Always:     Change ((x & m) <=u m  ) or ((m & x) <=u m  ) to always true   (true by Lemma 1)
+// (1b) If m != -1: Change ((x & m) <u  m + 1) or ((m & x) <u  m + 1) to always true:
+//    x & m <=u m          is always true   // (Lemma 1)
+//    x & m <=u m <u m + 1 is always true   // (Lemma 2: m <u m + 1, if m != -1)
+//
+// A counter example for (1b), if we allowed m == -1:
+//     (x & m)  <u m + 1
+//     (x & -1) <u 0
+//      x       <u 0
+//   which is false for any x (Lemma 3)
+//
+// (2) Change ((x & (m - 1)) <u m) or (((m - 1) & x) <u m) to (m >u 0)
+// This is the off-by-one variant of the above.
+//
+// We now prove that this replacement is correct. This is the same as proving
+//   "m >u 0" if and only if "x & (m - 1) <u m", i.e. "m >u 0 <=> x & (m - 1) <u m"
+//
+// We use (Lemma 1) and (Lemma 3) from above.
+//
+// Case "x & (m - 1) <u m => m >u 0":
+//   We prove this by contradiction:
+//     Assume m <=u 0 which is equivalent to m == 0:
+//   and thus
+//     x & (m - 1) <u m = 0               // m == 0
+//     y           <u     0               // y = x & (m - 1)
+//   by Lemma 3, this is always false, i.e. a contradiction to our assumption.
+//
+// Case "m >u 0 => x & (m - 1) <u m":
+//   x & (m - 1) <=u (m - 1)              // (Lemma 1)
+//   x & (m - 1) <=u (m - 1) <u m         // Using assumption m >u 0, no underflow of "m - 1"
+//
+//
+// Note that the signed version of "m > 0":
+//   m > 0 <=> x & (m - 1) <u m
+// does not hold:
+//   Assume m == -1 and x == -1:
+//     x  & (m - 1) <u m
+//     -1 & -2      <u -1
+//     -2           <u -1
+//     UINT_MAX - 1 <u UINT_MAX           // Signed to unsigned numbers
+// which is true while
+//   m > 0
+// is false which is a contradiction.
+//
+// (1a) and (1b) is covered by this method since we can directly return the corresponding TypeInt::CC_*
+// while (2) is covered in BoolNode::Ideal since we create a new non-constant node (see [CMPU_MASK]).
+const Type* CmpUNode::Value_cmpu_and_mask(PhaseValues* phase, const Node* in1, const Node* in2) {
+  if (in1->Opcode() == Op_AndI) {
+    // (1a) "(x & m) <=u m" and "(m & x) <=u m" are always true,
+    // so CmpU(x & m, m) and CmpU(m & x, m) are known to be LE.
+    const Node* rhs_m = in2;
+    if (in1->in(2) == rhs_m || in1->in(1) == rhs_m) {
+      return TypeInt::CC_LE;
+    }
+    // (1b) "(x & m) <u m + 1" and "(m & x) <u m + 1" are always true for m != -1,
+    // so CmpU(x & m, m + 1) and CmpU(m & x, m + 1) are known to be LT.
+    if (in2->Opcode() == Op_AddI && in2->in(2)->find_int_con(0) == 1) {
+      rhs_m = in2->in(1);
+      const TypeInt* rhs_m_type = phase->type(rhs_m)->isa_int();
+      // Exclude any case where m == -1 is possible.
+      if (rhs_m_type != nullptr && (rhs_m_type->_lo > -1 || rhs_m_type->_hi < -1)) {
+        if (in1->in(2) == rhs_m || in1->in(1) == rhs_m) {
+          return TypeInt::CC_LT;
+        }
+      }
+    }
+  }
+  return nullptr;
+}
+
 const Type* CmpUNode::Value(PhaseGVN* phase) const {
   const Type* t = SubNode::Value_common(phase);
   if (t != nullptr) {
@@ -808,6 +883,10 @@ const Type* CmpUNode::Value(PhaseGVN* phase) const {
   }
   const Node* in1 = in(1);
   const Node* in2 = in(2);
+  t = Value_cmpu_and_mask(phase, in1, in2);
+  if (t != nullptr) {
+    return t;
+  }
   const Type* t1 = phase->type(in1);
   const Type* t2 = phase->type(in2);
   assert(t1->isa_int(), "CmpU has only Int type inputs");
@@ -1639,7 +1718,7 @@ Node *BoolNode::Ideal(PhaseGVN *phase, bool can_reshape) {
   }
 
   // Transform: "((x & (m - 1)) <u m)" or "(((m - 1) & x) <u m)" into "(m >u 0)"
-  // This is case [CMPU_MASK] which is further described at the method comment of BoolNode::Value_cmpu_and_mask().
+  // This is case [CMPU_MASK] which is further described at the method comment of CmpUNode::Value_cmpu_and_mask().
   if (cop == Op_CmpU && _test._test == BoolTest::lt && cmp1_op == Op_AndI) {
     Node* m = cmp2; // RHS: m
     for (int add_idx = 1; add_idx <= 2; add_idx++) { // LHS: "(m + (-1)) & x" or "x & (m + (-1))"?
@@ -1814,95 +1893,9 @@ Node *BoolNode::Ideal(PhaseGVN *phase, bool can_reshape) {
   //    }
 }
 
-// We use the following Lemmas/insights for the following two transformations (1) and (2):
-//   x & y <=u y, for any x and y           (Lemma 1, masking always results in a smaller unsigned number)
-//   y <u y + 1 is always true if y != -1   (Lemma 2, (uint)(-1 + 1) == (uint)(UINT_MAX + 1) which overflows)
-//   y <u 0 is always false for any y       (Lemma 3, 0 == UINT_MIN and nothing can be smaller than that)
-//
-// (1a) Always:     Change ((x & m) <=u m  ) or ((m & x) <=u m  ) to always true   (true by Lemma 1)
-// (1b) If m != -1: Change ((x & m) <u  m + 1) or ((m & x) <u  m + 1) to always true:
-//    x & m <=u m          is always true   // (Lemma 1)
-//    x & m <=u m <u m + 1 is always true   // (Lemma 2: m <u m + 1, if m != -1)
-//
-// A counter example for (1b), if we allowed m == -1:
-//     (x & m)  <u m + 1
-//     (x & -1) <u 0
-//      x       <u 0
-//   which is false for any x (Lemma 3)
-//
-// (2) Change ((x & (m - 1)) <u m) or (((m - 1) & x) <u m) to (m >u 0)
-// This is the off-by-one variant of the above.
-//
-// We now prove that this replacement is correct. This is the same as proving
-//   "m >u 0" if and only if "x & (m - 1) <u m", i.e. "m >u 0 <=> x & (m - 1) <u m"
-//
-// We use (Lemma 1) and (Lemma 3) from above.
-//
-// Case "x & (m - 1) <u m => m >u 0":
-//   We prove this by contradiction:
-//     Assume m <=u 0 which is equivalent to m == 0:
-//   and thus
-//     x & (m - 1) <u m = 0               // m == 0
-//     y           <u     0               // y = x & (m - 1)
-//   by Lemma 3, this is always false, i.e. a contradiction to our assumption.
-//
-// Case "m >u 0 => x & (m - 1) <u m":
-//   x & (m - 1) <=u (m - 1)              // (Lemma 1)
-//   x & (m - 1) <=u (m - 1) <u m         // Using assumption m >u 0, no underflow of "m - 1"
-//
-//
-// Note that the signed version of "m > 0":
-//   m > 0 <=> x & (m - 1) <u m
-// does not hold:
-//   Assume m == -1 and x == -1:
-//     x  & (m - 1) <u m
-//     -1 & -2      <u -1
-//     -2           <u -1
-//     UINT_MAX - 1 <u UINT_MAX           // Signed to unsigned numbers
-// which is true while
-//   m > 0
-// is false which is a contradiction.
-//
-// (1a) and (1b) is covered by this method since we can directly return a true value as type while (2) is covered
-// in BoolNode::Ideal since we create a new non-constant node (see [CMPU_MASK]).
-const Type* BoolNode::Value_cmpu_and_mask(PhaseValues* phase) const {
-  Node* cmp = in(1);
-  if (cmp != nullptr && cmp->Opcode() == Op_CmpU) {
-    Node* cmp1 = cmp->in(1);
-    Node* cmp2 = cmp->in(2);
-
-    if (cmp1->Opcode() == Op_AndI) {
-      Node* m = nullptr;
-      if (_test._test == BoolTest::le) {
-        // (1a) "((x & m) <=u m)", cmp2 = m
-        m = cmp2;
-      } else if (_test._test == BoolTest::lt && cmp2->Opcode() == Op_AddI && cmp2->in(2)->find_int_con(0) == 1) {
-        // (1b) "(x & m) <u m + 1" and "(m & x) <u m + 1", cmp2 = m + 1
-        Node* rhs_m = cmp2->in(1);
-        const TypeInt* rhs_m_type = phase->type(rhs_m)->isa_int();
-        if (rhs_m_type != nullptr && (rhs_m_type->_lo > -1 || rhs_m_type->_hi < -1)) {
-          // Exclude any case where m == -1 is possible.
-          m = rhs_m;
-        }
-      }
-
-      if (cmp1->in(2) == m || cmp1->in(1) == m) {
-        return TypeInt::ONE;
-      }
-    }
-  }
-
-  return nullptr;
-}
-
 // Simplify a Bool (convert condition codes to boolean (1 or 0)) node,
 // based on local information.   If the input is constant, do it.
 const Type* BoolNode::Value(PhaseGVN* phase) const {
-  const Type* t = Value_cmpu_and_mask(phase);
-  if (t != nullptr) {
-    return t;
-  }
-
   return _test.cc2logical( phase->type( in(1) ) );
 }
 

--- a/src/hotspot/share/opto/subnode.cpp
+++ b/src/hotspot/share/opto/subnode.cpp
@@ -1898,16 +1898,12 @@ const Type* BoolNode::Value_cmpu_and_mask(PhaseValues* phase) const {
 // Simplify a Bool (convert condition codes to boolean (1 or 0)) node,
 // based on local information.   If the input is constant, do it.
 const Type* BoolNode::Value(PhaseGVN* phase) const {
-  const Type* input_type = phase->type(in(1));
-  if (input_type == Type::TOP) {
-    return Type::TOP;
-  }
   const Type* t = Value_cmpu_and_mask(phase);
   if (t != nullptr) {
     return t;
   }
 
-  return _test.cc2logical(input_type);
+  return _test.cc2logical( phase->type( in(1) ) );
 }
 
 #ifndef PRODUCT

--- a/src/hotspot/share/opto/subnode.hpp
+++ b/src/hotspot/share/opto/subnode.hpp
@@ -171,6 +171,7 @@ public:
 //------------------------------CmpUNode---------------------------------------
 // Compare 2 unsigned values (integer or pointer), returning condition codes (-1, 0 or 1).
 class CmpUNode : public CmpNode {
+  static const Type* Value_cmpu_and_mask(PhaseValues*, const Node*, const Node*);
 public:
   CmpUNode( Node *in1, Node *in2 ) : CmpNode(in1,in2) {}
   virtual int Opcode() const;
@@ -359,7 +360,6 @@ public:
   BoolNode* negate(PhaseGVN* phase);
   virtual int Opcode() const;
   virtual Node *Ideal(PhaseGVN *phase, bool can_reshape);
-  const Type* Value_cmpu_and_mask(PhaseValues* phase) const;
   virtual const Type* Value(PhaseGVN* phase) const;
   virtual const Type *bottom_type() const { return TypeInt::BOOL; }
   uint match_edge(uint idx) const { return 0; }


### PR DESCRIPTION
Hi, this pull request is a second take of 1383fec41756322bf2832c55633e46395b937b40, by updating the `CmpUNode` type as either `TypeInt::CC_LE` (case 1a) or `TypeInt::CC_LT` (case 1b) instead of updating the `BoolNode` type as `TypeInt::ONE`.

With this approach a56cd371a2c497e4323756f8b8a08a0bba059bf2 becomes unnecessary. Additionally, having the right type in `CmpUNode` could potentially enable further optimizations.

#### Testing

In order to evaluate the changes, the following testing has been performed:

* `jdk:tier1` (see [GitHub Actions run](https://github.com/franferrax/jdk/actions/runs/16789994433))
* [`TestBoolNodeGVN.java`](https://github.com/openjdk/jdk/blob/jdk-26+9/test/hotspot/jtreg/compiler/c2/gvn/TestBoolNodeGVN.java), created for [JDK-8327381: Refactor type-improving transformations in BoolNode::Ideal to BoolNode::Value](https://bugs.openjdk.org/browse/JDK-8327381) (1383fec41756322bf2832c55633e46395b937b40)
    * I also checked it breaks if I remove the `CmpUNode::Value_cmpu_and_mask` call
* Private reproducer for [JDK-8349584: Improve compiler processing](https://bugs.openjdk.org/browse/JDK-8349584) (a56cd371a2c497e4323756f8b8a08a0bba059bf2)
* A local run of the `test/hotspot/jtreg/compiler/c2` category on _Fedora Linux x86_64_
    * 🚧 ongoing