### PR TITLE
8366854: Extend jtreg failure handler with THP info

### DIFF
--- a/test/failure_handler/src/share/conf/linux.properties
+++ b/test/failure_handler/src/share/conf/linux.properties
@@ -124,7 +124,7 @@ memory.proc_vmstat.app=bash
 memory.proc_vmstat.args=-c\0cat /proc/vmstat
 memory.proc_vmstat.delimiter=\0
 memory.thp.app=bash
-memory.thp.args=-c\0cat /sys/kernel/mm/transparent_hugepage/{enabled,defrag}
+memory.thp.args=-c\0cat /sys/kernel/mm/transparent_hugepage/{enabled,defrag,shmem_enabled}
 memory.thp.delimiter=\0
 
 files.app=lsof

--- a/test/failure_handler/src/share/conf/linux.properties
+++ b/test/failure_handler/src/share/conf/linux.properties
@@ -78,6 +78,8 @@ environment=\
   process.top process.ps \
   memory.free memory.vmstat.default memory.vmstat.statistics \
         memory.vmstat.slabinfo memory.vmstat.disk \
+        memory.proc_meminfo memory.proc_vmstat \
+        memory.thp \
   files \
   locks \
   net.sockets net.statistics net.ifconfig net.hostsfile \
@@ -115,6 +117,15 @@ memory.vmstat.default.args=3 3
 memory.vmstat.statistics.args=-s
 memory.vmstat.slabinfo.args=-m
 memory.vmstat.disk.args=-d
+memory.proc_meminfo.app=bash
+memory.proc_meminfo.args=-c\0cat /proc/meminfo
+memory.proc_meminfo.delimiter=\0
+memory.proc_vmstat.app=bash
+memory.proc_vmstat.args=-c\0cat /proc/vmstat
+memory.proc_vmstat.delimiter=\0
+memory.thp.app=bash
+memory.thp.args=-c\0cat /sys/kernel/mm/transparent_hugepage/{enabled,defrag}
+memory.thp.delimiter=\0
 
 files.app=lsof
 locks.app=lslocks


### PR DESCRIPTION
I propose that we also dump /proc/meminfo, /proc/vmstat, and /sys/kernel/mm/transparent_hugepage/{enabled, defrag} from the failure handler.

This information has been helpful when investigating a failure where there was an unexpected lack of transparent huge pages.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8366854](https://bugs.openjdk.org/browse/JDK-8366854): Extend jtreg failure handler with THP info (**Enhancement** - P4)


### Reviewers
 * [Stefan Johansson](https://openjdk.org/census#sjohanss) (@kstefanj - **Reviewer**) Review applies to [0470c67f](https://git.openjdk.org/jdk/pull/27086/files/0470c67fd7c1ba9756a2bff6a30216881cca42cb)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27086/head:pull/27086` \
`$ git checkout pull/27086`

Update a local copy of the PR: \
`$ git checkout pull/27086` \
`$ git pull https://git.openjdk.org/jdk.git pull/27086/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27086`

View PR using the GUI difftool: \
`$ git pr show -t 27086`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27086.diff">https://git.openjdk.org/jdk/pull/27086.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27086#issuecomment-3252241900)
</details>
