### PR TITLE
8366369: Add @requires linux for GTK L&F tests

### DIFF
--- a/test/jdk/com/sun/java/swing/plaf/gtk/4928019/bug4928019.java
+++ b/test/jdk/com/sun/java/swing/plaf/gtk/4928019/bug4928019.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,8 +25,8 @@
  * @test
  * @bug 4928019
  * @key headful
+ * @requires os.family == "linux"
  * @summary Makes sure all the basic classes can be created with GTK.
- * @author Scott Violet
  */
 
 import javax.swing.*;
@@ -34,17 +34,8 @@ import javax.swing.plaf.basic.*;
 
 public class bug4928019 {
     public static void main(String[] args) throws Throwable {
-        try {
-            UIManager.setLookAndFeel("com.sun.java.swing.plaf.gtk.GTKLookAndFeel");
-        } catch (UnsupportedLookAndFeelException ex) {
-            System.err.println("GTKLookAndFeel is not supported on this platform." +
-                    " Test is considered passed.");
-            return;
-        } catch (ClassNotFoundException ex) {
-            System.err.println("GTKLookAndFeel class is not found." +
-                    " Test is considered passed.");
-            return;
-        }
+        UIManager.setLookAndFeel("com.sun.java.swing.plaf.gtk.GTKLookAndFeel");
+
         new JButton() {
             public void updateUI() {
                 setUI(new BasicButtonUI());

--- a/test/jdk/com/sun/java/swing/plaf/gtk/Test6635110.java
+++ b/test/jdk/com/sun/java/swing/plaf/gtk/Test6635110.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,18 +21,24 @@
  * questions.
  */
 
-/* @test
-   @bug 6635110
-   @key headful
-   @summary GTK icons should not throw NPE when called by non-GTK UI
-   @author Peter Zhelezniakov
-   @run main Test6635110
+/*
+ * @test
+ * @bug 6635110
+ * @key headful
+ * @requires os.family == "linux"
+ * @summary GTK icons should not throw NPE when called by non-GTK UI
+ * @run main Test6635110
 */
 
-import javax.swing.*;
-import java.awt.*;
+import java.awt.Component;
 import java.awt.image.BufferedImage;
-import javax.swing.plaf.basic.*;
+
+import javax.swing.JMenu;
+import javax.swing.JToolBar;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+import javax.swing.plaf.basic.BasicMenuUI;
+import javax.swing.plaf.basic.BasicToolBarUI;
 
 
 public class Test6635110 implements Runnable {
@@ -59,12 +65,8 @@ public class Test6635110 implements Runnable {
     }
 
     public static void main(String[] args) throws Exception {
-        try {
-            UIManager.setLookAndFeel("com.sun.java.swing.plaf.gtk.GTKLookAndFeel");
-        } catch (Exception e) {
-            System.out.println("GTKLookAndFeel cannot be set, skipping this test");
-            return;
-        }
+        UIManager.setLookAndFeel("com.sun.java.swing.plaf.gtk.GTKLookAndFeel");
+
         SwingUtilities.invokeAndWait(new Test6635110());
     }
 }

--- a/test/jdk/com/sun/java/swing/plaf/gtk/Test6963870.java
+++ b/test/jdk/com/sun/java/swing/plaf/gtk/Test6963870.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,14 +21,15 @@
  * questions.
  */
 
-/* @test
-   @bug 6963870
-   @key headful
-   @summary Tests that GTKPainter.ListTableFocusBorder.getBorderInsets()
-            doesn't return null
-   @author Peter Zhelezniakov
-   @run main Test6963870
-*/
+/*
+ * @test
+ * @bug 6963870
+ * @key headful
+ * @requires os.family == "linux"
+ * @summary Tests that GTKPainter.ListTableFocusBorder.getBorderInsets()
+ *          doesn't return null
+ * @run main Test6963870
+ */
 
 import java.awt.Insets;
 import javax.swing.SwingUtilities;
@@ -60,14 +61,8 @@ public class Test6963870 implements Runnable {
     }
 
     public static void main(String[] args) throws Exception {
-        try {
-            UIManager.setLookAndFeel("com.sun.java.swing.plaf.gtk.GTKLookAndFeel");
-        } catch (Exception e) {
-            System.out.println("GTKLookAndFeel cannot be set, skipping this test");
-            return;
-        }
+        UIManager.setLookAndFeel("com.sun.java.swing.plaf.gtk.GTKLookAndFeel");
 
         SwingUtilities.invokeAndWait(new Test6963870());
     }
 }
-


### PR DESCRIPTION
* Add `@requires os.family == "linux"` to prevent GTK L&F tests from running on other OS but Linux.
* Let any exceptions from `UIManager.setLookAndFeel` propagate.
* Remove `@author` tag.
* Expand imports in `test/jdk/com/sun/java/swing/plaf/gtk/Test6635110.java`.
* Add leading asterisks to jtreg comment block.