### PR TITLE
8366561: Improve documentation for how the -Xlint flag works

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Lint.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Lint.java
@@ -160,25 +160,20 @@ public class Lint {
             // if -Xlint:none is given, disable all categories by default
             values = LintCategory.newEmptySet();
         } else {
-            // otherwise, enable on-by-default categories
-            values = LintCategory.newEmptySet();
 
+            // Otherwise, enable the on-by-default categories; for some categories,
+            // whether the category is on by default depends on other options.
+            values = LintCategory.newEmptySet();
             Source source = Source.instance(context);
-            if (source.compareTo(Source.JDK9) >= 0) {
-                values.add(LintCategory.DEP_ANN);
-            }
-            if (Source.Feature.REDUNDANT_STRICTFP.allowedInSource(source)) {
-                values.add(LintCategory.STRICTFP);
-            }
-            values.add(LintCategory.REQUIRES_TRANSITIVE_AUTOMATIC);
-            values.add(LintCategory.OPENS);
-            values.add(LintCategory.MODULE);
-            values.add(LintCategory.REMOVAL);
-            if (!options.isSet(Option.PREVIEW)) {
-                values.add(LintCategory.PREVIEW);
-            }
-            values.add(LintCategory.IDENTITY);
-            values.add(LintCategory.INCUBATING);
+            Stream.of(LintCategory.values())
+              .filter(lc ->
+                switch (lc) {
+                    case DEP_ANN  -> source.compareTo(Source.JDK9) >= 0;
+                    case STRICTFP -> Source.Feature.REDUNDANT_STRICTFP.allowedInSource(source);
+                    case PREVIEW  -> !options.isSet(Option.PREVIEW);
+                    default       -> lc.enabledByDefault;
+                })
+              .forEach(values::add);
         }
 
         // Look for specific overrides
@@ -221,7 +216,7 @@ public class Lint {
          * <p>
          * This category is not supported by {@code @SuppressWarnings}.
          */
-        CLASSFILE("classfile", false),
+        CLASSFILE("classfile", false, false),
 
         /**
          * Warn about "dangling" documentation comments,
@@ -238,7 +233,7 @@ public class Lint {
          * Warn about items which are documented with an {@code @deprecated} JavaDoc
          * comment, but which do not have {@code @Deprecated} annotation.
          */
-        DEP_ANN("dep-ann"),
+        DEP_ANN("dep-ann", true, true),
 
         /**
          * Warn about division by constant integer 0.
@@ -268,7 +263,7 @@ public class Lint {
         /**
          * Warn about uses of @ValueBased classes where an identity class is expected.
          */
-        IDENTITY("identity", true, "synchronization"),
+        IDENTITY("identity", true, true, "synchronization"),
 
         /**
          * Warn about use of incubating modules.
@@ -276,7 +271,7 @@ public class Lint {
          * <p>
          * This category is not supported by {@code @SuppressWarnings}.
          */
-        INCUBATING("incubating", false),
+        INCUBATING("incubating", false, true),
 
         /**
           * Warn about compiler possible lossy conversions.
@@ -291,12 +286,12 @@ public class Lint {
         /**
          * Warn about module system related issues.
          */
-        MODULE("module"),
+        MODULE("module", true, true),
 
         /**
          * Warn about issues regarding module opens.
          */
-        OPENS("opens"),
+        OPENS("opens", true, true),
 
         /**
          * Warn about issues relating to use of command line options.
@@ -304,7 +299,7 @@ public class Lint {
          * <p>
          * This category is not supported by {@code @SuppressWarnings}.
          */
-        OPTIONS("options", false),
+        OPTIONS("options", false, false),
 
         /**
          * Warn when any output file is written to more than once.
@@ -312,7 +307,7 @@ public class Lint {
          * <p>
          * This category is not supported by {@code @SuppressWarnings}.
          */
-        OUTPUT_FILE_CLASH("output-file-clash", false),
+        OUTPUT_FILE_CLASH("output-file-clash", false, false),
 
         /**
          * Warn about issues regarding method overloads.
@@ -330,7 +325,7 @@ public class Lint {
          * <p>
          * This category is not supported by {@code @SuppressWarnings}.
          */
-        PATH("path", false),
+        PATH("path", false, false),
 
         /**
          * Warn about issues regarding annotation processing.
@@ -345,7 +340,7 @@ public class Lint {
         /**
          * Warn about use of deprecated-for-removal items.
          */
-        REMOVAL("removal"),
+        REMOVAL("removal", true, true),
 
         /**
          * Warn about use of automatic modules in the requires clauses.
@@ -355,7 +350,7 @@ public class Lint {
         /**
          * Warn about automatic modules in requires transitive.
          */
-        REQUIRES_TRANSITIVE_AUTOMATIC("requires-transitive-automatic"),
+        REQUIRES_TRANSITIVE_AUTOMATIC("requires-transitive-automatic", true, true),
 
         /**
          * Warn about Serializable classes that do not provide a serial version ID.
@@ -370,7 +365,7 @@ public class Lint {
         /**
          * Warn about unnecessary uses of the strictfp modifier
          */
-        STRICTFP("strictfp"),
+        STRICTFP("strictfp", true, true),
 
         /**
          * Warn about issues relating to use of text blocks
@@ -400,7 +395,7 @@ public class Lint {
         /**
          * Warn about use of preview features.
          */
-        PREVIEW("preview"),
+        PREVIEW("preview", true, true),
 
         /**
          * Warn about use of restricted methods.
@@ -408,12 +403,13 @@ public class Lint {
         RESTRICTED("restricted");
 
         LintCategory(String option) {
-            this(option, true);
+            this(option, true, false);
         }
 
-        LintCategory(String option, boolean annotationSuppression, String... aliases) {
+        LintCategory(String option, boolean annotationSuppression, boolean enabledByDefault, String... aliases) {
             this.option = option;
             this.annotationSuppression = annotationSuppression;
+            this.enabledByDefault = enabledByDefault;
             ArrayList<String> optionList = new ArrayList<>(1 + aliases.length);
             optionList.add(option);
             Collections.addAll(optionList, aliases);
@@ -450,6 +446,12 @@ public class Lint {
 
         /** Does this category support being suppressed by the {@code @SuppressWarnings} annotation? */
         public final boolean annotationSuppression;
+
+        /**
+         * Is this category included in the default set of enabled lint categories?
+         * Note that for some categories, command line options can alter this at runtime.
+         */
+        public final boolean enabledByDefault;
     }
 
     /**

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/javac.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/javac.properties
@@ -168,18 +168,19 @@ javac.opt.Xbootclasspath.p=\
 javac.opt.Xbootclasspath.a=\
     Append to the bootstrap class path
 javac.opt.Xlint=\
-    Enable recommended warning categories
+    Enable all lint warning categories
 javac.opt.Xlint.all=\
-    Enable all warning categories
+    Enable all lint warning categories
 javac.opt.Xlint.none=\
-    Disable all warning categories
+    Disable all lint warning categories
 #L10N: do not localize: -Xlint
 javac.opt.arg.Xlint=\
     <key>(,<key>)*
 javac.opt.Xlint.custom=\
-    Warning categories to enable or disable, separated by comma.\n\
-    Precede a key by ''-'' to disable the specified warning.\n\
-    Use --help-lint to see the supported keys.
+    Lint warning categories to enable or disable, separated by comma.\n\
+    Precede a key by ''-'' to disable the specified category. Use\n\
+    ''--help-lint'' to show supported keys and which categories are\n\
+    enabled by default.
 javac.opt.Xlint.desc.auxiliaryclass=\
     Warn about an auxiliary class that is hidden in a source file, and is used from other files.
 
@@ -291,15 +292,12 @@ javac.opt.Xlint.desc.preview=\
 javac.opt.Xlint.desc.restricted=\
     Warn about use of restricted methods.
 
-# L10N: do not localize: identity synchronization
-javac.opt.Xlint.desc.synchronization=\
-    Warn about synchronization attempts on instances of value-based classes.\n\
-\                         This key is a deprecated alias for ''identity'', which has the same uses and\n\
-\                         effects. Users are encouraged to use the ''identity'' category for all future\n\
-\                         and existing uses of ''synchronization''.
-
 javac.opt.Xlint.desc.identity=\
     Warn about uses of value-based classes where an identity class is expected.
+
+javac.opt.Xlint.alias.of=\
+    Deprecated alias for ''{0}'' with an identical effect. Users are encouraged to use\n\
+\                         ''{0}'' instead of ''{1}'' for all current and future uses.
 
 javac.opt.Xdoclint=\
     Enable recommended checks for problems in javadoc comments
@@ -334,6 +332,10 @@ javac.opt.help.lint=\
     Print the supported keys for -Xlint
 javac.opt.help.lint.header=\
     The supported keys for -Xlint are:
+javac.opt.help.lint.footer=\
+    Lint categories marked with ''*'' are in the default set of enabled categories.\n\
+    Categories and their aliases can be used interchangeably; for example, the flag\n\
+    ''-Xlint:{0},{1}'' would be redundant.
 javac.opt.print=\
     Print out a textual representation of specified types
 javac.opt.printRounds=\
@@ -346,8 +348,9 @@ javac.opt.userpathsfirst=\
 javac.opt.prefer=\
     Specify which file to read when both a source file and class file\n\
     are found for an implicitly compiled class
+# L10N: do not localize: ''preview''
 javac.opt.preview=\
-    Enable preview language features.\n\
+    Enable preview language features. Also disables the ''preview'' lint category.\n\
     To be used in conjunction with either -source or --release.
 javac.opt.AT=\
     Read options and filenames from file

--- a/src/jdk.compiler/share/classes/module-info.java
+++ b/src/jdk.compiler/share/classes/module-info.java
@@ -152,7 +152,6 @@ import javax.tools.StandardLocation;
  * <tr><th scope="row">{@code auxiliaryclass}       <td>an auxiliary class that is hidden in a source file, and is used
  *                                                      from other files
  * <tr><th scope="row">{@code cast}                 <td>use of unnecessary casts
- * <tr><th scope="row">{@code classfile}            <td>issues related to classfile contents
  * <tr><th scope="row">{@code dangling-doc-comments} <td>issues related to "dangling" documentation comments,
  *                                                       not attached to a declaration
  * <tr><th scope="row">{@code deprecation}          <td>use of deprecated items
@@ -165,7 +164,6 @@ import javax.tools.StandardLocation;
  *                                                      the next
  * <tr><th scope="row">{@code finally}              <td>{@code finally} clauses that do not terminate normally
  * <tr><th scope="row">{@code identity}             <td>use of a value-based class where an identity class is expected
- * <tr><th scope="row">{@code incubating}           <td>use of incubating modules
  * <tr><th scope="row">{@code lossy-conversions}    <td>possible lossy conversions in compound assignment
  * <tr><th scope="row">{@code missing-explicit-ctor} <td>missing explicit constructors in public and protected classes
  *                                                      in exported packages
@@ -173,13 +171,13 @@ import javax.tools.StandardLocation;
  * <tr><th scope="row">{@code opens}                <td>issues regarding module opens
  * <tr><th scope="row">{@code overloads}            <td>issues regarding method overloads
  * <tr><th scope="row">{@code overrides}            <td>issues regarding method overrides
- * <tr><th scope="row">{@code path}                 <td>invalid path elements on the command line
  * <tr><th scope="row">{@code preview}              <td>use of preview language features
+ * <tr><th scope="row">{@code processing}           <td>issues regarding annotation processing
  * <tr><th scope="row">{@code rawtypes}             <td>use of raw types
  * <tr><th scope="row">{@code removal}              <td>use of API that has been marked for removal
- * <tr><th scope="row">{@code restricted}           <td>use of restricted methods
  * <tr><th scope="row">{@code requires-automatic}   <td>use of automatic modules in the {@code requires} clauses
  * <tr><th scope="row">{@code requires-transitive-automatic} <td>automatic modules in {@code requires transitive}
+ * <tr><th scope="row">{@code restricted}           <td>use of restricted methods
  * <tr><th scope="row">{@code serial}               <td>{@link java.base/java.io.Serializable Serializable} classes
  *                                                      that do not have a {@code serialVersionUID} field, or other
  *                                                      suspect declarations in {@code Serializable} and
@@ -187,11 +185,9 @@ import javax.tools.StandardLocation;
  *                                                      and interfaces
  * <tr><th scope="row">{@code static}               <td>accessing a static member using an instance
  * <tr><th scope="row">{@code strictfp}             <td>unnecessary use of the {@code strictfp} modifier
- * <tr><th scope="row">{@code synchronization}      <td>synchronization attempts on instances of value-based classes;
- *                                                      this key is a deprecated alias for {@code identity}, which has
- *                                                      the same uses and effects. Users are encouraged to use the
- *                                                      {@code identity} category for all future and existing uses of
- *                                                      {@code synchronization}
+ * <tr><th scope="row">{@code synchronization}      <td>deprecated alias for {@code identity} with an identical effect.
+ *                                                      Users are encouraged to use {@code identity} instead of
+ *                                                      {@code synchronization} for all current and future uses.
  * <tr><th scope="row">{@code text-blocks}          <td>inconsistent white space characters in text block indentation
  * <tr><th scope="row">{@code this-escape}          <td>superclass constructor leaking {@code this} before subclass initialized
  * <tr><th scope="row">{@code try}                  <td>issues relating to use of {@code try} blocks


### PR DESCRIPTION
This is a documentation-only change to improve compiler documentation around the `-Xlint` flag and lint categories.

* Changes to `--help-lint` output:
  * Sort lint categories and aliases alphabetically together
  * Indicate which lint categories are enabled by default
  * Tighten up "alias" verbiage and generalize it to work with future category aliases
  * Add a footer blurb clarifying that aliases are interchangeable with their primary keys

* Changes to `--help-extra` output:
  * Note that some categories are enabled by default even without a `-Xlint` flag
  * Refer to "lint warning categories" instead of "warning categories" when appropriate

* Changes to `--help` output:
  * Note that `--enable-preview` disables the `preview` lint category (otherwise enabled by default)

* Changes to `module-info.java` javadoc:
  * Remove lint categories not actually supported by `@SuppressWarnings` from the list of such
  * Add missing entry for category `processing`
