### PR TITLE
8365407: Race condition in MethodTrainingData::verify()

### DIFF
--- a/src/hotspot/share/compiler/compilationPolicy.cpp
+++ b/src/hotspot/share/compiler/compilationPolicy.cpp
@@ -138,7 +138,7 @@ void CompilationPolicy::compile_if_required(const methodHandle& m, TRAPS) {
   }
 }
 
- void CompilationPolicy::flush_replay_training_at_init(TRAPS) {
+ void CompilationPolicy::flush_replay_training_at_init(JavaThread* THREAD) {
     MonitorLocker locker(THREAD, TrainingReplayQueue_lock);
     while (!_training_replay_queue.is_empty_unlocked() || _training_replay_queue.is_processing_unlocked()) {
       locker.wait(); // let the replay training thread drain the queue

--- a/src/hotspot/share/compiler/compilationPolicy.cpp
+++ b/src/hotspot/share/compiler/compilationPolicy.cpp
@@ -138,7 +138,7 @@ void CompilationPolicy::compile_if_required(const methodHandle& m, TRAPS) {
   }
 }
 
- void CompilationPolicy::flush_replay_training_at_init(JavaThread* THREAD) {
+ void CompilationPolicy::wait_replay_training_at_init(JavaThread* THREAD) {
     MonitorLocker locker(THREAD, TrainingReplayQueue_lock);
     while (!_training_replay_queue.is_empty_unlocked() || _training_replay_queue.is_processing_unlocked()) {
       locker.wait(); // let the replay training thread drain the queue
@@ -170,7 +170,7 @@ void CompilationPolicy::replay_training_at_init_impl(InstanceKlass* klass, TRAPS
   }
 }
 
-void CompilationPolicy::replay_training_at_init(InstanceKlass* klass, TRAPS) {
+void CompilationPolicy::replay_training_at_init(InstanceKlass* klass, JavaThread* THREAD) {
   assert(klass->is_initialized(), "");
   if (TrainingData::have_data() && klass->is_shared()) {
     _training_replay_queue.push(klass, TrainingReplayQueue_lock, THREAD);
@@ -188,7 +188,7 @@ void CompilationPolicyUtils::Queue<InstanceKlass>::print_on(outputStream* st) {
   }
 }
 
-void CompilationPolicy::replay_training_at_init_loop(TRAPS) {
+void CompilationPolicy::replay_training_at_init_loop(JavaThread* THREAD) {
   while (!CompileBroker::is_compilation_disabled_forever()) {
     InstanceKlass* ik = _training_replay_queue.pop(TrainingReplayQueue_lock, THREAD);
     if (ik != nullptr) {

--- a/src/hotspot/share/compiler/compilationPolicy.hpp
+++ b/src/hotspot/share/compiler/compilationPolicy.hpp
@@ -362,7 +362,7 @@ class CompilationPolicy : AllStatic {
   // This supports the -Xcomp option.
   static void compile_if_required(const methodHandle& m, TRAPS);
 
-  static void flush_replay_training_at_init(TRAPS);
+  static void flush_replay_training_at_init(JavaThread* THREAD);
   static void replay_training_at_init(InstanceKlass* klass, TRAPS);
   static void replay_training_at_init_loop(TRAPS);
 

--- a/src/hotspot/share/compiler/compilationPolicy.hpp
+++ b/src/hotspot/share/compiler/compilationPolicy.hpp
@@ -80,7 +80,7 @@ class Queue {
   }
 public:
   Queue() : _head(nullptr), _tail(nullptr), _processing(0) { }
-  void push(T* value, Monitor* lock, TRAPS) {
+  void push(T* value, Monitor* lock, JavaThread* THREAD) {
     MonitorLocker locker(THREAD, lock);
     push_unlocked(value);
     locker.notify_all();
@@ -89,7 +89,7 @@ public:
   bool is_empty_unlocked() const { return _head == nullptr; }
   bool is_processing_unlocked() const { return _processing > 0; }
 
-  T* pop(Monitor* lock, TRAPS) {
+  T* pop(Monitor* lock, JavaThread* THREAD) {
     MonitorLocker locker(THREAD, lock);
     while(is_empty_unlocked() && !CompileBroker::is_compilation_disabled_forever()) {
       locker.wait();
@@ -98,13 +98,13 @@ public:
     return value;
   }
 
-  T* try_pop(Monitor* lock, TRAPS) {
+  T* try_pop(Monitor* lock, JavaThread* THREAD) {
     MonitorLocker locker(THREAD, lock);
     T* value = pop_unlocked();
     return value;
   }
 
-  void processing_done(Monitor* lock, TRAPS) {
+  void processing_done(Monitor* lock, JavaThread* THREAD) {
     MonitorLocker locker(THREAD, lock);
     processing_done_unlocked();
     locker.notify_all();
@@ -362,9 +362,9 @@ class CompilationPolicy : AllStatic {
   // This supports the -Xcomp option.
   static void compile_if_required(const methodHandle& m, TRAPS);
 
-  static void flush_replay_training_at_init(JavaThread* THREAD);
-  static void replay_training_at_init(InstanceKlass* klass, TRAPS);
-  static void replay_training_at_init_loop(TRAPS);
+  static void wait_replay_training_at_init(JavaThread* THREAD);
+  static void replay_training_at_init(InstanceKlass* klass, JavaThread* THREAD);
+  static void replay_training_at_init_loop(JavaThread* THREAD);
 
   // m is allowed to be compiled
   static bool can_be_compiled(const methodHandle& m, int comp_level = CompLevel_any);

--- a/src/hotspot/share/compiler/compilationPolicy.hpp
+++ b/src/hotspot/share/compiler/compilationPolicy.hpp
@@ -362,7 +362,7 @@ class CompilationPolicy : AllStatic {
   // This supports the -Xcomp option.
   static void compile_if_required(const methodHandle& m, TRAPS);
 
-  static void wait_replay_training_at_init(JavaThread* current);
+  static void wait_replay_training_to_finish(JavaThread* current);
   static void replay_training_at_init(InstanceKlass* klass, JavaThread* current);
   static void replay_training_at_init_loop(JavaThread* current);
 

--- a/src/hotspot/share/compiler/compilationPolicy.hpp
+++ b/src/hotspot/share/compiler/compilationPolicy.hpp
@@ -91,7 +91,7 @@ public:
 
   T* pop(Monitor* lock, JavaThread* current) {
     MonitorLocker locker(current, lock);
-    while(is_empty_unlocked() && !CompileBroker::is_compilation_disabled_forever()) {
+    while (is_empty_unlocked() && (!CompileBroker::is_compilation_disabled_forever() || AOTVerifyTrainingData)) {
       locker.wait();
     }
     T* value = pop_unlocked();

--- a/src/hotspot/share/oops/trainingData.cpp
+++ b/src/hotspot/share/oops/trainingData.cpp
@@ -98,7 +98,7 @@ void TrainingData::verify() {
           Key k(mtd->holder());
           verify_archived_entry(td, &k);
         }
-        mtd->verify(true);
+        mtd->verify(/*verify_dep_counter*/true);
       }
     });
   }
@@ -110,7 +110,9 @@ void TrainingData::verify() {
         ktd->verify();
       } else if (td->is_MethodTrainingData()) {
         MethodTrainingData* mtd = td->as_MethodTrainingData();
-        mtd->verify(false);
+        // During the training run init deps tracking is not setup yet,
+        // don't verify it.
+        mtd->verify(/*verify_dep_counter*/false);
       }
     });
   }

--- a/src/hotspot/share/oops/trainingData.cpp
+++ b/src/hotspot/share/oops/trainingData.cpp
@@ -241,7 +241,7 @@ CompileTrainingData* CompileTrainingData::make(CompileTask* task) {
 }
 
 
-void CompileTrainingData::dec_init_deps_left(KlassTrainingData* ktd) {
+void CompileTrainingData::dec_init_deps_left_release(KlassTrainingData* ktd) {
   LogStreamHandle(Trace, training) log;
   if (log.is_enabled()) {
     log.print("CTD "); print_on(&log); log.cr();
@@ -462,7 +462,7 @@ void KlassTrainingData::notice_fully_initialized() {
   TrainingDataLocker l; // Not a real lock if we don't collect the data,
                         // that's why we need the atomic decrement below.
   for (int i = 0; i < comp_dep_count(); i++) {
-    comp_dep(i)->dec_init_deps_left(this);
+    comp_dep(i)->dec_init_deps_left_release(this);
   }
   holder()->set_has_init_deps_processed();
 }
@@ -629,7 +629,7 @@ void CompileTrainingData::verify(bool verify_dep_counter) {
   }
 
   if (verify_dep_counter) {
-    int init_deps_left1 = init_deps_left();
+    int init_deps_left1 = init_deps_left_acquire();
     int init_deps_left2 = compute_init_deps_left();
 
     if (init_deps_left1 != init_deps_left2) {

--- a/src/hotspot/share/oops/trainingData.cpp
+++ b/src/hotspot/share/oops/trainingData.cpp
@@ -83,7 +83,7 @@ static void verify_archived_entry(TrainingData* td, const TrainingData::Key* k) 
 }
 
 void TrainingData::verify() {
-  if (TrainingData::have_data()) {
+  if (TrainingData::have_data() && !TrainingData::assembling_data()) {
     archived_training_data_dictionary()->iterate([&](TrainingData* td) {
       if (td->is_KlassTrainingData()) {
         KlassTrainingData* ktd = td->as_KlassTrainingData();
@@ -98,9 +98,19 @@ void TrainingData::verify() {
           Key k(mtd->holder());
           verify_archived_entry(td, &k);
         }
-        mtd->verify();
-      } else if (td->is_CompileTrainingData()) {
-        td->as_CompileTrainingData()->verify();
+        mtd->verify(true);
+      }
+    });
+  }
+  if (TrainingData::need_data()) {
+    TrainingDataLocker l;
+    training_data_set()->iterate([&](TrainingData* td) {
+      if (td->is_KlassTrainingData()) {
+        KlassTrainingData* ktd = td->as_KlassTrainingData();
+        ktd->verify();
+      } else if (td->is_MethodTrainingData()) {
+        MethodTrainingData* mtd = td->as_MethodTrainingData();
+        mtd->verify(false);
       }
     });
   }
@@ -476,10 +486,10 @@ void TrainingData::init_dumptime_table(TRAPS) {
         _dumptime_training_data_dictionary->append(td);
       }
     });
+  }
 
-    if (AOTVerifyTrainingData) {
-      training_data_set()->verify();
-    }
+  if (AOTVerifyTrainingData) {
+    TrainingData::verify();
   }
 }
 
@@ -592,22 +602,13 @@ void KlassTrainingData::verify() {
   }
 }
 
-void MethodTrainingData::verify() {
-  iterate_compiles([](CompileTrainingData* ctd) {
-    ctd->verify();
-
-    int init_deps_left1 = ctd->init_deps_left();
-    int init_deps_left2 = ctd->compute_init_deps_left();
-
-    if (init_deps_left1 != init_deps_left2) {
-      ctd->print_on(tty); tty->cr();
-    }
-    guarantee(init_deps_left1 == init_deps_left2, "mismatch: %d %d %d",
-              init_deps_left1, init_deps_left2, ctd->init_deps_left());
+void MethodTrainingData::verify(bool verify_dep_counter) {
+  iterate_compiles([&](CompileTrainingData* ctd) {
+    ctd->verify(verify_dep_counter);
   });
 }
 
-void CompileTrainingData::verify() {
+void CompileTrainingData::verify(bool verify_dep_counter) {
   for (int i = 0; i < init_dep_count(); i++) {
     KlassTrainingData* ktd = init_dep(i);
     if (ktd->has_holder() && ktd->holder()->defined_by_other_loaders()) {
@@ -623,6 +624,18 @@ void CompileTrainingData::verify() {
       ktd->print_on(tty); tty->cr();
     }
     guarantee(ktd->_comp_deps.contains(this), "");
+  }
+
+  if (verify_dep_counter) {
+    int init_deps_left1 = init_deps_left();
+    int init_deps_left2 = compute_init_deps_left();
+
+    if (init_deps_left1 != init_deps_left2) {
+      print_on(tty);
+      tty->cr();
+    }
+    guarantee(init_deps_left1 == init_deps_left2,
+              "init deps invariant violation: %d == %d", init_deps_left1, init_deps_left2);
   }
 }
 

--- a/src/hotspot/share/oops/trainingData.cpp
+++ b/src/hotspot/share/oops/trainingData.cpp
@@ -632,12 +632,12 @@ void CompileTrainingData::verify(bool verify_dep_counter) {
     int init_deps_left1 = init_deps_left_acquire();
     int init_deps_left2 = compute_init_deps_left();
 
-    if (init_deps_left1 != init_deps_left2) {
+    bool invariant = (init_deps_left1 >= init_deps_left2);
+    if (!invariant) {
       print_on(tty);
       tty->cr();
     }
-    guarantee(init_deps_left1 == init_deps_left2,
-              "init deps invariant violation: %d == %d", init_deps_left1, init_deps_left2);
+    guarantee(invariant, "init deps invariant violation: %d >= %d", init_deps_left1, init_deps_left2);
   }
 }
 

--- a/src/hotspot/share/oops/trainingData.hpp
+++ b/src/hotspot/share/oops/trainingData.hpp
@@ -675,7 +675,7 @@ public:
   }
   void dec_init_deps_left(KlassTrainingData* ktd);
   int init_deps_left() const {
-    return Atomic::load(&_init_deps_left);
+    return Atomic::load_acquire(&_init_deps_left);
   }
   uint compute_init_deps_left(bool count_initialized = false);
 
@@ -707,7 +707,7 @@ public:
     return (int)align_metadata_size(align_up(sizeof(CompileTrainingData), BytesPerWord)/BytesPerWord);
   }
 
-  void verify();
+  void verify(bool verify_dep_counter);
 
   static CompileTrainingData* allocate(MethodTrainingData* mtd, int level, int compile_id) {
     return TrainingData::allocate<CompileTrainingData>(mtd, level, compile_id);
@@ -828,7 +828,7 @@ class MethodTrainingData : public TrainingData {
     return "{ method training data }";
   };
 
-  void verify();
+  void verify(bool verify_dep_counter);
 
   static MethodTrainingData* allocate(Method* m, KlassTrainingData* ktd) {
     return TrainingData::allocate<MethodTrainingData>(m, ktd);

--- a/src/hotspot/share/oops/trainingData.hpp
+++ b/src/hotspot/share/oops/trainingData.hpp
@@ -673,8 +673,10 @@ public:
     }
     _init_deps.clear();
   }
-  void dec_init_deps_left(KlassTrainingData* ktd);
-  int init_deps_left() const { return _init_deps_left; }
+  void dec_init_deps_left_release(KlassTrainingData* ktd);
+  int init_deps_left_acquire() const {
+    return Atomic::load_acquire(&_init_deps_left);
+  }
   uint compute_init_deps_left(bool count_initialized = false);
 
   void notice_inlined_method(CompileTask* task, const methodHandle& method) NOT_CDS_RETURN;

--- a/src/hotspot/share/oops/trainingData.hpp
+++ b/src/hotspot/share/oops/trainingData.hpp
@@ -674,9 +674,7 @@ public:
     _init_deps.clear();
   }
   void dec_init_deps_left(KlassTrainingData* ktd);
-  int init_deps_left() const {
-    return Atomic::load_acquire(&_init_deps_left);
-  }
+  int init_deps_left() const { return _init_deps_left; }
   uint compute_init_deps_left(bool count_initialized = false);
 
   void notice_inlined_method(CompileTask* task, const methodHandle& method) NOT_CDS_RETURN;

--- a/src/hotspot/share/runtime/init.cpp
+++ b/src/hotspot/share/runtime/init.cpp
@@ -195,10 +195,7 @@ jint init_globals2() {
   }
 #endif
 
-  // Initialize TrainingData only we're recording/replaying
-  if (TrainingData::have_data() || TrainingData::need_data()) {
-   TrainingData::initialize();
-  }
+  TrainingData::initialize();
 
   if (!universe_post_init()) {
     return JNI_ERR;

--- a/src/hotspot/share/runtime/java.cpp
+++ b/src/hotspot/share/runtime/java.cpp
@@ -34,6 +34,7 @@
 #include "classfile/systemDictionary.hpp"
 #include "code/codeCache.hpp"
 #include "compiler/compilationMemoryStatistic.hpp"
+#include "compiler/compilationPolicy.hpp"
 #include "compiler/compileBroker.hpp"
 #include "compiler/compilerOracle.hpp"
 #include "gc/shared/collectedHeap.hpp"
@@ -514,6 +515,12 @@ void before_exit(JavaThread* thread, bool halt) {
   // Terminate the signal thread
   // Note: we don't wait until it actually dies.
   os::terminate_signal_thread();
+
+  if (AOTVerifyTrainingData) {
+    EXCEPTION_MARK;
+    CompilationPolicy::flush_replay_training_at_init(THREAD);
+    TrainingData::verify();
+  }
 
   print_statistics();
 

--- a/src/hotspot/share/runtime/java.cpp
+++ b/src/hotspot/share/runtime/java.cpp
@@ -519,7 +519,7 @@ void before_exit(JavaThread* thread, bool halt) {
   #if INCLUDE_CDS
   if (AOTVerifyTrainingData) {
     EXCEPTION_MARK;
-    CompilationPolicy::flush_replay_training_at_init(THREAD);
+    CompilationPolicy::wait_replay_training_at_init(THREAD);
     TrainingData::verify();
   }
   #endif

--- a/src/hotspot/share/runtime/java.cpp
+++ b/src/hotspot/share/runtime/java.cpp
@@ -518,8 +518,6 @@ void before_exit(JavaThread* thread, bool halt) {
 
   #if INCLUDE_CDS
   if (AOTVerifyTrainingData) {
-    EXCEPTION_MARK;
-    CompilationPolicy::wait_replay_training_to_finish(THREAD);
     TrainingData::verify();
   }
   #endif

--- a/src/hotspot/share/runtime/java.cpp
+++ b/src/hotspot/share/runtime/java.cpp
@@ -516,11 +516,13 @@ void before_exit(JavaThread* thread, bool halt) {
   // Note: we don't wait until it actually dies.
   os::terminate_signal_thread();
 
+  #if INCLUDE_CDS
   if (AOTVerifyTrainingData) {
     EXCEPTION_MARK;
     CompilationPolicy::flush_replay_training_at_init(THREAD);
     TrainingData::verify();
   }
+  #endif
 
   print_statistics();
 

--- a/src/hotspot/share/runtime/java.cpp
+++ b/src/hotspot/share/runtime/java.cpp
@@ -519,7 +519,7 @@ void before_exit(JavaThread* thread, bool halt) {
   #if INCLUDE_CDS
   if (AOTVerifyTrainingData) {
     EXCEPTION_MARK;
-    CompilationPolicy::wait_replay_training_at_init(THREAD);
+    CompilationPolicy::wait_replay_training_to_finish(THREAD);
     TrainingData::verify();
   }
   #endif


### PR DESCRIPTION
This change fixes multiple issue with training data verification. While the current state of things in the mainline will not cause  any issues (because of the absence of the call to `TD::verify()` during the shutdown) it does problems in the leyden repo. This change strengthens verification in the mainline (by adding the shutdown verify call), and fixes the problems that prevent  it from working reliably.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8365407](https://bugs.openjdk.org/browse/JDK-8365407): Race condition in MethodTrainingData::verify() (**Bug** - P3)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Vladimir Ivanov](https://openjdk.org/census#vlivanov) (@iwanowww - **Reviewer**)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26866/head:pull/26866` \
`$ git checkout pull/26866`

Update a local copy of the PR: \
`$ git checkout pull/26866` \
`$ git pull https://git.openjdk.org/jdk.git pull/26866/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26866`

View PR using the GUI difftool: \
`$ git pr show -t 26866`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26866.diff">https://git.openjdk.org/jdk/pull/26866.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26866#issuecomment-3207571739)
</details>
