### PR TITLE
8363966: GHA: Switch cross-compiling sysroots to Debian trixie

### DIFF
--- a/.github/workflows/build-cross-compile.yml
+++ b/.github/workflows/build-cross-compile.yml
@@ -64,33 +64,33 @@ jobs:
             gnu-arch: aarch64
             debian-arch: arm64
             debian-repository: https://httpredir.debian.org/debian/
-            debian-version: bookworm
+            debian-version: trixie
             tolerate-sysroot-errors: false
           - target-cpu: arm
             gnu-arch: arm
             debian-arch: armhf
             debian-repository: https://httpredir.debian.org/debian/
-            debian-version: bookworm
+            debian-version: trixie
             tolerate-sysroot-errors: false
             gnu-abi: eabihf
           - target-cpu: s390x
             gnu-arch: s390x
             debian-arch: s390x
             debian-repository: https://httpredir.debian.org/debian/
-            debian-version: bookworm
+            debian-version: trixie
             tolerate-sysroot-errors: false
           - target-cpu: ppc64le
             gnu-arch: powerpc64le
             debian-arch: ppc64el
             debian-repository: https://httpredir.debian.org/debian/
-            debian-version: bookworm
+            debian-version: trixie
             tolerate-sysroot-errors: false
           - target-cpu: riscv64
             gnu-arch: riscv64
             debian-arch: riscv64
             debian-repository: https://httpredir.debian.org/debian/
-            debian-version: sid
-            tolerate-sysroot-errors: true
+            debian-version: trixie
+            tolerate-sysroot-errors: false
 
     steps:
       - name: 'Checkout the JDK source'


### PR DESCRIPTION
Same as [JDK-8363965](https://bugs.openjdk.org/browse/JDK-8363965), but switching to Debian trixie. We have waited for about a month for it to stabilize, and it seems good to switch now. The benefit of doing this now is making RISC-V sysroot more stable using the same distro as everything else.

Additional testing:
 - [x] GHA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8363966](https://bugs.openjdk.org/browse/JDK-8363966): GHA: Switch cross-compiling sysroots to Debian trixie (**Enhancement** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27047/head:pull/27047` \
`$ git checkout pull/27047`

Update a local copy of the PR: \
`$ git checkout pull/27047` \
`$ git pull https://git.openjdk.org/jdk.git pull/27047/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27047`

View PR using the GUI difftool: \
`$ git pr show -t 27047`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27047.diff">https://git.openjdk.org/jdk/pull/27047.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27047#issuecomment-3245142416)
</details>
