### PR TITLE
8366874: Test gc/arguments/TestParallelGCErgo.java fails with UseTransparentHugePages

### DIFF
--- a/test/hotspot/jtreg/gc/arguments/TestParallelGCErgo.java
+++ b/test/hotspot/jtreg/gc/arguments/TestParallelGCErgo.java
@@ -27,7 +27,7 @@ package gc.arguments;
  * @test TestParallelGCErgo
  * @bug 8272364
  * @requires vm.gc.Parallel
- * @requires vm.opt.UseLargePages == null | !vm.opt.UseLargePages
+ * @requires !vm.opt.final.UseLargePages
  * @summary Verify ParallelGC minimum young and old ergonomics are setup correctly
  * @modules java.base/jdk.internal.misc
  * @library /test/lib


### PR DESCRIPTION
Hello,

I found this test issue when running all GC tests with THP enabled (always or madvise mode) and using the `-XX:+UseTransparentHugePages` flag. The `@requires` flag was added in [JDK-8333306](https://bugs.openjdk.org/browse/JDK-8333306) to prevent the test from being invoked with explicit large pages (HugeTLBfs) enabled. The test also doesn't work with `-XX:+UseTransparentHugePages`.

Changing the `@requires`-line to check if `UseLargePages` is evaluated to false in the VM prevents the test from being run when either setting `-XX:+UseLargePages` or `-XX:+UseTransparentHugePages`.

I've tested locally that the test no longer runs with the `-XX:+UseTransparentHugePages` or `-XX:+UseLargePages` flags. Without either of the flags, the test runs fine.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8366874](https://bugs.openjdk.org/browse/JDK-8366874): Test gc/arguments/TestParallelGCErgo.java fails with UseTransparentHugePages (**Bug** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27090/head:pull/27090` \
`$ git checkout pull/27090`

Update a local copy of the PR: \
`$ git checkout pull/27090` \
`$ git pull https://git.openjdk.org/jdk.git pull/27090/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27090`

View PR using the GUI difftool: \
`$ git pr show -t 27090`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27090.diff">https://git.openjdk.org/jdk/pull/27090.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27090#issuecomment-3253274102)
</details>
