### PR TITLE
8365200: RISC-V: compiler/loopopts/superword/TestGeneralizedReductions.java fails with Zvbb and vlen=128

### DIFF
--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestGeneralizedReductions.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestGeneralizedReductions.java
@@ -160,13 +160,13 @@ public class TestGeneralizedReductions {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"avx2", "true"},
-        applyIfAnd = {"SuperWordReductions", "true","UsePopCountInstruction", "true"},
+        applyIfAnd = {"SuperWordReductions", "true", "UsePopCountInstruction", "true"},
         applyIfPlatform = {"64-bit", "true"},
         counts = {IRNode.ADD_REDUCTION_VI, ">= 1",
                   IRNode.POPCOUNT_VL, ">= 1"})
     @IR(applyIfPlatform = {"riscv64", "true"},
         applyIfCPUFeatureOr = {"zvbb", "true"},
-        applyIfAnd = {"SuperWordReductions", "true","UsePopCountInstruction", "true", "MaxVectorSize", ">=32"},
+        applyIfAnd = {"SuperWordReductions", "true", "UsePopCountInstruction", "true", "MaxVectorSize", ">=32"},
         counts = {IRNode.ADD_REDUCTION_VI, ">= 1",
                   IRNode.POPCOUNT_VL, ">= 1"})
     private static long testMapReductionOnGlobalAccumulator(long[] array) {


### PR DESCRIPTION
Hi all,
Please take a look and review this PR, thanks!

[JDK-8352529](https://bugs.openjdk.org/browse/JDK-8352529) enables this IR verification test for riscv. This test pass with zvbb when vlen=256, but fail when vlen=128.

The reason for the error is the same as [JDK-8357694](https://bugs.openjdk.org/browse/JDK-8357694). 2-element reductions for INT/LONG are not profitable, so the compiler won't generate the corresponding reductions IR.

This issue was not addressed together with [JDK-8357694](https://bugs.openjdk.org/browse/JDK-8357694) because the testMapReductionOnGlobalAccumulator case where the error is reported has a different applyif method from other cases: zvbb needs to be enabled.

### Test (fastdebug)
- [x] Run compiler/loopopts/superword/TestGeneralizedReductions.java on qemu-system w/ and w/o zvbb when vlen=256
- [x] Run compiler/loopopts/superword/TestGeneralizedReductions.java on qemu-system w/ and w/o zvbb when vlen=128

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8365200](https://bugs.openjdk.org/browse/JDK-8365200): RISC-V: compiler/loopopts/superword/TestGeneralizedReductions.java fails with Zvbb and vlen=128 (**Bug** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Feilong Jiang](https://openjdk.org/census#fjiang) (@feilongjiang - Committer) Review applies to [cdae1d05](https://git.openjdk.org/jdk/pull/26719/files/cdae1d056a3d8e7a5a0e0425d54bcf48959c6284)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26719/head:pull/26719` \
`$ git checkout pull/26719`

Update a local copy of the PR: \
`$ git checkout pull/26719` \
`$ git pull https://git.openjdk.org/jdk.git pull/26719/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26719`

View PR using the GUI difftool: \
`$ git pr show -t 26719`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26719.diff">https://git.openjdk.org/jdk/pull/26719.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26719#issuecomment-3173112684)
</details>
