### PR TITLE
SimpleClassTypeSignature: intern member names used for generic type signatures

### DIFF
--- a/src/java.base/share/classes/sun/reflect/generics/tree/SimpleClassTypeSignature.java
+++ b/src/java.base/share/classes/sun/reflect/generics/tree/SimpleClassTypeSignature.java
@@ -41,7 +41,7 @@ public class SimpleClassTypeSignature implements FieldTypeSignature {
     public static SimpleClassTypeSignature make(String n,
                                                 boolean dollar,
                                                 TypeArgument[] tas){
-        return new SimpleClassTypeSignature(n, dollar, tas);
+        return new SimpleClassTypeSignature(n.intern(), dollar, tas);
     }
 
     /*


### PR DESCRIPTION
The MethodRepository constructs SimpleClassTypeSignature instances for each method with generic signatures used by reflection. These are constructed once and held as long as the method is. Since many methods refer to the same class name, this name copy ends up potentially in the heap many thousands of times.

Full context:
https://mail.openjdk.org/pipermail/core-libs-dev/2025-August/150022.html

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26730/head:pull/26730` \
`$ git checkout pull/26730`

Update a local copy of the PR: \
`$ git checkout pull/26730` \
`$ git pull https://git.openjdk.org/jdk.git pull/26730/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26730`

View PR using the GUI difftool: \
`$ git pr show -t 26730`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26730.diff">https://git.openjdk.org/jdk/pull/26730.diff</a>

</details>
