### PR TITLE
8365317: ZGC: Setting ZYoungGCThreads lower than ZOldGCThreads may result in a crash

### DIFF
--- a/src/hotspot/share/gc/z/zDirector.cpp
+++ b/src/hotspot/share/gc/z/zDirector.cpp
@@ -725,8 +725,8 @@ static ZWorkerCounts select_worker_threads(const ZDirectorStats& stats, uint you
       // Adjust down the old workers so the next minor during major will be less sad
       old_workers = old_workers_clamped;
       // Since collecting the old generation depends on the initial young collection
-      // finishing, we don't want it to have fewer workers than the old generation.
-      young_workers = MAX2(old_workers, young_workers);
+      // finishing, we ideally don't want it to have fewer workers than the old generation.
+      young_workers = clamp(MAX2(old_workers, young_workers), 1u, ZYoungGCThreads);
     } else if (type == ZWorkerSelectionType::minor_during_old) {
       // Adjust young and old workers for minor during old to fit within ConcGCThreads
       young_workers = young_workers_clamped;


### PR DESCRIPTION
Hello,

Setting ZYoungGCThreads lower than ZOldGCThreads may result in a crash, for example using `-XX:ZYoungGCThreads=4` and `-XX:ZOldGCThreads=8`. The problem is in `select_worker_threads()` in zDirector.cpp, where the number of young threads may be set to the number of old threads in an attempt to speed up the young collection so that the old collection can begin faster in a major collection. If the number of old threads exceed the maximum number of young threads, i.e. ZYoungGCThreads, a crash may occur. See the JBS issue for details on the crash.

Even though it may not be common, or reasonable in all scenarios, to set the maximum number of young threads to less than the maximum number of old threads, the combination should be possible and not result in a crash. To solve this issue, I suggest we clamp or otherwise limit the number of young threads to the maximum amount of young threads (i.e., `ZYoungGCThreads`).

Testing:
* Oracle's tier1-2, both with and without `-XX:ConcGCThreads=20 -XX:ZYoungGCThreads=2 -XX:ZOldGCThreadds=20` pass.
* I can no longer observe the intermittent crashes in release builds after 1000 runs.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8365317](https://bugs.openjdk.org/browse/JDK-8365317): ZGC: Setting ZYoungGCThreads lower than ZOldGCThreads may result in a crash (**Bug** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26745/head:pull/26745` \
`$ git checkout pull/26745`

Update a local copy of the PR: \
`$ git checkout pull/26745` \
`$ git pull https://git.openjdk.org/jdk.git pull/26745/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26745`

View PR using the GUI difftool: \
`$ git pr show -t 26745`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26745.diff">https://git.openjdk.org/jdk/pull/26745.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26745#issuecomment-3179195466)
</details>
