### PR TITLE
8366147: ZGC: ZPageAllocator::cleanup_failed_commit_single_partition may leak memory

### DIFF
--- a/test/hotspot/jtreg/gc/z/TestCommitFailure.java
+++ b/test/hotspot/jtreg/gc/z/TestCommitFailure.java
@@ -24,6 +24,15 @@
 package gc.z;
 
 /*
+ * @test id=Normal
+ * @requires vm.gc.Z & vm.debug
+ * @summary Test ZGC graceful failure when a commit fails
+ * @library / /test/lib
+ * @run main/othervm gc.z.TestCommitFailure
+ *
+ */
+
+/*
  * @test id=ZFakeNUMA
  * @requires vm.gc.Z & vm.debug
  * @library / /test/lib


### PR DESCRIPTION
ZPageAllocator::cleanup_failed_commit_single_partition is responsible for cleaning up the successful part of a failed allocation by returning it to the cache so it can be reused.

When a commit fails the the parts that should be returned is any "harvested" memory (memory it took from the cache) and any partially freshly committed memory.

In a late revision of [JDK-8350441](https://bugs.openjdk.org/browse/JDK-8350441) we rewrote part of the allocation logic such that the "harvested" part was no longer part of the partial vmems after successfully harvesting. However the cleanup code was not adapted to this change.

The solution is to add back both the harvested and newly committed memory, not just the newly committed part.

* Testing (In progress)
  * Oracle supported platforms tier1 + ZGC tier1-8