### PR TITLE
8366775: TestCompileTaskTimeout should use timeoutFactor

### DIFF
--- a/test/hotspot/jtreg/compiler/arguments/TestCompileTaskTimeout.java
+++ b/test/hotspot/jtreg/compiler/arguments/TestCompileTaskTimeout.java
@@ -37,6 +37,11 @@ import jdk.test.lib.process.ProcessTools;
 public class TestCompileTaskTimeout {
 
     public static void main(String[] args) throws Throwable {
+        double timeoutFactor = 1.0;
+        try {
+            timeoutFactor = Double.parseDouble(System.getProperty("test.timeout.factor", "1.0"));
+        } catch (NumberFormatException ignored) {}
+
         ProcessTools.executeTestJava("-Xcomp", "-XX:CompileTaskTimeout=1", "--version")
                     .shouldHaveExitValue(134)
                     .shouldContain("timed out after");
@@ -49,7 +54,8 @@ public class TestCompileTaskTimeout {
                     .shouldHaveExitValue(134)
                     .shouldContain("timed out after");
 
-        ProcessTools.executeTestJava("-Xcomp", "-XX:CompileTaskTimeout=2000", "--version")
+        int timeout = (int)(500.0 * timeoutFactor);
+        ProcessTools.executeTestJava("-Xcomp", "-XX:CompileTaskTimeout=" + timeout, "--version")
                     .shouldHaveExitValue(0);
     }
 }


### PR DESCRIPTION
`TestCompileTaskTimeout.java` employs a timeout to test that methods compiled faster than a specified `CompileTaskTimeout`. However, it does not make use of the jtreg timeout factor, which lead to #26963 increasing the timeout to 2 s. This PR remedies this, by using the timeout factor and reducing the default timeout to 500 ms.

Testing:
 - [ ] Github Actions
 - [ ] tier1, tier2 linux-x64-debug, linux-x64, linux-aarch64-debug, linux-aarch64