### PR TITLE
8365638: JFR: Add --exact for debugging out-of-order events

### DIFF
--- a/test/jdk/jdk/jfr/tool/TestPrintContextual.java
+++ b/test/jdk/jdk/jfr/tool/TestPrintContextual.java
@@ -410,6 +410,7 @@ public class TestPrintContextual {
     private static List<String> readPrintedLines(Path file, String... options) throws Exception {
         JDKToolLauncher launcher = JDKToolLauncher.createUsingTestJDK("jfr");
         launcher.addToolArg("print");
+        launcher.addToolArg("--exact");
         for (String option : options) {
             launcher.addToolArg(option);
         }


### PR DESCRIPTION
Could I have review of PR that add --exact so the failure of a test can be debugged more easily. 

Testing: test/jdk/jdk/jfr/tool/TestPrintContextual.java

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8365638](https://bugs.openjdk.org/browse/JDK-8365638): JFR: Add --exact for debugging out-of-order events (**Sub-task** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26812/head:pull/26812` \
`$ git checkout pull/26812`

Update a local copy of the PR: \
`$ git checkout pull/26812` \
`$ git pull https://git.openjdk.org/jdk.git pull/26812/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26812`

View PR using the GUI difftool: \
`$ git pr show -t 26812`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26812.diff">https://git.openjdk.org/jdk/pull/26812.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26812#issuecomment-3194598865)
</details>
