### PR TITLE
8365175: Replace Unicode extension anchor elements with link tag

### DIFF
--- a/src/java.base/share/classes/java/text/DateFormat.java
+++ b/src/java.base/share/classes/java/text/DateFormat.java
@@ -101,7 +101,7 @@ import sun.util.locale.provider.LocaleServiceProviderPool;
  * </blockquote>
  *
  * <p>If the specified locale contains "ca" (calendar), "rg" (region override),
- * and/or "tz" (timezone) {@link Locale##def_locale_extension Unicode
+ * and/or "tz" (timezone) {@linkplain Locale##def_locale_extension Unicode
  * extensions}, the calendar, the country and/or the time zone for formatting
  * are overridden. If both "ca" and "rg" are specified, the calendar from the "ca"
  * extension supersedes the implicit one from the "rg" extension.

--- a/src/java.base/share/classes/java/text/DateFormatSymbols.java
+++ b/src/java.base/share/classes/java/text/DateFormatSymbols.java
@@ -84,7 +84,7 @@ import sun.util.locale.provider.TimeZoneNameUtility;
  * </blockquote>
  *
  * <p>If the locale contains "rg" (region override)
- * {@link Locale##def_locale_extension Unicode extension},
+ * {@linkplain Locale##def_locale_extension Unicode extension},
  * the symbols are overridden for the designated region.
  *
  * <p>

--- a/src/java.base/share/classes/java/text/DecimalFormatSymbols.java
+++ b/src/java.base/share/classes/java/text/DecimalFormatSymbols.java
@@ -60,7 +60,7 @@ import sun.util.locale.provider.ResourceBundleBasedAdapter;
  * your {@code DecimalFormat} and modify it.
  *
  * <p>The "rg" (region override), "nu" (numbering system), and "cu" (currency)
- * {@code Locale} {@link Locale##def_locale_extension Unicode
+ * {@code Locale} {@linkplain Locale##def_locale_extension Unicode
  * extensions} are supported which may override values within the symbols.
  * For both "nu" and "cu", if they are specified in addition to "rg" by the
  * backing {@code Locale}, the respective values from the "nu" and "cu" extension

--- a/src/java.base/share/classes/java/text/NumberFormat.java
+++ b/src/java.base/share/classes/java/text/NumberFormat.java
@@ -92,7 +92,7 @@ import sun.util.locale.provider.LocaleServiceProviderPool;
  *
  * <h3>Locale Extensions</h3>
  * Formatting behavior can be changed when using a locale that contains any of the following
- * {@link Locale##def_locale_extension Unicode extensions},
+ * {@linkplain Locale##def_locale_extension Unicode extensions},
  * <ul>
  * <li> "nu"
  * (<a href="https://unicode.org/reports/tr35/#UnicodeNumberSystemIdentifier">
@@ -110,7 +110,7 @@ import sun.util.locale.provider.LocaleServiceProviderPool;
  * <p>
  * For both "nu" and "cu", if they are specified in addition to "rg", the respective
  * values from the "nu" and "cu" extension supersede the implicit ones from the "rg" extension.
- * Although {@link Locale##def_locale_extension Unicode extensions}
+ * Although {@linkplain Locale##def_locale_extension Unicode extensions}
  * defines various keys and values, actual locale-sensitive service implementations
  * in a Java Runtime Environment might not support any particular Unicode locale
  * attributes or key/type pairs.
@@ -691,7 +691,7 @@ public abstract class NumberFormat extends Format  {
      * <p>If the specified locale contains the "{@code cf}" (
      * <a href="https://www.unicode.org/reports/tr35/tr35.html#UnicodeCurrencyFormatIdentifier">
      * currency format style</a>)
-     * {@link Locale##def_locale_extension Unicode extension},
+     * {@linkplain Locale##def_locale_extension Unicode extension},
      * the returned currency format uses the style if it is available.
      * Otherwise, the style uses the default "{@code standard}" currency format.
      * For example, if the style designates "{@code account}", negative

--- a/src/java.base/share/classes/java/text/spi/DecimalFormatSymbolsProvider.java
+++ b/src/java.base/share/classes/java/text/spi/DecimalFormatSymbolsProvider.java
@@ -34,7 +34,7 @@ import java.util.spi.LocaleServiceProvider;
  * provide instances of the
  * {@link java.text.DecimalFormatSymbols DecimalFormatSymbols} class.
  *
- * <p>The requested {@code Locale} may contain an {@link
+ * <p>The requested {@code Locale} may contain an {@linkplain
  * Locale##def_locale_extension extension} for
  * specifying the desired numbering system. For example, {@code "ar-u-nu-arab"}
  * (in the BCP 47 language tag form) specifies Arabic with the Arabic-Indic

--- a/src/java.base/share/classes/java/time/format/DateTimeFormatter.java
+++ b/src/java.base/share/classes/java/time/format/DateTimeFormatter.java
@@ -1508,7 +1508,7 @@ public final class DateTimeFormatter {
      * localization, such as the text or localized pattern.
      * <p>
      * The locale is stored as passed in, without further processing.
-     * If the locale has {@link Locale##def_locale_extension Unicode extensions},
+     * If the locale has {@linkplain Locale##def_locale_extension Unicode extensions},
      * they may be used later in text processing.
      * To set the chronology, time-zone and decimal style from
      * unicode extensions, see {@link #localizedBy localizedBy()}.
@@ -1535,7 +1535,7 @@ public final class DateTimeFormatter {
      * localization, such as the text or localized pattern. If the locale contains the
      * "ca" (calendar), "nu" (numbering system), "rg" (region override), and/or
      * "tz" (timezone)
-     * {@link Locale##def_locale_extension Unicode extensions},
+     * {@linkplain Locale##def_locale_extension Unicode extensions},
      * the chronology, numbering system and/or the zone are overridden. If both "ca"
      * and "rg" are specified, the chronology from the "ca" extension supersedes the
      * implicit one from the "rg" extension. Same is true for the "nu" extension.

--- a/src/java.base/share/classes/java/time/format/DateTimeFormatterBuilder.java
+++ b/src/java.base/share/classes/java/time/format/DateTimeFormatterBuilder.java
@@ -205,7 +205,7 @@ public final class DateTimeFormatterBuilder {
      * for the requested dateStyle and/or timeStyle.
      * <p>
      * If the locale contains the "rg" (region override)
-     * {@link Locale##def_locale_extension Unicode extensions},
+     * {@linkplain Locale##def_locale_extension Unicode extensions},
      * the formatting pattern is overridden with the one appropriate for the region.
      *
      * @param dateStyle  the FormatStyle for the date, null for time-only pattern
@@ -235,7 +235,7 @@ public final class DateTimeFormatterBuilder {
      * for the requested template.
      * <p>
      * If the locale contains the "rg" (region override)
-     * {@link Locale##def_locale_extension Unicode extensions},
+     * {@linkplain Locale##def_locale_extension Unicode extensions},
      * the formatting pattern is overridden with the one appropriate for the region.
      * <p>
      * Refer to {@link #appendLocalized(String)} for the detail of {@code requestedTemplate}

--- a/src/java.base/share/classes/java/time/format/DecimalStyle.java
+++ b/src/java.base/share/classes/java/time/format/DecimalStyle.java
@@ -150,7 +150,7 @@ public final class DecimalStyle {
      * <p>
      * This method provides access to locale sensitive decimal style symbols.
      * If the locale contains "nu" (Numbering System) and/or "rg"
-     * (Region Override) {@link Locale##def_locale_extension Unicode extensions},
+     * (Region Override) {@linkplain Locale##def_locale_extension Unicode extensions},
      * returned instance will reflect the values specified with
      * those extensions. If both "nu" and "rg" are specified, the value from
      * the "nu" extension supersedes the implicit one from the "rg" extension.

--- a/src/java.base/share/classes/java/time/temporal/WeekFields.java
+++ b/src/java.base/share/classes/java/time/temporal/WeekFields.java
@@ -289,7 +289,7 @@ public final class WeekFields implements Serializable {
      * <p>
      * This will look up appropriate values from the provider of localization data.
      * If the locale contains "fw" (First day of week) and/or "rg"
-     * (Region Override) {@link Locale##def_locale_extension Unicode extensions},
+     * (Region Override) {@linkplain Locale##def_locale_extension Unicode extensions},
      * returned instance will reflect the values specified with
      * those extensions. If both "fw" and "rg" are specified, the value from
      * the "fw" extension supersedes the implicit one from the "rg" extension.

--- a/src/java.base/share/classes/java/util/Calendar.java
+++ b/src/java.base/share/classes/java/util/Calendar.java
@@ -129,7 +129,7 @@ import sun.util.spi.CalendarProvider;
  * parameters: the first day of the week and the minimal days in first week
  * (from 1 to 7).  These numbers are taken from the locale resource data or the
  * locale itself when a {@code Calendar} is constructed. If the designated
- * locale contains "fw" and/or "rg" {@link Locale##def_locale_extension
+ * locale contains "fw" and/or "rg" {@linkplain Locale##def_locale_extension
  * Unicode extensions}, the first day of the week will be obtained according to
  * those extensions. If both "fw" and "rg" are specified, the value from the "fw"
  * extension supersedes the implicit one from the "rg" extension.
@@ -1454,7 +1454,7 @@ public abstract class Calendar implements Serializable, Cloneable, Comparable<Ca
          * parameters haven't been given explicitly.
          * <p>
          * If the locale contains the time zone with "tz"
-         * {@link Locale##def_locale_extension Unicode extension},
+         * {@linkplain Locale##def_locale_extension Unicode extension},
          * and time zone hasn't been given explicitly, time zone in the locale
          * is used.
          *
@@ -1615,7 +1615,7 @@ public abstract class Calendar implements Serializable, Cloneable, Comparable<Ca
      * {@link Locale.Category#FORMAT FORMAT} locale.
      * <p>
      * If the locale contains the time zone with "tz"
-     * {@link Locale##def_locale_extension Unicode extension},
+     * {@linkplain Locale##def_locale_extension Unicode extension},
      * that time zone is used instead.
      *
      * @return a Calendar.
@@ -1647,7 +1647,7 @@ public abstract class Calendar implements Serializable, Cloneable, Comparable<Ca
      * in the default time zone with the given locale.
      * <p>
      * If the locale contains the time zone with "tz"
-     * {@link Locale##def_locale_extension Unicode extension},
+     * {@linkplain Locale##def_locale_extension Unicode extension},
      * that time zone is used instead.
      *
      * @param aLocale the locale for the week data
@@ -2632,7 +2632,7 @@ public abstract class Calendar implements Serializable, Cloneable, Comparable<Ca
     /**
      * Returns an unmodifiable {@code Set} containing all calendar types
      * supported by {@code Calendar} in the runtime environment. The available
-     * calendar types can be used for the {@link Locale##def_locale_extension
+     * calendar types can be used for the {@linkplain Locale##def_locale_extension
      * Unicode locale extensions}.
      * The {@code Set} returned contains at least {@code "gregory"}. The
      * calendar types don't include aliases, such as {@code "gregorian"} for

--- a/src/java.base/share/classes/java/util/ResourceBundle.java
+++ b/src/java.base/share/classes/java/util/ResourceBundle.java
@@ -3052,7 +3052,7 @@ public abstract class ResourceBundle {
          * {@code IllegalArgumentException} is thrown.</li>
          *
          * <li>If the {@code locale}'s language is one of the
-         * {@link Locale##legacy_language_codes Legacy language
+         * {@linkplain Locale##legacy_language_codes Legacy language
          * codes}, either old or new, then repeat the loading process
          * if needed, with the bundle name with the other language.
          * For example, "iw" for "he" and vice versa.

--- a/src/java.base/share/classes/java/util/spi/LocaleNameProvider.java
+++ b/src/java.base/share/classes/java/util/spi/LocaleNameProvider.java
@@ -145,7 +145,7 @@ public abstract class LocaleNameProvider extends LocaleServiceProvider {
 
     /**
      * Returns a localized name for the given
-     * {@link Locale##def_locale_extension Unicode extension} key,
+     * {@linkplain Locale##def_locale_extension Unicode extension} key,
      * and the given locale that is appropriate for display to the user.
      * If the name returned cannot be localized according to {@code locale},
      * this method returns null.
@@ -169,7 +169,7 @@ public abstract class LocaleNameProvider extends LocaleServiceProvider {
 
     /**
      * Returns a localized name for the given
-     * {@link Locale##def_locale_extension Unicode extension} type,
+     * {@linkplain Locale##def_locale_extension Unicode extension} type,
      * and the given locale that is appropriate for display to the user.
      * If the name returned cannot be localized according to {@code locale},
      * this method returns null.


### PR DESCRIPTION
This PR is a cleanup change which replaces anchor element references of the Locale `def_locale_extension` section with the Javadoc link tag. This is a doc only change and is a result of the discussion in the PR of https://github.com/openjdk/jdk/pull/26683.

This includes one additional conversion of the `legacy_language_codes` section to get rid of all Locale.html anchor element references.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8365175](https://bugs.openjdk.org/browse/JDK-8365175): Replace Unicode extension anchor elements with link tag (**Bug** - P4)


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**) Review applies to [a9208477](https://git.openjdk.org/jdk/pull/26996/files/a92084771a41ee01d8088f0bfa17391ad5482bfa)
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**) Review applies to [5ce79b86](https://git.openjdk.org/jdk/pull/26996/files/5ce79b86caa5750d2b229c36c9e22c8c5177180e)
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26996/head:pull/26996` \
`$ git checkout pull/26996`

Update a local copy of the PR: \
`$ git checkout pull/26996` \
`$ git pull https://git.openjdk.org/jdk.git pull/26996/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26996`

View PR using the GUI difftool: \
`$ git pr show -t 26996`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26996.diff">https://git.openjdk.org/jdk/pull/26996.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26996#issuecomment-3234845478)
</details>
