### PR TITLE
8364501: Compiler shutdown crashes on access to deleted CompileTask

### DIFF
--- a/src/hotspot/share/compiler/compileBroker.cpp
+++ b/src/hotspot/share/compiler/compileBroker.cpp
@@ -371,6 +371,7 @@ void CompileQueue::delete_all() {
 
   // Iterate over all tasks in the compile queue
   while (current != nullptr) {
+    CompileTask* next = current->next();
     if (!current->is_blocking()) {
       // Non-blocking task. No one is waiting for it, delete it now.
       delete current;
@@ -379,7 +380,7 @@ void CompileQueue::delete_all() {
       // to delete the task. We cannot delete it here, because we do not
       // coordinate with waiters. We will notify the waiters later.
     }
-    current = current->next();
+    current = next;
   }
   _first = nullptr;
   _last = nullptr;
@@ -504,6 +505,8 @@ void CompileQueue::remove(CompileTask* task) {
     assert(task == _last, "Sanity");
     _last = task->prev();
   }
+  task->set_next(nullptr);
+  task->set_prev(nullptr);
   --_size;
   ++_total_removed;
 }
@@ -1728,17 +1731,22 @@ void CompileBroker::wait_for_completion(CompileTask* task) {
 
   // It is harmless to check this status without the lock, because
   // completion is a stable property.
-  if (!task->is_complete() && is_compilation_disabled_forever()) {
-    // Task is not complete, and we are exiting for compilation shutdown.
-    // The task can still be executed by some compiler thread, therefore
-    // we cannot delete it. This will leave task allocated, which leaks it.
-    // At this (degraded) point, it is less risky to abandon the task,
-    // rather than attempting a more complicated deletion protocol.
+  if (!task->is_complete()) {
+    // Task is not complete, likely because we are exiting for compilation
+    // shutdown. The task can still be reached through the queue, or executed
+    // by some compiler thread. There is no coordination with either MCQ lock
+    // holders or compilers, therefore we cannot delete the task.
+    //
+    // This will leave task allocated, which leaks it. At this (degraded) point,
+    // it is less risky to abandon the task, rather than attempting a more
+    // complicated deletion protocol.
     free_task = false;
   }
 
   if (free_task) {
     assert(task->is_complete(), "Compilation should have completed");
+    assert(task->next() == nullptr, "Completed task should not be in the queue");
+    assert(task->prev() == nullptr, "Completed task should not be in the queue");
 
     // By convention, the waiter is responsible for deleting a
     // blocking CompileTask. Since there is only one waiter ever

--- a/src/hotspot/share/compiler/compileBroker.cpp
+++ b/src/hotspot/share/compiler/compileBroker.cpp
@@ -1745,8 +1745,8 @@ void CompileBroker::wait_for_completion(CompileTask* task) {
 
   if (free_task) {
     assert(task->is_complete(), "Compilation should have completed");
-    assert(task->next() == nullptr, "Completed task should not be in the queue");
-    assert(task->prev() == nullptr, "Completed task should not be in the queue");
+    assert(task->next() == nullptr && task->prev() == nullptr,
+           "Completed task should not be in the queue");
 
     // By convention, the waiter is responsible for deleting a
     // blocking CompileTask. Since there is only one waiter ever

--- a/src/hotspot/share/compiler/compileTask.cpp
+++ b/src/hotspot/share/compiler/compileTask.cpp
@@ -74,6 +74,7 @@ CompileTask::CompileTask(int compile_id,
   _arena_bytes = 0;
 
   _next = nullptr;
+  _prev = nullptr;
 
   Atomic::add(&_active_tasks, 1, memory_order_relaxed);
 }
@@ -91,7 +92,8 @@ CompileTask::~CompileTask() {
   }
 
 #ifdef ASSERT
-  // Zap the deleted task space to catch lifecycle errors
+  // Zap the deleted task memory to catch lifecycle errors.
+  // Do this before notifying potential waiters: they cannot wait on this task.
   memset(this, freeBlockPad, sizeof(CompileTask));
 #endif
 

--- a/src/hotspot/share/compiler/compileTask.cpp
+++ b/src/hotspot/share/compiler/compileTask.cpp
@@ -90,6 +90,11 @@ CompileTask::~CompileTask() {
     _failure_reason_on_C_heap = false;
   }
 
+#ifdef ASSERT
+  // Zap the deleted task space to catch lifecycle errors
+  memset(this, freeBlockPad, sizeof(CompileTask));
+#endif
+
   if (Atomic::sub(&_active_tasks, 1, memory_order_relaxed) == 0) {
     MonitorLocker wait_ml(CompileTaskWait_lock);
     wait_ml.notify_all();

--- a/src/hotspot/share/compiler/compileTask.cpp
+++ b/src/hotspot/share/compiler/compileTask.cpp
@@ -91,12 +91,6 @@ CompileTask::~CompileTask() {
     _failure_reason_on_C_heap = false;
   }
 
-#ifdef ASSERT
-  // Zap the deleted task memory to catch lifecycle errors.
-  // Do this before notifying any waiters: nothing can wait on this task.
-  memset(this, freeBlockPad, sizeof(CompileTask));
-#endif
-
   if (Atomic::sub(&_active_tasks, 1, memory_order_relaxed) == 0) {
     MonitorLocker wait_ml(CompileTaskWait_lock);
     wait_ml.notify_all();

--- a/src/hotspot/share/compiler/compileTask.cpp
+++ b/src/hotspot/share/compiler/compileTask.cpp
@@ -93,7 +93,7 @@ CompileTask::~CompileTask() {
 
 #ifdef ASSERT
   // Zap the deleted task memory to catch lifecycle errors.
-  // Do this before notifying potential waiters: they cannot wait on this task.
+  // Do this before notifying any waiters: nothing can wait on this task.
   memset(this, freeBlockPad, sizeof(CompileTask));
 #endif
 

--- a/src/hotspot/share/compiler/compileTask.hpp
+++ b/src/hotspot/share/compiler/compileTask.hpp
@@ -101,7 +101,8 @@ class CompileTask : public CHeapObj<mtCompiler> {
 #endif
   int                  _comp_level;
   int                  _num_inlined_bytecodes;
-  CompileTask*         _next, *_prev;
+  CompileTask*         _next;
+  CompileTask*         _prev;
   // Fields used for logging why the compilation was initiated:
   jlong                _time_queued;  // time when task was enqueued
   jlong                _time_started; // time when compilation started


### PR DESCRIPTION
See the bug for more investigation. 

In short, with recent changes to `delete` `CompileTask`-s, we end up in the rare situation where we can access tasks that have been already deleted. The major and obivous mistake I committed myself with [JDK-8361752](https://bugs.openjdk.org/browse/JDK-8361752) in `CompileQueue::delete_all`: the code first `delete`-s, then asks for `next` (facepalms). 

Another case is less trivial, and mostly fix in abundance of caution: in `wait_for_completion`, we can exit while blocking task is still in queue. Current code skip deletions only when compiler is shutdown for compilation, but I think the condition should be stronger: unless the task is completed, we should assume it might carry the queue-ing `next`/`prev` pointers that `delete_all` would need, and skip deletion. Realistically, it would "leak" only on compiler shutdown, like before.

I have also put in some diagnostic code to catch the lifecycle issues like this more reliably, and cleaned up `next`, `prev` lifecycle to clearly disconnect the `CompileTasks` that are no longer in queue.

Additional testing:
 - [x] Linux AArch64 server fastdebug, reproducer no longer fails
 - [x] Linux AArch64 server fastdebug, `compiler`
 - [x] Linux AArch64 server fastdebug, `all`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8364501](https://bugs.openjdk.org/browse/JDK-8364501): Compiler shutdown crashes on access to deleted CompileTask (**Bug** - P4)


### Reviewers
 * [Manuel Hässig](https://openjdk.org/census#mhaessig) (@mhaessig - Committer) Review applies to [e5f0a180](https://git.openjdk.org/jdk/pull/26696/files/e5f0a180b73604706319d00496e8d2c4012dd902)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26696/head:pull/26696` \
`$ git checkout pull/26696`

Update a local copy of the PR: \
`$ git checkout pull/26696` \
`$ git pull https://git.openjdk.org/jdk.git pull/26696/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26696`

View PR using the GUI difftool: \
`$ git pr show -t 26696`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26696.diff">https://git.openjdk.org/jdk/pull/26696.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26696#issuecomment-3167766992)
</details>
