### PR TITLE
Update comments to mention native.encoding instead of file.encoding

### DIFF
--- a/src/java.base/unix/native/libjava/java_props_md.c
+++ b/src/java.base/unix/native/libjava/java_props_md.c
@@ -438,7 +438,7 @@ GetJavaProperties(JNIEnv *env)
 
     /* Determine the language, country, variant, and encoding from the host,
      * and store these in the user.language, user.country, user.variant and
-     * file.encoding system properties. */
+     * native.encoding system properties. */
     setlocale(LC_ALL, "");
     if (ParseLocale(env, LC_CTYPE,
                     &(sprops.format_language),

--- a/src/java.base/windows/native/libjava/java_props_md.c
+++ b/src/java.base/windows/native/libjava/java_props_md.c
@@ -622,7 +622,7 @@ GetJavaProperties(JNIEnv* env)
     /*
      *  user.language
      *  user.script, user.country, user.variant (if user's environment specifies them)
-     *  file.encoding
+     *  native.encoding
      */
     {
         /*


### PR DESCRIPTION
The `file.encoding` system property is no longer used by the JDK.
Updated code comments to reference the correct replacement: `native.encoding`.

/trivial