### PR TITLE
8365550: JFR: The active-settings view should not use LAST_BATCH

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/query/view.ini
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/query/view.ini
@@ -40,9 +40,9 @@ table = "COLUMN 'Event Type', 'Enabled', 'Threshold',
                 'Stack Trace','Period','Cutoff', 'Throttle'
          FORMAT none, missing:whitespace, missing:whitespace, missing:whitespace,
                 missing:whitespace, missing:whitespace, missing:whitespace
-         SELECT E.id, LAST_BATCH(E.value), LAST_BATCH(T.value),
-                LAST_BATCH(S.value), LAST_BATCH(P.value),
-                LAST_BATCH(C.value), LAST_BATCH(U.value)
+         SELECT E.id, LAST(E.value), LAST(T.value),
+                LAST(S.value), LAST(P.value),
+                LAST(C.value), LAST(U.value)
          FROM
                 ActiveSetting AS E,
                 ActiveSetting AS T,


### PR DESCRIPTION
Could I have a review of the change that updates the active-settings query to use LAST instead of LAST_BATCH?

The problem with using LAST_BATCH is that it doesn’t work with older recordings where the jdk.ActiveSetting event was not emitted as a batch, or with later recordings where a single setting is changed programmatically.

Testing: jdk/jdk/jfr

Thanks
Erik