### PR TITLE
8366065: ZGC: Differentiate Young Collection type strings in statistics

### DIFF
--- a/src/hotspot/share/gc/z/zGeneration.cpp
+++ b/src/hotspot/share/gc/z/zGeneration.cpp
@@ -68,9 +68,9 @@
 
 static const ZStatPhaseGeneration ZPhaseGenerationYoung[] {
   ZStatPhaseGeneration("Young Generation", ZGenerationId::young),
-  ZStatPhaseGeneration("Young Generation (Promote All)", ZGenerationId::young),
-  ZStatPhaseGeneration("Young Generation (Collect Roots)", ZGenerationId::young),
-  ZStatPhaseGeneration("Young Generation", ZGenerationId::young)
+  ZStatPhaseGeneration("Young Generation (Preclean)", ZGenerationId::young),
+  ZStatPhaseGeneration("Young Generation (Full Roots)", ZGenerationId::young),
+  ZStatPhaseGeneration("Young Generation (Partial Roots)", ZGenerationId::young)
 };
 
 static const ZStatPhaseGeneration ZPhaseGenerationOld("Old Generation", ZGenerationId::old);


### PR DESCRIPTION
Hello,

Currently, two different Young Collection (YC) types print identical strings in the GC statistics at the end of `-Xlog:gc*`. This makes it difficult to distinguish statistics for specific YC types when analyzing logs for performance issues. This PR updates the strings to match the `ZYoungType` enum names, improving traceability and making logs clearer.

Relevant enum for reference:
```c++
enum class ZYoungType {
  minor,
  major_full_preclean,
  major_full_roots,
  major_partial_roots,
  none
};
```

Testing:
* GHA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8366065](https://bugs.openjdk.org/browse/JDK-8366065): ZGC: Differentiate Young Collection type strings in statistics (**Enhancement** - P4)


### Reviewers
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26986/head:pull/26986` \
`$ git checkout pull/26986`

Update a local copy of the PR: \
`$ git checkout pull/26986` \
`$ git pull https://git.openjdk.org/jdk.git pull/26986/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26986`

View PR using the GUI difftool: \
`$ git pr show -t 26986`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26986.diff">https://git.openjdk.org/jdk/pull/26986.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26986#issuecomment-3233304280)
</details>
