### PR TITLE
Atomic value

### DIFF
--- a/make/autoconf/flags-cflags.m4
+++ b/make/autoconf/flags-cflags.m4
@@ -597,11 +597,11 @@ AC_DEFUN([FLAGS_SETUP_CFLAGS_HELPER],
 
   # CXXFLAGS C++ language level for all of JDK, including Hotspot.
   if test "x$TOOLCHAIN_TYPE" = xgcc || test "x$TOOLCHAIN_TYPE" = xclang; then
-    LANGSTD_CXXFLAGS="-std=c++14"
+    LANGSTD_CXXFLAGS="-std=c++17"
   elif test "x$TOOLCHAIN_TYPE" = xmicrosoft; then
-    LANGSTD_CXXFLAGS="-std:c++14"
+    LANGSTD_CXXFLAGS="-std:c++17"
   else
-    AC_MSG_ERROR([Cannot enable C++14 for this toolchain])
+    AC_MSG_ERROR([Cannot enable C++17 for this toolchain])
   fi
   TOOLCHAIN_CFLAGS_JDK_CXXONLY="$TOOLCHAIN_CFLAGS_JDK_CXXONLY $LANGSTD_CXXFLAGS"
   TOOLCHAIN_CFLAGS_JVM="$TOOLCHAIN_CFLAGS_JVM $LANGSTD_CXXFLAGS"

--- a/make/ide/vscode/hotspot/indexers/ccls-settings.txt
+++ b/make/ide/vscode/hotspot/indexers/ccls-settings.txt
@@ -1,7 +1,7 @@
 		// Configure cpptools IntelliSense
 		"C_Cpp.intelliSenseCachePath": "{{OUTPUTDIR}}/.vscode",
 		"C_Cpp.default.compileCommands": "{{OUTPUTDIR}}/compile_commands.json",
-		"C_Cpp.default.cppStandard": "c++14",
+		"C_Cpp.default.cppStandard": "c++17",
 		"C_Cpp.default.compilerPath": "{{COMPILER}}",
 
 		// Configure ccls

--- a/make/ide/vscode/hotspot/indexers/clangd-settings.txt
+++ b/make/ide/vscode/hotspot/indexers/clangd-settings.txt
@@ -1,7 +1,7 @@
 		// Configure cpptools IntelliSense
 		"C_Cpp.intelliSenseCachePath": "{{OUTPUTDIR}}/.vscode",
 		"C_Cpp.default.compileCommands": "{{OUTPUTDIR}}/compile_commands.json",
-		"C_Cpp.default.cppStandard": "c++14",
+		"C_Cpp.default.cppStandard": "c++17",
 		"C_Cpp.default.compilerPath": "{{COMPILER}}",
 
 		// Configure clangd

--- a/make/ide/vscode/hotspot/indexers/cpptools-settings.txt
+++ b/make/ide/vscode/hotspot/indexers/cpptools-settings.txt
@@ -1,5 +1,5 @@
 		// Configure cpptools IntelliSense
 		"C_Cpp.intelliSenseCachePath": "{{OUTPUTDIR}}/.vscode",
 		"C_Cpp.default.compileCommands": "{{OUTPUTDIR}}/compile_commands.json",
-		"C_Cpp.default.cppStandard": "c++14",
+		"C_Cpp.default.cppStandard": "c++17",
 		"C_Cpp.default.compilerPath": "{{COMPILER}}",

--- a/make/ide/vscode/hotspot/indexers/rtags-settings.txt
+++ b/make/ide/vscode/hotspot/indexers/rtags-settings.txt
@@ -1,7 +1,7 @@
 		// Configure cpptools IntelliSense
 		"C_Cpp.intelliSenseCachePath": "{{OUTPUTDIR}}/.vscode",
 		"C_Cpp.default.compileCommands": "{{OUTPUTDIR}}/compile_commands.json",
-		"C_Cpp.default.cppStandard": "c++14",
+		"C_Cpp.default.cppStandard": "c++17",
 		"C_Cpp.default.compilerPath": "{{COMPILER}}",
 
 		// Configure RTags

--- a/src/hotspot/share/classfile/classLoaderData.cpp
+++ b/src/hotspot/share/classfile/classLoaderData.cpp
@@ -449,8 +449,8 @@ void ClassLoaderData::modules_do(void f(ModuleEntry*)) {
   if (_unnamed_module != nullptr) {
     f(_unnamed_module);
   }
-  if (_modules != nullptr) {
-    _modules->modules_do(f);
+  if (_modules.load_relaxed() != nullptr) {
+    _modules.load_relaxed()->modules_do(f);
   }
 }
 
@@ -635,17 +635,17 @@ void ClassLoaderData::unload() {
 ModuleEntryTable* ClassLoaderData::modules() {
   // Lazily create the module entry table at first request.
   // Lock-free access requires load_acquire.
-  ModuleEntryTable* modules = Atomic::load_acquire(&_modules);
+  ModuleEntryTable* modules = _modules.load_acquire();
   if (modules == nullptr) {
     MutexLocker m1(Module_lock);
     // Check if _modules got allocated while we were waiting for this lock.
-    if ((modules = _modules) == nullptr) {
+    if ((modules = _modules.load_relaxed()) == nullptr) {
       modules = new ModuleEntryTable();
 
       {
         MutexLocker m1(metaspace_lock(), Mutex::_no_safepoint_check_flag);
         // Ensure _modules is stable, since it is examined without a lock
-        Atomic::release_store(&_modules, modules);
+        _modules.release_store(modules);
       }
     }
   }
@@ -740,11 +740,7 @@ ClassLoaderData::~ClassLoaderData() {
   }
 
   // Release C heap allocated hashtable for all the modules.
-  if (_modules != nullptr) {
-    // Destroy the table itself
-    delete _modules;
-    _modules = nullptr;
-  }
+  delete _modules.fetch_then_clear(memory_order_relaxed);
 
   // Release C heap allocated hashtable for the dictionary
   if (_dictionary != nullptr) {
@@ -1045,7 +1041,7 @@ void ClassLoaderData::print_on(outputStream* out) const {
   }
   out->print_cr(" }");
   out->print_cr(" - packages            " INTPTR_FORMAT, p2i(_packages));
-  out->print_cr(" - module              " INTPTR_FORMAT, p2i(_modules));
+  out->print_cr(" - module              " INTPTR_FORMAT, p2i(_modules.load_relaxed()));
   out->print_cr(" - unnamed module      " INTPTR_FORMAT, p2i(_unnamed_module));
   if (_dictionary != nullptr) {
     out->print   (" - dictionary          " INTPTR_FORMAT " ", p2i(_dictionary));
@@ -1100,8 +1096,8 @@ void ClassLoaderData::verify() {
     assert(k != k->next_link(), "no loops!");
   }
 
-  if (_modules != nullptr) {
-    _modules->verify();
+  if (_modules.load_relaxed() != nullptr) {
+    _modules.load_relaxed()->verify();
   }
 
   if (_deallocate_list != nullptr) {

--- a/src/hotspot/share/classfile/classLoaderData.hpp
+++ b/src/hotspot/share/classfile/classLoaderData.hpp
@@ -134,7 +134,7 @@ class ClassLoaderData : public CHeapObj<mtClass> {
 
   Klass* volatile _klasses;              // The classes defined by the class loader.
   PackageEntryTable* volatile _packages; // The packages defined by the class loader.
-  ModuleEntryTable*  volatile _modules;  // The modules defined by the class loader.
+  AtomicValue<ModuleEntryTable*> _modules; // The modules defined by the class loader.
   ModuleEntry* _unnamed_module;          // This class loader's unnamed module.
   Dictionary*  _dictionary;              // The loaded InstanceKlasses, including initiated by this class loader
 
@@ -330,7 +330,7 @@ private:
   PackageEntryTable* packages() { return _packages; }
   ModuleEntry* unnamed_module() { return _unnamed_module; }
   ModuleEntryTable* modules();
-  bool modules_defined() { return (_modules != nullptr); }
+  bool modules_defined() { return (_modules.load_relaxed() != nullptr); }
 
   // Offsets
   static ByteSize holder_offset() { return byte_offset_of(ClassLoaderData, _holder); }

--- a/src/hotspot/share/gc/shared/freeListAllocator.cpp
+++ b/src/hotspot/share/gc/shared/freeListAllocator.cpp
@@ -164,8 +164,8 @@ void FreeListAllocator::release(void* free_node) {
 // in-progress transfer.
 bool FreeListAllocator::try_transfer_pending() {
   // Attempt to claim the lock.
-  if (Atomic::load(&_transfer_lock) || // Skip CAS if likely to fail.
-      Atomic::cmpxchg(&_transfer_lock, false, true)) {
+  if (_transfer_lock.load_relaxed() || // Skip CAS if likely to fail.
+      _transfer_lock.cmpxchg(false, true)) {
     return false;
   }
   // Have the lock; perform the transfer.
@@ -191,6 +191,6 @@ bool FreeListAllocator::try_transfer_pending() {
     log_trace(gc, freelist)
              ("Transferred %s pending to free: %zu", name(), count);
   }
-  Atomic::release_store(&_transfer_lock, false);
+  _transfer_lock.release_store(false);
   return true;
 }

--- a/src/hotspot/share/gc/shared/freeListAllocator.hpp
+++ b/src/hotspot/share/gc/shared/freeListAllocator.hpp
@@ -115,7 +115,7 @@ class FreeListAllocator {
   Type Name; DEFINE_PAD_MINUS_SIZE(Id, DEFAULT_PADDING_SIZE, sizeof(Type))
   DECLARE_PADDED_MEMBER(1, volatile size_t, _free_count);
   DECLARE_PADDED_MEMBER(2, Stack, _free_list);
-  DECLARE_PADDED_MEMBER(3, volatile bool, _transfer_lock);
+  DECLARE_PADDED_MEMBER(3, AtomicValue<bool>, _transfer_lock);
 #undef DECLARE_PADDED_MEMBER
 
   volatile uint _active_pending_list;

--- a/src/hotspot/share/gc/shared/stringdedup/stringDedupTable.hpp
+++ b/src/hotspot/share/gc/shared/stringdedup/stringDedupTable.hpp
@@ -30,6 +30,7 @@
 #include "memory/allStatic.hpp"
 #include "oops/typeArrayOop.hpp"
 #include "oops/weakHandle.hpp"
+#include "runtime/atomic.hpp"
 #include "utilities/globalDefinitions.hpp"
 #include "utilities/macros.hpp"
 
@@ -88,7 +89,7 @@ private:
   // These are always written while holding StringDedup_lock, but may be
   // read by the dedup thread without holding the lock lock.
   static volatile size_t _dead_count;
-  static volatile DeadState _dead_state;
+  static AtomicValue<DeadState> _dead_state;
 
   static uint compute_hash(typeArrayOop obj);
   static size_t hash_to_index(uint hash_code);

--- a/src/hotspot/share/runtime/atomic.hpp
+++ b/src/hotspot/share/runtime/atomic.hpp
@@ -488,6 +488,25 @@ private:
   class PrefetchBitopsUsingCmpxchg;
   class PostfetchBitopsUsingCmpxchg;
   class PostfetchBitopsUsingPrefetch;
+
+  // Implementation support for AtomicValue<T>.
+
+  template<typename T> class ValueAccess;
+  template<typename T> class ValueSupportsXchg;
+  template<typename T> class ValueSupportsArithmetic;
+  template<typename T> class IntegerValue;
+  template<typename T> class ByteValue;
+  template<typename T> class PointerValue;
+  template<typename T> class TranslatingValue;
+
+  template<typename T> class AtomicValueHasExchange;
+  template<typename T, typename Enable = void> class IntegerValueSelector;
+  template<typename T, typename Enable = void> class ValueSelectorImpl;
+
+public:
+  // Public for accessibility by AtomicValue.
+  template<typename T> class ValueSelector;
+  template<typename T> static auto value_selector(T);
 };
 
 template<typename From, typename To>
@@ -1231,5 +1250,493 @@ inline T Atomic::XchgUsingCmpxchg<byte_size>::operator()(T volatile* dest,
   } while (old_value != Atomic::cmpxchg(dest, old_value, exchange_value, order));
   return old_value;
 }
+
+// AtomicValue<T> is used to declare a variable of type T with atomic access.
+//
+// The following value types T are supported:
+//
+// (1) Integers with sizeof the same as sizeof int, long, or long long. These
+// are referred to as atomic integers below.
+//
+// (2) Integers with sizeof 1, including bool. These are referred to as atomic
+// bytes below.
+//
+// (3) Pointers. These are referred to as atomic pointers below.
+//
+// (4) Types with a PrimitiveValues::Translate definition. These are referred
+// to as atomic translated types below. The atomic value for the associated
+// decayed type is referred to as the atomic decayed type.
+//
+// The interface for an AtomicValue provided depends on the value type.
+//
+// If T is the value type, v is an AtomicValue<T>, x and y are instances of T,
+// i is an integer, and o is an atomic_memory_order, then:
+//
+// (1) All AtomicValue types provide
+//
+//   nested types:
+//     ValueType -> T
+//
+//   special functions:
+//     explicit constructor(T)
+//     noncopyable
+//     destructor
+//
+//   static member functions:
+//     value_offset_in_bytes() -> int
+//     value_size_in_bytes() -> int
+//
+//   member functions:
+//     v.load_relaxed() -> T
+//     v.load_acquire() -> T
+//     v.relaxed_store(x) -> void
+//     v.release_store(x) -> void
+//     v.release_store_fence(x) -> void
+//     v.cmpxchg(x, y [, o]) -> T
+//
+// (2) All except atomic translated types are default constructible, value
+// initializing the value. An atomic translated type is default constructible
+// only if its value type is default constructible.
+//
+// (3) Atomic pointers and atomic integers additionally provide
+//
+//   member functions:
+//     v.xchg(x [, o]) -> T
+//     v.add_then_fetch(i [, o]) -> T
+//     v.sub_then_fetch(i [, o]) -> T
+//     v.fetch_then_add(i [, o]) -> T
+//     v.fetch_then_sub(i [, o]) -> T
+//     v.atomic_inc([o]) -> void
+//     v.atomic_dec([o]) -> void
+//
+// (4) An atomic translated type additionally provides the xchg function if
+// its associated atomic decayed type provides that function.
+//
+// (5) Atomic integers additionally provide
+//
+//   member functions:
+//     v.and_then_fetch(x [, o]) -> T
+//     v.or_then_fetch(x [, o]) -> T
+//     v.xor_then_fetch(x [, o]) -> T
+//     v.fetch_then_and(x [, o]) -> T
+//     v.fetch_then_or(x [, o]) -> T
+//     v.fetch_then_xor(x [, o]) -> T
+//
+// (6) Atomic pointers additionally provide
+//
+//   nested types:
+//     ElementType -> std::remove_pointer_t<T>
+//
+//   member functions:
+//     v.replace_if_null(x [, o]) -> bool
+//     v.clear_if(x [, o]) -> bool
+//     v.fetch_then_clear([o]) -> T
+//
+// Atomic bytes don't provide xchg. This is because that operation hasn't been
+// implemented for 1 byte values. That could be changed if needed.
+//
+// AtomicValue for 2 byte integers is not supported. This is because atomic
+// operations of that size have not been implemented. There haven't been
+// required use-cases. Many platforms don't provide hardware support.
+//
+// Atomic translated types don't provide the full interface of the associated
+// atomic decayed type. They could do so, perhaps under the control of an
+// associated type trait. The conditional definition of xchg for atomic
+// translated types demonstrates an approach to doing so.
+
+#if 0  // Use pre-C++17 selection of AtomicValue implementation from T
+template<typename T>
+using AtomicValue = typename Atomic::ValueSelector<T>::type;
+#else  // Use C++17 selection
+template<typename T>
+using AtomicValue = decltype(Atomic::value_selector(declval<T>()));
+#endif
+
+// FIXME: Move this to globalDefinitions.hpp.
+// This provides a workaround for static_assert(false) in discarded or
+// otherwise uninstantiated places.  Instead use
+//   static_assert(dependent_always_false<T>, "...")
+// See http://wg21.link/p2593r1. Some, but not all compiler versions we're
+// using have implemented that change as a DR:
+// https://cplusplus.github.io/CWG/issues/2518.html
+template<typename T> inline constexpr bool dependent_always_false = false;
+
+// C++17 selection of AtomicValue implementation from T.
+template<typename T>
+inline auto Atomic::value_selector(T v) {
+  static_assert(std::is_same_v<T, std::remove_cv_t<T>>,
+                "Value type must not be cv-qualified");
+  if constexpr (std::is_integral_v<T>) {
+    if constexpr (sizeof(T) >= sizeof(int)) {
+      return IntegerValue<T>(v);
+    } else if constexpr (sizeof(T) == 1) {
+      return ByteValue<T>(v);
+    } else {
+      static_assert(dependent_always_false<T>, "Invalid atomic integer type");
+    }
+  } else if constexpr (std::is_pointer_v<T>) {
+    return PointerValue<T>(v);
+  } else if constexpr (PrimitiveConversions::Translate<T>::value) {
+    return TranslatingValue<T>(v);
+  } else {
+    static_assert(dependent_always_false<T>, "Invalid atomic value type");
+  }
+}
+
+// pre-C++17 selection of AtomicValue implementation from T.
+// Uses IntegerValueSelector, ValueSelectorImpl, and ValueSelector.
+template<typename T>
+class Atomic::IntegerValueSelector<T, std::enable_if_t<(sizeof(T) >= sizeof(int))>> {
+public:
+  using type = IntegerValue<T>;
+};
+
+template<typename T>
+class Atomic::IntegerValueSelector<T, std::enable_if_t<(sizeof(T) == 1)>> {
+public:
+  using type = ByteValue<T>;
+};
+
+template<typename T>
+class Atomic::ValueSelectorImpl<
+  T,
+  std::enable_if_t<std::is_integral<T>::value>> {
+public:
+  using type = typename IntegerValueSelector<T>::type;
+};
+
+template<typename T>
+class Atomic::ValueSelectorImpl<T*> {
+public:
+  using type = PointerValue<T*>;
+};
+
+template<typename T>
+class Atomic::ValueSelectorImpl<
+  T,
+  std::enable_if_t<PrimitiveConversions::Translate<T>::value>>
+{
+public:
+  using type = TranslatingValue<T>;
+};
+
+template<typename T>
+class Atomic::ValueSelector {
+  static_assert(std::is_same<T, std::remove_cv_t<T>>::value,
+                "Value type must not be cv-qualified");
+
+public:
+  using type = typename ValueSelectorImpl<T>::type;
+};
+// End of pre-C++17 selection of AtomicValue implementation from T.
+
+template<typename T>
+class Atomic::ValueAccess {
+  T volatile _value;
+
+protected:
+  explicit ValueAccess(T value) : _value(value) {}
+  ~ValueAccess() = default;
+
+public:
+  NONCOPYABLE(ValueAccess);
+
+  // Used internally, not part of final derived public API.
+  T volatile* value_ptr() { return &_value; }
+  T const volatile* value_ptr() const { return &_value; }
+
+  // These are mostly for assembly language access to the value.
+  static int value_offset_in_bytes() { return offset_of(ValueAccess, _value); }
+  static int value_size_in_bytes() { return sizeof(_value); }
+
+  T load_relaxed() const { return Atomic::load(value_ptr()); }
+  T load_acquire() const { return Atomic::load_acquire(value_ptr()); }
+
+  void relaxed_store(T value) { Atomic::store(value_ptr(), value); }
+  void release_store(T value) { Atomic::release_store(value_ptr(), value); }
+  void release_store_fence(T value) { Atomic::release_store_fence(value_ptr(), value); }
+
+  T cmpxchg(T compare_value, T exchange_value,
+            atomic_memory_order order = memory_order_conservative) {
+    return Atomic::cmpxchg(value_ptr(), compare_value, exchange_value);
+  }
+};
+
+template<typename T>
+class Atomic::ValueSupportsXchg : public ValueAccess<T> {
+  using Base = ValueAccess<T>;
+
+protected:
+  explicit ValueSupportsXchg(T value) : Base(value) {}
+  ~ValueSupportsXchg() = default;
+
+public:
+  using Base::value_ptr;
+
+  using Base::value_offset_in_bytes;
+  using Base::value_size_in_bytes;
+  using Base::load_relaxed;
+  using Base::load_acquire;
+  using Base::relaxed_store;
+  using Base::release_store;
+  using Base::release_store_fence;
+  using Base::cmpxchg;
+
+  T xchg(T exchange_value,
+         atomic_memory_order order = memory_order_conservative) {
+    return Atomic::xchg(value_ptr(), exchange_value);
+  }
+};
+
+template<typename T>
+class Atomic::ValueSupportsArithmetic : public ValueSupportsXchg<T> {
+  using Base = ValueSupportsXchg<T>;
+
+protected:
+  explicit ValueSupportsArithmetic(T value) : Base(value) {}
+  ~ValueSupportsArithmetic() = default;
+
+public:
+  using Base::value_ptr;
+
+  using Base::value_offset_in_bytes;
+  using Base::value_size_in_bytes;
+  using Base::load_relaxed;
+  using Base::load_acquire;
+  using Base::relaxed_store;
+  using Base::release_store;
+  using Base::release_store_fence;
+  using Base::cmpxchg;
+  using Base::xchg;
+
+  template<typename I>
+  T add_then_fetch(I add_value,
+                   atomic_memory_order order = memory_order_conservative) {
+    return Atomic::add(value_ptr(), add_value, order);
+  }
+
+  template<typename I>
+  T fetch_then_add(I add_value,
+                   atomic_memory_order order = memory_order_conservative) {
+    return Atomic::fetch_then_add(value_ptr(), add_value, order);
+  }
+
+  template<typename I>
+  T sub_then_fetch(I sub_value,
+                   atomic_memory_order order = memory_order_conservative) {
+    return Atomic::sub(value_ptr(), sub_value, order);
+  }
+
+  template<typename I>
+  T fetch_then_sub(I sub_value,
+                   atomic_memory_order order = memory_order_conservative) {
+    // Atomic doesn't currently provide fetch_then_sub.
+    return sub_then_fetch(sub_value, order) + sub_value;
+  }
+
+  void atomic_inc(atomic_memory_order order = memory_order_conservative) {
+    Atomic::inc(value_ptr(), order);
+  }
+
+  void atomic_dec(atomic_memory_order order = memory_order_conservative) {
+    Atomic::dec(value_ptr(), order);
+  }
+};
+
+template<typename T>
+class Atomic::IntegerValue : private ValueSupportsArithmetic<T> {
+  using Base = ValueSupportsArithmetic<T>;
+  using Base::value_ptr;
+
+public:
+  explicit IntegerValue(T value = 0) : Base(value) {}
+
+  NONCOPYABLE(IntegerValue);
+
+  using ValueType = T;
+
+  using Base::value_offset_in_bytes;
+  using Base::value_size_in_bytes;
+  using Base::load_relaxed;
+  using Base::load_acquire;
+  using Base::relaxed_store;
+  using Base::release_store;
+  using Base::release_store_fence;
+  using Base::cmpxchg;
+  using Base::xchg;
+  using Base::add_then_fetch;
+  using Base::fetch_then_add;
+  using Base::sub_then_fetch;
+  using Base::fetch_then_sub;
+  using Base::atomic_inc;
+  using Base::atomic_dec;
+
+  T fetch_then_and(T bits, atomic_memory_order order = memory_order_conservative) {
+    return Atomic::fetch_then_and(value_ptr(), bits, order);
+  }
+
+  T fetch_then_or(T bits, atomic_memory_order order = memory_order_conservative) {
+    return Atomic::fetch_then_or(value_ptr(), bits, order);
+  }
+
+  T fetch_then_xor(T bits, atomic_memory_order order = memory_order_conservative) {
+    return Atomic::fetch_then_xor(value_ptr(), bits, order);
+  }
+
+  T and_then_fetch(T bits, atomic_memory_order order = memory_order_conservative) {
+    return Atomic::and_then_fetch(value_ptr(), bits, order);
+  }
+
+  T or_then_fetch(T bits, atomic_memory_order order = memory_order_conservative) {
+    return Atomic::or_then_fetch(value_ptr(), bits, order);
+  }
+
+  T xor_then_fetch(T bits, atomic_memory_order order = memory_order_conservative) {
+    return Atomic::xor_then_fetch(value_ptr(), bits, order);
+  }
+};
+
+template<typename T>
+class Atomic::ByteValue : private ValueAccess<T> {
+  using Base = ValueAccess<T>;
+
+public:
+  explicit ByteValue(T value = 0) : Base(value) {}
+
+  NONCOPYABLE(ByteValue);
+
+  using ValueType = T;
+
+  using Base::value_offset_in_bytes;
+  using Base::value_size_in_bytes;
+  using Base::load_relaxed;
+  using Base::load_acquire;
+  using Base::relaxed_store;
+  using Base::release_store;
+  using Base::release_store_fence;
+  using Base::cmpxchg;
+};
+
+template<typename T>
+class Atomic::PointerValue : private ValueSupportsArithmetic<T> {
+  using Base = ValueSupportsArithmetic<T>;
+  using Base::value_ptr;
+
+public:
+  explicit PointerValue(T value = nullptr) : Base(value) {}
+
+  NONCOPYABLE(PointerValue);
+
+  using ValueType = T;
+  using ElementType = std::remove_pointer_t<T>;
+
+  using Base::value_offset_in_bytes;
+  using Base::value_size_in_bytes;
+  using Base::load_relaxed;
+  using Base::load_acquire;
+  using Base::relaxed_store;
+  using Base::release_store;
+  using Base::release_store_fence;
+  using Base::cmpxchg;
+  using Base::xchg;
+  using Base::add_then_fetch;
+  using Base::fetch_then_add;
+  using Base::sub_then_fetch;
+  using Base::fetch_then_sub;
+  using Base::atomic_inc;
+  using Base::atomic_dec;
+
+  bool replace_if_null(T exchange_value,
+                       atomic_memory_order order = memory_order_conservative) {
+    return Atomic::replace_if_null(value_ptr(), exchange_value, order);
+  }
+
+  bool clear_if(T compare_value,
+                atomic_memory_order order = memory_order_conservative) {
+    return compare_value == cmpxchg(compare_value, (T)nullptr, order);
+  }
+
+  T fetch_then_clear(atomic_memory_order order = memory_order_conservative) {
+    return xchg((T)nullptr);
+  }
+};
+
+template<typename T>
+class Atomic::AtomicValueHasExchange {
+  template<typename Check> static char* test(decltype(&Check::xchg));
+  template<typename> static char test(...);
+  using test_type = decltype(test<AtomicValue<T>>(nullptr));
+public:
+  static const bool value = std::is_pointer_v<test_type>;
+};
+
+template<typename T>
+class Atomic::TranslatingValue {
+  using Translator = PrimitiveConversions::Translate<T>;
+  using Decayed = typename Translator::Decayed;
+
+  AtomicValue<Decayed> _value;
+
+  static Decayed decay(T x) { return Translator::decay(x); }
+  static T recover(Decayed x) { return Translator::recover(x); }
+
+  // "Unit test" AtomicValueHasExchange.
+  static_assert(AtomicValueHasExchange<int>::value);
+  static_assert(AtomicValueHasExchange<void*>::value);
+  static_assert(!AtomicValueHasExchange<char>::value);
+
+public:
+  using ValueType = T;
+
+  template<typename Dummy = int,
+           std::enable_if_t<std::is_default_constructible_v<T>, Dummy> = 0>
+  TranslatingValue() : TranslatingValue(T()) {}
+
+  explicit TranslatingValue(T value) : _value(decay(value)) {}
+
+  NONCOPYABLE(TranslatingValue);
+
+  static int value_offset_in_bytes() {
+    return (offset_of(TranslatingValue, _value) +
+            AtomicValue<Decayed>::value_offset_in_bytes());
+  }
+
+  static int value_size_in_bytes() {
+    return AtomicValue<Decayed>::value_size_in_bytes();
+  }
+
+  T load_relaxed() const {
+    return recover(_value.load_relaxed());
+  }
+
+  T load_acquire() const {
+    return recover(_value.load_acquire());
+  }
+
+  void relaxed_store(T value) {
+    _value.relaxed_store(decay(value));
+  }
+
+  void release_store(T value) {
+    _value.release_store(decay(value));
+  }
+
+  void release_store_fence(T value) {
+    _value.release_store_fence(decay(value));
+  }
+
+  T cmpxchg(T compare_value, T exchange_value,
+            atomic_memory_order order = memory_order_conservative) {
+    return recover(_value.cmpxchg(decay(compare_value),
+                                  decay(exchange_value),
+                                  order));
+  }
+
+  template<typename Dummy = int,
+           std::enable_if_t<AtomicValueHasExchange<Decayed>::value, Dummy> = 0>
+  T xchg(T exchange_value, atomic_memory_order order = memory_order_conservative) {
+    return recover(_value.xchg(decay(exchange_value), order));
+  }
+};
 
 #endif // SHARE_RUNTIME_ATOMIC_HPP

--- a/src/hotspot/share/utilities/singleWriterSynchronizer.cpp
+++ b/src/hotspot/share/utilities/singleWriterSynchronizer.cpp
@@ -43,17 +43,17 @@ SingleWriterSynchronizer::SingleWriterSynchronizer() :
 // synchronization have exited that critical section.
 void SingleWriterSynchronizer::synchronize() {
   // Side-effect in assert balanced by debug-only dec at end.
-  assert(Atomic::add(&_writers, 1u) == 1u, "multiple writers");
+  assert(_writers.fetch_then_add(1u) == 0u, "multiple writers");
   // We don't know anything about the muxing between this invocation
   // and invocations in other threads.  We must start with the latest
   // _enter polarity, else we could clobber the wrong _exit value on
   // the first iteration.  So fence to ensure everything here follows
   // whatever muxing was used.
   OrderAccess::fence();
-  uint value = _enter;
+  uint value = _enter.load_relaxed();
   // (1) Determine the old and new exit counters, based on the
   // polarity (bit0 value) of the on-entry enter counter.
-  volatile uint* new_ptr = &_exit[(value + 1) & 1];
+  AtomicValue<uint>& new_exit = _exit[(value + 1) & 1];
   // (2) Change the in-use exit counter to the new counter, by adding
   // 1 to the enter counter (flipping the polarity), meanwhile
   // "simultaneously" initializing the new exit counter to that enter
@@ -62,29 +62,28 @@ void SingleWriterSynchronizer::synchronize() {
   uint old;
   do {
     old = value;
-    *new_ptr = ++value;
-    value = Atomic::cmpxchg(&_enter, old, value);
+    new_exit.relaxed_store(++value);
+    value = _enter.cmpxchg(old, value);
   } while (old != value);
   // Critical sections entered before we changed the polarity will use
   // the old exit counter.  Critical sections entered after the change
   // will use the new exit counter.
-  volatile uint* old_ptr = &_exit[old & 1];
-  assert(old_ptr != new_ptr, "invariant");
+  AtomicValue<uint>& old_exit = _exit[old & 1];
   // (3) Inform threads in in-progress critical sections that there is
   // a pending synchronize waiting.  The thread that completes the
   // request (_exit value == old) will signal the _wakeup semaphore to
   // allow us to proceed.
-  _waiting_for = old;
+  _waiting_for.relaxed_store(old);
   // Write of _waiting_for must precede read of _exit and associated
   // conditional semaphore wait.  If they were re-ordered then a
   // critical section exit could miss the wakeup request, failing to
   // signal us while we're waiting.
   OrderAccess::fence();
   // (4) Wait for all the critical sections started before the change
-  // to complete, e.g. for the value of old_ptr to catch up with old.
+  // to complete, e.g. for the value of old_exit to catch up with old.
   // Loop because there could be pending wakeups unrelated to this
   // synchronize request.
-  while (old != Atomic::load_acquire(old_ptr)) {
+  while (old != old_exit.load_acquire()) {
     _wakeup.wait();
   }
   // (5) Drain any pending wakeups. A critical section exit may have
@@ -95,5 +94,5 @@ void SingleWriterSynchronizer::synchronize() {
   // lead to semaphore overflow.  This doesn't guarantee no unrelated
   // wakeups for the next wait, but prevents unbounded accumulation.
   while (_wakeup.trywait()) {}
-  DEBUG_ONLY(Atomic::dec(&_writers);)
+  DEBUG_ONLY(_writers.atomic_dec();)
 }


### PR DESCRIPTION
I said I might work on an atomic value class, to encapsulate volatile + Atomic
usage. So here's a proposal. I'm showing it to a small number of folks first
in case anyone hates it and wants something completely different (possibly
including continuing with more or less what we currently have). Of course, I'm
putting this on github as a draft PR, so somene else might notice it. I'm not
worried about that.

The approach taken here is that there's AtomicValue<T>, which is an alias
template. It selects an internal implementation class to use, based on T. A
different approach would be to expose those implementation classes and have
clients use them directly. I chose not to do that for a couple of reasons.
They'd need good names, and their names would likely be longer, so more
verbosity. We might change / restructure things over time, and having the
implementation type selected for the client makes clients insensitive to such
changes. Also, letting clients chose the implementation type would require
more error checking to ensure the implementation type and the value type are
consistent. With automatic selection I get to skip all that.

One of the things this approach has that I think is essential is that it is
fairly easy to be incremental about updating. Also, I'm expecting there will
be some cases that just shouldn't be AtomicValues, but should continue to use
Atomic operations directly.

I thought I was going to want some C++17 features for this, so I have that
turned on in the repo where I'm doing this work.  It turned out I didn't take
the approach I'd been thinking would need that though. But I expect there are
a few C++17-isms that have crept in anyway. At minimum, there are uses of the
variable form of some type traits. I haven't gotten around to removing the
C++17 enabling and seeing what breaks, but should probably do that.

[later] OK, I lied. I realized there was a different way to calculate the
AtomicValue implementation type from T that leans heavily on C++17. In
particular, it relies on `if constexpr` and Mandatory Copy Elision. Both
methods are present in the current draft PR, though of course only one should
be kept.  But which one? Oh, and I finally learned why `static_assert(false)`
doesn't work sometimes. And there's a DR for that, but not all the compiler
versions we use or otherwise care about have implemented that DR.

Some of the function names I'm proposing for AtomicValue differ from the
Atomic names.  Without the explicit Atomic:: prefix, I found some names a
little too subtle when looking at some updated examples. So I have

load => load_relaxed
store => relaxed_store
add => add_then_fetch (goes with existing Atomic::fetch_then_add)
sub => sub_then_fetch (goes with missing Atomic::fetch_then_sub)
inc => atomic_inc
dec => atomic_dec

I also added a couple of operations to the pointer case, things I've seen
synthesized in multiple places. These involve cmpxchg or xchg with nullptr
arguments. Though I've also figured out how to change things to eliminate the
casts we currently need when passing nullptr to those functions. That's not
part of this proposal though. (There's a C++20 type_trait that showed me what
to do, and we could easily add our own version of it.)

I'm expecting some bike-shedding on names, including AtomicValue.

I've included a couple of uses, to demonstrate things are working. Obviosly
real tests are needed. I haven't put effort in that direction, wanting to
first see whether this is a direction we want to take.

Pointer values look to often be messy. We'll also need to do something about
the APIs for things like LockFreeStack, which currently expect the element
class to provide a function that returns a pointer to volatile next member,
and would need to return a pointer to an AtomicValue with this new scheme. I
can probably figure out a way to detect which one is being provided and adapt
accordingly, so that we don't have to fix all users of such classes in one go.

We don't currently have Atomic::fetch_and_sub, which is odd. But I guess we
haven't needed it? Or have been working around the lack, rather than doing the
work to properly provide it?

We don't currently have Atomic::xchg for 1-byte values. We do have
Atomic::XchgUsingCmpxchg, so it should be pretty easy to provide a default
implementation. We can specialize for x86 (and others?) if we really want. I
suspect the amount of code involved to provide a default implementation is
comparable to the amount needed to work around that lack in AtomicValue. And I
even noticed a couple of use-cases (currently using CAS) while looking for
places to modify for demonstration purposes.

Some of these variables are known to assembly code. I've provided some helpers
for that. Some of these variables are known to VMStruct (and perhaps
JVMCIStruct, but I don't know if we care about that). I'm not sure what to do
about that.
