### PR TITLE
8366434: THP not working properly with G1 after JDK-8345655

### DIFF
--- a/src/hotspot/share/memory/memoryReserver.cpp
+++ b/src/hotspot/share/memory/memoryReserver.cpp
@@ -110,12 +110,13 @@ static char* reserve_memory_inner(char* requested_address,
 ReservedSpace MemoryReserver::reserve_memory(char* requested_address,
                                              size_t size,
                                              size_t alignment,
+                                             size_t page_size,
                                              bool exec,
                                              MemTag mem_tag) {
   char* base = reserve_memory_inner(requested_address, size, alignment, exec, mem_tag);
 
   if (base != nullptr) {
-    return ReservedSpace(base, size, alignment, os::vm_page_size(), exec, false /* special */);
+    return ReservedSpace(base, size, alignment, page_size, exec, false /* special */);
   }
 
   // Failed
@@ -188,7 +189,7 @@ ReservedSpace MemoryReserver::reserve(char* requested_address,
   }
 
   // == Case 3 ==
-  return reserve_memory(requested_address, size, alignment, executable, mem_tag);
+  return reserve_memory(requested_address, size, alignment, page_size, executable, mem_tag);
 }
 
 ReservedSpace MemoryReserver::reserve(char* requested_address,

--- a/src/hotspot/share/memory/memoryReserver.hpp
+++ b/src/hotspot/share/memory/memoryReserver.hpp
@@ -34,6 +34,7 @@ class MemoryReserver : AllStatic {
   static ReservedSpace reserve_memory(char* requested_address,
                                       size_t size,
                                       size_t alignment,
+                                      size_t page_size,
                                       bool exec,
                                       MemTag mem_tag);
 

--- a/test/hotspot/jtreg/gc/TestTransparentHugePagesHeap.java
+++ b/test/hotspot/jtreg/gc/TestTransparentHugePagesHeap.java
@@ -73,7 +73,7 @@ import jtreg.SkippedException;
 // -XX:+UseTransparentHugePages is specified.
 //
 // Note: we don't verify if the heap is backed by huge pages because we
-// can't now if the underlying system have any available.
+// can't know if the underlying system have any available.
 public class TestTransparentHugePagesHeap {
 
     public static void main(String args[]) throws Exception {

--- a/test/hotspot/jtreg/gc/TestTransparentHugePagesHeap.java
+++ b/test/hotspot/jtreg/gc/TestTransparentHugePagesHeap.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test id=G1
+ * @summary Run tests with G1
+ * @library /test/lib
+ * @build jdk.test.lib.Platform
+ * @requires os.family == "linux"
+ * @requires vm.gc.G1
+ * @run driver TestTransparentHugePagesHeap G1
+*/
+/*
+ * @test id=Parallel
+ * @summary Run tests with Parallel
+ * @library /test/lib
+ * @build jdk.test.lib.Platform
+ * @requires os.family == "linux"
+ * @requires vm.gc.Parallel
+ * @run driver TestTransparentHugePagesHeap Parallel
+*/
+/*
+ * @test id=Serial
+ * @summary Run tests with Serial
+ * @library /test/lib
+ * @build jdk.test.lib.Platform
+ * @requires os.family == "linux"
+ * @requires vm.gc.Serial
+ * @run driver TestTransparentHugePagesHeap Serial
+*/
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.Scanner;
+
+import jdk.test.lib.os.linux.HugePageConfiguration;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+import jdk.test.lib.Platform;
+
+import jtreg.SkippedException;
+
+// Check that we get THP for the heap
+public class TestTransparentHugePagesHeap {
+
+    public static void main(String args[]) throws Exception {
+        // To be able to detect large page use (esp. THP) somewhat reliably, we
+        //  need at least kernel 3.8 to get the "VmFlags" tag in smaps.
+        // (Note: its still good we started the VM at least since this serves as a nice
+        //  test for all manners of large page options).
+        if (Platform.getOsVersionMajor() < 3 ||
+            (Platform.getOsVersionMajor() == 3 && Platform.getOsVersionMinor() < 8)) {
+            throw new SkippedException("Kernel older than 3.8 - skipping this test.");
+        }
+
+        final HugePageConfiguration hugePageConfiguration = HugePageConfiguration.readFromOS();
+        if (!hugePageConfiguration.supportsTHP()) {
+            throw new SkippedException("THP is turned off");
+        }
+
+        OutputAnalyzer oa = ProcessTools.executeTestJava("-XX:+Use" + args[0] + "GC", "-Xmx128m", "-Xms128m", "-Xlog:pagesize:thp-%p.log", "-XX:+UseTransparentHugePages", VerifyTHPEnabledForHeap.class.getName());
+        oa.shouldHaveExitValue(0);
+    }
+
+    // We verify that the heap can be backed by THP by looking at the
+    // THPeligible field for the heap section in /proc/self/smaps. This
+    // field indicates if a mapping can use THP.
+    // THP mode 'always': this field is 1 whenever huge pages can be used
+    // THP mode 'madvise': this field is 1 if the mapping has been madvised
+    // as MADV_HUGEPAGE. In the JVM that should happen when the flag
+    // -XX:+UseTransparentHugePages is specified.
+    class VerifyTHPEnabledForHeap {
+
+        public static void main(String args[]) throws Exception {
+            String heapAddress = readHeapAddressInLog();
+            Path smaps = makeSmapsCopy();
+
+            final Pattern heapSection = Pattern.compile("^" + heapAddress + ".*");
+            final Pattern thpEligible = Pattern.compile("THPeligible:\\s+1\\s*");
+            final Pattern vmFlags     = Pattern.compile("VmFlags.*");
+
+            Scanner smapsFile = new Scanner(smaps);
+            while (smapsFile.hasNextLine()) {
+                Matcher heapMatcher = heapSection.matcher(smapsFile.nextLine());
+
+                if (heapMatcher.matches()) {
+                    // Found heap section, verify that it is THP eligible
+                    while (smapsFile.hasNextLine()) {
+                        String line = smapsFile.nextLine();
+
+                        Matcher m;
+                        if ((m = thpEligible.matcher(line)).matches()) {
+                            // Heap is THP eligible
+                            return;
+                        } else if ((m = vmFlags.matcher(line)).matches()) {
+                            // Reached end of heap segment
+                            throw new RuntimeException("Heap segement is not THPeligible");
+                        }
+                    }
+                }
+            }
+            // Failed to verify THP for heap
+            throw new RuntimeException("Could not find heap segment in smaps file");
+        }
+
+        private static String readHeapAddressInLog() throws Exception {
+            final Pattern heapAddress = Pattern.compile(".* Heap: .*base=(0x[0-9A-Fa-f]*).*");
+
+            Scanner logFile = new Scanner(Paths.get("thp-" + ProcessHandle.current().pid() + ".log"));
+            while (logFile.hasNextLine()) {
+                Matcher m = heapAddress.matcher(logFile.nextLine());
+                if (m.matches()) {
+                    return Long.toHexString(Long.decode(m.group(1)));
+                }
+            }
+            throw new RuntimeException("Failed to parse heap address, failing test");
+        }
+
+        private static Path makeSmapsCopy() throws Exception {
+            Path src = Paths.get("/proc/self/smaps");
+            Path dest = Paths.get("smaps-copy-" +  ProcessHandle.current().pid() + ".txt");
+            Files.copy(src, dest, StandardCopyOption.REPLACE_EXISTING);
+            return dest;
+        }
+    }
+}
+


### PR DESCRIPTION
Please review this fix to enable transparent huge pages for G1,

**Summary**
In [JDK-8345655](https://bugs.openjdk.org/browse/JDK-8345655) we refactored the memory reservation code to be more maintainable and easier to follow. When doing this one of the code paths changed to always pass in `os::vm_page_size()` where it previously had used a page size provided by the caller.

Even if the alignment for `ReservedSpaces` created this way show that they should be aligned to support large pages the page size member for the `ReservedSpace` does not convey that we want large pages for the space. In G1 when using `G1PageBaseVirtualSpace` we use the above mentioned page size as the alignment for the reservation. This leads to reservations (made using the API) not being THP eligible even if `-XX:+UseTransparentHugePages` is specified.

This is only an issue when the system is configured with the THP mode `madvise`. If the mode is `always`, we will get THP eligible reservations. So a fairly simple workaround for this issue (given you have access to configuring your system) is to configure the THP mode to always.

The fix is to simply change back to the old behavior and pass in the user provided page size to the `ReservedSpace`. We've also added a test that verifies that we try to back the heap with transparent huge pages when `-XX:+UseTransparentHugePages` is specified on the command-line.

**Testing**
* Mach5 testing tier1-tier5
* Manual testing of the new test both locally and on mach5. Making sure it has been executed on system with both `madvise` and `always` configured. Also made sure the test actually failed without the fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8366434](https://bugs.openjdk.org/browse/JDK-8366434): THP not working properly with G1 after JDK-8345655 (**Bug** - P2)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Contributors
 * Stefan Karlsson `<stefank@openjdk.org>`
 * Stefan Johansson `<sjohanss@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27051/head:pull/27051` \
`$ git checkout pull/27051`

Update a local copy of the PR: \
`$ git checkout pull/27051` \
`$ git pull https://git.openjdk.org/jdk.git pull/27051/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27051`

View PR using the GUI difftool: \
`$ git pr show -t 27051`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27051.diff">https://git.openjdk.org/jdk/pull/27051.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27051#issuecomment-3245479247)
</details>
