### PR TITLE
8366155: Serial: Obsolete PretenureSizeThreshold

### DIFF
--- a/src/hotspot/share/gc/serial/defNewGeneration.cpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.cpp
@@ -267,7 +267,6 @@ DefNewGeneration::DefNewGeneration(ReservedSpace rs,
   update_counters();
   _old_gen = nullptr;
   _tenuring_threshold = MaxTenuringThreshold;
-  _pretenure_size_threshold_words = PretenureSizeThreshold >> LogHeapWordSize;
 
   _ref_processor = nullptr;
 

--- a/src/hotspot/share/gc/serial/defNewGeneration.hpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.hpp
@@ -55,8 +55,6 @@ class DefNewGeneration: public Generation {
 
   uint        _tenuring_threshold;   // Tenuring threshold for next collection.
   AgeTable    _age_table;
-  // Size of object to pretenure in words; command line provides bytes
-  size_t      _pretenure_size_threshold_words;
 
   // ("Weak") Reference processing support
   SpanSubjectToDiscoveryClosure _span_based_discoverer;
@@ -184,24 +182,6 @@ class DefNewGeneration: public Generation {
   void object_iterate(ObjectClosure* blk);
 
   HeapWord* block_start(const void* p) const;
-
-  // Allocation support
-  bool should_allocate(size_t word_size, bool is_tlab) {
-    assert(UseTLAB || !is_tlab, "Should not allocate tlab");
-    assert(word_size != 0, "precondition");
-
-    size_t overflow_limit    = (size_t)1 << (BitsPerSize_t - LogHeapWordSize);
-
-    const bool overflows     = word_size >= overflow_limit;
-    const bool check_too_big = _pretenure_size_threshold_words > 0;
-    const bool not_too_big   = word_size < _pretenure_size_threshold_words;
-    const bool size_ok       = is_tlab || !check_too_big || not_too_big;
-
-    bool result = !overflows &&
-                  size_ok;
-
-    return result;
-  }
 
   // Allocate requested size or return null; single-threaded and lock-free versions.
   HeapWord* allocate(size_t word_size);

--- a/src/hotspot/share/gc/serial/serialHeap.cpp
+++ b/src/hotspot/share/gc/serial/serialHeap.cpp
@@ -283,16 +283,12 @@ size_t SerialHeap::max_capacity() const {
 }
 
 HeapWord* SerialHeap::expand_heap_and_allocate(size_t size, bool is_tlab) {
-  HeapWord* result = nullptr;
-  if (_old_gen->should_allocate(size, is_tlab)) {
+  HeapWord* result = _young_gen->allocate(size);
+
+  if (result == nullptr) {
     result = _old_gen->expand_and_allocate(size);
   }
-  if (result == nullptr) {
-    if (_young_gen->should_allocate(size, is_tlab)) {
-      // Young-gen is not expanded.
-      result = _young_gen->allocate(size);
-    }
-  }
+
   assert(result == nullptr || is_in_reserved(result), "result not in heap");
   return result;
 }
@@ -301,11 +297,9 @@ HeapWord* SerialHeap::mem_allocate_work(size_t size, bool is_tlab) {
   HeapWord* result = nullptr;
 
   for (uint try_count = 1; /* break */; try_count++) {
-    if (_young_gen->should_allocate(size, is_tlab)) {
-      result = _young_gen->par_allocate(size);
-      if (result != nullptr) {
-        break;
-      }
+    result = _young_gen->par_allocate(size);
+    if (result != nullptr) {
+      break;
     }
     // Try old-gen allocation for non-TLAB.
     if (!is_tlab) {
@@ -340,25 +334,6 @@ HeapWord* SerialHeap::mem_allocate_work(size_t size, bool is_tlab) {
 
   assert(result == nullptr || is_in_reserved(result), "postcondition");
   return result;
-}
-
-HeapWord* SerialHeap::attempt_allocation(size_t size,
-                                         bool is_tlab,
-                                         bool first_only) {
-  HeapWord* res = nullptr;
-
-  if (_young_gen->should_allocate(size, is_tlab)) {
-    res = _young_gen->allocate(size);
-    if (res != nullptr || first_only) {
-      return res;
-    }
-  }
-
-  if (_old_gen->should_allocate(size, is_tlab)) {
-    res = _old_gen->allocate(size);
-  }
-
-  return res;
 }
 
 HeapWord* SerialHeap::mem_allocate(size_t size,
@@ -459,15 +434,10 @@ HeapWord* SerialHeap::satisfy_failed_allocation(size_t size, bool is_tlab) {
   HeapWord* result = nullptr;
 
   // If young-gen can handle this allocation, attempt young-gc firstly.
-  bool should_run_young_gc = _young_gen->should_allocate(size, is_tlab);
+  bool should_run_young_gc = is_tlab || size <= _young_gen->eden()->capacity();
   collect_at_safepoint(!should_run_young_gc);
 
-  result = attempt_allocation(size, is_tlab, false /*first_only*/);
-  if (result != nullptr) {
-    return result;
-  }
-
-  // OK, collection failed, try expansion.
+  // Just finished a GC, try to satisfy this allocation, using expansion if needed.
   result = expand_heap_and_allocate(size, is_tlab);
   if (result != nullptr) {
     return result;
@@ -484,10 +454,6 @@ HeapWord* SerialHeap::satisfy_failed_allocation(size_t size, bool is_tlab) {
     do_full_collection(clear_all_soft_refs);
   }
 
-  result = attempt_allocation(size, is_tlab, false /* first_only */);
-  if (result != nullptr) {
-    return result;
-  }
   // The previous full-gc can shrink the heap, so re-expand it.
   result = expand_heap_and_allocate(size, is_tlab);
   if (result != nullptr) {

--- a/src/hotspot/share/gc/serial/serialHeap.hpp
+++ b/src/hotspot/share/gc/serial/serialHeap.hpp
@@ -102,11 +102,6 @@ private:
   // old-gen.
   bool _is_heap_almost_full;
 
-  // Helper functions for allocation
-  HeapWord* attempt_allocation(size_t size,
-                               bool   is_tlab,
-                               bool   first_only);
-
   void do_full_collection(bool clear_all_soft_refs) override;
 
   // Does the "cause" of GC indicate that

--- a/src/hotspot/share/gc/serial/tenuredGeneration.hpp
+++ b/src/hotspot/share/gc/serial/tenuredGeneration.hpp
@@ -135,15 +135,6 @@ public:
   void gc_prologue();
   void gc_epilogue();
 
-  bool should_allocate(size_t word_size, bool is_tlab) {
-    bool result = false;
-    size_t overflow_limit = (size_t)1 << (BitsPerSize_t - LogHeapWordSize);
-    if (!is_tlab) {
-      result = (word_size > 0) && (word_size < overflow_limit);
-    }
-    return result;
-  }
-
   // Performance Counter support
   void update_counters();
 

--- a/src/hotspot/share/gc/shared/gc_globals.hpp
+++ b/src/hotspot/share/gc/shared/gc_globals.hpp
@@ -484,11 +484,6 @@
           "OS specific low limit for heap base address")                    \
           constraint(HeapBaseMinAddressConstraintFunc,AfterErgo)            \
                                                                             \
-  product(size_t, PretenureSizeThreshold, 0,                                \
-          "Maximum size in bytes of objects allocated in DefNew "           \
-          "generation; zero means no maximum")                              \
-          range(0, max_uintx)                                               \
-                                                                            \
   product(uintx, SurvivorRatio, 8,                                          \
           "Ratio of eden/survivor space size")                              \
           range(1, max_uintx-2)                                             \

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -567,6 +567,8 @@ static SpecialFlag const special_jvm_flags[] = {
   { "UseAdaptiveSizePolicyWithSystemGC",                JDK_Version::undefined(), JDK_Version::jdk(26), JDK_Version::jdk(27) },
   { "UsePSAdaptiveSurvivorSizePolicy",                  JDK_Version::undefined(), JDK_Version::jdk(26), JDK_Version::jdk(27) },
 
+  { "PretenureSizeThreshold",       JDK_Version::undefined(), JDK_Version::jdk(26), JDK_Version::jdk(27) },
+
 #ifdef ASSERT
   { "DummyObsoleteTestFlag",        JDK_Version::undefined(), JDK_Version::jdk(18), JDK_Version::undefined() },
 #endif


### PR DESCRIPTION
Remove obj-size checking before young/old-gen allocation -- an allocation succeeds iff there is enough free space.

This simplifies the allocation logic:
1. before attempting gc: `mem_allocate_work` does young-gen allocation then old-gen-no-expansion allocation
2. after gc (still inside gc safepoint): `satisfy_failed_allocation` does young-gen allocation old-gen-with-expansion allocation

Test: tier1-3

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8366156](https://bugs.openjdk.org/browse/JDK-8366156) to be approved

### Issues
 * [JDK-8366155](https://bugs.openjdk.org/browse/JDK-8366155): Serial: Obsolete PretenureSizeThreshold (**Enhancement** - P4)
 * [JDK-8366156](https://bugs.openjdk.org/browse/JDK-8366156): Serial: Obsolete PretenureSizeThreshold (**CSR**)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)

### Reviewers without OpenJDK IDs
 * @fandreuz (no known openjdk.org user name / role)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26941/head:pull/26941` \
`$ git checkout pull/26941`

Update a local copy of the PR: \
`$ git checkout pull/26941` \
`$ git pull https://git.openjdk.org/jdk.git pull/26941/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26941`

View PR using the GUI difftool: \
`$ git pr show -t 26941`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26941.diff">https://git.openjdk.org/jdk/pull/26941.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26941#issuecomment-3223857216)
</details>
