### PR TITLE
8366225: Linux Alpine (fast)debug build fails after JDK-8365909

### DIFF
--- a/src/hotspot/os/linux/compilerThreadTimeout_linux.cpp
+++ b/src/hotspot/os/linux/compilerThreadTimeout_linux.cpp
@@ -94,7 +94,7 @@ bool CompilerThreadTimeoutLinux::init_timeout() {
   JavaThread* thread = JavaThread::current();
 
   // Create a POSIX timer sending SIGALRM to this thread only.
-  sigevent_t sev;
+  struct sigevent sev;
   sev.sigev_value.sival_ptr = nullptr;
   sev.sigev_signo = TIMEOUT_SIGNAL;
   sev.sigev_notify = SIGEV_THREAD_ID;


### PR DESCRIPTION
The integration of #26882 broke debug builds on Alpine Linux (and probably other distributions using musl libc), because the typedef `sigevent_t`does not exist in musl libc. This PR fixes this by using `struct sigevent` as the type.

Testing:
 - [ ] Github Actions
 - [ ] tier1,tier2 Linux aarch64 and x64 fastdebug
 - [x] `make test TEST=compiler/arguments/TestCompileTaskTimeout.java` in Alpine Linux docker container 
 - [ ] tier1,tier2 on Alpine Linux fastdebug