### PR TITLE
8366035: Simplify CPUTimeCounters::publish_gc_total_cpu_time

### DIFF
--- a/src/hotspot/share/runtime/cpuTimeCounters.cpp
+++ b/src/hotspot/share/runtime/cpuTimeCounters.cpp
@@ -75,15 +75,8 @@ void CPUTimeCounters::inc_gc_total_cpu_time(jlong diff) {
 
 void CPUTimeCounters::publish_gc_total_cpu_time() {
   CPUTimeCounters* instance = CPUTimeCounters::get_instance();
-  // Ensure that we are only incrementing atomically by using Atomic::cmpxchg
-  // to set the value to zero after we obtain the new CPU time difference.
-  jlong old_value;
-  jlong fetched_value = Atomic::load(&(instance->_gc_total_cpu_time_diff));
-  jlong new_value = 0;
-  do {
-    old_value = fetched_value;
-    fetched_value = Atomic::cmpxchg(&(instance->_gc_total_cpu_time_diff), old_value, new_value);
-  } while (old_value != fetched_value);
+  // Atomically fetch the current _gc_total_cpu_time_diff and reset it to zero.
+  jlong fetched_value = Atomic::xchg(&(instance->_gc_total_cpu_time_diff), 0);
   get_counter(CPUTimeGroups::CPUTimeType::gc_total)->inc(fetched_value);
 }
 


### PR DESCRIPTION
This change refactors CPUTimeCounters::publish_gc_total_cpu_time() to use Atomic::xchg instead of a CAS (cmpxchg) loop.