### PR TITLE
8360160: ubuntu-22-04 machine is failing client tests

### DIFF
--- a/test/jdk/java/awt/Frame/FrameVisualTest.java
+++ b/test/jdk/java/awt/Frame/FrameVisualTest.java
@@ -56,7 +56,6 @@ public class FrameVisualTest {
     public static void main(String[] args) throws Exception {
         gcs = GraphicsEnvironment.getLocalGraphicsEnvironment().getDefaultScreenDevice().getConfigurations();
         robot = new Robot();
-        robot.waitForIdle();
         try {
             EventQueue.invokeAndWait(() -> createAndShowUI());
 
@@ -86,7 +85,6 @@ public class FrameVisualTest {
             for (index = 0; index < frames.length; index++) {
                 EventQueue.invokeAndWait(() -> {
                     if (frames[index] != null) {
-                        frames[index].setVisible(false);
                         frames[index].dispose();
                         frames[index] = null;
                     }


### PR DESCRIPTION
Ubuntu machine has multiple failing java awt tests. When looking at the screenshots of the desktop when each test fails, a white square can be seen at the top-left of the desktop.

<img width="803" height="344" alt="Screenshot 2025-08-20 at 10 06 37 AM" src="https://github.com/user-attachments/assets/52d023f6-18ff-46d4-98c4-e2e332ab6a03" />

This seems to be similar to the white square that `FrameVisualTest.java` creates so the frame was not disposed of properly during this failure. I have tried re-creating this failure on Ubuntu 22.04, similar to the failure OS that this originally occurred on, to no avail. I ran this test individually, and with all of the listed failing tests back-to-back but all the tests pass as normal. This stabilization fix to the test attempts to prevent this in case it occurs again.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8360160](https://bugs.openjdk.org/browse/JDK-8360160): ubuntu-22-04 machine is failing client tests (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26871/head:pull/26871` \
`$ git checkout pull/26871`

Update a local copy of the PR: \
`$ git checkout pull/26871` \
`$ git pull https://git.openjdk.org/jdk.git pull/26871/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26871`

View PR using the GUI difftool: \
`$ git pr show -t 26871`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26871.diff">https://git.openjdk.org/jdk/pull/26871.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26871#issuecomment-3208626455)
</details>
