### PR TITLE
8367313: CTW: Execute in AWT headless mode

### DIFF
--- a/test/hotspot/jtreg/testlibrary/ctw/src/sun/hotspot/tools/ctw/CtwRunner.java
+++ b/test/hotspot/jtreg/testlibrary/ctw/src/sun/hotspot/tools/ctw/CtwRunner.java
@@ -292,6 +292,8 @@ public class CtwRunner {
                 "--add-exports", "java.base/jdk.internal.misc=ALL-UNNAMED",
                 "--add-exports", "java.base/jdk.internal.reflect=ALL-UNNAMED",
                 "--add-exports", "java.base/jdk.internal.access=ALL-UNNAMED",
+                // Graphics clinits may run, force headless mode
+                "-Djava.awt.headless=true",
                 // enable diagnostic logging
                 "-XX:+LogCompilation",
                 // use phase specific log, hs_err and ciReplay files


### PR DESCRIPTION
I have been doing CTW parallelization improvements, and noticed that some of the AWT clinits run and initialize graphics stack. This is awkward for a few reasons:

 1. We might be running on headless environment and these clinits could fail, shrinking the CTW testing scope.
 2. There are dependencies in graphics stack initialization that break -- in one case in my parallelization tests, I have seen the VM crash due to uninitialized AWT lock, because randomized CTW runner managed to execute clinits in unusual order. Running in headless mode avoids dealing with that path altogether.

I think we should be running CTW tests in AWT headless mode to begin with. 

Additional testing:
 - [x] Linux x86_64 server fastdebug, `applications/ctw/modules`