### PR TITLE
8330341: Wrap call to MT in ExecuteWithLog

### DIFF
--- a/make/common/native/LinkMicrosoft.gmk
+++ b/make/common/native/LinkMicrosoft.gmk
@@ -113,9 +113,10 @@ define CreateDynamicLibraryOrExecutableMicrosoft
 	  $$(CHMOD) +x $$($1_TARGET)
         endif
         ifneq ($$($1_MANIFEST), )
-	  $$($1_MT) -nologo -manifest $$($1_MANIFEST) \
-	      -identity:"$$($1_NAME).exe, version=$$($1_MANIFEST_VERSION)" \
-	      -outputresource:$$@;#1
+	  $$(call ExecuteWithLog, $$($1_OBJECT_DIR)/$$($1_SAFE_NAME)_run_mt, \
+	      $$($1_MT) -nologo -manifest $$($1_MANIFEST) \
+	          -identity:"$$($1_NAME).exe$$(COMMA) version=$$($1_MANIFEST_VERSION)" \
+	          '-outputresource:$$($1_TARGET);$$(HASH)1')
         endif
         ifneq ($(SIGNING_HOOK), )
 	  $$(call ExecuteWithLog, $$($1_OBJECT_DIR)/$$($1_SAFE_NAME)_call_signing_hook, \


### PR DESCRIPTION
We should wrap the call to `mt` in `ExecuteWithLog`. I tried to do this earlier but ran into problems with the tricky command line. The solution was to use `$$(COMMA)` (and `$$(HASH)`); I'm not sure why I did not see this before.

I also noted that there is an actual bug in the MT command line -- the trailing `;#1` is not protected from the shell, so the command line will end after `-outputresource:$$@`, and then a new command -- the comment `#1` which does nothing, will be executed. This works out anyway since if you leave out the resource identifier index the value of `CREATEPROCESS_MANIFEST_RESOURCE` will be used by default, and that happens to be 1.
 (See https://learn.microsoft.com/en-us/windows/win32/sbscs/mt-exe)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8330341](https://bugs.openjdk.org/browse/JDK-8330341): Wrap call to MT in ExecuteWithLog (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27124/head:pull/27124` \
`$ git checkout pull/27124`

Update a local copy of the PR: \
`$ git checkout pull/27124` \
`$ git pull https://git.openjdk.org/jdk.git pull/27124/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27124`

View PR using the GUI difftool: \
`$ git pr show -t 27124`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27124.diff">https://git.openjdk.org/jdk/pull/27124.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27124#issuecomment-3261673250)
</details>
