### PR TITLE
8277444: Race condition on Instrumentation.retransformClasses() and class linking

### DIFF
--- a/src/hotspot/share/prims/jvmtiClassFileReconstituter.cpp
+++ b/src/hotspot/share/prims/jvmtiClassFileReconstituter.cpp
@@ -996,6 +996,14 @@ void JvmtiClassFileReconstituter::write_u8(u8 x) {
 
 void JvmtiClassFileReconstituter::copy_bytecodes(const methodHandle& mh,
                                                  unsigned char* bytecodes) {
+  // Method bytecodes can be rewritten during linking.
+  // Whilst the linking process rewriting bytescodes,
+  // is_rewritten() returns false. So we won't restore the original bytecodes.
+  // We hold a lock to guarantee we are not getting bytecodes
+  // at the same time the linking process are rewriting them.
+  Handle h_init_lock(Thread::current(), mh->method_holder()->init_lock());
+  ObjectLocker ol(h_init_lock, JavaThread::current());
+
   // use a BytecodeStream to iterate over the bytecodes. JVM/fast bytecodes
   // and the breakpoint bytecode are converted to their original bytecodes.
 


### PR DESCRIPTION
There is a race between `JvmtiClassFileReconstituter::copy_bytecodes` and `InstanceKlass::link_class_impl`.  `InstanceKlass::link_class_impl` can be rewriting bytecodes. `JvmtiClassFileReconstituter::copy_bytecodes` will not restore them to the original ones because the flag `rewritten` is `false`. This will result in invalid bytecode.

This PR adds a lock (`init_lock`) to the `copy_bytecodes` method to prevent reading bytecodes while they are being rewritten during class linking.

Tested fastdebug and release builds: Linux x86_64 and arm64
- The reproducer from JDK-8277444 passed.
- Tier1 - tier3 passed.