### PR TITLE
8366062: [ubsan] add non-zero offset to nullptr in cds/archiveBuilder.cpp

### DIFF
--- a/src/hotspot/share/cds/archiveBuilder.cpp
+++ b/src/hotspot/share/cds/archiveBuilder.cpp
@@ -1032,7 +1032,6 @@ uintx ArchiveBuilder::any_to_offset(address p) const {
 }
 
 address ArchiveBuilder::offset_to_buffered_address(u4 offset) const {
-  // As zero is allowed for _requested_static_archive_bottom, use integer arithmetic to avoid UB pointer arithmetic.
   address buffered_addr = _buffer_bottom + offset;
   assert(is_in_buffer_space(buffered_addr), "bad offset");
   return buffered_addr;
@@ -1100,8 +1099,8 @@ class RelocateBufferToRequested : public BitMapClosure {
     address top = _builder->buffer_top();
     // It is acceptable that new_bottom/new_top may be zero.
     // As zero is allowed for new_bottom, use integer arithmetic to avoid UB pointer arithmetic.
-    address new_bottom = (address)(bottom + _buffer_to_requested_delta);
-    address new_top = (address)(top + _buffer_to_requested_delta);
+    address new_bottom = (address)((intx)bottom + _buffer_to_requested_delta);
+    address new_top = top + _buffer_to_requested_delta;
     aot_log_debug(aot)("Relocating archive from [" INTPTR_FORMAT " - " INTPTR_FORMAT "] to "
                    "[" INTPTR_FORMAT " - " INTPTR_FORMAT "]",
                    p2i(bottom), p2i(top),


### PR DESCRIPTION
It is acceptable that the `SharedBaseAddress` option gets `0` at command line. The corresponding pointer arithmetic with `0` (`nullptr`) in archiveBuilder is UB.
Specific casts are used to avoid UBSAN error.

Tests:
linux-x64-debug: tier1 passed

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8366062](https://bugs.openjdk.org/browse/JDK-8366062): [ubsan] add non-zero offset to nullptr in cds/archiveBuilder.cpp (**Enhancement** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) Review applies to [5b0dbb9e](https://git.openjdk.org/jdk/pull/26983/files/5b0dbb9e75ee3d8403c88d1b0fb0171b72d52994)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26983/head:pull/26983` \
`$ git checkout pull/26983`

Update a local copy of the PR: \
`$ git checkout pull/26983` \
`$ git pull https://git.openjdk.org/jdk.git pull/26983/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26983`

View PR using the GUI difftool: \
`$ git pr show -t 26983`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26983.diff">https://git.openjdk.org/jdk/pull/26983.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26983#issuecomment-3232895625)
</details>
