### PR TITLE
8150564: Migrate useful ExtendedRobot methods into awt.Robot

### DIFF
--- a/src/java.desktop/share/classes/java/awt/Robot.java
+++ b/src/java.desktop/share/classes/java/awt/Robot.java
@@ -789,10 +789,10 @@ public class Robot {
     }
 
     /**
-     * A convenience method that simulates clicking a mouse button by calling {@code mousePress}, {@code mouseRelease},
-     * and {@code waitForIdle}. Invokes {@code waitForIdle} with a default delay of {@value #DEFAULT_DELAY} milliseconds after
-     * {@code mousePress} and {@code mouseRelease} calls. For specifics on valid inputs see
-     * {@link java.awt.Robot#mousePress(int)}.
+     * A convenience method that simulates clicking a mouse button by calling {@code mousePress},
+     * {@code mouseRelease} and {@code waitForIdle}. Invokes {@code waitForIdle} with a default
+     * delay of {@value #DEFAULT_DELAY} milliseconds after {@code mousePress} and {@code mouseRelease}
+     * calls. For specifics on valid inputs see {@link java.awt.Robot#mousePress(int)}.
      *
      * @param   buttons The button mask; a combination of one or more mouse button masks.
      * @throws  IllegalArgumentException if the {@code buttons} mask contains the mask for
@@ -958,8 +958,8 @@ public class Robot {
 
     /**
      * A convenience method that simulates typing a key by calling {@code keyPress}
-     * and {@code keyRelease}. Invokes {@code waitForIdle} with a delay of {@value #DEFAULT_DELAY} milliseconds
-     * after {@code keyPress} and {@code keyRelease} calls.
+     * and {@code keyRelease}. Invokes {@code waitForIdle} with a delay of {@value #DEFAULT_DELAY}
+     * milliseconds after {@code keyPress} and {@code keyRelease} calls.
      * <p>
      * Key codes that have more than one physical key associated with them
      * (e.g. {@code KeyEvent.VK_SHIFT} could mean either the


### PR DESCRIPTION
Some useful methods (click, glide, waitForIdle, type) in ExtendedRobot should be migrated into Robot itself so that ExtendedRobot can be removed in the future. The tests using these ExtendedRobot methods will be handled separately.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8349593](https://bugs.openjdk.org/browse/JDK-8349593) to be approved

### Issues
 * [JDK-8150564](https://bugs.openjdk.org/browse/JDK-8150564): Migrate useful ExtendedRobot methods into awt.Robot (**Enhancement** - P3)
 * [JDK-8349593](https://bugs.openjdk.org/browse/JDK-8349593): Migrate useful ExtendedRobot methods into awt.Robot (**CSR**)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**) Review applies to [c20d8263](https://git.openjdk.org/jdk/pull/26969/files/c20d82639fe7feccc5f767793c25fb85eee69b6e)
 * [Alexander Zuev](https://openjdk.org/census#kizune) (@azuev-java - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26969/head:pull/26969` \
`$ git checkout pull/26969`

Update a local copy of the PR: \
`$ git checkout pull/26969` \
`$ git pull https://git.openjdk.org/jdk.git pull/26969/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26969`

View PR using the GUI difftool: \
`$ git pr show -t 26969`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26969.diff">https://git.openjdk.org/jdk/pull/26969.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26969#issuecomment-3229348150)
</details>
