### PR TITLE
8365206: RISC-V: compiler/c2/irTests/TestFloat16ScalarOperations.java is failing on riscv64

### DIFF
--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
@@ -2391,18 +2391,7 @@ static void float_to_float16_slow_path(C2_MacroAssembler& masm, C2GeneralStub<Re
   Register tmp = stub.data<2>();
   __ bind(stub.entry());
 
-  __ fmv_x_w(dst, src);
-
-  // preserve the payloads of non-canonical NaNs.
-  __ srai(dst, dst, 13);
-  // preserve the sign bit.
-  __ srai(tmp, dst, 13);
-  __ slli(tmp, tmp, 10);
-  __ mv(t0, 0x3ff);
-  __ orr(tmp, tmp, t0);
-
-  // get the result by merging sign bit and payloads of preserved non-canonical NaNs.
-  __ andr(dst, dst, tmp);
+  __ float_to_float16_NaN(src, dst, t0, t1);
 
   __ j(stub.continuation());
 #undef __
@@ -2410,7 +2399,7 @@ static void float_to_float16_slow_path(C2_MacroAssembler& masm, C2GeneralStub<Re
 
 // j.l.Float.floatToFloat16
 void C2_MacroAssembler::float_to_float16(Register dst, FloatRegister src, FloatRegister ftmp, Register xtmp) {
-  auto stub = C2CodeStub::make<Register, FloatRegister, Register>(dst, src, xtmp, 130, float_to_float16_slow_path);
+  auto stub = C2CodeStub::make<Register, FloatRegister, Register>(dst, src, xtmp, 64, float_to_float16_slow_path);
 
   // On riscv, NaN needs a special process as fcvt does not work in that case.
 

--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
@@ -2391,7 +2391,7 @@ static void float_to_float16_slow_path(C2_MacroAssembler& masm, C2GeneralStub<Re
   Register tmp = stub.data<2>();
   __ bind(stub.entry());
 
-  __ float_to_float16_NaN(src, dst, t0, t1);
+  __ float_to_float16_NaN(dst, src, t0, tmp);
 
   __ j(stub.continuation());
 #undef __

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -5959,22 +5959,51 @@ void MacroAssembler::float_to_float16_NaN(Register dst, FloatRegister src,
                                           Register tmp1, Register tmp2) {
   fmv_x_w(dst, src);
 
-  // preserve the sign bit and exponent.
-  srai(tmp2, dst, 26);
-  slli(tmp2, tmp2, 10);
+//  Float (32 bits)
+//    Bit:     31        30 to 23          22 to 0
+//          +---+------------------+-----------------------------+
+//          | S |     Exponent     |      Mantissa (Fraction)    |
+//          +---+------------------+-----------------------------+
+//          1 bit       8 bits                  23 bits
+//
+//  Float (16 bits)
+//    Bit:    15        14 to 10         9 to 0
+//          +---+----------------+------------------+
+//          | S |    Exponent    |     Mantissa     |
+//          +---+----------------+------------------+
+//          1 bit      5 bits          10 bits
+  const int fp_sign_bits = 1;
+  const int fp32_bits = 32;
+  const int fp32_exponent_bits = 8;
+  const int fp32_mantissa_1st_part_bits = 10;
+  const int fp32_mantissa_2nd_part_bits = 9;
+  const int fp32_mantissa_3rd_part_bits = 4;
+  const int fp16_exponent_bits = 5;
+  const int fp16_mantissa_bits = 10;
+
+  // preserve the sign bit and exponent, clear mantissa.
+  srai(tmp2, dst, fp32_bits - fp_sign_bits - fp16_exponent_bits);
+  slli(tmp2, tmp2, fp16_mantissa_bits);
 
   // Preserve high order bit of float NaN in the
   // binary16 result NaN (tenth bit); OR in remaining
   // bits into lower 9 bits of binary 16 significand.
+  //   | (doppel & 0x007f_e000) >> 13 // 10 bits
+  //   | (doppel & 0x0000_1ff0) >> 4  //  9 bits
+  //   | (doppel & 0x0000_000f));     //  4 bits
   //
   // Check j.l.Float.floatToFloat16 for more information.
   // 10 bits
-  slli(tmp1, dst, 9+32);
-  srli(tmp1, tmp1, 9+32+13);
+  int left_shift = fp_sign_bits + fp32_exponent_bits + 32;
+  int right_shift = left_shift + fp32_mantissa_2nd_part_bits + fp32_mantissa_3rd_part_bits;
+  slli(tmp1, dst, left_shift);
+  srli(tmp1, tmp1, right_shift);
   orr(tmp2, tmp2, tmp1);
   // 9 bits
-  slli(tmp1, dst, 19+32);
-  srli(tmp1, tmp1, 19+32+4);
+  left_shift += fp32_mantissa_1st_part_bits;
+  right_shift = left_shift + fp32_mantissa_3rd_part_bits;
+  slli(tmp1, dst, left_shift);
+  srli(tmp1, tmp1, right_shift);
   orr(tmp2, tmp2, tmp1);
   // 4 bits
   andi(tmp1, dst, 0xf);

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -5954,9 +5954,8 @@ void MacroAssembler::java_round_double(Register dst, FloatRegister src, FloatReg
   bind(done);
 }
 
-// this is a utility method to process the slow path of NaN when converting float to float16
-// check j.l.Float.floatToFloat16
-void MacroAssembler::float_to_float16_NaN(FloatRegister src, Register dst,
+// Helper routine processing the slow path of NaN when converting float to float16
+void MacroAssembler::float_to_float16_NaN(Register dst, FloatRegister src,
                                           Register tmp1, Register tmp2) {
   fmv_x_w(dst, src);
 
@@ -5964,8 +5963,11 @@ void MacroAssembler::float_to_float16_NaN(FloatRegister src, Register dst,
   srai(tmp2, dst, 26);
   slli(tmp2, tmp2, 10);
 
-  // preserve the payloads of non-canonical NaNs.
-  // get the result by merging sign bit and payloads of preserved non-canonical NaNs.
+  // Preserve high order bit of float NaN in the
+  // binary16 result NaN (tenth bit); OR in remaining
+  // bits into lower 9 bits of binary 16 significand.
+  //
+  // check j.l.Float.floatToFloat16 for more information.
   slli(tmp1, dst, 9+32);
   srli(tmp1, tmp1, 9+32+13);
   orr(tmp2, tmp2, tmp1);

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -5967,13 +5967,16 @@ void MacroAssembler::float_to_float16_NaN(Register dst, FloatRegister src,
   // binary16 result NaN (tenth bit); OR in remaining
   // bits into lower 9 bits of binary 16 significand.
   //
-  // check j.l.Float.floatToFloat16 for more information.
+  // Check j.l.Float.floatToFloat16 for more information.
+  // 10 bits
   slli(tmp1, dst, 9+32);
   srli(tmp1, tmp1, 9+32+13);
   orr(tmp2, tmp2, tmp1);
+  // 9 bits
   slli(tmp1, dst, 19+32);
   srli(tmp1, tmp1, 19+32+4);
   orr(tmp2, tmp2, tmp1);
+  // 4 bits
   andi(tmp1, dst, 0xf);
   orr(dst, tmp2, tmp1);
 }

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -5959,19 +5959,19 @@ void MacroAssembler::float_to_float16_NaN(Register dst, FloatRegister src,
                                           Register tmp1, Register tmp2) {
   fmv_x_w(dst, src);
 
-//  Float (32 bits)
-//    Bit:     31        30 to 23          22 to 0
-//          +---+------------------+-----------------------------+
-//          | S |     Exponent     |      Mantissa (Fraction)    |
-//          +---+------------------+-----------------------------+
-//          1 bit       8 bits                  23 bits
-//
-//  Float (16 bits)
-//    Bit:    15        14 to 10         9 to 0
-//          +---+----------------+------------------+
-//          | S |    Exponent    |     Mantissa     |
-//          +---+----------------+------------------+
-//          1 bit      5 bits          10 bits
+  //  Float (32 bits)
+  //    Bit:     31        30 to 23          22 to 0
+  //          +---+------------------+-----------------------------+
+  //          | S |     Exponent     |      Mantissa (Fraction)    |
+  //          +---+------------------+-----------------------------+
+  //          1 bit       8 bits                  23 bits
+  //
+  //  Float (16 bits)
+  //    Bit:    15        14 to 10         9 to 0
+  //          +---+----------------+------------------+
+  //          | S |    Exponent    |     Mantissa     |
+  //          +---+----------------+------------------+
+  //          1 bit      5 bits          10 bits
   const int fp_sign_bits = 1;
   const int fp32_bits = 32;
   const int fp32_exponent_bits = 8;

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -1431,6 +1431,9 @@ public:
   void java_round_float(Register dst, FloatRegister src, FloatRegister ftmp);
   void java_round_double(Register dst, FloatRegister src, FloatRegister ftmp);
 
+  // this is a utility method to process the slow path of NaN when converting float to float16
+  void float_to_float16_NaN(FloatRegister src, Register dst, Register tmp1, Register tmp2);
+
   // vector load/store unit-stride instructions
   void vlex_v(VectorRegister vd, Register base, Assembler::SEW sew, VectorMask vm = unmasked) {
     switch (sew) {

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -1431,8 +1431,8 @@ public:
   void java_round_float(Register dst, FloatRegister src, FloatRegister ftmp);
   void java_round_double(Register dst, FloatRegister src, FloatRegister ftmp);
 
-  // this is a utility method to process the slow path of NaN when converting float to float16
-  void float_to_float16_NaN(FloatRegister src, Register dst, Register tmp1, Register tmp2);
+  // Helper routine processing the slow path of NaN when converting float to float16
+  void float_to_float16_NaN(Register dst, FloatRegister src, Register tmp1, Register tmp2);
 
   // vector load/store unit-stride instructions
   void vlex_v(VectorRegister vd, Register base, Assembler::SEW sew, VectorMask vm = unmasked) {

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -8554,7 +8554,7 @@ instruct convF2HF_reg_reg(iRegINoSp dst, fRegF src, fRegF ftmp, iRegINoSp xtmp) 
 instruct reinterpretS2HF(fRegF dst, iRegI src)
 %{
   match(Set dst (ReinterpretS2HF src));
-  format %{ "fmv.h.x $dst, $src" %}
+  format %{ "fmv.h.x $dst, $src\t# reinterpretS2HF" %}
   ins_encode %{
     __ fmv_h_x($dst$$FloatRegister, $src$$Register);
   %}
@@ -8574,7 +8574,7 @@ instruct convF2HFAndS2HF(fRegF dst, fRegF src)
 instruct reinterpretHF2S(iRegINoSp dst, fRegF src)
 %{
   match(Set dst (ReinterpretHF2S src));
-  format %{ "fmv.x.h $dst, $src" %}
+  format %{ "fmv.x.h $dst, $src\t# reinterpretHF2S" %}
   ins_encode %{
     __ fmv_x_h($dst$$Register, $src$$FloatRegister);
   %}

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -6358,7 +6358,7 @@ class StubGenerator: public StubCodeGenerator {
 
     __ bind(NaN_SLOW);
 
-    __ float_to_float16_NaN(src, dst, t0, t1);
+    __ float_to_float16_NaN(dst, src, t0, t1);
 
     __ ret();
     return entry;

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -6357,18 +6357,8 @@ class StubGenerator: public StubCodeGenerator {
     __ ret();
 
     __ bind(NaN_SLOW);
-    __ fmv_x_w(dst, src);
 
-    // preserve the payloads of non-canonical NaNs.
-    __ srai(dst, dst, 13);
-    // preserve the sign bit.
-    __ srai(t1, dst, 13);
-    __ slli(t1, t1, 10);
-    __ mv(t0, 0x3ff);
-    __ orr(t1, t1, t0);
-
-    // get the result by merging sign bit and payloads of preserved non-canonical NaNs.
-    __ andr(dst, dst, t1);
+    __ float_to_float16_NaN(src, dst, t0, t1);
 
     __ ret();
     return entry;

--- a/test/hotspot/jtreg/compiler/intrinsics/float16/Binary16ConversionNaN_2.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/float16/Binary16ConversionNaN_2.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, Rivos Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8365206
+ * @summary Verify NaN sign and significand bits are preserved across conversions,
+ *          float -> float16 -> float
+ * @requires (os.arch == "riscv64" & vm.cpu.features ~= ".*zfh.*")
+ * @requires vm.compiler1.enabled & vm.compiler2.enabled
+ * @requires vm.compMode != "Xcomp"
+ * @library /test/lib /
+ *
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *                   -Xmixed -XX:-BackgroundCompilation -XX:-UseOnStackReplacement
+ *                   -XX:CompileThresholdScaling=1000.0 Binary16ConversionNaN_2
+ */
+
+/*
+ * The behavior tested below is an implementation property not
+ * required by the specification. It would be acceptable for this
+ * information to not be preserved (as long as a NaN is returned) if,
+ * say, a intrinsified version using native hardware instructions
+ * behaved differently.
+ *
+ * If that is the case, this test should be modified to disable
+ * intrinsics or to otherwise not run on platforms with an differently
+ * behaving intrinsic.
+ */
+
+import compiler.whitebox.CompilerWhiteBoxTest;
+import jdk.test.whitebox.WhiteBox;
+import java.lang.reflect.Method;
+import java.util.Random;
+
+public class Binary16ConversionNaN_2 {
+
+    private static final WhiteBox WHITE_BOX = WhiteBox.getWhiteBox();
+
+    /*
+     * Put all 16-bit NaN values through a conversion loop and make
+     * sure the significand, sign, and exponent are all preserved.
+     */
+    public static void main(String... argv) throws NoSuchMethodException {
+        int errors = 0;
+        final int NAN_EXPONENT = 0x7f80_0000;
+        final int SIGN_BIT     = 0x8000_0000;
+
+        // First, run with Interpreter only to  collect "gold" data.
+        // Glags -Xmixed -XX:CompileThresholdScaling=1000.0 are used
+        // to prevent compilation during this phase.
+        float[] pVal = new float[1024];
+        float[] pRes = new float[1024];
+        float[] nVal = new float[1024];
+        float[] nRes = new float[1024];
+
+        Random rand = new Random();
+
+        // A NaN has a nonzero significand
+        for (int i = 1; i <= 0x3ff; i++) {
+            int shift = rand.nextInt(13+1);
+            int binaryNaN = (NAN_EXPONENT | (i << shift));
+            assert isNaN(binaryNaN);
+            // the payloads of non-canonical NaNs are preserved.
+            float f1 = Float.intBitsToFloat(binaryNaN);
+            float f2 = testRoundTrip(f1);
+            errors  += verify(f1, f2);
+            pVal[i] = f1;
+            pRes[i] = f2;
+
+            int binaryNegNaN = (SIGN_BIT | binaryNaN);
+            float f3 = Float.intBitsToFloat(binaryNegNaN);
+            float f4 = testRoundTrip(f3);
+            errors  += verify(f3, f4);
+            nVal[i] = f3;
+            nRes[i] = f4;
+        }
+        if (errors > 0) { // Exit if Interpreter failed
+            throw new RuntimeException(errors + " errors");
+        }
+
+        Method test_method = Binary16ConversionNaN_2.class.getDeclaredMethod("testRoundTrip", float.class);
+
+        // Compile with C1 and compare results
+        WHITE_BOX.enqueueMethodForCompilation(test_method, CompilerWhiteBoxTest.COMP_LEVEL_SIMPLE);
+        if (!WHITE_BOX.isMethodCompiled(test_method)) {
+            throw new RuntimeException("test is not compiled by C1");
+        }
+        for (int i = 1; i <= 0x3ff; i++) {
+            float f1 = testRoundTrip(pVal[i]);
+            errors  += verifyCompiler(pRes[i], f1, "C1");
+            float f2 = testRoundTrip(nVal[i]);
+            errors  += verifyCompiler(nRes[i], f2, "C1");
+        }
+
+        WHITE_BOX.deoptimizeMethod(test_method);
+
+        // Compile with C2 and compare results
+        WHITE_BOX.enqueueMethodForCompilation(test_method, CompilerWhiteBoxTest.COMP_LEVEL_FULL_OPTIMIZATION);
+        if (!WHITE_BOX.isMethodCompiled(test_method)) {
+            throw new RuntimeException("test is not compiled by C2");
+        }
+        for (int i = 1; i <= 0x3ff; i++) {
+            float f1 = testRoundTrip(pVal[i]);
+            errors  += verifyCompiler(pRes[i], f1, "C2");
+            float f2 = testRoundTrip(nVal[i]);
+            errors  += verifyCompiler(nRes[i], f2, "C2");
+        }
+
+        if (errors > 0) {
+            throw new RuntimeException(errors + " errors");
+        }
+    }
+
+    private static boolean isNaN(int binary) {
+        return ((binary & 0x7f80_0000) == 0x7f80_0000) // Max exponent and...
+            && ((binary & 0x007f_ffff) != 0 );         // significand nonzero.
+    }
+
+    private static float testRoundTrip(float f) {
+        short s =  Float.floatToFloat16(f);
+        return Float.float16ToFloat(s);
+    }
+
+    private static int verify(float f1, float f2) {
+        int errors = 0;
+        int i1 = Float.floatToRawIntBits(f1);
+        int i2 = Float.floatToRawIntBits(f2);
+        assert Float.isNaN(f1);
+        if (!Float.isNaN(f2) ||
+            ((i1 & 0x8000_0000) != (i1 & 0x8000_0000))) {
+            errors++;
+            System.out.println("Roundtrip failure on NaN value " +
+                               Integer.toHexString(i1) +
+                               "\t got back " + Integer.toHexString(i2));
+        }
+        return errors;
+    }
+
+    private static int verifyCompiler(float f1, float f2, String name) {
+        int errors = 0;
+        int i1 = Float.floatToRawIntBits(f1);
+        int i2 = Float.floatToRawIntBits(f2);
+        assert Float.isNaN(f1);
+        if (!Float.isNaN(f2) ||
+            ((i1 & 0x8000_0000) != (i1 & 0x8000_0000))) {
+            errors++;
+            System.out.println("Roundtrip failure on NaN value " +
+                               Integer.toHexString(i1) +
+                               "\t got back " + Integer.toHexString(i2) +
+                               "\t from " + name + " code");
+        }
+        return errors;
+    }
+}

--- a/test/hotspot/jtreg/compiler/intrinsics/float16/Binary16ConversionNaN_2.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/float16/Binary16ConversionNaN_2.java
@@ -151,7 +151,7 @@ public class Binary16ConversionNaN_2 {
         int i2 = Float.floatToRawIntBits(f2);
         assert Float.isNaN(f1);
         if (!Float.isNaN(f2) ||
-            ((i1 & 0x8000_0000) != (i1 & 0x8000_0000))) {
+            ((i1 & 0x8000_0000) != (i2 & 0x8000_0000))) {
             errors++;
             System.out.println("Roundtrip failure on NaN value " +
                                Integer.toHexString(i1) +
@@ -166,7 +166,7 @@ public class Binary16ConversionNaN_2 {
         int i2 = Float.floatToRawIntBits(f2);
         assert Float.isNaN(f1);
         if (!Float.isNaN(f2) ||
-            ((i1 & 0x8000_0000) != (i1 & 0x8000_0000))) {
+            ((i1 & 0x8000_0000) != (i2 & 0x8000_0000))) {
             errors++;
             System.out.println("Roundtrip failure on NaN value " +
                                Integer.toHexString(i1) +

--- a/test/hotspot/jtreg/compiler/intrinsics/float16/Binary16ConversionNaN_2.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/float16/Binary16ConversionNaN_2.java
@@ -141,7 +141,7 @@ public class Binary16ConversionNaN_2 {
     }
 
     private static float testRoundTrip(float f) {
-        short s =  Float.floatToFloat16(f);
+        short s = Float.floatToFloat16(f);
         return Float.float16ToFloat(s);
     }
 


### PR DESCRIPTION
Hi,
Can you help to review this patch?

Currently implementation of conversion from float to float16 only preserve some significant bits of a NaN, which is not right in some cases.
As this (NaN conversion from float to float16) is already in the slow path, so I'll just fix it by preserving all significant bits in the same way as j.l.Float.floatToFloat16.
As current tests does not catch the issue, except of TestFloat16ScalarOperations.java, so add another test.

There is also the similar issue in vector version of conversion from float to float16, I'll address it in another pr [JDK-8365772](https://bugs.openjdk.org/browse/JDK-8365772)

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8365206](https://bugs.openjdk.org/browse/JDK-8365206): RISC-V: compiler/c2/irTests/TestFloat16ScalarOperations.java is failing on riscv64 (**Bug** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Dingli Zhang](https://openjdk.org/census#dzhang) (@DingliZhang - Author) Review applies to [80929e94](https://git.openjdk.org/jdk/pull/26838/files/80929e9410adb51141ddc2f51dae24d35c5559ba)
 * [Robbin Ehn](https://openjdk.org/census#rehn) (@robehn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26838/head:pull/26838` \
`$ git checkout pull/26838`

Update a local copy of the PR: \
`$ git checkout pull/26838` \
`$ git pull https://git.openjdk.org/jdk.git pull/26838/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26838`

View PR using the GUI difftool: \
`$ git pr show -t 26838`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26838.diff">https://git.openjdk.org/jdk/pull/26838.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26838#issuecomment-3199765171)
</details>
