### PR TITLE
8365491: VSCode IDE: add basic configuration for the Oracle Java extension

### DIFF
--- a/make/ide/vscode/hotspot/template-workspace.jsonc
+++ b/make/ide/vscode/hotspot/template-workspace.jsonc
@@ -12,11 +12,16 @@
 	],
 	"extensions": {
 		"recommendations": [
+			"oracle.oracle-java",
 			// {{INDEXER_EXTENSIONS}}
 		]
 	},
 	"settings": {
 		// {{INDEXER_SETTINGS}}
+
+		// Java extension
+		"jdk.advanced.disable.nbjavac": true,
+		"jdk.project.jdkhome": "{{OUTPUTDIR}}/jdk",
 
 		// Additional conventions
 		"files.associations": {

--- a/make/ide/vscode/hotspot/template-workspace.jsonc
+++ b/make/ide/vscode/hotspot/template-workspace.jsonc
@@ -22,6 +22,7 @@
 		// Java extension
 		"jdk.advanced.disable.nbjavac": true,
 		"jdk.project.jdkhome": "{{OUTPUTDIR}}/jdk",
+		"jdk.java.onSave.organizeImports": false, // prevents unnecessary changes
 
 		// Additional conventions
 		"files.associations": {

--- a/make/ide/vscode/hotspot/template-workspace.jsonc
+++ b/make/ide/vscode/hotspot/template-workspace.jsonc
@@ -20,7 +20,6 @@
 		// {{INDEXER_SETTINGS}}
 
 		// Java extension
-		"jdk.advanced.disable.nbjavac": true,
 		"jdk.project.jdkhome": "{{OUTPUTDIR}}/jdk",
 		"jdk.java.onSave.organizeImports": false, // prevents unnecessary changes
 


### PR DESCRIPTION
This PR adds a basic configuration for the [Oracle Java VSCode extension](https://marketplace.visualstudio.com/items?itemName=Oracle.oracle-java) to the `vscode-project-*` targets.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8365491](https://bugs.openjdk.org/browse/JDK-8365491): VSCode IDE: add basic configuration for the Oracle Java extension (**Enhancement** - P5)


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26759/head:pull/26759` \
`$ git checkout pull/26759`

Update a local copy of the PR: \
`$ git checkout pull/26759` \
`$ git pull https://git.openjdk.org/jdk.git pull/26759/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26759`

View PR using the GUI difftool: \
`$ git pr show -t 26759`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26759.diff">https://git.openjdk.org/jdk/pull/26759.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26759#issuecomment-3183938457)
</details>
