### PR TITLE
8364761: (aio) AsynchronousChannelGroup.execute doesn't check null command

### DIFF
--- a/src/java.base/share/classes/sun/nio/ch/AsynchronousChannelGroupImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/AsynchronousChannelGroupImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,7 @@ import java.nio.channels.AsynchronousChannelGroup;
 import java.nio.channels.spi.AsynchronousChannelProvider;
 import java.io.IOException;
 import java.io.FileDescriptor;
+import java.util.Objects;
 import java.util.Queue;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -299,6 +300,7 @@ abstract class AsynchronousChannelGroupImpl
      */
     @Override
     public final void execute(Runnable task) {
+        Objects.requireNonNull(task, "task");
         executeOnPooledThread(task);
     }
 }

--- a/test/jdk/java/nio/channels/AsynchronousChannelGroup/AsExecutor.java
+++ b/test/jdk/java/nio/channels/AsynchronousChannelGroup/AsExecutor.java
@@ -25,60 +25,73 @@
  * @test
  * @bug 4607272 8364761
  * @summary tests tasks can be submitted to a channel group's thread pool.
- * @run main AsExecutor
+ * @run junit AsExecutor
  */
 
+import java.io.IOException;
 import java.nio.channels.AsynchronousChannelGroup;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class AsExecutor {
+    private static ThreadFactory factory;
 
-    public static void main(String[] args) throws Exception {
-        // create channel groups
-        ThreadFactory factory = Executors.defaultThreadFactory();
-        AsynchronousChannelGroup group1 = AsynchronousChannelGroup
-            .withFixedThreadPool(5, factory);
-        AsynchronousChannelGroup group2 = AsynchronousChannelGroup
-            .withCachedThreadPool(Executors.newCachedThreadPool(factory), 0);
-        AsynchronousChannelGroup group3 = AsynchronousChannelGroup
-            .withThreadPool(Executors.newFixedThreadPool(10, factory));
+    @BeforeAll
+    public static void createThreadFactory() {
+         factory = Executors.defaultThreadFactory();
+    }
 
+    private static Stream<Arguments> channelGroups() throws IOException {
+        List<Arguments> list = new ArrayList<Arguments>();
+        list.add(Arguments.of(AsynchronousChannelGroup
+            .withFixedThreadPool(5, factory)));
+        list.add(Arguments.of(AsynchronousChannelGroup
+            .withCachedThreadPool(Executors.newCachedThreadPool(factory), 0)));
+        list.add(Arguments.of(AsynchronousChannelGroup
+            .withThreadPool(Executors.newFixedThreadPool(10, factory))));
+        return list.stream();
+    }
+
+    @ParameterizedTest
+    @MethodSource("channelGroups")
+    public void simpleTask(AsynchronousChannelGroup group)
+        throws InterruptedException
+    {
         try {
-            // execute simple tasks
-            testSimpleTask(group1);
-            testSimpleTask(group2);
-            testSimpleTask(group3);
-
-            // check null tasks with all groups
-            Executor[] executors = new Executor[] {
-                (Executor)group1, (Executor)group2, (Executor)group3
-            };
-            for (Executor executor : executors) {
-                try {
-                    executor.execute(null);
-                    throw new RuntimeException("No NullPointerException");
-                } catch (NullPointerException npe) {
-                    System.out.println("Expected NullPointerException " + npe);
-                }
-            }
+            Executor executor = (Executor)group;
+            final CountDownLatch latch = new CountDownLatch(1);
+            executor.execute(new Runnable() {
+                    public void run() {
+                        latch.countDown();
+                    }
+                });
+            latch.await();
         } finally {
-            group1.shutdown();
-            group2.shutdown();
-            group3.shutdown();
+            group.shutdown();
         }
     }
 
-    static void testSimpleTask(AsynchronousChannelGroup group) throws Exception {
+    @ParameterizedTest
+    @MethodSource("channelGroups")
+    public void nullTask(AsynchronousChannelGroup group) {
         Executor executor = (Executor)group;
-        final CountDownLatch latch = new CountDownLatch(1);
-        executor.execute(new Runnable() {
-            public void run() {
-                latch.countDown();
-            }
-        });
-        latch.await();
+        try {
+            assertThrows(NullPointerException.class,
+                         () -> executor.execute(null));
+        } finally {
+            group.shutdown();
+        }
     }
 }

--- a/test/jdk/java/nio/channels/AsynchronousChannelGroup/AsExecutor.java
+++ b/test/jdk/java/nio/channels/AsynchronousChannelGroup/AsExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 4607272
+ * @bug 4607272 8364761
  * @summary tests tasks can be submitted to a channel group's thread pool.
  * @run main AsExecutor
  */
@@ -51,6 +51,19 @@ public class AsExecutor {
             testSimpleTask(group1);
             testSimpleTask(group2);
             testSimpleTask(group3);
+
+            // check null tasks with all groups
+            Executor[] executors = new Executor[] {
+                (Executor)group1, (Executor)group2, (Executor)group3
+            };
+            for (Executor executor : executors) {
+                try {
+                    executor.execute(null);
+                    throw new RuntimeException("No NullPointerException");
+                } catch (NullPointerException npe) {
+                    System.out.println("Expected NullPointerException " + npe);
+                }
+            }
         } finally {
             group1.shutdown();
             group2.shutdown();


### PR DESCRIPTION
Add `null` check to `AsynchronousChannelGroupImpl.execute`; update existing test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8364761](https://bugs.openjdk.org/browse/JDK-8364761): (aio) AsynchronousChannelGroup.execute doesn't check null command (**Bug** - P3)


### Reviewers
 * [Volkan Yazici](https://openjdk.org/census#vyazici) (@vy - Committer) Review applies to [5f1ddc6b](https://git.openjdk.org/jdk/pull/26709/files/5f1ddc6ba6099e9230ab95ecb39ff0a7388aada7)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26709/head:pull/26709` \
`$ git checkout pull/26709`

Update a local copy of the PR: \
`$ git checkout pull/26709` \
`$ git pull https://git.openjdk.org/jdk.git pull/26709/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26709`

View PR using the GUI difftool: \
`$ git pr show -t 26709`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26709.diff">https://git.openjdk.org/jdk/pull/26709.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26709#issuecomment-3169560003)
</details>
