### PR TITLE
8365312: __builtin_clear_padding not supported for variable length aggregates

### DIFF
--- a/make/autoconf/flags-cflags.m4
+++ b/make/autoconf/flags-cflags.m4
@@ -954,6 +954,17 @@ AC_DEFUN([FLAGS_SETUP_CFLAGS_CPU_DEP],
           [
             AC_MSG_RESULT([yes])
             $2SVE_CFLAGS="-march=armv8-a+sve"
+            # Switching the initialization mode with gcc from 'pattern' to 'zero'
+            # avoids the use of unsupported `__builtin_clear_padding` for variable
+            # length aggregates
+            if test "x$TOOLCHAIN_TYPE" = xgcc ; then
+              INIT_ZERO_FLAG="-ftrivial-auto-var-init=zero"
+              FLAGS_COMPILER_CHECK_ARGUMENTS(ARGUMENT: [$INIT_ZERO_FLAG],
+                IF_TRUE: [
+                  $2SVE_CFLAGS="${$2SVE_CFLAGS} $INIT_ZERO_FLAG"
+                ]
+              )
+            fi
           ],
           [
             AC_MSG_RESULT([no])


### PR DESCRIPTION
`-ftrivial-auto-var-init=pattern` [1] supported by gcc-12 was added recently to help detect uses of uninitialized memory. [2] Under this extension mode, `__builtin_clear_padding` is called to clear the padding bits in object representation. But the builtin function does not support variable length aggregates [3].

`vfloat2_sve_sleef` is a typedef of `svfloat32x2_t`, which is defined as an opaque sizeless type in ARM C Language Extensions (ACLE) [4]. When `__builtin_clear_padding` is applied to such a type, it triggers the unsupported code path and results in build failures when compiling libsleef on Linux-AArch64, as reported in JDK-8364185 [5].

Switching the initialization mode with gcc-12 from `pattern` to `zero` avoids the use of this unsupported `__builtin_clear_padding` and resolves the issue.

I did not encounter similar problems when building with Clang-16 [6].

This patch changes the initialization mode from `pattern` to `zero` when compiling libsleef SVE component on Linux-AArch64 with gcc-12 to fix the build failure and help avoid potential security issues related to uninitialized padding

Testing (combined with https://github.com/openjdk/jdk/pull/26577):
1. Release and fastdebug build with gcc-11, gcc-12, and clang-16
2. `test/jdk/jdk/incubator/vector` passed on both 256-bit SVE and NEON machines

[1] https://gcc.gnu.org/onlinedocs/gcc-12.1.0/gcc/Optimize-Options.html#index-ftrivial-auto-var-init
[2] https://github.com/openjdk/jdk/commit/fae37aaae8b36fd74309b84fa1fdf017c7d932ed
[3] https://gcc.gnu.org/pipermail/gcc-patches/2020-November/559214.html
[4] https://arm-software.github.io/acle/main/acle.html#arm_sveh
[5] https://bugs.openjdk.org/browse/JDK-8364185
[6] https://releases.llvm.org/16.0.0/tools/clang/docs/ReleaseNotes.html