### PR TITLE
8361370: runtime/Thread/TestThreadDumpMonitorContention.java fails due to time out on Windows

### DIFF
--- a/test/hotspot/jtreg/runtime/Thread/TestThreadDumpMonitorContention.java
+++ b/test/hotspot/jtreg/runtime/Thread/TestThreadDumpMonitorContention.java
@@ -50,10 +50,10 @@ public class TestThreadDumpMonitorContention {
     // getJDKTool() which can fall back to "compile.jdk".
     final static String JSTACK = JDKToolFinder.getTestJDKTool("jstack");
     final static String PID = Long.toString(ProcessHandle.current().pid());
-    // jstack streming output should be disabled because if the attach operation is executed at a safepoint,
-    // the attach streaming output is enabled and the tool output is lengthy we can get both buffers (the attach
+    // jstack streaming output should be disabled because if the attach operation is executed at a safepoint,
+    // the attach streaming output is enabled, and the tool output is lengthy, then we can get both buffers (the attach
     // channel and the tool redirection buffer) full and the test hangs.
-    // Instead the attach operation output is buffered and is sent after the operation is completed
+    // Instead the attach operation output is buffered and is sent after the operation is completed.
     final static String DISABLE_STREAMING_OUTPUT = "-J-Djdk.attach.allowStreamingOutput=false";
 
     // looking for header lines with these patterns:

--- a/test/hotspot/jtreg/runtime/Thread/TestThreadDumpMonitorContention.java
+++ b/test/hotspot/jtreg/runtime/Thread/TestThreadDumpMonitorContention.java
@@ -50,6 +50,10 @@ public class TestThreadDumpMonitorContention {
     // getJDKTool() which can fall back to "compile.jdk".
     final static String JSTACK = JDKToolFinder.getTestJDKTool("jstack");
     final static String PID = Long.toString(ProcessHandle.current().pid());
+    // jstack streming output should be disabled because if the attach operation is executed at a safepoint,
+    // the attach streaming output is enabled and the tool output is lengthy we can get both buffers (the attach
+    // channel and the tool redirection buffer) full and the test hangs.
+    // Instead the attach operation output is buffered and is sent after the operation is completed
     final static String DISABLE_STREAMING_OUTPUT = "-J-Djdk.attach.allowStreamingOutput=false";
 
     // looking for header lines with these patterns:

--- a/test/hotspot/jtreg/runtime/Thread/TestThreadDumpMonitorContention.java
+++ b/test/hotspot/jtreg/runtime/Thread/TestThreadDumpMonitorContention.java
@@ -50,6 +50,7 @@ public class TestThreadDumpMonitorContention {
     // getJDKTool() which can fall back to "compile.jdk".
     final static String JSTACK = JDKToolFinder.getTestJDKTool("jstack");
     final static String PID = Long.toString(ProcessHandle.current().pid());
+    final static String DISABLE_STREAMING_OUTPUT = "-J-Djdk.attach.allowStreamingOutput=false";
 
     // looking for header lines with these patterns:
     // "ContendingThread-1" #19 prio=5 os_prio=64 tid=0x000000000079c000 nid=0x23 runnable [0xffff80ffb8b87000]
@@ -379,7 +380,7 @@ public class TestThreadDumpMonitorContention {
             // we don't mix data between the two stack traces that do
             // match HEADER_PREFIX_PATTERN.
             //
-            Process process = new ProcessBuilder(JSTACK, PID)
+            Process process = new ProcessBuilder(JSTACK, DISABLE_STREAMING_OUTPUT, PID)
                 .redirectErrorStream(true).start();
 
             BufferedReader reader = new BufferedReader(new InputStreamReader(


### PR DESCRIPTION
Hi, please consider the following changes:

Jstack streaming output should be disabled in the test as JDK-8354461 suggest. 

When disabled, the test does not hang with ZGC enabled. 

Tested locally.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8361370](https://bugs.openjdk.org/browse/JDK-8361370): runtime/Thread/TestThreadDumpMonitorContention.java fails due to time out on Windows (**Bug** - P4)


### Reviewers
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**) Review applies to [3bed268a](https://git.openjdk.org/jdk/pull/26895/files/3bed268a07c29e0ad5a197d326850cfe4b02e5ec)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26895/head:pull/26895` \
`$ git checkout pull/26895`

Update a local copy of the PR: \
`$ git checkout pull/26895` \
`$ git pull https://git.openjdk.org/jdk.git pull/26895/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26895`

View PR using the GUI difftool: \
`$ git pr show -t 26895`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26895.diff">https://git.openjdk.org/jdk/pull/26895.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26895#issuecomment-3213763335)
</details>
