### PR TITLE
8366951: Test runtime/logging/StressAsyncUL.java is timing out

### DIFF
--- a/test/hotspot/jtreg/runtime/logging/StressAsyncUL.java
+++ b/test/hotspot/jtreg/runtime/logging/StressAsyncUL.java
@@ -45,12 +45,12 @@ public class StressAsyncUL {
         }
     }
     public static void main(String[] args) throws Exception {
-        analyze_output(false, "-Xlog:async:drop", "-Xlog:all=trace", InnerClass.class.getName());
-        analyze_output(true, "-Xlog:async:stall", "-Xlog:all=trace", InnerClass.class.getName());
+        analyze_output(false, "-Xlog:async:drop", "-Xlog:all=debug", InnerClass.class.getName());
+        analyze_output(true, "-Xlog:async:stall", "-Xlog:all=debug", InnerClass.class.getName());
         // Stress test with a very small buffer. Note: Any valid buffer size must be able to hold a flush token.
         // Therefore the size of the buffer cannot be zero.
-        analyze_output(false, "-Xlog:async:drop", "-Xlog:all=trace", "-XX:AsyncLogBufferSize=192", InnerClass.class.getName());
-        analyze_output(true, "-Xlog:async:stall", "-Xlog:all=trace", "-XX:AsyncLogBufferSize=192", InnerClass.class.getName());
+        analyze_output(false, "-Xlog:async:drop", "-Xlog:all=debug", "-XX:AsyncLogBufferSize=192", InnerClass.class.getName());
+        analyze_output(true, "-Xlog:async:stall", "-Xlog:all=debug", "-XX:AsyncLogBufferSize=192", InnerClass.class.getName());
     }
 
     public static class InnerClass {


### PR DESCRIPTION
Hi,

This test times out sometimes. This has been known to be caused previously by a resource-constrained execution environment. It may also be because of a race between async logging initialization and the loggers (see JDK-8362282).

This PR reduces the stress by changing the log level from `trace` to `debug`. This changes the amount of logging from 48M to 6.6M, a significant reduction.

The goal with the test was to find out if there are any bugs in the stalling mode by running it in a 'stressful' situation over a long time. The stalling mode was integrated in 2025-02-26 (see https://github.com/openjdk/jdk/pull/22770 ). I therefore believe that relaxing this test is in our interest, as it reduces the stress on our CICD infra.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8366951](https://bugs.openjdk.org/browse/JDK-8366951): Test runtime/logging/StressAsyncUL.java is timing out (**Bug** - P3)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Leo Korinth](https://openjdk.org/census#lkorinth) (@lkorinth - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [SendaoYan](https://openjdk.org/census#syan) (@sendaoYan - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27195/head:pull/27195` \
`$ git checkout pull/27195`

Update a local copy of the PR: \
`$ git checkout pull/27195` \
`$ git pull https://git.openjdk.org/jdk.git pull/27195/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27195`

View PR using the GUI difftool: \
`$ git pr show -t 27195`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27195.diff">https://git.openjdk.org/jdk/pull/27195.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27195#issuecomment-3275537356)
</details>
