### PR TITLE
8365291: Remove finalize() method from sun/awt/X11InputMethodBase.java

### DIFF
--- a/src/java.desktop/unix/classes/sun/awt/X11InputMethodBase.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11InputMethodBase.java
@@ -172,13 +172,6 @@ public abstract class X11InputMethodBase extends InputMethodAdapter {
         }
     }
 
-    @Override
-    @SuppressWarnings("removal")
-    protected void finalize() throws Throwable {
-        dispose();
-        super.finalize();
-    }
-
     /**
      * Invokes openIM() that invokes XOpenIM() if it's not opened yet.
      * @return  true if openXIM() is successful or it's already been opened.


### PR DESCRIPTION
It seems that finalize() in X11InputMethodBase.java isn't useful.
It calls dispose(), which in all actual implementations has just one native resource to release, which
is a native struct of type X11InputMethodData (this is a JDK-defined struct, not one from Xim),
and one of the fields is a JNI GlobalRef pointing to the XInputMethod instance which implements the dispose() method.
So finalize cannot be called unless dispose() is called first. But if dispose() has been called then there's no need for
finalize() since all it does is call dispose()

Many more details in JBS.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8365291](https://bugs.openjdk.org/browse/JDK-8365291): Remove finalize() method from sun/awt/X11InputMethodBase.java (**Bug** - P4)


### Reviewers
 * [Tejesh R](https://openjdk.org/census#tr) (@TejeshR13 - **Reviewer**)
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26751/head:pull/26751` \
`$ git checkout pull/26751`

Update a local copy of the PR: \
`$ git checkout pull/26751` \
`$ git pull https://git.openjdk.org/jdk.git pull/26751/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26751`

View PR using the GUI difftool: \
`$ git pr show -t 26751`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26751.diff">https://git.openjdk.org/jdk/pull/26751.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26751#issuecomment-3180622627)
</details>
