### PR TITLE
8365086: CookieStore.getURIs() and get(URI) should return an immutable List

### DIFF
--- a/src/java.base/share/classes/java/net/InMemoryCookieStore.java
+++ b/src/java.base/share/classes/java/net/InMemoryCookieStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,10 +25,6 @@
 
 package java.net;
 
-import java.net.URI;
-import java.net.CookieStore;
-import java.net.HttpCookie;
-import java.net.URISyntaxException;
 import java.util.List;
 import java.util.Map;
 import java.util.ArrayList;
@@ -72,6 +68,7 @@ class InMemoryCookieStore implements CookieStore {
     /**
      * Add one cookie into cookie store.
      */
+    @Override
     public void add(URI uri, HttpCookie cookie) {
         // pre-condition : argument can't be null
         if (cookie == null) {
@@ -109,6 +106,7 @@ class InMemoryCookieStore implements CookieStore {
      *  3) not expired.
      * See RFC 2965 sec. 3.3.4 for more detail.
      */
+    @Override
     public List<HttpCookie> get(URI uri) {
         // argument can't be null
         if (uri == null) {
@@ -127,12 +125,13 @@ class InMemoryCookieStore implements CookieStore {
             lock.unlock();
         }
 
-        return cookies;
+        return Collections.unmodifiableList(cookies);
     }
 
     /**
      * Get all cookies in cookie store, except those have expired
      */
+    @Override
     public List<HttpCookie> getCookies() {
         List<HttpCookie> rt;
 
@@ -156,6 +155,7 @@ class InMemoryCookieStore implements CookieStore {
      * Get all URIs, which are associated with at least one cookie
      * of this cookie store.
      */
+    @Override
     public List<URI> getURIs() {
         List<URI> uris = new ArrayList<>();
 
@@ -165,7 +165,7 @@ class InMemoryCookieStore implements CookieStore {
             while (it.hasNext()) {
                 URI uri = it.next();
                 List<HttpCookie> cookies = uriIndex.get(uri);
-                if (cookies == null || cookies.size() == 0) {
+                if (cookies == null || cookies.isEmpty()) {
                     // no cookies list or an empty list associated with
                     // this uri entry, delete it
                     it.remove();
@@ -176,13 +176,14 @@ class InMemoryCookieStore implements CookieStore {
             lock.unlock();
         }
 
-        return uris;
+        return Collections.unmodifiableList(uris);
     }
 
 
     /**
      * Remove a cookie from store
      */
+    @Override
     public boolean remove(URI uri, HttpCookie ck) {
         // argument can't be null
         if (ck == null) {
@@ -204,6 +205,7 @@ class InMemoryCookieStore implements CookieStore {
     /**
      * Remove all cookies in this cookie store.
      */
+    @Override
     public boolean removeAll() {
         lock.lock();
         try {

--- a/test/jdk/java/net/CookieStoreTest.java
+++ b/test/jdk/java/net/CookieStoreTest.java
@@ -69,11 +69,7 @@ class CookieStoreTest {
         final List<URI> uris = cookieStore.getURIs();
         assertNotNull(uris, "CookieStore.getURIs() returned null");
         assertEquals(expectEmpty, uris.isEmpty(), "CookieStore.getURIs() returned: " + uris);
-
-        // the returned list is expected to be immutable, so the attempt to add or remove
-        // an element must fail
-        assertThrows(UnsupportedOperationException.class, () -> uris.add(COOKIE_TEST_URI));
-        assertThrows(UnsupportedOperationException.class, () -> uris.remove(COOKIE_TEST_URI));
+        assertImmutableList(uris, COOKIE_TEST_URI);
     }
 
     /*
@@ -85,12 +81,7 @@ class CookieStoreTest {
         final List<HttpCookie> cookies = cookieStore.getCookies();
         assertNotNull(cookies, "CookieStore.getCookies() returned null");
         assertEquals(expectEmpty, cookies.isEmpty(), "CookieStore.getCookies() returned: " + cookies);
-
-        final HttpCookie cookie = new HttpCookie("hello", "world");
-        // the returned list is expected to be immutable, so the attempt to add or remove
-        // an element must fail
-        assertThrows(UnsupportedOperationException.class, () -> cookies.add(cookie));
-        assertThrows(UnsupportedOperationException.class, () -> cookies.remove(cookie));
+        assertImmutableList(cookies, new HttpCookie("hello", "world"));
     }
 
     /*
@@ -102,11 +93,17 @@ class CookieStoreTest {
         final List<HttpCookie> cookies = cookieStore.get(COOKIE_TEST_URI);
         assertNotNull(cookies, "CookieStore.get(URI) returned null");
         assertEquals(expectEmpty, cookies.isEmpty(), "CookieStore.get(URI) returned: " + cookies);
+        assertImmutableList(cookies, new HttpCookie("hello", "world"));
+    }
 
-        final HttpCookie cookie = new HttpCookie("hello", "world");
-        // the returned list is expected to be immutable, so the attempt to add or remove
+    /*
+     * Verifies that the attempt to add or remove the element to/from the list will fail
+     * due to the list being immutable.
+     */
+    private static <T> void assertImmutableList(final List<T> list, T elementToAddOrRemove) {
+        // the list is expected to be immutable, so the attempt to add or remove
         // an element must fail
-        assertThrows(UnsupportedOperationException.class, () -> cookies.add(cookie));
-        assertThrows(UnsupportedOperationException.class, () -> cookies.remove(cookie));
+        assertThrows(UnsupportedOperationException.class, () -> list.add(elementToAddOrRemove));
+        assertThrows(UnsupportedOperationException.class, () -> list.remove(elementToAddOrRemove));
     }
 }

--- a/test/jdk/java/net/CookieStoreTest.java
+++ b/test/jdk/java/net/CookieStoreTest.java
@@ -97,13 +97,17 @@ class CookieStoreTest {
     }
 
     /*
-     * Verifies that the attempt to add or remove the element to/from the list will fail
+     * Verifies that the attempt to modify the contents of the list will fail
      * due to the list being immutable.
      */
     private static <T> void assertImmutableList(final List<T> list, T elementToAddOrRemove) {
-        // the list is expected to be immutable, so the attempt to add or remove
-        // an element must fail
+        // the list is expected to be immutable, so each of these operations must fail
         assertThrows(UnsupportedOperationException.class, () -> list.add(elementToAddOrRemove));
         assertThrows(UnsupportedOperationException.class, () -> list.remove(elementToAddOrRemove));
+        assertThrows(UnsupportedOperationException.class, list::clear);
+        // even try the replace operation when the list isn't empty
+        if (!list.isEmpty()) {
+            assertThrows(UnsupportedOperationException.class, () -> list.set(0, elementToAddOrRemove));
+        }
     }
 }

--- a/test/jdk/java/net/CookieStoreTest.java
+++ b/test/jdk/java/net/CookieStoreTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.net.CookieManager;
+import java.net.CookieStore;
+import java.net.HttpCookie;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/*
+ * @test
+ * @bug 8365086
+ * @summary verify that the implementation of java.net.CookieStore works
+ *          as expected
+ * @run junit CookieStoreTest
+ */
+class CookieStoreTest {
+
+    // neither the scheme, host nor the port matters in this test
+    private static final URI COOKIE_TEST_URI = URI.create("https://127.0.0.1:12345");
+
+    static List<Arguments> cookieStores() {
+        final List<Arguments> params = new ArrayList<>();
+        // empty CookieStore
+        params.add(Arguments.of(new CookieManager().getCookieStore(), true));
+
+        final CookieStore cookieStore = new CookieManager().getCookieStore();
+        cookieStore.add(COOKIE_TEST_URI, new HttpCookie("foo", "bar"));
+        // non-empty CookieStore
+        params.add(Arguments.of(cookieStore, false));
+
+        return params;
+    }
+
+    /*
+     * Verify that the List returned by CookieStore.getURIs() is immutable.
+     */
+    @ParameterizedTest
+    @MethodSource("cookieStores")
+    void testImmutableGetURIs(final CookieStore cookieStore, final boolean expectEmpty) {
+        final List<URI> uris = cookieStore.getURIs();
+        assertNotNull(uris, "CookieStore.getURIs() returned null");
+        assertEquals(expectEmpty, uris.isEmpty(), "CookieStore.getURIs() returned: " + uris);
+
+        // the returned list is expected to be immutable, so the attempt to add or remove
+        // an element must fail
+        assertThrows(UnsupportedOperationException.class, () -> uris.add(COOKIE_TEST_URI));
+        assertThrows(UnsupportedOperationException.class, () -> uris.remove(COOKIE_TEST_URI));
+    }
+
+    /*
+     * Verify that the List returned by CookieStore.getCookies() is immutable.
+     */
+    @ParameterizedTest
+    @MethodSource("cookieStores")
+    void testImmutableGetCookies(final CookieStore cookieStore, final boolean expectEmpty) {
+        final List<HttpCookie> cookies = cookieStore.getCookies();
+        assertNotNull(cookies, "CookieStore.getCookies() returned null");
+        assertEquals(expectEmpty, cookies.isEmpty(), "CookieStore.getCookies() returned: " + cookies);
+
+        final HttpCookie cookie = new HttpCookie("hello", "world");
+        // the returned list is expected to be immutable, so the attempt to add or remove
+        // an element must fail
+        assertThrows(UnsupportedOperationException.class, () -> cookies.add(cookie));
+        assertThrows(UnsupportedOperationException.class, () -> cookies.remove(cookie));
+    }
+
+    /*
+     * Verify that the List returned by CookieStore.get(URI) is immutable.
+     */
+    @ParameterizedTest
+    @MethodSource("cookieStores")
+    void testImmutableGetCookiesForURI(final CookieStore cookieStore, final boolean expectEmpty) {
+        final List<HttpCookie> cookies = cookieStore.get(COOKIE_TEST_URI);
+        assertNotNull(cookies, "CookieStore.get(URI) returned null");
+        assertEquals(expectEmpty, cookies.isEmpty(), "CookieStore.get(URI) returned: " + cookies);
+
+        final HttpCookie cookie = new HttpCookie("hello", "world");
+        // the returned list is expected to be immutable, so the attempt to add or remove
+        // an element must fail
+        assertThrows(UnsupportedOperationException.class, () -> cookies.add(cookie));
+        assertThrows(UnsupportedOperationException.class, () -> cookies.remove(cookie));
+    }
+}


### PR DESCRIPTION
Can I please get a review of this change which proposes to address the issue noted in https://bugs.openjdk.org/browse/JDK-8365086?

`java.net.CookieStore` has some APIs which return a `java.util.List`. These API are specified to return an immutable `List`. The JDK ships an implementation of the `CookieStore` - the `java.net.InMemoryCookieStore`. The implementations of the `getURIs()` and `get(URI)` methods  in the `InMemoryCookieStore` currently return a `List` which is modifiable.

The changes in this PR fix those two method to return an immutable `List` to match the specification. A new regression test has been introduced to reproduce the issue and verify the fix.

I think this may not require a CSR since this fixes the implementation to match the already existing specification in `CookieStore`. I will create one if anyone suggests we should.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8365086](https://bugs.openjdk.org/browse/JDK-8365086): CookieStore.getURIs() and get(URI) should return an immutable List (**Bug** - P3)


### Reviewers
 * [Volkan Yazici](https://openjdk.org/census#vyazici) (@vy - Committer) Review applies to [914fde9a](https://git.openjdk.org/jdk/pull/26698/files/914fde9a4af8aa96857e1d6f956e7c4c9998b0ca)
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**) Review applies to [7b92b0a6](https://git.openjdk.org/jdk/pull/26698/files/7b92b0a6cb7e3eac4469b84ae9908324bd078b49)
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26698/head:pull/26698` \
`$ git checkout pull/26698`

Update a local copy of the PR: \
`$ git checkout pull/26698` \
`$ git pull https://git.openjdk.org/jdk.git pull/26698/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26698`

View PR using the GUI difftool: \
`$ git pr show -t 26698`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26698.diff">https://git.openjdk.org/jdk/pull/26698.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26698#issuecomment-3167936684)
</details>
