### PR TITLE
8366803: Bump timeout on sun/tools/jhsdb/BasicLauncherTest.java

### DIFF
--- a/test/jdk/sun/tools/jhsdb/BasicLauncherTest.java
+++ b/test/jdk/sun/tools/jhsdb/BasicLauncherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,7 @@
  * @library /test/lib
  * @requires vm.hasSA
  * @build jdk.test.lib.apps.*
- * @run main BasicLauncherTest
+ * @run main/timeout=480 BasicLauncherTest
  */
 
 import java.io.BufferedReader;


### PR DESCRIPTION
Just need the old timeout value

result: Error. Program `c:\ade\mesos\work_dir\jib-master\install\jdk-26+14-1410\windows-x64-debug.jdk\jdk-26\fastdebug\bin\java' timed out (timeout set to 120000ms, elapsed time including timeout handling was 178895ms).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8366803](https://bugs.openjdk.org/browse/JDK-8366803): Bump timeout on sun/tools/jhsdb/BasicLauncherTest.java (**Bug** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27070/head:pull/27070` \
`$ git checkout pull/27070`

Update a local copy of the PR: \
`$ git checkout pull/27070` \
`$ git pull https://git.openjdk.org/jdk.git pull/27070/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27070`

View PR using the GUI difftool: \
`$ git pr show -t 27070`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27070.diff">https://git.openjdk.org/jdk/pull/27070.diff</a>

</details>
