### PR TITLE
8362394: C2: Repeated stacked string concatenation fails with "Hit MemLimit" and other resourcing errors

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -82,6 +82,8 @@ compiler/c2/TestVerifyConstraintCasts.java 8355574 generic-all
 
 compiler/c2/aarch64/TestStaticCallStub.java 8359963 linux-aarch64,macosx-aarch64
 
+compiler/stringopts/TestStackedConcatsMany.java 8328078 generic-aarch64
+
 #############################################################################
 
 # :hotspot_gc

--- a/test/hotspot/jtreg/compiler/stringopts/TestStackedConcatsMany.java
+++ b/test/hotspot/jtreg/compiler/stringopts/TestStackedConcatsMany.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8357105
+ * @summary Test that repeated stacked string concatenations do not
+ *          consume too many compilation resources.
+ * @run main/othervm compiler.stringopts.TestStackedConcatsMany
+ * @run main/othervm -XX:-TieredCompilation -Xcomp
+ *                   -XX:CompileOnly=compiler.stringopts.TestStackedConcatsMany::*
+ *                   compiler.stringopts.TestStackedConcatsMany
+ */
+
+package compiler.stringopts;
+
+public class TestStackedConcatsMany {
+
+    public static void main (String... args) {
+        for (int i = 0; i < 10; i++) {
+            String s = f(" ");
+        }
+    }
+
+    static String f(String c) {
+        String s = " ";
+        s = new StringBuilder().append(s).append(s).toString();
+        s = new StringBuilder().append(s).append(s).toString();
+
+        s = new StringBuilder().append(s).append(s).toString();
+        s = new StringBuilder().append(s).append(s).toString();
+
+        s = new StringBuilder().append(s).append(s).toString();
+        s = new StringBuilder().append(s).append(s).toString();
+
+        s = new StringBuilder().append(s).append(s).toString();
+        s = new StringBuilder().append(s).append(s).toString();
+
+        s = new StringBuilder().append(s).append(s).toString();
+        s = new StringBuilder().append(s).append(s).toString();
+
+        s = new StringBuilder().append(s).append(s).toString();
+        s = new StringBuilder().append(s).append(s).toString();
+
+        s = new StringBuilder().append(s).append(s).toString();
+        s = new StringBuilder().append(s).append(s).toString();
+
+        s = new StringBuilder().append(s).append(s).toString();
+        s = new StringBuilder().append(s).append(s).toString();
+
+        s = new StringBuilder().append(s).append(s).toString();
+        s = new StringBuilder().append(s).append(s).toString();
+
+        s = new StringBuilder().append(s).append(s).toString();
+        s = new StringBuilder().append(s).append(s).toString();
+
+        s = new StringBuilder().append(s).append(s).toString();
+        s = new StringBuilder().append(s).append(s).toString();
+
+        s = new StringBuilder().append(s).append(s).toString();
+        s = new StringBuilder().append(s).append(s).toString();
+
+        return s;
+    }
+}


### PR DESCRIPTION
This PR addresses a bug in the stringopts phase. During string concatenation, repeated stacking of concatenations can lead to excessive compilation resource use and generation of questionable code as the merging of two StringBuilder-append-toString links sc1 and sc2 can result in a new StringBuilder with the size sc1->num_arguments() * sc2->num_arguments().

In the attached test, the size of the successively merged StringBuilder doubles on each merge -- there's 24 of them -- as the toString result of the first component is used twice in the second component [1], etc. Not only does the compiler hang on this test case, but the string concat optimization seems to give an arbitrary amount of back-to-back stores in the generated code depending on the number of stacked concatenations.

The proposed solution is to put an upper bound on the size of a merged concatenation, which guards against this case of repeated concatenations on the same string variable, and potentially other edge cases. 100 seems like a generous limit, and higher limits could be insufficient as each argument corresponds to about 20 new nodes later in replace_string_concat [2].

[1] https://github.com/openjdk/jdk/blob/0ceb366dc26e2e4f6252da9dd8930b016a5d46ba/src/hotspot/share/opto/stringopts.cpp#L303

[2] https://github.com/openjdk/jdk/blob/0ceb366dc26e2e4f6252da9dd8930b016a5d46ba/src/hotspot/share/opto/stringopts.cpp#L1806

Testing: T1-4.

Extra testing: verified that no method in T1-4 is being compiled with a merged concat candidate exceeding the suggested limit of 100 aguments, regardless of whether or not the later checks verify_control_flow() and verify_mem_flow pass.