### PR TITLE
8361610: Avoid wasted work in ImageIcon(Image) for setting description

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/ImageIcon.java
+++ b/src/java.desktop/share/classes/javax/swing/ImageIcon.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -209,8 +209,10 @@ public class ImageIcon implements Icon, Serializable, Accessible {
      * @param description a brief textual description of the image
      */
     public ImageIcon(Image image, String description) {
-        this(image);
+        this.image = image;
         this.description = description;
+
+        loadImage(image);
     }
 
     /**
@@ -222,12 +224,17 @@ public class ImageIcon implements Icon, Serializable, Accessible {
      * @see java.awt.Image#getProperty
      */
     public ImageIcon (Image image) {
-        this.image = image;
-        Object o = image.getProperty("comment", imageObserver);
-        if (o instanceof String) {
-            description = (String) o;
-        }
-        loadImage(image);
+        this(image, getImageComment(image));
+    }
+
+    /**
+     * @return the {@code "comment"} property of the image
+     *         if the value of the property is a sting}
+     * @param image the image to get the {@code "comment"} property
+     */
+    private static String getImageComment(Image image) {
+        Object o = image.getProperty("comment", null);
+        return (o instanceof String) ? (String) o : null;
     }
 
     /**


### PR DESCRIPTION
The `ImageIcon(Image)` constructor sets the description field to the value of "comment" property if it's a string. The `ImageIcon(Image, String)` constructor calls ImageIcon(Image). Since the two-parameter constructor explicitly provides the value for the description field, the implicitly set value for description is immediately overwritten, which is wasted work. 

Fix is to let `ImageIcon(Image, String) `constructor do the actual work of setting the fields and loading the image

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8361610](https://bugs.openjdk.org/browse/JDK-8361610): Avoid wasted work in ImageIcon(Image) for setting description (**Bug** - P4)


### Reviewers
 * [Alexander Zuev](https://openjdk.org/census#kizune) (@azuev-java - **Reviewer**)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26873/head:pull/26873` \
`$ git checkout pull/26873`

Update a local copy of the PR: \
`$ git checkout pull/26873` \
`$ git pull https://git.openjdk.org/jdk.git pull/26873/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26873`

View PR using the GUI difftool: \
`$ git pr show -t 26873`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26873.diff">https://git.openjdk.org/jdk/pull/26873.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26873#issuecomment-3208802033)
</details>
