### PR TITLE
8365807: (fs) Two-arg UnixFileAttributes.getIfExists should not use exception for control flow

### DIFF
--- a/src/java.base/unix/classes/sun/nio/fs/UnixFileAttributes.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixFileAttributes.java
@@ -83,18 +83,9 @@ class UnixFileAttributes
 
     // get the UnixFileAttributes for a given file.
     // Returns null if the file does not exist.
-    static UnixFileAttributes getIfExists(UnixPath path)
-        throws UnixException
+    static UnixFileAttributes getIfExists(UnixPath path) throws UnixException
     {
-        UnixFileAttributes attrs = new UnixFileAttributes();
-        int errno = UnixNativeDispatcher.stat2(path, attrs);
-        if (errno == 0) {
-            return attrs;
-        } else if (errno == UnixConstants.ENOENT) {
-            return null;
-        } else {
-            throw new UnixException(errno);
-        }
+        return getIfExists(path, true);
     }
 
     // get the UnixFileAttributes for a given file, optionally following links.
@@ -104,17 +95,15 @@ class UnixFileAttributes
     {
         UnixFileAttributes attrs = new UnixFileAttributes();
         int flag = (followLinks) ? 0 : UnixConstants.AT_SYMLINK_NOFOLLOW;
-        try {
-            UnixNativeDispatcher.fstatat(UnixConstants.AT_FDCWD,
-                                         path.asByteArray(), flag, attrs);
-        } catch (UnixException x) {
-            if (x.errno() == UnixConstants.ENOENT)
-                return null;
-
-            throw x;
+        int errno = UnixNativeDispatcher.fstatat(UnixConstants.AT_FDCWD,
+                                                 path, flag, attrs);
+        if (errno == 0) {
+            return attrs;
+        } else if (errno == UnixConstants.ENOENT) {
+            return null;
+        } else {
+            throw new UnixException(errno);
         }
-
-        return attrs;
     }
 
     // get the UnixFileAttributes for an open file
@@ -130,7 +119,7 @@ class UnixFileAttributes
     {
         UnixFileAttributes attrs = new UnixFileAttributes();
         int flag = (followLinks) ? 0 : UnixConstants.AT_SYMLINK_NOFOLLOW;
-        UnixNativeDispatcher.fstatat(dfd, path.asByteArray(), flag, attrs);
+        UnixNativeDispatcher.fstatat(dfd, path, flag, attrs);
         return attrs;
     }
 

--- a/src/java.base/unix/classes/sun/nio/fs/UnixNativeDispatcher.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixNativeDispatcher.java
@@ -288,14 +288,14 @@ class UnixNativeDispatcher {
     /**
      * fstatat(int filedes,const char* path,  struct stat* buf, int flag)
      */
-    static void fstatat(int dfd, byte[] path, int flag, UnixFileAttributes attrs)
+    static int fstatat(int dfd, UnixPath path, int flag, UnixFileAttributes attrs)
         throws UnixException
     {
-        try (NativeBuffer buffer = NativeBuffers.asNativeBuffer(path)) {
-            fstatat0(dfd, buffer.address(), flag, attrs);
+        try (NativeBuffer buffer = copyToNativeBuffer(path)) {
+            return fstatat0(dfd, buffer.address(), flag, attrs);
         }
     }
-    private static native void fstatat0(int dfd, long pathAddress, int flag,
+    private static native int fstatat0(int dfd, long pathAddress, int flag,
         UnixFileAttributes attrs) throws UnixException;
 
     /**


### PR DESCRIPTION
In the Unix implementation of `sun.nio.fs`, change

1. `UnixFileAttributes.getIfExists(UnixPath,boolean)` to use the system call success status and `errno` for control flow; and
2. `UnixFileAttributes.getIfExists(UnixPath)` to simply return `UnixFileAttributes.getIfExists(UnixPath,true)`.