### PR TITLE
8367150: Add a header line to improve VMErrorCallback printing

### DIFF
--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -1143,9 +1143,11 @@ void VMError::report(outputStream* st, bool _verbose) {
     }
 
   STEP_IF("printing registered callbacks", _verbose && _thread != nullptr);
+    size_t count = 0;
     for (VMErrorCallback* callback = _thread->_vm_error_callbacks;
         callback != nullptr;
         callback = callback->_next) {
+      st->print_cr("VMErrorCallback %zu:", ++count);
       callback->call(st);
       st->cr();
     }


### PR DESCRIPTION
Currently all the registered VMErrorCallback are printed one after another in the error report with only a newline separating them. It makes harder to both quickly find the section, or differentiate the where one starts and another begins in the case of multiple callbacks. I propose we add a simple header line before each callback.

```
VMErrorCallback 1:
[ First callback's print ]
VMErrorCallback 2:
[ Second callback's print ]
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8367150](https://bugs.openjdk.org/browse/JDK-8367150): Add a header line to improve VMErrorCallback printing (**Enhancement** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27160/head:pull/27160` \
`$ git checkout pull/27160`

Update a local copy of the PR: \
`$ git checkout pull/27160` \
`$ git pull https://git.openjdk.org/jdk.git pull/27160/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27160`

View PR using the GUI difftool: \
`$ git pr show -t 27160`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27160.diff">https://git.openjdk.org/jdk/pull/27160.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27160#issuecomment-3269090584)
</details>
