### PR TITLE
8366836: Don't execute post-IncludeCustomExtension if file was not included

### DIFF
--- a/make/common/MakeIncludeEnd.gmk
+++ b/make/common/MakeIncludeEnd.gmk
@@ -27,10 +27,15 @@
 # MakeIncludeEnd.gmk should be included last of all in all include files
 ################################################################################
 
-# Hook to include the corresponding custom file, if present.
-ifneq ($(NO_CUSTOM_EXTENSIONS), true)
-  CUSTOM_POST_NAME := $(subst .gmk,-post.gmk, $(THIS_INCLUDE))
-  $(eval $(call IncludeCustomExtension, $(CUSTOM_POST_NAME)))
+ifneq ($(INCLUDE_GUARD_$(THIS_INCLUDE)), true)
+  # This was the first time this file was included. Prevent future inclusion.
+  INCLUDE_GUARD_$(THIS_INCLUDE) := true
+
+  # Hook to include the corresponding custom file, if present.
+  ifneq ($(NO_CUSTOM_EXTENSIONS), true)
+    CUSTOM_POST_NAME := $(subst .gmk,-post.gmk, $(THIS_INCLUDE))
+    $(eval $(call IncludeCustomExtension, $(CUSTOM_POST_NAME)))
+  endif
 endif
 
 # Pop our helper name off the stack

--- a/make/common/MakeIncludeStart.gmk
+++ b/make/common/MakeIncludeStart.gmk
@@ -70,7 +70,6 @@ INCLUDE_STACK := $(THIS_INCLUDE) $(INCLUDE_STACK)
 
 # Setup an automatic include guard
 ifneq ($(INCLUDE_GUARD_$(THIS_INCLUDE)), true)
-  INCLUDE_GUARD_$(THIS_INCLUDE) := true
   INCLUDE := true
 
   # Hook to include the corresponding custom file, if present.


### PR DESCRIPTION
There is a bug in make/common/MakeIncludeEnd.gmk, which makes it always include the "post" custom extension. In MakeIncludeStart.gmk, the "pre" custom extension is properly guarded by the check if the file has not already been included. This is not the case for the "post" condition, so a custom "post" hook can be included multiple times.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8366836](https://bugs.openjdk.org/browse/JDK-8366836): Don't execute post-IncludeCustomExtension if file was not included (**Bug** - P3)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27077/head:pull/27077` \
`$ git checkout pull/27077`

Update a local copy of the PR: \
`$ git checkout pull/27077` \
`$ git pull https://git.openjdk.org/jdk.git pull/27077/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27077`

View PR using the GUI difftool: \
`$ git pr show -t 27077`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27077.diff">https://git.openjdk.org/jdk/pull/27077.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27077#issuecomment-3250389913)
</details>
