### PR TITLE
8365620: Using enhanced switch in MethodHandleDesc

### DIFF
--- a/src/java.base/share/classes/java/lang/constant/MethodHandleDesc.java
+++ b/src/java.base/share/classes/java/lang/constant/MethodHandleDesc.java
@@ -118,6 +118,8 @@ public sealed interface MethodHandleDesc
                                            String name,
                                            MethodTypeDesc lookupMethodType) {
         return switch (kind) {
+            case GETTER, SETTER, STATIC_GETTER, STATIC_SETTER
+                    -> throw new IllegalArgumentException(kind.toString());
             case VIRTUAL, SPECIAL, INTERFACE_VIRTUAL, INTERFACE_SPECIAL, INTERFACE_STATIC, STATIC, CONSTRUCTOR
                     -> new DirectMethodHandleDescImpl(kind, owner, name, lookupMethodType);
             default -> throw new IllegalArgumentException(kind.toString());


### PR DESCRIPTION
In MethodHandleDesc, the `ofField` method uses enhanced switch, while the `of` and `ofMethod` methods use traditional switch. The same class should have a unified style.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8365620](https://bugs.openjdk.org/browse/JDK-8365620): Using enhanced switch in MethodHandleDesc (**Enhancement** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26769/head:pull/26769` \
`$ git checkout pull/26769`

Update a local copy of the PR: \
`$ git checkout pull/26769` \
`$ git pull https://git.openjdk.org/jdk.git pull/26769/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26769`

View PR using the GUI difftool: \
`$ git pr show -t 26769`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26769.diff">https://git.openjdk.org/jdk/pull/26769.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26769#issuecomment-3192599663)
</details>
