### PR TITLE
8365307: AIX make fails after JDK-8364611

### DIFF
--- a/test/jdk/java/lang/ProcessBuilder/childSignalDisposition/exePrintSignalDisposition.c
+++ b/test/jdk/java/lang/ProcessBuilder/childSignalDisposition/exePrintSignalDisposition.c
@@ -72,7 +72,11 @@ int main(int argc, char** argv) {
         } else {
             printf("%p ", handler);
         }
+#ifdef _AIX
+        printf("%X\n", act.sa_flags);
+#else
         printf("%X %X\n", act.sa_flags, act.sa_mask);
+#endif
     }
 
     return 0;


### PR DESCRIPTION
After recent change [JDK-8364611](https://bugs.openjdk.org/browse/JDK-8364611), the build fails on AIX with :

```
/priv/jenkins/client-home/workspace/openjdk-jdk-aix_ppc64-opt/jdk/test/jdk/java/lang/ProcessBuilder/childSignalDisposition/exePrintSignalDisposition.c:75:41: error: format specifies type 'unsigned int' but the argument has type 'sigset_t' (aka 'struct sigset_t') [-Werror,-Wformat]
   75 | printf("%X %X\n", act.sa_flags, act.sa_mask);
      | ~~ ^~~~~~~~~~~
```

The printing of the mask is optional and not needed for a working test, so we can avoid it on AIX .

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8365307](https://bugs.openjdk.org/browse/JDK-8365307): AIX make fails after JDK-8364611 (**Bug** - P2)


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)
 * [Andreas Steiner](https://openjdk.org/census#asteiner) (@ansteiner - Author)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26739/head:pull/26739` \
`$ git checkout pull/26739`

Update a local copy of the PR: \
`$ git checkout pull/26739` \
`$ git pull https://git.openjdk.org/jdk.git pull/26739/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26739`

View PR using the GUI difftool: \
`$ git pr show -t 26739`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26739.diff">https://git.openjdk.org/jdk/pull/26739.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26739#issuecomment-3178273579)
</details>
