### PR TITLE
8365571: GenShen: PLAB promotions may remain disabled for evacuation threads

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
@@ -823,7 +823,6 @@ bool ShenandoahConcurrentGC::has_in_place_promotions(ShenandoahHeap* heap) {
   return heap->mode()->is_generational() && heap->old_generation()->has_in_place_promotions();
 }
 
-template<bool GENERATIONAL>
 class ShenandoahConcurrentEvacThreadClosure : public ThreadClosure {
 private:
   OopClosure* const _oops;
@@ -833,13 +832,9 @@ public:
   void do_thread(Thread* thread) override {
     JavaThread* const jt = JavaThread::cast(thread);
     StackWatermarkSet::finish_processing(jt, _oops, StackWatermarkKind::gc);
-    if (GENERATIONAL) {
-      ShenandoahThreadLocalData::enable_plab_promotions(thread);
-    }
   }
 };
 
-template<bool GENERATIONAL>
 class ShenandoahConcurrentEvacUpdateThreadTask : public WorkerTask {
 private:
   ShenandoahJavaThreadsIterator _java_threads;
@@ -851,30 +846,20 @@ public:
   }
 
   void work(uint worker_id) override {
-    if (GENERATIONAL) {
-      Thread* worker_thread = Thread::current();
-      ShenandoahThreadLocalData::enable_plab_promotions(worker_thread);
-    }
-
     // ShenandoahEvacOOMScope has to be setup by ShenandoahContextEvacuateUpdateRootsClosure.
     // Otherwise, may deadlock with watermark lock
     ShenandoahContextEvacuateUpdateRootsClosure oops_cl;
-    ShenandoahConcurrentEvacThreadClosure<GENERATIONAL> thr_cl(&oops_cl);
+    ShenandoahConcurrentEvacThreadClosure thr_cl(&oops_cl);
     _java_threads.threads_do(&thr_cl, worker_id);
   }
 };
 
 void ShenandoahConcurrentGC::op_thread_roots() {
-  ShenandoahHeap* const heap = ShenandoahHeap::heap();
+  const ShenandoahHeap* const heap = ShenandoahHeap::heap();
   assert(heap->is_evacuation_in_progress(), "Checked by caller");
   ShenandoahGCWorkerPhase worker_phase(ShenandoahPhaseTimings::conc_thread_roots);
-  if (heap->mode()->is_generational()) {
-    ShenandoahConcurrentEvacUpdateThreadTask<true> task(heap->workers()->active_workers());
-    heap->workers()->run_task(&task);
-  } else {
-    ShenandoahConcurrentEvacUpdateThreadTask<false> task(heap->workers()->active_workers());
-    heap->workers()->run_task(&task);
-  }
+  ShenandoahConcurrentEvacUpdateThreadTask task(heap->workers()->active_workers());
+  heap->workers()->run_task(&task);
 }
 
 void ShenandoahConcurrentGC::op_weak_refs() {

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -1216,6 +1216,11 @@ public:
       //  1. We need to make the plab memory parsable by remembered-set scanning.
       //  2. We need to establish a trustworthy UpdateWaterMark value within each old-gen heap region
       ShenandoahGenerationalHeap::heap()->retire_plab(plab, thread);
+
+      // Re-enable promotions for the next evacuation phase.
+      ShenandoahThreadLocalData::enable_plab_promotions(thread);
+
+      // Reset the fill size for next evacuation phase.
       if (_resize && ShenandoahThreadLocalData::plab_size(thread) > 0) {
         ShenandoahThreadLocalData::set_plab_size(thread, 0);
       }


### PR DESCRIPTION
Mutators and GC workers have old generation LABs for promotions and old generation evacuations. Priority is given to old evacuations by using a promotion budget. Once the promotion budget is exhausted, a thread local flag is set to disable further promotions (the LAB can still be used for old evacuations). This thread local flag is meant to be cleared to allow all threads to resume promotions on the next cycle. However, this flag is only reset for workers that perform thread root evacuations, which may not be the same workers that perform subsequent evacuations. This patch clears the flag for all threads when their LABs are retired at the end of evacuation.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8365571](https://bugs.openjdk.org/browse/JDK-8365571): GenShen: PLAB promotions may remain disabled for evacuation threads (**Bug** - P4)


### Reviewers
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - Committer)
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26785/head:pull/26785` \
`$ git checkout pull/26785`

Update a local copy of the PR: \
`$ git checkout pull/26785` \
`$ git pull https://git.openjdk.org/jdk.git pull/26785/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26785`

View PR using the GUI difftool: \
`$ git pr show -t 26785`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26785.diff">https://git.openjdk.org/jdk/pull/26785.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26785#issuecomment-3189456200)
</details>
