### PR TITLE
8365994: ZGC: Incorrect type signature in ZMappedCache comparator

### DIFF
--- a/src/hotspot/share/gc/z/zMappedCache.cpp
+++ b/src/hotspot/share/gc/z/zMappedCache.cpp
@@ -118,14 +118,11 @@ static ZMappedCacheEntry* create_entry(const ZVirtualMemory& vmem) {
   return entry;
 }
 
-int ZMappedCache::EntryCompare::cmp(const IntrusiveRBNode* a, const IntrusiveRBNode* b) {
+bool ZMappedCache::EntryCompare::cmp(const IntrusiveRBNode* a, const IntrusiveRBNode* b) {
   const ZVirtualMemory vmem_a = ZMappedCacheEntry::cast_to_entry(a)->vmem();
   const ZVirtualMemory vmem_b = ZMappedCacheEntry::cast_to_entry(b)->vmem();
 
-  if (vmem_a.end() < vmem_b.start()) { return -1; }
-  if (vmem_b.end() < vmem_a.start()) { return 1; }
-
-  return 0; // Overlapping
+  return vmem_a.end() < vmem_b.start();
 }
 
 int ZMappedCache::EntryCompare::cmp(zoffset key, const IntrusiveRBNode* node) {
@@ -171,12 +168,12 @@ void ZMappedCache::Tree::insert(TreeNode* node, const TreeCursor& cursor) {
   // Insert in tree
   TreeImpl::insert_at_cursor(node, cursor);
 
-  if (_left_most == nullptr || EntryCompare::cmp(node, _left_most) < 0) {
+  if (_left_most == nullptr || EntryCompare::cmp(node, _left_most)) {
     // Keep track of left most node
     _left_most = node;
   }
 
-  if (_right_most == nullptr || EntryCompare::cmp(_right_most, node) < 0) {
+  if (_right_most == nullptr || EntryCompare::cmp(_right_most, node)) {
     // Keep track of right most node
     _right_most = node;
   }

--- a/src/hotspot/share/gc/z/zMappedCache.hpp
+++ b/src/hotspot/share/gc/z/zMappedCache.hpp
@@ -41,7 +41,7 @@ class ZMappedCache {
 private:
   struct EntryCompare {
     static int cmp(zoffset a, const IntrusiveRBNode* b);
-    static int cmp(const IntrusiveRBNode*  a, const IntrusiveRBNode* b);
+    static bool cmp(const IntrusiveRBNode*  a, const IntrusiveRBNode* b);
   };
 
   struct ZSizeClassListNode {


### PR DESCRIPTION
Hello,

The comparator with two IntrusiveRBNode* in ZMappedCache has the incorrent type signature. This prevents IntrusiveRBTree from using the comparator as intended during validation, resulting in it using the fallback verify function, which always returns true. This could mask potential issues in the tree structure. 

Testing:
* Manually placing an assert in the fallback verify function to see if it is used. It is no longer used with this patch.
* Oracle's tier 1-2