### PR TITLE
8365240: [asan] exclude some tests when using asan enabled binaries

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/Allocate/alloc001/alloc001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/Allocate/alloc001/alloc001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,6 +43,8 @@
  *
  * @comment Not run on AIX as it does not support ulimit -v
  * @requires os.family != "aix"
+ * @comment Do not run with asan enabled because asan has issues with ulimit
+ * @requires !vm.asan
  * @run main/native nsk.jvmti.Allocate.alloc001.alloc001
  */
 

--- a/test/jdk/tools/launcher/TooSmallStackSize.java
+++ b/test/jdk/tools/launcher/TooSmallStackSize.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,8 @@
  * @bug 6762191 8222334
  * @summary Setting stack size to 16K causes segmentation fault
  * @compile TooSmallStackSize.java
+ * @comment VM fails to launch with minimum allowed stack size of 136k when asan is enabled
+ * @requires !vm.asan
  * @run main TooSmallStackSize
  */
 


### PR DESCRIPTION
When using asan - enabled binaries, the following tests fail (on Linux x86_64).
This one uses ulimit in a way problematic with asan :
vmTestbase/nsk/jvmti/Allocate/alloc001/alloc001.java

 ```
stdout: [];
 stderr: [==19509==ERROR: AddressSanitizer failed to allocate 0xdfff0001000 (15392894357504) bytes at address 2008fff7000 (errno: 12)
==19509==ReserveShadowMemoryRange failed while trying to map 0xdfff0001000 bytes. Perhaps you're using ulimit -v

 exitValue = 134
```

This one seems to have rather strict memory requirements , and fails for some minimum allowed stack size settings
tools/launcher/TooSmallStackSize.java
```
PASSED: got expected error message with stack size of 16k
PASSED: got expected error message with stack size of 64k
Test output:
*** exitValue = 139
FAILED: VM failed to launch with minimum allowed stack size of 136k
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8365240](https://bugs.openjdk.org/browse/JDK-8365240): [asan] exclude some tests when using asan enabled binaries (**Bug** - P4)


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26725/head:pull/26725` \
`$ git checkout pull/26725`

Update a local copy of the PR: \
`$ git checkout pull/26725` \
`$ git pull https://git.openjdk.org/jdk.git pull/26725/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26725`

View PR using the GUI difftool: \
`$ git pr show -t 26725`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26725.diff">https://git.openjdk.org/jdk/pull/26725.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26725#issuecomment-3174462696)
</details>
