### PR TITLE
8365316: Remove unnecessary default arg value in gcVMOperations

### DIFF
--- a/src/hotspot/share/gc/shared/gcVMOperations.hpp
+++ b/src/hotspot/share/gc/shared/gcVMOperations.hpp
@@ -117,8 +117,8 @@ class VM_GC_Operation: public VM_Heap_Sync_Operation {
  public:
   VM_GC_Operation(uint gc_count_before,
                   GCCause::Cause _cause,
-                  uint full_gc_count_before = 0,
-                  bool full = false) : VM_Heap_Sync_Operation() {
+                  uint full_gc_count_before,
+                  bool full) : VM_Heap_Sync_Operation() {
     _full = full;
     _prologue_succeeded = false;
     _gc_count_before    = gc_count_before;
@@ -156,8 +156,8 @@ class VM_GC_Service_Operation : public VM_GC_Operation {
 public:
   VM_GC_Service_Operation(uint gc_count_before,
                           GCCause::Cause _cause,
-                          uint full_gc_count_before = 0,
-                          bool full = false) :
+                          uint full_gc_count_before,
+                          bool full) :
     VM_GC_Operation(gc_count_before, _cause, full_gc_count_before, full) {}
 };
 


### PR DESCRIPTION
Trivial removing effectively dead code.

Test: tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8365316](https://bugs.openjdk.org/browse/JDK-8365316): Remove unnecessary default arg value in gcVMOperations (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26741/head:pull/26741` \
`$ git checkout pull/26741`

Update a local copy of the PR: \
`$ git checkout pull/26741` \
`$ git pull https://git.openjdk.org/jdk.git pull/26741/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26741`

View PR using the GUI difftool: \
`$ git pr show -t 26741`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26741.diff">https://git.openjdk.org/jdk/pull/26741.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26741#issuecomment-3178749375)
</details>
