### PR TITLE
8366781: Parallel: Include OS free memory in GC selection heuristics

### DIFF
--- a/src/hotspot/share/gc/parallel/psScavenge.cpp
+++ b/src/hotspot/share/gc/parallel/psScavenge.cpp
@@ -521,8 +521,8 @@ void PSScavenge::clean_up_failed_promotion() {
 }
 
 bool PSScavenge::should_attempt_scavenge() {
-  const bool SHOULD_RUN_YOUNG_GC = true;
-  const bool SHOULD_RUN_FULL_GC = false;
+  const bool ShouldRunYoungGC = true;
+  const bool ShouldRunFullGC = false;
 
   ParallelScavengeHeap* heap = ParallelScavengeHeap::heap();
   PSYoungGen* young_gen = heap->young_gen();
@@ -530,7 +530,7 @@ bool PSScavenge::should_attempt_scavenge() {
 
   if (!young_gen->to_space()->is_empty()) {
     log_debug(gc, ergo)("To-space is not empty; run full-gc instead.");
-    return SHOULD_RUN_FULL_GC;
+    return ShouldRunFullGC;
   }
 
   // Check if the predicted promoted bytes will overflow free space in old-gen.
@@ -548,7 +548,7 @@ bool PSScavenge::should_attempt_scavenge() {
   if (promotion_estimate >= free_in_old_gen_with_expansion) {
     log_debug(gc, ergo)("Run full-gc; predicted promotion size >= max free space in old-gen: %zu >= %zu",
       promotion_estimate, free_in_old_gen_with_expansion);
-    return SHOULD_RUN_FULL_GC;
+    return ShouldRunFullGC;
   }
 
   if (UseAdaptiveSizePolicy) {
@@ -564,13 +564,13 @@ bool PSScavenge::should_attempt_scavenge() {
       if (promotion_estimate > actual_free) {
         log_debug(gc, ergo)("Run full-gc; predicted promotion size > free space in old-gen and OS: %zu > %zu",
           promotion_estimate, actual_free);
-        return SHOULD_RUN_FULL_GC;
+        return ShouldRunFullGC;
       }
     }
   }
 
   // No particular reasons to run full-gc, so young-gc.
-  return SHOULD_RUN_YOUNG_GC;
+  return ShouldRunYoungGC;
 }
 
 // Adaptive size policy support.


### PR DESCRIPTION
Add a new condition checking if OS has enough free memory to commit/expand old-gen, which determines whether the upcoming GC should be young or full.

This is needed only when `UseAdaptiveSizePolicy` is on, because this is intended to avoid including extra OS-time in gc-pause-time tracking, used for young-gen resizing.

Test: tier1-3

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8366781](https://bugs.openjdk.org/browse/JDK-8366781): Parallel: Include OS free memory in GC selection heuristics (**Enhancement** - P4)


### Reviewers
 * [Guoxiong Li](https://openjdk.org/census#gli) (@lgxbslgx - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27068/head:pull/27068` \
`$ git checkout pull/27068`

Update a local copy of the PR: \
`$ git checkout pull/27068` \
`$ git pull https://git.openjdk.org/jdk.git pull/27068/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27068`

View PR using the GUI difftool: \
`$ git pr show -t 27068`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27068.diff">https://git.openjdk.org/jdk/pull/27068.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27068#issuecomment-3248579540)
</details>
