### PR TITLE
8366127: RISC-V: compiler/intrinsics/TestVerifyIntrinsicChecks.java fails when running without RVV

### DIFF
--- a/test/hotspot/jtreg/compiler/intrinsics/TestVerifyIntrinsicChecks.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/TestVerifyIntrinsicChecks.java
@@ -34,6 +34,7 @@
  * @comment `vm.debug == true` is required since `VerifyIntrinsicChecks` is a
  *          development flag
  * @requires vm.debug == true & vm.flavor == "server" & !vm.graal.enabled
+ * @requires (os.arch != "riscv64" | (os.arch == "riscv64" & vm.cpu.features ~= ".*rvv.*"))
  * @run main/othervm compiler.intrinsics.TestVerifyIntrinsicChecks verify
  */
 


### PR DESCRIPTION
Hi,
Can you help to review this patch? Thanks!

We noticed that compiler/intrinsics/TestVerifyIntrinsicChecks.java fails when running on sg2042.
The error is caused by the intrinsic EncodeISOArray corresponding to encodeAsciiArray0 requiring RVV on riscv. (See encode_iso_array_v in c2_MacroAssembler_riscv.cpp)

### Test (fastdebug)
- [x] Run compiler/intrinsics/TestVerifyIntrinsicChecks.java on k1 and sg2042