### PR TITLE
8367130: JDK builds broken by 8366837: Clean up gensrc by spp.Spp

### DIFF
--- a/make/modules/java.base/gensrc/GensrcVarHandles.gmk
+++ b/make/modules/java.base/gensrc/GensrcVarHandles.gmk
@@ -157,7 +157,7 @@ $(foreach t, $(PRIMITIVE_TYPES), \
 
 ################################################################################
 
-GENSRC_VARHANDLEGUARDS := $(VARHANDLES_GENSRC_DIR)/VarHandleGuards.java
+GENSRC_VARHANDLEGUARDS := $(VARHANDLES_OUTPUT_DIR)/VarHandleGuards.java
 
 $(GENSRC_VARHANDLEGUARDS): $(BUILD_TOOLS_JDK)
 	$(call LogInfo, Generating $@)


### PR DESCRIPTION
Builds on all platforms are currently broken due to a clash between [JDK-8366837](https://bugs.openjdk.org/browse/JDK-8366837) and [JDK-8366455](https://bugs.openjdk.org/browse/JDK-8366455).  The former changed the name of a variable that the latter introduced a new usage of. The fix is simple, just change the usage of the variable to the new name.

I'm running a quick verification in internal CI.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8367130](https://bugs.openjdk.org/browse/JDK-8367130): JDK builds broken by 8366837: Clean up gensrc by spp.Spp (**Bug** - P1)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27150/head:pull/27150` \
`$ git checkout pull/27150`

Update a local copy of the PR: \
`$ git checkout pull/27150` \
`$ git pull https://git.openjdk.org/jdk.git pull/27150/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27150`

View PR using the GUI difftool: \
`$ git pr show -t 27150`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27150.diff">https://git.openjdk.org/jdk/pull/27150.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27150#issuecomment-3267739558)
</details>
