### PR TITLE
8365192: post_meth_exit should be in vm state when calling get_jvmti_thread_state

### DIFF
--- a/src/hotspot/share/prims/jvmtiExport.cpp
+++ b/src/hotspot/share/prims/jvmtiExport.cpp
@@ -1860,6 +1860,7 @@ void JvmtiExport::post_method_exit_transition(JavaThread* thread, methodHandle m
     }
 
     if (state->is_enabled(JVMTI_EVENT_METHOD_EXIT)) {
+      // Deferred saving Object result into value.
       if (is_reference_type(type)) {
        value.l = JNIHandles::make_local(thread, result());
       }

--- a/src/hotspot/share/prims/jvmtiExport.cpp
+++ b/src/hotspot/share/prims/jvmtiExport.cpp
@@ -1832,7 +1832,7 @@ void JvmtiExport::post_method_exit(JavaThread* thread, Method* method, frame cur
   // The post_method_exit_transition always makes transition to vm and back
   // where GC can happen. So it is needed to preserve result  and then restore it
   // even if events are not actually posted.
-  // Saving oop_result into valu.j is deferred until jvmti state is ready.
+  // Saving oop_result into value.j is deferred until jvmti state is ready.
   HandleMark hm(thread);
   methodHandle mh(thread, method);
   oop oop_result;

--- a/src/hotspot/share/prims/jvmtiExport.cpp
+++ b/src/hotspot/share/prims/jvmtiExport.cpp
@@ -1847,9 +1847,11 @@ void JvmtiExport::post_method_exit(JavaThread* thread, Method* method, frame cur
   }
   JvmtiThreadState* state; // should be initialized in vm state only
   JavaThread* current = thread; // for JRT_BLOCK
+  bool interp_only; // might be changed in JRT_BLOCK_END
   JRT_BLOCK
     state = get_jvmti_thread_state(thread);
-    if (state != nullptr && state->is_interp_only_mode()) {
+    interp_only = state != nullptr && state->is_interp_only_mode();
+    if (interp_only) {
       if (state->is_enabled(JVMTI_EVENT_METHOD_EXIT)) {
         // Deferred saving Object result into value.
         if (is_reference_type(type)) {
@@ -1864,7 +1866,7 @@ void JvmtiExport::post_method_exit(JavaThread* thread, Method* method, frame cur
       post_method_exit_inner(thread, mh, state, false /* not exception exit */, current_frame, value);
     }
   JRT_BLOCK_END
-  if (state != nullptr && state->is_interp_only_mode()) {
+  if (interp_only) {
     // The JRT_BLOCK_END can safepoint in ThreadInVMfromJava desctructor. Now it is safe to allow
     // adding FramePop event requests as no safepoint can happen before removing activation.
     state->clr_top_frame_is_exiting();

--- a/src/hotspot/share/prims/jvmtiExport.cpp
+++ b/src/hotspot/share/prims/jvmtiExport.cpp
@@ -1830,7 +1830,7 @@ void JvmtiExport::post_method_exit(JavaThread* thread, Method* method, frame cur
   // At this point we only have the address of a "raw result" and
   // we just call into the interpreter to convert this into a jvalue.
   // This method always makes transition to vm and back where GC can happen.
-  // So it is needed to preserve result  and then restore it
+  // So it is needed to preserve result and then restore it
   // even if events are not actually posted.
   // Saving oop_result into value.j is deferred until jvmti state is ready.
   HandleMark hm(thread);
@@ -1840,8 +1840,8 @@ void JvmtiExport::post_method_exit(JavaThread* thread, Method* method, frame cur
   jvalue value;
   value.j = 0L;
   BasicType type = current_frame.interpreter_frame_result(&oop_result, &value);
-  assert(type == T_VOID || current_frame.interpreter_frame_expression_stack_size() > 0,
-          "Stack shouldn't be empty");
+  assert(mh->is_native() || type == T_VOID || current_frame.interpreter_frame_expression_stack_size() > 0,
+         "Stack shouldn't be empty");
   if (is_reference_type(type)) {
     result = Handle(thread, oop_result);
   }

--- a/src/hotspot/share/prims/jvmtiExport.cpp
+++ b/src/hotspot/share/prims/jvmtiExport.cpp
@@ -1867,7 +1867,7 @@ void JvmtiExport::post_method_exit(JavaThread* thread, Method* method, frame cur
     }
   JRT_BLOCK_END
   if (interp_only) {
-    // The JRT_BLOCK_END can safepoint in ThreadInVMfromJava desctructor. Now it is safe to allow
+    // The JRT_BLOCK_END can safepoint in ThreadInVMfromJava destructor. Now it is safe to allow
     // adding FramePop event requests as no safepoint can happen before removing activation.
     state->clr_top_frame_is_exiting();
   }

--- a/src/hotspot/share/prims/jvmtiExport.cpp
+++ b/src/hotspot/share/prims/jvmtiExport.cpp
@@ -418,6 +418,7 @@ JvmtiExport::get_jvmti_interface(JavaVM *jvm, void **penv, jint version) {
 JvmtiThreadState*
 JvmtiExport::get_jvmti_thread_state(JavaThread *thread, bool allow_suspend) {
   assert(thread == JavaThread::current(), "must be current thread");
+  assert(thread->thread_state() == _thread_in_vm, "thread should be in vm");
   if (thread->is_vthread_mounted() && thread->jvmti_thread_state() == nullptr) {
     JvmtiEventController::thread_started(thread);
     if (allow_suspend && thread->is_suspended()) {
@@ -1826,58 +1827,60 @@ void JvmtiExport::post_method_entry(JavaThread *thread, Method* method, frame cu
 }
 
 void JvmtiExport::post_method_exit(JavaThread* thread, Method* method, frame current_frame) {
+  // At this point we only have the address of a "raw result" and
+  // we just call into the interpreter to convert this into a jvalue.
+  // The post_method_exit_transition always makes transition to vm and back
+  // where GC can happen. So it is needed to preserve result  and then restore it
+  // even if events are not actually posted.
+  // Saving oop_result into valu.j is deferred until jvmti state is ready.
   HandleMark hm(thread);
   methodHandle mh(thread, method);
-
-  JvmtiThreadState *state = get_jvmti_thread_state(thread);
-
-  if (state == nullptr || !state->is_interp_only_mode()) {
-    // for any thread that actually wants method exit, interp_only_mode is set
-    return;
-  }
-
-  Handle result;
+  oop oop_result;
   jvalue value;
   value.j = 0L;
-
-  if (state->is_enabled(JVMTI_EVENT_METHOD_EXIT)) {
-    // At this point we only have the address of a "raw result" and
-    // we just call into the interpreter to convert this into a jvalue.
-    oop oop_result;
-    BasicType type = current_frame.interpreter_frame_result(&oop_result, &value);
-    assert(type == T_VOID || current_frame.interpreter_frame_expression_stack_size() > 0,
-           "Stack shouldn't be empty");
-    if (is_reference_type(type)) {
-      result = Handle(thread, oop_result);
-      value.l = JNIHandles::make_local(thread, result());
-    }
+  BasicType type = current_frame.interpreter_frame_result(&oop_result, &value);
+  assert(type == T_VOID || current_frame.interpreter_frame_expression_stack_size() > 0,
+          "Stack shouldn't be empty");
+  Handle result = Handle(thread, oop_result);
+  post_method_exit_transition(thread, mh, type, result, value);
+  if (result.not_null() && !mh->is_native()) {
+    *(oop*)current_frame.interpreter_frame_tos_address() = result();
   }
+}
 
-  // Do not allow NotifyFramePop to add new FramePop event request at
-  // depth 0 as it is already late in the method exiting dance.
-  state->set_top_frame_is_exiting();
-
-  // Deferred transition to VM, so we can stash away the return oop before GC.
+void JvmtiExport::post_method_exit_transition(JavaThread* thread, methodHandle mh,
+                                    BasicType type, Handle result, jvalue value) {
+  JvmtiThreadState * state; // should be initialized in vm state only
   JavaThread* current = thread; // for JRT_BLOCK
   JRT_BLOCK
-    post_method_exit_inner(thread, mh, state, false /* not exception exit */, current_frame, value);
+    state = get_jvmti_thread_state(thread);
+    if (state == nullptr || !state->is_interp_only_mode()) {
+      // The transition from vm to java
+      return;
+    }
+
+    if (state->is_enabled(JVMTI_EVENT_METHOD_EXIT)) {
+      if (is_reference_type(type)) {
+       value.l = JNIHandles::make_local(thread, result());
+      }
+    }
+
+    // Do not allow NotifyFramePop to add new FramePop event request at
+    // depth 0 as it is already late in the method exiting dance.
+    state->set_top_frame_is_exiting();
+
+    post_method_exit_inner(thread, mh, state, false /* not exception exit */, value);
   JRT_BLOCK_END
 
   // The JRT_BLOCK_END can safepoint in ThreadInVMfromJava desctructor. Now it is safe to allow
   // adding FramePop event requests as no safepoint can happen before removing activation.
   state->clr_top_frame_is_exiting();
-
-  if (result.not_null() && !mh->is_native()) {
-    // We have to restore the oop on the stack for interpreter frames
-    *(oop*)current_frame.interpreter_frame_tos_address() = result();
-  }
 }
 
 void JvmtiExport::post_method_exit_inner(JavaThread* thread,
                                          methodHandle& mh,
                                          JvmtiThreadState *state,
                                          bool exception_exit,
-                                         frame current_frame,
                                          jvalue& value) {
   if (mh->jvmti_mount_transition() || thread->should_hide_jvmti_events()) {
     return;
@@ -2107,7 +2110,7 @@ void JvmtiExport::notice_unwind_due_to_exception(JavaThread *thread, Method* met
         // When these events are enabled code should be in running in interp mode.
         jvalue no_value;
         no_value.j = 0L;
-        JvmtiExport::post_method_exit_inner(thread, mh, state, true, thread->last_frame(), no_value);
+        JvmtiExport::post_method_exit_inner(thread, mh, state, true, no_value);
         // The cached cur_stack_depth might have changed from the
         // operations of frame pop or method exit. We are not 100% sure
         // the cached cur_stack_depth is still valid depth so invalidate

--- a/src/hotspot/share/prims/jvmtiExport.hpp
+++ b/src/hotspot/share/prims/jvmtiExport.hpp
@@ -214,6 +214,7 @@ class JvmtiExport : public AllStatic {
                                      methodHandle& mh,
                                      JvmtiThreadState *state,
                                      bool exception_exit,
+                                     frame current_frame,
                                      jvalue& value);
 
  public:

--- a/src/hotspot/share/prims/jvmtiExport.hpp
+++ b/src/hotspot/share/prims/jvmtiExport.hpp
@@ -210,12 +210,6 @@ class JvmtiExport : public AllStatic {
   // dependency information is complete or not.
   static bool _all_dependencies_are_recorded;
 
-  static void post_method_exit_transition(JavaThread* thread,
-                                          methodHandle mh,
-                                          BasicType type,
-                                          Handle result,
-                                          jvalue value);
-
   static void post_method_exit_inner(JavaThread* thread,
                                      methodHandle& mh,
                                      JvmtiThreadState *state,

--- a/src/hotspot/share/prims/jvmtiExport.hpp
+++ b/src/hotspot/share/prims/jvmtiExport.hpp
@@ -210,11 +210,16 @@ class JvmtiExport : public AllStatic {
   // dependency information is complete or not.
   static bool _all_dependencies_are_recorded;
 
+  static void post_method_exit_transition(JavaThread* thread,
+                                          methodHandle mh,
+                                          BasicType type,
+                                          Handle result,
+                                          jvalue value);
+
   static void post_method_exit_inner(JavaThread* thread,
                                      methodHandle& mh,
                                      JvmtiThreadState *state,
                                      bool exception_exit,
-                                     frame current_frame,
                                      jvalue& value);
 
  public:


### PR DESCRIPTION
This is the second attempt to fix method `post_meth_exit` to correctly set state and preserve result.
The related fix here:
https://github.com/openjdk/jdk/commit/b7b64bb6c800b45e32ff37b1b92b5927a3b3fb56
Hope fix became clarere now.

There 2 problems in this post_meth_exit:
1) The result is preserved only if `state->is_enabled(JVMTI_EVENT_METHOD_EXIT)` however transition in the JRT_BLOCK_END happens always. So there is a risk of loosing method results in the interp_only mode.
2) The method `get_jvmti_thread_state` should be called when thread is in vm state only.

The fix adds `post_method_exit_transition` to have single exit point with oop restoration.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8365192](https://bugs.openjdk.org/browse/JDK-8365192): post_meth_exit should be in vm state when calling get_jvmti_thread_state (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) Review applies to [3a169797](https://git.openjdk.org/jdk/pull/27112/files/3a169797614a710e4ebfe31cfbbf1e46e06bd746)
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27112/head:pull/27112` \
`$ git checkout pull/27112`

Update a local copy of the PR: \
`$ git checkout pull/27112` \
`$ git pull https://git.openjdk.org/jdk.git pull/27112/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27112`

View PR using the GUI difftool: \
`$ git pr show -t 27112`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27112.diff">https://git.openjdk.org/jdk/pull/27112.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27112#issuecomment-3257222721)
</details>
