### PR TITLE
8367027: java/lang/ProcessBuilder/Basic.java fails on Windows AArch64

### DIFF
--- a/test/jdk/java/lang/ProcessBuilder/Basic.java
+++ b/test/jdk/java/lang/ProcessBuilder/Basic.java
@@ -212,7 +212,7 @@ public class Basic {
 
     private static String winEnvFilter(String env) {
         return env.replaceAll("\r", "")
-            .replaceAll("(?m)^(?:COMSPEC|PROMPT|PATHEXT)=.*\n","");
+            .replaceAll("(?m)^(?:COMSPEC|PROMPT|PATHEXT|PROCESSOR_ARCHITECTURE)=.*\n","");
     }
 
     private static String unixEnvProg() {
@@ -811,6 +811,14 @@ public class Basic {
         return vars.replace("AIXTHREAD_GUARDPAGES=0,", "");
     }
 
+    /* Only used for Windows AArch64 --
+     * Windows AArch64 adds the variable PROCESSOR_ARCHITECTURE=ARM64 to the environment.
+     * Remove it from the list of env variables
+     */
+    private static String removeWindowsAArch64ExpectedVars(String vars) {
+        return vars.replace("PROCESSOR_ARCHITECTURE=ARM64,", "");
+    }
+
     private static String sortByLinesWindowsly(String text) {
         String[] lines = text.split("\n");
         Arrays.sort(lines, new WindowsComparator());
@@ -1320,6 +1328,9 @@ public class Basic {
             }
             if (AIX.is()) {
                 result = removeAixExpectedVars(result);
+            }
+            if (Windows.is() && Platform.isAArch64()) {
+                result = removeWindowsAArch64ExpectedVars(result);
             }
             equal(result, expected);
         } catch (Throwable t) { unexpected(t); }
@@ -1833,6 +1844,9 @@ public class Basic {
             if (AIX.is()) {
                 commandOutput = removeAixExpectedVars(commandOutput);
             }
+            if (Windows.is() && Platform.isAArch64()) {
+                commandOutput = removeWindowsAArch64ExpectedVars(commandOutput);
+            }
             equal(commandOutput, expected);
             if (Windows.is()) {
                 ProcessBuilder pb = new ProcessBuilder(childArgs);
@@ -1840,7 +1854,11 @@ public class Basic {
                 pb.environment().put("SystemRoot", systemRoot);
                 pb.environment().put("=ExitValue", "3");
                 pb.environment().put("=C:", "\\");
-                equal(commandOutput(pb), expected);
+                commandOutput = commandOutput(pb);
+                if (Platform.isAArch64()) {
+                    commandOutput = removeWindowsAArch64ExpectedVars(commandOutput);
+                }
+                equal(commandOutput, expected);
             }
         } catch (Throwable t) { unexpected(t); }
 
@@ -1891,6 +1909,9 @@ public class Basic {
             }
             if (AIX.is()) {
                 commandOutput = removeAixExpectedVars(commandOutput);
+            }
+            if (Windows.is() && Platform.isAArch64()) {
+                commandOutput = removeWindowsAArch64ExpectedVars(commandOutput);
             }
             check(commandOutput.equals(Windows.is()
                     ? "LC_ALL=C,SystemRoot="+systemRoot+","


### PR DESCRIPTION
This test fails with errors like >'=C:=,=ExitValue=3,PROCESSOR_ARCHITECTURE=ARM64,SystemRoot=C:\Windows,'< not equal to '=C:=,=ExitValue=3,SystemRoot=C:\Windows,'

The test does not expect the PROCESSOR_ARCHITECTURE variable to be returned from the ProcessBuilder (called at https://github.com/openjdk/jdk/blob/431f46724658b703e995e518cb7a2149c50d6a9d/test/jdk/java/lang/ProcessBuilder/Basic.java#L127 for example). The fix is to treat it as an expected variable and strip it out from the results, similar to how macOS and AIX strip out their expected variables.

The winEnvFilter method needs to be updated because some checks like https://github.com/openjdk/jdk/blob/431f46724658b703e995e518cb7a2149c50d6a9d/test/jdk/java/lang/ProcessBuilder/Basic.java#L1694 have the output on separate lines as opposed to the inline comma-separated format where removeWindowsAArch64ExpectedVars is used.