### PR TITLE
8365050: Too verbose warning in os::commit_memory_limit() on Windows

### DIFF
--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -3297,13 +3297,28 @@ static char* map_or_reserve_memory_aligned(size_t size, size_t alignment, int fi
 }
 
 size_t os::commit_memory_limit() {
-  JOBOBJECT_EXTENDED_LIMIT_INFORMATION jeli = {};
-  BOOL res = QueryInformationJobObject(nullptr, JobObjectExtendedLimitInformation, &jeli, sizeof(jeli), nullptr);
-
+  BOOL is_in_job_object = false;
+  BOOL res = IsProcessInJob(GetCurrentProcess(), nullptr, &is_in_job_object);
   if (!res) {
     char buf[512];
     size_t buf_len = os::lasterror(buf, sizeof(buf));
-    warning("Attempt to query job object information failed: %s", buf_len != 0 ? buf : "<unknown error>");
+    warning("Attempt to determine whether the process is running in a job failed for commit limit: %s", buf_len != 0 ? buf : "<unknown error>");
+
+    // Conservatively assume no limit when there was an error calling IsProcessInJob.
+    return SIZE_MAX;
+  }
+
+  if (!is_in_job_object) {
+    // Not limited by a Job Object
+    return SIZE_MAX;
+  }
+
+  JOBOBJECT_EXTENDED_LIMIT_INFORMATION jeli = {};
+  res = QueryInformationJobObject(nullptr, JobObjectExtendedLimitInformation, &jeli, sizeof(jeli), nullptr);
+  if (!res) {
+    char buf[512];
+    size_t buf_len = os::lasterror(buf, sizeof(buf));
+    warning("Attempt to query job object information failed for commit limit: %s", buf_len != 0 ? buf : "<unknown error>");
 
     // Conservatively assume no limit when there was an error calling QueryInformationJobObject.
     return SIZE_MAX;


### PR DESCRIPTION
Hello,

This is a follow-up to [JDK-8364518](https://bugs.openjdk.org/browse/JDK-8364518), which introduced support for Job Objects in os::commit_memory_limit() on Windows. The single `warning(...)` turned out to be too verbose, as getting an error from `QueryInformationJobObject` is common when the process is not in a job and does not have permission to query information about a job. The verbosity results both in a lot of warning prints when building, and some tests to fail, which expects the output to contain something specific or nothing at all. See more details in the JBS issue.

To address this, I suggest we revise os::commit_memory_limit() to first check if the process is in a job before calling `QueryInformationJobObject`. When testing this locally, I can see that the verbose warnings when building are gone and the tests pass.

Testing:
* Oracle's tier1-4
* Reported test failures now pass

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8365050](https://bugs.openjdk.org/browse/JDK-8365050): Too verbose warning in os::commit_memory_limit() on Windows (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26680/head:pull/26680` \
`$ git checkout pull/26680`

Update a local copy of the PR: \
`$ git checkout pull/26680` \
`$ git pull https://git.openjdk.org/jdk.git pull/26680/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26680`

View PR using the GUI difftool: \
`$ git pr show -t 26680`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26680.diff">https://git.openjdk.org/jdk/pull/26680.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26680#issuecomment-3164979471)
</details>
