### PR TITLE
8365939: [Redo] G1: Move collection set related full gc reset code into abandon_collection_set() method

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -2797,6 +2797,8 @@ void G1CollectedHeap::abandon_collection_set() {
   collection_set()->stop_incremental_building();
 
   collection_set()->abandon_all_candidates();
+
+  young_regions_cset_group()->clear(true /* uninstall_group_cardset */);
 }
 
 bool G1CollectedHeap::is_old_gc_alloc_region(G1HeapRegion* hr) {

--- a/src/hotspot/share/gc/g1/g1FullCollector.cpp
+++ b/src/hotspot/share/gc/g1/g1FullCollector.cpp
@@ -244,11 +244,6 @@ void G1FullCollector::complete_collection(size_t allocation_word_size) {
 
   _heap->resize_all_tlabs();
 
-  // We clear remembered sets for young regions this late in the full GC because
-  // G1HeapVerifier expects the remembered sets for all young regions to be complete
-  // throughout most of the collection process (e.g. G1FullCollector::verify_after_marking).
-  _heap->young_regions_cset_group()->clear();
-
   _heap->policy()->record_full_collection_end();
   _heap->gc_epilogue(true);
 

--- a/src/hotspot/share/gc/g1/g1HeapVerifier.cpp
+++ b/src/hotspot/share/gc/g1/g1HeapVerifier.cpp
@@ -235,6 +235,8 @@ private:
   VerifyOption     _vo;
   bool             _failures;
 
+  bool is_in_full_gc() const { return G1CollectedHeap::heap()->collector_state()->in_full_gc(); }
+
 public:
   VerifyRegionClosure(VerifyOption vo)
     : _vo(vo),
@@ -246,7 +248,7 @@ public:
 
   bool do_heap_region(G1HeapRegion* r) {
     guarantee(!r->has_index_in_opt_cset(), "Region %u still has opt collection set index %u", r->hrm_index(), r->index_in_opt_cset());
-    guarantee(!r->is_young() || r->rem_set()->is_complete(), "Remembered set for Young region %u must be complete, is %s", r->hrm_index(), r->rem_set()->get_state_str());
+    guarantee(is_in_full_gc() || !r->is_young() || r->rem_set()->is_complete(), "Remembered set for Young region %u must be complete outside full gc, is %s", r->hrm_index(), r->rem_set()->get_state_str());
     // Humongous and old regions regions might be of any state, so can't check here.
     guarantee(!r->is_free() || !r->rem_set()->is_tracked(), "Remembered set for free region %u must be untracked, is %s", r->hrm_index(), r->rem_set()->get_state_str());
 


### PR DESCRIPTION
Hi all,

  please review this attempt on clearing the young regions cset group early in `abandon_collection_set()` during full gc.

The initial attempt failed because some verification code depended on the young gen remembered set being `Complete` and contain valid card entries.

This change fixes both:

- we need to clear the `young_regions_cset_group` with `uninstall_group_cardsets` being `true` to a) remove the cards and b) make it incomplete
- some verification expects that the young gen remset is always complete, which is not necessary during full gc.

Test: tier1-5, the failing test that caused the failures in JDK-8365780 passes always.

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8365939](https://bugs.openjdk.org/browse/JDK-8365939): [Redo] G1: Move collection set related full gc reset code into abandon_collection_set() method (**Enhancement** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26948/head:pull/26948` \
`$ git checkout pull/26948`

Update a local copy of the PR: \
`$ git checkout pull/26948` \
`$ git pull https://git.openjdk.org/jdk.git pull/26948/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26948`

View PR using the GUI difftool: \
`$ git pr show -t 26948`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26948.diff">https://git.openjdk.org/jdk/pull/26948.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26948#issuecomment-3228481142)
</details>
