### PR TITLE
Refactor optional according to java 21 standards

### DIFF
--- a/src/java.base/share/classes/java/util/Optional.java
+++ b/src/java.base/share/classes/java/util/Optional.java
@@ -36,24 +36,31 @@ import java.util.stream.Stream;
  * value is present, the object is considered <i>empty</i> and
  * {@code isPresent()} returns {@code false}.
  *
- * <p>Additional methods that depend on the presence or absence of a contained
+ * <p>
+ * Additional methods that depend on the presence or absence of a contained
  * value are provided, such as {@link #orElse(Object) orElse()}
  * (returns a default value if no value is present) and
  * {@link #ifPresent(Consumer) ifPresent()} (performs an
  * action if a value is present).
  *
- * <p>This is a <a href="{@docRoot}/java.base/java/lang/doc-files/ValueBased.html">value-based</a>
+ * <p>
+ * This is a <a href="
+ * {@docRoot}/java.base/java/lang/doc-files/ValueBased.html">value-based</a>
  * class; programmers should treat instances that are
  * {@linkplain #equals(Object) equal} as interchangeable and should not
  * use instances for synchronization, or unpredictable behavior may
  * occur. For example, in a future release, synchronization may fail.
  *
  * @apiNote
- * {@code Optional} is primarily intended for use as a method return type where
- * there is a clear need to represent "no result," and where using {@code null}
- * is likely to cause errors. A variable whose type is {@code Optional} should
- * never itself be {@code null}; it should always point to an {@code Optional}
- * instance.
+ *          {@code Optional} is primarily intended for use as a method return
+ *          type where
+ *          there is a clear need to represent "no result," and where using
+ *          {@code null}
+ *          is likely to cause errors. A variable whose type is {@code Optional}
+ *          should
+ *          never itself be {@code null}; it should always point to an
+ *          {@code Optional}
+ *          instance.
  *
  * @param <T> the type of value
  * @since 1.8
@@ -64,33 +71,37 @@ public sealed interface Optional<T> {
 
     /**
      * A record class representing a non-empty Optional
+     *
      * @param <T> the type of value
      */
     public record Some<T>(T value) implements Optional<T> {}
 
     /**
      * A record class representing an empty Optional
+     *
      * @param <T> the type of value
      */
     public record None<T>() implements Optional<T> {
         private static final None<?> INSTANCE = new None<>();
     }
 
-
     /**
-     * Returns an empty {@code Optional} instance.  No value is present for this
+     * Returns an empty {@code Optional} instance. No value is present for this
      * {@code Optional}.
      *
      * @apiNote
-     * Though it may be tempting to do so, avoid testing if an object is empty
-     * by comparing with {@code ==} or {@code !=} against instances returned by
-     * {@code Optional.empty()}.  There is no guarantee that it is a singleton.
-     * Instead, use {@link #isEmpty()} or {@link #isPresent()}.
+     *          Though it may be tempting to do so, avoid testing if an object is
+     *          empty
+     *          by comparing with {@code ==} or {@code !=} against instances
+     *          returned by
+     *          {@code Optional.empty()}. There is no guarantee that it is a
+     *          singleton.
+     *          Instead, use {@link #isEmpty()} or {@link #isPresent()}.
      *
      * @param <T> The type of the non-existent value
      * @return an empty {@code Optional}
      */
-    public static<T> Optional<T> empty() {
+    public static <T> Optional<T> empty() {
         @SuppressWarnings("unchecked")
         Optional<T> t = (Optional<T>) None.INSTANCE;
         return t;
@@ -101,7 +112,7 @@ public sealed interface Optional<T> {
      * value.
      *
      * @param value the value to describe, which must be non-{@code null}
-     * @param <T> the type of the value
+     * @param <T>   the type of the value
      * @return an {@code Optional} with the value present
      * @throws NullPointerException if value is {@code null}
      */
@@ -114,14 +125,13 @@ public sealed interface Optional<T> {
      * non-{@code null}, otherwise returns an empty {@code Optional}.
      *
      * @param value the possibly-{@code null} value to describe
-     * @param <T> the type of the value
+     * @param <T>   the type of the value
      * @return an {@code Optional} with a present value if the specified value
      *         is non-{@code null}, otherwise an empty {@code Optional}
      */
     @SuppressWarnings("unchecked")
     public static <T> Optional<T> ofNullable(T value) {
-        return value == null ? (Optional<T>) None.INSTANCE
-                             : new Some<>(value);
+        return value == null ? (Optional<T>) None.INSTANCE : new Some<>(value);
     }
 
     /**
@@ -129,12 +139,12 @@ public sealed interface Optional<T> {
      * {@code NoSuchElementException}.
      *
      * @apiNote
-     * The preferred alternative to this method is {@link #orElseThrow()}.
+     *          The preferred alternative to this method is {@link #orElseThrow()}.
      *
      * @return the non-{@code null} value described by this {@code Optional}
      * @throws NoSuchElementException if no value is present
      */
-    default public T get() {
+    public default T get() {
         return switch (this) {
             case Some<T>(var value) -> value;
             case None<T>() -> throw new NoSuchElementException("No value present");
@@ -146,18 +156,18 @@ public sealed interface Optional<T> {
      *
      * @return {@code true} if a value is present, otherwise {@code false}
      */
-    default public boolean isPresent() {
+    public default boolean isPresent() {
         return this instanceof Some<?>;
     }
 
     /**
-     * If a value is  not present, returns {@code true}, otherwise
+     * If a value is not present, returns {@code true}, otherwise
      * {@code false}.
      *
-     * @return  {@code true} if a value is not present, otherwise {@code false}
-     * @since   11
+     * @return {@code true} if a value is not present, otherwise {@code false}
+     * @since 11
      */
-    default public boolean isEmpty() {
+    public default boolean isEmpty() {
         return this instanceof None<?>;
     }
 
@@ -167,9 +177,9 @@ public sealed interface Optional<T> {
      *
      * @param action the action to be performed, if a value is present
      * @throws NullPointerException if value is present and the given action is
-     *         {@code null}
+     *                              {@code null}
      */
-    default public void ifPresent(Consumer<? super T> action) {
+    public default void ifPresent(Consumer<? super T> action) {
         Objects.requireNonNull(action);
         if (this instanceof Some<T>(var value)) {
             action.accept(value);
@@ -180,15 +190,16 @@ public sealed interface Optional<T> {
      * If a value is present, performs the given action with the value,
      * otherwise performs the given empty-based action.
      *
-     * @param action the action to be performed, if a value is present
+     * @param action      the action to be performed, if a value is present
      * @param emptyAction the empty-based action to be performed, if no value is
-     *        present
+     *                    present
      * @throws NullPointerException if a value is present and the given action
-     *         is {@code null}, or no value is present and the given empty-based
-     *         action is {@code null}.
+     *                              is {@code null}, or no value is present and the
+     *                              given empty-based
+     *                              action is {@code null}.
      * @since 9
      */
-    default public void ifPresentOrElse(Consumer<? super T> action, Runnable emptyAction) {
+    public default void ifPresentOrElse(Consumer<? super T> action, Runnable emptyAction) {
         Objects.requireNonNull(action);
         Objects.requireNonNull(emptyAction);
         switch (this) {
@@ -208,7 +219,7 @@ public sealed interface Optional<T> {
      *         given predicate, otherwise an empty {@code Optional}
      * @throws NullPointerException if the predicate is {@code null}
      */
-    default public Optional<T> filter(Predicate<? super T> predicate) {
+    public default Optional<T> filter(Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate);
         return switch (this) {
             case Some<T>(var value) -> predicate.test(value) ? this : empty();
@@ -221,35 +232,37 @@ public sealed interface Optional<T> {
      * {@link #ofNullable}) the result of applying the given mapping function to
      * the value, otherwise returns an empty {@code Optional}.
      *
-     * <p>If the mapping function returns a {@code null} result then this method
+     * <p>
+     * If the mapping function returns a {@code null} result then this method
      * returns an empty {@code Optional}.
      *
      * @apiNote
-     * This method supports post-processing on {@code Optional} values, without
-     * the need to explicitly check for a return status.  For example, the
-     * following code traverses a stream of URIs, selects one that has not
-     * yet been processed, and creates a path from that URI, returning
-     * an {@code Optional<Path>}:
+     *          This method supports post-processing on {@code Optional} values,
+     *          without
+     *          the need to explicitly check for a return status. For example, the
+     *          following code traverses a stream of URIs, selects one that has not
+     *          yet been processed, and creates a path from that URI, returning
+     *          an {@code Optional<Path>}:
      *
-     * <pre>{@code
+     *          <pre>{@code
      *     Optional<Path> p =
      *         uris.stream().filter(uri -> !isProcessedYet(uri))
      *                       .findFirst()
      *                       .map(Paths::get);
      * }</pre>
      *
-     * Here, {@code findFirst} returns an {@code Optional<URI>}, and then
-     * {@code map} returns an {@code Optional<Path>} for the desired
-     * URI if one exists.
+     *          Here, {@code findFirst} returns an {@code Optional<URI>}, and then
+     *          {@code map} returns an {@code Optional<Path>} for the desired
+     *          URI if one exists.
      *
      * @param mapper the mapping function to apply to a value, if present
-     * @param <U> The type of the value returned from the mapping function
+     * @param <U>    The type of the value returned from the mapping function
      * @return an {@code Optional} describing the result of applying a mapping
      *         function to the value of this {@code Optional}, if a value is
      *         present, otherwise an empty {@code Optional}
      * @throws NullPointerException if the mapping function is {@code null}
      */
-    default public <U> Optional<U> map(Function<? super T, ? extends U> mapper) {
+    public default <U> Optional<U> map(Function<? super T, ? extends U> mapper) {
         Objects.requireNonNull(mapper);
         return switch (this) {
             case Some<T>(var value) -> ofNullable(mapper.apply(value));
@@ -262,21 +275,23 @@ public sealed interface Optional<T> {
      * {@code Optional}-bearing mapping function to the value, otherwise returns
      * an empty {@code Optional}.
      *
-     * <p>This method is similar to {@link #map(Function)}, but the mapping
+     * <p>
+     * This method is similar to {@link #map(Function)}, but the mapping
      * function is one whose result is already an {@code Optional}, and if
      * invoked, {@code flatMap} does not wrap it within an additional
      * {@code Optional}.
      *
-     * @param <U> The type of value of the {@code Optional} returned by the
-     *            mapping function
+     * @param <U>    The type of value of the {@code Optional} returned by the
+     *               mapping function
      * @param mapper the mapping function to apply to a value, if present
      * @return the result of applying an {@code Optional}-bearing mapping
      *         function to the value of this {@code Optional}, if a value is
      *         present, otherwise an empty {@code Optional}
      * @throws NullPointerException if the mapping function is {@code null} or
-     *         returns a {@code null} result
+     *                              returns a {@code null} result
      */
-    default public <U> Optional<U> flatMap(Function<? super T, ? extends Optional<? extends U>> mapper) {
+    public default <U> Optional<U> flatMap(
+            Function<? super T, ? extends Optional<? extends U>> mapper) {
         Objects.requireNonNull(mapper);
         return switch (this) {
             case Some<T>(var value) -> {
@@ -293,15 +308,15 @@ public sealed interface Optional<T> {
      * otherwise returns an {@code Optional} produced by the supplying function.
      *
      * @param supplier the supplying function that produces an {@code Optional}
-     *        to be returned
+     *                 to be returned
      * @return returns an {@code Optional} describing the value of this
      *         {@code Optional}, if a value is present, otherwise an
      *         {@code Optional} produced by the supplying function.
      * @throws NullPointerException if the supplying function is {@code null} or
-     *         produces a {@code null} result
+     *                              produces a {@code null} result
      * @since 9
      */
-    default public Optional<T> or(Supplier<? extends Optional<? extends T>> supplier) {
+    public default Optional<T> or(Supplier<? extends Optional<? extends T>> supplier) {
         Objects.requireNonNull(supplier);
         return switch (this) {
             case Some<T>(var value) -> this;
@@ -318,9 +333,10 @@ public sealed interface Optional<T> {
      * only that value, otherwise returns an empty {@code Stream}.
      *
      * @apiNote
-     * This method can be used to transform a {@code Stream} of optional
-     * elements to a {@code Stream} of present value elements:
-     * <pre>{@code
+     *          This method can be used to transform a {@code Stream} of optional
+     *          elements to a {@code Stream} of present value elements:
+     *
+     *          <pre>{@code
      *     Stream<Optional<T>> os = ..
      *     Stream<T> s = os.flatMap(Optional::stream)
      * }</pre>
@@ -328,7 +344,7 @@ public sealed interface Optional<T> {
      * @return the optional value as a {@code Stream}
      * @since 9
      */
-    default public Stream<T> stream() {
+    public default Stream<T> stream() {
         return switch (this) {
             case Some<T>(var value) -> Stream.of(value);
             case None<T>() -> Stream.empty();
@@ -340,10 +356,10 @@ public sealed interface Optional<T> {
      * {@code other}.
      *
      * @param other the value to be returned, if no value is present.
-     *        May be {@code null}.
+     *              May be {@code null}.
      * @return the value, if present, otherwise {@code other}
      */
-    default public T orElse(T other) {
+    public default T orElse(T other) {
         return switch (this) {
             case Some<T>(var value) -> value;
             case None<T>() -> other;
@@ -358,9 +374,9 @@ public sealed interface Optional<T> {
      * @return the value, if present, otherwise the result produced by the
      *         supplying function
      * @throws NullPointerException if no value is present and the supplying
-     *         function is {@code null}
+     *                              function is {@code null}
      */
-    default public T orElseGet(Supplier<? extends T> supplier) {
+    public default T orElseGet(Supplier<? extends T> supplier) {
         Objects.requireNonNull(supplier);
         return switch (this) {
             case Some<T>(var value) -> value;
@@ -376,7 +392,7 @@ public sealed interface Optional<T> {
      * @throws NoSuchElementException if no value is present
      * @since 10
      */
-    default public T orElseThrow() {
+    public default T orElseThrow() {
         return switch (this) {
             case Some<T>(var value) -> value;
             case None<T>() -> throw new NoSuchElementException("No value present");
@@ -388,19 +404,22 @@ public sealed interface Optional<T> {
      * produced by the exception supplying function.
      *
      * @apiNote
-     * A method reference to the exception constructor with an empty argument
-     * list can be used as the supplier. For example,
-     * {@code IllegalStateException::new}
+     *          A method reference to the exception constructor with an empty
+     *          argument
+     *          list can be used as the supplier. For example,
+     *          {@code IllegalStateException::new}
      *
-     * @param <X> Type of the exception to be thrown
+     * @param <X>               Type of the exception to be thrown
      * @param exceptionSupplier the supplying function that produces an
-     *        exception to be thrown
+     *                          exception to be thrown
      * @return the value, if present
-     * @throws X if no value is present
+     * @throws X                    if no value is present
      * @throws NullPointerException if no value is present and the exception
-     *         supplying function is {@code null} or produces a {@code null} result
+     *                              supplying function is {@code null} or produces a
+     *                              {@code null} result
      */
-    default public <X extends Throwable> T orElseThrow(Supplier<? extends X> exceptionSupplier) throws X {
+    public default <X extends Throwable> T orElseThrow(Supplier<? extends X> exceptionSupplier)
+            throws X {
         Objects.requireNonNull(exceptionSupplier);
         return switch (this) {
             case Some<T>(var value) -> value;


### PR DESCRIPTION
Right now Optional can't be used with enchanted switch statement, this pull request will solve this MAJOR problem, code is well tested.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27013/head:pull/27013` \
`$ git checkout pull/27013`

Update a local copy of the PR: \
`$ git checkout pull/27013` \
`$ git pull https://git.openjdk.org/jdk.git pull/27013/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27013`

View PR using the GUI difftool: \
`$ git pr show -t 27013`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27013.diff">https://git.openjdk.org/jdk/pull/27013.diff</a>

</details>
