### PR TITLE
8365238: 'jfr' feature requires 'services' with 'custom' build variant

### DIFF
--- a/make/autoconf/jvm-features.m4
+++ b/make/autoconf/jvm-features.m4
@@ -513,6 +513,10 @@ AC_DEFUN([JVM_FEATURES_VERIFY],
 [
   variant=$1
 
+  if JVM_FEATURES_IS_ACTIVE(jfr) && ! JVM_FEATURES_IS_ACTIVE(services); then
+    AC_MSG_ERROR([Specified JVM feature 'jfr' requires feature 'services' for variant '$variant'])
+  fi
+
   if JVM_FEATURES_IS_ACTIVE(jvmci) && ! (JVM_FEATURES_IS_ACTIVE(compiler1) || \
       JVM_FEATURES_IS_ACTIVE(compiler2)); then
     AC_MSG_ERROR([Specified JVM feature 'jvmci' requires feature 'compiler2' or 'compiler1' for variant '$variant'])


### PR DESCRIPTION
In this PR I add an `autoconfigure` check to make sure that `jfr` is not built without the feature `services`, which would lead to the following error:
```
/jdk/src/hotspot/share/jfr/periodic/jfrPeriodic.cpp: In member function ‘virtual void VM_GC_SendObjectCountEvent::doit()’:
/jdk/src/hotspot/share/jfr/periodic/jfrPeriodic.cpp:402:5: error: ‘ObjectCountEventSender’ has not been declared
  402 |     ObjectCountEventSender::enable_requestable_event();
      |     ^~~~~~~~~~~~~~~~~~~~~~
/jdk/src/hotspot/share/jfr/periodic/jfrPeriodic.cpp:404:5: error: ‘ObjectCountEventSender’ has not been declared
  404 |     ObjectCountEventSender::disable_requestable_event();
      |     ^~~~~~~~~~~~~~~~~~~~~~
```

To reproduce:
```
sh configure --with-jvm-variants=custom --with-conf-name=cstm --enable-jvm-feature-jfr --enable-jvm-feature-serialgc
make -j hotspot CONF_NAME=cstm
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8365238](https://bugs.openjdk.org/browse/JDK-8365238): 'jfr' feature requires 'services' with 'custom' build variant (**Enhancement** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26723/head:pull/26723` \
`$ git checkout pull/26723`

Update a local copy of the PR: \
`$ git checkout pull/26723` \
`$ git pull https://git.openjdk.org/jdk.git pull/26723/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26723`

View PR using the GUI difftool: \
`$ git pr show -t 26723`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26723.diff">https://git.openjdk.org/jdk/pull/26723.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26723#issuecomment-3174245124)
</details>
