### PR TITLE
8365290: [perf] x86 ArrayFill intrinsic generates SPLIT_STORE for unaligned arrays

### DIFF
--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -5869,7 +5869,7 @@ void MacroAssembler::generate_fill(BasicType t, bool aligned,
     BIND(L_skip_align2);
   }
   {
-    Label L_fill_32_bytes, L_C_align, L_align_64_bytes;
+    Label L_fill_32_bytes;
     if (!UseUnalignedLoadStores) {
       // align to 8 bytes, we know we are 4 byte aligned to start
       testptr(to, 4);
@@ -5878,7 +5878,6 @@ void MacroAssembler::generate_fill(BasicType t, bool aligned,
       addptr(to, 4);
       subptr(count, 1<<shift);
     }
-
     BIND(L_fill_32_bytes);
     {
       Label L_fill_32_bytes_loop, L_check_fill_8_bytes, L_fill_8_bytes_loop, L_fill_8_bytes;
@@ -5908,9 +5907,8 @@ void MacroAssembler::generate_fill(BasicType t, bool aligned,
 
           BIND(L_check_fill_64_bytes_avx2);
         }
-
         // align data for 64-byte chunks
-        Label L_fill_64_bytes_loop, L_fill_64_start;
+        Label L_fill_64_bytes_loop, L_fill_64_start, L_align_64_bytes;
         if (EnableX86ECoreOpts) {
             // align 'big' arrays to 64 bytes (cache line size) to minimize split_stores
             cmpptr(count, 256<<shift);

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -5873,25 +5873,10 @@ void MacroAssembler::generate_fill(BasicType t, bool aligned,
     if (!UseUnalignedLoadStores) {
       // align to 8 bytes, we know we are 4 byte aligned to start
       testptr(to, 4);
-      jccb(Assembler::zero, L_C_align);
-      movl(Address(to, 0), value);
-      addptr(to, 4);
-      subptr(count, 1<<shift);
-    }
-
-    BIND(L_C_align);
-    if (EnableX86ECoreOpts) {
-      // align 'big' arrays to 64 bytes (cache line size) to minimize split_stores
-      cmpptr(count, 256<<shift);
-      jcc(Assembler::below, L_fill_32_bytes);
-
-      BIND(L_align_64_bytes);
-      testptr(to, 0x3f); // low 7 bits shoud be zero
       jccb(Assembler::zero, L_fill_32_bytes);
       movl(Address(to, 0), value);
       addptr(to, 4);
       subptr(count, 1<<shift);
-      jmpb(L_align_64_bytes);
     }
 
     BIND(L_fill_32_bytes);
@@ -5923,8 +5908,27 @@ void MacroAssembler::generate_fill(BasicType t, bool aligned,
 
           BIND(L_check_fill_64_bytes_avx2);
         }
+
+        // align data for 64-byte chunks
+        Label L_fill_64_bytes_loop, L_fill_64_start;
+        if (EnableX86ECoreOpts) {
+            // align 'big' arrays to 64 bytes (cache line size) to minimize split_stores
+            cmpptr(count, 256<<shift);
+            jcc(Assembler::below, L_fill_64_start);
+
+            align(16);
+
+            BIND(L_align_64_bytes);
+            testptr(to, 0x3f); // low 7 bits shoud be zero
+            jccb(Assembler::zero, L_fill_64_start);
+            movl(Address(to, 0), value);
+            addptr(to, 4);
+            subptr(count, 1<<shift);
+            jmpb(L_align_64_bytes);
+        }
+
         // Fill 64-byte chunks
-        Label L_fill_64_bytes_loop;
+        BIND(L_fill_64_start);
         vpbroadcastd(xtmp, xtmp, Assembler::AVX_256bit);
 
         subptr(count, 16 << shift);

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -6015,7 +6015,6 @@ void MacroAssembler::generate_fill(BasicType t, bool aligned,
 
   if (t == T_BYTE || t == T_SHORT) {
     Label L_fill_byte;
-    addptr(count, 1 << shift);
     BIND(L_fill_2_bytes);
     // fill trailing 2 bytes
     testl(count, 1<<(shift-1));


### PR DESCRIPTION
On the SRF platform after PR https://github.com/openjdk/jdk/pull/26974  the fill intrinsics used by default.
For some types/ sizes scores for the ArrayFill test reports ~2x drop due to a lot of the 'MEM_UOPS_RETIRED.SPLIT_STORES' events. For example, the 'good' case for the ArraysFill.testCharFill with size=8195 reports numbers like
MEM_UOPS_RETIRED.SPLIT_LOADS | 22.6711
MEM_UOPS_RETIRED.SPLIT_STORES | 4.0859
while for 'bad' case these metrics are
MEM_UOPS_RETIRED.SPLIT_LOADS | 69.1785
MEM_UOPS_RETIRED.SPLIT_STORES | 259200.3659

With alignment for the cache line size no score drops due to split_stores but small reduction may be reported for 'good' cases due to extra instructions in the intrinsic. The default options set was used for testing with '-XX:-OptimizeFill' for compiled code and with '-XX:+OptimizeFill' to force intrinsic.
SRF 6740E | Size | compiled code| patched intrinsic| patched/compiled
-- | -- | -- | -- | --
ArraysFill.testByteFill | 16 | 152031.2 | 157001.2 | 1.03
ArraysFill.testByteFill | 31 | 125795.9 | 177399.2 | 1.41
ArraysFill.testByteFill | 250 | 57961.69 | 120981.9 | 2.09
ArraysFill.testByteFill | 266 | 44900.15 | 147893.8 | 3.29
ArraysFill.testByteFill | 511 | 61908.17 | 129830.1 | 2.10
ArraysFill.testByteFill | 2047 | 32255.51 | 41986.6 | 1.30
ArraysFill.testByteFill | 2048 | 31928.97 | 42154.3 | 1.32
ArraysFill.testByteFill | 8195 | 10690.15 | 11036.3 | 1.03
ArraysFill.testIntFill | 16 | 145030.7 | 318796.9 | 2.20
ArraysFill.testIntFill | 31 | 134138.4 | 212487 | 1.58
ArraysFill.testIntFill | 250 | 74179.23 | 79522.66 | 1.07
ArraysFill.testIntFill | 266 | 68112.72 | 60116.49 | 0.88
ArraysFill.testIntFill | 511 | 39693.28 | 36225.09 | 0.91
ArraysFill.testIntFill | 2047 | 11504.14 | 10616.91 | 0.92
ArraysFill.testIntFill | 2048 | 11244.71 | 10969.14 | 0.98
ArraysFill.testIntFill | 8195 | 2751.289 | 2692.216 | 0.98
ArraysFill.testLongFill | 16 | 212532.5 | 212526 | 1.00
ArraysFill.testLongFill | 31 | 137432.4 | 137283.3 | 1.00
ArraysFill.testLongFill | 250 | 43185 | 43159.78 | 1.00
ArraysFill.testLongFill | 266 | 42172.22 | 42170.5 | 1.00
ArraysFill.testLongFill | 511 | 23370.15 | 23370.86 | 1.00
ArraysFill.testLongFill | 2047 | 6123.008 | 6122.73 | 1.00
ArraysFill.testLongFill | 2048 | 5793.722 | 5792.855 | 1.00
ArraysFill.testLongFill | 8195 | 616.552 | 616.585 | 1.00
ArraysFill.testShortFill | 16 | 152088.6 | 265646.1 | 1.75
ArraysFill.testShortFill | 31 | 137369.8 | 185596.4 | 1.35
ArraysFill.testShortFill | 250 | 58872.03 | 99621.15 | 1.69
ArraysFill.testShortFill | 266 | 91085.31 | 93746.62 | 1.03
ArraysFill.testShortFill | 511 | 65331.96 | 78003.83 | 1.19
ArraysFill.testShortFill | 2047 | 21716.32 | 21216.81 | 0.98
ArraysFill.testShortFill | 2048 | 21664.91 | 21328.72 | 0.98
ArraysFill.testShortFill | 8195 | 5922.547 | 5799.964 | 0.98

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8365290](https://bugs.openjdk.org/browse/JDK-8365290): [perf] x86 ArrayFill intrinsic generates SPLIT_STORE for unaligned arrays (**Bug** - P4)


### Reviewers
 * [Sandhya Viswanathan](https://openjdk.org/census#sviswanathan) (@sviswa7 - **Reviewer**)
 * [Volodymyr Paprotski](https://openjdk.org/census#vpaprotski) (@vpaprotsk - Committer)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26747/head:pull/26747` \
`$ git checkout pull/26747`

Update a local copy of the PR: \
`$ git checkout pull/26747` \
`$ git pull https://git.openjdk.org/jdk.git pull/26747/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26747`

View PR using the GUI difftool: \
`$ git pr show -t 26747`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26747.diff">https://git.openjdk.org/jdk/pull/26747.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26747#issuecomment-3179736089)
</details>
