### PR TITLE
8366002

### DIFF
--- a/src/java.desktop/share/classes/java/beans/Beans.java
+++ b/src/java.desktop/share/classes/java/beans/Beans.java
@@ -64,6 +64,22 @@ public class Beans {
      * <p>
      * Instantiate a JavaBean.
      * </p>
+     * The bean is created based on a name relative to a class-loader.
+     * This name should be a dot-separated name such as "a.b.c".
+     * <p>
+     * The given name can indicate either a serialized object or a class.
+     * We first try to treat the beanName as a serialized object
+     * name then as a class name.
+     * <p>
+     * When using the beanName as a serialized object name we convert the
+     * given beanName to a resource pathname and add a trailing ".ser" suffix.
+     * We then try to load a serialized object from that resource.
+     * <p>
+     * For example, given a beanName of "x.y", Beans.instantiate would first
+     * try to read a serialized object from the resource "x/y.ser" and if
+     * that failed it would try to load the class "x.y" and create an
+     * instance of that class.
+     *
      * @return a JavaBean
      * @param     cls         the class-loader from which we should create
      *                        the bean.  If this is null, then the system
@@ -84,6 +100,22 @@ public class Beans {
      * <p>
      * Instantiate a JavaBean.
      * </p>
+     * The bean is created based on a name relative to a class-loader.
+     * This name should be a dot-separated name such as "a.b.c".
+     * <p>
+     * The given name can indicate either a serialized object or a class.
+     * We first try to treat the beanName as a serialized object
+     * name then as a class name.
+     * <p>
+     * When using the beanName as a serialized object name we convert the
+     * given beanName to a resource pathname and add a trailing ".ser" suffix.
+     * We then try to load a serialized object from that resource.
+     * <p>
+     * For example, given a beanName of "x.y", Beans.instantiate would first
+     * try to read a serialized object from the resource "x/y.ser" and if
+     * that failed it would try to load the class "x.y" and create an
+     * instance of that class.
+     *
      * @return a JavaBean
      *
      * @param     cls         the class-loader from which we should create


### PR DESCRIPTION
Some text describing the Beans.instantiate lookup process existed only on the method that used the now removed AppletInitializer.
Since there are two other Beans.instantiate methods, we need to move that text to the remaining methods.

Note that one of the methods is also deprecated for removal, so it seems prudent to add it to both so that when the next to be removed method is gone, this problem doesn't recur.