### PR TITLE
8365189: Remove LockingMode related code from arm32

### DIFF
--- a/src/hotspot/cpu/arm/c1_LIRAssembler_arm.cpp
+++ b/src/hotspot/cpu/arm/c1_LIRAssembler_arm.cpp
@@ -2426,13 +2426,7 @@ void LIR_Assembler::emit_lock(LIR_OpLock* op) {
   Register hdr = op->hdr_opr()->as_pointer_register();
   Register lock = op->lock_opr()->as_pointer_register();
 
-  if (LockingMode == LM_MONITOR) {
-    if (op->info() != nullptr) {
-      add_debug_info_for_null_check_here(op->info());
-      __ null_check(obj);
-    }
-    __ b(*op->stub()->entry());
-  } else if (op->code() == lir_lock) {
+  if (op->code() == lir_lock) {
     assert(BasicLock::displaced_header_offset_in_bytes() == 0, "lock_reg must point to the displaced header");
     int null_check_offset = __ lock_object(hdr, obj, lock, *op->stub()->entry());
     if (op->info() != nullptr) {

--- a/src/hotspot/cpu/arm/c1_MacroAssembler_arm.cpp
+++ b/src/hotspot/cpu/arm/c1_MacroAssembler_arm.cpp
@@ -177,18 +177,16 @@ void C1_MacroAssembler::allocate_array(Register obj, Register len,
 }
 
 int C1_MacroAssembler::lock_object(Register hdr, Register obj, Register disp_hdr, Label& slow_case) {
-  Label done, fast_lock, fast_lock_done;
   int null_check_offset = 0;
 
   const Register tmp2 = Rtemp; // Rtemp should be free at c1 LIR level
   assert_different_registers(hdr, obj, disp_hdr, tmp2);
 
   assert(BasicObjectLock::lock_offset() == 0, "adjust this code");
-  const ByteSize obj_offset = BasicObjectLock::obj_offset();
-  const int mark_offset = BasicLock::displaced_header_offset_in_bytes();
+  assert(oopDesc::mark_offset_in_bytes() == 0, "Required by atomic instructions");
 
   // save object being locked into the BasicObjectLock
-  str(obj, Address(disp_hdr, obj_offset));
+  str(obj, Address(disp_hdr, BasicObjectLock::obj_offset()));
 
   null_check_offset = offset();
 
@@ -199,95 +197,29 @@ int C1_MacroAssembler::lock_object(Register hdr, Register obj, Register disp_hdr
     b(slow_case, ne);
   }
 
-  assert(oopDesc::mark_offset_in_bytes() == 0, "Required by atomic instructions");
+  Register t1 = disp_hdr; // Needs saving, probably
+  Register t2 = hdr;      // blow
+  Register t3 = Rtemp;    // blow
 
-  if (LockingMode == LM_LIGHTWEIGHT) {
-
-    Register t1 = disp_hdr; // Needs saving, probably
-    Register t2 = hdr;      // blow
-    Register t3 = Rtemp;    // blow
-
-    lightweight_lock(obj /* obj */, t1, t2, t3, 1 /* savemask - save t1 */, slow_case);
-    // Success: fall through
-
-  } else if (LockingMode == LM_LEGACY) {
-
-    // On MP platforms the next load could return a 'stale' value if the memory location has been modified by another thread.
-    // That would be acceptable as ether CAS or slow case path is taken in that case.
-
-    // Must be the first instruction here, because implicit null check relies on it
-    ldr(hdr, Address(obj, oopDesc::mark_offset_in_bytes()));
-
-    tst(hdr, markWord::unlocked_value);
-    b(fast_lock, ne);
-
-    // Check for recursive locking
-    // See comments in InterpreterMacroAssembler::lock_object for
-    // explanations on the fast recursive locking check.
-    // -1- test low 2 bits
-    movs(tmp2, AsmOperand(hdr, lsl, 30));
-    // -2- test (hdr - SP) if the low two bits are 0
-    sub(tmp2, hdr, SP, eq);
-    movs(tmp2, AsmOperand(tmp2, lsr, exact_log2(os::vm_page_size())), eq);
-    // If still 'eq' then recursive locking OK
-    // set to zero if recursive lock, set to non zero otherwise (see discussion in JDK-8267042)
-    str(tmp2, Address(disp_hdr, mark_offset));
-    b(fast_lock_done, eq);
-    // else need slow case
-    b(slow_case);
-
-
-    bind(fast_lock);
-    // Save previous object header in BasicLock structure and update the header
-    str(hdr, Address(disp_hdr, mark_offset));
-
-    cas_for_lock_acquire(hdr, disp_hdr, obj, tmp2, slow_case);
-
-    bind(fast_lock_done);
-  }
-  bind(done);
-
+  lightweight_lock(obj, t1, t2, t3, 1 /* savemask - save t1 */, slow_case);
+  // Success: fall through
   return null_check_offset;
 }
 
 void C1_MacroAssembler::unlock_object(Register hdr, Register obj, Register disp_hdr, Label& slow_case) {
   assert_different_registers(hdr, obj, disp_hdr, Rtemp);
-  Register tmp2 = Rtemp;
 
   assert(BasicObjectLock::lock_offset() == 0, "adjust this code");
-  const ByteSize obj_offset = BasicObjectLock::obj_offset();
-  const int mark_offset = BasicLock::displaced_header_offset_in_bytes();
-
-  Label done;
-
   assert(oopDesc::mark_offset_in_bytes() == 0, "Required by atomic instructions");
 
-  if (LockingMode == LM_LIGHTWEIGHT) {
+  ldr(obj, Address(disp_hdr, BasicObjectLock::obj_offset()));
 
-    ldr(obj, Address(disp_hdr, obj_offset));
+  Register t1 = disp_hdr; // Needs saving, probably
+  Register t2 = hdr;      // blow
+  Register t3 = Rtemp;    // blow
 
-    Register t1 = disp_hdr; // Needs saving, probably
-    Register t2 = hdr;      // blow
-    Register t3 = Rtemp;    // blow
-
-    lightweight_unlock(obj /* object */, t1, t2, t3, 1 /* savemask (save t1) */,
-                       slow_case);
-    // Success: Fall through
-
-  } else if (LockingMode == LM_LEGACY) {
-
-    // Load displaced header and object from the lock
-    ldr(hdr, Address(disp_hdr, mark_offset));
-    // If hdr is null, we've got recursive locking and there's nothing more to do
-    cbz(hdr, done);
-
-    // load object
-    ldr(obj, Address(disp_hdr, obj_offset));
-
-    // Restore the object header
-    cas_for_lock_release(disp_hdr, hdr, obj, tmp2, slow_case);
-  }
-  bind(done);
+  lightweight_unlock(obj, t1, t2, t3, 1 /* savemask - save t1 */, slow_case);
+  // Success: fall through
 }
 
 #ifndef PRODUCT

--- a/src/hotspot/cpu/arm/c2_MacroAssembler_arm.cpp
+++ b/src/hotspot/cpu/arm/c2_MacroAssembler_arm.cpp
@@ -81,7 +81,7 @@ void C2_MacroAssembler::fast_lock(Register Roop, Register Rbox, Register Rscratc
   assert(VM_Version::supports_ldrex(), "unsupported, yet?");
   assert_different_registers(Roop, Rbox, Rscratch, Rscratch2);
 
-  Label fast_lock, done;
+  Label done;
 
   if (DiagnoseSyncOnValueBasedClasses != 0) {
     load_klass(Rscratch, Roop);
@@ -90,43 +90,10 @@ void C2_MacroAssembler::fast_lock(Register Roop, Register Rbox, Register Rscratc
     b(done, ne);
   }
 
-  if (LockingMode == LM_LIGHTWEIGHT) {
+  lightweight_lock(Roop /* obj */, Rbox /* t1 */, Rscratch /* t2 */, Rscratch2 /* t3 */,
+                   1 /* savemask (save t1) */, done);
 
-    lightweight_lock(Roop /* obj */, Rbox /* t1 */, Rscratch /* t2 */, Rscratch2 /* t3 */,
-                     1 /* savemask (save t1) */, done);
-
-    // Success: set Z
-    cmp(Roop, Roop);
-
-  } else if (LockingMode == LM_LEGACY) {
-
-    Register Rmark      = Rscratch2;
-
-    ldr(Rmark, Address(Roop, oopDesc::mark_offset_in_bytes()));
-    tst(Rmark, markWord::unlocked_value);
-    b(fast_lock, ne);
-
-    // Check for recursive lock
-    // See comments in InterpreterMacroAssembler::lock_object for
-    // explanations on the fast recursive locking check.
-    // -1- test low 2 bits
-    movs(Rscratch, AsmOperand(Rmark, lsl, 30));
-    // -2- test (hdr - SP) if the low two bits are 0
-    sub(Rscratch, Rmark, SP, eq);
-    movs(Rscratch, AsmOperand(Rscratch, lsr, exact_log2(os::vm_page_size())), eq);
-    // If still 'eq' then recursive locking OK
-    // set to zero if recursive lock, set to non zero otherwise (see discussion in JDK-8153107)
-    str(Rscratch, Address(Rbox, BasicLock::displaced_header_offset_in_bytes()));
-    b(done);
-
-    bind(fast_lock);
-    str(Rmark, Address(Rbox, BasicLock::displaced_header_offset_in_bytes()));
-
-    bool allow_fallthrough_on_failure = true;
-    bool one_shot = true;
-    cas_for_lock_acquire(Rmark, Rbox, Roop, Rscratch, done, allow_fallthrough_on_failure, one_shot);
-  }
-
+  cmp(Roop, Roop); // Success: set Z
   bind(done);
 
   // At this point flags are set as follows:
@@ -140,29 +107,12 @@ void C2_MacroAssembler::fast_unlock(Register Roop, Register Rbox, Register Rscra
 
   Label done;
 
-  if (LockingMode == LM_LIGHTWEIGHT) {
+  lightweight_unlock(Roop /* obj */, Rbox /* t1 */, Rscratch /* t2 */, Rscratch2 /* t3 */,
+                     1 /* savemask (save t1) */, done);
 
-    lightweight_unlock(Roop /* obj */, Rbox /* t1 */, Rscratch /* t2 */, Rscratch2 /* t3 */,
-                       1 /* savemask (save t1) */, done);
+  cmp(Roop, Roop); // Success: Set Z
+  // Fall through
 
-    cmp(Roop, Roop); // Success: Set Z
-    // Fall through
-
-  } else if (LockingMode == LM_LEGACY) {
-
-    Register Rmark      = Rscratch2;
-
-    // Find the lock address and load the displaced header from the stack.
-    ldr(Rmark, Address(Rbox, BasicLock::displaced_header_offset_in_bytes()));
-    // If hdr is null, we've got recursive locking and there's nothing more to do
-    cmp(Rmark, 0);
-    b(done, eq);
-
-    // Restore the object header
-    bool allow_fallthrough_on_failure = true;
-    bool one_shot = true;
-    cas_for_lock_release(Rbox, Rmark, Roop, Rscratch, done, allow_fallthrough_on_failure, one_shot);
-  }
   bind(done);
 
   // At this point flags are set as follows:

--- a/src/hotspot/cpu/arm/interp_masm_arm.cpp
+++ b/src/hotspot/cpu/arm/interp_masm_arm.cpp
@@ -888,105 +888,30 @@ void InterpreterMacroAssembler::set_do_not_unlock_if_synchronized(bool flag, Reg
 void InterpreterMacroAssembler::lock_object(Register Rlock) {
   assert(Rlock == R1, "the second argument");
 
-  if (LockingMode == LM_MONITOR) {
-    call_VM(noreg, CAST_FROM_FN_PTR(address, InterpreterRuntime::monitorenter), Rlock);
-  } else {
-    Label done;
+  const Register Robj = R2;
+  const Register Rmark = R3;
+  assert_different_registers(Robj, Rmark, Rlock, R0, Rtemp);
 
-    const Register Robj = R2;
-    const Register Rmark = R3;
-    assert_different_registers(Robj, Rmark, Rlock, R0, Rtemp);
+  Label done, slow_case;
 
-    const int obj_offset = in_bytes(BasicObjectLock::obj_offset());
-    const int lock_offset = in_bytes(BasicObjectLock::lock_offset());
-    const int mark_offset = lock_offset + BasicLock::displaced_header_offset_in_bytes();
+  // Load object pointer
+  ldr(Robj, Address(Rlock, BasicObjectLock::obj_offset()));
 
-    Label already_locked, slow_case;
-
-    // Load object pointer
-    ldr(Robj, Address(Rlock, obj_offset));
-
-    if (DiagnoseSyncOnValueBasedClasses != 0) {
-      load_klass(R0, Robj);
-      ldrb(R0, Address(R0, Klass::misc_flags_offset()));
-      tst(R0, KlassFlags::_misc_is_value_based_class);
-      b(slow_case, ne);
-    }
-
-    if (LockingMode == LM_LIGHTWEIGHT) {
-      lightweight_lock(Robj, R0 /* t1 */, Rmark /* t2 */, Rtemp /* t3 */, 0 /* savemask */, slow_case);
-      b(done);
-    } else if (LockingMode == LM_LEGACY) {
-      // On MP platforms the next load could return a 'stale' value if the memory location has been modified by another thread.
-      // That would be acceptable as ether CAS or slow case path is taken in that case.
-      // Exception to that is if the object is locked by the calling thread, then the recursive test will pass (guaranteed as
-      // loads are satisfied from a store queue if performed on the same processor).
-
-      assert(oopDesc::mark_offset_in_bytes() == 0, "must be");
-      ldr(Rmark, Address(Robj, oopDesc::mark_offset_in_bytes()));
-
-      // Test if object is already locked
-      tst(Rmark, markWord::unlocked_value);
-      b(already_locked, eq);
-
-      // Save old object->mark() into BasicLock's displaced header
-      str(Rmark, Address(Rlock, mark_offset));
-
-      cas_for_lock_acquire(Rmark, Rlock, Robj, Rtemp, slow_case);
-
-      b(done);
-
-      // If we got here that means the object is locked by ether calling thread or another thread.
-      bind(already_locked);
-      // Handling of locked objects: recursive locks and slow case.
-
-      // Fast check for recursive lock.
-      //
-      // Can apply the optimization only if this is a stack lock
-      // allocated in this thread. For efficiency, we can focus on
-      // recently allocated stack locks (instead of reading the stack
-      // base and checking whether 'mark' points inside the current
-      // thread stack):
-      //  1) (mark & 3) == 0
-      //  2) SP <= mark < SP + os::pagesize()
-      //
-      // Warning: SP + os::pagesize can overflow the stack base. We must
-      // neither apply the optimization for an inflated lock allocated
-      // just above the thread stack (this is why condition 1 matters)
-      // nor apply the optimization if the stack lock is inside the stack
-      // of another thread. The latter is avoided even in case of overflow
-      // because we have guard pages at the end of all stacks. Hence, if
-      // we go over the stack base and hit the stack of another thread,
-      // this should not be in a writeable area that could contain a
-      // stack lock allocated by that thread. As a consequence, a stack
-      // lock less than page size away from SP is guaranteed to be
-      // owned by the current thread.
-      //
-      // Note: assuming SP is aligned, we can check the low bits of
-      // (mark-SP) instead of the low bits of mark. In that case,
-      // assuming page size is a power of 2, we can merge the two
-      // conditions into a single test:
-      // => ((mark - SP) & (3 - os::pagesize())) == 0
-
-      // (3 - os::pagesize()) cannot be encoded as an ARM immediate operand.
-      // Check independently the low bits and the distance to SP.
-      // -1- test low 2 bits
-      movs(R0, AsmOperand(Rmark, lsl, 30));
-      // -2- test (mark - SP) if the low two bits are 0
-      sub(R0, Rmark, SP, eq);
-      movs(R0, AsmOperand(R0, lsr, exact_log2(os::vm_page_size())), eq);
-      // If still 'eq' then recursive locking OK: store 0 into lock record
-      str(R0, Address(Rlock, mark_offset), eq);
-
-      b(done, eq);
-    }
-
-    bind(slow_case);
-
-    // Call the runtime routine for slow case
-    call_VM(noreg, CAST_FROM_FN_PTR(address, InterpreterRuntime::monitorenter), Rlock);
-    bind(done);
+  if (DiagnoseSyncOnValueBasedClasses != 0) {
+    load_klass(R0, Robj);
+    ldrb(R0, Address(R0, Klass::misc_flags_offset()));
+    tst(R0, KlassFlags::_misc_is_value_based_class);
+    b(slow_case, ne);
   }
+
+  lightweight_lock(Robj, R0 /* t1 */, Rmark /* t2 */, Rtemp /* t3 */, 0 /* savemask */, slow_case);
+  b(done);
+
+  bind(slow_case);
+
+  // Call the runtime routine for slow case
+  call_VM(noreg, CAST_FROM_FN_PTR(address, InterpreterRuntime::monitorenter), Rlock);
+  bind(done);
 }
 
 // Unlocks an object. Used in monitorexit bytecode and remove_activation.
@@ -997,65 +922,39 @@ void InterpreterMacroAssembler::lock_object(Register Rlock) {
 void InterpreterMacroAssembler::unlock_object(Register Rlock) {
   assert(Rlock == R0, "the first argument");
 
-  if (LockingMode == LM_MONITOR) {
-    call_VM_leaf(CAST_FROM_FN_PTR(address, InterpreterRuntime::monitorexit), Rlock);
-  } else {
-    Label done, slow_case;
+  Label done, slow_case;
 
-    const Register Robj = R2;
-    const Register Rmark = R3;
-    assert_different_registers(Robj, Rmark, Rlock, Rtemp);
+  const Register Robj = R2;
+  const Register Rmark = R3;
+  assert_different_registers(Robj, Rmark, Rlock, Rtemp);
 
-    const int obj_offset = in_bytes(BasicObjectLock::obj_offset());
-    const int lock_offset = in_bytes(BasicObjectLock::lock_offset());
-    const int mark_offset = lock_offset + BasicLock::displaced_header_offset_in_bytes();
+  const int obj_offset = in_bytes(BasicObjectLock::obj_offset());
+  const Register Rzero = zero_register(Rtemp);
 
-    const Register Rzero = zero_register(Rtemp);
+  // Load oop into Robj
+  ldr(Robj, Address(Rlock, obj_offset));
 
-    // Load oop into Robj
-    ldr(Robj, Address(Rlock, obj_offset));
+  // Free entry
+  str(Rzero, Address(Rlock, obj_offset));
 
-    // Free entry
-    str(Rzero, Address(Rlock, obj_offset));
+  // Check for non-symmetric locking. This is allowed by the spec and the interpreter
+  // must handle it.
+  ldr(Rtemp, Address(Rthread, JavaThread::lock_stack_top_offset()));
+  sub(Rtemp, Rtemp, oopSize);
+  ldr(Rtemp, Address(Rthread, Rtemp));
+  cmpoop(Rtemp, Robj);
+  b(slow_case, ne);
 
-    if (LockingMode == LM_LIGHTWEIGHT) {
+  lightweight_unlock(Robj /* obj */, Rlock /* t1 */, Rmark /* t2 */, Rtemp /* t3 */,
+                     1 /* savemask (save t1) */, slow_case);
+  b(done);
 
-      // Check for non-symmetric locking. This is allowed by the spec and the interpreter
-      // must handle it.
-      ldr(Rtemp, Address(Rthread, JavaThread::lock_stack_top_offset()));
-      sub(Rtemp, Rtemp, oopSize);
-      ldr(Rtemp, Address(Rthread, Rtemp));
-      cmpoop(Rtemp, Robj);
-      b(slow_case, ne);
+  bind(slow_case);
+  // Call the runtime routine for slow case.
+  str(Robj, Address(Rlock, obj_offset)); // restore obj
+  call_VM_leaf(CAST_FROM_FN_PTR(address, InterpreterRuntime::monitorexit), Rlock);
 
-      lightweight_unlock(Robj /* obj */, Rlock /* t1 */, Rmark /* t2 */, Rtemp /* t3 */,
-                         1 /* savemask (save t1) */, slow_case);
-
-      b(done);
-
-    } else if (LockingMode == LM_LEGACY) {
-
-      // Load the old header from BasicLock structure
-      ldr(Rmark, Address(Rlock, mark_offset));
-
-      // Test for recursion (zero mark in BasicLock)
-      cbz(Rmark, done);
-
-      bool allow_fallthrough_on_failure = true;
-
-      cas_for_lock_release(Rlock, Rmark, Robj, Rtemp, slow_case, allow_fallthrough_on_failure);
-
-      b(done, eq);
-
-    }
-    bind(slow_case);
-
-    // Call the runtime routine for slow case.
-    str(Robj, Address(Rlock, obj_offset)); // restore obj
-    call_VM_leaf(CAST_FROM_FN_PTR(address, InterpreterRuntime::monitorexit), Rlock);
-
-    bind(done);
-  }
+  bind(done);
 }
 
 // Test ImethodDataPtr.  If it is null, continue at the specified label

--- a/src/hotspot/cpu/arm/macroAssembler_arm.cpp
+++ b/src/hotspot/cpu/arm/macroAssembler_arm.cpp
@@ -1758,7 +1758,6 @@ void MacroAssembler::read_polling_page(Register dest, relocInfo::relocType rtype
 //  - Success: fallthrough
 //  - Error:   break to slow, Z cleared.
 void MacroAssembler::lightweight_lock(Register obj, Register t1, Register t2, Register t3, unsigned savemask, Label& slow) {
-  assert(LockingMode == LM_LIGHTWEIGHT, "only used with new lightweight locking");
   assert_different_registers(obj, t1, t2, t3);
 
 #ifdef ASSERT
@@ -1816,7 +1815,6 @@ void MacroAssembler::lightweight_lock(Register obj, Register t1, Register t2, Re
 //  - Success: fallthrough
 //  - Error:   break to slow, Z cleared.
 void MacroAssembler::lightweight_unlock(Register obj, Register t1, Register t2, Register t3, unsigned savemask, Label& slow) {
-  assert(LockingMode == LM_LIGHTWEIGHT, "only used with new lightweight locking");
   assert_different_registers(obj, t1, t2, t3);
 
 #ifdef ASSERT

--- a/src/hotspot/cpu/arm/sharedRuntime_arm.cpp
+++ b/src/hotspot/cpu/arm/sharedRuntime_arm.cpp
@@ -1139,41 +1139,10 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
     // Remember the handle for the unlocking code
     __ mov(sync_handle, R1);
 
-    if (LockingMode == LM_LIGHTWEIGHT) {
-      log_trace(fastlock)("SharedRuntime lock fast");
-      __ lightweight_lock(sync_obj /* object */, disp_hdr /* t1 */, tmp /* t2 */, Rtemp /* t3 */,
-                          0x7 /* savemask */, slow_lock);
+    log_trace(fastlock)("SharedRuntime lock fast");
+    __ lightweight_lock(sync_obj /* object */, disp_hdr /* t1 */, tmp /* t2 */, Rtemp /* t3 */,
+                        0x7 /* savemask */, slow_lock);
       // Fall through to lock_done
-    } else if (LockingMode == LM_LEGACY) {
-      const Register mark = tmp;
-      // On MP platforms the next load could return a 'stale' value if the memory location has been modified by another thread.
-      // That would be acceptable as either CAS or slow case path is taken in that case
-
-      __ ldr(mark, Address(sync_obj, oopDesc::mark_offset_in_bytes()));
-      __ sub(disp_hdr, FP, lock_slot_fp_offset);
-      __ tst(mark, markWord::unlocked_value);
-      __ b(fast_lock, ne);
-
-      // Check for recursive lock
-      // See comments in InterpreterMacroAssembler::lock_object for
-      // explanations on the fast recursive locking check.
-      // Check independently the low bits and the distance to SP
-      // -1- test low 2 bits
-      __ movs(Rtemp, AsmOperand(mark, lsl, 30));
-      // -2- test (hdr - SP) if the low two bits are 0
-      __ sub(Rtemp, mark, SP, eq);
-      __ movs(Rtemp, AsmOperand(Rtemp, lsr, exact_log2(os::vm_page_size())), eq);
-      // If still 'eq' then recursive locking OK
-      // set to zero if recursive lock, set to non zero otherwise (see discussion in JDK-8267042)
-      __ str(Rtemp, Address(disp_hdr, BasicLock::displaced_header_offset_in_bytes()));
-      __ b(lock_done, eq);
-      __ b(slow_lock);
-
-      __ bind(fast_lock);
-      __ str(mark, Address(disp_hdr, BasicLock::displaced_header_offset_in_bytes()));
-
-      __ cas_for_lock_acquire(mark, disp_hdr, sync_obj, Rtemp, slow_lock);
-    }
     __ bind(lock_done);
   }
 
@@ -1226,21 +1195,11 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
 
   Label slow_unlock, unlock_done;
   if (method->is_synchronized()) {
-    if (LockingMode == LM_LIGHTWEIGHT) {
-      log_trace(fastlock)("SharedRuntime unlock fast");
-      __ lightweight_unlock(sync_obj, R2 /* t1 */, tmp /* t2 */, Rtemp /* t3 */,
-                            7 /* savemask */, slow_unlock);
-      // Fall through
-    } else if (LockingMode == LM_LEGACY) {
-      // See C1_MacroAssembler::unlock_object() for more comments
-      __ ldr(sync_obj, Address(sync_handle));
+    log_trace(fastlock)("SharedRuntime unlock fast");
+    __ lightweight_unlock(sync_obj, R2 /* t1 */, tmp /* t2 */, Rtemp /* t3 */,
+                          7 /* savemask */, slow_unlock);
+    // Fall through
 
-      // See C1_MacroAssembler::unlock_object() for more comments
-      __ ldr(R2, Address(disp_hdr, BasicLock::displaced_header_offset_in_bytes()));
-      __ cbz(R2, unlock_done);
-
-      __ cas_for_lock_release(disp_hdr, R2, sync_obj, Rtemp, slow_unlock);
-    }
     __ bind(unlock_done);
   }
 


### PR DESCRIPTION
Since the integration of [JDK-8359437](https://bugs.openjdk.org/browse/JDK-8359437) the `LockingMode` flag can no longer be set by the user, instead it's declared as `const int LockingMode = LM_LIGHTWEIGHT;`. This means that we can now safely remove all `LockingMode` related code from all platforms.

This PR removes `LockingMode` related code from the **arm32** platform.

When all the `LockingMode` code has been removed from all platforms, we can go on and remove it from shared (non-platform specific) files as well. And finally remove the `LockingMode` variable itself.