### PR TITLE
8366400: JCK test api/java_text/DecimalFormat/Parse.html fails after JDK-8363972

### DIFF
--- a/src/java.base/share/classes/java/text/DecimalFormat.java
+++ b/src/java.base/share/classes/java/text/DecimalFormat.java
@@ -3517,12 +3517,13 @@ public class DecimalFormat extends NumberFormat {
         var alen = affix.length();
         var tlen = text.length();
 
+        // Verify position can fit length wise before checking char by char
+        if (position + alen > tlen || position < 0) {
+            return false;
+        }
         if (alen == 0) {
             // always match with an empty affix, as affix is optional
             return true;
-        }
-        if (position >= tlen) {
-            return false;
         }
         if (parseStrict) {
             return text.regionMatches(position, affix, 0, alen);

--- a/test/jdk/java/text/Format/NumberFormat/LenientParseTest.java
+++ b/test/jdk/java/text/Format/NumberFormat/LenientParseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8327640 8331485 8333456 8335668
+ * @bug 8327640 8331485 8333456 8335668 8366400
  * @summary Test suite for NumberFormat parsing when lenient.
  * @run junit/othervm -Duser.language=en -Duser.country=US LenientParseTest
  * @run junit/othervm -Duser.language=ja -Duser.country=JP LenientParseTest
@@ -160,6 +160,14 @@ public class LenientParseTest {
         assertEquals(1.23E45, successParse(fmt, "1.23E45.123", 7));
         assertEquals(1.23E45, successParse(fmt, "1.23E45.", 7));
         assertEquals(1.23E45, successParse(fmt, "1.23E45FOO3222", 7));
+    }
+
+    @Test // Non-localized, only run once
+    @EnabledIfSystemProperty(named = "user.language", matches = "en")
+    public void invalidPositionParseTest() {
+        // -1 index should fail properly. Ensure SIOOBE not thrown during
+        // affix matching when position may be less than 0
+        assertNull(assertDoesNotThrow(() -> new DecimalFormat().parse("1", new ParsePosition(-1))));
     }
 
     // ---- CurrencyFormat tests ----

--- a/test/jdk/java/text/Format/NumberFormat/LenientParseTest.java
+++ b/test/jdk/java/text/Format/NumberFormat/LenientParseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8327640 8331485 8333456 8335668 8366400
+ * @bug 8327640 8331485 8333456 8335668
  * @summary Test suite for NumberFormat parsing when lenient.
  * @run junit/othervm -Duser.language=en -Duser.country=US LenientParseTest
  * @run junit/othervm -Duser.language=ja -Duser.country=JP LenientParseTest
@@ -160,14 +160,6 @@ public class LenientParseTest {
         assertEquals(1.23E45, successParse(fmt, "1.23E45.123", 7));
         assertEquals(1.23E45, successParse(fmt, "1.23E45.", 7));
         assertEquals(1.23E45, successParse(fmt, "1.23E45FOO3222", 7));
-    }
-
-    @Test // Non-localized, only run once
-    @EnabledIfSystemProperty(named = "user.language", matches = "en")
-    public void invalidPositionParseTest() {
-        // -1 index should fail properly. Ensure SIOOBE not thrown during
-        // affix matching when position may be less than 0
-        assertNull(assertDoesNotThrow(() -> new DecimalFormat().parse("1", new ParsePosition(-1))));
     }
 
     // ---- CurrencyFormat tests ----

--- a/test/jdk/java/text/Format/NumberFormat/PositionTest.java
+++ b/test/jdk/java/text/Format/NumberFormat/PositionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,12 +21,6 @@
  * questions.
  */
 
-/**
- * @test
- * @bug 4109023 4153060 4153061
- * @summary test ParsePosition and FieldPosition
- * @run junit PositionTest
- */
 /*
 (C) Copyright Taligent, Inc. 1996 - All Rights Reserved
 (C) Copyright IBM Corp. 1996 - All Rights Reserved
@@ -39,14 +33,70 @@ attribution to Taligent may not be removed.
   Taligent is a registered trademark of Taligent, Inc.
 */
 
-import java.text.*;
-import java.io.*;
+/*
+ * @test
+ * @bug 4109023 4153060 4153061
+ * @summary test ParsePosition and FieldPosition
+ * @run junit PositionTest
+ */
 
 import org.junit.jupiter.api.Test;
 
+import java.text.DecimalFormat;
+import java.text.FieldPosition;
+import java.text.NumberFormat;
+import java.text.ParsePosition;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class PositionTest {
+
+    // Parsing text which contains un-parseable data, but the index
+    // begins at the valid portion. Ensure PP is properly updated.
+    @Test
+    public void modifiedPositionTest() {
+        var df = new DecimalFormat("YY#");
+        df.setStrict(false); // Lenient by default, set for test explicitness
+        var pp = new ParsePosition(9);
+        assertEquals(123L, assertDoesNotThrow(() -> df.parse("FOOBARBAZYY123", pp)));
+        assertEquals(-1, pp.getErrorIndex());
+        assertEquals(14, pp.getIndex());
+    }
+
+    // Clearly invalid index value that could not work under any scenarios
+    // Specifically, ensuring no SIOOBE during affix matching
+    @Test
+    public void invalidPositionParseTest() {
+        var df = new DecimalFormat();
+        df.setStrict(false); // Lenient by default, set for test explicitness
+        assertNull(assertDoesNotThrow(() -> df.parse("1", new ParsePosition(-1))));
+        assertNull(assertDoesNotThrow(() -> df.parse("1", new ParsePosition(Integer.MAX_VALUE))));
+    }
+
+    // When prefix matching, position + affix length is greater than parsed String length
+    // Ensure we do not index out of bounds of the length of the parsed String
+    @Test
+    public void prefixMatchingTest() {
+        var df = new DecimalFormat("ZZZ#;YYY#");
+        df.setStrict(false); // Lenient by default, set for test explicitness
+        // 0 + 3 > 2 = (pos + prefix > text)
+        assertNull(assertDoesNotThrow(() -> df.parse("Z1", new ParsePosition(0))));
+        assertNull(assertDoesNotThrow(() -> df.parse("Y1", new ParsePosition(0))));
+    }
+
+    // When suffix matching, position + affix length is greater than parsed String length
+    // Ensure we do not index out of bounds of the length of the parsed String
+    @Test
+    public void suffixMatchingTest() {
+        var df = new DecimalFormat("#ZZ;#YY");
+        df.setStrict(false); // Lenient by default, set for test explicitness
+        // Matches prefix properly first. Then 3 + 2 > 4 = (pos + suffix > text)
+        assertNull(assertDoesNotThrow(() -> df.parse("123Z", new ParsePosition(0))));
+        assertNull(assertDoesNotThrow(() -> df.parse("123Y", new ParsePosition(0))));
+    }
 
     @Test
     public void TestParsePosition() {

--- a/test/jdk/java/text/Format/NumberFormat/PositionTest.java
+++ b/test/jdk/java/text/Format/NumberFormat/PositionTest.java
@@ -35,7 +35,7 @@ attribution to Taligent may not be removed.
 
 /*
  * @test
- * @bug 4109023 4153060 4153061
+ * @bug 4109023 4153060 4153061 8366400
  * @summary test ParsePosition and FieldPosition
  * @run junit PositionTest
  */


### PR DESCRIPTION
This PR addresses a JCK test failure of an unexpected SIOOBE during DecimalFormat parsing. During the char by char comparison in `matchAffix`, the minimum of the length of the parsed String and the PP index + affix length are iterated on. The parse position index needs to be checked to not be negative to ensure that we do not index the String below 0. Taking the minimum of those two previously mentioned values already guarantees that we do not index the String above the length.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8366400](https://bugs.openjdk.org/browse/JDK-8366400): JCK test api/java_text/DecimalFormat/Parse.html fails after JDK-8363972 (**Bug** - P2)


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27014/head:pull/27014` \
`$ git checkout pull/27014`

Update a local copy of the PR: \
`$ git checkout pull/27014` \
`$ git pull https://git.openjdk.org/jdk.git pull/27014/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27014`

View PR using the GUI difftool: \
`$ git pr show -t 27014`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27014.diff">https://git.openjdk.org/jdk/pull/27014.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27014#issuecomment-3238738209)
</details>
