### PR TITLE
8366126: Feedback on two errors in JSR 400

### DIFF
--- a/src/java.base/share/classes/java/security/spec/EncodedKeySpec.java
+++ b/src/java.base/share/classes/java/security/spec/EncodedKeySpec.java
@@ -79,7 +79,6 @@ public abstract class EncodedKeySpec implements KeySpec {
      * <a href="{@docRoot}/../specs/security/standard-names.html#asymmetrickey-algorithms">
      * Java Security Standard Algorithm Names Specification</a>
      * for information about standard asymmetric key algorithm names.
-     * @spec security/standard-names.html Java Security Standard Algorithm Names
      * @throws NullPointerException if {@code encodedKey}
      * or {@code algorithm} is null.
      * @throws IllegalArgumentException if {@code algorithm} is

--- a/src/java.base/share/classes/java/security/spec/PKCS8EncodedKeySpec.java
+++ b/src/java.base/share/classes/java/security/spec/PKCS8EncodedKeySpec.java
@@ -101,7 +101,6 @@ public non-sealed class PKCS8EncodedKeySpec extends EncodedKeySpec implements
      * <a href="{@docRoot}/../specs/security/standard-names.html#asymmetrickey-algorithms">
      * Java Security Standard Algorithm Names Specification</a>
      * for information about standard asymmetric key algorithm names.
-     * @spec security/standard-names.html Java Security Standard Algorithm Names
      * @throws NullPointerException if {@code encodedKey}
      * or {@code algorithm} is null.
      * @throws IllegalArgumentException if {@code algorithm} is

--- a/src/java.base/share/classes/java/security/spec/X509EncodedKeySpec.java
+++ b/src/java.base/share/classes/java/security/spec/X509EncodedKeySpec.java
@@ -80,7 +80,6 @@ public non-sealed class X509EncodedKeySpec extends EncodedKeySpec implements
      * <a href="{@docRoot}/../specs/security/standard-names.html#asymmetrickey-algorithms">
      * Java Security Standard Algorithm Names Specification</a>
      * for information about standard asymmetric key algorithm names.
-     * @spec security/standard-names.html Java Security Standard Algorithm Names
      * @throws NullPointerException if {@code encodedKey}
      * or {@code algorithm} is null.
      * @throws IllegalArgumentException if {@code algorithm} is


### PR DESCRIPTION
Remove redundant `@spec` tags.

Note: the RMI spec fixed mentioned in the same bug will be fixed in the doc repo.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8366126](https://bugs.openjdk.org/browse/JDK-8366126): Feedback on two errors in JSR 400 (**Bug** - P4)


### Reviewers
 * [Hai-May Chao](https://openjdk.org/census#hchao) (@haimaychao - **Reviewer**)
 * [Bradford Wetmore](https://openjdk.org/census#wetmore) (@bradfordwetmore - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26945/head:pull/26945` \
`$ git checkout pull/26945`

Update a local copy of the PR: \
`$ git checkout pull/26945` \
`$ git pull https://git.openjdk.org/jdk.git pull/26945/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26945`

View PR using the GUI difftool: \
`$ git pr show -t 26945`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26945.diff">https://git.openjdk.org/jdk/pull/26945.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26945#issuecomment-3224910665)
</details>
