### PR TITLE
8365711: Declare menuBarHeight and hotTrackingOn private

### DIFF
--- a/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsMenuUI.java
+++ b/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsMenuUI.java
@@ -51,8 +51,8 @@ import com.sun.java.swing.plaf.windows.TMSchema.State;
  * Windows rendition of the component.
  */
 public final class WindowsMenuUI extends BasicMenuUI {
-    protected Integer menuBarHeight;
-    protected boolean hotTrackingOn;
+    private Integer menuBarHeight;
+    private boolean hotTrackingOn;
 
     final WindowsMenuItemUIAccessor accessor =
         new WindowsMenuItemUIAccessor() {


### PR DESCRIPTION
Since `WindowsMenuUI` is a final class after PR #24170 for [JDK-8352638](https://bugs.openjdk.org/browse/JDK-8352638)), it cannot be extended, therefore the `protected` modifier doesn't make sense.

Mark both `menuBarHeight` and `hotTrackingOn` as `private` fields.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8365711](https://bugs.openjdk.org/browse/JDK-8365711): Declare menuBarHeight and hotTrackingOn private (**Bug** - P5)


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)
 * [Alexander Zuev](https://openjdk.org/census#kizune) (@azuev-java - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26829/head:pull/26829` \
`$ git checkout pull/26829`

Update a local copy of the PR: \
`$ git checkout pull/26829` \
`$ git pull https://git.openjdk.org/jdk.git pull/26829/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26829`

View PR using the GUI difftool: \
`$ git pr show -t 26829`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26829.diff">https://git.openjdk.org/jdk/pull/26829.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26829#issuecomment-3197770521)
</details>
