### PR TITLE
8366544: Parallel: Inline PSParallelCompact::invoke_no_policy

### DIFF
--- a/src/hotspot/share/gc/parallel/psParallelCompact.cpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.cpp
@@ -969,18 +969,10 @@ bool PSParallelCompact::invoke(bool clear_all_soft_refs) {
   assert(SafepointSynchronize::is_at_safepoint(), "should be at safepoint");
   assert(Thread::current() == (Thread*)VMThread::vm_thread(),
          "should be in vm thread");
+  assert(ref_processor() != nullptr, "Sanity");
 
   SvcGCMarker sgcm(SvcGCMarker::FULL);
   IsSTWGCActiveMark mark;
-
-  return PSParallelCompact::invoke_no_policy(clear_all_soft_refs);
-}
-
-// This method contains no policy. You should probably
-// be calling invoke() instead.
-bool PSParallelCompact::invoke_no_policy(bool clear_all_soft_refs) {
-  assert(SafepointSynchronize::is_at_safepoint(), "must be at a safepoint");
-  assert(ref_processor() != nullptr, "Sanity");
 
   ParallelScavengeHeap* heap = ParallelScavengeHeap::heap();
 

--- a/src/hotspot/share/gc/parallel/psParallelCompact.hpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.hpp
@@ -762,7 +762,6 @@ public:
   static void fill_dead_objs_in_dense_prefix(uint worker_id, uint num_workers);
 
   static bool invoke(bool clear_all_soft_refs);
-  static bool invoke_no_policy(bool clear_all_soft_refs);
 
   template<typename Func>
   static void adjust_in_space_helper(SpaceId id, volatile uint* claim_counter, Func&& on_stripe);


### PR DESCRIPTION
Trivial inlining a method to its single caller.

Test: tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8366544](https://bugs.openjdk.org/browse/JDK-8366544): Parallel: Inline PSParallelCompact::invoke_no_policy (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27032/head:pull/27032` \
`$ git checkout pull/27032`

Update a local copy of the PR: \
`$ git checkout pull/27032` \
`$ git pull https://git.openjdk.org/jdk.git pull/27032/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27032`

View PR using the GUI difftool: \
`$ git pr show -t 27032`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27032.diff">https://git.openjdk.org/jdk/pull/27032.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27032#issuecomment-3242023280)
</details>
