### PR TITLE
8365559: jarsigner shows files non-existent if signed with a weak algorithm

### DIFF
--- a/src/jdk.jartool/share/classes/sun/security/tools/jarsigner/Main.java
+++ b/src/jdk.jartool/share/classes/sun/security/tools/jarsigner/Main.java
@@ -876,6 +876,11 @@ public class Main {
                         sb.append('|');
                     }
 
+                    // If the file exists, remove it from all entries in entriesInSF
+                    for (var signed : entriesInSF.values()) {
+                        signed.remove(name);
+                    }
+
                     // When -certs provided, display info has extra empty
                     // lines at the beginning and end.
                     if (isSigned) {
@@ -889,9 +894,6 @@ public class Main {
                                 sb.append(si);
                                 sb.append('\n');
                             }
-                        }
-                        for (var signed : entriesInSF.values()) {
-                            signed.remove(name);
                         }
                     } else if (showcerts && !verbose.equals("all")) {
                         // Print no info for unsigned entries when -verbose:all,

--- a/test/jdk/sun/security/tools/jarsigner/RemovedFiles.java
+++ b/test/jdk/sun/security/tools/jarsigner/RemovedFiles.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8309841
+ * @bug 8309841 8365559
  * @summary Jarsigner should print a warning if an entry is removed
  * @library /test/lib
  */
@@ -40,8 +40,15 @@ public class RemovedFiles {
 
     private static final String NONEXISTENT_ENTRIES_FOUND
             = "This jar contains signed entries for files that do not exist. See the -verbose output for more details.";
+    private static final String WEAK_UNSIGNED
+            = "The jar will be treated as unsigned, because it is signed with a weak algorithm that is now disabled";
 
     public static void main(String[] args) throws Exception {
+        t8309841();
+        t8365559();
+    }
+
+    static void t8309841() throws Exception {
         JarUtils.createJarFile(
                 Path.of("a.jar"),
                 Path.of("."),
@@ -89,6 +96,23 @@ public class RemovedFiles {
         SecurityTools.jarsigner("-verbose -verify b.jar")
                 .shouldContain("Warning: nonexistent signed entries: [Hello]")
                 .shouldContain(NONEXISTENT_ENTRIES_FOUND);
+    }
 
+    static void t8365559() throws Exception {
+        JarUtils.createJarFile(
+                Path.of("c.jar"),
+                Path.of("."),
+                Files.writeString(Path.of("c"), "c"));
+        SecurityTools.keytool("-genkeypair -storepass changeit -keystore ks -alias w -dname CN=w -keyalg ec");
+        SecurityTools.jarsigner("-storepass changeit -keystore ks c.jar w -sigalg SHA1withECDSA")
+                        .shouldContain("the -sigalg option is considered a security risk and is disabled.");
+
+        SecurityTools.jarsigner("-verify c.jar")
+                .shouldContain(WEAK_UNSIGNED)
+                .shouldNotContain(NONEXISTENT_ENTRIES_FOUND);
+        SecurityTools.jarsigner("-verify -verbose c.jar")
+                .shouldContain(WEAK_UNSIGNED)
+                .shouldNotContain(NONEXISTENT_ENTRIES_FOUND)
+                .shouldNotContain("Warning: nonexistent signed entries:");
     }
 }

--- a/test/jdk/sun/security/tools/jarsigner/RemovedFiles.java
+++ b/test/jdk/sun/security/tools/jarsigner/RemovedFiles.java
@@ -104,6 +104,9 @@ public class RemovedFiles {
                 Path.of("."),
                 Files.writeString(Path.of("c"), "c"));
         SecurityTools.keytool("-genkeypair -storepass changeit -keystore ks -alias w -dname CN=w -keyalg ec");
+
+        // Sign the JAR using an already disabled signature algorithm SHA1withECDSA.
+        // The file can still be signed but verification will treat it as unsigned.
         SecurityTools.jarsigner("-storepass changeit -keystore ks c.jar w -sigalg SHA1withECDSA")
                         .shouldContain("the -sigalg option is considered a security risk and is disabled.");
 


### PR DESCRIPTION
See the bug report for details. Basically, entries in the SF set should always be removed no matter if it's treated signed or not.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8365559: jarsigner shows files non-existent if signed with a weak algorithm`

### Issue
 * [JDK-8365559](https://bugs.openjdk.org/browse/JDK-8365559): jarsigner shows files non-existent if signed with a weak algorithm (**Bug** - P4)


### Reviewers
 * [Artur Barashev](https://openjdk.org/census#abarashev) (@artur-oracle - Committer)
 * [Bradford Wetmore](https://openjdk.org/census#wetmore) (@bradfordwetmore - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26781/head:pull/26781` \
`$ git checkout pull/26781`

Update a local copy of the PR: \
`$ git checkout pull/26781` \
`$ git pull https://git.openjdk.org/jdk.git pull/26781/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26781`

View PR using the GUI difftool: \
`$ git pr show -t 26781`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26781.diff">https://git.openjdk.org/jdk/pull/26781.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26781#issuecomment-3188866133)
</details>
