### PR TITLE
8365416: java.desktop no longer needs preview feature access

### DIFF
--- a/src/java.base/share/classes/module-info.java
+++ b/src/java.base/share/classes/module-info.java
@@ -154,7 +154,6 @@ module java.base {
     // module declaration be annotated with jdk.internal.javac.ParticipatesInPreview
     exports jdk.internal.javac to
         java.compiler,
-        java.desktop, // for ScopedValue
         jdk.compiler,
         jdk.incubator.vector, // participates in preview features
         jdk.jartool, // participates in preview features


### PR DESCRIPTION
Now that Scoped Values is no longer preview, the desktop module does not need the entry in the base module-info.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8365416](https://bugs.openjdk.org/browse/JDK-8365416): java.desktop no longer needs preview feature access (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26765/head:pull/26765` \
`$ git checkout pull/26765`

Update a local copy of the PR: \
`$ git checkout pull/26765` \
`$ git pull https://git.openjdk.org/jdk.git pull/26765/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26765`

View PR using the GUI difftool: \
`$ git pr show -t 26765`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26765.diff">https://git.openjdk.org/jdk/pull/26765.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26765#issuecomment-3185103199)
</details>
