### PR TITLE
8332872: SetupExecute should cd to temp directory

### DIFF
--- a/make/CreateJmods.gmk
+++ b/make/CreateJmods.gmk
@@ -257,7 +257,8 @@ $(eval $(call SetupExecute, create_$(JMOD_FILE), \
     WARN := Creating $(INTERIM_MSG)$(JMOD_FILE), \
     DEPS := $(DEPS), \
     OUTPUT_FILE := $(JMODS_DIR)/$(JMOD_FILE), \
-    SUPPORT_DIR := $(JMODS_SUPPORT_DIR)/_support_$(JMOD_FILE), \
+    WORKING_DIR := $(WORKSPACE_ROOT), \
+    SUPPORT_DIR := $(JMODS_SUPPORT_DIR), \
     PRE_COMMAND := $(RM) $(JMODS_DIR)/$(JMOD_FILE) $(JMODS_SUPPORT_DIR)/$(JMOD_FILE), \
     COMMAND := $(JMOD) $(JMOD_SMALL_FLAGS) create --module-version $(VERSION_SHORT) \
         --target-platform '$(JMOD_TARGET_PLATFORM)' \

--- a/make/CreateJmods.gmk
+++ b/make/CreateJmods.gmk
@@ -257,7 +257,7 @@ $(eval $(call SetupExecute, create_$(JMOD_FILE), \
     WARN := Creating $(INTERIM_MSG)$(JMOD_FILE), \
     DEPS := $(DEPS), \
     OUTPUT_FILE := $(JMODS_DIR)/$(JMOD_FILE), \
-    SUPPORT_DIR := $(JMODS_SUPPORT_DIR), \
+    SUPPORT_DIR := $(JMODS_SUPPORT_DIR)/_support_$(JMOD_FILE), \
     PRE_COMMAND := $(RM) $(JMODS_DIR)/$(JMOD_FILE) $(JMODS_SUPPORT_DIR)/$(JMOD_FILE), \
     COMMAND := $(JMOD) $(JMOD_SMALL_FLAGS) create --module-version $(VERSION_SHORT) \
         --target-platform '$(JMOD_TARGET_PLATFORM)' \

--- a/make/UpdateSleefSource.gmk
+++ b/make/UpdateSleefSource.gmk
@@ -81,8 +81,8 @@ SLEEF_CMAKE_FILE := toolchains/$(OPENJDK_TARGET_CPU)-$(SLEEF_TOOLCHAIN_TYPE).cma
 $(eval $(call SetupExecute, sleef_native_config, \
     INFO := Configuring native sleef build, \
     OUTPUT_DIR := $(SLEEF_NATIVE_BUILD_DIR), \
-    COMMAND := cd $(SLEEF_SOURCE_DIR) && $(CMAKE) -S . -B \
-        $(SLEEF_NATIVE_BUILD_DIR), \
+    WORKING_DIR := $(SLEEF_SOURCE_DIR), \
+    COMMAND := $(CMAKE) -S . -B $(SLEEF_NATIVE_BUILD_DIR), \
 ))
 
 TARGETS := $(sleef_native_config)
@@ -91,8 +91,8 @@ $(eval $(call SetupExecute, sleef_native_build, \
     INFO := Building native sleef, \
     DEPS := $(sleef_native_config), \
     OUTPUT_DIR := $(SLEEF_NATIVE_BUILD_DIR), \
-    COMMAND := cd $(SLEEF_SOURCE_DIR) && $(CMAKE) --build \
-        $(SLEEF_NATIVE_BUILD_DIR) -j, \
+    WORKING_DIR := $(SLEEF_SOURCE_DIR), \
+    COMMAND := $(CMAKE) --build $(SLEEF_NATIVE_BUILD_DIR) -j, \
 ))
 
 TARGETS := $(sleef_native_build)
@@ -101,8 +101,8 @@ $(eval $(call SetupExecute, sleef_cross_config, \
     INFO := Configuring cross-compiling sleef build, \
     DEPS := $(sleef_native_build), \
     OUTPUT_DIR := $(SLEEF_CROSS_BUILD_DIR), \
-    COMMAND := cd $(SLEEF_SOURCE_DIR) && $(CMAKE) -S . -B \
-        $(SLEEF_CROSS_BUILD_DIR) \
+    WORKING_DIR := $(SLEEF_SOURCE_DIR), \
+    COMMAND := $(CMAKE) -S . -B $(SLEEF_CROSS_BUILD_DIR) \
         -DCMAKE_C_COMPILER=$(CC) \
         -DCMAKE_TOOLCHAIN_FILE=$(SLEEF_CMAKE_FILE) \
         -DNATIVE_BUILD_DIR=$(SLEEF_NATIVE_BUILD_DIR) \
@@ -116,8 +116,8 @@ $(eval $(call SetupExecute, sleef_cross_build, \
     INFO := Building cross-compiling sleef, \
     DEPS := $(sleef_cross_config), \
     OUTPUT_DIR := $(SLEEF_NATIVE_BUILD_DIR), \
-    COMMAND := cd $(SLEEF_SOURCE_DIR) && $(CMAKE) --build \
-        $(SLEEF_CROSS_BUILD_DIR) -j, \
+    WORKING_DIR := $(SLEEF_SOURCE_DIR), \
+    COMMAND := $(CMAKE) --build $(SLEEF_CROSS_BUILD_DIR) -j, \
 ))
 
 TARGETS := $(sleef_cross_build)

--- a/make/common/Execute.gmk
+++ b/make/common/Execute.gmk
@@ -45,6 +45,9 @@ ifeq ($(INCLUDE), true)
 # e.g. a simple sed replacement on the input file. If the operations are
 # unrelated to the main COMMAND, this is not a suitable solution.
 #
+# Before execution, the current working directory is changed to SUPPORT_DIR.
+# This can be overridden with WORKING_DIR.
+#
 # If your command outputs a variety of files, or if it's really a single file
 # but you don't really care about the output from the perspective, you can just
 # supply an OUTPUT_DIR. You are supposed to make sure the command creates files
@@ -75,6 +78,7 @@ ifeq ($(INCLUDE), true)
 #   OUTPUT_DIR  : The directory that will contain the result from the command
 #   OUTPUT_FILE : Use this if the command results in a single output file
 #   SUPPORT_DIR : Where to store generated support files
+#   WORKING_DIR : Directory to cd to before executing the command
 #   INFO        : Message to display at LOG=info level when running command (optional)
 #   WARN        : Message to display at LOG=warn level when running command (optional)
 #   DEPS        : Dependencies for the execution to take place
@@ -133,6 +137,10 @@ define SetupExecuteBody
 
   endif
 
+  ifeq ($$($1_WORKING_DIR), )
+    $1_WORKING_DIR := $$($1_SUPPORT_DIR)
+  endif
+
   ifeq ($$($1_INFO)$$($1_WARN), )
     # If neither info nor warn is provided, add basic info text.
     $1_INFO := Running commands for $1
@@ -147,14 +155,14 @@ define SetupExecuteBody
         ifneq ($$($1_INFO), )
 	  $$(call LogInfo, $$($1_INFO))
         endif
-	$$(call MakeDir, $$($1_SUPPORT_DIR) $$($1_OUTPUT_DIR))
+	$$(call MakeDir, $$(call EncodeSpace, $$($1_WORKING_DIR)) $$(call EncodeSpace, $$($1_SUPPORT_DIR)) $$(call EncodeSpace, $$($1_OUTPUT_DIR)))
 	$$(call ExecuteWithLog, $$($1_BASE)_pre, \
-	    $$($1_PRE_COMMAND))
+	    cd $$($1_WORKING_DIR) && $$($1_PRE_COMMAND))
 	$$(TOUCH) $$@
 
     $$($1_EXEC_RESULT): $$($1_PRE_MARKER)
 	$$(call ExecuteWithLog, $$($1_BASE)_exec, \
-	    $$($1_COMMAND))
+	    cd $$($1_WORKING_DIR) && $$($1_COMMAND))
         ifeq ($$($1_EXEC_RESULT), $$($1_EXEC_MARKER))
 	  $$(TOUCH) $$@
         endif
@@ -168,9 +176,9 @@ define SetupExecuteBody
         ifneq ($$($1_INFO), )
 	  $$(call LogInfo, $$($1_INFO))
         endif
-	$$(call MakeDir, $$(call EncodeSpace, $$($1_SUPPORT_DIR)) $$(call EncodeSpace, $$($1_OUTPUT_DIR)))
+	$$(call MakeDir, $$(call EncodeSpace, $$($1_WORKING_DIR)) $$(call EncodeSpace, $$($1_SUPPORT_DIR)) $$(call EncodeSpace, $$($1_OUTPUT_DIR)))
 	$$(call ExecuteWithLog, $$($1_BASE)_exec, \
-	    $$($1_COMMAND))
+	    cd $$($1_WORKING_DIR) && $$($1_COMMAND))
         ifeq ($$($1_EXEC_RESULT), $$($1_EXEC_MARKER))
 	  $$(TOUCH) $$@
         endif
@@ -182,7 +190,7 @@ define SetupExecuteBody
 
     $$($1_FINAL_RESULT): $$($1_EXEC_RESULT)
 	$$(call ExecuteWithLog, $$($1_BASE)_post, \
-	    $$($1_POST_COMMAND))
+	    cd $$($1_WORKING_DIR) && $$($1_POST_COMMAND))
 	$$(TOUCH) $$@
 
     $1 += $$($1_FINAL_RESULT)

--- a/test/make/TestExecute.gmk
+++ b/test/make/TestExecute.gmk
@@ -1,0 +1,76 @@
+#
+# Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+#
+
+include MakeFileStart.gmk
+
+################################################################################
+
+include Execute.gmk
+include UtilsForTests.gmk
+
+THIS_FILE := $(TOPDIR)/test/make/TestExecute.gmk
+DEPS := $(THIS_FILE) \
+    $(TOPDIR)/make/common/MakeBase.gmk \
+    #
+
+OUTPUT_DIR := $(TESTMAKE_OUTPUTDIR)/execute
+$(call MakeDir, $(OUTPUT_DIR))
+
+################################################################################
+# Test SetupExecute
+
+$(eval $(call SetupExecute, EXEC_1, \
+    INFO := Testing that SetupExecute runs from SUPPORT_DIR, \
+    OUTPUT_DIR := $(OUTPUT_DIR)/exec_1, \
+    SUPPORT_DIR := $(OUTPUT_DIR)/exec_1/support, \
+    COMMAND := $(ECHO) "Generating junk file" > ./junkfile, \
+))
+
+run-test1: $(EXEC_1)
+	fd . $(OUTPUT_DIR)/exec_1
+	test -f $(OUTPUT_DIR)/exec_1/support/junkfile
+
+$(eval $(call SetupExecute, EXEC_2, \
+    INFO := Testing that SetupExecute runs from SUPPORT_DIR, \
+    OUTPUT_DIR := $(OUTPUT_DIR)/exec_2, \
+    SUPPORT_DIR := $(OUTPUT_DIR)/exec_2/support, \
+    WORKING_DIR := $(OUTPUT_DIR)/exec_2/special, \
+    COMMAND := $(ECHO) "Generating special file" > ./specialfile, \
+))
+
+run-test2: $(EXEC_2)
+	fd . $(OUTPUT_DIR)/exec_2
+	test -f $(OUTPUT_DIR)/exec_2/special/specialfile
+
+
+TEST_TARGETS += run-test1 run-test2
+
+.PHONY: run-test1 run-test2
+
+################################################################################
+
+all: $(TEST_TARGETS)
+
+################################################################################
+
+include MakeFileEnd.gmk

--- a/test/make/TestExecute.gmk
+++ b/test/make/TestExecute.gmk
@@ -47,7 +47,6 @@ $(eval $(call SetupExecute, EXEC_1, \
 ))
 
 run-test1: $(EXEC_1)
-	fd . $(OUTPUT_DIR)/exec_1
 	test -f $(OUTPUT_DIR)/exec_1/support/junkfile
 
 $(eval $(call SetupExecute, EXEC_2, \
@@ -59,7 +58,6 @@ $(eval $(call SetupExecute, EXEC_2, \
 ))
 
 run-test2: $(EXEC_2)
-	fd . $(OUTPUT_DIR)/exec_2
 	test -f $(OUTPUT_DIR)/exec_2/special/specialfile
 
 

--- a/test/make/TestMake.gmk
+++ b/test/make/TestMake.gmk
@@ -34,6 +34,9 @@ java-compilation:
 copy-files:
 	+$(MAKE) -f TestCopyFiles.gmk $(TEST_SUBTARGET)
 
+execute:
+	+$(MAKE) -f TestExecute.gmk $(TEST_SUBTARGET)
+
 fix-deps-file:
 	+$(MAKE) -f TestFixDepsFile.gmk $(TEST_SUBTARGET)
 
@@ -47,7 +50,7 @@ configure:
 	$(BASH) $(TOPDIR)/test/make/autoconf/test-configure.sh \
 	    "$(AUTOCONF)" "$(TOPDIR)" "$(TEST_SUPPORT_DIR)"
 
-TARGETS += make-base java-compilation copy-files fix-deps-file idea \
+TARGETS += make-base java-compilation copy-files execute fix-deps-file idea \
     compile-commands configure
 
 # Prints targets to TARGETS_FILE which must be set when calling this target.


### PR DESCRIPTION
Some commands create junk files all around in the current directory. We should change directory to a special working dir (typically the support dir) in SetupExecute, before running any command.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332872](https://bugs.openjdk.org/browse/JDK-8332872): SetupExecute should cd to temp directory (**Enhancement** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27103/head:pull/27103` \
`$ git checkout pull/27103`

Update a local copy of the PR: \
`$ git checkout pull/27103` \
`$ git pull https://git.openjdk.org/jdk.git pull/27103/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27103`

View PR using the GUI difftool: \
`$ git pr show -t 27103`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27103.diff">https://git.openjdk.org/jdk/pull/27103.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27103#issuecomment-3258830198)
</details>
