### PR TITLE
8366890: C2: Split through phi printing with TraceLoopOpts misses line break

### DIFF
--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -230,8 +230,8 @@ Node* PhaseIdealLoop::split_thru_phi(Node* n, Node* region, int policy) {
 
 #ifndef PRODUCT
   if (TraceLoopOpts) {
-    tty->print("Split %d %s through %d Phi in %d %s",
-               n->_idx, n->Name(), phi->_idx, region->_idx, region->Name());
+    tty->print_cr("Split %d %s through %d Phi in %d %s",
+                  n->_idx, n->Name(), phi->_idx, region->_idx, region->Name());
   }
 #endif // !PRODUCT
 


### PR DESCRIPTION
[JDK-8356176](https://bugs.openjdk.org/browse/JDK-8356176) added new printing code for `TraceLoopOpts` when splitting nodes through a phi but missed a line break. This will result in:
```
Split 974 CmpI through 1465 Phi in 953 RegionSplit 474 Bool through 1468 Phi in 953 RegionSplit-If
```
instead of
```
Split 974 CmpI through 1465 Phi in 953 RegionSplit 474 Bool through 1468 Phi in 953 Region
Split-If
```
This patch fixes this.

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8366890](https://bugs.openjdk.org/browse/JDK-8366890): C2: Split through phi printing with TraceLoopOpts misses line break (**Bug** - P5)


### Reviewers
 * [Roberto Castañeda Lozano](https://openjdk.org/census#rcastanedalo) (@robcasloz - **Reviewer**)
 * [Manuel Hässig](https://openjdk.org/census#mhaessig) (@mhaessig - Committer)
 * [Emanuel Peter](https://openjdk.org/census#epeter) (@eme64 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27092/head:pull/27092` \
`$ git checkout pull/27092`

Update a local copy of the PR: \
`$ git checkout pull/27092` \
`$ git pull https://git.openjdk.org/jdk.git pull/27092/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27092`

View PR using the GUI difftool: \
`$ git pr show -t 27092`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27092.diff">https://git.openjdk.org/jdk/pull/27092.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27092#issuecomment-3253549776)
</details>
