### PR TITLE
8356218: [macos] Document --app-content

### DIFF
--- a/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/MacApplicationBuilder.java
+++ b/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/MacApplicationBuilder.java
@@ -27,7 +27,6 @@ package jdk.jpackage.internal;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Path;
-import java.text.MessageFormat;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -130,9 +129,8 @@ final class MacApplicationBuilder {
         for (var contentDir : app.contentDirs()) {
             if (!CONTENTS_SUB_DIRS.stream()
                     .anyMatch(subDir -> contentDir.getFileName().toString()
-                                                  .equalsIgnoreCase(subDir))) {
-                Log.info(MessageFormat.format(I18N.getString(
-                        "warning.non.standard.contents.sub.dir"),
+                                                  .equals(subDir))) {
+                Log.info(I18N.format("warning.non.standard.contents.sub.dir",
                         contentDir));
             }
         }

--- a/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/MacApplicationBuilder.java
+++ b/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/MacApplicationBuilder.java
@@ -26,8 +26,10 @@ package jdk.jpackage.internal;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Set;
 import java.util.Objects;
 import java.util.Optional;
 import jdk.jpackage.internal.model.Application;
@@ -127,9 +129,10 @@ final class MacApplicationBuilder {
 
     private static void validateAppContentDirs(Application app) {
         for (var contentDir : app.contentDirs()) {
-            if (!CONTENTS_SUB_DIRS.stream()
-                    .anyMatch(subDir -> contentDir.getFileName().toString()
-                                                  .equals(subDir))) {
+            if (!Files.isDirectory(contentDir)) {
+                Log.info(I18N.format("warning.app.content.is.not.dir",
+                        contentDir));
+            } else if (!CONTENTS_SUB_DIRS.contains(contentDir.getFileName().toString())) {
                 Log.info(I18N.format("warning.non.standard.contents.sub.dir",
                         contentDir));
             }
@@ -248,6 +251,6 @@ final class MacApplicationBuilder {
     private static final int MAX_BUNDLE_NAME_LENGTH = 16;
 
     // List of standard subdirectories of the "Contents" directory
-    private static final List<String> CONTENTS_SUB_DIRS = List.of("MacOS",
+    private static final Set<String> CONTENTS_SUB_DIRS = Set.of("MacOS",
             "Resources", "Frameworks", "PlugIns", "SharedSupport");
 }

--- a/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/MacApplicationBuilder.java
+++ b/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/MacApplicationBuilder.java
@@ -27,6 +27,8 @@ package jdk.jpackage.internal;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Path;
+import java.text.MessageFormat;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import jdk.jpackage.internal.model.Application;
@@ -94,6 +96,7 @@ final class MacApplicationBuilder {
         }
 
         validateAppVersion(app);
+        validateAppContentDirs(app);
 
         final var mixin = new MacApplicationMixin.Stub(validatedIcon(), validatedBundleName(),
                 validatedBundleIdentifier(), validatedCategory(), appStore, createSigningConfig());
@@ -120,6 +123,18 @@ final class MacApplicationBuilder {
             CFBundleVersion.of(app.version());
         } catch (IllegalArgumentException ex) {
             throw I18N.buildConfigException(ex).advice("error.invalid-cfbundle-version.advice").create();
+        }
+    }
+
+    private static void validateAppContentDirs(Application app) {
+        for (var contentDir : app.contentDirs()) {
+            if (!CONTENTS_SUB_DIRS.stream()
+                    .anyMatch(subDir -> contentDir.getFileName().toString()
+                                                  .equalsIgnoreCase(subDir))) {
+                Log.info(MessageFormat.format(I18N.getString(
+                        "warning.non.standard.contents.sub.dir"),
+                        contentDir));
+            }
         }
     }
 
@@ -233,4 +248,8 @@ final class MacApplicationBuilder {
     private static final Defaults DEFAULTS = new Defaults("utilities");
 
     private static final int MAX_BUNDLE_NAME_LENGTH = 16;
+
+    // List of standard subdirectories of the "Contents" directory
+    private static final List<String> CONTENTS_SUB_DIRS = List.of("MacOS",
+            "Resources", "Frameworks", "PlugIns", "SharedSupport");
 }

--- a/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/resources/MacResources.properties
+++ b/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/resources/MacResources.properties
@@ -85,3 +85,4 @@ message.codesign.failed.reason.app.content="codesign" failed and additional appl
 message.codesign.failed.reason.xcode.tools=Possible reason for "codesign" failure is missing Xcode with command line developer tools. Install Xcode with command line developer tools to see if it resolves the problem.
 warning.unsigned.app.image=Warning: Using unsigned app-image to build signed {0}.
 warning.per.user.app.image.signed=Warning: Support for per-user configuration of the installed application will not be supported due to missing "{0}" in predefined signed application image.
+warning.non.standard.contents.sub.dir=Warning: --app-content value "{0}" points to the non-standard subdirectory in the "Contents" directory of the application bundle.

--- a/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/resources/MacResources.properties
+++ b/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/resources/MacResources.properties
@@ -85,4 +85,5 @@ message.codesign.failed.reason.app.content="codesign" failed and additional appl
 message.codesign.failed.reason.xcode.tools=Possible reason for "codesign" failure is missing Xcode with command line developer tools. Install Xcode with command line developer tools to see if it resolves the problem.
 warning.unsigned.app.image=Warning: Using unsigned app-image to build signed {0}.
 warning.per.user.app.image.signed=Warning: Support for per-user configuration of the installed application will not be supported due to missing "{0}" in predefined signed application image.
-warning.non.standard.contents.sub.dir=Warning: --app-content value "{0}" points to the non-standard subdirectory in the "Contents" directory of the application bundle. As a result jpackage may produce invalid application bundle which may fail code signing and/or notarization.
+warning.non.standard.contents.sub.dir=Warning: The file name of the directory "{0}" specified for the --app-content option is not a standard subdirectory name in the "Contents" directory of the application bundle. The result application bundle may fail code signing and/or notarization.
+warning.app.content.is.not.dir=Warning: The value "{0}" of the --app-content option is not a directory. The result application bundle may fail code signing and/or notarization.

--- a/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/resources/MacResources.properties
+++ b/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/resources/MacResources.properties
@@ -85,4 +85,4 @@ message.codesign.failed.reason.app.content="codesign" failed and additional appl
 message.codesign.failed.reason.xcode.tools=Possible reason for "codesign" failure is missing Xcode with command line developer tools. Install Xcode with command line developer tools to see if it resolves the problem.
 warning.unsigned.app.image=Warning: Using unsigned app-image to build signed {0}.
 warning.per.user.app.image.signed=Warning: Support for per-user configuration of the installed application will not be supported due to missing "{0}" in predefined signed application image.
-warning.non.standard.contents.sub.dir=Warning: --app-content value "{0}" points to the non-standard subdirectory in the "Contents" directory of the application bundle.
+warning.non.standard.contents.sub.dir=Warning: --app-content value "{0}" points to the non-standard subdirectory in the "Contents" directory of the application bundle. As a result jpackage may produce invalid application bundle which may fail code signing and/or notarization.

--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/CLIHelp.java
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/CLIHelp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -55,6 +55,7 @@ public class CLIHelp {
             String pInstallDir;
             String pAppImageDescription;
             String pSignSampleUsage;
+            String pAppContentNote;
             switch (platform) {
                 case MACOS:
                     types = "{\"app-image\", \"dmg\", \"pkg\"}";
@@ -66,6 +67,8 @@ public class CLIHelp {
                             = I18N.getString("MSG_Help_mac_app_image");
                     pSignSampleUsage
                             = I18N.getString("MSG_Help_mac_sign_sample_usage");
+                    pAppContentNote
+                            = I18N.getString("MSG_Help_mac_app_content_note");
                     break;
                 case LINUX:
                     types = "{\"app-image\", \"rpm\", \"deb\"}";
@@ -76,6 +79,7 @@ public class CLIHelp {
                     pAppImageDescription
                             = I18N.getString("MSG_Help_default_app_image");
                     pSignSampleUsage = "";
+                    pAppContentNote = "";
                     break;
                 case WINDOWS:
                     types = "{\"app-image\", \"exe\", \"msi\"}";
@@ -86,6 +90,7 @@ public class CLIHelp {
                     pAppImageDescription
                             = I18N.getString("MSG_Help_default_app_image");
                     pSignSampleUsage = "";
+                    pAppContentNote = "";
                     break;
                 default:
                     types = "{\"app-image\", \"exe\", \"msi\", \"rpm\", \"deb\", \"pkg\", \"dmg\"}";
@@ -99,12 +104,13 @@ public class CLIHelp {
                     pAppImageDescription
                             = I18N.getString("MSG_Help_default_app_image");
                     pSignSampleUsage = "";
+                    pAppContentNote = "";
                     break;
             }
             Log.info(MessageFormat.format(I18N.getString("MSG_Help"),
                     File.pathSeparator, types, pLaunchOptions,
                     pInstallOptions, pInstallDir, pAppImageDescription,
-                    pSignSampleUsage));
+                    pSignSampleUsage, pAppContentNote));
         }
     }
 }

--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/resources/HelpResources.properties
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/resources/HelpResources.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -133,7 +133,7 @@ Generic Options:\n\
 \          A comma separated list of paths to files and/or directories\n\
 \          to add to the application payload.\n\
 \          This option can be used more than once.\n\
-\n\
+{7}\n\
 \Options for creating the application launcher(s):\n\
 \  --add-launcher <launcher name>=<file path>\n\
 \          Name of launcher, and a path to a Properties file that contains\n\
@@ -334,3 +334,10 @@ MSG_Help_mac_sign_sample_usage=\
 \            --mac-sign [<additional signing options>...]\n\
 \        Note: the only additional options that are permitted in this mode are:\n\
 \              the set of additional mac signing options and --verbose\n\
+
+MSG_Help_mac_app_content_note=\
+\          Note: The value should be a directory with the "Resources"\n\
+\          subdirectory (or any other directory that is valid in the "Contents"\n\
+\          directory of the application bundle). Otherwise, jpackage may produce\n\
+\          invalid application bundle which may fail code signing and/or\n\
+\          notarization.\n\

--- a/src/jdk.jpackage/share/man/jpackage.md
+++ b/src/jdk.jpackage/share/man/jpackage.md
@@ -190,6 +190,12 @@ The `jpackage` tool will take as input a Java application and a Java run-time im
 
     This option can be used more than once.
 
+    macOS note: The value should be a directory with the "Resources"
+                subdirectory (or any other directory that is valid in the
+                "Contents" directory of the application bundle). Otherwise,
+                jpackage may produce invalid application bundle which may fail
+                code signing and/or notarization.
+
 ### Options for creating the application launcher(s):
 
 

--- a/test/jdk/tools/jpackage/share/AppContentTest.java
+++ b/test/jdk/tools/jpackage/share/AppContentTest.java
@@ -33,12 +33,12 @@ import jdk.jpackage.test.TKit;
 import jdk.jpackage.test.Annotations.Test;
 import jdk.jpackage.test.Annotations.Parameter;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.List;
 import java.util.stream.Stream;
 import jdk.jpackage.internal.util.FileUtils;
 import jdk.jpackage.internal.util.function.ThrowingFunction;
 import jdk.jpackage.test.JPackageCommand;
+import jdk.jpackage.test.JPackageStringBundle;
 
 
 /**
@@ -114,6 +114,21 @@ public class AppContentTest {
             })
             .setExpectedExitCode(expectedJPackageExitCode)
             .run();
+    }
+
+    @Test(ifOS = MACOS)
+    @Parameter({TEST_DIR, "warning.non.standard.contents.sub.dir"})
+    @Parameter({TEST_DUKE, "warning.app.content.is.not.dir"})
+    public void testWarnings(String... args) throws Exception {
+        final var testPathArg = TKit.TEST_SRC_ROOT.resolve(args[0]);
+        final var expectedWarning = JPackageStringBundle.MAIN.cannedFormattedString(
+                args[1], testPathArg);
+
+        JPackageCommand.helloAppImage()
+            .addArguments("--app-content", testPathArg)
+            .validateOutput(expectedWarning)
+            .setIgnoreExitCode(true)
+            .execute();
     }
 
     private static Path getAppContentRoot(JPackageCommand cmd) {

--- a/test/jdk/tools/jpackage/share/AppContentTest.java
+++ b/test/jdk/tools/jpackage/share/AppContentTest.java
@@ -119,16 +119,15 @@ public class AppContentTest {
     @Test(ifOS = MACOS)
     @Parameter({TEST_DIR, "warning.non.standard.contents.sub.dir"})
     @Parameter({TEST_DUKE, "warning.app.content.is.not.dir"})
-    public void testWarnings(String... args) throws Exception {
-        final var testPathArg = TKit.TEST_SRC_ROOT.resolve(args[0]);
+    public void testWarnings(String testPath, String warningId) throws Exception {
+        final var appContentValue = TKit.TEST_SRC_ROOT.resolve(testPath);
         final var expectedWarning = JPackageStringBundle.MAIN.cannedFormattedString(
-                args[1], testPathArg);
+                warningId, appContentValue);
 
         JPackageCommand.helloAppImage()
-            .addArguments("--app-content", testPathArg)
+            .addArguments("--app-content", appContentValue)
             .validateOutput(expectedWarning)
-            .setIgnoreExitCode(true)
-            .execute();
+            .executeIgnoreExitCode();
     }
 
     private static Path getAppContentRoot(JPackageCommand cmd) {

--- a/test/jdk/tools/jpackage/share/ErrorTest.java
+++ b/test/jdk/tools/jpackage/share/ErrorTest.java
@@ -88,7 +88,13 @@ public final class ErrorTest {
 
             return appImageCmd.outputBundle().toString();
         }),
-        ADD_LAUNCHER_PROPERTY_FILE;
+        ADD_LAUNCHER_PROPERTY_FILE,
+        APP_CONTENT_NON_STANDARD_DIR(cmd -> {
+            final var appContentDir
+                    = TKit.createTempDirectory("app-content-non-standard-dir");
+
+            return TKit.createTempFile(appContentDir.resolve("Foo.txt"));
+        });
 
         private Token() {
             this.valueSupplier = Optional.empty();
@@ -606,7 +612,11 @@ public final class ErrorTest {
                 testSpec().nativeType().addArgs("--mac-app-store", "--runtime-image", Token.JAVA_HOME.token())
                         .error("ERR_MacAppStoreRuntimeBinExists", JPackageCommand.cannedArgument(cmd -> {
                             return Path.of(cmd.getArgumentValue("--runtime-image")).toAbsolutePath();
-                        }, Token.JAVA_HOME.token()))
+                        }, Token.JAVA_HOME.token())),
+                testSpec().nativeType().addArgs("--app-content", Token.APP_CONTENT_NON_STANDARD_DIR.token())
+                        .error("warning.non.standard.contents.sub.dir", JPackageCommand.cannedArgument(cmd -> {
+                            return Path.of(cmd.getArgumentValue("--app-content"));
+                        }, Token.APP_CONTENT_NON_STANDARD_DIR.token()))
         ).map(TestSpec.Builder::create).toList());
 
         // Test a few app-image options that should not be used when signing external app image

--- a/test/jdk/tools/jpackage/share/ErrorTest.java
+++ b/test/jdk/tools/jpackage/share/ErrorTest.java
@@ -88,13 +88,7 @@ public final class ErrorTest {
 
             return appImageCmd.outputBundle().toString();
         }),
-        ADD_LAUNCHER_PROPERTY_FILE,
-        APP_CONTENT_NON_STANDARD_DIR(cmd -> {
-            final var appContentDir
-                    = TKit.createTempDirectory("app-content-non-standard-dir");
-
-            return TKit.createTempFile(appContentDir.resolve("Foo.txt"));
-        });
+        ADD_LAUNCHER_PROPERTY_FILE;
 
         private Token() {
             this.valueSupplier = Optional.empty();
@@ -612,11 +606,7 @@ public final class ErrorTest {
                 testSpec().nativeType().addArgs("--mac-app-store", "--runtime-image", Token.JAVA_HOME.token())
                         .error("ERR_MacAppStoreRuntimeBinExists", JPackageCommand.cannedArgument(cmd -> {
                             return Path.of(cmd.getArgumentValue("--runtime-image")).toAbsolutePath();
-                        }, Token.JAVA_HOME.token())),
-                testSpec().nativeType().addArgs("--app-content", Token.APP_CONTENT_NON_STANDARD_DIR.token())
-                        .error("warning.non.standard.contents.sub.dir", JPackageCommand.cannedArgument(cmd -> {
-                            return Path.of(cmd.getArgumentValue("--app-content"));
-                        }, Token.APP_CONTENT_NON_STANDARD_DIR.token()))
+                        }, Token.JAVA_HOME.token()))
         ).map(TestSpec.Builder::create).toList());
 
         // Test a few app-image options that should not be used when signing external app image


### PR DESCRIPTION
- Added following note for `--app-content` on macOS to help and man page: `The value should be a directory with the "Resources" subdirectory (or any other directory that is valid in the "Contents" directory of the application bundle). Otherwise, jpackage may produce invalid application bundle which may fail code signing and/or notarization.`
- Added warning if `--app-content` if it points to non-standard subdirectory in "Contents" directory.
- Added test to cover warning message.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8356218](https://bugs.openjdk.org/browse/JDK-8356218): [macos] Document --app-content (**Enhancement** - P3)


### Reviewers
 * [Alexey Semenyuk](https://openjdk.org/census#asemenyuk) (@alexeysemenyukoracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26848/head:pull/26848` \
`$ git checkout pull/26848`

Update a local copy of the PR: \
`$ git checkout pull/26848` \
`$ git pull https://git.openjdk.org/jdk.git pull/26848/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26848`

View PR using the GUI difftool: \
`$ git pr show -t 26848`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26848.diff">https://git.openjdk.org/jdk/pull/26848.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26848#issuecomment-3202083404)
</details>
