### PR TITLE
8364768: JDK javax.imageio ImageWriters do not all flush the output stream

### DIFF
--- a/src/java.desktop/share/classes/com/sun/imageio/plugins/gif/GIFImageWriter.java
+++ b/src/java.desktop/share/classes/com/sun/imageio/plugins/gif/GIFImageWriter.java
@@ -734,6 +734,7 @@ public class GIFImageWriter extends ImageWriter {
         if (writeTrailer) {
             writeTrailer();
         }
+        stream.flush();
     }
 
     /**

--- a/src/java.desktop/share/classes/com/sun/imageio/plugins/tiff/TIFFImageWriter.java
+++ b/src/java.desktop/share/classes/com/sun/imageio/plugins/tiff/TIFFImageWriter.java
@@ -2327,6 +2327,7 @@ public class TIFFImageWriter extends ImageWriter {
         if (abortRequested()) {
             resetPositions();
         }
+        stream.flush();
     }
 
     private void writeHeader() throws IOException {

--- a/test/jdk/javax/imageio/FlushTest.java
+++ b/test/jdk/javax/imageio/FlushTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2005, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8364768
+ * @summary Tests that the standard plugins flush the stream after writing a complete image.
+ */
+
+import static java.awt.Color.WHITE;
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+import java.io.ByteArrayOutputStream;
+import javax.imageio.ImageIO;
+import javax.imageio.ImageWriter;
+import javax.imageio.stream.FileCacheImageOutputStream;
+
+public class FlushTest {
+
+    static final int SZ = 1000;
+    static BufferedImage bi;
+    static final String[] FORMATS = { "jpg", "png", "gif", "tiff", "bmp", "wbmp" } ;
+    static boolean failed = false;
+
+    public static void main(String[] args) throws IOException {
+
+        bi = new BufferedImage(SZ, SZ, BufferedImage.TYPE_BYTE_BINARY);
+        Graphics2D g2d = bi.createGraphics();
+        g2d.setPaint(WHITE);
+        g2d.fillRect(0, 0, SZ, SZ);
+
+        for (String f : FORMATS) {
+            testWrite(f);
+        }
+        if (failed) {
+           throw new RuntimeException("Stream sizes differ.");
+        }
+    }
+
+    static void testWrite(String fmt) throws IOException {
+        ImageWriter iw = ImageIO.getImageWritersBySuffix(fmt).next();
+        System.out.println(iw);
+        try {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            FileCacheImageOutputStream fcs = new FileCacheImageOutputStream(baos, null);
+            iw.setOutput(fcs);
+            iw.write(bi);
+            int sz0 = baos.size();
+            fcs.close();
+            int sz1 = baos.size();
+            System.out.println("fmt=" + fmt + " sizes=" + sz0 + ", " + sz1);
+            if (sz0 != sz1) {
+               failed = true;
+            }
+        } finally {
+        }
+    }
+}

--- a/test/jdk/javax/imageio/FlushTest.java
+++ b/test/jdk/javax/imageio/FlushTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -61,19 +61,16 @@ public class FlushTest {
     static void testWrite(String fmt) throws IOException {
         ImageWriter iw = ImageIO.getImageWritersBySuffix(fmt).next();
         System.out.println(iw);
-        try {
-            ByteArrayOutputStream baos = new ByteArrayOutputStream();
-            FileCacheImageOutputStream fcs = new FileCacheImageOutputStream(baos, null);
-            iw.setOutput(fcs);
-            iw.write(bi);
-            int sz0 = baos.size();
-            fcs.close();
-            int sz1 = baos.size();
-            System.out.println("fmt=" + fmt + " sizes=" + sz0 + ", " + sz1);
-            if (sz0 != sz1) {
-               failed = true;
-            }
-        } finally {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        FileCacheImageOutputStream fcs = new FileCacheImageOutputStream(baos, null);
+        iw.setOutput(fcs);
+        iw.write(bi);
+        int sz0 = baos.size();
+        fcs.close();
+        int sz1 = baos.size();
+        System.out.println("fmt=" + fmt + " sizes=" + sz0 + ", " + sz1);
+        if (sz0 != sz1) {
+           failed = true;
         }
     }
 }


### PR DESCRIPTION
4 of the 6 JDK ImageWriters flush the stream at the end of writing. 2 (TIFF and GIF) do not. 

This will matter if you are using a caching ImageOutputStream.

This fix makes it consistent.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8364768](https://bugs.openjdk.org/browse/JDK-8364768): JDK javax.imageio ImageWriters do not all flush the output stream (**Bug** - P4)


### Reviewers
 * [Prasanta Sadhukhan](https://openjdk.org/census#psadhukhan) (@prsadhuk - **Reviewer**)
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26703/head:pull/26703` \
`$ git checkout pull/26703`

Update a local copy of the PR: \
`$ git checkout pull/26703` \
`$ git pull https://git.openjdk.org/jdk.git pull/26703/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26703`

View PR using the GUI difftool: \
`$ git pr show -t 26703`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26703.diff">https://git.openjdk.org/jdk/pull/26703.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26703#issuecomment-3168831030)
</details>
