### PR TITLE
8365622: Shenandoah: Fix Shenandoah simple bit map test

### DIFF
--- a/test/hotspot/gtest/gc/shenandoah/test_shenandoahSimpleBitMap.cpp
+++ b/test/hotspot/gtest/gc/shenandoah/test_shenandoahSimpleBitMap.cpp
@@ -443,7 +443,7 @@ public:
 
 };
 
-TEST(ShenandoahSimpleBitMapTest, minimum_test) {
+TEST_F(ShenandoahSimpleBitMapTest, minimum_test) {
 
   bool result = ShenandoahSimpleBitMapTest::run_test();
   ASSERT_EQ(result, true);


### PR DESCRIPTION
Simple fix. Test passes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8365622](https://bugs.openjdk.org/browse/JDK-8365622): Shenandoah: Fix Shenandoah simple bit map test (**Enhancement** - P4)


### Reviewers
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26805/head:pull/26805` \
`$ git checkout pull/26805`

Update a local copy of the PR: \
`$ git checkout pull/26805` \
`$ git pull https://git.openjdk.org/jdk.git pull/26805/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26805`

View PR using the GUI difftool: \
`$ git pr show -t 26805`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26805.diff">https://git.openjdk.org/jdk/pull/26805.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26805#issuecomment-3192496045)
</details>
