### PR TITLE
8366517: Refine null locale processing of ctor/factory methods in `Date/DecimalFormatSymbols`

### DIFF
--- a/src/java.base/share/classes/java/text/DateFormatSymbols.java
+++ b/src/java.base/share/classes/java/text/DateFormatSymbols.java
@@ -149,7 +149,8 @@ public class DateFormatSymbols implements Serializable, Cloneable {
      */
     public DateFormatSymbols(Locale locale)
     {
-        initializeData(locale);
+        initializeData(Objects.requireNonNull(locale,
+            "locale should not be null"));
     }
 
     /**

--- a/src/java.base/share/classes/java/text/DateFormatSymbols.java
+++ b/src/java.base/share/classes/java/text/DateFormatSymbols.java
@@ -346,6 +346,7 @@ public class DateFormatSymbols implements Serializable, Cloneable {
      * @since 1.6
      */
     public static final DateFormatSymbols getInstance(Locale locale) {
+        Objects.requireNonNull(locale, "locale should not be null");
         DateFormatSymbols dfs = getProviderInstance(locale);
         if (dfs != null) {
             return dfs;

--- a/src/java.base/share/classes/java/text/DateFormatSymbols.java
+++ b/src/java.base/share/classes/java/text/DateFormatSymbols.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -145,6 +145,7 @@ public class DateFormatSymbols implements Serializable, Cloneable {
      * @throws     java.util.MissingResourceException
      *             if the resources for the specified locale cannot be
      *             found or cannot be loaded.
+     * @throws     NullPointerException if {@code locale} is null
      */
     public DateFormatSymbols(Locale locale)
     {

--- a/src/java.base/share/classes/java/text/DecimalFormatSymbols.java
+++ b/src/java.base/share/classes/java/text/DecimalFormatSymbols.java
@@ -115,7 +115,8 @@ public class DecimalFormatSymbols implements Cloneable, Serializable {
      * @throws    NullPointerException if {@code locale} is null
      */
     public DecimalFormatSymbols(Locale locale) {
-        initialize(locale);
+        initialize(Objects.requireNonNull(locale,
+            "locale should not be null"));
     }
 
     /**
@@ -180,6 +181,7 @@ public class DecimalFormatSymbols implements Cloneable, Serializable {
      * @since 1.6
      */
     public static final DecimalFormatSymbols getInstance(Locale locale) {
+        Objects.requireNonNull(locale, "locale should not be null");
         LocaleProviderAdapter adapter;
         adapter = LocaleProviderAdapter.getAdapter(DecimalFormatSymbolsProvider.class, locale);
         DecimalFormatSymbolsProvider provider = adapter.getDecimalFormatSymbolsProvider();

--- a/test/jdk/java/text/Format/DateFormat/IntlTestDateFormatSymbols.java
+++ b/test/jdk/java/text/Format/DateFormat/IntlTestDateFormatSymbols.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 /*
  * @test
  * @summary test International Date Format Symbols
+ * @bug 8366517
  * @run junit IntlTestDateFormatSymbols
  */
 /*
@@ -43,6 +44,7 @@ import java.util.*;
 
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class IntlTestDateFormatSymbols
@@ -204,5 +206,10 @@ public class IntlTestDateFormatSymbols
         if(! en.equals(fr)) {
             fail("ERROR: Clone failed");
         }
+    }
+
+    @Test
+    void nullLocaleTest() {
+        assertThrows(NullPointerException.class, () -> new DateFormatSymbols(null));
     }
 }

--- a/test/jdk/java/text/Format/DateFormat/IntlTestDateFormatSymbols.java
+++ b/test/jdk/java/text/Format/DateFormat/IntlTestDateFormatSymbols.java
@@ -211,5 +211,6 @@ public class IntlTestDateFormatSymbols
     @Test
     void nullLocaleTest() {
         assertThrows(NullPointerException.class, () -> new DateFormatSymbols(null));
+        assertThrows(NullPointerException.class, () -> DateFormatSymbols.getInstance(null));
     }
 }

--- a/test/jdk/java/text/Format/NumberFormat/IntlTestDecimalFormatSymbols.java
+++ b/test/jdk/java/text/Format/NumberFormat/IntlTestDecimalFormatSymbols.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8282625
+ * @bug 8282625 8366517
  * @summary test International Decimal Format Symbols
  * @run junit IntlTestDecimalFormatSymbols
  */
@@ -44,6 +44,7 @@ import java.util.*;
 
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class IntlTestDecimalFormatSymbols
@@ -145,5 +146,11 @@ public class IntlTestDecimalFormatSymbols
         if(! en.equals(fr)) {
             fail("ERROR: Clone failed");
         }
+    }
+
+    @Test
+    void nullLocaleTest() {
+        assertThrows(NullPointerException.class, () -> new DecimalFormatSymbols(null));
+        assertThrows(NullPointerException.class, () -> DecimalFormatSymbols.getInstance(null));
     }
 }


### PR DESCRIPTION
Adding a `@throws` clause for NPE in `java.text.DateFormatSymbols(Locale)` constructor. The bug suggests it should  throw a `MissingResourceException`, but I don't think we can change this long standing behavior. Instead, explicitly specify the NPE in the javadoc.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8366735](https://bugs.openjdk.org/browse/JDK-8366735) to be approved

### Issues
 * [JDK-8366517](https://bugs.openjdk.org/browse/JDK-8366517): Refine null locale processing of ctor/factory methods in `Date/DecimalFormatSymbols` (**Bug** - P4)
 * [JDK-8366735](https://bugs.openjdk.org/browse/JDK-8366735): Refine null locale processing of ctor/factory methods in `Date/DecimalFormatSymbols` (**CSR**)


### Reviewers
 * [Justin Lu](https://openjdk.org/census#jlu) (@justin-curtis-lu - Committer)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27060/head:pull/27060` \
`$ git checkout pull/27060`

Update a local copy of the PR: \
`$ git checkout pull/27060` \
`$ git pull https://git.openjdk.org/jdk.git pull/27060/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27060`

View PR using the GUI difftool: \
`$ git pr show -t 27060`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27060.diff">https://git.openjdk.org/jdk/pull/27060.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27060#issuecomment-3246555117)
</details>
