### PR TITLE
8365893: test/jdk/java/lang/Thread/virtual/JfrEvents.java failing intermittently

### DIFF
--- a/test/jdk/java/lang/Thread/virtual/JfrEvents.java
+++ b/test/jdk/java/lang/Thread/virtual/JfrEvents.java
@@ -42,6 +42,7 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.LockSupport;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import jdk.jfr.EventType;
@@ -77,12 +78,13 @@ class JfrEvents {
 
             // execute 100 tasks, each in their own virtual thread
             recording.start();
-            ThreadFactory factory = Thread.ofVirtual().factory();
-            try (var executor = Executors.newThreadPerTaskExecutor(factory)) {
-                for (int i = 0; i < 100; i++) {
-                    executor.submit(() -> { });
+            try {
+                List<Thread> threads = IntStream.range(0, 100)
+                        .mapToObj(_ -> Thread.startVirtualThread(() -> { }))
+                        .toList();
+                for (Thread t : threads) {
+                    t.join();
                 }
-                Thread.sleep(1000); // give time for thread end events to be recorded
             } finally {
                 recording.stop();
             }


### PR DESCRIPTION
Under load conditions, testVirtualThreadStartAndEnd can fail because the JFR recording doesn't have a VirtualThreadEndEvent recorded for all virtual threads. This is a test issue. ExecutorService::close waits for all tasks (not threads) to finish. For ThreadPerTaskExecutor the thread terminates after executing the task but there is still a small window between task completion and thread termination.  The test is changed to use Thread::join so it waits for the 100 threads to terminate, avoid the fragile sleep that we had in the original test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8365893](https://bugs.openjdk.org/browse/JDK-8365893): test/jdk/java/lang/Thread/virtual/JfrEvents.java failing intermittently (**Bug** - P4)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26916/head:pull/26916` \
`$ git checkout pull/26916`

Update a local copy of the PR: \
`$ git checkout pull/26916` \
`$ git pull https://git.openjdk.org/jdk.git pull/26916/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26916`

View PR using the GUI difftool: \
`$ git pr show -t 26916`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26916.diff">https://git.openjdk.org/jdk/pull/26916.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26916#issuecomment-3217936379)
</details>
