### PR TITLE
8365442: [asan] runtime/ErrorHandling/CreateCoredumpOnCrash.java fails

### DIFF
--- a/test/hotspot/jtreg/runtime/ErrorHandling/CreateCoredumpOnCrash.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/CreateCoredumpOnCrash.java
@@ -30,6 +30,7 @@
  *          jdk.internal.jvmstat/sun.jvmstat.monitor
  * @run driver CreateCoredumpOnCrash
  * @requires vm.flagless
+ * @requires !vm.asan
  */
 
 import jdk.test.lib.process.ProcessTools;


### PR DESCRIPTION
When running with asan - enabled binaries, the test CreateCoredumpOnCrash.java fails with the output below. Seems asan does not work well with ulimit used in the test, so better avoid running it with asan enabled.
```

[2025-08-09T09:25:35.801707203Z] Gathering output for process 4376
[2025-08-09T09:25:41.863125073Z] Waiting for completion for process 4376
[2025-08-09T09:25:41.863790182Z] Waiting for completion finished for process 4376
[2025-08-09T09:25:41.876094199Z] Gathering output for process 5017
[2025-08-09T09:25:41.883445027Z] Waiting for completion for process 5017
[2025-08-09T09:25:41.883598661Z] Waiting for completion finished for process 5017
----------System.err:(10/570)----------
java.lang.Exception: ulimit is not set correctly, try 'ulimit -c unlimited' and re-run.
at CreateCoredumpOnCrash.main(CreateCoredumpOnCrash.java:82)
at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
at java.base/java.lang.reflect.Method.invoke(Method.java:565)
at com.sun.javatest.regtest.agent.MainActionHelper$AgentVMRunnable.run(MainActionHelper.java:335)
at java.base/java.lang.Thread.run(Thread.java:1474)
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8365442](https://bugs.openjdk.org/browse/JDK-8365442): [asan] runtime/ErrorHandling/CreateCoredumpOnCrash.java fails (**Bug** - P4)


### Reviewers
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@jdksjolen - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26927/head:pull/26927` \
`$ git checkout pull/26927`

Update a local copy of the PR: \
`$ git checkout pull/26927` \
`$ git pull https://git.openjdk.org/jdk.git pull/26927/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26927`

View PR using the GUI difftool: \
`$ git pr show -t 26927`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26927.diff">https://git.openjdk.org/jdk/pull/26927.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26927#issuecomment-3220176024)
</details>
