### PR TITLE
8364780: Ambiguity in DecimalFormatSymbols Unicode extension priority

### DIFF
--- a/src/java.base/share/classes/java/text/DecimalFormatSymbols.java
+++ b/src/java.base/share/classes/java/text/DecimalFormatSymbols.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/text/DecimalFormatSymbols.java
+++ b/src/java.base/share/classes/java/text/DecimalFormatSymbols.java
@@ -90,7 +90,7 @@ public class DecimalFormatSymbols implements Cloneable, Serializable {
      * @see java.util.Locale.Category#FORMAT
      */
     public DecimalFormatSymbols() {
-        initialize( Locale.getDefault(Locale.Category.FORMAT) );
+        initialize(Locale.getDefault(Locale.Category.FORMAT));
     }
 
     /**
@@ -113,8 +113,8 @@ public class DecimalFormatSymbols implements Cloneable, Serializable {
      * @param locale the desired locale
      * @throws    NullPointerException if {@code locale} is null
      */
-    public DecimalFormatSymbols( Locale locale ) {
-        initialize( locale );
+    public DecimalFormatSymbols(Locale locale) {
+        initialize(locale);
     }
 
     /**

--- a/src/java.base/share/classes/java/text/DecimalFormatSymbols.java
+++ b/src/java.base/share/classes/java/text/DecimalFormatSymbols.java
@@ -59,9 +59,11 @@ import sun.util.locale.provider.ResourceBundleBasedAdapter;
  * of these symbols, you can get the {@code DecimalFormatSymbols} object from
  * your {@code DecimalFormat} and modify it.
  *
- * <p>If the locale contains "rg" (region override)
- * <a href="../util/Locale.html#def_locale_extension">Unicode extension</a>,
- * the symbols are overridden for the designated region.
+ * <p> The "rg" (region override) and "nu" (numbering system) {@code Locale}
+ * <a href="../util/Locale.html#def_locale_extension">Unicode extensions</a>
+ * are supported which may override the symbols. If both "nu" and "rg" are
+ * specified by the backing {@code Locale}, the symbols from the "nu" extension
+ * supersedes the implicit ones from the "rg" extension.
  *
  * @see          java.util.Locale
  * @see          DecimalFormat


### PR DESCRIPTION
This PR clarifies the Unicode extension wording in the DecimalFormatSymbols class description to make apparent that the "nu" extension is supported in addition to the "rg" extension. There already exists "nu" commentary in the specification of the  Locale accepting method APIs, the main purpose of this change is to clarify the behavior when both extensions are supplied.

Note that "may" wording is intentionally used, as symbols are only overridden if the JRE implementation provides support.