### PR TITLE
8362243: Devkit creation for Fedora base OS is broken

### DIFF
--- a/doc/building.html
+++ b/doc/building.html
@@ -1657,27 +1657,34 @@ are:</p>
 <td>zero</td>
 </tr>
 <tr class="even">
+<td>ppc64be</td>
+<td>sid</td>
+<td>ppc64</td>
+<td>powerpc64-linux-gnu</td>
+<td>(all)</td>
+</tr>
+<tr class="odd">
 <td>m68k</td>
 <td>sid</td>
 <td>m68k</td>
 <td>m68k-linux-gnu</td>
 <td>zero</td>
 </tr>
-<tr class="odd">
+<tr class="even">
 <td>alpha</td>
 <td>sid</td>
 <td>alpha</td>
 <td>alpha-linux-gnu</td>
 <td>zero</td>
 </tr>
-<tr class="even">
+<tr class="odd">
 <td>sh4</td>
 <td>sid</td>
 <td>sh4</td>
 <td>sh4-linux-gnu</td>
 <td>zero</td>
 </tr>
-<tr class="odd">
+<tr class="even">
 <td>riscv64</td>
 <td>sid</td>
 <td>riscv64</td>

--- a/doc/building.html
+++ b/doc/building.html
@@ -1451,10 +1451,10 @@ of a cross-compiling toolchain and a sysroot environment which can
 easily be used together with the <code>--with-devkit</code> configure
 option to cross compile the JDK. On Linux/x86_64, the following
 command:</p>
-<pre><code>bash configure --with-devkit=&lt;devkit-path&gt; --openjdk-target=ppc64-linux-gnu &amp;&amp; make</code></pre>
-<p>will configure and build the JDK for Linux/ppc64 assuming that
-<code>&lt;devkit-path&gt;</code> points to a Linux/x86_64 to Linux/ppc64
-devkit.</p>
+<pre><code>bash configure --with-devkit=&lt;devkit-path&gt; --openjdk-target=ppc64le-linux-gnu &amp;&amp; make</code></pre>
+<p>will configure and build the JDK for Linux/ppc64le assuming that
+<code>&lt;devkit-path&gt;</code> points to a Linux/x86_64 to
+Linux/ppc64le devkit.</p>
 <p>Devkits can be created from the <code>make/devkit</code> directory by
 executing:</p>
 <pre><code>make [ TARGETS=&quot;&lt;TARGET_TRIPLET&gt;+&quot; ] [ BASE_OS=&lt;OS&gt; ] [ BASE_OS_VERSION=&lt;VER&gt; ]</code></pre>
@@ -1481,10 +1481,10 @@ following targets are known to work:</p>
 <td>arm-linux-gnueabihf</td>
 </tr>
 <tr class="even">
-<td>ppc64-linux-gnu</td>
+<td>ppc64le-linux-gnu</td>
 </tr>
 <tr class="odd">
-<td>ppc64le-linux-gnu</td>
+<td>riscv64-linux-gnu</td>
 </tr>
 <tr class="even">
 <td>s390x-linux-gnu</td>
@@ -1657,34 +1657,27 @@ are:</p>
 <td>zero</td>
 </tr>
 <tr class="even">
-<td>ppc64be</td>
-<td>sid</td>
-<td>ppc64</td>
-<td>powerpc64-linux-gnu</td>
-<td>(all)</td>
-</tr>
-<tr class="odd">
 <td>m68k</td>
 <td>sid</td>
 <td>m68k</td>
 <td>m68k-linux-gnu</td>
 <td>zero</td>
 </tr>
-<tr class="even">
+<tr class="odd">
 <td>alpha</td>
 <td>sid</td>
 <td>alpha</td>
 <td>alpha-linux-gnu</td>
 <td>zero</td>
 </tr>
-<tr class="odd">
+<tr class="even">
 <td>sh4</td>
 <td>sid</td>
 <td>sh4</td>
 <td>sh4-linux-gnu</td>
 <td>zero</td>
 </tr>
-<tr class="even">
+<tr class="odd">
 <td>riscv64</td>
 <td>sid</td>
 <td>riscv64</td>

--- a/doc/building.md
+++ b/doc/building.md
@@ -1282,6 +1282,7 @@ at least the following targets are known to work:
 | aarch64-linux-gnu        |
 | arm-linux-gnueabihf      |
 | ppc64le-linux-gnu        |
+| riscv64-linux-gnu        |
 | s390x-linux-gnu          |
 
 `BASE_OS` must be one of `OL` for Oracle Enterprise Linux or `Fedora`. If the

--- a/doc/building.md
+++ b/doc/building.md
@@ -1258,11 +1258,11 @@ toolchain and a sysroot environment which can easily be used together with the
 following command:
 
 ```
-bash configure --with-devkit=<devkit-path> --openjdk-target=ppc64-linux-gnu && make
+bash configure --with-devkit=<devkit-path> --openjdk-target=ppc64le-linux-gnu && make
 ```
 
-will configure and build the JDK for Linux/ppc64 assuming that `<devkit-path>`
-points to a Linux/x86_64 to Linux/ppc64 devkit.
+will configure and build the JDK for Linux/ppc64le assuming that `<devkit-path>`
+points to a Linux/x86_64 to Linux/ppc64le devkit.
 
 Devkits can be created from the `make/devkit` directory by executing:
 
@@ -1281,7 +1281,6 @@ at least the following targets are known to work:
 | x86_64-linux-gnu         |
 | aarch64-linux-gnu        |
 | arm-linux-gnueabihf      |
-| ppc64-linux-gnu          |
 | ppc64le-linux-gnu        |
 | s390x-linux-gnu          |
 
@@ -1401,7 +1400,6 @@ Architectures that are known to successfully cross-compile like this are:
 | mips64le     | buster       | mips64el      | mips64el-linux-gnueabi64 | zero                      |
 | armel        | buster       | arm           | arm-linux-gnueabi        | zero                      |
 | ppc          | sid          | powerpc       | powerpc-linux-gnu        | zero                      |
-| ppc64be      | sid          | ppc64         | powerpc64-linux-gnu      | (all)                     |
 | m68k         | sid          | m68k          | m68k-linux-gnu           | zero                      |
 | alpha        | sid          | alpha         | alpha-linux-gnu          | zero                      |
 | sh4          | sid          | sh4           | sh4-linux-gnu            | zero                      |

--- a/doc/building.md
+++ b/doc/building.md
@@ -1401,6 +1401,7 @@ Architectures that are known to successfully cross-compile like this are:
 | mips64le     | buster       | mips64el      | mips64el-linux-gnueabi64 | zero                      |
 | armel        | buster       | arm           | arm-linux-gnueabi        | zero                      |
 | ppc          | sid          | powerpc       | powerpc-linux-gnu        | zero                      |
+| ppc64be      | sid          | ppc64         | powerpc64-linux-gnu      | (all)                     |
 | m68k         | sid          | m68k          | m68k-linux-gnu           | zero                      |
 | alpha        | sid          | alpha         | alpha-linux-gnu          | zero                      |
 | sh4          | sid          | sh4           | sh4-linux-gnu            | zero                      |

--- a/make/devkit/Makefile
+++ b/make/devkit/Makefile
@@ -39,7 +39,7 @@
 #
 # make TARGETS="aarch64-linux-gnu" BASE_OS=Fedora
 # or
-# make TARGETS="arm-linux-gnueabihf ppc64-linux-gnu" BASE_OS=Fedora BASE_OS_VERSION=17
+# make TARGETS="arm-linux-gnueabihf ppc64le-linux-gnu" BASE_OS=Fedora BASE_OS_VERSION=17
 #
 # to build several devkits for a specific OS version at once.
 # You can find the final results under ../../build/devkit/result/<host>-to-<target>
@@ -50,7 +50,7 @@
 # makefile again for cross compilation. Ex:
 #
 # PATH=$PWD/../../build/devkit/result/x86_64-linux-gnu-to-x86_64-linux-gnu/bin:$PATH \
-#    make TARGETS="arm-linux-gnueabihf,ppc64-linux-gnu" BASE_OS=Fedora
+#    make TARGETS="arm-linux-gnueabihf ppc64le-linux-gnu" BASE_OS=Fedora
 #
 # This is the makefile which iterates over all host and target platforms.
 #

--- a/make/devkit/Tools.gmk
+++ b/make/devkit/Tools.gmk
@@ -85,7 +85,7 @@ else ifeq ($(BASE_OS), Fedora)
       FEDORA_TYPE := fedora/linux
     endif
     ifeq ($(ARCH), armhfp)
-      ifneq ($(BASE_OS_VERSION),36)
+      ifneq ($(BASE_OS_VERSION), 36)
         $(error Fedora 36 is the last release supporting "armhfp", but $(BASE_OS) was requested)
       endif
     endif

--- a/make/devkit/Tools.gmk
+++ b/make/devkit/Tools.gmk
@@ -73,7 +73,7 @@ else ifeq ($(BASE_OS), Fedora)
     $(error Only "aarch64 armhfp ppc64le riscv64 s390x x86_64" architectures are supported for Fedora, but "$(ARCH)" was requested)
   endif
   ifeq ($(ARCH), riscv64)
-    ifeq ($(filter 36 37, $(BASE_OS_VERSION)), )
+    ifeq ($(filter 38 39 40 41, $(BASE_OS_VERSION)), )
       $(error Only Fedora 38-41 are supported for "$(ARCH)", but Fedora $(BASE_OS_VERSION) was requested)
     endif
     BASE_URL := http://fedora.riscv.rocks/repos-dist/f$(BASE_OS_VERSION)/latest/$(ARCH)/Packages/

--- a/make/devkit/Tools.gmk
+++ b/make/devkit/Tools.gmk
@@ -464,7 +464,7 @@ ifeq ($(ARCH), armhfp)
   $(BUILDDIR)/$(gcc_ver)/Makefile : CONFIG +=  --with-float=hard
 endif
 
-ifneq ($(filter riscv64 ppc64 ppc64le s390x, $(ARCH)), )
+ifneq ($(filter riscv64 ppc64le s390x, $(ARCH)), )
   # We only support 64-bit on these platforms anyway
   CONFIG += --disable-multilib
 endif

--- a/make/devkit/Tools.gmk
+++ b/make/devkit/Tools.gmk
@@ -69,14 +69,25 @@ else ifeq ($(BASE_OS), Fedora)
   ifeq ($(BASE_OS_VERSION), )
     BASE_OS_VERSION := $(DEFAULT_OS_VERSION)
   endif
+  ifeq ($(filter aarch64 armhfp ppc64le riscv64 s390x x86_64, $(ARCH)), )
+    $(error Only "aarch64 armhfp ppc64le riscv64 s390x x86_64" architectures are supported for Fedora, but "$(ARCH)" was requested)
+  endif
   ifeq ($(ARCH), riscv64)
+    ifeq ($(filter 36 37, $(BASE_OS_VERSION)), )
+      $(error Only Fedora 38-41 are supported for "$(ARCH)", but Fedora $(BASE_OS_VERSION) was requested)
+    endif
     BASE_URL := http://fedora.riscv.rocks/repos-dist/f$(BASE_OS_VERSION)/latest/$(ARCH)/Packages/
   else
-    LATEST_ARCHIVED_OS_VERSION := 35
-    ifeq ($(filter x86_64 armhfp, $(ARCH)), )
+    LATEST_ARCHIVED_OS_VERSION := 36
+    ifeq ($(filter aarch64 armhfp x86_64, $(ARCH)), )
       FEDORA_TYPE := fedora-secondary
     else
       FEDORA_TYPE := fedora/linux
+    endif
+    ifeq ($(ARCH), armhfp)
+      ifneq ($(BASE_OS_VERSION),36)
+        $(error Fedora 36 is the last release supporting "armhfp", but $(BASE_OS) was requested)
+      endif
     endif
     NOT_ARCHIVED := $(shell [ $(BASE_OS_VERSION) -gt $(LATEST_ARCHIVED_OS_VERSION) ] && echo true)
     ifeq ($(NOT_ARCHIVED),true)


### PR DESCRIPTION
In Devkit, removes `ppc64`/`ppc64be`, which is superseded by `ppc64le`, fixes Fedora repository links, and bumps the `LATEST_ARCHIVED_OS_VERSION` to 36.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8362243](https://bugs.openjdk.org/browse/JDK-8362243): Devkit creation for Fedora base OS is broken (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**) Review applies to [91acc87a](https://git.openjdk.org/jdk/pull/26821/files/91acc87af33954ef0b08d35fce88dac33811e4f6)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**) Review applies to [c320f258](https://git.openjdk.org/jdk/pull/26821/files/c320f2584e6f5f8b7eb29f4bcd81d87fc564de74)
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26821/head:pull/26821` \
`$ git checkout pull/26821`

Update a local copy of the PR: \
`$ git checkout pull/26821` \
`$ git pull https://git.openjdk.org/jdk.git pull/26821/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26821`

View PR using the GUI difftool: \
`$ git pr show -t 26821`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26821.diff">https://git.openjdk.org/jdk/pull/26821.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26821#issuecomment-3196572443)
</details>
