### PR TITLE
8365165: Zap C-heap memory at delete/free

### DIFF
--- a/src/hotspot/share/nmt/mallocTracker.cpp
+++ b/src/hotspot/share/nmt/mallocTracker.cpp
@@ -207,6 +207,10 @@ void* MallocTracker::record_free_block(void* memblock) {
 
   deaccount(header->free_info());
 
+  if (ZapCHeapObjects) {
+    memset(memblock, freeBlockPad, header->size());
+  }
+
   header->mark_block_as_dead();
 
   return (void*)header;

--- a/src/hotspot/share/nmt/mallocTracker.cpp
+++ b/src/hotspot/share/nmt/mallocTracker.cpp
@@ -207,7 +207,9 @@ void* MallocTracker::record_free_block(void* memblock) {
 
   deaccount(header->free_info());
 
-  if (ZapCHeapObjects) {
+  if (ZapCHeap) {
+    // To do this zapping, we need to know the block size.
+    // This is why we have to do it here, and not in os::free.
     memset(memblock, freeBlockPad, header->size());
   }
 

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -483,8 +483,8 @@ const int ObjectAlignmentInBytes = 8;
   develop(bool, ZapFillerObjects, trueInDebug,                              \
           "Zap filler objects")                                             \
                                                                             \
-  develop(bool, ZapCHeapObjects, trueInDebug,                               \
-          "Zap C heap objects")                                             \
+  develop(bool, ZapCHeap, trueInDebug,                                      \
+          "Zap allocated/freed C heap space")                               \
                                                                             \
   develop(bool, ZapTLAB, trueInDebug,                                       \
           "Zap allocated TLABs")                                            \

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -483,6 +483,9 @@ const int ObjectAlignmentInBytes = 8;
   develop(bool, ZapFillerObjects, trueInDebug,                              \
           "Zap filler objects")                                             \
                                                                             \
+  develop(bool, ZapCHeapObjects, trueInDebug,                               \
+          "Zap C heap objects")                                             \
+                                                                            \
   develop(bool, ZapTLAB, trueInDebug,                                       \
           "Zap allocated TLABs")                                            \
   develop(bool, TestingAsyncLoggingDeathTest, false,                        \

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -666,8 +666,8 @@ void* os::malloc(size_t size, MemTag mem_tag, const NativeCallStack& stack) {
   if (CDSConfig::is_dumping_static_archive()) {
     // Need to deterministically fill all the alignment gaps in C++ structures.
     ::memset(inner_ptr, 0, size);
-  } else {
-    DEBUG_ONLY(::memset(inner_ptr, uninitBlockPad, size);)
+  } else if (ZapCHeap) {
+    ::memset(inner_ptr, uninitBlockPad, size);
   }
   DEBUG_ONLY(break_if_ptr_caught(inner_ptr);)
   return inner_ptr;
@@ -740,7 +740,7 @@ void* os::realloc(void *memblock, size_t size, MemTag mem_tag, const NativeCallS
 
 #ifdef ASSERT
     assert(old_size == free_info.size, "Sanity");
-    if (old_size < size) {
+    if (ZapCHeap && old_size < size) {
       // We also zap the newly extended region.
       ::memset((char*)new_inner_ptr + old_size, uninitBlockPad, size - old_size);
     }


### PR DESCRIPTION
We sometimes have a lifecycle problem with C-heap allocated objects. The most recent I dealt with is [JDK-8364501](https://bugs.openjdk.org/browse/JDK-8364501). It would be convenient to have diagnostic code to zap the memory that is freed on C heap. We already do this for alloc/realloc. When NMT is enabled (which it is for debug builds), we can also do this for frees, as NMT tells us the size of the free-ed block.

This PR introduces a new diagnostic flag to match other `Zap*` flags we already have, puts the zapping on free path, and wraps alloc/realloc zapping with the flag as well. The last part is not really necessary, but it is nicer to wrap zapping code with a flag like this, so we can disable it for testing performance. JCStress routinely opts-out of most of the zapping to gain higher sampling throughput on fastdebug builds.

Additional testing:
 - [x] Linux AArch64 server fastdebug, selectively rolling back [JDK-8364501](https://bugs.openjdk.org/browse/JDK-8364501) -- starts to immediately crash on reproducer
 - [ ] Linux AArch64 server fastdebug, `all` (no new crashes)
 - [ ] Linux x86_64 server fastdebug, `all` (no new crashes)