### PR TITLE
4138921: TextLayout handling of empty strings

### DIFF
--- a/src/java.desktop/share/classes/java/awt/font/TextLayout.java
+++ b/src/java.desktop/share/classes/java/awt/font/TextLayout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -256,7 +256,6 @@ public final class TextLayout implements Cloneable {
      */
     private boolean cacheIsValid = false;
 
-
     // This value is obtained from an attribute, and constrained to the
     // interval [0,1].  If 0, the layout cannot be justified.
     private float justifyRatio;
@@ -367,6 +366,7 @@ public final class TextLayout implements Cloneable {
      *       device resolution, and attributes such as antialiasing.  This
      *       parameter does not specify a translation between the
      *       {@code TextLayout} and user space.
+     * @throws IllegalArgumentException if any of the parameters are null.
      */
     public TextLayout(String string, Font font, FontRenderContext frc) {
 
@@ -378,8 +378,8 @@ public final class TextLayout implements Cloneable {
             throw new IllegalArgumentException("Null string passed to TextLayout constructor.");
         }
 
-        if (string.length() == 0) {
-            throw new IllegalArgumentException("Zero length string passed to TextLayout constructor.");
+        if (frc == null) {
+            throw new IllegalArgumentException("Null font render context passed to TextLayout constructor.");
         }
 
         Map<? extends Attribute, ?> attributes = null;
@@ -415,6 +415,7 @@ public final class TextLayout implements Cloneable {
      *       device resolution, and attributes such as antialiasing.  This
      *       parameter does not specify a translation between the
      *       {@code TextLayout} and user space.
+     * @throws IllegalArgumentException if any of the parameters are null.
      */
     public TextLayout(String string, Map<? extends Attribute,?> attributes,
                       FontRenderContext frc)
@@ -427,8 +428,8 @@ public final class TextLayout implements Cloneable {
             throw new IllegalArgumentException("Null map passed to TextLayout constructor.");
         }
 
-        if (string.length() == 0) {
-            throw new IllegalArgumentException("Zero length string passed to TextLayout constructor.");
+        if (frc == null) {
+            throw new IllegalArgumentException("Null font render context passed to TextLayout constructor.");
         }
 
         char[] text = string.toCharArray();
@@ -499,6 +500,7 @@ public final class TextLayout implements Cloneable {
      *       device resolution, and attributes such as antialiasing.  This
      *       parameter does not specify a translation between the
      *       {@code TextLayout} and user space.
+     * @throws IllegalArgumentException if any of the parameters are null.
      */
     public TextLayout(AttributedCharacterIterator text, FontRenderContext frc) {
 
@@ -506,12 +508,12 @@ public final class TextLayout implements Cloneable {
             throw new IllegalArgumentException("Null iterator passed to TextLayout constructor.");
         }
 
-        int start = text.getBeginIndex();
-        int limit = text.getEndIndex();
-        if (start == limit) {
-            throw new IllegalArgumentException("Zero length iterator passed to TextLayout constructor.");
+        if (frc == null) {
+            throw new IllegalArgumentException("Null font render context passed to TextLayout constructor.");
         }
 
+        int start = text.getBeginIndex();
+        int limit = text.getEndIndex();
         int len = limit - start;
         text.first();
         char[] chars = new char[len];
@@ -1125,7 +1127,12 @@ public final class TextLayout implements Cloneable {
         float top1X, top2X;
         float bottom1X, bottom2X;
 
-        if (caret == 0 || caret == characterCount) {
+        if (caret == 0 && characterCount == 0) {
+
+            top1X = top2X = 0;
+            bottom1X = bottom2X = 0;
+
+        } else if (caret == 0 || caret == characterCount) {
 
             float pos;
             int logIndex;
@@ -1143,8 +1150,8 @@ public final class TextLayout implements Cloneable {
             pos += angle * shift;
             top1X = top2X = pos + angle*textLine.getCharAscent(logIndex);
             bottom1X = bottom2X = pos - angle*textLine.getCharDescent(logIndex);
-        }
-        else {
+
+        } else {
 
             {
                 int logIndex = textLine.visualToLogical(caret-1);
@@ -1884,7 +1891,6 @@ public final class TextLayout implements Cloneable {
         Shape[] result = new Shape[2];
 
         TextHitInfo hit = TextHitInfo.afterOffset(offset);
-
         int hitCaret = hitToCaret(hit);
 
         LayoutPathImpl lp = textLine.getLayoutPath();
@@ -2180,11 +2186,15 @@ public final class TextLayout implements Cloneable {
         checkTextHit(firstEndpoint);
         checkTextHit(secondEndpoint);
 
-        if(bounds == null) {
-                throw new IllegalArgumentException("Null Rectangle2D passed to TextLayout.getVisualHighlightShape()");
+        if (bounds == null) {
+            throw new IllegalArgumentException("Null Rectangle2D passed to TextLayout.getVisualHighlightShape()");
         }
 
         GeneralPath result = new GeneralPath(GeneralPath.WIND_EVEN_ODD);
+
+        if (characterCount == 0) {
+            return result;
+        }
 
         int firstCaret = hitToCaret(firstEndpoint);
         int secondCaret = hitToCaret(secondEndpoint);
@@ -2194,8 +2204,9 @@ public final class TextLayout implements Cloneable {
 
         if (firstCaret == 0 || secondCaret == 0) {
             GeneralPath ls = leftShape(bounds);
-            if (!ls.getBounds().isEmpty())
+            if (!ls.getBounds().isEmpty()) {
                 result.append(ls, false);
+            }
         }
 
         if (firstCaret == characterCount || secondCaret == characterCount) {
@@ -2282,11 +2293,15 @@ public final class TextLayout implements Cloneable {
             secondEndpoint = t;
         }
 
-        if(firstEndpoint < 0 || secondEndpoint > characterCount) {
+        if (firstEndpoint < 0 || secondEndpoint > characterCount) {
             throw new IllegalArgumentException("Range is invalid in TextLayout.getLogicalHighlightShape()");
         }
 
         GeneralPath result = new GeneralPath(GeneralPath.WIND_EVEN_ODD);
+
+        if (characterCount == 0) {
+            return result;
+        }
 
         int[] carets = new int[10]; // would this ever not handle all cases?
         int count = 0;

--- a/src/java.desktop/share/classes/java/awt/font/TextLine.java
+++ b/src/java.desktop/share/classes/java/awt/font/TextLine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -836,13 +836,17 @@ final class TextLine {
         }
 
         if (result == null) {
-            result = new Rectangle2D.Float(Float.MAX_VALUE, Float.MAX_VALUE, Float.MIN_VALUE, Float.MIN_VALUE);
+            result = new Rectangle2D.Float(0, 0, 0, 0);
         }
 
         return result;
     }
 
     public Rectangle2D getItalicBounds() {
+
+        if (fComponents.length == 0) {
+            return new Rectangle2D.Float(0, 0, 0, 0);
+        }
 
         float left = Float.MAX_VALUE, right = -Float.MAX_VALUE;
         float top = Float.MAX_VALUE, bottom = -Float.MAX_VALUE;
@@ -927,7 +931,7 @@ final class TextLine {
         // dlf: get baseRot from font for now???
 
         if (!requiresBidi) {
-            requiresBidi = Bidi.requiresBidi(chars, 0, chars.length);
+            requiresBidi = Bidi.requiresBidi(chars, 0, characterCount);
         }
 
         if (requiresBidi) {
@@ -935,7 +939,7 @@ final class TextLine {
               ? Bidi.DIRECTION_DEFAULT_LEFT_TO_RIGHT
               : values.getRunDirection();
 
-          bidi = new Bidi(chars, 0, embs, 0, chars.length, bidiflags);
+          bidi = new Bidi(chars, 0, embs, 0, characterCount, bidiflags);
           if (!bidi.isLeftToRight()) {
               levels = BidiUtils.getLevels(bidi);
               int[] charsVtoL = BidiUtils.createVisualToLogicalMap(levels);
@@ -945,13 +949,11 @@ final class TextLine {
         }
 
         Decoration decorator = Decoration.getDecoration(values);
-
         int layoutFlags = 0; // no extra info yet, bidi determines run and line direction
         TextLabelFactory factory = new TextLabelFactory(frc, chars, bidi, layoutFlags);
 
         TextLineComponent[] components = new TextLineComponent[1];
-
-        components = createComponentsOnRun(0, chars.length,
+        components = createComponentsOnRun(0, characterCount,
                                            chars,
                                            charsLtoV, levels,
                                            factory, font, lm,
@@ -972,7 +974,7 @@ final class TextLine {
         }
 
         return new TextLine(frc, components, lm.baselineOffsets,
-                            chars, 0, chars.length, charsLtoV, levels, isDirectionLTR);
+                            chars, 0, characterCount, charsLtoV, levels, isDirectionLTR);
     }
 
     private static TextLineComponent[] expandArray(TextLineComponent[] orig) {

--- a/src/java.desktop/share/classes/sun/font/TextLabelFactory.java
+++ b/src/java.desktop/share/classes/sun/font/TextLabelFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -119,7 +119,7 @@ public final class TextLabelFactory {
                                           int start,
                                           int limit) {
 
-    if (start >= limit || start < lineStart || limit > lineLimit) {
+    if (start > limit || start < lineStart || limit > lineLimit) {
       throw new IllegalArgumentException("bad start: " + start + " or limit: " + limit);
     }
 
@@ -145,7 +145,7 @@ public final class TextLabelFactory {
                                 int start,
                                 int limit) {
 
-    if (start >= limit || start < lineStart || limit > lineLimit) {
+    if (start > limit || start < lineStart || limit > lineLimit) {
       throw new IllegalArgumentException("bad start: " + start + " or limit: " + limit);
     }
 

--- a/test/jdk/java/awt/font/TextLayout/TextLayoutConstructorTest.java
+++ b/test/jdk/java/awt/font/TextLayout/TextLayoutConstructorTest.java
@@ -150,7 +150,7 @@ public class TextLayoutConstructorTest {
         assertEqual(0, tl.getVisibleAdvance(), "visible advance");
         assertEqual(ref.getAscent(), tl.getAscent(), "ascent");
         assertEqual(ref.getDescent(), tl.getDescent(), "descent");
-        assertEqual(0, tl.getLeading(), "leading");
+        assertEqual(ref.getLeading(), tl.getLeading(), "leading");
         assertEqual(zero2D, tl.getBounds(), "bounds");
         assertEqual(zero2D, tl.getPixelBounds(frc, 0, 0), "pixel bounds 1");
         assertEqual(oneTwo, tl.getPixelBounds(frc, 1, 2), "pixel bounds 2");

--- a/test/jdk/java/awt/font/TextLayout/TextLayoutConstructorTest.java
+++ b/test/jdk/java/awt/font/TextLayout/TextLayoutConstructorTest.java
@@ -1,0 +1,316 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4138921
+ * @summary Confirm constructor behavior for various edge cases.
+ */
+
+import java.awt.Font;
+import java.awt.Graphics2D;
+import java.awt.Rectangle;
+import java.awt.Shape;
+import java.awt.font.FontRenderContext;
+import java.awt.font.TextAttribute;
+import java.awt.font.TextHitInfo;
+import java.awt.font.TextLayout;
+import java.awt.geom.AffineTransform;
+import java.awt.geom.Point2D;
+import java.awt.geom.Rectangle2D;
+import java.awt.image.BufferedImage;
+import java.text.AttributedCharacterIterator;
+import java.text.AttributedString;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+
+public class TextLayoutConstructorTest {
+
+    public static void main(String[] args) throws Exception {
+        testFontConstructor();
+        testMapConstructor();
+        testIteratorConstructor();
+    }
+
+    private static void testFontConstructor() {
+
+        // new TextLayout(String, Font, FontRenderContext)
+
+        Font font = new Font(Font.DIALOG, Font.PLAIN, 20);
+        FontRenderContext frc = new FontRenderContext(null, true, true);
+
+        assertThrows(() -> new TextLayout(null, font, frc),
+            IllegalArgumentException.class,
+            "Null string passed to TextLayout constructor.");
+
+        assertThrows(() -> new TextLayout("test", (Font) null, frc),
+            IllegalArgumentException.class,
+            "Null font passed to TextLayout constructor.");
+
+        assertThrows(() -> new TextLayout("test", font, null),
+            IllegalArgumentException.class,
+            "Null font render context passed to TextLayout constructor.");
+
+        Function< String, TextLayout > creator = (s) -> new TextLayout(s, font, frc);
+        assertEmptyTextLayoutBehavior(creator);
+    }
+
+    private static void testMapConstructor() {
+
+        // new TextLayout(String, Map, FontRenderContext)
+
+        Map< TextAttribute, Object > attributes = Map.of(TextAttribute.WEIGHT, TextAttribute.WEIGHT_BOLD);
+        FontRenderContext frc = new FontRenderContext(null, true, true);
+
+        assertThrows(() -> new TextLayout(null, attributes, frc),
+            IllegalArgumentException.class,
+            "Null string passed to TextLayout constructor.");
+
+        assertThrows(() -> new TextLayout("test", (Map) null, frc),
+            IllegalArgumentException.class,
+            "Null map passed to TextLayout constructor.");
+
+        assertThrows(() -> new TextLayout("test", attributes, null),
+            IllegalArgumentException.class,
+            "Null font render context passed to TextLayout constructor.");
+
+        Function< String, TextLayout > creator = (s) -> new TextLayout(s, attributes, frc);
+        assertEmptyTextLayoutBehavior(creator);
+    }
+
+    private static void testIteratorConstructor() {
+
+        // new TextLayout(AttributedCharacterIterator, FontRenderContext)
+
+        Map< TextAttribute, Object > attributes = Map.of();
+        FontRenderContext frc = new FontRenderContext(null, true, true);
+
+        assertThrows(() -> new TextLayout(null, frc),
+            IllegalArgumentException.class,
+            "Null iterator passed to TextLayout constructor.");
+
+        AttributedCharacterIterator it1 = new AttributedString("test", attributes).getIterator();
+        assertThrows(() -> new TextLayout(it1, null),
+            IllegalArgumentException.class,
+            "Null font render context passed to TextLayout constructor.");
+
+        Function< String, TextLayout > creator = (s) -> {
+            AttributedCharacterIterator it2 = new AttributedString(s, attributes).getIterator();
+            return new TextLayout(it2, frc);
+        };
+        assertEmptyTextLayoutBehavior(creator);
+    }
+
+    private static void assertEmptyTextLayoutBehavior(Function< String, TextLayout > creator) {
+
+        TextLayout tl = creator.apply("");
+        TextLayout ref = creator.apply(" "); // space
+        FontRenderContext frc = new FontRenderContext(null, true, true);
+        Rectangle zero = new Rectangle(0, 0, 0, 0);
+        Rectangle2D.Float zero2D = new Rectangle2D.Float(0, 0, 0, 0);
+        Rectangle2D.Float oneTwo = new Rectangle2D.Float(1, 2, 0, 0);
+        Rectangle2D.Float kilo = new Rectangle2D.Float(0, 0, 1000, 1000);
+        AffineTransform identity = new AffineTransform();
+        TextLayout.CaretPolicy policy = new TextLayout.CaretPolicy();
+        TextHitInfo start = TextHitInfo.trailing(-1);
+        TextHitInfo end = TextHitInfo.leading(0);
+
+        assertEqual(0, tl.getJustifiedLayout(100).getAdvance(), "justified advance");
+        assertEqual(0, tl.getBaseline(), "baseline");
+
+        float[] offsets = tl.getBaselineOffsets();
+        float[] refOffsets = ref.getBaselineOffsets();
+        assertEqual(3, offsets.length, "baseline offsets");
+        assertEqual(refOffsets[0], offsets[0], "baseline offset 1");
+        assertEqual(refOffsets[1], offsets[1], "baseline offset 2");
+        assertEqual(refOffsets[2], offsets[2], "baseline offset 3");
+
+        assertEqual(0, tl.getAdvance(), "advance");
+        assertEqual(0, tl.getVisibleAdvance(), "visible advance");
+        assertEqual(ref.getAscent(), tl.getAscent(), "ascent");
+        assertEqual(ref.getDescent(), tl.getDescent(), "descent");
+        assertEqual(0, tl.getLeading(), "leading");
+        assertEqual(zero2D, tl.getBounds(), "bounds");
+        assertEqual(zero2D, tl.getPixelBounds(frc, 0, 0), "pixel bounds 1");
+        assertEqual(oneTwo, tl.getPixelBounds(frc, 1, 2), "pixel bounds 2");
+        assertEqual(true, tl.isLeftToRight(), "left to right");
+        assertEqual(false, tl.isVertical(), "is vertical");
+        assertEqual(0, tl.getCharacterCount(), "character count");
+
+        float[] caretInfo = tl.getCaretInfo(start, kilo);
+        float[] refCaretInfo = ref.getCaretInfo(start, kilo);
+        assertEqual(6, caretInfo.length, "caret info length 1");
+        assertEqual(refCaretInfo[0], caretInfo[0], "first caret info 1");
+        assertEqual(refCaretInfo[1], caretInfo[1], "second caret info 1");
+        assertEqual(refCaretInfo[2], caretInfo[2], "third caret info 1");
+        assertEqual(refCaretInfo[3], caretInfo[3], "fourth caret info 1");
+        assertEqual(refCaretInfo[4], caretInfo[4], "fifth caret info 1");
+        assertEqual(refCaretInfo[5], caretInfo[5], "sixth caret info 1");
+
+        float[] caretInfo2 = tl.getCaretInfo(start);
+        float[] refCaretInfo2 = ref.getCaretInfo(start);
+        assertEqual(6, caretInfo2.length, "caret info length 2");
+        assertEqual(refCaretInfo2[0], caretInfo2[0], "first caret info 2");
+        assertEqual(refCaretInfo2[1], caretInfo2[1], "second caret info 2");
+        assertEqual(refCaretInfo2[2], caretInfo2[2], "third caret info 2");
+        assertEqual(refCaretInfo2[3], caretInfo2[3], "fourth caret info 2");
+        assertEqual(refCaretInfo2[4], caretInfo2[4], "fifth caret info 2");
+        assertEqual(refCaretInfo2[5], caretInfo2[5], "sixth caret info 2");
+
+        assertEqual(null, tl.getNextRightHit(start), "next right hit 1");
+        assertEqual(null, tl.getNextRightHit(end), "next right hit 2");
+        assertEqual(null, tl.getNextRightHit(0, policy), "next right hit 3");
+        assertEqual(null, tl.getNextRightHit(0), "next right hit 4");
+        assertEqual(null, tl.getNextLeftHit(start), "next left hit 1");
+        assertEqual(null, tl.getNextLeftHit(end), "next left hit 2");
+        assertEqual(null, tl.getNextLeftHit(0, policy), "next left hit 3");
+        assertEqual(null, tl.getNextLeftHit(0), "next left hit 4");
+        assertEqual(end, tl.getVisualOtherHit(start), "visual other hit");
+
+        Shape caretShape = tl.getCaretShape(start, kilo);
+        Shape refCaretShape = ref.getCaretShape(start, kilo);
+        assertEqual(refCaretShape.getBounds(), caretShape.getBounds(), "caret shape 1");
+
+        Shape caretShape2 = tl.getCaretShape(start);
+        Shape refCaretShape2 = ref.getCaretShape(start);
+        assertEqual(refCaretShape2.getBounds(), caretShape2.getBounds(), "caret shape 2");
+
+        assertEqual(0, tl.getCharacterLevel(0), "character level");
+
+        Shape[] caretShapes = tl.getCaretShapes(0, kilo, policy);
+        Shape[] refCaretShapes = ref.getCaretShapes(0, kilo, policy);
+        assertEqual(2, caretShapes.length, "caret shapes length 1");
+        assertEqual(refCaretShapes[0].getBounds(), caretShapes[0].getBounds(), "caret shapes strong 1");
+        assertEqual(refCaretShapes[1], caretShapes[1], "caret shapes weak 1");
+        assertEqual(null, caretShapes[1], "caret shapes weak 1");
+
+        Shape[] caretShapes2 = tl.getCaretShapes(0, kilo);
+        Shape[] refCaretShapes2 = ref.getCaretShapes(0, kilo);
+        assertEqual(2, caretShapes2.length, "caret shapes length 2");
+        assertEqual(refCaretShapes2[0].getBounds(), caretShapes2[0].getBounds(), "caret shapes strong 2");
+        assertEqual(refCaretShapes2[1], caretShapes2[1], "caret shapes weak 2");
+        assertEqual(null, caretShapes2[1], "caret shapes weak 2");
+
+        Shape[] caretShapes3 = tl.getCaretShapes(0);
+        Shape[] refCaretShapes3 = ref.getCaretShapes(0);
+        assertEqual(2, caretShapes3.length, "caret shapes length 3");
+        assertEqual(refCaretShapes3[0].getBounds(), caretShapes3[0].getBounds(), "caret shapes strong 3");
+        assertEqual(refCaretShapes3[1], caretShapes3[1], "caret shapes weak 3");
+        assertEqual(null, caretShapes3[1], "caret shapes weak 3");
+
+        assertEqual(0, tl.getLogicalRangesForVisualSelection(start, start).length, "logical ranges for visual selection");
+        assertEqual(zero2D, tl.getVisualHighlightShape(start, start, kilo).getBounds(), "visual highlight shape 1");
+        assertEqual(zero2D, tl.getVisualHighlightShape(start, start).getBounds(), "visual highlight shape 2");
+        assertEqual(zero, tl.getLogicalHighlightShape(0, 0, kilo).getBounds(), "logical highlight shape 1");
+        assertEqual(zero, tl.getLogicalHighlightShape(0, 0).getBounds(), "logical highlight shape 2");
+        assertEqual(zero, tl.getBlackBoxBounds(0, 0).getBounds(), "black box bounds");
+
+        TextHitInfo hit = tl.hitTestChar(0, 0);
+        assertEqual(-1, hit.getCharIndex(), "hit test char index 1");
+        assertEqual(false, hit.isLeadingEdge(), "hit test leading edge 1");
+
+        TextHitInfo hit2 = tl.hitTestChar(0, 0, kilo);
+        assertEqual(-1, hit2.getCharIndex(), "hit test char index 2");
+        assertEqual(false, hit2.isLeadingEdge(), "hit test leading edge 2");
+
+        assertEqual(false, tl.equals(creator.apply("")), "equals");
+        assertEqual(false, tl.toString().isEmpty(), "to string");
+        assertDoesNotDraw(tl);
+        assertEqual(zero2D, tl.getOutline(identity).getBounds(), "outline");
+        assertEqual(null, tl.getLayoutPath(), "layout path");
+
+        Point2D.Float point = new Point2D.Float(7, 7);
+        tl.hitToPoint(start, point);
+        assertEqual(0, point.x, "hit to point x");
+        assertEqual(0, point.y, "hit to point y");
+    }
+
+    private static void assertEqual(int expected, int actual, String name) {
+        if (expected != actual) {
+            throw new RuntimeException("Expected " + name + " = " + expected + ", but got " + actual);
+        }
+    }
+
+    private static void assertEqual(float expected, float actual, String name) {
+        if (expected != actual) {
+            throw new RuntimeException("Expected " + name + " = " + expected + ", but got " + actual);
+        }
+    }
+
+    private static void assertEqual(boolean expected, boolean actual, String name) {
+        if (expected != actual) {
+            throw new RuntimeException("Expected " + name + " = " + expected + ", but got " + actual);
+        }
+    }
+
+    private static void assertEqual(Object expected, Object actual, String name) {
+        if (!Objects.equals(expected, actual)) {
+            throw new RuntimeException("Expected " + name + " = " + expected + ", but got " + actual);
+        }
+    }
+
+    private static void assertThrows(Runnable r, Class< ? > type, String message) {
+        Class< ? > actualType;
+        String actualMessage;
+        Exception actualException;
+        try {
+            r.run();
+            actualType = null;
+            actualMessage = null;
+            actualException = null;
+        } catch (Exception e) {
+            actualType = e.getClass();
+            actualMessage = e.getMessage();
+            actualException = e;
+        }
+        if (!Objects.equals(type, actualType)) {
+            throw new RuntimeException(type + " != " + actualType, actualException);
+        }
+        if (!Objects.equals(message, actualMessage)) {
+            throw new RuntimeException(message + " != " + actualMessage, actualException);
+        }
+    }
+
+    private static void assertDoesNotDraw(TextLayout layout) {
+
+        int w = 200;
+        int h = 200;
+        BufferedImage image = new BufferedImage(w, h, BufferedImage.TYPE_BYTE_BINARY);
+        Graphics2D g2d = image.createGraphics();
+        int expected = image.getRGB(0, 0);
+
+        layout.draw(g2d, w / 2f, h / 2f); // should not actually draw anything
+
+        int[] rowPixels = new int[w];
+        for (int y = 0; y < h; y++) {
+            image.getRGB(0, y, w, 1, rowPixels, 0, w);
+            for (int x = 0; x < w; x++) {
+                if (rowPixels[x] != expected) {
+                    throw new RuntimeException(
+                        "pixel (" + x + ", " + y +"): " + expected + " != " + rowPixels[x]);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
`TextLayout` should deal more gracefully with zero length strings. Currently the exception listed below is the one that is thrown.

`new TextLayout("", f, new FontRenderContext(null, false, false));`

> Exception in thread "main" java.lang.IllegalArgumentException: Zero length
> string passed to TextLayout constructor.
> at java.lang.Throwable.<init>(Compiled Code)
> at java.lang.Exception.<init>(Compiled Code)
> at java.lang.RuntimeException.<init>(Compiled Code)
> at java.lang.IllegalArgumentException.<init>(Compiled Code)
> at java.awt.font.TextLayout.<init>(Compiled Code)
> at test.main(Compiled Code)

**REVIEWER NOTE:** Please check the empty-string `TextLayout` behavior documented in `TextLayoutConstructorTest` carefully; a badly-behaving empty `TextLayout` is probably worse than a `TextLayout` which doesn't allow empty strings...