### PR TITLE
8367098: RISC-V: sync CPU features with related JVM flags for dependant ones

### DIFF
--- a/src/hotspot/cpu/riscv/vm_version_riscv.hpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.hpp
@@ -86,25 +86,27 @@ class VM_Version : public Abstract_VM_Version {
     }                                    \
   }                                      \
 
-  #define UPDATE_DEFAULT_DEP(flag, dep)    \
-  void update_flag() {                     \
-      assert(enabled(), "Must be.");       \
-      /* dep must be declared before */    \
-      assert((uintptr_t)(this) >           \
-             (uintptr_t)(&dep), "Invalid");\
-      if (FLAG_IS_DEFAULT(flag)) {         \
-        if (dep.enabled()) {               \
-          FLAG_SET_DEFAULT(flag, true);    \
-        } else {                           \
-          FLAG_SET_DEFAULT(flag, false);   \
-        }                                  \
-      } else {                             \
-        /* Sync CPU features with flags */ \
-        if (!flag) {                       \
-          disable_feature();               \
-        }                                  \
-      }                                    \
-  }                                        \
+  #define UPDATE_DEFAULT_DEP(flag, dep)      \
+  void update_flag() {                       \
+      assert(enabled(), "Must be.");         \
+      /* dep must be declared before */      \
+      assert((uintptr_t)(this) >             \
+             (uintptr_t)(&dep), "Invalid");  \
+      if (FLAG_IS_DEFAULT(flag)) {           \
+        if (dep.enabled()) {                 \
+          FLAG_SET_DEFAULT(flag, true);      \
+        } else {                             \
+          FLAG_SET_DEFAULT(flag, false);     \
+          /* Sync CPU features with flags */ \
+          disable_feature();                 \
+        }                                    \
+      } else {                               \
+        /* Sync CPU features with flags */   \
+        if (!flag) {                         \
+          disable_feature();                 \
+        }                                    \
+      }                                      \
+  }                                          \
 
   #define NO_UPDATE_DEFAULT                \
   void update_flag() {}                    \


### PR DESCRIPTION
Hi,
Can you help to review this patch?

some extensions depends on another one, for example, zvbb depends on rvv.
That means if rvv is disabled or not supported by the CPU, UseZvbb should return false, and zvbb should not appear in cpu string.
But the currently, the cpu string contains zvbb even if rvv is disabled, which is not right.
This needs to be fixed.

Thanks

before fix, output for `-XX-UseRVV -Xlog:cpu*=debug`
```
[0.064s][info ][os,cpu] CPU: total 32 (initial active 32) qemu rv64 rvi rvm rva rvf rvd rvc rvv zicbom zicboz zicbop zba zbb zbs zbkb zcb zfa zfh zfhmin zicsr zifencei zic64b ztso zacas zvbb zvbc zvfh zicond
```

after fix, output for `-XX-UseRVV -Xlog:cpu*=debug`
```
[0.065s][info ][os,cpu] CPU: total 32 (initial active 32) qemu rv64 rvi rvm rva rvf rvd rvc zicbom zicboz zicbop zba zbb zbs zbkb zcb zfa zfh zfhmin zicsr zifencei zic64b ztso zacas zicond
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8367098](https://bugs.openjdk.org/browse/JDK-8367098): RISC-V: sync CPU features with related JVM flags for dependant ones (**Bug** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27142/head:pull/27142` \
`$ git checkout pull/27142`

Update a local copy of the PR: \
`$ git checkout pull/27142` \
`$ git pull https://git.openjdk.org/jdk.git pull/27142/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27142`

View PR using the GUI difftool: \
`$ git pr show -t 27142`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27142.diff">https://git.openjdk.org/jdk/pull/27142.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27142#issuecomment-3266048663)
</details>
