### PR TITLE
8365886: JSplitPane loses track of the left component when the component orientation is changed

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/JSplitPane.java
+++ b/src/java.desktop/share/classes/javax/swing/JSplitPane.java
@@ -371,24 +371,30 @@ public class JSplitPane extends JComponent implements Accessible
     public void setComponentOrientation(ComponentOrientation orientation) {
         ComponentOrientation curOrn = this.getComponentOrientation();
         super.setComponentOrientation(orientation);
+        Component comp = null;
         if (!orientation.equals(curOrn)) {
             Component leftComponent = this.getLeftComponent();
             Component rightComponent = this.getRightComponent();
             if (!this.getComponentOrientation().isLeftToRight()) {
                 if (rightComponent != null) {
-                    setLeftComponent(rightComponent);
-                }
-                if (leftComponent != null) {
-                    setRightComponent(leftComponent);
+                    comp = this.leftComponent;
+                    this.leftComponent = this.rightComponent;
+                    this.rightComponent = comp;
+                } else if (leftComponent != null) {
+                    comp = this.rightComponent;
+                    this.rightComponent = this.leftComponent;
+                    this.leftComponent = comp;
                 }
             } else {
                 if (leftComponent != null) {
-                    setLeftComponent(leftComponent);
+                    this.leftComponent = rightComponent;
                 }
                 if (rightComponent != null) {
-                    setRightComponent(rightComponent);
+                    this.rightComponent = leftComponent;
                 }
             }
+            this.revalidate();
+            this.repaint();
         }
     }
 

--- a/test/jdk/javax/swing/JSplitPane/TestSplitPaneOrientationTest.java
+++ b/test/jdk/javax/swing/JSplitPane/TestSplitPaneOrientationTest.java
@@ -48,6 +48,33 @@ public class TestSplitPaneOrientationTest {
         }
     }
 
+    private static void testSwitchOrientation() {
+        JSplitPane jsp = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT,
+                                        new JButton("Red"), new JButton("Green"));
+        for (int i = 0; i < 3; i++) {
+            ComponentOrientation co = jsp.getComponentOrientation();
+            if (co.isLeftToRight()) {
+                jsp.setComponentOrientation(ComponentOrientation.RIGHT_TO_LEFT);
+            } else {
+                jsp.setComponentOrientation(ComponentOrientation.LEFT_TO_RIGHT);
+            }
+
+            StringBuilder sb = new StringBuilder();
+            sb.append("Left=");
+            if (jsp.getLeftComponent() instanceof JButton leftButton) {
+                sb.append(leftButton.getText());
+            }
+            sb.append(" Right=");
+            if (jsp.getRightComponent() instanceof JButton rightButton) {
+                sb.append(rightButton.getText());
+            }
+            System.out.println(sb.toString());
+        }
+        if (jsp.getLeftComponent() == null) {
+            throw new RuntimeException("JSplitPane repeated orientation change not working");
+        }
+    }
+
     public static void main(String[] args) throws Exception {
         for (UIManager.LookAndFeelInfo laf : UIManager.getInstalledLookAndFeels()) {
             System.out.println("Testing LAF : " + laf.getClassName());
@@ -63,6 +90,7 @@ public class TestSplitPaneOrientationTest {
                         throw new RuntimeException("JSplitPane did not support ComponentOrientation");
                     }
                 }
+                testSwitchOrientation();
             });
         }
     }


### PR DESCRIPTION
When the component orientation is changed from LTR to RTL or the other way around, JSplitPane exchanges the left and right components. However, it does this by adding and removing components instead of swapping the leftComponent and rightComponent fields which results in leftComponent field is left as null.

This is because when JSplitPane calls `setLeftComponent(rightComponent)` it calls `JSplitPane.addImpl` which calls `super.addImpl`
which [removes] https://github.com/openjdk/jdk/blob/f423e1d9ad37135abacb8deb2d2151e21768a23e/src/java.desktop/share/classes/java/awt/Container.java#L1118 the component from the JSplitPane as it calls `JSplitPane.remove` so the sequence is
At start `leftComponent = Red, rightComponent = Green`

before `super.addImpl` is called in `JSplitPane.addImpl` the 

`leftComponent = Green, rightComponent = Green`

After super.addImpl is called, it calls [JSplitPane.remove] (https://github.com/openjdk/jdk/blob/f423e1d9ad37135abacb8deb2d2151e21768a23e/src/java.desktop/share/classes/javax/swing/JSplitPane.java#L918) where it sets
leftComponent = null.

so we have
leftComponent = null, rightComponent = Green and then it calls [super.remove] (https://github.com/openjdk/jdk/blob/f423e1d9ad37135abacb8deb2d2151e21768a23e/src/java.desktop/share/classes/javax/swing/JSplitPane.java#L922) which calls `JSplitPane.remove(index)` and since index=1 because "Green" is 1 it removes rightComponent 
so we have now
leftComponent = null, rightComponent = null

so when we now call [setRightComponent](https://github.com/openjdk/jdk/blob/f423e1d9ad37135abacb8deb2d2151e21768a23e/src/java.desktop/share/classes/javax/swing/JSplitPane.java#L382) it sets rightComponent to Red but leftComponent is not set and is still null.

So fix is to just swap the left and right component in setComponentOrientation call itself without using Container add/remove components