### PR TITLE
8367066: RISC-V: refine register selection in MacroAssembler:: decode_klass_not_null

### DIFF
--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -3421,8 +3421,9 @@ void MacroAssembler::decode_klass_not_null(Register dst, Register src, Register 
   mv(xbase, (uintptr_t)CompressedKlassPointers::base());
 
   if (CompressedKlassPointers::shift() != 0) {
-    Register t = src == dst ? dst : t0;
+    Register t = dst == xbase ? t0 : dst;
     assert_different_registers(t, xbase);
+    // dst = (src << shift) + xbase
     shadd(dst, src, xbase, t, CompressedKlassPointers::shift());
   } else {
     add(dst, xbase, src);


### PR DESCRIPTION
Hi,
Can you help to review this patch?

Previously, the register selection in MacroAssembler:: decode_klass_not_null is misleading, better to refine it to improve the readability.

Thanks!

Running runtime test tier1/2/3...