### PR TITLE
JDK-8367243

### DIFF
--- a/src/hotspot/share/opto/phaseX.cpp
+++ b/src/hotspot/share/opto/phaseX.cpp
@@ -780,7 +780,7 @@ void PhaseGVN::dead_loop_check( Node *n ) {
         }
       }
     }
-    if (!no_dead_loop) n->dump_bfs(100,nullptr,"#");
+    if (!no_dead_loop) { n->dump_bfs(100, nullptr, ""); }
     assert(no_dead_loop, "dead loop detected");
   }
 }


### PR DESCRIPTION
The `#` option adds color to the terminal. But that only usually works on people's terminals, and not if it is piped to a file on the server. Hence, `#` is only really a debugging feature, and not one to report with in connection with `assert`s.

Simply removed the `#`, and fixed some braces and spaces.