### PR TITLE
8313655: sun/tools/jhsdb/HeapDumpTestWithActiveProcess.java frequently fails with SerialGC

### DIFF
--- a/test/jdk/sun/tools/jhsdb/JShellHeapDumpTest.java
+++ b/test/jdk/sun/tools/jhsdb/JShellHeapDumpTest.java
@@ -162,12 +162,7 @@ public class JShellHeapDumpTest {
         long startTime = System.currentTimeMillis();
         try {
             JDKToolLauncher launcher = JDKToolLauncher.createUsingTestJDK("jshell");
-            if (doSleep) {
-                launcher.addVMArgs(Utils.getTestJavaOpts());
-            } else {
-                // Don't allow use of SerialGC. See JDK-8313655.
-                launcher.addVMArgs(Utils.getFilteredTestJavaOpts("-XX:\\+UseSerialGC"));
-            }
+            launcher.addVMArgs(Utils.getTestJavaOpts());
             ProcessBuilder pb = new ProcessBuilder(launcher.getCommand());
             // Needed so we can properly parse the "Welcome to JShell" output.
             pb.command().add("-J-Duser.language=en");


### PR DESCRIPTION
VM argument UseSerialGC was not allowed while launching the debuggee process due to classloader related issue. During the effort to improve the test's handling of the issue, it was observed that SerialGC doesn't cause any issue any more. This could possibly due to improved handling of ClassLoaderData or SerialGC.
After extensively testing the argument in various platforms and for many iterations, it was decided to allow the argument here on.

Testing: Tiers1,2,3 and other ties where the test runs.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313655](https://bugs.openjdk.org/browse/JDK-8313655): sun/tools/jhsdb/HeapDumpTestWithActiveProcess.java frequently fails with SerialGC (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26690/head:pull/26690` \
`$ git checkout pull/26690`

Update a local copy of the PR: \
`$ git checkout pull/26690` \
`$ git pull https://git.openjdk.org/jdk.git pull/26690/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26690`

View PR using the GUI difftool: \
`$ git pr show -t 26690`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26690.diff">https://git.openjdk.org/jdk/pull/26690.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26690#issuecomment-3167229855)
</details>
