### PR TITLE
8365656: [ubsan] G1CSetCandidateGroup::liveness() reports division by 0

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectionSetCandidates.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSetCandidates.cpp
@@ -59,6 +59,7 @@ void G1CSetCandidateGroup::calculate_efficiency() {
 }
 
 double G1CSetCandidateGroup::liveness_percent() const {
+  assert(length() > 0, "must be");
   size_t capacity = length() * G1HeapRegion::GrainBytes;
   return ((capacity - _reclaimable_bytes) * 100.0) / capacity;
 }

--- a/src/hotspot/share/gc/g1/g1CollectionSetCandidates.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSetCandidates.cpp
@@ -59,7 +59,9 @@ void G1CSetCandidateGroup::calculate_efficiency() {
 }
 
 double G1CSetCandidateGroup::liveness_percent() const {
-  assert(length() > 0, "must be");
+  if (length() == 0) {
+    return 0.0f;
+  }
   size_t capacity = length() * G1HeapRegion::GrainBytes;
   return ((capacity - _reclaimable_bytes) * 100.0) / capacity;
 }

--- a/src/hotspot/share/gc/g1/g1CollectionSetCandidates.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSetCandidates.cpp
@@ -59,9 +59,7 @@ void G1CSetCandidateGroup::calculate_efficiency() {
 }
 
 double G1CSetCandidateGroup::liveness_percent() const {
-  if (length() == 0) {
-    return 0.0f;
-  }
+  assert(length() > 0, "must be");
   size_t capacity = length() * G1HeapRegion::GrainBytes;
   return ((capacity - _reclaimable_bytes) * 100.0) / capacity;
 }

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -3122,7 +3122,7 @@ void G1PrintRegionLivenessInfoClosure::log_cset_candidate_group_add_total(G1CSet
                           group->group_id(),
                           group->length(),
                           group->gc_efficiency(),
-                          group->length() > 0 ? group->liveness_percent() : 0.0f,
+                          group->liveness_percent(),
                           group->card_set()->mem_size(),
                           type);
   _total_remset_bytes += group->card_set()->mem_size();
@@ -3162,7 +3162,9 @@ void G1PrintRegionLivenessInfoClosure::log_cset_candidate_groups() {
 
   G1CollectedHeap* g1h = G1CollectedHeap::heap();
 
-  log_cset_candidate_group_add_total(g1h->young_regions_cset_group(), "Y");
+  if (g1h->young_regions_cset_group()->length() != 0) {
+    log_cset_candidate_group_add_total(g1h->young_regions_cset_group(), "Y");
+  }
 
   G1CollectionSetCandidates* candidates = g1h->policy()->candidates();
   log_cset_candidate_grouplist(candidates->from_marking_groups(), "M");

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -3121,8 +3121,8 @@ void G1PrintRegionLivenessInfoClosure::log_cset_candidate_group_add_total(G1CSet
                           G1PPRL_TYPE_H_FORMAT,
                           group->group_id(),
                           group->length(),
-                          group->gc_efficiency(),
-                          group->liveness_percent(),
+                          group->length() > 0 ? group->gc_efficiency() : 0.0f,
+                          group->length() > 0 ? group->liveness_percent() : 0.0f,
                           group->card_set()->mem_size(),
                           type);
   _total_remset_bytes += group->card_set()->mem_size();

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -3121,8 +3121,8 @@ void G1PrintRegionLivenessInfoClosure::log_cset_candidate_group_add_total(G1CSet
                           G1PPRL_TYPE_H_FORMAT,
                           group->group_id(),
                           group->length(),
-                          group->length() > 0 ? group->gc_efficiency() : 0.0f,
-                          group->length() > 0 ? group->liveness_percent() : 0.0f,
+                          group->length() > 0 ? group->gc_efficiency() : 0.0,
+                          group->length() > 0 ? group->liveness_percent() : 0.0,
                           group->card_set()->mem_size(),
                           type);
   _total_remset_bytes += group->card_set()->mem_size();

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -3122,7 +3122,7 @@ void G1PrintRegionLivenessInfoClosure::log_cset_candidate_group_add_total(G1CSet
                           group->group_id(),
                           group->length(),
                           group->gc_efficiency(),
-                          group->liveness_percent(),
+                          group->length() > 0 ? group->liveness_percent() : 0.0f,
                           group->card_set()->mem_size(),
                           type);
   _total_remset_bytes += group->card_set()->mem_size();

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -3162,9 +3162,7 @@ void G1PrintRegionLivenessInfoClosure::log_cset_candidate_groups() {
 
   G1CollectedHeap* g1h = G1CollectedHeap::heap();
 
-  if (g1h->young_regions_cset_group()->length() != 0) {
-    log_cset_candidate_group_add_total(g1h->young_regions_cset_group(), "Y");
-  }
+  log_cset_candidate_group_add_total(g1h->young_regions_cset_group(), "Y");
 
   G1CollectionSetCandidates* candidates = g1h->policy()->candidates();
   log_cset_candidate_grouplist(candidates->from_marking_groups(), "M");


### PR DESCRIPTION
Hi all,

  please review this change that fixes a div-by-zero in calculating liveness for logging.

It is possible that the young gen group cardset is empty (has no regions assigned to it as no eden region has retired yet) when the `Cleanup` pause starts, making the liveness calculation divide by zero.

The change special-cases this case when printing - I decided to always print the group in this case, regardless of length, just fudging the output value a bit. An alternative would be not printing it at all in this case. Feel free to argue for that solution. Also the printed value for liveness (0.0%) is up for discussion.

Testing: failing test case does not fail any more now and then, gha, tier1-4

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8365656](https://bugs.openjdk.org/browse/JDK-8365656): [ubsan] G1CSetCandidateGroup::liveness() reports division by 0 (**Bug** - P4)


### Reviewers
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26888/head:pull/26888` \
`$ git checkout pull/26888`

Update a local copy of the PR: \
`$ git checkout pull/26888` \
`$ git pull https://git.openjdk.org/jdk.git pull/26888/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26888`

View PR using the GUI difftool: \
`$ git pr show -t 26888`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26888.diff">https://git.openjdk.org/jdk/pull/26888.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26888#issuecomment-3211278967)
</details>
