### PR TITLE
8365976: G1: Full gc should mark nmethods on stack

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -800,6 +800,7 @@ void G1CollectedHeap::prepare_for_mutator_after_full_collection(size_t allocatio
 
   // Rebuild the code root lists for each region
   rebuild_code_roots();
+  finish_codecache_marking_cycle();
 
   start_new_collection_set();
   _allocator->init_mutator_alloc_regions();

--- a/src/hotspot/share/gc/g1/g1FullCollector.cpp
+++ b/src/hotspot/share/gc/g1/g1FullCollector.cpp
@@ -224,8 +224,6 @@ void G1FullCollector::collect() {
   }
 
   phase5_reset_metadata();
-
-  G1CollectedHeap::finish_codecache_marking_cycle();
 }
 
 void G1FullCollector::complete_collection(size_t allocation_word_size) {


### PR DESCRIPTION
Hi all,

  please review this fix that moves the nmethod arming after registering the nmethods during full gc to make sure that the remaining ones are armed. That changed after [JDK-8360540](https://bugs.openjdk.org/browse/JDK-8360540).

Testing: gha

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8365976](https://bugs.openjdk.org/browse/JDK-8365976): G1: Full gc should mark nmethods on stack (**Bug** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26899/head:pull/26899` \
`$ git checkout pull/26899`

Update a local copy of the PR: \
`$ git checkout pull/26899` \
`$ git pull https://git.openjdk.org/jdk.git pull/26899/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26899`

View PR using the GUI difftool: \
`$ git pr show -t 26899`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26899.diff">https://git.openjdk.org/jdk/pull/26899.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26899#issuecomment-3213981825)
</details>
