### PR TITLE
8365166: ARM32: missing os::fetch_bcp_from_context implementation

### DIFF
--- a/src/hotspot/os_cpu/linux_arm/os_linux_arm.cpp
+++ b/src/hotspot/os_cpu/linux_arm/os_linux_arm.cpp
@@ -213,7 +213,7 @@ intptr_t* os::fetch_bcp_from_context(const void* ucVoid) {
   const ucontext_t* uc = (const ucontext_t*)ucVoid;
   assert(os::Posix::ucontext_is_interpreter(uc), "invariant");
 #if (FP_REG_NUM == 11)
-  assert(Rbcp == R7,  "expected FP=R11, Rbcp=R7");
+  assert(Rbcp == R7, "expected FP=R11, Rbcp=R7");
   return (intptr_t*)uc->uc_mcontext.arm_r7;
 #else
   assert(Rbcp == R11, "expected FP=R7, Rbcp=R11");

--- a/src/hotspot/os_cpu/linux_arm/os_linux_arm.cpp
+++ b/src/hotspot/os_cpu/linux_arm/os_linux_arm.cpp
@@ -212,7 +212,13 @@ intptr_t* os::fetch_bcp_from_context(const void* ucVoid) {
   assert(ucVoid != nullptr, "invariant");
   const ucontext_t* uc = (const ucontext_t*)ucVoid;
   assert(os::Posix::ucontext_is_interpreter(uc), "invariant");
+#if (FP_REG_NUM == 11)
+  assert(Rbcp == R7,  "expected FP=R11, Rbcp=R7");
   return (intptr_t*)uc->uc_mcontext.arm_r7;
+#else
+  assert(Rbcp == R11, "expected FP=R7, Rbcp=R11");
+  return (intptr_t*)uc->uc_mcontext.arm_fp; // r11
+#endif
 }
 
 frame os::get_sender_for_C_frame(frame* fr) {

--- a/src/hotspot/os_cpu/linux_arm/os_linux_arm.cpp
+++ b/src/hotspot/os_cpu/linux_arm/os_linux_arm.cpp
@@ -209,8 +209,10 @@ frame os::fetch_compiled_frame_from_context(const void* ucVoid) {
 }
 
 intptr_t* os::fetch_bcp_from_context(const void* ucVoid) {
-  Unimplemented();
-  return nullptr;
+  assert(ucVoid != nullptr, "invariant");
+  const ucontext_t* uc = (const ucontext_t*)ucVoid;
+  assert(os::Posix::ucontext_is_interpreter(uc), "invariant");
+  return (intptr_t*)uc->uc_mcontext.arm_r7;
 }
 
 frame os::get_sender_for_C_frame(frame* fr) {


### PR DESCRIPTION
Since [JDK-8352251](https://bugs.openjdk.org/browse/JDK-8352251) (JEP 518: JFR Cooperative Sampling), jfrSampleRequest calls os::fetch_bcp_from_context(). On ARM32 port it is still Unimplemented(). It should read the corresponding field from uc_mcontext and return the BCP value.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8365166](https://bugs.openjdk.org/browse/JDK-8365166): ARM32: missing os::fetch_bcp_from_context implementation (**Bug** - P3)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26699/head:pull/26699` \
`$ git checkout pull/26699`

Update a local copy of the PR: \
`$ git checkout pull/26699` \
`$ git pull https://git.openjdk.org/jdk.git pull/26699/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26699`

View PR using the GUI difftool: \
`$ git pr show -t 26699`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26699.diff">https://git.openjdk.org/jdk/pull/26699.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26699#issuecomment-3180755531)
</details>
