### PR TITLE
8366029: Do not add -XX:VerifyArchivedFields by default to CDS tests

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/LotsOfSyntheticClasses.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/LotsOfSyntheticClasses.java
@@ -120,9 +120,9 @@ public class LotsOfSyntheticClasses {
             OutputAnalyzer output = TestCommon.createArchive(
                 APP_JAR.toString(),
                 listAppClasses(),
-                MAIN_CLASS_NAME,
                 // Verification for lots of classes slows down the test.
                 "-XX:+IgnoreUnrecognizedVMOptions",
+                "-XX:+UnlockDiagnosticVMOptions",
                 "-XX:-VerifyDependencies",
                 "-XX:-VerifyBeforeExit"
             );
@@ -134,6 +134,7 @@ public class LotsOfSyntheticClasses {
             TestCommon.run(
                 // Verification for lots of classes slows down the test.
                 "-XX:+IgnoreUnrecognizedVMOptions",
+                "-XX:+UnlockDiagnosticVMOptions",
                 "-XX:-VerifyDependencies",
                 "-XX:-VerifyBeforeExit",
                 "-cp", APP_JAR.toString(),

--- a/test/hotspot/jtreg/runtime/cds/appcds/TestCommon.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/TestCommon.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -426,8 +426,6 @@ public class TestCommon extends CDSTestUtils {
             cmd.add("-cp");
             cmd.add(opts.appJar);
         }
-
-        CDSTestUtils.addVerifyArchivedFields(cmd);
 
         for (String s : opts.suffix) cmd.add(s);
 

--- a/test/lib/jdk/test/lib/cds/CDSAppTester.java
+++ b/test/lib/jdk/test/lib/cds/CDSAppTester.java
@@ -402,8 +402,6 @@ abstract public class CDSAppTester {
     public OutputAnalyzer productionRun(String[] extraVmArgs, String[] extraAppArgs) throws Exception {
         RunMode runMode = RunMode.PRODUCTION;
         String[] cmdLine = StringArrayUtils.concat(vmArgs(runMode),
-                                                   "-XX:+UnlockDiagnosticVMOptions",
-                                                   "-XX:VerifyArchivedFields=2", // make sure archived heap objects are good.
                                                    logToFile(productionRunLog(), "aot", "cds"));
         cmdLine = addCommonVMArgs(runMode, cmdLine);
 

--- a/test/lib/jdk/test/lib/cds/CDSTestUtils.java
+++ b/test/lib/jdk/test/lib/cds/CDSTestUtils.java
@@ -440,7 +440,6 @@ public class CDSTestUtils {
                 opts.archiveName = getDefaultArchiveName();
             cmd.add("-XX:SharedArchiveFile=" + opts.archiveName);
         }
-        addVerifyArchivedFields(cmd);
 
         if (opts.useVersion)
             cmd.add("-version");


### PR DESCRIPTION
The diagnostic flag `VerifyArchivedFields` verifies the heap multiple times during VM bootstrap. It's supposed to find problems when heap corruptions when loading the CDS archive.

We added this option to almost all CDS tests by default, but this is rather costly and has not found any bugs for quite a while now.

This PR removes `VerifyArchivedFields` from most of the CDS tests. There is still one test case that explicitly runs with this flag so we have some coverage already.

When running all the CDS tests, this RFE can reduce the elapsed time by about 10%.