### PR TITLE
8365671: Typo in Joiner.allUntil example

### DIFF
--- a/src/java.base/share/classes/java/util/concurrent/StructuredTaskScope.java
+++ b/src/java.base/share/classes/java/util/concurrent/StructuredTaskScope.java
@@ -700,12 +700,12 @@ public sealed interface StructuredTaskScope<T, R>
          *         }
          *     }
          *
-         *     var joiner = Joiner.all(new CancelAfterTwoFailures<String>());
+         *     var joiner = Joiner.allUntil(new CancelAfterTwoFailures<String>());
          * }
          *
          * <p> The following example uses {@code allUntil} to wait for all subtasks to
          * complete without any cancellation. This is similar to {@link #awaitAll()}
-         * except that it yields a stream of the completed subtasks.
+         * except that it yields a list of the completed subtasks.
          * {@snippet lang=java :
          *    <T> List<Subtask<T>> invokeAll(Collection<Callable<T>> tasks) throws InterruptedException {
          *        try (var scope = StructuredTaskScope.open(Joiner.<T>allUntil(_ -> false))) {


### PR DESCRIPTION
Fix two typos in one of the examples in Joiner.allUntil's API. (We may re-visit the example in a future update, for now, just the typos).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8365671](https://bugs.openjdk.org/browse/JDK-8365671): Typo in Joiner.allUntil example (**Bug** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26856/head:pull/26856` \
`$ git checkout pull/26856`

Update a local copy of the PR: \
`$ git checkout pull/26856` \
`$ git pull https://git.openjdk.org/jdk.git pull/26856/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26856`

View PR using the GUI difftool: \
`$ git pr show -t 26856`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26856.diff">https://git.openjdk.org/jdk/pull/26856.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26856#issuecomment-3206682958)
</details>
