### PR TITLE
8024419: Can not find the specified directory in the frame.

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -789,7 +789,6 @@ java/foreign/TestBufferStackStress.java                         8350455 macosx-a
 ############################################################################
 # Client manual tests
 
-javax/swing/JFileChooser/6698013/bug6698013.java 8024419 macosx-all
 javax/swing/JColorChooser/8065098/bug8065098.java 8065647 macosx-all
 javax/swing/JTabbedPane/bug4499556.java 8267500 macosx-all
 javax/swing/JTabbedPane/bug4666224.java 8144124  macosx-all

--- a/test/jdk/javax/swing/JFileChooser/6698013/bug6698013.java
+++ b/test/jdk/javax/swing/JFileChooser/6698013/bug6698013.java
@@ -29,6 +29,7 @@ import javax.swing.filechooser.FileSystemView;
 /*
  * @test
  * @bug 6698013
+ * @requires (os.family != "mac")
  * @library /java/awt/regtesthelpers
  * @build PassFailJFrame
  * @summary JFileChooser can no longer navigate non-local file systems.

--- a/test/jdk/javax/swing/JFileChooser/6698013/bug6698013.java
+++ b/test/jdk/javax/swing/JFileChooser/6698013/bug6698013.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,10 +42,13 @@ public class bug6698013 {
 
     public static void main(String[] args) throws Exception {
         String instructions = """
-                1. Go into 'subdir' folder via double click
-                2. Return to parent directory
-                3. Go into 'subdir' folder: select 'subdir' folder and press the 'Open' button
-                If both methods of navigating into the subdir work, pass test. Otherwise fail.""";
+            This test verifies navigating into 'subdir' folder in couple of ways
+
+            1. Go into 'subdir' folder via double click and then
+                    return to 'testdir' parent directory
+            2. Select 'subdir' folder and press the 'Open' button
+
+            If both methods of navigating into the 'subdir' folder work, press Pass else Fail.""";
 
         PassFailJFrame pfframe = PassFailJFrame.builder()
                 .title("bug6698013")


### PR DESCRIPTION
Test tests navigation on virtual file created on Virtual File System which is not supported in macos so restricting it for osx run.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8024419](https://bugs.openjdk.org/browse/JDK-8024419)

### Warning
&nbsp;⚠️ Found trailing period in issue title for `8024419: Can not find the specified directory in the frame.`

### Issue
 * [JDK-8024419](https://bugs.openjdk.org/browse/JDK-8024419): Cannot find the specified directory in the frame (**Bug** - P4) ⚠️ Title mismatch between PR and JBS.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27185/head:pull/27185` \
`$ git checkout pull/27185`

Update a local copy of the PR: \
`$ git checkout pull/27185` \
`$ git pull https://git.openjdk.org/jdk.git pull/27185/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27185`

View PR using the GUI difftool: \
`$ git pr show -t 27185`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27185.diff">https://git.openjdk.org/jdk/pull/27185.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27185#issuecomment-3273554208)
</details>
