### PR TITLE
8367309: Test runtime/os/windows/TestAvailableProcessors.java fails to compile after mis-merge

### DIFF
--- a/test/hotspot/jtreg/runtime/os/windows/TestAvailableProcessors.java
+++ b/test/hotspot/jtreg/runtime/os/windows/TestAvailableProcessors.java
@@ -34,8 +34,10 @@
  * @run testng/othervm/native TestAvailableProcessors
  */
 
-import java.io.File;
+
 import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.HashSet;
 import java.util.Set;


### PR DESCRIPTION
Restored the deleted imports. Removed an unneeded import.

Thanks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8367309](https://bugs.openjdk.org/browse/JDK-8367309): Test runtime/os/windows/TestAvailableProcessors.java fails to compile after mis-merge (**Bug** - P2)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27186/head:pull/27186` \
`$ git checkout pull/27186`

Update a local copy of the PR: \
`$ git checkout pull/27186` \
`$ git pull https://git.openjdk.org/jdk.git pull/27186/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27186`

View PR using the GUI difftool: \
`$ git pr show -t 27186`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27186.diff">https://git.openjdk.org/jdk/pull/27186.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27186#issuecomment-3273853744)
</details>
