### PR TITLE
8365436: ImageReaderTest fails when jmods directory not present

### DIFF
--- a/test/jdk/jdk/internal/jimage/ImageReaderTest.java
+++ b/test/jdk/jdk/internal/jimage/ImageReaderTest.java
@@ -25,14 +25,11 @@ import jdk.internal.jimage.ImageReader;
 import jdk.internal.jimage.ImageReader.Node;
 import jdk.test.lib.compiler.InMemoryJavaCompiler;
 import jdk.test.lib.util.JarBuilder;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.opentest4j.TestAbortedException;
-import org.opentest4j.TestSkippedException;
 import tests.Helper;
 import tests.JImageGenerator;
 

--- a/test/jdk/jdk/internal/jimage/ImageReaderTest.java
+++ b/test/jdk/jdk/internal/jimage/ImageReaderTest.java
@@ -25,10 +25,13 @@ import jdk.internal.jimage.ImageReader;
 import jdk.internal.jimage.ImageReader.Node;
 import jdk.test.lib.compiler.InMemoryJavaCompiler;
 import jdk.test.lib.util.JarBuilder;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.opentest4j.TestAbortedException;
 import org.opentest4j.TestSkippedException;
 import tests.Helper;
 import tests.JImageGenerator;
@@ -214,15 +217,18 @@ public class ImageReaderTest {
 
     ///  Returns the helper for building JAR and jimage files.
     private static Helper getHelper() {
+        Helper helper;
         try {
-            Helper helper = Helper.newHelper();
-            if (helper == null) {
-                throw new TestSkippedException("Cannot create test helper (exploded image?)");
-            }
-            return helper;
+            helper = Helper.newHelper();
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
+        // Gracefully skip if there's no jimage to work with (e.g. if
+        // '--generate-linkable-runtime' was used to build the runtime).
+        // This may be reporting as a skipped test, or a pass, depending
+        // on how the test was run.
+        Assumptions.assumeTrue(helper != null, "Cannot create test helper (no jimage file)");
+        return helper;
     }
 
     /// Loads and performs actions on classes stored in a given `ImageReader`.


### PR DESCRIPTION
Switched from TestSkippedException (not honoured by JUnit) to TestAbortedException (via Assumptions class) to avoid false negative test "failure". Note that now, the test is either shown as skipped, or passed, depending on which report is being looked at. Tweaked error message slightly since using an "exploded image" isn't the only cause.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8365436](https://bugs.openjdk.org/browse/JDK-8365436): ImageReaderTest fails when jmods directory not present (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26773/head:pull/26773` \
`$ git checkout pull/26773`

Update a local copy of the PR: \
`$ git checkout pull/26773` \
`$ git pull https://git.openjdk.org/jdk.git pull/26773/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26773`

View PR using the GUI difftool: \
`$ git pr show -t 26773`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26773.diff">https://git.openjdk.org/jdk/pull/26773.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26773#issuecomment-3187645661)
</details>
