### PR TITLE
8367051: Build failure with clang on linux and AIX after switch to C++17

### DIFF
--- a/src/hotspot/share/utilities/forbiddenFunctions.hpp
+++ b/src/hotspot/share/utilities/forbiddenFunctions.hpp
@@ -38,6 +38,15 @@
 #include <stdlib.h>
 #endif
 
+// Workaround for noexcept functions in glibc when using clang.
+// clang errors if declaration without exception specification preceeds
+// noexcept declaration, but not the other way around.
+#ifdef __clang__
+#include <stdio.h>
+#include <string.h>
+#include <wchar.h>
+#endif
+
 #ifdef _WINDOWS
 #include "forbiddenFunctions_windows.hpp"
 #else


### PR DESCRIPTION
8367051: Build failure with clang on linux and AIX after switch to C++17

Please review this change to work around build failures with clang on some
platforms after the switch to C++17.

C++17 made the exception specification part of a function's type. Some
standard libraries declare C library functions as noexcept. If HotSpot has a
forbidding declaration for such a function (without a noexcept spec) before
including the standard library header, clang reports this as an error (not
just a warning that could be suppressed, a hard error). If the standard
library header containing the noexpect declaration is first, then clang
does *not* complain about the following forbidding declaration that doesn't
have an exception spec. gcc permits either order.

So the workaround consists of ensuring all the standard library headers for
forbidden functions are included before the forbidding declarations.

Exploration of other approaches to follow, but for now we need to fix the
build errors.

Testing: mach5 tier1
GHA saniticy checks in progress

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8367051](https://bugs.openjdk.org/browse/JDK-8367051): Build failure with clang on linux and AIX after switch to C++17 (**Bug** - P1)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27154/head:pull/27154` \
`$ git checkout pull/27154`

Update a local copy of the PR: \
`$ git checkout pull/27154` \
`$ git pull https://git.openjdk.org/jdk.git pull/27154/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27154`

View PR using the GUI difftool: \
`$ git pr show -t 27154`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27154.diff">https://git.openjdk.org/jdk/pull/27154.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27154#issuecomment-3268503226)
</details>
