### PR TITLE
8365044: Missing copyright header in Contextual.java

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/Contextual.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/Contextual.java
@@ -1,3 +1,28 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
 package jdk.jfr;
 
 import java.lang.annotation.ElementType;


### PR DESCRIPTION
Adding missing copyright header to Contextual.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8365044](https://bugs.openjdk.org/browse/JDK-8365044): Missing copyright header in Contextual.java (**Bug** - P4)


### Reviewers
 * [Erik Gahlin](https://openjdk.org/census#egahlin) (@egahlin - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26693/head:pull/26693` \
`$ git checkout pull/26693`

Update a local copy of the PR: \
`$ git checkout pull/26693` \
`$ git pull https://git.openjdk.org/jdk.git pull/26693/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26693`

View PR using the GUI difftool: \
`$ git pr show -t 26693`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26693.diff">https://git.openjdk.org/jdk/pull/26693.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26693#issuecomment-3167437235)
</details>
