### PR TITLE
8365055

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -2445,6 +2445,17 @@ void G1CollectedHeap::update_perf_counter_cpu_time() {
 void G1CollectedHeap::start_new_collection_set() {
   collection_set()->start_incremental_building();
 
+  assert(policy()->collector_state()->in_full_gc() ||
+         young_regions_cardset()->occupied() == policy()->num_young_rem_set_cards_at_start(),
+         "Should not add cards to young gen remembered set during young GC, but "
+         "changed from %zu at start to %zu now.",
+         policy()->num_young_rem_set_cards_at_start(), young_regions_cardset()->occupied());
+  // Clear current young only collection set. As cards will be refined, they will
+  // be added to the remembered set.
+  // It is fine to clear it this late - evacuation does not add any remembered sets
+  // by itself, but only mark cards.
+  young_regions_cset_group()->clear();
+
   clear_region_attr();
 
   guarantee(_eden.length() == 0, "eden should have been cleared");

--- a/src/hotspot/share/gc/g1/g1Policy.cpp
+++ b/src/hotspot/share/gc/g1/g1Policy.cpp
@@ -67,7 +67,7 @@ G1Policy::G1Policy(STWGCTimer* gc_timer) :
   _reserve_regions(0),
   _young_gen_sizer(),
   _free_regions_at_end_of_collection(0),
-  _card_rs_length(0),
+  DEBUG_ONLY(_num_young_rem_set_cards_at_start(0) COMMA)
   _pending_cards_at_gc_start(0),
   _concurrent_start_to_mixed(),
   _collection_set(nullptr),
@@ -930,7 +930,7 @@ void G1Policy::record_young_collection_end(bool concurrent_operation_is_full_mar
     _analytics->report_constant_other_time_ms(constant_other_time_ms(pause_time_ms));
 
     _analytics->report_pending_cards((double)pending_cards_at_gc_start(), is_young_only_pause);
-    _analytics->report_card_rs_length((double)_card_rs_length, is_young_only_pause);
+    _analytics->report_card_rs_length((double)_g1h->young_regions_cardset()->occupied(), is_young_only_pause);
     _analytics->report_code_root_rs_length((double)total_code_roots_scanned, is_young_only_pause);
   }
 

--- a/src/hotspot/share/gc/g1/g1Policy.hpp
+++ b/src/hotspot/share/gc/g1/g1Policy.hpp
@@ -101,7 +101,7 @@ class G1Policy: public CHeapObj<mtGC> {
 
   uint _free_regions_at_end_of_collection;
 
-  size_t _card_rs_length;
+  DEBUG_ONLY(size_t _num_young_rem_set_cards_at_start;)
 
   size_t _pending_cards_at_gc_start;
 
@@ -129,9 +129,13 @@ public:
     hr->install_surv_rate_group(_survivor_surv_rate_group);
   }
 
-  void record_card_rs_length(size_t card_rs_length) {
-    _card_rs_length = card_rs_length;
+#ifdef ASSERT
+  void record_young_rem_set_cards_at_start(size_t num_cards) {
+    _num_young_rem_set_cards_at_start = num_cards;
   }
+
+  size_t num_young_rem_set_cards_at_start() const { return _num_young_rem_set_cards_at_start; }
+#endif
 
   double cur_pause_start_sec() const {
     return _cur_pause_start_sec;

--- a/src/hotspot/share/gc/g1/g1RemSet.cpp
+++ b/src/hotspot/share/gc/g1/g1RemSet.cpp
@@ -1440,16 +1440,6 @@ void G1RemSet::merge_heap_roots(bool initial_evacuation) {
     workers->run_task(&cl, num_workers);
   }
 
-  {
-    size_t young_rs_length = g1h->young_regions_cardset()->occupied();
-    // We only use young_rs_length statistics to estimate young regions length.
-    g1h->policy()->record_card_rs_length(young_rs_length);
-
-    // Clear current young only collection set. Survivor regions will be added
-    // to the set during evacuation.
-    g1h->young_regions_cset_group()->clear();
-  }
-
   print_merge_heap_roots_stats();
 
   if (initial_evacuation) {

--- a/src/hotspot/share/gc/g1/g1YoungCollector.cpp
+++ b/src/hotspot/share/gc/g1/g1YoungCollector.cpp
@@ -519,8 +519,9 @@ void G1YoungCollector::pre_evacuate_collection_set(G1EvacInfo* evacuation_info) 
     G1MonotonicArenaMemoryStats sampled_card_set_stats = g1_prep_task.all_card_set_stats();
     sampled_card_set_stats.add(_g1h->young_regions_card_set_memory_stats());
     _g1h->set_young_gen_card_set_stats(sampled_card_set_stats);
-
     _g1h->set_humongous_stats(g1_prep_task.humongous_total(), g1_prep_task.humongous_candidates());
+
+    DEBUG_ONLY(_g1h->policy()->record_young_rem_set_cards_at_start(_g1h->young_regions_cardset()->occupied()));
 
     phase_times()->record_register_regions(task_time.seconds() * 1000.0);
   }


### PR DESCRIPTION
Hi all,

  please review this fix to G1 heap root merging that cleared the young gen remembered set multiple times (for every merging) and overwriting the most recent statistics for the number of young gen cards.

The latter is probably the more problematic, as it directly impacts young gen sizing statistics, potentially making young gen too large.

The fix is to move the two statements to the proper place - get current number of young gen cards at startup, clear the young gen remset when starting a new collection set - we do not need to do that earlier after all. Additionally we can add some (superfluous?) verification that during GC we really do not add to the young gen remset.

Testing: tier1-5

Thanks,
  Thomas