### PR TITLE
8366787: Test runtime/StackGuardPages/TestStackGuardPagesNative.java hangs on some platforms

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -106,6 +106,7 @@ runtime/os/TestTracePageSizes.java#compiler-options 8267460 linux-aarch64
 runtime/os/TestTracePageSizes.java#G1 8267460 linux-aarch64
 runtime/os/TestTracePageSizes.java#Parallel 8267460 linux-aarch64
 runtime/os/TestTracePageSizes.java#Serial 8267460 linux-aarch64
+runtime/StackGuardPages/TestStackGuardPagesNative.java 8303612 linux-all
 runtime/ErrorHandling/MachCodeFramesInErrorFile.java 8313315 linux-ppc64le
 runtime/NMT/VirtualAllocCommitMerge.java 8309698 linux-s390x
 


### PR DESCRIPTION
#### Summary

This PR fixes a hang in the `TestStackGuardPagesNative.java` test that occurs on certain Linux distributions (e.g., CentOS 7). The fix replaces an unbounded `for(;;)` loop in the native test code (`exeinvoke.c`) with a bounded `while` loop, making the test's behavior deterministic and robust across all platforms.

#### Problem

The test would hang and eventually time out on some platforms. This was caused by an unbounded `for(;;)` loop in the `do_overflow` function, which was introduced as part of the "hardening" fix in `JDK-8295344`.

*   On platforms like **CentOS 7**, this unbounded loop would not encounter a terminating signal in a timely manner, causing the native process to hang indefinitely until killed by the test harness.
*   In contrast, on platforms like **Ubuntu 24**, the test would coincidentally pass because a `SEGV_MAPERR` would happen to terminate the loop. This highlighted that the test's success was reliant on platform-specific side effects, masking the underlying issue.

#### Solution

The solution is to replace the unbounded `for(;;)` loop with a bounded `while` loop. The condition `while (_kp_rec_count == 0 || _rec_count < _kp_rec_count)` ensures that the loop terminates deterministically after a specific number of allocations, corresponding to the overflow depth detected in the test's first phase.

This change makes the test's logic robust and its behavior consistent across different environments.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8366787](https://bugs.openjdk.org/browse/JDK-8366787): Test runtime/StackGuardPages/TestStackGuardPagesNative.java hangs on some platforms (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27114/head:pull/27114` \
`$ git checkout pull/27114`

Update a local copy of the PR: \
`$ git checkout pull/27114` \
`$ git pull https://git.openjdk.org/jdk.git pull/27114/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27114`

View PR using the GUI difftool: \
`$ git pr show -t 27114`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27114.diff">https://git.openjdk.org/jdk/pull/27114.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27114#issuecomment-3257782569)
</details>
