### PR TITLE
8366238: Improve RBTree API with stricter comparator semantics and pluggable validation/printing hooks

### DIFF
--- a/src/hotspot/share/gc/z/zMappedCache.cpp
+++ b/src/hotspot/share/gc/z/zMappedCache.cpp
@@ -128,10 +128,10 @@ bool ZMappedCache::EntryCompare::less_than(const IntrusiveRBNode* a, const Intru
 RBTreeOrdering ZMappedCache::EntryCompare::cmp(zoffset key, const IntrusiveRBNode* node) {
   const ZVirtualMemory vmem = ZMappedCacheEntry::cast_to_entry(node)->vmem();
 
-  if (key < vmem.start()) { return RBTreeOrdering::less; }
-  if (key > vmem.end()) { return RBTreeOrdering::greater; }
+  if (key < vmem.start()) { return RBTreeOrdering::LT; }
+  if (key > vmem.end()) { return RBTreeOrdering::GT; }
 
-  return RBTreeOrdering::equal; // Containing
+  return RBTreeOrdering::EQ; // Containing
 }
 
 void ZMappedCache::Tree::verify() const {

--- a/src/hotspot/share/gc/z/zMappedCache.cpp
+++ b/src/hotspot/share/gc/z/zMappedCache.cpp
@@ -118,20 +118,20 @@ static ZMappedCacheEntry* create_entry(const ZVirtualMemory& vmem) {
   return entry;
 }
 
-bool ZMappedCache::EntryCompare::cmp(const IntrusiveRBNode* a, const IntrusiveRBNode* b) {
+bool ZMappedCache::EntryCompare::less(const IntrusiveRBNode* a, const IntrusiveRBNode* b) {
   const ZVirtualMemory vmem_a = ZMappedCacheEntry::cast_to_entry(a)->vmem();
   const ZVirtualMemory vmem_b = ZMappedCacheEntry::cast_to_entry(b)->vmem();
 
   return vmem_a.end() < vmem_b.start();
 }
 
-int ZMappedCache::EntryCompare::cmp(zoffset key, const IntrusiveRBNode* node) {
+RBTreeOrdering ZMappedCache::EntryCompare::cmp(zoffset key, const IntrusiveRBNode* node) {
   const ZVirtualMemory vmem = ZMappedCacheEntry::cast_to_entry(node)->vmem();
 
-  if (key < vmem.start()) { return -1; }
-  if (key > vmem.end()) { return 1; }
+  if (key < vmem.start()) { return RBTreeOrdering::less; }
+  if (key > vmem.end()) { return RBTreeOrdering::greater; }
 
-  return 0; // Containing
+  return RBTreeOrdering::equal; // Containing
 }
 
 void ZMappedCache::Tree::verify() const {
@@ -168,12 +168,12 @@ void ZMappedCache::Tree::insert(TreeNode* node, const TreeCursor& cursor) {
   // Insert in tree
   TreeImpl::insert_at_cursor(node, cursor);
 
-  if (_left_most == nullptr || EntryCompare::cmp(node, _left_most)) {
+  if (_left_most == nullptr || EntryCompare::less(node, _left_most)) {
     // Keep track of left most node
     _left_most = node;
   }
 
-  if (_right_most == nullptr || EntryCompare::cmp(_right_most, node)) {
+  if (_right_most == nullptr || EntryCompare::less(_right_most, node)) {
     // Keep track of right most node
     _right_most = node;
   }

--- a/src/hotspot/share/gc/z/zMappedCache.cpp
+++ b/src/hotspot/share/gc/z/zMappedCache.cpp
@@ -118,7 +118,7 @@ static ZMappedCacheEntry* create_entry(const ZVirtualMemory& vmem) {
   return entry;
 }
 
-bool ZMappedCache::EntryCompare::less(const IntrusiveRBNode* a, const IntrusiveRBNode* b) {
+bool ZMappedCache::EntryCompare::less_than(const IntrusiveRBNode* a, const IntrusiveRBNode* b) {
   const ZVirtualMemory vmem_a = ZMappedCacheEntry::cast_to_entry(a)->vmem();
   const ZVirtualMemory vmem_b = ZMappedCacheEntry::cast_to_entry(b)->vmem();
 
@@ -168,12 +168,12 @@ void ZMappedCache::Tree::insert(TreeNode* node, const TreeCursor& cursor) {
   // Insert in tree
   TreeImpl::insert_at_cursor(node, cursor);
 
-  if (_left_most == nullptr || EntryCompare::less(node, _left_most)) {
+  if (_left_most == nullptr || EntryCompare::less_than(node, _left_most)) {
     // Keep track of left most node
     _left_most = node;
   }
 
-  if (_right_most == nullptr || EntryCompare::less(_right_most, node)) {
+  if (_right_most == nullptr || EntryCompare::less_than(_right_most, node)) {
     // Keep track of right most node
     _right_most = node;
   }

--- a/src/hotspot/share/gc/z/zMappedCache.hpp
+++ b/src/hotspot/share/gc/z/zMappedCache.hpp
@@ -40,8 +40,8 @@ class ZMappedCache {
 
 private:
   struct EntryCompare {
-    static int cmp(zoffset a, const IntrusiveRBNode* b);
-    static bool cmp(const IntrusiveRBNode*  a, const IntrusiveRBNode* b);
+    static RBTreeOrdering cmp(zoffset a, const IntrusiveRBNode* b);
+    static bool less(const IntrusiveRBNode*  a, const IntrusiveRBNode* b);
   };
 
   struct ZSizeClassListNode {

--- a/src/hotspot/share/gc/z/zMappedCache.hpp
+++ b/src/hotspot/share/gc/z/zMappedCache.hpp
@@ -41,7 +41,7 @@ class ZMappedCache {
 private:
   struct EntryCompare {
     static RBTreeOrdering cmp(zoffset a, const IntrusiveRBNode* b);
-    static bool less(const IntrusiveRBNode*  a, const IntrusiveRBNode* b);
+    static bool less_than(const IntrusiveRBNode*  a, const IntrusiveRBNode* b);
   };
 
   struct ZSizeClassListNode {

--- a/src/hotspot/share/nmt/vmatree.hpp
+++ b/src/hotspot/share/nmt/vmatree.hpp
@@ -51,9 +51,9 @@ public:
   class PositionComparator {
   public:
     static RBTreeOrdering cmp(position a, position b) {
-      if (a < b) return RBTreeOrdering::less;
-      if (a > b) return RBTreeOrdering::greater;
-      return RBTreeOrdering::equal;
+      if (a < b) return RBTreeOrdering::LT;
+      if (a > b) return RBTreeOrdering::GT;
+      return RBTreeOrdering::EQ;
     }
   };
 

--- a/src/hotspot/share/nmt/vmatree.hpp
+++ b/src/hotspot/share/nmt/vmatree.hpp
@@ -52,9 +52,8 @@ public:
   public:
     static RBTreeOrdering cmp(position a, position b) {
       if (a < b) return RBTreeOrdering::less;
-      if (a == b) return RBTreeOrdering::equal;
       if (a > b) return RBTreeOrdering::greater;
-      ShouldNotReachHere();
+      return RBTreeOrdering::equal;
     }
   };
 

--- a/src/hotspot/share/nmt/vmatree.hpp
+++ b/src/hotspot/share/nmt/vmatree.hpp
@@ -50,10 +50,10 @@ public:
 
   class PositionComparator {
   public:
-    static int cmp(position a, position b) {
-      if (a < b) return -1;
-      if (a == b) return 0;
-      if (a > b) return 1;
+    static RBTreeOrdering cmp(position a, position b) {
+      if (a < b) return RBTreeOrdering::less;
+      if (a == b) return RBTreeOrdering::equal;
+      if (a > b) return RBTreeOrdering::greater;
       ShouldNotReachHere();
     }
   };

--- a/src/hotspot/share/opto/printinlining.hpp
+++ b/src/hotspot/share/opto/printinlining.hpp
@@ -68,9 +68,9 @@ private:
 
   struct Cmp {
     static RBTreeOrdering cmp(int a, int b) {
-      if (a < b) return RBTreeOrdering::less;
-      if (a > b) return RBTreeOrdering::greater;
-      return RBTreeOrdering::equal;
+      if (a < b) return RBTreeOrdering::LT;
+      if (a > b) return RBTreeOrdering::GT;
+      return RBTreeOrdering::EQ;
     }
   };
 

--- a/src/hotspot/share/opto/printinlining.hpp
+++ b/src/hotspot/share/opto/printinlining.hpp
@@ -67,8 +67,10 @@ private:
   };
 
   struct Cmp {
-    static int cmp(int a, int b) {
-      return a - b;
+    static RBTreeOrdering cmp(int a, int b) {
+      if (a < b) return RBTreeOrdering::less;
+      if (a > b) return RBTreeOrdering::greater;
+      return RBTreeOrdering::equal;
     }
   };
 

--- a/src/hotspot/share/utilities/rbTree.hpp
+++ b/src/hotspot/share/utilities/rbTree.hpp
@@ -209,12 +209,12 @@ private:
   static constexpr bool HasNodeComparator = has_cmp_type<CMP, RBTreeOrdering, K, const NodeType*>::value;
 
   template <typename CMP, typename RET, typename ARG1, typename ARG2, typename = void>
-  struct has_less_type : std::false_type {};
+  struct has_less_than_type : std::false_type {};
   template <typename CMP, typename RET, typename ARG1, typename ARG2>
-  struct has_less_type<CMP, RET, ARG1, ARG2, decltype(static_cast<RET(*)(ARG1, ARG2)>(CMP::less), void())> : std::true_type {};
+  struct has_less_than_type<CMP, RET, ARG1, ARG2, decltype(static_cast<RET(*)(ARG1, ARG2)>(CMP::less), void())> : std::true_type {};
 
   template <typename CMP>
-  static constexpr bool HasNodeVerifier = has_less_type<CMP, bool, const NodeType*, const NodeType*>::value;
+  static constexpr bool HasNodeVerifier = has_less_than_type<CMP, bool, const NodeType*, const NodeType*>::value;
 
   template <typename CMP = COMPARATOR, ENABLE_IF(HasKeyComparator<CMP> && !HasNodeComparator<CMP>)>
   RBTreeOrdering cmp(const K& a, const NodeType* b) const {

--- a/src/hotspot/share/utilities/rbTree.hpp
+++ b/src/hotspot/share/utilities/rbTree.hpp
@@ -38,7 +38,7 @@
 //     - RBTreeOrdering::less when a < b
 //     - RBTreeOrdering::equal when a == b
 //     - RBTreeOrdering::greater when a > b
-// A second static function `less(const IntrusiveRBNode* a, const IntrusiveRBNode* b)`
+// A second static function `less_than(const IntrusiveRBNode* a, const IntrusiveRBNode* b)`
 // used for extra validation can optionally be provided. This should return:
 //     - true if a < b
 //     - false otherwise
@@ -53,7 +53,7 @@
 //     - RBTreeOrdering::less when a < b
 //     - RBTreeOrdering::equal when a == b
 //     - RBTreeOrdering::greater when a > b
-// A second static function `less(const RBNode<K, V>* a, const RBNode<K, V>* b)`
+// A second static function `less_than(const RBNode<K, V>* a, const RBNode<K, V>* b)`
 // used for extra validation can optionally be provided. This should return:
 //     - true if a < b
 //     - false otherwise
@@ -227,13 +227,13 @@ private:
   }
 
   template <typename CMP = COMPARATOR, ENABLE_IF(!HasNodeVerifier<CMP>)>
-  bool less(const NodeType* a, const NodeType* b) const {
+  bool less_than(const NodeType* a, const NodeType* b) const {
     return true;
   }
 
   template <typename CMP = COMPARATOR, ENABLE_IF(HasNodeVerifier<CMP>)>
-  bool less(const NodeType* a, const NodeType* b) const {
-    return COMPARATOR::less(a, b);
+  bool less_than(const NodeType* a, const NodeType* b) const {
+    return COMPARATOR::less_than(a, b);
   }
 
   // Cannot assert if no key comparator exist.
@@ -445,7 +445,7 @@ public:
   // If provided, each node is also verified through this callable.
   template <typename USER_VERIFIER = empty_verifier, typename CMP = COMPARATOR, ENABLE_IF(HasNodeVerifier<CMP>)>
   void verify_self(const USER_VERIFIER& extra_verifier = USER_VERIFIER()) const {
-    verify_self([](const NodeType* a, const NodeType* b){ return COMPARATOR::less(a, b);}, extra_verifier);
+    verify_self([](const NodeType* a, const NodeType* b){ return COMPARATOR::less_than(a, b);}, extra_verifier);
   }
 
   template <typename USER_VERIFIER = empty_verifier, typename CMP = COMPARATOR,

--- a/src/hotspot/share/utilities/rbTree.inline.hpp
+++ b/src/hotspot/share/utilities/rbTree.inline.hpp
@@ -123,10 +123,10 @@ inline IntrusiveRBNode* IntrusiveRBNode::next() {
   return const_cast<IntrusiveRBNode*>(static_cast<const IntrusiveRBNode*>(this)->next());
 }
 
-template <typename NodeType, typename NodeVerifier, typename USER_VERIFIER>
+template <typename NodeType, typename NODE_VERIFIER, typename USER_VERIFIER>
 inline void IntrusiveRBNode::verify(
     size_t& num_nodes, size_t& black_nodes_until_leaf, size_t& shortest_leaf_path, size_t& longest_leaf_path,
-    size_t& tree_depth, bool expect_visited, NodeVerifier verifier, const USER_VERIFIER& extra_verifier) const {
+    size_t& tree_depth, bool expect_visited, NODE_VERIFIER verifier, const USER_VERIFIER& extra_verifier) const {
   assert(extra_verifier(static_cast<const NodeType*>(this)), "user provided verifier failed");
   assert(expect_visited != _visited, "node already visited");
   DEBUG_ONLY(_visited = !_visited);
@@ -196,8 +196,8 @@ AbstractRBTree<K, NodeType, COMPARATOR>::cursor(const K& key, const NodeType* hi
       const RBTreeOrdering parent_cmp = cmp(key, (NodeType*)hint_node->parent());
       // Move up until the parent would put us on the other side of the key.
       // Meaning we are in the correct subtree.
-      if ((parent_cmp != RBTreeOrdering::greater && hint_cmp == RBTreeOrdering::less) ||
-          (parent_cmp != RBTreeOrdering::less    && hint_cmp == RBTreeOrdering::greater)) {
+      if ((parent_cmp != RBTreeOrdering::GT && hint_cmp == RBTreeOrdering::LT) ||
+          (parent_cmp != RBTreeOrdering::LT    && hint_cmp == RBTreeOrdering::GT)) {
         hint_node = (NodeType*)hint_node->parent();
       } else {
         break;
@@ -215,12 +215,12 @@ AbstractRBTree<K, NodeType, COMPARATOR>::cursor(const K& key, const NodeType* hi
     NodeType* curr = (NodeType*)*insert_location;
     const RBTreeOrdering key_cmp_k = cmp(key, curr);
 
-    if (key_cmp_k == RBTreeOrdering::equal) {
+    if (key_cmp_k == RBTreeOrdering::EQ) {
       break;
     }
 
     parent = *insert_location;
-    if (key_cmp_k == RBTreeOrdering::less) {
+    if (key_cmp_k == RBTreeOrdering::LT) {
       insert_location = &curr->_left;
     } else {
       insert_location = &curr->_right;
@@ -662,8 +662,8 @@ inline void AbstractRBTree<K, NodeType, COMPARATOR>::visit_range_in_order(const 
 }
 
 template <typename K, typename NodeType, typename COMPARATOR>
-template <typename NodeVerifier, typename USER_VERIFIER>
-inline void AbstractRBTree<K, NodeType, COMPARATOR>::verify_self(NodeVerifier verifier, const USER_VERIFIER& extra_verifier) const {
+template <typename NODE_VERIFIER, typename USER_VERIFIER>
+inline void AbstractRBTree<K, NodeType, COMPARATOR>::verify_self(NODE_VERIFIER verifier, const USER_VERIFIER& extra_verifier) const {
   if (_root == nullptr) {
     assert(_num_nodes == 0, "rbtree has %zu nodes but no root", _num_nodes);
     return;

--- a/src/hotspot/share/utilities/rbTree.inline.hpp
+++ b/src/hotspot/share/utilities/rbTree.inline.hpp
@@ -123,10 +123,11 @@ inline IntrusiveRBNode* IntrusiveRBNode::next() {
   return const_cast<IntrusiveRBNode*>(static_cast<const IntrusiveRBNode*>(this)->next());
 }
 
-template <typename NodeType, typename NodeVerifier>
+template <typename NodeType, typename NodeVerifier, typename USER_VERIFIER>
 inline void IntrusiveRBNode::verify(
     size_t& num_nodes, size_t& black_nodes_until_leaf, size_t& shortest_leaf_path, size_t& longest_leaf_path,
-    size_t& tree_depth, bool expect_visited, NodeVerifier verifier) const {
+    size_t& tree_depth, bool expect_visited, NodeVerifier verifier, const USER_VERIFIER& extra_verifier) const {
+  assert(extra_verifier(static_cast<const NodeType*>(this)), "user provided verifier failed");
   assert(expect_visited != _visited, "node already visited");
   DEBUG_ONLY(_visited = !_visited);
 
@@ -143,7 +144,7 @@ inline void IntrusiveRBNode::verify(
     assert(is_black() || _left->is_black(), "2 red nodes in a row");
     assert(_left->parent() == this, "pointer mismatch");
     _left->verify<NodeType>(num_nodes, num_black_nodes_left, shortest_leaf_path_left,
-                  longest_leaf_path_left, tree_depth_left, expect_visited, verifier);
+                  longest_leaf_path_left, tree_depth_left, expect_visited, verifier, extra_verifier);
   }
 
   size_t num_black_nodes_right = 0;
@@ -159,7 +160,7 @@ inline void IntrusiveRBNode::verify(
     assert(is_black() || _left->is_black(), "2 red nodes in a row");
     assert(_right->parent() == this, "pointer mismatch");
     _right->verify<NodeType>(num_nodes, num_black_nodes_right, shortest_leaf_path_right,
-                   longest_leaf_path_right, tree_depth_right, expect_visited, verifier);
+                   longest_leaf_path_right, tree_depth_right, expect_visited, verifier, extra_verifier);
   }
 
   shortest_leaf_path = MAX2(longest_leaf_path_left, longest_leaf_path_right);
@@ -190,13 +191,13 @@ AbstractRBTree<K, NodeType, COMPARATOR>::cursor(const K& key, const NodeType* hi
   IntrusiveRBNode* const* insert_location = &_root;
 
   if (hint_node != nullptr) {
-    const int hint_cmp = cmp(key, hint_node);
+    const RBTreeOrdering hint_cmp = cmp(key, hint_node);
     while (hint_node->parent() != nullptr) {
-      const int parent_cmp = cmp(key, (NodeType*)hint_node->parent());
+      const RBTreeOrdering parent_cmp = cmp(key, (NodeType*)hint_node->parent());
       // Move up until the parent would put us on the other side of the key.
       // Meaning we are in the correct subtree.
-      if ((parent_cmp <= 0 && hint_cmp < 0) ||
-          (parent_cmp >= 0 && hint_cmp > 0)) {
+      if ((parent_cmp != RBTreeOrdering::greater && hint_cmp == RBTreeOrdering::less) ||
+          (parent_cmp != RBTreeOrdering::less    && hint_cmp == RBTreeOrdering::greater)) {
         hint_node = (NodeType*)hint_node->parent();
       } else {
         break;
@@ -212,14 +213,14 @@ AbstractRBTree<K, NodeType, COMPARATOR>::cursor(const K& key, const NodeType* hi
 
   while (*insert_location != nullptr) {
     NodeType* curr = (NodeType*)*insert_location;
-    const int key_cmp_k = cmp(key, curr);
+    const RBTreeOrdering key_cmp_k = cmp(key, curr);
 
-    if (key_cmp_k == 0) {
+    if (key_cmp_k == RBTreeOrdering::equal) {
       break;
     }
 
     parent = *insert_location;
-    if (key_cmp_k < 0) {
+    if (key_cmp_k == RBTreeOrdering::less) {
       insert_location = &curr->_left;
     } else {
       insert_location = &curr->_right;
@@ -551,19 +552,19 @@ inline void AbstractRBTree<K, NodeType, COMPARATOR>::replace_at_cursor(NodeType*
   new_node->_parent = old_node->_parent;
 
   if (new_node->is_left_child()) {
-    assert(cmp(static_cast<const NodeType*>(new_node), static_cast<const NodeType*>(new_node->parent())), "new node not < parent");
+    assert(less(static_cast<const NodeType*>(new_node), static_cast<const NodeType*>(new_node->parent())), "new node not < parent");
   } else if (new_node->is_right_child()) {
-    assert(cmp(static_cast<const NodeType*>(new_node->parent()), static_cast<const NodeType*>(new_node)), "new node not > parent");
+    assert(less(static_cast<const NodeType*>(new_node->parent()), static_cast<const NodeType*>(new_node)), "new node not > parent");
   }
 
   new_node->_left = old_node->_left;
   new_node->_right = old_node->_right;
   if (new_node->_left != nullptr) {
-    assert(cmp(static_cast<const NodeType*>(new_node->_left), static_cast<const NodeType*>(new_node)), "left child not < new node");
+    assert(less(static_cast<const NodeType*>(new_node->_left), static_cast<const NodeType*>(new_node)), "left child not < new node");
     new_node->_left->set_parent(new_node);
   }
   if (new_node->_right != nullptr) {
-    assert(cmp(static_cast<const NodeType*>(new_node), static_cast<const NodeType*>(new_node->_right)), "right child not > new node");
+    assert(less(static_cast<const NodeType*>(new_node), static_cast<const NodeType*>(new_node->_right)), "right child not > new node");
     new_node->_right->set_parent(new_node);
   }
 
@@ -661,8 +662,8 @@ inline void AbstractRBTree<K, NodeType, COMPARATOR>::visit_range_in_order(const 
 }
 
 template <typename K, typename NodeType, typename COMPARATOR>
-template <typename NodeVerifier>
-inline void AbstractRBTree<K, NodeType, COMPARATOR>::verify_self(NodeVerifier verifier) const {
+template <typename NodeVerifier, typename USER_VERIFIER>
+inline void AbstractRBTree<K, NodeType, COMPARATOR>::verify_self(NodeVerifier verifier, const USER_VERIFIER& extra_verifier) const {
   if (_root == nullptr) {
     assert(_num_nodes == 0, "rbtree has %zu nodes but no root", _num_nodes);
     return;
@@ -679,7 +680,7 @@ inline void AbstractRBTree<K, NodeType, COMPARATOR>::verify_self(NodeVerifier ve
   bool expected_visited = DEBUG_ONLY(_expected_visited) NOT_DEBUG(false);
 
   _root->verify<NodeType>(num_nodes, black_depth, shortest_leaf_path, longest_leaf_path,
-                tree_depth, expected_visited, verifier);
+                tree_depth, expected_visited, verifier, extra_verifier);
 
   const unsigned int maximum_depth = log2i(size() + 1) * 2;
 
@@ -731,21 +732,23 @@ inline void RBNode<K, V>::print_on(outputStream* st, int depth) const {
 }
 
 template <typename K, typename NodeType, typename COMPARATOR>
-void AbstractRBTree<K, NodeType, COMPARATOR>::print_node_on(outputStream* st, int depth, const NodeType* n) const {
-  n->print_on(st, depth);
+template <typename PRINTER>
+void AbstractRBTree<K, NodeType, COMPARATOR>::print_node_on(outputStream* st, int depth, const NodeType* n, const PRINTER& node_printer) const {
+  node_printer(st, n, depth);
   depth++;
-  if (n->_right != nullptr) {
-    print_node_on(st, depth, (NodeType*)n->_right);
-  }
   if (n->_left != nullptr) {
-    print_node_on(st, depth, (NodeType*)n->_left);
+    print_node_on(st, depth, (NodeType*)n->_left, node_printer);
+  }
+  if (n->_right != nullptr) {
+    print_node_on(st, depth, (NodeType*)n->_right, node_printer);
   }
 }
 
 template <typename K, typename NodeType, typename COMPARATOR>
-void AbstractRBTree<K, NodeType, COMPARATOR>::print_on(outputStream* st) const {
+template <typename PRINTER>
+void AbstractRBTree<K, NodeType, COMPARATOR>::print_on(outputStream* st, const PRINTER& node_printer) const {
   if (_root != nullptr) {
-    print_node_on(st, 0, (NodeType*)_root);
+    print_node_on(st, 0, (NodeType*)_root, node_printer);
   }
 }
 

--- a/src/hotspot/share/utilities/rbTree.inline.hpp
+++ b/src/hotspot/share/utilities/rbTree.inline.hpp
@@ -552,19 +552,19 @@ inline void AbstractRBTree<K, NodeType, COMPARATOR>::replace_at_cursor(NodeType*
   new_node->_parent = old_node->_parent;
 
   if (new_node->is_left_child()) {
-    assert(less(static_cast<const NodeType*>(new_node), static_cast<const NodeType*>(new_node->parent())), "new node not < parent");
+    assert(less_than(static_cast<const NodeType*>(new_node), static_cast<const NodeType*>(new_node->parent())), "new node not < parent");
   } else if (new_node->is_right_child()) {
-    assert(less(static_cast<const NodeType*>(new_node->parent()), static_cast<const NodeType*>(new_node)), "new node not > parent");
+    assert(less_than(static_cast<const NodeType*>(new_node->parent()), static_cast<const NodeType*>(new_node)), "new node not > parent");
   }
 
   new_node->_left = old_node->_left;
   new_node->_right = old_node->_right;
   if (new_node->_left != nullptr) {
-    assert(less(static_cast<const NodeType*>(new_node->_left), static_cast<const NodeType*>(new_node)), "left child not < new node");
+    assert(less_than(static_cast<const NodeType*>(new_node->_left), static_cast<const NodeType*>(new_node)), "left child not < new node");
     new_node->_left->set_parent(new_node);
   }
   if (new_node->_right != nullptr) {
-    assert(less(static_cast<const NodeType*>(new_node), static_cast<const NodeType*>(new_node->_right)), "right child not > new node");
+    assert(less_than(static_cast<const NodeType*>(new_node), static_cast<const NodeType*>(new_node->_right)), "right child not > new node");
     new_node->_right->set_parent(new_node);
   }
 

--- a/test/hotspot/gtest/utilities/test_rbtree.cpp
+++ b/test/hotspot/gtest/utilities/test_rbtree.cpp
@@ -36,26 +36,30 @@ public:
   using RBTreeIntNode = RBNode<int, int>;
 
   struct Cmp {
-    static int cmp(int a, int b) {
-      return a - b;
+    static RBTreeOrdering cmp(int a, int b) {
+      if (a < b) return RBTreeOrdering::less;
+      if (a > b) return RBTreeOrdering::greater;
+      return RBTreeOrdering::equal;
     }
 
-    static bool cmp(const RBTreeIntNode* a, const RBTreeIntNode* b) {
+    static bool less(const RBTreeIntNode* a, const RBTreeIntNode* b) {
       return a->key() < b->key();
     }
   };
 
   struct CmpInverse {
-    static int cmp(int a, int b) {
-      return b - a;
+    static RBTreeOrdering cmp(int a, int b) {
+      if (a < b) return RBTreeOrdering::greater;
+      if (a > b) return RBTreeOrdering::less;
+      return RBTreeOrdering::equal;
     }
   };
 
   struct FCmp {
-    static int cmp(float a, float b) {
-      if (a < b) return -1;
-      if (a == b) return 0;
-      return 1;
+    static RBTreeOrdering cmp(float a, float b) {
+      if (a < b) return RBTreeOrdering::less;
+      if (a > b) return RBTreeOrdering::greater;
+      return RBTreeOrdering::equal;
     }
   };
 
@@ -94,16 +98,15 @@ struct ArrayAllocator {
   };
 
   struct IntrusiveCmp {
-    static int cmp(int a, const IntrusiveTreeNode* b) {
-      return a - IntrusiveHolder::cast_to_self(b)->key;
-    }
-
-    static int cmp(int a, int b) {
-      return a - b;
+    static RBTreeOrdering cmp(int a, const IntrusiveTreeNode* b_node) {
+      int b = IntrusiveHolder::cast_to_self(b_node)->key;
+      if (a < b) return RBTreeOrdering::less;
+      if (a > b) return RBTreeOrdering::greater;
+      return RBTreeOrdering::equal;
     }
 
     // true if a < b
-    static bool cmp(const IntrusiveTreeNode* a, const IntrusiveTreeNode* b) {
+    static bool less(const IntrusiveTreeNode* a, const IntrusiveTreeNode* b) {
       return (IntrusiveHolder::cast_to_self(a)->key -
               IntrusiveHolder::cast_to_self(b)->key) < 0;
     }
@@ -837,6 +840,50 @@ public:
     }
   }
 
+  static bool custom_validator(const IntrusiveRBNode* n) {
+    IntrusiveHolder* holder = IntrusiveHolder::cast_to_self(n);
+    assert(holder->key == holder->data, "must be");
+
+    return true;
+  }
+
+  void test_custom_verify_intrusive() {
+    IntrusiveTreeInt intrusive_tree;
+    int num_nodes = 100;
+
+    // Insert values
+    for (int n = 0; n < num_nodes; n++) {
+      IntrusiveCursor cursor = intrusive_tree.cursor(n);
+      EXPECT_NULL(cursor.node());
+
+      // Custom allocation here is just malloc
+      IntrusiveHolder* place = (IntrusiveHolder*)os::malloc(sizeof(IntrusiveHolder), mtTest);
+      new (place) IntrusiveHolder(n, n);
+
+      intrusive_tree.insert_at_cursor(place->get_node(), cursor);
+      IntrusiveCursor cursor2 = intrusive_tree.cursor(n);
+
+      EXPECT_NOT_NULL(cursor2.node());
+    }
+
+    intrusive_tree.verify_self(RBTreeTest::custom_validator);
+
+    int node_count = 0;
+    intrusive_tree.verify_self([&](const IntrusiveRBNode* n) {
+      node_count++;
+
+      IntrusiveHolder* holder = IntrusiveHolder::cast_to_self(n);
+      assert(holder->key >= 0, "must be");
+      assert(holder->data >= 0, "must be");
+      assert(holder->key < num_nodes, "must be");
+      assert(holder->data < num_nodes, "must be");
+
+      return true;
+    });
+
+    EXPECT_EQ(node_count, num_nodes);
+  }
+
   #ifdef ASSERT
   void test_nodes_visited_once() {
     constexpr size_t memory_size = 65536;
@@ -945,10 +992,13 @@ TEST_VM_F(RBTreeTest, LeftMostRightMost) {
 }
 
 struct PtrCmp {
-  static int cmp(const void* a, const void* b) {
+  static RBTreeOrdering cmp(const void* a, const void* b) {
     const uintptr_t ai = p2u(a);
     const uintptr_t bi = p2u(b);
-    return ai == bi ? 0 : (ai > bi ? 1 : -1);
+
+    if (ai < bi) return RBTreeOrdering::less;
+    if (ai > bi) return RBTreeOrdering::greater;
+    return RBTreeOrdering::equal;
   }
 };
 
@@ -982,7 +1032,11 @@ TEST_VM(RBTreeTestNonFixture, TestPrintPointerTree) {
 }
 
 struct IntCmp {
-  static int cmp(int a, int b) { return a == b ? 0 : (a > b ? 1 : -1); }
+  static RBTreeOrdering cmp(int a, int b) {
+    if (a < b) return RBTreeOrdering::less;
+    if (a > b) return RBTreeOrdering::greater;
+    return RBTreeOrdering::equal;
+  }
 };
 
 TEST_VM(RBTreeTestNonFixture, TestPrintIntegerTree) {
@@ -1005,8 +1059,40 @@ TEST_VM(RBTreeTestNonFixture, TestPrintIntegerTree) {
     ASSERT_NE(strstr(ss.base(), s3), N);
 }
 
+TEST_VM(RBTreeTestNonFixture, TestPrintCustomPrinter) {
+  typedef RBTree<int, unsigned, IntCmp, RBTreeCHeapAllocator<mtTest> > TreeType;
+  typedef RBNode<int, unsigned> NodeType;
+
+  TreeType tree;
+  const int i1 = -13591;
+  const int i2 = 0;
+  const int i3 = 82924;
+  tree.upsert(i1, 1U);
+  tree.upsert(i2, 2U);
+  tree.upsert(i3, 3U);
+
+  stringStream ss;
+  int print_count = 0;
+  tree.print_on(&ss, [&](outputStream* st, const NodeType* n, int depth) {
+    st->print_cr("[%d] (%d): %d", depth, n->val(), n->key());
+    print_count++;
+  });
+
+const char* const expected =
+    "[0] (2): 0\n"
+    "[1] (1): -13591\n"
+    "[1] (3): 82924\n";
+
+  ASSERT_EQ(print_count, 3);
+  ASSERT_STREQ(ss.base(), expected);
+}
+
 TEST_VM_F(RBTreeTest, IntrusiveTest) {
   this->test_intrusive();
+}
+
+TEST_VM_F(RBTreeTest, IntrusiveCustomVerifyTest) {
+  this->test_custom_verify_intrusive();
 }
 
 TEST_VM_F(RBTreeTest, FillAndVerify) {
@@ -1021,6 +1107,22 @@ TEST_VM_F(RBTreeTest, CursorReplace) {
 TEST_VM_F(RBTreeTest, NodesVisitedOnce) {
   this->test_nodes_visited_once();
 }
+
+TEST_VM_ASSERT_MSG(RBTreeTestNonFixture, CustomVerifyAssert, ".*failed on key = 7") {
+  typedef RBTreeCHeap<int, int, IntCmp, mtTest> TreeType;
+  typedef RBNode<int, int> NodeType;
+
+  TreeType tree;
+  for (int i = 0; i < 10; i++) {
+    tree.upsert(i, i);
+  }
+
+  tree.verify_self([&](const NodeType* n) {
+    assert(n->key() != 7, "failed on key = %d", n->key());
+    return true;
+  });
+}
+
 #endif // ASSERT
 
 TEST_VM_F(RBTreeTest, InsertRemoveVerify) {
@@ -1037,6 +1139,25 @@ TEST_VM_F(RBTreeTest, InsertRemoveVerify) {
       tree.verify_self();
     }
   }
+}
+
+TEST_VM_F(RBTreeTest, CustomVerify) {
+  constexpr int num_nodes = 1000;
+  RBTreeInt tree;
+  for (int i = 0; i < num_nodes; i++) {
+    tree.upsert(i, i);
+  }
+
+  int node_count = 0;
+  tree.verify_self([&](const RBTreeIntNode* n) {
+    node_count++;
+
+    assert(n->key() >= 0, "must be");
+    assert(n->key() < num_nodes, "must be");
+    return true;
+  });
+
+  EXPECT_EQ(node_count, num_nodes);
 }
 
 TEST_VM_F(RBTreeTest, VerifyItThroughStressTest) {

--- a/test/hotspot/gtest/utilities/test_rbtree.cpp
+++ b/test/hotspot/gtest/utilities/test_rbtree.cpp
@@ -37,9 +37,9 @@ public:
 
   struct Cmp {
     static RBTreeOrdering cmp(int a, int b) {
-      if (a < b) return RBTreeOrdering::less;
-      if (a > b) return RBTreeOrdering::greater;
-      return RBTreeOrdering::equal;
+      if (a < b) return RBTreeOrdering::LT;
+      if (a > b) return RBTreeOrdering::GT;
+      return RBTreeOrdering::EQ;
     }
 
     static bool less_than(const RBTreeIntNode* a, const RBTreeIntNode* b) {
@@ -49,17 +49,17 @@ public:
 
   struct CmpInverse {
     static RBTreeOrdering cmp(int a, int b) {
-      if (a < b) return RBTreeOrdering::greater;
-      if (a > b) return RBTreeOrdering::less;
-      return RBTreeOrdering::equal;
+      if (a < b) return RBTreeOrdering::GT;
+      if (a > b) return RBTreeOrdering::LT;
+      return RBTreeOrdering::EQ;
     }
   };
 
   struct FCmp {
     static RBTreeOrdering cmp(float a, float b) {
-      if (a < b) return RBTreeOrdering::less;
-      if (a > b) return RBTreeOrdering::greater;
-      return RBTreeOrdering::equal;
+      if (a < b) return RBTreeOrdering::LT;
+      if (a > b) return RBTreeOrdering::GT;
+      return RBTreeOrdering::EQ;
     }
   };
 
@@ -100,9 +100,9 @@ struct ArrayAllocator {
   struct IntrusiveCmp {
     static RBTreeOrdering cmp(int a, const IntrusiveTreeNode* b_node) {
       int b = IntrusiveHolder::cast_to_self(b_node)->key;
-      if (a < b) return RBTreeOrdering::less;
-      if (a > b) return RBTreeOrdering::greater;
-      return RBTreeOrdering::equal;
+      if (a < b) return RBTreeOrdering::LT;
+      if (a > b) return RBTreeOrdering::GT;
+      return RBTreeOrdering::EQ;
     }
 
     // true if a < b
@@ -996,9 +996,9 @@ struct PtrCmp {
     const uintptr_t ai = p2u(a);
     const uintptr_t bi = p2u(b);
 
-    if (ai < bi) return RBTreeOrdering::less;
-    if (ai > bi) return RBTreeOrdering::greater;
-    return RBTreeOrdering::equal;
+    if (ai < bi) return RBTreeOrdering::LT;
+    if (ai > bi) return RBTreeOrdering::GT;
+    return RBTreeOrdering::EQ;
   }
 };
 
@@ -1033,9 +1033,9 @@ TEST_VM(RBTreeTestNonFixture, TestPrintPointerTree) {
 
 struct IntCmp {
   static RBTreeOrdering cmp(int a, int b) {
-    if (a < b) return RBTreeOrdering::less;
-    if (a > b) return RBTreeOrdering::greater;
-    return RBTreeOrdering::equal;
+    if (a < b) return RBTreeOrdering::LT;
+    if (a > b) return RBTreeOrdering::GT;
+    return RBTreeOrdering::EQ;
   }
 };
 

--- a/test/hotspot/gtest/utilities/test_rbtree.cpp
+++ b/test/hotspot/gtest/utilities/test_rbtree.cpp
@@ -42,7 +42,7 @@ public:
       return RBTreeOrdering::equal;
     }
 
-    static bool less(const RBTreeIntNode* a, const RBTreeIntNode* b) {
+    static bool less_than(const RBTreeIntNode* a, const RBTreeIntNode* b) {
       return a->key() < b->key();
     }
   };
@@ -106,7 +106,7 @@ struct ArrayAllocator {
     }
 
     // true if a < b
-    static bool less(const IntrusiveTreeNode* a, const IntrusiveTreeNode* b) {
+    static bool less_than(const IntrusiveTreeNode* a, const IntrusiveTreeNode* b) {
       return (IntrusiveHolder::cast_to_self(a)->key -
               IntrusiveHolder::cast_to_self(b)->key) < 0;
     }


### PR DESCRIPTION
Hi everyone,

The current red-black tree can be made safer, and its inspection capabilities improved.

As briefly discussed in #26904, `COMPARATOR::cmp` could be made clearer and more robust. In particular, its `int` return type invites unsafe `return a ‑ b` arithmetic, and the boolean validation function also named `cmp` is misleading.

To address this, I’ve introduced the `RBTreeOrdering` enum, inspired by C++20’s `<=>`, which makes incorrect arithmetic impossible. The return type of `COMPARATOR::cmp` is now this enum, forcing users to write an explicit and safe comparison. From the discussion in that PR, I have also renamed the boolean `cmp` to `less`, making its purpose obvious and preventing confusion between the two functions.

Inspection has also been improved, especially for intrusive trees. Previously, `verify_self` only verified core RB-tree properties, yet intrusive nodes often hold additional data with their own separate invariants. Users had to perform those checks in a second traversal, and if an error occurs `print_on` produced little diagnostic value by only printing node addresses.

To solve this, the tree now accepts user-supplied verification and printing callables. This lets users validate their custom node data during the same walk and print richer information when errors occur.

Everything is implemented via template parameters with set defaults, so existing code remains unchanged while new code can opt in to the expanded functionality.

Testing:
- Oracle tiers 1-3

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8366238](https://bugs.openjdk.org/browse/JDK-8366238): Improve RBTree API with stricter comparator semantics and pluggable validation/printing hooks (**Enhancement** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**) Review applies to [f780a53e](https://git.openjdk.org/jdk/pull/26981/files/f780a53ea79935be0f409700867b754c03d04609)
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@jdksjolen - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26981/head:pull/26981` \
`$ git checkout pull/26981`

Update a local copy of the PR: \
`$ git checkout pull/26981` \
`$ git pull https://git.openjdk.org/jdk.git pull/26981/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26981`

View PR using the GUI difftool: \
`$ git pr show -t 26981`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26981.diff">https://git.openjdk.org/jdk/pull/26981.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26981#issuecomment-3232654602)
</details>
