### PR TITLE
JDK-8365305: The ARIA role ‘contentinfo’ is not valid for the element <footer>

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/html/HtmlTree.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/html/HtmlTree.java
@@ -586,8 +586,7 @@ public class HtmlTree extends Content {
      * @return the element
      */
     public static HtmlTree FOOTER() {
-        return new HtmlTree(HtmlTag.FOOTER)
-                .setRole(HtmlAttr.Role.CONTENTINFO);
+        return new HtmlTree(HtmlTag.FOOTER);
     }
 
     /**

--- a/test/langtools/jdk/javadoc/doclet/testHtmlLandmarkRegions/TestHtmlLandmarkRegions.java
+++ b/test/langtools/jdk/javadoc/doclet/testHtmlLandmarkRegions/TestHtmlLandmarkRegions.java
@@ -83,7 +83,7 @@ public class TestHtmlLandmarkRegions extends JavadocTester {
                     <div class="header">
                     <h1 class="title">Document Title</h1>""",
                 """
-                    <footer role="contentinfo"> """,
+                    <footer> """,
                 """
                     bottom text"""
         );
@@ -113,7 +113,7 @@ public class TestHtmlLandmarkRegions extends JavadocTester {
                     <div class="header">
                     <h1 class="title">Document Title</h1>""",
                 """
-                    <footer role="contentinfo">""",
+                    <footer>""",
                 """
                     bottom text""");
     }
@@ -150,7 +150,7 @@ public class TestHtmlLandmarkRegions extends JavadocTester {
                 """
                     <main role="main">A sample doc file""",
                 """
-                    <footer role="contentinfo">""",
+                    <footer>""",
                 """
                     bottom text"""
                 );

--- a/test/langtools/jdk/javadoc/doclet/testHtmlVersion/TestHtmlVersion.java
+++ b/test/langtools/jdk/javadoc/doclet/testHtmlVersion/TestHtmlVersion.java
@@ -85,7 +85,7 @@ public class TestHtmlVersion extends JavadocTester {
                     <nav role="navigation">
                     <!-- ========= START OF TOP NAVBAR ======= -->""",
                 """
-                    <footer role="contentinfo">""",
+                    <footer>""",
                 """
                     bottom text""");
 
@@ -109,7 +109,7 @@ public class TestHtmlVersion extends JavadocTester {
                     <section class="package-description" id="package-description">
                     <div class="block">Test package.</div>""",
                 """
-                    <footer role="contentinfo">""",
+                    <footer>""",
                 """
                     bottom text""");
         // No package description
@@ -150,7 +150,7 @@ public class TestHtmlVersion extends JavadocTester {
                     <section class="hierarchy">
                     <h2 title="Enum Class Hierarchy">Enum Class Hierarchy</h2>""",
                 """
-                    <footer role="contentinfo">""",
+                    <footer>""",
                 """
                     bottom text""" );
 
@@ -171,7 +171,7 @@ public class TestHtmlVersion extends JavadocTester {
                     <main role="main">
                     <div class="header">""",
                 """
-                    <footer role="contentinfo">""",
+                    <footer>""",
                 """
                     bottom text""");
 
@@ -199,7 +199,7 @@ public class TestHtmlVersion extends JavadocTester {
                     <h2 title="pkg.*">pkg.*</h2>
                     """,
                 """
-                    <footer role="contentinfo">""",
+                    <footer>""",
                 """
                     bottom text""");
 
@@ -220,7 +220,7 @@ public class TestHtmlVersion extends JavadocTester {
                     <main role="main">
                     <div class="header">""",
                 """
-                    <footer role="contentinfo">""",
+                    <footer>""",
                 """
                     bottom text""");
 
@@ -243,7 +243,7 @@ public class TestHtmlVersion extends JavadocTester {
                     <h2 title="Package">Package&nbsp;<a href="pkg/package-summary.html">pkg</a></h2>
                     """,
                 """
-                    <footer role="contentinfo">""",
+                    <footer>""",
                 """
                     bottom text""");
 
@@ -279,7 +279,7 @@ public class TestHtmlVersion extends JavadocTester {
                     <h2 title="Enum Class Hierarchy">Enum Class Hierarchy</h2>
                     """,
                 """
-                    <footer role="contentinfo">""",
+                    <footer>""",
                 """
                     bottom text""");
 
@@ -299,7 +299,7 @@ public class TestHtmlVersion extends JavadocTester {
                     <div class="main-grid">
                     <main role="main">""",
                 """
-                    <footer role="contentinfo">""",
+                    <footer>""",
                 """
                     bottom text""");
 
@@ -337,7 +337,7 @@ public class TestHtmlVersion extends JavadocTester {
                     <h3>Class or Interface</h3>
                     """,
                 """
-                    <footer role="contentinfo">""",
+                    <footer>""",
                 """
                     bottom text""");
 
@@ -387,7 +387,7 @@ public class TestHtmlVersion extends JavadocTester {
                     <h2>Method Details</h2>
                     """,
                 """
-                    <footer role="contentinfo">""",
+                    <footer>""",
                 """
                     bottom text""");
 
@@ -428,7 +428,7 @@ public class TestHtmlVersion extends JavadocTester {
                     <h2>Method Details</h2>
                     """,
                 """
-                    <footer role="contentinfo">""",
+                    <footer>""",
                 """
                     bottom text""");
 
@@ -460,7 +460,7 @@ public class TestHtmlVersion extends JavadocTester {
                     <h2>Method Details</h2>
                     """,
                 """
-                    <footer role="contentinfo">""",
+                    <footer>""",
                 """
                     bottom text""");
 
@@ -487,7 +487,7 @@ public class TestHtmlVersion extends JavadocTester {
                     <h2>Constructor Details</h2>
                     """,
                 """
-                    <footer role="contentinfo">""",
+                    <footer>""",
                 """
                     bottom text""");
 
@@ -514,7 +514,7 @@ public class TestHtmlVersion extends JavadocTester {
                     <h2>Constructor Details</h2>
                     """,
                 """
-                    <footer role="contentinfo">""",
+                    <footer>""",
                 """
                     bottom text""");
 
@@ -552,7 +552,7 @@ public class TestHtmlVersion extends JavadocTester {
                     <h2>Element Details</h2>
                     """,
                 """
-                    <footer role="contentinfo">""",
+                    <footer>""",
                 """
                     bottom text""");
 
@@ -581,7 +581,7 @@ public class TestHtmlVersion extends JavadocTester {
                     /span></div>
                     <div class="summary-table three-column-summary">""",
                 """
-                    <footer role="contentinfo">""",
+                    <footer>""",
                 """
                     bottom text""");
     }


### PR DESCRIPTION
Accessibility testing reported a violation with rule_id aria_role_valid for API docs which has role=contentinfo for footer HTML element. As per https://www.w3.org/TR/html-aria/#docconformance, if footer is a descendant of an article, aside, main, nav or section element, or an element with role=article, complementary, main, navigation or region then role=contentinfo is not allowed.