### PR TITLE
8365579: ml64.exe is not the right assembler for Windows aarch64

### DIFF
--- a/make/autoconf/flags-other.m4
+++ b/make/autoconf/flags-other.m4
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/make/autoconf/flags-other.m4
+++ b/make/autoconf/flags-other.m4
@@ -115,7 +115,11 @@ AC_DEFUN([FLAGS_SETUP_ASFLAGS],
     # Force preprocessor to run, just to make sure
     BASIC_ASFLAGS="-x assembler-with-cpp"
   elif test "x$TOOLCHAIN_TYPE" = xmicrosoft; then
-    BASIC_ASFLAGS="-nologo -c"
+    if test "x$OPENJDK_TARGET_CPU" = xaarch64; then
+      BASIC_ASFLAGS="-nologo"
+    else
+      BASIC_ASFLAGS="-nologo -c -Ta"
+    fi
   fi
   AC_SUBST(BASIC_ASFLAGS)
 

--- a/make/autoconf/flags-other.m4
+++ b/make/autoconf/flags-other.m4
@@ -118,7 +118,7 @@ AC_DEFUN([FLAGS_SETUP_ASFLAGS],
     if test "x$OPENJDK_TARGET_CPU" = xaarch64; then
       BASIC_ASFLAGS="-nologo"
     else
-      BASIC_ASFLAGS="-nologo -c -Ta"
+      BASIC_ASFLAGS="-nologo -c"
     fi
   fi
   AC_SUBST(BASIC_ASFLAGS)

--- a/make/autoconf/toolchain.m4
+++ b/make/autoconf/toolchain.m4
@@ -655,12 +655,17 @@ AC_DEFUN_ONCE([TOOLCHAIN_DETECT_TOOLCHAIN_CORE],
   if test "x$TOOLCHAIN_TYPE" != xmicrosoft; then
     AS="$CC -c"
   else
-    if test "x$OPENJDK_TARGET_CPU_BITS" = "x64"; then
-      # On 64 bit windows, the assembler is "ml64.exe"
-      UTIL_LOOKUP_TOOLCHAIN_PROGS(AS, ml64)
+    if test "x$OPENJDK_TARGET_CPU" = "xaarch64"; then
+      # On Windows aarch64, the assembler is "armasm64.exe"
+      UTIL_LOOKUP_TOOLCHAIN_PROGS(AS, armasm64)
     else
-      # otherwise, the assembler is "ml.exe"
-      UTIL_LOOKUP_TOOLCHAIN_PROGS(AS, ml)
+      if test "x$OPENJDK_TARGET_CPU_BITS" = "x64"; then
+        # On Windows x64, the assembler is "ml64.exe"
+        UTIL_LOOKUP_TOOLCHAIN_PROGS(AS, ml64)
+      else
+        # otherwise, the assembler is "ml.exe"
+        UTIL_LOOKUP_TOOLCHAIN_PROGS(AS, ml)
+      fi
     fi
   fi
   AC_SUBST(AS)

--- a/make/autoconf/toolchain.m4
+++ b/make/autoconf/toolchain.m4
@@ -658,14 +658,12 @@ AC_DEFUN_ONCE([TOOLCHAIN_DETECT_TOOLCHAIN_CORE],
     if test "x$OPENJDK_TARGET_CPU" = "xaarch64"; then
       # On Windows aarch64, the assembler is "armasm64.exe"
       UTIL_LOOKUP_TOOLCHAIN_PROGS(AS, armasm64)
+    elif test "x$OPENJDK_TARGET_CPU_BITS" = "x64"; then
+      # On Windows x64, the assembler is "ml64.exe"
+      UTIL_LOOKUP_TOOLCHAIN_PROGS(AS, ml64)
     else
-      if test "x$OPENJDK_TARGET_CPU_BITS" = "x64"; then
-        # On Windows x64, the assembler is "ml64.exe"
-        UTIL_LOOKUP_TOOLCHAIN_PROGS(AS, ml64)
-      else
-        # otherwise, the assembler is "ml.exe"
-        UTIL_LOOKUP_TOOLCHAIN_PROGS(AS, ml)
-      fi
+      # otherwise, the assembler is "ml.exe"
+      UTIL_LOOKUP_TOOLCHAIN_PROGS(AS, ml)
     fi
   fi
   AC_SUBST(AS)

--- a/make/common/native/CompileFile.gmk
+++ b/make/common/native/CompileFile.gmk
@@ -236,7 +236,7 @@ define CreateCompiledNativeFileBody
             # For assembler calls just create empty dependency lists
 	    $$(call ExecuteWithLog, $$@, $$(call MakeCommandRelative, \
 	        $$($1_COMPILER) $$($1_FLAGS) \
-	        $(CC_OUT_OPTION)$$($1_OBJ) -Ta $$($1_SRC_FILE))) \
+	        $(CC_OUT_OPTION)$$($1_OBJ) $$($1_SRC_FILE))) \
 	        | $(TR) -d '\r' | $(GREP) -v -e "Assembling:" || test "$$$$?" = "1" ; \
 	    $(ECHO) > $$($1_DEPS_FILE) ; \
 	    $(ECHO) > $$($1_DEPS_TARGETS_FILE)

--- a/make/common/native/CompileFile.gmk
+++ b/make/common/native/CompileFile.gmk
@@ -155,6 +155,12 @@ define CreateCompiledNativeFileBody
         endif
         $1_FLAGS := $$($1_FLAGS) -DASSEMBLY_SRC_FILE='"$$($1_REL_ASM_SRC)"' \
             -include $(TOPDIR)/make/data/autoheaders/assemblyprefix.h
+      else ifeq ($(TOOLCHAIN_TYPE), microsoft)
+        ifeq ($(OPENJDK_TARGET_CPU), aarch64)
+          $1_NON_ASM_EXTENSION_FLAG :=
+        else
+          $1_NON_ASM_EXTENSION_FLAG := "-Ta"
+        endif
       endif
     else ifneq ($$(filter %.cpp %.cc %.mm, $$($1_FILENAME)), )
       # Compile as a C++ or Objective-C++ file
@@ -236,7 +242,7 @@ define CreateCompiledNativeFileBody
             # For assembler calls just create empty dependency lists
 	    $$(call ExecuteWithLog, $$@, $$(call MakeCommandRelative, \
 	        $$($1_COMPILER) $$($1_FLAGS) \
-	        $(CC_OUT_OPTION)$$($1_OBJ) $$($1_SRC_FILE))) \
+	        $(CC_OUT_OPTION)$$($1_OBJ) $$($1_NON_ASM_EXTENSION_FLAG) $$($1_SRC_FILE))) \
 	        | $(TR) -d '\r' | $(GREP) -v -e "Assembling:" || test "$$$$?" = "1" ; \
 	    $(ECHO) > $$($1_DEPS_FILE) ; \
 	    $(ECHO) > $$($1_DEPS_TARGETS_FILE)


### PR DESCRIPTION
[ml64](https://learn.microsoft.com/en-us/cpp/assembler/masm/ml-and-ml64-command-line-reference?view=msvc-170) is set as the assembler for the Windows platform but is specific to the x64 platform. The [armasm64](https://learn.microsoft.com/en-us/cpp/assembler/arm/arm-assembler-command-line-reference?view=msvc-170) assembler should be used for Windows AArch64.

The -c and -Ta options are only valid for ml64 and -Ta can be removed from CompileFile.gmk (assembling for x64 works without it).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8365579](https://bugs.openjdk.org/browse/JDK-8365579): ml64.exe is not the right assembler for Windows aarch64 (**Bug** - P4)


### Reviewers
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**) Review applies to [2ae8f30c](https://git.openjdk.org/jdk/pull/26791/files/2ae8f30cbab75081c7840019997460c03bfd82c2)
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26791/head:pull/26791` \
`$ git checkout pull/26791`

Update a local copy of the PR: \
`$ git checkout pull/26791` \
`$ git pull https://git.openjdk.org/jdk.git pull/26791/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26791`

View PR using the GUI difftool: \
`$ git pr show -t 26791`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26791.diff">https://git.openjdk.org/jdk/pull/26791.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26791#issuecomment-3190244635)
</details>
