### PR TITLE
8365885: Clean up constant pool reflection native code

### DIFF
--- a/src/hotspot/share/include/jvm.h
+++ b/src/hotspot/share/include/jvm.h
@@ -644,58 +644,58 @@ JNIEXPORT jobject JNICALL
 JVM_GetClassConstantPool(JNIEnv *env, jclass cls);
 
 JNIEXPORT jint JNICALL JVM_ConstantPoolGetSize
-(JNIEnv *env, jobject unused, jobject jcpool);
+(JNIEnv *env, jobject jcpool);
 
 JNIEXPORT jclass JNICALL JVM_ConstantPoolGetClassAt
-(JNIEnv *env, jobject unused, jobject jcpool, jint index);
+(JNIEnv *env, jobject jcpool, jint index);
 
 JNIEXPORT jclass JNICALL JVM_ConstantPoolGetClassAtIfLoaded
-(JNIEnv *env, jobject unused, jobject jcpool, jint index);
+(JNIEnv *env, jobject jcpool, jint index);
 
 JNIEXPORT jint JNICALL JVM_ConstantPoolGetClassRefIndexAt
-(JNIEnv *env, jobject obj, jobject unused, jint index);
+(JNIEnv *env, jobject jcpool, jint index);
 
 JNIEXPORT jobject JNICALL JVM_ConstantPoolGetMethodAt
-(JNIEnv *env, jobject unused, jobject jcpool, jint index);
+(JNIEnv *env, jobject jcpool, jint index);
 
 JNIEXPORT jobject JNICALL JVM_ConstantPoolGetMethodAtIfLoaded
-(JNIEnv *env, jobject unused, jobject jcpool, jint index);
+(JNIEnv *env, jobject jcpool, jint index);
 
 JNIEXPORT jobject JNICALL JVM_ConstantPoolGetFieldAt
-(JNIEnv *env, jobject unused, jobject jcpool, jint index);
+(JNIEnv *env, jobject jcpool, jint index);
 
 JNIEXPORT jobject JNICALL JVM_ConstantPoolGetFieldAtIfLoaded
-(JNIEnv *env, jobject unused, jobject jcpool, jint index);
+(JNIEnv *env, jobject jcpool, jint index);
 
 JNIEXPORT jobjectArray JNICALL JVM_ConstantPoolGetMemberRefInfoAt
-(JNIEnv *env, jobject unused, jobject jcpool, jint index);
+(JNIEnv *env, jobject jcpool, jint index);
 
 JNIEXPORT jint JNICALL JVM_ConstantPoolGetNameAndTypeRefIndexAt
-(JNIEnv *env, jobject obj, jobject unused, jint index);
+(JNIEnv *env, jobject jcpool, jint index);
 
 JNIEXPORT jobjectArray JNICALL JVM_ConstantPoolGetNameAndTypeRefInfoAt
-(JNIEnv *env, jobject obj, jobject unused, jint index);
+(JNIEnv *env, jobject jcpool, jint index);
 
 JNIEXPORT jint JNICALL JVM_ConstantPoolGetIntAt
-(JNIEnv *env, jobject unused, jobject jcpool, jint index);
+(JNIEnv *env, jobject jcpool, jint index);
 
 JNIEXPORT jlong JNICALL JVM_ConstantPoolGetLongAt
-(JNIEnv *env, jobject unused, jobject jcpool, jint index);
+(JNIEnv *env, jobject jcpool, jint index);
 
 JNIEXPORT jfloat JNICALL JVM_ConstantPoolGetFloatAt
-(JNIEnv *env, jobject unused, jobject jcpool, jint index);
+(JNIEnv *env, jobject jcpool, jint index);
 
 JNIEXPORT jdouble JNICALL JVM_ConstantPoolGetDoubleAt
-(JNIEnv *env, jobject unused, jobject jcpool, jint index);
+(JNIEnv *env, jobject jcpool, jint index);
 
 JNIEXPORT jstring JNICALL JVM_ConstantPoolGetStringAt
-(JNIEnv *env, jobject unused, jobject jcpool, jint index);
+(JNIEnv *env, jobject jcpool, jint index);
 
 JNIEXPORT jstring JNICALL JVM_ConstantPoolGetUTF8At
-(JNIEnv *env, jobject unused, jobject jcpool, jint index);
+(JNIEnv *env, jobject jcpool, jint index);
 
 JNIEXPORT jbyte JNICALL JVM_ConstantPoolGetTagAt
-(JNIEnv *env, jobject unused, jobject jcpool, jint index);
+(JNIEnv *env, jobject jcpool, jint index);
 
 /*
  * Parameter reflection

--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -1927,7 +1927,7 @@ JVM_ENTRY(jobject, JVM_GetClassConstantPool(JNIEnv *env, jclass cls))
 JVM_END
 
 
-JVM_ENTRY(jint, JVM_ConstantPoolGetSize(JNIEnv *env, jobject obj, jobject unused))
+JVM_ENTRY(jint, JVM_ConstantPoolGetSize(JNIEnv *env, jobject obj))
 {
   constantPoolHandle cp = constantPoolHandle(THREAD, reflect_ConstantPool::get_cp(JNIHandles::resolve_non_null(obj)));
   return cp->length();
@@ -1935,7 +1935,7 @@ JVM_ENTRY(jint, JVM_ConstantPoolGetSize(JNIEnv *env, jobject obj, jobject unused
 JVM_END
 
 
-JVM_ENTRY(jclass, JVM_ConstantPoolGetClassAt(JNIEnv *env, jobject obj, jobject unused, jint index))
+JVM_ENTRY(jclass, JVM_ConstantPoolGetClassAt(JNIEnv *env, jobject obj, jint index))
 {
   constantPoolHandle cp = constantPoolHandle(THREAD, reflect_ConstantPool::get_cp(JNIHandles::resolve_non_null(obj)));
   bounds_check(cp, index, CHECK_NULL);
@@ -1948,7 +1948,7 @@ JVM_ENTRY(jclass, JVM_ConstantPoolGetClassAt(JNIEnv *env, jobject obj, jobject u
 }
 JVM_END
 
-JVM_ENTRY(jclass, JVM_ConstantPoolGetClassAtIfLoaded(JNIEnv *env, jobject obj, jobject unused, jint index))
+JVM_ENTRY(jclass, JVM_ConstantPoolGetClassAtIfLoaded(JNIEnv *env, jobject obj, jint index))
 {
   constantPoolHandle cp = constantPoolHandle(THREAD, reflect_ConstantPool::get_cp(JNIHandles::resolve_non_null(obj)));
   bounds_check(cp, index, CHECK_NULL);
@@ -1992,7 +1992,7 @@ static jobject get_method_at_helper(const constantPoolHandle& cp, jint index, bo
   return JNIHandles::make_local(THREAD, method);
 }
 
-JVM_ENTRY(jobject, JVM_ConstantPoolGetMethodAt(JNIEnv *env, jobject obj, jobject unused, jint index))
+JVM_ENTRY(jobject, JVM_ConstantPoolGetMethodAt(JNIEnv *env, jobject obj, jint index))
 {
   JvmtiVMObjectAllocEventCollector oam;
   constantPoolHandle cp = constantPoolHandle(THREAD, reflect_ConstantPool::get_cp(JNIHandles::resolve_non_null(obj)));
@@ -2002,7 +2002,7 @@ JVM_ENTRY(jobject, JVM_ConstantPoolGetMethodAt(JNIEnv *env, jobject obj, jobject
 }
 JVM_END
 
-JVM_ENTRY(jobject, JVM_ConstantPoolGetMethodAtIfLoaded(JNIEnv *env, jobject obj, jobject unused, jint index))
+JVM_ENTRY(jobject, JVM_ConstantPoolGetMethodAtIfLoaded(JNIEnv *env, jobject obj, jint index))
 {
   JvmtiVMObjectAllocEventCollector oam;
   constantPoolHandle cp = constantPoolHandle(THREAD, reflect_ConstantPool::get_cp(JNIHandles::resolve_non_null(obj)));
@@ -2037,7 +2037,7 @@ static jobject get_field_at_helper(constantPoolHandle cp, jint index, bool force
   return JNIHandles::make_local(THREAD, field);
 }
 
-JVM_ENTRY(jobject, JVM_ConstantPoolGetFieldAt(JNIEnv *env, jobject obj, jobject unusedl, jint index))
+JVM_ENTRY(jobject, JVM_ConstantPoolGetFieldAt(JNIEnv *env, jobject obj, jint index))
 {
   JvmtiVMObjectAllocEventCollector oam;
   constantPoolHandle cp = constantPoolHandle(THREAD, reflect_ConstantPool::get_cp(JNIHandles::resolve_non_null(obj)));
@@ -2047,7 +2047,7 @@ JVM_ENTRY(jobject, JVM_ConstantPoolGetFieldAt(JNIEnv *env, jobject obj, jobject 
 }
 JVM_END
 
-JVM_ENTRY(jobject, JVM_ConstantPoolGetFieldAtIfLoaded(JNIEnv *env, jobject obj, jobject unused, jint index))
+JVM_ENTRY(jobject, JVM_ConstantPoolGetFieldAtIfLoaded(JNIEnv *env, jobject obj, jint index))
 {
   JvmtiVMObjectAllocEventCollector oam;
   constantPoolHandle cp = constantPoolHandle(THREAD, reflect_ConstantPool::get_cp(JNIHandles::resolve_non_null(obj)));
@@ -2057,7 +2057,7 @@ JVM_ENTRY(jobject, JVM_ConstantPoolGetFieldAtIfLoaded(JNIEnv *env, jobject obj, 
 }
 JVM_END
 
-JVM_ENTRY(jobjectArray, JVM_ConstantPoolGetMemberRefInfoAt(JNIEnv *env, jobject obj, jobject unused, jint index))
+JVM_ENTRY(jobjectArray, JVM_ConstantPoolGetMemberRefInfoAt(JNIEnv *env, jobject obj, jint index))
 {
   JvmtiVMObjectAllocEventCollector oam;
   constantPoolHandle cp = constantPoolHandle(THREAD, reflect_ConstantPool::get_cp(JNIHandles::resolve_non_null(obj)));
@@ -2082,7 +2082,7 @@ JVM_ENTRY(jobjectArray, JVM_ConstantPoolGetMemberRefInfoAt(JNIEnv *env, jobject 
 }
 JVM_END
 
-JVM_ENTRY(jint, JVM_ConstantPoolGetClassRefIndexAt(JNIEnv *env, jobject obj, jobject unused, jint index))
+JVM_ENTRY(jint, JVM_ConstantPoolGetClassRefIndexAt(JNIEnv *env, jobject obj, jint index))
 {
   JvmtiVMObjectAllocEventCollector oam;
   constantPoolHandle cp(THREAD, reflect_ConstantPool::get_cp(JNIHandles::resolve_non_null(obj)));
@@ -2095,7 +2095,7 @@ JVM_ENTRY(jint, JVM_ConstantPoolGetClassRefIndexAt(JNIEnv *env, jobject obj, job
 }
 JVM_END
 
-JVM_ENTRY(jint, JVM_ConstantPoolGetNameAndTypeRefIndexAt(JNIEnv *env, jobject obj, jobject unused, jint index))
+JVM_ENTRY(jint, JVM_ConstantPoolGetNameAndTypeRefIndexAt(JNIEnv *env, jobject obj, jint index))
 {
   JvmtiVMObjectAllocEventCollector oam;
   constantPoolHandle cp(THREAD, reflect_ConstantPool::get_cp(JNIHandles::resolve_non_null(obj)));
@@ -2108,7 +2108,7 @@ JVM_ENTRY(jint, JVM_ConstantPoolGetNameAndTypeRefIndexAt(JNIEnv *env, jobject ob
 }
 JVM_END
 
-JVM_ENTRY(jobjectArray, JVM_ConstantPoolGetNameAndTypeRefInfoAt(JNIEnv *env, jobject obj, jobject unused, jint index))
+JVM_ENTRY(jobjectArray, JVM_ConstantPoolGetNameAndTypeRefInfoAt(JNIEnv *env, jobject obj, jint index))
 {
   JvmtiVMObjectAllocEventCollector oam;
   constantPoolHandle cp(THREAD, reflect_ConstantPool::get_cp(JNIHandles::resolve_non_null(obj)));
@@ -2129,7 +2129,7 @@ JVM_ENTRY(jobjectArray, JVM_ConstantPoolGetNameAndTypeRefInfoAt(JNIEnv *env, job
 }
 JVM_END
 
-JVM_ENTRY(jint, JVM_ConstantPoolGetIntAt(JNIEnv *env, jobject obj, jobject unused, jint index))
+JVM_ENTRY(jint, JVM_ConstantPoolGetIntAt(JNIEnv *env, jobject obj, jint index))
 {
   constantPoolHandle cp = constantPoolHandle(THREAD, reflect_ConstantPool::get_cp(JNIHandles::resolve_non_null(obj)));
   bounds_check(cp, index, CHECK_0);
@@ -2141,7 +2141,7 @@ JVM_ENTRY(jint, JVM_ConstantPoolGetIntAt(JNIEnv *env, jobject obj, jobject unuse
 }
 JVM_END
 
-JVM_ENTRY(jlong, JVM_ConstantPoolGetLongAt(JNIEnv *env, jobject obj, jobject unused, jint index))
+JVM_ENTRY(jlong, JVM_ConstantPoolGetLongAt(JNIEnv *env, jobject obj, jint index))
 {
   constantPoolHandle cp = constantPoolHandle(THREAD, reflect_ConstantPool::get_cp(JNIHandles::resolve_non_null(obj)));
   bounds_check(cp, index, CHECK_(0L));
@@ -2153,7 +2153,7 @@ JVM_ENTRY(jlong, JVM_ConstantPoolGetLongAt(JNIEnv *env, jobject obj, jobject unu
 }
 JVM_END
 
-JVM_ENTRY(jfloat, JVM_ConstantPoolGetFloatAt(JNIEnv *env, jobject obj, jobject unused, jint index))
+JVM_ENTRY(jfloat, JVM_ConstantPoolGetFloatAt(JNIEnv *env, jobject obj, jint index))
 {
   constantPoolHandle cp = constantPoolHandle(THREAD, reflect_ConstantPool::get_cp(JNIHandles::resolve_non_null(obj)));
   bounds_check(cp, index, CHECK_(0.0f));
@@ -2165,7 +2165,7 @@ JVM_ENTRY(jfloat, JVM_ConstantPoolGetFloatAt(JNIEnv *env, jobject obj, jobject u
 }
 JVM_END
 
-JVM_ENTRY(jdouble, JVM_ConstantPoolGetDoubleAt(JNIEnv *env, jobject obj, jobject unused, jint index))
+JVM_ENTRY(jdouble, JVM_ConstantPoolGetDoubleAt(JNIEnv *env, jobject obj, jint index))
 {
   constantPoolHandle cp = constantPoolHandle(THREAD, reflect_ConstantPool::get_cp(JNIHandles::resolve_non_null(obj)));
   bounds_check(cp, index, CHECK_(0.0));
@@ -2177,7 +2177,7 @@ JVM_ENTRY(jdouble, JVM_ConstantPoolGetDoubleAt(JNIEnv *env, jobject obj, jobject
 }
 JVM_END
 
-JVM_ENTRY(jstring, JVM_ConstantPoolGetStringAt(JNIEnv *env, jobject obj, jobject unused, jint index))
+JVM_ENTRY(jstring, JVM_ConstantPoolGetStringAt(JNIEnv *env, jobject obj, jint index))
 {
   constantPoolHandle cp = constantPoolHandle(THREAD, reflect_ConstantPool::get_cp(JNIHandles::resolve_non_null(obj)));
   bounds_check(cp, index, CHECK_NULL);
@@ -2190,7 +2190,7 @@ JVM_ENTRY(jstring, JVM_ConstantPoolGetStringAt(JNIEnv *env, jobject obj, jobject
 }
 JVM_END
 
-JVM_ENTRY(jstring, JVM_ConstantPoolGetUTF8At(JNIEnv *env, jobject obj, jobject unused, jint index))
+JVM_ENTRY(jstring, JVM_ConstantPoolGetUTF8At(JNIEnv *env, jobject obj, jint index))
 {
   JvmtiVMObjectAllocEventCollector oam;
   constantPoolHandle cp = constantPoolHandle(THREAD, reflect_ConstantPool::get_cp(JNIHandles::resolve_non_null(obj)));
@@ -2205,7 +2205,7 @@ JVM_ENTRY(jstring, JVM_ConstantPoolGetUTF8At(JNIEnv *env, jobject obj, jobject u
 }
 JVM_END
 
-JVM_ENTRY(jbyte, JVM_ConstantPoolGetTagAt(JNIEnv *env, jobject obj, jobject unused, jint index))
+JVM_ENTRY(jbyte, JVM_ConstantPoolGetTagAt(JNIEnv *env, jobject obj, jint index))
 {
   constantPoolHandle cp = constantPoolHandle(THREAD, reflect_ConstantPool::get_cp(JNIHandles::resolve_non_null(obj)));
   bounds_check(cp, index, CHECK_0);

--- a/src/java.base/share/classes/jdk/internal/reflect/ConstantPool.java
+++ b/src/java.base/share/classes/jdk/internal/reflect/ConstantPool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,41 +34,41 @@ import java.util.Set;
 
 public class ConstantPool {
   // Number of entries in this constant pool (= maximum valid constant pool index)
-  public int      getSize()                      { return getSize0            (constantPoolOop);        }
-  public Class<?> getClassAt         (int index) { return getClassAt0         (constantPoolOop, index); }
-  public Class<?> getClassAtIfLoaded (int index) { return getClassAtIfLoaded0 (constantPoolOop, index); }
+  public int      getSize()                      { return getSize0            ();        }
+  public Class<?> getClassAt         (int index) { return getClassAt0         (index); }
+  public Class<?> getClassAtIfLoaded (int index) { return getClassAtIfLoaded0 (index); }
   // Returns a class reference index for a method or a field.
   public int getClassRefIndexAt(int index) {
-      return getClassRefIndexAt0(constantPoolOop, index);
+      return getClassRefIndexAt0(index);
   }
   // Returns either a Method or Constructor.
   // Static initializers are returned as Method objects.
-  public Member   getMethodAt        (int index) { return getMethodAt0        (constantPoolOop, index); }
-  public Member   getMethodAtIfLoaded(int index) { return getMethodAtIfLoaded0(constantPoolOop, index); }
-  public Field    getFieldAt         (int index) { return getFieldAt0         (constantPoolOop, index); }
-  public Field    getFieldAtIfLoaded (int index) { return getFieldAtIfLoaded0 (constantPoolOop, index); }
+  public Member   getMethodAt        (int index) { return getMethodAt0        (index); }
+  public Member   getMethodAtIfLoaded(int index) { return getMethodAtIfLoaded0(index); }
+  public Field    getFieldAt         (int index) { return getFieldAt0         (index); }
+  public Field    getFieldAtIfLoaded (int index) { return getFieldAtIfLoaded0 (index); }
   // Fetches the class name, member (field, method or interface
   // method) name, and type descriptor as an array of three Strings
-  public String[] getMemberRefInfoAt (int index) { return getMemberRefInfoAt0 (constantPoolOop, index); }
+  public String[] getMemberRefInfoAt (int index) { return getMemberRefInfoAt0 (index); }
   // Returns a name and type reference index for a method, a field or an invokedynamic.
   public int getNameAndTypeRefIndexAt(int index) {
-      return getNameAndTypeRefIndexAt0(constantPoolOop, index);
+      return getNameAndTypeRefIndexAt0(index);
   }
   // Fetches the name and type from name_and_type index as an array of two Strings
   public String[] getNameAndTypeRefInfoAt(int index) {
-      return getNameAndTypeRefInfoAt0(constantPoolOop, index);
+      return getNameAndTypeRefInfoAt0(index);
   }
-  public int      getIntAt           (int index) { return getIntAt0           (constantPoolOop, index); }
-  public long     getLongAt          (int index) { return getLongAt0          (constantPoolOop, index); }
-  public float    getFloatAt         (int index) { return getFloatAt0         (constantPoolOop, index); }
-  public double   getDoubleAt        (int index) { return getDoubleAt0        (constantPoolOop, index); }
-  public String   getStringAt        (int index) { return getStringAt0        (constantPoolOop, index); }
-  public String   getUTF8At          (int index) { return getUTF8At0          (constantPoolOop, index); }
+  public int      getIntAt           (int index) { return getIntAt0           (index); }
+  public long     getLongAt          (int index) { return getLongAt0          (index); }
+  public float    getFloatAt         (int index) { return getFloatAt0         (index); }
+  public double   getDoubleAt        (int index) { return getDoubleAt0        (index); }
+  public String   getStringAt        (int index) { return getStringAt0        (index); }
+  public String   getUTF8At          (int index) { return getUTF8At0          (index); }
   public Tag getTagAt(int index) {
-      return Tag.valueOf(getTagAt0(constantPoolOop, index));
+      return Tag.valueOf(getTagAt0(index));
   }
 
-  public static enum Tag {
+  public enum Tag {
       UTF8(1),
       INTEGER(3),
       FLOAT(4),
@@ -82,7 +82,9 @@ public class ConstantPool {
       NAMEANDTYPE(12),
       METHODHANDLE(15),
       METHODTYPE(16),
+      DYNAMIC(17),
       INVOKEDYNAMIC(18),
+      // For index after long/double and 0
       INVALID(0);
 
       private final int tagCode;
@@ -111,22 +113,22 @@ public class ConstantPool {
   // HotSpot-internal constant pool object (set by the VM, name known to the VM)
   private Object constantPoolOop;
 
-  private native int      getSize0            (Object constantPoolOop);
-  private native Class<?> getClassAt0         (Object constantPoolOop, int index);
-  private native Class<?> getClassAtIfLoaded0 (Object constantPoolOop, int index);
-  private native int      getClassRefIndexAt0 (Object constantPoolOop, int index);
-  private native Member   getMethodAt0        (Object constantPoolOop, int index);
-  private native Member   getMethodAtIfLoaded0(Object constantPoolOop, int index);
-  private native Field    getFieldAt0         (Object constantPoolOop, int index);
-  private native Field    getFieldAtIfLoaded0 (Object constantPoolOop, int index);
-  private native String[] getMemberRefInfoAt0 (Object constantPoolOop, int index);
-  private native int      getNameAndTypeRefIndexAt0(Object constantPoolOop, int index);
-  private native String[] getNameAndTypeRefInfoAt0(Object constantPoolOop, int index);
-  private native int      getIntAt0           (Object constantPoolOop, int index);
-  private native long     getLongAt0          (Object constantPoolOop, int index);
-  private native float    getFloatAt0         (Object constantPoolOop, int index);
-  private native double   getDoubleAt0        (Object constantPoolOop, int index);
-  private native String   getStringAt0        (Object constantPoolOop, int index);
-  private native String   getUTF8At0          (Object constantPoolOop, int index);
-  private native byte     getTagAt0           (Object constantPoolOop, int index);
+  private native int      getSize0            ();
+  private native Class<?> getClassAt0         (int index);
+  private native Class<?> getClassAtIfLoaded0 (int index);
+  private native int      getClassRefIndexAt0 (int index);
+  private native Member   getMethodAt0        (int index);
+  private native Member   getMethodAtIfLoaded0(int index);
+  private native Field    getFieldAt0         (int index);
+  private native Field    getFieldAtIfLoaded0 (int index);
+  private native String[] getMemberRefInfoAt0 (int index);
+  private native int      getNameAndTypeRefIndexAt0(int index);
+  private native String[] getNameAndTypeRefInfoAt0(int index);
+  private native int      getIntAt0           (int index);
+  private native long     getLongAt0          (int index);
+  private native float    getFloatAt0         (int index);
+  private native double   getDoubleAt0        (int index);
+  private native String   getStringAt0        (int index);
+  private native String   getUTF8At0          (int index);
+  private native byte     getTagAt0           (int index);
 }

--- a/src/java.base/share/native/libjava/ConstantPool.c
+++ b/src/java.base/share/native/libjava/ConstantPool.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,110 +27,110 @@
 #include "jdk_internal_reflect_ConstantPool.h"
 
 JNIEXPORT jint JNICALL Java_jdk_internal_reflect_ConstantPool_getSize0
-(JNIEnv *env, jobject unused, jobject jcpool)
+(JNIEnv *env, jobject jcpool)
 {
-  return JVM_ConstantPoolGetSize(env, unused, jcpool);
+  return JVM_ConstantPoolGetSize(env, jcpool);
 }
 
 JNIEXPORT jclass JNICALL Java_jdk_internal_reflect_ConstantPool_getClassAt0
-(JNIEnv *env, jobject unused, jobject jcpool, jint index)
+(JNIEnv *env, jobject jcpool, jint index)
 {
-  return JVM_ConstantPoolGetClassAt(env, unused, jcpool, index);
+  return JVM_ConstantPoolGetClassAt(env, jcpool, index);
 }
 
 JNIEXPORT jclass JNICALL Java_jdk_internal_reflect_ConstantPool_getClassAtIfLoaded0
-(JNIEnv *env, jobject unused, jobject jcpool, jint index)
+(JNIEnv *env, jobject jcpool, jint index)
 {
-  return JVM_ConstantPoolGetClassAtIfLoaded(env, unused, jcpool, index);
+  return JVM_ConstantPoolGetClassAtIfLoaded(env, jcpool, index);
 }
 
 JNIEXPORT jint JNICALL Java_jdk_internal_reflect_ConstantPool_getClassRefIndexAt0
-(JNIEnv *env, jobject unused, jobject jcpool, jint index)
+(JNIEnv *env, jobject jcpool, jint index)
 {
-    return JVM_ConstantPoolGetClassRefIndexAt(env, unused, jcpool, index);
+    return JVM_ConstantPoolGetClassRefIndexAt(env, jcpool, index);
 }
 
 JNIEXPORT jobject JNICALL Java_jdk_internal_reflect_ConstantPool_getMethodAt0
-(JNIEnv *env, jobject unused, jobject jcpool, jint index)
+(JNIEnv *env, jobject jcpool, jint index)
 {
-  return JVM_ConstantPoolGetMethodAt(env, unused, jcpool, index);
+  return JVM_ConstantPoolGetMethodAt(env, jcpool, index);
 }
 
 JNIEXPORT jobject JNICALL Java_jdk_internal_reflect_ConstantPool_getMethodAtIfLoaded0
-(JNIEnv *env, jobject unused, jobject jcpool, jint index)
+(JNIEnv *env, jobject jcpool, jint index)
 {
-  return JVM_ConstantPoolGetMethodAtIfLoaded(env, unused, jcpool, index);
+  return JVM_ConstantPoolGetMethodAtIfLoaded(env, jcpool, index);
 }
 
 JNIEXPORT jobject JNICALL Java_jdk_internal_reflect_ConstantPool_getFieldAt0
-(JNIEnv *env, jobject unused, jobject jcpool, jint index)
+(JNIEnv *env, jobject jcpool, jint index)
 {
-  return JVM_ConstantPoolGetFieldAt(env, unused, jcpool, index);
+  return JVM_ConstantPoolGetFieldAt(env, jcpool, index);
 }
 
 JNIEXPORT jobject JNICALL Java_jdk_internal_reflect_ConstantPool_getFieldAtIfLoaded0
-(JNIEnv *env, jobject unused, jobject jcpool, jint index)
+(JNIEnv *env, jobject jcpool, jint index)
 {
-  return JVM_ConstantPoolGetFieldAtIfLoaded(env, unused, jcpool, index);
+  return JVM_ConstantPoolGetFieldAtIfLoaded(env, jcpool, index);
 }
 
 JNIEXPORT jobjectArray JNICALL Java_jdk_internal_reflect_ConstantPool_getMemberRefInfoAt0
-(JNIEnv *env, jobject unused, jobject jcpool, jint index)
+(JNIEnv *env, jobject jcpool, jint index)
 {
-  return JVM_ConstantPoolGetMemberRefInfoAt(env, unused, jcpool, index);
+  return JVM_ConstantPoolGetMemberRefInfoAt(env, jcpool, index);
 }
 
 JNIEXPORT jint JNICALL Java_jdk_internal_reflect_ConstantPool_getNameAndTypeRefIndexAt0
-(JNIEnv *env, jobject unused, jobject jcpool, jint index)
+(JNIEnv *env, jobject jcpool, jint index)
 {
-    return JVM_ConstantPoolGetNameAndTypeRefIndexAt(env, unused, jcpool, index);
+    return JVM_ConstantPoolGetNameAndTypeRefIndexAt(env, jcpool, index);
 }
 
 JNIEXPORT jobjectArray JNICALL Java_jdk_internal_reflect_ConstantPool_getNameAndTypeRefInfoAt0
-(JNIEnv *env, jobject unused, jobject jcpool, jint index)
+(JNIEnv *env, jobject jcpool, jint index)
 {
-  return JVM_ConstantPoolGetNameAndTypeRefInfoAt(env, unused, jcpool, index);
+  return JVM_ConstantPoolGetNameAndTypeRefInfoAt(env, jcpool, index);
 }
 
 JNIEXPORT jint JNICALL Java_jdk_internal_reflect_ConstantPool_getIntAt0
-(JNIEnv *env, jobject unused, jobject jcpool, jint index)
+(JNIEnv *env, jobject jcpool, jint index)
 {
-  return JVM_ConstantPoolGetIntAt(env, unused, jcpool, index);
+  return JVM_ConstantPoolGetIntAt(env, jcpool, index);
 }
 
 JNIEXPORT jlong JNICALL Java_jdk_internal_reflect_ConstantPool_getLongAt0
-(JNIEnv *env, jobject unused, jobject jcpool, jint index)
+(JNIEnv *env, jobject jcpool, jint index)
 {
-  return JVM_ConstantPoolGetLongAt(env, unused, jcpool, index);
+  return JVM_ConstantPoolGetLongAt(env, jcpool, index);
 }
 
 JNIEXPORT jfloat JNICALL Java_jdk_internal_reflect_ConstantPool_getFloatAt0
-(JNIEnv *env, jobject unused, jobject jcpool, jint index)
+(JNIEnv *env, jobject jcpool, jint index)
 {
-  return JVM_ConstantPoolGetFloatAt(env, unused, jcpool, index);
+  return JVM_ConstantPoolGetFloatAt(env, jcpool, index);
 }
 
 JNIEXPORT jdouble JNICALL Java_jdk_internal_reflect_ConstantPool_getDoubleAt0
-(JNIEnv *env, jobject unused, jobject jcpool, jint index)
+(JNIEnv *env, jobject jcpool, jint index)
 {
-  return JVM_ConstantPoolGetDoubleAt(env, unused, jcpool, index);
+  return JVM_ConstantPoolGetDoubleAt(env, jcpool, index);
 }
 
 JNIEXPORT jstring JNICALL Java_jdk_internal_reflect_ConstantPool_getStringAt0
-(JNIEnv *env, jobject unused, jobject jcpool, jint index)
+(JNIEnv *env, jobject jcpool, jint index)
 {
-  return JVM_ConstantPoolGetStringAt(env, unused, jcpool, index);
+  return JVM_ConstantPoolGetStringAt(env, jcpool, index);
 }
 
 JNIEXPORT jstring JNICALL Java_jdk_internal_reflect_ConstantPool_getUTF8At0
-(JNIEnv *env, jobject unused, jobject jcpool, jint index)
+(JNIEnv *env, jobject jcpool, jint index)
 {
-  return JVM_ConstantPoolGetUTF8At(env, unused, jcpool, index);
+  return JVM_ConstantPoolGetUTF8At(env, jcpool, index);
 }
 
 JNIEXPORT jbyte JNICALL Java_jdk_internal_reflect_ConstantPool_getTagAt0
-(JNIEnv *env, jobject unused, jobject jcpool, jint index)
+(JNIEnv *env, jobject jcpool, jint index)
 {
-  return JVM_ConstantPoolGetTagAt(env, unused, jcpool, index);
+  return JVM_ConstantPoolGetTagAt(env, jcpool, index);
 }
 

--- a/test/jdk/jdk/internal/reflect/constantPool/ConstantPoolTest.java
+++ b/test/jdk/jdk/internal/reflect/constantPool/ConstantPoolTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,16 +29,21 @@
  *          java.base/jdk.internal.reflect
  * @library /test/lib
  * @compile ConstantPoolTestDummy.jasm
- * @run main jdk.internal.reflect.constantPool.ConstantPoolTest
+ * @compile ConstantPoolTest.java
+ * @run junit ConstantPoolTest
  */
 
-package jdk.internal.reflect.constantPool;
-
+import java.lang.classfile.ClassFile;
 import java.util.HashMap;
 import java.util.Map;
 import jdk.internal.access.SharedSecrets;
 import jdk.internal.reflect.ConstantPool;
 import jdk.test.lib.Asserts;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ConstantPoolTest {
 
@@ -46,13 +51,23 @@ public class ConstantPoolTest {
     private static final ConstantPool CP = SharedSecrets.getJavaLangAccess()
             .getConstantPool(TEST_CLASS);
 
-    public static void main(String[] s) {
-        for (TestCase testCase : TestCase.values()) {
-            testCase.test();
-        }
+    @ParameterizedTest
+    @EnumSource(TestCase.class)
+    void runTestCases(TestCase testCase) {
+        testCase.test();
     }
 
-    public static enum TestCase {
+    @Test
+    void testSize() throws Throwable {
+        byte[] data;
+        try (var in = ConstantPoolTest.class.getResourceAsStream("/ConstantPoolTestDummy.class")) {
+            data = in.readAllBytes();
+        }
+        var testClass = ClassFile.of().parse(data);
+        assertEquals(testClass.constantPool().size(), CP.getSize());
+    }
+
+    public enum TestCase {
         GET_TAG_AT {
             {
                 referenceMap.put(1, ConstantPool.Tag.METHODREF);

--- a/test/jdk/jdk/internal/reflect/constantPool/ConstantPoolTestDummy.jasm
+++ b/test/jdk/jdk/internal/reflect/constantPool/ConstantPoolTestDummy.jasm
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,8 +21,6 @@
  * questions.
  */
 
-package  jdk/internal/reflect/constantPool;
-
 super public    #2; //class ConstantPoolTestDummy
     version 52:0
 {
@@ -41,7 +39,7 @@ const #7 = Asciz    "LineNumberTable";
 const #8 = Asciz    "SourceFile";
 const #9 = Asciz    "ConstantPoolTestDummy.java";
 const #10 = NameAndType #4:#5;  //  "<init>":"()V"
-const #11 = Asciz   "jdk/internal/reflect/constantPool/ConstantPoolTestDummy";
+const #11 = Asciz   "ConstantPoolTestDummy";
 const #12 = Asciz   "java/lang/Object";
 const #13 = long    6l;
 const #15 = int     1;
@@ -76,7 +74,7 @@ const #44 = Asciz   "Lookup";
 const #45 = class   #47;    //  java/lang/invoke/MethodHandles
 const #46 = Asciz   "java/lang/invoke/MethodHandles$Lookup";
 const #47 = Asciz   "java/lang/invoke/MethodHandles";
-const #48 = Field    #2.#49;    //  jdk/internal/reflect/constantPool/ConstantPoolTestDummy.myField:"I"
+const #48 = Field    #2.#49;    //  ConstantPoolTestDummy.myField:"I"
 const #49 = NameAndType #50:#51;    //  myField:"I"
 const #50 = Asciz   "myField";
 const #51 = Asciz   "I";


### PR DESCRIPTION
When I was trying to reuse this constant pool reflection for assembly phase indy argument validation, I noted the JNI code has a lot of confusing arguments. In particular, the JVM_ConstantPoolGetSize is wrong because of argument confusion. We should remove the unused arguments to reduce confusion.