### PR TITLE
8366666: Bump timeout on StressAsyncUL

### DIFF
--- a/test/hotspot/jtreg/runtime/logging/StressAsyncUL.java
+++ b/test/hotspot/jtreg/runtime/logging/StressAsyncUL.java
@@ -28,7 +28,7 @@
  * @requires vm.debug
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
- * @run driver StressAsyncUL
+ * @run driver/timeout=480 StressAsyncUL
  */
 
 import jdk.test.lib.process.OutputAnalyzer;


### PR DESCRIPTION
Timeout after "8260555: Change the default TIMEOUT_FACTOR from 4 to 1"

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8366666](https://bugs.openjdk.org/browse/JDK-8366666): Bump timeout on StressAsyncUL (**Enhancement** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27044/head:pull/27044` \
`$ git checkout pull/27044`

Update a local copy of the PR: \
`$ git checkout pull/27044` \
`$ git pull https://git.openjdk.org/jdk.git pull/27044/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27044`

View PR using the GUI difftool: \
`$ git pr show -t 27044`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27044.diff">https://git.openjdk.org/jdk/pull/27044.diff</a>

</details>
