### PR TITLE
8366341: [BACKOUT] JDK-8365256: RelocIterator should use indexes instead of pointers

### DIFF
--- a/src/hotspot/share/code/codeBlob.cpp
+++ b/src/hotspot/share/code/codeBlob.cpp
@@ -128,7 +128,7 @@ CodeBlob::CodeBlob(const char* name, CodeBlobKind kind, CodeBuffer* cb, int size
                    int mutable_data_size) :
   _oop_maps(nullptr), // will be set by set_oop_maps() call
   _name(name),
-  _mutable_data(nullptr),
+  _mutable_data(header_begin() + size), // default value is blob_end()
   _size(size),
   _relocation_size(align_up(cb->total_relocation_size(), oopSize)),
   _content_offset(CodeBlob::align_code_offset(header_size)),
@@ -158,8 +158,10 @@ CodeBlob::CodeBlob(const char* name, CodeBlobKind kind, CodeBuffer* cb, int size
     if (_mutable_data == nullptr) {
       vm_exit_out_of_memory(_mutable_data_size, OOM_MALLOC_ERROR, "codebuffer: no space for mutable data");
     }
+  } else {
+    // We need unique and valid not null address
+    assert(_mutable_data == blob_end(), "sanity");
   }
-  assert(_mutable_data != nullptr || _mutable_data_size == 0, "No mutable data => mutable data size is 0");
 
   set_oop_maps(oop_maps);
 }
@@ -168,7 +170,7 @@ CodeBlob::CodeBlob(const char* name, CodeBlobKind kind, CodeBuffer* cb, int size
 CodeBlob::CodeBlob(const char* name, CodeBlobKind kind, int size, uint16_t header_size) :
   _oop_maps(nullptr),
   _name(name),
-  _mutable_data(nullptr),
+  _mutable_data(header_begin() + size), // default value is blob_end()
   _size(size),
   _relocation_size(0),
   _content_offset(CodeBlob::align_code_offset(header_size)),
@@ -182,9 +184,9 @@ CodeBlob::CodeBlob(const char* name, CodeBlobKind kind, int size, uint16_t heade
   _kind(kind),
   _caller_must_gc_arguments(false)
 {
-  assert(_mutable_data == nullptr && _mutable_data_size == 0, "invariant");
   assert(is_aligned(size,            oopSize), "unaligned size");
   assert(is_aligned(header_size,     oopSize), "unaligned size");
+  assert(_mutable_data == blob_end(), "sanity");
 }
 
 void CodeBlob::restore_mutable_data(address reloc_data) {
@@ -195,7 +197,7 @@ void CodeBlob::restore_mutable_data(address reloc_data) {
       vm_exit_out_of_memory(_mutable_data_size, OOM_MALLOC_ERROR, "codebuffer: no space for mutable data");
     }
   } else {
-    _mutable_data = nullptr;
+    _mutable_data = blob_end(); // default value
   }
   if (_relocation_size > 0) {
     assert(_mutable_data_size > 0, "relocation is part of mutable data section");
@@ -204,13 +206,17 @@ void CodeBlob::restore_mutable_data(address reloc_data) {
 }
 
 void CodeBlob::purge() {
-  os::free(_mutable_data);
-  _mutable_data = nullptr;
-  _mutable_data_size = 0;
-  delete _oop_maps;
-  _oop_maps = nullptr;
-  _relocation_size = 0;
-
+  assert(_mutable_data != nullptr, "should never be null");
+  if (_mutable_data != blob_end()) {
+    os::free(_mutable_data);
+    _mutable_data = blob_end(); // Valid not null address
+    _mutable_data_size = 0;
+    _relocation_size = 0;
+  }
+  if (_oop_maps != nullptr) {
+    delete _oop_maps;
+    _oop_maps = nullptr;
+  }
   NOT_PRODUCT(_asm_remarks.clear());
   NOT_PRODUCT(_dbg_strings.clear());
 }

--- a/src/hotspot/share/code/nmethod.cpp
+++ b/src/hotspot/share/code/nmethod.cpp
@@ -1327,8 +1327,8 @@ nmethod::nmethod(
            "wrong mutable data size: %d != %d + %d",
            _mutable_data_size, _relocation_size, metadata_size);
 
-    // native wrapper does not have read-only data
-    _immutable_data          = nullptr;
+    // native wrapper does not have read-only data but we need unique not null address
+    _immutable_data          = blob_end();
     _immutable_data_size     = 0;
     _nul_chk_table_offset    = 0;
     _handler_table_offset    = 0;
@@ -1510,7 +1510,8 @@ nmethod::nmethod(
       assert(immutable_data != nullptr, "required");
       _immutable_data     = immutable_data;
     } else {
-      _immutable_data     = nullptr;
+      // We need unique not null address
+      _immutable_data     = blob_end();
     }
     CHECKED_CAST(_nul_chk_table_offset, uint16_t, (align_up((int)dependencies->size_in_bytes(), oopSize)));
     CHECKED_CAST(_handler_table_offset, uint16_t, (_nul_chk_table_offset + align_up(nul_chk_table->size_in_bytes(), oopSize)));
@@ -2146,14 +2147,15 @@ void nmethod::purge(bool unregister_nmethod) {
     delete ec;
     ec = next;
   }
-
-  delete _pc_desc_container;
+  if (_pc_desc_container != nullptr) {
+    delete _pc_desc_container;
+  }
   delete[] _compiled_ic_data;
 
-  os::free(_immutable_data);
-  _immutable_data = nullptr;
-  _immutable_data_size = 0;
-
+  if (_immutable_data != blob_end()) {
+    os::free(_immutable_data);
+    _immutable_data = blob_end(); // Valid not null address
+  }
   if (unregister_nmethod) {
     Universe::heap()->unregister_nmethod(this);
   }


### PR DESCRIPTION
Hi,

 When a null pointer is accessed in SA it's serialized into the null Java object, this in turn causes runtime NPE:s when attempts are made to perform arithmetic on them. As we changed `_immutable_data` to be null when missing, this hits that corner case in the SA.

Example of code which fails:

```java
  public PCDesc getPCDescAt(Address pc) {
    // NOTE: scopesPCsBegin() depends on the value of _immutable_data and will throw NPE if immutable_data is null
    for (Address p = scopesPCsBegin(); p.lessThan(scopesPCsEnd()); p = p.addOffsetTo(pcDescSize)) {
      PCDesc pcDesc = new PCDesc(p);
      if (pcDesc.getRealPC(this).equals(pc)) {
        return pcDesc;
      }
    }
    return null;
  }
```

There are similar iterators in Hotspot code, they will cause UBSAN to complain instead as we're adding something to a null pointer.

The "real fix" requires a lot of work on the SA side, and we cannot prioritize that. Instead, I'm backing out my changes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8366341](https://bugs.openjdk.org/browse/JDK-8366341): [BACKOUT] JDK-8365256: RelocIterator should use indexes instead of pointers (**Enhancement** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26984/head:pull/26984` \
`$ git checkout pull/26984`

Update a local copy of the PR: \
`$ git checkout pull/26984` \
`$ git pull https://git.openjdk.org/jdk.git pull/26984/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26984`

View PR using the GUI difftool: \
`$ git pr show -t 26984`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26984.diff">https://git.openjdk.org/jdk/pull/26984.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26984#issuecomment-3233034287)
</details>
