### PR TITLE
8367007: javadoc generation of JavaFX docs fails after fix for JDK-8350920

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AbstractMemberWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AbstractMemberWriter.java
@@ -319,7 +319,7 @@ public abstract class AbstractMemberWriter {
                 inheritedHeader.add(links);
 
                 if (utils.isIncluded(inheritedClass)) {
-                    var pHelper = writer.getPropertyHelper();
+                    var pHelper = configuration.propertyUtils.getPropertyHelper(inheritedClass);
                     Table<Element> table = createInheritedSummaryTable(inheritedClass);
 
                     for (Element member : inheritedMembers) {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ClassWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ClassWriter.java
@@ -96,7 +96,7 @@ public class ClassWriter extends SubWriterHolderWriter {
         this.typeElement = typeElement;
         this.classTree = classTree;
 
-        pHelper = new PropertyUtils.PropertyHelper(configuration, typeElement);
+        pHelper = configuration.propertyUtils.getPropertyHelper(typeElement);
 
         switch (typeElement.getKind()) {
             case ENUM   -> setEnumDocumentation(typeElement);

--- a/test/langtools/jdk/javadoc/doclet/testJavaFX/TestJavaFX.java
+++ b/test/langtools/jdk/javadoc/doclet/testJavaFX/TestJavaFX.java
@@ -25,7 +25,7 @@
  * @test
  * @bug 7112427 8012295 8025633 8026567 8061305 8081854 8150130 8162363
  *      8167967 8172528 8175200 8178830 8182257 8186332 8182765 8025091
- *      8203791 8184205 8249633 8261976 8350920
+ *      8203791 8184205 8249633 8261976 8350920 8367007
  * @summary Test of the JavaFX doclet features.
  * @library ../../lib
  * @modules jdk.javadoc/jdk.javadoc.internal.tool
@@ -54,10 +54,17 @@ public class TestJavaFX extends JavadocTester {
                 "-sourcepath", testSrc,
                 "-javafx",
                 "--disable-javafx-strict-checks",
-                "-Xdoclint:all,-missing",
                 "-package",
                 "pkg1");
         checkExit(Exit.OK);
+
+        checkOutput(Output.OUT, true,
+                "C.java:78: warning: no comment");
+        checkOutput(Output.OUT, false,
+                "C.java:59: warning: no comment",
+                "C.java:61: warning: no comment",
+                "C.java:63: warning: no comment",
+                "C.java:67: warning: no comment");
 
         checkOutput("pkg1/C.html", true,
                 """
@@ -266,6 +273,31 @@ public class TestJavaFX extends JavadocTester {
                     </section>""");
 
         checkOutput("pkg1/D.html", false, "shouldNotAppear");
+
+        // Test for inherited properties and property methods.
+        checkOrder("pkg1/B.html",
+                """
+                    Properties inherited from class&nbsp;<a href="C.html#property-summary" title="class in pkg1">C</a>""",
+                """
+                    <div class="block">Defines if paused.</div>""",
+                """
+                    <div class="block">Defines the direction/speed at which the <code>Timeline</code> is expected to
+                    be played.</div>""",
+                """
+                    Methods inherited from class&nbsp;<a href="C.html#method-summary" title="class in pkg1">C</a>""",
+                """
+                    <div class="block">Gets the value of the <code>rate</code> property.</div>""",
+                """
+                    <div class="block">Gets the value of the <code>paused</code> property.</div>""",
+                """
+                    <div class="block">Defines if paused.</div>""",
+                """
+                    <div class="block">Defines the direction/speed at which the <code>Timeline</code> is expected to
+                    be played.</div>""",
+                """
+                    <div class="block">Sets the value of the <code>paused</code> property.</div>""",
+                """
+                    <div class="block">Sets the value of the <code>rate</code> property.</div>""");
     }
 
     /*

--- a/test/langtools/jdk/javadoc/doclet/testJavaFX/pkg1/B.java
+++ b/test/langtools/jdk/javadoc/doclet/testJavaFX/pkg1/B.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package pkg1;
+
+public class B extends C {
+}


### PR DESCRIPTION
Please review a change to fix a regression when documenting inherited JavaFX property members after [JDK-8350920](https://bugs.openjdk.org/browse/JDK-8350920). The wrong `PropertyHelper` instance was used to initialize synthetic doc comments on property members, leading to potentially missing comments.

Since using the correct `PropertyHelper` instance would have led to property info being computed multiple times (previously it was only needed in `ClassWriter`), I added caching of `PropertyHelper` instances in the enclosing `PropertyUtils` instance. In the process I also removed some unnecessary fields from `PropertyHelper`, made the property member map lazily initialized, and cleaned up code and doc comments in `PropertyUtils` a bit.

The test adds a new subclass to a property-holding class in `TestJavaFX` to make sure inherited property members are documented correctly and no warnings are issued for missing synthetic doc comments.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8367007: javadoc generation of JavaFX docs fails after fix for JDK-8350920`

### Issue
 * [JDK-8367007](https://bugs.openjdk.org/browse/JDK-8367007): javadoc generation of JavaFX docs fails after fix for JDK-8350920 (**Bug** - P3)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)
 * [Nizar Benalla](https://openjdk.org/census#nbenalla) (@nizarbenalla - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27168/head:pull/27168` \
`$ git checkout pull/27168`

Update a local copy of the PR: \
`$ git checkout pull/27168` \
`$ git pull https://git.openjdk.org/jdk.git pull/27168/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27168`

View PR using the GUI difftool: \
`$ git pr show -t 27168`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27168.diff">https://git.openjdk.org/jdk/pull/27168.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27168#issuecomment-3270018832)
</details>
