### PR TITLE
8366850

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -749,6 +749,10 @@ java/util/zip/CloseInflaterDeflaterTest.java  8339216 linux-s390x
 
 sun/tools/jstatd/TestJstatdRmiPort.java                         8251259,8293577 generic-all
 
+<<<<<<< Updated upstream
+=======
+
+>>>>>>> Stashed changes
 ############################################################################
 
 # jdk_other

--- a/test/jdk/com/sun/jdi/JdbStopInNotificationThreadTest.java
+++ b/test/jdk/com/sun/jdi/JdbStopInNotificationThreadTest.java
@@ -113,7 +113,7 @@ public class JdbStopInNotificationThreadTest extends JdbTest {
     private static final String DEBUGGEE_CLASS = JdbStopInNotificationThreadTestTarg.class.getName();
     private static final String PATTERN1_TEMPLATE = "^Breakpoint hit: \"thread=Notification Thread\", " +
             "JdbStopInNotificationThreadTestTarg\\$1\\.handleNotification\\(\\), line=%LINE_NUMBER.*\\R%LINE_NUMBER\\s+System\\.out\\.println\\(\"Memory usage low!!!\"\\);.*";
-    private static final String[] DEBUGGEE_OPTIONS = {"-Xmx64M"};
+    private static final String[] DEBUGGEE_OPTIONS = {"-Xmx256M"};
 
     private JdbStopInNotificationThreadTest() {
         super(new LaunchOptions(DEBUGGEE_CLASS)


### PR DESCRIPTION
In order to make this test run faster, its heap size was reduced to 64m. This proved to be too small resulting in sometimes exceeding 10% usage before the notification can be setup. This meant that once the memory consumption loop started, it never stopped until OOME (it's suppose to stop when 10% usage has been achieved). I tried 128m and that also proved to be too small when using ZGC and -Xcomp. 256m seems to be enough. I tested 10x times on all our debug platforms with ZGC, ZGC + -Xcomp, and G1 + -Xcomp.