### PR TITLE
8366131: ProblemList java/rmi/transport/checkLeaseInfoLeak/CheckLeaseLeak.java

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -617,7 +617,7 @@ java/rmi/transport/rapidExportUnexport/RapidExportUnexport.java 7146541 linux-al
 
 java/rmi/registry/readTest/CodebaseTest.java                    8173324 windows-all
 java/rmi/registry/multipleRegistries/MultipleRegistries.java    8268182 macosx-all
-
+java/rmi/transport/checkLeaseInfoLeak/CheckLeaseLeak.java       8365398 generic-all
 java/rmi/Naming/DefaultRegistryPort.java                        8005619 windows-all
 java/rmi/Naming/legalRegistryNames/LegalRegistryNames.java      8005619 windows-all
 


### PR DESCRIPTION
Problem listing the test case till the fix for JDK-8365398 approved and integrated

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8366131](https://bugs.openjdk.org/browse/JDK-8366131): ProblemList java/rmi/transport/checkLeaseInfoLeak/CheckLeaseLeak.java (**Sub-task** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26937/head:pull/26937` \
`$ git checkout pull/26937`

Update a local copy of the PR: \
`$ git checkout pull/26937` \
`$ git pull https://git.openjdk.org/jdk.git pull/26937/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26937`

View PR using the GUI difftool: \
`$ git pr show -t 26937`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26937.diff">https://git.openjdk.org/jdk/pull/26937.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26937#issuecomment-3223739389)
</details>
