### PR TITLE
Track the next KEY_TYPED related to the mnemonic key press event so i…

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicPopupMenuUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicPopupMenuUI.java
@@ -379,6 +379,7 @@ public class BasicPopupMenuUI extends PopupMenuUI {
                 } else if (item.isEnabled()) {
                     // we have a menu item
                     manager.clearSelectedPath();
+                    sun.awt.SunToolkit.consumeNextKeyTyped(e);
                     item.doClick();
                 }
                 e.consume();

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -491,7 +491,6 @@ java/awt/Graphics2D/DrawString/RotTransText.java 8316878 linux-all
 java/awt/KeyboardFocusmanager/TypeAhead/ButtonActionKeyTest/ButtonActionKeyTest.java 8257529 windows-x64
 java/awt/KeyboardFocusmanager/ConsumeNextMnemonicKeyTypedTest/ConsumeForModalDialogTest/ConsumeForModalDialogTest.java 8302787 windows-all
 java/awt/KeyboardFocusmanager/TypeAhead/MenuItemActivatedTest/MenuItemActivatedTest.java 8302787 windows-all
-java/awt/KeyboardFocusmanager/ConsumeNextMnemonicKeyTypedTest/ConsumeNextMnemonicKeyTypedTest.java 8321303 linux-all
 
 java/awt/Window/GetScreenLocation/GetScreenLocationTest.java 8225787 linux-x64
 java/awt/Dialog/MakeWindowAlwaysOnTop/MakeWindowAlwaysOnTop.java 8266243 macosx-aarch64


### PR DESCRIPTION
**Analysis :**
When the problem occurred, the key press event related to the mnemonic triggered the item selection. However, as we returned to the menu, the subsequent key typed event arrived and was treated as a normal key press instead of being recognized as part of the mnemonic sequence.

**Propose Fix:**
As a fix, we are tagging the next key typed event to be consumed by the Keyboard Focus Manager

```
    public void processKeyEvent(Component focusedComponent, KeyEvent e) {
        // consume processed event if needed
        if (consumeProcessedKeyEvent(e)) { <--- consumed here
            return;
        }
...
```