### PR TITLE
8321289: open/test/jdk/javax/swing/JFrame/MaximizeWindowTest.java fails on Linux

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -674,7 +674,6 @@ javax/sound/sampled/Clip/ClipFlushCrash.java 8308395 linux-x64
 javax/swing/plaf/basic/BasicTextUI/8001470/bug8001470.java 8233177 linux-all,windows-all
 javax/swing/plaf/basic/BasicDirectoryModel/LoaderThreadCount.java 8333880 windows-all
 
-javax/swing/JFrame/MaximizeWindowTest.java 8321289 linux-all
 javax/swing/JWindow/ShapedAndTranslucentWindows/ShapedTranslucentPerPixelTranslucentGradient.java 8233582 linux-all
 javax/swing/JWindow/ShapedAndTranslucentWindows/ShapedPerPixelTranslucentGradient.java 8233582 linux-all
 javax/swing/JWindow/ShapedAndTranslucentWindows/PerPixelTranslucentSwing.java 8194128 macosx-all

--- a/test/jdk/javax/swing/JFrame/MaximizeWindowTest.java
+++ b/test/jdk/javax/swing/JFrame/MaximizeWindowTest.java
@@ -28,15 +28,14 @@ import java.awt.Dimension;
 import java.awt.Robot;
 import java.awt.event.ComponentAdapter;
 import java.awt.event.ComponentEvent;
-import java.lang.reflect.InvocationTargetException;
 
 /*
  * @test
  * @key headful
  * @summary setExtendedFrame not executed immediately
+ * @requires (os.family != "linux")
  * @run main MaximizeWindowTest
  */
-@SuppressWarnings("serial")
 public class MaximizeWindowTest extends JFrame {
     private static JFrame frame;
     private static final Dimension ORIGINAL_SIZE = new Dimension(200, 200);


### PR DESCRIPTION
This changeset excludes the test from running on Linux. We receive a ConfigureNotify from the system (Gnome Shell) with the initial window size. However, this does not happen on Plasma.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8321289](https://bugs.openjdk.org/browse/JDK-8321289): open/test/jdk/javax/swing/JFrame/MaximizeWindowTest.java fails on Linux (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27149/head:pull/27149` \
`$ git checkout pull/27149`

Update a local copy of the PR: \
`$ git checkout pull/27149` \
`$ git pull https://git.openjdk.org/jdk.git pull/27149/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27149`

View PR using the GUI difftool: \
`$ git pr show -t 27149`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27149.diff">https://git.openjdk.org/jdk/pull/27149.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27149#issuecomment-3267103630)
</details>
