### PR TITLE
8317269: Store old classes in linked state in AOT cache

### DIFF
--- a/src/hotspot/share/cds/archiveBuilder.cpp
+++ b/src/hotspot/share/cds/archiveBuilder.cpp
@@ -931,7 +931,7 @@ void ArchiveBuilder::make_klasses_shareable() {
         ADD_COUNT(num_enum_klasses);
       }
 
-      if (!ik->can_be_verified_at_dumptime()) {
+      if (CDSConfig::is_old_class_for_verifier(ik)) {
         ADD_COUNT(num_old_klasses);
         old = " old";
       }

--- a/src/hotspot/share/cds/cdsConfig.cpp
+++ b/src/hotspot/share/cds/cdsConfig.cpp
@@ -55,6 +55,7 @@ bool CDSConfig::_has_temp_aot_config_file = false;
 bool CDSConfig::_old_cds_flags_used = false;
 bool CDSConfig::_new_aot_flags_used = false;
 bool CDSConfig::_disable_heap_dumping = false;
+bool CDSConfig::_is_at_cds_safepoint = false;
 
 const char* CDSConfig::_default_archive_path = nullptr;
 const char* CDSConfig::_input_static_archive_path = nullptr;
@@ -908,6 +909,35 @@ void CDSConfig::log_reasons_for_not_dumping_heap() {
 // This is *Legacy* optimization for lambdas before JEP 483. May be removed in the future.
 bool CDSConfig::is_dumping_lambdas_in_legacy_mode() {
   return !is_dumping_method_handles();
+}
+
+bool CDSConfig::is_preserving_verification_dependencies() {
+  // Verification dependencies are classes used in assignability checks by the
+  // bytecode verifier. In the following example, the verification dependencies
+  // for X are A and B.
+  //
+  //     class X {
+  //        A getA() { return new B(); }
+  //     }
+  //
+  // With the AOT cache, we can ensure that all the verification dependencies
+  // (A and B in the above example) are unconditionally loaded during the bootstrap
+  // of the production run. This means that if a class was successfully verified
+  // in the assembly phase, all of the verifier's assignability checks will remain
+  // valid in the production run, so we don't need to verify aot-lined classes again.
+
+  if (is_dumping_preimage_static_archive()) { // writing AOT config
+    return AOTClassLinking;
+  } else if (is_dumping_final_static_archive()) { // writing AOT cache
+    return is_dumping_aot_linked_classes();
+  } else {
+    // For simplicity, we don't support this optimization with the old CDS workflow.
+    return false;
+  }
+}
+
+bool CDSConfig::is_old_class_for_verifier(const InstanceKlass* ik) {
+  return ik->major_version() < 50 /*JAVA_6_VERSION*/;
 }
 
 #if INCLUDE_CDS_JAVA_HEAP

--- a/src/hotspot/share/cds/cdsConfig.hpp
+++ b/src/hotspot/share/cds/cdsConfig.hpp
@@ -30,6 +30,7 @@
 #include "utilities/macros.hpp"
 
 class JavaThread;
+class InstanceKlass;
 
 class CDSConfig : public AllStatic {
 #if INCLUDE_CDS
@@ -43,6 +44,7 @@ class CDSConfig : public AllStatic {
   static bool _has_aot_linked_classes;
   static bool _is_single_command_training;
   static bool _has_temp_aot_config_file;
+  static bool _is_at_cds_safepoint;
 
   const static char* _default_archive_path;
   const static char* _input_static_archive_path;
@@ -98,6 +100,9 @@ public:
   static const char* type_of_archive_being_loaded();
   static const char* type_of_archive_being_written();
   static void prepare_for_dumping();
+
+  static bool is_at_cds_safepoint()                          { return CDS_ONLY(_is_at_cds_safepoint) NOT_CDS(false); }
+  static void set_is_at_cds_safepoint(bool value)            { CDS_ONLY(_is_at_cds_safepoint = value); }
 
   // --- Basic CDS features
 
@@ -160,6 +165,10 @@ public:
   static bool is_dumping_aot_linked_classes()                NOT_CDS_JAVA_HEAP_RETURN_(false);
   static bool is_using_aot_linked_classes()                  NOT_CDS_JAVA_HEAP_RETURN_(false);
   static void set_has_aot_linked_classes(bool has_aot_linked_classes) NOT_CDS_JAVA_HEAP_RETURN;
+
+  // Bytecode verification
+  static bool is_preserving_verification_dependencies();
+  static bool is_old_class_for_verifier(const InstanceKlass* ik);
 
   // archive_path
 

--- a/src/hotspot/share/cds/dumpTimeClassInfo.cpp
+++ b/src/hotspot/share/cds/dumpTimeClassInfo.cpp
@@ -36,6 +36,9 @@ DumpTimeClassInfo::~DumpTimeClassInfo() {
     delete _verifier_constraints;
     delete _verifier_constraint_flags;
   }
+  if (_old_verifier_dependencies != nullptr) {
+    delete _old_verifier_dependencies;
+  }
   if (_loader_constraints != nullptr) {
     delete _loader_constraints;
   }
@@ -43,11 +46,12 @@ DumpTimeClassInfo::~DumpTimeClassInfo() {
 
 size_t DumpTimeClassInfo::runtime_info_bytesize() const {
   return RunTimeClassInfo::byte_size(_klass, num_verifier_constraints(),
+                                     num_old_verifier_dependencies(),
                                      num_loader_constraints(),
                                      num_enum_klass_static_fields());
 }
 
-void DumpTimeClassInfo::add_verification_constraint(InstanceKlass* k, Symbol* name,
+void DumpTimeClassInfo::add_verification_constraint(Symbol* name,
          Symbol* from_name, bool from_field_is_protected, bool from_is_array, bool from_is_object) {
   if (_verifier_constraints == nullptr) {
     _verifier_constraints = new (mtClass) GrowableArray<DTVerifierConstraint>(4, mtClass);
@@ -73,11 +77,25 @@ void DumpTimeClassInfo::add_verification_constraint(InstanceKlass* k, Symbol* na
 
   if (log_is_enabled(Trace, aot, verification)) {
     ResourceMark rm;
-    log_trace(aot, verification)("add_verification_constraint: %s: %s must be subclass of %s [0x%x] array len %d flags len %d",
-                                 k->external_name(), from_name->as_klass_external_name(),
-                                 name->as_klass_external_name(), c, vc_array->length(), vcflags_array->length());
+    log_trace(aot, verification)("add_verification_constraint: %s: %s must be subclass of %s [0x%x]",
+                                 _klass->external_name(), from_name->as_klass_external_name(),
+                                 name->as_klass_external_name(), c);
   }
 }
+
+void DumpTimeClassInfo::add_old_verification_dependency(Symbol* name) {
+  if (_old_verifier_dependencies == nullptr) {
+    _old_verifier_dependencies = new (mtClass) GrowableArray<Symbol*>(4, mtClass);
+  }
+  _old_verifier_dependencies->append(name);
+
+  if (log_is_enabled(Trace, aot, verification)) {
+    ResourceMark rm;
+    log_trace(aot, verification)("add old verification dependency: %s: %s must be also be archived",
+                                 _klass->external_name(), name->as_klass_external_name());
+  }
+}
+
 
 static char get_loader_type_by(oop  loader) {
   assert(SystemDictionary::is_builtin_class_loader(loader), "Must be built-in loader");

--- a/src/hotspot/share/cds/dumpTimeClassInfo.hpp
+++ b/src/hotspot/share/cds/dumpTimeClassInfo.hpp
@@ -129,6 +129,7 @@ public:
   int                          _clsfile_crc32;
   GrowableArray<DTVerifierConstraint>* _verifier_constraints;
   GrowableArray<char>*                 _verifier_constraint_flags;
+  GrowableArray<Symbol*>*              _old_verifier_dependencies;
   GrowableArray<DTLoaderConstraint>*   _loader_constraints;
   GrowableArray<int>*                  _enum_klass_static_fields;
 
@@ -146,14 +147,16 @@ public:
     _is_early_klass = JvmtiExport::is_early_phase();
     _verifier_constraints = nullptr;
     _verifier_constraint_flags = nullptr;
+    _old_verifier_dependencies = nullptr;
     _loader_constraints = nullptr;
     _enum_klass_static_fields = nullptr;
   }
   DumpTimeClassInfo& operator=(const DumpTimeClassInfo&) = delete;
   ~DumpTimeClassInfo();
 
-  void add_verification_constraint(InstanceKlass* k, Symbol* name,
+  void add_verification_constraint(Symbol* name,
          Symbol* from_name, bool from_field_is_protected, bool from_is_array, bool from_is_object);
+  void add_old_verification_dependency(Symbol* name);
   void record_linking_constraint(Symbol* name, Handle loader1, Handle loader2);
   void add_enum_klass_static_field(int archived_heap_root_index);
   int  enum_klass_static_field(int which_field);
@@ -173,6 +176,22 @@ public:
 
   int num_verifier_constraints() const {
     return array_length_or_zero(_verifier_constraint_flags);
+  }
+
+  Symbol* verifier_constraint_name_at(int i) const {
+    return _verifier_constraints->at(i).name();
+  }
+
+  Symbol* verifier_constraint_from_name_at(int i) const {
+    return _verifier_constraints->at(i).from_name();
+  }
+
+  int num_old_verifier_dependencies() const {
+    return array_length_or_zero(_old_verifier_dependencies);
+  }
+
+  Symbol* old_verifier_dependency_at(int i) const {
+    return _old_verifier_dependencies->at(i);
   }
 
   int num_loader_constraints() const {

--- a/src/hotspot/share/cds/lambdaProxyClassDictionary.cpp
+++ b/src/hotspot/share/cds/lambdaProxyClassDictionary.cpp
@@ -471,12 +471,12 @@ class LambdaProxyClassDictionary::CleanupDumpTimeLambdaProxyClassTable: StackObj
 
     // If the caller class and/or nest_host are excluded, the associated lambda proxy
     // must also be excluded.
-    bool always_exclude = SystemDictionaryShared::check_for_exclusion(caller_ik, nullptr) ||
-                          SystemDictionaryShared::check_for_exclusion(nest_host, nullptr);
+    bool always_exclude = SystemDictionaryShared::should_be_excluded(caller_ik) ||
+                          SystemDictionaryShared::should_be_excluded(nest_host);
 
     for (int i = info._proxy_klasses->length() - 1; i >= 0; i--) {
       InstanceKlass* ik = info._proxy_klasses->at(i);
-      if (always_exclude || SystemDictionaryShared::check_for_exclusion(ik, nullptr)) {
+      if (always_exclude || SystemDictionaryShared::should_be_excluded(ik)) {
         LambdaProxyClassDictionary::reset_registered_lambda_proxy_class(ik);
         info._proxy_klasses->remove_at(i);
       }

--- a/src/hotspot/share/cds/metaspaceShared.hpp
+++ b/src/hotspot/share/cds/metaspaceShared.hpp
@@ -132,6 +132,7 @@ public:
   }
 
   static bool try_link_class(JavaThread* current, InstanceKlass* ik);
+  static void link_all_loaded_classes(JavaThread* current);
   static void link_shared_classes(TRAPS) NOT_CDS_RETURN;
   static bool may_be_eagerly_linked(InstanceKlass* ik) NOT_CDS_RETURN_(false);
 

--- a/src/hotspot/share/cds/runTimeClassInfo.cpp
+++ b/src/hotspot/share/cds/runTimeClassInfo.cpp
@@ -52,6 +52,14 @@ void RunTimeClassInfo::init(DumpTimeClassInfo& info) {
     }
   }
 
+  _num_old_verifier_dependencies = info.num_old_verifier_dependencies();
+  if (_num_old_verifier_dependencies > 0) {
+    u4* constraints = old_verifier_dependencies();
+    for (i = 0; i < _num_old_verifier_dependencies; i++) {
+      constraints[i] = builder->any_to_offset_u4(info.old_verifier_dependency_at(i));
+    }
+  }
+
   if (_num_loader_constraints > 0) {
     RTLoaderConstraint* ld_constraints = loader_constraints();
     for (i = 0; i < _num_loader_constraints; i++) {

--- a/src/hotspot/share/classfile/systemDictionaryShared.cpp
+++ b/src/hotspot/share/classfile/systemDictionaryShared.cpp
@@ -203,26 +203,151 @@ DumpTimeClassInfo* SystemDictionaryShared::get_info_locked(InstanceKlass* k) {
   return info;
 }
 
-bool SystemDictionaryShared::check_for_exclusion(InstanceKlass* k, DumpTimeClassInfo* info) {
-  if (CDSConfig::is_dumping_dynamic_archive() && MetaspaceShared::is_in_shared_metaspace(k)) {
-    // We have reached a super type that's already in the base archive. Treat it
-    // as "not excluded".
-    return false;
-  }
-
-  if (info == nullptr) {
-    info = _dumptime_table->get(k);
-    assert(info != nullptr, "supertypes of any classes in _dumptime_table must either be shared, or must also be in _dumptime_table");
-  }
+bool SystemDictionaryShared::should_be_excluded_impl(InstanceKlass* k, DumpTimeClassInfo* info) {
+  assert_lock_strong(DumpTimeTable_lock);
 
   if (!info->has_checked_exclusion()) {
-    if (check_for_exclusion_impl(k)) {
-      info->set_excluded();
-    }
-    info->set_has_checked_exclusion();
+    check_exclusion_for_self_and_dependencies(k);
+    assert(info->has_checked_exclusion(), "must be");
   }
 
   return info->is_excluded();
+}
+
+// <func> returns bool and takes a single parameter of Symbol*
+// - If <func> returns true for any name, this method terminates immediately.
+// - If <func> never returns true, we will iterate over all the names.
+template<typename Function>
+void SystemDictionaryShared::iterate_all_verification_dependency_names(InstanceKlass* k, DumpTimeClassInfo* info, Function func) {
+  int n = info->num_verifier_constraints();
+  for (int i = 0; i < n; i++) {
+    if (func(info->verifier_constraint_name_at(i))) {
+      return;
+    }
+    if (func(info->verifier_constraint_from_name_at(i))) {
+      return;
+    }
+  }
+
+  n = info->num_old_verifier_dependencies();
+  for (int i = 0; i < n; i++) {
+    if (func(info->old_verifier_dependency_at(i))) {
+      return;
+    }
+  }
+}
+
+// This is a table of classes that need to be check for exclusion.
+class SystemDictionaryShared::ExclusionCheckCandidates
+  : public ResourceHashtable<InstanceKlass*, DumpTimeClassInfo*, 15889> {
+  void add_candidate(InstanceKlass* k) {
+    if (contains(k)) {
+      return;
+    }
+    if (CDSConfig::is_dumping_dynamic_archive() && MetaspaceShared::is_in_shared_metaspace(k)) {
+      return;
+    }
+
+    DumpTimeClassInfo* info = SystemDictionaryShared::get_info_locked(k);
+    if (info->has_checked_exclusion()) {
+      // We have check exclusion of k and all of its dependencies, so there's no need to check again.
+      return;
+    }
+
+    put(k, info);
+
+    InstanceKlass* super = k->java_super();
+    if (super != nullptr) {
+      add_candidate(super);
+    }
+
+    Array<InstanceKlass*>* interfaces = k->local_interfaces();
+    int len = interfaces->length();
+    for (int i = 0; i < len; i++) {
+      add_candidate(interfaces->at(i));
+    }
+
+    InstanceKlass* nest_host = k->nest_host_or_null();
+    if (nest_host != nullptr && nest_host != k) {
+      add_candidate(nest_host);
+    }
+
+    if (CDSConfig::is_preserving_verification_dependencies()) {
+      SystemDictionaryShared::iterate_all_verification_dependency_names(k, info, [&] (Symbol* dependency_class_name) {
+        Klass* dependency_bottom_class = find_verification_dependency_bottom_class(k, dependency_class_name);
+        if (dependency_bottom_class != nullptr && dependency_bottom_class->is_instance_klass()) {
+          add_candidate(InstanceKlass::cast(dependency_bottom_class));
+        }
+        return false; // Keep iterating.
+      });
+    }
+  }
+
+public:
+  ExclusionCheckCandidates(InstanceKlass* k) {
+    add_candidate(k);
+  }
+};
+
+// A class X is excluded if check_self_exclusion() returns true for X or any of
+// X's "exclusion dependency" classes, which include:
+//     - ik's super types
+//     - ik's nest host (if any)
+//
+//  plus, if CDSConfig::is_preserving_verification_dependencies()==true:
+//     - ik's verification dependencies. These are the classes used in assignability checks
+//         when verifying ik's bytecodes.
+//
+// This method ensure that exclusion check is performed on X and all of its exclusion dependencies.
+void SystemDictionaryShared::check_exclusion_for_self_and_dependencies(InstanceKlass *ik) {
+  assert_lock_strong(DumpTimeTable_lock);
+  ResourceMark rm;
+
+  // This will recursive find ik and all of its exclusion dependencies that have not yet been checked.
+  ExclusionCheckCandidates candidates(ik);
+
+  // (1) Check each class to see if it should be excluded due to its own problems
+  candidates.iterate_all([&] (InstanceKlass* k, DumpTimeClassInfo* info) {
+    if (check_self_exclusion(k)) {
+      info->set_excluded();
+    }
+  });
+
+  // (2) Check each class to see if it should be excluded because of problems in a depeendency class
+  while (true) {
+    bool found_new_exclusion = false;
+
+    candidates.iterate_all([&] (InstanceKlass* k, DumpTimeClassInfo* info) {
+      if (!info->is_excluded() && check_dependencies_exclusion(k, info)) {
+        info->set_excluded();
+        found_new_exclusion = true;
+      }
+    });
+
+    // Algorithm notes:
+    //
+    // The dependencies is a directed graph, possibly cyclic. Class X is excluded
+    // if it has at least one directed path that reaches class Y, where
+    // check_self_exclusion(Y) returns true.
+    //
+    // Because of the possibility of cycles in the graph, we cannot use simple
+    // recursion. Otherwise we will either never terminate, or will miss some paths.
+    //
+    // Hence, we keep doing a linear scan of the candidate until we stop finding
+    // new exclusions.
+    //
+    // In the worst case, we find one exclusion per iteration of the while loop,
+    // so the while loop gets executed O(N^2) times. However, in reality we have
+    // very few exclusions, so in most cases the while loop executes only once, and we
+    // walk each edge in the dependencies graph exactly once.
+    if (!found_new_exclusion) {
+      break;
+    }
+  }
+  candidates.iterate_all([&] (InstanceKlass* k, DumpTimeClassInfo* info) {
+    // All candidates have been fully checked, so we don't need to check them again.
+    info->set_has_checked_exclusion();
+  });
 }
 
 // Returns true so the caller can do:    return warn_excluded(".....");
@@ -247,7 +372,8 @@ bool SystemDictionaryShared::is_early_klass(InstanceKlass* ik) {
   return (info != nullptr) ? info->is_early_klass() : false;
 }
 
-bool SystemDictionaryShared::check_for_exclusion_impl(InstanceKlass* k) {
+bool SystemDictionaryShared::check_self_exclusion(InstanceKlass* k) {
+  assert_lock_strong(DumpTimeTable_lock);
   if (CDSConfig::is_dumping_final_static_archive() && k->defined_by_other_loaders()
       && k->is_shared()) {
     return false; // Do not exclude: unregistered classes are passed from preimage to final image.
@@ -300,9 +426,8 @@ bool SystemDictionaryShared::check_for_exclusion_impl(InstanceKlass* k) {
       return warn_excluded(k, "Failed verification");
     } else if (CDSConfig::is_dumping_aot_linked_classes()) {
       // Most loaded classes should have been speculatively linked by MetaspaceShared::link_class_for_cds().
-      // However, we do not speculatively link old classes, as they are not recorded by
-      // SystemDictionaryShared::record_linking_constraint(). As a result, such an unlinked
-      // class may fail to verify in AOTLinkedClassBulkLoader::init_required_classes_for_loader(),
+      // Old classes may not be linked if CDSConfig::is_preserving_verification_dependencies()==false.
+      // An unlinked class may fail to verify in AOTLinkedClassBulkLoader::init_required_classes_for_loader(),
       // causing the JVM to fail at bootstrap.
       return warn_excluded(k, "Unlinked class not supported by AOTClassLinking");
     } else if (CDSConfig::is_dumping_preimage_static_archive()) {
@@ -328,10 +453,13 @@ bool SystemDictionaryShared::check_for_exclusion_impl(InstanceKlass* k) {
     return true;
   }
 
+  return false;
+}
+
+// Returns true if the DumpTimeClassInfo::is_excluded() is true for at least one of k's exclusion dependencies.
+bool SystemDictionaryShared::check_dependencies_exclusion(InstanceKlass* k, DumpTimeClassInfo* info) {
   InstanceKlass* super = k->java_super();
-  if (super != nullptr && check_for_exclusion(super, nullptr)) {
-    ResourceMark rm;
-    aot_log_warning(aot)("Skipping %s: super class %s is excluded", k->name()->as_C_string(), super->name()->as_C_string());
+  if (super != nullptr && is_dependency_excluded(k, super, "super")) {
     return true;
   }
 
@@ -339,21 +467,83 @@ bool SystemDictionaryShared::check_for_exclusion_impl(InstanceKlass* k) {
   int len = interfaces->length();
   for (int i = 0; i < len; i++) {
     InstanceKlass* intf = interfaces->at(i);
-    if (check_for_exclusion(intf, nullptr)) {
-      ResourceMark rm;
-      aot_log_warning(aot)("Skipping %s: interface %s is excluded", k->name()->as_C_string(), intf->name()->as_C_string());
+    if (is_dependency_excluded(k, intf, "interface")) {
       return true;
     }
   }
 
   InstanceKlass* nest_host = k->nest_host_or_null();
-  if (nest_host != nullptr && nest_host != k && check_for_exclusion(nest_host, nullptr)) {
-    ResourceMark rm;
-    aot_log_warning(aot)("Skipping %s: nest_host class %s is excluded", k->name()->as_C_string(), nest_host->name()->as_C_string());
+  if (nest_host != nullptr && nest_host != k && is_dependency_excluded(k, nest_host, "nest host class")) {
     return true;
   }
 
-  return false; // false == k should NOT be excluded
+  if (CDSConfig::is_preserving_verification_dependencies()) {
+    bool excluded = false;
+
+    iterate_all_verification_dependency_names(k, info, [&] (Symbol* dependency_class_name) {
+      if (check_verification_dependency_exclusion(k, dependency_class_name)) {
+        // If one of the verification dependency class has been excluded, the assignability checks
+        // by the verifier may no longer be valid in the production run. For safety, exclude this class.
+        excluded = true;
+        return true; // terminate iteration; k will be excluded
+      } else {
+        return false; // keep iterating
+      }
+    });
+
+    if (excluded) {
+      // At least one verification dependency class has been excluded
+      return true;
+    }
+  }
+
+  return false;
+}
+
+bool SystemDictionaryShared::is_dependency_excluded(InstanceKlass* k, InstanceKlass* dependency, const char* type) {
+  if (CDSConfig::is_dumping_dynamic_archive() && MetaspaceShared::is_in_shared_metaspace(dependency)) {
+    return false;
+  }
+  DumpTimeClassInfo* dependency_info = get_info_locked(dependency);
+  if (dependency_info->is_excluded()) {
+    ResourceMark rm;
+    aot_log_warning(aot)("Skipping %s: %s %s is excluded", k->name()->as_C_string(), type, dependency->name()->as_C_string());
+    return true;
+  }
+  return false;
+}
+
+bool SystemDictionaryShared::check_verification_dependency_exclusion(InstanceKlass* k, Symbol* dependency_class_name) {
+  Klass* dependency_bottom_class = find_verification_dependency_bottom_class(k, dependency_class_name);
+  if (dependency_bottom_class == nullptr) {
+    // The new verifier was checking if dependency_class_name is assignable to an interface, and found
+    // the answer without resolving dependency_class_name.
+    return false;
+  } else if (dependency_bottom_class->is_instance_klass()) {
+    if (is_dependency_excluded(k, InstanceKlass::cast(dependency_bottom_class), "verification dependency")) {
+      return true;
+    }
+  } else {
+    assert(dependency_bottom_class->is_typeArray_klass(), "must be");
+  }
+
+  return false;
+}
+
+Klass* SystemDictionaryShared::find_verification_dependency_bottom_class(InstanceKlass* k, Symbol* dependency_class_name) {
+  Thread* current = Thread::current();
+  Handle loader(current, k->class_loader());
+  Klass* dependency_class = SystemDictionary::find_instance_or_array_klass(current, dependency_class_name, loader);
+  if (dependency_class == nullptr) {
+    return nullptr;
+  }
+
+  if (dependency_class->is_objArray_klass()) {
+    dependency_class = ObjArrayKlass::cast(dependency_class)->bottom_klass();
+  }
+
+  precond(dependency_class->is_typeArray_klass() || dependency_class->is_instance_klass());
+  return dependency_class;
 }
 
 bool SystemDictionaryShared::is_builtin_loader(ClassLoaderData* loader_data) {
@@ -555,7 +745,7 @@ void SystemDictionaryShared::handle_class_unloading(InstanceKlass* klass) {
 
 void SystemDictionaryShared::init_dumptime_info_from_preimage(InstanceKlass* k) {
   init_dumptime_info(k);
-  copy_verification_constraints_from_preimage(k);
+  copy_verification_info_from_preimage(k);
   copy_linking_constraints_from_preimage(k);
 
   if (SystemDictionary::is_platform_class_loader(k->class_loader())) {
@@ -650,16 +840,21 @@ public:
 // Returns true if the class should be excluded. This can be called by
 // AOTConstantPoolResolver before or after we enter the CDS safepoint.
 // When called before the safepoint, we need to link the class so that
-// it can be checked by check_for_exclusion().
+// it can be checked by should_be_excluded_impl().
 bool SystemDictionaryShared::should_be_excluded(Klass* k) {
   assert(CDSConfig::is_dumping_archive(), "sanity");
   assert(CDSConfig::current_thread_is_vm_or_dumper(), "sanity");
 
-  if (k->is_objArray_klass()) {
-    return should_be_excluded(ObjArrayKlass::cast(k)->bottom_klass());
+  if (CDSConfig::is_dumping_dynamic_archive() && MetaspaceShared::is_in_shared_metaspace(k)) {
+    // We have reached a super type that's already in the base archive. Treat it
+    // as "not excluded".
+    return false;
   }
 
-  if (!k->is_instance_klass()) {
+  if (k->is_objArray_klass()) {
+    return should_be_excluded(ObjArrayKlass::cast(k)->bottom_klass());
+  } else if (!k->is_instance_klass()) {
+    assert(k->is_typeArray_klass(), "must be");
     return false;
   } else {
     InstanceKlass* ik = InstanceKlass::cast(k);
@@ -671,7 +866,7 @@ bool SystemDictionaryShared::should_be_excluded(Klass* k) {
 
     if (!SafepointSynchronize::is_at_safepoint()) {
       if (!ik->is_linked()) {
-        // check_for_exclusion() below doesn't link unlinked classes. We come
+        // should_be_excluded_impl() below doesn't link unlinked classes. We come
         // here only when we are trying to aot-link constant pool entries, so
         // we'd better link the class.
         JavaThread* THREAD = JavaThread::current();
@@ -680,6 +875,10 @@ bool SystemDictionaryShared::should_be_excluded(Klass* k) {
           CLEAR_PENDING_EXCEPTION;
           return true; // linking failed -- let's exclude it
         }
+
+        // Also link any classes that were loaded for the verification of ik or its supertypes.
+        // Otherwise we might miss the verification constraints of those classes.
+        MetaspaceShared::link_all_loaded_classes(THREAD);
       }
 
       MutexLocker ml(DumpTimeTable_lock, Mutex::_no_safepoint_check_flag);
@@ -687,7 +886,7 @@ bool SystemDictionaryShared::should_be_excluded(Klass* k) {
       if (p->is_excluded()) {
         return true;
       }
-      return check_for_exclusion(ik, p);
+      return should_be_excluded_impl(ik, p);
     } else {
       // No need to check for is_linked() as all eligible classes should have
       // already been linked in MetaspaceShared::link_class_for_cds().
@@ -696,12 +895,13 @@ bool SystemDictionaryShared::should_be_excluded(Klass* k) {
       if (p->is_excluded()) {
         return true;
       }
-      return check_for_exclusion(ik, p);
+      return should_be_excluded_impl(ik, p);
     }
   }
 }
 
 void SystemDictionaryShared::finish_exclusion_checks() {
+  assert_at_safepoint();
   if (CDSConfig::is_dumping_dynamic_archive() || CDSConfig::is_dumping_preimage_static_archive()) {
     // Do this first -- if a base class is excluded due to duplication,
     // all of its subclasses will also be excluded.
@@ -712,7 +912,7 @@ void SystemDictionaryShared::finish_exclusion_checks() {
   }
 
   _dumptime_table->iterate_all_live_classes([&] (InstanceKlass* k, DumpTimeClassInfo& info) {
-    SystemDictionaryShared::check_for_exclusion(k, &info);
+    SystemDictionaryShared::should_be_excluded_impl(k, &info);
   });
 
   _dumptime_table->update_counts();
@@ -792,7 +992,7 @@ void SystemDictionaryShared::add_verification_constraint(InstanceKlass* k, Symbo
          bool* skip_assignability_check) {
   assert(CDSConfig::is_dumping_archive(), "sanity");
   DumpTimeClassInfo* info = get_info(k);
-  info->add_verification_constraint(k, name, from_name, from_field_is_protected,
+  info->add_verification_constraint(name, from_name, from_field_is_protected,
                                     from_is_array, from_is_object);
 
   if (CDSConfig::is_dumping_classic_static_archive() && !is_builtin(k)) {
@@ -814,6 +1014,26 @@ void SystemDictionaryShared::add_verification_constraint(InstanceKlass* k, Symbo
     // In all other cases, we are using an *actual* class loader to load k, so it should be able
     // to resolve any types that are needed for the verification of k.
     *skip_assignability_check = false;
+  }
+}
+
+// When the old verifier is verifying the class <ik> at dump time, it tries to resolve a
+// class with the given <name>. For the verification result to be valid at run time, we must
+// ensure that <name> resolves to the exact same Klass as in dump time.
+void SystemDictionaryShared::add_old_verification_dependency(Thread* current, InstanceKlass* ik, Symbol* name) {
+  precond(CDSConfig::is_preserving_verification_dependencies());
+  DumpTimeClassInfo* info = get_info(ik);
+  Handle loader(current, ik->class_loader());
+  Klass* k = SystemDictionary::find_instance_or_array_klass(current, name, loader);
+  if (k != nullptr) {
+    if (k->is_objArray_klass()) {
+      k = ObjArrayKlass::cast(k)->bottom_klass();
+    }
+    // No need to record any supertypes, as ik cannot be loaded at run time unless the
+    // exact same set of super types are loaded.
+    if (k->is_instance_klass() && !ik->is_subclass_of(k)) {
+      info->add_old_verification_dependency(k->name());
+    }
   }
 }
 
@@ -859,7 +1079,7 @@ void SystemDictionaryShared::check_verification_constraints(InstanceKlass* klass
   }
 }
 
-void SystemDictionaryShared::copy_verification_constraints_from_preimage(InstanceKlass* klass) {
+void SystemDictionaryShared::copy_verification_info_from_preimage(InstanceKlass* klass) {
   assert(CDSConfig::is_using_archive(), "called at run time with CDS enabled only");
   DumpTimeClassInfo* dt_info = get_info(klass);
   RunTimeClassInfo* rt_info = RunTimeClassInfo::get_for(klass); // from preimage
@@ -871,8 +1091,16 @@ void SystemDictionaryShared::copy_verification_constraints_from_preimage(Instanc
       Symbol* name      = vc->name();
       Symbol* from_name = vc->from_name();
 
-      dt_info->add_verification_constraint(klass, name, from_name,
+      dt_info->add_verification_constraint(name, from_name,
          rt_info->from_field_is_protected(i), rt_info->from_is_array(i), rt_info->from_is_object(i));
+    }
+  }
+
+  length = rt_info->num_old_verifier_dependencies();
+  if (length > 0) {
+    for (int i = 0; i < length; i++) {
+      Symbol* name = rt_info->old_verifier_constraint_at(i);
+      dt_info->add_old_verification_dependency(name);
     }
   }
 }

--- a/src/hotspot/share/classfile/systemDictionaryShared.hpp
+++ b/src/hotspot/share/classfile/systemDictionaryShared.hpp
@@ -144,7 +144,7 @@ class SystemDictionaryShared: public SystemDictionary {
   };
 
 private:
-
+  class ExclusionCheckCandidates;
   static DumpTimeSharedClassTable* _dumptime_table;
 
   static ArchiveInfo _static_archive;
@@ -173,13 +173,26 @@ private:
   static void write_dictionary(RunTimeSharedDictionary* dictionary,
                                bool is_builtin);
   static bool is_jfr_event_class(InstanceKlass *k);
-  static bool check_for_exclusion_impl(InstanceKlass* k);
+  static bool should_be_excluded_impl(InstanceKlass* k, DumpTimeClassInfo* info);
+
+  // exclusion checks
+  static void check_exclusion_for_self_and_dependencies(InstanceKlass *k);
+  static bool check_self_exclusion(InstanceKlass* k);
+  static bool check_dependencies_exclusion(InstanceKlass* k, DumpTimeClassInfo* info);
+  static bool check_verification_dependency_exclusion(InstanceKlass* k, Symbol* dependency_class_name);
+  static bool is_dependency_excluded(InstanceKlass* k, InstanceKlass* dependency, const char* type);
+  static bool is_excluded_verification_dependency(InstanceKlass* k, Symbol* dependency_class_name);
+  static Klass* find_verification_dependency_bottom_class(InstanceKlass* k, Symbol* dependency_class_name);
+
   static void remove_dumptime_info(InstanceKlass* k) NOT_CDS_RETURN;
   static bool has_been_redefined(InstanceKlass* k);
   DEBUG_ONLY(static bool _class_loading_may_happen;)
 
-  static void copy_verification_constraints_from_preimage(InstanceKlass* klass);
+  static void copy_verification_info_from_preimage(InstanceKlass* klass);
   static void copy_linking_constraints_from_preimage(InstanceKlass* klass);
+
+  template<typename Function>
+  static void iterate_all_verification_dependency_names(InstanceKlass* k, DumpTimeClassInfo* info, Function func);
 
 public:
   static bool is_early_klass(InstanceKlass* k);   // Was k loaded while JvmtiExport::is_early_phase()==true
@@ -237,6 +250,7 @@ public:
                   Symbol* from_name, bool from_field_is_protected,
                   bool from_is_array, bool from_is_object,
                   bool* skip_assignability_check);
+  static void add_old_verification_dependency(Thread* current, InstanceKlass* k, Symbol* name);
   static void check_verification_constraints(InstanceKlass* klass,
                                              TRAPS) NOT_CDS_RETURN;
   static void add_enum_klass_static_field(InstanceKlass* ik, int root_index);
@@ -256,7 +270,6 @@ public:
   static DumpTimeSharedClassTable* dumptime_table() { return _dumptime_table; }
 
   static bool should_be_excluded(Klass* k);
-  static bool check_for_exclusion(InstanceKlass* k, DumpTimeClassInfo* info);
   static void validate_before_archiving(InstanceKlass* k);
   static bool is_excluded_class(InstanceKlass* k);
   static void set_excluded(InstanceKlass* k);

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -2840,18 +2840,20 @@ void InstanceKlass::restore_unshareable_info(ClassLoaderData* loader_data, Handl
   DEBUG_ONLY(FieldInfoStream::validate_search_table(_constants, _fieldinfo_stream, _fieldinfo_search_table));
 }
 
-// Check if a class or any of its supertypes has a version older than 50.
-// CDS will not perform verification of old classes during dump time because
-// without changing the old verifier, the verification constraint cannot be
-// retrieved during dump time.
-// Verification of archived old classes will be performed during run time.
 bool InstanceKlass::can_be_verified_at_dumptime() const {
   if (MetaspaceShared::is_in_shared_metaspace(this)) {
     // This is a class that was dumped into the base archive, so we know
     // it was verified at dump time.
     return true;
   }
-  if (major_version() < 50 /*JAVA_6_VERSION*/) {
+
+  if (CDSConfig::is_preserving_verification_dependencies()) {
+    return true;
+  }
+
+  if (CDSConfig::is_old_class_for_verifier(this)) {
+    // The old verifier does not save verification constraints, so at run time
+    // SystemDictionaryShared::check_verification_constraints() will not work for this class.
     return false;
   }
   if (java_super() != nullptr && !java_super()->can_be_verified_at_dumptime()) {

--- a/src/hotspot/share/oops/methodData.cpp
+++ b/src/hotspot/share/oops/methodData.cpp
@@ -323,9 +323,8 @@ void VirtualCallTypeData::post_initialize(BytecodeStream* stream, MethodData* md
 
 static bool is_excluded(Klass* k) {
 #if INCLUDE_CDS
-  if (SafepointSynchronize::is_at_safepoint() &&
-      CDSConfig::is_dumping_archive() &&
-      CDSConfig::current_thread_is_vm_or_dumper()) {
+  if (CDSConfig::is_at_cds_safepoint()) {
+    // Check for CDS exclusion only at CDS safe point.
     if (k->is_instance_klass() && !InstanceKlass::cast(k)->is_loaded()) {
       log_debug(aot, training)("Purged %s from MDO: unloaded class", k->name()->as_C_string());
       return true;

--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -850,6 +850,13 @@ JVM_ENTRY(jclass, JVM_FindClassFromClass(JNIEnv *env, const char *name,
     log_debug(class, resolve)("%s %s (verification)", from_name, to);
   }
 
+#if INCLUDE_CDS
+  if (CDSConfig::is_preserving_verification_dependencies() && from_class->is_instance_klass()) {
+    InstanceKlass* ik = InstanceKlass::cast(from_class);
+    SystemDictionaryShared::add_old_verification_dependency(THREAD, ik, h_name);
+  }
+#endif
+
   return result;
 JVM_END
 

--- a/test/hotspot/jtreg/TEST.groups
+++ b/test/hotspot/jtreg/TEST.groups
@@ -526,6 +526,7 @@ hotspot_aot_classlinking = \
  -runtime/cds/appcds/cacheObject/ArchivedIntegerCacheTest.java \
  -runtime/cds/appcds/cacheObject/ArchivedModuleCompareTest.java \
  -runtime/cds/appcds/CDSandJFR.java \
+ -runtime/cds/appcds/LambdaContainsOldInf.java \
  -runtime/cds/appcds/customLoader/CustomClassListDump.java \
  -runtime/cds/appcds/customLoader/HelloCustom_JFR.java \
  -runtime/cds/appcds/customLoader/OldClassAndInf.java \
@@ -533,14 +534,17 @@ hotspot_aot_classlinking = \
  -runtime/cds/appcds/customLoader/ParallelTestSingleFP.java \
  -runtime/cds/appcds/customLoader/SameNameInTwoLoadersTest.java \
  -runtime/cds/appcds/DumpClassListWithLF.java \
- -runtime/cds/appcds/dynamicArchive/ModulePath.java \
+ -runtime/cds/appcds/dynamicArchive/LambdaContainsOldInf.java \
  -runtime/cds/appcds/dynamicArchive/LambdaCustomLoader.java \
  -runtime/cds/appcds/dynamicArchive/LambdaForOldInfInBaseArchive.java \
  -runtime/cds/appcds/dynamicArchive/LambdaInBaseArchive.java \
  -runtime/cds/appcds/dynamicArchive/LambdasInTwoArchives.java \
+ -runtime/cds/appcds/dynamicArchive/ModulePath.java \
+ -runtime/cds/appcds/dynamicArchive/NestHostOldInf.java \
  -runtime/cds/appcds/dynamicArchive/OldClassAndInf.java \
  -runtime/cds/appcds/dynamicArchive/OldClassInBaseArchive.java \
  -runtime/cds/appcds/dynamicArchive/OldClassVerifierTrouble.java \
+ -runtime/cds/appcds/dynamicArchive/RedefineCallerClassTest.java \
  -runtime/cds/appcds/HelloExtTest.java \
  -runtime/cds/appcds/javaldr/ExceptionDuringDumpAtObjectsInitPhase.java \
  -runtime/cds/appcds/javaldr/GCDuringDump.java \

--- a/test/hotspot/jtreg/runtime/cds/appcds/aotCache/ExcludedClasses.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotCache/ExcludedClasses.java
@@ -99,7 +99,6 @@ public class ExcludedClasses {
             if (runMode == RunMode.ASSEMBLY) {
                 out.shouldNotMatch("aot,resolve.*archived field.*TestApp.Foo => TestApp.Foo.ShouldBeExcluded.f:I");
             } else if (runMode == RunMode.PRODUCTION) {
-                out.shouldContain("check_verification_constraint: TestApp$Foo$Taz: TestApp$Foo$ShouldBeExcludedChild must be subclass of TestApp$Foo$ShouldBeExcluded");
                 out.shouldContain("jdk.jfr.Event source: jrt:/jdk.jfr");
                 out.shouldMatch("TestApp[$]Foo[$]ShouldBeExcluded source: .*/app.jar");
                 out.shouldMatch("TestApp[$]Foo[$]ShouldBeExcludedChild source: .*/app.jar");
@@ -259,14 +258,9 @@ class TestApp {
 
         static class Taz {
             static ShouldBeExcluded m() {
-                // When verifying this method, we need to check the constraint that
-                // ShouldBeExcluded must be a supertype of ShouldBeExcludedChild. This information
-                // is checked by SystemDictionaryShared::check_verification_constraints() when the Taz
-                // class is linked during the production run.
-                //
-                // Because ShouldBeExcluded is excluded from the AOT archive, it must be loaded
-                // dynamically from app.jar inside SystemDictionaryShared::check_verification_constraints().
-                // This must happen after the app class loader has been fully restored from the AOT cache.
+                // Taz should be excluded from the AOT cache because it has a verification constraint that
+                // "ShouldBeExcludedChild must be a subtype of ShouldBeExcluded", but ShouldBeExcluded is
+                // excluded from the AOT cache.
                 return new ShouldBeExcludedChild();
             }
             static void hotSpot4() {

--- a/test/hotspot/jtreg/runtime/cds/appcds/aotCache/OldA.jasm
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotCache/OldA.jasm
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+super public class OldA
+    version 49:0
+{
+
+
+public Method "<init>":"()V"
+    stack 1 locals 1
+{
+        aload_0;
+        invokespecial    Method java/lang/Object."<init>":"()V";
+        return;
+}
+
+}

--- a/test/hotspot/jtreg/runtime/cds/appcds/aotCache/OldClassSupport.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotCache/OldClassSupport.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test
+ * @summary Store old classes linked state in AOT cache as long as their verification constraints are not excluded.
+ * @bug 8317269
+ * @requires vm.cds.supports.aot.class.linking
+ * @library /test/jdk/lib/testlibrary /test/lib /test/hotspot/jtreg/runtime/cds/appcds/test-classes
+ * @build OldClass OldA OldClassWithVerifierConstraints OldClassWithExcludedVerifierConstraints
+ * @build OldClassSupport
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar app.jar
+ *                 AppUsesOldClass MyIntf OldClass OldA NewB MyEvent MyEvent2
+ *                 OldClassWithVerifierConstraints
+ *                 OldClassWithExcludedVerifierConstraints
+ *                 NewClassWithExcludedVerifierConstraints
+ * @run driver OldClassSupport
+ */
+
+import jdk.jfr.Event;
+import jdk.test.lib.cds.CDSAppTester;
+import jdk.test.lib.helpers.ClassFileInstaller;
+import jdk.test.lib.process.OutputAnalyzer;
+
+public class OldClassSupport {
+    static final String appJar = ClassFileInstaller.getJarPath("app.jar");
+    static final String mainClass = "AppUsesOldClass";
+
+    public static void main(String[] args) throws Exception {
+        Tester tester = new Tester();
+        tester.run(new String[] {"AOT", "--two-step-training"} );
+    }
+
+    static class Tester extends CDSAppTester {
+        public Tester() {
+            super(mainClass);
+        }
+
+        @Override
+        public String classpath(RunMode runMode) {
+            return appJar;
+        }
+
+        @Override
+        public String[] vmArgs(RunMode runMode) {
+            return new String[] {
+                "-Xlog:aot+class=debug",
+                "-Xlog:aot+resolve=trace",
+            };
+        }
+
+        @Override
+        public String[] appCommandLine(RunMode runMode) {
+            return new String[] {"-Xlog:cds+class=debug", mainClass};
+        }
+
+        @Override
+        public void checkExecution(OutputAnalyzer out, RunMode runMode) {
+            Class[] included = {
+                OldClass.class,
+                OldA.class,
+                NewB.class,
+                OldClassWithVerifierConstraints.class,
+            };
+
+            Class[] excluded = {
+                OldClassWithExcludedVerifierConstraints.class,
+                NewClassWithExcludedVerifierConstraints.class,
+            };
+
+
+            if (runMode == RunMode.TRAINING) {
+                shouldInclude(out, false, included);
+                shouldNotInclude(out, excluded);
+                shouldSkip(out, excluded);
+            } else if (runMode == RunMode.ASSEMBLY) {
+                shouldInclude(out, true, included);
+                shouldNotInclude(out, excluded);
+            }
+        }
+    }
+
+    static void shouldInclude(OutputAnalyzer out, boolean linked, Class[] classes) {
+        for (Class c : classes) {
+            out.shouldMatch("aot,class.* = 0x.* app *" + c.getName() + (linked ? " .*aot-linked" : ""));
+        }
+    }
+
+    static void shouldNotInclude(OutputAnalyzer out, Class[] classes) {
+        for (Class c : classes) {
+            out.shouldNotMatch("aot,class.* = 0x.* app *" + c.getName());
+        }
+    }
+
+    static void shouldSkip(OutputAnalyzer out, Class[] classes) {
+        for (Class c : classes) {
+            out.shouldMatch("Skipping " + c.getName() + ": verification dependency .* is excluded");
+        }
+    }
+}
+
+class AppUsesOldClass {
+    public static void main(String args[]) {
+        System.out.println("Old Class Instance: " + new OldClass());
+
+        System.out.println(get_OldA_from_NewB());
+        System.out.println(OldClassWithVerifierConstraints.get_OldA_from_NewB());
+        System.out.println(OldClassWithExcludedVerifierConstraints.get_Event_from_MyEvent());
+        System.out.println(NewClassWithExcludedVerifierConstraints.get_MyEvent_from_MyEvent2());
+        System.out.println(new MyEvent());
+
+        // OldClassWithExcludedVerifierConstraints should still be excluded even it has been used
+        // in a lambda expression during the training run.
+        run((OldClassWithExcludedVerifierConstraints x) -> {
+                System.out.println(x);
+            });
+    }
+
+    static OldA get_OldA_from_NewB() {
+        return new NewB();
+    }
+
+    static void run(MyIntf intf) {
+        intf.function(new OldClassWithExcludedVerifierConstraints());
+    }
+}
+
+interface MyIntf {
+    public void function(OldClassWithExcludedVerifierConstraints x);
+}
+
+class NewB extends OldA {}
+
+class MyEvent extends Event {}
+class MyEvent2 extends MyEvent {}
+
+class NewClassWithExcludedVerifierConstraints {
+    static MyEvent get_MyEvent_from_MyEvent2() {
+        return new MyEvent2();
+    }
+}

--- a/test/hotspot/jtreg/runtime/cds/appcds/aotCache/OldClassWithExcludedVerifierConstraints.jasm
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotCache/OldClassWithExcludedVerifierConstraints.jasm
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+// This old class has a verification constraint that "MyEvent must be a subtype of Event". However,
+// Event and all of its subtypes are excluded from the AOT cache, so this class must also be excluded.
+
+super public class OldClassWithExcludedVerifierConstraints
+    version 49:0
+{
+
+
+public Method "<init>":"()V"
+    stack 1 locals 1
+{
+        aload_0;
+        invokespecial    Method java/lang/Object."<init>":"()V";
+        return;
+}
+
+static Method get_Event_from_MyEvent:"()Ljdk/jfr/Event;"
+    stack 2 locals 0
+{
+        new              class MyEvent;
+        dup;
+        invokespecial    Method MyEvent."<init>":"()V";
+        areturn;
+}
+
+}

--- a/test/hotspot/jtreg/runtime/cds/appcds/aotCache/OldClassWithVerifierConstraints.jasm
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotCache/OldClassWithVerifierConstraints.jasm
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+// This old class as a verification constraint that "NewB must be a subtype of OldA". Since both
+// OldA and NewB are not excluded, then this class should be cached in aot-linked state.
+
+super public class OldClassWithVerifierConstraints
+    version 49:0
+{
+
+
+public Method "<init>":"()V"
+    stack 1 locals 1
+{
+        aload_0;
+        invokespecial    Method java/lang/Object."<init>":"()V";
+        return;
+}
+
+static Method get_OldA_from_NewB:"()LOldA;"
+    stack 2 locals 0
+{
+        new              class NewB;
+        dup;
+        invokespecial    Method NewB."<init>":"()V";
+        areturn;
+}
+
+}

--- a/test/hotspot/jtreg/runtime/cds/appcds/aotClassLinking/AOTClassLinkingVerification.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotClassLinking/AOTClassLinkingVerification.java
@@ -1,0 +1,277 @@
+/*
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test
+ * @bug 8317269
+ * @requires vm.cds
+ * @requires vm.cds.supports.aot.class.linking
+ * @summary Test for verification of classes that are aot-linked
+ * @library /test/jdk/lib/testlibrary
+ *          /test/lib
+ *          /test/hotspot/jtreg/runtime/cds/appcds
+ *          /test/hotspot/jtreg/runtime/cds/appcds/test-classes
+ * @build GoodOldClass BadOldClass BadOldClass2 BadNewClass BadNewClass2
+ * @build AOTClassLinkingVerification
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar WhiteBox.jar jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar app1.jar
+ *                 AOTClassLinkingVerificationApp
+ *                 Unlinked UnlinkedSuper
+ *                 BadOldClass
+ *                 BadOldClass2
+ *                 BadNewClass
+ *                 BadNewClass2
+ *                 GoodOldClass Vehicle Car
+ *                 Util
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar app2.jar
+ *                 Foo NotFoo
+ *                 UnlinkedSub
+ * @run driver AOTClassLinkingVerification
+ */
+
+import java.io.File;
+import java.lang.invoke.MethodHandles;
+import jdk.test.lib.cds.CDSAppTester;
+import jdk.test.lib.helpers.ClassFileInstaller;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.whitebox.WhiteBox;
+
+public class AOTClassLinkingVerification {
+    static final String app1Jar = ClassFileInstaller.getJarPath("app1.jar");
+    static final String app2Jar = ClassFileInstaller.getJarPath("app2.jar");
+    static final String wbJar = TestCommon.getTestJar("WhiteBox.jar");
+    static final String bootAppendWhiteBox = "-Xbootclasspath/a:" + wbJar;
+    static final String mainClass = AOTClassLinkingVerificationApp.class.getName();
+
+    static class Tester extends CDSAppTester {
+        public Tester(String testName) {
+            super(testName);
+        }
+
+        @Override
+        public String[] vmArgs(RunMode runMode) {
+            if (runMode == RunMode.TRAINING ||
+                runMode == RunMode.ASSEMBLY) {
+                return new String[] {
+                    "-XX:+AOTClassLinking", "-Xlog:cds+class=debug", bootAppendWhiteBox,
+                };
+            } else {
+                return new String[] {
+                    "-XX:+UnlockDiagnosticVMOptions", "-XX:+WhiteBoxAPI", bootAppendWhiteBox,
+                };
+            }
+        }
+
+        @Override
+        public String classpath(RunMode runMode) {
+            if (runMode == RunMode.TRAINING ||
+                runMode == RunMode.ASSEMBLY) {
+                return app1Jar;
+            } else {
+                return app1Jar + File.pathSeparator + app2Jar;
+            }
+        }
+
+        @Override
+        public String[] appCommandLine(RunMode runMode) {
+            if (runMode == RunMode.TRAINING ||
+                runMode == RunMode.ASSEMBLY) {
+                return new String[] {
+                    "AOTClassLinkingVerificationApp", app1Jar, "ASSEMBLY"
+                };
+            } else {
+                return new String[] {
+                    "AOTClassLinkingVerificationApp", app1Jar, "PRODUCTION"
+                };
+            }
+        }
+
+        @Override
+        public void checkExecution(OutputAnalyzer out, RunMode runMode) throws Exception {
+            if (runMode == RunMode.TRAINING ||
+                runMode == RunMode.ASSEMBLY) {
+                out.shouldContain("Preload Warning: Verification failed for BadNewClass2");
+                out.shouldContain("Preload Warning: Verification failed for BadNewClass");
+                out.shouldContain("Preload Warning: Verification failed for BadOldClass2");
+                out.shouldContain("Preload Warning: Verification failed for BadOldClass");
+                out.shouldContain("Preload Warning: Verification failed for Unlinked");
+            }
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        // Dump without app2.jar so:
+        //  - Unlinked can be resolved, but UnlinkedSuper UnlinkedSub cannot be resolved,
+        //    so Unlinked cannot be verified at dump time.
+        //  - BadOldClass2 can be resolved, but Foo and NotFoo cannot be resolved,
+        //    so BadOldClass2 cannot be verified at dump time.
+        //  - BadNewClass2 can be resolved, but Foo and NotFoo cannot be resolved,
+        //    so BadNewClass2 cannot be verified at dump time.
+        Tester t1 = new Tester("verification-aot-linked-classes");
+        t1.run("AOT");
+    }
+}
+
+class AOTClassLinkingVerificationApp {
+    static WhiteBox wb = WhiteBox.getWhiteBox();
+    static ClassLoader classLoader = AOTClassLinkingVerificationApp.class.getClassLoader();
+    static File app1Jar;
+
+    public static void main(String[] args) throws Exception {
+        app1Jar = new File(args[0]);
+        boolean isProduction = args[1].equals("PRODUCTION");
+        if (isProduction) {
+            assertNotShared(UnlinkedSub.class);
+            assertShared(UnlinkedSuper.class);
+            assertNotShared(Unlinked.class); // failed verification during dump time
+            assertNotShared(Foo.class);
+            assertNotShared(NotFoo.class);
+        }
+        String s = null;
+        try {
+            s = Unlinked.doit();
+        } catch (NoClassDefFoundError ncdfe) {
+            // UnlinkedSub is in app2Jar but only app1Jar is used during training
+            // and assembly phases. So NoClassDefFoundError is expected during
+            // during training and assembly phases.
+            if (isProduction) {
+                throw ncdfe;
+            }
+        }
+        if (isProduction && !s.equals("heyhey")) {
+            throw new RuntimeException("Unlinked.doit() returns wrong result: " + s);
+        }
+
+        Class cls_BadOldClass = Class.forName("BadOldClass", false, classLoader);
+        if (isProduction) {
+            assertNotShared(cls_BadOldClass); // failed verification during dump time
+        }
+        try {
+            cls_BadOldClass.newInstance();
+            throw new RuntimeException("BadOldClass cannot be verified");
+        } catch (VerifyError expected) {}
+
+        Class cls_BadOldClass2 = Class.forName("BadOldClass2", false, classLoader);
+        if (isProduction) {
+            assertNotShared(cls_BadOldClass2); // failed verification during dump time
+        }
+        try {
+            cls_BadOldClass2.newInstance();
+            throw new RuntimeException("BadOldClass2 cannot be verified");
+        } catch (NoClassDefFoundError ncdfe) {
+            // BadOldClass2 loads Foo and NotFoo which is in app2Jar which is used
+            // only in production run.
+            if (isProduction) {
+                throw ncdfe;
+            }
+        } catch (VerifyError expected) {}
+
+        Class cls_BadNewClass = Class.forName("BadNewClass", false, classLoader);
+        if (isProduction) {
+            assertNotShared(cls_BadNewClass); // failed verification during dump time
+        }
+        try {
+            cls_BadNewClass.newInstance();
+            throw new RuntimeException("BadNewClass cannot be verified");
+        } catch (VerifyError expected) {}
+
+        Class cls_BadNewClass2 = Class.forName("BadNewClass2", false, classLoader);
+        if (isProduction) {
+            assertNotShared(cls_BadNewClass2); // failed verification during dump time
+        }
+        try {
+            cls_BadNewClass2.newInstance();
+            throw new RuntimeException("BadNewClass2 cannot be verified");
+        } catch (NoClassDefFoundError ncdfe) {
+            // BadNewClass2 loads Foo and NotFoo which is in app2Jar which is used
+            // only in production run.
+            if (isProduction) {
+                throw ncdfe;
+            }
+        } catch (VerifyError expected) {}
+
+
+        if (isProduction) {
+            assertAlreadyLoaded("Vehicle");
+            assertAlreadyLoaded("Car");
+            assertAlreadyLoaded("GoodOldClass");
+
+            assertShared(GoodOldClass.class);
+            assertShared(Vehicle.class);
+            assertShared(Car.class);
+        }
+
+        GoodOldClass.doit(); // Should not fail
+    }
+
+    static void assertShared(Class c) {
+        if (!wb.isSharedClass(c)) {
+            throw new RuntimeException("wb.isSharedClass(" + c.getName() + ") should be true");
+        }
+    }
+
+    static void assertNotShared(Class c) {
+        if (wb.isSharedClass(c)) {
+            throw new RuntimeException("wb.isSharedClass(" + c.getName() + ") should be false");
+        }
+    }
+
+    static void assertAlreadyLoaded(String className) throws Exception {
+        byte[] data = Util.getClassFileFromJar(app1Jar, className);
+        try {
+            MethodHandles.lookup().defineClass(data);
+        } catch (LinkageError e) {
+            if (e.getMessage().contains("duplicate class definition for " + className)) {
+                return;
+            } else {
+                throw e;
+            }
+        }
+        throw new RuntimeException(className + " must have already been loaded");
+    }
+}
+
+
+class Unlinked {
+    static String doit() {
+        UnlinkedSuper sup = new UnlinkedSub();
+        return sup.doit();
+    }
+}
+
+abstract class UnlinkedSuper {
+    abstract String doit();
+}
+
+class UnlinkedSub extends UnlinkedSuper {
+    String doit() {
+        return "heyhey";
+    }
+}
+
+class Foo {}
+class NotFoo {}
+
+class Vehicle {}
+class Car extends Vehicle {}

--- a/test/hotspot/jtreg/runtime/cds/appcds/aotClassLinking/BadNewClass.jasm
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotClassLinking/BadNewClass.jasm
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * ORACLE PROPRIETARY/CONFIDENTIAL. Use is subject to license terms.
+ */
+
+// When -XX:+PreloadSharedClasses is enabled, this class will be
+// archived in the unlinked state. When we try to use this class
+// at runtime, a VerifyError should be thrown.
+
+super public class BadNewClass
+    version 49:0
+{
+
+
+public Method "<init>":"()V"
+    stack 1 locals 1
+{
+        aload_0;
+        invokespecial    Method java/lang/Object."<init>":"()V";
+        return;
+}
+
+    /*
+     * The following method tries to return an Object as a String.
+     * Verifier should fail.
+     */
+public Method doit:"()Ljava/lang/String;"
+    stack 2 locals 1
+{
+        new              class java/lang/Object;
+        dup;
+        invokespecial    Method java/lang/Object."<init>":"()V";
+        astore_0;
+        aload_0;
+        areturn;   // tries to return an Object as a String
+}
+
+}

--- a/test/hotspot/jtreg/runtime/cds/appcds/aotClassLinking/BadNewClass2.jasm
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotClassLinking/BadNewClass2.jasm
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * ORACLE PROPRIETARY/CONFIDENTIAL. Use is subject to license terms.
+ */
+
+// When -XX:+PreloadSharedClasses is enabled, this class will be
+// archived in the unlinked state. When we try to use this class
+// at runtime, a VerifyError should be thrown.
+
+super public class BadNewClass2
+    version 52:0
+{
+
+
+public Method "<init>":"()V"
+    stack 1 locals 1
+{
+        aload_0;
+        invokespecial    Method java/lang/Object."<init>":"()V";
+        return;
+}
+
+    /*
+     * The following method tries to return a NotFoo as a Foo.
+     * Verifier should fail.
+     */
+public Method doit:"()LFoo;"
+    stack 2 locals 1
+{
+        new              class NotFoo;
+        dup;
+        invokespecial    Method NotFoo."<init>":"()V";
+        astore_0;
+        aload_0;
+        areturn;   // tries to return a NotFoo as a Foo
+}
+
+}

--- a/test/hotspot/jtreg/runtime/cds/appcds/aotClassLinking/BadOldClass.jasm
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotClassLinking/BadOldClass.jasm
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * ORACLE PROPRIETARY/CONFIDENTIAL. Use is subject to license terms.
+ */
+
+// When -XX:+PreloadSharedClasses is enabled, this class will be
+// archived in the unlinked state. When we try to use this class
+// at runtime, a VerifyError should be thrown.
+
+super public class BadOldClass
+    version 49:0
+{
+
+
+public Method "<init>":"()V"
+    stack 1 locals 1
+{
+        aload_0;
+        invokespecial    Method java/lang/Object."<init>":"()V";
+        return;
+}
+
+    /*
+     * The following method tries to return an Object as a String.
+     * Verifier should fail.
+     */
+public Method doit:"()Ljava/lang/String;"
+    stack 2 locals 1
+{
+        new              class java/lang/Object;
+        dup;
+        invokespecial    Method java/lang/Object."<init>":"()V";
+        astore_0;
+        aload_0;
+        areturn;   // tries to return an Object as a String
+}
+
+}

--- a/test/hotspot/jtreg/runtime/cds/appcds/aotClassLinking/BadOldClass2.jasm
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotClassLinking/BadOldClass2.jasm
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * ORACLE PROPRIETARY/CONFIDENTIAL. Use is subject to license terms.
+ */
+
+// When -XX:+PreloadSharedClasses is enabled, this class will be
+// archived in the unlinked state. When we try to use this class
+// at runtime, a VerifyError should be thrown.
+
+super public class BadOldClass2
+    version 49:0
+{
+
+
+public Method "<init>":"()V"
+    stack 1 locals 1
+{
+        aload_0;
+        invokespecial    Method java/lang/Object."<init>":"()V";
+        return;
+}
+
+    /*
+     * The following method tries to return a NotFoo as a Foo.
+     * Verifier should fail.
+     */
+public Method doit:"()LFoo;"
+    stack 2 locals 1
+{
+        new              class NotFoo;
+        dup;
+        invokespecial    Method NotFoo."<init>":"()V";
+        astore_0;
+        aload_0;
+        areturn;   // tries to return a NotFoo as a Foo
+}
+
+}

--- a/test/hotspot/jtreg/runtime/cds/appcds/aotClassLinking/BulkLoaderTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotClassLinking/BulkLoaderTest.java
@@ -147,7 +147,7 @@ public class BulkLoaderTest {
         @Override
         public void checkExecution(OutputAnalyzer out, RunMode runMode) throws Exception {
             if (isAOTWorkflow() && runMode == RunMode.TRAINING) {
-                out.shouldContain("Skipping BadOldClassA: Unlinked class not supported by AOTConfiguration");
+                out.shouldContain("Skipping BadOldClassA: Failed verification");
                 out.shouldContain("Skipping SimpleCusty: Duplicated unregistered class");
             }
 

--- a/test/hotspot/jtreg/runtime/cds/appcds/aotClassLinking/GoodOldClass.jasm
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotClassLinking/GoodOldClass.jasm
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * ORACLE PROPRIETARY/CONFIDENTIAL. Use is subject to license terms.
+ */
+
+// When -XX:+PreloadSharedClasses is enabled, this class will be
+// archived in the unlinked state. When we try to use this class
+// at runtime, a VerifyError should be thrown.
+
+super public class GoodOldClass
+    version 49:0
+{
+
+
+public Method "<init>":"()V"
+    stack 1 locals 1
+{
+        aload_0;
+        invokespecial    Method java/lang/Object."<init>":"()V";
+        return;
+}
+
+
+public static Method doit:"()LVehicle;"
+    stack 2 locals 1
+{
+        new              class Car;
+        dup;
+        invokespecial    Method Car."<init>":"()V";
+        astore_0;
+        aload_0;
+        areturn;   // tries to return a Car as a Vehicle
+}
+
+}


### PR DESCRIPTION
During the assembly phase of the AOT cache, we link and verify all classes that were loaded during the training run. When verifying a class like this:

```
class X {
    A getA() { return new B(); } // Verifier requires B to be a subtype of A.
}
```

We remember `A` and `B` as the "verification dependencies" of `X`. A class will be excluded from the AOT cache if any of its verification dependencies are excluded. For example, `X` will be excluded if

- `A` fails verification
- `B` is a signed class, which is always excluded from the AOT cache

Conversely, if both `A` and `B`  are in the AOT cache, in the production run, they will be unconditionally loaded during VM bootstrap. Therefore, we can guarantee that the verification result computed for `X` will remain valid during the production run.

Notes for reviewers:

- The checks for verification dependencies are done inside `SystemDictionaryShared::check_exclusion_for_self_and_dependencies()`. These checks are done for both old and new classes. Since the dependencies can form a cyclic graph, the checks cannot be implemented with a simple recursion. See "Algorithm notes" in this function for details. 
- The verification dependencies for "new" classes are already stored in `DumpTimeClassInfo::_verifier_constraints`.
- This PR adds code to record the verification dependencies for "old" classes into `DumpTimeClassInfo::_old_verifier_dependencies`, by intercepting `JVM_FindClassFromCaller()`.
