### PR TITLE
8365700: Jar --validate without any --file option leaves around a temporary file /tmp/tmpJar<number>.jar

### DIFF
--- a/src/jdk.jartool/share/classes/sun/tools/jar/Main.java
+++ b/src/jdk.jartool/share/classes/sun/tools/jar/Main.java
@@ -420,7 +420,8 @@ public class Main {
                 if (fname != null) {
                     file = new File(fname);
                 } else {
-                    file = createTemporaryFile("tmpJar", ".jar");
+                    tmpFile = createTemporaryFile("tmpJar", ".jar");
+                    file = tmpFile;
                     try (InputStream in = new FileInputStream(FileDescriptor.in);
                          OutputStream os = Files.newOutputStream(file.toPath())) {
                         in.transferTo(os);


### PR DESCRIPTION
The jtreg test tools/jar/JarNoFileArgOperations.java seems to create files like /tmp/tmpJar12065714313154611400.jar in the file system and keeps them there after the test finishes (also in case of SUCCESS) .
This has been observed at least on Linux and AIX .

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8365700](https://bugs.openjdk.org/browse/JDK-8365700): Jar --validate without any --file option leaves around a temporary file /tmp/tmpJar&lt;number&gt;.jar (**Bug** - P4)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Andreas Steiner](https://openjdk.org/census#asteiner) (@ansteiner - Author)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26837/head:pull/26837` \
`$ git checkout pull/26837`

Update a local copy of the PR: \
`$ git checkout pull/26837` \
`$ git pull https://git.openjdk.org/jdk.git pull/26837/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26837`

View PR using the GUI difftool: \
`$ git pr show -t 26837`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26837.diff">https://git.openjdk.org/jdk/pull/26837.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26837#issuecomment-3199671771)
</details>
