### PR TITLE
8365533: Remove outdated jdk.internal.javac package export to several modules from java.base

### DIFF
--- a/src/java.base/share/classes/module-info.java
+++ b/src/java.base/share/classes/module-info.java
@@ -155,13 +155,7 @@ module java.base {
     exports jdk.internal.javac to
         java.compiler,
         java.desktop, // for ScopedValue
-        jdk.compiler,
-        jdk.incubator.vector, // participates in preview features
-        jdk.jartool, // participates in preview features
-        jdk.jdeps, // participates in preview features
-        jdk.jfr, // participates in preview features
-        jdk.jlink,   // participates in preview features
-        jdk.jshell; // participates in preview features
+        jdk.compiler;
     exports jdk.internal.access to
         java.desktop,
         java.logging,

--- a/src/jdk.jartool/share/classes/module-info.java
+++ b/src/jdk.jartool/share/classes/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,8 +22,6 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-
-import jdk.internal.javac.ParticipatesInPreview;
 
 /**
  * Defines tools for manipulating Java Archive (JAR) files,
@@ -49,7 +47,6 @@ import jdk.internal.javac.ParticipatesInPreview;
  * @moduleGraph
  * @since 9
  */
-@ParticipatesInPreview
 module jdk.jartool {
     requires jdk.internal.opt;
 

--- a/src/jdk.jdeps/share/classes/module-info.java
+++ b/src/jdk.jdeps/share/classes/module-info.java
@@ -23,8 +23,6 @@
  * questions.
  */
 
-import jdk.internal.javac.ParticipatesInPreview;
-
 /**
  * Defines tools for analysing dependencies in Java libraries and programs,
  * including the <em>{@index jdeps jdeps tool}</em>,
@@ -62,7 +60,6 @@ import jdk.internal.javac.ParticipatesInPreview;
  * @moduleGraph
  * @since 9
  */
-@ParticipatesInPreview
 module jdk.jdeps {
     requires java.compiler;
     requires jdk.compiler;

--- a/src/jdk.jfr/share/classes/module-info.java
+++ b/src/jdk.jfr/share/classes/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,15 +23,12 @@
  * questions.
  */
 
-import jdk.internal.javac.ParticipatesInPreview;
-
 /**
  * Defines the API for JDK Flight Recorder.
  *
  * @moduleGraph
  * @since 9
  */
-@ParticipatesInPreview
 module jdk.jfr {
     exports jdk.jfr;
     exports jdk.jfr.consumer;

--- a/src/jdk.jlink/share/classes/module-info.java
+++ b/src/jdk.jlink/share/classes/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,8 +22,6 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-
-import jdk.internal.javac.ParticipatesInPreview;
 
 /**
  * Defines the <em>{@index jlink jlink tool}</em> tool for creating run-time
@@ -53,7 +51,6 @@ import jdk.internal.javac.ParticipatesInPreview;
  * @moduleGraph
  * @since 9
  */
-@ParticipatesInPreview
 module jdk.jlink {
     requires jdk.internal.opt;
     requires jdk.jdeps;

--- a/src/jdk.jshell/share/classes/jdk/jshell/JShellConsole.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/JShellConsole.java
@@ -28,7 +28,6 @@ import java.io.IOError;
 import java.io.PrintWriter;
 import java.io.Reader;
 import java.nio.charset.Charset;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * An interface providing functionality for {@link java.io.Console} in the user's snippet.

--- a/src/jdk.jshell/share/classes/module-info.java
+++ b/src/jdk.jshell/share/classes/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,8 +22,6 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-
-import jdk.internal.javac.ParticipatesInPreview;
 
 /**
  * Provides the <em>{@index jshell jshell tool}</em> tool for evaluating
@@ -65,7 +63,6 @@ import jdk.internal.javac.ParticipatesInPreview;
  * @moduleGraph
  * @since 9
  */
-@ParticipatesInPreview
 module jdk.jshell {
     requires java.logging;
     requires jdk.compiler;


### PR DESCRIPTION
Can I please get a review of these change which removes the outdated use of `jdk.internal.javac.ParticipatesInPreview` and the qualified export of `jdk.internal.javac` package? This addresses https://bugs.openjdk.org/browse/JDK-8365533.

These qualified exports in `java.base` were added in https://bugs.openjdk.org/browse/JDK-8308753 when ClassFile API was in preview. Starting Java 24, ClassFile API is now a part of Java SE. These affected modules don't use any other preview feature, so there's no longer a need to export the `jdk.internal.javac` package to these modules.

tier1, tier2 and tier3 testing of this change completed without any related failures.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8365533](https://bugs.openjdk.org/browse/JDK-8365533): Remove outdated jdk.internal.javac package export to several modules from java.base (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26776/head:pull/26776` \
`$ git checkout pull/26776`

Update a local copy of the PR: \
`$ git checkout pull/26776` \
`$ git pull https://git.openjdk.org/jdk.git pull/26776/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26776`

View PR using the GUI difftool: \
`$ git pr show -t 26776`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26776.diff">https://git.openjdk.org/jdk/pull/26776.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26776#issuecomment-3187984134)
</details>
