### PR TITLE
8367348: Enhance PassFailJFrame to support links in HTML

### DIFF
--- a/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
+++ b/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
@@ -99,8 +99,8 @@ import static javax.swing.SwingUtilities.isEventDispatchThread;
  * tester. The instructions can be either plain text or HTML. If the
  * text of the instructions starts with {@code "<html>"}, the
  * instructions are displayed as HTML, as supported by Swing, which
- * provides richer formatting options. {@link Builder#hyperlinkListener}
- * can be called to add a listener to hyperlinks inside the HTML.
+ * provides richer formatting options. To handle navigating links in the
+ * instructions, call {@link Builder#hyperlinkListener} to install a listener.
  * <p>
  * The instructions are displayed in a text component with word-wrapping
  * so that there's no horizontal scroll bar. If the text doesn't fit, a
@@ -1488,7 +1488,8 @@ public final class PassFailJFrame {
         }
 
         /**
-         * Sets a {@link HyperlinkListener} for navigating links inside the instructions pane.
+         * Sets a {@link HyperlinkListener} for navigating links inside
+         * the instructions pane.
          *
          * @param hyperlinkListener the listener
          * @return this builder


### PR DESCRIPTION
Add HTML link processing ability in instructions. For example:
```
PassFailJFrame.builder()
        .instructions(htmlWithLinks)
        .addHyperlinkListener(e -> {
            if (e.getEventType() == HyperlinkEvent.EventType.ACTIVATED) {
                performActionOnLink(e.getDescription());
            }
        })
```
I also take this chance to make a CSS change for fix-width text to show a light-gray background color.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8367348](https://bugs.openjdk.org/browse/JDK-8367348): Enhance PassFailJFrame to support links in HTML (**Enhancement** - P4)


### Reviewers
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27197/head:pull/27197` \
`$ git checkout pull/27197`

Update a local copy of the PR: \
`$ git checkout pull/27197` \
`$ git pull https://git.openjdk.org/jdk.git pull/27197/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27197`

View PR using the GUI difftool: \
`$ git pr show -t 27197`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27197.diff">https://git.openjdk.org/jdk/pull/27197.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27197#issuecomment-3275662623)
</details>
