### PR TITLE
8366232: JFR startup messages are shown with -Xlog:jfr+startup=warning

### DIFF
--- a/src/hotspot/share/jfr/dcmd/jfrDcmds.cpp
+++ b/src/hotspot/share/jfr/dcmd/jfrDcmds.cpp
@@ -162,13 +162,13 @@ static void handle_dcmd_result(outputStream* output,
   assert(!HAS_PENDING_EXCEPTION, "invariant");
 
   if (startup) {
-    if (log_is_enabled(Warning, jfr, startup))  {
-      // if warning is set, assume user hasn't configured log level
+    if (log_is_default(jfr, startup))  {
+      // The user hasn't configured a log level
       // Log to Info and reset to Warning. This way user can disable
-      // default output by setting -Xlog:jfr+startup=error/off
+      // default output by setting -Xlog:jfr+startup=error/warning/off
       LogConfiguration::configure_stdout(LogLevel::Info, true, LOG_TAGS(jfr, startup));
       log(result, THREAD);
-      LogConfiguration::configure_stdout(LogLevel::Warning, true, LOG_TAGS(jfr, startup));
+      LogConfiguration::reset_stdout(true, LOG_TAGS(jfr, startup));
     } else {
       log(result, THREAD);
     }

--- a/src/hotspot/share/logging/log.hpp
+++ b/src/hotspot/share/logging/log.hpp
@@ -66,6 +66,7 @@ class LogMessageBuffer;
 
 // Convenience macro to test if the logging is enabled on the specified level for given tags.
 #define log_is_enabled(level, ...) (LogImpl<LOG_TAGS(__VA_ARGS__)>::is_level(LogLevel::level))
+#define log_is_default(...) (!LogImpl<LOG_TAGS(__VA_ARGS__)>::is_output_level_configured_by_user())
 
 //
 // Log class for more advanced logging scenarios.
@@ -120,6 +121,10 @@ class LogImpl {
 
   static bool is_level(LogLevelType level) {
     return LogTagSetMapping<T0, T1, T2, T3, T4>::tagset().is_level(level);
+  }
+
+  static bool is_output_level_configured_by_user() {
+    return LogTagSetMapping<T0, T1, T2, T3, T4>::tagset().is_output_level_configured_by_user();
   }
 
   ATTRIBUTE_PRINTF(2, 3)

--- a/src/hotspot/share/logging/logConfiguration.hpp
+++ b/src/hotspot/share/logging/logConfiguration.hpp
@@ -88,7 +88,7 @@ private:
   static size_t find_output(const char* name);
 
   // Configure output (add or update existing configuration) to log on tag-level combination using specified decorators.
-  static void configure_output(size_t idx, const LogSelectionList& tag_level_expression, const LogDecorators& decorators);
+  static void configure_output(size_t idx, const LogSelectionList& tag_level_expression, const LogDecorators& decorators, bool is_user_provided);
 
   // This should be called after any configuration change while still holding ConfigurationLock
   static void notify_update_listeners();
@@ -125,6 +125,9 @@ private:
   // Tags should be specified using the LOG_TAGS macro, e.g.
   // LogConfiguration::configure_stdout(LogLevel::<level>, <true/false>, LOG_TAGS(<tags>));
   static void configure_stdout(LogLevelType level, int exact_match, ...);
+
+  // Configures logging on stdout for the given tags to be the default level, not specified by users
+  static void reset_stdout(int exact_match, ...);
 
   // Parse command line configuration. Parameter 'opts' is the string immediately following the -Xlog: argument ("gc" for -Xlog:gc).
   static bool parse_command_line_arguments(const char* opts = "all");

--- a/src/hotspot/share/logging/logTagSet.hpp
+++ b/src/hotspot/share/logging/logTagSet.hpp
@@ -116,6 +116,18 @@ class LogTagSet {
     _output_list.set_output_level(output, level);
   }
 
+  void set_output_level_configured_by_user() {
+    _output_list.set_output_level_configured_by_user();
+  }
+
+  void set_output_level_not_configured_by_user() {
+    _output_list.set_output_level_not_configured_by_user();
+  }
+
+  bool is_output_level_configured_by_user() const {
+    return _output_list.is_output_level_configured_by_user();
+  }
+
   // Refresh the decorators for this tagset to contain the decorators for all
   // of its current outputs combined with the given decorators.
   void update_decorators(const LogDecorators& decorator = LogDecorators::None);

--- a/test/jdk/jdk/jfr/startupargs/TestMultipleStartupRecordings.java
+++ b/test/jdk/jdk/jfr/startupargs/TestMultipleStartupRecordings.java
@@ -63,6 +63,7 @@ public class TestMultipleStartupRecordings {
         String recording1 = START_FLIGHT_RECORDING + (options1 != null ? options1 : "");
         String recording2 = START_FLIGHT_RECORDING + (options2 != null ? options2 : "");
         ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(recording1, recording2, MainClass.class.getName());
+        System.err.println("Out: " + pb.command());
         test(pb, "Started recording 1", "Started recording 2");
     }
 

--- a/test/jdk/jdk/jfr/startupargs/TestStartupMessage.java
+++ b/test/jdk/jdk/jfr/startupargs/TestStartupMessage.java
@@ -55,8 +55,10 @@ public class TestStartupMessage {
              .shouldNotContain("Started recording")
              .shouldNotContain("Use jcmd");
 
-         // Known limitation.
-         // Can't turn off log with -Xlog:jfr+startup=warning
+        startJfrJvm("-Xlog:jfr+startup=warning")
+             .shouldNotContain("[jfr,startup")
+             .shouldNotContain("Started recording")
+             .shouldNotContain("Use jcmd");
 
          startJfrJvm()
              .shouldContain("[info][jfr,startup")


### PR DESCRIPTION
Only print the JFR startup messages when no or a < warning log level is set explicitly by the user.