### PR TITLE
8366121: Hotspot Style Guide should document conventions for lock-free code

### DIFF
--- a/doc/hotspot-style.html
+++ b/doc/hotspot-style.html
@@ -209,6 +209,16 @@ lines of code. Name what you must repeat.</p></li>
 attribute, the change should be done with a "setter" accessor matched to
 the simple "getter".</p></li>
 </ul>
+<h4 id="conventions-for-lock-free-code">Conventions for Lock-free
+Code</h4>
+<p>Sometimes variables are accessed concurrently without appropriate
+synchronization context, such as a held mutex or at a safepoint. In such
+cases the variable should be declared <code>volatile</code> and it
+should NOT be accessed as a normal C++ lvalue. Rather, access should be
+performed via functions from <code>Atomic</code>, such as
+<code>Atomic::load</code>, <code>Atomic::store</code>, etc.</p>
+<p>This special formulation makes it more clear to maintainers that the
+variable is accessed concurrently in a lock-free manner.</p>
 <h3 id="source-files">Source Files</h3>
 <ul>
 <li><p>All source files must have a globally unique basename. The build

--- a/doc/hotspot-style.md
+++ b/doc/hotspot-style.md
@@ -135,6 +135,17 @@ lines of code.  Name what you must repeat.
 change should be done with a "setter" accessor matched to the simple
 "getter".
 
+#### Conventions for Lock-free Code
+
+Sometimes variables are accessed concurrently without appropriate synchronization
+context, such as a held mutex or at a safepoint. In such cases the variable should
+be declared `volatile` and it should NOT be accessed as a normal C++ lvalue. Rather,
+access should be performed via functions from `Atomic`, such as `Atomic::load`,
+`Atomic::store`, etc.
+
+This special formulation makes it more clear to maintainers that the variable is
+accessed concurrently in a lock-free manner.
+
 ### Source Files
 
 * All source files must have a globally unique basename. The build


### PR DESCRIPTION
This is a topic that we, at Oracle, have discussed numerous times over the years and we have some simple guidelines that never get written down properly and which we/I tend to forget and then can't locate. To remedy that I would like to capture a few very simple style rules that exist for documentation purposes not necessarily correctness.

Thanks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8366121](https://bugs.openjdk.org/browse/JDK-8366121): Hotspot Style Guide should document conventions for lock-free code (**Enhancement** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@jdksjolen - **Reviewer**)
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26934/head:pull/26934` \
`$ git checkout pull/26934`

Update a local copy of the PR: \
`$ git checkout pull/26934` \
`$ git pull https://git.openjdk.org/jdk.git pull/26934/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26934`

View PR using the GUI difftool: \
`$ git pr show -t 26934`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26934.diff">https://git.openjdk.org/jdk/pull/26934.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26934#issuecomment-3222144993)
</details>
