### PR TITLE
8365611: Use lookup table for JfrEventThrottler

### DIFF
--- a/src/hotspot/share/jfr/recorder/service/jfrEventThrottler.cpp
+++ b/src/hotspot/share/jfr/recorder/service/jfrEventThrottler.cpp
@@ -38,23 +38,17 @@ constexpr static const JfrSamplerParams _disabled_params = {
                                                            };
 
 constexpr static const JfrEventId throttleble_events[] = {
-    JfrCPUTimeSampleEvent,
-    JfrObjectAllocationSampleEvent,
-    JfrSafepointLatencyEvent
+    JfrCPUTimeSampleEvent, JfrObjectAllocationSampleEvent,  JfrSafepointLatencyEvent
 };
-static constexpr int num_throttled_events = sizeof(throttleble_events) / sizeof(throttleble_events[0]);
+constexpr static int num_throttled_events = sizeof(throttleble_events) / sizeof(throttleble_events[0]);
 
 // Throttler-by-ID lookup table
 class ThrottlerLookupTable {
-
   static constexpr int max = (int)LAST_EVENT_ID;
   STATIC_ASSERT(max < 1000); // should this ever get unreasonably large, we rethink this table.
   JfrEventThrottler* _table[max];
-
 public:
-  ThrottlerLookupTable() {
-    memset(_table, 0, sizeof(_table));
-  }
+  ThrottlerLookupTable() { memset(_table, 0, sizeof(_table)); }
 
   bool initialize() {
     for (int i = 0; i < num_throttled_events; i++) {
@@ -95,8 +89,7 @@ JfrEventThrottler::JfrEventThrottler(JfrEventId event_id) :
 bool JfrEventThrottler::create() {
   bool rc = _throttler_table.initialize();
   if (rc) {
-    // CPU time sampler disabled
-    _throttler_table.at(JfrCPUTimeSampleEvent)->_disabled = true;
+    _throttler_table.at(JfrCPUTimeSampleEvent)->_disabled = true; // CPU time sampler disabled
   }
   return rc;
 }
@@ -110,13 +103,13 @@ void JfrEventThrottler::destroy() {
 // When introducing many more throttlers, consider adding a lookup map keyed by event id.
 JfrEventThrottler* JfrEventThrottler::for_event(JfrEventId event_id) {
   JfrEventThrottler* const throttler = _throttler_table.at(event_id);
-  assert(throttler != nullptr, "Event type has an unconfigured throttler");
+  assert(throttler != nullptr, "Event type %d has an unconfigured throttler", (int)event_id);
   return throttler;
 }
 
 void JfrEventThrottler::configure(JfrEventId event_id, int64_t sample_size, int64_t period_ms) {
   JfrEventThrottler* const throttler = _throttler_table.at(event_id);
-  assert(throttler != nullptr, "Event type has an unconfigured throttler");
+  assert(throttler != nullptr, "Event type %d has an unconfigured throttler", (int)event_id);
   throttler->configure(sample_size, period_ms);
 }
 

--- a/src/hotspot/share/jfr/recorder/service/jfrEventThrottler.cpp
+++ b/src/hotspot/share/jfr/recorder/service/jfrEventThrottler.cpp
@@ -98,9 +98,6 @@ void JfrEventThrottler::destroy() {
   _throttler_table.destroy();
 }
 
-// There is currently only two throttler instances, one for the jdk.ObjectAllocationSample event
-// and another for the SamplingLatency event.
-// When introducing many more throttlers, consider adding a lookup map keyed by event id.
 JfrEventThrottler* JfrEventThrottler::for_event(JfrEventId event_id) {
   JfrEventThrottler* const throttler = _throttler_table.at(event_id);
   assert(throttler != nullptr, "Event type %d has an unconfigured throttler", (int)event_id);
@@ -115,7 +112,7 @@ void JfrEventThrottler::configure(JfrEventId event_id, int64_t sample_size, int6
 
 JfrEventThrottler* JfrEventThrottler::create_throttler(JfrEventId id) {
   JfrEventThrottler* p = new JfrEventThrottler(id);
-  if (p->initialize() == false) {
+  if (p != nullptr && p->initialize() == false) {
     delete p;
     p = nullptr;
   }

--- a/src/hotspot/share/jfr/recorder/service/jfrEventThrottler.cpp
+++ b/src/hotspot/share/jfr/recorder/service/jfrEventThrottler.cpp
@@ -1,7 +1,6 @@
 /*
  * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020, Datadog, Inc. All rights reserved.
- * Copyright (c) 2025, IBM Corporation. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/jfr/recorder/service/jfrEventThrottler.cpp
+++ b/src/hotspot/share/jfr/recorder/service/jfrEventThrottler.cpp
@@ -25,7 +25,10 @@
 
 #include "jfr/recorder/service/jfrEventThrottler.hpp"
 #include "jfr/utilities/jfrSpinlockHelper.hpp"
+#include "jfrfiles/jfrEventIds.hpp"
 #include "logging/log.hpp"
+#include "utilities/debug.hpp"
+#include "utilities/globalDefinitions.hpp"
 
 constexpr static const JfrSamplerParams _disabled_params = {
                                                              0, // sample points per window
@@ -34,9 +37,50 @@ constexpr static const JfrSamplerParams _disabled_params = {
                                                              false // reconfigure
                                                            };
 
-static JfrEventThrottler* _disabled_cpu_time_sample_throttler = nullptr;
-static JfrEventThrottler* _object_allocation_throttler = nullptr;
-static JfrEventThrottler* _safepoint_latency_throttler = nullptr;
+constexpr static const JfrEventId throttleble_events[] = {
+    JfrCPUTimeSampleEvent,
+    JfrObjectAllocationSampleEvent,
+    JfrSafepointLatencyEvent
+};
+static constexpr int num_throttled_events = sizeof(throttleble_events) / sizeof(throttleble_events[0]);
+
+// Throttler-by-ID lookup table
+class ThrottlerLookupTable {
+
+  static constexpr int max = (int)LAST_EVENT_ID;
+  STATIC_ASSERT(max < 1000); // should this ever get unreasonably large, we rethink this table.
+  JfrEventThrottler* _table[max];
+
+public:
+  ThrottlerLookupTable() {
+    memset(_table, 0, sizeof(_table));
+  }
+
+  bool initialize() {
+    for (int i = 0; i < num_throttled_events; i++) {
+      const JfrEventId id = throttleble_events[i];
+      JfrEventThrottler* p = JfrEventThrottler::create_throttler(id);
+      _table[(int)id] = p;
+      if (p == nullptr) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  void destroy() {
+    for (int i = 0; i < max; i++) {
+      delete _table[i];
+      _table[i] = nullptr;
+    }
+  }
+
+  JfrEventThrottler* at(JfrEventId id) const {
+    return _table[(int)id];
+  }
+};
+
+static ThrottlerLookupTable _throttler_table;
 
 JfrEventThrottler::JfrEventThrottler(JfrEventId event_id) :
   JfrAdaptiveSampler(),
@@ -49,58 +93,40 @@ JfrEventThrottler::JfrEventThrottler(JfrEventId event_id) :
   _update(false) {}
 
 bool JfrEventThrottler::create() {
-  assert(_disabled_cpu_time_sample_throttler == nullptr, "invariant");
-  _disabled_cpu_time_sample_throttler = new JfrEventThrottler(JfrCPUTimeSampleEvent);
-  _disabled_cpu_time_sample_throttler->_disabled = true;
-  assert(_object_allocation_throttler == nullptr, "invariant");
-  _object_allocation_throttler = new JfrEventThrottler(JfrObjectAllocationSampleEvent);
-  if (_object_allocation_throttler == nullptr || !_object_allocation_throttler->initialize()) {
-    return false;
+  bool rc = _throttler_table.initialize();
+  if (rc) {
+    // CPU time sampler disabled
+    _throttler_table.at(JfrCPUTimeSampleEvent)->_disabled = true;
   }
-  assert(_safepoint_latency_throttler == nullptr, "invariant");
-  _safepoint_latency_throttler = new JfrEventThrottler(JfrSafepointLatencyEvent);
-  return _safepoint_latency_throttler != nullptr && _safepoint_latency_throttler->initialize();
+  return rc;
 }
 
 void JfrEventThrottler::destroy() {
-  delete _disabled_cpu_time_sample_throttler;
-  _disabled_cpu_time_sample_throttler = nullptr;
-  delete _object_allocation_throttler;
-  _object_allocation_throttler = nullptr;
-  delete _safepoint_latency_throttler;
-  _safepoint_latency_throttler = nullptr;
+  _throttler_table.destroy();
 }
 
 // There is currently only two throttler instances, one for the jdk.ObjectAllocationSample event
 // and another for the SamplingLatency event.
 // When introducing many more throttlers, consider adding a lookup map keyed by event id.
 JfrEventThrottler* JfrEventThrottler::for_event(JfrEventId event_id) {
-  assert(_disabled_cpu_time_sample_throttler != nullptr, "Disabled CPU time throttler has not been properly initialized");
-  assert(_object_allocation_throttler != nullptr, "ObjectAllocation throttler has not been properly initialized");
-  assert(_safepoint_latency_throttler != nullptr, "SafepointLatency throttler has not been properly initialized");
-  assert(event_id == JfrObjectAllocationSampleEvent || event_id == JfrSafepointLatencyEvent || event_id == JfrCPUTimeSampleEvent, "Event type has an unconfigured throttler");
-  if (event_id == JfrObjectAllocationSampleEvent) {
-    return _object_allocation_throttler;
-  }
-  if (event_id == JfrSafepointLatencyEvent) {
-    return _safepoint_latency_throttler;
-  }
-  if (event_id == JfrCPUTimeSampleEvent) {
-    return _disabled_cpu_time_sample_throttler;
-  }
-  return nullptr;
+  JfrEventThrottler* const throttler = _throttler_table.at(event_id);
+  assert(throttler != nullptr, "Event type has an unconfigured throttler");
+  return throttler;
 }
 
 void JfrEventThrottler::configure(JfrEventId event_id, int64_t sample_size, int64_t period_ms) {
-  if (event_id == JfrObjectAllocationSampleEvent) {
-    assert(_object_allocation_throttler != nullptr, "ObjectAllocation throttler has not been properly initialized");
-    _object_allocation_throttler->configure(sample_size, period_ms);
-    return;
+  JfrEventThrottler* const throttler = _throttler_table.at(event_id);
+  assert(throttler != nullptr, "Event type has an unconfigured throttler");
+  throttler->configure(sample_size, period_ms);
+}
+
+JfrEventThrottler* JfrEventThrottler::create_throttler(JfrEventId id) {
+  JfrEventThrottler* p = new JfrEventThrottler(id);
+  if (p->initialize() == false) {
+    delete p;
+    p = nullptr;
   }
-  if (event_id == JfrSafepointLatencyEvent) {
-    assert(_safepoint_latency_throttler != nullptr, "SafepointLatency throttler has not been properly initialized");
-    _safepoint_latency_throttler->configure(sample_size, period_ms);
-  }
+  return p;
 }
 
 /*

--- a/src/hotspot/share/jfr/recorder/service/jfrEventThrottler.cpp
+++ b/src/hotspot/share/jfr/recorder/service/jfrEventThrottler.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020, Datadog, Inc. All rights reserved.
+ * Copyright (c) 2025, IBM Corporation. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/jfr/recorder/service/jfrEventThrottler.hpp
+++ b/src/hotspot/share/jfr/recorder/service/jfrEventThrottler.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020, Datadog, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/src/hotspot/share/jfr/recorder/service/jfrEventThrottler.hpp
+++ b/src/hotspot/share/jfr/recorder/service/jfrEventThrottler.hpp
@@ -29,8 +29,11 @@
 #include "jfrfiles/jfrEventIds.hpp"
 #include "jfr/support/jfrAdaptiveSampler.hpp"
 
+class ThrottlerLookupTable;
+
 class JfrEventThrottler : public JfrAdaptiveSampler {
   friend class JfrRecorder;
+  friend class ThrottlerLookupTable;
  private:
   JfrSamplerParams _last_params;
   int64_t _sample_size;
@@ -43,6 +46,7 @@ class JfrEventThrottler : public JfrAdaptiveSampler {
   static bool create();
   static void destroy();
   JfrEventThrottler(JfrEventId event_id);
+  static JfrEventThrottler* create_throttler(JfrEventId event_id);
   void configure(int64_t event_sample_size, int64_t period_ms);
 
   const JfrSamplerParams& update_params(const JfrSamplerWindow* expired);
@@ -50,7 +54,6 @@ class JfrEventThrottler : public JfrAdaptiveSampler {
   static JfrEventThrottler* for_event(JfrEventId event_id);
 
  public:
-  static JfrEventThrottler* create_throttler(JfrEventId event_id);
   static void configure(JfrEventId event_id, int64_t event_sample_size, int64_t period_ms);
   static bool accept(JfrEventId event_id, int64_t timestamp = 0);
 };

--- a/src/hotspot/share/jfr/recorder/service/jfrEventThrottler.hpp
+++ b/src/hotspot/share/jfr/recorder/service/jfrEventThrottler.hpp
@@ -50,6 +50,7 @@ class JfrEventThrottler : public JfrAdaptiveSampler {
   static JfrEventThrottler* for_event(JfrEventId event_id);
 
  public:
+  static JfrEventThrottler* create_throttler(JfrEventId event_id);
   static void configure(JfrEventId event_id, int64_t event_sample_size, int64_t period_ms);
   static bool accept(JfrEventId event_id, int64_t timestamp = 0);
 };


### PR DESCRIPTION
This patch prepares the way to throttle any JFR event, not only the three events for which we hard-code throttlers. It also cleans up the throttler code and replaces the switch construct with a lookup table.

The patch does not yet enable throttling for any other event, since that may be a contentious move, and I would like for this patch to go in without too much fuss. So I did not make any new events "throttleble".

If it turns out to be non-contentious, I am fine with just enabling throttling capability for all events.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8365611](https://bugs.openjdk.org/browse/JDK-8365611): Use lookup table for JfrEventThrottler (**Enhancement** - P4)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)

### Reviewers without OpenJDK IDs
 * @roberttoyonaga (no known openjdk.org user name / role)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26801/head:pull/26801` \
`$ git checkout pull/26801`

Update a local copy of the PR: \
`$ git checkout pull/26801` \
`$ git pull https://git.openjdk.org/jdk.git pull/26801/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26801`

View PR using the GUI difftool: \
`$ git pr show -t 26801`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26801.diff">https://git.openjdk.org/jdk/pull/26801.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26801#issuecomment-3193372730)
</details>
