### PR TITLE
8365919: Replace currentTimeMillis with nanoTime in Stresser.java

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/share/test/Stresser.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/test/Stresser.java
@@ -182,7 +182,7 @@ public class Stresser implements ExecutionController {
      */
     public void printExecutionInfo(PrintStream out) {
         println(out, "Completed iterations: " + iterations);
-        println(out, "Execution time: " + (currentTime - startTime)/1_000_000_000.0 + " seconds");
+        println(out, "Execution time: " + (currentTime - startTime) / 1_000_000_000.0 + " seconds");
         if (!finished) {
             println(out, "Execution is not finished yet");
         } else if (forceFinish) {


### PR DESCRIPTION
Mostly a mechanic change from `currentTimeMillis()` to `nanoTime()/1000000`. It also removes `finishTime` to avoid overflowing.

The change in `iteration()` is to ensure `currentTime` is properly initialized.

(Was investigating a timeout on Windows-x64, which led me to this code. I think this fix is good enough by its own.)
 
Test: tier1-5

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8365919](https://bugs.openjdk.org/browse/JDK-8365919): Replace currentTimeMillis with nanoTime in Stresser.java (**Enhancement** - P4)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**) Review applies to [10404cea](https://git.openjdk.org/jdk/pull/26879/files/10404ceaaa0b5730b44edeb81c85296c5ddabfc4)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26879/head:pull/26879` \
`$ git checkout pull/26879`

Update a local copy of the PR: \
`$ git checkout pull/26879` \
`$ git pull https://git.openjdk.org/jdk.git pull/26879/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26879`

View PR using the GUI difftool: \
`$ git pr show -t 26879`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26879.diff">https://git.openjdk.org/jdk/pull/26879.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26879#issuecomment-3209908453)
</details>
