### PR TITLE
8362239: Reconcile enter_internal and reenter_internal in the ObjectMonitor code

### DIFF
--- a/src/hotspot/share/runtime/objectMonitor.hpp
+++ b/src/hotspot/share/runtime/objectMonitor.hpp
@@ -409,7 +409,7 @@ class ObjectMonitor : public CHeapObj<mtObjectMonitor> {
   ObjectWaiter* dequeue_waiter();
   void      dequeue_specific_waiter(ObjectWaiter* waiter);
   void      enter_internal(JavaThread* current, ExitOnSuspend& eos);
-  void      reenter_internal(JavaThread* current, ObjectWaiter* current_node);
+  void      reenter_internal(JavaThread* current, ClearSuccOnSuspend& csos, ObjectWaiter* current_node);
   void      entry_list_build_dll(JavaThread* current);
   void      unlink_after_acquire(JavaThread* current, ObjectWaiter* current_node);
   ObjectWaiter* entry_list_tail(JavaThread* current);

--- a/src/hotspot/share/runtime/objectMonitor.hpp
+++ b/src/hotspot/share/runtime/objectMonitor.hpp
@@ -368,6 +368,13 @@ class ObjectMonitor : public CHeapObj<mtObjectMonitor> {
     ClearSuccOnSuspend(ObjectMonitor* om) : _om(om)  {}
     void operator()(JavaThread* current);
   };
+  class NoOpOnSuspend {
+  protected:
+    ObjectMonitor* _om;
+  public:
+    NoOpOnSuspend(ObjectMonitor* om) : _om(om) {}
+    void operator()(JavaThread* current);
+  };
 
   bool      enter_is_async_deflating();
   void      notify_contended_enter(JavaThread *current);
@@ -401,7 +408,7 @@ class ObjectMonitor : public CHeapObj<mtObjectMonitor> {
   bool      notify_internal(JavaThread* current);
   ObjectWaiter* dequeue_waiter();
   void      dequeue_specific_waiter(ObjectWaiter* waiter);
-  void      enter_internal(JavaThread* current);
+  void      enter_internal(JavaThread* current, ExitOnSuspend& eos);
   void      reenter_internal(JavaThread* current, ObjectWaiter* current_node);
   void      entry_list_build_dll(JavaThread* current);
   void      unlink_after_acquire(JavaThread* current, ObjectWaiter* current_node);

--- a/src/hotspot/share/runtime/objectMonitor.hpp
+++ b/src/hotspot/share/runtime/objectMonitor.hpp
@@ -378,17 +378,13 @@ class ObjectMonitor : public CHeapObj<mtObjectMonitor> {
   template<typename ProcIn = void(JavaThread*), typename ProcPost = void(JavaThread*)>
    class EnterInternalHelper {
    private:
-     bool fast_track(JavaThread* current, ObjectWaiter *node);
-     void checks(JavaThread* current);
-     void loop(JavaThread* current, ObjectWaiter* node, int& recheck_interval, bool do_timed_parked);
-     void egress(JavaThread* current, ObjectWaiter* node);
-     void loop_and_egress(JavaThread* current, ObjectWaiter* node, ProcIn* proc_in, ProcPost* proc_post, int& recheck_interval, bool do_timed_parked);
-     void park(JavaThread* current, int& recheck_interval, bool do_timed_parked);
-   protected:
-     ObjectMonitor* _om;
+     static bool fast_track(ObjectMonitor* om, JavaThread* current, ObjectWaiter *node);
+     static void loop(ObjectMonitor* om, JavaThread* current, ObjectWaiter* node, ProcIn* proc_in, int& recheck_interval, bool do_timed_parked);
+     static void egress(ObjectMonitor* om, JavaThread* current, ObjectWaiter* node);
+     static void loop_and_egress(ObjectMonitor* om, JavaThread* current, ObjectWaiter* node, ProcIn* proc_in, ProcPost* proc_post, int& recheck_interval, bool do_timed_parked);
+     static void park(JavaThread* current, ProcIn* proc_in, int& recheck_interval, bool do_timed_parked);
    public:
-     EnterInternalHelper(ObjectMonitor* om) : _om(om) {}
-     void enter_internal(JavaThread* current, ObjectWaiter* node, ProcIn* proc_in, ProcPost* proc_post);
+     static void enter_internal(ObjectMonitor* om, JavaThread* current, ObjectWaiter* node, ProcIn* proc_in, ProcPost* proc_post);
   };
 
   bool      enter_is_async_deflating();
@@ -423,8 +419,6 @@ class ObjectMonitor : public CHeapObj<mtObjectMonitor> {
   bool      notify_internal(JavaThread* current);
   ObjectWaiter* dequeue_waiter();
   void      dequeue_specific_waiter(ObjectWaiter* waiter);
-  void      enter_internal(JavaThread* current, ExitOnSuspend& eos);
-  void      reenter_internal(JavaThread* current, ClearSuccOnSuspend& csos, ObjectWaiter* current_node);
   void      entry_list_build_dll(JavaThread* current);
   void      unlink_after_acquire(JavaThread* current, ObjectWaiter* current_node);
   ObjectWaiter* entry_list_tail(JavaThread* current);

--- a/src/hotspot/share/runtime/objectMonitor.hpp
+++ b/src/hotspot/share/runtime/objectMonitor.hpp
@@ -375,6 +375,21 @@ class ObjectMonitor : public CHeapObj<mtObjectMonitor> {
     NoOpOnSuspend(ObjectMonitor* om) : _om(om) {}
     void operator()(JavaThread* current);
   };
+  template<typename ProcIn = void(JavaThread*), typename ProcPost = void(JavaThread*)>
+   class EnterInternalHelper {
+   private:
+     bool fast_track(JavaThread* current, ObjectWaiter *node);
+     void checks(JavaThread* current);
+     void loop(JavaThread* current, ObjectWaiter* node, int& recheck_interval, bool do_timed_parked);
+     void egress(JavaThread* current, ObjectWaiter* node);
+     void loop_and_egress(JavaThread* current, ObjectWaiter* node, ProcIn* proc_in, ProcPost* proc_post, int& recheck_interval, bool do_timed_parked);
+     void park(JavaThread* current, int& recheck_interval, bool do_timed_parked);
+   protected:
+     ObjectMonitor* _om;
+   public:
+     EnterInternalHelper(ObjectMonitor* om) : _om(om) {}
+     void enter_internal(JavaThread* current, ObjectWaiter* node, ProcIn* proc_in, ProcPost* proc_post);
+  };
 
   bool      enter_is_async_deflating();
   void      notify_contended_enter(JavaThread *current);


### PR DESCRIPTION
This is an attempt to reconcile two OM methods: `enter_internal()` and `reenter_internal().`

The fundamental problem is the operations executed in (or after) leaving a blocked thread state. 

`ExitOnSuspend` requires ownership of the monitor and can be executed only upon exiting the method. 

`ClearSuccOnSuspend` does not require that, and can be executed multiple times in the loop. 

This inconsistency is addressed by changes in the length of the blocked thread state region. Common parts are extracted, whereas substantial differences are addressed in template specialized methods.

Tested in tiers 1 - 5.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8362239](https://bugs.openjdk.org/browse/JDK-8362239): Reconcile enter_internal and reenter_internal in the ObjectMonitor code (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26669/head:pull/26669` \
`$ git checkout pull/26669`

Update a local copy of the PR: \
`$ git checkout pull/26669` \
`$ git pull https://git.openjdk.org/jdk.git pull/26669/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26669`

View PR using the GUI difftool: \
`$ git pr show -t 26669`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26669.diff">https://git.openjdk.org/jdk/pull/26669.diff</a>

</details>
