### PR TITLE
8366543: Clean up include headers in numberSeq

### DIFF
--- a/src/hotspot/share/utilities/numberSeq.cpp
+++ b/src/hotspot/share/utilities/numberSeq.cpp
@@ -22,7 +22,6 @@
  *
  */
 
-#include "memory/allocation.hpp"
 #include "utilities/debug.hpp"
 #include "utilities/globalDefinitions.hpp"
 #include "utilities/numberSeq.hpp"

--- a/src/hotspot/share/utilities/numberSeq.hpp
+++ b/src/hotspot/share/utilities/numberSeq.hpp
@@ -25,6 +25,7 @@
 #ifndef SHARE_UTILITIES_NUMBERSEQ_HPP
 #define SHARE_UTILITIES_NUMBERSEQ_HPP
 
+#include "memory/allocation.hpp"
 #include "utilities/ostream.hpp"
 
 /**


### PR DESCRIPTION
Trivial changing to use the correct includes in `numberSeq.hpp/cpp`.

Test: tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8366543](https://bugs.openjdk.org/browse/JDK-8366543): Clean up include headers in numberSeq (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27031/head:pull/27031` \
`$ git checkout pull/27031`

Update a local copy of the PR: \
`$ git checkout pull/27031` \
`$ git pull https://git.openjdk.org/jdk.git pull/27031/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27031`

View PR using the GUI difftool: \
`$ git pr show -t 27031`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27031.diff">https://git.openjdk.org/jdk/pull/27031.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27031#issuecomment-3241997829)
</details>
