### PR TITLE
8364806: Test sun/security/krb5/config/IncludeRandom.java times out on Windows

### DIFF
--- a/test/jdk/sun/security/krb5/config/IncludeRandom.java
+++ b/test/jdk/sun/security/krb5/config/IncludeRandom.java
@@ -53,7 +53,7 @@ public class IncludeRandom {
 
     public static void main(String[] args) throws Exception {
         System.setProperty("java.security.krb5.conf", "f");
-        for (var i = 0; i < 10_000; i++) {
+        for (var i = 0; i < 1000; i++) {
             test();
         }
     }


### PR DESCRIPTION
Here's a draft PR for the time out bug on Windows.  I haven't verified the fix, but will test late this week.