### PR TITLE
8366076: arm32: Fix register allocation for vector instructions

### DIFF
--- a/src/hotspot/cpu/arm/arm.ad
+++ b/src/hotspot/cpu/arm/arm.ad
@@ -2282,6 +2282,16 @@ operand flagsRegF() %{
 operand vecD() %{
   constraint(ALLOC_IN_RC(actual_dflt_reg));
   match(VecD);
+  match(vecD_low);
+
+  format %{ %}
+  interface(REG_INTER);
+%}
+
+operand vecD_low() %{
+  constraint(ALLOC_IN_RC(dflt_low_reg));
+  match(VecD);
+  match(vecD);
 
   format %{ %}
   interface(REG_INTER);
@@ -2290,6 +2300,16 @@ operand vecD() %{
 operand vecX() %{
   constraint(ALLOC_IN_RC(vectorx_reg));
   match(VecX);
+  match(vecX_low);
+
+  format %{ %}
+  interface(REG_INTER);
+%}
+
+operand vecX_low() %{
+  constraint(ALLOC_IN_RC(dflt_low_reg));
+  match(VecX);
+  match(vecX);
 
   format %{ %}
   interface(REG_INTER);
@@ -9894,7 +9914,7 @@ instruct vadd2F_reg(vecD dst, vecD src1, vecD src2) %{
   ins_pipe( faddD_reg_reg ); // FIXME
 %}
 
-instruct vadd2F_reg_vfp(vecD dst, vecD src1, vecD src2) %{
+instruct vadd2F_reg_vfp(vecD_low dst, vecD_low src1, vecD_low src2) %{
   predicate(n->as_Vector()->length() == 2 && !VM_Version::simd_math_is_compliant());
   match(Set dst (AddVF src1 src2));
   ins_cost(DEFAULT_COST*2); // FIXME
@@ -9925,7 +9945,7 @@ instruct vadd4F_reg_simd(vecX dst, vecX src1, vecX src2) %{
   ins_pipe( faddD_reg_reg ); // FIXME
 %}
 
-instruct vadd4F_reg_vfp(vecX dst, vecX src1, vecX src2) %{
+instruct vadd4F_reg_vfp(vecX_low dst, vecX_low src1, vecX_low src2) %{
   predicate(n->as_Vector()->length() == 4 && !VM_Version::simd_math_is_compliant());
   match(Set dst (AddVF src1 src2));
   size(4*4);
@@ -10091,7 +10111,7 @@ instruct vsub2F_reg(vecD dst, vecD src1, vecD src2) %{
   ins_pipe( faddF_reg_reg ); // FIXME
 %}
 
-instruct vsub2F_reg_vfp(vecD dst, vecD src1, vecD src2) %{
+instruct vsub2F_reg_vfp(vecD_low dst, vecD_low src1, vecD_low src2) %{
   predicate(n->as_Vector()->length() == 2 && !VM_Version::simd_math_is_compliant());
   match(Set dst (SubVF src1 src2));
   size(4*2);
@@ -10128,7 +10148,7 @@ instruct vsub4F_reg(vecX dst, vecX src1, vecX src2) %{
   ins_pipe( faddF_reg_reg ); // FIXME
 %}
 
-instruct vsub4F_reg_vfp(vecX dst, vecX src1, vecX src2) %{
+instruct vsub4F_reg_vfp(vecX_low dst, vecX_low src1, vecX_low src2) %{
   predicate(n->as_Vector()->length() == 4 && !VM_Version::simd_math_is_compliant());
   match(Set dst (SubVF src1 src2));
   size(4*4);
@@ -10247,7 +10267,7 @@ instruct vmul2F_reg(vecD dst, vecD src1, vecD src2) %{
   ins_pipe( fmulF_reg_reg ); // FIXME
 %}
 
-instruct vmul2F_reg_vfp(vecD dst, vecD src1, vecD src2) %{
+instruct vmul2F_reg_vfp(vecD_low dst, vecD_low src1, vecD_low src2) %{
   predicate(n->as_Vector()->length() == 2 && !VM_Version::simd_math_is_compliant());
   match(Set dst (MulVF src1 src2));
   size(4*2);
@@ -10277,7 +10297,7 @@ instruct vmul4F_reg(vecX dst, vecX src1, vecX src2) %{
   ins_pipe( fmulF_reg_reg ); // FIXME
 %}
 
-instruct vmul4F_reg_vfp(vecX dst, vecX src1, vecX src2) %{
+instruct vmul4F_reg_vfp(vecX_low dst, vecX_low src1, vecX_low src2) %{
   predicate(n->as_Vector()->length() == 4 && !VM_Version::simd_math_is_compliant());
   match(Set dst (MulVF src1 src2));
   size(4*4);


### PR DESCRIPTION
Arm32 has 32 double-precision floating point registers, the first 16 of which coincide with the 32 single-precision floating point registers. Some vector-operation nodes were implemented in terms of scalar instructions, which only really works for the first 16 doubles. This commit addresses that.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Error
&nbsp;⚠️ Pull request body is missing required line: `- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).`

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8366076](https://bugs.openjdk.org/browse/JDK-8366076)

### Issue
 * [JDK-8366076](https://bugs.openjdk.org/browse/JDK-8366076): ARM32 Invalid registers allocated for vector instructions. (**Bug** - P3) ⚠️ Title mismatch between PR and JBS.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27071/head:pull/27071` \
`$ git checkout pull/27071`

Update a local copy of the PR: \
`$ git checkout pull/27071` \
`$ git pull https://git.openjdk.org/jdk.git pull/27071/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27071`

View PR using the GUI difftool: \
`$ git pr show -t 27071`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27071.diff">https://git.openjdk.org/jdk/pull/27071.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27071#issuecomment-3522188022)
</details>
