### PR TITLE
8284499: Add the ability to right-click and open in new tab JavaDoc Search results

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/search.js.template
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/search.js.template
@@ -423,7 +423,8 @@ $.widget("custom.catcomplete", $.ui.autocomplete, {
         var label = getResultLabel(item);
         var resultDesc = getResultDescription(item);
         return $("<li/>")
-            .append($("<div/>")
+            .append($("<a/>")
+                .attr("href", item.indexItem ? pathtoroot + getURL(item.indexItem, item.category) : null)
                 .append($("<span/>").addClass("search-result-label").html(label))
                 .append($("<span/>").addClass("search-result-desc").html(resultDesc)))
             .appendTo(ul);
@@ -515,7 +516,7 @@ $(function() {
             this.menu.previousFilter = "_";
             this.menu.filterTimer = this.menu._delay(function() {
                 delete this.previousFilter;
-            }, 1000);
+            }, 500);
             return doSearch(request, response);
         },
         response: function(event, ui) {
@@ -531,6 +532,11 @@ $(function() {
             collision: "flip"
         },
         select: function(event, ui) {
+            for (var e = event.originalEvent; e != null; e = e.originalEvent) {
+                if (e.type === "click") {
+                    return;
+                }
+            }
             if (ui.item.indexItem) {
                 var url = getURL(ui.item.indexItem, ui.item.category);
                 window.location.href = pathtoroot + url;

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/stylesheet.css
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/stylesheet.css
@@ -1235,11 +1235,11 @@ li.ui-static-link a, li.ui-static-link a:visited {
     grid-template-columns: auto auto;
 }
 .ui-autocomplete > li,
-.ui-autocomplete > li > div {
+.ui-autocomplete > li > a {
     grid-column: 1 / 3;
 }
 .ui-autocomplete > li.result-item,
-.ui-autocomplete > li.result-item > div {
+.ui-autocomplete > li.result-item > a {
     display: grid;
     grid-template-columns: subgrid;
 }
@@ -1250,6 +1250,7 @@ li.ui-static-link a, li.ui-static-link a:visited {
 }
 .ui-autocomplete .search-result-label {
     padding: 1px 4px;
+    color: var(--block-text-color);
     overflow: hidden;
     text-overflow: ellipsis;
 }
@@ -1263,6 +1264,7 @@ li.ui-static-link a, li.ui-static-link a:visited {
 .ui-autocomplete .result-highlight {
     font-weight:bold;
 }
+.ui-menu .ui-state-active .search-result-label,
 .ui-menu .ui-state-active .search-result-desc {
     color: var(--selected-text-color);
 }
@@ -1843,9 +1845,9 @@ table.striped > tbody > tr > th {
         grid-template-columns: none;
     }
     .ui-autocomplete > li,
-    .ui-autocomplete > li > div,
+    .ui-autocomplete > li > a,
     .ui-autocomplete > li.result-item,
-    .ui-autocomplete > li.result-item > div {
+    .ui-autocomplete > li.result-item > a {
         grid-column: unset;
         display: block;
         grid-template-columns: none;


### PR DESCRIPTION
Please review a change to use HTML `<a href=...>` elements for displaying JavaDoc search results, thereby opening additional ways of interacting with links implemented by browsers (clicking with various modifier keys or right-clicking to obtain a context menu to open in new tab, copy the link target, etc.).  

The main change is in the search script to create the `<a href=...>` element instead of a generic `<div>`, and to ignore menu selection events caused by mouse click (these are now handled natively by the browser). The reduction of the menu delay from 1000 to 500 ms is an unrelated change to make the menu more responsive when popping up. The changes in the stylesheet are to maintain the appearance of the search results. 

The new feature [can be tested here](https://cr.openjdk.org/~hannesw/8284499/api.00/java.base/module-summary.html) (module java.base only).