### PR TITLE
8364280: NMTCommittedVirtualMemoryTracker.test_committed_virtualmemory_region_vm fails with assertion "negative distance"

### DIFF
--- a/test/hotspot/gtest/runtime/test_committed_virtualmemory.cpp
+++ b/test/hotspot/gtest/runtime/test_committed_virtualmemory.cpp
@@ -67,7 +67,7 @@ public:
           EXPECT_TRUE(cmr.size() <= stack_size);
           found_stack_top = true;
         }
-        if(i_addr < stack_top && i_addr >= cmr.base()) {
+        if (i_addr < stack_top && i_addr >= cmr.base()) {
           found_i_addr = true;
         }
         i++;

--- a/test/hotspot/gtest/runtime/test_committed_virtualmemory.cpp
+++ b/test/hotspot/gtest/runtime/test_committed_virtualmemory.cpp
@@ -43,9 +43,15 @@ public:
     // snapshot current stack usage
     VirtualMemoryTracker::Instance::snapshot_thread_stacks();
 
-    ReservedMemoryRegion rmr_found = VirtualMemoryTracker::Instance::tree()->find_reserved_region(stack_end);
+    ReservedMemoryRegion rmr_found;
+    {
+      MemTracker::NmtVirtualMemoryLocker vml;
+      rmr_found = VirtualMemoryTracker::Instance::tree()->find_reserved_region(stack_end);
+    }
+
     ASSERT_TRUE(rmr_found.is_valid());
     ASSERT_EQ(rmr_found.base(), stack_end);
+
 
     int i = 0;
     address i_addr = (address)&i;
@@ -54,18 +60,20 @@ public:
     // stack grows downward
     address stack_top = stack_end + stack_size;
     bool found_stack_top = false;
-    VirtualMemoryTracker::Instance::tree()->visit_committed_regions(rmr_found, [&](const CommittedMemoryRegion& cmr) {
-      if (cmr.base() + cmr.size() == stack_top) {
-        EXPECT_TRUE(cmr.size() <= stack_size);
-        found_stack_top = true;
-      }
-      if(i_addr < stack_top && i_addr >= cmr.base()) {
-        found_i_addr = true;
-      }
-      i++;
-      return true;
-    });
-
+    {
+      MemTracker::NmtVirtualMemoryLocker vml;
+      VirtualMemoryTracker::Instance::tree()->visit_committed_regions(rmr_found, [&](const CommittedMemoryRegion& cmr) {
+        if (cmr.base() + cmr.size() == stack_top) {
+          EXPECT_TRUE(cmr.size() <= stack_size);
+          found_stack_top = true;
+        }
+        if(i_addr < stack_top && i_addr >= cmr.base()) {
+          found_i_addr = true;
+        }
+        i++;
+        return true;
+      });
+    }
 
     // stack and guard pages may be contiguous as one region
     ASSERT_TRUE(i >= 1);


### PR DESCRIPTION
The VirtualMemoryTracker API uses a tree internally for tracking the memory regions and their states/info. This tree should not be changed when looking for some regions. If not synch'ed, the nodes in the tree may change meanwhile and the retrieved info are not as expected. The unit test in this PR did not synch these looking up with VMT. The corresponding lock is used to address the problem.

Tests:
local: linux-x64-debug NMTGtests
mach5: tiers 1-5, {macosx-aarch64, linux-x64, windows-x64} x {debug, release}

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8364280](https://bugs.openjdk.org/browse/JDK-8364280): NMTCommittedVirtualMemoryTracker.test_committed_virtualmemory_region_vm fails with assertion "negative distance" (**Bug** - P3)


### Reviewers
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@jdksjolen - **Reviewer**) Review applies to [829cce44](https://git.openjdk.org/jdk/pull/26689/files/829cce44eb0fb9dffbac9b6d1e0d788ad14d126f)
 * [Gerard Ziemski](https://openjdk.org/census#gziemski) (@gerard-ziemski - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26689/head:pull/26689` \
`$ git checkout pull/26689`

Update a local copy of the PR: \
`$ git checkout pull/26689` \
`$ git pull https://git.openjdk.org/jdk.git pull/26689/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26689`

View PR using the GUI difftool: \
`$ git pr show -t 26689`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26689.diff">https://git.openjdk.org/jdk/pull/26689.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26689#issuecomment-3167091336)
</details>
