### PR TITLE
8365229: ARM32: c2i_no_clinit_check_entry assert failed after JDK-8364269

### DIFF
--- a/src/hotspot/share/code/codeBlob.cpp
+++ b/src/hotspot/share/code/codeBlob.cpp
@@ -450,8 +450,9 @@ AdapterBlob::AdapterBlob(int size, CodeBuffer* cb, int entry_offset[AdapterBlob:
   BufferBlob("I2C/C2I adapters", CodeBlobKind::Adapter, cb, size, sizeof(AdapterBlob)) {
   assert(entry_offset[0] == 0, "sanity check");
   for (int i = 1; i < AdapterBlob::ENTRY_COUNT; i++) {
-    assert(entry_offset[i] > 0 && entry_offset[i] < cb->insts()->size(),
-           "invalid entry offset 0x%x", entry_offset[i]);
+    assert((entry_offset[i] > 0 && entry_offset[i] < cb->insts()->size()) || // Within the adapter blob
+           (entry_offset[i] + p2i(cb->insts_begin()) == 0),                  // Or wraps back to nullptr
+           "invalid entry offset[%d] = 0x%x", i, entry_offset[i]);
   }
   _c2i_offset = entry_offset[1];
   _c2i_unverified_offset = entry_offset[2];

--- a/src/hotspot/share/code/codeBlob.cpp
+++ b/src/hotspot/share/code/codeBlob.cpp
@@ -451,7 +451,7 @@ AdapterBlob::AdapterBlob(int size, CodeBuffer* cb, int entry_offset[AdapterBlob:
   assert(entry_offset[0] == 0, "sanity check");
   for (int i = 1; i < AdapterBlob::ENTRY_COUNT; i++) {
     assert((entry_offset[i] > 0 && entry_offset[i] < cb->insts()->size()) || // Within the adapter blob
-           (entry_offset[i] + p2i(cb->insts_begin()) == 0),                  // Or wraps back to nullptr
+           (p2u(cb->insts_begin()) + (uintptr_t)entry_offset[i] == 0),       // Or wraps back to nullptr
            "invalid entry offset[%d] = 0x%x", i, entry_offset[i]);
   }
   _c2i_offset = entry_offset[1];


### PR DESCRIPTION
When recording adapter entries, we record _offsets_, not the actual addresses:

```
  entry_offset[3] = handler->get_c2i_no_clinit_check_entry() - i2c_entry;
```

Every platform except ARM32 and Zero have all these entries set up, so offset are always sane. But those two platforms set up `nullptr` as entry points for `c2i_no_clinit_check_entry`, because they have clinits unimplemented. So the new assert added in [JDK-8364269](https://bugs.openjdk.org/browse/JDK-8364269) fails. I think the math later wraps these around to `nullptr`-s. 

This PR is the second least horrible (IMO) fix for this: relaxing assert by checking that "out of range" values are actually wrapping around. The least horrible solution would be storing the actual `address`-es instead of `int` offsets. But that likely has footprint implications.

Additional testing:
 - [x] Linux ARM32 server fastdebug, `java -version` now works