### PR TITLE
8359104: gc/TestAlwaysPreTouchBehavior.java#<gcname> fails on Linux

### DIFF
--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -376,9 +376,9 @@ size_t os::physical_memory() {
 // Users requiring accurate RSS values should be aware of this limitation.
 size_t os::rss() {
   size_t size = 0;
-  os::Linux::accurate_meminfo_t info;
-  if (os::Linux::query_accurate_process_memory_info(&info) && info.rss != -1) {
-    size = info.rss * K;
+  os::Linux::accurate_meminfo_t accurate_info;
+  if (os::Linux::query_accurate_process_memory_info(&accurate_info) && accurate_info.rss != -1) {
+    size = accurate_info.rss * K;
   } else {
     os::Linux::meminfo_t info;
     if (os::Linux::query_process_memory_info(&info)) {
@@ -2374,30 +2374,32 @@ bool os::Linux::query_process_memory_info(os::Linux::meminfo_t* info) {
 // Accurate memory information need Linux 4.14 or newer
 bool os::Linux::query_accurate_process_memory_info(os::Linux::accurate_meminfo_t* info) {
   FILE* f = os::fopen("/proc/self/smaps_rollup", "r");
-  const int num_values = sizeof(os::Linux::accurate_meminfo_t) / sizeof(size_t);
-  int num_found = 0;
+  if (f == nullptr) {
+    return false;
+  }
+
+  const size_t num_values = sizeof(os::Linux::accurate_meminfo_t) / sizeof(size_t);
+  size_t num_found = 0;
   char buf[256];
   info->rss = info->pss = info->pssdirty = info->pssanon =
       info->pssfile = info->pssshmem = info->swap = info->swappss = -1;
-  if (f != nullptr) {
-    while (::fgets(buf, sizeof(buf), f) != nullptr && num_found < num_values) {
-      if ( (info->rss == -1        && sscanf(buf, "Rss: %zd kB", &info->rss) == 1) ||
-           (info->pss == -1        && sscanf(buf, "Pss: %zd kB", &info->pss) == 1) ||
-           (info->pssdirty == -1   && sscanf(buf, "Pss_Dirty: %zd kB", &info->pssdirty) == 1) ||
-           (info->pssanon == -1    && sscanf(buf, "Pss_Anon: %zd kB", &info->pssanon) == 1) ||
-           (info->pssfile == -1    && sscanf(buf, "Pss_File: %zd kB", &info->pssfile) == 1) ||
-           (info->pssshmem == -1   && sscanf(buf, "Pss_Shmem: %zd kB", &info->pssshmem) == 1) ||
-           (info->swap == -1       && sscanf(buf, "Swap: %zd kB", &info->swap) == 1) ||
-           (info->swappss == -1    && sscanf(buf, "SwapPss: %zd kB", &info->swappss) == 1)
-           )
-      {
-        num_found ++;
-      }
+
+  while (::fgets(buf, sizeof(buf), f) != nullptr && num_found < num_values) {
+    if ( (info->rss == -1        && sscanf(buf, "Rss: %zd kB", &info->rss) == 1) ||
+         (info->pss == -1        && sscanf(buf, "Pss: %zd kB", &info->pss) == 1) ||
+         (info->pssdirty == -1   && sscanf(buf, "Pss_Dirty: %zd kB", &info->pssdirty) == 1) ||
+         (info->pssanon == -1    && sscanf(buf, "Pss_Anon: %zd kB", &info->pssanon) == 1) ||
+         (info->pssfile == -1    && sscanf(buf, "Pss_File: %zd kB", &info->pssfile) == 1) ||
+         (info->pssshmem == -1   && sscanf(buf, "Pss_Shmem: %zd kB", &info->pssshmem) == 1) ||
+         (info->swap == -1       && sscanf(buf, "Swap: %zd kB", &info->swap) == 1) ||
+         (info->swappss == -1    && sscanf(buf, "SwapPss: %zd kB", &info->swappss) == 1)
+         )
+    {
+      num_found ++;
     }
-    fclose(f);
-    return true;
   }
-  return false;
+  fclose(f);
+  return true;
 }
 
 #ifdef __GLIBC__

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -370,11 +370,20 @@ size_t os::physical_memory() {
   return phys_mem;
 }
 
+// Returns the resident set size (RSS) of the process.
+// Falls back to using VmRSS from /proc/self/status if /proc/self/smaps_rollup is unavailable.
+// Note: On kernels with memory cgroups or shared memory, VmRSS may underreport RSS.
+// Users requiring accurate RSS values should be aware of this limitation.
 size_t os::rss() {
   size_t size = 0;
-  os::Linux::meminfo_t info;
-  if (os::Linux::query_process_memory_info(&info)) {
-    size = info.vmrss * K;
+  os::Linux::accurate_meminfo_t info;
+  if (os::Linux::query_accurate_process_memory_info(&info)) {
+    size = info.rss * K;
+  } else {
+    os::Linux::meminfo_t info;
+    if (os::Linux::query_process_memory_info(&info)) {
+      size = info.vmrss * K;
+    }
   }
   return size;
 }
@@ -2351,6 +2360,35 @@ bool os::Linux::query_process_memory_info(os::Linux::meminfo_t* info) {
            (info->rssanon == -1   && sscanf(buf, "RssAnon: %zd kB", &info->rssanon) == 1) || // Needs Linux 4.5
            (info->rssfile == -1   && sscanf(buf, "RssFile: %zd kB", &info->rssfile) == 1) || // Needs Linux 4.5
            (info->rssshmem == -1  && sscanf(buf, "RssShmem: %zd kB", &info->rssshmem) == 1)  // Needs Linux 4.5
+           )
+      {
+        num_found ++;
+      }
+    }
+    fclose(f);
+    return true;
+  }
+  return false;
+}
+
+// Accurate memory information need Linux 4.14 or newer
+bool os::Linux::query_accurate_process_memory_info(os::Linux::accurate_meminfo_t* info) {
+  FILE* f = os::fopen("/proc/self/smaps_rollup", "r");
+  const int num_values = sizeof(os::Linux::accurate_meminfo_t) / sizeof(size_t);
+  int num_found = 0;
+  char buf[256];
+  info->rss = info->pss = info->pssdirty = info->pssanon =
+      info->pssfile = info->pssshmem = info->swap = info->swappss = -1;
+  if (f != nullptr) {
+    while (::fgets(buf, sizeof(buf), f) != nullptr && num_found < num_values) {
+      if ( (info->rss == -1        && sscanf(buf, "Rss: %zd kB", &info->rss) == 1) ||
+           (info->pss == -1        && sscanf(buf, "Pss: %zd kB", &info->pss) == 1) ||
+           (info->pssdirty == -1   && sscanf(buf, "Pss_Dirty: %zd kB", &info->pssdirty) == 1) ||
+           (info->pssanon == -1    && sscanf(buf, "Pss_Anon: %zd kB", &info->pssanon) == 1) ||
+           (info->pssfile == -1    && sscanf(buf, "Pss_File: %zd kB", &info->pssfile) == 1) ||
+           (info->pssshmem == -1   && sscanf(buf, "Pss_Shmem: %zd kB", &info->pssshmem) == 1) ||
+           (info->swap == -1       && sscanf(buf, "Swap: %zd kB", &info->swap) == 1) ||
+           (info->swappss == -1    && sscanf(buf, "SwapPss: %zd kB", &info->swappss) == 1)
            )
       {
         num_found ++;

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -377,7 +377,7 @@ size_t os::physical_memory() {
 size_t os::rss() {
   size_t size = 0;
   os::Linux::accurate_meminfo_t info;
-  if (os::Linux::query_accurate_process_memory_info(&info)) {
+  if (os::Linux::query_accurate_process_memory_info(&info) && info.rss != -1) {
     size = info.rss * K;
   } else {
     os::Linux::meminfo_t info;

--- a/src/hotspot/os/linux/os_linux.hpp
+++ b/src/hotspot/os/linux/os_linux.hpp
@@ -181,6 +181,23 @@ class os::Linux {
   // fields will contain -1.
   static bool query_process_memory_info(meminfo_t* info);
 
+  // Output structure for query_accurate_process_memory_info() (all values in KB)
+  struct accurate_meminfo_t {
+    ssize_t rss;        // current resident set size
+    ssize_t pss;        // current proportional set size
+    ssize_t pssdirty;   // proportional set size (dirty)
+    ssize_t pssanon;    // proportional set size (anonymous mappings)
+    ssize_t pssfile;    // proportional set size (file mappings)
+    ssize_t pssshmem;   // proportional set size (shared mappings)
+    ssize_t swap;       // swapped out
+    ssize_t swappss;    // proportional set size (swapped out)
+  };
+
+  // Attempts to query accurate memory information from /proc/self/smaps_rollup and return it in the output structure.
+  // May fail (returns false) or succeed (returns true) but not all output fields are available; unavailable
+  // fields will contain -1.
+  static bool query_accurate_process_memory_info(accurate_meminfo_t* info);
+
   // Tells if the user asked for transparent huge pages.
   static bool _thp_requested;
 

--- a/test/hotspot/jtreg/gc/TestAlwaysPreTouchBehavior.java
+++ b/test/hotspot/jtreg/gc/TestAlwaysPreTouchBehavior.java
@@ -155,7 +155,7 @@ public class TestAlwaysPreTouchBehavior {
         }
         if (available > requiredAvailable) {
             Asserts.assertGreaterThan(rss, minRequiredRss, "RSS of this process(" + rss + "b) should be bigger " +
-                                      "than or equal to heap size(" + heapSize + "b) (available memory: " + available + ")");
+                                      "than or equal to heap size(" + heapSize + "b) (available memory: " + available + "). On Linux Kernel < 4.14 RSS can be inaccurate");
         }
     }
 }


### PR DESCRIPTION
Get accurate RSS, from smaps_rollup if available(Linux >= 4.14), because the RSS from status is inaccurate especially on systems with more than 32 CPUs.

Not sure if all the additional meminfos like the Pss, Pss_dirty, Pss_Anon, Pss_File, Pss_Shmem, Swap and SwapPss are really needed too. But can be perhaps helpful too.

As the inaccurate memory infos are still used in other methods:
- [print_process_memory_info()](https://github.com/openjdk/jdk/blob/385c13298932f1de16e6161652be35d966d822ec/src/hotspot/os/linux/os_linux.cpp#L2393)
- [jfr_report_memory_info()](https://github.com/openjdk/jdk/blob/385c13298932f1de16e6161652be35d966d822ec/src/hotspot/os/linux/os_linux.cpp#L2686)
- [trim_native_heap()](https://github.com/openjdk/jdk/blob/385c13298932f1de16e6161652be35d966d822ec/src/hotspot/os/linux/os_linux.cpp#L5376)

one can think about to use the accurate values there too.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8359104](https://bugs.openjdk.org/browse/JDK-8359104): gc/TestAlwaysPreTouchBehavior.java#&lt;gcname&gt; fails on Linux (**Bug** - P2)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27192/head:pull/27192` \
`$ git checkout pull/27192`

Update a local copy of the PR: \
`$ git checkout pull/27192` \
`$ git pull https://git.openjdk.org/jdk.git pull/27192/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27192`

View PR using the GUI difftool: \
`$ git pr show -t 27192`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27192.diff">https://git.openjdk.org/jdk/pull/27192.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27192#issuecomment-3275131313)
</details>
