### PR TITLE
8366908: Use a different class for testing JDK-8351654

### DIFF
--- a/test/hotspot/jtreg/runtime/verifier/CFLH/TestVerify.java
+++ b/test/hotspot/jtreg/runtime/verifier/CFLH/TestVerify.java
@@ -39,7 +39,6 @@
  */
 
 import java.lang.invoke.MethodHandles;
-import java.time.Duration;
 import java.lang.classfile.ClassFile;
 import java.lang.classfile.ClassTransform;
 import java.lang.classfile.MethodTransform;
@@ -61,7 +60,7 @@ import java.io.FileNotFoundException;
 
 public class TestVerify {
 
-    private static final String CLASS_TO_BREAK = "java.time.Duration";
+    private static final String CLASS_TO_BREAK = "java.util.Date";
     private static final String INTERNAL_CLASS_TO_BREAK = CLASS_TO_BREAK.replace('.', '/');
     private static final boolean DEBUG = false;
 
@@ -91,7 +90,7 @@ public class TestVerify {
                     }
                     builder.with(element);
                 });
-                var classTransform = ClassTransform.transformingMethods(mm -> mm.methodName().stringValue().equals("getSeconds"), methodTransform);
+                var classTransform = ClassTransform.transformingMethods(mm -> mm.methodName().stringValue().equals("parse"), methodTransform);
 
                 byte[] bytes;
                 try {
@@ -164,7 +163,8 @@ public class TestVerify {
             } else {
                 // Load the class instrumented with CFLH for the VerifyError.
                 inst.addTransformer(new BadTransformer());
-                System.out.println("1 hour is " + Duration.ofHours(1).getSeconds() + " seconds");
+                Class<?> cls = Class.forName(CLASS_TO_BREAK);
+                System.out.println("class loaded" + cls);
             }
             throw new RuntimeException("Failed: Did not throw VerifyError");
         } catch (VerifyError e) {


### PR DESCRIPTION
java.time.Duration is a migrated class (to be a value type) in the Valhalla repo, so it's preloaded, which causes this test to fail.  Using a different java.base class achieves the purpose of this test.
Tested with tier1.