### PR TITLE
8361699: C2: assert(can_reduce_phi(n->as_Phi())) failed: Sanity: previous reducible Phi is no longer reducible before SUT

### DIFF
--- a/src/hotspot/share/opto/escape.cpp
+++ b/src/hotspot/share/opto/escape.cpp
@@ -3131,13 +3131,11 @@ void ConnectionGraph::find_scalar_replaceable_allocs(GrowableArray<JavaObjectNod
           }
         } else if (use->is_LocalVar()) {
           Node* phi = use->ideal_node();
-          if (phi->Opcode() == Op_Phi && reducible_merges.member(phi)) {
-            if (!can_reduce_phi(phi->as_Phi())) {
-              set_not_scalar_replaceable(jobj NOT_PRODUCT(COMMA "is merged in a non-reducible phi"));
-              reducible_merges.yank(phi);
-              found_nsr_alloc = true;
-              break;
-            }
+          if (phi->Opcode() == Op_Phi && reducible_merges.member(phi) && !can_reduce_phi(phi->as_Phi())) {
+            set_not_scalar_replaceable(jobj NOT_PRODUCT(COMMA "is merged in a non-reducible phi"));
+            reducible_merges.yank(phi);
+            found_nsr_alloc = true;
+            break;
           }
         }
       }

--- a/test/hotspot/jtreg/compiler/escapeAnalysis/TestReduceAllocationNotReducibleAnymore.java
+++ b/test/hotspot/jtreg/compiler/escapeAnalysis/TestReduceAllocationNotReducibleAnymore.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8361699
+ * @summary Check that NSR state propagate correctly to initially reducible Phis
+ *          and turns them into non-reducible Phis.
+ * @run main/othervm -XX:CompileCommand=compileonly,*TestReduceAllocationNotReducibleAnymore*::*
+ *                   -XX:CompileCommand=dontinline,*TestReduceAllocationNotReducibleAnymore*::*
+ *                   -Xcomp compiler.escapeAnalysis.TestReduceAllocationNotReducibleAnymore
+ * @run main compiler.escapeAnalysis.TestReduceAllocationNotReducibleAnymore
+ */
+
+package compiler.escapeAnalysis;
+
+public class TestReduceAllocationNotReducibleAnymore {
+    public static void main(String[] args) {
+        for (int i =0; i< 100; i++) {
+            test(4, null);
+        }
+    }
+
+    static void test(int x, A a) {
+        Object[] objects = { new Object() };
+        Object object = new Object();
+        for (int i = 0; i < 150; i++) {
+            try {
+                objects[x] = object;
+                object = new byte[10];
+            } catch (Exception e) {
+            }
+            try {
+                a.foo();
+            } catch (Exception e) {
+            }
+        }
+    }
+
+    class A {
+        void foo() {}
+    }
+}

--- a/test/hotspot/jtreg/compiler/escapeAnalysis/TestReduceAllocationNotReducibleAnymore.java
+++ b/test/hotspot/jtreg/compiler/escapeAnalysis/TestReduceAllocationNotReducibleAnymore.java
@@ -36,7 +36,7 @@ package compiler.escapeAnalysis;
 
 public class TestReduceAllocationNotReducibleAnymore {
     public static void main(String[] args) {
-        for (int i =0; i< 100; i++) {
+        for (int i = 0; i < 100; i++) {
             test(4, null);
         }
     }

--- a/test/hotspot/jtreg/compiler/escapeAnalysis/TestReduceAllocationNotReducibleAnymore.java
+++ b/test/hotspot/jtreg/compiler/escapeAnalysis/TestReduceAllocationNotReducibleAnymore.java
@@ -48,11 +48,11 @@ public class TestReduceAllocationNotReducibleAnymore {
             try {
                 objects[x] = object;
                 object = new byte[10];
-            } catch (Exception e) {
+            } catch (ArrayIndexOutOfBoundsException e) {
             }
             try {
                 a.foo();
-            } catch (Exception e) {
+            } catch (NullPointerException e) {
             }
         }
     }


### PR DESCRIPTION
Please, review this patch to fix issue that may occur when reducing allocation merge.

As the assert message describe, the problem is a `Phi` considered reducible during one invocation of  `adjust_scalar_replaceable_state` turned out to be later non-reducible. This situation can happen if a subsequent invocation of the same method causes all inputs to the phi to be NSR; therefore there is no point in reducing the Phi. It can also happen during the propagation of NSR state done by `find_scalar_replaceable_allocs`. 

The change in `revisit_reducible_phi_status` is just a clean-up.
The real fix is in `find_scalar_replaceable_allocs`.

Tested on Linux x64/Aarch64 release/fastdebug with JTREG tier1-3.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8361699](https://bugs.openjdk.org/browse/JDK-8361699): C2: assert(can_reduce_phi(n-&gt;as_Phi())) failed: Sanity: previous reducible Phi is no longer reducible before SUT (**Bug** - P3)


### Reviewers
 * [Roberto Castañeda Lozano](https://openjdk.org/census#rcastanedalo) (@robcasloz - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27063/head:pull/27063` \
`$ git checkout pull/27063`

Update a local copy of the PR: \
`$ git checkout pull/27063` \
`$ git pull https://git.openjdk.org/jdk.git pull/27063/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27063`

View PR using the GUI difftool: \
`$ git pr show -t 27063`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27063.diff">https://git.openjdk.org/jdk/pull/27063.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27063#issuecomment-3250095236)
</details>
