### PR TITLE
8366399: Allow custom base reference for update_copyright_year.sh

### DIFF
--- a/make/scripts/update_copyright_year.sh
+++ b/make/scripts/update_copyright_year.sh
@@ -62,17 +62,22 @@ Help()
   echo "options:"
   echo "-c     Specifies the company. Set to Oracle by default."
   echo "-y     Specifies the copyright year. Set to current year by default."
+  echo "-b     Specifies the base reference for change set lookup."
   echo "-f     Updates the copyright for all change sets in a given year,"
-  echo "       as specified by -y."
+  echo "       as specified by -y. Overrides -b flag."
   echo "-h     Print this help."
   echo
 }
 
 full_year=false
+base_reference=master
 
 # Process options
-while getopts "c:fhy:" option; do
+while getopts "b:c:fhy:" option; do
   case $option in
+    b) # supplied base reference
+      base_reference=${OPTARG}
+      ;;
     c) # supplied company year
       company=${OPTARG}
       ;;
@@ -111,7 +116,7 @@ else
   if [ "$full_year" = "true" ]; then
     vcs_list_changesets=(git log --no-merges --since="${year}-01-01T00:00:00Z" --until="${year}-12-31T23:59:59Z" --pretty=tformat:"%H")
   else
-    vcs_list_changesets=(git log --no-merges 'master..HEAD' --since="${year}-01-01T00:00:00Z" --until="${year}-12-31T23:59:59Z" --pretty=tformat:"%H")
+    vcs_list_changesets=(git log --no-merges "${base_reference}..HEAD" --since="${year}-01-01T00:00:00Z" --until="${year}-12-31T23:59:59Z" --pretty=tformat:"%H")
   fi
   vcs_changeset_message=(git log -1 --pretty=tformat:"%B") # followed by ${changeset}
   vcs_changeset_files=(git diff-tree --no-commit-id --name-only -r) # followed by ${changeset}


### PR DESCRIPTION
Currently, `update_copyright_year.sh` hardcodes `master` to be the base reference. While this works on mainline and update release repos, this does not work for projects like Valhalla or Leyden, whose PRs target lworld/premain branches. We can add a new flag to allow customized base reference to adapt to these use cases.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8366399](https://bugs.openjdk.org/browse/JDK-8366399): Allow custom base reference for update_copyright_year.sh (**Enhancement** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/26998/head:pull/26998` \
`$ git checkout pull/26998`

Update a local copy of the PR: \
`$ git checkout pull/26998` \
`$ git pull https://git.openjdk.org/jdk.git pull/26998/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26998`

View PR using the GUI difftool: \
`$ git pr show -t 26998`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/26998.diff">https://git.openjdk.org/jdk/pull/26998.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/26998#issuecomment-3235177419)
</details>
