### PR TITLE
8366328:  G1: Crash on reading os::thread_cpu_time

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -1207,6 +1207,7 @@ G1CollectedHeap::G1CollectedHeap() :
   _cr(nullptr),
   _task_queues(nullptr),
   _partial_array_state_manager(nullptr),
+  _is_shutting_down(false),
   _ref_processor_stw(nullptr),
   _is_alive_closure_stw(this),
   _is_subject_to_discovery_stw(this),
@@ -1505,11 +1506,12 @@ jint G1CollectedHeap::initialize() {
   return JNI_OK;
 }
 
-bool G1CollectedHeap::concurrent_mark_is_terminating() const {
-  return _cm_thread->should_terminate();
+bool G1CollectedHeap::is_shutting_down() const {
+  return Atomic::load_acquire(&_is_shutting_down);
 }
 
 void G1CollectedHeap::stop() {
+  Atomic::release_store_fence(&_is_shutting_down, true);
   // Stop all concurrent threads. We do this to make sure these threads
   // do not continue to execute and access resources (e.g. logging)
   // that are destroyed during shutdown.

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -817,6 +817,9 @@ public:
   G1ScannerTasksQueueSet* _task_queues;
   PartialArrayStateManager* _partial_array_state_manager;
 
+  // Flag to indicate that VM is shutting down.
+  volatile bool _is_shutting_down;
+
   // ("Weak") Reference processing support.
   //
   // G1 has 2 instances of the reference processor class.
@@ -901,8 +904,8 @@ public:
   // specified by the policy object.
   jint initialize() override;
 
-  // Returns whether concurrent mark threads (and the VM) are about to terminate.
-  bool concurrent_mark_is_terminating() const;
+  // Returns whether the VM are about to terminate.
+  bool is_shutting_down() const;
 
   void safepoint_synchronize_begin() override;
   void safepoint_synchronize_end() override;

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -2041,7 +2041,7 @@ bool G1ConcurrentMark::concurrent_cycle_abort() {
   // nothing, but this situation should be extremely rare (a full gc after shutdown
   // has been signalled is already rare), and this work should be negligible compared
   // to actual full gc work.
-  if (!cm_thread()->in_progress() && !_g1h->concurrent_mark_is_terminating()) {
+  if (!cm_thread()->in_progress() && !_g1h->is_shutting_down()) {
     return false;
   }
 

--- a/src/hotspot/share/gc/g1/g1RemSet.cpp
+++ b/src/hotspot/share/gc/g1/g1RemSet.cpp
@@ -1105,7 +1105,7 @@ class G1MergeHeapRootsTask : public WorkerTask {
       // There might actually have been scheduled multiple collections, but at that point we do
       // not care that much about performance and just do the work multiple times if needed.
       return (_g1h->collector_state()->clear_bitmap_in_progress() ||
-              _g1h->concurrent_mark_is_terminating()) &&
+              _g1h->is_shutting_down()) &&
               hr->is_old();
     }
 

--- a/src/hotspot/share/gc/g1/g1VMOperations.cpp
+++ b/src/hotspot/share/gc/g1/g1VMOperations.cpp
@@ -84,7 +84,7 @@ void VM_G1TryInitiateConcMark::doit() {
   GCCauseSetter x(g1h, _gc_cause);
 
   // Record for handling by caller.
-  _terminating = g1h->concurrent_mark_is_terminating();
+  _terminating = g1h->is_shutting_down();
 
   _mark_in_progress = g1h->collector_state()->mark_in_progress();
   _cycle_already_in_progress = g1h->concurrent_mark()->cm_thread()->in_progress();


### PR DESCRIPTION
Hi,

Please review this patch to ensure that we do not attempt to read CPU time for GC threads that have already been terminated.

Testing: Tier 1-3. 