### PR TITLE
JDK-8365487: [asan] some oops (mode) related tests fail

### DIFF
--- a/test/hotspot/jtreg/runtime/CompressedOops/UseCompressedOops.java
+++ b/test/hotspot/jtreg/runtime/CompressedOops/UseCompressedOops.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,8 @@
  * @modules java.base/jdk.internal.misc
  *          java.management
  * @build jdk.test.whitebox.WhiteBox
+ * @comment Do not run with asan enabled, because it changes memory layout and we get a different coops mode
+ * @requires !vm.asan
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
  * @run main/othervm/timeout=480 -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:. UseCompressedOops
  */

--- a/test/jdk/jdk/jfr/event/gc/configuration/TestGCHeapConfigurationEventWith32BitOops.java
+++ b/test/jdk/jdk/jfr/event/gc/configuration/TestGCHeapConfigurationEventWith32BitOops.java
@@ -35,6 +35,8 @@ import jdk.test.whitebox.WhiteBox;
  * @requires vm.gc == "Parallel" | vm.gc == null
  * @requires os.family == "linux" | os.family == "windows"
  * @requires sun.arch.data.model == "64"
+ * @comment Asan changes memory layout and we get a different coops mode
+ * @requires !vm.asan
  * @library /test/lib /test/jdk
  * @build jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox

--- a/test/jdk/jdk/jfr/event/gc/configuration/TestGCHeapConfigurationEventWithZeroBasedOops.java
+++ b/test/jdk/jdk/jfr/event/gc/configuration/TestGCHeapConfigurationEventWithZeroBasedOops.java
@@ -33,6 +33,8 @@ import jdk.test.lib.jfr.EventVerifier;
  * @requires vm.gc == "Parallel" | vm.gc == null
  * @requires os.family == "linux" | os.family == "windows"
  * @requires sun.arch.data.model == "64"
+ * @comment Asan changes memory layout and we get a different coops mode
+ * @requires !vm.asan
  * @library /test/lib /test/jdk
  * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:-UseFastUnorderedTimeStamps -XX:+UseParallelGC -XX:+UseCompressedOops -Xmx4g jdk.jfr.event.gc.configuration.TestGCHeapConfigurationEventWithZeroBasedOops
  */


### PR DESCRIPTION
When running with asan - enabled binaries, some oops related tests fail.
This seems to be related to (small) changes in memory layout caused by asan.
examples :
runtime/CompressedOops/UseCompressedOops.java

```
java.lang.RuntimeException: 'Zero based' missing from stdout/stderr
               at jdk.test.lib.process.OutputAnalyzer.shouldContain(OutputAnalyzer.java:253)
               at UseCompressedOops.testCompressedOopsModes(UseCompressedOops.java:98)
               at UseCompressedOops.testCompressedOopsModesGCs(UseCompressedOops.java:59)
               at UseCompressedOops.main(UseCompressedOops.java:48)
               at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
               at java.base/java.lang.reflect.Method.invoke(Method.java:565)
               at com.sun.javatest.regtest.agent.MainWrapper$MainTask.run(MainWrapper.java:138)
               at java.base/java.lang.Thread.run(Thread.java:1474)

```


jdk/jfr/event/gc/configuration/TestGCHeapConfigurationEventWith32BitOops.java

```
Error: Value not equal to 32-bit, field='compressedOopsMode', value='Non-zero based' expected: Non-zero based but was: 32-bit
Failed event:
jdk.GCHeapConfiguration {
  startTime = 13:13:02.886 (2025-08-09)
  minSize = 100.0 MB
  maxSize = 100.0 MB
  initialSize = 100.0 MB
  usesCompressedOops = true
  compressedOopsMode = "Non-zero based"
  objectAlignment = 8 bytes
  heapAddressBits = 32
}

----------System.err:(20/1718)----------
java.lang.RuntimeException: Value not equal to 32-bit, field='compressedOopsMode', value='Non-zero based' expected: Non-zero based but was: 32-bit
               at jdk.test.lib.Asserts.fail(Asserts.java:715)
               at jdk.test.lib.Asserts.assertEquals(Asserts.java:208)
               at jdk.test.lib.jfr.EventField.lambda$equal$0(EventField.java:50)
               at jdk.test.lib.jfr.EventField.doAssert(EventField.java:114)
               at jdk.test.lib.jfr.EventField.equal(EventField.java:50)
               at jdk.test.lib.jfr.EventVerifier.verifyEquals(EventVerifier.java:35)
               at jdk.jfr.event.gc.configuration.GCHeapConfigurationEventVerifier.verifyCompressedOopModeIs(GCHeapConfigurationEventVerifier.java:59)
               at jdk.jfr.event.gc.configuration.ThirtyTwoBitsVerifier.verify(TestGCHeapConfigurationEventWith32BitOops.java:74)
               at jdk.jfr.event.gc.configuration.GCHeapConfigurationEventTester.run(GCHeapConfigurationEventTester.java:46)
               at jdk.jfr.event.gc.configuration.TestGCHeapConfigurationEventWith32BitOops.main(TestGCHeapConfigurationEventWith32BitOops.java:49)
               at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
               at java.base/java.lang.reflect.Method.invoke(Method.java:565)
               at com.sun.javatest.regtest.agent.MainWrapper$MainTask.run(MainWrapper.java:138)
               at java.base/java.lang.Thread.run(Thread.java:1474)

```

jdk/jfr/event/gc/configuration/TestGCHeapConfigurationEventWithZeroBasedOops.java


```
Error: Value not equal to Zero based, field='compressedOopsMode', value='Non-zero based' expected: Non-zero based but was: Zero based
Failed event:
jdk.GCHeapConfiguration {
  startTime = 13:13:02.073 (2025-08-09)
  minSize = 8.0 MB
  maxSize = 4.0 GB
  initialSize = 1000.0 MB
  usesCompressedOops = true
  compressedOopsMode = "Non-zero based"
  objectAlignment = 8 bytes
  heapAddressBits = 32
}

----------System.err:(20/1754)----------
java.lang.RuntimeException: Value not equal to Zero based, field='compressedOopsMode', value='Non-zero based' expected: Non-zero based but was: Zero based
               at jdk.test.lib.Asserts.fail(Asserts.java:715)
               at jdk.test.lib.Asserts.assertEquals(Asserts.java:208)
               at jdk.test.lib.jfr.EventField.lambda$equal$0(EventField.java:50)
               at jdk.test.lib.jfr.EventField.doAssert(EventField.java:114)
               at jdk.test.lib.jfr.EventField.equal(EventField.java:50)
               at jdk.test.lib.jfr.EventVerifier.verifyEquals(EventVerifier.java:35)
               at jdk.jfr.event.gc.configuration.GCHeapConfigurationEventVerifier.verifyCompressedOopModeIs(GCHeapConfigurationEventVerifier.java:59)
               at jdk.jfr.event.gc.configuration.ZeroBasedOopsVerifier.verify(TestGCHeapConfigurationEventWithZeroBasedOops.java:67)
               at jdk.jfr.event.gc.configuration.GCHeapConfigurationEventTester.run(GCHeapConfigurationEventTester.java:46)
               at jdk.jfr.event.gc.configuration.TestGCHeapConfigurationEventWithZeroBasedOops.main(TestGCHeapConfigurationEventWithZeroBasedOops.java:44)
               at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
               at java.base/java.lang.reflect.Method.invoke(Method.java:565)
               at com.sun.javatest.regtest.agent.MainWrapper$MainTask.run(MainWrapper.java:138)
               at java.base/java.lang.Thread.run(Thread.java:1474)

```
