### PR TITLE
8364781: Re-examine DigitList digits resizing during parsing

### DIFF
--- a/src/java.base/share/classes/java/text/DigitList.java
+++ b/src/java.base/share/classes/java/text/DigitList.java
@@ -42,6 +42,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.math.RoundingMode;
 import jdk.internal.math.FloatingDecimal;
+import jdk.internal.util.ArraysSupport;
 
 /**
  * Digit List. Private to DecimalFormat.
@@ -153,8 +154,7 @@ final class DigitList implements Cloneable {
      */
     public void append(char digit) {
         if (count == digits.length) {
-            char[] data = new char[count > Integer.MAX_VALUE / 2 ?
-                    Integer.MAX_VALUE : count * 2];
+            char[] data = new char[ArraysSupport.newLength(count, 1, count)];
             System.arraycopy(digits, 0, data, 0, count);
             digits = data;
         }


### PR DESCRIPTION
This PR changes the DigitList resizing from adding increments of 100 to a doubling resizing approach. This helps with performance of larger String values during `DecimalFormat` parsing. See the comment on the associated JBS issue for further detail.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8364781](https://bugs.openjdk.org/browse/JDK-8364781): Re-examine DigitList digits resizing during parsing (**Bug** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26705/head:pull/26705` \
`$ git checkout pull/26705`

Update a local copy of the PR: \
`$ git checkout pull/26705` \
`$ git pull https://git.openjdk.org/jdk.git pull/26705/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26705`

View PR using the GUI difftool: \
`$ git pr show -t 26705`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26705.diff">https://git.openjdk.org/jdk/pull/26705.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26705#issuecomment-3169255660)
</details>
