### PR TITLE
8366537: Test "java/util/TimeZone/DefaultTimeZoneTest.java" is not updating the zone ID as expected

### DIFF
--- a/test/jdk/java/util/TimeZone/DefaultTimeZoneTest.java
+++ b/test/jdk/java/util/TimeZone/DefaultTimeZoneTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/util/TimeZone/DefaultTimeZoneTest.java
+++ b/test/jdk/java/util/TimeZone/DefaultTimeZoneTest.java
@@ -54,7 +54,6 @@ public class DefaultTimeZoneTest  {
 
     private static final SimpleDateFormat SDF =
             new SimpleDateFormat("yyyy-MM-dd HH:mm:ss zzzz (XXX)");
-    static JLabel tzid;
     private static final String INSTRUCTIONS =
             """
             Tests the platform time zone detection on all platforms.
@@ -109,7 +108,7 @@ public class DefaultTimeZoneTest  {
         var panel = new JPanel();
         panel.setLayout(new BoxLayout(panel, BoxLayout.PAGE_AXIS));
         // Time zone ID label
-        tzid = new JLabel("Time zone ID: " + SDF.getTimeZone().getID(), SwingConstants.CENTER);
+        var tzid = new JLabel("Time zone ID: " + SDF.getTimeZone().getID(), SwingConstants.CENTER);
         tzid.setAlignmentX(Component.CENTER_ALIGNMENT);
         // Time label
         var label = new JLabel(SDF.format(new Date()), SwingConstants.CENTER);

--- a/test/jdk/java/util/TimeZone/DefaultTimeZoneTest.java
+++ b/test/jdk/java/util/TimeZone/DefaultTimeZoneTest.java
@@ -38,6 +38,11 @@ import javax.swing.JButton;
 import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
+import javax.swing.SwingConstants;
+import javax.swing.BoxLayout;
+import javax.swing.Box;
+import java.awt.Dimension;
+import java.awt.Component;
 import java.awt.BorderLayout;
 import java.awt.Window;
 import java.lang.reflect.InvocationTargetException;
@@ -49,6 +54,7 @@ public class DefaultTimeZoneTest  {
 
     private static final SimpleDateFormat SDF =
             new SimpleDateFormat("yyyy-MM-dd HH:mm:ss zzzz (XXX)");
+    static JLabel tzid;
     private static final String INSTRUCTIONS =
             """
             Tests the platform time zone detection on all platforms.
@@ -98,17 +104,36 @@ public class DefaultTimeZoneTest  {
 
     private static Window createTest() {
         var contents = new JFrame("DefaultTimeZoneTest");
-        var label = new JLabel(SDF.format(new Date()));
-        var panel = new JPanel();
-        var button = new JButton("Update Time Zone");
-        panel.add(button);
         contents.setSize(350, 250);
-        contents.add(label, BorderLayout.NORTH);
-        contents.add(panel, BorderLayout.CENTER);
+        // Panel with vertical layout
+        var panel = new JPanel();
+        panel.setLayout(new BoxLayout(panel, BoxLayout.PAGE_AXIS));
+        // Time zone ID label
+        tzid = new JLabel("Time zone ID: " + SDF.getTimeZone().getID(), SwingConstants.CENTER);
+        tzid.setAlignmentX(Component.CENTER_ALIGNMENT);
+        // Time label
+        var label = new JLabel(SDF.format(new Date()), SwingConstants.CENTER);
+        label.setAlignmentX(Component.CENTER_ALIGNMENT);
+        // Update button
+        var button = new JButton("Update Time Zone");
+        button.setAlignmentX(Component.CENTER_ALIGNMENT);
+        // Add components with spacing
+        panel.add(Box.createRigidArea(new Dimension(0, 10)));
+        panel.add(tzid);
+        panel.add(Box.createRigidArea(new Dimension(0, 5)));
+        panel.add(label);
+        panel.add(Box.createRigidArea(new Dimension(0, 10)));
+        panel.add(button);
+        contents.add(panel);
+
         // Update default time zone on button click
         button.addActionListener(e -> {
+            // Clear JVM cached timezone and force reload from OS
+            TimeZone.setDefault(null);
+            System.setProperty("user.timezone", "");
             TimeZone tz = TimeZone.getDefault();
             SDF.setTimeZone(tz);
+            tzid.setText("Time zone ID: " + tz.getID());
             label.setText(SDF.format(new Date()));
             contents.repaint();
         });

--- a/test/jdk/java/util/TimeZone/DefaultTimeZoneTest.java
+++ b/test/jdk/java/util/TimeZone/DefaultTimeZoneTest.java
@@ -108,8 +108,8 @@ public class DefaultTimeZoneTest  {
         var panel = new JPanel();
         panel.setLayout(new BoxLayout(panel, BoxLayout.PAGE_AXIS));
         // Time zone ID label
-        var tzid = new JLabel("Time zone ID: " + SDF.getTimeZone().getID(), SwingConstants.CENTER);
-        tzid.setAlignmentX(Component.CENTER_ALIGNMENT);
+        var timeZoneID = new JLabel("Time zone ID: " + SDF.getTimeZone().getID(), SwingConstants.CENTER);
+        timeZoneID.setAlignmentX(Component.CENTER_ALIGNMENT);
         // Time label
         var label = new JLabel(SDF.format(new Date()), SwingConstants.CENTER);
         label.setAlignmentX(Component.CENTER_ALIGNMENT);
@@ -118,7 +118,7 @@ public class DefaultTimeZoneTest  {
         button.setAlignmentX(Component.CENTER_ALIGNMENT);
         // Add components with spacing
         panel.add(Box.createRigidArea(new Dimension(0, 10)));
-        panel.add(tzid);
+        panel.add(timeZoneID);
         panel.add(Box.createRigidArea(new Dimension(0, 5)));
         panel.add(label);
         panel.add(Box.createRigidArea(new Dimension(0, 10)));
@@ -132,7 +132,7 @@ public class DefaultTimeZoneTest  {
             System.setProperty("user.timezone", "");
             TimeZone tz = TimeZone.getDefault();
             SDF.setTimeZone(tz);
-            tzid.setText("Time zone ID: " + tz.getID());
+            timeZoneID.setText("Time zone ID: " + tz.getID());
             label.setText(SDF.format(new Date()));
             contents.repaint();
         });


### PR DESCRIPTION
Problem Statements: 
1. ZoneID is not updating when the user change the platform time zone setting, then click the "Update Time Zone" button.
2. ZoneID was not displaying in the window as it is displaying in the lower releases.

Test Results:
jdk-25.0.1/bin/java -jar jtreg/lib/jtreg.jar -verbose:summary -testjdk:jdk-25.0.1  -dir:open/test/jdk java/util/TimeZone/DefaultTimeZoneTest.java

Passed: java/util/TimeZone/DefaultTimeZoneTest.java
Test results: passed: 1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8366537](https://bugs.openjdk.org/browse/JDK-8366537): Test "java/util/TimeZone/DefaultTimeZoneTest.java" is not updating the zone ID as expected (**Bug** - P3)


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)
 * [Justin Lu](https://openjdk.org/census#jlu) (@justin-curtis-lu - Committer) Review applies to [1d553994](https://git.openjdk.org/jdk/pull/27043/files/1d553994abe49a3c41329b460f57c99c1bf6993c)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27043/head:pull/27043` \
`$ git checkout pull/27043`

Update a local copy of the PR: \
`$ git checkout pull/27043` \
`$ git pull https://git.openjdk.org/jdk.git pull/27043/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27043`

View PR using the GUI difftool: \
`$ git pr show -t 27043`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27043.diff">https://git.openjdk.org/jdk/pull/27043.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27043#issuecomment-3244534955)
</details>
