### PR TITLE
8366462: Test gc/z/TestCommitFailure.java#Normal failed: expected output missing

### DIFF
--- a/test/hotspot/jtreg/gc/z/TestCommitFailure.java
+++ b/test/hotspot/jtreg/gc/z/TestCommitFailure.java
@@ -106,7 +106,6 @@ public class TestCommitFailure {
         ProcessTools.executeTestJava(arguments)
                 .outputTo(System.out)
                 .errorTo(System.out)
-                .shouldContain("Forced to lower max Java heap size")
                 .shouldHaveExitValue(0);
     }
 }


### PR DESCRIPTION
The newly introduced test is intermittently failing where it tries to verify that we got a commit failure. I suggest we simply remove this verification as an initial fix. 

Trying to reproduce these failure paths reliably with a blackbox test is probably not possible. So we would have to extend the JVM with whitebox hooks for doing exactly what we want. I think we need to be very careful in such a design to not affect the maintainability and readability to the code. 

For now it is enough that this test intermittently exercises the commit failure paths and intermittently would reproduce any regressions. 

The risk is having to be more diligent in the future with checking that this test still works when changing ZPageAllocator policies or implementation details.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8366462](https://bugs.openjdk.org/browse/JDK-8366462): Test gc/z/TestCommitFailure.java#Normal failed: expected output missing (**Bug** - P3)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27023/head:pull/27023` \
`$ git checkout pull/27023`

Update a local copy of the PR: \
`$ git checkout pull/27023` \
`$ git pull https://git.openjdk.org/jdk.git pull/27023/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27023`

View PR using the GUI difftool: \
`$ git pr show -t 27023`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27023.diff">https://git.openjdk.org/jdk/pull/27023.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27023#issuecomment-3240033092)
</details>
