### PR TITLE
8366490: C2 SuperWord: wrong result because CastP2X is missing ctrl and floats over SafePoint creating stale oops

### DIFF
--- a/src/hotspot/share/opto/vectorization.cpp
+++ b/src/hotspot/share/opto/vectorization.cpp
@@ -1125,7 +1125,7 @@ Node* VPointer::make_pointer_expression(Node* iv_value, Node* ctrl) const {
       Node* scaleL = igvn.longcon(s.scaleL().value());
       Node* variable = (s.variable() == iv) ? iv_value : s.variable();
       if (variable->bottom_type()->isa_ptr() != nullptr) {
-        // Make sure that ctrl is late enough, so that we do not
+        // Use a ctrl that is late enough, so that we do not
         // evaluate the cast before a SafePoint.
         variable = new CastP2XNode(ctrl, variable);
         phase->register_new_node(variable, ctrl);

--- a/src/hotspot/share/opto/vectorization.cpp
+++ b/src/hotspot/share/opto/vectorization.cpp
@@ -934,7 +934,7 @@ BoolNode* make_a_plus_b_leq_c(Node* a, Node* b, Node* c, PhaseIdealLoop* phase) 
   return bol;
 }
 
-BoolNode* VPointer::make_speculative_aliasing_check_with(const VPointer& other) const {
+BoolNode* VPointer::make_speculative_aliasing_check_with(const VPointer& other, Node* ctrl) const {
   // Ensure iv_scale1 <= iv_scale2.
   const VPointer& vp1 = (this->iv_scale() <= other.iv_scale()) ? *this : other;
   const VPointer& vp2 = (this->iv_scale() <= other.iv_scale()) ? other :*this ;
@@ -971,8 +971,8 @@ BoolNode* VPointer::make_speculative_aliasing_check_with(const VPointer& other) 
   Node* main_init = new ConvL2INode(main_initL);
   phase->register_new_node_with_ctrl_of(main_init, pre_init);
 
-  Node* p1_init = vp1.make_pointer_expression(main_init);
-  Node* p2_init = vp2.make_pointer_expression(main_init);
+  Node* p1_init = vp1.make_pointer_expression(main_init, ctrl);
+  Node* p2_init = vp2.make_pointer_expression(main_init, ctrl);
   Node* size1 = igvn.longcon(vp1.size());
   Node* size2 = igvn.longcon(vp2.size());
 
@@ -1092,13 +1092,18 @@ BoolNode* VPointer::make_speculative_aliasing_check_with(const VPointer& other) 
   return bol;
 }
 
-Node* VPointer::make_pointer_expression(Node* iv_value) const {
+// Creates the long pointer expression, evaluated with iv = iv_value.
+// Since we are casting pointers to long with CastP2X, we must be careful
+// that the values do not cross SafePoints, where the oop could be moved
+// by GC, and the already cast value would not be updated, as it is not in
+// the oop-map. For this, we must set a ctrl that is late enough, so that we
+// cannot cross a SafePoint.
+Node* VPointer::make_pointer_expression(Node* iv_value, Node* ctrl) const {
   assert(is_valid(), "must be valid");
 
   PhaseIdealLoop* phase = _vloop.phase();
   PhaseIterGVN& igvn = phase->igvn();
   Node* iv = _vloop.iv();
-  Node* ctrl = phase->get_ctrl(iv_value);
 
   auto maybe_add = [&] (Node* n1, Node* n2, BasicType bt) {
     if (n1 == nullptr) { return n2; }
@@ -1120,7 +1125,9 @@ Node* VPointer::make_pointer_expression(Node* iv_value) const {
       Node* scaleL = igvn.longcon(s.scaleL().value());
       Node* variable = (s.variable() == iv) ? iv_value : s.variable();
       if (variable->bottom_type()->isa_ptr() != nullptr) {
-        variable = new CastP2XNode(nullptr, variable);
+        // Make sure that ctlr is late enough, so that we do not
+        // evaluate the cast before a SafePoint.
+        variable = new CastP2XNode(ctrl, variable);
         phase->register_new_node(variable, ctrl);
       }
       node = new MulLNode(scaleL, variable);

--- a/src/hotspot/share/opto/vectorization.cpp
+++ b/src/hotspot/share/opto/vectorization.cpp
@@ -1125,7 +1125,7 @@ Node* VPointer::make_pointer_expression(Node* iv_value, Node* ctrl) const {
       Node* scaleL = igvn.longcon(s.scaleL().value());
       Node* variable = (s.variable() == iv) ? iv_value : s.variable();
       if (variable->bottom_type()->isa_ptr() != nullptr) {
-        // Make sure that ctlr is late enough, so that we do not
+        // Make sure that ctrl is late enough, so that we do not
         // evaluate the cast before a SafePoint.
         variable = new CastP2XNode(ctrl, variable);
         phase->register_new_node(variable, ctrl);

--- a/src/hotspot/share/opto/vectorization.hpp
+++ b/src/hotspot/share/opto/vectorization.hpp
@@ -1013,8 +1013,8 @@ public:
   }
 
   bool can_make_speculative_aliasing_check_with(const VPointer& other) const;
-  Node* make_pointer_expression(Node* iv_value) const;
-  BoolNode* make_speculative_aliasing_check_with(const VPointer& other) const;
+  Node* make_pointer_expression(Node* iv_value, Node* ctrl) const;
+  BoolNode* make_speculative_aliasing_check_with(const VPointer& other, Node* ctrl) const;
 
   NOT_PRODUCT( void print_on(outputStream* st, bool end_with_cr = true) const; )
 

--- a/src/hotspot/share/opto/vtransform.cpp
+++ b/src/hotspot/share/opto/vtransform.cpp
@@ -217,7 +217,7 @@ void VTransform::add_speculative_alignment_check(Node* node, juint alignment) {
   TRACE_SPECULATIVE_ALIGNMENT_CHECK(cmp_alignment);
   TRACE_SPECULATIVE_ALIGNMENT_CHECK(bol_alignment);
 
-  add_speculative_check(bol_alignment);
+  add_speculative_check([&] (Node* ctrl) { return bol_alignment; });
 }
 
 class VPointerWeakAliasingPair : public StackObj {
@@ -389,8 +389,9 @@ void VTransform::apply_speculative_aliasing_runtime_checks() {
       }
 #endif
 
-      BoolNode* bol = vp1_union.make_speculative_aliasing_check_with(vp2_union);
-      add_speculative_check(bol);
+      add_speculative_check([&] (Node* ctrl) {
+        return vp1_union.make_speculative_aliasing_check_with(vp2_union, ctrl);
+      });
 
       group_start = group_end;
     }
@@ -420,7 +421,13 @@ void VTransform::apply_speculative_aliasing_runtime_checks() {
 //       Multiversioning takes more compile time and code cache, but it also
 //       produces fast code for when the runtime check passes (vectorized) and
 //       when it fails (scalar performance).
-void VTransform::add_speculative_check(BoolNode* bol) {
+//
+// Callback:
+//   In some cases, we require the ctrl just before the check iff_speculate to
+//   generate the values required in the check. We pass this ctrl into the
+//   callback, which is expected to produce the check, i.e. a BoolNode.
+template<typename Callback>
+void VTransform::add_speculative_check(Callback callback) {
   assert(_vloop.are_speculative_checks_possible(), "otherwise we cannot make speculative assumptions");
   ParsePredicateSuccessProj* parse_predicate_proj = _vloop.auto_vectorization_parse_predicate_proj();
   IfTrueNode* new_check_proj = nullptr;
@@ -432,6 +439,10 @@ void VTransform::add_speculative_check(BoolNode* bol) {
     new_check_proj = phase()->create_new_if_for_multiversion(_vloop.multiversioning_fast_proj());
   }
   Node* iff_speculate = new_check_proj->in(0);
+
+  // Create the check, given the ctrl just before the iff.
+  BoolNode* bol = callback(iff_speculate->in(0));
+
   igvn().replace_input_of(iff_speculate, 1, bol);
   TRACE_SPECULATIVE_ALIGNMENT_CHECK(iff_speculate);
 }

--- a/src/hotspot/share/opto/vtransform.hpp
+++ b/src/hotspot/share/opto/vtransform.hpp
@@ -255,7 +255,9 @@ private:
   void apply_speculative_alignment_runtime_checks();
   void apply_speculative_aliasing_runtime_checks();
   void add_speculative_alignment_check(Node* node, juint alignment);
-  void add_speculative_check(BoolNode* bol);
+
+  template<typename Callback>
+  void add_speculative_check(Callback callback);
 
   void apply_vectorization() const;
 };

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestAliasingCastP2XCtrl.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestAliasingCastP2XCtrl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestAliasingCastP2XCtrl.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestAliasingCastP2XCtrl.java
@@ -30,12 +30,13 @@
  *          and render the cast value stale.
  *
  * @run main/othervm
+ *      -XX:+IgnoreUnrecognizedVMOptions
  *      -XX:CompileCommand=compileonly,*TestAliasingCastP2XCtrl::test
  *      -XX:CompileCommand=dontinline,*TestAliasingCastP2XCtrl::allocateArrays
  *      -XX:-TieredCompilation
  *      -Xbatch
- *      -XX:+StressGCM
  *      -XX:+UseG1GC
+ *      -XX:+UnlockDiagnosticVMOptions -XX:+StressGCM
  *      compiler.loopopts.superword.TestAliasingCastP2XCtrl
  */
 
@@ -43,10 +44,11 @@
  * @test id=fewer-flags
  * @bug 8366490
  * @run main/othervm
+ *      -XX:+IgnoreUnrecognizedVMOptions
  *      -XX:CompileCommand=compileonly,*TestAliasingCastP2XCtrl::test
  *      -XX:CompileCommand=dontinline,*TestAliasingCastP2XCtrl::allocateArrays
  *      -Xbatch
- *      -XX:+StressGCM
+ *      -XX:+UnlockDiagnosticVMOptions -XX:+StressGCM
  *      compiler.loopopts.superword.TestAliasingCastP2XCtrl
  */
 

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestAliasingCastP2XCtrl.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestAliasingCastP2XCtrl.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test id=all-flags
+ * @bug 8366490
+ * @summary Test that we set the ctrl of CastP2X when generating
+ *          the aliasing runtime check, preventing the CastP2X
+ *          from floating over a SafePoint that could move the oop,
+ *          and render the cast value stale.
+ *
+ * @run main/othervm
+ *      -XX:CompileCommand=compileonly,*TestAliasingCastP2XCtrl::test
+ *      -XX:CompileCommand=dontinline,*TestAliasingCastP2XCtrl::allocateArrays
+ *      -XX:-TieredCompilation
+ *      -Xbatch
+ *      -XX:+StressGCM
+ *      -XX:+UseG1GC
+ *      compiler.loopopts.superword.TestAliasingCastP2XCtrl
+ */
+
+/*
+ * @test id=fewer-flags
+ * @bug 8366490
+ * @run main/othervm
+ *      -XX:CompileCommand=compileonly,*TestAliasingCastP2XCtrl::test
+ *      -XX:CompileCommand=dontinline,*TestAliasingCastP2XCtrl::allocateArrays
+ *      -Xbatch
+ *      -XX:+StressGCM
+ *      compiler.loopopts.superword.TestAliasingCastP2XCtrl
+ */
+
+/*
+ * @test id=vanilla
+ * @bug 8366490
+ * @run driver compiler.loopopts.superword.TestAliasingCastP2XCtrl
+ */
+
+package compiler.loopopts.superword;
+
+public class TestAliasingCastP2XCtrl {
+    static final int N = 400;
+    static boolean flag = false;
+
+    static void allocateArrays() {
+        for (int i = 0; 200_000 > i; ++i) {
+            int[] a = new int[N];
+        }
+        // Makes GC more likely.
+        // Without it I could not reproduce it on slowdebug,
+        // but only with fastdebug.
+        if (flag) { System.gc(); }
+        flag = !flag;
+    }
+
+    static int[] test() {
+        int a[] = new int[N];
+        // We must make sure that no CastP2X happens before
+        // the call below, otherwise we may have an old oop.
+        allocateArrays();
+        // The CastP2X for the aliasing runtime check should
+        // only be emitted after the call, to ensure we only
+        // deal with oops that are updated if there is a GC
+        // that could move our allocated array.
+
+        // Not fully sure why we need the outer loop, but maybe
+        // it is needed so that a part of the check is hoisted,
+        // and the floats up, over the call if we do not set
+        // the ctrl.
+        for (int k = 0; k < 500; k++) {
+            for (int i = 1; i < 69; i++) {
+                // Aliasing references -> needs runtime check,
+                // should always fail.
+                a[i] =  14;
+                a[4] -= 14;
+                // The range computation for the constant access
+                // produces a shape:
+                //   AddL(CastP2X(a), 0x20)
+                // And this shape only depends on a, so it could
+                // easily float above the call to allocateArrays
+                // if we do not set a ctrl that prevents that.
+            }
+        }
+        return a;
+    }
+
+    public static void main(String[] args) {
+        int[] gold = test();
+        for (int r = 0; r < 20; r++) {
+            int[] a = test();
+            if (a[4] != gold[4]) {
+                throw new RuntimeException("wrong value " + gold[4] + " " + a[4]);
+            }
+        }
+    }
+}

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestAliasingCastP2XCtrl.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestAliasingCastP2XCtrl.java
@@ -29,6 +29,7 @@
  *          from floating over a SafePoint that could move the oop,
  *          and render the cast value stale.
  *
+ * @requires vm.gc == "G1" | vm.gc == "null"
  * @run main/othervm
  *      -XX:+IgnoreUnrecognizedVMOptions
  *      -XX:CompileCommand=compileonly,*TestAliasingCastP2XCtrl::test

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestAliasingCastP2XCtrl.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestAliasingCastP2XCtrl.java
@@ -28,7 +28,6 @@
  *          the aliasing runtime check, preventing the CastP2X
  *          from floating over a SafePoint that could move the oop,
  *          and render the cast value stale.
- *
  * @requires vm.gc == "G1" | vm.gc == "null"
  * @run main/othervm
  *      -XX:+IgnoreUnrecognizedVMOptions
@@ -56,7 +55,7 @@
 /*
  * @test id=vanilla
  * @bug 8366490
- * @run driver compiler.loopopts.superword.TestAliasingCastP2XCtrl
+ * @run main compiler.loopopts.superword.TestAliasingCastP2XCtrl
  */
 
 package compiler.loopopts.superword;


### PR DESCRIPTION
**Analysis**

A `CastP2X` without ctrl can float. If it floats over a `SafePoint` (or call), we may GC and move the oop. But the `CastP2X` value does not end up on the oop-map, and so the pointer is stale (old).

With `StressGCM`, the aliasing runtime check has one `CastP2X` that floats over the SafePoint, and another that stays after the SafePoint. Both read the oop of the same array, so instead of getting the same address, we now get the old and the new oop. And so the aliasing runtime check passes (thinks there is no aliasing), even though there is aliasing. We end up vectorizing, which reorders the loads/stores and would only be safe if there is no aliasing.

**Fix:** add control to the `CastP2X` so that it cannot float too far.

**Details**

```
rbp = Allcoate array
spill <- rbp + 0x20

call to allocateArrays
-> allocates a lot, and triggers GC. That moves the allocated array behind rbp
-> rbp is oop-mapped, so it is updated automatically to the new oop
-> spill value remains based on the old oop

We now compute the aliasing runtime check:
-> one side of the comparison is computed from rbp (new oop)
-> the other side is computed from the the spill value (old oop)
-> the cmp returns a nonsensical value, and we take the wrong branch
-> vectorize even though we have aliasing!
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8366490](https://bugs.openjdk.org/browse/JDK-8366490): C2 SuperWord: wrong result because CastP2X is missing ctrl and floats over SafePoint creating stale oops (**Bug** - P3)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Manuel Hässig](https://openjdk.org/census#mhaessig) (@mhaessig - Committer) Review applies to [13f70d31](https://git.openjdk.org/jdk/pull/27045/files/13f70d3193095a7c23cb47dc95e8c094604382e7)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27045/head:pull/27045` \
`$ git checkout pull/27045`

Update a local copy of the PR: \
`$ git checkout pull/27045` \
`$ git pull https://git.openjdk.org/jdk.git pull/27045/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27045`

View PR using the GUI difftool: \
`$ git pr show -t 27045`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27045.diff">https://git.openjdk.org/jdk/pull/27045.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27045#issuecomment-3245133548)
</details>
