### PR TITLE
8366157: Clarify in man pages that only G1 and Parallel supports MaxGCPauseMillis

### DIFF
--- a/src/java.base/share/man/java.md
+++ b/src/java.base/share/man/java.md
@@ -2502,9 +2502,9 @@ Java HotSpot VM.
 `-XX:MaxGCPauseMillis=`*time*
 :   Sets a target for the maximum GC pause time (in milliseconds). This is a
     soft goal, and the JVM will make its best effort to achieve it. The
-    specified value doesn't adapt to your heap size. By default, for G1 the
-    maximum pause time target is 200 milliseconds. The other generational
-    collectors do not use a pause time goal by default.
+    specified value doesn't adapt to your heap size. G1's default for the
+    maximum pause time target is 200 milliseconds and only G1 currently supports
+    a maximum GC pause time target.
 
     The following example shows how to set the maximum target pause time to 500
     ms:

--- a/src/java.base/share/man/java.md
+++ b/src/java.base/share/man/java.md
@@ -2502,8 +2502,9 @@ Java HotSpot VM.
 `-XX:MaxGCPauseMillis=`*time*
 :   Sets a target for the maximum GC pause time (in milliseconds). This is a
     soft goal, and the JVM will make its best effort to achieve it. Only G1
-    supports a maximum GC pause time target. The default value is 200
-    milliseconds.
+    and Parallel supports a maximum GC pause time target. For G1, the default
+    maximum pause time target is 200 milliseconds. Parallel do not use a
+    pause time goal by default.
 
     The following example shows how to set the maximum target pause time to 500
     ms:

--- a/src/java.base/share/man/java.md
+++ b/src/java.base/share/man/java.md
@@ -2501,10 +2501,9 @@ Java HotSpot VM.
 
 `-XX:MaxGCPauseMillis=`*time*
 :   Sets a target for the maximum GC pause time (in milliseconds). This is a
-    soft goal, and the JVM will make its best effort to achieve it. The
-    specified value doesn't adapt to your heap size. G1's default for the
-    maximum pause time target is 200 milliseconds and only G1 currently supports
-    a maximum GC pause time target.
+    soft goal, and the JVM will make its best effort to achieve it. Only G1
+    supports a maximum GC pause time target. The default value is 200
+    milliseconds.
 
     The following example shows how to set the maximum target pause time to 500
     ms:

--- a/src/java.base/share/man/java.md
+++ b/src/java.base/share/man/java.md
@@ -2502,9 +2502,8 @@ Java HotSpot VM.
 `-XX:MaxGCPauseMillis=`*time*
 :   Sets a target for the maximum GC pause time (in milliseconds). This is a
     soft goal, and the JVM will make its best effort to achieve it. Only G1
-    and Parallel supports a maximum GC pause time target. For G1, the default
-    maximum pause time target is 200 milliseconds. Parallel do not use a
-    pause time goal by default.
+    and Parallel support a maximum GC pause time target. For G1, the default
+    maximum pause time target is 200 milliseconds.
 
     The following example shows how to set the maximum target pause time to 500
     ms:


### PR DESCRIPTION
Hi all,

This patch clarifies the description of `MaxGCPauseMillis`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8366157](https://bugs.openjdk.org/browse/JDK-8366157): Clarify in man pages that only G1 and Parallel supports MaxGCPauseMillis (**Bug** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Stefan Johansson](https://openjdk.org/census#sjohanss) (@kstefanj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26940/head:pull/26940` \
`$ git checkout pull/26940`

Update a local copy of the PR: \
`$ git checkout pull/26940` \
`$ git pull https://git.openjdk.org/jdk.git pull/26940/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26940`

View PR using the GUI difftool: \
`$ git pr show -t 26940`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26940.diff">https://git.openjdk.org/jdk/pull/26940.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26940#issuecomment-3223802809)
</details>
