### PR TITLE
8359955: Regressions ~7% in several J2DBench in 25-b26

### DIFF
--- a/src/java.desktop/macosx/classes/sun/font/CCharToGlyphMapper.java
+++ b/src/java.desktop/macosx/classes/sun/font/CCharToGlyphMapper.java
@@ -33,9 +33,10 @@ import static sun.font.FontUtilities.isIgnorableWhitespace;
 public final class CCharToGlyphMapper extends CharToGlyphMapper {
     private static native int countGlyphs(final long nativeFontPtr);
 
-    private Cache cache = new Cache();
-    CFont fFont;
-    int numGlyphs = -1;
+    private final Cache rawCache = new Cache(true);
+    private final Cache modCache = new Cache(false);
+    private final CFont fFont;
+    private int numGlyphs = -1;
 
     public CCharToGlyphMapper(CFont font) {
         fFont = font;
@@ -101,13 +102,18 @@ public final class CCharToGlyphMapper extends CharToGlyphMapper {
     }
 
     private int charToGlyph(char unicode, boolean raw) {
-        int glyph = cache.get(unicode, raw);
+        Cache cache = raw ? rawCache : modCache;
+        int glyph = cache.get(unicode);
         if (glyph != 0) return glyph;
 
-        final char[] unicodeArray = new char[] { unicode };
-        final int[] glyphArray = new int[1];
-        nativeCharsToGlyphs(fFont.getNativeFontPtr(), 1, unicodeArray, glyphArray);
-        glyph = glyphArray[0];
+        if (isIgnorableWhitespace(unicode) || (isDefaultIgnorable(unicode) && !raw)) {
+            glyph = INVISIBLE_GLYPH_ID;
+        } else {
+            final char[] unicodeArray = new char[]{unicode};
+            final int[] glyphArray = new int[1];
+            nativeCharsToGlyphs(fFont.getNativeFontPtr(), 1, unicodeArray, glyphArray);
+            glyph = glyphArray[0];
+        }
 
         cache.put(unicode, glyph);
 
@@ -131,7 +137,8 @@ public final class CCharToGlyphMapper extends CharToGlyphMapper {
             int base = unicode - 0x10000;
             surrogates[0] = (char)((base >>> 10) + HI_SURROGATE_START);
             surrogates[1] = (char)((base % 0x400) + LO_SURROGATE_START);
-            cache.get(2, surrogates, glyphs, raw);
+            Cache cache = raw ? rawCache : modCache;
+            cache.get(2, surrogates, glyphs);
             return glyphs[0];
          } else {
              return charToGlyph((char) unicode, raw);
@@ -140,7 +147,7 @@ public final class CCharToGlyphMapper extends CharToGlyphMapper {
 
     @Override
     public synchronized void charsToGlyphs(int count, char[] unicodes, int[] glyphs) {
-        cache.get(count, unicodes, glyphs, false);
+        modCache.get(count, unicodes, glyphs);
     }
 
     @Override
@@ -164,20 +171,18 @@ public final class CCharToGlyphMapper extends CharToGlyphMapper {
         private static final int FIRST_LAYER_SIZE = 256;
         private static final int SECOND_LAYER_SIZE = 16384; // 16384 = 128x128
 
+        private final boolean raw;
         private final int[] firstLayerCache = new int[FIRST_LAYER_SIZE];
         private SparseBitShiftingTwoLayerArray secondLayerCache;
         private HashMap<Integer, Integer> generalCache;
 
-        Cache() {
+        Cache(boolean raw) {
+            this.raw = raw;
             // <rdar://problem/5331678> need to prevent getting '-1' stuck in the cache
             firstLayerCache[1] = 1;
         }
 
-        public synchronized int get(final int index, final boolean raw) {
-            if (isIgnorableWhitespace(index) || (isDefaultIgnorable(index) && !raw)) {
-                return INVISIBLE_GLYPH_ID;
-            }
-
+        public synchronized int get(final int index) {
             if (index < FIRST_LAYER_SIZE) {
                 // catch common glyphcodes
                 return firstLayerCache[index];
@@ -248,7 +253,7 @@ public final class CCharToGlyphMapper extends CharToGlyphMapper {
             }
         }
 
-        public synchronized void get(int count, char[] indices, int[] values, boolean raw)
+        public synchronized void get(int count, char[] indices, int[] values)
         {
             // "missed" is the count of 'char' that are not mapped.
             // Surrogates count for 2.
@@ -270,13 +275,16 @@ public final class CCharToGlyphMapper extends CharToGlyphMapper {
                     }
                 }
 
-                final int value = get(code, raw);
+                final int value = get(code);
                 if (value != 0 && value != -1) {
                     values[i] = value;
                     if (code >= 0x10000) {
                         values[i+1] = INVISIBLE_GLYPH_ID;
                         i++;
                     }
+                } else if (isIgnorableWhitespace(code) || (isDefaultIgnorable(code) && !raw)) {
+                    values[i] = INVISIBLE_GLYPH_ID;
+                    put(code, INVISIBLE_GLYPH_ID);
                 } else {
                     values[i] = 0;
                     put(code, -1);


### PR DESCRIPTION
Addresses recent slight performance regressions in some J2DBench benchmarks focused on text drawing.

`CCharToGlyphMapper` and `CompositeGlyphMapper` cache glyph IDs, but after JDK-8353230 they weren't caching glyph IDs for chars which might be affected by the raw / non-raw glyph distinction, since the cached value may not be correct if we ask for a raw glyph ID one time, but a non-raw glyph ID the next time (or vice versa). This caching exception was the reason for the slightly degraded performance (the `CCharToGlyphMapper` behavior was affecting macOS, and the `CompositeGlyphMapper` behavior was affecting some versions of Windows). This change splits the cache in each of these two classes into two caches, one for raw glyph IDs and one for non-raw glyph IDs, so that all glyphs can benefit from caching.

All of the fonts test (`make test TEST="jtreg:test/jdk/java/awt/font"`) pass for me locally with this change on Linux, macOS and Windows.