### PR TITLE
8365643: JShell EditPad out of bounds on Windows

### DIFF
--- a/src/jdk.editpad/share/classes/jdk/editpad/EditPad.java
+++ b/src/jdk.editpad/share/classes/jdk/editpad/EditPad.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
When calling the `setLocationRelativeTo()` method, a null parameter means that it centers the window in the screen. However, any subsequent resizing operations will change only the size, not the location of the window. Understandable, but now the window is no longer centered. So, changing the order of operations.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8365643](https://bugs.openjdk.org/browse/JDK-8365643): JShell EditPad out of bounds on Windows (**Bug** - P4)


### Reviewers
 * [Christian Stein](https://openjdk.org/census#cstein) (@sormuras - Committer) Review applies to [409f392d](https://git.openjdk.org/jdk/pull/26814/files/409f392d468bb045000250a578aa873ab0f37de3)
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**) Review applies to [409f392d](https://git.openjdk.org/jdk/pull/26814/files/409f392d468bb045000250a578aa873ab0f37de3)
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26814/head:pull/26814` \
`$ git checkout pull/26814`

Update a local copy of the PR: \
`$ git checkout pull/26814` \
`$ git pull https://git.openjdk.org/jdk.git pull/26814/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26814`

View PR using the GUI difftool: \
`$ git pr show -t 26814`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26814.diff">https://git.openjdk.org/jdk/pull/26814.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26814#issuecomment-3195101250)
</details>
