### PR TITLE
8366342: Key generator and key pair generator tests skipping, but showing as passed

### DIFF
--- a/test/jdk/sun/security/pkcs11/KeyGenerator/DESParity.java
+++ b/test/jdk/sun/security/pkcs11/KeyGenerator/DESParity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,6 +32,8 @@
  * @run main/othervm DESParity
  */
 
+import jtreg.SkippedException;
+
 import java.security.Provider;
 import java.util.Random;
 import javax.crypto.SecretKey;
@@ -45,8 +47,7 @@ public class DESParity extends PKCS11Test {
     @Override
     public void main(Provider p) throws Exception {
         if (p.getService("SecretKeyFactory", "DES") == null) {
-            System.out.println("Not supported by provider, skipping");
-            return;
+            throw new SkippedException("Not supported by provider, skipping");
         }
         Random random = new Random();
         SecretKeyFactory kf;
@@ -57,7 +58,7 @@ public class DESParity extends PKCS11Test {
             random.nextBytes(b);
             SecretKeySpec spec = new SecretKeySpec(b, "DES");
             SecretKey key = kf.generateSecret(spec);
-            if (DESKeySpec.isParityAdjusted(key.getEncoded(), 0) == false) {
+            if (!DESKeySpec.isParityAdjusted(key.getEncoded(), 0)) {
                 throw new Exception("DES key not parity adjusted");
             }
         }
@@ -68,7 +69,7 @@ public class DESParity extends PKCS11Test {
             random.nextBytes(b);
             SecretKeySpec spec = new SecretKeySpec(b, "DESede");
             SecretKey key = kf.generateSecret(spec);
-            if (DESedeKeySpec.isParityAdjusted(key.getEncoded(), 0) == false) {
+            if (!DESedeKeySpec.isParityAdjusted(key.getEncoded(), 0)) {
                 throw new Exception("DESede key not parity adjusted");
             }
         }

--- a/test/jdk/sun/security/pkcs11/KeyGenerator/TestAES.java
+++ b/test/jdk/sun/security/pkcs11/KeyGenerator/TestAES.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,13 +30,14 @@
  * @library /test/lib ..
  * @run main TestAES
  */
+import jtreg.SkippedException;
+import sun.security.util.SecurityProviderConstants;
+
 import java.security.Provider;
-import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidParameterException;
 import java.security.NoSuchAlgorithmException;
 import javax.crypto.KeyGenerator;
 import javax.crypto.SecretKey;
-import static sun.security.util.SecurityProviderConstants.*;
 
 public class TestAES extends PKCS11Test {
 
@@ -53,17 +54,16 @@ public class TestAES extends PKCS11Test {
         try {
             kg = KeyGenerator.getInstance(ALGO, p);
         } catch (NoSuchAlgorithmException nsae) {
-            System.out.println("Skip; no support for " + ALGO);
-            return;
+            throw new SkippedException("Skip; no support for " + ALGO, nsae);
         }
 
         // first try w/o setting a key length and check if the generated key
         // length matches
         SecretKey key = kg.generateKey();
         byte[] keyValue = key.getEncoded();
-        if (key.getEncoded().length != getDefAESKeySize() >> 3) {
+        if (key.getEncoded().length != SecurityProviderConstants.getDefAESKeySize() >> 3) {
             throw new RuntimeException("Default AES key length should be " +
-                    getDefAESKeySize());
+                                       SecurityProviderConstants.getDefAESKeySize());
         }
 
         for (int keySize : new int[] { 16, 32, 64, 128, 256, 512, 1024 }) {

--- a/test/jdk/sun/security/pkcs11/KeyGenerator/TestChaCha20.java
+++ b/test/jdk/sun/security/pkcs11/KeyGenerator/TestChaCha20.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,8 @@
  * @library /test/lib ..
  * @run main/othervm TestChaCha20
  */
+import jtreg.SkippedException;
+
 import java.security.Provider;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidParameterException;
@@ -54,8 +56,7 @@ public class TestChaCha20 extends PKCS11Test {
         try {
             kg = KeyGenerator.getInstance(ALGO, p);
         } catch (NoSuchAlgorithmException nsae) {
-            System.out.println("Skip; no support for " + ALGO);
-            return;
+            throw new SkippedException("Skip; no support for " + ALGO, nsae);
         }
 
         try {

--- a/test/jdk/sun/security/pkcs11/KeyGenerator/TestKeyGenerator.java
+++ b/test/jdk/sun/security/pkcs11/KeyGenerator/TestKeyGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/sun/security/pkcs11/KeyPairGenerator/TestDH2048.java
+++ b/test/jdk/sun/security/pkcs11/KeyPairGenerator/TestDH2048.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,8 @@
  * @run main/othervm TestDH2048
  */
 
+import jtreg.SkippedException;
+
 import java.security.InvalidParameterException;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
@@ -50,8 +52,7 @@ public class TestDH2048 extends PKCS11Test {
     @Override
     public void main(Provider p) throws Exception {
         if (p.getService("KeyPairGenerator", "DH") == null) {
-            System.out.println("KPG for DH not supported, skipping");
-            return;
+            throw new SkippedException("KPG for DH not supported, skipping");
         }
         KeyPairGenerator kpg = KeyPairGenerator.getInstance("DH", p);
         kpg.initialize(512);

--- a/test/jdk/sun/security/pkcs11/KeyPairGenerator/TestDefaultDHPrivateExpSize.java
+++ b/test/jdk/sun/security/pkcs11/KeyPairGenerator/TestDefaultDHPrivateExpSize.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,12 +21,12 @@
  * questions.
  */
 
-import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.Provider;
-import java.security.PrivateKey;
 import javax.crypto.spec.DHParameterSpec;
 import javax.crypto.interfaces.DHPrivateKey;
+
+import jtreg.SkippedException;
 import sun.security.util.SecurityProviderConstants;
 import sun.security.provider.ParameterCache;
 
@@ -47,8 +47,7 @@ public class TestDefaultDHPrivateExpSize extends PKCS11Test {
         System.out.println("Testing " + p.getName());
 
         if (p.getService("KeyPairGenerator", "DH") == null) {
-            System.out.println("Skip, no support for DH KeyPairGenerator");
-            return;
+            throw new SkippedException("Skip, no support for DH KeyPairGenerator");
         }
 
         KeyPairGenerator kpg = KeyPairGenerator.getInstance("DH", p);


### PR DESCRIPTION
* Minor cleanup
* Key generator and key pair generator tests skipping, but showing as passed:
   * test/jdk/sun/security/pkcs11/KeyGenerator/DESParity.java
   * test/jdk/sun/security/pkcs11/KeyGenerator/TestAES.java
   * test/jdk/sun/security/pkcs11/KeyGenerator/TestChaCha20.java
   * test/jdk/sun/security/pkcs11/KeyGenerator/TestKeyGenerator.java
   * test/jdk/sun/security/pkcs11/KeyPairGenerator/TestDH2048.java
   * test/jdk/sun/security/pkcs11/KeyPairGenerator/TestDefaultDHPrivateExpSize.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8366342](https://bugs.openjdk.org/browse/JDK-8366342): Key generator and key pair generator tests skipping, but showing as passed (**Bug** - P4)


### Reviewers
 * [Weijun Wang](https://openjdk.org/census#weijun) (@wangweij - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26985/head:pull/26985` \
`$ git checkout pull/26985`

Update a local copy of the PR: \
`$ git checkout pull/26985` \
`$ git pull https://git.openjdk.org/jdk.git pull/26985/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26985`

View PR using the GUI difftool: \
`$ git pr show -t 26985`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26985.diff">https://git.openjdk.org/jdk/pull/26985.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26985#issuecomment-3233123711)
</details>
