### PR TITLE
8356411: Comment tree not reporting correct position for label

### DIFF
--- a/src/jdk.internal.md/share/classes/jdk/internal/markdown/MarkdownTransformer.java
+++ b/src/jdk.internal.md/share/classes/jdk/internal/markdown/MarkdownTransformer.java
@@ -362,7 +362,7 @@ public class MarkdownTransformer implements JavacTrees.DocCommentTreeTransformer
             // leading reference affects the position of the label following it (JDK-8356411),
             var ref = tree.reference;
             var hasReference = !ref.isEmpty() && ref.getFirst().getKind() == DocTree.Kind.REFERENCE;
-            List<DCTree> transformed  = new ArrayList<>();
+            List<DCTree> transformed = new ArrayList<>();
             if (hasReference) {
                 transformed.add(ref.getFirst());
                 transformed.addAll(transform(ref.subList(1, ref.size())));

--- a/src/jdk.internal.md/share/classes/jdk/internal/markdown/MarkdownTransformer.java
+++ b/src/jdk.internal.md/share/classes/jdk/internal/markdown/MarkdownTransformer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -358,10 +358,20 @@ public class MarkdownTransformer implements JavacTrees.DocCommentTreeTransformer
         }
 
         private DCTree.DCSee transform(DCTree.DCSee tree) {
-            List<? extends DocTree> ref2 = transform(tree.reference);
-            return (equal(ref2, tree.getReference()))
+            // Some extra work is required to accommodate various forms of @see tags, as a
+            // leading reference affects the position of the label following it (JDK-8356411),
+            var ref = tree.reference;
+            var hasReference = !ref.isEmpty() && ref.getFirst().getKind() == DocTree.Kind.REFERENCE;
+            List<DCTree> transformed  = new ArrayList<>();
+            if (hasReference) {
+                transformed.add(ref.getFirst());
+                transformed.addAll(transform(ref.subList(1, ref.size())));
+            } else {
+                transformed.addAll(transform(ref));
+            }
+            return (equal(ref, transformed))
                     ? tree
-                    : m.at(tree.pos).newSeeTree(ref2);
+                    : m.at(tree.pos).newSeeTree(transformed);
         }
 
         private DCTree.DCSerial transform(DCTree.DCSerial tree) {

--- a/test/langtools/tools/javac/doctree/DocCommentTester.java
+++ b/test/langtools/tools/javac/doctree/DocCommentTester.java
@@ -128,9 +128,9 @@ public class DocCommentTester {
 
     public final boolean useIdentityTransformer;
 
-    public DocCommentTester(boolean useBreakIterator, boolean useIdentityTtransformer) {
+    public DocCommentTester(boolean useBreakIterator, boolean useIdentityTransformer) {
         this.useBreakIterator = useBreakIterator;
-        this.useIdentityTransformer = useIdentityTtransformer;
+        this.useIdentityTransformer = useIdentityTransformer;
     }
 
     public void run(List<String> args) throws Exception {

--- a/test/langtools/tools/javac/doctree/MarkdownTest.java
+++ b/test/langtools/tools/javac/doctree/MarkdownTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8298405
+ * @bug 8298405 8356411
  * @summary Markdown support in the standard doclet
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.file
@@ -659,5 +659,29 @@ DocComment[DOC_COMMENT, pos:0
 ]
 */
 
+    /// @see Ref label
+    /// @see <a href="..">link<a>
+    /// @see "Text"
+    void seeTags() { }
+/*
+DocComment[DOC_COMMENT, pos:0
+  firstSentence: empty
+  body: empty
+  block tags: 3
+    See[SEE, pos:0
+      reference: 2
+        Reference[REFERENCE, pos:5, Ref]
+        RawText[MARKDOWN, pos:9, label]
+    ]
+    See[SEE, pos:15
+      reference: 1
+        RawText[MARKDOWN, pos:20, <a_href="..">link<a>]
+    ]
+    See[SEE, pos:41
+      reference: 1
+        Text[TEXT, pos:46, "Text"]
+    ]
+]
+*/
 
 }

--- a/test/langtools/tools/javac/doctree/MarkdownTransformerPositionTest.java
+++ b/test/langtools/tools/javac/doctree/MarkdownTransformerPositionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8332858
+ * @bug 8332858 8356411
  * @summary test case for Markdown positions
  * @run main/othervm --limit-modules jdk.compiler MarkdownTransformerPositionTest
  * @run main MarkdownTransformerPositionTest links
@@ -53,6 +53,7 @@ public class MarkdownTransformerPositionTest {
 
         t.simpleTest();
         t.testWithReplacements();
+        t.testSeeTags();
 
         if (args.length > 0 && "links".equals(args[0])) {
             t.linkWithEscapes();
@@ -81,6 +82,19 @@ public class MarkdownTransformerPositionTest {
                 """,
                 "Markdown \uFFFC test \uFFFC with \uFFFC replacements.",
                 "testAuthor");
+    }
+
+    private void testSeeTags() throws Exception {
+        // @see "Text" does not produce a Markdown text
+        runTest("""
+                /// @see Ref label
+                /// @see <a href="..">link<a>
+                /// @see "Text"
+                public class Test {
+                }
+                """,
+                "label",
+                "<a href=\"..\">link<a>");
     }
 
     private void linkWithEscapes() throws Exception {


### PR DESCRIPTION
Please review a change to fix the reported position of the label in `@see` tags in Markdown doc comments. When `MarkdownTransformer` would process the label of a `@see` tag together with the leading reference, it would set the position of the label to the position immediately following the reference, losing the actual source position of the label. The solution is to process the label without the leading reference. 

I have looked for other standard tags that may be affected by similar problems, but the `@see` tag is the only tag that [supports multiple forms](https://docs.oracle.com/en/java/javase/24/docs/specs/javadoc/doc-comment-spec.html#see) where Markdown text is stored in a list together with non-Markdown arguments.

The two tests are slightly redundant, but they test slightly different aspects of the fix and they were easy to implement in their respective frameworks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8356411](https://bugs.openjdk.org/browse/JDK-8356411): Comment tree not reporting correct position for label (**Bug** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26842/head:pull/26842` \
`$ git checkout pull/26842`

Update a local copy of the PR: \
`$ git checkout pull/26842` \
`$ git pull https://git.openjdk.org/jdk.git pull/26842/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26842`

View PR using the GUI difftool: \
`$ git pr show -t 26842`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26842.diff">https://git.openjdk.org/jdk/pull/26842.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26842#issuecomment-3200480638)
</details>
