### PR TITLE
8154364: (fs) Files.isSameFile() throws NoSuchFileException with broken symbolic links

### DIFF
--- a/src/java.base/unix/classes/sun/nio/fs/UnixFileAttributes.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixFileAttributes.java
@@ -81,8 +81,11 @@ class UnixFileAttributes
         return attrs;
     }
 
-    // get the UnixFileAttributes for a given file. Returns null if the file does not exist.
-    static UnixFileAttributes getIfExists(UnixPath path) throws UnixException {
+    // get the UnixFileAttributes for a given file.
+    // Returns null if the file does not exist.
+    static UnixFileAttributes getIfExists(UnixPath path)
+        throws UnixException
+    {
         UnixFileAttributes attrs = new UnixFileAttributes();
         int errno = UnixNativeDispatcher.stat2(path, attrs);
         if (errno == 0) {
@@ -92,6 +95,26 @@ class UnixFileAttributes
         } else {
             throw new UnixException(errno);
         }
+    }
+
+    // get the UnixFileAttributes for a given file, optionally following links.
+    // Returns null if the file does not exist.
+    static UnixFileAttributes getIfExists(UnixPath path, boolean followLinks)
+        throws UnixException
+    {
+        UnixFileAttributes attrs = new UnixFileAttributes();
+        int flag = (followLinks) ? 0 : UnixConstants.AT_SYMLINK_NOFOLLOW;
+        try {
+            UnixNativeDispatcher.fstatat(UnixConstants.AT_FDCWD,
+                                         path.asByteArray(), flag, attrs);
+        } catch (UnixException x) {
+            if (x.errno() == UnixConstants.ENOENT)
+                return null;
+
+            throw x;
+        }
+
+        return attrs;
     }
 
     // get the UnixFileAttributes for an open file

--- a/src/java.base/unix/classes/sun/nio/fs/UnixFileSystemProvider.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixFileSystemProvider.java
@@ -425,8 +425,9 @@ public abstract class UnixFileSystemProvider
             return false;
         }
 
-        // neither exists, compare normalized paths without filesystem access
-        return obj1.normalize().equals(obj2.normalize());
+        // neither exist and comparison of normalized paths is problematic,
+        // so return false
+        return false;
     }
 
     @Override

--- a/src/java.base/windows/classes/sun/nio/fs/WindowsFileSystemProvider.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsFileSystemProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -434,8 +434,15 @@ class WindowsFileSystemProvider
         try {
             h1 = file1.openForReadAttributeAccess(true);
         } catch (WindowsException x) {
-            x.rethrowAsIOException(file1);
+            if (x.lastError() != ERROR_FILE_NOT_FOUND &&
+                x.lastError() != ERROR_PATH_NOT_FOUND)
+                x.rethrowAsIOException(file1);
         }
+
+        // if file1 does not exist, it cannot equal file2
+        if (h1 == 0L)
+            return false;
+
         try {
             WindowsFileAttributes attrs1 = null;
             try {
@@ -447,8 +454,15 @@ class WindowsFileSystemProvider
             try {
                 h2 = file2.openForReadAttributeAccess(true);
             } catch (WindowsException x) {
-                x.rethrowAsIOException(file2);
+                if (x.lastError() != ERROR_FILE_NOT_FOUND &&
+                    x.lastError() != ERROR_PATH_NOT_FOUND)
+                    x.rethrowAsIOException(file2);
             }
+
+            // if file2 does not exist, it cannot equal file1, which does
+            if (h2 == 0L)
+                return false;
+
             try {
                 WindowsFileAttributes attrs2 = null;
                 try {

--- a/src/java.base/windows/classes/sun/nio/fs/WindowsFileSystemProvider.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsFileSystemProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -420,6 +420,7 @@ class WindowsFileSystemProvider
 
     @Override
     public boolean isSameFile(Path obj1, Path obj2) throws IOException {
+        // toWindowsPath verifies its argument is a non-null UnixPath
         WindowsPath file1 = WindowsPath.toWindowsPath(obj1);
         if (file1.equals(obj2))
             return true;
@@ -429,40 +430,52 @@ class WindowsFileSystemProvider
             return false;
         WindowsPath file2 = (WindowsPath)obj2;
 
-        // open both files and see if they are the same
-        long h1 = 0L;
-        try {
-            h1 = file1.openForReadAttributeAccess(true);
-        } catch (WindowsException x) {
-            x.rethrowAsIOException(file1);
-        }
-        try {
-            WindowsFileAttributes attrs1 = null;
+        // check existence
+        boolean exists1 = exists(obj1);
+        boolean exists2 = exists(obj2);
+
+        if (exists1 && exists2) {
+            // open both files and see if they are the same
+            long h1 = 0L;
             try {
-                attrs1 = WindowsFileAttributes.readAttributes(h1);
+                h1 = file1.openForReadAttributeAccess(true);
             } catch (WindowsException x) {
                 x.rethrowAsIOException(file1);
             }
-            long h2 = 0L;
             try {
-                h2 = file2.openForReadAttributeAccess(true);
-            } catch (WindowsException x) {
-                x.rethrowAsIOException(file2);
-            }
-            try {
-                WindowsFileAttributes attrs2 = null;
+                WindowsFileAttributes attrs1 = null;
                 try {
-                    attrs2 = WindowsFileAttributes.readAttributes(h2);
+                    attrs1 = WindowsFileAttributes.readAttributes(h1);
+                } catch (WindowsException x) {
+                    x.rethrowAsIOException(file1);
+                }
+                long h2 = 0L;
+                try {
+                    h2 = file2.openForReadAttributeAccess(true);
                 } catch (WindowsException x) {
                     x.rethrowAsIOException(file2);
                 }
-                return WindowsFileAttributes.isSameFile(attrs1, attrs2);
+                try {
+                    WindowsFileAttributes attrs2 = null;
+                    try {
+                        attrs2 = WindowsFileAttributes.readAttributes(h2);
+                    } catch (WindowsException x) {
+                        x.rethrowAsIOException(file2);
+                    }
+                    return WindowsFileAttributes.isSameFile(attrs1, attrs2);
+                } finally {
+                    CloseHandle(h2);
+                }
             } finally {
-                CloseHandle(h2);
+                CloseHandle(h1);
             }
-        } finally {
-            CloseHandle(h1);
+        } else if (exists1 || exists2) {
+            // only one exists, they cannot be equal
+            return false;
         }
+
+        // neither exists, compare normalized paths without filesystem access
+        return obj1.normalize().equals(obj2.normalize());
     }
 
     @Override

--- a/src/java.base/windows/classes/sun/nio/fs/WindowsFileSystemProvider.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsFileSystemProvider.java
@@ -474,8 +474,9 @@ class WindowsFileSystemProvider
             return false;
         }
 
-        // neither exists, compare normalized paths without filesystem access
-        return obj1.normalize().equals(obj2.normalize());
+        // neither exist and comparison of normalized paths is problematic,
+        // so return false
+        return false;
     }
 
     @Override

--- a/test/jdk/java/nio/file/Files/IsSameFile.java
+++ b/test/jdk/java/nio/file/Files/IsSameFile.java
@@ -32,6 +32,7 @@ import java.io.IOException;
 import java.io.FileOutputStream;
 import java.nio.file.Files;
 import java.nio.file.FileSystem;
+import java.nio.file.FileSystemException;
 import java.nio.file.FileSystems;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -429,7 +430,7 @@ public class IsSameFile {
     //
     // L1 -> L2 -> L3 -> L1...
     //
-    // This is a loop, but isSameFile(LX,LY) should be true for all X, Y
+    // This is a loop and should throw FileSystemException.
     //
     private Stream<Arguments> linkLoopSource() throws IOException {
         deleteFiles();
@@ -453,6 +454,6 @@ public class IsSameFile {
     @MethodSource("linkLoopSource")
     @DisabledOnOs(OS.WINDOWS)
     public void linkLoop(boolean expect, Path x, Path y) throws IOException {
-        test(expect, x, y);
+        assertThrows(FileSystemException.class, () -> Files.isSameFile(x, y));
     }
 }

--- a/test/jdk/java/nio/file/Files/IsSameFile.java
+++ b/test/jdk/java/nio/file/Files/IsSameFile.java
@@ -49,8 +49,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -422,7 +420,6 @@ public class IsSameFile {
 
     @ParameterizedTest
     @MethodSource("multiLinkNoTargetSource")
-    @DisabledOnOs(OS.WINDOWS)
     public void multiLinkNoTarget(boolean expect, Path x, Path y)
         throws IOException {
         test(expect, x, y);
@@ -453,7 +450,6 @@ public class IsSameFile {
 
     @ParameterizedTest
     @MethodSource("linkLoopSource")
-    @DisabledOnOs(OS.WINDOWS)
     public void linkLoop(boolean expect, Path x, Path y) throws IOException {
         assertThrows(FileSystemException.class, () -> Files.isSameFile(x, y));
     }

--- a/test/jdk/java/nio/file/Files/IsSameFile.java
+++ b/test/jdk/java/nio/file/Files/IsSameFile.java
@@ -1,0 +1,458 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @bug 8154364
+ * @summary Test of Files.isSameFile
+ * @library .. /test/lib
+ * @build IsSameFile jdk.test.lib.util.FileUtils
+ * @run junit IsSameFile
+ */
+import java.io.IOException;
+import java.io.FileOutputStream;
+import java.nio.file.Files;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import jdk.test.lib.util.FileUtils;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@TestInstance(Lifecycle.PER_CLASS)
+public class IsSameFile {
+    private Path home;
+    private Path a;
+    private Path aa;
+    private Path b;
+    private Path c;
+    private List<Path> allFiles;
+
+    @BeforeAll
+    public void init() throws IOException {
+        home = Files.createTempDirectory("TestIsSameFile");
+
+        allFiles = new ArrayList();
+        allFiles.add(a = home.resolve("a"));
+        allFiles.add(aa = home.resolve("a"));
+        allFiles.add(b = home.resolve("b"));
+        allFiles.add(c = home.resolve("c"));
+    }
+
+    public void deleteFiles() throws IOException {
+        for (Path p : allFiles)
+            Files.deleteIfExists(p);
+    }
+
+    @AfterAll
+    public void deleteHome() throws IOException {
+        TestUtil.removeAll(home);
+    }
+
+    public void test(boolean expect, Path x, Path y) throws IOException {
+        assertTrue(Files.isSameFile(x, y) == expect);
+    }
+
+    private Stream<Arguments> stringCompareSource() throws IOException {
+        deleteFiles();
+        List<Arguments> list = new ArrayList<Arguments>();
+        Path x = Path.of("x/y/z");
+        list.add(Arguments.of(true, x, x));
+        list.add(Arguments.of(false, Path.of("w/x/y/z"), x));
+        Path y = Path.of("v/w/x/../y/z");
+        list.add(Arguments.of(true, y, Path.of("v/w/y/z")));
+        list.add(Arguments.of(false, y, Path.of("v/w/x/y/../z")));
+        return list.stream();
+    }
+
+    @ParameterizedTest
+    @MethodSource("stringCompareSource")
+    public void stringCompare(boolean expect, Path x, Path y)
+        throws IOException {
+        test(expect, x, y);
+    }
+
+    private Stream<Arguments> noneExistSource() throws IOException {
+        deleteFiles();
+        List<Arguments> list = new ArrayList<Arguments>();
+        list.add(Arguments.of(true, a, a));
+        list.add(Arguments.of(true, a, aa));
+        list.add(Arguments.of(false, a, b));
+        list.add(Arguments.of(true, b, b));
+        return list.stream();
+    }
+
+    @Test
+    public void obj2Null() {
+        Path x = Path.of("x/y");
+        assertThrows(NullPointerException.class, () -> Files.isSameFile(x, null));
+    }
+
+    private static void zipStringToFile(String entry, String content,
+                                        Path path)
+        throws IOException
+    {
+        FileOutputStream fos = new FileOutputStream(path.toString());
+        ZipOutputStream zos = new ZipOutputStream(fos);
+
+        ZipEntry zipEntry = new ZipEntry(entry);
+        zos.putNextEntry(zipEntry);
+        zos.write(content.getBytes());
+
+        zos.close();
+        fos.close();
+    }
+
+    private Stream<Arguments> obj2ZipSource() throws IOException {
+        deleteFiles();
+        Files.createFile(a);
+        zipStringToFile("quote.txt", "To be determined", b);
+        FileSystem zipfs = FileSystems.newFileSystem(b);
+        List<Arguments> list = new ArrayList<Arguments>();
+        list.add(Arguments.of(false, a, zipfs.getPath(b.toString())));
+        return list.stream();
+    }
+
+    @ParameterizedTest
+    @MethodSource("obj2ZipSource")
+    public void obj2Zip(boolean expect, Path x, Path y)
+        throws IOException {
+        test(expect, x, y);
+    }
+
+    @ParameterizedTest
+    @MethodSource("noneExistSource")
+    public void noneExist(boolean expect, Path x, Path y)
+        throws IOException {
+        test(expect, x, y);
+    }
+
+    private Stream<Arguments> aExistsSource() throws IOException {
+        deleteFiles();
+        Files.createFile(a);
+        List<Arguments> list = new ArrayList<Arguments>();
+        list.add(Arguments.of(true, a, a));
+        list.add(Arguments.of(true, a, aa));
+        list.add(Arguments.of(false, a, b));
+        return list.stream();
+    }
+
+    @ParameterizedTest
+    @MethodSource("aExistsSource")
+    public void aExists(boolean expect, Path x, Path y) throws IOException {
+        test(expect, x, y);
+    }
+
+    private Stream<Arguments> abExistSource() throws IOException {
+        deleteFiles();
+        Files.createFile(a);
+        Files.createFile(b);
+        List<Arguments> list = new ArrayList<Arguments>();
+        list.add(Arguments.of(false, a, b));
+        list.add(Arguments.of(true, b, b));
+        list.add(Arguments.of(false, a, c));
+        return list.stream();
+    }
+
+    @ParameterizedTest
+    @MethodSource("abExistSource")
+    public void abExist(boolean expect, Path x, Path y)
+        throws IOException {
+        test(expect, x, y);
+    }
+
+    private Stream<Arguments> abcExistSource() throws IOException {
+        deleteFiles();
+        Files.createFile(a);
+        Files.createFile(b);
+        Files.createSymbolicLink(c, a);
+        List<Arguments> list = new ArrayList<Arguments>();
+        list.add(Arguments.of(true, a, c));
+        list.add(Arguments.of(false, a, b));
+        return list.stream();
+    }
+
+    @ParameterizedTest
+    @MethodSource("abcExistSource")
+    public void abcExist(boolean expect, Path x, Path y)
+        throws IOException {
+        test(expect, x, y);
+    }
+
+    private Stream<Arguments> bcExistSource() throws IOException {
+        deleteFiles();
+        Files.createFile(b);
+        Files.createSymbolicLink(c, a);
+        List<Arguments> list = new ArrayList<Arguments>();
+        list.add(Arguments.of(true, a, a));
+        list.add(Arguments.of(true, a, aa));
+        list.add(Arguments.of(false, a, b));
+        list.add(Arguments.of(true, b, b));
+        list.add(Arguments.of(false, a, c));
+        return list.stream();
+    }
+
+    @ParameterizedTest
+    @MethodSource("bcExistSource")
+    public void bcExist(boolean expect, Path x, Path y)
+        throws IOException {
+        test(expect, x, y);
+    }
+
+    //
+    // L1 => L2 => target
+    // L3 => L4 => target
+    //
+    private Stream<Arguments> equalFollowingSource() throws IOException {
+        deleteFiles();
+        Path target = home.resolve("target");
+        Files.createFile(target);
+        allFiles.add(target);
+
+        Path L2 = Path.of("link2");
+        Files.createSymbolicLink(L2, target);
+        allFiles.add(L2);
+
+        Path L1 = Path.of("link1");
+        Files.createSymbolicLink(L1, L2);
+        allFiles.add(L1);
+
+        Path L4 = Path.of("link4");
+        Files.createSymbolicLink(L4, target);
+        allFiles.add(L4);
+
+        Path L3 = Path.of("link3");
+        Files.createSymbolicLink(L3, L4);
+        allFiles.add(L3);
+
+        List<Arguments> list = new ArrayList<Arguments>();
+        list.add(Arguments.of(true, L1, L3));
+        return list.stream();
+    }
+
+    @ParameterizedTest
+    @MethodSource("equalFollowingSource")
+    public void equalFollowing(boolean expect, Path x, Path y)
+        throws IOException {
+        test(expect, x, y);
+    }
+
+    //
+    // L1 => L2 => target
+    // L3 => L4 => cible
+    //
+    private Stream<Arguments> unequalFollowingSource() throws IOException {
+        deleteFiles();
+        Path target = home.resolve("target");
+        Files.createFile(target);
+        allFiles.add(target);
+
+        Path L2 = Path.of("link2");
+        Files.createSymbolicLink(L2, target);
+        allFiles.add(L2);
+
+        Path L1 = Path.of("link1");
+        Files.createSymbolicLink(L1, L2);
+        allFiles.add(L1);
+
+        Path cible = home.resolve("cible");
+        Files.createFile(cible);
+        allFiles.add(cible);
+
+        Path L4 = Path.of("link4");
+        Files.createSymbolicLink(L4, cible);
+        allFiles.add(L4);
+
+        Path L3 = Path.of("link3");
+        Files.createSymbolicLink(L3, L4);
+        allFiles.add(L3);
+
+        List<Arguments> list = new ArrayList<Arguments>();
+        list.add(Arguments.of(false, L1, L3));
+        return list.stream();
+    }
+
+    @ParameterizedTest
+    @MethodSource("unequalFollowingSource")
+    public void unequalFollowing(boolean expect, Path x, Path y)
+        throws IOException {
+        test(expect, x, y);
+    }
+
+    //
+    // L1 => L2 => <does not exist>
+    // L3 => L4 => <does not exist>
+    //
+    private Stream<Arguments> unequalNotFollowingSource() throws IOException {
+        deleteFiles();
+
+        Path doesNotExist = Path.of("doesNotExist");
+
+        Path L2 = Path.of("link2");
+        Files.createSymbolicLink(L2, doesNotExist);
+        allFiles.add(L2);
+
+        Path L1 = Path.of("link1");
+        Files.createSymbolicLink(L1, L2);
+        allFiles.add(L1);
+
+        Path L4 = Path.of("link4");
+        Files.createSymbolicLink(L4, doesNotExist);
+        allFiles.add(L4);
+
+        Path L3 = Path.of("link3");
+        Files.createSymbolicLink(L3, L4);
+        allFiles.add(L3);
+
+        List<Arguments> list = new ArrayList<Arguments>();
+        list.add(Arguments.of(false, L1, L3));
+        return list.stream();
+    }
+
+    @ParameterizedTest
+    @MethodSource("unequalNotFollowingSource")
+    public void unequalNotFollowing(boolean expect, Path x, Path y)
+        throws IOException {
+        test(expect, x, y);
+    }
+
+    //
+    // L1 => L2 => L3 => L4 => target
+    //
+    // isSameFile(LX,LY) should be true for all X, Y
+    //
+    private Stream<Arguments> multiLinkSource() throws IOException {
+        deleteFiles();
+        Path target = home.resolve("target");
+        Files.createFile(target);
+        allFiles.add(target);
+        Path[] links = new Path[4];
+        links[3] = Files.createSymbolicLink(Path.of("link4"), target);
+        allFiles.add(links[3]);
+        for (int i = 3; i > 0; i--) {
+            links[i-1] = Files.createSymbolicLink(Path.of("link"+i), links[i]);
+            allFiles.add(links[i-1]);
+        }
+
+        List<Arguments> list = new ArrayList<Arguments>();
+        for (int i = 0; i < 4; i++) {
+            list.add(Arguments.of(true, links[i], target));
+            for (int j = i+1; j < 4; j++)
+                list.add(Arguments.of(true, links[i], links[j]));
+        }
+
+        return list.stream();
+    }
+
+    @ParameterizedTest
+    @MethodSource("multiLinkSource")
+    public void multiLink(boolean expect, Path x, Path y)
+        throws IOException {
+        test(expect, x, y);
+    }
+
+    //
+    // L1 => L2 => L3 => L4 => <does not exist>
+    //
+    // isSameFile(LX,LY) should be true for all X, Y
+    //
+    private Stream<Arguments> multiLinkNoTargetSource() throws IOException {
+        deleteFiles();
+        Path target = home.resolve("target");
+        Files.createFile(target);
+        allFiles.add(target);
+        Path[] links = new Path[4];
+        links[3] = Files.createSymbolicLink(Path.of("link4"), target);
+        allFiles.add(links[3]);
+        Files.delete(target);
+        allFiles.remove(target);
+        for (int i = 3; i > 0; i--) {
+            links[i-1] = Files.createSymbolicLink(Path.of("link"+i), links[i]);
+            allFiles.add(links[i-1]);
+        }
+
+        List<Arguments> list = new ArrayList<Arguments>();
+        for (int i = 0; i < 4; i++) {
+            list.add(Arguments.of(false, links[i], target));
+            for (int j = i+1; j < 4; j++)
+                list.add(Arguments.of(true, links[i], links[j]));
+        }
+
+        return list.stream();
+    }
+
+    @ParameterizedTest
+    @MethodSource("multiLinkNoTargetSource")
+    @DisabledOnOs(OS.WINDOWS)
+    public void multiLinkNoTarget(boolean expect, Path x, Path y)
+        throws IOException {
+        test(expect, x, y);
+    }
+
+    //
+    // L1 -> L2 -> L3 -> L1...
+    //
+    // This is a loop, but isSameFile(LX,LY) should be true for all X, Y
+    //
+    private Stream<Arguments> linkLoopSource() throws IOException {
+        deleteFiles();
+
+        Path link1 = home.resolve("L1");
+        Path link2 = home.resolve("L2");
+        Path link3 = home.resolve("L3");
+        allFiles.add(Files.createSymbolicLink(link1, link2));
+        allFiles.add(Files.createSymbolicLink(link2, link3));
+        allFiles.add(Files.createSymbolicLink(link3, link1));
+
+        List<Arguments> list = new ArrayList<Arguments>();
+        list.add(Arguments.of(true, link1, link2));
+        list.add(Arguments.of(true, link2, link3));
+        list.add(Arguments.of(true, link3, link1));
+
+        return list.stream();
+    }
+
+    @ParameterizedTest
+    @MethodSource("linkLoopSource")
+    @DisabledOnOs(OS.WINDOWS)
+    public void linkLoop(boolean expect, Path x, Path y) throws IOException {
+        test(expect, x, y);
+    }
+}

--- a/test/jdk/java/nio/file/Files/IsSameFile.java
+++ b/test/jdk/java/nio/file/Files/IsSameFile.java
@@ -24,6 +24,7 @@
 /* @test
  * @bug 8154364
  * @summary Test of Files.isSameFile
+ * @requires (os.family != "windows")
  * @library .. /test/lib
  * @build IsSameFile jdk.test.lib.util.FileUtils
  * @run junit IsSameFile

--- a/test/jdk/java/nio/file/Files/IsSameFile.java
+++ b/test/jdk/java/nio/file/Files/IsSameFile.java
@@ -97,7 +97,7 @@ public class IsSameFile {
         list.add(Arguments.of(true, x, x));
         list.add(Arguments.of(false, Path.of("w/x/y/z"), x));
         Path y = Path.of("v/w/x/../y/z");
-        list.add(Arguments.of(true, y, Path.of("v/w/y/z")));
+        list.add(Arguments.of(false, y, Path.of("v/w/y/z")));
         list.add(Arguments.of(false, y, Path.of("v/w/x/y/../z")));
         return list.stream();
     }

--- a/test/jdk/java/nio/file/Files/Misc.java
+++ b/test/jdk/java/nio/file/Files/Misc.java
@@ -115,42 +115,16 @@ public class Misc {
         /**
          * Test: Neither file exists
          */
-        if (Platform.isWindows()) {
-            try {
-                isSameFile(thisFile, thatFile);
-                throw new RuntimeException("IOException not thrown");
-            } catch (IOException x) {
-            }
-            try {
-                isSameFile(thatFile, thisFile);
-                throw new RuntimeException("IOException not thrown");
-            } catch (IOException x) {
-            }
-        } else {
-            assertTrue(!isSameFile(thisFile, thatFile));
-            assertTrue(!isSameFile(thatFile, thisFile));
-        }
+        assertTrue(!isSameFile(thisFile, thatFile));
+        assertTrue(!isSameFile(thatFile, thisFile));
 
         createFile(thisFile);
         try {
             /**
              * Test: One file exists
              */
-            if (Platform.isWindows()) {
-                try {
-                    isSameFile(thisFile, thatFile);
-                    throw new RuntimeException("IOException not thrown");
-                } catch (IOException x) {
-                }
-                try {
-                    isSameFile(thatFile, thisFile);
-                    throw new RuntimeException("IOException not thrown");
-                } catch (IOException x) {
-                }
-            } else {
-                assertTrue(!isSameFile(thisFile, thatFile));
-                assertTrue(!isSameFile(thatFile, thisFile));
-            }
+            assertTrue(!isSameFile(thisFile, thatFile));
+            assertTrue(!isSameFile(thatFile, thisFile));
 
             /**
              * Test: Both file exists

--- a/test/jdk/java/nio/file/Files/Misc.java
+++ b/test/jdk/java/nio/file/Files/Misc.java
@@ -113,18 +113,44 @@ public class Misc {
         assertTrue(isSameFile(thisFile, thisFile));
 
         /**
-         * Test: Neither files exist
+         * Test: Neither file exists
          */
-        assertTrue(!isSameFile(thisFile, thatFile));
-        assertTrue(!isSameFile(thatFile, thisFile));
+        if (Platform.isWindows()) {
+            try {
+                isSameFile(thisFile, thatFile);
+                throw new RuntimeException("IOException not thrown");
+            } catch (IOException x) {
+            }
+            try {
+                isSameFile(thatFile, thisFile);
+                throw new RuntimeException("IOException not thrown");
+            } catch (IOException x) {
+            }
+        } else {
+            assertTrue(!isSameFile(thisFile, thatFile));
+            assertTrue(!isSameFile(thatFile, thisFile));
+        }
 
         createFile(thisFile);
         try {
             /**
              * Test: One file exists
              */
-            assertTrue(!isSameFile(thisFile, thatFile));
-            assertTrue(!isSameFile(thatFile, thisFile));
+            if (Platform.isWindows()) {
+                try {
+                    isSameFile(thisFile, thatFile);
+                    throw new RuntimeException("IOException not thrown");
+                } catch (IOException x) {
+                }
+                try {
+                    isSameFile(thatFile, thisFile);
+                    throw new RuntimeException("IOException not thrown");
+                } catch (IOException x) {
+                }
+            } else {
+                assertTrue(!isSameFile(thisFile, thatFile));
+                assertTrue(!isSameFile(thatFile, thisFile));
+            }
 
             /**
              * Test: Both file exists

--- a/test/jdk/java/nio/file/Files/Misc.java
+++ b/test/jdk/java/nio/file/Files/Misc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,7 +22,7 @@
  */
 
 /* @test
- * @bug 4313887 6838333 8005566 8215467 8255576 8286160
+ * @bug 4313887 6838333 8005566 8154364 8215467 8255576 8286160
  * @summary Unit test for miscellaneous methods in java.nio.file.Files
  * @library .. /test/lib
  * @build jdk.test.lib.Platform
@@ -115,32 +115,16 @@ public class Misc {
         /**
          * Test: Neither files exist
          */
-        try {
-            isSameFile(thisFile, thatFile);
-            throw new RuntimeException("IOException not thrown");
-        } catch (IOException x) {
-        }
-        try {
-            isSameFile(thatFile, thisFile);
-            throw new RuntimeException("IOException not thrown");
-        } catch (IOException x) {
-        }
+        assertTrue(!isSameFile(thisFile, thatFile));
+        assertTrue(!isSameFile(thatFile, thisFile));
 
         createFile(thisFile);
         try {
             /**
              * Test: One file exists
              */
-            try {
-                isSameFile(thisFile, thatFile);
-                throw new RuntimeException("IOException not thrown");
-            } catch (IOException x) {
-            }
-            try {
-                isSameFile(thatFile, thisFile);
-                throw new RuntimeException("IOException not thrown");
-            } catch (IOException x) {
-            }
+            assertTrue(!isSameFile(thisFile, thatFile));
+            assertTrue(!isSameFile(thatFile, thisFile));
 
             /**
              * Test: Both file exists


### PR DESCRIPTION
This request proposes to broaden the definition of which paths are considered to be the same by `java.nio.file.Files.isSameFile()`. A new test is added to cover many comparisons.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8154364](https://bugs.openjdk.org/browse/JDK-8154364): (fs) Files.isSameFile() throws NoSuchFileException with broken symbolic links (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26736/head:pull/26736` \
`$ git checkout pull/26736`

Update a local copy of the PR: \
`$ git checkout pull/26736` \
`$ git pull https://git.openjdk.org/jdk.git pull/26736/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26736`

View PR using the GUI difftool: \
`$ git pr show -t 26736`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26736.diff">https://git.openjdk.org/jdk/pull/26736.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26736#issuecomment-3177387204)
</details>
