### PR TITLE
8344333: Spurious System.err.flush() in LWCToolkit.java

### DIFF
--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/LWCToolkit.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/LWCToolkit.java
@@ -141,8 +141,6 @@ public final class LWCToolkit extends LWToolkit {
     private static CInputMethodDescriptor sInputMethodDescriptor;
 
     static {
-        System.err.flush();
-
         ResourceBundle platformResources = null;
         try {
             platformResources = ResourceBundle.getBundle("sun.awt.resources.awtosx");


### PR DESCRIPTION
trivial internal cleanup

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344333](https://bugs.openjdk.org/browse/JDK-8344333): Spurious System.err.flush() in LWCToolkit.java (**Bug** - P4)


### Reviewers
 * [Prasanta Sadhukhan](https://openjdk.org/census#psadhukhan) (@prsadhuk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26931/head:pull/26931` \
`$ git checkout pull/26931`

Update a local copy of the PR: \
`$ git checkout pull/26931` \
`$ git pull https://git.openjdk.org/jdk.git pull/26931/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26931`

View PR using the GUI difftool: \
`$ git pr show -t 26931`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26931.diff">https://git.openjdk.org/jdk/pull/26931.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26931#issuecomment-3221519786)
</details>
