### PR TITLE
8356779 IGV: dump the index of the SafePointNode containing the current JVMS during parsing

### DIFF
--- a/src/hotspot/share/opto/parse2.cpp
+++ b/src/hotspot/share/opto/parse2.cpp
@@ -2779,7 +2779,7 @@ void Parse::do_one_bytecode() {
   if (C->should_print_igv(perBytecode)) {
     IdealGraphPrinter* printer = C->igv_printer();
     char buffer[256];
-    jio_snprintf(buffer, sizeof(buffer), "Bytecode %d: %s", bci(), Bytecodes::name(bc()));
+    jio_snprintf(buffer, sizeof(buffer), "Bytecode %d: %s, map: %d", bci(), Bytecodes::name(bc()), map() == nullptr ? -1 : map()->_idx);
     bool old = printer->traverse_outs();
     printer->set_traverse_outs(true);
     printer->print_graph(buffer);


### PR DESCRIPTION
This PR prints index of the SafePointNode containing the current JVMS during parsing in IGV. As stated in JBS the reason for this is that there are a lot of nodes during parsing, it would be nice to know what are the current nodes in the local slots or in the stack when looking at a graph.
