### PR TITLE
8366038: Thread::SpinRelease should use Atomic::release_store

### DIFF
--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -602,7 +602,6 @@ void Thread::SpinAcquire(volatile int * adr) {
 
 void Thread::SpinRelease(volatile int * adr) {
   assert(*adr != 0, "invariant");
-  OrderAccess::fence();      // guarantee at least release consistency.
   // Roach-motel semantics.
   // It's safe if subsequent LDs and STs float "up" into the critical section,
   // but prior LDs and STs within the critical section can't be allowed
@@ -613,5 +612,7 @@ void Thread::SpinRelease(volatile int * adr) {
   // Conceptually we need a #loadstore|#storestore "release" MEMBAR before
   // the ST of 0 into the lock-word which releases the lock, so fence
   // more than covers this on all platforms.
-  *adr = 0;
+  // However, a full fence is an overkill on most platforms,
+  // the same effect can be achieved with Atomic::release_store().
+  Atomic::release_store(adr, 0);
 }


### PR DESCRIPTION
Hi, please consider the following changes:

`Thread::SpinRelease()` uses an `OrderAccess::fence()` to prevent loads and stores from within the critical section to float down out of the section. A full fence is expensive and it is an overkill on most platforms. Instead, one can achieve the same effect with `Atomic::release_store()`. 

Tested in tiers 1 - 3.