### PR TITLE
8023263: [TESTBUG] Test closed/java/awt/Focus/InactiveWindowTest/InactiveFocusRace fails due to not enough time to initialize graphic components

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -817,7 +817,6 @@ java/awt/Focus/FrameMinimizeTest/FrameMinimizeTest.java 8016266 linux-x64
 java/awt/Frame/SizeMinimizedTest.java 8305915 linux-x64
 java/awt/PopupMenu/PopupHangTest.java 8340022 windows-all
 java/awt/Focus/MinimizeNonfocusableWindowTest.java 8024487 windows-all
-java/awt/Focus/InactiveFocusRace.java 8023263 linux-all
 java/awt/List/HandlingKeyEventIfMousePressedTest.java 6848358 macosx-all,windows-all
 java/awt/List/ListScrollbarCursorTest.java 8066410 generic-all
 java/awt/Checkbox/CheckboxBoxSizeTest.java 8340870 windows-all

--- a/test/jdk/java/awt/Focus/InactiveFocusRace.java
+++ b/test/jdk/java/awt/Focus/InactiveFocusRace.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,7 @@
 */
 
 import java.awt.Button;
+import java.awt.EventQueue;
 import java.awt.FlowLayout;
 import java.awt.Frame;
 import java.awt.KeyboardFocusManager;
@@ -48,19 +49,27 @@ public class InactiveFocusRace {
     Button activeButton, inactiveButton1, inactiveButton2;
     Semaphore sema;
     final static int TIMEOUT = 10000;
+    private static Robot robot;
 
     public static void main(String[] args) throws Exception {
         try {
+            robot = new Robot();
             InactiveFocusRace test = new InactiveFocusRace();
-            test.init();
+            EventQueue.invokeAndWait(() -> {
+                test.init();
+            });
+            robot.waitForIdle();
+            robot.delay(1000);
             test.start();
         } finally {
-            if (activeFrame != null) {
-                activeFrame.dispose();
-            }
-            if (inactiveFrame != null) {
-                inactiveFrame.dispose();
-            }
+            EventQueue.invokeAndWait(() -> {
+                if (activeFrame != null) {
+                    activeFrame.dispose();
+                }
+                if (inactiveFrame != null) {
+                    inactiveFrame.dispose();
+                }
+            });
         }
     }
 
@@ -97,18 +106,12 @@ public class InactiveFocusRace {
                 sema.raise();
             }
         });
+        inactiveFrame.setVisible(true);
+        activeFrame.setVisible(true);
     }
 
     public void start() {
-        Robot robot = null;
-        try {
-            robot = new Robot();
-        } catch (Exception e) {
-            throw new RuntimeException("Unable to create robot");
-        }
 
-        inactiveFrame.setVisible(true);
-        activeFrame.setVisible(true);
 
         // Wait for active frame to become active
         try {


### PR DESCRIPTION
Test was failing due to lack of time between initializing graphics components and test start.
Added robot delay and execution under EDT.

Several iterations of test is passing so deproblemlisting, CI job link in JBS

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8023263](https://bugs.openjdk.org/browse/JDK-8023263): [TESTBUG] Test closed/java/awt/Focus/InactiveWindowTest/InactiveFocusRace fails due to not enough time to initialize graphic components (**Bug** - P4)


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27156/head:pull/27156` \
`$ git checkout pull/27156`

Update a local copy of the PR: \
`$ git checkout pull/27156` \
`$ git pull https://git.openjdk.org/jdk.git pull/27156/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27156`

View PR using the GUI difftool: \
`$ git pr show -t 27156`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27156.diff">https://git.openjdk.org/jdk/pull/27156.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27156#issuecomment-3268875202)
</details>
