### PR TITLE
8366128: jdk/jdk/nio/zipfs/TestPosix.java::testJarFile uses wrong file

### DIFF
--- a/test/jdk/jdk/nio/zipfs/TestPosix.java
+++ b/test/jdk/jdk/nio/zipfs/TestPosix.java
@@ -60,7 +60,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-/**
+/*
  * @test
  * @bug 8213031 8273935 8324635
  * @summary Test POSIX ZIP file operations.
@@ -756,7 +756,7 @@ public class TestPosix {
         delTree(UNZIP_DIR);
         Files.createDirectory(UNZIP_DIR);
         File targetDir = UNZIP_DIR.toFile();
-        try (JarFile jf = new JarFile(ZIP_FILE.toFile())) {
+        try (JarFile jf = new JarFile(JAR_FILE.toFile())) {
             Enumeration<? extends JarEntry> zenum = jf.entries();
             while (zenum.hasMoreElements()) {
                 JarEntry ze = zenum.nextElement();


### PR DESCRIPTION
Can I please get a review of this test-only change which fixes a typo in a test method?

The `test/jdk/jdk/nio/zipfs/TestPosix.java` test was introduced in Java 14 in https://bugs.openjdk.org/browse/JDK-8213031. This test has several test methods. One of those is the `testJarFile()` which first creates a JAR file `JAR_FILE` and then uses a `JarFile` instance to open that JAR file. There's however a typo in that code which causes the test method to use `JarFile` to open an unrelated `ZIP_FILE`. The reason why this test passes is because there's another test method in that test which previously has created the `ZIP_FILE` and thus the `JarFile` is able to open and parse that file.

A failure of this `testJarFile()` test method can be reproduced by changing the order of these test methods to enusre that this test method is run before the others. Doing so results in the following exception:

```
STARTED    TestPosix::testJarFile 'testJarFile()'
java.nio.file.NoSuchFileException: testPosix.zip
    at java.base/sun.nio.fs.UnixException.translateToIOException(UnixException.java:92)
    at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:106)
    at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:111)
    at java.base/sun.nio.fs.UnixFileAttributeViews$Basic.readAttributes(UnixFileAttributeViews.java:57)
    at java.base/sun.nio.fs.UnixFileSystemProvider.readAttributes(UnixFileSystemProvider.java:162)
    at java.base/java.nio.file.Files.readAttributes(Files.java:1702)
    at java.base/java.util.zip.ZipFile$Source.get(ZipFile.java:1505)
    at java.base/java.util.zip.ZipFile$CleanableResource.<init>(ZipFile.java:705)
    at java.base/java.util.zip.ZipFile.<init>(ZipFile.java:204)
    at java.base/java.util.zip.ZipFile.<init>(ZipFile.java:150)
    at java.base/java.util.jar.JarFile.<init>(JarFile.java:336)
    at java.base/java.util.jar.JarFile.<init>(JarFile.java:309)
    at java.base/java.util.jar.JarFile.<init>(JarFile.java:279)
    at TestPosix.testJarFile(TestPosix.java:764)
    at java.base/java.lang.reflect.Method.invoke(Method.java:565)
    at java.base/java.util.ArrayList.forEach(ArrayList.java:1604)
    at java.base/java.util.ArrayList.forEach(ArrayList.java:1604)
FAILED     TestPosix::testJarFile 'testJarFile()' [32ms]
```

The commit in this PR fixes that typo.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8366128](https://bugs.openjdk.org/browse/JDK-8366128): jdk/jdk/nio/zipfs/TestPosix.java::testJarFile uses wrong file (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26936/head:pull/26936` \
`$ git checkout pull/26936`

Update a local copy of the PR: \
`$ git checkout pull/26936` \
`$ git pull https://git.openjdk.org/jdk.git pull/26936/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26936`

View PR using the GUI difftool: \
`$ git pr show -t 26936`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26936.diff">https://git.openjdk.org/jdk/pull/26936.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26936#issuecomment-3222682850)
</details>
