### PR TITLE
8338197: [ubsan] ad_x86.hpp:6417:11: runtime error: shift exponent 100 is too large for 32-bit type 'unsigned int'

### DIFF
--- a/src/hotspot/share/adlc/output_h.cpp
+++ b/src/hotspot/share/adlc/output_h.cpp
@@ -757,15 +757,10 @@ void ArchDesc::declare_pipe_classes(FILE *fp_hpp) {
 
   if (_pipeline->_maxcycleused <= 32) {
     fprintf(fp_hpp, "protected:\n");
-    fprintf(fp_hpp, "  %s _mask;\n\n", _pipeline->_maxcycleused <= 32 ? "uint" : "uint64_t" );
+    fprintf(fp_hpp, "  uint _mask;\n\n");
     fprintf(fp_hpp, "public:\n");
     fprintf(fp_hpp, "  Pipeline_Use_Cycle_Mask() : _mask(0) {}\n\n");
-    if (_pipeline->_maxcycleused <= 32)
-      fprintf(fp_hpp, "  Pipeline_Use_Cycle_Mask(uint mask) : _mask(mask) {}\n\n");
-    else {
-      fprintf(fp_hpp, "  Pipeline_Use_Cycle_Mask(uint mask1, uint mask2) : _mask((((uint64_t)mask1) << 32) | mask2) {}\n\n");
-      fprintf(fp_hpp, "  Pipeline_Use_Cycle_Mask(uint64_t mask) : _mask(mask) {}\n\n");
-    }
+    fprintf(fp_hpp, "  Pipeline_Use_Cycle_Mask(uint mask) : _mask(mask) {}\n\n");
     fprintf(fp_hpp, "  bool overlaps(const Pipeline_Use_Cycle_Mask &in2) const {\n");
     fprintf(fp_hpp, "    return ((_mask & in2._mask) != 0);\n");
     fprintf(fp_hpp, "  }\n\n");

--- a/src/hotspot/share/adlc/output_h.cpp
+++ b/src/hotspot/share/adlc/output_h.cpp
@@ -757,16 +757,15 @@ void ArchDesc::declare_pipe_classes(FILE *fp_hpp) {
 
   if (_pipeline->_maxcycleused <= 32) {
     fprintf(fp_hpp, "protected:\n");
-    fprintf(fp_hpp, "  uint _mask;\n\n");
+    fprintf(fp_hpp, "  uint32_t _mask;\n\n");
     fprintf(fp_hpp, "public:\n");
     fprintf(fp_hpp, "  Pipeline_Use_Cycle_Mask() : _mask(0) {}\n\n");
-    fprintf(fp_hpp, "  Pipeline_Use_Cycle_Mask(uint mask) : _mask(mask) {}\n\n");
+    fprintf(fp_hpp, "  Pipeline_Use_Cycle_Mask(uint32_t mask) : _mask(mask) {}\n\n");
     fprintf(fp_hpp, "  bool overlaps(const Pipeline_Use_Cycle_Mask &in2) const {\n");
     fprintf(fp_hpp, "    return ((_mask & in2._mask) != 0);\n");
     fprintf(fp_hpp, "  }\n\n");
     fprintf(fp_hpp, "  Pipeline_Use_Cycle_Mask& operator<<=(int n) {\n");
-    fprintf(fp_hpp, "    int max_shift = 8 * sizeof(_mask) - 1;\n");
-    fprintf(fp_hpp, "    _mask <<= (n < max_shift) ? n : max_shift;\n");
+    fprintf(fp_hpp, "    _mask <<= (n < 32) ? n : 31;\n");
     fprintf(fp_hpp, "    return *this;\n");
     fprintf(fp_hpp, "  }\n\n");
     fprintf(fp_hpp, "  void Or(const Pipeline_Use_Cycle_Mask &in2) {\n");
@@ -779,7 +778,7 @@ void ArchDesc::declare_pipe_classes(FILE *fp_hpp) {
     fprintf(fp_hpp, "protected:\n");
     uint masklen = (_pipeline->_maxcycleused + 31) >> 5;
     uint l;
-    fprintf(fp_hpp, "  uint ");
+    fprintf(fp_hpp, "  uint32_t ");
     for (l = 1; l <= masklen; l++)
       fprintf(fp_hpp, "_mask%d%s", l, l < masklen ? ", " : ";\n\n");
     fprintf(fp_hpp, "public:\n");
@@ -788,7 +787,7 @@ void ArchDesc::declare_pipe_classes(FILE *fp_hpp) {
       fprintf(fp_hpp, "_mask%d(0)%s", l, l < masklen ? ", " : " {}\n\n");
     fprintf(fp_hpp, "  Pipeline_Use_Cycle_Mask(");
     for (l = 1; l <= masklen; l++)
-      fprintf(fp_hpp, "uint mask%d%s", l, l < masklen ? ", " : ") : ");
+      fprintf(fp_hpp, "uint32_t mask%d%s", l, l < masklen ? ", " : ") : ");
     for (l = 1; l <= masklen; l++)
       fprintf(fp_hpp, "_mask%d(mask%d)%s", l, l, l < masklen ? ", " : " {}\n\n");
 
@@ -799,10 +798,10 @@ void ArchDesc::declare_pipe_classes(FILE *fp_hpp) {
     fprintf(fp_hpp, "    return out;\n");
     fprintf(fp_hpp, "  }\n\n");
     fprintf(fp_hpp, "  bool overlaps(const Pipeline_Use_Cycle_Mask &in2) const {\n");
-    fprintf(fp_hpp, "    return (");
+    fprintf(fp_hpp, "    return ");
     for (l = 1; l <= masklen; l++)
       fprintf(fp_hpp, "((_mask%d & in2._mask%d) != 0)%s", l, l, l < masklen ? " || " : "");
-    fprintf(fp_hpp, ") ? true : false;\n");
+    fprintf(fp_hpp, ";\n");
     fprintf(fp_hpp, "  }\n\n");
     fprintf(fp_hpp, "  Pipeline_Use_Cycle_Mask& operator<<=(int n) {\n");
     fprintf(fp_hpp, "    if (n >= 32)\n");
@@ -813,10 +812,10 @@ void ArchDesc::declare_pipe_classes(FILE *fp_hpp) {
     fprintf(fp_hpp, "      } while ((n -= 32) >= 32);\n\n");
     fprintf(fp_hpp, "    if (n > 0) {\n");
     fprintf(fp_hpp, "      uint m = 32 - n;\n");
-    fprintf(fp_hpp, "      uint mask = (1 << n) - 1;\n");
-    fprintf(fp_hpp, "      uint temp%d = mask & (_mask%d >> m); _mask%d <<= n;\n", 2, 1, 1);
+    fprintf(fp_hpp, "      uint32_t mask = (1 << n) - 1;\n");
+    fprintf(fp_hpp, "      uint32_t temp%d = mask & (_mask%d >> m); _mask%d <<= n;\n", 2, 1, 1);
     for (l = 2; l < masklen; l++) {
-      fprintf(fp_hpp, "      uint temp%d = mask & (_mask%d >> m); _mask%d <<= n; _mask%d |= temp%d;\n", l+1, l, l, l, l);
+      fprintf(fp_hpp, "      uint32_t temp%d = mask & (_mask%d >> m); _mask%d <<= n; _mask%d |= temp%d;\n", l+1, l, l, l, l);
     }
     fprintf(fp_hpp, "      _mask%d <<= n; _mask%d |= temp%d;\n", masklen, masklen, masklen);
     fprintf(fp_hpp, "    }\n");

--- a/src/hotspot/share/adlc/output_h.cpp
+++ b/src/hotspot/share/adlc/output_h.cpp
@@ -770,7 +770,8 @@ void ArchDesc::declare_pipe_classes(FILE *fp_hpp) {
     fprintf(fp_hpp, "    return ((_mask & in2._mask) != 0);\n");
     fprintf(fp_hpp, "  }\n\n");
     fprintf(fp_hpp, "  Pipeline_Use_Cycle_Mask& operator<<=(int n) {\n");
-    fprintf(fp_hpp, "    _mask <<= n;\n");
+    fprintf(fp_hpp, "    int max_shift = 8 * sizeof(_mask) - 1;\n");
+    fprintf(fp_hpp, "    _mask <<= (n < max_shift) ? n : max_shift;\n");
     fprintf(fp_hpp, "    return *this;\n");
     fprintf(fp_hpp, "  }\n\n");
     fprintf(fp_hpp, "  void Or(const Pipeline_Use_Cycle_Mask &in2) {\n");
@@ -870,8 +871,7 @@ void ArchDesc::declare_pipe_classes(FILE *fp_hpp) {
   fprintf(fp_hpp, "  }\n\n");
   fprintf(fp_hpp, "  void step(uint cycles) {\n");
   fprintf(fp_hpp, "    _used = 0;\n");
-  fprintf(fp_hpp, "    uint max_shift = 8 * sizeof(_mask) - 1;\n");
-  fprintf(fp_hpp, "    _mask <<= (cycles < max_shift) ? cycles : max_shift;\n");
+  fprintf(fp_hpp, "    _mask <<= cycles;\n");
   fprintf(fp_hpp, "  }\n\n");
   fprintf(fp_hpp, "  friend class Pipeline_Use;\n");
   fprintf(fp_hpp, "};\n\n");


### PR DESCRIPTION
This reworks the recent update https://github.com/openjdk/jdk/pull/24696 to fix a UBSan issue on aarch64. The problem now reproduces on x86_64 as well, which suggests the previous update was not optimal.

The issue reproduces with a HeapByteBufferTest jtreg test on a UBSan-enabled build. Actually the trigger is `XX:+OptoScheduling` option used by test (by default OptoScheduling is disabled on most x86 CPUs). With the option enabled, the failure can be reproduced with a simple `java -version` run.

This fix is in ADLC-generated code. For simplicity, the examples below show the generated fragments.

The problems is that shift count `n` may be too large here:
```cpp
class Pipeline_Use_Cycle_Mask {
protected:
  uint _mask;
  ..
  Pipeline_Use_Cycle_Mask& operator<<=(int n) {
    _mask <<= n;
    return *this;
  }
};
```
The recent change attempted to cap the shift amount at one call site:
```cpp
class Pipeline_Use_Element {
protected:
  ..
  // Mask of specific used cycles
  Pipeline_Use_Cycle_Mask _mask;
  ..
  void step(uint cycles) {
    _used = 0;
    uint max_shift = 8 * sizeof(_mask) - 1;
    _mask <<= (cycles < max_shift) ? cycles : max_shift;
  }
}
```
However, there is another site where `Pipeline_Use_Cycle_Mask::operator<<=` can be called with a too-large shift count:
```cpp
// The following two routines assume that the root Pipeline_Use entity
// consists of exactly 1 element for each functional unit
// start is relative to the current cycle; used for latency-based info
uint Pipeline_Use::full_latency(uint delay, const Pipeline_Use &pred) const {
  for (uint i = 0; i < pred._count; i++) {
    const Pipeline_Use_Element *predUse = pred.element(i);
    if (predUse->_multiple) {
      uint min_delay = 7;
      // Multiple possible functional units, choose first unused one
      for (uint j = predUse->_lb; j <= predUse->_ub; j++) {
        const Pipeline_Use_Element *currUse = element(j);
        uint curr_delay = delay;
        if (predUse->_used & currUse->_used) {
          Pipeline_Use_Cycle_Mask x = predUse->_mask;
          Pipeline_Use_Cycle_Mask y = currUse->_mask;

          for ( y <<= curr_delay; x.overlaps(y); curr_delay++ )
            y <<= 1;
        }
        if (min_delay > curr_delay)
          min_delay = curr_delay;
      }
      if (delay < min_delay)
      delay = min_delay;
    }
    else {
      for (uint j = predUse->_lb; j <= predUse->_ub; j++) {
        const Pipeline_Use_Element *currUse = element(j);
        if (predUse->_used & currUse->_used) {
          Pipeline_Use_Cycle_Mask x = predUse->_mask;
          Pipeline_Use_Cycle_Mask y = currUse->_mask;

>        for ( y <<= delay; x.overlaps(y); delay++ )
            y <<= 1;
        }
      }
    }
  }

  return (delay);
}
```
**Fix:** cap the shift **inside** `Pipeline_Use_Cycle_Mask::operator<<=` so all call sites are safe:
```cpp
class Pipeline_Use_Cycle_Mask {
protected:
  uint _mask;
  ..
  Pipeline_Use_Cycle_Mask& operator<<=(int n) {
    int max_shift = 8 * sizeof(_mask) - 1;
    _mask <<= (n < max_shift) ? n : max_shift;
    return *this;
  }
};

class Pipeline_Use_Element {
protected:
  ..
  // Mask of specific used cycles
  Pipeline_Use_Cycle_Mask _mask;
  ..
  void step(uint cycles) {
    _used = 0;
    _mask <<= cycles;
  }
}
```

Note: on platforms where PipelineForm::_maxcycleused > 32 (e.g., ARM32), the Pipeline_Use_Cycle_Mask implementation already handles large shifts, so no additional check is needed:
```cpp
class Pipeline_Use_Cycle_Mask {
protected:
  uint _mask1, _mask2, _mask3;

  Pipeline_Use_Cycle_Mask& operator<<=(int n) {
    if (n >= 32)
      do {
        _mask3 = _mask2; _mask2 = _mask1; _mask1 = 0;
      } while ((n -= 32) >= 32);

    if (n > 0) {
      uint m = 32 - n;
      uint mask = (1 << n) - 1;
      uint temp2 = mask & (_mask1 >> m); _mask1 <<= n;
      uint temp3 = mask & (_mask2 >> m); _mask2 <<= n; _mask2 |= temp2;
      _mask3 <<= n; _mask3 |= temp3;
    }
    return *this;
  }
}
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338197](https://bugs.openjdk.org/browse/JDK-8338197): [ubsan] ad_x86.hpp:6417:11: runtime error: shift exponent 100 is too large for 32-bit type 'unsigned int' (**Bug** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**) Review applies to [fe6edc7f](https://git.openjdk.org/jdk/pull/26890/files/fe6edc7f4f20bee2fb78da9b290c0ae6bde09d44)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26890/head:pull/26890` \
`$ git checkout pull/26890`

Update a local copy of the PR: \
`$ git checkout pull/26890` \
`$ git pull https://git.openjdk.org/jdk.git pull/26890/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26890`

View PR using the GUI difftool: \
`$ git pr show -t 26890`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26890.diff">https://git.openjdk.org/jdk/pull/26890.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26890#issuecomment-3214961838)
</details>
