### PR TITLE
8365048: idea.sh script does not correctly detect/handle git worktrees

### DIFF
--- a/bin/idea.sh
+++ b/bin/idea.sh
@@ -125,7 +125,8 @@ if [ -d "$TOPLEVEL_DIR/.hg" ] ; then
     VCS_TYPE="hg4idea"
 fi
 
-if [ -d "$TOPLEVEL_DIR/.git" ] ; then
+# Git workstrees use a '.git' file rather than directory, so test both.
+if [ -d "$TOPLEVEL_DIR/.git" -o -f "$TOPLEVEL_DIR/.git" ] ; then
     VCS_TYPE="Git"
 fi
 


### PR DESCRIPTION
Allows files or directories called .git to indicate likely use of Git for VCS in IntelliJ.
Tested locally in a worktree and normal repository. It produces:

 <component name="VcsDirectoryMappings">
    <mapping directory="$PROJECT_DIR$" vcs="Git" />
    <mapping directory="$PROJECT_DIR$/open" vcs="Git" />
  </component>

in both cases, as expected.