### PR TITLE
8365265: x86 short forward jump exceeds 8-bit offset in methodHandles_x86.cpp when using Intel APX

### DIFF
--- a/src/hotspot/cpu/x86/methodHandles_x86.cpp
+++ b/src/hotspot/cpu/x86/methodHandles_x86.cpp
@@ -137,7 +137,7 @@ void MethodHandles::verify_method(MacroAssembler* _masm, Register method, Regist
       case vmIntrinsicID::_invokeBasic:
         // Require compiled LambdaForm class to be fully initialized.
         __ cmpb(Address(method_holder, InstanceKlass::init_state_offset()), InstanceKlass::fully_initialized);
-        __ jccb(Assembler::equal, L_ok);
+        __ jcc(Assembler::equal, L_ok);
         break;
 
       case vmIntrinsicID::_linkToStatic:


### PR DESCRIPTION
The goal of this PR is to address the failure caused by x86 forward jump offset exceeding imm8 displacement when running the HotSpot jtreg test `test/hotspot/jtreg/compiler/c2/TestLWLockingCodeGen.java` using Intel APX (on SDE emulator).

This bug triggers an assertion failure in methodHandles_x86.cpp because the assembler emits a short forward jump (imm8 displacement) whose target is more than 127 bytes away, exceeding the allowed range. This appears to be caused by larger stub code size when APX instruction encoding is enabled.

The fix for this issue is to replace the `jccb` instruction with` jcc` in methodHandles_x86.cpp.