### PR TITLE
8365198

### DIFF
--- a/src/java.desktop/share/classes/javax/imageio/ImageReader.java
+++ b/src/java.desktop/share/classes/javax/imageio/ImageReader.java
@@ -2501,8 +2501,7 @@ public abstract class ImageReader {
 
     /**
      * Allows any resources held by this object to be released.  The
-     * result of calling any other method (other than
-     * {@code finalize}) subsequent to a call to this method
+     * result of calling any other method subsequent to a call to this method
      * is undefined.
      *
      * <p>It is important for applications to call this method when they

--- a/src/java.desktop/share/classes/javax/imageio/ImageWriter.java
+++ b/src/java.desktop/share/classes/javax/imageio/ImageWriter.java
@@ -2000,8 +2000,7 @@ public abstract class ImageWriter implements ImageTranscoder {
 
     /**
      * Allows any resources held by this object to be released.  The
-     * result of calling any other method (other than
-     * {@code finalize}) subsequent to a call to this method
+     * result of calling any other method subsequent to a call to this method
      * is undefined.
      *
      * <p>It is important for applications to call this method when they


### PR DESCRIPTION
Image I/O's ImageReader and ImageWriter have never had finalize() methods, yet have a gratuitous mention of finalize(). This should be removed. Simple doc only change