### PR TITLE
8365264

### DIFF
--- a/src/hotspot/share/asm/codeBuffer.hpp
+++ b/src/hotspot/share/asm/codeBuffer.hpp
@@ -541,7 +541,7 @@ class CodeBuffer: public StackObj DEBUG_ONLY(COMMA private Scrubber) {
   };
 
   typedef LinkedListImpl<int> Offsets;
-  typedef ResizeableResourceHashtable<address, Offsets, AnyObj::C_HEAP, mtCompiler> SharedTrampolineRequests;
+  typedef ResizeableHashTable<address, Offsets, AnyObj::C_HEAP, mtCompiler> SharedTrampolineRequests;
 
  private:
   enum {

--- a/src/hotspot/share/cds/aotArtifactFinder.cpp
+++ b/src/hotspot/share/cds/aotArtifactFinder.cpp
@@ -37,7 +37,7 @@
 #include "oops/instanceKlass.hpp"
 #include "oops/objArrayKlass.hpp"
 #include "oops/trainingData.hpp"
-#include "utilities/resourceHash.hpp"
+#include "utilities/hashtable.hpp"
 
 // All the classes that should be included in the AOT cache (in at least the "allocated" state)
 static GrowableArrayCHeap<Klass*, mtClassShared>* _all_cached_classes = nullptr;

--- a/src/hotspot/share/cds/aotArtifactFinder.cpp
+++ b/src/hotspot/share/cds/aotArtifactFinder.cpp
@@ -47,7 +47,7 @@ static GrowableArrayCHeap<Klass*, mtClassShared>* _all_cached_classes = nullptr;
 static GrowableArrayCHeap<InstanceKlass*, mtClassShared>* _pending_aot_inited_classes = nullptr;
 
 static const int TABLE_SIZE = 15889; // prime number
-using ClassesTable = ResourceHashtable<Klass*, bool, TABLE_SIZE, AnyObj::C_HEAP, mtClassShared>;
+using ClassesTable = HashTable<Klass*, bool, TABLE_SIZE, AnyObj::C_HEAP, mtClassShared>;
 static ClassesTable* _seen_classes;       // all classes that have been seen by AOTArtifactFinder
 static ClassesTable* _aot_inited_classes; // all classes that need to be AOT-initialized.
 

--- a/src/hotspot/share/cds/aotClassLinker.hpp
+++ b/src/hotspot/share/cds/aotClassLinker.hpp
@@ -69,7 +69,7 @@ enum class AOTLinkedClassCategory : int;
 //
 class AOTClassLinker :  AllStatic {
   static const int TABLE_SIZE = 15889; // prime number
-  using ClassesTable = ResourceHashtable<InstanceKlass*, bool, TABLE_SIZE, AnyObj::C_HEAP, mtClassShared>;
+  using ClassesTable = HashTable<InstanceKlass*, bool, TABLE_SIZE, AnyObj::C_HEAP, mtClassShared>;
 
   // Classes loaded inside vmClasses::resolve_all()
   static ClassesTable* _vm_classes;

--- a/src/hotspot/share/cds/aotClassLinker.hpp
+++ b/src/hotspot/share/cds/aotClassLinker.hpp
@@ -32,7 +32,7 @@
 #include "utilities/exceptions.hpp"
 #include "utilities/growableArray.hpp"
 #include "utilities/macros.hpp"
-#include "utilities/resourceHash.hpp"
+#include "utilities/hashtable.hpp"
 
 class AOTLinkedClassTable;
 class InstanceKlass;

--- a/src/hotspot/share/cds/aotConstantPoolResolver.hpp
+++ b/src/hotspot/share/cds/aotConstantPoolResolver.hpp
@@ -53,7 +53,7 @@ template <typename T> class GrowableArray;
 // if all of its supertypes are loaded from the CDS archive.
 class AOTConstantPoolResolver :  AllStatic {
   static const int TABLE_SIZE = 15889; // prime number
-  using ClassesTable = ResourceHashtable<InstanceKlass*, bool, TABLE_SIZE, AnyObj::C_HEAP, mtClassShared> ;
+  using ClassesTable = HashTable<InstanceKlass*, bool, TABLE_SIZE, AnyObj::C_HEAP, mtClassShared> ;
   static ClassesTable* _processed_classes;
 
 #ifdef ASSERT

--- a/src/hotspot/share/cds/aotConstantPoolResolver.hpp
+++ b/src/hotspot/share/cds/aotConstantPoolResolver.hpp
@@ -32,7 +32,7 @@
 #include "runtime/handles.hpp"
 #include "utilities/exceptions.hpp"
 #include "utilities/macros.hpp"
-#include "utilities/resourceHash.hpp"
+#include "utilities/hashtable.hpp"
 
 class ConstantPool;
 class constantPoolHandle;

--- a/src/hotspot/share/cds/aotReferenceObjSupport.cpp
+++ b/src/hotspot/share/cds/aotReferenceObjSupport.cpp
@@ -92,7 +92,7 @@
 
 #if INCLUDE_CDS_JAVA_HEAP
 
-class KeepAliveObjectsTable : public ResourceHashtable<oop, bool,
+class KeepAliveObjectsTable : public HashTable<oop, bool,
     36137, // prime number
     AnyObj::C_HEAP,
     mtClassShared,

--- a/src/hotspot/share/cds/aotReferenceObjSupport.cpp
+++ b/src/hotspot/share/cds/aotReferenceObjSupport.cpp
@@ -35,7 +35,7 @@
 #include "oops/oopHandle.inline.hpp"
 #include "runtime/fieldDescriptor.inline.hpp"
 #include "runtime/javaCalls.hpp"
-#include "utilities/resourceHash.hpp"
+#include "utilities/hashtable.hpp"
 
 // Handling of java.lang.ref.Reference objects in the AOT cache
 // ============================================================

--- a/src/hotspot/share/cds/archiveBuilder.hpp
+++ b/src/hotspot/share/cds/archiveBuilder.hpp
@@ -37,7 +37,7 @@
 #include "utilities/bitMap.hpp"
 #include "utilities/growableArray.hpp"
 #include "utilities/resizeableResourceHash.hpp"
-#include "utilities/resourceHash.hpp"
+#include "utilities/hashtable.hpp"
 
 class ArchiveHeapInfo;
 class CHeapBitMap;

--- a/src/hotspot/share/cds/archiveBuilder.hpp
+++ b/src/hotspot/share/cds/archiveBuilder.hpp
@@ -229,8 +229,8 @@ private:
 
   SourceObjList _rw_src_objs;                 // objs to put in rw region
   SourceObjList _ro_src_objs;                 // objs to put in ro region
-  ResizeableResourceHashtable<address, SourceObjInfo, AnyObj::C_HEAP, mtClassShared> _src_obj_table;
-  ResizeableResourceHashtable<address, address, AnyObj::C_HEAP, mtClassShared> _buffered_to_src_table;
+  ResizeableHashTable<address, SourceObjInfo, AnyObj::C_HEAP, mtClassShared> _src_obj_table;
+  ResizeableHashTable<address, address, AnyObj::C_HEAP, mtClassShared> _buffered_to_src_table;
   GrowableArray<Klass*>* _klasses;
   GrowableArray<Symbol*>* _symbols;
   unsigned int _entropy_seed;

--- a/src/hotspot/share/cds/archiveHeapLoader.cpp
+++ b/src/hotspot/share/cds/archiveHeapLoader.cpp
@@ -348,10 +348,10 @@ bool ArchiveHeapLoader::load_heap_region(FileMapInfo* mapinfo) {
 }
 
 class VerifyLoadedHeapEmbeddedPointers: public BasicOopIterateClosure {
-  ResourceHashtable<uintptr_t, bool>* _table;
+  HashTable<uintptr_t, bool>* _table;
 
  public:
-  VerifyLoadedHeapEmbeddedPointers(ResourceHashtable<uintptr_t, bool>* table) : _table(table) {}
+  VerifyLoadedHeapEmbeddedPointers(HashTable<uintptr_t, bool>* table) : _table(table) {}
 
   virtual void do_oop(narrowOop* p) {
     // This should be called before the loaded region is modified, so all the embedded pointers
@@ -411,7 +411,7 @@ void ArchiveHeapLoader::verify_loaded_heap() {
   log_info(aot, heap)("Verify all oops and pointers in loaded heap");
 
   ResourceMark rm;
-  ResourceHashtable<uintptr_t, bool> table;
+  HashTable<uintptr_t, bool> table;
   VerifyLoadedHeapEmbeddedPointers verifier(&table);
   HeapWord* bottom = (HeapWord*)_loaded_heap_bottom;
   HeapWord* top    = (HeapWord*)_loaded_heap_top;

--- a/src/hotspot/share/cds/archiveHeapWriter.cpp
+++ b/src/hotspot/share/cds/archiveHeapWriter.cpp
@@ -70,7 +70,7 @@ ArchiveHeapWriter::BufferOffsetToSourceObjectTable*
   ArchiveHeapWriter::_buffer_offset_to_source_obj_table = nullptr;
 
 
-typedef ResourceHashtable<
+typedef HashTable<
       size_t,    // offset of a filler from ArchiveHeapWriter::buffer_bottom()
       size_t,    // size of this filler (in bytes)
       127,       // prime number

--- a/src/hotspot/share/cds/archiveHeapWriter.hpp
+++ b/src/hotspot/share/cds/archiveHeapWriter.hpp
@@ -152,7 +152,7 @@ private:
   };
   static GrowableArrayCHeap<HeapObjOrder, mtClassShared>* _source_objs_order;
 
-  typedef ResizeableResourceHashtable<size_t, oop,
+  typedef ResizeableHashTable<size_t, oop,
       AnyObj::C_HEAP,
       mtClassShared> BufferOffsetToSourceObjectTable;
   static BufferOffsetToSourceObjectTable* _buffer_offset_to_source_obj_table;

--- a/src/hotspot/share/cds/archiveHeapWriter.hpp
+++ b/src/hotspot/share/cds/archiveHeapWriter.hpp
@@ -33,7 +33,7 @@
 #include "utilities/exceptions.hpp"
 #include "utilities/growableArray.hpp"
 #include "utilities/macros.hpp"
-#include "utilities/resourceHash.hpp"
+#include "utilities/hashtable.hpp"
 
 class MemRegion;
 

--- a/src/hotspot/share/cds/cdsHeapVerifier.hpp
+++ b/src/hotspot/share/cds/cdsHeapVerifier.hpp
@@ -47,7 +47,7 @@ class CDSHeapVerifier : public KlassClosure {
     Symbol* _name;
   };
 
-  ResourceHashtable<oop, StaticFieldInfo,
+  HashTable<oop, StaticFieldInfo,
       15889, // prime number
       AnyObj::C_HEAP,
       mtClassShared,
@@ -79,7 +79,7 @@ public:
   // Overrides KlassClosure::do_klass()
   virtual void do_klass(Klass* k);
 
-  // For ResourceHashtable::iterate()
+  // For HashTable::iterate()
   inline bool do_entry(oop& orig_obj, HeapShared::CachedOopInfo& value);
 
   static void verify();

--- a/src/hotspot/share/cds/cdsHeapVerifier.hpp
+++ b/src/hotspot/share/cds/cdsHeapVerifier.hpp
@@ -28,7 +28,7 @@
 #include "cds/heapShared.hpp"
 #include "memory/iterator.hpp"
 #include "utilities/growableArray.hpp"
-#include "utilities/resourceHash.hpp"
+#include "utilities/hashtable.hpp"
 
 class InstanceKlass;
 class Symbol;

--- a/src/hotspot/share/cds/classListParser.hpp
+++ b/src/hotspot/share/cds/classListParser.hpp
@@ -77,7 +77,7 @@ public:
 
 private:
   // Must be C_HEAP allocated -- we don't want nested resource allocations.
-  typedef ResizeableResourceHashtable<int, InstanceKlass*,
+  typedef ResizeableHashTable<int, InstanceKlass*,
                                       AnyObj::C_HEAP, mtClassShared> ID2KlassTable;
 
   enum {

--- a/src/hotspot/share/cds/classListWriter.cpp
+++ b/src/hotspot/share/cds/classListWriter.cpp
@@ -66,7 +66,7 @@ void ClassListWriter::write(const InstanceKlass* k, const ClassFileStream* cfs) 
   write_to_stream(k, w.stream(), cfs);
 }
 
-class ClassListWriter::IDTable : public ResourceHashtable<
+class ClassListWriter::IDTable : public HashTable<
   const InstanceKlass*, int,
   15889, // prime number
   AnyObj::C_HEAP> {};

--- a/src/hotspot/share/cds/dumpTimeClassInfo.hpp
+++ b/src/hotspot/share/cds/dumpTimeClassInfo.hpp
@@ -240,7 +240,7 @@ inline unsigned DumpTimeSharedClassTable_hash(T* const& k) {
   }
 }
 
-using DumpTimeSharedClassTableBaseType = ResourceHashtable<
+using DumpTimeSharedClassTableBaseType = HashTable<
   InstanceKlass*,
   DumpTimeClassInfo,
   15889, // prime number

--- a/src/hotspot/share/cds/heapShared.cpp
+++ b/src/hotspot/share/cds/heapShared.cpp
@@ -367,7 +367,7 @@ bool HeapShared::archive_object(oop obj, oop referrer, KlassSubGraphInfo* subgra
   }
 }
 
-class MetaspaceObjToOopHandleTable: public ResourceHashtable<MetaspaceObj*, OopHandle,
+class MetaspaceObjToOopHandleTable: public HashTable<MetaspaceObj*, OopHandle,
     36137, // prime number
     AnyObj::C_HEAP,
     mtClassShared> {

--- a/src/hotspot/share/cds/heapShared.hpp
+++ b/src/hotspot/share/cds/heapShared.hpp
@@ -202,14 +202,14 @@ public:
 private:
   static const int INITIAL_TABLE_SIZE = 15889; // prime number
   static const int MAX_TABLE_SIZE     = 1000000;
-  typedef ResizeableResourceHashtable<oop, CachedOopInfo,
+  typedef ResizeableHashTable<oop, CachedOopInfo,
       AnyObj::C_HEAP,
       mtClassShared,
       HeapShared::oop_hash> ArchivedObjectCache;
   static ArchivedObjectCache* _archived_object_cache;
 
   class DumpTimeKlassSubGraphInfoTable
-    : public ResourceHashtable<Klass*, KlassSubGraphInfo,
+    : public HashTable<Klass*, KlassSubGraphInfo,
                                137, // prime number
                                AnyObj::C_HEAP,
                                mtClassShared,
@@ -264,7 +264,7 @@ private:
   // !UseCompressedOops only: used to relocate pointers to the archived objects
   static ptrdiff_t _runtime_delta;
 
-  typedef ResizeableResourceHashtable<oop, bool,
+  typedef ResizeableHashTable<oop, bool,
       AnyObj::C_HEAP,
       mtClassShared,
       HeapShared::oop_hash> SeenObjectsTable;
@@ -468,14 +468,14 @@ private:
 
 #if INCLUDE_CDS_JAVA_HEAP
 class DumpedInternedStrings :
-  public ResizeableResourceHashtable<oop, bool,
+  public ResizeableHashTable<oop, bool,
                            AnyObj::C_HEAP,
                            mtClassShared,
                            HeapShared::string_oop_hash>
 {
 public:
   DumpedInternedStrings(unsigned size, unsigned max_size) :
-    ResizeableResourceHashtable<oop, bool,
+    ResizeableHashTable<oop, bool,
                                 AnyObj::C_HEAP,
                                 mtClassShared,
                                 HeapShared::string_oop_hash>(size, max_size) {}

--- a/src/hotspot/share/cds/heapShared.hpp
+++ b/src/hotspot/share/cds/heapShared.hpp
@@ -37,7 +37,7 @@
 #include "oops/oopHandle.hpp"
 #include "oops/oopsHierarchy.hpp"
 #include "utilities/growableArray.hpp"
-#include "utilities/resourceHash.hpp"
+#include "utilities/hashtable.hpp"
 
 #if INCLUDE_CDS_JAVA_HEAP
 class DumpedInternedStrings;

--- a/src/hotspot/share/cds/lambdaProxyClassDictionary.hpp
+++ b/src/hotspot/share/cds/lambdaProxyClassDictionary.hpp
@@ -30,7 +30,7 @@
 #include "classfile/javaClasses.hpp"
 #include "memory/metaspaceClosure.hpp"
 #include "utilities/growableArray.hpp"
-#include "utilities/resourceHash.hpp"
+#include "utilities/hashtable.hpp"
 
 // This file contains *legacy* optimization for lambdas before JEP 483. May be removed in the future.
 //

--- a/src/hotspot/share/cds/lambdaProxyClassDictionary.hpp
+++ b/src/hotspot/share/cds/lambdaProxyClassDictionary.hpp
@@ -249,7 +249,7 @@ public:
 };
 
 class DumpTimeLambdaProxyClassDictionary
-  : public ResourceHashtable<LambdaProxyClassKey,
+  : public HashTable<LambdaProxyClassKey,
                              DumpTimeLambdaProxyClassInfo,
                              137, // prime number
                              AnyObj::C_HEAP,

--- a/src/hotspot/share/cds/metaspaceShared.cpp
+++ b/src/hotspot/share/cds/metaspaceShared.cpp
@@ -99,7 +99,7 @@
 #include "utilities/defaultStream.hpp"
 #include "utilities/macros.hpp"
 #include "utilities/ostream.hpp"
-#include "utilities/resourceHash.hpp"
+#include "utilities/hashtable.hpp"
 
 #include <sys/stat.h>
 

--- a/src/hotspot/share/cds/metaspaceShared.cpp
+++ b/src/hotspot/share/cds/metaspaceShared.cpp
@@ -178,7 +178,7 @@ class DumpClassListCLDClosure : public CLDClosure {
   static const int MAX_TABLE_SIZE = 61333;
 
   fileStream *_stream;
-  ResizeableResourceHashtable<InstanceKlass*, bool,
+  ResizeableHashTable<InstanceKlass*, bool,
                               AnyObj::C_HEAP, mtClassShared> _dumped_classes;
 
   void dump(InstanceKlass* ik) {

--- a/src/hotspot/share/cds/regeneratedClasses.cpp
+++ b/src/hotspot/share/cds/regeneratedClasses.cpp
@@ -34,7 +34,7 @@
 #include "utilities/growableArray.hpp"
 #include "utilities/resourceHash.hpp"
 
-using RegeneratedObjTable = ResourceHashtable<address, address, 15889, AnyObj::C_HEAP, mtClassShared>;
+using RegeneratedObjTable = HashTable<address, address, 15889, AnyObj::C_HEAP, mtClassShared>;
 static RegeneratedObjTable* _regenerated_objs = nullptr; // InstanceKlass* and Method*  orig_obj  -> regen_obj
 static RegeneratedObjTable* _original_objs = nullptr;    // InstanceKlass* and Method*  regen_obj -> orig_obj
 static GrowableArrayCHeap<OopHandle, mtClassShared>* _regenerated_mirrors = nullptr;

--- a/src/hotspot/share/cds/regeneratedClasses.cpp
+++ b/src/hotspot/share/cds/regeneratedClasses.cpp
@@ -32,7 +32,7 @@
 #include "runtime/mutexLocker.hpp"
 #include "runtime/thread.hpp"
 #include "utilities/growableArray.hpp"
-#include "utilities/resourceHash.hpp"
+#include "utilities/hashtable.hpp"
 
 using RegeneratedObjTable = HashTable<address, address, 15889, AnyObj::C_HEAP, mtClassShared>;
 static RegeneratedObjTable* _regenerated_objs = nullptr; // InstanceKlass* and Method*  orig_obj  -> regen_obj

--- a/src/hotspot/share/classfile/bytecodeAssembler.hpp
+++ b/src/hotspot/share/classfile/bytecodeAssembler.hpp
@@ -30,7 +30,7 @@
 #include "oops/symbol.hpp"
 #include "utilities/globalDefinitions.hpp"
 #include "utilities/growableArray.hpp"
-#include "utilities/resourceHash.hpp"
+#include "utilities/hashtable.hpp"
 
 
 /**

--- a/src/hotspot/share/classfile/bytecodeAssembler.hpp
+++ b/src/hotspot/share/classfile/bytecodeAssembler.hpp
@@ -125,7 +125,7 @@ class BytecodeCPEntry {
 
 class BytecodeConstantPool : public ResourceObj {
  private:
-  typedef ResourceHashtable<BytecodeCPEntry, u2,
+  typedef HashTable<BytecodeCPEntry, u2,
       256, AnyObj::RESOURCE_AREA, mtInternal,
       &BytecodeCPEntry::hash, &BytecodeCPEntry::equals> IndexHash;
 

--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -83,7 +83,7 @@
 #include "utilities/growableArray.hpp"
 #include "utilities/macros.hpp"
 #include "utilities/ostream.hpp"
-#include "utilities/resourceHash.hpp"
+#include "utilities/hashtable.hpp"
 #include "utilities/utf8.hpp"
 #if INCLUDE_CDS
 #include "classfile/systemDictionaryShared.hpp"

--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -782,7 +782,7 @@ class NameSigHash: public ResourceObj {
   }
 };
 
-using NameSigHashtable = ResourceHashtable<NameSigHash, int,
+using NameSigHashtable = HashTable<NameSigHash, int,
                                            NameSigHash::HASH_ROW_SIZE,
                                            AnyObj::RESOURCE_AREA, mtInternal,
                                            &NameSigHash::hash, &NameSigHash::equals>;
@@ -849,7 +849,7 @@ void ClassFileParser::parse_interfaces(const ClassFileStream* const stream,
     // Check if there's any duplicates in interfaces
     ResourceMark rm(THREAD);
     // Set containing interface names
-    ResourceHashtable<Symbol*, int>* interface_names = new ResourceHashtable<Symbol*, int>();
+    HashTable<Symbol*, int>* interface_names = new HashTable<Symbol*, int>();
     for (index = 0; index < itfs_len; index++) {
       const InstanceKlass* const k = _local_interfaces->at(index);
       Symbol* interface_name = k->name();
@@ -2022,7 +2022,7 @@ void ClassFileParser::copy_localvariable_table(const ConstMethod* cm,
 
   ResourceMark rm(THREAD);
 
-  typedef ResourceHashtable<LocalVariableTableElement, LocalVariableTableElement*,
+  typedef HashTable<LocalVariableTableElement, LocalVariableTableElement*,
                             256, AnyObj::RESOURCE_AREA, mtInternal,
                             &LVT_Hash::hash, &LVT_Hash::equals> LVT_HashTable;
 

--- a/src/hotspot/share/classfile/classLoaderStats.hpp
+++ b/src/hotspot/share/classfile/classLoaderStats.hpp
@@ -105,7 +105,7 @@ protected:
     return hash;
   }
 
-  typedef ResourceHashtable<oop, ClassLoaderStats,
+  typedef HashTable<oop, ClassLoaderStats,
                             256, AnyObj::C_HEAP, mtStatistics,
                             ClassLoaderStatsClosure::oop_hash> StatsTable;
 

--- a/src/hotspot/share/classfile/classLoaderStats.hpp
+++ b/src/hotspot/share/classfile/classLoaderStats.hpp
@@ -32,7 +32,7 @@
 #include "oops/oopsHierarchy.hpp"
 #include "runtime/vmOperation.hpp"
 #include "services/diagnosticCommand.hpp"
-#include "utilities/resourceHash.hpp"
+#include "utilities/hashtable.hpp"
 
 
 class ClassLoaderStatsDCmd : public DCmd {

--- a/src/hotspot/share/classfile/loaderConstraints.cpp
+++ b/src/hotspot/share/classfile/loaderConstraints.cpp
@@ -31,7 +31,7 @@
 #include "oops/klass.inline.hpp"
 #include "oops/symbolHandle.hpp"
 #include "runtime/mutexLocker.hpp"
-#include "utilities/resourceHash.hpp"
+#include "utilities/hashtable.hpp"
 
 // Overview
 //

--- a/src/hotspot/share/classfile/loaderConstraints.cpp
+++ b/src/hotspot/share/classfile/loaderConstraints.cpp
@@ -147,7 +147,7 @@ class ConstraintSet {                               // copied into hashtable as 
 };
 
 
-using InternalLoaderConstraintTable = ResourceHashtable<SymbolHandle, ConstraintSet, 107, AnyObj::C_HEAP, mtClass, SymbolHandle::compute_hash>;
+using InternalLoaderConstraintTable = HashTable<SymbolHandle, ConstraintSet, 107, AnyObj::C_HEAP, mtClass, SymbolHandle::compute_hash>;
 static InternalLoaderConstraintTable* _loader_constraint_table;
 
 void LoaderConstraint::extend_loader_constraint(Symbol* class_name,

--- a/src/hotspot/share/classfile/moduleEntry.cpp
+++ b/src/hotspot/share/classfile/moduleEntry.cpp
@@ -47,7 +47,7 @@
 #include "utilities/growableArray.hpp"
 #include "utilities/ostream.hpp"
 #include "utilities/quickSort.hpp"
-#include "utilities/resourceHash.hpp"
+#include "utilities/hashtable.hpp"
 
 ModuleEntry* ModuleEntryTable::_javabase_module = nullptr;
 

--- a/src/hotspot/share/classfile/moduleEntry.cpp
+++ b/src/hotspot/share/classfile/moduleEntry.cpp
@@ -403,7 +403,7 @@ void ModuleEntry::set_loader_data(ClassLoaderData* cld) {
 }
 
 #if INCLUDE_CDS_JAVA_HEAP
-typedef ResourceHashtable<
+typedef HashTable<
   const ModuleEntry*,
   ModuleEntry*,
   557, // prime number

--- a/src/hotspot/share/classfile/moduleEntry.hpp
+++ b/src/hotspot/share/classfile/moduleEntry.hpp
@@ -33,7 +33,7 @@
 #include "utilities/growableArray.hpp"
 #include "utilities/macros.hpp"
 #include "utilities/ostream.hpp"
-#include "utilities/resourceHash.hpp"
+#include "utilities/hashtable.hpp"
 #if INCLUDE_JFR
 #include "jfr/support/jfrTraceIdExtension.hpp"
 #endif

--- a/src/hotspot/share/classfile/moduleEntry.hpp
+++ b/src/hotspot/share/classfile/moduleEntry.hpp
@@ -233,7 +233,7 @@ class ModuleClosure: public StackObj {
 class ModuleEntryTable : public CHeapObj<mtModule> {
 private:
   static ModuleEntry* _javabase_module;
-  ResourceHashtable<SymbolHandle, ModuleEntry*, 109, AnyObj::C_HEAP, mtModule,
+  HashTable<SymbolHandle, ModuleEntry*, 109, AnyObj::C_HEAP, mtModule,
                     SymbolHandle::compute_hash> _table;
 
 public:

--- a/src/hotspot/share/classfile/packageEntry.cpp
+++ b/src/hotspot/share/classfile/packageEntry.cpp
@@ -40,7 +40,7 @@
 #include "utilities/growableArray.hpp"
 #include "utilities/ostream.hpp"
 #include "utilities/quickSort.hpp"
-#include "utilities/resourceHash.hpp"
+#include "utilities/hashtable.hpp"
 
 PackageEntry::PackageEntry(Symbol* name, ModuleEntry* module) :
   _name(name),

--- a/src/hotspot/share/classfile/packageEntry.cpp
+++ b/src/hotspot/share/classfile/packageEntry.cpp
@@ -212,7 +212,7 @@ PackageEntryTable::~PackageEntryTable() {
 }
 
 #if INCLUDE_CDS_JAVA_HEAP
-typedef ResourceHashtable<
+typedef HashTable<
   const PackageEntry*,
   PackageEntry*,
   557, // prime number

--- a/src/hotspot/share/classfile/packageEntry.hpp
+++ b/src/hotspot/share/classfile/packageEntry.hpp
@@ -32,7 +32,7 @@
 #include "utilities/growableArray.hpp"
 #include "utilities/macros.hpp"
 #include "utilities/ostream.hpp"
-#include "utilities/resourceHash.hpp"
+#include "utilities/hashtable.hpp"
 #if INCLUDE_JFR
 #include "jfr/support/jfrTraceIdExtension.hpp"
 #endif

--- a/src/hotspot/share/classfile/packageEntry.hpp
+++ b/src/hotspot/share/classfile/packageEntry.hpp
@@ -233,7 +233,7 @@ public:
 // The PackageEntryTable is a Hashtable containing a list of all packages defined
 // by a particular class loader.  Each package is represented as a PackageEntry node.
 class PackageEntryTable : public CHeapObj<mtModule> {
-  ResourceHashtable<SymbolHandle, PackageEntry*, 109, AnyObj::C_HEAP, mtModule,
+  HashTable<SymbolHandle, PackageEntry*, 109, AnyObj::C_HEAP, mtModule,
                     SymbolHandle::compute_hash> _table;
 public:
   PackageEntryTable();

--- a/src/hotspot/share/classfile/placeholders.cpp
+++ b/src/hotspot/share/classfile/placeholders.cpp
@@ -31,7 +31,7 @@
 #include "oops/symbolHandle.hpp"
 #include "runtime/javaThread.hpp"
 #include "runtime/mutexLocker.hpp"
-#include "utilities/resourceHash.hpp"
+#include "utilities/hashtable.hpp"
 
 class PlaceholderKey {
   SymbolHandle _name;

--- a/src/hotspot/share/classfile/placeholders.cpp
+++ b/src/hotspot/share/classfile/placeholders.cpp
@@ -49,7 +49,7 @@ class PlaceholderKey {
 };
 
 const int _placeholder_table_size = 503;   // Does this really have to be prime?
-using InternalPlaceholderTable = ResourceHashtable<PlaceholderKey, PlaceholderEntry, _placeholder_table_size, AnyObj::C_HEAP, mtClass,
+using InternalPlaceholderTable = HashTable<PlaceholderKey, PlaceholderEntry, _placeholder_table_size, AnyObj::C_HEAP, mtClass,
                   PlaceholderKey::hash, PlaceholderKey::equals>;
 static InternalPlaceholderTable* _placeholders;
 

--- a/src/hotspot/share/classfile/resolutionErrors.cpp
+++ b/src/hotspot/share/classfile/resolutionErrors.cpp
@@ -30,7 +30,7 @@
 #include "oops/symbol.hpp"
 #include "runtime/handles.inline.hpp"
 #include "runtime/mutexLocker.hpp"
-#include "utilities/resourceHash.hpp"
+#include "utilities/hashtable.hpp"
 
 class ResolutionErrorKey {
   ConstantPool* _cpool;

--- a/src/hotspot/share/classfile/resolutionErrors.cpp
+++ b/src/hotspot/share/classfile/resolutionErrors.cpp
@@ -53,7 +53,7 @@ class ResolutionErrorKey {
   }
 };
 
-using InternalResolutionErrorTable = ResourceHashtable<ResolutionErrorKey, ResolutionErrorEntry*, 107, AnyObj::C_HEAP, mtClass,
+using InternalResolutionErrorTable = HashTable<ResolutionErrorKey, ResolutionErrorEntry*, 107, AnyObj::C_HEAP, mtClass,
                   ResolutionErrorKey::hash,
                   ResolutionErrorKey::equals>;
 

--- a/src/hotspot/share/classfile/stringTable.cpp
+++ b/src/hotspot/share/classfile/stringTable.cpp
@@ -810,7 +810,7 @@ class StringTable::VerifyCompStrings : StackObj {
     return java_lang_String::equals(a, b);
   }
 
-  ResizeableResourceHashtable<oop, bool, AnyObj::C_HEAP, mtInternal,
+  ResizeableHashTable<oop, bool, AnyObj::C_HEAP, mtInternal,
                               string_hash, string_equals> _table;
  public:
   size_t _errors;

--- a/src/hotspot/share/classfile/systemDictionary.cpp
+++ b/src/hotspot/share/classfile/systemDictionary.cpp
@@ -111,10 +111,10 @@ class InvokeMethodKey : public StackObj {
 
 };
 
-using InvokeMethodIntrinsicTable = ResourceHashtable<InvokeMethodKey, Method*, 139, AnyObj::C_HEAP, mtClass,
+using InvokeMethodIntrinsicTable = HashTable<InvokeMethodKey, Method*, 139, AnyObj::C_HEAP, mtClass,
                   InvokeMethodKey::compute_hash, InvokeMethodKey::key_comparison>;
 static InvokeMethodIntrinsicTable* _invoke_method_intrinsic_table;
-using InvokeMethodTypeTable = ResourceHashtable<SymbolHandle, OopHandle, 139, AnyObj::C_HEAP, mtClass, SymbolHandle::compute_hash>;
+using InvokeMethodTypeTable = HashTable<SymbolHandle, OopHandle, 139, AnyObj::C_HEAP, mtClass, SymbolHandle::compute_hash>;
 static InvokeMethodTypeTable* _invoke_method_type_table;
 
 OopHandle   SystemDictionary::_java_system_loader;

--- a/src/hotspot/share/classfile/systemDictionaryShared.cpp
+++ b/src/hotspot/share/classfile/systemDictionaryShared.cpp
@@ -445,7 +445,7 @@ InstanceKlass* SystemDictionaryShared::find_or_load_shared_class(
   return k;
 }
 
-class UnregisteredClassesTable : public ResourceHashtable<
+class UnregisteredClassesTable : public HashTable<
   Symbol*, InstanceKlass*,
   15889, // prime number
   AnyObj::C_HEAP> {};

--- a/src/hotspot/share/classfile/systemDictionaryShared.cpp
+++ b/src/hotspot/share/classfile/systemDictionaryShared.cpp
@@ -74,7 +74,7 @@
 #include "runtime/java.hpp"
 #include "runtime/javaCalls.hpp"
 #include "runtime/mutexLocker.hpp"
-#include "utilities/resourceHash.hpp"
+#include "utilities/hashtable.hpp"
 #include "utilities/stringUtils.hpp"
 
 SystemDictionaryShared::ArchiveInfo SystemDictionaryShared::_static_archive;

--- a/src/hotspot/share/classfile/verifier.hpp
+++ b/src/hotspot/share/classfile/verifier.hpp
@@ -270,7 +270,7 @@ class sig_as_verification_types : public ResourceObj {
 
 // This hashtable is indexed by the Utf8 constant pool indexes pointed to
 // by constant pool (Interface)Method_refs' NameAndType signature entries.
-typedef ResourceHashtable<int, sig_as_verification_types*, 1007>
+typedef HashTable<int, sig_as_verification_types*, 1007>
                           method_signatures_table_type;
 
 // A new instance of this class is created for each class being verified

--- a/src/hotspot/share/classfile/verifier.hpp
+++ b/src/hotspot/share/classfile/verifier.hpp
@@ -31,7 +31,7 @@
 #include "runtime/handles.hpp"
 #include "utilities/exceptions.hpp"
 #include "utilities/growableArray.hpp"
-#include "utilities/resourceHash.hpp"
+#include "utilities/hashtable.hpp"
 
 // The verifier class
 class Verifier : AllStatic {

--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -1185,7 +1185,7 @@ static void check_live_nmethods_dependencies(DepChange& changes) {
   // Turn off dependency tracing while actually testing dependencies.
   FlagSetting fs(Dependencies::_verify_in_progress, true);
 
-  typedef ResourceHashtable<DependencySignature, int, 11027,
+  typedef HashTable<DependencySignature, int, 11027,
                             AnyObj::RESOURCE_AREA, mtInternal,
                             &DependencySignature::hash,
                             &DependencySignature::equals> DepTable;

--- a/src/hotspot/share/code/nmethod.cpp
+++ b/src/hotspot/share/code/nmethod.cpp
@@ -79,7 +79,7 @@
 #include "utilities/dtrace.hpp"
 #include "utilities/events.hpp"
 #include "utilities/globalDefinitions.hpp"
-#include "utilities/resourceHash.hpp"
+#include "utilities/hashtable.hpp"
 #include "utilities/xmlstream.hpp"
 #if INCLUDE_JVMCI
 #include "jvmci/jvmciRuntime.hpp"

--- a/src/hotspot/share/compiler/disassembler.cpp
+++ b/src/hotspot/share/compiler/disassembler.cpp
@@ -40,7 +40,7 @@
 #include "runtime/os.hpp"
 #include "runtime/stubCodeGenerator.hpp"
 #include "runtime/stubRoutines.hpp"
-#include "utilities/resourceHash.hpp"
+#include "utilities/hashtable.hpp"
 
 void*       Disassembler::_library               = nullptr;
 bool        Disassembler::_tried_to_load_library = false;

--- a/src/hotspot/share/compiler/disassembler.cpp
+++ b/src/hotspot/share/compiler/disassembler.cpp
@@ -189,7 +189,7 @@ class decode_env {
     }
   };
 
-  typedef ResourceHashtable<
+  typedef HashTable<
       address, SourceFileInfo,
       15889,      // prime number
       AnyObj::C_HEAP> SourceFileInfoTable;

--- a/src/hotspot/share/gc/z/zVerify.cpp
+++ b/src/hotspot/share/gc/z/zVerify.cpp
@@ -516,7 +516,7 @@ void ZVerify::after_weak_processing() {
 // Remembered set verification
 //
 
-typedef ResourceHashtable<volatile zpointer*, bool, 1009, AnyObj::C_HEAP, mtGC> ZStoreBarrierBufferTable;
+typedef HashTable<volatile zpointer*, bool, 1009, AnyObj::C_HEAP, mtGC> ZStoreBarrierBufferTable;
 
 static ZStoreBarrierBufferTable* z_verify_store_barrier_buffer_table = nullptr;
 

--- a/src/hotspot/share/gc/z/zVerify.cpp
+++ b/src/hotspot/share/gc/z/zVerify.cpp
@@ -52,7 +52,7 @@
 #include "utilities/debug.hpp"
 #include "utilities/globalDefinitions.hpp"
 #include "utilities/preserveException.hpp"
-#include "utilities/resourceHash.hpp"
+#include "utilities/hashtable.hpp"
 #include "utilities/vmError.hpp"
 
 #ifdef ASSERT

--- a/src/hotspot/share/jfr/support/methodtracer/jfrClassFilterClosure.hpp
+++ b/src/hotspot/share/jfr/support/methodtracer/jfrClassFilterClosure.hpp
@@ -40,7 +40,7 @@ template<typename T> class GrowableArray;
 template<typename K, typename V,
          AnyObj::allocation_type, MemTag,
          unsigned (*HASH)  (K const&),
-         bool (*EQUALS)(K const&, K const&)> class ResizeableResourceHashtable;
+         bool (*EQUALS)(K const&, K const&)> class ResizeableHashTable;
 
 // Knuth multiplicative hashing.
 inline uint32_t knuth_hash(const traceid& id) {
@@ -48,7 +48,7 @@ inline uint32_t knuth_hash(const traceid& id) {
   return v * UINT32_C(2654435761);
 }
 
-typedef ResizeableResourceHashtable<traceid, jclass,
+typedef ResizeableHashTable<traceid, jclass,
                                     AnyObj::RESOURCE_AREA,
                                     mtTracing,
                                     knuth_hash,

--- a/src/hotspot/share/jfr/utilities/jfrSet.hpp
+++ b/src/hotspot/share/jfr/utilities/jfrSet.hpp
@@ -60,7 +60,7 @@ template <typename CONFIG>
 class JfrSet : public CONFIG::STORAGE {
  public:
   typedef typename CONFIG::TYPE TYPE;
-  typedef ResizeableResourceHashtable<TYPE, TYPE, CONFIG::alloc_type(), CONFIG::memory_tag(), CONFIG::hash, CONFIG::cmp> HashMap;
+  typedef ResizeableHashTable<TYPE, TYPE, CONFIG::alloc_type(), CONFIG::memory_tag(), CONFIG::hash, CONFIG::cmp> HashMap;
 
   constexpr static bool is_cheap() {
     return CONFIG::alloc_type() == AnyObj::C_HEAP;

--- a/src/hotspot/share/jvmci/jvmciCompilerToVMInit.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVMInit.cpp
@@ -51,7 +51,7 @@
 #include "runtime/flags/jvmFlag.hpp"
 #include "runtime/sharedRuntime.hpp"
 #include "runtime/stubRoutines.hpp"
-#include "utilities/resourceHash.hpp"
+#include "utilities/hashtable.hpp"
 #if INCLUDE_SHENANDOAHGC
 #include "gc/shenandoah/shenandoahHeap.hpp"
 #include "gc/shenandoah/shenandoahHeapRegion.hpp"

--- a/src/hotspot/share/jvmci/jvmciCompilerToVMInit.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVMInit.cpp
@@ -437,8 +437,8 @@ JVMCIObjectArray CompilerToVM::initialize_intrinsics(JVMCI_TRAPS) {
 
 jobjectArray readConfiguration0(JNIEnv *env, JVMCI_TRAPS) {
   JavaThread* THREAD = JavaThread::current(); // For exception macros.
-  ResourceHashtable<jlong, JVMCIObject> longs;
-  ResourceHashtable<const char*, JVMCIObject,
+  HashTable<jlong, JVMCIObject> longs;
+  HashTable<const char*, JVMCIObject,
                     256, AnyObj::RESOURCE_AREA, mtInternal,
                     &CompilerToVM::cstring_hash, &CompilerToVM::cstring_equals> strings;
 

--- a/src/hotspot/share/logging/logAsyncWriter.hpp
+++ b/src/hotspot/share/logging/logAsyncWriter.hpp
@@ -32,7 +32,7 @@
 #include "runtime/os.inline.hpp"
 #include "runtime/nonJavaThread.hpp"
 #include "runtime/semaphore.hpp"
-#include "utilities/resourceHash.hpp"
+#include "utilities/hashtable.hpp"
 
 class LogFileStreamOutput;
 

--- a/src/hotspot/share/logging/logAsyncWriter.hpp
+++ b/src/hotspot/share/logging/logAsyncWriter.hpp
@@ -66,7 +66,7 @@ class AsyncLogWriter : public NonJavaThread {
 
   // account for dropped messages
   template <AnyObj::allocation_type ALLOC_TYPE>
-  using AsyncLogMap = ResourceHashtable<LogFileStreamOutput*,
+  using AsyncLogMap = HashTable<LogFileStreamOutput*,
                           uint32_t, 17, /*table_size*/
                           ALLOC_TYPE, mtLogging>;
 

--- a/src/hotspot/share/memory/metaspaceClosure.hpp
+++ b/src/hotspot/share/memory/metaspaceClosure.hpp
@@ -374,7 +374,7 @@ public:
   UniqueMetaspaceClosure() : _has_been_visited(INITIAL_TABLE_SIZE, MAX_TABLE_SIZE) {}
 
 private:
-  ResizeableResourceHashtable<address, bool, AnyObj::C_HEAP,
+  ResizeableHashTable<address, bool, AnyObj::C_HEAP,
                               mtClassShared> _has_been_visited;
 };
 

--- a/src/hotspot/share/nmt/nativeCallStackPrinter.hpp
+++ b/src/hotspot/share/nmt/nativeCallStackPrinter.hpp
@@ -41,7 +41,7 @@ class NativeCallStackPrinter {
   // Cache-related data are mutable to be able to use NativeCallStackPrinter as
   // inline member in classes with const printing methods.
   mutable Arena _text_storage;
-  mutable ResourceHashtable<address, const char*, 293, AnyObj::C_HEAP, mtNMT> _cache;
+  mutable HashTable<address, const char*, 293, AnyObj::C_HEAP, mtNMT> _cache;
   outputStream* const _out;
 public:
   NativeCallStackPrinter(outputStream* out);

--- a/src/hotspot/share/nmt/nativeCallStackPrinter.hpp
+++ b/src/hotspot/share/nmt/nativeCallStackPrinter.hpp
@@ -29,7 +29,7 @@
 #include "memory/arena.hpp"
 #include "nmt/memTag.hpp"
 #include "utilities/globalDefinitions.hpp"
-#include "utilities/resourceHash.hpp"
+#include "utilities/hashtable.hpp"
 
 class outputStream;
 class NativeCallStack;

--- a/src/hotspot/share/oops/constantPool.hpp
+++ b/src/hotspot/share/oops/constantPool.hpp
@@ -38,7 +38,7 @@
 #include "utilities/bytes.hpp"
 #include "utilities/constantTag.hpp"
 #include "utilities/macros.hpp"
-#include "utilities/resourceHash.hpp"
+#include "utilities/hashtable.hpp"
 
 // A ConstantPool is an array containing class constants as described in the
 // class file.

--- a/src/hotspot/share/oops/constantPool.hpp
+++ b/src/hotspot/share/oops/constantPool.hpp
@@ -872,7 +872,7 @@ private:
 
  private:
   class SymbolHash: public CHeapObj<mtSymbol> {
-    ResourceHashtable<const Symbol*, u2, 256, AnyObj::C_HEAP, mtSymbol, Symbol::compute_hash> _table;
+    HashTable<const Symbol*, u2, 256, AnyObj::C_HEAP, mtSymbol, Symbol::compute_hash> _table;
 
    public:
     void add_if_absent(const Symbol* sym, u2 value) {

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -1116,7 +1116,7 @@ void InstanceKlass::initialize_super_interfaces(TRAPS) {
   }
 }
 
-using InitializationErrorTable = ResourceHashtable<const InstanceKlass*, OopHandle, 107, AnyObj::C_HEAP, mtClass>;
+using InitializationErrorTable = HashTable<const InstanceKlass*, OopHandle, 107, AnyObj::C_HEAP, mtClass>;
 static InitializationErrorTable* _initialization_error_table;
 
 void InstanceKlass::add_initialization_error(JavaThread* current, Handle exception) {

--- a/src/hotspot/share/oops/trainingData.hpp
+++ b/src/hotspot/share/oops/trainingData.hpp
@@ -173,7 +173,7 @@ public:
   // A set of TD objects that we collect during the training run.
   class TrainingDataSet {
     friend TrainingData;
-    ResizeableResourceHashtable<const Key*, TrainingData*,
+    ResizeableHashTable<const Key*, TrainingData*,
                                 AnyObj::C_HEAP, MemTag::mtCompiler,
                                 &TrainingData::Key::hash,
                                 &TrainingData::Key::equals>
@@ -229,7 +229,7 @@ public:
   // A widget to ensure that we visit TD object only once (TD objects can have pointer to
   // other TD object that are sometimes circular).
   class Visitor {
-    ResizeableResourceHashtable<TrainingData*, bool> _visited;
+    ResizeableHashTable<TrainingData*, bool> _visited;
   public:
     Visitor(unsigned size) : _visited(size, 0x3fffffff) { }
     bool is_visited(TrainingData* td) {

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -2787,7 +2787,7 @@ uint Compile::eval_macro_logic_op(uint func, uint in1 , uint in2, uint in3) {
   return res;
 }
 
-static uint eval_operand(Node* n, ResourceHashtable<Node*,uint>& eval_map) {
+static uint eval_operand(Node* n, HashTable<Node*,uint>& eval_map) {
   assert(n != nullptr, "");
   assert(eval_map.contains(n), "absent");
   return *(eval_map.get(n));
@@ -2795,7 +2795,7 @@ static uint eval_operand(Node* n, ResourceHashtable<Node*,uint>& eval_map) {
 
 static void eval_operands(Node* n,
                           uint& func1, uint& func2, uint& func3,
-                          ResourceHashtable<Node*,uint>& eval_map) {
+                          HashTable<Node*,uint>& eval_map) {
   assert(is_vector_bitwise_op(n), "");
 
   if (is_vector_unary_bitwise_op(n)) {
@@ -2819,7 +2819,7 @@ uint Compile::compute_truth_table(Unique_Node_List& partition, Unique_Node_List&
   assert(inputs.size() <= 3, "sanity");
   ResourceMark rm;
   uint res = 0;
-  ResourceHashtable<Node*,uint> eval_map;
+  HashTable<Node*,uint> eval_map;
 
   // Populate precomputed functions for inputs.
   // Each input corresponds to one column of 3 input truth-table.

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -88,7 +88,7 @@
 #include "utilities/align.hpp"
 #include "utilities/copy.hpp"
 #include "utilities/macros.hpp"
-#include "utilities/resourceHash.hpp"
+#include "utilities/hashtable.hpp"
 
 // -------------------- Compile::mach_constant_base_node -----------------------
 // Constant table base node singleton.

--- a/src/hotspot/share/opto/loopnode.hpp
+++ b/src/hotspot/share/opto/loopnode.hpp
@@ -1982,7 +1982,7 @@ class DataNodeGraph : public StackObj {
   DataNodeGraph(const Unique_Node_List& data_nodes, PhaseIdealLoop* phase)
       : _phase(phase),
         _data_nodes(data_nodes),
-        // Use 107 as best guess which is the first resize value in ResizeableResourceHashtable::large_table_sizes.
+        // Use 107 as best guess which is the first resize value in ResizeableHashTable::large_table_sizes.
         _orig_to_new(107, MaxNodeLimit)
   {
 #ifdef ASSERT

--- a/src/hotspot/share/opto/mempointer.cpp
+++ b/src/hotspot/share/opto/mempointer.cpp
@@ -25,7 +25,7 @@
 #include "classfile/vmSymbols.hpp"
 #include "opto/addnode.hpp"
 #include "opto/mempointer.hpp"
-#include "utilities/resourceHash.hpp"
+#include "utilities/hashtable.hpp"
 
 MemPointerParserCallback MemPointerParserCallback::_empty;
 

--- a/src/hotspot/share/opto/node.hpp
+++ b/src/hotspot/share/opto/node.hpp
@@ -222,7 +222,7 @@ typedef Node** DUIterator_Fast;
 typedef Node** DUIterator_Last;
 #endif
 
-typedef ResizeableResourceHashtable<Node*, Node*, AnyObj::RESOURCE_AREA, mtCompiler> OrigToNewHashtable;
+typedef ResizeableHashTable<Node*, Node*, AnyObj::RESOURCE_AREA, mtCompiler> OrigToNewHashtable;
 
 // Node Sentinel
 #define NodeSentinel (Node*)-1

--- a/src/hotspot/share/opto/superwordVTransformBuilder.hpp
+++ b/src/hotspot/share/opto/superwordVTransformBuilder.hpp
@@ -35,7 +35,7 @@ private:
   const PackSet& _packset;
   VTransform& _vtransform;
 
-  ResourceHashtable</* Node::_idx*/ int, VTransformNode* /* or null*/> _idx_to_vtnode;
+  HashTable</* Node::_idx*/ int, VTransformNode* /* or null*/> _idx_to_vtnode;
 
 public:
   SuperWordVTransformBuilder(const PackSet& packset,

--- a/src/hotspot/share/prims/foreignGlobals.cpp
+++ b/src/hotspot/share/prims/foreignGlobals.cpp
@@ -26,7 +26,7 @@
 #include "memory/resourceArea.hpp"
 #include "prims/foreignGlobals.inline.hpp"
 #include "runtime/jniHandles.inline.hpp"
-#include "utilities/resourceHash.hpp"
+#include "utilities/hashtable.hpp"
 
 StubLocations::StubLocations() {
   for (uint32_t i = 0; i < LOCATION_LIMIT; i++) {

--- a/src/hotspot/share/prims/foreignGlobals.cpp
+++ b/src/hotspot/share/prims/foreignGlobals.cpp
@@ -201,7 +201,7 @@ class ArgumentShuffle::ComputeMoveOrder: public StackObj {
     return a.type() == b.type() && a.index_or_offset() == b.index_or_offset();
   }
 
-  using KillerTable = ResourceHashtable<
+  using KillerTable = HashTable<
     VMStorage, MoveOperation*,
     32, // doesn't need to be big. don't have that many argument registers (in known ABIs)
     AnyObj::RESOURCE_AREA,

--- a/src/hotspot/share/prims/jvmtiTagMapTable.hpp
+++ b/src/hotspot/share/prims/jvmtiTagMapTable.hpp
@@ -65,7 +65,7 @@ class JvmtiTagMapKey : public CHeapObj<mtServiceability> {
 };
 
 typedef
-ResizeableResourceHashtable <JvmtiTagMapKey, jlong,
+ResizeableHashTable <JvmtiTagMapKey, jlong,
                               AnyObj::C_HEAP, mtServiceability,
                               JvmtiTagMapKey::get_hash,
                               JvmtiTagMapKey::equals> ResizableResourceHT;

--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -2450,7 +2450,7 @@ class ArchivedAdapterTable : public OffsetCompactHashtable<
 #endif // INCLUDE_CDS
 
 // A hashtable mapping from AdapterFingerPrints to AdapterHandlerEntries
-using AdapterHandlerTable = ResourceHashtable<AdapterFingerPrint*, AdapterHandlerEntry*, 293,
+using AdapterHandlerTable = HashTable<AdapterFingerPrint*, AdapterHandlerEntry*, 293,
                   AnyObj::C_HEAP, mtCode,
                   AdapterFingerPrint::compute_hash,
                   AdapterFingerPrint::equals>;

--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -80,7 +80,7 @@
 #include "utilities/dtrace.hpp"
 #include "utilities/events.hpp"
 #include "utilities/globalDefinitions.hpp"
-#include "utilities/resourceHash.hpp"
+#include "utilities/hashtable.hpp"
 #include "utilities/macros.hpp"
 #include "utilities/xmlstream.hpp"
 #ifdef COMPILER1

--- a/src/hotspot/share/runtime/synchronizer.hpp
+++ b/src/hotspot/share/runtime/synchronizer.hpp
@@ -30,7 +30,7 @@
 #include "runtime/basicLock.hpp"
 #include "runtime/handles.hpp"
 #include "runtime/javaThread.hpp"
-#include "utilities/resourceHash.hpp"
+#include "utilities/hashtable.hpp"
 
 template <typename T> class GrowableArray;
 class LogStream;

--- a/src/hotspot/share/runtime/threadSMR.cpp
+++ b/src/hotspot/share/runtime/threadSMR.cpp
@@ -41,7 +41,7 @@
 #include "utilities/globalDefinitions.hpp"
 #include "utilities/ostream.hpp"
 #include "utilities/powerOfTwo.hpp"
-#include "utilities/resourceHash.hpp"
+#include "utilities/hashtable.hpp"
 #include "utilities/vmError.hpp"
 
 // The '_cnt', '_max' and '_times" fields are enabled via

--- a/src/hotspot/share/runtime/threadSMR.cpp
+++ b/src/hotspot/share/runtime/threadSMR.cpp
@@ -191,15 +191,15 @@ class ThreadScanHashtable : public CHeapObj<mtThread> {
     return (unsigned int)(((uint32_t)(uintptr_t)s1) * 2654435761u);
   }
 
-  // ResourceHashtable SIZE is specified at compile time so we
+  // HashTable SIZE is specified at compile time so we
   // use 1031 which is the first prime after 1024.
-  typedef ResourceHashtable<void *, int, 1031,
+  typedef HashTable<void *, int, 1031,
                             AnyObj::C_HEAP, mtThread,
                             &ThreadScanHashtable::ptr_hash> PtrTable;
   PtrTable * _ptrs;
 
  public:
-  // ResourceHashtable is passed to various functions and populated in
+  // HashTable is passed to various functions and populated in
   // different places so we allocate it using C_HEAP to make it immune
   // from any ResourceMarks that happen to be in the code paths.
   ThreadScanHashtable() : _ptrs(new (mtThread) PtrTable()) {}

--- a/src/hotspot/share/runtime/vmOperations.cpp
+++ b/src/hotspot/share/runtime/vmOperations.cpp
@@ -291,9 +291,9 @@ class ObjectMonitorsDump : public MonitorClosure, public ObjectMonitorsView {
                           AnyObj::C_HEAP, mtThread,
                           AllocFailStrategy::RETURN_NULL> {};
 
-  // ResourceHashtable SIZE is specified at compile time so we
+  // HashTable SIZE is specified at compile time so we
   // use 1031 which is the first prime after 1024.
-  typedef ResourceHashtable<int64_t, ObjectMonitorLinkedList*, 1031, AnyObj::C_HEAP, mtThread,
+  typedef HashTable<int64_t, ObjectMonitorLinkedList*, 1031, AnyObj::C_HEAP, mtThread,
                             &ObjectMonitorsDump::ptr_hash> PtrTable;
   PtrTable* _ptrs;
   size_t _key_count;
@@ -326,7 +326,7 @@ class ObjectMonitorsDump : public MonitorClosure, public ObjectMonitorsView {
   }
 
  public:
-  // ResourceHashtable is passed to various functions and populated in
+  // HashTable is passed to various functions and populated in
   // different places so we allocate it using C_HEAP to make it immune
   // from any ResourceMarks that happen to be in the code paths.
   ObjectMonitorsDump() : _ptrs(new (mtThread) PtrTable), _key_count(0), _om_count(0) {}

--- a/src/hotspot/share/services/heapDumper.cpp
+++ b/src/hotspot/share/services/heapDumper.cpp
@@ -831,7 +831,7 @@ public:
 
 class DumperClassCacheTable {
 private:
-  // ResourceHashtable SIZE is specified at compile time so we
+  // HashTable SIZE is specified at compile time so we
   // use 1031 which is the first prime after 1024.
   static constexpr size_t TABLE_SIZE = 1031;
 
@@ -841,7 +841,7 @@ private:
   // sized table from overloading.
   static constexpr int CACHE_TOP = 256;
 
-  typedef ResourceHashtable<InstanceKlass*, DumperClassCacheTableEntry*,
+  typedef HashTable<InstanceKlass*, DumperClassCacheTableEntry*,
                             TABLE_SIZE, AnyObj::C_HEAP, mtServiceability> PtrTable;
   PtrTable* _ptrs;
 

--- a/src/hotspot/share/utilities/globalDefinitions.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions.hpp
@@ -1332,7 +1332,7 @@ typedef const char* ccstr;
 typedef const char* ccstrlist;   // represents string arguments which accumulate
 
 //----------------------------------------------------------------------------------------------------
-// Default hash/equals functions used by ResourceHashtable
+// Default hash/equals functions used by HashTable
 
 template<typename K> unsigned primitive_hash(const K& k) {
   unsigned hash = (unsigned)((uintptr_t)k);

--- a/src/hotspot/share/utilities/hashtable.hpp
+++ b/src/hotspot/share/utilities/hashtable.hpp
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef SHARE_UTILITIES_RESOURCEHASH_HPP
-#define SHARE_UTILITIES_RESOURCEHASH_HPP
+#ifndef SHARE_UTILITIES_HASHTABLE_HPP
+#define SHARE_UTILITIES_HASHTABLE_HPP
 
 #include "memory/allocation.hpp"
 #include "utilities/globalDefinitions.hpp"
@@ -377,4 +377,4 @@ public:
                                               K, V, ALLOC_TYPE, MEM_TAG, HASH, EQUALS>() {}
 };
 
-#endif // SHARE_UTILITIES_RESOURCEHASH_HPP
+#endif // SHARE_UTILITIES_HASHTABLE_HPP

--- a/src/hotspot/share/utilities/nativeCallStack.hpp
+++ b/src/hotspot/share/utilities/nativeCallStack.hpp
@@ -28,7 +28,7 @@
 #include "memory/allocation.hpp"
 #include "nmt/nmtCommon.hpp"
 #include "utilities/ostream.hpp"
-#include "utilities/resourceHash.hpp"
+#include "utilities/hashtable.hpp"
 
 /*
  * This class represents a native call path (does not include Java frame)

--- a/src/hotspot/share/utilities/objectBitSet.hpp
+++ b/src/hotspot/share/utilities/objectBitSet.hpp
@@ -52,7 +52,7 @@ class ObjectBitSet : public CHeapObj<MT> {
     return hash ^ (hash >> 3);
   }
 
-  typedef ResizeableResourceHashtable<uintptr_t, CHeapBitMap*, AnyObj::C_HEAP, MT,
+  typedef ResizeableHashTable<uintptr_t, CHeapBitMap*, AnyObj::C_HEAP, MT,
                                       hash_segment> BitMapFragmentTable;
 
   CHeapBitMap* get_fragment_bits(uintptr_t addr);

--- a/src/hotspot/share/utilities/objectBitSet.inline.hpp
+++ b/src/hotspot/share/utilities/objectBitSet.inline.hpp
@@ -52,8 +52,8 @@ ObjectBitSet<MT>::~ObjectBitSet() {
     delete current;
     current = next;
   }
-  // destructors for ResourceHashtable base deletes nodes, and
-  // ResizeableResourceHashtableStorage deletes the table.
+  // destructors for HashTable base deletes nodes, and
+  // ResizeableHashTableStorage deletes the table.
 }
 
 template<MemTag MT>

--- a/src/hotspot/share/utilities/resizeableResourceHash.hpp
+++ b/src/hotspot/share/utilities/resizeableResourceHash.hpp
@@ -25,7 +25,7 @@
 #ifndef SHARE_UTILITIES_RESIZEABLERESOURCEHASH_HPP
 #define SHARE_UTILITIES_RESIZEABLERESOURCEHASH_HPP
 
-#include "utilities/resourceHash.hpp"
+#include "utilities/hashtable.hpp"
 
 template<
     typename K, typename V,

--- a/src/hotspot/share/utilities/resizeableResourceHash.hpp
+++ b/src/hotspot/share/utilities/resizeableResourceHash.hpp
@@ -31,19 +31,19 @@ template<
     typename K, typename V,
     AnyObj::allocation_type ALLOC_TYPE,
     MemTag MEM_TAG>
-class ResizeableResourceHashtableStorage : public AnyObj {
-  using Node = ResourceHashtableNode<K, V>;
+class ResizeableHashTableStorage : public AnyObj {
+  using Node = HashTableNode<K, V>;
 
 protected:
   unsigned _table_size;
   Node** _table;
 
-  ResizeableResourceHashtableStorage(unsigned table_size) {
+  ResizeableHashTableStorage(unsigned table_size) {
     _table_size = table_size;
     _table = alloc_table(table_size);
   }
 
-  ~ResizeableResourceHashtableStorage() {
+  ~ResizeableHashTableStorage() {
     if (ALLOC_TYPE == C_HEAP) {
       FREE_C_HEAP_ARRAY(Node*, _table);
     }
@@ -76,15 +76,15 @@ template<
     unsigned (*HASH)  (K const&)           = primitive_hash<K>,
     bool     (*EQUALS)(K const&, K const&) = primitive_equals<K>
     >
-class ResizeableResourceHashtable : public ResourceHashtableBase<
-    ResizeableResourceHashtableStorage<K, V, ALLOC_TYPE, MEM_TAG>,
+class ResizeableHashTable : public HashTableBase<
+    ResizeableHashTableStorage<K, V, ALLOC_TYPE, MEM_TAG>,
     K, V, ALLOC_TYPE, MEM_TAG, HASH, EQUALS> {
   unsigned _max_size;
 
-  using BASE = ResourceHashtableBase<ResizeableResourceHashtableStorage<K, V, ALLOC_TYPE, MEM_TAG>,
+  using BASE = HashTableBase<ResizeableHashTableStorage<K, V, ALLOC_TYPE, MEM_TAG>,
                                      K, V, ALLOC_TYPE, MEM_TAG, HASH, EQUALS>;
-  using Node = ResourceHashtableNode<K, V>;
-  NONCOPYABLE(ResizeableResourceHashtable);
+  using Node = HashTableNode<K, V>;
+  NONCOPYABLE(ResizeableHashTable);
 
   // Calculate next "good" hashtable size based on requested count
   int calculate_resize(bool use_large_table_sizes) const {
@@ -111,7 +111,7 @@ class ResizeableResourceHashtable : public ResourceHashtableBase<
   }
 
 public:
-  ResizeableResourceHashtable(unsigned size, unsigned max_size)
+  ResizeableHashTable(unsigned size, unsigned max_size)
   : BASE(size), _max_size(max_size) {
     assert(size <= 0x3fffffff && max_size <= 0x3fffffff, "avoid overflow in resize");
   }

--- a/src/hotspot/share/utilities/resourceHash.hpp
+++ b/src/hotspot/share/utilities/resourceHash.hpp
@@ -33,20 +33,20 @@
 #include <type_traits>
 
 template<typename K, typename V>
-class ResourceHashtableNode : public AnyObj {
+class HashTableNode : public AnyObj {
 public:
   unsigned _hash;
   K _key;
   V _value;
-  ResourceHashtableNode* _next;
+  HashTableNode* _next;
 
-  ResourceHashtableNode(unsigned hash, K const& key, V const& value,
-                        ResourceHashtableNode* next = nullptr) :
+  HashTableNode(unsigned hash, K const& key, V const& value,
+                        HashTableNode* next = nullptr) :
     _hash(hash), _key(key), _value(value), _next(next) {}
 
   // Create a node with a default-constructed value.
-  ResourceHashtableNode(unsigned hash, K const& key,
-                        ResourceHashtableNode* next = nullptr) :
+  HashTableNode(unsigned hash, K const& key,
+                        HashTableNode* next = nullptr) :
     _hash(hash), _key(key), _value(), _next(next) {}
 };
 
@@ -58,12 +58,12 @@ template<
     unsigned (*HASH)  (K const&),
     bool     (*EQUALS)(K const&, K const&)
     >
-class ResourceHashtableBase : public STORAGE {
+class HashTableBase : public STORAGE {
   static_assert(ALLOC_TYPE == AnyObj::C_HEAP || std::is_trivially_destructible<K>::value,
                 "Destructor for K is only called with C_HEAP");
   static_assert(ALLOC_TYPE == AnyObj::C_HEAP || std::is_trivially_destructible<V>::value,
                 "Destructor for V is only called with C_HEAP");
-  using Node = ResourceHashtableNode<K, V>;
+  using Node = HashTableNode<K, V>;
  private:
   int _number_of_entries;
 
@@ -94,17 +94,17 @@ class ResourceHashtableBase : public STORAGE {
 
   Node const** lookup_node(unsigned hash, K const& key) const {
     return const_cast<Node const**>(
-        const_cast<ResourceHashtableBase*>(this)->lookup_node(hash, key));
+        const_cast<HashTableBase*>(this)->lookup_node(hash, key));
   }
 
  protected:
   Node** table() const { return STORAGE::table(); }
 
-  ResourceHashtableBase() : STORAGE(), _number_of_entries(0) {}
-  ResourceHashtableBase(unsigned size) : STORAGE(size), _number_of_entries(0) {}
-  NONCOPYABLE(ResourceHashtableBase);
+  HashTableBase() : STORAGE(), _number_of_entries(0) {}
+  HashTableBase(unsigned size) : STORAGE(size), _number_of_entries(0) {}
+  NONCOPYABLE(HashTableBase);
 
-  ~ResourceHashtableBase() {
+  ~HashTableBase() {
     if (ALLOC_TYPE == AnyObj::C_HEAP) {
       Node* const* bucket = table();
       const unsigned sz = table_size();
@@ -343,13 +343,13 @@ class ResourceHashtableBase : public STORAGE {
 };
 
 template<unsigned TABLE_SIZE, typename K, typename V>
-class FixedResourceHashtableStorage : public AnyObj {
-  using Node = ResourceHashtableNode<K, V>;
+class FixedHashTableStorage : public AnyObj {
+  using Node = HashTableNode<K, V>;
 
   Node* _table[TABLE_SIZE];
 protected:
-  FixedResourceHashtableStorage() { memset(_table, 0, sizeof(_table)); }
-  ~FixedResourceHashtableStorage() = default;
+  FixedHashTableStorage() { memset(_table, 0, sizeof(_table)); }
+  ~FixedHashTableStorage() = default;
 
   constexpr unsigned table_size() const {
     return TABLE_SIZE;
@@ -368,12 +368,12 @@ template<
     unsigned (*HASH)  (K const&)           = primitive_hash<K>,
     bool     (*EQUALS)(K const&, K const&) = primitive_equals<K>
     >
-class ResourceHashtable : public ResourceHashtableBase<
-  FixedResourceHashtableStorage<SIZE, K, V>,
+class HashTable : public HashTableBase<
+  FixedHashTableStorage<SIZE, K, V>,
     K, V, ALLOC_TYPE, MEM_TAG, HASH, EQUALS> {
-  NONCOPYABLE(ResourceHashtable);
+  NONCOPYABLE(HashTable);
 public:
-  ResourceHashtable() : ResourceHashtableBase<FixedResourceHashtableStorage<SIZE, K, V>,
+  HashTable() : HashTableBase<FixedHashTableStorage<SIZE, K, V>,
                                               K, V, ALLOC_TYPE, MEM_TAG, HASH, EQUALS>() {}
 };
 

--- a/test/hotspot/gtest/runtime/test_os_reserve_between.cpp
+++ b/test/hotspot/gtest/runtime/test_os_reserve_between.cpp
@@ -206,7 +206,7 @@ static void test_attempt_reserve_memory_between_random_distribution(unsigned num
   // Allocate n times within that hole (with subsequent deletions) and remember unique addresses returned.
   constexpr unsigned num_tries_per_attach_point = 100;
   ResourceMark rm;
-  ResourceHashtable<char*, unsigned> ht;
+  HashTable<char*, unsigned> ht;
   const unsigned num_tries = expect_failure ? 3 : (num_possible_attach_points * num_tries_per_attach_point);
   unsigned num_uniq = 0; // Number of uniq addresses returned
 

--- a/test/hotspot/gtest/runtime/test_os_reserve_between.cpp
+++ b/test/hotspot/gtest/runtime/test_os_reserve_between.cpp
@@ -28,7 +28,7 @@
 #include "utilities/align.hpp"
 #include "utilities/globalDefinitions.hpp"
 #include "utilities/macros.hpp"
-#include "utilities/resourceHash.hpp"
+#include "utilities/hashtable.hpp"
 
 // #define LOG_PLEASE
 #include "testutils.hpp"

--- a/test/hotspot/gtest/utilities/test_hashtable.cpp
+++ b/test/hotspot/gtest/utilities/test_hashtable.cpp
@@ -29,7 +29,7 @@
 #include "unittest.hpp"
 #include "utilities/debug.hpp"
 #include "utilities/globalDefinitions.hpp"
-#include "utilities/resourceHash.hpp"
+#include "utilities/hashtable.hpp"
 
 class CommonHashTableTest : public ::testing::Test {
  protected:

--- a/test/hotspot/gtest/utilities/test_resourceHash.cpp
+++ b/test/hotspot/gtest/utilities/test_resourceHash.cpp
@@ -31,7 +31,7 @@
 #include "utilities/globalDefinitions.hpp"
 #include "utilities/resourceHash.hpp"
 
-class CommonResourceHashtableTest : public ::testing::Test {
+class CommonHashTableTest : public ::testing::Test {
  protected:
   typedef void* K;
   typedef uintx V;
@@ -79,7 +79,7 @@ class CommonResourceHashtableTest : public ::testing::Test {
 
 };
 
-class SmallResourceHashtableTest : public CommonResourceHashtableTest {
+class SmallHashTableTest : public CommonHashTableTest {
  protected:
 
   template<
@@ -93,7 +93,7 @@ class SmallResourceHashtableTest : public CommonResourceHashtableTest {
 
     static void test(V step) {
       EqualityTestIter et;
-      ResourceHashtable<K, V, SIZE, ALLOC_TYPE, MEM_TAG, HASH, EQUALS> rh;
+      HashTable<K, V, SIZE, ALLOC_TYPE, MEM_TAG, HASH, EQUALS> rh;
 
       ASSERT_FALSE(rh.contains(as_K(step)));
 
@@ -157,61 +157,61 @@ class SmallResourceHashtableTest : public CommonResourceHashtableTest {
   };
 };
 
-TEST_VM_F(SmallResourceHashtableTest, default) {
+TEST_VM_F(SmallHashTableTest, default) {
   ResourceMark rm;
   Runner<>::test(0x1);
 }
 
-TEST_VM_F(SmallResourceHashtableTest, default_shifted) {
+TEST_VM_F(SmallHashTableTest, default_shifted) {
   ResourceMark rm;
   Runner<>::test(0x10);
 }
 
-TEST_VM_F(SmallResourceHashtableTest, bad_hash) {
+TEST_VM_F(SmallHashTableTest, bad_hash) {
   ResourceMark rm;
   Runner<bad_hash>::test(0x1);
 }
 
-TEST_VM_F(SmallResourceHashtableTest, bad_hash_shifted) {
+TEST_VM_F(SmallHashTableTest, bad_hash_shifted) {
   ResourceMark rm;
   Runner<bad_hash>::test(0x10);
 }
 
-TEST_VM_F(SmallResourceHashtableTest, identity_hash) {
+TEST_VM_F(SmallHashTableTest, identity_hash) {
   ResourceMark rm;
   Runner<identity_hash>::test(0x1);
 }
 
-TEST_VM_F(SmallResourceHashtableTest, identity_hash_shifted) {
+TEST_VM_F(SmallHashTableTest, identity_hash_shifted) {
   ResourceMark rm;
   Runner<identity_hash>::test(0x10);
 }
 
-TEST_VM_F(SmallResourceHashtableTest, primitive_hash_no_rm) {
+TEST_VM_F(SmallHashTableTest, primitive_hash_no_rm) {
   Runner<primitive_hash<K>, primitive_equals<K>, 512, AnyObj::C_HEAP>::test(0x1);
 }
 
-TEST_VM_F(SmallResourceHashtableTest, primitive_hash_no_rm_shifted) {
+TEST_VM_F(SmallHashTableTest, primitive_hash_no_rm_shifted) {
   Runner<primitive_hash<K>, primitive_equals<K>, 512, AnyObj::C_HEAP>::test(0x10);
 }
 
-TEST_VM_F(SmallResourceHashtableTest, bad_hash_no_rm) {
+TEST_VM_F(SmallHashTableTest, bad_hash_no_rm) {
   Runner<bad_hash, primitive_equals<K>, 512, AnyObj::C_HEAP>::test(0x1);
 }
 
-TEST_VM_F(SmallResourceHashtableTest, bad_hash_no_rm_shifted) {
+TEST_VM_F(SmallHashTableTest, bad_hash_no_rm_shifted) {
   Runner<bad_hash, primitive_equals<K>, 512, AnyObj::C_HEAP>::test(0x10);
 }
 
-TEST_VM_F(SmallResourceHashtableTest, identity_hash_no_rm) {
+TEST_VM_F(SmallHashTableTest, identity_hash_no_rm) {
   Runner<identity_hash, primitive_equals<K>, 1, AnyObj::C_HEAP>::test(0x1);
 }
 
-TEST_VM_F(SmallResourceHashtableTest, identity_hash_no_rm_shifted) {
+TEST_VM_F(SmallHashTableTest, identity_hash_no_rm_shifted) {
   Runner<identity_hash, primitive_equals<K>, 1, AnyObj::C_HEAP>::test(0x10);
 }
 
-class GenericResourceHashtableTest : public CommonResourceHashtableTest {
+class GenericHashTableTest : public CommonHashTableTest {
  protected:
 
   template<
@@ -225,7 +225,7 @@ class GenericResourceHashtableTest : public CommonResourceHashtableTest {
 
     static void test(unsigned num_elements = SIZE) {
       EqualityTestIter et;
-      ResourceHashtable<K, V, SIZE, ALLOC_TYPE, MEM_TAG, HASH, EQUALS> rh;
+      HashTable<K, V, SIZE, ALLOC_TYPE, MEM_TAG, HASH, EQUALS> rh;
 
       for (uintptr_t i = 0; i < num_elements; ++i) {
         ASSERT_TRUE(rh.put(as_K(i), i));
@@ -263,39 +263,39 @@ class GenericResourceHashtableTest : public CommonResourceHashtableTest {
   };
 };
 
-TEST_VM_F(GenericResourceHashtableTest, default) {
+TEST_VM_F(GenericHashTableTest, default) {
   ResourceMark rm;
   Runner<>::test();
 }
 
-TEST_VM_F(GenericResourceHashtableTest, bad_hash) {
+TEST_VM_F(GenericHashTableTest, bad_hash) {
   ResourceMark rm;
   Runner<bad_hash>::test();
 }
 
-TEST_VM_F(GenericResourceHashtableTest, identity_hash) {
+TEST_VM_F(GenericHashTableTest, identity_hash) {
   ResourceMark rm;
   Runner<identity_hash>::test();
 }
 
-TEST_VM_F(GenericResourceHashtableTest, primitive_hash_no_rm) {
+TEST_VM_F(GenericHashTableTest, primitive_hash_no_rm) {
   Runner<primitive_hash<K>, primitive_equals<K>, 512, AnyObj::C_HEAP>::test();
 }
 
-TEST_VM_F(GenericResourceHashtableTest, bad_hash_no_rm) {
+TEST_VM_F(GenericHashTableTest, bad_hash_no_rm) {
   Runner<bad_hash, primitive_equals<K>, 512, AnyObj::C_HEAP>::test();
 }
 
-TEST_VM_F(GenericResourceHashtableTest, identity_hash_no_rm) {
+TEST_VM_F(GenericHashTableTest, identity_hash_no_rm) {
   Runner<identity_hash, primitive_equals<K>, 1, AnyObj::C_HEAP>::test(512);
 }
 
-// Simple ResourceHashtable whose key is a SymbolHandle and value is an int
+// Simple HashTable whose key is a SymbolHandle and value is an int
 // This test is to show that the SymbolHandle will correctly handle the refcounting
 // in the table.
-class SimpleResourceHashtableDeleteTest : public ::testing::Test {
+class SimpleHashTableDeleteTest : public ::testing::Test {
  public:
-    ResourceHashtable<SymbolHandle, int, 107, AnyObj::C_HEAP, mtTest, SymbolHandle::compute_hash> _simple_test_table;
+    HashTable<SymbolHandle, int, 107, AnyObj::C_HEAP, mtTest, SymbolHandle::compute_hash> _simple_test_table;
 
     class SimpleDeleter : public StackObj {
       public:
@@ -305,7 +305,7 @@ class SimpleResourceHashtableDeleteTest : public ::testing::Test {
     };
 };
 
-TEST_VM_F(SimpleResourceHashtableDeleteTest, simple_remove) {
+TEST_VM_F(SimpleHashTableDeleteTest, simple_remove) {
   TempNewSymbol t = SymbolTable::new_symbol("abcdefg_simple");
   Symbol* s = t;
   int s_orig_count = s->refcount();
@@ -317,7 +317,7 @@ TEST_VM_F(SimpleResourceHashtableDeleteTest, simple_remove) {
   ASSERT_EQ(s->refcount(), s_orig_count) << "refcount should be same as start";
 }
 
-TEST_VM_F(SimpleResourceHashtableDeleteTest, simple_delete) {
+TEST_VM_F(SimpleHashTableDeleteTest, simple_delete) {
   TempNewSymbol t = SymbolTable::new_symbol("abcdefg_simple");
   Symbol* s = t;
   int s_orig_count = s->refcount();
@@ -330,10 +330,10 @@ TEST_VM_F(SimpleResourceHashtableDeleteTest, simple_delete) {
   ASSERT_EQ(s->refcount(), s_orig_count) << "refcount should be same as start";
 }
 
-// More complicated ResourceHashtable with SymbolHandle in the key. Since the *same* Symbol is part
+// More complicated HashTable with SymbolHandle in the key. Since the *same* Symbol is part
 // of the value, it's not necessary to manipulate the refcount of the key, but you must in the value.
 // Luckily SymbolHandle does this.
-class ResourceHashtableDeleteTest : public ::testing::Test {
+class HashTableDeleteTest : public ::testing::Test {
  public:
     class TestValue : public CHeapObj<mtTest> {
         SymbolHandle _s;
@@ -348,8 +348,8 @@ class ResourceHashtableDeleteTest : public ::testing::Test {
         // Symbol* s() const { return _s; }  // needed for conversion from TempNewSymbol to SymbolHandle member
     };
 
-    // ResourceHashtable whose value is a *copy* of TestValue.
-    ResourceHashtable<Symbol*, TestValue, 107, AnyObj::C_HEAP, mtTest> _test_table;
+    // HashTable whose value is a *copy* of TestValue.
+    HashTable<Symbol*, TestValue, 107, AnyObj::C_HEAP, mtTest> _test_table;
 
     class Deleter : public StackObj {
       public:
@@ -362,8 +362,8 @@ class ResourceHashtableDeleteTest : public ::testing::Test {
         }
     };
 
-    // ResourceHashtable whose value is a pointer to TestValue.
-    ResourceHashtable<Symbol*, TestValue*, 107, AnyObj::C_HEAP, mtTest> _ptr_test_table;
+    // HashTable whose value is a pointer to TestValue.
+    HashTable<Symbol*, TestValue*, 107, AnyObj::C_HEAP, mtTest> _ptr_test_table;
 
     class PtrDeleter : public StackObj {
       public:
@@ -378,7 +378,7 @@ class ResourceHashtableDeleteTest : public ::testing::Test {
 };
 
 
-TEST_VM_F(ResourceHashtableDeleteTest, value_remove) {
+TEST_VM_F(HashTableDeleteTest, value_remove) {
   TempNewSymbol s = SymbolTable::new_symbol("abcdefg");
   int s_orig_count = s->refcount();
   {
@@ -396,7 +396,7 @@ TEST_VM_F(ResourceHashtableDeleteTest, value_remove) {
   ASSERT_EQ(s->refcount(), s_orig_count) << "refcount should be as we started";
 }
 
-TEST_VM_F(ResourceHashtableDeleteTest, value_delete) {
+TEST_VM_F(HashTableDeleteTest, value_delete) {
   TempNewSymbol d = SymbolTable::new_symbol("defghijklmnop");
   int d_orig_count = d->refcount();
   {
@@ -412,7 +412,7 @@ TEST_VM_F(ResourceHashtableDeleteTest, value_delete) {
   ASSERT_EQ(d->refcount(), d_orig_count) << "refcount should be as we started";
 }
 
-TEST_VM_F(ResourceHashtableDeleteTest, check_delete_ptr) {
+TEST_VM_F(HashTableDeleteTest, check_delete_ptr) {
   TempNewSymbol s = SymbolTable::new_symbol("abcdefg_ptr");
   int s_orig_count = s->refcount();
   {
@@ -432,7 +432,7 @@ TEST_VM_F(ResourceHashtableDeleteTest, check_delete_ptr) {
   ASSERT_EQ(s->refcount(), s_orig_count) << "refcount should be as we started";
 }
 
-class ResourceHashtablePrintTest : public ::testing::Test {
+class HashTablePrintTest : public ::testing::Test {
  public:
     class TestValue {
       int _i;
@@ -441,7 +441,7 @@ class ResourceHashtablePrintTest : public ::testing::Test {
      public:
       TestValue(int i) : _i(i), _j(i+1), _k(i+2) {}
     };
-    ResourceHashtable<int, TestValue*, 30, AnyObj::C_HEAP, mtTest> _test_table;
+    HashTable<int, TestValue*, 30, AnyObj::C_HEAP, mtTest> _test_table;
 
     class TableDeleter {
      public:
@@ -452,7 +452,7 @@ class ResourceHashtablePrintTest : public ::testing::Test {
     };
 };
 
-TEST_VM_F(ResourceHashtablePrintTest, print_test) {
+TEST_VM_F(HashTablePrintTest, print_test) {
   for (int i = 0; i < 300; i++) {
     TestValue* tv = new TestValue(i);
     _test_table.put(i, tv);  // all the entries can be the same.


### PR DESCRIPTION
Hi,

This PR renames `ResourceHashtable` to `HashTable`. The "resource" part of the name isn't true anymore, it does many types of allocations. The RHT should be HT to signify that it's the default choice of hashtable in Hotspot.

Thanks