### PR TITLE
8365765

### DIFF
--- a/src/hotspot/share/runtime/thread.inline.hpp
+++ b/src/hotspot/share/runtime/thread.inline.hpp
@@ -26,7 +26,7 @@
 #ifndef SHARE_RUNTIME_THREAD_INLINE_HPP
 #define SHARE_RUNTIME_THREAD_INLINE_HPP
 
-#include "runtime/javaThread.hpp"
+#include "thread.hpp"
 
 #include "gc/shared/tlab_globals.hpp"
 #include "runtime/atomic.hpp"


### PR DESCRIPTION
Hi all,

This ensures `thread.inline.hpp` adheres to the style guide:
> All .inline.hpp files should include their corresponding .hpp file as the first include line with a blank line separating it from the rest of the include lines. [...]

I've run tests with JDK tiers 1-3 on macOS (AArch64, x64), Linux (AArch64, x64), and Windows (x64); all green.