### PR TITLE
8365436: ImageReaderTest fails when jmods directory not present

### DIFF
--- a/test/jdk/jdk/internal/jimage/ImageReaderTest.java
+++ b/test/jdk/jdk/internal/jimage/ImageReaderTest.java
@@ -25,11 +25,12 @@ import jdk.internal.jimage.ImageReader;
 import jdk.internal.jimage.ImageReader.Node;
 import jdk.test.lib.compiler.InMemoryJavaCompiler;
 import jdk.test.lib.util.JarBuilder;
+import jdk.tools.jlink.internal.LinkableRuntimeImage;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.opentest4j.TestSkippedException;
 import tests.Helper;
 import tests.JImageGenerator;
 
@@ -54,6 +55,7 @@ import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
  * @test
  * @summary Tests for ImageReader.
  * @modules java.base/jdk.internal.jimage
+ *          jdk.jlink/jdk.tools.jlink.internal
  *          jdk.jlink/jdk.tools.jimage
  * @library /test/jdk/tools/lib
  *          /test/lib
@@ -214,15 +216,15 @@ public class ImageReaderTest {
 
     ///  Returns the helper for building JAR and jimage files.
     private static Helper getHelper() {
+        Helper helper;
         try {
-            Helper helper = Helper.newHelper();
-            if (helper == null) {
-                throw new TestSkippedException("Cannot create test helper (exploded image?)");
-            }
-            return helper;
+            boolean isLinkableRuntime = LinkableRuntimeImage.isLinkableRuntime();
+            helper = Helper.newHelper(isLinkableRuntime);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
+        Assumptions.assumeTrue(helper != null, "Cannot create test helper, skipping test!");
+        return helper;
     }
 
     /// Loads and performs actions on classes stored in a given `ImageReader`.


### PR DESCRIPTION
Changed test helper creation to know about linkable images, and changed how test skipping is reported (JUnit doesn't honor TestSkippedException, only TestAbortedException).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8365436](https://bugs.openjdk.org/browse/JDK-8365436): ImageReaderTest fails when jmods directory not present (**Bug** - P4)


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26774/head:pull/26774` \
`$ git checkout pull/26774`

Update a local copy of the PR: \
`$ git checkout pull/26774` \
`$ git pull https://git.openjdk.org/jdk.git pull/26774/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26774`

View PR using the GUI difftool: \
`$ git pr show -t 26774`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26774.diff">https://git.openjdk.org/jdk/pull/26774.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26774#issuecomment-3187808745)
</details>
