### PR TITLE
8356324: JVM crash (SIGSEGV at ClassListParser::resolve_indy_impl) during -Xshare:dump starting from 21.0.5

### DIFF
--- a/src/hotspot/share/oops/cpCache.inline.hpp
+++ b/src/hotspot/share/oops/cpCache.inline.hpp
@@ -73,6 +73,9 @@ inline ResolvedIndyEntry* ConstantPoolCache::resolved_indy_entry_at(int index) c
 }
 
 inline int ConstantPoolCache::resolved_indy_entries_length() const {
+  if (_resolved_indy_entries == nullptr) {
+    return 0;
+  }
   return _resolved_indy_entries->length();
 }
 #endif // SHARE_OOPS_CPCACHE_INLINE_HPP


### PR DESCRIPTION
A crash occurs when running with `-Xshare:dump` and specifying a class list file generated by an older JDK (e.g. JDK 17) via `-XX:SharedClassListFile`.
This pull request fixes the issue and prevents the crash.

# Details
Example command to reproduce:
```
$ ./jdk-26/fastdebug/bin/java -Xshare:dump -XX:SharedClassListFile=classes.list -XX:SharedArchiveFile=noop.jsa HelloWorld              
#                                                                                                                                                              
# A fatal error has been detected by the Java Runtime Environment:                                                                                             
#                                                                                                                                                              
#  SIGSEGV (0xb) at pc=0x0000ffff8610355c, pid=53155, tid=53156                                                                                                
#                                                                                                                                                              
# JRE version: OpenJDK Runtime Environment (26.0) (fastdebug build 26-internal-adhoc.jyukutyo.jyukutyo-jdk)                                                    
# Java VM: OpenJDK 64-Bit Server VM (fastdebug 26-internal-adhoc.jyukutyo.jyukutyo-jdk, interpreted mode, compressed oops, compressed class ptrs, g1 gc, linux-
aarch64)                                                                                                                                                       
# Problematic frame:                                                                                                                                           
# V  [libjvm.so+0x90355c]  ClassListParser::resolve_indy_impl(Symbol*, JavaThread*)+0x2dc 
[full crash log omitted for brevity]
```
The class list file that triggers the problem, generated by JDK 17, looks like this:
```
@lambda-proxy java/lang/System$LoggerFinder run ()Ljava/security/PrivilegedAction; ()Ljava/lang/Object; REF_invokeStatic java/lang/System$LoggerFinder lambda$accessProvider$0 ()Ljava/lang/System$LoggerFinder; ()Ljava/lang/System$LoggerFinder;
```

In contrast, the recent JDK generates class list contents as follows:
```
@cp jdk/internal/logger/LoggerFinderLoader 15 21 30 96 99 105 110 117 118 122 141
@cp jdk/internal/logger/DefaultLoggerFinder 1 2 7 8 14 22 29 30
@cp java/lang/System$LoggerFinder 1 2 10 27 31
```

When an old-style class list file is used, the `_resolved_indy_entries` variable remains null, which leads to a crash during `-Xshare:dump`.
This PR adds a null check to avoid the crash.
After applying this fix, running with the same options no longer results in a crash. Instead, a warning is shown as expected:
```
$ ./jdk-26_fixed/jdk-26/fastdebug/bin/java -Xshare:dump -XX:SharedClassListFile=classes.list -XX:SharedArchiveFile=noop.jsa HelloWorld
[0.094s][warning][cds] No invoke dynamic constant pool entry can be found for class java/lang/System$LoggerFinder. The classlist is probably out-of-date.
```

# Additional note
We may also want to apply the same fix to the `resolved_indy_entry_at` function in the `ConstantPoolCache` class. Please let me know if that is desirable.
For reference, the current implementation is:
```
inline ResolvedIndyEntry* ConstantPoolCache::resolved_indy_entry_at(int index) const {
  return _resolved_indy_entries->adr_at(index);
}
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8356324](https://bugs.openjdk.org/browse/JDK-8356324): JVM crash (SIGSEGV at ClassListParser::resolve_indy_impl) during -Xshare:dump starting from 21.0.5 (**Bug** - P3)


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)
 * [Matias Saavedra Silva](https://openjdk.org/census#matsaave) (@matias9927 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26770/head:pull/26770` \
`$ git checkout pull/26770`

Update a local copy of the PR: \
`$ git checkout pull/26770` \
`$ git pull https://git.openjdk.org/jdk.git pull/26770/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26770`

View PR using the GUI difftool: \
`$ git pr show -t 26770`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26770.diff">https://git.openjdk.org/jdk/pull/26770.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26770#issuecomment-3187305264)
</details>
