### PR TITLE
8362335: [macos] Change value of CFBundleDevelopmentRegion from "English" to "en-US"

### DIFF
--- a/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/resources/ApplicationRuntime-Info.plist.template
+++ b/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/resources/ApplicationRuntime-Info.plist.template
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
         <key>CFBundleDevelopmentRegion</key>
-        <string>English</string>
+        <string>en-US</string>
         <key>CFBundleExecutable</key>
         <string>libjli.dylib</string>
         <key>CFBundleIdentifier</key>

--- a/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/resources/Info-lite.plist.template
+++ b/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/resources/Info-lite.plist.template
@@ -5,7 +5,7 @@
   <key>LSMinimumSystemVersion</key>
   <string>10.11</string>
   <key>CFBundleDevelopmentRegion</key>
-  <string>English</string>
+  <string>en-US</string>
   <key>CFBundleAllowMixedLocalizations</key>
   <true/>
   <key>CFBundleExecutable</key>

--- a/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/resources/Runtime-Info.plist.template
+++ b/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/resources/Runtime-Info.plist.template
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
         <key>CFBundleDevelopmentRegion</key>
-        <string>English</string>
+        <string>en-US</string>
         <key>CFBundleExecutable</key>
         <string>libjli.dylib</string>
         <key>CFBundleIdentifier</key>


### PR DESCRIPTION
After some consideration value of CFBundleDevelopmentRegion will be set to "en-US" (default documented valued) from "English" (not valid value based on documentation). Even if this option is set to default it was not removed for easy customization. CLI options is not added, since it is unclear how often end user need to override this value. CLI option might be considered if users needs to update CFBundleDevelopmentRegion more often.