### PR TITLE
8367131: Test com/sun/jdi/ThreadMemoryLeakTest.java fails on 32 bits

### DIFF
--- a/test/jdk/com/sun/jdi/ThreadMemoryLeakTest.java
+++ b/test/jdk/com/sun/jdi/ThreadMemoryLeakTest.java
@@ -28,7 +28,7 @@
  *
  * @comment Don't allow -Xcomp or -Xint as they impact memory useage and number of iterations.
  *          Require compressed oops because not doing so increases memory usage.
- * @requires (vm.compMode == "Xmixed") & ((vm.bits == 64 & vm.opt.final.UseCompressedOops) | vm.bits == 32)
+ * @requires (vm.compMode == "Xmixed") & (vm.bits == 32 | vm.opt.final.UseCompressedOops)
  * @run build TestScaffold VMConnection TargetListener TargetAdapter
  * @run compile -g ThreadMemoryLeakTest.java
  * @comment run with -Xmx7m so any leak will quickly produce OOME

--- a/test/jdk/com/sun/jdi/ThreadMemoryLeakTest.java
+++ b/test/jdk/com/sun/jdi/ThreadMemoryLeakTest.java
@@ -28,7 +28,7 @@
  *
  * @comment Don't allow -Xcomp or -Xint as they impact memory useage and number of iterations.
  *          Require compressed oops because not doing so increases memory usage.
- * @requires (vm.compMode == "Xmixed") & vm.opt.final.UseCompressedOops
+ * @requires (vm.compMode == "Xmixed") & ((vm.bits == 64 & vm.opt.final.UseCompressedOops) | vm.bits == 32)
  * @run build TestScaffold VMConnection TargetListener TargetAdapter
  * @run compile -g ThreadMemoryLeakTest.java
  * @comment run with -Xmx7m so any leak will quickly produce OOME


### PR DESCRIPTION
On 32-bit systems, the ThreadMemoryLeakTest can be run as is. The option vm.opt.final.UseCompressedOops must be guarded by vm.bits == 64; otherwise, an error occurs.

Tested on:
 - 64-bit: with and without -Xcomp, -Xint, -Xmixed, and with/without -+UseCompressedOops
 - 32-bit: with and without -Xcomp, -Xint, -Xmixed

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8367131](https://bugs.openjdk.org/browse/JDK-8367131): Test com/sun/jdi/ThreadMemoryLeakTest.java fails on 32 bits (**Bug** - P4)


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27177/head:pull/27177` \
`$ git checkout pull/27177`

Update a local copy of the PR: \
`$ git checkout pull/27177` \
`$ git pull https://git.openjdk.org/jdk.git pull/27177/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27177`

View PR using the GUI difftool: \
`$ git pr show -t 27177`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27177.diff">https://git.openjdk.org/jdk/pull/27177.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27177#issuecomment-3272455076)
</details>
