### PR TITLE
8366092: [GCC static analyzer] UnixOperatingSystem.c warning: use of uninitialized value 'systemTicks'

### DIFF
--- a/src/jdk.management/linux/native/libmanagement_ext/UnixOperatingSystem.c
+++ b/src/jdk.management/linux/native/libmanagement_ext/UnixOperatingSystem.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -195,7 +195,7 @@ static int get_jvmticks(ticks *pticks) {
     uint64_t userTicks;
     uint64_t systemTicks;
 
-    if (read_ticks("/proc/self/stat", &userTicks, &systemTicks) < 0) {
+    if (read_ticks("/proc/self/stat", &userTicks, &systemTicks) != 2) {
         return -1;
     }
 

--- a/src/jdk.management/linux/native/libmanagement_ext/UnixOperatingSystem.c
+++ b/src/jdk.management/linux/native/libmanagement_ext/UnixOperatingSystem.c
@@ -192,8 +192,8 @@ static int read_ticks(const char *procfile, uint64_t *userTicks, uint64_t *syste
  * to the JVM on any CPU.
  */
 static int get_jvmticks(ticks *pticks) {
-    uint64_t userTicks = 0;
-    uint64_t systemTicks = 0;
+    uint64_t userTicks;
+    uint64_t systemTicks;
 
     if (read_ticks("/proc/self/stat", &userTicks, &systemTicks) != 2) {
         return -1;

--- a/src/jdk.management/linux/native/libmanagement_ext/UnixOperatingSystem.c
+++ b/src/jdk.management/linux/native/libmanagement_ext/UnixOperatingSystem.c
@@ -192,8 +192,8 @@ static int read_ticks(const char *procfile, uint64_t *userTicks, uint64_t *syste
  * to the JVM on any CPU.
  */
 static int get_jvmticks(ticks *pticks) {
-    uint64_t userTicks;
-    uint64_t systemTicks;
+    uint64_t userTicks = 0;
+    uint64_t systemTicks = 0;
 
     if (read_ticks("/proc/self/stat", &userTicks, &systemTicks) != 2) {
         return -1;


### PR DESCRIPTION
When using gcc static analyzer (-fanalyzer) with gcc 13.2 the following issue is reported :
```
/jdk/src/jdk.management/linux/native/libmanagement_ext/UnixOperatingSystem.c: In function 'get_jvmticks':
/jdk/src/jdk.management/linux/native/libmanagement_ext/UnixOperatingSystem.c:208:24: warning: use of uninitialized value 'systemTicks' [CWE-457] [-Wanalyzer-use-of-uninitialized-value]
  208 | pticks->usedKernel = systemTicks;

```
vsscanf usually/normally reads the systemTicks info from /proc file system. see
https://github.com/openjdk/jdk/blob/45726a1f8b8f76586037867a32b82f8ab9b96937/src/jdk.management/linux/native/libmanagement_ext/UnixOperatingSystem.c#L163
but we never check that the *exact* number of params is read with vsscanf :
n = vsscanf(tmp, fmt, args);
So potentially we could get a non complete info without systemTicks and the call would still succeed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8366092](https://bugs.openjdk.org/browse/JDK-8366092): [GCC static analyzer] UnixOperatingSystem.c warning: use of uninitialized value 'systemTicks' (**Bug** - P4)


### Reviewers
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - **Reviewer**)
 * [Andreas Steiner](https://openjdk.org/census#asteiner) (@ansteiner - Author)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26962/head:pull/26962` \
`$ git checkout pull/26962`

Update a local copy of the PR: \
`$ git checkout pull/26962` \
`$ git pull https://git.openjdk.org/jdk.git pull/26962/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26962`

View PR using the GUI difftool: \
`$ git pr show -t 26962`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26962.diff">https://git.openjdk.org/jdk/pull/26962.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26962#issuecomment-3228444710)
</details>
