### PR TITLE
8366588: VectorAPI: Re-intrinsify VectorMask.laneIsSet where the input index is a variable

### DIFF
--- a/src/hotspot/share/opto/vectorIntrinsics.cpp
+++ b/src/hotspot/share/opto/vectorIntrinsics.cpp
@@ -2502,7 +2502,7 @@ bool LibraryCallKit::inline_vector_extract() {
   if (vector_klass == nullptr || vector_klass->const_oop() == nullptr ||
       elem_klass   == nullptr || elem_klass->const_oop()   == nullptr ||
       vlen         == nullptr || !vlen->is_con() ||
-      idx          == nullptr || !idx->is_con()) {
+      idx          == nullptr) {
     log_if_needed("  ** missing constant: vclass=%s etype=%s vlen=%s",
                     NodeClassNames[argument(0)->Opcode()],
                     NodeClassNames[argument(1)->Opcode()],

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
@@ -1417,6 +1417,11 @@ public class IRNode {
         beforeMatchingNameRegex(VECTOR_MASK_TO_LONG, "VectorMaskToLong");
     }
 
+    public static final String VECTOR_MASK_LANE_IS_SET = PREFIX + "VECTOR_MASK_LANE_IS_SET" + POSTFIX;
+    static {
+        beforeMatchingNameRegex(VECTOR_MASK_LANE_IS_SET, "ExtractUB");
+    }
+
     // Can only be used if avx512_vnni is available.
     public static final String MUL_ADD_VS2VI_VNNI = PREFIX + "MUL_ADD_VS2VI_VNNI" + POSTFIX;
     static {

--- a/test/hotspot/jtreg/compiler/vectorapi/VectorMaskLaneIsSetTest.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/VectorMaskLaneIsSetTest.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.vectorapi;
+
+import compiler.lib.ir_framework.*;
+import jdk.incubator.vector.*;
+import jdk.test.lib.Asserts;
+
+/**
+ * @test
+ * @bug 8366588
+ * @key randomness
+ * @library /test/lib /
+ * @summary VectorAPI: Re-intrinsify VectorMask.laneIsSet where the input index is a variable
+ * @modules jdk.incubator.vector
+ *
+ * @run driver compiler.vectorapi.VectorMaskLaneIsSetTest
+ */
+
+public class VectorMaskLaneIsSetTest {
+    static final VectorSpecies<Byte> B_SPECIES = ByteVector.SPECIES_MAX;
+    static final VectorSpecies<Short> S_SPECIES = ShortVector.SPECIES_MAX;
+    static final VectorSpecies<Integer> I_SPECIES = IntVector.SPECIES_MAX;
+    static final VectorSpecies<Float> F_SPECIES = FloatVector.SPECIES_MAX;
+    static final VectorSpecies<Long> L_SPECIES = LongVector.SPECIES_MAX;
+    static final VectorSpecies<Double> D_SPECIES = DoubleVector.SPECIES_MAX;
+    static final int LENGTH = 512;
+    static boolean[] ma;
+    static VectorMask<Byte> mask_b;
+    static VectorMask<Short> mask_s;
+    static VectorMask<Integer> mask_i;
+    static VectorMask<Long> mask_l;
+    static VectorMask<Float> mask_f;
+    static VectorMask<Double> mask_d;
+
+    static {
+        ma = new boolean[LENGTH];
+        for (int i = 0; i < LENGTH; i++) {
+            ma[i] = i % 2 == 0;
+        }
+        mask_b = VectorMask.fromArray(B_SPECIES, ma, 0);
+        mask_s = VectorMask.fromArray(S_SPECIES, ma, 0);
+        mask_i = VectorMask.fromArray(I_SPECIES, ma, 0);
+        mask_l = VectorMask.fromArray(L_SPECIES, ma, 0);
+        mask_f = VectorMask.fromArray(F_SPECIES, ma, 0);
+        mask_d = VectorMask.fromArray(D_SPECIES, ma, 0);
+    }
+
+    @Test
+    @IR(counts = { IRNode.VECTOR_MASK_LANE_IS_SET, "= 6" }, applyIfCPUFeature = { "asimd", "true" })
+    @IR(counts = { IRNode.VECTOR_MASK_TO_LONG, "= 6" }, applyIfCPUFeature = { "avx2", "true" })
+    public static void testVectorMaskLaneIsSetByte_const() {
+        Asserts.assertEquals(ma[0], mask_b.laneIsSet(0));
+        Asserts.assertEquals(ma[0], mask_s.laneIsSet(0));
+        Asserts.assertEquals(ma[0], mask_i.laneIsSet(0));
+        Asserts.assertEquals(ma[0], mask_l.laneIsSet(0));
+        Asserts.assertEquals(ma[0], mask_f.laneIsSet(0));
+        Asserts.assertEquals(ma[0], mask_d.laneIsSet(0));
+    }
+
+    @Test
+    @IR(counts = { IRNode.VECTOR_MASK_LANE_IS_SET, "= 1" }, applyIfCPUFeature = { "asimd", "true" })
+    @IR(counts = { IRNode.VECTOR_MASK_TO_LONG, "= 1" }, applyIfCPUFeature = { "avx", "true" })
+    public static boolean testVectorMaskLaneIsSet_Byte_variable(int i) {
+        return mask_b.laneIsSet(i);
+    }
+
+    @Run(test = "testVectorMaskLaneIsSet_Byte_variable")
+    public static void testVectorMaskLaneIsSet_Byte_variable_runner() {
+        Asserts.assertEquals(ma[0], testVectorMaskLaneIsSet_Byte_variable(0));
+    }
+
+    @Test
+    @IR(counts = { IRNode.VECTOR_MASK_LANE_IS_SET, "= 1" }, applyIfCPUFeature = { "asimd", "true" })
+    @IR(counts = { IRNode.VECTOR_MASK_TO_LONG, "= 1" }, applyIfCPUFeature = { "avx", "true" })
+    public static boolean testVectorMaskLaneIsSet_Short_variable(int i) {
+        return mask_s.laneIsSet(i);
+    }
+
+    @Run(test = "testVectorMaskLaneIsSet_Short_variable")
+    public static void testVectorMaskLaneIsSet_Short_variable_runner() {
+        Asserts.assertEquals(ma[0], testVectorMaskLaneIsSet_Short_variable(0));
+    }
+
+    @Test
+    @IR(counts = { IRNode.VECTOR_MASK_LANE_IS_SET, "= 1" }, applyIfCPUFeature = { "asimd", "true" })
+    @IR(counts = { IRNode.VECTOR_MASK_TO_LONG, "= 1" }, applyIfCPUFeature = { "avx", "true" })
+    public static boolean testVectorMaskLaneIsSet_Int_variable(int i) {
+        return mask_i.laneIsSet(i);
+    }
+
+    @Run(test = "testVectorMaskLaneIsSet_Int_variable")
+    public static void testVectorMaskLaneIsSet_Int_variable_runner() {
+        Asserts.assertEquals(ma[0], testVectorMaskLaneIsSet_Int_variable(0));
+    }
+
+    @Test
+    @IR(counts = { IRNode.VECTOR_MASK_LANE_IS_SET, "= 1" }, applyIfCPUFeature = { "asimd", "true" })
+    @IR(counts = { IRNode.VECTOR_MASK_TO_LONG, "= 1" }, applyIfCPUFeature = { "avx2", "true" })
+    public static boolean testVectorMaskLaneIsSet_Long_variable(int i) {
+        return mask_l.laneIsSet(i);
+    }
+
+    @Run(test = "testVectorMaskLaneIsSet_Long_variable")
+    public static void testVectorMaskLaneIsSet_Long_variable_runner() {
+        Asserts.assertEquals(ma[0], testVectorMaskLaneIsSet_Long_variable(0));
+    }
+
+    @Test
+    @IR(counts = { IRNode.VECTOR_MASK_LANE_IS_SET, "= 1" }, applyIfCPUFeature = { "asimd", "true" })
+    @IR(counts = { IRNode.VECTOR_MASK_TO_LONG, "= 1" }, applyIfCPUFeature = { "avx", "true" })
+    public static boolean testVectorMaskLaneIsSet_Float_variable(int i) {
+        return mask_f.laneIsSet(i);
+    }
+
+    @Run(test = "testVectorMaskLaneIsSet_Float_variable")
+    public static void testVectorMaskLaneIsSet_Float_variable_runner() {
+        Asserts.assertEquals(ma[0], testVectorMaskLaneIsSet_Float_variable(0));
+    }
+
+    @Test
+    @IR(counts = { IRNode.VECTOR_MASK_LANE_IS_SET, "= 1" }, applyIfCPUFeature = { "asimd", "true" })
+    @IR(counts = { IRNode.VECTOR_MASK_TO_LONG, "= 1" }, applyIfCPUFeature = { "avx2", "true" })
+    public static boolean testVectorMaskLaneIsSet_Double_variable(int i) {
+        return mask_d.laneIsSet(i);
+    }
+
+    @Run(test = "testVectorMaskLaneIsSet_Double_variable")
+    public static void testVectorMaskLaneIsSet_Double_variable_runner() {
+        Asserts.assertEquals(ma[0], testVectorMaskLaneIsSet_Double_variable(0));
+    }
+
+    public static void main(String[] args) {
+        TestFramework testFramework = new TestFramework();
+        testFramework.setDefaultWarmup(10000)
+                     .addFlags("--add-modules=jdk.incubator.vector")
+                     .start();
+    }
+}

--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/VectorExtractBenchmark.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/VectorExtractBenchmark.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2023, Arm Limited. All rights reserved.
+ * Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +29,9 @@ import org.openjdk.jmh.annotations.*;
 
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Thread)
-@Fork(jvmArgs = {"--add-modules=jdk.incubator.vector"})
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(value = 1, jvmArgs = {"--add-modules=jdk.incubator.vector"})
 public class VectorExtractBenchmark {
     private int idx = 0;
     private boolean[] res = new boolean[8];


### PR DESCRIPTION
Intrinsic support for `VectorMask.laneIsSet` with a **variable** input index was introduced in PR #14200, but was inadvertently broken by PR #25673. This PR restores the intrinsic functionality and adds some JTReg tests.

Benchmarks on Nvidia Grace machine with 128-bit SVE:
```
Benchmark			            Unit	Before		Score Error	After		Score Error	Uplift
microMaskLaneIsSetByte128_var	ops/ms	21702.14415	91.902159	103472.9391	36.057447	4.767867
microMaskLaneIsSetByte64_var	ops/ms	21468.51868	107.94177	103365.6561	69.47736	4.814754
microMaskLaneIsSetDouble128_var	ops/ms	77489.32791	153.242699	413499.4127	311.854079	5.336211
microMaskLaneIsSetFloat128_var	ops/ms	41034.95204	399.421823	206840.0988	74.702234	5.040583
microMaskLaneIsSetFloat64_var	ops/ms	77607.40268	175.938921	413745.3001	149.716794	5.33126
microMaskLaneIsSetInt128_var	ops/ms	41452.48893	76.143208	206845.9754	59.371129	4.989953
microMaskLaneIsSetInt64_var	    ops/ms	77726.2542	173.180518	413427.8838	363.575023	5.319024
microMaskLaneIsSetLong128_var	ops/ms	77646.11218	177.496587	413403.4404	236.609314	5.3242
microMaskLaneIsSetShort128_var	ops/ms	21374.93265	48.13101	103417.4618	34.827021	4.838259
microMaskLaneIsSetShort64_var	ops/ms	41066.19395	353.320621	206801.109	106.408938	5.035799
```

Benchmarks on Intel 6444y machine with 512-bit avx3:
```
Benchmark			            Unit	Before		Score Error	After		Score Error	Uplift
microMaskLaneIsSetByte128_var	ops/ms	57658.45497	240.209309	211643.8406	29.214532	3.670647
microMaskLaneIsSetByte256_var	ops/ms	57451.68169	116.994128	211609.4652	160.48513	3.683259
microMaskLaneIsSetByte512_var	ops/ms	57530.22411	311.63868	199802.8084	408.144015	3.473005
microMaskLaneIsSetByte64_var	ops/ms	57642.2672	161.406221	205252.4464	196.86852	3.560797
microMaskLaneIsSetDouble256_var	ops/ms	114401.3789	231.797375	361400.344	565.593984	3.159055
microMaskLaneIsSetDouble512_var	ops/ms	57379.27882	159.699503	211476.1138	136.980026	3.685583
microMaskLaneIsSetFloat128_var	ops/ms	113943.9512	141.062663	360855.3915	494.471996	3.166955
microMaskLaneIsSetFloat256_var	ops/ms	57682.78182	138.142053	211659.5098	30.167972	3.66937
microMaskLaneIsSetFloat512_var	ops/ms	57617.66405	301.748599	211246.8588	597.18949	3.666355
microMaskLaneIsSetInt128_var	ops/ms	113914.5062	118.681382	360856.4465	555.097397	3.167783
microMaskLaneIsSetInt256_var	ops/ms	57681.79883	112.391639	211555.6742	217.556981	3.667633
microMaskLaneIsSetInt512_var	ops/ms	57350.20346	206.146723	211657.7207	68.461571	3.690618
microMaskLaneIsSetLong256_var	ops/ms	113838.3822	415.784529	360782.0645	710.076899	3.169247
microMaskLaneIsSetLong512_var	ops/ms	57314.02695	190.1762	211690.8492	26.47233	3.693526
microMaskLaneIsSetShort128_var	ops/ms	57675.58965	65.940976	211549.9551	276.57545	3.667928
microMaskLaneIsSetShort256_var	ops/ms	57628.8642	91.957833	211694.0864	16.559412	3.673403
microMaskLaneIsSetShort512_var	ops/ms	57845.35211	160.537421	211358.872	660.777147	3.65386
microMaskLaneIsSetShort64_var	ops/ms	113848.8846	222.787418	360294.6295	491.425656	3.164674
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8366588](https://bugs.openjdk.org/browse/JDK-8366588): VectorAPI: Re-intrinsify VectorMask.laneIsSet where the input index is a variable (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Xiaohong Gong](https://openjdk.org/census#xgong) (@XiaohongGong - Committer)
 * [Emanuel Peter](https://openjdk.org/census#epeter) (@eme64 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27113/head:pull/27113` \
`$ git checkout pull/27113`

Update a local copy of the PR: \
`$ git checkout pull/27113` \
`$ git pull https://git.openjdk.org/jdk.git pull/27113/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27113`

View PR using the GUI difftool: \
`$ git pr show -t 27113`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27113.diff">https://git.openjdk.org/jdk/pull/27113.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27113#issuecomment-3257489478)
</details>
