### PR TITLE
8367107: JFR: Refactor policy tests out of TestRemoteDump

### DIFF
--- a/test/jdk/jdk/jfr/jmx/streaming/TestDumpRetention.java
+++ b/test/jdk/jdk/jfr/jmx/streaming/TestDumpRetention.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jdk.jfr.jmx.streaming;
+
+import java.lang.management.ManagementFactory;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.function.Consumer;
+import javax.management.MBeanServerConnection;
+
+import jdk.jfr.Event;
+import jdk.jfr.Name;
+import jdk.jfr.Recording;
+import jdk.jfr.consumer.RecordedEvent;
+import jdk.jfr.consumer.RecordingFile;
+import jdk.management.jfr.RemoteRecordingStream;
+
+/**
+ * @test
+ * @summary Tests retention with RemoteRecordingStream::dump(Path)
+ * @requires vm.flagless
+ * @requires vm.hasJFR
+ * @library /test/lib
+ * @run main/othervm jdk.jfr.jmx.streaming.TestDumpRetention
+ */
+public class TestDumpRetention {
+
+    private static final MBeanServerConnection CONNECTION = ManagementFactory.getPlatformMBeanServer();
+
+    @Name("TestDumpRetention")
+    static class DumpEvent extends Event {
+    }
+
+    public static void main(String... args) throws Exception {
+        testSetNoPolicy();
+        testSetMaxAge();
+        testSetMaxSize();
+    }
+
+    private static List<RecordedEvent> recordWithPolicy(String filename, Consumer<RemoteRecordingStream> policy) throws Exception {
+        CountDownLatch latch1 = new CountDownLatch(1);
+        CountDownLatch latch2 = new CountDownLatch(2);
+        CountDownLatch latch3 = new CountDownLatch(3);
+        try (var rs = new RemoteRecordingStream(CONNECTION)) {
+            policy.accept(rs);
+            rs.onEvent(e -> {
+                latch1.countDown();
+                latch2.countDown();
+                latch3.countDown();
+            });
+            rs.startAsync();
+            DumpEvent e1 = new DumpEvent();
+            e1.commit();
+            latch1.await();
+            // Force chunk rotation
+            try (Recording r = new Recording()) {
+                r.start();
+                DumpEvent e2 = new DumpEvent();
+                e2.commit();
+            }
+            latch2.await();
+            DumpEvent e3 = new DumpEvent();
+            e3.commit();
+            latch3.await();
+            Path p = Path.of(filename);
+            rs.dump(p);
+            return RecordingFile.readAllEvents(p);
+        }
+    }
+
+    private static void testSetNoPolicy() throws Exception {
+        var events = recordWithPolicy("no-policy.jfr", rs -> {
+            // use default policy, remove after consumption
+        });
+        // Since latch3 have been triggered at least two events/chunks
+        // before must have been consumed, possibly 3, but it's a race.
+        if (events.size() > 1) {
+            throw new Exception("Expected at most one event to not be consumed");
+        }
+    }
+
+    private static void testSetMaxAge() throws Exception {
+        var events = recordWithPolicy("max-age.jfr", rs -> {
+            // keeps all events for the dump
+            rs.setMaxAge(Duration.ofDays(1));
+        });
+        if (events.size() != 3) {
+            throw new Exception("Expected all 3 events to be in dump after setMaxAge");
+        }
+    }
+
+    private static void testSetMaxSize() throws Exception {
+        var events = recordWithPolicy("max-size.jfr", rs -> {
+            // keeps all events for the dump
+            rs.setMaxSize(100_000_000);
+        });
+        if (events.size() != 3) {
+            throw new Exception("Expected all 3 events to be in dump after setMaxSize");
+        }
+    }
+}

--- a/test/jdk/jdk/jfr/jmx/streaming/TestRemoteDump.java
+++ b/test/jdk/jdk/jfr/jmx/streaming/TestRemoteDump.java
@@ -33,7 +33,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
-import java.util.function.Function;
 import javax.management.MBeanServerConnection;
 
 import jdk.jfr.Event;
@@ -41,12 +40,11 @@ import jdk.jfr.Name;
 import jdk.jfr.Recording;
 import jdk.jfr.consumer.RecordedEvent;
 import jdk.jfr.consumer.RecordingFile;
-import jdk.jfr.consumer.RecordingStream;
 import jdk.management.jfr.RemoteRecordingStream;
 
 /**
  * @test
- * @summary Tests RecordingStream::dump(Path)
+ * @summary Tests RemoteRecordingStream::dump(Path)
  * @requires vm.flagless
  * @requires vm.hasJFR
  * @library /test/lib
@@ -66,9 +64,6 @@ public class TestRemoteDump {
         testOneDump();
         testMultipleDumps();
         testEventAfterDump();
-        testSetNoPolicy();
-        testSetMaxAge();
-        testSetMaxSize();
     }
 
     private static void testUnstarted() throws Exception {
@@ -94,74 +89,6 @@ public class TestRemoteDump {
             throw new Exception("Should not be able to dump closed recording");
         } catch (IOException ise) {
             // OK, expected
-        }
-    }
-
-    private static List<RecordedEvent> recordWithPolicy(String filename, boolean awaitEvents, Consumer<RemoteRecordingStream> policy) throws Exception {
-        CountDownLatch latch1 = new CountDownLatch(1);
-        CountDownLatch latch2 = new CountDownLatch(2);
-        CountDownLatch latch3 = new CountDownLatch(3);
-        try (var rs = new RemoteRecordingStream(CONNECTION)) {
-            policy.accept(rs);
-            rs.onEvent(e -> {
-                latch1.countDown();
-                latch2.countDown();
-                latch3.countDown();
-            });
-            rs.startAsync();
-            DumpEvent e1 = new DumpEvent();
-            e1.commit();
-            if (awaitEvents) {
-                latch1.await();
-            }
-            // Force chunk rotation
-            try (Recording r = new Recording()) {
-                r.start();
-                DumpEvent e2 = new DumpEvent();
-                e2.commit();
-            }
-            if (awaitEvents) {
-                latch2.await();
-            }
-            DumpEvent e3 = new DumpEvent();
-            e3.commit();
-            latch3.await();
-            Path p = Path.of(filename);
-            rs.dump(p);
-            return RecordingFile.readAllEvents(p);
-        }
-    }
-
-    private static void testSetMaxSize() throws Exception {
-        var events = recordWithPolicy("max-size.jfr", false, rs -> {
-            // keeps all events for the dump
-            rs.setMaxSize(100_000_000);
-        });
-        if (events.size() != 3) {
-            throw new Exception("Expected all 3 events to be in dump after setMaxSize");
-        }
-
-    }
-
-    private static void testSetMaxAge() throws Exception {
-        var events = recordWithPolicy("max-age.jfr", false, rs -> {
-            // keeps all events for the dump
-            rs.setMaxAge(Duration.ofDays(1));
-        });
-        if (events.size() != 3) {
-            throw new Exception("Expected all 3 events to be in dump after setMaxAge");
-        }
-
-    }
-
-    private static void testSetNoPolicy() throws Exception {
-        var events = recordWithPolicy("no-policy.jfr", true, rs -> {
-            // use default policy, remove after consumption
-        });
-        // Since latch3 have been triggered at least two events/chunks
-        // before must have been consumed, possibly 3, but it's a race.
-        if (events.size() > 1) {
-            throw new Exception("Expected at most one event to not be consumed");
         }
     }
 


### PR DESCRIPTION
Could I get a review of a PR that splits TestRemoteDump.java into two test files?

This change prevents timeouts and reduces wall clock time, as the tests can now run in parallel. As part of the change, I am reverting the modification to TestRemoteDump introduced with [JFR: Improve slow tests](https://bugs.openjdk.org/browse/JDK-8364756), which made the test flaky. I also removed unused imports and fixed the incorrect test summary.

Testing: 100 * (TestRemoteDump and TestDumpRetention)

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8367107](https://bugs.openjdk.org/browse/JDK-8367107): JFR: Refactor policy tests out of TestRemoteDump (**Enhancement** - P3)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27153/head:pull/27153` \
`$ git checkout pull/27153`

Update a local copy of the PR: \
`$ git checkout pull/27153` \
`$ git pull https://git.openjdk.org/jdk.git pull/27153/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27153`

View PR using the GUI difftool: \
`$ git pr show -t 27153`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27153.diff">https://git.openjdk.org/jdk/pull/27153.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27153#issuecomment-3267837692)
</details>
