### PR TITLE
8366893: java/lang/Thread/virtual/stress/GetStackTraceALotWhenPinned.java timed out on macos-aarch64

### DIFF
--- a/test/jdk/java/lang/Thread/virtual/stress/GetStackTraceALotWhenBlocking.java
+++ b/test/jdk/java/lang/Thread/virtual/stress/GetStackTraceALotWhenBlocking.java
@@ -53,8 +53,8 @@ public class GetStackTraceALotWhenBlocking {
 
         int iterations;
         int value = Integer.parseInt(args[0]);
-        if (Platform.isOSX() && Platform.isX64()) {
-            // reduced iterations on macosx-x64
+        if (Platform.isOSX()) {
+            // reduced iterations on macosx
             iterations = Math.max(value / 4, 1);
         } else {
             iterations = value;

--- a/test/jdk/java/lang/Thread/virtual/stress/GetStackTraceALotWhenPinned.java
+++ b/test/jdk/java/lang/Thread/virtual/stress/GetStackTraceALotWhenPinned.java
@@ -56,8 +56,8 @@ public class GetStackTraceALotWhenPinned {
 
         int iterations;
         int value = Integer.parseInt(args[0]);
-        if (Platform.isOSX() && Platform.isX64()) {
-            // reduced iterations on macosx-x64
+        if (Platform.isOSX()) {
+            // reduced iterations on macosx
             iterations = Math.max(value / 4, 1);
         } else {
             iterations = value;

--- a/test/jdk/java/lang/Thread/virtual/stress/ParkALot.java
+++ b/test/jdk/java/lang/Thread/virtual/stress/ParkALot.java
@@ -49,8 +49,8 @@ public class ParkALot {
     public static void main(String[] args) throws Exception {
         int iterations;
         int value = Integer.parseInt(args[0]);
-        if (Platform.isOSX() && Platform.isX64()) {
-            // reduced iterations on macosx-x64
+        if (Platform.isOSX()) {
+            // reduced iterations on macosx
             iterations = Math.max(value / 4, 1);
         } else {
             iterations = value;


### PR DESCRIPTION
GetStackTraceALotWhenPinned test times out every so often in GHA.

The last sightings are on macos-aarch64:

```
2025-09-04T10:41:29.357879Z => 87894 of 100000
2025-09-04T10:41:30.365534Z => 88105 of 100000
Timeout signalled after 300 seconds
2025-09-04T10:41:31.367068Z => 88298 of 100000
2025-09-04T10:41:32.377128Z => 88400 of 100000

2025-09-03T10:08:37.713537Z => 74715 of 100000
2025-09-03T10:08:38.717750Z => 74818 of 100000
Timeout signalled after 300 seconds
2025-09-03T10:08:39.722960Z => 74922 of 100000
2025-09-03T10:08:40.726642Z => 75024 of 100000
```

Looks like we are nearly there, just need fewer iterations. I think like with [JDK-8344577](https://bugs.openjdk.org/browse/JDK-8344577), we just need to extend the test check for AArch64 macs as well.

Additional testing:
 - [x] MacOS AArch64 server fastdebug, `java/lang/Thread/virtual/stress`, 10x