### PR TITLE
8366211: Block signature scheme names to be used with CertificateSignature algorithm constraints usage

### DIFF
--- a/src/java.base/share/conf/security/java.security
+++ b/src/java.base/share/conf/security/java.security
@@ -755,7 +755,12 @@ http.auth.digest.disabledAlgorithms = MD5, SHA-1
 #     other usage types defined in the jdk.certpath.disabledAlgorithms
 #     property. The usage type follows the keyword and more than one usage type
 #     can be specified with a whitespace delimiter.
-#     Example: "rsa_pkcs1_sha1 usage HandshakeSignature"
+#     Note that TLS signature scheme names can't be used as algorithms with
+#     CertificateSignature usage type, only certificate's signature algorithm
+#     or certificate's key algorithm are supported for this usage type.
+#     Examples:
+#       - rsa_pkcs1_sha1 usage HandshakeSignature
+#       - SHA1withRSA usage CertificateSignature
 #
 # Note: The algorithm restrictions do not apply to trust anchors or
 # self-signed certificates.

--- a/test/jdk/sun/security/ssl/SignatureScheme/BlockSignatureSchemesForCert.java
+++ b/test/jdk/sun/security/ssl/SignatureScheme/BlockSignatureSchemesForCert.java
@@ -23,11 +23,12 @@
 
 /*
  * @test
- * @bug 8349583
- * @summary Add mechanism to disable signature schemes based on their TLS scope
+ * @bug 8366211
+ * @summary Block signature scheme names to be used with CertificateSignature
+ *          algorithm constraints usage
  * @library /javax/net/ssl/templates
  *          /test/lib
- * @run main/othervm MixingTLSUsageConstraintsWithNonTLS
+ * @run main/othervm BlockSignatureSchemesForCert
  */
 
 import static jdk.test.lib.Asserts.assertEquals;
@@ -36,21 +37,21 @@ import static jdk.test.lib.Utils.runAndCheckException;
 
 import java.security.Security;
 
-public class MixingTLSUsageConstraintsWithNonTLS extends SSLSocketTemplate {
+public class BlockSignatureSchemesForCert extends SSLSocketTemplate {
 
     public static void main(String[] args) throws Exception {
         Security.setProperty("jdk.tls.disabledAlgorithms",
-                "SHA1withRSA usage handshakeSignature certificateSignature TLSServer");
+                "rsa_pss_pss_sha256 usage CertificateSignature");
 
         runAndCheckException(
-                () -> new MixingTLSUsageConstraintsWithNonTLS().run(),
+                () -> new BlockSignatureSchemesForCert().run(),
                 e -> {
                     assertTrue(e instanceof ExceptionInInitializerError);
                     assertTrue(
                             e.getCause() instanceof IllegalArgumentException);
                     assertEquals(e.getCause().getMessage(),
-                            "Can't mix TLS protocol specific constraints"
-                                    + " with other usage constraints");
+                            "Can't use signature scheme names with "
+                                    + "CertificateSignature usage constraint");
                 });
     }
 }

--- a/test/jdk/sun/security/ssl/SignatureScheme/DisableSignatureSchemePerScopeTLS12.java
+++ b/test/jdk/sun/security/ssl/SignatureScheme/DisableSignatureSchemePerScopeTLS12.java
@@ -44,14 +44,16 @@ public class DisableSignatureSchemePerScopeTLS12 extends
     protected static final String HANDSHAKE_DISABLED_SIG = "rsa_pss_rsae_sha384";
 
     // Disabled for Certificate scope.
+    private static final String CERTIFICATE_DISABLED_ALG = "SHA384withECDSA";
     protected static final String CERTIFICATE_DISABLED_SIG = "ecdsa_secp384r1_sha384";
 
     // jdk.tls.disabledAlgorithms value
     // We differ from "HandshakeSignature" and "CertificateSignature" specified
     // in java.security to check case-insensitive matching.
-    protected static final String DISABLED_CONSTRAINTS =
-            HANDSHAKE_DISABLED_SIG + " usage HandShakesignature, "
-            + CERTIFICATE_DISABLED_SIG + " usage certificateSignature";
+    protected static final String DISABLED_CONSTRAINTS = HANDSHAKE_DISABLED_SIG
+            + " usage HandShakesignature, "
+            + CERTIFICATE_DISABLED_ALG
+            + " usage certificateSignature";
 
     protected DisableSignatureSchemePerScopeTLS12() throws Exception {
         super();


### PR DESCRIPTION
To avoid any user confusion, we should block signature scheme names to be used with `CertificateSignature` algorithm constraints usage. For example, `RSASSA-PSS` certificate signature algorithm corresponds to multiple signature scheme names and blocking one of those signature scheme with `CertificateSignature` usage directive won't block `RSASSA-PSS` certificate signature because other rsa_pss_* signature schemes still will be allowed. We should direct users to use certificate signature algorithm with `CertificateSignature` usage directive. For example:

- To be blocked: "rsa_pss_pss_sha256 usage CertificateSignature"
- To be allowed: `RSASSA-PSS usage CertificateSignature` or `RSA usage CertificateSignature`
