### PR TITLE
8365425: [macos26] javax/swing/JInternalFrame/8160248/JInternalFrameDraggingTest.java fails on macOS 26

### DIFF
--- a/test/jdk/javax/swing/JInternalFrame/8160248/JInternalFrameDraggingTest.java
+++ b/test/jdk/javax/swing/JInternalFrame/8160248/JInternalFrameDraggingTest.java
@@ -22,7 +22,9 @@
  */
 
 import java.awt.BorderLayout;
+import java.awt.image.BufferedImage;
 import java.awt.Color;
+import java.awt.Graphics2D;
 import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.Robot;
@@ -66,23 +68,17 @@ public class JInternalFrameDraggingTest {
 
             Point p = getDesktopPaneLocation();
             int size = translate / 2;
-            Rectangle rect = new Rectangle(p.x, p.y, size, size);
-            BufferedImage img = robot.createScreenCapture(rect);
+            BufferedImage bi = new BufferedImage(size, size, BufferedImage.TYPE_INT_ARGB);
+            final Graphics2D graphics = bi.createGraphics();
+            desktopPane.paint(graphics);
+            graphics.dispose();
 
             int testRGB = BACKGROUND_COLOR.getRGB();
-            Color testColor = new Color(testRGB);
             for (int i = 1; i < size; i++) {
-                int rgbCW = img.getRGB(i, size / 2);
-                int rgbCH = img.getRGB(size / 2, i);
-                Color rgbCWColor = new Color(rgbCW);
-                Color rgbCHColor = new Color(rgbCH);
+                int rgbCW = bi.getRGB(i, size / 2);
+                int rgbCH = bi.getRGB(size / 2, i);
 
-                if (Math.abs(rgbCWColor.getRed() - testColor.getRed()) > tolerance
-                    || Math.abs(rgbCWColor.getGreen() - testColor.getGreen()) > tolerance
-                    || Math.abs(rgbCWColor.getBlue() - testColor.getBlue()) > tolerance
-                    || Math.abs(rgbCHColor.getRed() - testColor.getRed()) > tolerance
-                    || Math.abs(rgbCHColor.getGreen() - testColor.getGreen()) > tolerance
-                    || Math.abs(rgbCHColor.getBlue() - testColor.getBlue()) > tolerance) {
+                if (rgbCW != testRGB || rgbCH != testRGB) {
                     System.out.println("i " + i + " rgbCW " +
                                        Integer.toHexString(rgbCW) +
                                        " testRGB " + Integer.toHexString(testRGB) +

--- a/test/jdk/javax/swing/JInternalFrame/8160248/JInternalFrameDraggingTest.java
+++ b/test/jdk/javax/swing/JInternalFrame/8160248/JInternalFrameDraggingTest.java
@@ -70,10 +70,10 @@ public class JInternalFrameDraggingTest {
             BufferedImage img = robot.createScreenCapture(rect);
 
             int testRGB = BACKGROUND_COLOR.getRGB();
+            Color testColor = new Color(testRGB);
             for (int i = 1; i < size; i++) {
                 int rgbCW = img.getRGB(i, size / 2);
                 int rgbCH = img.getRGB(size / 2, i);
-                Color testColor = new Color(rgbCW);
                 Color rgbCWColor = new Color(rgbCW);
                 Color rgbCHColor = new Color(rgbCH);
 

--- a/test/jdk/javax/swing/JInternalFrame/8160248/JInternalFrameDraggingTest.java
+++ b/test/jdk/javax/swing/JInternalFrame/8160248/JInternalFrameDraggingTest.java
@@ -23,7 +23,6 @@
 
 import java.io.File;
 import java.awt.BorderLayout;
-import java.awt.image.BufferedImage;
 import java.awt.Color;
 import java.awt.Point;
 import java.awt.Rectangle;

--- a/test/jdk/javax/swing/JInternalFrame/8160248/JInternalFrameDraggingTest.java
+++ b/test/jdk/javax/swing/JInternalFrame/8160248/JInternalFrameDraggingTest.java
@@ -81,10 +81,6 @@ public class JInternalFrameDraggingTest {
                 Color rgbCWColor = new Color(rgbCW);
                 Color rgbCHColor = new Color(rgbCH);
 
-                    System.out.println("i " + i + " rgbCW " +
-                                       Integer.toHexString(rgbCW) +
-                                       " testRGB " + Integer.toHexString(testRGB) +
-                                       " rgbCH " + Integer.toHexString(rgbCH));
                 if (Math.abs(rgbCWColor.getRed() - testColor.getRed()) > tolerance
                     || Math.abs(rgbCWColor.getGreen() - testColor.getGreen()) > tolerance
                     || Math.abs(rgbCWColor.getBlue() - testColor.getBlue()) > tolerance

--- a/test/jdk/javax/swing/JInternalFrame/8160248/JInternalFrameDraggingTest.java
+++ b/test/jdk/javax/swing/JInternalFrame/8160248/JInternalFrameDraggingTest.java
@@ -25,7 +25,6 @@ import java.io.File;
 import java.awt.BorderLayout;
 import java.awt.image.BufferedImage;
 import java.awt.Color;
-import java.awt.Graphics2D;
 import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.Robot;

--- a/test/jdk/javax/swing/JInternalFrame/8160248/JInternalFrameDraggingTest.java
+++ b/test/jdk/javax/swing/JInternalFrame/8160248/JInternalFrameDraggingTest.java
@@ -1,5 +1,3 @@
-/*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,6 +49,7 @@ public class JInternalFrameDraggingTest {
     private static JInternalFrame internalFrame;
     private static int FRAME_SIZE = 500;
     private static Color BACKGROUND_COLOR = Color.ORANGE;
+    private static final int tolerance = 10;
 
     public static void main(String[] args) throws Exception {
         try {
@@ -72,7 +71,16 @@ public class JInternalFrameDraggingTest {
             for (int i = 1; i < size; i++) {
                 int rgbCW = img.getRGB(i, size / 2);
                 int rgbCH = img.getRGB(size / 2, i);
-                if (rgbCW != testRGB || rgbCH != testRGB) {
+                Color testColor = new Color(rgbCW);
+                Color rgbCWColor = new Color(rgbCW);
+                Color rgbCHColor = new Color(rgbCH);
+
+                if (Math.abs(rgbCWColor.getRed() - testColor.getRed()) > tolerance
+                    || Math.abs(rgbCWColor.getGreen() - testColor.getGreen()) > tolerance
+                    || Math.abs(rgbCWColor.getBlue() - testColor.getBlue()) > tolerance
+                    || Math.abs(rgbCHColor.getRed() - testColor.getRed()) > tolerance
+                    || Math.abs(rgbCHColor.getGreen() - testColor.getGreen()) > tolerance
+                    || Math.abs(rgbCHColor.getBlue() - testColor.getBlue()) > tolerance) {
                     System.out.println("i " + i + " rgbCW " +
                                        Integer.toHexString(rgbCW) +
                                        " testRGB " + Integer.toHexString(testRGB) +

--- a/test/jdk/javax/swing/JInternalFrame/8160248/JInternalFrameDraggingTest.java
+++ b/test/jdk/javax/swing/JInternalFrame/8160248/JInternalFrameDraggingTest.java
@@ -1,3 +1,5 @@
+/*
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/javax/swing/JInternalFrame/8160248/JInternalFrameDraggingTest.java
+++ b/test/jdk/javax/swing/JInternalFrame/8160248/JInternalFrameDraggingTest.java
@@ -21,6 +21,7 @@
  * questions.
  */
 
+import java.io.File;
 import java.awt.BorderLayout;
 import java.awt.image.BufferedImage;
 import java.awt.Color;
@@ -30,6 +31,7 @@ import java.awt.Rectangle;
 import java.awt.Robot;
 import java.awt.event.InputEvent;
 import java.awt.image.BufferedImage;
+import javax.imageio.ImageIO;
 import javax.swing.JDesktopPane;
 import javax.swing.JFrame;
 import javax.swing.JInternalFrame;
@@ -68,21 +70,32 @@ public class JInternalFrameDraggingTest {
 
             Point p = getDesktopPaneLocation();
             int size = translate / 2;
-            BufferedImage bi = new BufferedImage(size, size, BufferedImage.TYPE_INT_ARGB);
-            final Graphics2D graphics = bi.createGraphics();
-            desktopPane.paint(graphics);
-            graphics.dispose();
+            Rectangle rect = new Rectangle(p.x, p.y, size, size);
+            BufferedImage img = robot.createScreenCapture(rect);
 
             int testRGB = BACKGROUND_COLOR.getRGB();
+            Color testColor = new Color(testRGB);
             for (int i = 1; i < size; i++) {
-                int rgbCW = bi.getRGB(i, size / 2);
-                int rgbCH = bi.getRGB(size / 2, i);
+                int rgbCW = img.getRGB(i, size / 2);
+                int rgbCH = img.getRGB(size / 2, i);
+                Color rgbCWColor = new Color(rgbCW);
+                Color rgbCHColor = new Color(rgbCH);
 
-                if (rgbCW != testRGB || rgbCH != testRGB) {
                     System.out.println("i " + i + " rgbCW " +
                                        Integer.toHexString(rgbCW) +
                                        " testRGB " + Integer.toHexString(testRGB) +
                                        " rgbCH " + Integer.toHexString(rgbCH));
+                if (Math.abs(rgbCWColor.getRed() - testColor.getRed()) > tolerance
+                    || Math.abs(rgbCWColor.getGreen() - testColor.getGreen()) > tolerance
+                    || Math.abs(rgbCWColor.getBlue() - testColor.getBlue()) > tolerance
+                    || Math.abs(rgbCHColor.getRed() - testColor.getRed()) > tolerance
+                    || Math.abs(rgbCHColor.getGreen() - testColor.getGreen()) > tolerance
+                    || Math.abs(rgbCHColor.getBlue() - testColor.getBlue()) > tolerance) {
+                    System.out.println("i " + i + " rgbCW " +
+                                       Integer.toHexString(rgbCW) +
+                                       " testRGB " + Integer.toHexString(testRGB) +
+                                       " rgbCH " + Integer.toHexString(rgbCH));
+                    ImageIO.write(img, "png", new File("JInternalFrameDraggingTest.png"));
                     throw new RuntimeException("Background color is wrong!");
                 }
             }


### PR DESCRIPTION
Test compares specific pixels with expected color and needed color profile setting in macOS26 is not available it seems.
Since the pixel color difference is slightly off, I have added a tolerance which had been present in many other tests so it's not without precedent

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8365425](https://bugs.openjdk.org/browse/JDK-8365425): [macos26] javax/swing/JInternalFrame/8160248/JInternalFrameDraggingTest.java fails on macOS 26 (**Bug** - P4)


### Reviewers
 * [Damon Nguyen](https://openjdk.org/census#dnguyen) (@DamonGuy - Committer)
 * [Alexander Zuev](https://openjdk.org/census#kizune) (@azuev-java - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26833/head:pull/26833` \
`$ git checkout pull/26833`

Update a local copy of the PR: \
`$ git checkout pull/26833` \
`$ git pull https://git.openjdk.org/jdk.git pull/26833/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26833`

View PR using the GUI difftool: \
`$ git pr show -t 26833`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26833.diff">https://git.openjdk.org/jdk/pull/26833.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26833#issuecomment-3199370812)
</details>
