### PR TITLE
8362573: Incorrect weight of the first ObjectAllocationSample JFR event (regression)

### DIFF
--- a/src/hotspot/share/jfr/recorder/checkpoint/jfrCheckpointManager.cpp
+++ b/src/hotspot/share/jfr/recorder/checkpoint/jfrCheckpointManager.cpp
@@ -566,7 +566,7 @@ size_t JfrCheckpointManager::write_static_type_set_and_threads() {
 void JfrCheckpointManager::on_rotation() {
   assert(SafepointSynchronize::is_at_safepoint(), "invariant");
   JfrTypeManager::on_rotation();
-  notify_threads();
+  notify_threads(false);
 }
 
 void JfrCheckpointManager::clear_type_set() {
@@ -676,18 +676,36 @@ void JfrCheckpointManager::write_simplified_vthread_checkpoint(traceid vtid) {
   JfrTypeManager::write_simplified_vthread_checkpoint(vtid);
 }
 
-class JfrNotifyClosure : public ThreadClosure {
+// Reset thread local state used for object allocation sampling.
+static void clear_last_allocated_bytes(JavaThread* jt) {
+  assert(jt != nullptr, "invariant");
+  assert(!JfrRecorder::is_recording(), "invariant");
+  JfrThreadLocal* const tl = jt->jfr_thread_local();
+  assert(tl != nullptr, "invariant");
+  if (tl->last_allocated_bytes() != 0) {
+    tl->clear_last_allocated_bytes();
+  }
+  assert(tl->last_allocated_bytes() == 0, "invariant");
+}
+
+class JfrNotifyClosure : public StackObj {
+ private:
+  bool _clear;
  public:
-  void do_thread(Thread* thread) {
-    assert(thread != nullptr, "invariant");
+  JfrNotifyClosure(bool clear) : _clear(clear) {}
+  void do_thread(JavaThread* jt) {
+    assert(jt != nullptr, "invariant");
     assert_locked_or_safepoint(Threads_lock);
-    JfrJavaEventWriter::notify(JavaThread::cast(thread));
+    JfrJavaEventWriter::notify(jt);
+    if (_clear) {
+      clear_last_allocated_bytes(jt);
+    }
   }
 };
 
-void JfrCheckpointManager::notify_threads() {
+void JfrCheckpointManager::notify_threads(bool clear /* true */) {
   assert(SafepointSynchronize::is_at_safepoint(), "invariant");
-  JfrNotifyClosure tc;
+  JfrNotifyClosure tc(clear);
   JfrJavaThreadIterator iter;
   while (iter.has_next()) {
     tc.do_thread(iter.next());

--- a/src/hotspot/share/jfr/recorder/checkpoint/jfrCheckpointManager.cpp
+++ b/src/hotspot/share/jfr/recorder/checkpoint/jfrCheckpointManager.cpp
@@ -566,7 +566,7 @@ size_t JfrCheckpointManager::write_static_type_set_and_threads() {
 void JfrCheckpointManager::on_rotation() {
   assert(SafepointSynchronize::is_at_safepoint(), "invariant");
   JfrTypeManager::on_rotation();
-  notify_threads(false);
+  notify_threads();
 }
 
 void JfrCheckpointManager::clear_type_set() {
@@ -703,7 +703,7 @@ class JfrNotifyClosure : public StackObj {
   }
 };
 
-void JfrCheckpointManager::notify_threads(bool clear /* true */) {
+void JfrCheckpointManager::notify_threads(bool clear /* false */) {
   assert(SafepointSynchronize::is_at_safepoint(), "invariant");
   JfrNotifyClosure tc(clear);
   JfrJavaThreadIterator iter;

--- a/src/hotspot/share/jfr/recorder/checkpoint/jfrCheckpointManager.hpp
+++ b/src/hotspot/share/jfr/recorder/checkpoint/jfrCheckpointManager.hpp
@@ -88,7 +88,7 @@ class JfrCheckpointManager : public JfrCHeapObj {
 
   size_t clear();
   size_t write();
-  void notify_threads();
+  void notify_threads(bool clear = true);
 
   size_t write_static_type_set(Thread* thread);
   size_t write_threads(JavaThread* thread);

--- a/src/hotspot/share/jfr/recorder/checkpoint/jfrCheckpointManager.hpp
+++ b/src/hotspot/share/jfr/recorder/checkpoint/jfrCheckpointManager.hpp
@@ -88,7 +88,7 @@ class JfrCheckpointManager : public JfrCHeapObj {
 
   size_t clear();
   size_t write();
-  void notify_threads(bool clear = true);
+  void notify_threads(bool clear = false);
 
   size_t write_static_type_set(Thread* thread);
   size_t write_threads(JavaThread* thread);

--- a/src/hotspot/share/jfr/recorder/service/jfrRecorderService.cpp
+++ b/src/hotspot/share/jfr/recorder/service/jfrRecorderService.cpp
@@ -122,30 +122,6 @@ const Thread* JfrRotationLock::_owner_thread = nullptr;
 const int JfrRotationLock::retry_wait_millis = 10;
 volatile int JfrRotationLock::_lock = 0;
 
-// Reset thread local state used for object allocation sampling.
-class ClearObjectAllocationSampling : public ThreadClosure {
- public:
-  void do_thread(Thread* t) {
-    assert(t != nullptr, "invariant");
-    t->jfr_thread_local()->clear_last_allocated_bytes();
-  }
-};
-
-template <typename Iterator>
-static inline void iterate(Iterator& it, ClearObjectAllocationSampling& coas) {
-  while (it.has_next()) {
-    coas.do_thread(it.next());
-  }
-}
-
-static void clear_object_allocation_sampling() {
-  ClearObjectAllocationSampling coas;
-  JfrJavaThreadIterator jit;
-  iterate(jit, coas);
-  JfrNonJavaThreadIterator njit;
-  iterate(njit, coas);
-}
-
 template <typename Instance, size_t(Instance::*func)()>
 class Content {
  private:
@@ -472,7 +448,6 @@ void JfrRecorderService::clear() {
 }
 
 void JfrRecorderService::pre_safepoint_clear() {
-  clear_object_allocation_sampling();
   _storage.clear();
   JfrStackTraceRepository::clear();
 }

--- a/src/hotspot/share/jfr/recorder/service/jfrRecorderService.cpp
+++ b/src/hotspot/share/jfr/recorder/service/jfrRecorderService.cpp
@@ -461,7 +461,7 @@ void JfrRecorderService::invoke_safepoint_clear() {
 void JfrRecorderService::safepoint_clear() {
   assert(SafepointSynchronize::is_at_safepoint(), "invariant");
   _storage.clear();
-  _checkpoint_manager.notify_threads();
+  _checkpoint_manager.notify_threads(true);
   _chunkwriter.set_time_stamp();
   JfrDeprecationManager::on_safepoint_clear();
   JfrStackTraceRepository::clear();

--- a/src/hotspot/share/jfr/support/jfrAllocationTracer.cpp
+++ b/src/hotspot/share/jfr/support/jfrAllocationTracer.cpp
@@ -22,6 +22,7 @@
 *
 */
 
+#include "jfr/jfrEvents.hpp"
 #include "jfr/leakprofiler/leakProfiler.hpp"
 #include "jfr/support/jfrAllocationTracer.hpp"
 #include "jfr/support/jfrObjectAllocationSample.hpp"
@@ -31,5 +32,7 @@ JfrAllocationTracer::JfrAllocationTracer(const Klass* klass, HeapWord* obj, size
   if (LeakProfiler::is_running()) {
     LeakProfiler::sample(obj, alloc_size, thread);
   }
-  JfrObjectAllocationSample::send_event(klass, alloc_size, outside_tlab, thread);
+  if (EventObjectAllocationSample::is_enabled()) {
+    JfrObjectAllocationSample::send_event(klass, alloc_size, outside_tlab, thread);
+  }
 }

--- a/src/hotspot/share/jfr/support/jfrObjectAllocationSample.hpp
+++ b/src/hotspot/share/jfr/support/jfrObjectAllocationSample.hpp
@@ -27,12 +27,12 @@
 
 #include "memory/allStatic.hpp"
 
+class JavaThread;
 class Klass;
-class Thread;
 
 class JfrObjectAllocationSample : AllStatic {
   friend class JfrAllocationTracer;
-  static void send_event(const Klass* klass, size_t alloc_size, bool outside_tlab, Thread* thread);
+  static void send_event(const Klass* klass, size_t alloc_size, bool outside_tlab, JavaThread* jt);
 };
 
 #endif // SHARE_JFR_SUPPORT_JFROBJECTALLOCATIONSAMPLE_HPP

--- a/test/jdk/jdk/jfr/event/allocation/TestObjectAllocationSampleEventInitialWeight.java
+++ b/test/jdk/jdk/jfr/event/allocation/TestObjectAllocationSampleEventInitialWeight.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.jfr.event.allocation;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.CountDownLatch;
+import jdk.jfr.consumer.RecordedEvent;
+import jdk.jfr.consumer.RecordingStream;
+import jdk.test.lib.jfr.EventNames;
+import jdk.test.lib.jfr.Events;
+
+/**
+ * @test
+ * @summary Tests that the VM maintains proper initialization state for ObjectAllocationSampleEvent.
+ * @requires vm.hasJFR
+ * @library /test/lib
+ * @run main/othervm -XX:+UseTLAB -XX:TLABSize=2k -XX:-ResizeTLAB jdk.jfr.event.allocation.TestObjectAllocationSampleEventInitialWeight
+ */
+public class TestObjectAllocationSampleEventInitialWeight {
+    private static final String EVENT_NAME = EventNames.ObjectAllocationSample;
+    private static final int OBJECT_SIZE = 4 * 1024;
+    private static final int OBJECTS_TO_ALLOCATE = 16;
+    private static final int OBJECTS_TO_ALLOCATE_BEFORE_RECORDING = 1024;
+    private static final long BEFORE_RECORDING_SAMPLE_WEIGHT = OBJECT_SIZE * OBJECTS_TO_ALLOCATE_BEFORE_RECORDING;
+    private static final String BYTE_ARRAY_CLASS_NAME = new byte[0].getClass().getName();
+
+    private static AtomicBoolean onError = null;
+
+    // Make sure allocation isn't dead code eliminated.
+    public static byte[] tmp;
+
+    public static void main(String... args) throws Exception {
+        test();
+        // Test again to ensure reset logic works correctly for subsequent physical recordings.
+        test();
+    }
+
+    private static void test() throws Exception {
+        CountDownLatch delivered = new CountDownLatch(1);
+        onError = new AtomicBoolean();
+        Thread current = Thread.currentThread();
+        allocateBeforeRecording();
+        try (RecordingStream rs = new RecordingStream()) {
+            rs.enable(EVENT_NAME);
+            rs.onEvent(EVENT_NAME, e -> {
+                if (verify(e, current)) {
+                    delivered.countDown();
+                }
+            });
+            rs.startAsync();
+            allocate(OBJECTS_TO_ALLOCATE);
+            delivered.await();
+            if (onError.get()) {
+                throw new RuntimeException("Sample weight is not below " + BEFORE_RECORDING_SAMPLE_WEIGHT);
+            }
+        }
+    }
+
+    private static void allocateBeforeRecording() throws Exception {
+        allocate(OBJECTS_TO_ALLOCATE_BEFORE_RECORDING);
+    }
+
+    private static void allocate(int number) throws Exception {
+        for (int i = 0; i < number; ++i) {
+            tmp = new byte[OBJECT_SIZE];
+        }
+    }
+
+    private static boolean verify(RecordedEvent event, Thread thread) {
+        if (thread.getId() != event.getThread().getJavaThreadId()) {
+            return false;
+        }
+        System.out.println(event);
+        if (event.getLong("weight") >= BEFORE_RECORDING_SAMPLE_WEIGHT) {
+            onError.set(true);
+        }
+        return true;
+    }
+}

--- a/test/jdk/jdk/jfr/event/allocation/TestObjectAllocationSampleEventInitialWeight.java
+++ b/test/jdk/jdk/jfr/event/allocation/TestObjectAllocationSampleEventInitialWeight.java
@@ -25,6 +25,8 @@ package jdk.jfr.event.allocation;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.CountDownLatch;
+import java.util.List;
+import jdk.jfr.Recording;
 import jdk.jfr.consumer.RecordedEvent;
 import jdk.jfr.consumer.RecordingStream;
 import jdk.test.lib.jfr.EventNames;


### PR DESCRIPTION
Greetings,

Fix to ensure that the ObjectAllocationSample event sample weight property is initialized correctly when the event is enabled.

The previous clearing logic has been integrated into the existing thread iteration as part of the notify process, to avoid double passes. In addition, clearing and the event only apply to the set of JavaThreads.

This time also includes a regression test.

Testing: jdk_jfr

Thanks
Markus

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8362573](https://bugs.openjdk.org/browse/JDK-8362573): Incorrect weight of the first ObjectAllocationSample JFR event (regression) (**Bug** - P4)


### Reviewers
 * [Erik Gahlin](https://openjdk.org/census#egahlin) (@egahlin - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26900/head:pull/26900` \
`$ git checkout pull/26900`

Update a local copy of the PR: \
`$ git checkout pull/26900` \
`$ git pull https://git.openjdk.org/jdk.git pull/26900/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26900`

View PR using the GUI difftool: \
`$ git pr show -t 26900`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26900.diff">https://git.openjdk.org/jdk/pull/26900.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26900#issuecomment-3214052918)
</details>
