### PR TITLE
8365098: make/RunTests.gmk generates a wrong path to test artifacts on Alpine

### DIFF
--- a/make/RunTests.gmk
+++ b/make/RunTests.gmk
@@ -1243,7 +1243,7 @@ UseSpecialTestHandler = \
 # Now process each test to run and setup a proper make rule
 $(foreach test, $(TESTS_TO_RUN), \
   $(eval TEST_ID := $(shell $(ECHO) $(strip $(test)) | \
-      $(TR) -cs '[a-z][A-Z][0-9]\n' '[_*1000]')) \
+      $(TR) -cs '[a-z][A-Z][0-9]\n' '_')) \
   $(eval ALL_TEST_IDS += $(TEST_ID)) \
   $(if $(call UseCustomTestHandler, $(test)), \
     $(eval $(call SetupRunCustomTest, $(TEST_ID), \
@@ -1323,9 +1323,9 @@ run-test-report: post-run-test
 	    TEST TOTAL PASS FAIL ERROR SKIP " "
 	$(foreach test, $(TESTS_TO_RUN), \
 	  $(eval TEST_ID := $(shell $(ECHO) $(strip $(test)) | \
-	      $(TR) -cs '[a-z][A-Z][0-9]\n' '[_*1000]')) \
+	      $(TR) -cs '[a-z][A-Z][0-9]\n' '_')) \
 	    $(ECHO) >> $(TEST_LAST_IDS) $(TEST_ID) $(NEWLINE) \
-	  $(eval NAME_PATTERN := $(shell $(ECHO) $(test) | $(TR) -c '\n' '[_*1000]')) \
+	  $(eval NAME_PATTERN := $(shell $(ECHO) $(test) | $(TR) -c '\n' '_')) \
 	  $(if $(filter __________________________________________________%, $(NAME_PATTERN)), \
 	    $(eval TEST_NAME := ) \
 	    $(PRINTF) >> $(TEST_SUMMARY) "%2s %-49s\n" "  " "$(test)"  $(NEWLINE) \


### PR DESCRIPTION
This change fixes the test artifact path on Alpine as `'[_*1000]'` is not recognized as a correct pattern, at least on Alpine 3.11.

Without this fix, on Alpine the command `make test-prebuilt` generated paths like the following:
```
Test report is stored in build/run-test-prebuilt/test-results/jtreg]test]hotspot]jtreg]tier1]common
```

Now it looks better:
```
Test report is stored in build/run-test-prebuilt/test-results/jtreg_test_hotspot_jtreg_tier1_common
```
All checks (tier1) are passed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8365098](https://bugs.openjdk.org/browse/JDK-8365098): make/RunTests.gmk generates a wrong path to test artifacts on Alpine (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26742/head:pull/26742` \
`$ git checkout pull/26742`

Update a local copy of the PR: \
`$ git checkout pull/26742` \
`$ git pull https://git.openjdk.org/jdk.git pull/26742/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26742`

View PR using the GUI difftool: \
`$ git pr show -t 26742`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26742.diff">https://git.openjdk.org/jdk/pull/26742.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26742#issuecomment-3178829506)
</details>
