### PR TITLE
8365378: Redundant code in Deoptimization::print_statistics

### DIFF
--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -2924,8 +2924,6 @@ void Deoptimization::print_statistics() {
           if (counter != 0) {
             char name[1*K];
             Bytecodes::Code bc = (Bytecodes::Code)(counter & LSB_MASK);
-            if (bc_case == BC_CASE_LIMIT && (int)bc == 0)
-              bc = Bytecodes::_illegal;
             os::snprintf_checked(name, sizeof(name), "%s/%s/%s",
                     trap_reason_name(reason),
                     trap_action_name(action),


### PR DESCRIPTION
Hi all,

The `Deoptimization::print_statistics` function has a conditional that is never invoked. `bc_case` is bound in a for loop and will always be < `BC_CASE_LIMIT`. Therefore, the entire condition will never hold, and the branch never execute. This change removes the dead code in order to increase maintainability.

I've run hotspot:tier1 to hotspot:tier3, in which I observed no test failures.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8365378](https://bugs.openjdk.org/browse/JDK-8365378): Redundant code in Deoptimization::print_statistics (**Bug** - P4)


### Reviewers
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@jdksjolen - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26744/head:pull/26744` \
`$ git checkout pull/26744`

Update a local copy of the PR: \
`$ git checkout pull/26744` \
`$ git pull https://git.openjdk.org/jdk.git pull/26744/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26744`

View PR using the GUI difftool: \
`$ git pr show -t 26744`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26744.diff">https://git.openjdk.org/jdk/pull/26744.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26744#issuecomment-3206834883)
</details>
