### PR TITLE
JDK-8367096: jdk/open/test/jdk/sun/security/pkcs11/ rsa, ec, config, secmod and sslecc tests are skipping but showing as pass

### DIFF
--- a/test/jdk/sun/security/pkcs11/Config/ReadConfInUTF16Env.java
+++ b/test/jdk/sun/security/pkcs11/Config/ReadConfInUTF16Env.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,7 @@
  */
 
 import jdk.test.lib.process.ProcessTools;
+import jtreg.SkippedException;
 import org.testng.annotations.Test;
 
 import java.security.Provider;
@@ -47,8 +48,7 @@ public class ReadConfInUTF16Env {
         public static void main(String[] args) throws Exception {
             Provider p = Security.getProvider("SunPKCS11");
             if (p == null) {
-                System.out.println("Skipping test - no PKCS11 provider available");
-                return;
+                throw new SkippedException("Skipping test - no PKCS11 provider available");
             }
             System.out.println(p.getName());
         }

--- a/test/jdk/sun/security/pkcs11/PKCS11Test.java
+++ b/test/jdk/sun/security/pkcs11/PKCS11Test.java
@@ -781,7 +781,7 @@ public abstract class PKCS11Test {
 
     private void premain(Provider p) throws Exception {
         if (skipTest(p)) {
-            return;
+            throw new SkippedException("Test is skipped due to skipTest() result, please see the log");
         }
 
         long start = System.currentTimeMillis();

--- a/test/jdk/sun/security/pkcs11/Secmod/AddPrivateKey.java
+++ b/test/jdk/sun/security/pkcs11/Secmod/AddPrivateKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -62,9 +62,7 @@ public class AddPrivateKey extends SecmodTest {
     private static final byte[] DATA = generateData(DATA_LENGTH);
 
     public static void main(String[] args) throws Exception {
-        if (initSecmod() == false) {
-            return;
-        }
+        initSecmod();
 
         String configName = BASE + SEP + "nss.cfg";
         Provider p = getSunPKCS11(configName);

--- a/test/jdk/sun/security/pkcs11/Secmod/AddTrustedCert.java
+++ b/test/jdk/sun/security/pkcs11/Secmod/AddTrustedCert.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,6 @@
  * @run main/othervm AddTrustedCert
  */
 
-import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStream;
 import java.security.KeyStore;
@@ -47,9 +46,7 @@ import java.util.TreeSet;
 public class AddTrustedCert extends SecmodTest {
 
     public static void main(String[] args) throws Exception {
-        if (initSecmod() == false) {
-            return;
-        }
+        initSecmod();
 
         X509Certificate cert;
         try (InputStream in = new FileInputStream(BASE + SEP + "anchor.cer")) {

--- a/test/jdk/sun/security/pkcs11/Secmod/Crypto.java
+++ b/test/jdk/sun/security/pkcs11/Secmod/Crypto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,6 @@
  * @run main/othervm Crypto
  */
 
-import java.io.File;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.Provider;
@@ -40,9 +39,7 @@ import java.security.Signature;
 public class Crypto extends SecmodTest {
 
     public static void main(String[] args) throws Exception {
-        if (initSecmod() == false) {
-            return;
-        }
+        initSecmod();
 
         String configName = BASE + SEP + "nsscrypto.cfg";
         Provider p = getSunPKCS11(configName);

--- a/test/jdk/sun/security/pkcs11/Secmod/GetPrivateKey.java
+++ b/test/jdk/sun/security/pkcs11/Secmod/GetPrivateKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,7 +32,6 @@
  * @run main/othervm GetPrivateKey
  */
 
-import java.io.File;
 import java.security.KeyStore;
 import java.security.PrivateKey;
 import java.security.Provider;
@@ -46,9 +45,7 @@ import java.util.TreeSet;
 public class GetPrivateKey extends SecmodTest {
 
     public static void main(String[] args) throws Exception {
-        if (initSecmod() == false) {
-            return;
-        }
+        initSecmod();
 
         String configName = BASE + SEP + "nss.cfg";
         Provider p = getSunPKCS11(configName);

--- a/test/jdk/sun/security/pkcs11/Secmod/JksSetPrivateKey.java
+++ b/test/jdk/sun/security/pkcs11/Secmod/JksSetPrivateKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,6 @@
  * @run main/othervm JksSetPrivateKey
  */
 
-import java.io.File;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.PrivateKey;
@@ -45,9 +44,7 @@ import java.util.TreeSet;
 public class JksSetPrivateKey extends SecmodTest {
 
     public static void main(String[] args) throws Exception {
-        if (initSecmod() == false) {
-            return;
-        }
+        initSecmod();
 
         String configName = BASE + SEP + "nss.cfg";
         Provider p = getSunPKCS11(configName);

--- a/test/jdk/sun/security/pkcs11/Secmod/LoadKeystore.java
+++ b/test/jdk/sun/security/pkcs11/Secmod/LoadKeystore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,6 @@
  * @run main/othervm LoadKeystore
  */
 
-import java.io.File;
 import java.io.IOException;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
@@ -42,9 +41,7 @@ import java.util.Collections;
 public class LoadKeystore extends SecmodTest {
 
     public static void main(String[] args) throws Exception {
-        if (!initSecmod()) {
-            return;
-        }
+        initSecmod();
 
         String configName = BASE + SEP + "nss.cfg";
         Provider p = getSunPKCS11(configName);

--- a/test/jdk/sun/security/pkcs11/Secmod/TestNssDbSqlite.java
+++ b/test/jdk/sun/security/pkcs11/Secmod/TestNssDbSqlite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Red Hat, Inc. and/or its affiliates.
+ * Copyright (c) 2017, 2025, Red Hat, Inc. and/or its affiliates.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -46,6 +46,7 @@ import java.security.KeyStore;
 import java.security.Provider;
 import java.security.Signature;
 
+import jtreg.SkippedException;
 import sun.security.rsa.SunRsaSign;
 import sun.security.jca.ProviderList;
 import sun.security.jca.Providers;
@@ -66,9 +67,7 @@ public final class TestNssDbSqlite extends SecmodTest {
 
     public static void main(String[] args) throws Exception {
 
-        if (!initialize()) {
-            return;
-        }
+        initializeProvider();
 
         if (enableDebug) {
             System.out.println("SunPKCS11 provider: " +
@@ -110,16 +109,9 @@ public final class TestNssDbSqlite extends SecmodTest {
         }
     }
 
-    private static boolean initialize() throws Exception {
-        return initializeProvider();
-    }
-
-    private static boolean initializeProvider() throws Exception {
+    private static void initializeProvider() throws Exception {
         useSqlite(true);
-        if (!initSecmod()) {
-            System.out.println("Cannot init security module database, skipping");
-            return false;
-        }
+        initSecmod();
 
         sunPKCS11NSSProvider = getSunPKCS11(BASE + SEP + "nss-sqlite.cfg");
         sunJCEProvider = new com.sun.crypto.provider.SunJCE();
@@ -135,7 +127,5 @@ public final class TestNssDbSqlite extends SecmodTest {
         gen.generate(2048);
         privateKey = gen.getPrivateKey();
         certificate = gen.getSelfCertificate(new X500Name("CN=Me"), 365);
-
-        return true;
     }
 }

--- a/test/jdk/sun/security/pkcs11/Secmod/TrustAnchors.java
+++ b/test/jdk/sun/security/pkcs11/Secmod/TrustAnchors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,6 @@
  * @run main/othervm TrustAnchors
  */
 
-import java.io.File;
 import java.security.KeyStore;
 import java.security.Provider;
 import java.security.Security;
@@ -43,9 +42,7 @@ import java.util.TreeSet;
 public class TrustAnchors extends SecmodTest {
 
     public static void main(String[] args) throws Exception {
-        if (initSecmod() == false) {
-            return;
-        }
+        initSecmod();
 
         // our secmod.db file says nssckbi.*so*, so NSS does not find the
         // *DLL* on Windows nor the *DYLIB* on Mac OSX.

--- a/test/jdk/sun/security/pkcs11/SecmodTest.java
+++ b/test/jdk/sun/security/pkcs11/SecmodTest.java
@@ -42,7 +42,7 @@ public class SecmodTest extends PKCS11Test {
         useSqlite = b;
     }
 
-    static boolean initSecmod() throws Exception {
+    static void initSecmod() throws Exception {
         useNSS();
         LIBPATH = getNSSLibDir();
         // load all the libraries except libnss3 into memory
@@ -60,7 +60,7 @@ public class SecmodTest extends PKCS11Test {
             System.setProperty("pkcs11test.nss.db", DBDIR);
         }
         File dbdirFile = new File(DBDIR);
-        if (dbdirFile.exists() == false) {
+        if (!dbdirFile.exists()) {
             dbdirFile.mkdir();
         }
 
@@ -73,7 +73,6 @@ public class SecmodTest extends PKCS11Test {
             copyFile("key3.db", BASE, DBDIR);
             copyFile("cert8.db", BASE, DBDIR);
         }
-        return true;
     }
 
     private static void copyFile(String name, String srcDir, String dstDir) throws IOException {

--- a/test/jdk/sun/security/pkcs11/ec/ReadCertificates.java
+++ b/test/jdk/sun/security/pkcs11/ec/ReadCertificates.java
@@ -55,6 +55,7 @@ import java.util.List;
 import java.util.Map;
 import javax.security.auth.x500.X500Principal;
 import jdk.test.lib.security.Providers;
+import jtreg.SkippedException;
 
 public class ReadCertificates extends PKCS11Test {
 
@@ -78,8 +79,7 @@ public class ReadCertificates extends PKCS11Test {
     @Override
     public void main(Provider p) throws Exception {
         if (p.getService("Signature", "SHA1withECDSA") == null) {
-            System.out.println("Provider does not support ECDSA, skipping...");
-            return;
+            throw new SkippedException("Provider does not support ECDSA, skipping...");
         }
 
         /*

--- a/test/jdk/sun/security/pkcs11/ec/ReadPKCS12.java
+++ b/test/jdk/sun/security/pkcs11/ec/ReadPKCS12.java
@@ -54,6 +54,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import jdk.test.lib.security.Providers;
+import jtreg.SkippedException;
 
 public class ReadPKCS12 extends PKCS11Test {
 
@@ -66,8 +67,7 @@ public class ReadPKCS12 extends PKCS11Test {
     @Override
     public void main(Provider p) throws Exception {
         if (p.getService("Signature", "SHA1withECDSA") == null) {
-            System.out.println("Provider does not support ECDSA, skipping...");
-            return;
+            throw new SkippedException("Provider does not support ECDSA, skipping...");
         }
 
         /*

--- a/test/jdk/sun/security/pkcs11/ec/TestKeyFactory.java
+++ b/test/jdk/sun/security/pkcs11/ec/TestKeyFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,8 @@
  * @modules jdk.crypto.cryptoki
  * @run main/othervm TestKeyFactory
  */
+
+import jtreg.SkippedException;
 
 import java.security.Key;
 import java.security.KeyFactory;
@@ -126,8 +128,7 @@ public class TestKeyFactory extends PKCS11Test {
     @Override
     public void main(Provider p) throws Exception {
         if (p.getService("KeyFactory", "EC") == null) {
-            System.out.println("Provider does not support EC, skipping");
-            return;
+            throw new SkippedException("Provider does not support EC, skipping");
         }
         int[] keyLengths = {256, 521};
         KeyFactory kf = KeyFactory.getInstance("EC", p);

--- a/test/jdk/sun/security/pkcs11/rsa/KeyWrap.java
+++ b/test/jdk/sun/security/pkcs11/rsa/KeyWrap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,6 +32,8 @@
  * @run main/othervm KeyWrap
  */
 
+import jtreg.SkippedException;
+
 import java.security.GeneralSecurityException;
 import java.security.InvalidKeyException;
 import java.security.Key;
@@ -54,8 +56,7 @@ public class KeyWrap extends PKCS11Test {
         try {
             Cipher.getInstance("RSA/ECB/PKCS1Padding", p);
         } catch (GeneralSecurityException e) {
-            System.out.println("Not supported by provider, skipping");
-            return;
+            throw new SkippedException("Not supported by provider, skipping");
         }
         KeyPair kp;
         try {
@@ -74,8 +75,7 @@ public class KeyWrap extends PKCS11Test {
                 kp = new KeyPair(pub, priv);
             } catch (NoSuchAlgorithmException | InvalidKeyException ee) {
                 ee.printStackTrace();
-                System.out.println("Provider does not support RSA, skipping");
-                return;
+                throw new SkippedException("Provider does not support RSA, skipping");
             }
         }
         System.out.println(kp);

--- a/test/jdk/sun/security/pkcs11/sslecc/ClientJSSEServerJSSE.java
+++ b/test/jdk/sun/security/pkcs11/sslecc/ClientJSSEServerJSSE.java
@@ -40,6 +40,7 @@
 import java.security.Provider;
 import java.security.Security;
 import jdk.test.lib.security.Providers;
+import jtreg.SkippedException;
 
 public class ClientJSSEServerJSSE extends PKCS11Test {
 
@@ -58,8 +59,7 @@ public class ClientJSSEServerJSSE extends PKCS11Test {
     @Override
     public void main(Provider p) throws Exception {
         if (p.getService("KeyFactory", "EC") == null) {
-            System.out.println("Provider does not support EC, skipping");
-            return;
+            throw new SkippedException("Provider does not support EC, skipping");
         }
         Providers.setAt(p, 1);
         CipherTest.main(new JSSEFactory(), cmdArgs);


### PR DESCRIPTION
Tests changed:  
* test/jdk/sun/security/pkcs11/Config/ReadConfInUTF16Env.java
* test/jdk/sun/security/pkcs11/PKCS11Test.java
* test/jdk/sun/security/pkcs11/Secmod/AddPrivateKey.java
* test/jdk/sun/security/pkcs11/Secmod/AddTrustedCert.java
* test/jdk/sun/security/pkcs11/Secmod/Crypto.java
* test/jdk/sun/security/pkcs11/Secmod/GetPrivateKey.java
* test/jdk/sun/security/pkcs11/Secmod/JksSetPrivateKey.java
* test/jdk/sun/security/pkcs11/Secmod/LoadKeystore.java
* test/jdk/sun/security/pkcs11/Secmod/TestNssDbSqlite.java
* test/jdk/sun/security/pkcs11/Secmod/TrustAnchors.java
* test/jdk/sun/security/pkcs11/SecmodTest.java
* test/jdk/sun/security/pkcs11/ec/ReadCertificates.java
* test/jdk/sun/security/pkcs11/ec/ReadPKCS12.java
* test/jdk/sun/security/pkcs11/ec/TestKeyFactory.java
* test/jdk/sun/security/pkcs11/rsa/KeyWrap.java
* test/jdk/sun/security/pkcs11/sslecc/ClientJSSEServerJSSE.java