### PR TITLE
8333783: java/nio/channels/FileChannel/directio/DirectIOTest.java is unstable with AV software

### DIFF
--- a/test/jdk/java/nio/channels/FileChannel/directio/DirectIOTest.java
+++ b/test/jdk/java/nio/channels/FileChannel/directio/DirectIOTest.java
@@ -70,8 +70,6 @@ public class DirectIOTest {
 
             int bs = (int)blockSize;
             int size = Math.max(BASE_SIZE, bs);
-            flushFileCache(size, fd);
-
             int alignment = bs;
             ByteBuffer src = ByteBuffer.allocateDirect(size + alignment - 1)
                                        .alignedSlice(alignment);
@@ -107,7 +105,6 @@ public class DirectIOTest {
 
             int bs = (int)blockSize;
             int size = Math.max(BASE_SIZE, bs);
-
             int alignment = bs;
             ByteBuffer dest = ByteBuffer.allocateDirect(size + alignment - 1)
                                         .alignedSlice(alignment);


### PR DESCRIPTION
This test routinely fails on our instances that have AV software enabled: that software apparently reads the file in background on access, which trips the very sensitive "is file in cache" test. It looks like there is a reliable way to mitigate this by keeping the file open, and attempting the (read|write)+check several times, with cache flush in between.

This is not perfect, but works in practice. Second attempt seems to work in >99% of the cases, we are doing 3 attempts to make test extra reliable.

Additional testing:
 - [x] Linux AArch64 server fastdebug; sensitivity check: dropped `DIRECT` from the test, test starts failing immediately
 - [x] Linux AArch64 server fastdebug, test does not fail after 100x repetitions
 - [x] Linux AArch64 server fastdebug, test does not fail after 10000x repetitions

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333783](https://bugs.openjdk.org/browse/JDK-8333783): java/nio/channels/FileChannel/directio/DirectIOTest.java is unstable with AV software (**Bug** - P4)


### Reviewers
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26961/head:pull/26961` \
`$ git checkout pull/26961`

Update a local copy of the PR: \
`$ git checkout pull/26961` \
`$ git pull https://git.openjdk.org/jdk.git pull/26961/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26961`

View PR using the GUI difftool: \
`$ git pr show -t 26961`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26961.diff">https://git.openjdk.org/jdk/pull/26961.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26961#issuecomment-3228398432)
</details>
