### PR TITLE
8365163: [ubsan] left-shift issue in globalDefinitions.hpp

### DIFF
--- a/src/hotspot/share/utilities/globalDefinitions.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions.hpp
@@ -641,6 +641,13 @@ inline jdouble jdouble_cast (jlong   x)  { return ((DoubleLongConv*)&x)->d;  }
 inline jint low (jlong value)                    { return jint(value); }
 inline jint high(jlong value)                    { return jint(value >> 32); }
 
+inline jlong jlong_from(jint h, jint l) {
+  // First cast jint values to juint, so cast to julong will zero-extend.
+  julong high = (julong)(juint)h << 32;
+  julong low = (julong)(juint)l;
+  return (jlong)(high | low);
+}
+
 union jlong_accessor {
   jint  words[2];
   jlong long_value;
@@ -1053,28 +1060,6 @@ template<class T> inline T nth_bit_typed(int n) {
 }
 template<class T> inline T right_n_bits_typed(int n) {
   return nth_bit_typed<T>(n) - 1;
-}
-
-// the fancy casts are a hopefully portable way
-// to do unsigned 32 to 64 bit type conversion
-inline void set_low (jlong* value, jint low ) {
-  *value &= (jlong)0xffffffff << 32;
-  *value |= (jlong)(julong)(juint)low;
-}
-
-inline void set_high(jlong* value, jint high) {
-  *value &= (jlong)(julong)(juint)0xffffffff;
-  jlong low_32bits = right_n_bits_typed<jlong>(32);
-  // high 32 bits are cleared before left-shift, since left-shift of a negative value is UB
-  assert((high & low_32bits) << 32 == ((jlong)high << 32), "must be");
-  *value |= (high & low_32bits) << 32;
-}
-
-inline jlong jlong_from(jint h, jint l) {
-  jlong result = 0; // initialization to avoid warning
-  set_high(&result, h);
-  set_low(&result,  l);
-  return result;
 }
 
 // bit-operations using a mask m

--- a/test/hotspot/gtest/utilities/test_globalDefinitions.cpp
+++ b/test/hotspot/gtest/utilities/test_globalDefinitions.cpp
@@ -295,3 +295,31 @@ TEST(globalDefinitions, format_specifiers) {
   // Check all platforms print this compatibly without leading 0x.
   check_format(UINT64_FORMAT_0,        (u8)0x123,         "0000000000000123");
 }
+
+TEST(globalDefinitions, jlong_from) {
+  jlong val = jlong_from(0xFF, 0);
+  EXPECT_EQ(val, 0x00000000FF00000000);
+
+  val = jlong_from(0, 0xFF);
+  EXPECT_EQ(val, 0x00000000000000FF);
+
+  val = jlong_from(0xFFFFFFFF, 0);
+  EXPECT_EQ(               val, (signed long)0xFFFFFFFF00000000);
+  EXPECT_EQ((unsigned long)val,              0xFFFFFFFF00000000);
+
+  val = jlong_from(0, 0xFFFFFFFF);
+  EXPECT_EQ(val, 0x00000000FFFFFFFF);
+
+  val = jlong_from(0, -1);
+  EXPECT_EQ(val, 0x00000000FFFFFFFF);
+
+  val = jlong_from(-1, 0);
+  EXPECT_EQ(val, (signed long)0xFFFFFFFF00000000);
+
+  val = jlong_from(-1, -1);
+  EXPECT_EQ(val, (signed long)0xFFFFFFFFFFFFFFFF);
+  EXPECT_EQ(val, -1);
+
+  val = jlong_from(0xABCD, 0xEFEF);
+  EXPECT_EQ(val, 0x0000ABCD0000EFEF);
+}

--- a/test/hotspot/gtest/utilities/test_globalDefinitions.cpp
+++ b/test/hotspot/gtest/utilities/test_globalDefinitions.cpp
@@ -304,8 +304,8 @@ TEST(globalDefinitions, jlong_from) {
   EXPECT_EQ(val, 0x00000000000000FF);
 
   val = jlong_from(0xFFFFFFFF, 0);
-  EXPECT_EQ(               val, (signed long)0xFFFFFFFF00000000);
-  EXPECT_EQ((unsigned long)val,              0xFFFFFFFF00000000);
+  EXPECT_EQ(                    val, (signed long long)0xFFFFFFFF00000000);
+  EXPECT_EQ((unsigned long long)val,                   0xFFFFFFFF00000000);
 
   val = jlong_from(0, 0xFFFFFFFF);
   EXPECT_EQ(val, 0x00000000FFFFFFFF);
@@ -314,10 +314,10 @@ TEST(globalDefinitions, jlong_from) {
   EXPECT_EQ(val, 0x00000000FFFFFFFF);
 
   val = jlong_from(-1, 0);
-  EXPECT_EQ(val, (signed long)0xFFFFFFFF00000000);
+  EXPECT_EQ(val, (signed long long)0xFFFFFFFF00000000);
 
   val = jlong_from(-1, -1);
-  EXPECT_EQ(val, (signed long)0xFFFFFFFFFFFFFFFF);
+  EXPECT_EQ(val, (signed long long)0xFFFFFFFFFFFFFFFF);
   EXPECT_EQ(val, -1);
 
   val = jlong_from(0xABCD, 0xEFEF);

--- a/test/hotspot/gtest/utilities/test_globalDefinitions.cpp
+++ b/test/hotspot/gtest/utilities/test_globalDefinitions.cpp
@@ -298,27 +298,27 @@ TEST(globalDefinitions, format_specifiers) {
 
 TEST(globalDefinitions, jlong_from) {
   jlong val = jlong_from(0xFF, 0);
-  EXPECT_EQ(val, 0x00000000FF00000000);
+  EXPECT_EQ(val, CONST64(0x00000000FF00000000));
 
   val = jlong_from(0, 0xFF);
-  EXPECT_EQ(val, 0x00000000000000FF);
+  EXPECT_EQ(val, CONST64(0x00000000000000FF));
 
   val = jlong_from(0xFFFFFFFF, 0);
   EXPECT_EQ((julong)val, UCONST64(0xFFFFFFFF00000000));
 
   val = jlong_from(0, 0xFFFFFFFF);
-  EXPECT_EQ(val, 0x00000000FFFFFFFF);
+  EXPECT_EQ(val, CONST64(0x00000000FFFFFFFF));
 
   val = jlong_from(0, -1);
-  EXPECT_EQ(val, 0x00000000FFFFFFFF);
+  EXPECT_EQ(val, CONST64(0x00000000FFFFFFFF));
 
   val = jlong_from(-1, 0);
   EXPECT_EQ((julong)val, UCONST64(0xFFFFFFFF00000000));
 
   val = jlong_from(-1, -1);
   EXPECT_EQ((julong)val, UCONST64(0xFFFFFFFFFFFFFFFF));
-  EXPECT_EQ(val, -1);
+  EXPECT_EQ(val, CONST64(-1));
 
   val = jlong_from(0xABCD, 0xEFEF);
-  EXPECT_EQ(val, 0x0000ABCD0000EFEF);
+  EXPECT_EQ(val, CONST64(0x0000ABCD0000EFEF));
 }

--- a/test/hotspot/gtest/utilities/test_globalDefinitions.cpp
+++ b/test/hotspot/gtest/utilities/test_globalDefinitions.cpp
@@ -304,8 +304,7 @@ TEST(globalDefinitions, jlong_from) {
   EXPECT_EQ(val, 0x00000000000000FF);
 
   val = jlong_from(0xFFFFFFFF, 0);
-  EXPECT_EQ(                    val, (signed long long)0xFFFFFFFF00000000);
-  EXPECT_EQ((unsigned long long)val,                   0xFFFFFFFF00000000);
+  EXPECT_EQ((julong)val, UCONST64(0xFFFFFFFF00000000));
 
   val = jlong_from(0, 0xFFFFFFFF);
   EXPECT_EQ(val, 0x00000000FFFFFFFF);
@@ -314,10 +313,10 @@ TEST(globalDefinitions, jlong_from) {
   EXPECT_EQ(val, 0x00000000FFFFFFFF);
 
   val = jlong_from(-1, 0);
-  EXPECT_EQ(val, (signed long long)0xFFFFFFFF00000000);
+  EXPECT_EQ((julong)val, UCONST64(0xFFFFFFFF00000000));
 
   val = jlong_from(-1, -1);
-  EXPECT_EQ(val, (signed long long)0xFFFFFFFFFFFFFFFF);
+  EXPECT_EQ((julong)val, UCONST64(0xFFFFFFFFFFFFFFFF));
   EXPECT_EQ(val, -1);
 
   val = jlong_from(0xABCD, 0xEFEF);


### PR DESCRIPTION
There was a left-shift of negative value UB in `set_high` function where the high value sign bit is on and is left-shifted 32 bits to put it in high word of the destination address.
To address it, first the left 32 bits of the provided `high` arg is cleared and then left-shifted 32 bits. 

Tests:
mach5 tiers 1-5 {macosx-aarch64, linux-x64, windows-x64} x {debug, product}

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8365163](https://bugs.openjdk.org/browse/JDK-8365163): [ubsan] left-shift issue in globalDefinitions.hpp (**Bug** - P4)


### Reviewers
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**) Review applies to [b525ba07](https://git.openjdk.org/jdk/pull/26809/files/b525ba07afd16add799756df69580970813bba63)
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26809/head:pull/26809` \
`$ git checkout pull/26809`

Update a local copy of the PR: \
`$ git checkout pull/26809` \
`$ git pull https://git.openjdk.org/jdk.git pull/26809/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26809`

View PR using the GUI difftool: \
`$ git pr show -t 26809`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26809.diff">https://git.openjdk.org/jdk/pull/26809.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26809#issuecomment-3194178905)
</details>
