### PR TITLE
8365302: RISC-V: compiler/loopopts/superword/TestAlignVector.java fails when vlen=128

### DIFF
--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestAlignVector.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestAlignVector.java
@@ -1063,8 +1063,16 @@ public class TestAlignVector {
                   IRNode.ADD_VL, IRNode.VECTOR_SIZE + "min(max_int, max_long)", "> 0",
                   IRNode.STORE_VECTOR, "> 0"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"avx2", "true", "rvv", "true"})
+        applyIfCPUFeature = {"avx2", "true"})
     // require avx to ensure vectors are larger than what unrolling produces
+    @IR(counts = {IRNode.LOAD_VECTOR_I, IRNode.VECTOR_SIZE + "min(max_int, max_long)", "> 0",
+                  IRNode.LOAD_VECTOR_L, IRNode.VECTOR_SIZE + "min(max_int, max_long)", "> 0",
+                  IRNode.ADD_VI, IRNode.VECTOR_SIZE + "min(max_int, max_long)", "> 0",
+                  IRNode.ADD_VL, IRNode.VECTOR_SIZE + "min(max_int, max_long)", "> 0",
+                  IRNode.STORE_VECTOR, "> 0"},
+        applyIfPlatform = {"riscv64", "true"},
+        applyIfCPUFeature = {"rvv", "true"},
+        applyIf = {"MaxVectorSize", ">=32"})
     static Object[] test13aIL(int[] a, long[] b) {
         for (int i = 0; i < RANGE; i++) {
             a[i]++;
@@ -1175,8 +1183,16 @@ public class TestAlignVector {
                   IRNode.ADD_VL, IRNode.VECTOR_SIZE + "min(max_int, max_long)", "> 0",
                   IRNode.STORE_VECTOR, "> 0"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"avx2", "true", "rvv", "true"})
+        applyIfCPUFeature = {"avx2", "true"})
     // require avx to ensure vectors are larger than what unrolling produces
+    @IR(counts = {IRNode.LOAD_VECTOR_I, IRNode.VECTOR_SIZE + "min(max_int, max_long)", "> 0",
+                  IRNode.LOAD_VECTOR_L, IRNode.VECTOR_SIZE + "min(max_int, max_long)", "> 0",
+                  IRNode.ADD_VI, IRNode.VECTOR_SIZE + "min(max_int, max_long)", "> 0",
+                  IRNode.ADD_VL, IRNode.VECTOR_SIZE + "min(max_int, max_long)", "> 0",
+                  IRNode.STORE_VECTOR, "> 0"},
+        applyIfPlatform = {"riscv64", "true"},
+        applyIfCPUFeature = {"rvv", "true"},
+        applyIf = {"MaxVectorSize", ">=32"})
     static Object[] test13bIL(int[] a, long[] b) {
         for (int i = 1; i < RANGE; i++) {
             a[i]++;


### PR DESCRIPTION
Hi all,
Please take a look and review this PR, thanks!

[JDK-8352529](https://bugs.openjdk.org/browse/JDK-8352529) enables this IR verification test for riscv. This test pass when vlen=256, but fail when vlen=128.

The error occurs because the test13aIL and test13bIL cases require ensuring that vectors are larger than what unrolling produces; otherwise, the corresponding vector IR will not be generated.

We can use `JTREG="JAVA_OPTIONS=-XX:+TraceSuperWordLoopUnrollAnalysis"` during testing. 
The tips in the log:
```
76844 1333 b 4 compiler.loopopts.superword.TestAlignVector::test13aIL (42 bytes)
slp analysis fails: unroll limit greater than max vector

slp analysis: set max unroll to 4
```

Therefore, we need to limit MaxVectorSize to greater than or equal to 32 bytes.

### Test (fastdebug)
- [x] Run compiler/loopopts/superword/TestAlignVector.java on qemu-system with RVV when vlen=128/256

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8365302](https://bugs.openjdk.org/browse/JDK-8365302): RISC-V: compiler/loopopts/superword/TestAlignVector.java fails when vlen=128 (**Bug** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Feilong Jiang](https://openjdk.org/census#fjiang) (@feilongjiang - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26738/head:pull/26738` \
`$ git checkout pull/26738`

Update a local copy of the PR: \
`$ git checkout pull/26738` \
`$ git pull https://git.openjdk.org/jdk.git pull/26738/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26738`

View PR using the GUI difftool: \
`$ git pr show -t 26738`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26738.diff">https://git.openjdk.org/jdk/pull/26738.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26738#issuecomment-3177924735)
</details>
