### PR TITLE
8366255: Remove 'package_to_module' function from imageFile.cpp

### DIFF
--- a/src/java.base/share/native/libjimage/imageFile.cpp
+++ b/src/java.base/share/native/libjimage/imageFile.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/src/java.base/share/native/libjimage/imageFile.cpp
+++ b/src/java.base/share/native/libjimage/imageFile.cpp
@@ -148,65 +148,6 @@ void ImageLocation::clear_data() {
     memset(_attributes, 0, sizeof(_attributes));
 }
 
-// ImageModuleData constructor maps out sub-tables for faster access.
-ImageModuleData::ImageModuleData(const ImageFileReader* image_file) :
-        _image_file(image_file),
-        _endian(image_file->endian()) {
-}
-
-// Release module data resource.
-ImageModuleData::~ImageModuleData() {
-}
-
-
-// Return the module in which a package resides.    Returns NULL if not found.
-const char* ImageModuleData::package_to_module(const char* package_name) {
-    // replace all '/' by '.'
-    char* replaced = new char[(int) strlen(package_name) + 1];
-    assert(replaced != NULL && "allocation failed");
-    int i;
-    for (i = 0; package_name[i] != '\0'; i++) {
-      replaced[i] = package_name[i] == '/' ? '.' : package_name[i];
-    }
-    replaced[i] = '\0';
-
-    // build path /packages/<package_name>
-    const char* radical = "/packages/";
-    char* path = new char[(int) strlen(radical) + (int) strlen(package_name) + 1];
-    assert(path != NULL && "allocation failed");
-    strcpy(path, radical);
-    strcat(path, replaced);
-    delete[] replaced;
-
-    // retrieve package location
-    ImageLocation location;
-    bool found = _image_file->find_location(path, location);
-    delete[] path;
-    if (!found) {
-        return NULL;
-    }
-
-    // retrieve offsets to module name
-    int size = (int)location.get_attribute(ImageLocation::ATTRIBUTE_UNCOMPRESSED);
-    u1* content = new u1[size];
-    assert(content != NULL && "allocation failed");
-    _image_file->get_resource(location, content);
-    u1* ptr = content;
-    // sequence of sizeof(8) isEmpty|offset. Use the first module that is not empty.
-    u4 offset = 0;
-    for (i = 0; i < size; i+=8) {
-        u4 isEmpty = _endian->get(*((u4*)ptr));
-        ptr += 4;
-        if (!isEmpty) {
-            offset = _endian->get(*((u4*)ptr));
-            break;
-        }
-        ptr += 4;
-    }
-    delete[] content;
-    return _image_file->get_strings().get(offset);
-}
-
 // Manage a table of open image files.  This table allows multiple access points
 // to share an open image.
 ImageFileReaderTable::ImageFileReaderTable() : _count(0), _max(_growth) {
@@ -340,8 +281,7 @@ ImageFileReader* ImageFileReader::id_to_reader(u8 id) {
 }
 
 // Constructor initializes to a closed state.
-ImageFileReader::ImageFileReader(const char* name, bool big_endian) :
-    _module_data(NULL) {
+ImageFileReader::ImageFileReader(const char* name, bool big_endian) {
     // Copy the image file name.
      int len = (int) strlen(name) + 1;
     _name = new char[len];
@@ -361,10 +301,6 @@ ImageFileReader::~ImageFileReader() {
     if (_name) {
         delete[] _name;
         _name = NULL;
-    }
-
-    if (_module_data != NULL) {
-        delete _module_data;
     }
 }
 
@@ -414,11 +350,7 @@ bool ImageFileReader::open() {
     _location_bytes = _index_data + location_bytes_offset;
     // Compute address of index string table.
     _string_bytes = _index_data + string_bytes_offset;
-
-    // Initialize the module data
-    _module_data = new ImageModuleData(this);
-    // Successful open (if memory allocation succeeded).
-    return _module_data != NULL;
+    return true;
 }
 
 // Close image file.
@@ -432,11 +364,6 @@ void ImageFileReader::close() {
     if (_fd != -1) {
         osSupport::close(_fd);
         _fd = -1;
-    }
-
-    if (_module_data != NULL) {
-        delete _module_data;
-        _module_data = NULL;
     }
 }
 
@@ -566,9 +493,4 @@ void ImageFileReader::get_resource(ImageLocation& location, u1* uncompressed_dat
         bool is_read = read_at(uncompressed_data, uncompressed_size, _index_size + offset);
         assert(is_read && "error reading from image or short read");
     }
-}
-
-// Return the ImageModuleData for this image
-ImageModuleData * ImageFileReader::get_image_module_data() {
-    return _module_data;
 }

--- a/src/java.base/share/native/libjimage/imageFile.hpp
+++ b/src/java.base/share/native/libjimage/imageFile.hpp
@@ -302,20 +302,6 @@ public:
     }
 };
 
-//
-// Manage the image module meta data.
-class ImageModuleData {
-    const ImageFileReader* _image_file; // Source image file
-    Endian* _endian;                    // Endian handler
-
-public:
-    ImageModuleData(const ImageFileReader* image_file);
-    ~ImageModuleData();
-
-    // Return the module in which a package resides.    Returns NULL if not found.
-    const char* package_to_module(const char* package_name);
-};
-
 // Image file header, starting at offset 0.
 class ImageHeader {
 private:
@@ -428,7 +414,6 @@ private:
     u4* _offsets_table;  // Location offset table
     u1* _location_bytes; // Location attributes
     u1* _string_bytes;   // String table
-    ImageModuleData *_module_data;       // The ImageModuleData for this image
 
     ImageFileReader(const char* name, bool big_endian);
     ~ImageFileReader();
@@ -577,9 +562,5 @@ public:
 
     // Return the resource for the supplied path.
     void get_resource(ImageLocation& location, u1* uncompressed_data) const;
-
-    // Return the ImageModuleData for this image
-    ImageModuleData * get_image_module_data();
-
 };
 #endif // LIBJIMAGE_IMAGEFILE_HPP

--- a/src/java.base/share/native/libjimage/imageFile.hpp
+++ b/src/java.base/share/native/libjimage/imageFile.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/src/java.base/share/native/libjimage/jimage.cpp
+++ b/src/java.base/share/native/libjimage/jimage.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/src/java.base/share/native/libjimage/jimage.cpp
+++ b/src/java.base/share/native/libjimage/jimage.cpp
@@ -87,23 +87,6 @@ JIMAGE_Close(JImageFile* image) {
 }
 
 /*
- * JImagePackageToModule - Given an open image file (see JImageOpen) and the name
- * of a package, return the name of module where the package resides. If the
- * package does not exist in the image file, the function returns NULL.
- * The resulting string does/should not have to be released. All strings are
- * utf-8, zero byte terminated.
- *
- * Ex.
- *  const char* package = (*JImagePackageToModule)(image, "java/lang");
- *  tty->print_cr(package);
- *  -> java.base
- */
-extern "C" JNIEXPORT const char*
-JIMAGE_PackageToModule(JImageFile* image, const char* package_name) {
-    return ((ImageFileReader*) image)->get_image_module_data()->package_to_module(package_name);
-}
-
-/*
  * JImageFindResource - Given an open image file (see JImageOpen), a module
  * name, a version string and the name of a class/resource, return location
  * information describing the resource and its size. If no resource is found, the

--- a/src/java.base/share/native/libjimage/jimage.hpp
+++ b/src/java.base/share/native/libjimage/jimage.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/src/java.base/share/native/libjimage/jimage.hpp
+++ b/src/java.base/share/native/libjimage/jimage.hpp
@@ -94,25 +94,6 @@ typedef void (*JImageClose_t)(JImageFile* jimage);
 
 
 /*
- * JImagePackageToModule - Given an open image file (see JImageOpen) and the name
- * of a package, return the name of module where the package resides. If the
- * package does not exist in the image file, the function returns NULL.
- * The resulting string does/should not have to be released. All strings are
- * utf-8, zero byte terminated.
- *
- * Ex.
- *  const char* package = (*JImagePackageToModule)(image, "java/lang");
- *  tty->print_cr(package);
- *  -> java.base
- */
-
-extern "C" JNIEXPORT const char *
-JIMAGE_PackageToModule(JImageFile* jimage, const char* package_name);
-
-typedef const char* (*JImagePackageToModule_t)(JImageFile* jimage, const char* package_name);
-
-
-/*
  * JImageFindResource - Given an open image file (see JImageOpen), a module
  * name, a version string and the name of a class/resource, return location
  * information describing the resource and its size. If no resource is found, the


### PR DESCRIPTION
Removing the 'package_to_module' function from imageFile.cpp and the associated JNI export.
This code isn't used or referenced from anywhere, and removing it makes adapting the package flags for use with preview mode simpler.

A clone of the Valhalla PR:
https://github.com/openjdk/valhalla/pull/1535

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8366255](https://bugs.openjdk.org/browse/JDK-8366255): Remove 'package_to_module' function from imageFile.cpp (**Sub-task** - P4)


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26965/head:pull/26965` \
`$ git checkout pull/26965`

Update a local copy of the PR: \
`$ git checkout pull/26965` \
`$ git pull https://git.openjdk.org/jdk.git pull/26965/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26965`

View PR using the GUI difftool: \
`$ git pr show -t 26965`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26965.diff">https://git.openjdk.org/jdk/pull/26965.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26965#issuecomment-3229190580)
</details>
