### PR TITLE
8361387 : Test bug4655513.java fails intermittently on Windows platform.

### DIFF
--- a/test/jdk/javax/swing/DataTransfer/bug4655513.java
+++ b/test/jdk/javax/swing/DataTransfer/bug4655513.java
@@ -69,6 +69,7 @@ public class bug4655513 {
             for (int y = dragStartLoc.y; y < dragEndLoc.y; y += 2) {
                 robot.mouseMove(dragStartLoc.x, y);
             }
+            robot.waitForIdle();
             robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
             robot.waitForIdle();
             robot.delay(500);


### PR DESCRIPTION
This test was recently automated and is failing intermittently in the CI due to timing issues.
This enhancement aims to stabilize the test and also adds the missing null pointer check.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8361387](https://bugs.openjdk.org/browse/JDK-8361387)

### Warning
&nbsp;⚠️ Found trailing period in issue title for `8361387: Test bug4655513.java fails intermittently on Windows platform.`

### Issue
 * [JDK-8361387](https://bugs.openjdk.org/browse/JDK-8361387): Test bug4655513.java fails intermittently on Windows platform (**Bug** - P4) ⚠️ Title mismatch between PR and JBS.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26824/head:pull/26824` \
`$ git checkout pull/26824`

Update a local copy of the PR: \
`$ git checkout pull/26824` \
`$ git pull https://git.openjdk.org/jdk.git pull/26824/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26824`

View PR using the GUI difftool: \
`$ git pr show -t 26824`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26824.diff">https://git.openjdk.org/jdk/pull/26824.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26824#issuecomment-3197613738)
</details>
