### PR TITLE
8364750: Remove unused declaration in jvm.h

### DIFF
--- a/src/hotspot/share/include/jvm.h
+++ b/src/hotspot/share/include/jvm.h
@@ -599,16 +599,6 @@ JVM_GetClassDeclaredFields(JNIEnv *env, jclass ofClass, jboolean publicOnly);
 JNIEXPORT jobjectArray JNICALL
 JVM_GetClassDeclaredConstructors(JNIEnv *env, jclass ofClass, jboolean publicOnly);
 
-
-/* Differs from JVM_GetClassModifiers in treatment of inner classes.
-   This returns the access flags for the class as specified in the
-   class file rather than searching the InnerClasses attribute (if
-   present) to find the source-level access flags. Only the values of
-   the low 13 bits (i.e., a mask of 0x1FFF) are guaranteed to be
-   valid. */
-JNIEXPORT jint JNICALL
-JVM_GetClassAccessFlags(JNIEnv *env, jclass cls);
-
 /* Nestmates - since JDK 11 */
 
 JNIEXPORT jboolean JNICALL


### PR DESCRIPTION
Please review this trivial change to remove the declaration of the native JVM function that I removed in [JDK-8364187](https://bugs.openjdk.org/browse/JDK-8364187).
Tested with tier1 on Oracle supported platforms as sanity test (in progress).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8364750](https://bugs.openjdk.org/browse/JDK-8364750): Remove unused declaration in jvm.h (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26732/head:pull/26732` \
`$ git checkout pull/26732`

Update a local copy of the PR: \
`$ git checkout pull/26732` \
`$ git pull https://git.openjdk.org/jdk.git pull/26732/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26732`

View PR using the GUI difftool: \
`$ git pr show -t 26732`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26732.diff">https://git.openjdk.org/jdk/pull/26732.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26732#issuecomment-3176145920)
</details>
