### PR TITLE
8353468: [ubsan] arguments.cpp:2422:23: runtime error: 2.14748e+11 is outside the range of representable values of type 'int'

### DIFF
--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -2426,7 +2426,7 @@ jint Arguments::parse_each_vm_init_arg(const JavaVMInitArgs* args, JVMFlagOrigin
         }
         if (MinHeapFreeRatio > (uintx)(dmaxf * 100)) {
           jio_fprintf(defaultStream::error_stream(),
-                      "-Xmaxf value (%s) which is also used for MaxHeapFreeRatio must be greater than or equal to MinHeapFreeRatio (%3.2lf)\n",
+                      "-Xmaxf value (%s) must be greater than or equal to the implicit -Xmaxf value (%3.2lf)\n",
                       tail, MinHeapFreeRatio / 100.0);
           return JNI_EINVAL;
         }
@@ -2452,7 +2452,7 @@ jint Arguments::parse_each_vm_init_arg(const JavaVMInitArgs* args, JVMFlagOrigin
         }
         if (MaxHeapFreeRatio < (uintx)(dminf * 100)) {
           jio_fprintf(defaultStream::error_stream(),
-                      "-Xminf value (%s) which is also used for MinHeapFreeRatio must be less than or equal to MaxHeapFreeRatio (%3.2lf)\n",
+                      "-Xminf value (%s) must be less than or equal to the implicit -Xmaxf value (%3.2lf)\n",
                       tail, MaxHeapFreeRatio / 100.0);
           return JNI_EINVAL;
         }

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -2411,7 +2411,8 @@ jint Arguments::parse_each_vm_init_arg(const JavaVMInitArgs* args, JVMFlagOrigin
     // Xmaxf
     } else if (match_option(option, "-Xmaxf", &tail)) {
       char* err;
-      int maxf = (int)(strtod(tail, &err) * 100);
+      double dmaxf = strtod(tail, &err) * 100;
+      int maxf = dmaxf > (double)INT_MAX ? INT_MAX : (int)dmaxf;
       if (*err != '\0' || *tail == '\0') {
         jio_fprintf(defaultStream::error_stream(),
                     "Bad max heap free percentage size: %s\n",
@@ -2425,7 +2426,8 @@ jint Arguments::parse_each_vm_init_arg(const JavaVMInitArgs* args, JVMFlagOrigin
     // Xminf
     } else if (match_option(option, "-Xminf", &tail)) {
       char* err;
-      int minf = (int)(strtod(tail, &err) * 100);
+      double dminf = strtod(tail, &err) * 100;
+      int minf = dminf > (double)INT_MAX ? INT_MAX : (int)dminf;
       if (*err != '\0' || *tail == '\0') {
         jio_fprintf(defaultStream::error_stream(),
                     "Bad min heap free percentage size: %s\n",

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -2426,7 +2426,7 @@ jint Arguments::parse_each_vm_init_arg(const JavaVMInitArgs* args, JVMFlagOrigin
         }
         if (MinHeapFreeRatio > (uintx)(dmaxf * 100)) {
           jio_fprintf(defaultStream::error_stream(),
-                      "-Xmaxf value (%s) must be greater than or equal to the implicit -Xmaxf value (%3.2lf)\n",
+                      "-Xmaxf value (%s) must be greater than or equal to the implicit -Xminf value (%3.2lf)\n",
                       tail, MinHeapFreeRatio / 100.0);
           return JNI_EINVAL;
         }

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -2412,7 +2412,8 @@ jint Arguments::parse_each_vm_init_arg(const JavaVMInitArgs* args, JVMFlagOrigin
     } else if (match_option(option, "-Xmaxf", &tail)) {
       char* err;
       double dmaxf = strtod(tail, &err) * 100;
-      int maxf = dmaxf > (double)INT_MAX ? INT_MAX : (int)dmaxf;
+      int maxf = dmaxf > (double)INT_MAX ? INT_MAX :
+                 dmaxf < (double)INT_MIN ? INT_MIN : (int)dmaxf;
       if (*err != '\0' || *tail == '\0') {
         jio_fprintf(defaultStream::error_stream(),
                     "Bad max heap free percentage size: %s\n",
@@ -2427,7 +2428,8 @@ jint Arguments::parse_each_vm_init_arg(const JavaVMInitArgs* args, JVMFlagOrigin
     } else if (match_option(option, "-Xminf", &tail)) {
       char* err;
       double dminf = strtod(tail, &err) * 100;
-      int minf = dminf > (double)INT_MAX ? INT_MAX : (int)dminf;
+      int minf = dminf > (double)INT_MAX ? INT_MAX :
+                 dminf < (double)INT_MIN ? INT_MIN : (int)dminf;
       if (*err != '\0' || *tail == '\0') {
         jio_fprintf(defaultStream::error_stream(),
                     "Bad min heap free percentage size: %s\n",

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -2419,7 +2419,15 @@ jint Arguments::parse_each_vm_init_arg(const JavaVMInitArgs* args, JVMFlagOrigin
         return JNI_EINVAL;
       } else {
         if (dmaxf < 0.0 || dmaxf > 1.0) {
-          JVMFlag::printError(true,"uintx MaxHeapFreeRatio=%s is outside the allowed range  [ 0.0 ... 1.0 ]\n", tail);
+          jio_fprintf(defaultStream::error_stream(),
+                      "-Xmaxf value (%s) is outside the allowed range [ 0.0 ... 1.0 ]\n",
+                      option->optionString);
+          return JNI_EINVAL;
+        }
+        if (MinHeapFreeRatio > (uintx)(dmaxf * 100)) {
+          jio_fprintf(defaultStream::error_stream(),
+                      "-Xmaxf value (%s) which is also used for MaxHeapFreeRatio must be greater than or equal to MinHeapFreeRatio (%3.2lf)\n",
+                      tail, MinHeapFreeRatio / 100.0);
           return JNI_EINVAL;
         }
         if (FLAG_SET_CMDLINE(MaxHeapFreeRatio, (uintx)(dmaxf * 100)) != JVMFlag::SUCCESS) {
@@ -2437,7 +2445,15 @@ jint Arguments::parse_each_vm_init_arg(const JavaVMInitArgs* args, JVMFlagOrigin
         return JNI_EINVAL;
       } else {
         if (dminf < 0.0 || dminf > 1.0) {
-          JVMFlag::printError(true,"uintx MinHeapFreeRatio=%s is outside the allowed range [ 0.0 ... 1.0 ]\n", tail);
+          jio_fprintf(defaultStream::error_stream(),
+                      "-Xminf value (%s) is outside the allowed range [ 0.0 ... 1.0 ]\n",
+                      tail);
+          return JNI_EINVAL;
+        }
+        if (MaxHeapFreeRatio < (uintx)(dminf * 100)) {
+          jio_fprintf(defaultStream::error_stream(),
+                      "-Xminf value (%s) which is also used for MinHeapFreeRatio must be less than or equal to MaxHeapFreeRatio (%3.2lf)\n",
+                      tail, MaxHeapFreeRatio / 100.0);
           return JNI_EINVAL;
         }
         if (FLAG_SET_CMDLINE(MinHeapFreeRatio, (uintx)(dminf * 100)) != JVMFlag::SUCCESS) {

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -2414,25 +2414,25 @@ jint Arguments::parse_each_vm_init_arg(const JavaVMInitArgs* args, JVMFlagOrigin
       double dmaxf = strtod(tail, &err);
       if (*err != '\0' || *tail == '\0') {
         jio_fprintf(defaultStream::error_stream(),
-                    "Bad max heap free percentage size: %s\n",
+                    "Bad max heap free ratio: %s\n",
                     option->optionString);
         return JNI_EINVAL;
-      } else {
-        if (dmaxf < 0.0 || dmaxf > 1.0) {
-          jio_fprintf(defaultStream::error_stream(),
-                      "-Xmaxf value (%s) is outside the allowed range [ 0.0 ... 1.0 ]\n",
-                      option->optionString);
-          return JNI_EINVAL;
-        }
-        if (MinHeapFreeRatio > (uintx)(dmaxf * 100)) {
-          jio_fprintf(defaultStream::error_stream(),
-                      "-Xmaxf value (%s) must be greater than or equal to the implicit -Xminf value (%3.2lf)\n",
-                      tail, MinHeapFreeRatio / 100.0);
-          return JNI_EINVAL;
-        }
-        if (FLAG_SET_CMDLINE(MaxHeapFreeRatio, (uintx)(dmaxf * 100)) != JVMFlag::SUCCESS) {
-            return JNI_EINVAL;
-        }
+      }
+      if (dmaxf < 0.0 || dmaxf > 1.0) {
+        jio_fprintf(defaultStream::error_stream(),
+                    "-Xmaxf value (%s) is outside the allowed range [ 0.0 ... 1.0 ]\n",
+                    option->optionString);
+        return JNI_EINVAL;
+      }
+      const uintx umaxf = (uintx)(dmaxf * 100);
+      if (MinHeapFreeRatio > umaxf) {
+        jio_fprintf(defaultStream::error_stream(),
+                    "-Xmaxf value (%s) must be greater than or equal to the implicit -Xminf value (%.2f)\n",
+                    tail, MinHeapFreeRatio / 100.0f);
+        return JNI_EINVAL;
+      }
+      if (FLAG_SET_CMDLINE(MaxHeapFreeRatio, umaxf) != JVMFlag::SUCCESS) {
+        return JNI_EINVAL;
       }
     // Xminf
     } else if (match_option(option, "-Xminf", &tail)) {
@@ -2440,25 +2440,25 @@ jint Arguments::parse_each_vm_init_arg(const JavaVMInitArgs* args, JVMFlagOrigin
       double dminf = strtod(tail, &err);
       if (*err != '\0' || *tail == '\0') {
         jio_fprintf(defaultStream::error_stream(),
-                    "Bad min heap free percentage size: %s\n",
+                    "Bad min heap free ratio: %s\n",
                     option->optionString);
         return JNI_EINVAL;
-      } else {
-        if (dminf < 0.0 || dminf > 1.0) {
-          jio_fprintf(defaultStream::error_stream(),
-                      "-Xminf value (%s) is outside the allowed range [ 0.0 ... 1.0 ]\n",
-                      tail);
-          return JNI_EINVAL;
-        }
-        if (MaxHeapFreeRatio < (uintx)(dminf * 100)) {
-          jio_fprintf(defaultStream::error_stream(),
-                      "-Xminf value (%s) must be less than or equal to the implicit -Xmaxf value (%3.2lf)\n",
-                      tail, MaxHeapFreeRatio / 100.0);
-          return JNI_EINVAL;
-        }
-        if (FLAG_SET_CMDLINE(MinHeapFreeRatio, (uintx)(dminf * 100)) != JVMFlag::SUCCESS) {
-          return JNI_EINVAL;
-        }
+      }
+      if (dminf < 0.0 || dminf > 1.0) {
+        jio_fprintf(defaultStream::error_stream(),
+                    "-Xminf value (%s) is outside the allowed range [ 0.0 ... 1.0 ]\n",
+                    tail);
+        return JNI_EINVAL;
+      }
+      const uintx uminf = (uintx)(dminf * 100);
+      if (MaxHeapFreeRatio < uminf) {
+        jio_fprintf(defaultStream::error_stream(),
+                    "-Xminf value (%s) must be less than or equal to the implicit -Xmaxf value (%.2f)\n",
+                    tail, MaxHeapFreeRatio / 100.0f);
+        return JNI_EINVAL;
+      }
+      if (FLAG_SET_CMDLINE(MinHeapFreeRatio, uminf) != JVMFlag::SUCCESS) {
+        return JNI_EINVAL;
       }
     // -Xss
     } else if (match_option(option, "-Xss", &tail)) {

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -2411,32 +2411,36 @@ jint Arguments::parse_each_vm_init_arg(const JavaVMInitArgs* args, JVMFlagOrigin
     // Xmaxf
     } else if (match_option(option, "-Xmaxf", &tail)) {
       char* err;
-      double dmaxf = strtod(tail, &err) * 100;
-      int maxf = dmaxf > (double)INT_MAX ? INT_MAX :
-                 dmaxf < (double)INT_MIN ? INT_MIN : (int)dmaxf;
+      double dmaxf = strtod(tail, &err);
       if (*err != '\0' || *tail == '\0') {
         jio_fprintf(defaultStream::error_stream(),
                     "Bad max heap free percentage size: %s\n",
                     option->optionString);
         return JNI_EINVAL;
       } else {
-        if (FLAG_SET_CMDLINE(MaxHeapFreeRatio, maxf) != JVMFlag::SUCCESS) {
+        if (dmaxf < 0.0 || dmaxf > 1.0) {
+          JVMFlag::printError(true,"uintx MaxHeapFreeRatio=%s is outside the allowed range  [ 0.0 ... 1.0 ]\n", tail);
+          return JNI_EINVAL;
+        }
+        if (FLAG_SET_CMDLINE(MaxHeapFreeRatio, (uintx)(dmaxf * 100)) != JVMFlag::SUCCESS) {
             return JNI_EINVAL;
         }
       }
     // Xminf
     } else if (match_option(option, "-Xminf", &tail)) {
       char* err;
-      double dminf = strtod(tail, &err) * 100;
-      int minf = dminf > (double)INT_MAX ? INT_MAX :
-                 dminf < (double)INT_MIN ? INT_MIN : (int)dminf;
+      double dminf = strtod(tail, &err);
       if (*err != '\0' || *tail == '\0') {
         jio_fprintf(defaultStream::error_stream(),
                     "Bad min heap free percentage size: %s\n",
                     option->optionString);
         return JNI_EINVAL;
       } else {
-        if (FLAG_SET_CMDLINE(MinHeapFreeRatio, minf) != JVMFlag::SUCCESS) {
+        if (dminf < 0.0 || dminf > 1.0) {
+          JVMFlag::printError(true,"uintx MinHeapFreeRatio=%s is outside the allowed range [ 0.0 ... 1.0 ]\n", tail);
+          return JNI_EINVAL;
+        }
+        if (FLAG_SET_CMDLINE(MinHeapFreeRatio, (uintx)(dminf * 100)) != JVMFlag::SUCCESS) {
           return JNI_EINVAL;
         }
       }

--- a/test/hotspot/jtreg/gc/arguments/TestHeapFreeRatio.java
+++ b/test/hotspot/jtreg/gc/arguments/TestHeapFreeRatio.java
@@ -54,12 +54,12 @@ public class TestHeapFreeRatio {
       output.shouldHaveExitValue(0);
       break;
     case MIN_INVALID:
-      output.shouldContain("Bad min heap free percentage size: -Xminf" + min);
+      output.shouldContain("Bad min heap free ratio: -Xminf" + min);
       output.shouldContain("Error");
       output.shouldHaveExitValue(1);
       break;
     case MAX_INVALID:
-      output.shouldContain("Bad max heap free percentage size: -Xmaxf" + max);
+      output.shouldContain("Bad max heap free ratio: -Xmaxf" + max);
       output.shouldContain("Error");
       output.shouldHaveExitValue(1);
       break;

--- a/test/hotspot/jtreg/gc/arguments/TestHeapFreeRatio.java
+++ b/test/hotspot/jtreg/gc/arguments/TestHeapFreeRatio.java
@@ -69,7 +69,7 @@ public class TestHeapFreeRatio {
       output.shouldHaveExitValue(1);
       break;
     case COMBINATION_INVALID:
-      output.shouldMatch("must be (less|greater) than or equal to M..HeapFreeRatio");
+      output.shouldMatch("must be (less|greater) than or equal to the implicit -Xm..f value");
       output.shouldContain("Error");
       output.shouldHaveExitValue(1);
       break;

--- a/test/hotspot/jtreg/gc/arguments/TestHeapFreeRatio.java
+++ b/test/hotspot/jtreg/gc/arguments/TestHeapFreeRatio.java
@@ -86,9 +86,10 @@ public class TestHeapFreeRatio {
   }
 
   public static void main(String args[]) throws Exception {
-    testMinMaxFreeRatio( "0.1", "0.5", Validation.VALID);
-    testMinMaxFreeRatio(  ".1",  ".5", Validation.VALID);
-    testMinMaxFreeRatio( "0.5", "0.5", Validation.VALID);
+    testMinMaxFreeRatio( "0.1",  "0.5", Validation.VALID);
+    testMinMaxFreeRatio(  ".1",   ".5", Validation.VALID);
+    testMinMaxFreeRatio( "0.5",  "0.5", Validation.VALID);
+    testMinMaxFreeRatio( "0.0","0.001", Validation.VALID);
 
     testMinMaxFreeRatio("=0.1", "0.5", Validation.MIN_INVALID);
     testMinMaxFreeRatio("0.1f", "0.5", Validation.MIN_INVALID);

--- a/test/hotspot/jtreg/gc/arguments/TestHeapFreeRatio.java
+++ b/test/hotspot/jtreg/gc/arguments/TestHeapFreeRatio.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -104,10 +104,14 @@ public class TestHeapFreeRatio {
     testMinMaxFreeRatio( "1.1", "0.5", Validation.OUT_OF_RANGE);
     testMinMaxFreeRatio(
                   "2147483647", "0.5", Validation.OUT_OF_RANGE);
+    testMinMaxFreeRatio(
+                  "-2147483647", "0.5", Validation.OUT_OF_RANGE);
     testMinMaxFreeRatio( "0.1", "-0.5", Validation.OUT_OF_RANGE);
     testMinMaxFreeRatio( "0.1",  "1.5", Validation.OUT_OF_RANGE);
     testMinMaxFreeRatio(
                    "0.1", "2147483647", Validation.OUT_OF_RANGE);
+    testMinMaxFreeRatio(
+                   "0.1", "-2147483647", Validation.OUT_OF_RANGE);
 
     testMinMaxFreeRatio( "0.5",  "0.1", Validation.COMBINATION_INVALID);
     testMinMaxFreeRatio(  ".5",  ".10", Validation.COMBINATION_INVALID);


### PR DESCRIPTION
In converting values of `-XMinf` and `-XMaxf` options to `int`, overflow was not checked. 
The values are checked against INT_MAX and clamped.

Tests: tiers 1-5.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8353468](https://bugs.openjdk.org/browse/JDK-8353468): [ubsan] arguments.cpp:2422:23: runtime error: 2.14748e+11 is outside the range of representable values of type 'int' (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) Review applies to [0b532758](https://git.openjdk.org/jdk/pull/26859/files/0b532758a31130b2056ceaea74d07e805b63da71)
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26859/head:pull/26859` \
`$ git checkout pull/26859`

Update a local copy of the PR: \
`$ git checkout pull/26859` \
`$ git pull https://git.openjdk.org/jdk.git pull/26859/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26859`

View PR using the GUI difftool: \
`$ git pr show -t 26859`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26859.diff">https://git.openjdk.org/jdk/pull/26859.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26859#issuecomment-3206081475)
</details>
