### PR TITLE
8366222: TestCompileTaskTimeout causes asserts after JDK-8365909

### DIFF
--- a/test/hotspot/jtreg/compiler/arguments/TestCompileTaskTimeout.java
+++ b/test/hotspot/jtreg/compiler/arguments/TestCompileTaskTimeout.java
@@ -49,7 +49,7 @@ public class TestCompileTaskTimeout {
                     .shouldHaveExitValue(134)
                     .shouldContain("timed out after");
 
-        ProcessTools.executeTestJava("-Xcomp", "-XX:CompileTaskTimeout=200", "--version")
+        ProcessTools.executeTestJava("-Xcomp", "-XX:CompileTaskTimeout=2000", "--version")
                     .shouldHaveExitValue(0);
     }
 }


### PR DESCRIPTION
This PR increases the timeout of the positive test case in `compiler/arguments/TestCompileTaskTimeout.java`, because it was too low, such that the test case failed on some systems. The new timeout of 2s should be large enough for all systems.

Testing:
 - [x] Github Actions
 - [x] tier1,tier2 Linux fastdebug x64, aarch64

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8366222](https://bugs.openjdk.org/browse/JDK-8366222): TestCompileTaskTimeout causes asserts after JDK-8365909 (**Bug** - P4)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26963/head:pull/26963` \
`$ git checkout pull/26963`

Update a local copy of the PR: \
`$ git checkout pull/26963` \
`$ git pull https://git.openjdk.org/jdk.git pull/26963/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26963`

View PR using the GUI difftool: \
`$ git pr show -t 26963`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26963.diff">https://git.openjdk.org/jdk/pull/26963.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26963#issuecomment-3228598220)
</details>
