### PR TITLE
8365314: javac fails with an exception for erroneous source

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Lint.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Lint.java
@@ -528,14 +528,15 @@ public class Lint {
     // Given a @SuppressWarnings annotation, extract the recognized suppressions
     private EnumSet<LintCategory> suppressionsFrom(Attribute.Compound suppressWarnings) {
         EnumSet<LintCategory> result = LintCategory.newEmptySet();
-        Attribute.Array values = (Attribute.Array)suppressWarnings.member(names.value);
-        for (Attribute value : values.values) {
-            Optional.of(value)
-              .filter(val -> val instanceof Attribute.Constant)
-              .map(val -> (String) ((Attribute.Constant) val).value)
-              .flatMap(LintCategory::get)
-              .filter(lc -> lc.annotationSuppression)
-              .ifPresent(result::add);
+        if (suppressWarnings.member(names.value) instanceof Attribute.Array values) {
+            for (Attribute value : values.values) {
+                Optional.of(value)
+                  .filter(val -> val instanceof Attribute.Constant)
+                  .map(val -> (String) ((Attribute.Constant) val).value)
+                  .flatMap(LintCategory::get)
+                  .filter(lc -> lc.annotationSuppression)
+                  .ifPresent(result::add);
+            }
         }
         return result;
     }

--- a/test/langtools/tools/javac/recovery/AnnotationRecovery.java
+++ b/test/langtools/tools/javac/recovery/AnnotationRecovery.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8270139 8361445
+ * @bug 8270139 8361445 8365314
  * @summary Verify error recovery w.r.t. annotations
  * @library /tools/lib
  * @modules jdk.compiler/com.sun.tools.javac.api
@@ -224,4 +224,28 @@ public class AnnotationRecovery extends TestRunner {
         }
     }
 
+    @Test //JDK-8365314
+    public void testSuppressWarningsMissingAttribute() throws Exception {
+        String code = """
+                      @SuppressWarnings
+                      public class Test {
+                      }
+                      """;
+        Path curPath = Path.of(".");
+        List<String> actual = new JavacTask(tb)
+                .options("-XDrawDiagnostics", "-XDdev")
+                .sources(code)
+                .outdir(curPath)
+                .run(Expect.FAIL)
+                .getOutputLines(OutputKind.DIRECT);
+
+        List<String> expected = List.of(
+                "Test.java:1:1: compiler.err.annotation.missing.default.value: java.lang.SuppressWarnings, value",
+                "1 error"
+        );
+
+        if (!Objects.equals(actual, expected)) {
+            error("Expected: " + expected + ", but got: " + actual);
+        }
+    }
 }


### PR DESCRIPTION
For very broken code like:
```
$ cat /tmp/BrokenSuppressWarnings.java
@SuppressWarnings
public class BrokenSuppressWarnings {}
```

javac may fail with an exception:
```
$ javac -XDdev /tmp/BrokenSuppressWarnings.java
/tmp/BrokenSuppressWarnings.java:1: error: annotation @SuppressWarnings is missing a default value for the element 'value'
@SuppressWarnings
^
1 error
An exception has occurred in the compiler (26-internal). Please file a bug against the Java compiler via the Java bug reporting page (https://bugreport.java.com/) after checking the Bug Database (https://bugs.java.com/) for duplicates. Include your program, the following diagnostic, and the parameters passed to the Java compiler in your report. Thank you.
java.lang.NullPointerException: Cannot read field "values" because "values" is null
        at jdk.compiler/com.sun.tools.javac.code.Lint.suppressionsFrom(Lint.java:532)
...
printing javac parameters to: /tmp/javac.20250812_114830.args
```

This is because the `Attribute` for `value` is missing. The proposed solution here is to ignore the missing attribute/`null`, by using `instanceof`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8365314: javac fails with an exception for erroneous source`

### Issue
 * [JDK-8365314](https://bugs.openjdk.org/browse/JDK-8365314): javac fails with an exception for erroneous source (**Bug** - P4)


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26758/head:pull/26758` \
`$ git checkout pull/26758`

Update a local copy of the PR: \
`$ git checkout pull/26758` \
`$ git pull https://git.openjdk.org/jdk.git pull/26758/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26758`

View PR using the GUI difftool: \
`$ git pr show -t 26758`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26758.diff">https://git.openjdk.org/jdk/pull/26758.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26758#issuecomment-3183736482)
</details>
