### PR TITLE
8365719: Refactor uses of JLA.uncheckedNewStringNoRepl

### DIFF
--- a/src/java.base/share/classes/java/io/DataInputStream.java
+++ b/src/java.base/share/classes/java/io/DataInputStream.java
@@ -599,7 +599,7 @@ loop:   while (true) {
         if (ascii == utflen) {
             String str;
             if (trusted) {
-                str = JLA.uncheckedNewStringNoRepl(bytearr, StandardCharsets.ISO_8859_1);
+                str = JLA.uncheckedNewStringWithLatin1Bytes(bytearr);
             } else {
                 str = new String(bytearr, 0, utflen, StandardCharsets.ISO_8859_1);
             }

--- a/src/java.base/share/classes/java/lang/String.java
+++ b/src/java.base/share/classes/java/lang/String.java
@@ -759,6 +759,21 @@ public final class String
         return new String(dst, UTF16);
     }
 
+    /**
+     * {@return a new String created using the supplied latin1 bytes}
+     * @param src a byte array with the bytes for a latin1 string
+     */
+    static String newStringWithLatin1Bytes(byte[] src) {
+        int len = src.length;
+        if (len == 0) {
+            return "";
+        }
+
+        if (COMPACT_STRINGS)
+            return new String(src, LATIN1);
+        return new String(StringLatin1.inflate(src, 0, src.length), UTF16);
+    }
+
     static String newStringNoRepl(byte[] src, Charset cs) throws CharacterCodingException {
         try {
             return newStringNoRepl1(src, cs);

--- a/src/java.base/share/classes/java/lang/System.java
+++ b/src/java.base/share/classes/java/lang/System.java
@@ -55,7 +55,6 @@ import java.util.Properties;
 import java.util.ResourceBundle;
 import java.util.Set;
 import java.util.concurrent.Executor;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Supplier;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Stream;
@@ -2127,6 +2126,11 @@ public final class System {
             public int countNonZeroAscii(String s) {
                 return StringCoding.countNonZeroAscii(s);
             }
+
+            public String uncheckedNewStringWithLatin1Bytes(byte[] bytes) {
+                return String.newStringWithLatin1Bytes(bytes);
+            }
+
             public String uncheckedNewStringNoRepl(byte[] bytes, Charset cs) throws CharacterCodingException  {
                 return String.newStringNoRepl(bytes, cs);
             }

--- a/src/java.base/share/classes/java/math/BigDecimal.java
+++ b/src/java.base/share/classes/java/math/BigDecimal.java
@@ -35,8 +35,6 @@ import java.io.InvalidObjectException;
 import java.io.ObjectInputStream;
 import java.io.ObjectStreamException;
 import java.io.StreamCorruptedException;
-import java.nio.charset.CharacterCodingException;
-import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Objects;
 
@@ -4149,11 +4147,7 @@ public class BigDecimal extends Number implements Comparable<BigDecimal> {
             DecimalDigits.uncheckedGetCharsLatin1(highInt, highIntSize, buf);
             buf[highIntSize] = '.';
             DecimalDigits.uncheckedPutPairLatin1(buf, highIntSize + 1, lowInt);
-            try {
-                return JLA.uncheckedNewStringNoRepl(buf, StandardCharsets.ISO_8859_1);
-            } catch (CharacterCodingException cce) {
-                throw new AssertionError(cce);
-            }
+            return JLA.uncheckedNewStringWithLatin1Bytes(buf);
         }
 
         char[] coeff;

--- a/src/java.base/share/classes/java/util/HexFormat.java
+++ b/src/java.base/share/classes/java/util/HexFormat.java
@@ -33,8 +33,6 @@ import jdk.internal.util.HexDigits;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.CharBuffer;
-import java.nio.charset.CharacterCodingException;
-import java.nio.charset.StandardCharsets;
 
 /**
  * {@code HexFormat} converts between bytes and chars and hex-encoded strings which may include
@@ -460,12 +458,7 @@ public final class HexFormat {
             // Delimiter formatting not to a single byte
             return null;
         }
-        try {
-            // Return a new string using the bytes without making a copy
-            return jla.uncheckedNewStringNoRepl(rep, StandardCharsets.ISO_8859_1);
-        } catch (CharacterCodingException cce) {
-            throw new AssertionError(cce);
-        }
+        return jla.uncheckedNewStringWithLatin1Bytes(rep);
     }
 
     /**
@@ -695,11 +688,7 @@ public final class HexFormat {
         byte[] rep = new byte[2];
         rep[0] = (byte)toHighHexDigit(value);
         rep[1] = (byte)toLowHexDigit(value);
-        try {
-            return jla.uncheckedNewStringNoRepl(rep, StandardCharsets.ISO_8859_1);
-        } catch (CharacterCodingException cce) {
-            throw new AssertionError(cce);
-        }
+        return jla.uncheckedNewStringWithLatin1Bytes(rep);
     }
 
     /**
@@ -731,11 +720,7 @@ public final class HexFormat {
         rep[2] = (byte)toHighHexDigit((byte)value);
         rep[3] = (byte)toLowHexDigit((byte)value);
 
-        try {
-            return jla.uncheckedNewStringNoRepl(rep, StandardCharsets.ISO_8859_1);
-        } catch (CharacterCodingException cce) {
-            throw new AssertionError(cce);
-        }
+        return jla.uncheckedNewStringWithLatin1Bytes(rep);
     }
 
     /**
@@ -759,11 +744,7 @@ public final class HexFormat {
         rep[6] = (byte)toHighHexDigit((byte)value);
         rep[7] = (byte)toLowHexDigit((byte)value);
 
-        try {
-            return jla.uncheckedNewStringNoRepl(rep, StandardCharsets.ISO_8859_1);
-        } catch (CharacterCodingException cce) {
-            throw new AssertionError(cce);
-        }
+        return jla.uncheckedNewStringWithLatin1Bytes(rep);
     }
 
     /**
@@ -795,11 +776,7 @@ public final class HexFormat {
         rep[14] = (byte)toHighHexDigit((byte)value);
         rep[15] = (byte)toLowHexDigit((byte)value);
 
-        try {
-            return jla.uncheckedNewStringNoRepl(rep, StandardCharsets.ISO_8859_1);
-        } catch (CharacterCodingException cce) {
-            throw new AssertionError(cce);
-        }
+        return jla.uncheckedNewStringWithLatin1Bytes(rep);
     }
 
     /**
@@ -823,11 +800,7 @@ public final class HexFormat {
             rep[i] = (byte)toLowHexDigit((byte)(value));
             value = value >>> 4;
         }
-        try {
-            return jla.uncheckedNewStringNoRepl(rep, StandardCharsets.ISO_8859_1);
-        } catch (CharacterCodingException cce) {
-            throw new AssertionError(cce);
-        }
+        return jla.uncheckedNewStringWithLatin1Bytes(rep);
     }
 
     /**

--- a/src/java.base/share/classes/java/util/UUID.java
+++ b/src/java.base/share/classes/java/util/UUID.java
@@ -25,8 +25,6 @@
 
 package java.util;
 
-import java.nio.charset.CharacterCodingException;
-import java.nio.charset.StandardCharsets;
 import java.security.*;
 
 import jdk.internal.access.JavaLangAccess;
@@ -479,11 +477,7 @@ public final class UUID implements java.io.Serializable, Comparable<UUID> {
         ByteArrayLittleEndian.setInt(buf, 24, (int) (x1 >>> 32));
         ByteArrayLittleEndian.setLong(buf, 28, hex8(leastSigBits));
 
-        try {
-            return jla.uncheckedNewStringNoRepl(buf, StandardCharsets.ISO_8859_1);
-        } catch (CharacterCodingException cce) {
-            throw new AssertionError(cce);
-        }
+        return jla.uncheckedNewStringWithLatin1Bytes(buf);
     }
 
     /**

--- a/src/java.base/share/classes/jdk/internal/access/JavaLangAccess.java
+++ b/src/java.base/share/classes/jdk/internal/access/JavaLangAccess.java
@@ -318,6 +318,18 @@ public interface JavaLangAccess {
     int countNonZeroAscii(String s);
 
     /**
+     * Constructs a new {@code String} with the supplied Latin1 bytes.
+     * <p>
+     * <b>WARNING: The caller of this method shall relinquish and transfer the
+     * ownership of the byte array to the callee</b>, since the latter will not
+     * make a copy.
+     *
+     * @param bytes the byte array source
+     * @return the newly created string
+     */
+    String uncheckedNewStringWithLatin1Bytes(byte[] bytes);
+
+    /**
      * Constructs a new {@code String} by decoding the specified byte array
      * using the specified {@linkplain java.nio.charset.Charset charset}.
      * <p>


### PR DESCRIPTION
Refactor uses of JLAuncheckedNewStringNoRepl(byte[], ISO_8859_1) adding JLA.uncheckedNewStringWithLatin1Bytes(byte[]).
There is no decoding needed, and no exceptions expected or thrown when creating the string from the supplied latin1 bytes. 
If COMPACT_STRINGS is false, the bytes are inflated to UTF16.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8365719](https://bugs.openjdk.org/browse/JDK-8365719): Refactor uses of JLA.uncheckedNewStringNoRepl (**Enhancement** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)
 * [Volkan Yazici](https://openjdk.org/census#vyazici) (@vy - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26831/head:pull/26831` \
`$ git checkout pull/26831`

Update a local copy of the PR: \
`$ git checkout pull/26831` \
`$ git pull https://git.openjdk.org/jdk.git pull/26831/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26831`

View PR using the GUI difftool: \
`$ git pr show -t 26831`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26831.diff">https://git.openjdk.org/jdk/pull/26831.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26831#issuecomment-3198516462)
</details>
