### PR TITLE
8365609 Null pointer dereference in src/java.desktop/share/native/common/java2d/opengl/OGLBlitLoops.c OGLBlitToSurfaceViaTexture()

### DIFF
--- a/src/java.desktop/share/native/common/java2d/opengl/OGLBlitLoops.c
+++ b/src/java.desktop/share/native/common/java2d/opengl/OGLBlitLoops.c
@@ -321,7 +321,8 @@ OGLBlitToSurfaceViaTexture(OGLContext *oglc, SurfaceDataRasInfo *srcInfo,
                 GLvoid *pSrc = PtrCoord(srcInfo->rasBase,
                                         sx, srcInfo->pixelStride,
                                         sy, srcInfo->scanStride);
-                if (slowPath) {
+                                        if (pf != NULL) {
+                                                            if (slowPath) {
                     jint tmph = sh;
                     while (tmph > 0) {
                         j2d_glTexSubImage2D(GL_TEXTURE_2D, 0,
@@ -337,6 +338,8 @@ OGLBlitToSurfaceViaTexture(OGLContext *oglc, SurfaceDataRasInfo *srcInfo,
                                         pf->format, pf->type,
                                         pSrc);
                 }
+                                        }
+
 
                 // the texture image is "right side up", so we align the
                 // upper-left texture corner with the upper-left quad corner

--- a/src/java.desktop/share/native/common/java2d/opengl/OGLBlitLoops.c
+++ b/src/java.desktop/share/native/common/java2d/opengl/OGLBlitLoops.c
@@ -409,7 +409,8 @@ OGLBlitSwToTexture(SurfaceDataRasInfo *srcInfo, OGLPixelFormat *pf,
 
     // in case pixel stride is not a multiple of scanline stride the copy
     // has to be done line by line (see 6207877)
-    if (srcInfo->scanStride % srcInfo->pixelStride != 0) {
+    if (pf != NULL) {
+            if (srcInfo->scanStride % srcInfo->pixelStride != 0) {
         jint width = dx2 - dx1;
         jint height = dy2 - dy1;
         GLvoid *pSrc = srcInfo->rasBase;
@@ -425,6 +426,7 @@ OGLBlitSwToTexture(SurfaceDataRasInfo *srcInfo, OGLPixelFormat *pf,
         j2d_glTexSubImage2D(dstOps->textureTarget, 0,
                             dx1, dy1, dx2-dx1, dy2-dy1,
                             pf->format, pf->type, srcInfo->rasBase);
+    }
     }
     if (adjustAlpha) {
         // restore scale/bias to their original values

--- a/src/java.desktop/share/native/libsplashscreen/splashscreen_gif.c
+++ b/src/java.desktop/share/native/libsplashscreen/splashscreen_gif.c
@@ -279,7 +279,8 @@ SplashDecodeGif(Splash * splash, GifFileType * gif)
                 ImageRect dstRect;
                 rgbquad_t fillColor = 0;                        // 0 is transparent
 
-                if (transparentColor < 0) {
+                if (((colorMap != NULL) && (colorMap->Colors != NULL)) &&
+                (transparentColor < 0)) {
                     fillColor= MAKE_QUAD_GIF(
                         colorMap->Colors[gif->SBackGroundColor], 0xff);
                 }

--- a/src/java.desktop/unix/native/libawt_xawt/awt/gtk3_interface.c
+++ b/src/java.desktop/unix/native/libawt_xawt/awt/gtk3_interface.c
@@ -615,14 +615,17 @@ GtkApi* gtk3_load(JNIEnv *env, const char* lib_name)
         fp_g_string_set_size = dl_symbol("g_string_set_size");
         fp_g_string_free = dl_symbol("g_string_free");
 
-        glib_version_2_68 = !fp_glib_check_version(2, 68, 0);
-        if (glib_version_2_68) {
-            // those function are called only by Screencast / Remote desktop
-            fp_g_string_replace = dl_symbol("g_string_replace"); //since: 2.68
-            fp_g_uuid_string_is_valid = //since: 2.52
-                    dl_symbol("g_uuid_string_is_valid");
-            fp_g_variant_print = dl_symbol("g_variant_print"); // since 2.24
+        if (fp_glib_check_version != NULL) {
+            glib_version_2_68 = !fp_glib_check_version(2, 68, 0);
+            if (glib_version_2_68) {
+                // those function are called only by Screencast / Remote desktop
+                fp_g_string_replace = dl_symbol("g_string_replace"); //since: 2.68
+                fp_g_uuid_string_is_valid = //since: 2.52
+                        dl_symbol("g_uuid_string_is_valid");
+                fp_g_variant_print = dl_symbol("g_variant_print"); // since 2.24
+            }
         }
+
         fp_g_string_printf = dl_symbol("g_string_printf");
         fp_g_strconcat = dl_symbol("g_strconcat");
 


### PR DESCRIPTION
The defect has been detected and confirmed in the function OGLBlitToSurfaceViaTexture() located in the file src/java.desktop/share/native/common/java2d/opengl/OGLBlitLoops.c with static code analysis. This defect can potentially lead to a null pointer dereference.

The pointer pf is dereferenced in line 324 without checking for nullptr, although earlier in line 274 the same pointer is checked for nullptr, which indicates that it can be null.

According to [this](https://github.com/openjdk/jdk/pull/26002#issuecomment-3023050372) comment, this PR contains fixes for similar cases in other places.
