### PR TITLE
8342640: GenShen: Silently ignoring ShenandoahGCHeuristics considered poor user-experience

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahArguments.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahArguments.cpp
@@ -194,8 +194,11 @@ void ShenandoahArguments::initialize() {
       err_msg("GCCardSizeInBytes ( %u ) must be >= %u\n", GCCardSizeInBytes, (unsigned int) ShenandoahMinCardSizeInBytes));
   }
 
-  if ((strcmp(ShenandoahGCMode, "generational") == 0) && !FLAG_IS_DEFAULT(ShenandoahGCHeuristics)) {
-    log_warning(gc)("Ignoring -XX:ShenandoahGCHeuristics input because generational shenandoah is in use");
+  // Gen shen does not support any ShenandoahGCHeuristics value except for the default "adaptive"
+  if ((strcmp(ShenandoahGCMode, "generational") == 0)
+      && strcmp(ShenandoahGCHeuristics, "adaptive") != 0) {
+    log_warning(gc)("Ignoring -XX:ShenandoahGCHeuristics input: %s, because generational shenandoah only"
+      " supports adaptive heuristics", ShenandoahGCHeuristics);
   }
 
   FullGCForwarding::initialize_flags(MaxHeapSize);


### PR DESCRIPTION
When generational shenandoah is enabled, it ignores the value of ShenandoahGCHeuristics input silently:
```
java -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC -XX:ShenandoahGCMode=generational -XX:ShenandoahGCHeuristics=junk -version
openjdk version "25" 2025-09-16 LTS
OpenJDK Runtime Environment Corretto-25.0.0.36.1 (build 25+36-LTS)
OpenJDK 64-Bit Server VM Corretto-25.0.0.36.1 (build 25+36-LTS, mixed mode, sharing)
```

Adding additional guard rail to gen shen is not an option - it is actually by design that gen shen does not support non adaptive heuristics due to the complexity brought by generational design. 

So print out a warning to users to indicate that their `ShenandoahGCHeuristics` input is ignored.

```
x64 (8342640) % java -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC -XX:ShenandoahGCMode=generational -XX:ShenandoahGCHeuristics=static -version
[0.001s][warning][gc] Ignoring -XX:ShenandoahGCHeuristics input: static, because generational shenandoah only supports adaptive heuristics
openjdk version "26" 2026-03-17
OpenJDK Runtime Environment Corretto-26.0.2.1.1 (slowdebug build 26+2-FR)
OpenJDK 64-Bit Server VM Corretto-26.0.2.1.1 (slowdebug build 26+2-FR, mixed mode)

x64 (8342640) % java -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC -XX:ShenandoahGCMode=generational -XX:ShenandoahGCHeuristics=junk -version
[0.001s][warning][gc] Ignoring -XX:ShenandoahGCHeuristics input: junk, because generational shenandoah only supports adaptive heuristics
openjdk version "26" 2026-03-17
OpenJDK Runtime Environment Corretto-26.0.2.1.1 (slowdebug build 26+2-FR)
OpenJDK 64-Bit Server VM Corretto-26.0.2.1.1 (slowdebug build 26+2-FR, mixed mode)

x64 (8342640) % java -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC -XX:ShenandoahGCMode=generational -XX:ShenandoahGCHeuristics=adaptive -version
openjdk version "26" 2026-03-17
OpenJDK Runtime Environment Corretto-26.0.2.1.1 (slowdebug build 26+2-FR)
OpenJDK 64-Bit Server VM Corretto-26.0.2.1.1 (slowdebug build 26+2-FR, mixed mode)

x64 (8342640) % java -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC -XX:ShenandoahGCMode=generational -version  
openjdk version "26" 2026-03-17
OpenJDK Runtime Environment Corretto-26.0.2.1.1 (slowdebug build 26+2-FR)
OpenJDK 64-Bit Server VM Corretto-26.0.2.1.1 (slowdebug build 26+2-FR, mixed mode)
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8342640](https://bugs.openjdk.org/browse/JDK-8342640): GenShen: Silently ignoring ShenandoahGCHeuristics considered poor user-experience (**Sub-task** - P5)


### Reviewers
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - **Reviewer**)
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26968/head:pull/26968` \
`$ git checkout pull/26968`

Update a local copy of the PR: \
`$ git checkout pull/26968` \
`$ git pull https://git.openjdk.org/jdk.git pull/26968/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26968`

View PR using the GUI difftool: \
`$ git pr show -t 26968`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26968.diff">https://git.openjdk.org/jdk/pull/26968.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26968#issuecomment-3229300796)
</details>
