### PR TITLE
8364993 JFR: Disable jdk.ModuleExport in default.jfc

### DIFF
--- a/src/jdk.jfr/share/conf/jfr/default.jfc
+++ b/src/jdk.jfr/share/conf/jfr/default.jfc
@@ -762,7 +762,7 @@
     </event>
 
     <event name="jdk.ModuleExport">
-      <setting name="enabled">true</setting>
+      <setting name="enabled">false</setting>
       <setting name="period">endChunk</setting>
     </event>
 


### PR DESCRIPTION
Could I have a review of a change that disables the ModuleExport event in default.jfc? It can use a significant amount of space in some applications, and the event is not that useful. See the bug for details.

Testing: jdk/jdk/jfr

Thanks
Erik