### PR TITLE
Why can't the thread state be blocked only during park?

### DIFF
--- a/src/hotspot/share/runtime/objectMonitor.cpp
+++ b/src/hotspot/share/runtime/objectMonitor.cpp
@@ -580,20 +580,10 @@ void ObjectMonitor::enter_with_contention_mark(JavaThread* current, ObjectMonito
 
     assert(current->thread_state() == _thread_in_vm, "invariant");
 
-    for (;;) {
-      enter_internal(current);
-      current->set_current_pending_monitor(nullptr);
-        // We can go to a safepoint at the end of this block. If we
-        // do a thread dump during that safepoint, then this thread will show
-        // as having "-locked" the monitor, but the OS and java.lang.Thread
-        // states will still report that the thread is blocked trying to
-        // acquire it.
-        // If there is a suspend request, ExitOnSuspend will exit the OM
-        // and set the OM as pending.
-    }
+    enter_internal(current);
+    current->set_current_pending_monitor(nullptr);
 
-    // We've just gotten past the enter-check-for-suspend dance and we now own
-    // the monitor free and clear.
+    // We now own the monitor free and clear.
   }
 
   assert(contentions() >= 0, "must not be negative: contentions=%d", contentions());


### PR DESCRIPTION
Why can't we move the ThreadState around where we do the park???  Why does JVMTI suspend have to mess things up?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26782/head:pull/26782` \
`$ git checkout pull/26782`

Update a local copy of the PR: \
`$ git checkout pull/26782` \
`$ git pull https://git.openjdk.org/jdk.git pull/26782/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26782`

View PR using the GUI difftool: \
`$ git pr show -t 26782`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26782.diff">https://git.openjdk.org/jdk/pull/26782.diff</a>

</details>
