### PR TITLE
8366780: Enhance ProcSmapsParser and Printer to handle THPeligible field

### DIFF
--- a/src/hotspot/os/linux/memMapPrinter_linux.cpp
+++ b/src/hotspot/os/linux/memMapPrinter_linux.cpp
@@ -107,6 +107,7 @@ public:
       PRINTIF(info.ht, "huge");
       PRINTIF(info.anonhugepages > 0, "thp");
       PRINTIF(info.hg, "thpad");
+      PRINTIF(!info.hg && info.thpeligible == 1, "thpel");
       PRINTIF(info.nh, "nothp");
       if (num_printed == 0) {
         st->print("-");
@@ -136,6 +137,7 @@ public:
     st->print_cr("                      swap: mapping partly or completely swapped out");
     st->print_cr("                       thp: mapping uses THP");
     st->print_cr("                     thpad: mapping is THP-madvised");
+    st->print_cr("                     thpel: mapping is THP-eligible");
     st->print_cr("                     nothp: mapping is forbidden to use THP");
     st->print_cr("                      huge: mapping uses hugetlb pages");
     st->print_cr("vm info:         VM information (requires NMT)");

--- a/src/hotspot/os/linux/procMapsParser.cpp
+++ b/src/hotspot/os/linux/procMapsParser.cpp
@@ -66,18 +66,24 @@ void ProcSmapsParser::scan_header_line(ProcSmapsInfo& out) {
 
 void ProcSmapsParser::scan_additional_line(ProcSmapsInfo& out) {
 #define SCAN(key, var) \
- if (::sscanf(_line, key ": %zu kB", &var) == 1) { \
-     var *= K; \
-     return; \
+ if (::sscanf(_line, key ": %zu", &var) == 1) { \
+   return; \
  }
-  SCAN("KernelPageSize", out.kernelpagesize);
-  SCAN("Rss", out.rss);
-  SCAN("AnonHugePages", out.anonhugepages);
-  SCAN("Private_Hugetlb", out.private_hugetlb);
-  SCAN("Shared_Hugetlb", out.shared_hugetlb);
-  SCAN("Swap", out.swap);
+#define SCAN_KB(key, var) \
+ if (::sscanf(_line, key ": %zu kB", &var) == 1) { \
+   var *= K; \
+   return; \
+ }
+  SCAN_KB("KernelPageSize", out.kernelpagesize);
+  SCAN_KB("Rss", out.rss);
+  SCAN_KB("AnonHugePages", out.anonhugepages);
+  SCAN_KB("Private_Hugetlb", out.private_hugetlb);
+  SCAN_KB("Shared_Hugetlb", out.shared_hugetlb);
+  SCAN_KB("Swap", out.swap);
+  SCAN("THPeligible", out.thpeligible);
   int i = 0;
 #undef SCAN
+#undef SCAN_KB
   // scan some flags too
   if (strncmp(_line, "VmFlags:", 8) == 0) {
 #define SCAN(flag) { out.flag = (::strstr(_line + 8, " " #flag) != nullptr); }

--- a/src/hotspot/os/linux/procMapsParser.hpp
+++ b/src/hotspot/os/linux/procMapsParser.hpp
@@ -49,6 +49,7 @@ struct ProcSmapsInfo {
   size_t shared_hugetlb;
   size_t anonhugepages;
   size_t swap;
+  size_t thpeligible;
   bool rd, wr, ex;
   bool sh; // shared
   bool nr; // no reserve
@@ -63,7 +64,7 @@ struct ProcSmapsInfo {
   void reset() {
     from = to = nullptr;
     prot[0] = filename[0] = '\0';
-    kernelpagesize = rss = private_hugetlb = shared_hugetlb = anonhugepages = swap = 0;
+    kernelpagesize = rss = private_hugetlb = shared_hugetlb = anonhugepages = swap = thpeligible = 0;
     rd = wr = ex = sh = nr = hg = ht = nh = false;
   }
 };

--- a/test/hotspot/jtreg/serviceability/dcmd/vm/SystemMapTestBase.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/vm/SystemMapTestBase.java
@@ -99,8 +99,8 @@ public class SystemMapTestBase {
             regexBase_java_heap + "JAVAHEAP.*",
             // metaspace
             regexBase_committed + "META.*",
-            // parts of metaspace should be uncommitted
-            regexBase + "-" + space + "META.*",
+            // parts of metaspace should be uncommitted, those parts can be thp eligible
+            regexBase + "(-|thpel)" + space + "META.*",
             // code cache
             regexBase_committed + "CODE.*",
             // Main thread stack


### PR DESCRIPTION
Please review this enhancement to the smaps parser and printer.

**Summary**
While working on [JDK-8366434](https://bugs.openjdk.org/browse/JDK-8366434) one idea for a test to verify if the heap CAN be backed by transparent huge pages (THP) was to use PrintMemoryMapAtExit and look at the tags printed for JAVAHEAP.

It turns out this worked in most cases but on systems where the THP mode is configured as 'always' but there are no huge pages available for use, the JAVAHEAP line will not show any indication that it can be backed by huge pages.

For this to be possible we need to parse the field THPeligible as well and include this information in the printouts. With this change we now parse the THPeligible field and tag mapping that are THP eligible with `thpel`. We skip this tag for mappings that are tagged with `thpad` (madvised with MADV_HUGEPAGE) to avoid too much THP info on one mapping.

**Testing**
* Mach5 testing with the existing test showed a need to update the regex for verifying Metaspace and the fix have been tested manually locally as well as in Mach5.