### PR TITLE
8366420: AOTMapTest fails when default jsa is missing from JDK

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/CDSMapTest.java
+++ b/test/hotspot/jtreg/runtime/cds/CDSMapTest.java
@@ -25,7 +25,6 @@
  * @test
  * @bug 8308903
  * @summary Test the contents of -Xlog:aot+map
- * @requires vm.flagless
  * @requires vm.cds
  * @library /test/lib
  * @run driver CDSMapTest

--- a/test/hotspot/jtreg/runtime/cds/appcds/aotCache/AOTMapTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotCache/AOTMapTest.java
@@ -38,6 +38,7 @@
  * @bug 8362566
  * @summary Test the contents of -Xlog:aot+map with AOT workflow
  * @requires vm.flagless
+ * @requires vm.cds.default.archive.available
  * @requires vm.cds.supports.aot.class.linking
  * @library /test/lib /test/hotspot/jtreg/runtime/cds
  * @build jdk.test.whitebox.WhiteBox

--- a/test/hotspot/jtreg/runtime/cds/appcds/aotCache/AOTMapTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotCache/AOTMapTest.java
@@ -36,7 +36,6 @@
  * @test id=dynamic
  * @bug 8362566
  * @summary Test the contents of -Xlog:aot+map with AOT workflow
- * @requires vm.cds.default.archive.available
  * @requires vm.cds.supports.aot.class.linking
  * @library /test/lib /test/hotspot/jtreg/runtime/cds
  * @build jdk.test.whitebox.WhiteBox

--- a/test/hotspot/jtreg/runtime/cds/appcds/aotCache/AOTMapTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotCache/AOTMapTest.java
@@ -25,7 +25,6 @@
  * @test id=aot
  * @bug 8362566
  * @summary Test the contents of -Xlog:aot+map with AOT workflow
- * @requires vm.flagless
  * @requires vm.cds.supports.aot.class.linking
  * @library /test/lib /test/hotspot/jtreg/runtime/cds
  * @build AOTMapTest
@@ -37,7 +36,6 @@
  * @test id=dynamic
  * @bug 8362566
  * @summary Test the contents of -Xlog:aot+map with AOT workflow
- * @requires vm.flagless
  * @requires vm.cds.default.archive.available
  * @requires vm.cds.supports.aot.class.linking
  * @library /test/lib /test/hotspot/jtreg/runtime/cds
@@ -59,16 +57,11 @@ public class AOTMapTest {
     static final String mainClass = "AOTMapTestApp";
 
     public static void main(String[] args) throws Exception {
-        doTest(args, false);
-
-        if (Platform.is64bit()) {
-            // There's no oop/klass compression on 32-bit.
-            doTest(args, true);
-        }
+        doTest(args);
     }
 
-    public static void doTest(String[] args, boolean compressed) throws Exception {
-        Tester tester = new Tester(compressed);
+    public static void doTest(String[] args) throws Exception {
+        Tester tester = new Tester();
         tester.run(args);
 
         validate(tester.dumpMapFile);
@@ -81,16 +74,14 @@ public class AOTMapTest {
     }
 
     static class Tester extends CDSAppTester {
-        boolean compressed;
         String dumpMapFile;
         String runMapFile;
 
-        public Tester(boolean compressed) {
+        public Tester() {
             super(mainClass);
-            this.compressed = compressed;
 
-            dumpMapFile = "test" + (compressed ? "0" : "1") + ".dump.aotmap";
-            runMapFile  = "test" + (compressed ? "0" : "1") + ".run.aotmap";
+            dumpMapFile = "test" + "0" + ".dump.aotmap";
+            runMapFile  = "test" + "0" + ".run.aotmap";
         }
 
         @Override
@@ -104,12 +95,6 @@ public class AOTMapTest {
 
             vmArgs.add("-Xmx128M");
             vmArgs.add("-Xlog:aot=debug");
-
-            if (Platform.is64bit()) {
-                // These options are available only on 64-bit.
-                String sign = (compressed) ?  "+" : "-";
-                vmArgs.add("-XX:" + sign + "UseCompressedOops");
-            }
 
             // filesize=0 ensures that a large map file not broken up in multiple files.
             String logMapPrefix = "-Xlog:aot+map=debug,aot+map+oops=trace:file=";


### PR DESCRIPTION
We fail in one of our test setups with this output :
runtime/cds/appcds/aotCache/AOTMapTest_dynamic

```
 stdout: [[0.003s][error][cds] An error has occurred while processing the shared archive file. Run with -Xlog:aot,cds for details.
[0.003s][error][cds] Specified shared archive file not found (AOTMapTestApp.dynamic.jsa)
[0.003s][error][cds] Not a valid shared archive file (AOTMapTestApp.dynamic.jsa)
[0.003s][error][cds] CDS is incompatible with other specified options.
Error occurred during initialization of VM
Unable to use shared archive: invalid archive
];
 stderr: []
 exitValue = 1

java.lang.RuntimeException: Expected to get exit value of [0], exit value is: [1]
at jdk.test.lib.process.OutputAnalyzer.shouldHaveExitValue(OutputAnalyzer.java:522)
at jdk.test.lib.cds.CDSAppTester.executeAndCheck(CDSAppTester.java:217)
at jdk.test.lib.cds.CDSAppTester.productionRun(CDSAppTester.java:426)
at jdk.test.lib.cds.CDSAppTester.productionRun(CDSAppTester.java:393)
at jdk.test.lib.cds.CDSAppTester.runDynamicWorkflow(CDSAppTester.java:464)
at jdk.test.lib.cds.CDSAppTester.run(CDSAppTester.java:445)
at AOTMapTest.doTest(AOTMapTest.java:71)
at AOTMapTest.main(AOTMapTest.java:61)
at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
at java.base/java.lang.reflect.Method.invoke(Method.java:565)
at com.sun.javatest.regtest.agent.MainWrapper$MainTask.run(MainWrapper.java:138)
at java.base/java.lang.Thread.run(Thread.java:1474)
```

This test setup is a bit special because it contains only one jsa cds archive (the one for compressed object headers).  So the  'classes.jsa' is missing .

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8366420](https://bugs.openjdk.org/browse/JDK-8366420): AOTMapTest fails when default jsa is missing from JDK (**Bug** - P4)


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)
 * [Arno Zeller](https://openjdk.org/census#azeller) (@ArnoZeller - Author)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27001/head:pull/27001` \
`$ git checkout pull/27001`

Update a local copy of the PR: \
`$ git checkout pull/27001` \
`$ git pull https://git.openjdk.org/jdk.git pull/27001/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27001`

View PR using the GUI difftool: \
`$ git pr show -t 27001`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27001.diff">https://git.openjdk.org/jdk/pull/27001.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27001#issuecomment-3236127445)
</details>
