### PR TITLE
8365296: Build failure with Clang due to -Wformat warning after JDK-8364611

### DIFF
--- a/test/jdk/java/lang/ProcessBuilder/childSignalDisposition/exePrintSignalDisposition.c
+++ b/test/jdk/java/lang/ProcessBuilder/childSignalDisposition/exePrintSignalDisposition.c
@@ -72,25 +72,7 @@ int main(int argc, char** argv) {
         } else {
             printf("%p ", handler);
         }
-#ifdef _AIX
         printf("%X\n", act.sa_flags);
-#else
-        // Note: for shortness, just print out the first 32. That should
-        // cover most of the useful ones, apart from realtime signals.
-        const int NUM_IMPORTANT_SIGS = 32;
-        printf("%X ", act.sa_flags);
-        char buf[NUM_IMPORTANT_SIGS + 1];
-        for (size_t sig = 1; sig <= NUM_IMPORTANT_SIGS; sig++) {
-            int rc = sigismember(&act.sa_mask, sig);
-            if (rc == -1) {
-                buf[sig - 1] = '?';
-            } else {
-                buf[sig - 1] = rc ? '1' : '0';
-            }
-        }
-        buf[NUM_IMPORTANT_SIGS] = '\0';
-        printf("%s\n", buf);
-#endif
     }
 
     return 0;


### PR DESCRIPTION
This issue is related to the definition of __sigset_t (__sigset_t  act.sa_mask).   In the glibc source, __sigset_t is defined in multiple places:  
- bits/types/__sigset_t.h 
<img width="1071" height="415" alt="image02" src="https://github.com/user-attachments/assets/4dff7546-f0b3-448c-832f-54f7b9ffc476" />


- sysdeps/unix/sysv/linux/bits/types/__sigset_t.h (introduced after glibc 2.25)   
<img width="1059" height="487" alt="image01" src="https://github.com/user-attachments/assets/54101f9b-3b1a-4943-83ee-6f6471c060a6" />


During compilation with Clang, the latter definition appears to be used, where __sigset_t is a struct, causing the printf("%X", act.sa_mask) to fail.

we can detect whether _SIGSET_NWORDS is defined and handle the printing differently based on that, ensuring correct handling of the struct type.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8365296](https://bugs.openjdk.org/browse/JDK-8365296): Build failure with Clang due to -Wformat warning after JDK-8364611 (**Bug** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26771/head:pull/26771` \
`$ git checkout pull/26771`

Update a local copy of the PR: \
`$ git checkout pull/26771` \
`$ git pull https://git.openjdk.org/jdk.git pull/26771/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26771`

View PR using the GUI difftool: \
`$ git pr show -t 26771`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26771.diff">https://git.openjdk.org/jdk/pull/26771.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26771#issuecomment-3187491628)
</details>
