### PR TITLE
8366849: Problemlist jdk/jshell/ToolSimpleTest.java as generic-all

### DIFF
--- a/test/langtools/ProblemList.txt
+++ b/test/langtools/ProblemList.txt
@@ -52,8 +52,8 @@ jdk/jshell/UserJdiUserRemoteTest.java                                           
 jdk/jshell/UserInputTest.java                                                   8169536    generic-all
 jdk/jshell/ToolBasicTest.java                                                   8265357    macosx-aarch64
 jdk/jshell/HighlightUITest.java                                                 8284144    generic-all
-jdk/jshell/ToolSimpleTest.java                                                  8366582    windows-x64
-jdk/jshell/ToolLocalSimpleTest.java                                             8366582    windows-x64
+jdk/jshell/ToolSimpleTest.java                                                  8366582    generic-all
+jdk/jshell/ToolLocalSimpleTest.java                                             8366582    generic-all
 
 ###########################################################################
 #


### PR DESCRIPTION
Hi all,

Sorry for the interrupt.
At first we found that jdk/jshell/ToolSimpleTest.java and jdk/jshell/ToolLocalSimpleTest.java fails on windows-x64 several times, but we found the tests also fails on linux-aarch64 and macos-aarch64 intermittently later. So should we problemlist these two tests as generic-all.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8366849](https://bugs.openjdk.org/browse/JDK-8366849): Problemlist jdk/jshell/ToolSimpleTest.java as generic-all (**Sub-task** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27082/head:pull/27082` \
`$ git checkout pull/27082`

Update a local copy of the PR: \
`$ git checkout pull/27082` \
`$ git pull https://git.openjdk.org/jdk.git pull/27082/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27082`

View PR using the GUI difftool: \
`$ git pr show -t 27082`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27082.diff">https://git.openjdk.org/jdk/pull/27082.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27082#issuecomment-3251599723)
</details>
