### PR TITLE
8365633: Incorrect info is reported on hybrid CPU

### DIFF
--- a/src/hotspot/cpu/x86/vm_version_x86.cpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.cpp
@@ -1099,7 +1099,9 @@ void VM_Version::get_processor_features() {
   }
 
   stringStream ss(2048);
-  if (!supports_hybrid()) {
+  if (supports_hybrid()) {
+    ss.print("(hybrid)");
+  } else {
     ss.print("(%u cores per cpu, %u threads per core)", cores_per_cpu(), threads_per_core());
   }
   ss.print(" family %d model %d stepping %d microcode 0x%x",

--- a/src/hotspot/cpu/x86/vm_version_x86.cpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.cpp
@@ -1099,8 +1099,12 @@ void VM_Version::get_processor_features() {
   }
 
   stringStream ss(2048);
-  ss.print("(%u cores per cpu, %u threads per core) family %d model %d stepping %d microcode 0x%x",
-           cores_per_cpu(), threads_per_core(),
+  if (supports_hybrid()) {
+    ss.print("(%u threads)", _cpuid_info.tpl_cpuidB1_ebx.bits.logical_cpus);
+  } else {
+    ss.print("(%u cores per cpu, %u threads per core)", cores_per_cpu(), threads_per_core());
+  }
+  ss.print(" family %d model %d stepping %d microcode 0x%x",
            cpu_family(), _model, _stepping, os::cpu_microcode_revision());
   ss.print(", ");
   int features_offset = (int)ss.size();
@@ -3043,6 +3047,8 @@ VM_Version::VM_Features VM_Version::CpuidInfo::feature_flags() const {
   if (is_intel()) {
     if (sef_cpuid7_edx.bits.serialize != 0)
       vm_features.set_feature(CPU_SERIALIZE);
+    if (sef_cpuid7_edx.bits.hybrid != 0)
+      vm_features.set_feature(CPU_HYBRID);
     if (_cpuid_info.sef_cpuid7_edx.bits.avx512_fp16 != 0)
       vm_features.set_feature(CPU_AVX512_FP16);
   }

--- a/src/hotspot/cpu/x86/vm_version_x86.cpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.cpp
@@ -1099,9 +1099,7 @@ void VM_Version::get_processor_features() {
   }
 
   stringStream ss(2048);
-  if (supports_hybrid()) {
-    ss.print("(%u threads)", _cpuid_info.tpl_cpuidB1_ebx.bits.logical_cpus);
-  } else {
+  if (!supports_hybrid()) {
     ss.print("(%u cores per cpu, %u threads per core)", cores_per_cpu(), threads_per_core());
   }
   ss.print(" family %d model %d stepping %d microcode 0x%x",

--- a/src/hotspot/cpu/x86/vm_version_x86.hpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.hpp
@@ -276,7 +276,8 @@ class VM_Version : public Abstract_VM_Version {
         fast_short_rep_mov : 1,
                            : 9,
                  serialize : 1,
-                           : 5,
+                     hybrid: 1,
+                           : 4,
                    cet_ibt : 1,
                            : 2,
               avx512_fp16  : 1,
@@ -444,7 +445,8 @@ protected:
     decl(SHA512,            "sha512",            61) /* SHA512 instructions*/ \
     decl(AVX512_FP16,       "avx512_fp16",       62) /* AVX512 FP16 ISA support*/ \
     decl(AVX10_1,           "avx10_1",           63) /* AVX10 512 bit vector ISA Version 1 support*/ \
-    decl(AVX10_2,           "avx10_2",           64) /* AVX10 512 bit vector ISA Version 2 support*/
+    decl(AVX10_2,           "avx10_2",           64) /* AVX10 512 bit vector ISA Version 2 support*/ \
+    decl(HYBRID,            "hybrid",            65) /* Hybrid architecture */
 
 #define DECLARE_CPU_FEATURE_FLAG(id, name, bit) CPU_##id = (bit),
     CPU_FEATURE_FLAGS(DECLARE_CPU_FEATURE_FLAG)
@@ -877,6 +879,7 @@ public:
   static bool supports_avx512_fp16()  { return _features.supports_feature(CPU_AVX512_FP16); }
   static bool supports_hv()           { return _features.supports_feature(CPU_HV); }
   static bool supports_serialize()    { return _features.supports_feature(CPU_SERIALIZE); }
+  static bool supports_hybrid()       { return _features.supports_feature(CPU_HYBRID); }
   static bool supports_f16c()         { return _features.supports_feature(CPU_F16C); }
   static bool supports_pku()          { return _features.supports_feature(CPU_PKU); }
   static bool supports_ospke()        { return _features.supports_feature(CPU_OSPKE); }

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/amd64/AMD64.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/amd64/AMD64.java
@@ -287,7 +287,8 @@ public class AMD64 extends Architecture {
         SHA512,
         AVX512_FP16,
         AVX10_1,
-        AVX10_2
+        AVX10_2,
+        HYBRID
     }
 
     private final EnumSet<CPUFeature> features;


### PR DESCRIPTION
`VM.info` DCmd reports CPU information. I ran this on Intel Core Ultra 5 225U , then I got following result:

```
CPU: total 14 (initial active 14) (7 cores per cpu, 2 threads per core) family 6 model 181 stepping 0 microcode 0xffffffff, cx8, cmov, fxsr, ht, mmx, 3dnowpref, sse, sse2, sse3, ssse3, sse4.1, sse4.2, popcnt, lzcnt, tsc, tscinvbit, avx, avx2, aes, erms, clmul, bmi1, bmi2, adx, sha, fma, vzeroupper, clflush, clflushopt, clwb, hv, serialize, rdtscp, rdpid, fsrm, gfni, f16c, cet_ibt, cet_ss
CPU Model and flags from /proc/cpuinfo:
model name : Intel(R) Core(TM) Ultra 5 225U
flags : fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm pni pclmulqdq monitor est tm2 ssse3 fma cx16 xtpr pdcm pcid sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave osxsave avx f16c rdrand hypervisor lahf_lm abm 3dnowprefetch fsgsbase bmi1 avx2 smep bmi2 erms invpcid rdseed adx smap clflushopt clwb intel_pt sha_ni umip gfni vaes vpclmulqdq rdpid ibrs ibpb stibp ssbd
```

It reports "7 cores per cpu, 2 threads per core". 225U has hybrid architecture - 2 P cores, 8 E cores, 2 LP cores, and also P core has 2 threads per core. Then it should be "12 cores, 14 threads".
https://www.intel.com/content/www/us/en/products/sku/241861/intel-core-ultra-5-processor-225u-12m-cache-up-to-4-80-ghz/specifications.html

According to Intel Software Developer's Manual, it seems to be difficult to get number of physical cores. In Linux kernel, it seems to be calculated by complex logic: https://github.com/torvalds/linux/blob/v6.16/arch/x86/kernel/smpboot.c#L567-L597
In addition, all of P cores might not be enabled HT. Thus to show only number of threads is reasonable at this point.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8365633](https://bugs.openjdk.org/browse/JDK-8365633): Incorrect info is reported on hybrid CPU (**Bug** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26808/head:pull/26808` \
`$ git checkout pull/26808`

Update a local copy of the PR: \
`$ git checkout pull/26808` \
`$ git pull https://git.openjdk.org/jdk.git pull/26808/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26808`

View PR using the GUI difftool: \
`$ git pr show -t 26808`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26808.diff">https://git.openjdk.org/jdk/pull/26808.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26808#issuecomment-3193700954)
</details>
