### PR TITLE
Backport 9dd93c6a2c5fb4c3a9f2a063a7ab402f9292ad03

### DIFF
--- a/src/java.base/share/classes/java/lang/ScopedValue.java
+++ b/src/java.base/share/classes/java/lang/ScopedValue.java
@@ -566,7 +566,7 @@ public final class ScopedValue<T> {
 
     @SuppressWarnings("unchecked")
     private T slowGet() {
-        var value = findBinding();
+        Object value = scopedValueBindings().find(this);
         if (value == Snapshot.NIL) {
             throw new NoSuchElementException("ScopedValue not bound");
         }
@@ -575,32 +575,35 @@ public final class ScopedValue<T> {
     }
 
     /**
-     * {@return {@code true} if this scoped value is bound in the current thread}
+     * Return the value of the scoped value or NIL if not bound.
+     * Consult the cache, and only if the value is not found there
+     * search the list of bindings. Update the cache if the binding
+     * was found.
      */
-    public boolean isBound() {
+    private Object findBinding() {
         Object[] objects = scopedValueCache();
         if (objects != null) {
             int n = (hash & Cache.SLOT_MASK) * 2;
             if (objects[n] == this) {
-                return true;
+                return objects[n + 1];
             }
             n = ((hash >>> Cache.INDEX_BITS) & Cache.SLOT_MASK) * 2;
             if (objects[n] == this) {
-                return true;
+                return objects[n + 1];
             }
         }
-        var value = findBinding();
-        boolean result = (value != Snapshot.NIL);
-        if (result)  Cache.put(this, value);
-        return result;
+        Object value = scopedValueBindings().find(this);
+        boolean found = (value != Snapshot.NIL);
+        if (found)  Cache.put(this, value);
+        return value;
     }
 
     /**
-     * Return the value of the scoped value or NIL if not bound.
+     * {@return {@code true} if this scoped value is bound in the current thread}
      */
-    private Object findBinding() {
-        Object value = scopedValueBindings().find(this);
-        return value;
+    public boolean isBound() {
+        Object obj = findBinding();
+        return obj != Snapshot.NIL;
     }
 
     /**

--- a/test/micro/org/openjdk/bench/java/lang/ScopedValues.java
+++ b/test/micro/org/openjdk/bench/java/lang/ScopedValues.java
@@ -29,6 +29,7 @@ import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.infra.Blackhole;
 
+import static java.lang.ScopedValue.where;
 import static org.openjdk.bench.java.lang.ScopedValuesData.*;
 
 /**
@@ -92,6 +93,26 @@ public class ScopedValues {
         return result;
     }
 
+    @Benchmark
+    @OutputTimeUnit(TimeUnit.NANOSECONDS)
+    public int thousandUnboundOrElses(Blackhole bh) throws Exception {
+        int result = 0;
+        for (int i = 0; i < 1_000; i++) {
+            result += ScopedValuesData.unbound.orElse(1);
+        }
+        return result;
+    }
+
+    @Benchmark
+    @OutputTimeUnit(TimeUnit.NANOSECONDS)
+    public int thousandBoundOrElses(Blackhole bh) throws Exception {
+        int result = 0;
+        for (int i = 0; i < 1_000; i++) {
+            result += ScopedValuesData.sl1.orElse(1);
+        }
+        return result;
+    }
+
     // Test 2: stress the ScopedValue cache.
     // The idea here is to use a bunch of bound values cyclically, which
     // stresses the ScopedValue cache.
@@ -127,12 +148,12 @@ public class ScopedValues {
     @Benchmark
     @OutputTimeUnit(TimeUnit.NANOSECONDS)
     public int CreateBindThenGetThenRemove_ScopedValue() throws Exception {
-        return ScopedValue.where(sl1, THE_ANSWER).call(sl1::get);
+        return where(sl1, THE_ANSWER).call(sl1::get);
     }
 
 
     // Create a Carrier ahead of time: might be slightly faster
-    private static final ScopedValue.Carrier HOLD_42 = ScopedValue.where(sl1, 42);
+    private static final ScopedValue.Carrier HOLD_42 = where(sl1, 42);
     @Benchmark
     @OutputTimeUnit(TimeUnit.NANOSECONDS)
     public int bindThenGetThenRemove_ScopedValue() throws Exception {
@@ -213,4 +234,65 @@ public class ScopedValues {
         var ctr = tl_atomicInt.get();
         ctr.setPlain(ctr.getPlain() + 1);
     }
+
+    // Test 6: Performance with a large number of bindings
+    static final long deepCall(ScopedValue<Integer> outer, long n) {
+        long result = 0;
+        if (n > 0) {
+            ScopedValue<Long> sv = ScopedValue.newInstance();
+            return where(sv, n).call(() -> deepCall(outer, n - 1));
+        } else {
+            for (int i = 0; i < 1_000_000; i++) {
+                result += outer.orElse(12);
+            }
+        }
+        return result;
+    }
+
+    @Benchmark
+    @OutputTimeUnit(TimeUnit.MILLISECONDS)
+    public long deepBindingTest1() {
+        return deepCall(ScopedValuesData.unbound, 1000);
+    }
+
+    @Benchmark
+    @OutputTimeUnit(TimeUnit.MILLISECONDS)
+    public long deepBindingTest2() {
+        return deepCall(ScopedValuesData.sl1, 1000);
+    }
+
+
+    // Test 7: Performance with a large number of bindings
+    // Different from Test 6 in that we recursively build a very long
+    // list of Carriers and invoke Carrier.call() only once.
+    static final long deepCall2(ScopedValue<Integer> outer, ScopedValue.Carrier carrier, long n) {
+        long result = 0;
+        if (n > 0) {
+            ScopedValue<Long> sv = ScopedValue.newInstance();
+            return deepCall2(outer, carrier.where(sv, n), n - 1);
+        } else {
+            result = carrier.call(() -> {
+                long sum = 0;
+                for (int i = 0; i < 1_000_000; i++) {
+                    sum += outer.orElse(12);
+                }
+                return sum;
+            });
+        }
+        return result;
+    }
+
+    @Benchmark
+    @OutputTimeUnit(TimeUnit.MILLISECONDS)
+    public long deepBindingTest3() {
+        return deepCall2(ScopedValuesData.unbound, where(ScopedValuesData.sl2,0), 1000);
+    }
+
+    @Benchmark
+    @OutputTimeUnit(TimeUnit.MILLISECONDS)
+    public long deepBindingTest4() {
+        return deepCall2(ScopedValuesData.sl1, where(ScopedValuesData.sl2, 0), 1000);
+    }
+
+
 }


### PR DESCRIPTION
Backport of https://bugs.openjdk.org/browse/JDK-8361497

Not clean due to the lack of https://bugs.openjdk.org/browse/JDK-8360884. The cherry pick conflict was caused by the a new test added in the JDK-8360884., [code](https://github.com/openjdk/jdk/commit/4df9c873452293ccde3c7dbcd64e1ced6b6af52e#diff-314e483e41a8dd49577b207c12683b369ab87b6de6da289b9f7e89aae5f412cbR227-R232). Based on the conversation in [JDK-8360884](https://bugs.openjdk.org/browse/JDK-8360884), it seems people are not comfortable to backport JDK-8360884 into 25 yet. The conflict was easy to resolve tho. Just remove the additional test brought by JDK-8360884.