### PR TITLE
8302057: Wrong BeanProperty description for JTable.setShowGrid

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/JTable.java
+++ b/src/java.desktop/share/classes/javax/swing/JTable.java
@@ -1164,7 +1164,7 @@ public class JTable extends JComponent implements TableModelListener, Scrollable
      * @see     #setShowHorizontalLines
      */
     @BeanProperty(description
-            = "Whether grid lines should be drawn around the cells.")
+            = "Whether grid lines are drawn around the cells.")
     public void setShowGrid(boolean showGrid) {
         setShowHorizontalLines(showGrid);
         setShowVerticalLines(showGrid);


### PR DESCRIPTION
Hi Reviewers,

Updated the Bean Property description with meaningful string for JTable.setShowGrid.

Pleas review and let me know your suggestions if any.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302057](https://bugs.openjdk.org/browse/JDK-8302057): Wrong BeanProperty description for JTable.setShowGrid (**Bug** - P4)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**) Review applies to [1518aa24](https://git.openjdk.org/jdk/pull/26857/files/1518aa24b0cdc883d27238dd2c3083fc51ece412)
 * [Prasanta Sadhukhan](https://openjdk.org/census#psadhukhan) (@prsadhuk - **Reviewer**) Review applies to [33e8e04d](https://git.openjdk.org/jdk/pull/26857/files/33e8e04d351feecd58bb59812fc36b9a38a4bffa)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26857/head:pull/26857` \
`$ git checkout pull/26857`

Update a local copy of the PR: \
`$ git checkout pull/26857` \
`$ git pull https://git.openjdk.org/jdk.git pull/26857/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26857`

View PR using the GUI difftool: \
`$ git pr show -t 26857`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26857.diff">https://git.openjdk.org/jdk/pull/26857.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26857#issuecomment-3205171673)
</details>
