### PR TITLE
8362282: runtime/logging/StressAsyncUL.java failed with exitValue = 134

### DIFF
--- a/src/hotspot/share/logging/logAsyncWriter.cpp
+++ b/src/hotspot/share/logging/logAsyncWriter.cpp
@@ -320,7 +320,7 @@ void AsyncLogWriter::initialize() {
   if (self->_initialized) {
     // We use LogOutputList's RCU counters to ensure all synchronous logsites have completed.
     // After that, we publish the initalized _instance to readers.
-    // Then, start the AsyncLog Thread; It exclusively takes over all logging I/O.
+    // Then we start the AsyncLog Thread and it exclusively takes over all logging I/O.
     for (LogTagSet* ts = LogTagSet::first(); ts != nullptr; ts = ts->next()) {
       ts->wait_until_no_readers();
     }

--- a/src/hotspot/share/logging/logAsyncWriter.cpp
+++ b/src/hotspot/share/logging/logAsyncWriter.cpp
@@ -318,13 +318,13 @@ void AsyncLogWriter::initialize() {
 
   AsyncLogWriter* self = new AsyncLogWriter();
   if (self->_initialized) {
-    Atomic::release_store_fence(&AsyncLogWriter::_instance, self);
-    // All readers of _instance after the fence see non-null.
     // We use LogOutputList's RCU counters to ensure all synchronous logsites have completed.
-    // After that, we start AsyncLog Thread and it exclusively takes over all logging I/O.
+    // After that, we publish the initalized _instance to readers.
+    // Then, start the AsyncLog Thread; It exclusively takes over all logging I/O.
     for (LogTagSet* ts = LogTagSet::first(); ts != nullptr; ts = ts->next()) {
       ts->wait_until_no_readers();
     }
+    Atomic::release_store_fence(&AsyncLogWriter::_instance, self);
     os::start_thread(self);
     log_debug(logging, thread)("Async logging thread started.");
   } else {


### PR DESCRIPTION
Hi everyone,

During `AsyncLogWriter` initialization we previously published the global `AsyncLogWriter _instance` before waiting for existing synchronous logging activity to finish and before starting the async consumer thread. As soon as `_instance` became visible, `is_enqueue_allowed()` allowed new log calls to switch to the async path. Those calls bumped `LogOutputList`'s counters while `initialize()` was waiting for `wait_until_no_readers()` to observe no active readers. At the same time, because the consumer thread wasn’t yet running, producers could end up waiting for a consumer that didn’t exist. In rare timing, this created a circular wait that manifested as intermittent lock-ups in `StressAsyncUL.java`.

The initialization order is changed so that we do not make the async writer visible until after all pre-existing synchronous logging has completed. Concretely, `initialize()` now:

1. waits for each `LogTagSet` to report no readers, ensuring synchronous logging is done,
2. publishes `_instance` with a release store so readers observe a fully initialized writer, and
3. immediately starts the async logging thread.

With this ordering, new async producers cannot keep the counters inflated while initialization is waiting. Any messages produced in the brief window between publishing `_instance` and the thread's first run are safely buffered and then consumed as soon as the thread starts.

Testing:
- Oracle tiers 1-3
- Repeated runs of `StressAsyncUL.java` with no observed lock-ups

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8362282](https://bugs.openjdk.org/browse/JDK-8362282): runtime/logging/StressAsyncUL.java failed with exitValue = 134 (**Bug** - P3)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) Review applies to [d8dd6162](https://git.openjdk.org/jdk/pull/27169/files/d8dd61627ebf0b468e41cca10d0009c0ff38145e)
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@jdksjolen - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27169/head:pull/27169` \
`$ git checkout pull/27169`

Update a local copy of the PR: \
`$ git checkout pull/27169` \
`$ git pull https://git.openjdk.org/jdk.git pull/27169/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27169`

View PR using the GUI difftool: \
`$ git pr show -t 27169`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27169.diff">https://git.openjdk.org/jdk/pull/27169.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27169#issuecomment-3270286412)
</details>
