### PR TITLE
8366486: Test jdk/jfr/event/profiling/TestCPUTimeSampleMultipleRecordings.java is timing out

### DIFF
--- a/test/jdk/jdk/jfr/event/profiling/TestCPUTimeSampleMultipleRecordings.java
+++ b/test/jdk/jdk/jfr/event/profiling/TestCPUTimeSampleMultipleRecordings.java
@@ -39,20 +39,15 @@ import jdk.test.lib.jfr.EventNames;
  * @run main jdk.jfr.event.profiling.TestCPUTimeSampleMultipleRecordings
  */
 public class TestCPUTimeSampleMultipleRecordings {
-
-    static String nativeEvent = EventNames.CPUTimeSample;
-
     static volatile boolean alive = true;
 
     public static void main(String[] args) throws Exception {
         Thread t = new Thread(TestCPUTimeSampleMultipleRecordings::nativeMethod);
-        t.setDaemon(true);
         t.start();
         for (int i = 0; i < 2; i++) {
             try (RecordingStream rs = new RecordingStream()) {
-                rs.enable(nativeEvent).with("throttle", "1ms");
-                rs.onEvent(nativeEvent, e -> {
-                    alive = false;
+                rs.enable(EventNames.CPUTimeSample).with("throttle", "1ms");
+                rs.onEvent(EventNames.CPUTimeSample, e -> {
                     rs.close();
                 });
 
@@ -60,6 +55,7 @@ public class TestCPUTimeSampleMultipleRecordings {
             }
         }
         alive = false;
+        t.join();
     }
 
     public static void nativeMethod() {


### PR DESCRIPTION
Fix test case by keeping the sampled thread alive long enough.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8366486](https://bugs.openjdk.org/browse/JDK-8366486): Test jdk/jfr/event/profiling/TestCPUTimeSampleMultipleRecordings.java is timing out (**Bug** - P4)


### Reviewers
 * [Jaroslav Bachorik](https://openjdk.org/census#jbachorik) (@jbachorik - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27053/head:pull/27053` \
`$ git checkout pull/27053`

Update a local copy of the PR: \
`$ git checkout pull/27053` \
`$ git pull https://git.openjdk.org/jdk.git pull/27053/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27053`

View PR using the GUI difftool: \
`$ git pr show -t 27053`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27053.diff">https://git.openjdk.org/jdk/pull/27053.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27053#issuecomment-3245517589)
</details>
