### PR TITLE
8365122: G1: Minor clean up of G1SurvivorRegions

### DIFF
--- a/src/hotspot/share/gc/g1/g1Policy.cpp
+++ b/src/hotspot/share/gc/g1/g1Policy.cpp
@@ -508,12 +508,9 @@ uint G1Policy::calculate_desired_eden_length_before_mixed(double base_time_ms,
 }
 
 double G1Policy::predict_survivor_regions_evac_time() const {
-  const GrowableArray<G1HeapRegion*>* survivor_regions = _g1h->survivor()->regions();
   double survivor_regions_evac_time = predict_young_region_other_time_ms(_g1h->survivor()->length());
-  for (GrowableArrayIterator<G1HeapRegion*> it = survivor_regions->begin();
-       it != survivor_regions->end();
-       ++it) {
-    survivor_regions_evac_time += predict_region_copy_time_ms(*it, _g1h->collector_state()->in_young_only_phase());
+  for (G1HeapRegion* r : _g1h->survivor()->regions()) {
+    survivor_regions_evac_time += predict_region_copy_time_ms(r, _g1h->collector_state()->in_young_only_phase());
   }
 
   return survivor_regions_evac_time;
@@ -1461,16 +1458,13 @@ uint G1Policy::calc_max_old_cset_length() const {
 void G1Policy::transfer_survivors_to_cset(const G1SurvivorRegions* survivors) {
   start_adding_survivor_regions();
 
-  for (GrowableArrayIterator<G1HeapRegion*> it = survivors->regions()->begin();
-       it != survivors->regions()->end();
-       ++it) {
-    G1HeapRegion* curr = *it;
-    set_region_survivor(curr);
+  for (G1HeapRegion* r : survivors->regions()) {
+    set_region_survivor(r);
 
     // The region is a non-empty survivor so let's add it to
     // the incremental collection set for the next evacuation
     // pause.
-    _collection_set->add_survivor_regions(curr);
+    _collection_set->add_survivor_regions(r);
   }
   stop_adding_survivor_regions();
 

--- a/src/hotspot/share/gc/g1/g1SurvivorRegions.cpp
+++ b/src/hotspot/share/gc/g1/g1SurvivorRegions.cpp
@@ -28,18 +28,18 @@
 #include "utilities/growableArray.hpp"
 
 G1SurvivorRegions::G1SurvivorRegions() :
-  _regions(new (mtGC) GrowableArray<G1HeapRegion*>(8, mtGC)),
+  _regions(8, mtGC),
   _used_bytes(0),
   _regions_on_node() {}
 
 uint G1SurvivorRegions::add(G1HeapRegion* hr) {
   assert(hr->is_survivor(), "should be flagged as survivor region");
-  _regions->append(hr);
+  _regions.append(hr);
   return _regions_on_node.add(hr);
 }
 
 uint G1SurvivorRegions::length() const {
-  return (uint)_regions->length();
+  return (uint)_regions.length();
 }
 
 uint G1SurvivorRegions::regions_on_node(uint node_index) const {
@@ -47,17 +47,14 @@ uint G1SurvivorRegions::regions_on_node(uint node_index) const {
 }
 
 void G1SurvivorRegions::convert_to_eden() {
-  for (GrowableArrayIterator<G1HeapRegion*> it = _regions->begin();
-       it != _regions->end();
-       ++it) {
-    G1HeapRegion* hr = *it;
-    hr->set_eden_pre_gc();
+  for (G1HeapRegion* r : _regions) {
+    r->set_eden_pre_gc();
   }
   clear();
 }
 
 void G1SurvivorRegions::clear() {
-  _regions->clear();
+  _regions.clear();
   _used_bytes = 0;
   _regions_on_node.clear();
 }

--- a/src/hotspot/share/gc/g1/g1SurvivorRegions.hpp
+++ b/src/hotspot/share/gc/g1/g1SurvivorRegions.hpp
@@ -32,11 +32,11 @@ template <typename T>
 class GrowableArray;
 class G1HeapRegion;
 
+// Set of current survivor regions.
 class G1SurvivorRegions {
-private:
-  GrowableArray<G1HeapRegion*>* _regions;
-  volatile size_t             _used_bytes;
-  G1RegionsOnNodes            _regions_on_node;
+  GrowableArray<G1HeapRegion*> _regions;
+  volatile size_t _used_bytes;
+  G1RegionsOnNodes _regions_on_node;
 
 public:
   G1SurvivorRegions();
@@ -50,7 +50,7 @@ public:
   uint length() const;
   uint regions_on_node(uint node_index) const;
 
-  const GrowableArray<G1HeapRegion*>* regions() const {
+  const GrowableArray<G1HeapRegion*>& regions() const {
     return _regions;
   }
 

--- a/src/hotspot/share/gc/g1/g1SurvivorRegions.hpp
+++ b/src/hotspot/share/gc/g1/g1SurvivorRegions.hpp
@@ -27,6 +27,7 @@
 
 #include "gc/g1/g1RegionsOnNodes.hpp"
 #include "runtime/globals.hpp"
+#include "utilities/growableArray.hpp"
 
 template <typename T>
 class GrowableArray;


### PR DESCRIPTION
Hi all,

  please review this small cleanup around `G1SurvivorRegions`:

- make the `_regions` member a direct member of the class
- use the C++ for-each construct for iterating over `_regions` makes the code more readable

Testing: gha

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8365122](https://bugs.openjdk.org/browse/JDK-8365122): G1: Minor clean up of G1SurvivorRegions (**Enhancement** - P4)


### Reviewers
 * [Sangheon Kim](https://openjdk.org/census#sangheki) (@sangheon - **Reviewer**)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26692/head:pull/26692` \
`$ git checkout pull/26692`

Update a local copy of the PR: \
`$ git checkout pull/26692` \
`$ git pull https://git.openjdk.org/jdk.git pull/26692/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26692`

View PR using the GUI difftool: \
`$ git pr show -t 26692`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26692.diff">https://git.openjdk.org/jdk/pull/26692.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26692#issuecomment-3167350868)
</details>
