### PR TITLE
8365689: Elements.getFileObjectOf fails with a NullPointerException when an erroneous Element is passed in

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/model/JavacElements.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/model/JavacElements.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/model/JavacElements.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/model/JavacElements.java
@@ -800,6 +800,7 @@ public class JavacElements implements Elements {
                 yield msym.module_info.classfile;
             }
             case TYP -> ((ClassSymbol) sym).classfile;
+            case ERR -> null;
             default -> sym.enclClass().classfile;
         };
     }


### PR DESCRIPTION
If an erroneous/unresolvable `Element` is passed to `Elements.getFileObjectOf`, it fails with an NPE like:
```
Caused by: java.lang.NullPointerException: Cannot read field "classfile" because the return value of "com.sun.tools.javac.code.Symbol.enclClass()" is null
at jdk.compiler/com.sun.tools.javac.model.JavacElements.getFileObjectOf(JavacElements.java:803)
at TestFileObjectOf$PrintFiles.handleDeclaration(TestFileObjectOf.java:329)
at jdk.compiler/com.sun.tools.javac.tree.JCTree$JCIdent.accept(JCTree.java:2718)
```

The reason is the `Symbol.enclClass()` will return `null` for the erroneous `Element`. The proposed solution herein is to return `null` for erroneous/unresolvable `Element`s.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 2 [Reviewers](https://openjdk.org/bylaws#reviewer))

### Issue
 * [JDK-8365689](https://bugs.openjdk.org/browse/JDK-8365689): Elements.getFileObjectOf fails with a NullPointerException when an erroneous Element is passed in (**Bug** - P3)


### Reviewers
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - **Reviewer**)
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26836/head:pull/26836` \
`$ git checkout pull/26836`

Update a local copy of the PR: \
`$ git checkout pull/26836` \
`$ git pull https://git.openjdk.org/jdk.git pull/26836/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26836`

View PR using the GUI difftool: \
`$ git pr show -t 26836`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26836.diff">https://git.openjdk.org/jdk/pull/26836.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26836#issuecomment-3199606019)
</details>
