### PR TITLE
8366896: JFR: Use GarbageCollection.name in gc view

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/query/view.ini
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/query/view.ini
@@ -292,14 +292,16 @@ table = "SELECT finalizableClass, LAST_BATCH(objects) AS O, LAST_BATCH(totalFina
 label = "Garbage Collections"
 table = "COLUMN 'Start', 'GC ID', 'Type', 'Heap Before GC', 'Heap After GC', 'Longest Pause'
          FORMAT none, none, missing:Unknown, none, none, none
-         SELECT G.startTime, gcId, [Y|O].eventType.label,
+         SELECT G.startTime, gcId, [Y|ZY|O|ZO].eventType.label,
                 B.heapUsed, A.heapUsed, longestPause
          FROM
                 GarbageCollection AS G,
                 GCHeapSummary AS B,
                 GCHeapSummary AS A,
                 OldGarbageCollection AS O,
-                YoungGarbageCollection AS Y
+                ZOldGarbageCollection AS ZO,
+                YoungGarbageCollection AS Y,
+                ZYoungGarbageCollection AS ZY
          WHERE B.when = 'Before GC' AND A.when = 'After GC'
          GROUP BY gcId ORDER BY G.startTime"
 

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/query/view.ini
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/query/view.ini
@@ -303,7 +303,7 @@ table = "COLUMN 'Start', 'GC ID', 'Type', 'Heap Before GC', 'Heap After GC', 'Lo
                 YoungGarbageCollection AS Y,
                 ZYoungGarbageCollection AS ZY
          WHERE B.when = 'Before GC' AND A.when = 'After GC'
-         GROUP BY gcId ORDER BY G.startTime"
+         GROUP BY gcId ORDER BY gcId"
 
 [jvm.gc-concurrent-phases]
 label = "Concurrent GC Phases"

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/query/view.ini
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/query/view.ini
@@ -290,7 +290,7 @@ table = "SELECT finalizableClass, LAST_BATCH(objects) AS O, LAST_BATCH(totalFina
 
 [jvm.gc]
 label = "Garbage Collections"
-table = "COLUMN 'Start', 'GC ID', 'Type', 'Heap Before GC', 'Heap After GC', 'Longest Pause'
+table = "COLUMN 'Start', 'GC ID', 'GC Name', 'Heap Before GC', 'Heap After GC', 'Longest Pause'
          FORMAT none, none, missing:Unknown, none, none, none
          SELECT G.startTime, gcId, G.name,
                 B.heapUsed, A.heapUsed, longestPause

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/query/view.ini
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/query/view.ini
@@ -292,16 +292,12 @@ table = "SELECT finalizableClass, LAST_BATCH(objects) AS O, LAST_BATCH(totalFina
 label = "Garbage Collections"
 table = "COLUMN 'Start', 'GC ID', 'Type', 'Heap Before GC', 'Heap After GC', 'Longest Pause'
          FORMAT none, none, missing:Unknown, none, none, none
-         SELECT G.startTime, gcId, [Y|ZY|O|ZO].eventType.label,
+         SELECT G.startTime, gcId, G.name,
                 B.heapUsed, A.heapUsed, longestPause
          FROM
                 GarbageCollection AS G,
                 GCHeapSummary AS B,
-                GCHeapSummary AS A,
-                OldGarbageCollection AS O,
-                ZOldGarbageCollection AS ZO,
-                YoungGarbageCollection AS Y,
-                ZYoungGarbageCollection AS ZY
+                GCHeapSummary AS A
          WHERE B.when = 'Before GC' AND A.when = 'After GC'
          GROUP BY gcId ORDER BY gcId"
 

--- a/test/jdk/jdk/jfr/jcmd/TestJcmdView.java
+++ b/test/jdk/jdk/jfr/jcmd/TestJcmdView.java
@@ -163,7 +163,7 @@ public class TestJcmdView {
         // Verify verbose heading
         output.shouldContain("(longestPause)");
         // Verify row contents
-        output.shouldContain("Old Garbage Collection");
+        output.shouldContain("G1");
         // Verify verbose query
         output.shouldContain("SELECT");
     }

--- a/test/jdk/jdk/jfr/tool/TestView.java
+++ b/test/jdk/jdk/jfr/tool/TestView.java
@@ -84,7 +84,7 @@ public class TestView {
         // Verify verbose heading
         output.shouldContain("(longestPause)");
         // Verify row contents
-        output.shouldContain("Old Garbage Collection");
+        output.shouldContain("G1");
         // Verify verbose query
         output.shouldContain("SELECT");
     }


### PR DESCRIPTION
Could I have a review of a PR that fixes the 'jfr gc view'?


Before:

    $ jfr view gc z.jfr
    
                                  Garbage Collections
    
    Start    GC ID Type                  Heap Before GC Heap After GC Longest Pause
    -------- ----- --------------------- -------------- ------------- -------------
    N/A         61 Unknown                       5.2 GB           N/A           N/A
    N/A         63 Unknown                       7.2 GB           N/A           N/A
    16:13:43     0 Unknown                     868.0 MB        1.6 GB    0.00808 ms
    16:13:43     1 Unknown                       1.7 GB        3.8 GB    0.00796 ms
    16:13:44     2 Unknown                       3.8 GB        9.0 GB     0.0136 ms
    
    $ jfr view gc shen.jfr
    
                                  Garbage Collections
    
    Start    GC ID Type                  Heap Before GC Heap After GC Longest Pause
    -------- ----- --------------------- -------------- ------------- -------------
    16:16:07     0 Unknown                       2.3 GB        4.9 GB      0.139 ms
    16:16:08     1 Unknown                       4.9 GB        6.3 GB     0.0693 ms
    16:16:09     2 Unknown                       6.3 GB        1.2 GB     0.0812 ms
    16:16:09     3 Unknown                       1.8 GB        5.2 GB     0.0824 ms
    16:16:09     4 Unknown                       5.2 GB        9.0 GB     0.0930 ms
    
    $ jfr view gc g1.jfr
    
                                    Garbage Collections
    
    Start    GC ID Type                     Heap Before GC Heap After GC Longest Pause
    -------- ----- ------------------------ -------------- ------------- -------------
    14:45:23     0 Young Garbage Collection        49.1 MB       14.2 MB       2.52 ms
    14:45:24     1 Old Garbage Collection          46.2 MB       24.6 MB       16.1 ms
    14:45:24     2 Old Garbage Collection          40.6 MB       24.6 MB       12.0 ms
    14:45:25     3 Young Garbage Collection        40.6 MB       41.2 MB      0.946 ms
    14:45:25     4 Old Garbage Collection          41.2 MB       49.2 MB           0 s
    
    $ jfr view gc serial.jfr
    
                                    Garbage Collections
    
    Start    GC ID Type                     Heap Before GC Heap After GC Longest Pause
    -------- ----- ------------------------ -------------- ------------- -------------
    16:33:59     0 Young Garbage Collection       154.8 MB       83.2 MB       41.5 ms
    16:33:59     1 Young Garbage Collection       236.8 MB      219.4 MB       76.0 ms
    ...
    16:34:03    37 Old Garbage Collection           6.1 GB        5.6 GB        2.92 s
    16:34:07    38 Young Garbage Collection         8.0 GB        8.4 GB        1.85 s
    16:34:08    39 Old Garbage Collection           8.4 GB        2.6 GB        1.97 s
    
    $ jfr view gc parallel.jfr
    
                                    Garbage Collections
    
    Start    GC ID Type                     Heap Before GC Heap After GC Longest Pause
    -------- ----- ------------------------ -------------- ------------- -------------
    16:28:10     0 Young Garbage Collection       142.8 MB       80.5 MB       12.5 ms
    16:28:10     1 Young Garbage Collection       368.5 MB      326.6 MB       42.1 ms
    16:28:11     2 Young Garbage Collection       614.6 MB      556.4 MB       69.2 ms
    ...
    16:28:15    11 Old Garbage Collection           7.2 GB        3.2 GB        768 ms
    16:28:16    12 Young Garbage Collection         4.2 GB        4.2 GB       97.8 ms


After:


    $ jfr view gc z.jfr
    
                                  Garbage Collections
    
    Start    GC ID Name                  Heap Before GC Heap After GC Longest Pause
    -------- ----- --------------------- -------------- ------------- -------------
    16:13:43     0 ZGC Major                   868.0 MB        1.6 GB    0.00808 ms
    16:13:43     1 ZGC Major                     1.7 GB        3.8 GB    0.00796 ms
    16:13:44     2 ZGC Major                     3.8 GB        9.0 GB     0.0136 ms
    16:13:45     3 ZGC Minor                     6.6 GB        9.0 GB     0.0203 ms
    16:13:46     4 ZGC Minor                     9.0 GB        9.0 GB    0.00867 ms
    
    $ jfr view gc shen.jfr
     
                                  Garbage Collections
    
    Start    GC ID Name                  Heap Before GC Heap After GC Longest Pause
    -------- ----- --------------------- -------------- ------------- -------------
    16:16:07     0 Shenandoah                    2.3 GB        4.9 GB      0.139 ms
    16:16:08     1 Shenandoah                    4.9 GB        6.3 GB     0.0693 ms
    16:16:09     2 Shenandoah                    6.3 GB        1.2 GB     0.0812 ms
    16:16:09     3 Shenandoah                    1.8 GB        5.2 GB     0.0824 ms
    16:16:09     4 Shenandoah                    5.2 GB        9.0 GB     0.0930 ms
    
    $ jfr view gc g1.jfr
    
                                  Garbage Collections
    
    Start    GC ID Name                  Heap Before GC Heap After GC Longest Pause
    -------- ----- --------------------- -------------- ------------- -------------
    14:45:23     0 G1New                        49.1 MB       14.2 MB       2.52 ms
    14:45:24     1 G1Full                       46.2 MB       24.6 MB       16.1 ms
    14:45:24     2 G1Full                       40.6 MB       24.6 MB       12.0 ms
    14:45:25     3 G1New                        40.6 MB       41.2 MB      0.946 ms
    14:45:25     4 G1Old                        41.2 MB       49.2 MB           0 s
    
    $ jfr view gc serial.jfr
    
                                  Garbage Collections
    
    Start    GC ID Name                  Heap Before GC Heap After GC Longest Pause
    -------- ----- --------------------- -------------- ------------- -------------
    16:33:59     0 DefNew                      154.8 MB       83.2 MB       41.5 ms
    16:33:59     1 DefNew                      236.8 MB      219.4 MB       76.0 ms
    ...
    16:34:03    37 SerialOld                     6.1 GB        5.6 GB        2.92 s
    16:34:07    38 DefNew                        8.0 GB        8.4 GB        1.85 s
    16:34:08    39 SerialOld                     8.4 GB        2.6 GB        1.97 s
    
    $ jfr view gc parallel.jfr
    
                                  Garbage Collections
    
    Start    GC ID Name                  Heap Before GC Heap After GC Longest Pause
    -------- ----- --------------------- -------------- ------------- -------------
    16:28:10     0 ParallelScavenge            142.8 MB       80.5 MB       12.5 ms
    16:28:10     1 ParallelScavenge            368.5 MB      326.6 MB       42.1 ms
    16:28:11     2 ParallelScavenge            614.6 MB      556.4 MB       69.2 ms
    ...
    16:28:15    11 ParallelOld                   7.2 GB        3.2 GB        768 ms
    16:28:16    12 ParallelScavenge              4.2 GB        4.2 GB       97.8 ms

I changed so GarbageCollection.name is used instead of the event type and ordered events by GC ID and not by start time. This works better in case not all events for a GC ID has been emitted.

Testing: jdk/jdk/jfr + manual inspection with ZGC, Shenandoah, G1, Parallel and Serial.

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8366896](https://bugs.openjdk.org/browse/JDK-8366896): JFR: Use GarbageCollection.name in gc view (**Bug** - P3)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27099/head:pull/27099` \
`$ git checkout pull/27099`

Update a local copy of the PR: \
`$ git checkout pull/27099` \
`$ git pull https://git.openjdk.org/jdk.git pull/27099/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27099`

View PR using the GUI difftool: \
`$ git pr show -t 27099`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27099.diff">https://git.openjdk.org/jdk/pull/27099.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27099#issuecomment-3254121461)
</details>
