### PR TITLE
8365572: Shenandoah: Remove unused thread local _paced_time field

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahThreadLocalData.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahThreadLocalData.cpp
@@ -37,7 +37,6 @@ ShenandoahThreadLocalData::ShenandoahThreadLocalData() :
   _card_table(nullptr),
   _gclab(nullptr),
   _gclab_size(0),
-  _paced_time(0),
   _plab(nullptr),
   _plab_desired_size(0),
   _plab_actual_size(0),

--- a/src/hotspot/share/gc/shenandoah/shenandoahThreadLocalData.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahThreadLocalData.hpp
@@ -58,8 +58,6 @@ private:
   PLAB* _gclab;
   size_t _gclab_size;
 
-  double _paced_time;
-
   // Thread-local allocation buffer only used in generational mode.
   // Used both by mutator threads and by GC worker threads
   // for evacuations within the old generation and
@@ -235,18 +233,6 @@ public:
 
   static size_t get_plab_actual_size(Thread* thread) {
     return data(thread)->_plab_actual_size;
-  }
-
-  static void add_paced_time(Thread* thread, double v) {
-    data(thread)->_paced_time += v;
-  }
-
-  static double paced_time(Thread* thread) {
-    return data(thread)->_paced_time;
-  }
-
-  static void reset_paced_time(Thread* thread) {
-    data(thread)->_paced_time = 0;
   }
 
   // Evacuation OOM handling


### PR DESCRIPTION
We missed this spot when removing the ShenandoahPacer.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8365572](https://bugs.openjdk.org/browse/JDK-8365572): Shenandoah: Remove unused thread local _paced_time field (**Enhancement** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26788/head:pull/26788` \
`$ git checkout pull/26788`

Update a local copy of the PR: \
`$ git checkout pull/26788` \
`$ git pull https://git.openjdk.org/jdk.git pull/26788/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26788`

View PR using the GUI difftool: \
`$ git pr show -t 26788`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26788.diff">https://git.openjdk.org/jdk/pull/26788.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26788#issuecomment-3189631554)
</details>
