### PR TITLE
8365863: /test/jdk/sun/security/pkcs11/Cipher tests skip without SkippedException

### DIFF
--- a/test/jdk/sun/security/pkcs11/Cipher/ReinitCipher.java
+++ b/test/jdk/sun/security/pkcs11/Cipher/ReinitCipher.java
@@ -48,7 +48,7 @@ public class ReinitCipher extends PKCS11Test {
     @Override
     public void main(Provider p) throws Exception {
         if (p.getService("Cipher", "ARCFOUR") == null) {
-            throw new SkippedException("Not supported by provider, skipping");
+            throw new SkippedException("Algorithm ARCFOUR is not supported by provider, skipping");
         }
         Random random = new Random();
         byte[] data1 = new byte[10 * 1024];

--- a/test/jdk/sun/security/pkcs11/Cipher/ReinitCipher.java
+++ b/test/jdk/sun/security/pkcs11/Cipher/ReinitCipher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,6 +32,8 @@
  * @run main/othervm ReinitCipher
  */
 
+import jtreg.SkippedException;
+
 import java.security.Provider;
 import java.util.Random;
 import javax.crypto.Cipher;
@@ -46,8 +48,7 @@ public class ReinitCipher extends PKCS11Test {
     @Override
     public void main(Provider p) throws Exception {
         if (p.getService("Cipher", "ARCFOUR") == null) {
-            System.out.println("Not supported by provider, skipping");
-            return;
+            throw new SkippedException("Not supported by provider, skipping");
         }
         Random random = new Random();
         byte[] data1 = new byte[10 * 1024];

--- a/test/jdk/sun/security/pkcs11/Cipher/Test4512704.java
+++ b/test/jdk/sun/security/pkcs11/Cipher/Test4512704.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,14 +29,16 @@
  * @run main Test4512704
  * @summary Verify that AES cipher can generate default IV in encrypt mode
  */
-import java.io.PrintStream;
-import java.security.*;
-import java.security.spec.*;
-import java.util.Random;
+import jtreg.SkippedException;
 
-import javax.crypto.*;
-import javax.crypto.spec.*;
+import java.security.GeneralSecurityException;
+import java.security.InvalidAlgorithmParameterException;
+
+import javax.crypto.Cipher;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
 import java.security.Provider;
+import java.security.spec.AlgorithmParameterSpec;
 
 public class Test4512704 extends PKCS11Test {
 
@@ -48,9 +50,8 @@ public class Test4512704 extends PKCS11Test {
             transformation = "AES/" + mode + "/NoPadding";
             c = Cipher.getInstance(transformation, p);
         } catch (GeneralSecurityException e) {
-            System.out.println("Skip testing " + p.getName() +
-                    ", no support for " + mode);
-            return;
+            throw new SkippedException("Skip testing " + p.getName() +
+                                       ", no support for " + mode);
         }
         SecretKey key = new SecretKeySpec(new byte[16], "AES");
 

--- a/test/jdk/sun/security/pkcs11/Cipher/TestCICOWithGCM.java
+++ b/test/jdk/sun/security/pkcs11/Cipher/TestCICOWithGCM.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,13 +31,21 @@
  * @key randomness
  */
 
-import java.security.*;
-import javax.crypto.*;
-import javax.crypto.spec.*;
-import java.math.*;
-import java.io.*;
+import jtreg.SkippedException;
 
-import java.util.*;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import javax.crypto.Cipher;
+import javax.crypto.CipherInputStream;
+import javax.crypto.CipherOutputStream;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+
+import java.security.GeneralSecurityException;
+import java.security.Provider;
+import java.util.Arrays;
+import java.util.Random;
+
 
 public class TestCICOWithGCM extends PKCS11Test {
     public static void main(String[] args) throws Exception {
@@ -55,9 +63,8 @@ public class TestCICOWithGCM extends PKCS11Test {
             String transformation = "AES/" + mode + "/NoPadding";
             c = Cipher.getInstance(transformation, p);
         } catch (GeneralSecurityException e) {
-            System.out.println("Skip testing " + p.getName() +
-                    ", no support for " + mode);
-            return;
+            throw new SkippedException("Skip testing " + p.getName() +
+                                       ", no support for " + mode);
         }
 
         SecretKey key = new SecretKeySpec(new byte[16], "AES");

--- a/test/jdk/sun/security/pkcs11/Cipher/TestCICOWithGCMAndAAD.java
+++ b/test/jdk/sun/security/pkcs11/Cipher/TestCICOWithGCMAndAAD.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,8 @@
  * @summary Test CipherInputStream/OutputStream with AES GCM mode with AAD.
  * @key randomness
  */
+import jtreg.SkippedException;
+
 import java.io.*;
 import java.security.*;
 import java.util.*;
@@ -44,7 +46,6 @@ public class TestCICOWithGCMAndAAD extends PKCS11Test {
     @Override
     public void main(Provider p) throws Exception {
         test("GCM", p);
-//        test("CCM", p);
     }
 
     public void test(String mode, Provider p) throws Exception {
@@ -53,9 +54,8 @@ public class TestCICOWithGCMAndAAD extends PKCS11Test {
             String transformation = "AES/" + mode + "/NoPadding";
             c = Cipher.getInstance(transformation, p);
         } catch (GeneralSecurityException e) {
-            System.out.println("Skip testing " + p.getName() +
-                    ", no support for " + mode);
-            return;
+            throw new SkippedException("Skip testing " + p.getName() +
+                                       ", no support for " + mode);
         }
         SecretKey key = new SecretKeySpec(new byte[16], "AES");
 

--- a/test/jdk/sun/security/pkcs11/Cipher/TestChaChaPoly.java
+++ b/test/jdk/sun/security/pkcs11/Cipher/TestChaChaPoly.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,7 +47,7 @@ import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 import javax.crypto.NoSuchPaddingException;
 
-import jdk.test.lib.Utils;
+import jtreg.SkippedException;
 
 public class TestChaChaPoly extends PKCS11Test {
 
@@ -70,8 +70,7 @@ public class TestChaChaPoly extends PKCS11Test {
         try {
             Cipher.getInstance(ALGO, p);
         } catch (NoSuchAlgorithmException nsae) {
-            System.out.println("Skip; no support for " + ALGO);
-            return;
+            throw new SkippedException("Skip; no support for " + ALGO);
         }
         this.p = p;
         testTransformations();

--- a/test/jdk/sun/security/pkcs11/Cipher/TestChaChaPolyKAT.java
+++ b/test/jdk/sun/security/pkcs11/Cipher/TestChaChaPolyKAT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,17 +31,21 @@
  * @summary ChaCha20-Poly1305 Cipher Implementation (KAT)
  */
 
-import java.util.*;
+import jtreg.SkippedException;
+
 import java.security.GeneralSecurityException;
 import java.security.Provider;
 import java.security.NoSuchAlgorithmException;
 import javax.crypto.Cipher;
-import javax.crypto.spec.ChaCha20ParameterSpec;
 import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 import javax.crypto.AEADBadTagException;
 import java.nio.ByteBuffer;
-import jdk.test.lib.Convert;
+import java.util.Arrays;
+import java.util.HexFormat;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Objects;
 
 public class TestChaChaPolyKAT extends PKCS11Test {
     public static class TestData {
@@ -126,8 +130,7 @@ public class TestChaChaPolyKAT extends PKCS11Test {
         try {
             Cipher.getInstance(ALGO, p);
         } catch (NoSuchAlgorithmException nsae) {
-            System.out.println("Skip; no support for " + ALGO);
-            return;
+            throw new SkippedException("Skip; no support for " + ALGO);
         }
 
         int testsPassed = 0;

--- a/test/jdk/sun/security/pkcs11/Cipher/TestChaChaPolyKAT.java
+++ b/test/jdk/sun/security/pkcs11/Cipher/TestChaChaPolyKAT.java
@@ -26,7 +26,6 @@
  * @bug 8255410
  * @library /test/lib ..
  * @modules jdk.crypto.cryptoki
- * @build jdk.test.lib.Convert
  * @run main/othervm TestChaChaPolyKAT
  * @summary ChaCha20-Poly1305 Cipher Implementation (KAT)
  */

--- a/test/jdk/sun/security/pkcs11/Cipher/TestChaChaPolyNoReuse.java
+++ b/test/jdk/sun/security/pkcs11/Cipher/TestChaChaPolyNoReuse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,18 +30,22 @@
  * (key/nonce reuse check)
  */
 
-import java.util.*;
+import jtreg.SkippedException;
+
 import javax.crypto.Cipher;
 import java.security.spec.AlgorithmParameterSpec;
 import java.security.Provider;
 import java.security.NoSuchAlgorithmException;
-import javax.crypto.spec.ChaCha20ParameterSpec;
 import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
-import javax.crypto.AEADBadTagException;
 import javax.crypto.SecretKey;
 import java.security.InvalidKeyException;
 import java.security.InvalidAlgorithmParameterException;
+import java.util.Arrays;
+import java.util.HexFormat;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Objects;
 
 public class TestChaChaPolyNoReuse extends PKCS11Test {
 
@@ -238,8 +242,7 @@ public class TestChaChaPolyNoReuse extends PKCS11Test {
         try {
             Cipher.getInstance(CIPHER_ALGO, p);
         } catch (NoSuchAlgorithmException nsae) {
-            System.out.println("Skip; no support for " + CIPHER_ALGO);
-            return;
+            throw new SkippedException("Skip; no support for " + CIPHER_ALGO);
         }
 
         int testsPassed = 0;

--- a/test/jdk/sun/security/pkcs11/Cipher/TestChaChaPolyOutputSize.java
+++ b/test/jdk/sun/security/pkcs11/Cipher/TestChaChaPolyOutputSize.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,14 +30,14 @@
  * @run main TestChaChaPolyOutputSize
  */
 
+import jtreg.SkippedException;
+
 import java.nio.ByteBuffer;
 import java.security.GeneralSecurityException;
-import java.security.Key;
 import java.security.SecureRandom;
 import java.security.Provider;
 import java.security.NoSuchAlgorithmException;
 import javax.crypto.Cipher;
-import javax.crypto.spec.ChaCha20ParameterSpec;
 import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 
@@ -60,8 +60,7 @@ public class TestChaChaPolyOutputSize extends PKCS11Test {
         try {
             Cipher.getInstance(ALGO, p);
         } catch (NoSuchAlgorithmException nsae) {
-            System.out.println("Skip; no support for " + ALGO);
-            return;
+            throw new SkippedException("Skip; no support for " + ALGO);
         }
         testGetOutSize(p);
         testMultiPartAEADDec(p);

--- a/test/jdk/sun/security/pkcs11/Cipher/TestCipherMode.java
+++ b/test/jdk/sun/security/pkcs11/Cipher/TestCipherMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,30 +22,12 @@
  */
 
 /*
- * @test id=AES-ECB
+ * @test
  * @bug 8265500
  * @summary
  * @library /test/lib ..
  * @modules jdk.crypto.cryptoki
- * @run main/othervm TestCipherMode AES/ECB/PKCS5Padding
- */
-
-/*
- * @test id=AES-GCM
- * @bug 8265500
- * @summary
- * @library /test/lib ..
- * @modules jdk.crypto.cryptoki
- * @run main/othervm TestCipherMode AES/GCM/NoPadding
- */
-
-/*
- * @test id=RSA-ECB
- * @bug 8265500
- * @summary
- * @library /test/lib ..
- * @modules jdk.crypto.cryptoki
- * @run main/othervm TestCipherMode RSA/ECB/PKCS1Padding
+ * @run main/othervm TestCipherMode
  */
 
 import jtreg.SkippedException;
@@ -110,8 +92,25 @@ public class TestCipherMode extends PKCS11Test {
     }
 
     public static void main(String[] args) throws Exception {
+        final String[] transformations = {
+                "AES/ECB/PKCS5Padding", "AES/GCM/NoPadding", "RSA/ECB/PKCS1Padding"
+        };
 
-        main(new TestCipherMode(args[0]), args);
+        boolean skipEncountered = false;
+        for (final String t : transformations) {
+            try {
+                main(new TestCipherMode(t), args);
+            } catch (SkippedException skippedException) {
+                // printing to System.out, so it's easier to see which test it relates to
+                skippedException.printStackTrace(System.out);
+                skipEncountered = true;
+            }
+        }
+
+        if (skipEncountered) {
+            throw new SkippedException("One or more transformations skipped");
+        }
+
     }
 
     @Override

--- a/test/jdk/sun/security/pkcs11/Cipher/TestCipherMode.java
+++ b/test/jdk/sun/security/pkcs11/Cipher/TestCipherMode.java
@@ -113,7 +113,7 @@ public class TestCipherMode extends PKCS11Test {
         }
 
         if (!skipped.isEmpty()) {
-            throw new SkippedException("Some tests failed: " + skipped);
+            throw new SkippedException("Some tests skipped: " + skipped);
         } else {
             System.out.println("All tests passed");
         }

--- a/test/jdk/sun/security/pkcs11/Cipher/TestCipherMode.java
+++ b/test/jdk/sun/security/pkcs11/Cipher/TestCipherMode.java
@@ -22,7 +22,7 @@
  */
 
 /*
- * @test
+ * @test id=AES-ECB
  * @bug 8265500
  * @summary
  * @library /test/lib ..
@@ -31,7 +31,7 @@
  */
 
 /*
- * @test
+ * @test id=AES-GCM
  * @bug 8265500
  * @summary
  * @library /test/lib ..
@@ -40,7 +40,7 @@
  */
 
 /*
- * @test
+ * @test id=RSA-ECB
  * @bug 8265500
  * @summary
  * @library /test/lib ..

--- a/test/jdk/sun/security/pkcs11/Cipher/TestGCMKeyAndIvCheck.java
+++ b/test/jdk/sun/security/pkcs11/Cipher/TestGCMKeyAndIvCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,13 +31,21 @@
  */
 
 
-import java.security.*;
-import java.security.spec.AlgorithmParameterSpec;
-import javax.crypto.*;
-import javax.crypto.spec.*;
-import java.math.*;
+import jtreg.SkippedException;
 
-import java.util.*;
+import java.security.AlgorithmParameters;
+import java.security.GeneralSecurityException;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.InvalidKeyException;
+import java.security.Provider;
+import java.security.spec.AlgorithmParameterSpec;
+import javax.crypto.Cipher;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+
+import java.util.Arrays;
 
 public class TestGCMKeyAndIvCheck extends PKCS11Test {
 
@@ -77,9 +85,8 @@ public class TestGCMKeyAndIvCheck extends PKCS11Test {
             String transformation = "AES/" + mode + "/NoPadding";
             c = Cipher.getInstance(transformation, p);
         } catch (GeneralSecurityException e) {
-            System.out.println("Skip testing " + p.getName() +
-                    ", no support for " + mode);
-            return;
+            throw new SkippedException("Skip testing " + p.getName() +
+                                       ", no support for " + mode);
         }
         System.out.println("Testing against " + p.getName());
         SecretKey key = new SecretKeySpec(new byte[16], "AES");

--- a/test/jdk/sun/security/pkcs11/Cipher/TestKATForGCM.java
+++ b/test/jdk/sun/security/pkcs11/Cipher/TestKATForGCM.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,8 @@
  * @summary Known Answer Test for AES cipher with GCM mode support in
  * PKCS11 provider.
  */
+import jtreg.SkippedException;
+
 import java.security.GeneralSecurityException;
 import java.security.Provider;
 import java.util.Arrays;
@@ -311,9 +313,8 @@ public class TestKATForGCM extends PKCS11Test {
         try {
             c = Cipher.getInstance(transformation, p);
         } catch (GeneralSecurityException e) {
-            System.out.println("Skip testing " + p.getName() +
-                    ", no support for " + transformation);
-            return;
+            throw new SkippedException("Skip testing " + p.getName() +
+                                       ", no support for " + transformation);
         }
         try {
             if (execute(testValues, c)) {

--- a/test/jdk/sun/security/pkcs11/Cipher/TestPKCS5PaddingError.java
+++ b/test/jdk/sun/security/pkcs11/Cipher/TestPKCS5PaddingError.java
@@ -77,7 +77,7 @@ public class TestPKCS5PaddingError extends PKCS11Test {
                             KeyGenerator.getInstance(currTest.keyAlgo, p);
                     SecretKey key = kg.generateKey();
                     Cipher c1 = Cipher.getInstance(currTest.transformation,
-                            System.getProperty("test.provider.name", "SunJCE"));
+                               System.getProperty("test.provider.name", "SunJCE"));
                     c1.init(Cipher.ENCRYPT_MODE, key);
                     byte[] cipherText = c1.doFinal(plainText);
                     AlgorithmParameters params = c1.getParameters();
@@ -113,7 +113,7 @@ public class TestPKCS5PaddingError extends PKCS11Test {
                     System.out.println("DONE");
                 } catch (NoSuchAlgorithmException nsae) {
                     System.out.println("Skipping unsupported algorithm: " +
-                                   nsae);
+                            nsae);
                 }
             }
         } catch (Exception ex) {

--- a/test/jdk/sun/security/pkcs11/Cipher/TestPKCS5PaddingError.java
+++ b/test/jdk/sun/security/pkcs11/Cipher/TestPKCS5PaddingError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,14 +52,14 @@ public class TestPKCS5PaddingError extends PKCS11Test {
     }
 
     private static final CI[] TEST_LIST = {
-        // algorithms which use the native padding impl
-        new CI("DES/CBC/PKCS5Padding", "DES"),
-        new CI("DESede/CBC/PKCS5Padding", "DESede"),
-        new CI("AES/CBC/PKCS5Padding", "AES"),
-        // algorithms which use SunPKCS11's own padding impl
-        new CI("DES/ECB/PKCS5Padding", "DES"),
-        new CI("DESede/ECB/PKCS5Padding", "DESede"),
-        new CI("AES/ECB/PKCS5Padding", "AES"),
+            // algorithms which use the native padding impl
+            new CI("DES/CBC/PKCS5Padding", "DES"),
+            new CI("DESede/CBC/PKCS5Padding", "DESede"),
+            new CI("AES/CBC/PKCS5Padding", "AES"),
+            // algorithms which use SunPKCS11's own padding impl
+            new CI("DES/ECB/PKCS5Padding", "DES"),
+            new CI("DESede/ECB/PKCS5Padding", "DESede"),
+            new CI("AES/ECB/PKCS5Padding", "AES"),
     };
 
     private static StringBuffer debugBuf = new StringBuffer();
@@ -69,7 +69,8 @@ public class TestPKCS5PaddingError extends PKCS11Test {
         try {
             byte[] plainText = new byte[200];
 
-            for (CI currTest : TEST_LIST) {
+            for (int i = 0; i < TEST_LIST.length; i++) {
+                CI currTest = TEST_LIST[i];
                 System.out.println("===" + currTest.transformation + "===");
                 try {
                     KeyGenerator kg =

--- a/test/jdk/sun/security/pkcs11/Cipher/TestPKCS5PaddingError.java
+++ b/test/jdk/sun/security/pkcs11/Cipher/TestPKCS5PaddingError.java
@@ -52,14 +52,14 @@ public class TestPKCS5PaddingError extends PKCS11Test {
     }
 
     private static final CI[] TEST_LIST = {
-            // algorithms which use the native padding impl
-            new CI("DES/CBC/PKCS5Padding", "DES"),
-            new CI("DESede/CBC/PKCS5Padding", "DESede"),
-            new CI("AES/CBC/PKCS5Padding", "AES"),
-            // algorithms which use SunPKCS11's own padding impl
-            new CI("DES/ECB/PKCS5Padding", "DES"),
-            new CI("DESede/ECB/PKCS5Padding", "DESede"),
-            new CI("AES/ECB/PKCS5Padding", "AES"),
+        // algorithms which use the native padding impl
+        new CI("DES/CBC/PKCS5Padding", "DES"),
+        new CI("DESede/CBC/PKCS5Padding", "DESede"),
+        new CI("AES/CBC/PKCS5Padding", "AES"),
+        // algorithms which use SunPKCS11's own padding impl
+        new CI("DES/ECB/PKCS5Padding", "DES"),
+        new CI("DESede/ECB/PKCS5Padding", "DESede"),
+        new CI("AES/ECB/PKCS5Padding", "AES"),
     };
 
     private static StringBuffer debugBuf = new StringBuffer();
@@ -113,7 +113,7 @@ public class TestPKCS5PaddingError extends PKCS11Test {
                     System.out.println("DONE");
                 } catch (NoSuchAlgorithmException nsae) {
                     System.out.println("Skipping unsupported algorithm: " +
-                                       nsae);
+                                   nsae);
                 }
             }
         } catch (Exception ex) {

--- a/test/jdk/sun/security/pkcs11/Cipher/TestPKCS5PaddingError.java
+++ b/test/jdk/sun/security/pkcs11/Cipher/TestPKCS5PaddingError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -69,15 +69,14 @@ public class TestPKCS5PaddingError extends PKCS11Test {
         try {
             byte[] plainText = new byte[200];
 
-            for (int i = 0; i < TEST_LIST.length; i++) {
-                CI currTest = TEST_LIST[i];
+            for (CI currTest : TEST_LIST) {
                 System.out.println("===" + currTest.transformation + "===");
                 try {
                     KeyGenerator kg =
                             KeyGenerator.getInstance(currTest.keyAlgo, p);
                     SecretKey key = kg.generateKey();
                     Cipher c1 = Cipher.getInstance(currTest.transformation,
-                               System.getProperty("test.provider.name", "SunJCE"));
+                            System.getProperty("test.provider.name", "SunJCE"));
                     c1.init(Cipher.ENCRYPT_MODE, key);
                     byte[] cipherText = c1.doFinal(plainText);
                     AlgorithmParameters params = c1.getParameters();
@@ -113,7 +112,7 @@ public class TestPKCS5PaddingError extends PKCS11Test {
                     System.out.println("DONE");
                 } catch (NoSuchAlgorithmException nsae) {
                     System.out.println("Skipping unsupported algorithm: " +
-                            nsae);
+                                       nsae);
                 }
             }
         } catch (Exception ex) {

--- a/test/jdk/sun/security/pkcs11/Cipher/TestRSACipher.java
+++ b/test/jdk/sun/security/pkcs11/Cipher/TestRSACipher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,6 +44,7 @@ import javax.crypto.BadPaddingException;
 import javax.crypto.Cipher;
 import javax.crypto.IllegalBlockSizeException;
 import jdk.test.lib.security.SecurityUtils;
+import jtreg.SkippedException;
 
 public class TestRSACipher extends PKCS11Test {
 
@@ -55,8 +56,7 @@ public class TestRSACipher extends PKCS11Test {
         try {
             Cipher.getInstance(RSA_ALGOS[0], p);
         } catch (GeneralSecurityException e) {
-            System.out.println("Not supported by provider, skipping");
-            return;
+            throw new SkippedException("Not supported by provider, skipping");
         }
         String kpgAlgorithm = "RSA";
         int keySize = SecurityUtils.getTestKeySize(kpgAlgorithm);

--- a/test/jdk/sun/security/pkcs11/Cipher/TestRSACipher.java
+++ b/test/jdk/sun/security/pkcs11/Cipher/TestRSACipher.java
@@ -56,7 +56,7 @@ public class TestRSACipher extends PKCS11Test {
         try {
             Cipher.getInstance(RSA_ALGOS[0], p);
         } catch (GeneralSecurityException e) {
-            throw new SkippedException("Not supported by provider, skipping");
+            throw new SkippedException("Algorithm " + RSA_ALGOS[0] + " is not supported by provider, skipping");
         }
         String kpgAlgorithm = "RSA";
         int keySize = SecurityUtils.getTestKeySize(kpgAlgorithm);

--- a/test/jdk/sun/security/pkcs11/Cipher/TestRSACipherWrap.java
+++ b/test/jdk/sun/security/pkcs11/Cipher/TestRSACipherWrap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,6 +43,7 @@ import javax.crypto.KeyGenerator;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 import jdk.test.lib.security.SecurityUtils;
+import jtreg.SkippedException;
 
 public class TestRSACipherWrap extends PKCS11Test {
 
@@ -54,8 +55,7 @@ public class TestRSACipherWrap extends PKCS11Test {
         try {
             Cipher.getInstance(RSA_ALGOS[0], p);
         } catch (GeneralSecurityException e) {
-            System.out.println(RSA_ALGOS[0] + " unsupported, skipping");
-            return;
+            throw new SkippedException(RSA_ALGOS[0] + " unsupported, skipping");
         }
         String kpgAlgorithm = "RSA";
         KeyPairGenerator kpg = KeyPairGenerator.getInstance(kpgAlgorithm, p);

--- a/test/jdk/sun/security/pkcs11/Cipher/TestRawRSACipher.java
+++ b/test/jdk/sun/security/pkcs11/Cipher/TestRawRSACipher.java
@@ -50,7 +50,7 @@ public class TestRawRSACipher extends PKCS11Test {
         try {
             Cipher.getInstance("RSA/ECB/NoPadding", p);
         } catch (GeneralSecurityException e) {
-            throw new SkippedException("Not supported by provider, skipping");
+            throw new SkippedException("Algorithm RSA/ECB/NoPadding is not supported by provider, skipping");
         }
 
         String kpgAlgorithm = "RSA";

--- a/test/jdk/sun/security/pkcs11/Cipher/TestRawRSACipher.java
+++ b/test/jdk/sun/security/pkcs11/Cipher/TestRawRSACipher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,6 +41,7 @@ import java.util.HexFormat;
 import java.util.Random;
 import javax.crypto.Cipher;
 import jdk.test.lib.security.SecurityUtils;
+import jtreg.SkippedException;
 
 public class TestRawRSACipher extends PKCS11Test {
 
@@ -49,8 +50,7 @@ public class TestRawRSACipher extends PKCS11Test {
         try {
             Cipher.getInstance("RSA/ECB/NoPadding", p);
         } catch (GeneralSecurityException e) {
-            System.out.println("Not supported by provider, skipping");
-            return;
+            throw new SkippedException("Not supported by provider, skipping");
         }
 
         String kpgAlgorithm = "RSA";

--- a/test/jdk/sun/security/pkcs11/Cipher/TestSymmCiphers.java
+++ b/test/jdk/sun/security/pkcs11/Cipher/TestSymmCiphers.java
@@ -22,246 +22,15 @@
  */
 
 /*
- * @test id=ARCFOUR-ARCFOUR-400
+ * @test
  * @bug 4898461 6604496 8330842
  * @summary basic test for symmetric ciphers with padding
  * @author Valerie Peng
  * @library /test/lib ..
  * @key randomness
  * @modules jdk.crypto.cryptoki
- * @run main/othervm TestSymmCiphers ARCFOUR ARCFOUR 400
+ * @run main/othervm TestSymmCiphers
 */
-
-/*
- * @test id=RC4-RC4-401
- * @bug 4898461 6604496 8330842
- * @summary basic test for symmetric ciphers with padding
- * @author Valerie Peng
- * @library /test/lib ..
- * @key randomness
- * @modules jdk.crypto.cryptoki
- * @run main/othervm TestSymmCiphers RC4 RC4 401
- */
-
-/*
- * @test id=DES-CBC-NOPADDING-DES-400
- * @bug 4898461 6604496 8330842
- * @summary basic test for symmetric ciphers with padding
- * @author Valerie Peng
- * @library /test/lib ..
- * @key randomness
- * @modules jdk.crypto.cryptoki
- * @run main/othervm TestSymmCiphers DES/CBC/NoPadding DES 400
- */
-
-/*
- * @test id=DESEDE-CBC-NOPADDING-DESEDE-160
- * @bug 4898461 6604496 8330842
- * @summary basic test for symmetric ciphers with padding
- * @author Valerie Peng
- * @library /test/lib ..
- * @key randomness
- * @modules jdk.crypto.cryptoki
- * @run main/othervm TestSymmCiphers DESede/CBC/NoPadding DESede 160
- */
-
-/*
- * @test id=AES-CBC-NOPADDING-AES-4800
- * @bug 4898461 6604496 8330842
- * @summary basic test for symmetric ciphers with padding
- * @author Valerie Peng
- * @library /test/lib ..
- * @key randomness
- * @modules jdk.crypto.cryptoki
- * @run main/othervm TestSymmCiphers AES/CBC/NoPadding AES 4800
- */
-
-/*
- * @test id=BLOWFISH-CBC-NOPADDING-BLOWFISH-24
- * @bug 4898461 6604496 8330842
- * @summary basic test for symmetric ciphers with padding
- * @author Valerie Peng
- * @library /test/lib ..
- * @key randomness
- * @modules jdk.crypto.cryptoki
- * @run main/othervm TestSymmCiphers Blowfish/CBC/NoPadding Blowfish 24
- */
-
-/*
- * @test id=DES-CBC-PKCS5PADDING-DES-6401
- * @bug 4898461 6604496 8330842
- * @summary basic test for symmetric ciphers with padding
- * @author Valerie Peng
- * @library /test/lib ..
- * @key randomness
- * @modules jdk.crypto.cryptoki
- * @run main/othervm TestSymmCiphers DES/cbc/PKCS5Padding DES 6401
- */
-
-/*
- * @test id=DESEDE-CBC-PKCS5PADDING-DESEDE-402
- * @bug 4898461 6604496 8330842
- * @summary basic test for symmetric ciphers with padding
- * @author Valerie Peng
- * @library /test/lib ..
- * @key randomness
- * @modules jdk.crypto.cryptoki
- * @run main/othervm TestSymmCiphers DESede/CBC/PKCS5Padding DESede 402
- */
-
-/*
- * @test id=AES-CBC-PKCS5PADDING-AES-30
- * @bug 4898461 6604496 8330842
- * @summary basic test for symmetric ciphers with padding
- * @author Valerie Peng
- * @library /test/lib ..
- * @key randomness
- * @modules jdk.crypto.cryptoki
- * @run main/othervm TestSymmCiphers AES/CBC/PKCS5Padding AES 30
- */
-
-/*
- * @test id=BLOWFISH-CBC-PKCS5PADDING-BLOWFISH-19
- * @bug 4898461 6604496 8330842
- * @summary basic test for symmetric ciphers with padding
- * @author Valerie Peng
- * @library /test/lib ..
- * @key randomness
- * @modules jdk.crypto.cryptoki
- * @run main/othervm TestSymmCiphers Blowfish/CBC/PKCS5Padding Blowfish 19
- */
-
-/*
- * @test id=DES-ECB-NOPADDING-DES-400
- * @bug 4898461 6604496 8330842
- * @summary basic test for symmetric ciphers with padding
- * @author Valerie Peng
- * @library /test/lib ..
- * @key randomness
- * @modules jdk.crypto.cryptoki
- * @run main/othervm TestSymmCiphers DES/ECB/NoPadding DES 400
- */
-
-/*
- * @test id=DESEDE-ECB-NOPADDING-DESEDE-160
- * @bug 4898461 6604496 8330842
- * @summary basic test for symmetric ciphers with padding
- * @author Valerie Peng
- * @library /test/lib ..
- * @key randomness
- * @modules jdk.crypto.cryptoki
- * @run main/othervm TestSymmCiphers DESede/ECB/NoPadding DESede 160
- */
-
-/*
- * @test id=AES-ECB-NOPADDING-AES-4800
- * @bug 4898461 6604496 8330842
- * @summary basic test for symmetric ciphers with padding
- * @author Valerie Peng
- * @library /test/lib ..
- * @key randomness
- * @modules jdk.crypto.cryptoki
- * @run main/othervm TestSymmCiphers AES/ECB/NoPadding AES 4800
- */
-
-/*
- * @test id=DES-ECB-PKCS5PADDING-DES-32
- * @bug 4898461 6604496 8330842
- * @summary basic test for symmetric ciphers with padding
- * @author Valerie Peng
- * @library /test/lib ..
- * @key randomness
- * @modules jdk.crypto.cryptoki
- * @run main/othervm TestSymmCiphers DES/ECB/PKCS5Padding DES 32
- */
-
-/*
- * @test id=DES-ECB-PKCS5PADDING-DES-6400
- * @bug 4898461 6604496 8330842
- * @summary basic test for symmetric ciphers with padding
- * @author Valerie Peng
- * @library /test/lib ..
- * @key randomness
- * @modules jdk.crypto.cryptoki
- * @run main/othervm TestSymmCiphers DES/ECB/PKCS5Padding DES 6400
- */
-
-/*
- * @test id=DESEDE-ECB-PKCS5PADDING-DESEDE-400
- * @bug 4898461 6604496 8330842
- * @summary basic test for symmetric ciphers with padding
- * @author Valerie Peng
- * @library /test/lib ..
- * @key randomness
- * @modules jdk.crypto.cryptoki
- * @run main/othervm TestSymmCiphers DESede/ECB/PKCS5Padding DESede 400
- */
-
-/*
- * @test id=AES-ECB-PKCS5PADDING-AES-64
- * @bug 4898461 6604496 8330842
- * @summary basic test for symmetric ciphers with padding
- * @author Valerie Peng
- * @library /test/lib ..
- * @key randomness
- * @modules jdk.crypto.cryptoki
- * @run main/othervm TestSymmCiphers AES/ECB/PKCS5Padding AES 64
- */
-
-/*
- * @test id=DES-DES-6400
- * @bug 4898461 6604496 8330842
- * @summary basic test for symmetric ciphers with padding
- * @author Valerie Peng
- * @library /test/lib ..
- * @key randomness
- * @modules jdk.crypto.cryptoki
- * @run main/othervm TestSymmCiphers DES DES 6400
- */
-
-/*
- * @test id=DESEDE-DESEDE-408
- * @bug 4898461 6604496 8330842
- * @summary basic test for symmetric ciphers with padding
- * @author Valerie Peng
- * @library /test/lib ..
- * @key randomness
- * @modules jdk.crypto.cryptoki
- * @run main/othervm TestSymmCiphers DESede DESede 408
- */
-
-/*
- * @test id=AES-AES-128
- * @bug 4898461 6604496 8330842
- * @summary basic test for symmetric ciphers with padding
- * @author Valerie Peng
- * @library /test/lib ..
- * @key randomness
- * @modules jdk.crypto.cryptoki
- * @run main/othervm TestSymmCiphers AES AES 128
- */
-
-/*
- * @test id=AES-CTR-NOPADDING-AES-3200
- * @bug 4898461 6604496 8330842
- * @summary basic test for symmetric ciphers with padding
- * @author Valerie Peng
- * @library /test/lib ..
- * @key randomness
- * @modules jdk.crypto.cryptoki
- * @run main/othervm TestSymmCiphers AES/CTR/NoPadding AES 3200
- */
-
-/*
- * @test id=AES-CTS-NOPADDING-AES-3200
- * @bug 4898461 6604496 8330842
- * @summary basic test for symmetric ciphers with padding
- * @author Valerie Peng
- * @library /test/lib ..
- * @key randomness
- * @modules jdk.crypto.cryptoki
- * @run main/othervm TestSymmCiphers AES/CTS/NoPadding AES 3200
- */
 
 import jtreg.SkippedException;
 
@@ -270,6 +39,7 @@ import java.nio.ByteBuffer;
 import java.security.AlgorithmParameters;
 import java.security.NoSuchAlgorithmException;
 import java.security.Provider;
+import java.util.List;
 import java.util.Random;
 import javax.crypto.Cipher;
 import javax.crypto.KeyGenerator;
@@ -445,6 +215,47 @@ public class TestSymmCiphers extends PKCS11Test {
     }
 
     public static void main(String[] args) throws Exception {
-        main(new TestSymmCiphers(args[0], args[1], Integer.parseInt(args[2])), args);
+
+        final List<String[]> tests = List.of(
+                new String[]{"ARCFOUR", "ARCFOUR", "400"},
+                new String[]{"RC4", "RC4", "401"},
+                new String[]{"DES/CBC/NoPadding", "DES", "400"},
+                new String[]{"DESede/CBC/NoPadding", "DESede", "160"},
+                new String[]{"AES/CBC/NoPadding", "AES", "4800"},
+                new String[]{"Blowfish/CBC/NoPadding", "Blowfish", "24"},
+                new String[]{"DES/cbc/PKCS5Padding", "DES", "6401"},
+                new String[]{"DESede/CBC/PKCS5Padding", "DESede", "402"},
+                new String[]{"AES/CBC/PKCS5Padding", "AES", "30"},
+                new String[]{"Blowfish/CBC/PKCS5Padding", "Blowfish", "19"},
+                new String[]{"DES/ECB/NoPadding", "DES", "400"},
+                new String[]{"DESede/ECB/NoPadding", "DESede", "160"},
+                new String[]{"AES/ECB/NoPadding", "AES", "4800"},
+                new String[]{"DES/ECB/PKCS5Padding", "DES", "32"},
+                new String[]{"DES/ECB/PKCS5Padding", "DES", "6400"},
+                new String[]{"DESede/ECB/PKCS5Padding", "DESede", "400"},
+                new String[]{"AES/ECB/PKCS5Padding", "AES", "64"},
+
+                new String[]{"DES", "DES", "6400"},
+                new String[]{"DESede", "DESede", "408"},
+                new String[]{"AES", "AES", "128"},
+
+                new String[]{"AES/CTR/NoPadding", "AES", "3200"},
+                new String[]{"AES/CTS/NoPadding", "AES", "3200"}
+
+        );
+
+        boolean skipEncountered = false;
+        for (final String[] t : tests) {
+            try {
+                main(new TestSymmCiphers(t[0], t[1], Integer.parseInt(t[2])), args);
+            } catch (SkippedException skippedException) {
+                skippedException.printStackTrace(System.err);
+                skipEncountered = true;
+            }
+        }
+
+        if (skipEncountered) {
+            throw new SkippedException("One or more tests skipped");
+        }
     }
 }

--- a/test/jdk/sun/security/pkcs11/Cipher/TestSymmCiphers.java
+++ b/test/jdk/sun/security/pkcs11/Cipher/TestSymmCiphers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,8 +29,240 @@
  * @library /test/lib ..
  * @key randomness
  * @modules jdk.crypto.cryptoki
- * @run main/othervm TestSymmCiphers
+ * @run main/othervm TestSymmCiphers ARCFOUR ARCFOUR 400
  */
+
+/*
+ * @test
+ * @bug 4898461 6604496 8330842
+ * @summary basic test for symmetric ciphers with padding
+ * @author Valerie Peng
+ * @library /test/lib ..
+ * @key randomness
+ * @modules jdk.crypto.cryptoki
+ * @run main/othervm TestSymmCiphers RC4 RC4 401
+ */
+
+/*
+ * @test
+ * @bug 4898461 6604496 8330842
+ * @summary basic test for symmetric ciphers with padding
+ * @author Valerie Peng
+ * @library /test/lib ..
+ * @key randomness
+ * @modules jdk.crypto.cryptoki
+ * @run main/othervm TestSymmCiphers DES/CBC/NoPadding DES 400
+ */
+
+/*
+ * @test
+ * @bug 4898461 6604496 8330842
+ * @summary basic test for symmetric ciphers with padding
+ * @author Valerie Peng
+ * @library /test/lib ..
+ * @key randomness
+ * @modules jdk.crypto.cryptoki
+ * @run main/othervm TestSymmCiphers DESede/CBC/NoPadding DESede 160
+ */
+
+/*
+ * @test
+ * @bug 4898461 6604496 8330842
+ * @summary basic test for symmetric ciphers with padding
+ * @author Valerie Peng
+ * @library /test/lib ..
+ * @key randomness
+ * @modules jdk.crypto.cryptoki
+ * @run main/othervm TestSymmCiphers AES/CBC/NoPadding AES 4800
+ */
+
+/*
+ * @test
+ * @bug 4898461 6604496 8330842
+ * @summary basic test for symmetric ciphers with padding
+ * @author Valerie Peng
+ * @library /test/lib ..
+ * @key randomness
+ * @modules jdk.crypto.cryptoki
+ * @run main/othervm TestSymmCiphers Blowfish/CBC/NoPadding Blowfish 24
+ */
+
+/*
+ * @test
+ * @bug 4898461 6604496 8330842
+ * @summary basic test for symmetric ciphers with padding
+ * @author Valerie Peng
+ * @library /test/lib ..
+ * @key randomness
+ * @modules jdk.crypto.cryptoki
+ * @run main/othervm TestSymmCiphers DES/cbc/PKCS5Padding DES 6401
+ */
+
+/*
+ * @test
+ * @bug 4898461 6604496 8330842
+ * @summary basic test for symmetric ciphers with padding
+ * @author Valerie Peng
+ * @library /test/lib ..
+ * @key randomness
+ * @modules jdk.crypto.cryptoki
+ * @run main/othervm TestSymmCiphers DESede/CBC/PKCS5Padding DESede 402
+ */
+
+/*
+ * @test
+ * @bug 4898461 6604496 8330842
+ * @summary basic test for symmetric ciphers with padding
+ * @author Valerie Peng
+ * @library /test/lib ..
+ * @key randomness
+ * @modules jdk.crypto.cryptoki
+ * @run main/othervm TestSymmCiphers AES/CBC/PKCS5Padding AES 30
+ */
+
+/*
+ * @test
+ * @bug 4898461 6604496 8330842
+ * @summary basic test for symmetric ciphers with padding
+ * @author Valerie Peng
+ * @library /test/lib ..
+ * @key randomness
+ * @modules jdk.crypto.cryptoki
+ * @run main/othervm TestSymmCiphers Blowfish/CBC/PKCS5Padding Blowfish 19
+ */
+
+/*
+ * @test
+ * @bug 4898461 6604496 8330842
+ * @summary basic test for symmetric ciphers with padding
+ * @author Valerie Peng
+ * @library /test/lib ..
+ * @key randomness
+ * @modules jdk.crypto.cryptoki
+ * @run main/othervm TestSymmCiphers DES/ECB/NoPadding DES 400
+ */
+
+/*
+ * @test
+ * @bug 4898461 6604496 8330842
+ * @summary basic test for symmetric ciphers with padding
+ * @author Valerie Peng
+ * @library /test/lib ..
+ * @key randomness
+ * @modules jdk.crypto.cryptoki
+ * @run main/othervm TestSymmCiphers DESede/ECB/NoPadding DESede 160
+ */
+
+/*
+ * @test
+ * @bug 4898461 6604496 8330842
+ * @summary basic test for symmetric ciphers with padding
+ * @author Valerie Peng
+ * @library /test/lib ..
+ * @key randomness
+ * @modules jdk.crypto.cryptoki
+ * @run main/othervm TestSymmCiphers AES/ECB/NoPadding AES 4800
+ */
+
+/*
+ * @test
+ * @bug 4898461 6604496 8330842
+ * @summary basic test for symmetric ciphers with padding
+ * @author Valerie Peng
+ * @library /test/lib ..
+ * @key randomness
+ * @modules jdk.crypto.cryptoki
+ * @run main/othervm TestSymmCiphers DES/ECB/PKCS5Padding DES 32
+ */
+
+/*
+ * @test
+ * @bug 4898461 6604496 8330842
+ * @summary basic test for symmetric ciphers with padding
+ * @author Valerie Peng
+ * @library /test/lib ..
+ * @key randomness
+ * @modules jdk.crypto.cryptoki
+ * @run main/othervm TestSymmCiphers DES/ECB/PKCS5Padding DES 6400
+ */
+
+/*
+ * @test
+ * @bug 4898461 6604496 8330842
+ * @summary basic test for symmetric ciphers with padding
+ * @author Valerie Peng
+ * @library /test/lib ..
+ * @key randomness
+ * @modules jdk.crypto.cryptoki
+ * @run main/othervm TestSymmCiphers DESede/ECB/PKCS5Padding DESede 400
+ */
+
+/*
+ * @test
+ * @bug 4898461 6604496 8330842
+ * @summary basic test for symmetric ciphers with padding
+ * @author Valerie Peng
+ * @library /test/lib ..
+ * @key randomness
+ * @modules jdk.crypto.cryptoki
+ * @run main/othervm TestSymmCiphers AES/ECB/PKCS5Padding AES 64
+ */
+
+/*
+ * @test
+ * @bug 4898461 6604496 8330842
+ * @summary basic test for symmetric ciphers with padding
+ * @author Valerie Peng
+ * @library /test/lib ..
+ * @key randomness
+ * @modules jdk.crypto.cryptoki
+ * @run main/othervm TestSymmCiphers DES DES 6400
+ */
+/*
+ * @test
+ * @bug 4898461 6604496 8330842
+ * @summary basic test for symmetric ciphers with padding
+ * @author Valerie Peng
+ * @library /test/lib ..
+ * @key randomness
+ * @modules jdk.crypto.cryptoki
+ * @run main/othervm TestSymmCiphers DESede DESede 408
+ */
+
+/*
+ * @test
+ * @bug 4898461 6604496 8330842
+ * @summary basic test for symmetric ciphers with padding
+ * @author Valerie Peng
+ * @library /test/lib ..
+ * @key randomness
+ * @modules jdk.crypto.cryptoki
+ * @run main/othervm TestSymmCiphers AES AES 128
+ */
+
+/*
+ * @test
+ * @bug 4898461 6604496 8330842
+ * @summary basic test for symmetric ciphers with padding
+ * @author Valerie Peng
+ * @library /test/lib ..
+ * @key randomness
+ * @modules jdk.crypto.cryptoki
+ * @run main/othervm TestSymmCiphers AES/CTR/NoPadding AES 3200
+ */
+
+/*
+ * @test
+ * @bug 4898461 6604496 8330842
+ * @summary basic test for symmetric ciphers with padding
+ * @author Valerie Peng
+ * @library /test/lib ..
+ * @key randomness
+ * @modules jdk.crypto.cryptoki
+ * @run main/othervm TestSymmCiphers AES/CTS/NoPadding AES 3200
+ */
+
+import jtreg.SkippedException;
 
 import java.io.ByteArrayOutputStream;
 import java.nio.ByteBuffer;
@@ -44,87 +276,56 @@ import javax.crypto.SecretKey;
 
 public class TestSymmCiphers extends PKCS11Test {
 
-    private static class CI { // class for holding Cipher Information
-
-        String transformation;
-        String keyAlgo;
-        int dataSize;
-
-        CI(String transformation, String keyAlgo, int dataSize) {
-            this.transformation = transformation;
-            this.keyAlgo = keyAlgo;
-            this.dataSize = dataSize;
-        }
-    }
-    private static final CI[] TEST_LIST = {
-        new CI("ARCFOUR", "ARCFOUR", 400),
-        new CI("RC4", "RC4", 401),
-        new CI("DES/CBC/NoPadding", "DES", 400),
-        new CI("DESede/CBC/NoPadding", "DESede", 160),
-        new CI("AES/CBC/NoPadding", "AES", 4800),
-        new CI("Blowfish/CBC/NoPadding", "Blowfish", 24),
-        new CI("DES/cbc/PKCS5Padding", "DES", 6401),
-        new CI("DESede/CBC/PKCS5Padding", "DESede", 402),
-        new CI("AES/CBC/PKCS5Padding", "AES", 30),
-        new CI("Blowfish/CBC/PKCS5Padding", "Blowfish", 19),
-        new CI("DES/ECB/NoPadding", "DES", 400),
-        new CI("DESede/ECB/NoPadding", "DESede", 160),
-        new CI("AES/ECB/NoPadding", "AES", 4800),
-        new CI("DES/ECB/PKCS5Padding", "DES", 32),
-        new CI("DES/ECB/PKCS5Padding", "DES", 6400),
-        new CI("DESede/ECB/PKCS5Padding", "DESede", 400),
-        new CI("AES/ECB/PKCS5Padding", "AES", 64),
-
-        new CI("DES", "DES", 6400),
-        new CI("DESede", "DESede", 408),
-        new CI("AES", "AES", 128),
-
-        new CI("AES/CTR/NoPadding", "AES", 3200),
-        new CI("AES/CTS/NoPadding", "AES", 3200),
-
-    };
     private static final StringBuffer debugBuf = new StringBuffer();
+
+    private final String transformation;
+    private final String keyAlgo;
+    private final int dataSize;
+
+    public TestSymmCiphers(String transformation,
+                           String keyAlgo,
+                           int dataSize) {
+        this.transformation = transformation;
+        this.keyAlgo = keyAlgo;
+        this.dataSize = dataSize;
+    }
 
     @Override
     public void main(Provider p) throws Exception {
         // NSS reports CKR_DEVICE_ERROR when the data passed to
         // its EncryptUpdate/DecryptUpdate is not multiple of blocks
         int firstBlkSize = 16;
-        boolean status = true;
         Random random = new Random();
         try {
-            for (int i = 0; i < TEST_LIST.length; i++) {
-                CI currTest = TEST_LIST[i];
-                System.out.println("===" + currTest.transformation + "===");
-                try {
-                    KeyGenerator kg =
-                            KeyGenerator.getInstance(currTest.keyAlgo, p);
-                    SecretKey key = kg.generateKey();
-                    Cipher c1 = Cipher.getInstance(currTest.transformation, p);
-                    Cipher c2 = Cipher.getInstance(currTest.transformation,
-                            System.getProperty("test.provider.name", "SunJCE"));
+            System.out.println("===" + transformation + "===");
+            try {
+                KeyGenerator kg =
+                        KeyGenerator.getInstance(keyAlgo, p);
+                SecretKey key = kg.generateKey();
+                Cipher c1 = Cipher.getInstance(transformation, p);
+                Cipher c2 = Cipher.getInstance(transformation,
+                        System.getProperty("test.provider.name", "SunJCE"));
 
-                    byte[] plainTxt = new byte[currTest.dataSize];
-                    random.nextBytes(plainTxt);
-                    System.out.println("Testing inLen = " + plainTxt.length);
+                byte[] plainTxt = new byte[dataSize];
+                random.nextBytes(plainTxt);
+                System.out.println("Testing inLen = " + plainTxt.length);
 
-                    c2.init(Cipher.ENCRYPT_MODE, key);
-                    AlgorithmParameters params = c2.getParameters();
-                    byte[] answer = c2.doFinal(plainTxt);
-                    System.out.println("Encryption tests: START");
-                    test(c1, Cipher.ENCRYPT_MODE, key, params, firstBlkSize,
-                            plainTxt, answer);
-                    System.out.println("Encryption tests: DONE");
-                    c2.init(Cipher.DECRYPT_MODE, key, params);
-                    byte[] answer2 = c2.doFinal(answer);
-                    System.out.println("Decryption tests: START");
-                    test(c1, Cipher.DECRYPT_MODE, key, params, firstBlkSize,
-                            answer, answer2);
-                    System.out.println("Decryption tests: DONE");
-                } catch (NoSuchAlgorithmException nsae) {
-                    System.out.println("Skipping unsupported algorithm: " +
-                            nsae);
-                }
+                c2.init(Cipher.ENCRYPT_MODE, key);
+                AlgorithmParameters params = c2.getParameters();
+                byte[] answer = c2.doFinal(plainTxt);
+                System.out.println("Encryption tests: START");
+                test(c1, Cipher.ENCRYPT_MODE, key, params, firstBlkSize,
+                        plainTxt, answer);
+                System.out.println("Encryption tests: DONE");
+                c2.init(Cipher.DECRYPT_MODE, key, params);
+                byte[] answer2 = c2.doFinal(answer);
+                System.out.println("Decryption tests: START");
+                test(c1, Cipher.DECRYPT_MODE, key, params, firstBlkSize,
+                        answer, answer2);
+                System.out.println("Decryption tests: DONE");
+            } catch (NoSuchAlgorithmException nsae) {
+                throw new SkippedException("Skipping unsupported algorithm: " +
+                                           nsae);
             }
         } catch (Exception ex) {
             // print out debug info when exception is encountered
@@ -134,13 +335,12 @@ public class TestSymmCiphers extends PKCS11Test {
     }
 
     private static void test(Cipher cipher, int mode, SecretKey key,
-            AlgorithmParameters params, int firstBlkSize,
-            byte[] in, byte[] answer) throws Exception {
+                             AlgorithmParameters params, int firstBlkSize,
+                             byte[] in, byte[] answer) throws Exception {
         // test setup
         long startTime, endTime;
         cipher.init(mode, key, params);
         int outLen = cipher.getOutputSize(in.length);
-        //debugOut("Estimated output size = " + outLen + "\n");
 
         // test data preparation
         ByteBuffer inBuf = ByteBuffer.allocate(in.length);
@@ -153,8 +353,6 @@ public class TestSymmCiphers extends PKCS11Test {
         ByteBuffer outDirectBuf = ByteBuffer.allocateDirect(outLen);
 
         // test#1: byte[] in + byte[] out
-        //debugOut("Test#1:\n");
-
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
 
         startTime = System.nanoTime();
@@ -172,10 +370,6 @@ public class TestSymmCiphers extends PKCS11Test {
         match(testOut1, answer);
 
         // test#2: Non-direct Buffer in + non-direct Buffer out
-        //debugOut("Test#2:\n");
-        //debugOut("inputBuf: " + inBuf + "\n");
-        //debugOut("outputBuf: " + outBuf + "\n");
-
         startTime = System.nanoTime();
         cipher.update(inBuf, outBuf);
         cipher.doFinal(inBuf, outBuf);
@@ -184,26 +378,17 @@ public class TestSymmCiphers extends PKCS11Test {
         match(outBuf, answer);
 
         // test#3: Direct Buffer in + direc Buffer out
-        //debugOut("Test#3:\n");
-        //debugOut("(pre) inputBuf: " + inDirectBuf + "\n");
-        //debugOut("(pre) outputBuf: " + outDirectBuf + "\n");
-
         startTime = System.nanoTime();
         cipher.update(inDirectBuf, outDirectBuf);
         cipher.doFinal(inDirectBuf, outDirectBuf);
         endTime = System.nanoTime();
         perfOut("direct InBuf + direct OutBuf", endTime - startTime);
 
-        //debugOut("(post) inputBuf: " + inDirectBuf + "\n");
-        //debugOut("(post) outputBuf: " + outDirectBuf + "\n");
         match(outDirectBuf, answer);
 
         // test#4: Direct Buffer in + non-direct Buffer out
-        //debugOut("Test#4:\n");
         inDirectBuf.position(0);
         outBuf.position(0);
-        //debugOut("inputBuf: " + inDirectBuf + "\n");
-        //debugOut("outputBuf: " + outBuf + "\n");
 
         startTime = System.nanoTime();
         cipher.update(inDirectBuf, outBuf);
@@ -213,12 +398,8 @@ public class TestSymmCiphers extends PKCS11Test {
         match(outBuf, answer);
 
         // test#5: Non-direct Buffer in + direct Buffer out
-        //debugOut("Test#5:\n");
         inBuf.position(0);
         outDirectBuf.position(0);
-
-        //debugOut("(pre) inputBuf: " + inBuf + "\n");
-        //debugOut("(pre) outputBuf: " + outDirectBuf + "\n");
 
         startTime = System.nanoTime();
         cipher.update(inBuf, outDirectBuf);
@@ -226,8 +407,6 @@ public class TestSymmCiphers extends PKCS11Test {
         endTime = System.nanoTime();
         perfOut("non-direct InBuf + direct OutBuf", endTime - startTime);
 
-        //debugOut("(post) inputBuf: " + inBuf + "\n");
-        //debugOut("(post) outputBuf: " + outDirectBuf + "\n");
         match(outDirectBuf, answer);
 
         debugBuf.setLength(0);
@@ -265,6 +444,6 @@ public class TestSymmCiphers extends PKCS11Test {
     }
 
     public static void main(String[] args) throws Exception {
-        main(new TestSymmCiphers(), args);
+        main(new TestSymmCiphers(args[0], args[1], Integer.parseInt(args[2])), args);
     }
 }

--- a/test/jdk/sun/security/pkcs11/Cipher/TestSymmCiphers.java
+++ b/test/jdk/sun/security/pkcs11/Cipher/TestSymmCiphers.java
@@ -127,7 +127,7 @@ public class TestSymmCiphers extends PKCS11Test {
         }
 
         if (!skippedList.isEmpty()){
-            throw new SkippedException("Some tests failed: " + skippedList);
+            throw new SkippedException("Some tests skipped: " + skippedList);
         }
     }
 

--- a/test/jdk/sun/security/pkcs11/Cipher/TestSymmCiphers.java
+++ b/test/jdk/sun/security/pkcs11/Cipher/TestSymmCiphers.java
@@ -22,7 +22,7 @@
  */
 
 /*
- * @test
+ * @test id=ARCFOUR-ARCFOUR-400
  * @bug 4898461 6604496 8330842
  * @summary basic test for symmetric ciphers with padding
  * @author Valerie Peng
@@ -30,10 +30,10 @@
  * @key randomness
  * @modules jdk.crypto.cryptoki
  * @run main/othervm TestSymmCiphers ARCFOUR ARCFOUR 400
- */
+*/
 
 /*
- * @test
+ * @test id=RC4-RC4-401
  * @bug 4898461 6604496 8330842
  * @summary basic test for symmetric ciphers with padding
  * @author Valerie Peng
@@ -44,7 +44,7 @@
  */
 
 /*
- * @test
+ * @test id=DES-CBC-NOPADDING-DES-400
  * @bug 4898461 6604496 8330842
  * @summary basic test for symmetric ciphers with padding
  * @author Valerie Peng
@@ -55,7 +55,7 @@
  */
 
 /*
- * @test
+ * @test id=DESEDE-CBC-NOPADDING-DESEDE-160
  * @bug 4898461 6604496 8330842
  * @summary basic test for symmetric ciphers with padding
  * @author Valerie Peng
@@ -66,7 +66,7 @@
  */
 
 /*
- * @test
+ * @test id=AES-CBC-NOPADDING-AES-4800
  * @bug 4898461 6604496 8330842
  * @summary basic test for symmetric ciphers with padding
  * @author Valerie Peng
@@ -77,7 +77,7 @@
  */
 
 /*
- * @test
+ * @test id=BLOWFISH-CBC-NOPADDING-BLOWFISH-24
  * @bug 4898461 6604496 8330842
  * @summary basic test for symmetric ciphers with padding
  * @author Valerie Peng
@@ -88,7 +88,7 @@
  */
 
 /*
- * @test
+ * @test id=DES-CBC-PKCS5PADDING-DES-6401
  * @bug 4898461 6604496 8330842
  * @summary basic test for symmetric ciphers with padding
  * @author Valerie Peng
@@ -99,7 +99,7 @@
  */
 
 /*
- * @test
+ * @test id=DESEDE-CBC-PKCS5PADDING-DESEDE-402
  * @bug 4898461 6604496 8330842
  * @summary basic test for symmetric ciphers with padding
  * @author Valerie Peng
@@ -110,7 +110,7 @@
  */
 
 /*
- * @test
+ * @test id=AES-CBC-PKCS5PADDING-AES-30
  * @bug 4898461 6604496 8330842
  * @summary basic test for symmetric ciphers with padding
  * @author Valerie Peng
@@ -121,7 +121,7 @@
  */
 
 /*
- * @test
+ * @test id=BLOWFISH-CBC-PKCS5PADDING-BLOWFISH-19
  * @bug 4898461 6604496 8330842
  * @summary basic test for symmetric ciphers with padding
  * @author Valerie Peng
@@ -132,7 +132,7 @@
  */
 
 /*
- * @test
+ * @test id=DES-ECB-NOPADDING-DES-400
  * @bug 4898461 6604496 8330842
  * @summary basic test for symmetric ciphers with padding
  * @author Valerie Peng
@@ -143,7 +143,7 @@
  */
 
 /*
- * @test
+ * @test id=DESEDE-ECB-NOPADDING-DESEDE-160
  * @bug 4898461 6604496 8330842
  * @summary basic test for symmetric ciphers with padding
  * @author Valerie Peng
@@ -154,7 +154,7 @@
  */
 
 /*
- * @test
+ * @test id=AES-ECB-NOPADDING-AES-4800
  * @bug 4898461 6604496 8330842
  * @summary basic test for symmetric ciphers with padding
  * @author Valerie Peng
@@ -165,7 +165,7 @@
  */
 
 /*
- * @test
+ * @test id=DES-ECB-PKCS5PADDING-DES-32
  * @bug 4898461 6604496 8330842
  * @summary basic test for symmetric ciphers with padding
  * @author Valerie Peng
@@ -176,7 +176,7 @@
  */
 
 /*
- * @test
+ * @test id=DES-ECB-PKCS5PADDING-DES-6400
  * @bug 4898461 6604496 8330842
  * @summary basic test for symmetric ciphers with padding
  * @author Valerie Peng
@@ -187,7 +187,7 @@
  */
 
 /*
- * @test
+ * @test id=DESEDE-ECB-PKCS5PADDING-DESEDE-400
  * @bug 4898461 6604496 8330842
  * @summary basic test for symmetric ciphers with padding
  * @author Valerie Peng
@@ -198,7 +198,7 @@
  */
 
 /*
- * @test
+ * @test id=AES-ECB-PKCS5PADDING-AES-64
  * @bug 4898461 6604496 8330842
  * @summary basic test for symmetric ciphers with padding
  * @author Valerie Peng
@@ -209,7 +209,7 @@
  */
 
 /*
- * @test
+ * @test id=DES-DES-6400
  * @bug 4898461 6604496 8330842
  * @summary basic test for symmetric ciphers with padding
  * @author Valerie Peng
@@ -218,8 +218,9 @@
  * @modules jdk.crypto.cryptoki
  * @run main/othervm TestSymmCiphers DES DES 6400
  */
+
 /*
- * @test
+ * @test id=DESEDE-DESEDE-408
  * @bug 4898461 6604496 8330842
  * @summary basic test for symmetric ciphers with padding
  * @author Valerie Peng
@@ -230,7 +231,7 @@
  */
 
 /*
- * @test
+ * @test id=AES-AES-128
  * @bug 4898461 6604496 8330842
  * @summary basic test for symmetric ciphers with padding
  * @author Valerie Peng
@@ -241,7 +242,7 @@
  */
 
 /*
- * @test
+ * @test id=AES-CTR-NOPADDING-AES-3200
  * @bug 4898461 6604496 8330842
  * @summary basic test for symmetric ciphers with padding
  * @author Valerie Peng
@@ -252,7 +253,7 @@
  */
 
 /*
- * @test
+ * @test id=AES-CTS-NOPADDING-AES-3200
  * @bug 4898461 6604496 8330842
  * @summary basic test for symmetric ciphers with padding
  * @author Valerie Peng

--- a/test/jdk/sun/security/pkcs11/Cipher/TestSymmCiphersNoPad.java
+++ b/test/jdk/sun/security/pkcs11/Cipher/TestSymmCiphersNoPad.java
@@ -22,7 +22,7 @@
  */
 
 /*
- * @test
+ * @test id=ARCFOUR-ARCFOUR-400
  * @bug 4898484 6604496 8001284 8330842
  * @summary basic test for symmetric ciphers with no padding
  * @author Valerie Peng
@@ -33,7 +33,7 @@
  */
 
 /*
- * @test
+ * @test id=RC4-RC4-401
  * @bug 4898484 6604496 8001284 8330842
  * @summary basic test for symmetric ciphers with no padding
  * @author Valerie Peng
@@ -44,7 +44,7 @@
  */
 
 /*
- * @test
+ * @test id=DES-CBC-NOPADDING-DES-400
  * @bug 4898484 6604496 8001284 8330842
  * @summary basic test for symmetric ciphers with no padding
  * @author Valerie Peng
@@ -55,7 +55,7 @@
  */
 
 /*
- * @test
+ * @test id=DESEDE-CBC-NOPADDING-DESEDE-160
  * @bug 4898484 6604496 8001284 8330842
  * @summary basic test for symmetric ciphers with no padding
  * @author Valerie Peng
@@ -66,7 +66,7 @@
  */
 
 /*
- * @test
+ * @test id=AES-CBC-NOPADDING-AES-4800
  * @bug 4898484 6604496 8001284 8330842
  * @summary basic test for symmetric ciphers with no padding
  * @author Valerie Peng
@@ -77,7 +77,7 @@
  */
 
 /*
- * @test
+ * @test id=BLOWFISH-CBC-NOPADDING-BLOWFISH-24
  * @bug 4898484 6604496 8001284 8330842
  * @summary basic test for symmetric ciphers with no padding
  * @author Valerie Peng
@@ -88,7 +88,7 @@
  */
 
 /*
- * @test
+ * @test id=AES-CTR-NOPADDING-AES-1600
  * @bug 4898484 6604496 8001284 8330842
  * @summary basic test for symmetric ciphers with no padding
  * @author Valerie Peng
@@ -99,7 +99,7 @@
  */
 
 /*
- * @test
+ * @test id=AES-CTR-NOPADDING-AES-65
  * @bug 4898484 6604496 8001284 8330842
  * @summary basic test for symmetric ciphers with no padding
  * @author Valerie Peng
@@ -110,7 +110,7 @@
  */
 
 /*
- * @test
+ * @test id=AES-CTS-NOPADDING-AES-1600
  * @bug 4898484 6604496 8001284 8330842
  * @summary basic test for symmetric ciphers with no padding
  * @author Valerie Peng
@@ -121,7 +121,7 @@
  */
 
 /*
- * @test
+ * @test id=AES-CTS-NOPADDING-AES-65
  * @bug 4898484 6604496 8001284 8330842
  * @summary basic test for symmetric ciphers with no padding
  * @author Valerie Peng

--- a/test/jdk/sun/security/pkcs11/Cipher/TestSymmCiphersNoPad.java
+++ b/test/jdk/sun/security/pkcs11/Cipher/TestSymmCiphersNoPad.java
@@ -22,113 +22,14 @@
  */
 
 /*
- * @test id=ARCFOUR-ARCFOUR-400
+ * @test
  * @bug 4898484 6604496 8001284 8330842
  * @summary basic test for symmetric ciphers with no padding
  * @author Valerie Peng
  * @library /test/lib ..
  * @key randomness
  * @modules jdk.crypto.cryptoki
- * @run main/othervm TestSymmCiphersNoPad ARCFOUR ARCFOUR 400
- */
-
-/*
- * @test id=RC4-RC4-401
- * @bug 4898484 6604496 8001284 8330842
- * @summary basic test for symmetric ciphers with no padding
- * @author Valerie Peng
- * @library /test/lib ..
- * @key randomness
- * @modules jdk.crypto.cryptoki
- * @run main/othervm TestSymmCiphersNoPad RC4 RC4 401
- */
-
-/*
- * @test id=DES-CBC-NOPADDING-DES-400
- * @bug 4898484 6604496 8001284 8330842
- * @summary basic test for symmetric ciphers with no padding
- * @author Valerie Peng
- * @library /test/lib ..
- * @key randomness
- * @modules jdk.crypto.cryptoki
- * @run main/othervm TestSymmCiphersNoPad DES/CBC/NoPadding DES 400
- */
-
-/*
- * @test id=DESEDE-CBC-NOPADDING-DESEDE-160
- * @bug 4898484 6604496 8001284 8330842
- * @summary basic test for symmetric ciphers with no padding
- * @author Valerie Peng
- * @library /test/lib ..
- * @key randomness
- * @modules jdk.crypto.cryptoki
- * @run main/othervm TestSymmCiphersNoPad DESede/CBC/NoPadding DESede 160
- */
-
-/*
- * @test id=AES-CBC-NOPADDING-AES-4800
- * @bug 4898484 6604496 8001284 8330842
- * @summary basic test for symmetric ciphers with no padding
- * @author Valerie Peng
- * @library /test/lib ..
- * @key randomness
- * @modules jdk.crypto.cryptoki
- * @run main/othervm TestSymmCiphersNoPad AES/CBC/NoPadding AES 4800
- */
-
-/*
- * @test id=BLOWFISH-CBC-NOPADDING-BLOWFISH-24
- * @bug 4898484 6604496 8001284 8330842
- * @summary basic test for symmetric ciphers with no padding
- * @author Valerie Peng
- * @library /test/lib ..
- * @key randomness
- * @modules jdk.crypto.cryptoki
- * @run main/othervm TestSymmCiphersNoPad Blowfish/CBC/NoPadding Blowfish 24
- */
-
-/*
- * @test id=AES-CTR-NOPADDING-AES-1600
- * @bug 4898484 6604496 8001284 8330842
- * @summary basic test for symmetric ciphers with no padding
- * @author Valerie Peng
- * @library /test/lib ..
- * @key randomness
- * @modules jdk.crypto.cryptoki
- * @run main/othervm TestSymmCiphersNoPad AES/CTR/NoPadding AES 1600
- */
-
-/*
- * @test id=AES-CTR-NOPADDING-AES-65
- * @bug 4898484 6604496 8001284 8330842
- * @summary basic test for symmetric ciphers with no padding
- * @author Valerie Peng
- * @library /test/lib ..
- * @key randomness
- * @modules jdk.crypto.cryptoki
- * @run main/othervm TestSymmCiphersNoPad AES/CTR/NoPadding AES 65
- */
-
-/*
- * @test id=AES-CTS-NOPADDING-AES-1600
- * @bug 4898484 6604496 8001284 8330842
- * @summary basic test for symmetric ciphers with no padding
- * @author Valerie Peng
- * @library /test/lib ..
- * @key randomness
- * @modules jdk.crypto.cryptoki
- * @run main/othervm TestSymmCiphersNoPad AES/CTS/NoPadding AES 1600
- */
-
-/*
- * @test id=AES-CTS-NOPADDING-AES-65
- * @bug 4898484 6604496 8001284 8330842
- * @summary basic test for symmetric ciphers with no padding
- * @author Valerie Peng
- * @library /test/lib ..
- * @key randomness
- * @modules jdk.crypto.cryptoki
- * @run main/othervm TestSymmCiphersNoPad AES/CTS/NoPadding AES 65
+ * @run main/othervm TestSymmCiphersNoPad
  */
 
 import jtreg.SkippedException;
@@ -140,6 +41,7 @@ import java.nio.ByteBuffer;
 import java.security.AlgorithmParameters;
 import java.security.NoSuchAlgorithmException;
 import java.security.Provider;
+import java.util.List;
 import java.util.Random;
 import javax.crypto.Cipher;
 import javax.crypto.CipherInputStream;
@@ -323,6 +225,32 @@ public class TestSymmCiphersNoPad extends PKCS11Test {
     }
 
     public static void main(String[] args) throws Exception {
-        main(new TestSymmCiphersNoPad(args[0], args[1], Integer.parseInt(args[2])), args);
+
+        final List<String[]> tests = List.of(
+                new String[]{"ARCFOUR", "ARCFOUR", "400"},
+                new String[]{"RC4", "RC4", "401"},
+                new String[]{"DES/CBC/NoPadding", "DES", "400"},
+                new String[]{"DESede/CBC/NoPadding", "DESede", "160"},
+                new String[]{"AES/CBC/NoPadding", "AES", "4800"},
+                new String[]{"Blowfish/CBC/NoPadding", "Blowfish", "24"},
+                new String[]{"AES/CTR/NoPadding", "AES", "1600"},
+                new String[]{"AES/CTR/NoPadding", "AES", "65"},
+                new String[]{"AES/CTS/NoPadding", "AES", "1600"},
+                new String[]{"AES/CTS/NoPadding", "AES", "65"}
+        );
+
+        boolean skipEncountered = false;
+        for (final String[] t : tests) {
+            try {
+                main(new TestSymmCiphersNoPad(t[0], t[1], Integer.parseInt(t[2])), args);
+            } catch (SkippedException skippedException) {
+                skippedException.printStackTrace(System.err);
+                skipEncountered = true;
+            }
+        }
+
+        if (skipEncountered) {
+            throw new SkippedException("One or more tests skipped");
+        }
     }
 }

--- a/test/jdk/sun/security/pkcs11/Cipher/TestSymmCiphersNoPad.java
+++ b/test/jdk/sun/security/pkcs11/Cipher/TestSymmCiphersNoPad.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,8 +29,109 @@
  * @library /test/lib ..
  * @key randomness
  * @modules jdk.crypto.cryptoki
- * @run main/othervm TestSymmCiphersNoPad
+ * @run main/othervm TestSymmCiphersNoPad ARCFOUR ARCFOUR 400
  */
+
+/*
+ * @test
+ * @bug 4898484 6604496 8001284 8330842
+ * @summary basic test for symmetric ciphers with no padding
+ * @author Valerie Peng
+ * @library /test/lib ..
+ * @key randomness
+ * @modules jdk.crypto.cryptoki
+ * @run main/othervm TestSymmCiphersNoPad RC4 RC4 401
+ */
+
+/*
+ * @test
+ * @bug 4898484 6604496 8001284 8330842
+ * @summary basic test for symmetric ciphers with no padding
+ * @author Valerie Peng
+ * @library /test/lib ..
+ * @key randomness
+ * @modules jdk.crypto.cryptoki
+ * @run main/othervm TestSymmCiphersNoPad DES/CBC/NoPadding DES 400
+ */
+
+/*
+ * @test
+ * @bug 4898484 6604496 8001284 8330842
+ * @summary basic test for symmetric ciphers with no padding
+ * @author Valerie Peng
+ * @library /test/lib ..
+ * @key randomness
+ * @modules jdk.crypto.cryptoki
+ * @run main/othervm TestSymmCiphersNoPad DESede/CBC/NoPadding DESede 160
+ */
+
+/*
+ * @test
+ * @bug 4898484 6604496 8001284 8330842
+ * @summary basic test for symmetric ciphers with no padding
+ * @author Valerie Peng
+ * @library /test/lib ..
+ * @key randomness
+ * @modules jdk.crypto.cryptoki
+ * @run main/othervm TestSymmCiphersNoPad AES/CBC/NoPadding AES 4800
+ */
+
+/*
+ * @test
+ * @bug 4898484 6604496 8001284 8330842
+ * @summary basic test for symmetric ciphers with no padding
+ * @author Valerie Peng
+ * @library /test/lib ..
+ * @key randomness
+ * @modules jdk.crypto.cryptoki
+ * @run main/othervm TestSymmCiphersNoPad Blowfish/CBC/NoPadding Blowfish 24
+ */
+
+/*
+ * @test
+ * @bug 4898484 6604496 8001284 8330842
+ * @summary basic test for symmetric ciphers with no padding
+ * @author Valerie Peng
+ * @library /test/lib ..
+ * @key randomness
+ * @modules jdk.crypto.cryptoki
+ * @run main/othervm TestSymmCiphersNoPad AES/CTR/NoPadding AES 1600
+ */
+
+/*
+ * @test
+ * @bug 4898484 6604496 8001284 8330842
+ * @summary basic test for symmetric ciphers with no padding
+ * @author Valerie Peng
+ * @library /test/lib ..
+ * @key randomness
+ * @modules jdk.crypto.cryptoki
+ * @run main/othervm TestSymmCiphersNoPad AES/CTR/NoPadding AES 65
+ */
+
+/*
+ * @test
+ * @bug 4898484 6604496 8001284 8330842
+ * @summary basic test for symmetric ciphers with no padding
+ * @author Valerie Peng
+ * @library /test/lib ..
+ * @key randomness
+ * @modules jdk.crypto.cryptoki
+ * @run main/othervm TestSymmCiphersNoPad AES/CTS/NoPadding AES 1600
+ */
+
+/*
+ * @test
+ * @bug 4898484 6604496 8001284 8330842
+ * @summary basic test for symmetric ciphers with no padding
+ * @author Valerie Peng
+ * @library /test/lib ..
+ * @key randomness
+ * @modules jdk.crypto.cryptoki
+ * @run main/othervm TestSymmCiphersNoPad AES/CTS/NoPadding AES 65
+ */
+
+import jtreg.SkippedException;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -47,68 +148,51 @@ import javax.crypto.SecretKey;
 
 public class TestSymmCiphersNoPad extends PKCS11Test {
 
-    private static class CI { // class for holding Cipher Information
-        String transformation;
-        String keyAlgo;
-        int dataSize;
-
-        CI(String transformation, String keyAlgo, int dataSize) {
-            this.transformation = transformation;
-            this.keyAlgo = keyAlgo;
-            this.dataSize = dataSize;
-        }
-    }
-
-    private static final CI TEST_LIST[] = {
-        new CI("ARCFOUR", "ARCFOUR", 400),
-        new CI("RC4", "RC4", 401),
-        new CI("DES/CBC/NoPadding", "DES", 400),
-        new CI("DESede/CBC/NoPadding", "DESede", 160),
-        new CI("AES/CBC/NoPadding", "AES", 4800),
-        new CI("Blowfish/CBC/NoPadding", "Blowfish", 24),
-        new CI("AES/CTR/NoPadding", "AES", 1600),
-        new CI("AES/CTR/NoPadding", "AES", 65),
-        new CI("AES/CTS/NoPadding", "AES", 1600),
-        new CI("AES/CTS/NoPadding", "AES", 65),
-    };
-
     private static final StringBuffer debugBuf = new StringBuffer();
+
+    private final String transformation;
+    private final String keyAlgo;
+    private final int dataSize;
+
+    public TestSymmCiphersNoPad(String transformation,
+                                String keyAlgo,
+                                int dataSize) {
+        this.transformation = transformation;
+        this.keyAlgo = keyAlgo;
+        this.dataSize = dataSize;
+    }
 
     @Override
     public void main(Provider p) throws Exception {
-        boolean status = true;
         Random random = new Random();
         try {
-            for (int i = 0; i < TEST_LIST.length; i++) {
-                CI currTest = TEST_LIST[i];
-                System.out.println("===" + currTest.transformation + "===");
-                try {
-                    KeyGenerator kg =
-                        KeyGenerator.getInstance(currTest.keyAlgo, p);
-                    SecretKey key = kg.generateKey();
-                    Cipher c1 = Cipher.getInstance(currTest.transformation, p);
-                    Cipher c2 = Cipher.getInstance(currTest.transformation,
-                               System.getProperty("test.provider.name", "SunJCE"));
+            System.out.println("===" + transformation + "===");
+            try {
+                KeyGenerator kg =
+                        KeyGenerator.getInstance(keyAlgo, p);
+                SecretKey key = kg.generateKey();
+                Cipher c1 = Cipher.getInstance(transformation, p);
+                Cipher c2 = Cipher.getInstance(transformation,
+                        System.getProperty("test.provider.name", "SunJCE"));
 
-                    byte[] plainTxt = new byte[currTest.dataSize];
-                    random.nextBytes(plainTxt);
-                    System.out.println("Testing inLen = " + plainTxt.length);
+                byte[] plainTxt = new byte[dataSize];
+                random.nextBytes(plainTxt);
+                System.out.println("Testing inLen = " + plainTxt.length);
 
-                    c2.init(Cipher.ENCRYPT_MODE, key);
-                    AlgorithmParameters params = c2.getParameters();
-                    byte[] answer = c2.doFinal(plainTxt);
-                    test(c1, Cipher.ENCRYPT_MODE, key, params,
-                         plainTxt, answer);
-                    System.out.println("Encryption tests: DONE");
-                    c2.init(Cipher.DECRYPT_MODE, key, params);
-                    byte[] answer2 = c2.doFinal(answer);
-                    test(c1, Cipher.DECRYPT_MODE, key, params,
-                         answer, answer2);
-                    System.out.println("Decryption tests: DONE");
-                } catch (NoSuchAlgorithmException nsae) {
-                    System.out.println("Skipping unsupported algorithm: " +
-                                       nsae);
-                }
+                c2.init(Cipher.ENCRYPT_MODE, key);
+                AlgorithmParameters params = c2.getParameters();
+                byte[] answer = c2.doFinal(plainTxt);
+                test(c1, Cipher.ENCRYPT_MODE, key, params,
+                        plainTxt, answer);
+                System.out.println("Encryption tests: DONE");
+                c2.init(Cipher.DECRYPT_MODE, key, params);
+                byte[] answer2 = c2.doFinal(answer);
+                test(c1, Cipher.DECRYPT_MODE, key, params,
+                        answer, answer2);
+                System.out.println("Decryption tests: DONE");
+            } catch (NoSuchAlgorithmException nsae) {
+                throw new SkippedException("Skipping unsupported algorithm: " +
+                                           nsae);
             }
         } catch (Exception ex) {
             // print out debug info when exception is encountered
@@ -239,6 +323,6 @@ public class TestSymmCiphersNoPad extends PKCS11Test {
     }
 
     public static void main(String[] args) throws Exception {
-        main(new TestSymmCiphersNoPad(), args);
+        main(new TestSymmCiphersNoPad(args[0], args[1], Integer.parseInt(args[2])), args);
     }
 }


### PR DESCRIPTION
* cleanup
* changed tests hiding errors and skips to be different `@test`, so the errors could be thrown
* tests affected:
  - /test/jdk/sun/security/pkcs11/Cipher/TestChaChaPoly.java
  - /test/jdk/sun/security/pkcs11/Cipher/TestCipherMode.java
  - /test/jdk/sun/security/pkcs11/Cipher/TestChaChaPolyNoReuse.java 
  - /test/jdk/sun/security/pkcs11/Cipher/TestChaChaPolyKAT.java
  - /test/jdk/sun/security/pkcs11/Cipher/TestGCMKeyAndIvCheck.java
  - /test/jdk/sun/security/pkcs11/Cipher/TestCICOWithGCMAndAAD.java
  - /test/jdk/sun/security/pkcs11/Cipher/TestKATForGCM.java
  - /test/jdk/sun/security/pkcs11/Cipher/TestRSACipherWrap.java
  - /test/jdk/sun/security/pkcs11/Cipher/TestChaChaPolyOutputSize.java
  - /test/jdk/sun/security/pkcs11/Cipher/TestSymmCiphers.java
  - /test/jdk/sun/security/pkcs11/Cipher/TestCICOWithGCM.java
  - /test/jdk/sun/security/pkcs11/Cipher/TestRSACipher.java
  - /test/jdk/sun/security/pkcs11/Cipher/TestSymmCiphersNoPad.java
  - /test/jdk/sun/security/pkcs11/Cipher/ReinitCipher.java
  - /test/jdk/sun/security/pkcs11/Cipher/TestRawRSACipher.java
  - /test/jdk/sun/security/pkcs11/Cipher/Test4512704.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8365863](https://bugs.openjdk.org/browse/JDK-8365863): /test/jdk/sun/security/pkcs11/Cipher tests skip without SkippedException (**Bug** - P4)


### Reviewers
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - **Reviewer**) Review applies to [4a2ee597](https://git.openjdk.org/jdk/pull/26875/files/4a2ee597e92a62be4cecf7646fcd73660629ffb3)
 * [Weijun Wang](https://openjdk.org/census#weijun) (@wangweij - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26875/head:pull/26875` \
`$ git checkout pull/26875`

Update a local copy of the PR: \
`$ git checkout pull/26875` \
`$ git pull https://git.openjdk.org/jdk.git pull/26875/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26875`

View PR using the GUI difftool: \
`$ git pr show -t 26875`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26875.diff">https://git.openjdk.org/jdk/pull/26875.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26875#issuecomment-3209688703)
</details>
