### PR TITLE
8366695: Test sun/jvmstat/monitor/MonitoredVm/MonitorVmStartTerminate.java timed out

### DIFF
--- a/test/jdk/sun/jvmstat/monitor/MonitoredVm/MonitorVmStartTerminate.java
+++ b/test/jdk/sun/jvmstat/monitor/MonitoredVm/MonitorVmStartTerminate.java
@@ -70,7 +70,7 @@ import sun.jvmstat.monitor.event.VmStatusChangeEvent;
  * @modules java.management
  *          jdk.internal.jvmstat/sun.jvmstat.monitor
  *          jdk.internal.jvmstat/sun.jvmstat.monitor.event
- * @run main/othervm MonitorVmStartTerminate
+ * @run main/othervm/timeout=240 MonitorVmStartTerminate
  */
 public final class MonitorVmStartTerminate {
 


### PR DESCRIPTION
Hi all,

Test sun/jvmstat/monitor/MonitoredVm/MonitorVmStartTerminate.java create 10 java processes, and maybe this cause this test timed out when run this test with other jtreg tests concurrently. Though the run time statistics shows that it do not run timed out, but it did on the brink of timed out.

After JDK-8260555 change the default jtreg timeout factor from 4 to 1, I think it's necessary to change the timeout value in sun/jvmstat/monitor/MonitoredVm/MonitorVmStartTerminate.java from 120(default value) to 240, to avoid this test run timed out intermittently.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8366695](https://bugs.openjdk.org/browse/JDK-8366695): Test sun/jvmstat/monitor/MonitoredVm/MonitorVmStartTerminate.java timed out (**Bug** - P4)


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27064/head:pull/27064` \
`$ git checkout pull/27064`

Update a local copy of the PR: \
`$ git checkout pull/27064` \
`$ git pull https://git.openjdk.org/jdk.git pull/27064/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27064`

View PR using the GUI difftool: \
`$ git pr show -t 27064`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27064.diff">https://git.openjdk.org/jdk/pull/27064.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27064#issuecomment-3247551515)
</details>
