### PR TITLE
8366872: Wrong number of template arguments in test in test_rbtree.cpp

### DIFF
--- a/test/hotspot/gtest/utilities/test_rbtree.cpp
+++ b/test/hotspot/gtest/utilities/test_rbtree.cpp
@@ -1060,7 +1060,7 @@ TEST_VM(RBTreeTestNonFixture, TestPrintIntegerTree) {
 }
 
 TEST_VM(RBTreeTestNonFixture, TestPrintCustomPrinter) {
-  typedef RBTree<int, unsigned, IntCmp, RBTreeCHeapAllocator<mtTest> > TreeType;
+  typedef RBTreeCHeap<int, unsigned, IntCmp, mtTest> TreeType;
   typedef RBNode<int, unsigned> NodeType;
 
   TreeType tree;


### PR DESCRIPTION
After merging #26981, it did not consider the changes made in #27011, making the templates no longer match.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8366872](https://bugs.openjdk.org/browse/JDK-8366872): Wrong number of template arguments in test in test_rbtree.cpp (**Bug** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [SendaoYan](https://openjdk.org/census#syan) (@sendaoYan - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27089/head:pull/27089` \
`$ git checkout pull/27089`

Update a local copy of the PR: \
`$ git checkout pull/27089` \
`$ git pull https://git.openjdk.org/jdk.git pull/27089/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27089`

View PR using the GUI difftool: \
`$ git pr show -t 27089`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27089.diff">https://git.openjdk.org/jdk/pull/27089.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27089#issuecomment-3253001752)
</details>
