### PR TITLE
8365244: Some test control variables are undocumented in doc/testing.md

### DIFF
--- a/doc/testing.html
+++ b/doc/testing.html
@@ -72,11 +72,9 @@ id="toc-notes-for-specific-tests">Notes for Specific Tests</a>
 <li><a href="#non-us-locale" id="toc-non-us-locale">Non-US
 locale</a></li>
 <li><a href="#pkcs11-tests" id="toc-pkcs11-tests">PKCS11 Tests</a></li>
-</ul></li>
 <li><a href="#testing-ahead-of-time-optimizations"
-id="toc-testing-ahead-of-time-optimizations">### Testing Ahead-of-time
-Optimizations</a>
-<ul>
+id="toc-testing-ahead-of-time-optimizations">Testing Ahead-of-time
+Optimizations</a></li>
 <li><a href="#testing-with-alternative-security-providers"
 id="toc-testing-with-alternative-security-providers">Testing with
 alternative security providers</a></li>
@@ -435,6 +433,9 @@ the diff between the specified revision and the repository tip.</p>
 <p>The report is stored in
 <code>build/$BUILD/test-results/jcov-output/diff_coverage_report</code>
 file.</p>
+<h4 id="aot_jdk">AOT_JDK</h4>
+<p>See <a href="#testing-ahead-of-time-optimizations">Testing
+Ahead-of-time optimizations</a>.</p>
 <h3 id="jtreg-keywords">JTReg keywords</h3>
 <h4 id="jobs-1">JOBS</h4>
 <p>The test concurrency (<code>-concurrency</code>).</p>
@@ -556,6 +557,12 @@ each fork. Same as specifying <code>-wi &lt;num&gt;</code>.</p>
 same values as <code>-rff</code>, i.e., <code>text</code>,
 <code>csv</code>, <code>scsv</code>, <code>json</code>, or
 <code>latex</code>.</p>
+<h4 id="test_jdk">TEST_JDK</h4>
+<p>The path to the JDK that will be used to run the benchmarks.</p>
+<p>Defaults to <code>build/&lt;CONF-NAME&gt;/jdk</code>.</p>
+<h4 id="benchmarks_jar">BENCHMARKS_JAR</h4>
+<p>The path to the JAR containing the benchmarks.</p>
+<p>Defaults to <code>test/micro/benchmarks.jar</code>.</p>
 <h4 id="vm_options-2">VM_OPTIONS</h4>
 <p>Additional VM arguments to provide to forked off VMs. Same as
 <code>-jvmArgs &lt;args&gt;</code></p>
@@ -601,8 +608,8 @@ element of the appropriate <code>@Artifact</code> class. (See
     JTREG=&quot;JAVA_OPTIONS=-Djdk.test.lib.artifacts.nsslib-linux_aarch64=/path/to/NSS-libs&quot;</code></pre>
 <p>For more notes about the PKCS11 tests, please refer to
 test/jdk/sun/security/pkcs11/README.</p>
-<h2 id="testing-ahead-of-time-optimizations">### Testing Ahead-of-time
-Optimizations</h2>
+<h3 id="testing-ahead-of-time-optimizations">Testing Ahead-of-time
+Optimizations</h3>
 <p>One way to improve test coverage of ahead-of-time (AOT) optimizations
 in the JDK is to run existing jtreg test cases in a special "AOT_JDK"
 mode. Example:</p>

--- a/doc/testing.md
+++ b/doc/testing.md
@@ -367,6 +367,10 @@ between the specified revision and the repository tip.
 The report is stored in
 `build/$BUILD/test-results/jcov-output/diff_coverage_report` file.
 
+#### AOT_JDK
+
+See [Testing Ahead-of-time optimizations](#testing-ahead-of-time-optimizations).
+
 ### JTReg keywords
 
 #### JOBS
@@ -545,6 +549,18 @@ Amount of time to spend in each warmup iteration. Same as specifying `-w
 Specify to have the test run save a log of the values. Accepts the same values
 as `-rff`, i.e., `text`, `csv`, `scsv`, `json`, or `latex`.
 
+#### TEST_JDK
+
+The path to the JDK that will be used to run the benchmarks.
+
+Defaults to `build/<CONF-NAME>/jdk`.
+
+#### BENCHMARKS_JAR
+
+The path to the JAR containing the benchmarks.
+
+Defaults to `test/micro/benchmarks.jar`.
+
 #### VM_OPTIONS
 
 Additional VM arguments to provide to forked off VMs. Same as `-jvmArgs <args>`
@@ -612,7 +628,7 @@ For more notes about the PKCS11 tests, please refer to
 test/jdk/sun/security/pkcs11/README.
 
 ### Testing Ahead-of-time Optimizations
--------------------------------------------------------------------------------
+
 One way to improve test coverage of ahead-of-time (AOT) optimizations in
 the JDK is to run existing jtreg test cases in a special "AOT_JDK" mode.
 Example:


### PR DESCRIPTION
Synchronize `make/RunTests.gmk` keyword variables with `doc/testing.{md,html}`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8365244](https://bugs.openjdk.org/browse/JDK-8365244): Some test control variables are undocumented in doc/testing.md (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26789/head:pull/26789` \
`$ git checkout pull/26789`

Update a local copy of the PR: \
`$ git checkout pull/26789` \
`$ git pull https://git.openjdk.org/jdk.git pull/26789/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26789`

View PR using the GUI difftool: \
`$ git pr show -t 26789`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26789.diff">https://git.openjdk.org/jdk/pull/26789.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26789#issuecomment-3189647200)
</details>
