### PR TITLE
8365375: Method SU3.setAcceleratorSelectionForeground assigns to acceleratorForeground

### DIFF
--- a/src/java.desktop/share/classes/com/sun/java/swing/SwingUtilities3.java
+++ b/src/java.desktop/share/classes/com/sun/java/swing/SwingUtilities3.java
@@ -248,7 +248,7 @@ public class SwingUtilities3 {
     }
 
     public static void setAcceleratorSelectionForeground(Color acceleratorSelectionFg) {
-        acceleratorForeground = acceleratorSelectionFg;
+        acceleratorSelectionForeground = acceleratorSelectionFg;
     }
 
     public static void setAcceleratorForeground(Color acceleratorFg) {


### PR DESCRIPTION
An inadvertent copy-paste error in assignment is fixed

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8365375](https://bugs.openjdk.org/browse/JDK-8365375): Method SU3.setAcceleratorSelectionForeground assigns to acceleratorForeground (**Bug** - P3)


### Reviewers
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)
 * [Alexander Zuev](https://openjdk.org/census#kizune) (@azuev-java - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26743/head:pull/26743` \
`$ git checkout pull/26743`

Update a local copy of the PR: \
`$ git checkout pull/26743` \
`$ git pull https://git.openjdk.org/jdk.git pull/26743/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26743`

View PR using the GUI difftool: \
`$ git pr show -t 26743`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26743.diff">https://git.openjdk.org/jdk/pull/26743.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26743#issuecomment-3179149298)
</details>
