### PR TITLE
8367034: [REDO] Protect ExecuteWithLog from running with redirection without a subshell

### DIFF
--- a/make/RunTests.gmk
+++ b/make/RunTests.gmk
@@ -509,7 +509,7 @@ define SetupRunGtestTestBody
 	$$(call LogWarn)
 	$$(call LogWarn, Running test '$$($1_TEST)')
 	$$(call MakeDir, $$($1_TEST_RESULTS_DIR) $$($1_TEST_SUPPORT_DIR))
-	$$(call ExecuteWithLog, $$($1_TEST_SUPPORT_DIR)/gtest, ( \
+	$$(call ExecuteWithLog, $$($1_TEST_SUPPORT_DIR)/gtest, \
 	    $$(CD) $$($1_TEST_SUPPORT_DIR) && \
 	    $$(FIXPATH) $$(TEST_IMAGE_DIR)/hotspot/gtest/$$($1_VARIANT)/gtestLauncher \
 	        -jdk $(JDK_UNDER_TEST) $$($1_GTEST_FILTER) \
@@ -520,7 +520,7 @@ define SetupRunGtestTestBody
 	        > >($(TEE) $$($1_TEST_RESULTS_DIR)/gtest.txt) \
 	    && $$(ECHO) $$$$? > $$($1_EXITCODE) \
 	    || $$(ECHO) $$$$? > $$($1_EXITCODE) \
-	))
+	)
 
   $1_RESULT_FILE := $$($1_TEST_RESULTS_DIR)/gtest.txt
 
@@ -644,7 +644,7 @@ define SetupRunMicroTestBody
 	$$(call LogWarn)
 	$$(call LogWarn, Running test '$$($1_TEST)')
 	$$(call MakeDir, $$($1_TEST_RESULTS_DIR) $$($1_TEST_SUPPORT_DIR))
-	$$(call ExecuteWithLog, $$($1_TEST_SUPPORT_DIR)/micro, ( \
+	$$(call ExecuteWithLog, $$($1_TEST_SUPPORT_DIR)/micro, \
 	    $$(CD) $$(TEST_IMAGE_DIR) && \
 	    $$(FIXPATH) $$($1_MICRO_TEST_JDK)/bin/java $$($1_MICRO_JAVA_OPTIONS) \
 	        -jar $$($1_MICRO_BENCHMARKS_JAR) \
@@ -655,7 +655,7 @@ define SetupRunMicroTestBody
 	        > >($(TEE) $$($1_TEST_RESULTS_DIR)/micro.txt) \
 	    && $$(ECHO) $$$$? > $$($1_EXITCODE) \
 	    || $$(ECHO) $$$$? > $$($1_EXITCODE) \
-	))
+	)
 
   $1_RESULT_FILE := $$($1_TEST_RESULTS_DIR)/micro.txt
 
@@ -758,34 +758,34 @@ define SetupAOTBody
         ifeq ($$($1_TRAINING), onestep)
 
 	  $$(call LogWarn, AOT: Create AOT cache $$($1_AOT_JDK_CACHE) in one step with flags: $$($1_VM_OPTIONS)) \
-	  $$(call ExecuteWithLog, $$($1_AOT_JDK_OUTPUT_DIR), ( \
+	  $$(call ExecuteWithLog, $$($1_AOT_JDK_OUTPUT_DIR), \
 	      cd $$($1_AOT_JDK_OUTPUT_DIR); \
 	      $(JAR) --extract --file $(TEST_IMAGE_DIR)/setup_aot/TestSetupAOT.jar; \
 	      $$(FIXPATH) $(JDK_UNDER_TEST)/bin/java $$($1_VM_OPTIONS) \
-	          -Xlog:class+load,aot,aot+class=debug:file=$$($1_AOT_JDK_CACHE).log  -Xlog:cds*=error -Xlog:aot*=error  \
+	          -Xlog:class+load$$(COMMA)aot$$(COMMA)aot+class=debug:file=$$($1_AOT_JDK_CACHE).log  -Xlog:cds*=error -Xlog:aot*=error  \
 	          -XX:AOTMode=record -XX:AOTCacheOutput=$$($1_AOT_JDK_CACHE) \
 	          TestSetupAOT $$($1_AOT_JDK_OUTPUT_DIR) > $$($1_AOT_JDK_LOG) \
-	  ))
+	  )
 
         else
 
 	  $$(call LogWarn, AOT: Create cache configuration) \
-	  $$(call ExecuteWithLog, $$($1_AOT_JDK_OUTPUT_DIR), ( \
+	  $$(call ExecuteWithLog, $$($1_AOT_JDK_OUTPUT_DIR), \
 	      cd $$($1_AOT_JDK_OUTPUT_DIR); \
 	      $(JAR) --extract --file $(TEST_IMAGE_DIR)/setup_aot/TestSetupAOT.jar; \
 	      $$(FIXPATH) $(JDK_UNDER_TEST)/bin/java $$($1_VM_OPTIONS) \
-	          -Xlog:class+load,aot,aot+class=debug:file=$$($1_AOT_JDK_CONF).log  -Xlog:cds*=error -Xlog:aot*=error \
+	          -Xlog:class+load$$(COMMA)aot$$(COMMA)aot+class=debug:file=$$($1_AOT_JDK_CONF).log  -Xlog:cds*=error -Xlog:aot*=error \
 	          -XX:AOTMode=record -XX:AOTConfiguration=$$($1_AOT_JDK_CONF) \
 	          TestSetupAOT $$($1_AOT_JDK_OUTPUT_DIR) > $$($1_AOT_JDK_LOG) \
-	  ))
+	  )
 
 	  $$(call LogWarn, AOT: Generate AOT cache $$($1_AOT_JDK_CACHE) with flags: $$($1_VM_OPTIONS))
-	  $$(call ExecuteWithLog, $$($1_AOT_JDK_OUTPUT_DIR), ( \
+	  $$(call ExecuteWithLog, $$($1_AOT_JDK_OUTPUT_DIR), \
 	      $$(FIXPATH) $(JDK_UNDER_TEST)/bin/java \
-	          $$($1_VM_OPTIONS) -Xlog:aot,aot+class=debug:file=$$($1_AOT_JDK_CACHE).log -Xlog:cds*=error -Xlog:aot*=error \
+	          $$($1_VM_OPTIONS) -Xlog:aot$$(COMMA)aot+class=debug:file=$$($1_AOT_JDK_CACHE).log -Xlog:cds*=error -Xlog:aot*=error \
 	          -XX:ExtraSharedClassListFile=$(JDK_UNDER_TEST)/lib/classlist \
 	          -XX:AOTMode=create -XX:AOTConfiguration=$$($1_AOT_JDK_CONF) -XX:AOTCache=$$($1_AOT_JDK_CACHE) \
-	  ))
+	  )
 
         endif
 
@@ -1085,9 +1085,9 @@ define SetupRunJtregTestBody
 	$$(call LogWarn, Running test '$$($1_TEST)')
 	$$(call MakeDir, $$($1_TEST_RESULTS_DIR) $$($1_TEST_SUPPORT_DIR) \
 	    $$($1_TEST_TMP_DIR))
-	$$(call ExecuteWithLog, $$($1_TEST_SUPPORT_DIR)/jtreg, ( \
+	$$(call ExecuteWithLog, $$($1_TEST_SUPPORT_DIR)/jtreg, \
             $$(COV_ENVIRONMENT) $$($1_COMMAND_LINE) \
-	))
+	)
 
   $1_RESULT_FILE := $$($1_TEST_RESULTS_DIR)/text/stats.txt
 
@@ -1204,12 +1204,12 @@ define SetupRunSpecialTestBody
 	$$(call LogWarn)
 	$$(call LogWarn, Running test '$$($1_TEST)')
 	$$(call MakeDir, $$($1_TEST_RESULTS_DIR) $$($1_TEST_SUPPORT_DIR))
-	$$(call ExecuteWithLog, $$($1_TEST_SUPPORT_DIR)/test-execution, ( \
+	$$(call ExecuteWithLog, $$($1_TEST_SUPPORT_DIR)/test-execution, \
 	    $$($1_TEST_COMMAND_LINE) \
 	        > >($(TEE) $$($1_TEST_RESULTS_DIR)/test-output.txt) \
 	    && $$(ECHO) $$$$? > $$($1_EXITCODE) \
 	    || $$(ECHO) $$$$? > $$($1_EXITCODE) \
-	))
+	)
 
   # We can not parse the various "special" tests.
   parse-test-$1: run-test-$1

--- a/make/StaticLibs.gmk
+++ b/make/StaticLibs.gmk
@@ -111,7 +111,7 @@ else ifeq ($(call isTargetOs, aix), true)
       INFO := Generating export list for $(notdir $(lib)), \
       DEPS :=  $(lib), \
       OUTPUT_FILE := $(lib).exp, \
-      COMMAND := ( $(AR) $(ARFLAGS) -w $(lib) | $(GREP) -v '^\.' | $(AWK) '{print $$1}' | $(SORT) -u > $(lib).exp ), \
+      COMMAND := $(AR) $(ARFLAGS) -w $(lib) | $(GREP) -v '^\.' | $(AWK) '{print $$1}' | $(SORT) -u > $(lib).exp, \
     )) \
     $(eval STATIC_LIB_EXPORT_FILES += $(lib).exp) \
   )

--- a/make/common/MakeBase.gmk
+++ b/make/common/MakeBase.gmk
@@ -284,6 +284,12 @@ else
   LogCmdlines =
 endif
 
+# Check if the command line contains redirection, that is <, > or >>,
+# and if so, return a value that is interpreted as true in a make $(if)
+# construct.
+is_redirect = \
+    $(if $(filter < > >>, $1), true)
+
 ################################################################################
 # ExecuteWithLog will run a command and log the output appropriately. This is
 # meant to be used by commands that do "real" work, like a compilation.
@@ -291,21 +297,23 @@ endif
 # of the build in case of failure. The  command line itself is stored in a file,
 # and also logged to stdout if the LOG=cmdlines option has been given.
 #
-# NOTE: If the command redirects stdout, the caller needs to wrap it in a
-# subshell (by adding parentheses around it), otherwise the redirect to the
-# subshell tee process will create a race condition where the target file may
-# not be fully written when the make recipe is done.
-#
 # Param 1 - The path to base the name of the log file / command line file on
 # Param 2 - The command to run
 ExecuteWithLog = \
-  $(call LogCmdlines, Executing: [$(strip $2)]) \
+  $(call LogCmdlines, Executing: \
+      [$(if $(call is_redirect, $2),$(LEFT_PAREN) )$(strip $2)$(if $(call \
+      is_redirect, $2), $(RIGHT_PAREN))]) \
   $(call MakeDir, $(dir $(strip $1)) $(MAKESUPPORT_OUTPUTDIR)/failure-logs) \
   $(call WriteFile, $2, $(strip $1).cmdline) \
-  ( $(RM) $(strip $1).log && $(strip $2) > >($(TEE) -a $(strip $1).log) 2> >($(TEE) -a $(strip $1).log >&2) || \
+  ( $(RM) $(strip $1).log && \
+      $(if $(call is_redirect, $2),$(LEFT_PAREN) )$(strip $2)$(if $(call \
+      is_redirect, $2), $(RIGHT_PAREN)) \
+      > >($(TEE) -a $(strip $1).log) 2> >($(TEE) -a $(strip $1).log >&2) || \
       ( exitcode=$(DOLLAR)? && \
-      $(CP) $(strip $1).log $(MAKESUPPORT_OUTPUTDIR)/failure-logs/$(subst /,_,$(patsubst $(OUTPUTDIR)/%,%,$(strip $1))).log && \
-      $(CP) $(strip $1).cmdline $(MAKESUPPORT_OUTPUTDIR)/failure-logs/$(subst /,_,$(patsubst $(OUTPUTDIR)/%,%,$(strip $1))).cmdline && \
+      $(CP) $(strip $1).log $(MAKESUPPORT_OUTPUTDIR)/failure-logs/$(subst \
+      /,_,$(patsubst $(OUTPUTDIR)/%,%,$(strip $1))).log && \
+      $(CP) $(strip $1).cmdline $(MAKESUPPORT_OUTPUTDIR)/failure-logs/$(subst \
+      /,_,$(patsubst $(OUTPUTDIR)/%,%,$(strip $1))).cmdline && \
       exit $(DOLLAR)exitcode ) )
 
 ################################################################################

--- a/make/common/ProcessMarkdown.gmk
+++ b/make/common/ProcessMarkdown.gmk
@@ -109,7 +109,7 @@ define ProcessMarkdown
 	$$(call LogInfo, Post-processing markdown file $2)
 	$$(call MakeDir, $$(SUPPORT_OUTPUTDIR)/markdown $$($1_$2_TARGET_DIR))
 	$$(call ExecuteWithLog, $$(SUPPORT_OUTPUTDIR)/markdown/$$($1_$2_MARKER)_post, \
-	    ( $$($1_POST_PROCESS) $$($1_$2_PANDOC_OUTPUT) > $$($1_$2_OUTPUT_FILE) ) )
+	    $$($1_POST_PROCESS) $$($1_$2_PANDOC_OUTPUT) > $$($1_$2_OUTPUT_FILE) )
     endif
 
     $1 += $$($1_$2_OUTPUT_FILE)

--- a/make/hotspot/gensrc/GensrcDtrace.gmk
+++ b/make/hotspot/gensrc/GensrcDtrace.gmk
@@ -47,8 +47,9 @@ ifeq ($(call check-jvm-feature, dtrace), true)
 	$(call LogInfo, Generating dtrace header file $(@F))
 	$(call MakeDir, $(@D) $(DTRACE_SUPPORT_DIR))
 	$(call ExecuteWithLog, $(DTRACE_SUPPORT_DIR)/$(@F).d, \
-	    ($(CPP) $(DTRACE_CPP_FLAGS) $(SYSROOT_CFLAGS) $< > $(DTRACE_SUPPORT_DIR)/$(@F).d))
-	$(call ExecuteWithLog, $@, $(DTRACE) $(DTRACE_FLAGS) -h -o $@ -s $(DTRACE_SUPPORT_DIR)/$(@F).d)
+	    $(CPP) $(DTRACE_CPP_FLAGS) $(SYSROOT_CFLAGS) $< > $(DTRACE_SUPPORT_DIR)/$(@F).d)
+	$(call ExecuteWithLog, $@, \
+	    $(DTRACE) $(DTRACE_FLAGS) -h -o $@ -s $(DTRACE_SUPPORT_DIR)/$(@F).d)
 
   # Process all .d files in DTRACE_SOURCE_DIR. They are:
   # hotspot_jni.d hotspot.d hs_private.d


### PR DESCRIPTION
This is a redo of [JDK-8233115](https://bugs.openjdk.org/browse/JDK-8233115). The problem was that some of the AOT test command lines had `,` in them. Since this is interpreted as argument separator by make, it is not allowed, and it should be escaped to `$(COMMA)`. 

However, it seems like the GNU make parser did not consider `,` to be an argument parser if it was nested inside matching `(` ... `)`, and so by pure luck it worked anyway, until I removed those subshell parentheses.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8367034](https://bugs.openjdk.org/browse/JDK-8367034): [REDO] Protect ExecuteWithLog from running with redirection without a subshell (**Enhancement** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27140/head:pull/27140` \
`$ git checkout pull/27140`

Update a local copy of the PR: \
`$ git checkout pull/27140` \
`$ git pull https://git.openjdk.org/jdk.git pull/27140/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27140`

View PR using the GUI difftool: \
`$ git pr show -t 27140`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27140.diff">https://git.openjdk.org/jdk/pull/27140.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27140#issuecomment-3265896780)
</details>
