### PR TITLE
8366031: Mark com/sun/nio/sctp/SctpChannel/CloseDescriptors.java as intermittent

### DIFF
--- a/test/jdk/com/sun/nio/sctp/SctpChannel/CloseDescriptors.java
+++ b/test/jdk/com/sun/nio/sctp/SctpChannel/CloseDescriptors.java
@@ -24,6 +24,7 @@
 /*
  * @test
  * @bug 8238274
+ * @key intermittent
  * @summary Potential leak file descriptor for SCTP
  * @requires (os.family == "linux")
  * @library /test/lib


### PR DESCRIPTION
The test com/sun/nio/sctp/SctpChannel/CloseDescriptors.java observed intermittent fails. Before the root cause of failure has been fixed, should we mark this test `@key intermittent`, to make some setups skip this test or re-run this test when it's fails.

After the failure root cause has been fixed, we should remove the `@key intermittent` in test definition.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8366031](https://bugs.openjdk.org/browse/JDK-8366031): Mark com/sun/nio/sctp/SctpChannel/CloseDescriptors.java as intermittent (**Sub-task** - P4)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26910/head:pull/26910` \
`$ git checkout pull/26910`

Update a local copy of the PR: \
`$ git checkout pull/26910` \
`$ git pull https://git.openjdk.org/jdk.git pull/26910/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26910`

View PR using the GUI difftool: \
`$ git pr show -t 26910`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26910.diff">https://git.openjdk.org/jdk/pull/26910.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26910#issuecomment-3216164881)
</details>
