### PR TITLE
8366970: CPUTimeUsage: Add comment about usage during VM exit

### DIFF
--- a/src/hotspot/share/services/cpuTimeUsage.hpp
+++ b/src/hotspot/share/services/cpuTimeUsage.hpp
@@ -28,6 +28,9 @@
 #include "memory/allStatic.hpp"
 #include "utilities/globalDefinitions.hpp"
 
+// It may be unsafe to call these methods during VM exit
+// as threads are terminating
+
 namespace CPUTimeUsage {
   class GC : public AllStatic {
   public:


### PR DESCRIPTION
Some of the methods in CPUTimeUsage make a query on the underlying threads. Calling those methods during VM exit is therefore unsafe. This PR adds a comment to provide clarification.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8366970](https://bugs.openjdk.org/browse/JDK-8366970): CPUTimeUsage: Add comment about usage during VM exit (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27115/head:pull/27115` \
`$ git checkout pull/27115`

Update a local copy of the PR: \
`$ git checkout pull/27115` \
`$ git pull https://git.openjdk.org/jdk.git pull/27115/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27115`

View PR using the GUI difftool: \
`$ git pr show -t 27115`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27115.diff">https://git.openjdk.org/jdk/pull/27115.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27115#issuecomment-3257841118)
</details>
