### PR TITLE
8367048: RISC-V: Correct pipeline descriptions of the architecture

### DIFF
--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -3840,7 +3840,7 @@ attributes %{
   // Up to 4 instructions per bundle
   max_instructions_per_bundle = 4;
 
-  // The RISC-V processor 64 bytes...
+  // The RISC-V processor fetches 64 bytes...
   instruction_fetch_unit_size = 64;
 
   // ...in one line.

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -3833,13 +3833,18 @@ opclass immIorL(immI, immL);
 pipeline %{
 
 attributes %{
-  // RISC-V instructions are of fixed length
-  fixed_size_instructions;           // Fixed size instructions TODO does
-  max_instructions_per_bundle = 2;   // Generic RISC-V 1, Sifive Series 7 2
-  // RISC-V instructions come in 32-bit word units
-  instruction_unit_size = 4;         // An instruction is 4 bytes long
-  instruction_fetch_unit_size = 64;  // The processor fetches one line
-  instruction_fetch_units = 1;       // of 64 bytes
+  // RISC-V instructions are of length 2 or 4 bytes.
+  variable_size_instructions;
+  instruction_unit_size = 2;
+
+  // Up to 4 instructions per bundle
+  max_instructions_per_bundle = 4;
+
+  // The RISC-V processor 64 bytes...
+  instruction_fetch_unit_size = 64;
+
+  // ...in one line.
+  instruction_fetch_units = 1;
 
   // List of nop instructions
   nops( MachNop );


### PR DESCRIPTION
Hi,
Can you help to review this patch? Thanks!

This patch updates the RISC-V pipeline attributes to variable_size_instructions to properly account for the 2-byte compressed instructions from the C extension. 
Furthermore, it increases the max_instructions_per_bundle to 4 and adjusts the instruction_unit_size to match 4-issue RISC-V hardware like the UR-CP100.

### Test
- [x] Run tier1 and tier2 on sg2042

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8367048](https://bugs.openjdk.org/browse/JDK-8367048): RISC-V: Correct pipeline descriptions of the architecture (**Enhancement** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Feilong Jiang](https://openjdk.org/census#fjiang) (@feilongjiang - Committer) Review applies to [99846cd6](https://git.openjdk.org/jdk/pull/27134/files/99846cd6d9445de704660b7c94978bba946ffd48)
 * [Hamlin Li](https://openjdk.org/census#mli) (@Hamlin-Li - **Reviewer**) Review applies to [99846cd6](https://git.openjdk.org/jdk/pull/27134/files/99846cd6d9445de704660b7c94978bba946ffd48)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27134/head:pull/27134` \
`$ git checkout pull/27134`

Update a local copy of the PR: \
`$ git checkout pull/27134` \
`$ git pull https://git.openjdk.org/jdk.git pull/27134/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27134`

View PR using the GUI difftool: \
`$ git pr show -t 27134`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27134.diff">https://git.openjdk.org/jdk/pull/27134.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27134#issuecomment-3264741459)
</details>
