### PR TITLE
8365726: Test crashed with assert in C1 thread: Possible safepoint reached by thread that does not allow it

### DIFF
--- a/src/hotspot/share/oops/trainingData.hpp
+++ b/src/hotspot/share/oops/trainingData.hpp
@@ -96,7 +96,7 @@ public:
 
   // TrainingDataLocker is used to guard read/write operations on non-MT-safe data structures.
   // It supports recursive locking and a read-only mode (in which case no locks are taken).
-  // It is also a part of the TD collection termination protocol (see the "spanshot" field).
+  // It is also a part of the TD collection termination protocol (see the "snapshot" field).
   class TrainingDataLocker {
     static volatile bool _snapshot; // If true we're not allocating new training data
     static int _lock_mode;
@@ -105,7 +105,7 @@ public:
 #if INCLUDE_CDS
       assert(_lock_mode != 0, "Forgot to call TrainingDataLocker::initialize()");
       if (_lock_mode > 0) {
-        TrainingData_lock->lock();
+        TrainingData_lock->lock_without_safepoint_check();
       }
 #endif
     }

--- a/src/hotspot/share/runtime/mutexLocker.cpp
+++ b/src/hotspot/share/runtime/mutexLocker.cpp
@@ -263,7 +263,7 @@ void mutex_init() {
 
   MUTEX_DEFN(CompiledIC_lock                 , PaddedMutex  , nosafepoint);  // locks VtableStubs_lock
   MUTEX_DEFN(MethodCompileQueue_lock         , PaddedMonitor, safepoint);
-  MUTEX_DEFL(TrainingData_lock               , PaddedMutex  , MethodCompileQueue_lock);
+  MUTEX_DEFN(TrainingData_lock               , PaddedMutex  , nosafepoint);
   MUTEX_DEFN(TrainingReplayQueue_lock        , PaddedMonitor, safepoint);
   MUTEX_DEFN(CompileStatistics_lock          , PaddedMutex  , safepoint);
   MUTEX_DEFN(DirectivesStack_lock            , PaddedMutex  , nosafepoint);


### PR DESCRIPTION
`TrainingData_lock` guards a non-thread safe container and is only locked for a short time. Allow it to skip the safepoint check.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8365726](https://bugs.openjdk.org/browse/JDK-8365726): Test crashed with assert in C1 thread: Possible safepoint reached by thread that does not allow it (**Bug** - P3)


### Reviewers
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26964/head:pull/26964` \
`$ git checkout pull/26964`

Update a local copy of the PR: \
`$ git checkout pull/26964` \
`$ git pull https://git.openjdk.org/jdk.git pull/26964/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26964`

View PR using the GUI difftool: \
`$ git pr show -t 26964`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26964.diff">https://git.openjdk.org/jdk/pull/26964.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26964#issuecomment-3229043302)
</details>
