### PR TITLE
8367298: ZGC: Enhance zaddress type system's assert messages

### DIFF
--- a/src/hotspot/share/gc/z/zAddress.inline.hpp
+++ b/src/hotspot/share/gc/z/zAddress.inline.hpp
@@ -149,18 +149,18 @@ inline bool operator>=(offset_type first, offset_type##_end second) {           
 
 inline uintptr_t untype(zoffset offset) {
   const uintptr_t value = static_cast<uintptr_t>(offset);
-  assert(value < ZAddressOffsetMax, "must have no other bits");
+  assert(value < ZAddressOffsetMax, "Offset out of bounds (" PTR_FORMAT " < " PTR_FORMAT ")", value, ZAddressOffsetMax);
   return value;
 }
 
 inline uintptr_t untype(zoffset_end offset) {
   const uintptr_t value = static_cast<uintptr_t>(offset);
-  assert(value <= ZAddressOffsetMax, "must have no other bits");
+  assert(value <= ZAddressOffsetMax, "Offset out of bounds (" PTR_FORMAT " <= " PTR_FORMAT ")", value, ZAddressOffsetMax);
   return value;
 }
 
 inline zoffset to_zoffset(uintptr_t value) {
-  assert(value < ZAddressOffsetMax, "must have no other bits");
+  assert(value < ZAddressOffsetMax, "Value out of bounds (" PTR_FORMAT " < " PTR_FORMAT ")", value, ZAddressOffsetMax);
   return zoffset(value);
 }
 
@@ -186,7 +186,7 @@ inline zoffset_end to_zoffset_end(zoffset start, size_t size) {
 }
 
 inline zoffset_end to_zoffset_end(uintptr_t value) {
-  assert(value <= ZAddressOffsetMax, "Overflow");
+  assert(value <= ZAddressOffsetMax, "Value out of bounds (" PTR_FORMAT " <= " PTR_FORMAT ")", value, ZAddressOffsetMax);
   return zoffset_end(value);
 }
 
@@ -200,18 +200,18 @@ CREATE_ZOFFSET_OPERATORS(zoffset)
 
 inline uintptr_t untype(zbacking_offset offset) {
   const uintptr_t value = static_cast<uintptr_t>(offset);
-  assert(value < ZBackingOffsetMax, "must have no other bits");
+  assert(value < ZBackingOffsetMax, "Offset out of bounds (" PTR_FORMAT " < " PTR_FORMAT ")", value, ZAddressOffsetMax);
   return value;
 }
 
 inline uintptr_t untype(zbacking_offset_end offset) {
   const uintptr_t value = static_cast<uintptr_t>(offset);
-  assert(value <= ZBackingOffsetMax, "must have no other bits");
+  assert(value <= ZBackingOffsetMax, "Offset out of bounds (" PTR_FORMAT " <= " PTR_FORMAT ")", value, ZAddressOffsetMax);
   return value;
 }
 
 inline zbacking_offset to_zbacking_offset(uintptr_t value) {
-  assert(value < ZBackingOffsetMax, "must have no other bits");
+  assert(value < ZBackingOffsetMax, "Value out of bounds (" PTR_FORMAT " < " PTR_FORMAT ")", value, ZAddressOffsetMax);
   return zbacking_offset(value);
 }
 
@@ -228,7 +228,7 @@ inline zbacking_offset_end to_zbacking_offset_end(zbacking_offset start, size_t 
 }
 
 inline zbacking_offset_end to_zbacking_offset_end(uintptr_t value) {
-  assert(value <= ZBackingOffsetMax, "must have no other bits");
+  assert(value <= ZBackingOffsetMax, "Value out of bounds (" PTR_FORMAT " <= " PTR_FORMAT ")", value, ZAddressOffsetMax);
   return zbacking_offset_end(value);
 }
 
@@ -242,18 +242,18 @@ CREATE_ZOFFSET_OPERATORS(zbacking_offset)
 
 inline uint32_t untype(zbacking_index index) {
   const uint32_t value = static_cast<uint32_t>(index);
-  assert(value < ZBackingIndexMax, "must have no other bits");
+  assert(value < ZBackingIndexMax, "Offset out of bounds (" UINT32_FORMAT_X_0 " < " UINT32_FORMAT_X_0 ")", value, ZBackingIndexMax);
   return value;
 }
 
 inline uint32_t untype(zbacking_index_end index) {
   const uint32_t value = static_cast<uint32_t>(index);
-  assert(value <= ZBackingIndexMax, "must have no other bits");
+  assert(value <= ZBackingIndexMax, "Offset out of bounds (" UINT32_FORMAT_X_0 " <= " UINT32_FORMAT_X_0 ")", value, ZBackingIndexMax);
   return value;
 }
 
 inline zbacking_index to_zbacking_index(uint32_t value) {
-  assert(value < ZBackingIndexMax, "must have no other bits");
+  assert(value < ZBackingIndexMax, "Value out of bounds (" UINT32_FORMAT_X_0 " < " UINT32_FORMAT_X_0 ")", value, ZBackingIndexMax);
   return zbacking_index(value);
 }
 
@@ -266,12 +266,12 @@ inline zbacking_index_end to_zbacking_index_end(zbacking_index start, size_t siz
   const uint32_t start_value = untype(start);
   const uint32_t value = start_value + checked_cast<uint32_t>(size);
   assert(value <= ZBackingIndexMax && start_value <= value,
-         "Overflow start: %x size: %zu value: %x", start_value, size, value);
+         "Overflow start: " UINT32_FORMAT_X_0 " size: %zu value: " UINT32_FORMAT_X_0 "", start_value, size, value);
   return zbacking_index_end(value);
 }
 
 inline zbacking_index_end to_zbacking_index_end(uint32_t value) {
-  assert(value <= ZBackingIndexMax, "must have no other bits");
+  assert(value <= ZBackingIndexMax, "Value out of bounds (" UINT32_FORMAT_X_0 " <= " UINT32_FORMAT_X_0 ")", value, ZBackingIndexMax);
   return zbacking_index_end(value);
 }
 
@@ -287,7 +287,7 @@ CREATE_ZOFFSET_OPERATORS(zbacking_index)
 
 inline zbacking_index to_zbacking_index(zbacking_offset offset) {
   const uintptr_t value = untype(offset);
-  assert(is_aligned(value, ZGranuleSize), "must be granule aligned");
+  assert(is_aligned(value, ZGranuleSize), "Must be granule aligned (" PTR_FORMAT ")", value);
   return to_zbacking_index((uint32_t)(value >> ZGranuleSizeShift));
 }
 
@@ -420,7 +420,7 @@ inline bool is_null_any(zpointer ptr) {
 // Is it null - colored or not?
 inline bool is_null_assert_load_good(zpointer ptr) {
   const bool result = is_null_any(ptr);
-  assert(!result || ZPointer::is_load_good(ptr), "Got bad colored null");
+  assert(!result || ZPointer::is_load_good(ptr), "Got bad colored null: " PTR_FORMAT, untype(ptr));
   return result;
 }
 
@@ -620,7 +620,7 @@ inline zaddress ZPointer::uncolor_store_good(zpointer ptr) {
 }
 
 inline zaddress_unsafe ZPointer::uncolor_unsafe(zpointer ptr) {
-  assert(ZPointer::is_store_bad(ptr), "Unexpected ptr");
+  assert(ZPointer::is_store_bad(ptr), "Should be store bad: " PTR_FORMAT, untype(ptr));
   const uintptr_t raw_addr = untype(ptr);
   return to_zaddress_unsafe(raw_addr >> ZPointer::load_shift_lookup(raw_addr));
 }
@@ -642,7 +642,7 @@ inline bool ZPointer::is_load_good_or_null(zpointer ptr) {
   // the barrier as if it was null. This should be harmless as such
   // addresses should ever be passed through the barrier.
   const bool result = !is_load_bad(ptr);
-  assert((is_load_good(ptr) || is_null(ptr)) == result, "Bad address");
+  assert((is_load_good(ptr) || is_null(ptr)) == result, "Bad address: " PTR_FORMAT, untype(ptr));
   return result;
 }
 
@@ -673,7 +673,7 @@ inline bool ZPointer::is_mark_good_or_null(zpointer ptr) {
   // the barrier as if it was null. This should be harmless as such
   // addresses should ever be passed through the barrier.
   const bool result = !is_mark_bad(ptr);
-  assert((is_mark_good(ptr) || is_null(ptr)) == result, "Bad address");
+  assert((is_mark_good(ptr) || is_null(ptr)) == result, "Bad address: " PTR_FORMAT, untype(ptr));
   return result;
 }
 
@@ -694,7 +694,7 @@ inline bool ZPointer::is_store_good_or_null(zpointer ptr) {
   // the barrier as if it was null. This should be harmless as such
   // addresses should ever be passed through the barrier.
   const bool result = !is_store_bad(ptr);
-  assert((is_store_good(ptr) || is_null(ptr)) == result, "Bad address");
+  assert((is_store_good(ptr) || is_null(ptr)) == result, "Bad address: " PTR_FORMAT, untype(ptr));
   return result;
 }
 

--- a/src/hotspot/share/gc/z/zAddress.inline.hpp
+++ b/src/hotspot/share/gc/z/zAddress.inline.hpp
@@ -287,7 +287,7 @@ CREATE_ZOFFSET_OPERATORS(zbacking_index)
 
 inline zbacking_index to_zbacking_index(zbacking_offset offset) {
   const uintptr_t value = untype(offset);
-  assert(is_aligned(value, ZGranuleSize), "Must be granule aligned (" PTR_FORMAT ")", value);
+  assert(is_aligned(value, ZGranuleSize), "Must be granule aligned: " PTR_FORMAT, value);
   return to_zbacking_index((uint32_t)(value >> ZGranuleSizeShift));
 }
 


### PR DESCRIPTION
ZGC uses a family of strongly type integral types to test and verify invariants for addresses, offset, indices and colored pointers within the heap. It is usually the first place we hit an assert if something goes wrong, and looking at the actual value is often enough to identify if it is memory corruption, a broken color invariant or a mistake in the use of the type system.

Unfortunately not all asserts print the value in the assert message, requiring more extensive investigation to even identify the nature of the problem.

I propose we enhance all our zaddress assert printing to always include the invariant breaking value.

_While I chose to print the max values in the assert message of the offset and indices checks, I did not print the colors in the zpointer checks. Both colors and the max values are easily available in the error report, so it would only really be a problem if a hs_err file is missing._ 

We should probably also see if we can enhance all the rest of our asserts in ZGC similarly. I do not think I have ever seen a failed invariant check and thought "Why are we printing the invariant breaking value", but often feel that it is unfortunate that we did not print the actual value.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8367298](https://bugs.openjdk.org/browse/JDK-8367298): ZGC: Enhance zaddress type system's assert messages (**Enhancement** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27184/head:pull/27184` \
`$ git checkout pull/27184`

Update a local copy of the PR: \
`$ git checkout pull/27184` \
`$ git pull https://git.openjdk.org/jdk.git pull/27184/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27184`

View PR using the GUI difftool: \
`$ git pr show -t 27184`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27184.diff">https://git.openjdk.org/jdk/pull/27184.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27184#issuecomment-3273438591)
</details>
