### PR TITLE
8365841: RISC-V: Several IR verification tests fail after JDK-8350960 without Zvfh

### DIFF
--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -110,6 +110,7 @@ source %{
         if (vlen < 4) {
           return false;
         }
+        break;
       case Op_VectorCastHF2F:
       case Op_VectorCastF2HF:
       case Op_AddVHF:


### PR DESCRIPTION
Hi,
Can you help to review this patch? Thanks!

The error in both cases is caused by the same reason: the target IR, MulReductionVI, is not matched.
This is because the match_rule_supported_vector in riscv_v.ad is missing a break. If the if condition in `case MulReductionVI` evaluates to false, the loop will not exit until the `return UseZvfh`.

Failed IR tests:
compiler/loopopts/superword/ProdRed_Int.java
compiler/loopopts/superword/RedTest_int.java

### Test (fastdebug)
- [x] Run compiler/loopopts/superword/ProdRed_Int.java on k1 and k230
- [x] Run compiler/loopopts/superword/RedTest_int.java on k1 and k230

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8365841](https://bugs.openjdk.org/browse/JDK-8365841): RISC-V: Several IR verification tests fail after JDK-8350960 without Zvfh (**Bug** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Feilong Jiang](https://openjdk.org/census#fjiang) (@feilongjiang - Committer)
 * [Hamlin Li](https://openjdk.org/census#mli) (@Hamlin-Li - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26854/head:pull/26854` \
`$ git checkout pull/26854`

Update a local copy of the PR: \
`$ git checkout pull/26854` \
`$ git pull https://git.openjdk.org/jdk.git pull/26854/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26854`

View PR using the GUI difftool: \
`$ git pr show -t 26854`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26854.diff">https://git.openjdk.org/jdk/pull/26854.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26854#issuecomment-3204490489)
</details>
