### PR TITLE
8365772: RISC-V: correctly prereserve NaN payload when converting from float to float16 in vector way

### DIFF
--- a/src/hotspot/cpu/riscv/assembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv.hpp
@@ -1988,6 +1988,7 @@ enum VectorMask {
 
   // Vector Narrowing Integer Right Shift Instructions
   INSN(vnsra_wi, 0b1010111, 0b011, 0b101101);
+  INSN(vnsrl_wi, 0b1010111, 0b011, 0b101100);
 
 #undef INSN
 


### PR DESCRIPTION
Hi,
Can you help to review this patch?

This is a follow-up of https://github.com/openjdk/jdk/pull/26838, fixes the vector version in a similar way.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8365772](https://bugs.openjdk.org/browse/JDK-8365772): RISC-V: correctly prereserve NaN payload when converting from float to float16 in vector way (**Bug** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Robbin Ehn](https://openjdk.org/census#rehn) (@robehn - **Reviewer**) Review applies to [fa107180](https://git.openjdk.org/jdk/pull/26883/files/fa107180d1e237a0c28c88cc686d2cd53e96a60c)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26883/head:pull/26883` \
`$ git checkout pull/26883`

Update a local copy of the PR: \
`$ git checkout pull/26883` \
`$ git pull https://git.openjdk.org/jdk.git pull/26883/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26883`

View PR using the GUI difftool: \
`$ git pr show -t 26883`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26883.diff">https://git.openjdk.org/jdk/pull/26883.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26883#issuecomment-3210592577)
</details>
