### PR TITLE
8365532: java/lang/module/ModuleReader/ModuleReaderTest.testImage fails

### DIFF
--- a/src/java.base/share/classes/jdk/internal/module/SystemModuleFinders.java
+++ b/src/java.base/share/classes/jdk/internal/module/SystemModuleFinders.java
@@ -430,6 +430,7 @@ public final class SystemModuleFinders {
 
         @Override
         public Optional<URI> find(String name) throws IOException {
+            Objects.requireNonNull(name);
             String resourcePath = "/" + module + "/" + name;
             if (containsResource(resourcePath)) {
                 URI u = JNUA.create("jrt", resourcePath);


### PR DESCRIPTION
This should fix this issue and locally fixes the test() method in:

test/jdk/java/lang/module/ModuleReader/ModuleReaderTest.java

which does:

--------
            // test nulls
            try {
                reader.find(null);
                assertTrue(false);
            } catch (NullPointerException expected) { }
--------

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8365532](https://bugs.openjdk.org/browse/JDK-8365532): java/lang/module/ModuleReader/ModuleReaderTest.testImage fails (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26780/head:pull/26780` \
`$ git checkout pull/26780`

Update a local copy of the PR: \
`$ git checkout pull/26780` \
`$ git pull https://git.openjdk.org/jdk.git pull/26780/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26780`

View PR using the GUI difftool: \
`$ git pr show -t 26780`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26780.diff">https://git.openjdk.org/jdk/pull/26780.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26780#issuecomment-3188819179)
</details>
