### PR TITLE
8366864: Sort os/linux includes

### DIFF
--- a/src/hotspot/os/linux/cgroupSubsystem_linux.cpp
+++ b/src/hotspot/os/linux/cgroupSubsystem_linux.cpp
@@ -22,20 +22,21 @@
  *
  */
 
-#include <string.h>
-#include <math.h>
-#include <errno.h>
-#include <sys/vfs.h>
 #include "cgroupSubsystem_linux.hpp"
+#include "cgroupUtil_linux.hpp"
 #include "cgroupV1Subsystem_linux.hpp"
 #include "cgroupV2Subsystem_linux.hpp"
-#include "cgroupUtil_linux.hpp"
 #include "logging/log.hpp"
 #include "memory/allocation.hpp"
 #include "os_linux.hpp"
 #include "runtime/globals.hpp"
 #include "runtime/os.hpp"
 #include "utilities/globalDefinitions.hpp"
+
+#include <errno.h>
+#include <math.h>
+#include <string.h>
+#include <sys/vfs.h>
 
 // Inlined from <linux/magic.h> for portability.
 #ifndef CGROUP2_SUPER_MAGIC

--- a/src/hotspot/os/linux/cgroupSubsystem_linux.hpp
+++ b/src/hotspot/os/linux/cgroupSubsystem_linux.hpp
@@ -25,12 +25,12 @@
 #ifndef CGROUP_SUBSYSTEM_LINUX_HPP
 #define CGROUP_SUBSYSTEM_LINUX_HPP
 
-#include "memory/allocation.hpp"
-#include "runtime/os.hpp"
 #include "logging/log.hpp"
+#include "memory/allocation.hpp"
+#include "osContainer_linux.hpp"
+#include "runtime/os.hpp"
 #include "utilities/globalDefinitions.hpp"
 #include "utilities/macros.hpp"
-#include "osContainer_linux.hpp"
 
 // Shared cgroups code (used by cgroup version 1 and version 2)
 

--- a/src/hotspot/os/linux/cgroupUtil_linux.cpp
+++ b/src/hotspot/os/linux/cgroupUtil_linux.cpp
@@ -22,8 +22,8 @@
  *
  */
 
-#include "os_linux.hpp"
 #include "cgroupUtil_linux.hpp"
+#include "os_linux.hpp"
 
 int CgroupUtil::processor_count(CgroupCpuController* cpu_ctrl, int host_cpus) {
   assert(host_cpus > 0, "physical host cpus must be positive");

--- a/src/hotspot/os/linux/cgroupUtil_linux.hpp
+++ b/src/hotspot/os/linux/cgroupUtil_linux.hpp
@@ -25,8 +25,8 @@
 #ifndef CGROUP_UTIL_LINUX_HPP
 #define CGROUP_UTIL_LINUX_HPP
 
-#include "utilities/globalDefinitions.hpp"
 #include "cgroupSubsystem_linux.hpp"
+#include "utilities/globalDefinitions.hpp"
 
 class CgroupUtil: AllStatic {
 

--- a/src/hotspot/os/linux/cgroupV1Subsystem_linux.cpp
+++ b/src/hotspot/os/linux/cgroupV1Subsystem_linux.cpp
@@ -22,17 +22,18 @@
  *
  */
 
-#include <string.h>
-#include <math.h>
-#include <errno.h>
-#include "cgroupV1Subsystem_linux.hpp"
 #include "cgroupUtil_linux.hpp"
+#include "cgroupV1Subsystem_linux.hpp"
 #include "logging/log.hpp"
 #include "memory/allocation.hpp"
+#include "os_linux.hpp"
 #include "runtime/globals.hpp"
 #include "runtime/os.hpp"
 #include "utilities/globalDefinitions.hpp"
-#include "os_linux.hpp"
+
+#include <errno.h>
+#include <math.h>
+#include <string.h>
 
 /*
  * Set directory to subsystem specific files based

--- a/src/hotspot/os/linux/cgroupV1Subsystem_linux.hpp
+++ b/src/hotspot/os/linux/cgroupV1Subsystem_linux.hpp
@@ -25,10 +25,10 @@
 #ifndef CGROUP_V1_SUBSYSTEM_LINUX_HPP
 #define CGROUP_V1_SUBSYSTEM_LINUX_HPP
 
-#include "runtime/os.hpp"
-#include "memory/allocation.hpp"
 #include "cgroupSubsystem_linux.hpp"
 #include "cgroupUtil_linux.hpp"
+#include "memory/allocation.hpp"
+#include "runtime/os.hpp"
 
 // Cgroups version 1 specific implementation
 

--- a/src/hotspot/os/linux/cgroupV2Subsystem_linux.cpp
+++ b/src/hotspot/os/linux/cgroupV2Subsystem_linux.cpp
@@ -23,8 +23,8 @@
  *
  */
 
-#include "cgroupV2Subsystem_linux.hpp"
 #include "cgroupUtil_linux.hpp"
+#include "cgroupV2Subsystem_linux.hpp"
 
 // Constructor
 CgroupV2Controller::CgroupV2Controller(char* mount_path,

--- a/src/hotspot/os/linux/osContainer_linux.cpp
+++ b/src/hotspot/os/linux/osContainer_linux.cpp
@@ -22,15 +22,16 @@
  *
  */
 
-#include <string.h>
-#include <math.h>
-#include <errno.h>
-#include "runtime/globals.hpp"
-#include "runtime/os.hpp"
+#include "cgroupSubsystem_linux.hpp"
 #include "logging/log.hpp"
 #include "os_linux.hpp"
 #include "osContainer_linux.hpp"
-#include "cgroupSubsystem_linux.hpp"
+#include "runtime/globals.hpp"
+#include "runtime/os.hpp"
+
+#include <errno.h>
+#include <math.h>
+#include <string.h>
 
 
 bool  OSContainer::_is_initialized   = false;

--- a/src/hotspot/os/linux/osContainer_linux.hpp
+++ b/src/hotspot/os/linux/osContainer_linux.hpp
@@ -25,10 +25,10 @@
 #ifndef OS_LINUX_OSCONTAINER_LINUX_HPP
 #define OS_LINUX_OSCONTAINER_LINUX_HPP
 
+#include "memory/allStatic.hpp"
 #include "utilities/globalDefinitions.hpp"
 #include "utilities/macros.hpp"
 #include "utilities/ostream.hpp"
-#include "memory/allStatic.hpp"
 
 #define OSCONTAINER_ERROR (-2)
 

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -36,9 +36,9 @@
 #include "memory/allocation.inline.hpp"
 #include "nmt/memTracker.hpp"
 #include "oops/oop.inline.hpp"
-#include "osContainer_linux.hpp"
 #include "os_linux.inline.hpp"
 #include "os_posix.inline.hpp"
+#include "osContainer_linux.hpp"
 #include "prims/jniFastGetField.hpp"
 #include "prims/jvm_misc.hpp"
 #include "runtime/arguments.hpp"
@@ -81,42 +81,39 @@
 #include "jfr/support/jfrNativeLibraryLoadEvent.hpp"
 #endif
 
-// put OS-includes here
 # include <ctype.h>
-# include <stdlib.h>
-# include <sys/types.h>
-# include <sys/mman.h>
-# include <sys/stat.h>
-# include <sys/select.h>
-# include <sys/sendfile.h>
-# include <pthread.h>
-# include <signal.h>
+# include <dlfcn.h>
 # include <endian.h>
 # include <errno.h>
+# include <fcntl.h>
 # include <fenv.h>
-# include <dlfcn.h>
-# include <stdio.h>
-# include <unistd.h>
-# include <sys/resource.h>
+# include <inttypes.h>
+# include <link.h>
+# include <linux/elf-em.h>
+# include <poll.h>
 # include <pthread.h>
+# include <pwd.h>
+# include <signal.h>
+# include <stdint.h>
+# include <stdio.h>
+# include <stdlib.h>
+# include <string.h>
+# include <sys/ioctl.h>
+# include <sys/ipc.h>
+# include <sys/mman.h>
+# include <sys/prctl.h>
+# include <sys/resource.h>
+# include <sys/select.h>
+# include <sys/sendfile.h>
+# include <sys/socket.h>
 # include <sys/stat.h>
+# include <sys/sysinfo.h>
 # include <sys/time.h>
 # include <sys/times.h>
+# include <sys/types.h>
 # include <sys/utsname.h>
-# include <sys/socket.h>
-# include <pwd.h>
-# include <poll.h>
-# include <fcntl.h>
-# include <string.h>
 # include <syscall.h>
-# include <sys/sysinfo.h>
-# include <sys/ipc.h>
-# include <link.h>
-# include <stdint.h>
-# include <inttypes.h>
-# include <sys/ioctl.h>
-# include <linux/elf-em.h>
-# include <sys/prctl.h>
+# include <unistd.h>
 #ifdef __GLIBC__
 # include <malloc.h>
 #endif

--- a/src/hotspot/os/linux/os_linux.inline.hpp
+++ b/src/hotspot/os/linux/os_linux.inline.hpp
@@ -27,8 +27,8 @@
 
 #include "os_linux.hpp"
 
-#include "runtime/os.hpp"
 #include "os_posix.inline.hpp"
+#include "runtime/os.hpp"
 
 inline bool os::zero_page_read_protected() {
   return true;

--- a/src/hotspot/os/linux/os_perf_linux.cpp
+++ b/src/hotspot/os/linux/os_perf_linux.cpp
@@ -31,21 +31,21 @@
 #include "runtime/vm_version.hpp"
 #include "utilities/globalDefinitions.hpp"
 
-#include <stdio.h>
-#include <stdarg.h>
-#include <unistd.h>
+#include <dirent.h>
+#include <dlfcn.h>
 #include <errno.h>
+#include <fcntl.h>
+#include <ifaddrs.h>
+#include <limits.h>
+#include <pthread.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <sys/resource.h>
-#include <sys/types.h>
 #include <sys/stat.h>
-#include <dirent.h>
-#include <stdlib.h>
-#include <dlfcn.h>
-#include <pthread.h>
-#include <limits.h>
-#include <ifaddrs.h>
-#include <fcntl.h>
+#include <sys/types.h>
+#include <unistd.h>
 
 /**
    /proc/[number]/stat

--- a/src/hotspot/os/linux/waitBarrier_linux.cpp
+++ b/src/hotspot/os/linux/waitBarrier_linux.cpp
@@ -26,8 +26,9 @@
 #include "runtime/os.hpp"
 #include "utilities/debug.hpp"
 #include "waitBarrier_linux.hpp"
-#include <sys/syscall.h>
+
 #include <linux/futex.h>
+#include <sys/syscall.h>
 
 // 32-bit RISC-V has no SYS_futex syscall.
 #ifdef RISCV32

--- a/test/hotspot/jtreg/sources/TestIncludesAreSorted.java
+++ b/test/hotspot/jtreg/sources/TestIncludesAreSorted.java
@@ -43,6 +43,7 @@ public class TestIncludesAreSorted {
      * can be checked).
      */
     private static final String[] HOTSPOT_SOURCES_TO_CHECK = {
+                    "os/linux",
                     "share"
     };
 


### PR DESCRIPTION
This PR sorts the includes in hotspot/cpu/linux using `SortIncludes.java`. I'm also adding the directory to `TestIncludesAreSorted.java`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8366864](https://bugs.openjdk.org/browse/JDK-8366864): Sort os/linux includes (**Enhancement** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27088/head:pull/27088` \
`$ git checkout pull/27088`

Update a local copy of the PR: \
`$ git checkout pull/27088` \
`$ git pull https://git.openjdk.org/jdk.git pull/27088/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27088`

View PR using the GUI difftool: \
`$ git pr show -t 27088`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27088.diff">https://git.openjdk.org/jdk/pull/27088.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27088#issuecomment-3252832458)
</details>
