### PR TITLE
8365834: Mark java/net/httpclient/ManyRequests.java  as intermittent

### DIFF
--- a/test/jdk/java/net/httpclient/ManyRequests.java
+++ b/test/jdk/java/net/httpclient/ManyRequests.java
@@ -24,6 +24,7 @@
 /*
  * @test
  * @bug 8087112 8180044 8256459
+ * @key intermittent
  * @modules java.net.http
  *          java.logging
  *          jdk.httpserver


### PR DESCRIPTION
The test java/net/httpclient/ManyRequests.java has been observed intermittent failure such as https://bugs.openjdk.org/browse/JDK-8327968 and https://bugs.openjdk.org/browse/JDK-8365811. Should we mark this test as `@intermittent`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8365834](https://bugs.openjdk.org/browse/JDK-8365834): Mark java/net/httpclient/ManyRequests.java  as intermittent (**Sub-task** - P4)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26852/head:pull/26852` \
`$ git checkout pull/26852`

Update a local copy of the PR: \
`$ git checkout pull/26852` \
`$ git pull https://git.openjdk.org/jdk.git pull/26852/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26852`

View PR using the GUI difftool: \
`$ git pr show -t 26852`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26852.diff">https://git.openjdk.org/jdk/pull/26852.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26852#issuecomment-3204072285)
</details>
