### PR TITLE
8366584: Add an InstanceKlass::super() method that returns InstanceKlass*

### DIFF
--- a/src/hotspot/share/cds/aotArtifactFinder.cpp
+++ b/src/hotspot/share/cds/aotArtifactFinder.cpp
@@ -201,7 +201,7 @@ void AOTArtifactFinder::add_aot_inited_class(InstanceKlass* ik) {
     if (created) {
       _pending_aot_inited_classes->push(ik);
 
-      InstanceKlass* s = ik->java_super();
+      InstanceKlass* s = ik->super();
       if (s != nullptr) {
         add_aot_inited_class(s);
       }
@@ -236,7 +236,7 @@ void AOTArtifactFinder::add_cached_instance_class(InstanceKlass* ik) {
     append_to_all_cached_classes(ik);
 
     // All super types must be added.
-    InstanceKlass* s = ik->java_super();
+    InstanceKlass* s = ik->super();
     if (s != nullptr) {
       add_cached_instance_class(s);
     }

--- a/src/hotspot/share/cds/aotClassLinker.cpp
+++ b/src/hotspot/share/cds/aotClassLinker.cpp
@@ -93,7 +93,7 @@ void AOTClassLinker::add_vm_class(InstanceKlass* ik) {
       bool v = try_add_candidate(ik);
       assert(v, "must succeed for VM class");
     }
-    InstanceKlass* super = ik->java_super();
+    InstanceKlass* super = ik->super();
     if (super != nullptr) {
       add_vm_class(super);
     }
@@ -151,7 +151,7 @@ bool AOTClassLinker::try_add_candidate(InstanceKlass* ik) {
     }
   }
 
-  InstanceKlass* s = ik->java_super();
+  InstanceKlass* s = ik->super();
   if (s != nullptr && !try_add_candidate(s)) {
     return false;
   }

--- a/src/hotspot/share/cds/aotLinkedClassBulkLoader.cpp
+++ b/src/hotspot/share/cds/aotLinkedClassBulkLoader.cpp
@@ -294,7 +294,7 @@ void AOTLinkedClassBulkLoader::load_hidden_class(ClassLoaderData* loader_data, I
          HeapShared::is_lambda_proxy_klass(ik) ||
          HeapShared::is_string_concat_klass(ik), "sanity");
   DEBUG_ONLY({
-      assert(ik->java_super()->is_loaded(), "must be");
+      assert(ik->super()->is_loaded(), "must be");
       for (int i = 0; i < ik->local_interfaces()->length(); i++) {
         assert(ik->local_interfaces()->at(i)->is_loaded(), "must be");
       }

--- a/src/hotspot/share/cds/classListParser.cpp
+++ b/src/hotspot/share/cds/classListParser.cpp
@@ -561,10 +561,10 @@ InstanceKlass* ClassListParser::load_class_from_source(Symbol* class_name, TRAPS
   const char* source_path = ClassLoader::uri_to_path(_source);
   InstanceKlass* k = UnregisteredClasses::load_class(class_name, source_path, CHECK_NULL);
 
-  if (k->java_super() != specified_super) {
+  if (k->super() != specified_super) {
     error("The specified super class %s (id %d) does not match actual super class %s",
           specified_super->external_name(), _super,
-          k->java_super()->external_name());
+          k->super()->external_name());
   }
   if (k->local_interfaces()->length() != _interfaces->length()) {
     print_specified_interfaces();

--- a/src/hotspot/share/cds/classListWriter.cpp
+++ b/src/hotspot/share/cds/classListWriter.cpp
@@ -139,7 +139,7 @@ void ClassListWriter::write_to_stream(const InstanceKlass* k, outputStream* stre
   }
 
   {
-    InstanceKlass* super = k->java_super();
+    InstanceKlass* super = k->super();
     if (super != nullptr && !has_id(super)) {
       return;
     }
@@ -165,7 +165,7 @@ void ClassListWriter::write_to_stream(const InstanceKlass* k, outputStream* stre
   ResourceMark rm;
   stream->print("%s id: %d", k->name()->as_C_string(), get_id(k));
   if (!is_builtin_loader) {
-    InstanceKlass* super = k->java_super();
+    InstanceKlass* super = k->super();
     assert(super != nullptr, "must be");
     stream->print(" super: %d", get_id(super));
 

--- a/src/hotspot/share/cds/dynamicArchive.cpp
+++ b/src/hotspot/share/cds/dynamicArchive.cpp
@@ -276,7 +276,7 @@ void DynamicArchiveBuilder::sort_methods(InstanceKlass* ik) const {
   remark_pointers_for_instance_klass(ik, false);
 
   // Make sure all supertypes have been sorted
-  sort_methods(ik->java_super());
+  sort_methods(ik->super());
   Array<InstanceKlass*>* interfaces = ik->local_interfaces();
   int len = interfaces->length();
   for (int i = 0; i < len; i++) {

--- a/src/hotspot/share/cds/heapShared.cpp
+++ b/src/hotspot/share/cds/heapShared.cpp
@@ -183,7 +183,7 @@ static void reset_states(oop obj, TRAPS) {
       JavaCalls::call_special(&result, h_obj, klass,
                               method_name, method_sig, CHECK);
     }
-    klass = klass->java_super();
+    klass = klass->super();
   }
 }
 

--- a/src/hotspot/share/cds/metaspaceShared.cpp
+++ b/src/hotspot/share/cds/metaspaceShared.cpp
@@ -191,8 +191,8 @@ class DumpClassListCLDClosure : public CLDClosure {
     if (_dumped_classes.maybe_grow()) {
       log_info(aot, hashtables)("Expanded _dumped_classes table to %d", _dumped_classes.table_size());
     }
-    if (ik->java_super()) {
-      dump(ik->java_super());
+    if (ik->super()) {
+      dump(ik->super());
     }
     Array<InstanceKlass*>* interfaces = ik->local_interfaces();
     int len = interfaces->length();

--- a/src/hotspot/share/ci/ciReplay.cpp
+++ b/src/hotspot/share/ci/ciReplay.cpp
@@ -1572,7 +1572,7 @@ oop ciReplay::obj_field(oop obj, Symbol* name) {
 
   do {
     if (!ik->has_nonstatic_fields()) {
-      ik = ik->java_super();
+      ik = ik->super();
       continue;
     }
 
@@ -1591,7 +1591,7 @@ oop ciReplay::obj_field(oop obj, Symbol* name) {
       }
     }
 
-    ik = ik->java_super();
+    ik = ik->super();
   } while (ik != nullptr);
   return nullptr;
 }

--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -3957,7 +3957,7 @@ void OopMapBlocksBuilder::print_value_on(outputStream* st) const {
 void ClassFileParser::set_precomputed_flags(InstanceKlass* ik) {
   assert(ik != nullptr, "invariant");
 
-  const InstanceKlass* const super = ik->java_super();
+  const InstanceKlass* const super = ik->super();
 
   // Check if this klass has an empty finalize method (i.e. one with return bytecode only),
   // in which case we don't have to register objects as finalizable
@@ -4092,7 +4092,7 @@ static Array<InstanceKlass*>* compute_transitive_interfaces(const InstanceKlass*
 
 void ClassFileParser::check_super_class_access(const InstanceKlass* this_klass, TRAPS) {
   assert(this_klass != nullptr, "invariant");
-  const InstanceKlass* const super = this_klass->java_super();
+  const InstanceKlass* const super = this_klass->super();
 
   if (super != nullptr) {
     if (super->is_final()) {
@@ -4210,7 +4210,7 @@ static void check_final_method_override(const InstanceKlass* this_klass, TRAPS) 
 
       const Symbol* const name = m->name();
       const Symbol* const signature = m->signature();
-      const InstanceKlass* k = this_klass->java_super();
+      const InstanceKlass* k = this_klass->super();
       const Method* super_m = nullptr;
       while (k != nullptr) {
         // skip supers that don't have final methods.
@@ -4242,11 +4242,11 @@ static void check_final_method_override(const InstanceKlass* this_klass, TRAPS) 
           }
 
           // continue to look from super_m's holder's super.
-          k = super_m->method_holder()->java_super();
+          k = super_m->method_holder()->super();
           continue;
         }
 
-        k = k->java_super();
+        k = k->super();
       }
     }
   }
@@ -5292,10 +5292,10 @@ void ClassFileParser::fill_instance_klass(InstanceKlass* ik,
       ResourceMark rm;
       // print out the superclass.
       const char * from = ik->external_name();
-      if (ik->java_super() != nullptr) {
+      if (ik->super() != nullptr) {
         log_debug(class, resolve)("%s %s (super)",
                    from,
-                   ik->java_super()->external_name());
+                   ik->super()->external_name());
       }
       // print out each of the interface classes referred to by this class.
       const Array<InstanceKlass*>* const local_interfaces = ik->local_interfaces();

--- a/src/hotspot/share/classfile/defaultMethods.cpp
+++ b/src/hotspot/share/classfile/defaultMethods.cpp
@@ -123,7 +123,7 @@ class HierarchyVisitor : StackObj {
     InstanceKlass* interface_at(int index) {
       return _class->local_interfaces()->at(index);
     }
-    InstanceKlass* next_super() { return _class->java_super(); }
+    InstanceKlass* next_super() { return _class->super(); }
     InstanceKlass* next_interface() {
       return interface_at(interface_index());
     }
@@ -636,7 +636,7 @@ static void find_empty_vtable_slots(GrowableArray<EmptyVtableSlot*>* slots,
 
   // Also any overpasses in our superclasses, that we haven't implemented.
   // (can't use the vtable because it is not guaranteed to be initialized yet)
-  InstanceKlass* super = klass->java_super();
+  InstanceKlass* super = klass->super();
   while (super != nullptr) {
     for (int i = 0; i < super->methods()->length(); ++i) {
       Method* m = super->methods()->at(i);
@@ -668,7 +668,7 @@ static void find_empty_vtable_slots(GrowableArray<EmptyVtableSlot*>* slots,
         }
       }
     }
-    super = super->java_super();
+    super = super->super();
   }
 
   LogTarget(Debug, defaultmethods) lt;

--- a/src/hotspot/share/classfile/fieldLayoutBuilder.cpp
+++ b/src/hotspot/share/classfile/fieldLayoutBuilder.cpp
@@ -316,7 +316,7 @@ void FieldLayout::reconstruct_layout(const InstanceKlass* ik, bool& has_instance
       block->set_offset(fs.offset());
       all_fields->append(block);
     }
-    ik = ik->java_super() == nullptr ? nullptr : ik->java_super();
+    ik = ik->super() == nullptr ? nullptr : ik->super();
   }
   assert(last_offset == -1 || last_offset > 0, "Sanity");
   if (last_offset > 0 &&
@@ -474,7 +474,7 @@ void FieldLayout::print(outputStream* output, bool is_static, const InstanceKlas
               break;
             }
           }
-          ik = ik->java_super();
+          ik = ik->super();
         }
         break;
       }

--- a/src/hotspot/share/classfile/systemDictionary.cpp
+++ b/src/hotspot/share/classfile/systemDictionary.cpp
@@ -431,7 +431,7 @@ InstanceKlass* SystemDictionary::resolve_with_circularity_detection(Symbol* clas
       // (a) RedefineClasses -- the class is already loaded
       // (b) Rarely, the class might have been loaded by a parallel thread
       // We can do a quick check against the already assigned superclass's name and loader.
-      InstanceKlass* superk = klassk->java_super();
+      InstanceKlass* superk = klassk->super();
       if (superk != nullptr &&
           superk->name() == next_name &&
           superk->class_loader() == class_loader()) {
@@ -1049,7 +1049,7 @@ bool SystemDictionary::check_shared_class_super_types(InstanceKlass* ik, Handle 
   // load <ik> from the shared archive.
 
   if (ik->super() != nullptr) {
-    bool check_super = check_shared_class_super_type(ik, ik->java_super(),
+    bool check_super = check_shared_class_super_type(ik, ik->super(),
                                                      class_loader, true,
                                                      CHECK_false);
     if (!check_super) {

--- a/src/hotspot/share/classfile/systemDictionaryShared.cpp
+++ b/src/hotspot/share/classfile/systemDictionaryShared.cpp
@@ -238,7 +238,7 @@ bool SystemDictionaryShared::is_jfr_event_class(InstanceKlass *k) {
     if (k->name()->equals("jdk/internal/event/Event")) {
       return true;
     }
-    k = k->java_super();
+    k = k->super();
   }
   return false;
 }
@@ -329,7 +329,7 @@ bool SystemDictionaryShared::check_for_exclusion_impl(InstanceKlass* k) {
     return true;
   }
 
-  InstanceKlass* super = k->java_super();
+  InstanceKlass* super = k->super();
   if (super != nullptr && check_for_exclusion(super, nullptr)) {
     ResourceMark rm;
     aot_log_warning(aot)("Skipping %s: super class %s is excluded", k->name()->as_C_string(), super->name()->as_C_string());
@@ -571,7 +571,7 @@ bool SystemDictionaryShared::has_been_redefined(InstanceKlass* k) {
   if (k->has_been_redefined()) {
     return true;
   }
-  if (k->java_super() != nullptr && has_been_redefined(k->java_super())) {
+  if (k->super() != nullptr && has_been_redefined(k->super())) {
     return true;
   }
   Array<InstanceKlass*>* interfaces = k->local_interfaces();

--- a/src/hotspot/share/classfile/vmClasses.cpp
+++ b/src/hotspot/share/classfile/vmClasses.cpp
@@ -225,7 +225,7 @@ void vmClasses::resolve_shared_class(InstanceKlass* klass, ClassLoaderData* load
   }
 
   // add super and interfaces first
-  InstanceKlass* super = klass->java_super();
+  InstanceKlass* super = klass->super();
   if (super != nullptr && super->class_loader_data() == nullptr) {
     assert(super->is_instance_klass(), "Super should be instance klass");
     resolve_shared_class(super, loader_data, domain, CHECK);

--- a/src/hotspot/share/jfr/instrumentation/jfrEventClassTransformer.cpp
+++ b/src/hotspot/share/jfr/instrumentation/jfrEventClassTransformer.cpp
@@ -214,7 +214,7 @@ static bool annotation_value(const InstanceKlass* ik, const Symbol* annotation_t
   if (has_annotation(ik, annotation_type, default_value, value)) {
     return true;
   }
-  InstanceKlass* const super = ik->java_super();
+  InstanceKlass* const super = ik->super();
   return super != nullptr && JdkJfrEvent::is_a(super) ? annotation_value(super, annotation_type, default_value, value) : false;
 }
 

--- a/src/hotspot/share/jfr/leakprofiler/chains/edgeUtils.cpp
+++ b/src/hotspot/share/jfr/leakprofiler/chains/edgeUtils.cpp
@@ -76,7 +76,7 @@ const Symbol* EdgeUtils::field_name(const Edge& edge, jshort* modifiers) {
       }
       jfs.next();
     }
-    ik = ik->java_super();
+    ik = ik->super();
   }
   *modifiers = 0;
   return nullptr;

--- a/src/hotspot/share/memory/heapInspection.cpp
+++ b/src/hotspot/share/memory/heapInspection.cpp
@@ -364,6 +364,7 @@ void KlassHierarchy::print_class_hierarchy(outputStream* st, bool print_interfac
     } else {
       // We are only printing the hierarchy of a specific class.
       if (strcmp(classname, cie->klass()->external_name()) == 0) {
+        assert(cie->klass()->is_instance_klass(), "elements array contains only instance klasses");
         KlassHierarchy::set_do_print_for_class_hierarchy(cie, &cit, print_subclasses);
       }
     }

--- a/src/hotspot/share/memory/heapInspection.cpp
+++ b/src/hotspot/share/memory/heapInspection.cpp
@@ -402,7 +402,7 @@ void KlassHierarchy::print_class_hierarchy(outputStream* st, bool print_interfac
 void KlassHierarchy::set_do_print_for_class_hierarchy(KlassInfoEntry* cie, KlassInfoTable* cit,
                                                       bool print_subclasses) {
   // Set do_print for all superclasses of this class.
-  Klass* super = ((InstanceKlass*)cie->klass())->java_super();
+  InstanceKlass* super = InstanceKlass::cast(cie->klass())->super();
   while (super != nullptr) {
     KlassInfoEntry* super_cie = cit->lookup(super);
     super_cie->set_do_print(true);

--- a/src/hotspot/share/oops/fieldStreams.hpp
+++ b/src/hotspot/share/oops/fieldStreams.hpp
@@ -212,7 +212,7 @@ class HierarchicalFieldStream : public StackObj  {
     InstanceKlass* result = _next_klass;
     do  {
       if (!result->is_interface() && result->super() != nullptr) {
-        result = result->java_super();
+        result = result->super();
       } else if (_interface_index > 0) {
         result = _interfaces->at(--_interface_index);
       } else {

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -677,7 +677,7 @@ void InstanceKlass::deallocate_contents(ClassLoaderData* loader_data) {
   }
   set_secondary_supers(nullptr, SECONDARY_SUPERS_BITMAP_EMPTY);
 
-  deallocate_interfaces(loader_data, java_super(), local_interfaces(), transitive_interfaces());
+  deallocate_interfaces(loader_data, super(), local_interfaces(), transitive_interfaces());
   set_transitive_interfaces(nullptr);
   set_local_interfaces(nullptr);
 
@@ -748,7 +748,7 @@ void InstanceKlass::deallocate_contents(ClassLoaderData* loader_data) {
 bool InstanceKlass::is_record() const {
   return _record_components != nullptr &&
          is_final() &&
-         java_super() == vmClasses::Record_klass();
+         super() == vmClasses::Record_klass();
 }
 
 bool InstanceKlass::is_sealed() const {
@@ -763,9 +763,9 @@ bool InstanceKlass::is_sealed() const {
 // sealing conditions: it merely checks for a super of Enum.
 // This is sufficient for recognizing well-formed enums.
 bool InstanceKlass::is_enum_subclass() const {
-  InstanceKlass* s = java_super();
+  InstanceKlass* s = super();
   return (s == vmClasses::Enum_klass() ||
-          (s != nullptr && s->java_super() == vmClasses::Enum_klass()));
+          (s != nullptr && s->super() == vmClasses::Enum_klass()));
 }
 
 bool InstanceKlass::should_be_initialized() const {
@@ -829,7 +829,7 @@ void InstanceKlass::initialize(TRAPS) {
 void InstanceKlass::assert_no_clinit_will_run_for_aot_initialized_class() const {
   assert(has_aot_initialized_mirror(), "must be");
 
-  InstanceKlass* s = java_super();
+  InstanceKlass* s = super();
   if (s != nullptr) {
     DEBUG_ONLY(ResourceMark rm);
     assert(s->is_initialized(), "super class %s of aot-inited class %s must have been initialized",
@@ -942,7 +942,7 @@ bool InstanceKlass::link_class_impl(TRAPS) {
   JavaThread* jt = THREAD;
 
   // link super class before linking this class
-  InstanceKlass* super_klass = java_super();
+  InstanceKlass* super_klass = super();
   if (super_klass != nullptr) {
     if (super_klass->is_interface()) {  // check if super class is an interface
       ResourceMark rm(THREAD);
@@ -1465,7 +1465,7 @@ void InstanceKlass::add_implementor(InstanceKlass* ik) {
   // Filter out subclasses whose supers already implement me.
   // (Note: CHA must walk subclasses of direct implementors
   // in order to locate indirect implementors.)
-  InstanceKlass* super_ik = ik->java_super();
+  InstanceKlass* super_ik = ik->super();
   if (super_ik != nullptr && super_ik->implements_interface(this))
     // We only need to check one immediate superclass, since the
     // implements_interface query looks at transitive_interfaces.
@@ -1831,7 +1831,7 @@ Klass* InstanceKlass::find_field(Symbol* name, Symbol* sig, fieldDescriptor* fd)
     if (intf != nullptr) return intf;
   }
   // 3) apply field lookup recursively if superclass exists
-  { InstanceKlass* supr = java_super();
+  { InstanceKlass* supr = super();
     if (supr != nullptr) return supr->find_field(name, sig, fd);
   }
   // 4) otherwise field lookup fails
@@ -1851,7 +1851,7 @@ Klass* InstanceKlass::find_field(Symbol* name, Symbol* sig, bool is_static, fiel
     if (intf != nullptr) return intf;
   }
   // 3) apply field lookup recursively if superclass exists
-  { InstanceKlass* supr = java_super();
+  { InstanceKlass* supr = super();
     if (supr != nullptr) return supr->find_field(name, sig, is_static, fd);
   }
   // 4) otherwise field lookup fails
@@ -1876,7 +1876,7 @@ bool InstanceKlass::find_field_from_offset(int offset, bool is_static, fieldDesc
     if (klass->find_local_field_from_offset(offset, is_static, fd)) {
       return true;
     }
-    klass = klass->java_super();
+    klass = klass->super();
   }
   return false;
 }
@@ -1919,7 +1919,7 @@ void InstanceKlass::do_local_static_fields(void f(fieldDescriptor*, Handle, TRAP
 }
 
 void InstanceKlass::do_nonstatic_fields(FieldClosure* cl) {
-  InstanceKlass* super = java_super();
+  InstanceKlass* super = this->super();
   if (super != nullptr) {
     super->do_nonstatic_fields(cl);
   }
@@ -1936,7 +1936,7 @@ static int compare_fields_by_offset(FieldInfo* a, FieldInfo* b) {
 }
 
 void InstanceKlass::print_nonstatic_fields(FieldClosure* cl) {
-  InstanceKlass* super = java_super();
+  InstanceKlass* super = this->super();
   if (super != nullptr) {
     super->print_nonstatic_fields(cl);
   }
@@ -2241,7 +2241,7 @@ Method* InstanceKlass::uncached_lookup_method(const Symbol* name,
     if (method != nullptr) {
       return method;
     }
-    klass = klass->java_super();
+    klass = klass->super();
     overpass_local_mode = OverpassLookupMode::skip;   // Always ignore overpass methods in superclasses
   }
   return nullptr;
@@ -2256,7 +2256,7 @@ bool InstanceKlass::has_redefined_this_or_super() const {
     if (klass->has_been_redefined()) {
       return true;
     }
-    klass = klass->java_super();
+    klass = klass->super();
   }
   return false;
 }
@@ -2853,7 +2853,7 @@ bool InstanceKlass::can_be_verified_at_dumptime() const {
   if (major_version() < 50 /*JAVA_6_VERSION*/) {
     return false;
   }
-  if (java_super() != nullptr && !java_super()->can_be_verified_at_dumptime()) {
+  if (super() != nullptr && !super()->can_be_verified_at_dumptime()) {
     return false;
   }
   Array<InstanceKlass*>* interfaces = local_interfaces();
@@ -3985,7 +3985,7 @@ void InstanceKlass::print_class_load_helper(ClassLoaderData* loader_data,
 
     // Class hierarchy info
     debug_stream.print(" klass: " PTR_FORMAT " super: " PTR_FORMAT,
-                       p2i(this),  p2i(java_super()));
+                       p2i(this),  p2i(super()));
 
     // Interfaces
     if (local_interfaces() != nullptr && local_interfaces()->length() > 0) {

--- a/src/hotspot/share/oops/instanceKlass.hpp
+++ b/src/hotspot/share/oops/instanceKlass.hpp
@@ -918,7 +918,7 @@ public:
     return static_cast<const InstanceKlass*>(k);
   }
 
-  // This shadows Klass::super(). The _super of an InstanceKlass is
+  // This hides Klass::super(). The _super of an InstanceKlass is
   // always an InstanceKlass (or nullptr)
   InstanceKlass* super() const {
     return (Klass::super() == nullptr) ? nullptr : InstanceKlass::cast(Klass::super());

--- a/src/hotspot/share/oops/instanceKlass.hpp
+++ b/src/hotspot/share/oops/instanceKlass.hpp
@@ -918,8 +918,14 @@ public:
     return static_cast<const InstanceKlass*>(k);
   }
 
+  // This shadows Klass::super(). The _super of an InstanceKlass is
+  // always an InstanceKlass (or nullptr)
+  InstanceKlass* super() const {
+    return (Klass::super() == nullptr) ? nullptr : InstanceKlass::cast(Klass::super());
+  }
+
   virtual InstanceKlass* java_super() const {
-    return (super() == nullptr) ? nullptr : cast(super());
+    return InstanceKlass::super();
   }
 
   // Sizing (in words)

--- a/src/hotspot/share/oops/klass.hpp
+++ b/src/hotspot/share/oops/klass.hpp
@@ -217,7 +217,9 @@ protected:
 
   // super() cannot be InstanceKlass* -- Java arrays are covariant, and _super is used
   // to implement that. NB: the _super of "[Ljava/lang/Integer;" is "[Ljava/lang/Number;"
-  // If this is not what your code expects, you're probably looking for Klass::java_super().
+  // If this is not what your code expects, you're probably looking for:
+  // - Klass::java_super() - if you have a Klass*
+  // - InstanceKlass::super() - if you have an InstanceKlass* ik, ik->super() returns InstanceKlass*.
   Klass* super() const               { return _super; }
   void set_super(Klass* k)           { _super = k; }
 

--- a/src/hotspot/share/oops/klassVtable.cpp
+++ b/src/hotspot/share/oops/klassVtable.cpp
@@ -346,7 +346,7 @@ InstanceKlass* klassVtable::find_transitive_override(InstanceKlass* initialsuper
       break;
     }
     // if no override found yet, continue to search up
-    superk = superk->java_super();
+    superk = superk->super();
   }
 
   return superk;
@@ -683,14 +683,14 @@ bool klassVtable::needs_new_vtable_entry(Method* target_method,
   // a new entry
   Symbol* name = target_method->name();
   Symbol* signature = target_method->signature();
-  const InstanceKlass* k = super;
+  const InstanceKlass* ik = super;
   Method* super_method = nullptr;
   InstanceKlass *holder = nullptr;
   Method* recheck_method =  nullptr;
   bool found_pkg_prvt_method = false;
-  while (k != nullptr) {
+  while (ik != nullptr) {
     // lookup through the hierarchy for a method with matching name and sign.
-    super_method = InstanceKlass::cast(k)->lookup_method(name, signature);
+    super_method = ik->lookup_method(name, signature);
     if (super_method == nullptr) {
       break; // we still have to search for a matching miranda method
     }
@@ -722,7 +722,7 @@ bool klassVtable::needs_new_vtable_entry(Method* target_method,
 
     // Start with lookup result and continue to search up, for versions supporting transitive override
     if (major_version >= VTABLE_TRANSITIVE_OVERRIDE_VERSION) {
-      k = superk->java_super(); // haven't found an override match yet; continue to look
+      ik = superk->super(); // haven't found an override match yet; continue to look
     } else {
       break;
     }
@@ -774,7 +774,7 @@ bool klassVtable::is_miranda_entry_at(int i) {
   if (holder->is_interface()) {
     assert(m->is_public(), "should be public");
     assert(ik()->implements_interface(holder) , "this class should implement the interface");
-    if (is_miranda(m, ik()->methods(), ik()->default_methods(), ik()->java_super(), klass()->is_interface())) {
+    if (is_miranda(m, ik()->methods(), ik()->default_methods(), ik()->super(), klass()->is_interface())) {
       return true;
     }
   }
@@ -865,7 +865,7 @@ bool klassVtable::is_miranda(Method* m, Array<Method*>* class_methods,
   // Overpasses may or may not exist for supers for pass 1,
   // they should have been created for pass 2 and later.
 
-  for (const InstanceKlass* cursuper = super; cursuper != nullptr; cursuper = cursuper->java_super()) {
+  for (const InstanceKlass* cursuper = super; cursuper != nullptr; cursuper = cursuper->super()) {
      Method* found_mth = cursuper->find_local_method(name, signature,
                                                      Klass::OverpassLookupMode::find,
                                                      Klass::StaticLookupMode::skip,
@@ -959,7 +959,7 @@ void klassVtable::get_mirandas(GrowableArray<Method*>* new_mirandas,
 int klassVtable::fill_in_mirandas(Thread* current, int initialized) {
   ResourceMark rm(current);
   GrowableArray<Method*> mirandas(20);
-  get_mirandas(&mirandas, nullptr, ik()->java_super(), ik()->methods(),
+  get_mirandas(&mirandas, nullptr, ik()->super(), ik()->methods(),
                ik()->default_methods(), ik()->local_interfaces(),
                klass()->is_interface());
   for (int i = 0; i < mirandas.length(); i++) {
@@ -1571,7 +1571,7 @@ void klassVtable::verify(outputStream* st, bool forced) {
   // verify consistency with superKlass vtable
   Klass* super = _klass->super();
   if (super != nullptr) {
-    InstanceKlass* sk = InstanceKlass::cast(super);
+    InstanceKlass* sk = InstanceKlass::cast(super); // why are we sure this is InstanceKlass??
     klassVtable vt = sk->vtable();
     for (int i = 0; i < vt.length(); i++) {
       verify_against(st, &vt, i);

--- a/src/hotspot/share/oops/klassVtable.cpp
+++ b/src/hotspot/share/oops/klassVtable.cpp
@@ -1571,8 +1571,7 @@ void klassVtable::verify(outputStream* st, bool forced) {
   // verify consistency with superKlass vtable
   Klass* super = _klass->super();
   if (super != nullptr) {
-    InstanceKlass* sk = InstanceKlass::cast(super); // why are we sure this is InstanceKlass??
-    klassVtable vt = sk->vtable();
+    klassVtable vt = super->vtable();
     for (int i = 0; i < vt.length(); i++) {
       verify_against(st, &vt, i);
     }

--- a/src/hotspot/share/prims/jvmtiTagMap.cpp
+++ b/src/hotspot/share/prims/jvmtiTagMap.cpp
@@ -452,7 +452,7 @@ ClassFieldMap* ClassFieldMap::create_map_of_static_fields(Klass* k) {
   // Static fields of interfaces and superclasses are reported as references from the interfaces/superclasses.
   // Need to calculate start index of this class fields: number of fields in all interfaces and superclasses.
   int index = interfaces_field_count(ik);
-  for (InstanceKlass* super_klass = ik->java_super(); super_klass != nullptr; super_klass = super_klass->java_super()) {
+  for (InstanceKlass* super_klass = ik->super(); super_klass != nullptr; super_klass = super_klass->super()) {
     FilteredJavaFieldStream super_fld(super_klass);
     index += super_fld.field_count();
   }
@@ -479,12 +479,12 @@ ClassFieldMap* ClassFieldMap::create_map_of_instance_fields(oop obj) {
 
   // fields of the superclasses are reported first, so need to know total field number to calculate field indices
   int total_field_number = interfaces_field_count(ik);
-  for (InstanceKlass* klass = ik; klass != nullptr; klass = klass->java_super()) {
+  for (InstanceKlass* klass = ik; klass != nullptr; klass = klass->super()) {
     FilteredJavaFieldStream fld(klass);
     total_field_number += fld.field_count();
   }
 
-  for (InstanceKlass* klass = ik; klass != nullptr; klass = klass->java_super()) {
+  for (InstanceKlass* klass = ik; klass != nullptr; klass = klass->super()) {
     FilteredJavaFieldStream fld(klass);
     int start_index = total_field_number - fld.field_count();
     for (int index = 0; !fld.done(); fld.next(), index++) {
@@ -2598,10 +2598,10 @@ inline bool VM_HeapWalkOperation::iterate_over_class(oop java_class) {
     oop mirror = klass->java_mirror();
 
     // super (only if something more interesting than java.lang.Object)
-    InstanceKlass* java_super = ik->java_super();
-    if (java_super != nullptr && java_super != vmClasses::Object_klass()) {
-      oop super = java_super->java_mirror();
-      if (!CallbackInvoker::report_superclass_reference(mirror, super)) {
+    InstanceKlass* super_klass = ik->super();
+    if (super_klass != nullptr && super_klass != vmClasses::Object_klass()) {
+      oop super_oop = super_klass->java_mirror();
+      if (!CallbackInvoker::report_superclass_reference(mirror, super_oop)) {
         return false;
       }
     }

--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -1476,7 +1476,7 @@ public:
 
 // Gets the fields of `klass` that are eliminated by escape analysis and need to be reassigned
 static GrowableArray<ReassignedField>* get_reassigned_fields(InstanceKlass* klass, GrowableArray<ReassignedField>* fields, bool is_jvmci) {
-  InstanceKlass* super = klass->java_super();
+  InstanceKlass* super = klass->super();
   if (super != nullptr) {
     get_reassigned_fields(super, fields, is_jvmci);
   }

--- a/src/hotspot/share/runtime/javaThread.cpp
+++ b/src/hotspot/share/runtime/javaThread.cpp
@@ -1140,7 +1140,7 @@ void JavaThread::install_async_exception(AsyncExceptionHandshakeClosure* aehc) {
   ResourceMark rm;
   if (log_is_enabled(Info, exceptions)) {
     log_info(exceptions)("Pending Async. exception installed of type: %s",
-                         InstanceKlass::cast(exception->klass())->external_name());
+                         exception->klass()->external_name());
   }
   // for AbortVMOnException flag
   Exceptions::debug_check_abort(exception->klass()->external_name());

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -459,7 +459,7 @@ static void signal_thread_entry(JavaThread* thread, TRAPS) {
             char klass_name[256];
             char tmp_sig_name[16];
             const char* sig_name = "UNKNOWN";
-            InstanceKlass::cast(PENDING_EXCEPTION->klass())->
+            PENDING_EXCEPTION->klass()->
               name()->as_klass_external_name(klass_name, 256);
             if (os::exception_name(sig, tmp_sig_name, 16) != nullptr)
               sig_name = tmp_sig_name;

--- a/src/hotspot/share/services/heapDumper.cpp
+++ b/src/hotspot/share/services/heapDumper.cpp
@@ -765,7 +765,7 @@ class DumperSupport : AllStatic {
   // creates HPROF_GC_INSTANCE_DUMP record for the given object
   static void dump_instance(AbstractDumpWriter* writer, oop o, DumperClassCacheTable* class_cache);
   // creates HPROF_GC_CLASS_DUMP record for the given instance class
-  static void dump_instance_class(AbstractDumpWriter* writer, Klass* k);
+  static void dump_instance_class(AbstractDumpWriter* writer, InstanceKlass* ik);
   // creates HPROF_GC_CLASS_DUMP record for a given array class
   static void dump_array_class(AbstractDumpWriter* writer, Klass* k);
 
@@ -1204,9 +1204,7 @@ void DumperSupport::dump_instance(AbstractDumpWriter* writer, oop o, DumperClass
 }
 
 // creates HPROF_GC_CLASS_DUMP record for the given instance class
-void DumperSupport::dump_instance_class(AbstractDumpWriter* writer, Klass* k) {
-  InstanceKlass* ik = InstanceKlass::cast(k);
-
+void DumperSupport::dump_instance_class(AbstractDumpWriter* writer, InstanceKlass* ik) {
   // We can safepoint and do a heap dump at a point where we have a Klass,
   // but no java mirror class has been setup for it. So we need to check
   // that the class is at least loaded, to avoid crash from a null mirror.
@@ -1227,11 +1225,11 @@ void DumperSupport::dump_instance_class(AbstractDumpWriter* writer, Klass* k) {
   writer->write_u4(STACK_TRACE_ID);
 
   // super class ID
-  InstanceKlass* java_super = ik->java_super();
-  if (java_super == nullptr) {
+  InstanceKlass* super = ik->super();
+  if (super == nullptr) {
     writer->write_objectID(oop(nullptr));
   } else {
-    writer->write_classID(java_super);
+    writer->write_classID(super);
   }
 
   writer->write_objectID(ik->class_loader());
@@ -1505,7 +1503,7 @@ class ClassDumper : public KlassClosure {
 
   void do_klass(Klass* k) {
     if (k->is_instance_klass()) {
-      DumperSupport::dump_instance_class(writer(), k);
+      DumperSupport::dump_instance_class(writer(), InstanceKlass::cast(k));
     } else {
       DumperSupport::dump_array_class(writer(), k);
     }


### PR DESCRIPTION
By adding an `InstanceKlass* InstanceKlass::super()` method to shadow `Klass* Klass:super()`, this PR makes it possible to simplify the following code

```
InstanceKlass* ik;
InstanceKlass* s;
s = InstanceKlass::cast(ik->super()); // before JDK-8366024 
s = ik->java_super(); // after JDK-8366024 
```

to

```
s = k->super();
```

So you no longer need to do casting or need to understand what `java_super()` is.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8366584](https://bugs.openjdk.org/browse/JDK-8366584): Add an InstanceKlass::super() method that returns InstanceKlass* (**Enhancement** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27037/head:pull/27037` \
`$ git checkout pull/27037`

Update a local copy of the PR: \
`$ git checkout pull/27037` \
`$ git pull https://git.openjdk.org/jdk.git pull/27037/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27037`

View PR using the GUI difftool: \
`$ git pr show -t 27037`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27037.diff">https://git.openjdk.org/jdk/pull/27037.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27037#issuecomment-3243527472)
</details>
