### PR TITLE
8364382: Remove sun/tools/jstat/jstatLineCountsX.sh from ProblemList on linux-ppc64le and aix due to JDK-8248691

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -750,11 +750,6 @@ java/util/zip/CloseInflaterDeflaterTest.java  8339216 linux-s390x
 
 sun/tools/jstatd/TestJstatdRmiPort.java                         8251259,8293577 generic-all
 
-sun/tools/jstat/jstatLineCounts1.sh                             8248691,8268211 linux-ppc64le,aix-ppc64,linux-aarch64
-sun/tools/jstat/jstatLineCounts2.sh                             8248691,8268211 linux-ppc64le,aix-ppc64,linux-aarch64
-sun/tools/jstat/jstatLineCounts3.sh                             8248691,8268211 linux-ppc64le,aix-ppc64,linux-aarch64
-sun/tools/jstat/jstatLineCounts4.sh                             8248691,8268211 linux-ppc64le,aix-ppc64,linux-aarch64
-
 ############################################################################
 
 # jdk_other


### PR DESCRIPTION
The fix for [JDK-8279005](https://bugs.openjdk.org/browse/JDK-8279005) also fixed [JDK-8248691](https://bugs.openjdk.org/browse/JDK-8248691) and [JDK-8268211](https://bugs.openjdk.org/browse/JDK-8268211), which latter two are closed as dups. So, I've removed all jstatLineCountsX.sh from the ProblemList. I propose this patch is trivial.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8364382](https://bugs.openjdk.org/browse/JDK-8364382): Remove sun/tools/jstat/jstatLineCountsX.sh from ProblemList on linux-ppc64le and aix due to JDK-8248691 (**Sub-task** - P4)


### Reviewers
 * [Evgeny Astigeevich](https://openjdk.org/census#eastigeevich) (@eastig - Committer)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)

### Reviewers without OpenJDK IDs
 * @elifaslan1 (no known openjdk.org user name / role)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26844/head:pull/26844` \
`$ git checkout pull/26844`

Update a local copy of the PR: \
`$ git checkout pull/26844` \
`$ git pull https://git.openjdk.org/jdk.git pull/26844/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26844`

View PR using the GUI difftool: \
`$ git pr show -t 26844`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26844.diff">https://git.openjdk.org/jdk/pull/26844.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26844#issuecomment-3201128523)
</details>
