### PR TITLE
8352969: G1: Improve testability of optional collections

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectionSet.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSet.cpp
@@ -603,7 +603,7 @@ void G1CollectionSet::select_candidates_from_retained(double time_remaining_ms) 
                             predicted_initial_time_ms, predicted_optional_time_ms, time_remaining_ms, optional_time_remaining_ms);
 }
 
-double G1CollectionSet::select_candidates_from_optional_groups(double time_remaining_ms, uint& num_regions_selected) {
+double G1CollectionSet::select_candidates_from_optional_groups(double time_remaining_ms, uint& num_regions_selected, bool force_all) {
 
   assert(_optional_groups.num_regions() > 0,
          "Should only be called when there are optional regions");
@@ -614,7 +614,7 @@ double G1CollectionSet::select_candidates_from_optional_groups(double time_remai
   for (G1CSetCandidateGroup* group : _optional_groups) {
     double predicted_time_ms = group->predict_group_total_time_ms();
 
-    if (predicted_time_ms > time_remaining_ms) {
+    if (predicted_time_ms > time_remaining_ms && !force_all) {
       log_debug(gc, ergo, cset)("Prediction %.3fms for group with %u regions does not fit remaining time: %.3fms.",
                                 predicted_time_ms, group->length(), time_remaining_ms);
       break;
@@ -639,16 +639,14 @@ double G1CollectionSet::select_candidates_from_optional_groups(double time_remai
   return total_prediction_ms;
 }
 
-uint G1CollectionSet::select_optional_collection_set_regions(double time_remaining_ms) {
+uint G1CollectionSet::select_optional_collection_set_regions(double time_remaining_ms, bool force_all) {
   uint optional_regions_count = num_optional_regions();
   assert(optional_regions_count > 0,
          "Should only be called when there are optional regions");
 
   uint num_regions_selected = 0;
 
-  double total_prediction_ms = select_candidates_from_optional_groups(time_remaining_ms, num_regions_selected);
-
-  time_remaining_ms -= total_prediction_ms;
+  double total_prediction_ms = select_candidates_from_optional_groups(time_remaining_ms, num_regions_selected, force_all);
 
   log_debug(gc, ergo, cset)("Prepared %u regions out of %u for optional evacuation. Total predicted time: %.3fms",
                             num_regions_selected, optional_regions_count, total_prediction_ms);
@@ -694,10 +692,10 @@ void G1CollectionSet::finalize_initial_collection_set(double target_pause_time_m
   QuickSort::sort(_collection_set_regions, _collection_set_cur_length, compare_region_idx);
 }
 
-bool G1CollectionSet::finalize_optional_for_evacuation(double remaining_pause_time) {
+bool G1CollectionSet::finalize_optional_for_evacuation(double remaining_pause_time, bool force_all) {
   continue_incremental_building();
 
-  uint num_regions_selected = select_optional_collection_set_regions(remaining_pause_time);
+  uint num_regions_selected = select_optional_collection_set_regions(remaining_pause_time, force_all);
 
   stop_incremental_building();
 

--- a/src/hotspot/share/gc/g1/g1CollectionSet.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSet.hpp
@@ -191,8 +191,8 @@ class G1CollectionSet {
 
   // Select regions for evacuation from the optional candidates given the remaining time
   // and return the number  of actually selected regions.
-  uint select_optional_collection_set_regions(double time_remaining_ms, bool force_all);
-  double select_candidates_from_optional_groups(double time_remaining_ms, uint& num_regions_selected, bool force_all);
+  uint select_optional_collection_set_regions(double time_remaining_ms, bool force_all = false);
+  double select_candidates_from_optional_groups(double time_remaining_ms, uint& num_regions_selected, bool force_all = false);
 
   // Finalize the young part of the initial collection set. Relabel survivor regions
   // as Eden and calculate a prediction on how long the evacuation of all young regions
@@ -285,7 +285,7 @@ public:
   // few old gen regions.
   void finalize_initial_collection_set(double target_pause_time_ms, G1SurvivorRegions* survivor);
   // Finalize the next collection set from the set of available optional old gen regions.
-  bool finalize_optional_for_evacuation(double remaining_pause_time, bool force_all);
+  bool finalize_optional_for_evacuation(double remaining_pause_time, bool force_all = false);
   // Abandon (clean up) optional collection set regions that were not evacuated in this
   // pause.
   void abandon_optional_collection_set(G1ParScanThreadStateSet* pss);

--- a/src/hotspot/share/gc/g1/g1CollectionSet.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSet.hpp
@@ -191,8 +191,8 @@ class G1CollectionSet {
 
   // Select regions for evacuation from the optional candidates given the remaining time
   // and return the number  of actually selected regions.
-  uint select_optional_collection_set_regions(double time_remaining_ms);
-  double select_candidates_from_optional_groups(double time_remaining_ms, uint& num_regions_selected);
+  uint select_optional_collection_set_regions(double time_remaining_ms, bool force_all);
+  double select_candidates_from_optional_groups(double time_remaining_ms, uint& num_regions_selected, bool force_all);
 
   // Finalize the young part of the initial collection set. Relabel survivor regions
   // as Eden and calculate a prediction on how long the evacuation of all young regions
@@ -285,7 +285,7 @@ public:
   // few old gen regions.
   void finalize_initial_collection_set(double target_pause_time_ms, G1SurvivorRegions* survivor);
   // Finalize the next collection set from the set of available optional old gen regions.
-  bool finalize_optional_for_evacuation(double remaining_pause_time);
+  bool finalize_optional_for_evacuation(double remaining_pause_time, bool force_all);
   // Abandon (clean up) optional collection set regions that were not evacuated in this
   // pause.
   void abandon_optional_collection_set(G1ParScanThreadStateSet* pss);

--- a/src/hotspot/share/gc/g1/g1YoungCollector.cpp
+++ b/src/hotspot/share/gc/g1/g1YoungCollector.cpp
@@ -822,8 +822,8 @@ void G1YoungCollector::evacuate_optional_collection_set(G1ParScanThreadStateSet*
     double time_used_ms = os::elapsedTime() * 1000.0 - pause_start_time_ms;
     double time_left_ms = MaxGCPauseMillis - time_used_ms;
 
-    if (time_left_ms < 0 ||
-        !collection_set()->finalize_optional_for_evacuation(time_left_ms * policy()->optional_evacuation_fraction())) {
+    if ((time_left_ms <= 0 && !EvacuateAllOptionalRegions) ||
+        !collection_set()->finalize_optional_for_evacuation(time_left_ms * policy()->optional_evacuation_fraction(), EvacuateAllOptionalRegions)) {
       log_trace(gc, ergo, cset)("Skipping evacuation of %u optional regions, no more regions can be evacuated in %.3fms",
                                 collection_set()->num_optional_regions(), time_left_ms);
       break;

--- a/src/hotspot/share/gc/g1/g1_globals.hpp
+++ b/src/hotspot/share/gc/g1/g1_globals.hpp
@@ -370,6 +370,9 @@
           "scan cost related prediction samples. A sample must involve "    \
           "the same or more than this number of code roots to be used.")    \
                                                                             \
+  product(bool, EvacuateAllOptionalRegions, false, DIAGNOSTIC,              \
+          "Force to evacuate all optional regions.")                        \
+                                                                            \
   GC_G1_EVACUATION_FAILURE_FLAGS(develop,                                   \
                     develop_pd,                                             \
                     product,                                                \


### PR DESCRIPTION
This PR introduces a new diagnostic flag EvacuateAllOptionalRegions to force G1 GC to evacuate all optional regions regardless of the predicted pause time. The motivation is to allow testing and validation of optional region evacuation behavior without being constrained by the remaining pause time.