### PR TITLE
8365239: Spec Clarification - InterfaceAddress:getBroadcast() returning null for loop back address

### DIFF
--- a/src/java.base/share/classes/java/net/InterfaceAddress.java
+++ b/src/java.base/share/classes/java/net/InterfaceAddress.java
@@ -63,8 +63,8 @@ public final class InterfaceAddress {
      * Only IPv4 networks have broadcast address therefore, in the case
      * of an IPv6 network, {@code null} will be returned.
      * <p>
-     * Certain network interfaces, such as the loopback interface, do not support
-     * broadcasting and will also return {@code null}.
+     * Some network interfaces do not support broadcasting and may
+     * also return {@code null}.
      *
      * @return the {@code InetAddress} representing the broadcast
      *         address or {@code null} if there is no broadcast address.


### PR DESCRIPTION
Hi,

This is a documentation change only. The specification of  `InterfaceAddress:getBroadcast()` should not say anything specific about the loopback interface as it appears that on some systems a broadcast address can be configured on the loopback. The API documentation of `InterfaceAddress:getBroadcast()` is updated to simply say that:
```
     * Some network interfaces do not support broadcasting and may
     * also return {@code null}.
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8367262](https://bugs.openjdk.org/browse/JDK-8367262) to be approved

### Issues
 * [JDK-8365239](https://bugs.openjdk.org/browse/JDK-8365239): Spec Clarification - InterfaceAddress:getBroadcast() returning null for loop back address (**Enhancement** - P3)
 * [JDK-8367262](https://bugs.openjdk.org/browse/JDK-8367262): Spec Clarification - InterfaceAddress:getBroadcast() returning null for loop back address (**CSR**)


### Reviewers
 * [Mark Sheppard](https://openjdk.org/census#msheppar) (@msheppar - **Reviewer**)
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27174/head:pull/27174` \
`$ git checkout pull/27174`

Update a local copy of the PR: \
`$ git checkout pull/27174` \
`$ git pull https://git.openjdk.org/jdk.git pull/27174/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27174`

View PR using the GUI difftool: \
`$ git pr show -t 27174`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27174.diff">https://git.openjdk.org/jdk/pull/27174.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27174#issuecomment-3271183209)
</details>
