### PR TITLE
8364962: G1: Inline G1CollectionSet::finalize_incremental_building

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectionSet.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSet.cpp
@@ -127,11 +127,6 @@ void G1CollectionSet::start_incremental_building() {
   update_incremental_marker();
 }
 
-void G1CollectionSet::finalize_incremental_building() {
-  assert(_inc_build_state == Active, "Precondition");
-  assert(SafepointSynchronize::is_at_safepoint(), "should be at a safepoint");
-}
-
 void G1CollectionSet::clear() {
   assert_at_safepoint_on_vm_thread();
   _collection_set_cur_length = 0;
@@ -284,9 +279,10 @@ void G1CollectionSet::print(outputStream* st) {
 // pinned by JNI) to allow faster future evacuation. We already "paid" for this work
 // when sizing the young generation.
 double G1CollectionSet::finalize_young_part(double target_pause_time_ms, G1SurvivorRegions* survivors) {
-  Ticks start_time = Ticks::now();
+  assert(_inc_build_state == Active, "Precondition");
+  assert(SafepointSynchronize::is_at_safepoint(), "should be at a safepoint");
 
-  finalize_incremental_building();
+  Ticks start_time = Ticks::now();
 
   guarantee(target_pause_time_ms > 0.0,
             "target_pause_time_ms = %1.6lf should be positive", target_pause_time_ms);

--- a/src/hotspot/share/gc/g1/g1CollectionSet.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSet.hpp
@@ -200,9 +200,6 @@ class G1CollectionSet {
   // as Eden and calculate a prediction on how long the evacuation of all young regions
   // will take.
   double finalize_young_part(double target_pause_time_ms, G1SurvivorRegions* survivors);
-  // Perform any final calculations on the incremental collection set fields before we
-  // can use them.
-  void finalize_incremental_building();
 
   // Select the regions comprising the initial and optional collection set from marking
   // and retained collection set candidates.


### PR DESCRIPTION
Hi all,

  please review this inlining of `G1CollectionSet::finalize_incremental_building` - it does not do anything useful for some time now, only some fairly generic asserts. There is only one caller too.

Testing: gha

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8364962](https://bugs.openjdk.org/browse/JDK-8364962): G1: Inline G1CollectionSet::finalize_incremental_building (**Enhancement** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26687/head:pull/26687` \
`$ git checkout pull/26687`

Update a local copy of the PR: \
`$ git checkout pull/26687` \
`$ git pull https://git.openjdk.org/jdk.git pull/26687/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26687`

View PR using the GUI difftool: \
`$ git pr show -t 26687`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26687.diff">https://git.openjdk.org/jdk/pull/26687.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26687#issuecomment-3166961743)
</details>
