### PR TITLE
8366037: Remove oopDesc::mark_addr()

### DIFF
--- a/src/hotspot/share/gc/g1/g1OopClosures.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1OopClosures.inline.hpp
@@ -50,9 +50,8 @@ inline void G1ScanClosureBase::prefetch_and_push(T* p, const oop obj) {
   // stall. We'll try to prefetch the object (for write, given that
   // we might need to install the forwarding reference) and we'll
   // get back to it when pop it from the queue
-  void* base = cast_from_oop<void*>(obj);
-  Prefetch::write(base, oopDesc::mark_offset_in_bytes());
-  Prefetch::read(base, oopDesc::mark_offset_in_bytes() + (HeapWordSize*2));
+  Prefetch::write(obj->base_addr(), oopDesc::mark_offset_in_bytes());
+  Prefetch::read(obj->base_addr(), oopDesc::mark_offset_in_bytes() + (HeapWordSize*2));
 
   // slightly paranoid test; I'm trying to catch potential
   // problems before we go into push_on_queue to know where the

--- a/src/hotspot/share/gc/g1/g1OopClosures.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1OopClosures.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,8 +50,9 @@ inline void G1ScanClosureBase::prefetch_and_push(T* p, const oop obj) {
   // stall. We'll try to prefetch the object (for write, given that
   // we might need to install the forwarding reference) and we'll
   // get back to it when pop it from the queue
-  Prefetch::write(obj->mark_addr(), 0);
-  Prefetch::read(obj->mark_addr(), (HeapWordSize*2));
+  void* base = cast_from_oop<void*>(obj);
+  Prefetch::write(base, oopDesc::mark_offset_in_bytes());
+  Prefetch::read(base, oopDesc::mark_offset_in_bytes() + (HeapWordSize*2));
 
   // slightly paranoid test; I'm trying to catch potential
   // problems before we go into push_on_queue to know where the

--- a/src/hotspot/share/gc/parallel/psPromotionManager.inline.hpp
+++ b/src/hotspot/share/gc/parallel/psPromotionManager.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -61,7 +61,7 @@ inline void PSPromotionManager::claim_or_forward_depth(T* p) {
   if (PSScavenge::is_obj_in_young(heap_oop)) {
     oop obj = CompressedOops::decode_not_null(heap_oop);
     assert(!PSScavenge::is_obj_in_to_space(obj), "revisiting object?");
-    Prefetch::write(obj->mark_addr(), 0);
+    Prefetch::write(cast_from_oop<void*>(obj), oopDesc::mark_offset_in_bytes());
     push_depth(ScannerTask(p));
   }
 }

--- a/src/hotspot/share/gc/parallel/psPromotionManager.inline.hpp
+++ b/src/hotspot/share/gc/parallel/psPromotionManager.inline.hpp
@@ -61,7 +61,7 @@ inline void PSPromotionManager::claim_or_forward_depth(T* p) {
   if (PSScavenge::is_obj_in_young(heap_oop)) {
     oop obj = CompressedOops::decode_not_null(heap_oop);
     assert(!PSScavenge::is_obj_in_to_space(obj), "revisiting object?");
-    Prefetch::write(cast_from_oop<void*>(obj), oopDesc::mark_offset_in_bytes());
+    Prefetch::write(obj->base_addr(), oopDesc::mark_offset_in_bytes());
     push_depth(ScannerTask(p));
   }
 }

--- a/src/hotspot/share/oops/oop.hpp
+++ b/src/hotspot/share/oops/oop.hpp
@@ -65,6 +65,9 @@ class oopDesc {
   // Must be trivial; see verifying static assert after the class.
   oopDesc() = default;
 
+  inline void* base_addr();
+  inline const void* base_addr() const;
+
   inline markWord  mark()          const;
   inline markWord  mark_acquire()  const;
 

--- a/src/hotspot/share/oops/oop.hpp
+++ b/src/hotspot/share/oops/oop.hpp
@@ -67,7 +67,6 @@ class oopDesc {
 
   inline markWord  mark()          const;
   inline markWord  mark_acquire()  const;
-  inline markWord* mark_addr() const;
 
   inline void set_mark(markWord m);
   static inline void set_mark(HeapWord* mem, markWord m);

--- a/src/hotspot/share/oops/oop.inline.hpp
+++ b/src/hotspot/share/oops/oop.inline.hpp
@@ -47,6 +47,9 @@
 // Implementation of all inlined member functions defined in oop.hpp
 // We need a separate file to avoid circular references
 
+void* oopDesc::base_addr() { return this; }
+const void* oopDesc::base_addr() const { return this; }
+
 markWord oopDesc::mark() const {
   return Atomic::load(&_mark);
 }

--- a/src/hotspot/share/oops/oop.inline.hpp
+++ b/src/hotspot/share/oops/oop.inline.hpp
@@ -55,10 +55,6 @@ markWord oopDesc::mark_acquire() const {
   return Atomic::load_acquire(&_mark);
 }
 
-markWord* oopDesc::mark_addr() const {
-  return (markWord*) &_mark;
-}
-
 void oopDesc::set_mark(markWord m) {
   Atomic::store(&_mark, m);
 }


### PR DESCRIPTION
Please review this change that removes the function oopDesc::mark_addr().
It's kind of a suspicious function, since it is casting away the volatile for
a location that has concurrent reads and writes. But there isn't any code that
examines the value at the obtained address. Instead, it's just used as the
base address for a few prefetches. We change those places accordingly, and
remove the now unused mark_addr function.

Testing: mach5 tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8366037](https://bugs.openjdk.org/browse/JDK-8366037): Remove oopDesc::mark_addr() (**Enhancement** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26914/head:pull/26914` \
`$ git checkout pull/26914`

Update a local copy of the PR: \
`$ git checkout pull/26914` \
`$ git pull https://git.openjdk.org/jdk.git pull/26914/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26914`

View PR using the GUI difftool: \
`$ git pr show -t 26914`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26914.diff">https://git.openjdk.org/jdk/pull/26914.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26914#issuecomment-3217467418)
</details>
