### PR TITLE
8365791: IGV: Update build dependencies

### DIFF
--- a/src/utils/IdealGraphVisualizer/pom.xml
+++ b/src/utils/IdealGraphVisualizer/pom.xml
@@ -116,7 +116,7 @@
         <mvnjarplugin.version>3.3.0</mvnjarplugin.version>
         <mvnenforcerplugin.version>3.4.1</mvnenforcerplugin.version>
         <junit.version>4.13.2</junit.version>
-        <batik.version>1.17</batik.version>
+        <batik.version>1.19</batik.version>
         <openpdf.version>1.3.34</openpdf.version>
         <wala.version>1.6.2</wala.version>
         <brandingToken>idealgraphvisualizer</brandingToken>


### PR DESCRIPTION
This changeset updates IGV's Apache Batik dependency, which is used for exporting graphs into SVG files (`File -> Export current graph...`), to its latest version.

**Testing:** checked manually that a few graphs are correctly exported as SVG files.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8365791](https://bugs.openjdk.org/browse/JDK-8365791): IGV: Update build dependencies (**Bug** - P5)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27000/head:pull/27000` \
`$ git checkout pull/27000`

Update a local copy of the PR: \
`$ git checkout pull/27000` \
`$ git pull https://git.openjdk.org/jdk.git pull/27000/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27000`

View PR using the GUI difftool: \
`$ git pr show -t 27000`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27000.diff">https://git.openjdk.org/jdk/pull/27000.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27000#issuecomment-3235932602)
</details>
