### PR TITLE
8366193: Add comments about ResolvedFieldEntry::copy_from()

### DIFF
--- a/src/hotspot/share/oops/resolvedFieldEntry.hpp
+++ b/src/hotspot/share/oops/resolvedFieldEntry.hpp
@@ -80,7 +80,7 @@ public:
   ResolvedFieldEntry() :
     ResolvedFieldEntry(0) {}
 
-  // Notes on copy constructor, copy assignment operator, and copy_from(). 
+  // Notes on copy constructor, copy assignment operator, and copy_from().
   // These are necessary for generating deterministic CDS archives.
   //
   // We have some unused padding on 64-bit platforms (4 bytes at the tail end).

--- a/src/hotspot/share/oops/resolvedFieldEntry.hpp
+++ b/src/hotspot/share/oops/resolvedFieldEntry.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -80,10 +80,38 @@ public:
   ResolvedFieldEntry() :
     ResolvedFieldEntry(0) {}
 
+  // Notes on copy constructor, copy assignment operator, and copy_from(). 
+  // These are necessary for generating deterministic CDS archives.
+  //
+  // We have some unused padding on 64-bit platforms (4 bytes at the tail end).
+  //
+  // When ResolvedFieldEntries in a ConstantPoolCache are allocated from the metaspace,
+  // their entire content (including the padding) is filled with zeros. They are
+  // then initialized with initialize_resolved_entries_array() in cpCache.cpp from a
+  // GrowableArray.
+  //
+  // The GrowableArray is initialized in rewriter.cpp, using ResolvedFieldEntries that
+  // are originally allocated from the C++ stack. Functions like GrowableArray::expand_to()
+  // will also allocate ResolvedFieldEntries from the stack. These may have random bits
+  // in the padding as the C++ compiler is allowed to leave the padding in uninitialized
+  // states.
+  //
+  // If we use the default copy constructor and/or default copy assignment operator,
+  // the random padding will be copied into the GrowableArray, from there
+  // to the ConstantPoolCache, and eventually to the CDS archive. As a result, the
+  // CDS archive will contain random bits, causing failures in
+  // test/hotspot/jtreg/runtime/cds/DeterministicDump.java (usually on Windows).
+  //
+  // By using copy_from(), we can prevent the random padding from being copied,
+  // ensuring that the ResolvedFieldEntries in a ConstantPoolCache (and thus the
+  // CDS archive) will have all zeros in the padding.
+
+  // Copy constructor
   ResolvedFieldEntry(const ResolvedFieldEntry& other) {
     copy_from(other);
   }
 
+  // Copy assignment operator
   ResolvedFieldEntry& operator=(const ResolvedFieldEntry& other) {
     copy_from(other);
     return *this;

--- a/src/hotspot/share/oops/resolvedIndyEntry.hpp
+++ b/src/hotspot/share/oops/resolvedIndyEntry.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,6 +52,9 @@ class ResolvedIndyEntry {
   u1 _flags;                     // Flags: [0000|00|has_appendix|resolution_failed]
 
 public:
+  // The copy_from() pattern in resolvedFieldEntry.hpp is not necessary
+  // as we have no unused padding (on 32- or 64-bit platforms).
+
   ResolvedIndyEntry() :
     _method(nullptr),
     _resolved_references_index(0),

--- a/src/hotspot/share/oops/resolvedMethodEntry.hpp
+++ b/src/hotspot/share/oops/resolvedMethodEntry.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -82,6 +82,8 @@ class ResolvedMethodEntry {
   bool _has_table_index;
 #endif
 
+  // See comments in resolvedFieldEntry.hpp about copy_from and padding.
+  // We have unused padding on debug builds.
   void copy_from(const ResolvedMethodEntry& other) {
     _method = other._method;
     _entry_specific = other._entry_specific;


### PR DESCRIPTION
[JDK-8293980](https://bugs.openjdk.org/browse/JDK-8293980) added `ResolvedFieldEntry::copy_from()` to prevent random bits in the CDS archive. However, I forgot to add a comment to explain why this is necessary.

This PR adds the missing comment, which will be useful if we consider alternative solutions (using `memset()` in constructor??) in the future.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8366193](https://bugs.openjdk.org/browse/JDK-8366193): Add comments about ResolvedFieldEntry::copy_from() (**Enhancement** - P4)


### Reviewers
 * [Andrew Dinn](https://openjdk.org/census#adinn) (@adinn - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26946/head:pull/26946` \
`$ git checkout pull/26946`

Update a local copy of the PR: \
`$ git checkout pull/26946` \
`$ git pull https://git.openjdk.org/jdk.git pull/26946/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26946`

View PR using the GUI difftool: \
`$ git pr show -t 26946`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26946.diff">https://git.openjdk.org/jdk/pull/26946.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26946#issuecomment-3225025722)
</details>
