### PR TITLE
8367132: Build failure caused by java.nio.file.AccessDeniedException: /VarHandleGuards.java

### DIFF
--- a/make/modules/java.base/gensrc/GensrcVarHandles.gmk
+++ b/make/modules/java.base/gensrc/GensrcVarHandles.gmk
@@ -157,7 +157,7 @@ $(foreach t, $(PRIMITIVE_TYPES), \
 
 ################################################################################
 
-GENSRC_VARHANDLEGUARDS := $(VARHANDLES_GENSRC_DIR)/VarHandleGuards.java
+GENSRC_VARHANDLEGUARDS := $(VARHANDLES_OUTPUT_DIR)/VarHandleGuards.java
 
 $(GENSRC_VARHANDLEGUARDS): $(BUILD_TOOLS_JDK)
 	$(call LogInfo, Generating $@)


### PR DESCRIPTION
VARHANDLES_GENSRC_DIR is is not defined, which causes VarHandleGuardMethodGenerator.java to be not able to generate VarHandleGuards.java because of wrong file path to root, all the varhandler generated sources are written to folder VARHANDLES_OUTPUT_DIR, I assume it is the path where the file should be written.

@erikj79 please review the change and see if it make sense.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8367132](https://bugs.openjdk.org/browse/JDK-8367132): Build failure caused by java.nio.file.AccessDeniedException: /VarHandleGuards.java (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27151/head:pull/27151` \
`$ git checkout pull/27151`

Update a local copy of the PR: \
`$ git checkout pull/27151` \
`$ git pull https://git.openjdk.org/jdk.git pull/27151/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27151`

View PR using the GUI difftool: \
`$ git pr show -t 27151`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27151.diff">https://git.openjdk.org/jdk/pull/27151.diff</a>

</details>
