### PR TITLE
8365898: Specification of java.lang.module.ModuleDescriptor.packages() method can be improved

### DIFF
--- a/src/java.base/share/classes/java/lang/module/ModuleDescriptor.java
+++ b/src/java.base/share/classes/java/lang/module/ModuleDescriptor.java
@@ -1516,7 +1516,9 @@ public final class ModuleDescriptor
     }
 
     /**
-     * {@return a possibly-empty unmodifiable set of all packages in the module}
+     * Returns the set of all packages in the module.
+     *
+     * @return A possibly-empty unmodifiable set of the packages in the module
      */
     public Set<String> packages() {
         return packages;

--- a/src/java.base/share/classes/java/lang/module/ModuleDescriptor.java
+++ b/src/java.base/share/classes/java/lang/module/ModuleDescriptor.java
@@ -1516,7 +1516,7 @@ public final class ModuleDescriptor
     }
 
     /**
-     * Returns the set of packages in the module.
+     * Returns the set of all packages in the module.
      *
      * <p> The set of packages includes all exported and open packages, as well
      * as the packages of any service providers, and the package for the main

--- a/src/java.base/share/classes/java/lang/module/ModuleDescriptor.java
+++ b/src/java.base/share/classes/java/lang/module/ModuleDescriptor.java
@@ -1516,13 +1516,7 @@ public final class ModuleDescriptor
     }
 
     /**
-     * Returns the set of all packages in the module.
-     *
-     * <p> The set of packages includes all exported and open packages, as well
-     * as the packages of any service providers, and the package for the main
-     * class. </p>
-     *
-     * @return A possibly-empty unmodifiable set of the packages in the module
+     * {@return a possibly-empty unmodifiable set of all packages in the module}
      */
     public Set<String> packages() {
         return packages;


### PR DESCRIPTION
Can I please get a review of this trivial change to the `ModuleDescriptor.packages()` method's specification?

The change here clarifies that this method returns all packages that belong to the module and not just those that are exported or open. This clarification should help avoid any confusion that may have been caused by the second paragraph in that method's specification which talks about exported and open packages.

This updated specification matches the existing implementation of this method.

I believe this will require a CSR, which I'll create shortly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8366150](https://bugs.openjdk.org/browse/JDK-8366150) to be approved

### Issues
 * [JDK-8365898](https://bugs.openjdk.org/browse/JDK-8365898): Specification of java.lang.module.ModuleDescriptor.packages() method can be improved (**Bug** - P4)
 * [JDK-8366150](https://bugs.openjdk.org/browse/JDK-8366150): Specification of java.lang.module.ModuleDescriptor.packages() method can be improved (**CSR**)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26928/head:pull/26928` \
`$ git checkout pull/26928`

Update a local copy of the PR: \
`$ git checkout pull/26928` \
`$ git pull https://git.openjdk.org/jdk.git pull/26928/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26928`

View PR using the GUI difftool: \
`$ git pr show -t 26928`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26928.diff">https://git.openjdk.org/jdk/pull/26928.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26928#issuecomment-3220264725)
</details>
