### PR TITLE
8366028: MethodType::fromMethodDescriptorString should not throw UnsupportedOperationException for invalid descriptors

### DIFF
--- a/src/java.base/share/classes/sun/invoke/util/BytecodeDescriptor.java
+++ b/src/java.base/share/classes/sun/invoke/util/BytecodeDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -96,8 +96,15 @@ public class BytecodeDescriptor {
             }
         } else if (c == '[') {
             Class<?> t = parseSig(str, i, end, loader);
-            if (t != null)
-                t = t.arrayType();
+            if (t != null) {
+                try {
+                    t = t.arrayType();
+                } catch (UnsupportedOperationException ex) {
+                    // Bad arrays, such as [V or more than 255 dims
+                    // We have a more informative IAE
+                    return null;
+                }
+            }
             return t;
         } else {
             return Wrapper.forBasicType(c).primitiveType();

--- a/test/jdk/java/lang/invoke/MethodTypeTest.java
+++ b/test/jdk/java/lang/invoke/MethodTypeTest.java
@@ -229,6 +229,7 @@ public class MethodTypeTest {
                 "([V)V",
                 "(" + "[".repeat(256) + "J)I",
                 "(java/lang/Object)V",
+                "()java/lang/Object",
         };
     }
 

--- a/test/jdk/java/lang/invoke/MethodTypeTest.java
+++ b/test/jdk/java/lang/invoke/MethodTypeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,6 +35,8 @@ import java.lang.reflect.Method;
 
 import java.util.*;
 import org.testng.*;
+
+import static org.testng.Assert.assertThrows;
 import static org.testng.AssertJUnit.*;
 import org.testng.annotations.*;
 
@@ -216,6 +218,22 @@ public class MethodTypeTest {
             prevPart = part;
         }
         return sb.toString().replace('.', '/');
+    }
+
+    @DataProvider(name = "badMethodDescriptorStrings")
+    public String[] badMethodDescriptorStrings() {
+        return new String[] {
+                "(I)",
+                "(V)V",
+                "([V)V",
+                "(" + "[".repeat(256) + "J)I",
+                "(java/lang/Object)V",
+        };
+    }
+
+    @Test(dataProvider = "badMethodDescriptorStrings", expectedExceptions = IllegalArgumentException.class)
+    public void testFromMethodDescriptorStringNegatives(String desc) {
+        MethodType.fromMethodDescriptorString(desc, null);
     }
 
     @Test

--- a/test/jdk/java/lang/invoke/MethodTypeTest.java
+++ b/test/jdk/java/lang/invoke/MethodTypeTest.java
@@ -22,6 +22,7 @@
  */
 
 /* @test
+ * @bug 8366028
  * @summary unit tests for java.lang.invoke.MethodType
  * @compile MethodTypeTest.java
  * @run testng/othervm test.java.lang.invoke.MethodTypeTest
@@ -231,6 +232,7 @@ public class MethodTypeTest {
         };
     }
 
+    // JDK-8366028
     @Test(dataProvider = "badMethodDescriptorStrings", expectedExceptions = IllegalArgumentException.class)
     public void testFromMethodDescriptorStringNegatives(String desc) {
         MethodType.fromMethodDescriptorString(desc, null);


### PR DESCRIPTION
A previous cleanup #14642 accidentally omitted the fact that an `Array.newInstance` call in `BytecodeDescriptor::parseSig` is intended to propagate `IllegalArgumentException` to `MethodType::fromMethodDescriptorString`. This bug is discovered in a recent cleanup for `BytecodeDescriptor` in #24978.

Instead of restoring the original `newInstance` call, this patch catches the `UnsupportedOperationException` thrown by `Class::arrayType` to because the cause IAE thrown by `newInstance` has no message at all. The existing reporting system in `BytecodeDescriptor::parseMethod` includes the whole malformed descriptor string in the error message, which can be triggered by returning `null` in `parseSig`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8366028](https://bugs.openjdk.org/browse/JDK-8366028): MethodType::fromMethodDescriptorString should not throw UnsupportedOperationException for invalid descriptors (**Bug** - P4)


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26909/head:pull/26909` \
`$ git checkout pull/26909`

Update a local copy of the PR: \
`$ git checkout pull/26909` \
`$ git pull https://git.openjdk.org/jdk.git pull/26909/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26909`

View PR using the GUI difftool: \
`$ git pr show -t 26909`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26909.diff">https://git.openjdk.org/jdk/pull/26909.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26909#issuecomment-3216100929)
</details>
