### PR TITLE
8367291: Test runtime/verifier/CFLH/TestVerify.java fails after JDK-8366908

### DIFF
--- a/test/hotspot/jtreg/runtime/verifier/CFLH/TestVerify.java
+++ b/test/hotspot/jtreg/runtime/verifier/CFLH/TestVerify.java
@@ -148,7 +148,10 @@ public class TestVerify {
         // double check our class hasn't been loaded yet
         for (Class clazz : inst.getAllLoadedClasses()) {
             if (clazz.getName().equals(CLASS_TO_BREAK)) {
-                throw new AssertionError("Oops! Class " + CLASS_TO_BREAK + " is already loaded, the test can't work");
+                // This can happen to whatever java.base class I pick, so skip the test if the class is already
+                // loaded.
+                System.out.println("Oops! Class " + CLASS_TO_BREAK + " is already loaded, the test can't work");
+                return;
             }
         }
 


### PR DESCRIPTION
Please review this trivial change to exit the test if the class to verify has already been loaded.
Tested with the test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8367291](https://bugs.openjdk.org/browse/JDK-8367291): Test runtime/verifier/CFLH/TestVerify.java fails after JDK-8366908 (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27179/head:pull/27179` \
`$ git checkout pull/27179`

Update a local copy of the PR: \
`$ git checkout pull/27179` \
`$ git pull https://git.openjdk.org/jdk.git pull/27179/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27179`

View PR using the GUI difftool: \
`$ git pr show -t 27179`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27179.diff">https://git.openjdk.org/jdk/pull/27179.diff</a>

</details>
