### PR TITLE
8365468: EagerJVMCI should only apply to the CompilerBroker JVMCI runtime

### DIFF
--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotJVMCIRuntime.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotJVMCIRuntime.java
@@ -186,7 +186,10 @@ public final class HotSpotJVMCIRuntime implements JVMCIRuntime {
                         // Can only do eager initialization of the JVMCI compiler
                         // once the singleton instance is available.
                         if (result.config.getFlag("EagerJVMCI", Boolean.class)) {
-                            result.getCompiler();
+                            // EagerJVMCI only applies to JVMCI when used by the CompileBroker.
+                            if (result.getCompilerToVM().isCompilerThread()) {
+                                result.getCompiler();
+                            }
                         }
                     }
                     // Ensures JVMCIRuntime::_HotSpotJVMCIRuntime_instance is


### PR DESCRIPTION
The primary goal of [JDK-8356447](https://bugs.openjdk.org/browse/JDK-8356447) was to have initialization of the Graal JIT occur in the same phase as the rest of VM startup such that initialization problems are detected and reported prior to executing any user code.

This change caused a performance regression for Truffle when it is used in a JDK that includes both jargraal and libgraal. The problem is that Truffle needs jarjvmci but does not need jargraal when libgraal is available. Initializing jargraal in that configuration delays initialization of Truffle (not just Truffle compilation). Additionally, the jargraal instance created will never be used, wasting memory.

The solution in this PR is to make EagerJVMCI only apply when initializing JVMCI on a CompileBroker thread.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8365468](https://bugs.openjdk.org/browse/JDK-8365468): EagerJVMCI should only apply to the CompilerBroker JVMCI runtime (**Bug** - P4)


### Reviewers
 * [Tom Rodriguez](https://openjdk.org/census#never) (@tkrodriguez - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26768/head:pull/26768` \
`$ git checkout pull/26768`

Update a local copy of the PR: \
`$ git checkout pull/26768` \
`$ git pull https://git.openjdk.org/jdk.git pull/26768/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26768`

View PR using the GUI difftool: \
`$ git pr show -t 26768`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26768.diff">https://git.openjdk.org/jdk/pull/26768.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26768#issuecomment-3185916178)
</details>
