### PR TITLE
8366938: Test runtime/handshake/HandshakeTimeoutTest.java crashed

### DIFF
--- a/test/hotspot/jtreg/runtime/handshake/HandshakeTimeoutTest.java
+++ b/test/hotspot/jtreg/runtime/handshake/HandshakeTimeoutTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@ import jdk.test.whitebox.WhiteBox;
  * @library /testlibrary /test/lib
  * @build HandshakeTimeoutTest
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
- * @run driver HandshakeTimeoutTest
+ * @run driver/timeout=480 HandshakeTimeoutTest
  */
 
 public class HandshakeTimeoutTest {


### PR DESCRIPTION
Please review this trivial test fix to restore the timeout to 480 as it would implicitly have been before the timeout-factor change.

Thanks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8366938](https://bugs.openjdk.org/browse/JDK-8366938): Test runtime/handshake/HandshakeTimeoutTest.java crashed (**Bug** - P2)


### Reviewers
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27183/head:pull/27183` \
`$ git checkout pull/27183`

Update a local copy of the PR: \
`$ git checkout pull/27183` \
`$ git pull https://git.openjdk.org/jdk.git pull/27183/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27183`

View PR using the GUI difftool: \
`$ git pr show -t 27183`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27183.diff">https://git.openjdk.org/jdk/pull/27183.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27183#issuecomment-3273399599)
</details>
