### PR TITLE
JDK-8366817: test/jdk/javax/net/ssl/TLSCommon/interop/JdkProcServer.java and JdkProcClient.java should not delete logs

### DIFF
--- a/test/jdk/javax/net/ssl/TLSCommon/interop/AbstractPeer.java
+++ b/test/jdk/javax/net/ssl/TLSCommon/interop/AbstractPeer.java
@@ -50,13 +50,6 @@ public abstract class AbstractPeer implements Peer {
     }
 
     /*
-     * Deletes log file if exists.
-     */
-    protected void deleteLog() throws IOException {
-        Utilities.deleteFile(getLogPath());
-    }
-
-    /*
      * The negotiated application protocol.
      */
     public String getNegoAppProtocol() throws SSLTestException {

--- a/test/jdk/javax/net/ssl/TLSCommon/interop/JdkProcClient.java
+++ b/test/jdk/javax/net/ssl/TLSCommon/interop/JdkProcClient.java
@@ -148,7 +148,6 @@ public class JdkProcClient extends AbstractClient {
     @Override
     public void close() throws IOException {
         printLog();
-        deleteLog();
     }
 
     public static void main(String[] args) throws Exception {

--- a/test/jdk/javax/net/ssl/TLSCommon/interop/JdkProcServer.java
+++ b/test/jdk/javax/net/ssl/TLSCommon/interop/JdkProcServer.java
@@ -165,8 +165,6 @@ public class JdkProcServer extends AbstractServer {
     @Override
     public void close() throws IOException {
         printLog();
-        deletePort();
-        deleteLog();
     }
 
     private static int readPort() {
@@ -175,10 +173,6 @@ public class JdkProcServer extends AbstractServer {
         } catch (Exception e) {
             return 0;
         }
-    }
-
-    private static void deletePort() throws IOException {
-        Utilities.deleteFile(PORT_LOG);
     }
 
     private static void savePort(int port) throws IOException {


### PR DESCRIPTION
The following test helpers delete logs after the test completes:
jdk/javax/net/ssl/TLSCommon/interop/JdkProcServer.java
jdk/javax/net/ssl/TLSCommon/interop/JdkProcClient.java

These helpers are used by tests located in jdk/javax/net/ssl/compatibility/*.java. Cleanup should be left to JTREG, as with other tests.