### PR TITLE
8364984: Many jpackage tests are failing on Linux after JDK-8334238

### DIFF
--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/LinuxHelper.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/LinuxHelper.java
@@ -455,7 +455,7 @@ public final class LinuxHelper {
         var unpackedDir = cmd.appLayout().desktopIntegrationDirectory();
         var packageDir = cmd.pathToPackageFile(unpackedDir);
         return getPackageFiles(cmd).filter(path -> {
-            return path.getParent().equals(packageDir) && path.getFileName().toString().endsWith(".desktop");
+            return packageDir.equals(path.getParent()) && path.getFileName().toString().endsWith(".desktop");
         }).map(Path::getFileName).map(unpackedDir::resolve).toList();
     }
 


### PR DESCRIPTION
Fix NPE when `path.getParent()` in `LinuxHelper.getDesktopFiles()` returns null. The issue is deb-specific, there is no such problem with rpm packages.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8364984](https://bugs.openjdk.org/browse/JDK-8364984): Many jpackage tests are failing on Linux after JDK-8334238 (**Bug** - P3)


### Reviewers
 * [Alexander Matveev](https://openjdk.org/census#almatvee) (@sashamatveev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26677/head:pull/26677` \
`$ git checkout pull/26677`

Update a local copy of the PR: \
`$ git checkout pull/26677` \
`$ git pull https://git.openjdk.org/jdk.git pull/26677/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26677`

View PR using the GUI difftool: \
`$ git pr show -t 26677`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26677.diff">https://git.openjdk.org/jdk/pull/26677.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26677#issuecomment-3164372504)
</details>
