### PR TITLE
8366875: CompileTaskTimeout should be reset for each iteration of RepeatCompilation

### DIFF
--- a/src/hotspot/os/linux/compilerThreadTimeout_linux.hpp
+++ b/src/hotspot/os/linux/compilerThreadTimeout_linux.hpp
@@ -46,6 +46,10 @@ class CompilerThreadTimeoutLinux : public CHeapObj<mtCompiler> {
   bool init_timeout();
   void arm();
   void disarm();
+  void reset() {
+    disarm();
+    arm();
+  };
 };
 
 #endif //LINUX_COMPILER_THREAD_TIMEOUT_LINUX_HPP

--- a/src/hotspot/share/compiler/compileBroker.cpp
+++ b/src/hotspot/share/compiler/compileBroker.cpp
@@ -2346,6 +2346,7 @@ void CompileBroker::invoke_compiler_on_method(CompileTask* task) {
       while (repeat_compilation_count > 0) {
         ResourceMark rm(thread);
         task->print_ul("NO CODE INSTALLED");
+        thread->timeout()->reset();
         comp->compile_method(&ci_env, target, osr_bci, false, directive);
         repeat_compilation_count--;
       }

--- a/src/hotspot/share/compiler/compilerThread.hpp
+++ b/src/hotspot/share/compiler/compilerThread.hpp
@@ -51,6 +51,7 @@ class CompilerThreadTimeoutGeneric : public CHeapObj<mtCompiler> {
   CompilerThreadTimeoutGeneric() {};
   void arm() {};
   void disarm() {};
+  void reset() {};
   bool init_timeout() { return true; };
 };
 #endif // !LINUX


### PR DESCRIPTION
When running a debug JVM on Linux with a compile task timeout and repeated compilation, the execution will time out almost always because the timeout does not reset for repetitions of a compilation. The core of the compile task timeout is to limit the amount of time a single compilation can take. Thus, this PR resets the `CompileTaskTimeout` for every compilation when running with `-XX:RepeatCompilation=<n>` for n > 1.

Testing:
 - [ ] Github Actions
 - [x] tier1, tier2, tier3 plus some additional internal testing