### PR TITLE
8365556: ObjectMonitor::try_lock_or_add_to_entry_list() returns true with the wrong state of the node

### DIFF
--- a/src/hotspot/share/runtime/objectMonitor.cpp
+++ b/src/hotspot/share/runtime/objectMonitor.cpp
@@ -711,6 +711,7 @@ void ObjectMonitor::add_to_entry_list(JavaThread* current, ObjectWaiter* node) {
 // if we added current to _entry_list. Once on _entry_list, current
 // stays on-queue until it acquires the lock.
 bool ObjectMonitor::try_lock_or_add_to_entry_list(JavaThread* current, ObjectWaiter* node) {
+  assert(node->TState == ObjectWaiter::TS_RUN, "");
   node->_prev   = nullptr;
   node->TState  = ObjectWaiter::TS_ENTER;
 

--- a/src/hotspot/share/runtime/objectMonitor.cpp
+++ b/src/hotspot/share/runtime/objectMonitor.cpp
@@ -726,6 +726,7 @@ bool ObjectMonitor::try_lock_or_add_to_entry_list(JavaThread* current, ObjectWai
     if (try_lock(current) == TryLockResult::Success) {
       assert(!has_successor(current), "invariant");
       assert(has_owner(current), "invariant");
+      node->TState = ObjectWaiter::TS_RUN;
       return true;
     }
   }


### PR DESCRIPTION
Hi, please consider the following change:

`ObjectMonitor::try_lock_or_add_to_entry_list() `does not change the node state to `TS_RUN `in case of a successful acquisition of the object monitor. In certain cases this can break the guarantee statement in the `ObjectMonitor::wait()` method and lead to a crash. The missing statement is added.

Tested in tiers 1 - 5.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8365556](https://bugs.openjdk.org/browse/JDK-8365556): ObjectMonitor::try_lock_or_add_to_entry_list() returns true with the wrong state of the node (**Bug** - P4)


### Reviewers
 * [Fredrik Bredberg](https://openjdk.org/census#fbredberg) (@fbredber - Committer) Review applies to [bf872c07](https://git.openjdk.org/jdk/pull/26794/files/bf872c079737833d8602b9c341955523273ecf21)
 * [Patricio Chilano Mateo](https://openjdk.org/census#pchilanomate) (@pchilano - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26794/head:pull/26794` \
`$ git checkout pull/26794`

Update a local copy of the PR: \
`$ git checkout pull/26794` \
`$ git pull https://git.openjdk.org/jdk.git pull/26794/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26794`

View PR using the GUI difftool: \
`$ git pr show -t 26794`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26794.diff">https://git.openjdk.org/jdk/pull/26794.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26794#issuecomment-3191266005)
</details>
