### PR TITLE
8366495: Incorrect minimum memory size allocated in allocateNativeInternal()

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/SegmentFactories.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/SegmentFactories.java
@@ -197,8 +197,9 @@ public class SegmentFactories {
             throw new OutOfMemoryError();
         }
         // Always allocate at least some memory so that zero-length segments have distinct
-        // non-zero addresses.
-        alignedSize = Math.max(Long.BYTES, alignedSize);
+        // non-zero addresses. If we are initializing the allocated memory, then use a minimum
+        // size of 8 because we init the memory with longs.
+        alignedSize = Math.max((init ? Long.BYTES : 1), alignedSize);
 
         long allocationSize;
         long allocationBase;


### PR DESCRIPTION
Originally Reported in OpenJ9, fix by @AditiS11 present here: https://github.com/ibmruntimes/openj9-openjdk-jdk25/pull/32

These test failure were reported in OpenJ9 (x86), I can't reproduce on my system (s390x): 
```
java/foreign/TestFill.java
java/foreign/TestSegments.java
java/foreign/TestSegmentBulkOperationsContentHash.java
java/foreign/TestStringEncoding.java
java/foreign/TestVarArgs.java
```


```java 
        // Always allocate at least some memory so that zero-length segments have distinct
        // non-zero addresses.
        alignedSize = Math.max(1, alignedSize);
```

Here minimum-allocated size will be 1, which is incorrect because 

```java
    private static void initNativeMemory(long address, long byteSize) {
        for (long i = 0; i < byteSize; i += Long.BYTES) {
            UNSAFE.putLongUnaligned(null, address + i, 0);
        }
    }
```
`initNativeMemory()` is going to write Long.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Integration blocker
&nbsp;⚠️ Failed to retrieve information on issue `8366495`. Please make sure it exists and is accessible.

### Issue
 * ⚠️ Failed to retrieve information on issue `8366495`.


### Reviewers
 * [Per Minborg](https://openjdk.org/census#pminborg) (@minborg - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27027/head:pull/27027` \
`$ git checkout pull/27027`

Update a local copy of the PR: \
`$ git checkout pull/27027` \
`$ git pull https://git.openjdk.org/jdk.git pull/27027/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27027`

View PR using the GUI difftool: \
`$ git pr show -t 27027`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27027.diff">https://git.openjdk.org/jdk/pull/27027.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27027#issuecomment-3241007607)
</details>
