### PR TITLE
8366483: ShowRegistersOnAssertTest uses wrong register pattern string for Windows on AArch64

### DIFF
--- a/test/hotspot/jtreg/runtime/ErrorHandling/ShowRegistersOnAssertTest.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/ShowRegistersOnAssertTest.java
@@ -76,7 +76,11 @@ public class ShowRegistersOnAssertTest {
             } else if (Platform.isX86()) {
                 pattern = new Pattern[] { Pattern.compile("Registers:"), Pattern.compile("EAX=.*")};
             } else if (Platform.isAArch64()) {
-                pattern = new Pattern[] { Pattern.compile("Registers:"), Pattern.compile("R0=.*")};
+                if (Platform.isLinux()) {
+                    pattern = new Pattern[] { Pattern.compile("Registers:"), Pattern.compile("R0=.*")};
+                } else if (Platform.isWindows()) {
+                    pattern = new Pattern[] { Pattern.compile("Registers:"), Pattern.compile("X0 =.*")};
+                }
             } else if (Platform.isS390x()) {
                 pattern = new Pattern[] { Pattern.compile("General Purpose Registers:"),
                                           Pattern.compile("^-{26}$"),


### PR DESCRIPTION
ShowRegistersOnAssertTest.java verifies that registers are printed in the error log when VMError::controlled_crash() is called. However, it searches for the pattern "R0=", which is valid on Linux AArch64 only. The Windows AArch64 [os::print_context](https://github.com/openjdk/jdk/blob/999761d0f6d37c9cd6ec482620800b694c5fb9ad/src/hotspot/os_cpu/windows_aarch64/os_windows_aarch64.cpp#L184-L186) implementation outputs registers in the format "X0 =". This change updates the test to use this pattern on the Windows AArch64 platform. The test passes with this change.