### PR TITLE
8351260: java.lang.AssertionError: Unexpected type tree: (ERROR) = (ERROR)

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
@@ -1101,6 +1101,10 @@ public class JavacParser implements Parser {
             syntaxError(result.pos, Errors.RestrictedTypeNotAllowedHere(restrictedTypeName));
         }
 
+        if ((lastmode & TYPE) == 0) {
+            result = F.Erroneous(List.of(result));
+        }
+
         return result;
     }
 
@@ -1428,6 +1432,7 @@ public class JavacParser implements Parser {
     protected JCExpression term3() {
         int pos = token.pos;
         JCExpression t;
+        int startMode = mode;
         List<JCExpression> typeArgs = typeArgumentsOpt(EXPR);
         switch (token.kind) {
         case QUES:
@@ -1757,6 +1762,9 @@ public class JavacParser implements Parser {
             }
             // Not reachable.
         default:
+            if (typeArgs != null && (startMode & TYPE) != 0) {
+                return F.at(pos).TypeApply(F.Erroneous(), typeArgs);
+            }
             return illegal();
         }
         return term3Rest(t, typeArgs);

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
@@ -1102,6 +1102,7 @@ public class JavacParser implements Parser {
         }
 
         if ((lastmode & TYPE) == 0) {
+            //if the mode was switched to expression while expecting type, wrap with Erroneous:
             result = F.Erroneous(List.of(result));
         }
 

--- a/test/langtools/tools/javac/parser/JavacParserTest.java
+++ b/test/langtools/tools/javac/parser/JavacParserTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 7073631 7159445 7156633 8028235 8065753 8205418 8205913 8228451 8237041 8253584 8246774 8256411 8256149 8259050 8266436 8267221 8271928 8275097 8293897 8295401 8304671 8310326 8312093 8312204 8315452 8337976 8324859 8344706
+ * @bug 7073631 7159445 7156633 8028235 8065753 8205418 8205913 8228451 8237041 8253584 8246774 8256411 8256149 8259050 8266436 8267221 8271928 8275097 8293897 8295401 8304671 8310326 8312093 8312204 8315452 8337976 8324859 8344706 8351260
  * @summary tests error and diagnostics positions
  * @author  Jan Lahoda
  * @modules jdk.compiler/com.sun.tools.javac.api
@@ -3025,7 +3025,7 @@ public class JavacParserTest extends TestCase {
         DiagnosticCollector<JavaFileObject> coll =
                 new DiagnosticCollector<>();
         JavacTaskImpl ct = (JavacTaskImpl) tool.getTask(null, fm, coll,
-                List.of("--enable-preview", "--source", SOURCE_VERSION, "-XDdev"),
+                List.of("--enable-preview", "--source", SOURCE_VERSION),
                 null, Arrays.asList(new MyFileObject(code)));
         CompilationUnitTree cut = ct.parse().iterator().next();
 
@@ -3060,6 +3060,20 @@ public class JavacParserTest extends TestCase {
                              }
                          }
                      }""");
+    }
+
+    @Test //JDK-8351260
+    void testVeryBrokenTypeWithAnnotationsMinimal() throws IOException {
+        String code = """
+                      B<@C<@D(e f=
+                      """;
+        DiagnosticCollector<JavaFileObject> coll =
+                new DiagnosticCollector<>();
+        JavacTaskImpl ct = (JavacTaskImpl) tool.getTask(null, fm, coll,
+                List.of("--enable-preview", "--source", SOURCE_VERSION),
+                null, Arrays.asList(new MyFileObject(code)));
+        //no exceptions:
+        ct.parse().iterator().next();
     }
 
     void run(String[] args) throws Exception {

--- a/test/langtools/tools/javac/recovery/AttrRecovery.java
+++ b/test/langtools/tools/javac/recovery/AttrRecovery.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8301580 8322159 8333107 8332230 8338678
+ * @bug 8301580 8322159 8333107 8332230 8338678 8351260
  * @summary Verify error recovery w.r.t. Attr
  * @library /tools/lib
  * @modules jdk.compiler/com.sun.tools.javac.api
@@ -322,4 +322,22 @@ public class AttrRecovery extends TestRunner {
         }
     }
 
+    @Test //JDK-8351260
+    public void testVeryBrokenAnnotation() throws Exception {
+        String code = """
+                      class ListUtilsTest {
+                          void test(List<@AlphaChars <@StringLength(int value = 5)String> s){
+                          }
+                      }
+                      """;
+        Path curPath = Path.of(".");
+        //should not fail with an exception:
+        new JavacTask(tb)
+            .options("-XDrawDiagnostics",
+                     "-XDshould-stop.at=FLOW")
+            .sources(code)
+            .outdir(curPath)
+            .run(Expect.FAIL)
+            .writeAll();
+    }
 }


### PR DESCRIPTION
Consider a very broken declaration like this:
```
void test(List<@AlphaChars <@StringLength(int value = 5)String> s){ 
```

after seeing `@AlphaChars`, javac will try to parse `<@StringLength(int value = 5)String>` as a type, and assign the annotation to the type. But, the text does not parse as a type well (partly due to the `int value = 5`), and the parsing will proceed in an expression mode. Then a search for target type is performed to attach the annotation, and that fails, as the expression tree is not expected to be part of the type.

The main proposal here is to wrap the badly parsed type in an `Erroneous` tree. The overall error recovery then seems to handle the situation well.

The situation produces quite a few error reports, but it is not clear if this situation (esp. the nested `int value = 5`) is common enough to stretch the parsing error recovery capabilities to accommodate this code.
