### PR TITLE
4197755: Arc2D.getBounds() returns an unnecessarily large bounding box

### DIFF
--- a/src/java.desktop/share/classes/java/awt/geom/Arc2D.java
+++ b/src/java.desktop/share/classes/java/awt/geom/Arc2D.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/share/classes/java/awt/geom/Arc2D.java
+++ b/src/java.desktop/share/classes/java/awt/geom/Arc2D.java
@@ -1053,19 +1053,7 @@ public abstract class Arc2D extends RectangularShape {
     }
 
     /**
-     * Returns the high-precision framing rectangle of the arc.  The framing
-     * rectangle contains only the part of this {@code Arc2D} that is
-     * in between the starting and ending angles and contains the pie
-     * wedge, if this {@code Arc2D} has a {@code PIE} closure type.
-     * <p>
-     * This method differs from the
-     * {@link RectangularShape#getBounds() getBounds} in that the
-     * {@code getBounds} method only returns the bounds of the
-     * enclosing ellipse of this {@code Arc2D} without considering
-     * the starting and ending angles of this {@code Arc2D}.
-     *
-     * @return the {@code Rectangle2D} that represents the arc's
-     * framing rectangle.
+     * {@inheritDoc}
      * @since 1.2
      */
     public Rectangle2D getBounds2D() {
@@ -1111,6 +1099,10 @@ public abstract class Arc2D extends RectangularShape {
         return makeBounds(x1, y1, x2, y2);
     }
 
+    /**
+     * {@inheritDoc}
+     * @since 1.2
+     */
     @Override
     public Rectangle getBounds() {
         return getBounds2D().getBounds();

--- a/src/java.desktop/share/classes/java/awt/geom/Arc2D.java
+++ b/src/java.desktop/share/classes/java/awt/geom/Arc2D.java
@@ -25,6 +25,7 @@
 
 package java.awt.geom;
 
+import java.awt.Rectangle;
 import java.io.IOException;
 import java.io.Serial;
 import java.io.Serializable;
@@ -1108,6 +1109,11 @@ public abstract class Arc2D extends RectangularShape {
         x1 = getX() + (x1 * 0.5 + 0.5) * w;
         y1 = getY() + (y1 * 0.5 + 0.5) * h;
         return makeBounds(x1, y1, x2, y2);
+    }
+
+    @Override
+    public Rectangle getBounds() {
+        return getBounds2D().getBounds();
     }
 
     /**

--- a/test/jdk/java/awt/geom/Arc2D/Arc2DGetBoundsTest.java
+++ b/test/jdk/java/awt/geom/Arc2D/Arc2DGetBoundsTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4197755
+ * @summary Verifies that Arc2D.getBounds() is similar to Arc2D.getBounds2D()
+ */
+
+import java.awt.geom.Arc2D;
+import java.awt.geom.Point2D;
+import java.util.ArrayList;
+import java.util.List;
+
+public class Arc2DGetBoundsTest {
+    public static void main(String[] args) {
+        // Imagine a circle that represents a compass.
+        // This arc represents the northern / top quarter.
+        Arc2D arc = new Arc2D.Double(0, 0, 1000, 1000, 45, 90, Arc2D.PIE);
+
+        // Create 8 pie slices, and place a dot in the center of each
+        List<Point2D> samples = new ArrayList<>();
+        for (int segment = 0; segment < 8; segment++) {
+            double theta = -(segment + .5) / 8.0 * 2 * Math.PI;
+            Point2D p = new Point2D.Double(
+                    500 + 100 * Math.cos(theta),
+                    500 + 100 * Math.sin(theta)
+            );
+            samples.add(p);
+        }
+
+        // these assertions have never been known to fail:
+        assertTrue(!arc.contains(samples.get(0)));
+        assertTrue(arc.contains(samples.get(1)));
+        assertTrue(arc.contains(samples.get(2)));
+        assertTrue(!arc.contains(samples.get(3)));
+        assertTrue(!arc.contains(samples.get(4)));
+        assertTrue(!arc.contains(samples.get(5)));
+        assertTrue(!arc.contains(samples.get(6)));
+        assertTrue(!arc.contains(samples.get(7)));
+
+        assertTrue(arc.getBounds2D().contains(samples.get(0)));
+        assertTrue(arc.getBounds2D().contains(samples.get(1)));
+        assertTrue(arc.getBounds2D().contains(samples.get(2)));
+        assertTrue(arc.getBounds2D().contains(samples.get(3)));
+        assertTrue(!arc.getBounds2D().contains(samples.get(4)));
+        assertTrue(!arc.getBounds2D().contains(samples.get(5)));
+        assertTrue(!arc.getBounds2D().contains(samples.get(6)));
+        assertTrue(!arc.getBounds2D().contains(samples.get(7)));
+
+
+        assertTrue(arc.getBounds().contains(samples.get(0)));
+        assertTrue(arc.getBounds().contains(samples.get(1)));
+        assertTrue(arc.getBounds().contains(samples.get(2)));
+        assertTrue(arc.getBounds().contains(samples.get(3)));
+
+        // these are the assertions that failed before resolving 4197755
+        assertTrue(!arc.getBounds().contains(samples.get(4)));
+        assertTrue(!arc.getBounds().contains(samples.get(5)));
+        assertTrue(!arc.getBounds().contains(samples.get(6)));
+        assertTrue(!arc.getBounds().contains(samples.get(7)));
+    }
+
+    private static void assertTrue(boolean b) {
+        if (!b)
+            throw new Error();
+    }
+}


### PR DESCRIPTION
4197755 is marked as a duplicate of [JDK-8176501](https://bugs.openjdk.org/browse/JDK-8176501) , but I think that is a mistake. The complaint in that ticket still reproduces, and it is resolved in this PR.

The complaint is: Arc2D.getBounds() is too large. If an Arc2D represents a small slice of an ellipse, then Arc2D.getBounds() always returns the size of the total ellipse. Arc2D.getBounds2D(), by contrast, has been "high-precision" for decades.

This PR makes Arc2D.getBounds() resemble the same implementation already used in Area, CubicCurve2D, Line2D, Path2D, and QuadCurve2D:
```
    public Rectangle getBounds() {
        return getBounds2D().getBounds();
    }
```

This modifies (simplifies) the javadoc for Arc2D.getBounds2D(). If we generally like this PR I assume we'll need a CSR to approve the javadoc change.
