### PR TITLE
8365245: Move size reducing operations to GrowableArrayWithAllocator

### DIFF
--- a/src/hotspot/share/utilities/growableArray.hpp
+++ b/src/hotspot/share/utilities/growableArray.hpp
@@ -269,22 +269,6 @@ public:
     _len--;
   }
 
-  // Remove all elements up to the index (exclusive). The order is preserved.
-  void remove_till(int idx) {
-    remove_range(0, idx);
-  }
-
-  // Remove all elements in the range [start - end). The order is preserved.
-  void remove_range(int start, int end) {
-    assert(0 <= start, "illegal start index %d", start);
-    assert(start < end && end <= _len, "erase called with invalid range (%d, %d) for length %d", start, end, _len);
-
-    for (int i = start, j = end; j < length(); i++, j++) {
-      at_put(i, at(j));
-    }
-    this->_len -= (end - start);
-  }
-
   void sort(int f(E*, E*)) {
     if (_data == nullptr) return;
     qsort(_data, length(), sizeof(E), (_sort_Fn)f);
@@ -502,6 +486,24 @@ public:
   void trunc_to(int length) {
     assert(length <= this->_len,"cannot increase length");
     this->_len = length;
+  }
+
+  // Remove all elements up to the index (exclusive). The order is preserved.
+  void remove_till(int idx) {
+    remove_range(0, idx);
+  }
+
+  // Remove all elements in the range [start - end). The order is preserved.
+  void remove_range(int start, int end) {
+    assert(0 <= start, "illegal start index %d", start);
+    assert(start < end && end <= this->_len,
+           "erase called with invalid range (%d, %d) for length %d",
+           start, end, this->_len);
+
+    for (int i = start, j = end; j < this->length(); i++, j++) {
+      this->at_put(i, this->at(j));
+    }
+    this->_len -= (end - start);
   }
 
   // Replaces the designated element with the last element and shrinks by 1.

--- a/src/hotspot/share/utilities/growableArray.hpp
+++ b/src/hotspot/share/utilities/growableArray.hpp
@@ -285,15 +285,6 @@ public:
     this->_len -= (end - start);
   }
 
-  // The order is changed.
-  void delete_at(int index) {
-    assert(0 <= index && index < _len, "illegal index %d for length %d", index, _len);
-    if (index < --_len) {
-      // Replace removed element with last one.
-      _data[index] = _data[_len];
-    }
-  }
-
   void sort(int f(E*, E*)) {
     if (_data == nullptr) return;
     qsort(_data, length(), sizeof(E), (_sort_Fn)f);
@@ -511,6 +502,15 @@ public:
   void trunc_to(int length) {
     assert(length <= this->_len,"cannot increase length");
     this->_len = length;
+  }
+
+  // Replaces the designated element with the last element and shrinks by 1.
+  void delete_at(int index) {
+    assert(0 <= index && index < this->_len, "illegal index %d for length %d", index, this->_len);
+    if (index < --this->_len) {
+      // Replace removed element with last one.
+      this->_data[index] = this->_data[this->_len];
+    }
   }
 
   // Reduce capacity to length.

--- a/src/hotspot/share/utilities/growableArray.hpp
+++ b/src/hotspot/share/utilities/growableArray.hpp
@@ -241,16 +241,6 @@ public:
     return -1;
   }
 
-  // Order preserving remove operations.
-
-  void remove_at(int index) {
-    assert(0 <= index && index < _len, "illegal index %d for length %d", index, _len);
-    for (int j = index + 1; j < _len; j++) {
-      _data[j-1] = _data[j];
-    }
-    _len--;
-  }
-
   void sort(int f(E*, E*)) {
     if (_data == nullptr) return;
     qsort(_data, length(), sizeof(E), (_sort_Fn)f);
@@ -468,6 +458,17 @@ public:
   void trunc_to(int length) {
     assert(length <= this->_len,"cannot increase length");
     this->_len = length;
+  }
+
+  // Order preserving remove operations.
+
+  void remove_at(int index) {
+    assert(0 <= index && index < this->_len,
+           "illegal index %d for length %d", index, this->_len);
+    for (int j = index + 1; j < this->_len; j++) {
+      this->_data[j-1] = this->_data[j];
+    }
+    this->_len--;
   }
 
   void remove(const E& elem) {

--- a/src/hotspot/share/utilities/growableArray.hpp
+++ b/src/hotspot/share/utilities/growableArray.hpp
@@ -183,11 +183,6 @@ public:
     return GrowableArrayIterator<E>(this, length());
   }
 
-  E pop() {
-    assert(_len > 0, "empty list");
-    return _data[--_len];
-  }
-
   void at_put(int i, const E& elem) {
     assert(0 <= i && i < _len, "illegal index %d for length %d", i, _len);
     _data[i] = elem;
@@ -367,6 +362,11 @@ public:
   }
 
   void push(const E& elem) { append(elem); }
+
+  E pop() {
+    assert(this->_len > 0, "empty list");
+    return this->_data[--this->_len];
+  }
 
   E& at_grow(int i, const E& fill = E()) {
     assert(0 <= i, "negative index %d", i);

--- a/src/hotspot/share/utilities/growableArray.hpp
+++ b/src/hotspot/share/utilities/growableArray.hpp
@@ -243,13 +243,6 @@ public:
 
   // Order preserving remove operations.
 
-  void remove(const E& elem) {
-    // Assuming that element does exist.
-    bool removed = remove_if_existing(elem);
-    if (removed) return;
-    ShouldNotReachHere();
-  }
-
   bool remove_if_existing(const E& elem) {
     // Returns TRUE if elem is removed.
     for (int i = 0; i < _len; i++) {
@@ -486,6 +479,13 @@ public:
   void trunc_to(int length) {
     assert(length <= this->_len,"cannot increase length");
     this->_len = length;
+  }
+
+  void remove(const E& elem) {
+    // Assuming that element does exist.
+    bool removed = this->remove_if_existing(elem);
+    if (removed) return;
+    ShouldNotReachHere();
   }
 
   // Remove all elements up to the index (exclusive). The order is preserved.

--- a/src/hotspot/share/utilities/growableArray.hpp
+++ b/src/hotspot/share/utilities/growableArray.hpp
@@ -243,17 +243,6 @@ public:
 
   // Order preserving remove operations.
 
-  bool remove_if_existing(const E& elem) {
-    // Returns TRUE if elem is removed.
-    for (int i = 0; i < _len; i++) {
-      if (_data[i] == elem) {
-        remove_at(i);
-        return true;
-      }
-    }
-    return false;
-  }
-
   void remove_at(int index) {
     assert(0 <= index && index < _len, "illegal index %d for length %d", index, _len);
     for (int j = index + 1; j < _len; j++) {
@@ -486,6 +475,17 @@ public:
     bool removed = this->remove_if_existing(elem);
     if (removed) return;
     ShouldNotReachHere();
+  }
+
+  bool remove_if_existing(const E& elem) {
+    // Returns TRUE if elem is removed.
+    for (int i = 0; i < this->_len; i++) {
+      if (this->_data[i] == elem) {
+        this->remove_at(i);
+        return true;
+      }
+    }
+    return false;
   }
 
   // Remove all elements up to the index (exclusive). The order is preserved.

--- a/src/hotspot/share/utilities/growableArray.hpp
+++ b/src/hotspot/share/utilities/growableArray.hpp
@@ -93,11 +93,6 @@ public:
   bool  is_empty() const        { return _len == 0; }
   bool  is_nonempty() const     { return _len != 0; }
   bool  is_full() const         { return _len == _capacity; }
-
-  void  trunc_to(int length)    {
-    assert(length <= _len,"cannot increase length");
-    _len = length;
-  }
 };
 
 template <typename E> class GrowableArrayIterator;
@@ -287,7 +282,7 @@ public:
     for (int i = start, j = end; j < length(); i++, j++) {
       at_put(i, at(j));
     }
-    trunc_to(length() - (end - start));
+    this->_len -= (end - start);
   }
 
   // The order is changed.
@@ -512,6 +507,11 @@ public:
 
   // Ensure capacity is at least new_capacity.
   void reserve(int new_capacity);
+
+  void trunc_to(int length) {
+    assert(length <= this->_len,"cannot increase length");
+    this->_len = length;
+  }
 
   // Reduce capacity to length.
   void shrink_to_fit();

--- a/src/hotspot/share/utilities/growableArray.hpp
+++ b/src/hotspot/share/utilities/growableArray.hpp
@@ -94,7 +94,6 @@ public:
   bool  is_nonempty() const     { return _len != 0; }
   bool  is_full() const         { return _len == _capacity; }
 
-  void  clear()                 { _len = 0; }
   void  trunc_to(int length)    {
     assert(length <= _len,"cannot increase length");
     _len = length;
@@ -517,6 +516,7 @@ public:
   // Reduce capacity to length.
   void shrink_to_fit();
 
+  void clear() { this->_len = 0; }
   void clear_and_deallocate();
 };
 

--- a/test/hotspot/gtest/gc/z/test_zArray.cpp
+++ b/test/hotspot/gtest/gc/z/test_zArray.cpp
@@ -127,9 +127,11 @@ TEST_F(ZArrayTest, slice) {
 
       const auto check_reversed = [](ZArraySlice<const int> original, ZArraySlice<int> reversed) {
         ASSERT_EQ(original.length(), reversed.length());
+        int ri = reversed.length();
         for (int e : original) {
-          ASSERT_EQ(e, reversed.pop());
+          ASSERT_EQ(e, reversed.at(--ri));
         }
+        ASSERT_EQ(ri, 0);
       };
 
       ZArraySlice<int> a_reversed = reverse(a, reverse);


### PR DESCRIPTION
Please review this change to GrowableArray to move size reducing operations
from GrowableArrayBase and GrowableArrayView to GrowableArrayWithAllocator.
See JBS for rationale for this move.

This is mostly just a simple code motion change, with the moved functions
being updated to account for different name lookup rules now that they are in
a class with a class template base class. For the most part this refactoring
didn't require any client code changes. All but one use of one moved function
was with a GrowableArrayWithAllocator-derived class, so not affected by moving
the functions. The one exception was a test of ZArraySlice that was modified
to no longer use GA::pop().

Testing: mach5 tier1.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8365245](https://bugs.openjdk.org/browse/JDK-8365245): Move size reducing operations to GrowableArrayWithAllocator (**Enhancement** - P4)


### Reviewers
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@jdksjolen - **Reviewer**)
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26726/head:pull/26726` \
`$ git checkout pull/26726`

Update a local copy of the PR: \
`$ git checkout pull/26726` \
`$ git pull https://git.openjdk.org/jdk.git pull/26726/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26726`

View PR using the GUI difftool: \
`$ git pr show -t 26726`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26726.diff">https://git.openjdk.org/jdk/pull/26726.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26726#issuecomment-3174785508)
</details>
