### PR TITLE
8365180: Remove sun.awt.windows.WInputMethod.finalize()

### DIFF
--- a/src/java.desktop/windows/classes/sun/awt/windows/WInputMethod.java
+++ b/src/java.desktop/windows/classes/sun/awt/windows/WInputMethod.java
@@ -44,6 +44,8 @@ import java.util.Map;
 import sun.awt.AWTAccessor;
 import sun.awt.AWTAccessor.ComponentAccessor;
 import sun.awt.im.InputMethodAdapter;
+import sun.java2d.Disposer;
+import sun.java2d.DisposerRecord;
 
 final class WInputMethod extends InputMethodAdapter
 {
@@ -124,6 +126,8 @@ final class WInputMethod extends InputMethodAdapter
     public WInputMethod()
     {
         context = createNativeContext();
+        disposerRecord = new ContextDisposerRecord(context);
+        Disposer.addRecord(this, disposerRecord);
         cmode = getConversionStatus(context);
         open = getOpenStatus(context);
         currentLocale = getNativeLocale();
@@ -132,16 +136,23 @@ final class WInputMethod extends InputMethodAdapter
         }
     }
 
-    @Override
-    @SuppressWarnings("removal")
-    protected void finalize() throws Throwable
-    {
-        // Release the resources used by the native input context.
-        if (context!=0) {
-            destroyNativeContext(context);
-            context=0;
+    private final ContextDisposerRecord disposerRecord;
+
+    private static final class ContextDisposerRecord implements DisposerRecord {
+
+        private final int context;
+        private volatile boolean disposed;
+
+        ContextDisposerRecord(int c) {
+            context = c;
         }
-        super.finalize();
+
+        public synchronized void dispose() {
+            if (!disposed) {
+                destroyNativeContext(context);
+            }
+            disposed = true;
+        }
     }
 
     @Override
@@ -151,9 +162,7 @@ final class WInputMethod extends InputMethodAdapter
 
     @Override
     public void dispose() {
-        // Due to a memory management problem in Windows 98, we should retain
-        // the native input context until this object is finalized. So do
-        // nothing here.
+        disposerRecord.dispose();
     }
 
     /**
@@ -658,8 +667,8 @@ final class WInputMethod extends InputMethodAdapter
 
     }
 
-    private native int createNativeContext();
-    private native void destroyNativeContext(int context);
+    private static native int createNativeContext();
+    private static native void destroyNativeContext(int context);
     private native void enableNativeIME(WComponentPeer peer, int context, boolean useNativeCompWindow);
     private native void disableNativeIME(WComponentPeer peer);
     private native void handleNativeIMEEvent(WComponentPeer peer, AWTEvent e);

--- a/src/java.desktop/windows/classes/sun/awt/windows/WInputMethod.java
+++ b/src/java.desktop/windows/classes/sun/awt/windows/WInputMethod.java
@@ -457,6 +457,7 @@ final class WInputMethod extends InputMethodAdapter
     @Override
     public void removeNotify() {
         endCompositionNative(context, DISCARD_INPUT);
+        disableNativeIME(awtFocussedComponentPeer);
         awtFocussedComponent = null;
         awtFocussedComponentPeer = null;
     }

--- a/src/java.desktop/windows/native/libawt/windows/awt_InputMethod.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_InputMethod.cpp
@@ -52,7 +52,7 @@ extern BOOL g_bUserHasChangedInputLang;
  * Signature: ()I
  */
 JNIEXPORT jint JNICALL
-Java_sun_awt_windows_WInputMethod_createNativeContext(JNIEnv *env, jobject self)
+Java_sun_awt_windows_WInputMethod_createNativeContext(JNIEnv *env, jclass cls)
 {
     TRY;
 
@@ -69,7 +69,7 @@ Java_sun_awt_windows_WInputMethod_createNativeContext(JNIEnv *env, jobject self)
  * Signature: (I)V
  */
 JNIEXPORT void JNICALL
-Java_sun_awt_windows_WInputMethod_destroyNativeContext(JNIEnv *env, jobject self, jint context)
+Java_sun_awt_windows_WInputMethod_destroyNativeContext(JNIEnv *env, jclass cls, jint context)
 {
     TRY_NO_VERIFY;
 


### PR DESCRIPTION
Remove finalize() from WInputMethod.java - it is used to free a native id.
Also the reason dispose() didn't free it seems no longer relevant.
Although I did see (when instrumenting) that dispose() was called when I disposed() the Frame referencing the IM,
I don't know if I can be sure that is always done. So safest to add the Disposer in case it isn't.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8365180](https://bugs.openjdk.org/browse/JDK-8365180): Remove sun.awt.windows.WInputMethod.finalize() (**Bug** - P4)


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26706/head:pull/26706` \
`$ git checkout pull/26706`

Update a local copy of the PR: \
`$ git checkout pull/26706` \
`$ git pull https://git.openjdk.org/jdk.git pull/26706/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26706`

View PR using the GUI difftool: \
`$ git pr show -t 26706`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26706.diff">https://git.openjdk.org/jdk/pull/26706.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26706#issuecomment-3169385151)
</details>
