### PR TITLE
8366105: Update link to the external RuleBasedBreakIterator documentation

### DIFF
--- a/src/java.base/share/classes/sun/text/RuleBasedBreakIterator.java
+++ b/src/java.base/share/classes/sun/text/RuleBasedBreakIterator.java
@@ -210,7 +210,7 @@ import sun.text.SupplementaryCharacterData;
  * </blockquote>
  *
  * <p>For a more complete explanation, see <a
- * href="http://www.ibm.com/java/education/boundaries/boundaries.html">http://www.ibm.com/java/education/boundaries/boundaries.html</a>.
+ * href="https://icu-project.org/docs/papers/text_boundary_analysis_in_java/">Text Boundary Analysis in Java</a> by Richard Gillam.
  * &nbsp; For examples, see the resource data (which is annotated).</p>
  *
  * @author Richard Gillam


### PR DESCRIPTION
The JavaDoc of `sun.text.RuleBasedBreakIterator` contains the following link to "Text Boundary Analysis in Java" by Richard Gillam which describes its implementation details:

http://www.ibm.com/java/education/boundaries/boundaries.html

This link isn't online anymore since at least 2001, but fortunately its original content can still be found trough archive.org at https://web.archive.org/web/20001117163900/http://www.ibm.com/java/education/boundaries/boundaries.html

Replace the naked link text with the title and author of the publication and the link target with a new link to the ICU project which is still available: https://icu-project.org/docs/papers/text_boundary_analysis_in_java/
