### PR TITLE
8360882: Tests throw SkippedException when they should fail

### DIFF
--- a/test/jdk/sun/security/pkcs11/PKCS11Test.java
+++ b/test/jdk/sun/security/pkcs11/PKCS11Test.java
@@ -734,7 +734,12 @@ public abstract class PKCS11Test {
     }
 
     private static Path fetchNssLib(Class<?> clazz, Path libraryName) throws IOException {
-        Path p = ArtifactResolver.fetchOne(clazz);
+        Path p;
+        try {
+            p = ArtifactResolver.fetchOne(clazz);
+        } catch (IOException exc) {
+            throw new SkippedException("Could not find NSS", exc);
+        }
         return findNSSLibrary(p, libraryName);
     }
 

--- a/test/lib/jdk/test/lib/artifacts/ArtifactResolver.java
+++ b/test/lib/jdk/test/lib/artifacts/ArtifactResolver.java
@@ -23,8 +23,7 @@
 
 package jdk.test.lib.artifacts;
 
-import jtreg.SkippedException;
-
+import java.io.IOException;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
@@ -90,15 +89,15 @@ public class ArtifactResolver {
      * @return the local path to the artifact. If the artifact is a compressed
      * file that gets unpacked, this path will point to the root
      * directory of the uncompressed file(s).
-     * @throws SkippedException thrown if the artifact cannot be found
+     * @throws IOException thrown if the artifact cannot be found
      */
-    public static Path fetchOne(Class<?> klass) {
+    public static Path fetchOne(Class<?> klass) throws IOException {
         try {
             return ArtifactResolver.resolve(klass).entrySet().stream()
                     .findAny().get().getValue();
         } catch (ArtifactResolverException e) {
             Artifact artifact = klass.getAnnotation(Artifact.class);
-            throw new SkippedException("Cannot find the artifact " + artifact.name(), e);
+            throw new IOException("Cannot find the artifact " + artifact.name(), e);
         }
     }
 

--- a/test/lib/jdk/test/lib/security/OpensslArtifactFetcher.java
+++ b/test/lib/jdk/test/lib/security/OpensslArtifactFetcher.java
@@ -50,7 +50,7 @@ public class OpensslArtifactFetcher {
      *
      * @return openssl binary path of the current version
      * @throws SkippedException if a valid version of OpenSSL cannot be found
-     * 	              or if OpenSSL is not available on the target platform
+     *         or if OpenSSL is not available on the target platform
      */
     public static String getOpensslPath() {
         String path = getOpensslFromSystemProp(OPENSSL_BUNDLE_VERSION);

--- a/test/lib/jdk/test/lib/security/OpensslArtifactFetcher.java
+++ b/test/lib/jdk/test/lib/security/OpensslArtifactFetcher.java
@@ -49,10 +49,9 @@ public class OpensslArtifactFetcher {
            and return that path, if download fails then return null.
      *
      * @return openssl binary path of the current version
-     * @throws IOException if a valid version of OpenSSL cannot be found
      * @throws SkippedException if OpenSSL is not available on the target platform
      */
-    public static String getOpensslPath() throws IOException {
+    public static String getOpensslPath() {
         String path = getOpensslFromSystemProp(OPENSSL_BUNDLE_VERSION);
         if (path != null) {
             System.out.println("Using OpenSSL from system property.");
@@ -118,10 +117,14 @@ public class OpensslArtifactFetcher {
         return false;
     }
 
-    private static String fetchOpenssl(Class<?> clazz) throws IOException {
-        return ArtifactResolver.fetchOne(clazz)
-                .resolve("openssl", "bin", "openssl")
-                .toString();
+    private static String fetchOpenssl(Class<?> clazz) {
+        try {
+            return ArtifactResolver.fetchOne(clazz)
+                    .resolve("openssl", "bin", "openssl")
+                    .toString();
+        } catch (IOException exc) {
+            throw new SkippedException("Could not find openssl", exc);
+        }
     }
 
     // retrieve the provider directory path from <OPENSSL_HOME>/bin/openssl

--- a/test/lib/jdk/test/lib/security/OpensslArtifactFetcher.java
+++ b/test/lib/jdk/test/lib/security/OpensslArtifactFetcher.java
@@ -49,7 +49,8 @@ public class OpensslArtifactFetcher {
            and return that path, if download fails then return null.
      *
      * @return openssl binary path of the current version
-     * @throws SkippedException if OpenSSL is not available on the target platform
+     * @throws SkippedException if a valid version of OpenSSL cannot be found
+     * 	              or if OpenSSL is not available on the target platform
      */
     public static String getOpensslPath() {
         String path = getOpensslFromSystemProp(OPENSSL_BUNDLE_VERSION);

--- a/test/lib/jdk/test/lib/security/OpensslArtifactFetcher.java
+++ b/test/lib/jdk/test/lib/security/OpensslArtifactFetcher.java
@@ -50,9 +50,21 @@ public class OpensslArtifactFetcher {
      *
      * @return openssl binary path of the current version
      * @throws IOException if a valid version of OpenSSL cannot be found
+     * @throws SkippedException if OpenSSL is not available on the target platform
      */
     public static String getOpensslPath() throws IOException {
-        String path;
+        String path = getOpensslFromSystemProp(OPENSSL_BUNDLE_VERSION);
+        if (path != null) {
+            System.out.println("Using OpenSSL from system property.");
+            return path;
+        }
+
+        path = getDefaultSystemOpensslPath(OPENSSL_BUNDLE_VERSION);
+        if (path != null) {
+            System.out.println("Using OpenSSL from system.");
+            return path;
+        }
+
         if (Platform.isX64()) {
             if (Platform.isLinux()) {
                 return fetchOpenssl(LINUX_X64.class);
@@ -68,16 +80,6 @@ public class OpensslArtifactFetcher {
             if (Platform.isOSX()) {
                 return fetchOpenssl(MACOSX_AARCH64.class);
             }
-        }
-
-        path = getOpensslFromSystemProp(OPENSSL_BUNDLE_VERSION);
-        if (path != null) {
-            return path;
-        }
-
-        path = getDefaultSystemOpensslPath(OPENSSL_BUNDLE_VERSION);
-        if (path != null) {
-            return path;
         }
 
         throw new SkippedException(String.format("No OpenSSL %s found for %s/%s",


### PR DESCRIPTION
This PR updates `ArtifactResolver.fetchOne()` to throw an IOException instead of SkippedException. This allows tests to determine of a missing "artifact" should be treated as a failed or skipped test.`OpensslArtifactFetcher` is also updated to only throw SkippedException if OpenSSL is not available on the test platform.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8360882](https://bugs.openjdk.org/browse/JDK-8360882): Tests throw SkippedException when they should fail (**Bug** - P4)


### Reviewers
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26868/head:pull/26868` \
`$ git checkout pull/26868`

Update a local copy of the PR: \
`$ git checkout pull/26868` \
`$ git pull https://git.openjdk.org/jdk.git pull/26868/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26868`

View PR using the GUI difftool: \
`$ git pr show -t 26868`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26868.diff">https://git.openjdk.org/jdk/pull/26868.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26868#issuecomment-3207925666)
</details>
