### PR TITLE
8366359: Test should throw SkippedException when there is no lpstat

### DIFF
--- a/test/jdk/javax/print/PrintServiceLookup/CountPrintServices.java
+++ b/test/jdk/javax/print/PrintServiceLookup/CountPrintServices.java
@@ -33,17 +33,12 @@ import jtreg.SkippedException;
  * @bug 8032693
  * @key printer
  * @library /test/lib/
+ * @requires (os.family == "linux")
  * @summary Test that lpstat and JDK agree whether there are printers.
  */
 public class CountPrintServices {
 
   public static void main(String[] args) throws Exception {
-    String os = System.getProperty("os.name").toLowerCase();
-    System.out.println("OS is " + os);
-    if (!os.equals("linux")) {
-        System.out.println("Linux specific test. No need to continue");
-        return;
-    }
     PrintService services[] =
         PrintServiceLookup.lookupPrintServices(null, null);
     if (services.length > 0) {

--- a/test/jdk/javax/print/PrintServiceLookup/CountPrintServices.java
+++ b/test/jdk/javax/print/PrintServiceLookup/CountPrintServices.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,14 +25,14 @@ import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import javax.print.PrintService;
 import javax.print.PrintServiceLookup;
-import javax.print.attribute.AttributeSet;
-import javax.print.attribute.HashAttributeSet;
-import javax.print.attribute.standard.PrinterName;
+
+import jtreg.SkippedException;
 
 /*
  * @test
  * @bug 8032693
  * @key printer
+ * @library /test/lib/
  * @summary Test that lpstat and JDK agree whether there are printers.
  */
 public class CountPrintServices {
@@ -51,7 +51,14 @@ public class CountPrintServices {
        return;
     }
     String[] lpcmd = { "lpstat", "-a" };
-    Process proc = Runtime.getRuntime().exec(lpcmd);
+    Process proc = null;
+    try {
+        proc = Runtime.getRuntime().exec(lpcmd);
+    } catch (java.io.IOException e) {
+        if(e.getMessage().contains("No such file or directory")) {
+            throw new SkippedException("Can not find lpstat, test skip");
+        }
+    }
     proc.waitFor();
     InputStreamReader ir = new InputStreamReader(proc.getInputStream());
     BufferedReader br = new BufferedReader(ir);
@@ -66,4 +73,3 @@ public class CountPrintServices {
     }
  }
 }
-

--- a/test/jdk/javax/print/PrintServiceLookup/CountPrintServices.java
+++ b/test/jdk/javax/print/PrintServiceLookup/CountPrintServices.java
@@ -25,6 +25,7 @@ import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import javax.print.PrintService;
 import javax.print.PrintServiceLookup;
+import java.io.IOException;
 
 import jtreg.SkippedException;
 
@@ -49,9 +50,11 @@ public class CountPrintServices {
     Process proc = null;
     try {
         proc = Runtime.getRuntime().exec(lpcmd);
-    } catch (java.io.IOException e) {
+    } catch (IOException e) {
         if (e.getMessage().contains("No such file or directory")) {
             throw new SkippedException("Cannot find lpstat");
+        } else {
+            throw e;
         }
     }
     proc.waitFor();

--- a/test/jdk/javax/print/PrintServiceLookup/CountPrintServices.java
+++ b/test/jdk/javax/print/PrintServiceLookup/CountPrintServices.java
@@ -47,7 +47,7 @@ public class CountPrintServices {
        return;
     }
     String[] lpcmd = { "lpstat", "-a" };
-    Process proc = null;
+    Process proc;
     try {
         proc = Runtime.getRuntime().exec(lpcmd);
     } catch (IOException e) {

--- a/test/jdk/javax/print/PrintServiceLookup/CountPrintServices.java
+++ b/test/jdk/javax/print/PrintServiceLookup/CountPrintServices.java
@@ -50,8 +50,8 @@ public class CountPrintServices {
     try {
         proc = Runtime.getRuntime().exec(lpcmd);
     } catch (java.io.IOException e) {
-        if(e.getMessage().contains("No such file or directory")) {
-            throw new SkippedException("Can not find lpstat, test skip");
+        if (e.getMessage().contains("No such file or directory")) {
+            throw new SkippedException("Cannot find lpstat");
         }
     }
     proc.waitFor();


### PR DESCRIPTION
Hi all,

I think test javax/print/PrintServiceLookup/CountPrintServices.java should throw jtreg.SkippedException when there is no lpstat, rather that report test failure.

Only javax/print/PrintServiceLookup/CountPrintServices.java invokes lpstat explicitly.

Change has been verified locally, test-fix only, no risk.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8366359](https://bugs.openjdk.org/browse/JDK-8366359): Test should throw SkippedException when there is no lpstat (**Bug** - P4)


### Reviewers
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26988/head:pull/26988` \
`$ git checkout pull/26988`

Update a local copy of the PR: \
`$ git checkout pull/26988` \
`$ git pull https://git.openjdk.org/jdk.git pull/26988/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26988`

View PR using the GUI difftool: \
`$ git pr show -t 26988`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26988.diff">https://git.openjdk.org/jdk/pull/26988.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26988#issuecomment-3233733975)
</details>
