### PR TITLE
8365708: Add missing @Override annotations to WindowsMenuItemUIAccessor

### DIFF
--- a/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsCheckBoxMenuItemUI.java
+++ b/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsCheckBoxMenuItemUI.java
@@ -52,6 +52,7 @@ public final class WindowsCheckBoxMenuItemUI extends BasicCheckBoxMenuItemUI {
                 return menuItem;
             }
 
+            @Override
             public State getState(JMenuItem menuItem) {
                 return WindowsMenuItemUI.getState(this, menuItem);
             }

--- a/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsMenuItemUI.java
+++ b/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsMenuItemUI.java
@@ -72,13 +72,14 @@ public final class WindowsMenuItemUI extends BasicMenuItemUI {
     private static Color acceleratorForeground;
 
     final WindowsMenuItemUIAccessor accessor =
-        new  WindowsMenuItemUIAccessor() {
+        new WindowsMenuItemUIAccessor() {
 
             @Override
             public JMenuItem getMenuItem() {
                 return menuItem;
             }
 
+            @Override
             public State getState(JMenuItem menuItem) {
                 return WindowsMenuItemUI.getState(this, menuItem);
             }

--- a/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsMenuUI.java
+++ b/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsMenuUI.java
@@ -62,6 +62,7 @@ public final class WindowsMenuUI extends BasicMenuUI {
                 return menuItem;
             }
 
+            @Override
             public State getState(JMenuItem menu) {
                 State state = menu.isEnabled() ? State.NORMAL
                         : State.DISABLED;

--- a/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsRadioButtonMenuItemUI.java
+++ b/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsRadioButtonMenuItemUI.java
@@ -52,6 +52,7 @@ public final class WindowsRadioButtonMenuItemUI extends BasicRadioButtonMenuItem
                return menuItem;
            }
 
+           @Override
            public State getState(JMenuItem menuItem) {
                return WindowsMenuItemUI.getState(this, menuItem);
            }


### PR DESCRIPTION
Add the missing `@Override` annotations to anonymous classes implementing `WindowsMenuItemUIAccessor`.

PR #24170 for [JDK-8352638](https://bugs.openjdk.org/browse/JDK-8352638) added the `@Override` annotations to `getMenuItem` and `getPart` but left `getState` without the annotation.

For consistency, add the annotation to the `getState` method too.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8365708](https://bugs.openjdk.org/browse/JDK-8365708): Add missing @<!---->Override annotations to WindowsMenuItemUIAccessor (**Bug** - P5)


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)
 * [Alexander Zuev](https://openjdk.org/census#kizune) (@azuev-java - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26828/head:pull/26828` \
`$ git checkout pull/26828`

Update a local copy of the PR: \
`$ git checkout pull/26828` \
`$ git pull https://git.openjdk.org/jdk.git pull/26828/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26828`

View PR using the GUI difftool: \
`$ git pr show -t 26828`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26828.diff">https://git.openjdk.org/jdk/pull/26828.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26828#issuecomment-3197717052)
</details>
