### PR TITLE
8365917: Sort share/logging includes

### DIFF
--- a/src/hotspot/share/logging/log.hpp
+++ b/src/hotspot/share/logging/log.hpp
@@ -26,8 +26,8 @@
 
 #include "logging/logLevel.hpp"
 #include "logging/logPrefix.hpp"
-#include "logging/logTagSet.hpp"
 #include "logging/logTag.hpp"
+#include "logging/logTagSet.hpp"
 #include "utilities/debug.hpp"
 
 class LogMessageBuffer;

--- a/src/hotspot/share/logging/logDecorators.hpp
+++ b/src/hotspot/share/logging/logDecorators.hpp
@@ -24,8 +24,8 @@
 #ifndef SHARE_LOGGING_LOGDECORATORS_HPP
 #define SHARE_LOGGING_LOGDECORATORS_HPP
 
-#include "utilities/globalDefinitions.hpp"
 #include "logging/logSelection.hpp"
+#include "utilities/globalDefinitions.hpp"
 
 class outputStream;
 

--- a/src/hotspot/share/logging/logFileStreamOutput.cpp
+++ b/src/hotspot/share/logging/logFileStreamOutput.cpp
@@ -29,6 +29,7 @@
 #include "logging/logMessageBuffer.hpp"
 #include "memory/allocation.inline.hpp"
 #include "utilities/defaultStream.hpp"
+
 #include <string.h>
 
 const char* const LogFileStreamOutput::FoldMultilinesOptionKey = "foldmultilines";

--- a/src/hotspot/share/logging/logTag.cpp
+++ b/src/hotspot/share/logging/logTag.cpp
@@ -22,9 +22,9 @@
  *
  */
 #include "logging/logTag.hpp"
-#include "utilities/stringUtils.hpp"
 #include "utilities/globalDefinitions.hpp"
 #include "utilities/ostream.hpp"
+#include "utilities/stringUtils.hpp"
 
 const char* const LogTag::_name[] = {
   "", // __NO_TAG

--- a/test/hotspot/jtreg/sources/TestIncludesAreSorted.java
+++ b/test/hotspot/jtreg/sources/TestIncludesAreSorted.java
@@ -54,6 +54,7 @@ public class TestIncludesAreSorted {
                     "share/jfr",
                     "share/jvmci",
                     "share/libadt",
+                    "share/logging",
                     "share/metaprogramming",
                     "share/oops",
                     "share/opto",


### PR DESCRIPTION
This PR sorts the includes in `hotspot/share/logging` using `SortIncludes.java`. I'm also adding the directory to `TestIncludesAreSorted`.

Passes `tier1`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8365917](https://bugs.openjdk.org/browse/JDK-8365917): Sort share/logging includes (**Enhancement** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26877/head:pull/26877` \
`$ git checkout pull/26877`

Update a local copy of the PR: \
`$ git checkout pull/26877` \
`$ git pull https://git.openjdk.org/jdk.git pull/26877/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26877`

View PR using the GUI difftool: \
`$ git pr show -t 26877`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26877.diff">https://git.openjdk.org/jdk/pull/26877.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26877#issuecomment-3209847871)
</details>
