### PR TITLE
8366688: G1: Rename G1HeapRegionRemSet::is_added_to_cset_group() to has_cset_group()

### DIFF
--- a/src/hotspot/share/gc/g1/g1CardSet.cpp
+++ b/src/hotspot/share/gc/g1/g1CardSet.cpp
@@ -783,7 +783,7 @@ G1AddCardResult G1CardSet::add_card(uintptr_t card) {
   {
     uint region_idx = card_region >> config()->log2_card_regions_per_heap_region();
     G1HeapRegion* r = G1CollectedHeap::heap()->region_at(region_idx);
-    assert(!r->rem_set()->is_added_to_cset_group() ||
+    assert(!r->rem_set()->has_cset_group() ||
            r->rem_set()->cset_group()->card_set() != this, "Should not be sharing a cardset");
   }
 #endif

--- a/src/hotspot/share/gc/g1/g1CollectionSet.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSet.cpp
@@ -115,7 +115,7 @@ void G1CollectionSet::add_old_region(G1HeapRegion* hr) {
          "Precondition, actively building cset or adding optional later on");
   assert(hr->is_old(), "the region should be old");
 
-  assert(!hr->rem_set()->is_added_to_cset_group(), "Should have already uninstalled group remset");
+  assert(!hr->rem_set()->has_cset_group(), "Should have already uninstalled group remset");
 
   assert(!hr->in_collection_set(), "should not already be in the collection set");
   _g1h->register_old_region_with_region_attr(hr);

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -3054,7 +3054,7 @@ bool G1PrintRegionLivenessInfoClosure::do_heap_region(G1HeapRegion* r) {
   const char* remset_type = r->rem_set()->get_short_state_str();
   uint cset_group_id     = 0;
 
-  if (r->rem_set()->is_added_to_cset_group()) {
+  if (r->rem_set()->has_cset_group()) {
     cset_group_id = r->rem_set()->cset_group_id();
   }
 

--- a/src/hotspot/share/gc/g1/g1HeapRegionRemSet.cpp
+++ b/src/hotspot/share/gc/g1/g1HeapRegionRemSet.cpp
@@ -63,7 +63,7 @@ G1HeapRegionRemSet::G1HeapRegionRemSet(G1HeapRegion* hr) :
   _state(Untracked) { }
 
 G1HeapRegionRemSet::~G1HeapRegionRemSet() {
-  assert(!is_added_to_cset_group(), "Still assigned to a CSet group");
+  assert(!has_cset_group(), "Still assigned to a CSet group");
 }
 
 void G1HeapRegionRemSet::clear_fcc() {
@@ -76,7 +76,7 @@ void G1HeapRegionRemSet::clear(bool only_cardset, bool keep_tracked) {
   }
   clear_fcc();
 
-  if (is_added_to_cset_group()) {
+  if (has_cset_group()) {
     card_set()->clear();
     assert(card_set()->occupied() == 0, "Should be clear.");
   }
@@ -90,13 +90,13 @@ void G1HeapRegionRemSet::clear(bool only_cardset, bool keep_tracked) {
 
 void G1HeapRegionRemSet::reset_table_scanner() {
   _code_roots.reset_table_scanner();
-  if (is_added_to_cset_group()) {
+  if (has_cset_group()) {
     card_set()->reset_table_scanner();
   }
 }
 
 G1MonotonicArenaMemoryStats G1HeapRegionRemSet::card_set_memory_stats() const {
-  assert(is_added_to_cset_group(), "pre-condition");
+  assert(has_cset_group(), "pre-condition");
   return cset_group()->card_set_memory_stats();
 }
 

--- a/src/hotspot/share/gc/g1/g1HeapRegionRemSet.hpp
+++ b/src/hotspot/share/gc/g1/g1HeapRegionRemSet.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/g1/g1HeapRegionRemSet.hpp
+++ b/src/hotspot/share/gc/g1/g1HeapRegionRemSet.hpp
@@ -57,12 +57,12 @@ class G1HeapRegionRemSet : public CHeapObj<mtGC> {
   void clear_fcc();
 
   G1CardSet* card_set() {
-    assert(is_added_to_cset_group(), "pre-condition");
+    assert(has_cset_group(), "pre-condition");
     return cset_group()->card_set();
   }
 
   const G1CardSet* card_set() const {
-    assert(is_added_to_cset_group(), "pre-condition");
+    assert(has_cset_group(), "pre-condition");
     return cset_group()->card_set();
   }
 
@@ -71,7 +71,7 @@ public:
   ~G1HeapRegionRemSet();
 
   bool cardset_is_empty() const {
-    return !is_added_to_cset_group() || card_set()->is_empty();
+    return !has_cset_group() || card_set()->is_empty();
   }
 
   void install_cset_group(G1CSetCandidateGroup* cset_group) {
@@ -83,7 +83,7 @@ public:
 
   void uninstall_cset_group();
 
-  bool is_added_to_cset_group() const {
+  bool has_cset_group() const {
     return _cset_group != nullptr;
   }
 
@@ -96,7 +96,7 @@ public:
   }
 
   uint cset_group_id() const {
-    assert(is_added_to_cset_group(), "pre-condition");
+    assert(has_cset_group(), "pre-condition");
     return cset_group()->group_id();
   }
 
@@ -118,7 +118,7 @@ public:
   inline static void iterate_for_merge(G1CardSet* card_set, CardOrRangeVisitor& cl);
 
   size_t occupied() {
-    assert(is_added_to_cset_group(), "pre-condition");
+    assert(has_cset_group(), "pre-condition");
     return card_set()->occupied();
   }
 

--- a/src/hotspot/share/gc/g1/g1HeapRegionRemSet.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1HeapRegionRemSet.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/g1/g1HeapRegionRemSet.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1HeapRegionRemSet.inline.hpp
@@ -125,7 +125,7 @@ uintptr_t G1HeapRegionRemSet::to_card(OopOrNarrowOopStar from) const {
 }
 
 void G1HeapRegionRemSet::add_reference(OopOrNarrowOopStar from, uint tid) {
-  assert(is_added_to_cset_group(), "pre-condition");
+  assert(has_cset_group(), "pre-condition");
 
   assert(_state != Untracked, "must be");
 

--- a/src/hotspot/share/gc/g1/g1RemSetSummary.cpp
+++ b/src/hotspot/share/gc/g1/g1RemSetSummary.cpp
@@ -228,7 +228,7 @@ public:
 
     // Accumulate card set details for regions that are assigned to single region
     // groups. G1HeapRegionRemSet::mem_size() includes the size of the code roots
-    if (hrrs->is_added_to_cset_group() && hrrs->cset_group()->length() == 1) {
+    if (hrrs->has_cset_group() && hrrs->cset_group()->length() == 1) {
       G1CardSet* card_set = hrrs->cset_group()->card_set();
 
       rs_mem_sz = hrrs->mem_size() + card_set->mem_size();

--- a/src/hotspot/share/gc/g1/g1RemSetTrackingPolicy.cpp
+++ b/src/hotspot/share/gc/g1/g1RemSetTrackingPolicy.cpp
@@ -108,7 +108,7 @@ void G1RemSetTrackingPolicy::update_after_rebuild(G1HeapRegion* r) {
     size_t remset_bytes = r->rem_set()->mem_size();
     size_t occupied = 0;
     // per region cardset details only valid if group contains a single region.
-    if (r->rem_set()->is_added_to_cset_group() &&
+    if (r->rem_set()->has_cset_group() &&
         r->rem_set()->cset_group()->length() == 1 ) {
         G1CardSet *card_set = r->rem_set()->cset_group()->card_set();
         remset_bytes += card_set->mem_size();


### PR DESCRIPTION
Hi all,

  please review this trivial renaming of `G1HHRS::is_added_to_cset_group` - it's just misnamed, we never add G1HRRS to the cset groups.

Testing: gha, local compilation

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8366688](https://bugs.openjdk.org/browse/JDK-8366688): G1: Rename G1HeapRegionRemSet::is_added_to_cset_group() to has_cset_group() (**Enhancement** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27048/head:pull/27048` \
`$ git checkout pull/27048`

Update a local copy of the PR: \
`$ git checkout pull/27048` \
`$ git pull https://git.openjdk.org/jdk.git pull/27048/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27048`

View PR using the GUI difftool: \
`$ git pr show -t 27048`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27048.diff">https://git.openjdk.org/jdk/pull/27048.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27048#issuecomment-3245191279)
</details>
