### PR TITLE
8367021: Regression in LocaleDataTest refactoring

### DIFF
--- a/test/jdk/sun/text/resources/LocaleDataTest.java
+++ b/test/jdk/sun/text/resources/LocaleDataTest.java
@@ -41,7 +41,7 @@
  *      8187946 8195478 8181157 8179071 8193552 8202026 8204269 8202537 8208746
  *      8209775 8221432 8227127 8230284 8231273 8233579 8234288 8250665 8255086
  *      8251317 8274658 8283277 8283805 8265315 8287868 8295564 8284840 8296715
- *      8301206 8303472 8317979 8306116 8174269 8333582 8357075 8357882
+ *      8301206 8303472 8317979 8306116 8174269 8333582 8357075 8357882 8367021
  * @summary Verify locale data
  * @modules java.base/sun.util.resources
  * @modules jdk.localedata
@@ -204,7 +204,7 @@ public class LocaleDataTest
             in = new BufferedReader(new InputStreamReader(new
                             FileInputStream(localeData), StandardCharsets.UTF_8));
         }
-        out = new PrintWriter(new OutputStreamWriter(System.out, StandardCharsets.UTF_8));
+        out = new PrintWriter(new OutputStreamWriter(System.out, StandardCharsets.UTF_8), true);
 
         // perform the actual test
         int errorCount = doTest(in, out, writeNewFile);


### PR DESCRIPTION
A small fix to a locale test regression. Auto flush was incorrectly set to default (= false) by the prior fix.