### PR TITLE
8367656: Refactor Constantpool's operand array into two

### DIFF
--- a/src/hotspot/share/cds/aotConstantPoolResolver.cpp
+++ b/src/hotspot/share/cds/aotConstantPoolResolver.cpp
@@ -392,7 +392,7 @@ bool AOTConstantPoolResolver::check_lambda_metafactory_signature(ConstantPool* c
 }
 
 bool AOTConstantPoolResolver::check_lambda_metafactory_methodtype_arg(ConstantPool* cp, int bsms_attribute_index, int arg_i) {
-  int mt_index = cp->bsm_attribute_entry(bsms_attribute_index)->argument_index(arg_i);
+  int mt_index = cp->bsm_attribute_entry(bsms_attribute_index)->argument(arg_i);
   if (!cp->tag_at(mt_index).is_method_type()) {
     // malformed class?
     return false;
@@ -408,7 +408,7 @@ bool AOTConstantPoolResolver::check_lambda_metafactory_methodtype_arg(ConstantPo
 }
 
 bool AOTConstantPoolResolver::check_lambda_metafactory_methodhandle_arg(ConstantPool* cp, int bsms_attribute_index, int arg_i) {
-  int mh_index = cp->bsm_attribute_entry(bsms_attribute_index)->argument_index(arg_i);
+  int mh_index = cp->bsm_attribute_entry(bsms_attribute_index)->argument(arg_i);
   if (!cp->tag_at(mh_index).is_method_handle()) {
     // malformed class?
     return false;

--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -47,6 +47,7 @@
 #include "memory/resourceArea.hpp"
 #include "memory/universe.hpp"
 #include "oops/annotations.hpp"
+#include "oops/constantPool.hpp"
 #include "oops/constantPool.inline.hpp"
 #include "oops/fieldInfo.hpp"
 #include "oops/fieldStreams.inline.hpp"
@@ -3298,8 +3299,9 @@ void ClassFileParser::parse_classfile_bootstrap_methods_attribute(const ClassFil
                                                                   TRAPS) {
   assert(cfs != nullptr, "invariant");
   assert(cp != nullptr, "invariant");
+  const int cp_size = cp->length();
 
-  const u1* const current_start = cfs->current();
+  const u1* const current_before_parsing = cfs->current();
 
   guarantee_property(attribute_byte_length >= sizeof(u2),
                      "Invalid BootstrapMethods attribute length %u in class file %s",
@@ -3308,68 +3310,50 @@ void ClassFileParser::parse_classfile_bootstrap_methods_attribute(const ClassFil
 
   cfs->guarantee_more(attribute_byte_length, CHECK);
 
-  const int attribute_array_length = cfs->get_u2_fast();
+  const int num_bootstrap_methods = cfs->get_u2_fast();
 
-  guarantee_property(_max_bootstrap_specifier_index < attribute_array_length,
+  guarantee_property(_max_bootstrap_specifier_index < num_bootstrap_methods,
                      "Short length on BootstrapMethods in class file %s",
                      CHECK);
 
+  const u4 bootstrap_methods_u2_len = (attribute_byte_length - sizeof(u2)) / sizeof(u2);
 
-  // The attribute contains a counted array of counted tuples of shorts,
-  // represending bootstrap specifiers:
-  //    length*{bootstrap_method_index, argument_count*{argument_index}}
-  const unsigned int operand_count = (attribute_byte_length - (unsigned)sizeof(u2)) / (unsigned)sizeof(u2);
-  // operand_count = number of shorts in attr, except for leading length
-
-  // The attribute is copied into a short[] array.
-  // The array begins with a series of short[2] pairs, one for each tuple.
-  const int index_size = (attribute_array_length * 2);
-
-  Array<u2>* const operands =
-    MetadataFactory::new_array<u2>(_loader_data, index_size + operand_count, CHECK);
-
-  // Eagerly assign operands so they will be deallocated with the constant
+  // Eagerly assign the arrays so that they will be deallocated with the constant
   // pool if there is an error.
-  cp->set_operands(operands);
+  BSMAttributeEntries::InsertionIterator iter =
+    cp->bsm_entries().start_extension(num_bootstrap_methods,
+                                    bootstrap_methods_u2_len,
+                                    _loader_data,
+                                    CHECK);
 
-  int operand_fill_index = index_size;
-  const int cp_size = cp->length();
-
-  for (int n = 0; n < attribute_array_length; n++) {
-    // Store a 32-bit offset into the header of the operand array.
-    ConstantPool::operand_offset_at_put(operands, n, operand_fill_index);
-
-    // Read a bootstrap specifier.
+  for (int i = 0; i < num_bootstrap_methods; i++) {
     cfs->guarantee_more(sizeof(u2) * 2, CHECK);  // bsm, argc
-    const u2 bootstrap_method_index = cfs->get_u2_fast();
-    const u2 argument_count = cfs->get_u2_fast();
+    u2 bootstrap_method_ref = cfs->get_u2_fast();
+    u2 num_bootstrap_arguments = cfs->get_u2_fast();
     guarantee_property(
-      valid_cp_range(bootstrap_method_index, cp_size) &&
-      cp->tag_at(bootstrap_method_index).is_method_handle(),
-      "bootstrap_method_index %u has bad constant type in class file %s",
-      bootstrap_method_index,
-      CHECK);
+       valid_cp_range(bootstrap_method_ref, cp_size) &&
+       cp->tag_at(bootstrap_method_ref).is_method_handle(),
+       "bootstrap_method_index %u has bad constant type in class file %s",
+       bootstrap_method_ref,
+                       CHECK);
+    cfs->guarantee_more(sizeof(u2) * num_bootstrap_arguments, CHECK); // argv[argc]
 
-    guarantee_property((operand_fill_index + 1 + argument_count) < operands->length(),
-      "Invalid BootstrapMethods num_bootstrap_methods or num_bootstrap_arguments value in class file %s",
-      CHECK);
+    BSMAttributeEntry* entry = iter.reserve_new_entry(bootstrap_method_ref, num_bootstrap_arguments);
+    guarantee_property(entry != nullptr, "Invalid BootstrapMethods num_bootstrap_methods. The total amount of space reserved for the BootstrapMethod attribute was not sufficient", CHECK);
 
-    operands->at_put(operand_fill_index++, bootstrap_method_index);
-    operands->at_put(operand_fill_index++, argument_count);
-
-    cfs->guarantee_more(sizeof(u2) * argument_count, CHECK);  // argv[argc]
-    for (int j = 0; j < argument_count; j++) {
-      const u2 argument_index = cfs->get_u2_fast();
+    for (int argi = 0; argi < num_bootstrap_arguments; argi++) {
+      const u2 bootstrap_argument_index = cfs->get_u2_fast();
       guarantee_property(
-        valid_cp_range(argument_index, cp_size) &&
-        cp->tag_at(argument_index).is_loadable_constant(),
+        valid_cp_range(bootstrap_argument_index, cp_size) &&
+        cp->tag_at(bootstrap_argument_index).is_loadable_constant(),
         "argument_index %u has bad constant type in class file %s",
-        argument_index,
+        bootstrap_argument_index,
         CHECK);
-      operands->at_put(operand_fill_index++, argument_index);
+      entry->set_argument(argi, bootstrap_argument_index);
     }
   }
-  guarantee_property(current_start + attribute_byte_length == cfs->current(),
+  cp->bsm_entries().end_extension(iter, _loader_data, CHECK);
+  guarantee_property(current_before_parsing + attribute_byte_length == cfs->current(),
                      "Bad length on BootstrapMethods in class file %s",
                      CHECK);
 }

--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -3322,9 +3322,9 @@ void ClassFileParser::parse_classfile_bootstrap_methods_attribute(const ClassFil
   // pool if there is an error.
   BSMAttributeEntries::InsertionIterator iter =
     cp->bsm_entries().start_extension(num_bootstrap_methods,
-                                    bootstrap_methods_u2_len,
-                                    _loader_data,
-                                    CHECK);
+                                      bootstrap_methods_u2_len,
+                                      _loader_data,
+                                      CHECK);
 
   for (int i = 0; i < num_bootstrap_methods; i++) {
     cfs->guarantee_more(sizeof(u2) * 2, CHECK);  // bsm, argc
@@ -3335,7 +3335,7 @@ void ClassFileParser::parse_classfile_bootstrap_methods_attribute(const ClassFil
        cp->tag_at(bootstrap_method_ref).is_method_handle(),
        "bootstrap_method_index %u has bad constant type in class file %s",
        bootstrap_method_ref,
-                       CHECK);
+       CHECK);
     cfs->guarantee_more(sizeof(u2) * num_bootstrap_arguments, CHECK); // argv[argc]
 
     BSMAttributeEntry* entry = iter.reserve_new_entry(bootstrap_method_ref, num_bootstrap_arguments);

--- a/src/hotspot/share/oops/constantPool.cpp
+++ b/src/hotspot/share/oops/constantPool.cpp
@@ -2368,7 +2368,7 @@ BSMAttributeEntries::start_extension(int number_of_entries, int array_length,
   Array<u2>* new_array = MetadataFactory::new_array<u2>(loader_data, new_array_length, CHECK_(InsertionIterator()));
   { // Copy over all the old BSMAEntry's and their respective offsets
     BSMAttributeEntries carrier(new_offsets, new_array);
-    InsertionIterator copy_iter(&carrier);
+    InsertionIterator copy_iter(&carrier, 0, 0);
     copy_into(copy_iter, this->number_of_entries());
   }
   // Replace content
@@ -2408,7 +2408,7 @@ void BSMAttributeEntries::end_extension(InsertionIterator& iter, ClassLoaderData
     MetadataFactory::new_array<u2>(loader_data, iter._cur_array, CHECK);
   { // Copy over the constructed BSMAEntry's
     BSMAttributeEntries carrier(new_offsets, new_array);
-    InsertionIterator copy_iter(&carrier);
+    InsertionIterator copy_iter(&carrier, 0, 0);
     copy_into(copy_iter, iter._cur_offset);
   }
   copy_into(new_offsets, new_array, iter._cur_offset);

--- a/src/hotspot/share/oops/constantPool.cpp
+++ b/src/hotspot/share/oops/constantPool.cpp
@@ -2411,7 +2411,6 @@ void BSMAttributeEntries::end_extension(InsertionIterator& iter, ClassLoaderData
     InsertionIterator copy_iter(&carrier, 0, 0);
     copy_into(copy_iter, iter._cur_offset);
   }
-  copy_into(new_offsets, new_array, iter._cur_offset);
 
   deallocate_contents(loader_data);
   _offsets = new_offsets;

--- a/src/hotspot/share/oops/constantPool.cpp
+++ b/src/hotspot/share/oops/constantPool.cpp
@@ -2346,7 +2346,7 @@ void BSMAttributeEntries::copy_into(InsertionIterator& iter, int num_entries) co
   assert(num_entries + iter._cur_offset <= iter.insert_into->_offsets->length(), "must");
   for (int i = 0; i < num_entries; i++) {
     const BSMAttributeEntry* bsmae = entry(i);
-    BSMAttributeEntry* bsmae_new = iter.reserve_new_entry(i, bsmae->argument_count());
+    BSMAttributeEntry* bsmae_new = iter.reserve_new_entry(bsmae->bootstrap_method_index(), bsmae->argument_count());
     bsmae->copy_args_into(bsmae_new);
   }
 }

--- a/src/hotspot/share/oops/constantPool.cpp
+++ b/src/hotspot/share/oops/constantPool.cpp
@@ -1826,8 +1826,8 @@ int ConstantPool::find_matching_entry(int pattern_i,
 // Compare this constant pool's bootstrap specifier at idx1 to the constant pool
 // cp2's bootstrap specifier at idx2.
 bool ConstantPool::compare_bootstrap_entry_to(int idx1, const constantPoolHandle& cp2, int idx2) {
-  const BSMAttributeEntry* const bsmae1 = bsm_attribute_entry(idx1);
-  const BSMAttributeEntry* const bsmae2 = cp2->bsm_attribute_entry(idx2);
+  const BSMAttributeEntry* const e1 = bsm_attribute_entry(idx1);
+  const BSMAttributeEntry* const e2 = cp2->bsm_attribute_entry(idx2);
   int k1 = bsmae1->bootstrap_method_index();
   int k2 = bsmae2->bootstrap_method_index();
   bool match = compare_entry_to(k1, cp2, k2);

--- a/src/hotspot/share/oops/constantPool.cpp
+++ b/src/hotspot/share/oops/constantPool.cpp
@@ -2391,7 +2391,7 @@ void BSMAttributeEntries::append(const BSMAttributeEntries& other, ClassLoaderDa
   }
   InsertionIterator iter = start_extension(other, loader_data, CHECK);
   other.copy_into(iter, other.number_of_entries());
-  end_extension(iter, loader_data, CHECK);
+
 }
 
 void BSMAttributeEntries::end_extension(InsertionIterator& iter, ClassLoaderData* loader_data,

--- a/src/hotspot/share/oops/constantPool.cpp
+++ b/src/hotspot/share/oops/constantPool.cpp
@@ -2385,6 +2385,7 @@ void BSMAttributeEntries::append(const BSMAttributeEntries& other, ClassLoaderDa
   }
   InsertionIterator iter = start_extension(other, loader_data, CHECK);
   other.copy_into(iter, other.number_of_entries());
+  end_extension(iter, loader_data, CHECK);
 
 }
 

--- a/src/hotspot/share/oops/constantPool.cpp
+++ b/src/hotspot/share/oops/constantPool.cpp
@@ -1609,9 +1609,9 @@ bool ConstantPool::compare_entry_to(int index1, const constantPoolHandle& cp2,
 // Used in RedefineClasses for CP merge.
 BSMAttributeEntries::InsertionIterator
 ConstantPool::start_extension(const constantPoolHandle& ext_cp, TRAPS) {
-  InsertionIterator iter =
-      bsm_entries().start_extension(ext_cp->bsm_entries(), pool_holder()->class_loader_data(),
-                                    CHECK_(BSMAttributeEntries::InsertionIterator()));
+  BSMAttributeEntries::InsertionIterator iter =
+    bsm_entries().start_extension(ext_cp->bsm_entries(), pool_holder()->class_loader_data(),
+                                  CHECK_(BSMAttributeEntries::InsertionIterator()));
   return iter;
 }
 

--- a/src/hotspot/share/oops/constantPool.hpp
+++ b/src/hotspot/share/oops/constantPool.hpp
@@ -97,8 +97,6 @@ class BSMAttributeEntry {
   BSMAttributeEntry() = delete;
   NONCOPYABLE(BSMAttributeEntry);
 
-  // Returns number of u2s written
-  inline size_t copy_into(u2* data, size_t size) const;
   void copy_args_into(BSMAttributeEntry* entry) const;
 
 public:

--- a/src/hotspot/share/oops/constantPool.hpp
+++ b/src/hotspot/share/oops/constantPool.hpp
@@ -165,8 +165,8 @@ private:
 public:
   BSMAttributeEntries() : _offsets(nullptr), _bootstrap_methods(nullptr) {}
   BSMAttributeEntries(Array<u4>* offsets, Array<u2>* bootstrap_methods)
-  : _offsets(offsets),
-    _bootstrap_methods(bootstrap_methods) {}
+    : _offsets(offsets),
+      _bootstrap_methods(bootstrap_methods) {}
 
   bool is_empty() const {
     return _offsets == nullptr && _bootstrap_methods == nullptr;
@@ -197,11 +197,11 @@ public:
 
   // Extend to have the space for both this BSMAEntries and other's.
   // Does not copy in the other's BSMAEntrys, that must be done via the InsertionIterator.
-  // This starts an insertion iterator. Any call to start_extension must have a matching end_exntesion call.
+  // This starts an insertion iterator. Any call to start_extension must have a matching end_extension call.
   InsertionIterator start_extension(const BSMAttributeEntries& other, ClassLoaderData* loader_data, TRAPS);
   // Extend the BSMAEntries with an additional number_of_entries with a total data_size.
   InsertionIterator start_extension(int number_of_entries, int data_size, ClassLoaderData* loader_data, TRAPS);
-  // Reallocates the underlying memory to fit the limits of the InsertionITerator precisely.
+  // Reallocates the underlying memory to fit the limits of the InsertionIterator precisely.
   // This ends an insertion iteration. The memory is truncated to fit exactly the data used.
   void end_extension(InsertionIterator& iter, ClassLoaderData* loader_data, TRAPS);
   // Append all of the BSMAEs in other into this.

--- a/src/hotspot/share/oops/constantPool.hpp
+++ b/src/hotspot/share/oops/constantPool.hpp
@@ -99,6 +99,7 @@ class BSMAttributeEntry {
 
   // Returns number of u2s written
   inline size_t copy_into(u2* data, size_t size) const;
+  void copy_args_into(BSMAttributeEntry* entry) const;
 
 public:
   // Offsets for SA
@@ -114,7 +115,7 @@ public:
   int argument_count() const {
     return _argument_count;
   }
-  int argument_index(int n) const {
+  int argument(int n) const {
     assert(checked_cast<u2>(n) < _argument_count, "oob");
     return argument_indexes()[n];
   }
@@ -160,14 +161,8 @@ private:
   Array<u4>* _offsets;
   Array<u2>* _bootstrap_methods;
 
-  // Copy self into a different offsets and bsm array.
-  // Allows limiting the number of entries copied via num_entries.
-  // Use the optional arguments to adjust where in the offsets and array to start putting in the entries.
-  void copy_into(Array<u4>* new_offsets, Array<u2>* new_array, int num_entries,
-                 int initial_offset_index = 0,
-                 int initial_offset = 0) const;
   // Copy the first num_entries into iter
-  void copy_into(InsertionIterator iter, int num_entries) const;
+  void copy_into(InsertionIterator& iter, int num_entries) const;
 
 public:
   BSMAttributeEntries() : _offsets(nullptr), _bootstrap_methods(nullptr) {}
@@ -692,7 +687,7 @@ class ConstantPool : public Metadata {
     int bsmai = bootstrap_methods_attribute_index(cp_index);
     BSMAttributeEntry* bsme = bsm_attribute_entry(bsmai);
     assert((uint)j < (uint)bsme->argument_count(), "oob");
-    return bsm_attribute_entry(bsmai)->argument_index(j);
+    return bsm_attribute_entry(bsmai)->argument(j);
   }
 
   // The following methods (name/signature/klass_ref_at, klass_ref_at_noresolve,

--- a/src/hotspot/share/oops/constantPool.hpp
+++ b/src/hotspot/share/oops/constantPool.hpp
@@ -197,7 +197,7 @@ public:
 
   // Extend to have the space for both this BSMAEntries and other's.
   // Does not copy in the other's BSMAEntrys, that must be done via the InsertionIterator.
-  // This starts an insertion iterator.
+  // This starts an insertion iterator. Any call to start_extension must have a matching end_exntesion call.
   InsertionIterator start_extension(const BSMAttributeEntries& other, ClassLoaderData* loader_data, TRAPS);
   // Extend the BSMAEntries with an additional number_of_entries with a total data_size.
   InsertionIterator start_extension(int number_of_entries, int data_size, ClassLoaderData* loader_data, TRAPS);

--- a/src/hotspot/share/oops/constantPool.inline.hpp
+++ b/src/hotspot/share/oops/constantPool.inline.hpp
@@ -114,5 +114,12 @@ inline size_t BSMAttributeEntry::copy_into(u2* data, size_t size) const {
   return total_u2s_needed;
 }
 
+void BSMAttributeEntry::copy_args_into(BSMAttributeEntry* entry) const {
+  assert(entry->argument_count() == this->argument_count(), "must be same");
+  for (int i = 0; i < argument_count(); i++) {
+    entry->set_argument(i, this->argument(i));
+  }
+}
+
 
 #endif // SHARE_OOPS_CONSTANTPOOL_INLINE_HPP

--- a/src/hotspot/share/oops/constantPool.inline.hpp
+++ b/src/hotspot/share/oops/constantPool.inline.hpp
@@ -103,7 +103,7 @@ inline BSMAttributeEntry* BSMAttributeEntries::InsertionIterator::reserve_new_en
   return e;
 }
 
-void BSMAttributeEntry::copy_args_into(BSMAttributeEntry* entry) const {
+inline void BSMAttributeEntry::copy_args_into(BSMAttributeEntry* entry) const {
   assert(entry->argument_count() == this->argument_count(), "must be same");
   for (int i = 0; i < argument_count(); i++) {
     entry->set_argument(i, this->argument(i));

--- a/src/hotspot/share/oops/constantPool.inline.hpp
+++ b/src/hotspot/share/oops/constantPool.inline.hpp
@@ -87,4 +87,32 @@ inline oop ConstantPool::resolved_reference_from_indy(int index) const {
 inline oop ConstantPool::resolved_reference_from_method(int index) const {
   return resolved_references()->obj_at(cache()->resolved_method_entry_at(index)->resolved_references_index());
 }
+
+inline BSMAttributeEntry* BSMAttributeEntries::InsertionIterator::reserve_new_entry(u2 bsmi, u2 argc) {
+  if (_cur_offset + 1 > insert_into->offsets()->length() ||
+      _cur_array + 1 + 1 + argc > insert_into->bootstrap_methods()->length()) {
+    return nullptr;
+  }
+  insert_into->_offsets->at_put(_cur_offset, _cur_array);
+  BSMAttributeEntry* e = insert_into->entry(_cur_offset);
+  e->_bootstrap_method_index = bsmi;
+  e->_argument_count = argc;
+
+  _cur_array += 1 + 1 + argc;
+  _cur_offset += 1;
+  return e;
+}
+
+inline size_t BSMAttributeEntry::copy_into(u2* data, size_t size) const {
+  size_t total_u2s_needed = 1 + 1 + argument_count();
+  assert(size >= total_u2s_needed, "doesn't fit");
+  data[_bsmi_offset] = _bootstrap_method_index;
+  data[_argc_offset] = _argument_count;
+  for (int i = 0; i < argument_count(); i++) {
+    data[_argv_offset + i] = argument_indexes()[i];
+  }
+  return total_u2s_needed;
+}
+
+
 #endif // SHARE_OOPS_CONSTANTPOOL_INLINE_HPP

--- a/src/hotspot/share/oops/constantPool.inline.hpp
+++ b/src/hotspot/share/oops/constantPool.inline.hpp
@@ -103,17 +103,6 @@ inline BSMAttributeEntry* BSMAttributeEntries::InsertionIterator::reserve_new_en
   return e;
 }
 
-inline size_t BSMAttributeEntry::copy_into(u2* data, size_t size) const {
-  size_t total_u2s_needed = 1 + 1 + argument_count();
-  assert(size >= total_u2s_needed, "doesn't fit");
-  data[_bsmi_offset] = _bootstrap_method_index;
-  data[_argc_offset] = _argument_count;
-  for (int i = 0; i < argument_count(); i++) {
-    data[_argv_offset + i] = argument_indexes()[i];
-  }
-  return total_u2s_needed;
-}
-
 void BSMAttributeEntry::copy_args_into(BSMAttributeEntry* entry) const {
   assert(entry->argument_count() == this->argument_count(), "must be same");
   for (int i = 0; i < argument_count(); i++) {

--- a/src/hotspot/share/prims/jvmtiClassFileReconstituter.cpp
+++ b/src/hotspot/share/prims/jvmtiClassFileReconstituter.cpp
@@ -390,8 +390,8 @@ void JvmtiClassFileReconstituter::write_annotations_attribute(const char* attr_n
 //  }
 void JvmtiClassFileReconstituter::write_bootstrapmethod_attribute() {
   write_attribute_name_index("BootstrapMethods");
-  u4 length = sizeof(u2) + // num_bootstrap_methods
-              // The rest of it
+  u4 length = sizeof(u2) + // Size of num_bootstrap_methods
+              // The rest of the data for the attribute is exactly the u2s in the data array.
               sizeof(u2) * cpool()->bsm_entries().array_length();
   write_u4(length);
 

--- a/src/hotspot/share/prims/jvmtiClassFileReconstituter.cpp
+++ b/src/hotspot/share/prims/jvmtiClassFileReconstituter.cpp
@@ -404,7 +404,7 @@ void JvmtiClassFileReconstituter::write_bootstrapmethod_attribute() {
     write_u2(bsme->bootstrap_method_index());
     write_u2(num_bootstrap_arguments);
     for (int arg = 0; arg < num_bootstrap_arguments; arg++) {
-      u2 bootstrap_argument = bsme->argument_index(arg);
+      u2 bootstrap_argument = bsme->argument(arg);
       write_u2(bootstrap_argument);
     }
   }

--- a/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
+++ b/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
@@ -45,7 +45,6 @@
 #include "memory/resourceArea.hpp"
 #include "memory/universe.hpp"
 #include "oops/annotations.hpp"
-#include "oops/constantPool.hpp"
 #include "oops/constantPool.inline.hpp"
 #include "oops/fieldStreams.inline.hpp"
 #include "oops/klass.inline.hpp"

--- a/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
+++ b/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
@@ -46,6 +46,7 @@
 #include "memory/universe.hpp"
 #include "oops/annotations.hpp"
 #include "oops/constantPool.hpp"
+#include "oops/constantPool.inline.hpp"
 #include "oops/fieldStreams.inline.hpp"
 #include "oops/klass.inline.hpp"
 #include "oops/klassVtable.hpp"
@@ -591,10 +592,11 @@ void VM_RedefineClasses::append_entry(const constantPoolHandle& scratch_cp,
           ("Dynamic entry@%d name_and_type_index change: %d to %d", *merge_cp_length_p, old_ref_i, new_ref_i);
       }
 
-      if (scratch_cp->tag_at(scratch_i).is_dynamic_constant())
+      if (scratch_cp->tag_at(scratch_i).is_dynamic_constant()) {
         (*merge_cp_p)->dynamic_constant_at_put(*merge_cp_length_p, new_bs_i, new_ref_i);
-      else
+      } else {
         (*merge_cp_p)->invoke_dynamic_at_put(*merge_cp_length_p, new_bs_i, new_ref_i);
+      }
       if (scratch_i != *merge_cp_length_p) {
         // The new entry in *merge_cp_p is at a different index than
         // the new entry in scratch_cp so we need to map the index values.
@@ -663,7 +665,7 @@ u2 VM_RedefineClasses::find_or_append_indirect_entry(const constantPoolHandle& s
 // Append a bootstrap specifier into the merge_cp operands that is semantically equal
 // to the scratch_cp operands bootstrap specifier passed by the old_bs_i index.
 // Recursively append new merge_cp entries referenced by the new bootstrap specifier.
-void VM_RedefineClasses::append_operand(const constantPoolHandle& scratch_cp, const int old_bs_i,
+int VM_RedefineClasses::append_operand(const constantPoolHandle& scratch_cp, const int old_bs_i,
        constantPoolHandle *merge_cp_p, int *merge_cp_length_p) {
 
   BSMAttributeEntry* old_bsme = scratch_cp->bsm_attribute_entry(old_bs_i);
@@ -672,79 +674,70 @@ void VM_RedefineClasses::append_operand(const constantPoolHandle& scratch_cp, co
                                                merge_cp_length_p);
   if (new_ref_i != old_ref_i) {
     log_trace(redefine, class, constantpool)
-      ("operands entry@%d bootstrap method ref_index change: %d to %d", _operands_cur_length, old_ref_i, new_ref_i);
+      ("operands entry@%d bootstrap method ref_index change: %d to %d", _bsmae_iter.current_offset() - 1, old_ref_i, new_ref_i);
   }
 
-  Array<u2>* merge_ops = (*merge_cp_p)->operands();
-  int new_bs_i = _operands_cur_length;
-  // We have _operands_cur_length == 0 when the merge_cp operands is empty yet.
-  // However, the operand_offset_at(0) was set in the extend_operands() call.
-  int new_base = (new_bs_i == 0) ? (*merge_cp_p)->operand_offset_at(0)
-                                 : (*merge_cp_p)->operand_next_offset_at(new_bs_i - 1);
-  u2 argc      = old_bsme->argument_count();
-
-  ConstantPool::operand_offset_at_put(merge_ops, _operands_cur_length, new_base);
-  merge_ops->at_put(new_base++, new_ref_i);
-  merge_ops->at_put(new_base++, argc);
-
-  for (int i = 0; i < argc; i++) {
+  const int new_bs_i = _bsmae_iter.current_offset();
+  BSMAttributeEntry* new_bsme =
+    _bsmae_iter.reserve_new_entry(new_ref_i, old_bsme->argument_count());
+  for (int i = 0; i < new_bsme->argument_count(); i++) {
     u2 old_arg_ref_i = old_bsme->argument_index(i);
     u2 new_arg_ref_i = find_or_append_indirect_entry(scratch_cp, old_arg_ref_i, merge_cp_p,
                                                      merge_cp_length_p);
-    merge_ops->at_put(new_base++, new_arg_ref_i);
+    new_bsme->set_argument(i, new_arg_ref_i);
+
     if (new_arg_ref_i != old_arg_ref_i) {
       log_trace(redefine, class, constantpool)
         ("operands entry@%d bootstrap method argument ref_index change: %d to %d",
-         _operands_cur_length, old_arg_ref_i, new_arg_ref_i);
+         _bsmae_iter.current_offset() - 1, old_arg_ref_i, new_arg_ref_i);
     }
   }
-  if (old_bs_i != _operands_cur_length) {
-    // The bootstrap specifier in *merge_cp_p is at a different index than
-    // that in scratch_cp so we need to map the index values.
-    map_operand_index(old_bs_i, new_bs_i);
-  }
-  _operands_cur_length++;
+  // This is only for the logging
+  map_bsm_index(old_bs_i, new_bs_i);
+  return new_bs_i;
 } // end append_operand()
 
 
 int VM_RedefineClasses::find_or_append_operand(const constantPoolHandle& scratch_cp,
       int old_bs_i, constantPoolHandle *merge_cp_p, int *merge_cp_length_p) {
 
+  const int max_offset_in_merge = _bsmae_iter.current_offset();
   int new_bs_i = old_bs_i; // bootstrap specifier index
-  bool match = (old_bs_i < _operands_cur_length) &&
-               scratch_cp->compare_operand_to(old_bs_i, *merge_cp_p, old_bs_i);
+  // Has the old_bs_i index been used already? Check if it's the same so we know
+  // whether or not a remapping is required.
+  bool match = (old_bs_i < max_offset_in_merge) &&
+               scratch_cp->compare_bootstrap_entry_to(old_bs_i, *merge_cp_p, old_bs_i);
 
   if (!match) {
     // forward reference in *merge_cp_p or not a direct match
-    int found_i = scratch_cp->find_matching_operand(old_bs_i, *merge_cp_p,
-                                                    _operands_cur_length);
+    int found_i = scratch_cp->find_matching_bsm_entry(old_bs_i, *merge_cp_p,
+                                                    max_offset_in_merge);
     if (found_i != -1) {
-      guarantee(found_i != old_bs_i, "compare_operand_to() and find_matching_operand() disagree");
+      guarantee(found_i != old_bs_i, "compare_bootstrap_entry_to() and find_matching_operand() disagree");
       // found a matching operand somewhere else in *merge_cp_p so just need a mapping
       new_bs_i = found_i;
-      map_operand_index(old_bs_i, found_i);
+      map_bsm_index(old_bs_i, found_i);
     } else {
       // no match found so we have to append this bootstrap specifier to *merge_cp_p
-      append_operand(scratch_cp, old_bs_i, merge_cp_p, merge_cp_length_p);
-      new_bs_i = _operands_cur_length - 1;
+      new_bs_i = append_operand(scratch_cp, old_bs_i, merge_cp_p, merge_cp_length_p);
     }
   }
   return new_bs_i;
 } // end find_or_append_operand()
 
 
-void VM_RedefineClasses::finalize_operands_merge(const constantPoolHandle& merge_cp, TRAPS) {
-  if (merge_cp->operands() == nullptr) {
+void VM_RedefineClasses::finalize_bsmentries_merge(const constantPoolHandle& merge_cp, TRAPS) {
+  if (merge_cp->bsm_entries().number_of_entries() == 0) {
     return;
   }
-  // Shrink the merge_cp operands
-  merge_cp->shrink_operands(_operands_cur_length, CHECK);
+  // Finished extending the BSMAEs
+  merge_cp->end_extension(_bsmae_iter, CHECK);
 
   if (log_is_enabled(Trace, redefine, class, constantpool)) {
     // don't want to loop unless we are tracing
     int count = 0;
-    for (int i = 1; i < _operands_index_map_p->length(); i++) {
-      int value = _operands_index_map_p->at(i);
+    for (int i = 1; i < _bsm_index_map_p->length(); i++) {
+      int value = _bsm_index_map_p->at(i);
       if (value != -1) {
         log_trace(redefine, class, constantpool)("operands_index_map[%d]: old=%d new=%d", count, i, value);
         count++;
@@ -752,10 +745,10 @@ void VM_RedefineClasses::finalize_operands_merge(const constantPoolHandle& merge
     }
   }
   // Clean-up
-  _operands_index_map_p = nullptr;
-  _operands_cur_length = 0;
-  _operands_index_map_count = 0;
-} // end finalize_operands_merge()
+  _bsm_index_map_p = nullptr;
+  _bsm_index_map_count = 0;
+  _bsmae_iter = BSMAttributeEntries::InsertionIterator();
+} // end finalize_bsmentries_merge()
 
 // Symbol* comparator for qsort
 // The caller must have an active ResourceMark.
@@ -1273,18 +1266,18 @@ u2 VM_RedefineClasses::find_new_index(int old_index) {
 // value by searching the index map. Returns unused index (-1) if there is
 // no mapped value for the old bootstrap specifier index.
 int VM_RedefineClasses::find_new_operand_index(int old_index) {
-  if (_operands_index_map_count == 0) {
+  if (_bsm_index_map_count == 0) {
     // map is empty so nothing can be found
     return -1;
   }
 
-  if (old_index == -1 || old_index >= _operands_index_map_p->length()) {
+  if (old_index == -1 || old_index >= _bsm_index_map_p->length()) {
     // The old_index is out of range so it is not mapped.
     // This should not happen in regular constant pool merging use.
     return -1;
   }
 
-  int value = _operands_index_map_p->at(old_index);
+  int value = _bsm_index_map_p->at(old_index);
   if (value == -1) {
     // the old_index is not mapped
     return -1;
@@ -1560,22 +1553,15 @@ void VM_RedefineClasses::map_index(const constantPoolHandle& scratch_cp,
 
 
 // Map old_index to new_index as needed.
-void VM_RedefineClasses::map_operand_index(int old_index, int new_index) {
-  if (find_new_operand_index(old_index) != -1) {
-    // old_index is already mapped
-    return;
-  }
-
+void VM_RedefineClasses::map_bsm_index(int old_index, int new_index) {
   if (old_index == new_index) {
     // no mapping is needed
     return;
   }
-
-  _operands_index_map_p->at_put(old_index, new_index);
-  _operands_index_map_count++;
-
+  _bsm_index_map_p->at_put(old_index, new_index);
+  _bsm_index_map_count++;
   log_trace(redefine, class, constantpool)("mapped bootstrap specifier at index %d to %d", old_index, new_index);
-} // end map_index()
+} // end map_bsm_index()
 
 
 // Merge old_cp and scratch_cp and return the results of the merge via
@@ -1639,8 +1625,8 @@ bool VM_RedefineClasses::merge_constant_pools(const constantPoolHandle& old_cp,
       }
     } // end for each old_cp entry
 
-    ConstantPool::copy_operands(old_cp, merge_cp_p, CHECK_false);
-    merge_cp_p->extend_operands(scratch_cp, CHECK_false);
+    ConstantPool::copy_bsm_entries(old_cp, merge_cp_p, CHECK_false);
+    _bsmae_iter = merge_cp_p->start_extension(scratch_cp, CHECK_false);
 
     // We don't need to sanity check that *merge_cp_length_p is within
     // *merge_cp_p bounds since we have the minimum on-entry check above.
@@ -1737,7 +1723,7 @@ bool VM_RedefineClasses::merge_constant_pools(const constantPoolHandle& old_cp,
       ("after pass 1b: merge_cp_len=%d, scratch_i=%d, index_map_len=%d",
        merge_cp_length_p, scratch_i, _index_map_count);
   }
-  finalize_operands_merge(merge_cp_p, CHECK_false);
+  finalize_bsmentries_merge(merge_cp_p, CHECK_false);
 
   return true;
 } // end merge_constant_pools()
@@ -1807,10 +1793,9 @@ jvmtiError VM_RedefineClasses::merge_cp_and_rewrite(
   _index_map_count = 0;
   _index_map_p = new intArray(scratch_cp->length(), scratch_cp->length(), -1);
 
-  _operands_cur_length = ConstantPool::operand_array_length(old_cp->operands());
-  _operands_index_map_count = 0;
-  int operands_index_map_len = ConstantPool::operand_array_length(scratch_cp->operands());
-  _operands_index_map_p = new intArray(operands_index_map_len, operands_index_map_len, -1);
+  _bsm_index_map_count = 0;
+  int operands_index_map_len = scratch_cp->bsm_entries().array_length();
+  _bsm_index_map_p = new intArray(operands_index_map_len, operands_index_map_len, -1);
 
   // reference to the cp holder is needed for copy_operands()
   merge_cp->set_pool_holder(scratch_class);

--- a/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
+++ b/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
@@ -681,7 +681,7 @@ int VM_RedefineClasses::append_operand(const constantPoolHandle& scratch_cp, con
   BSMAttributeEntry* new_bsme =
     _bsmae_iter.reserve_new_entry(new_ref_i, old_bsme->argument_count());
   for (int i = 0; i < new_bsme->argument_count(); i++) {
-    u2 old_arg_ref_i = old_bsme->argument_index(i);
+    u2 old_arg_ref_i = old_bsme->argument(i);
     u2 new_arg_ref_i = find_or_append_indirect_entry(scratch_cp, old_arg_ref_i, merge_cp_p,
                                                      merge_cp_length_p);
     new_bsme->set_argument(i, new_arg_ref_i);

--- a/src/hotspot/share/prims/jvmtiRedefineClasses.hpp
+++ b/src/hotspot/share/prims/jvmtiRedefineClasses.hpp
@@ -368,7 +368,8 @@ class VM_RedefineClasses: public VM_Operation {
   int                         _bsm_index_map_count;
   intArray *                  _bsm_index_map_p;
 
-  // After merge_constant_pools pass 0 the BSMAttribute entries of merge_cp_p will have been expanded to fit scratch_cp.
+  // After merge_constant_pools pass 0, the BSMAttribute entries of merge_cp_p will have been expanded to fit
+  // scratch_cp's BSMAttribute entries as well.
   // However, the newly acquired space will not have been filled in yet.
   // To append to this new space, the iterator is used.
   BSMAttributeEntries::InsertionIterator _bsmae_iter;

--- a/src/hotspot/share/prims/jvmtiRedefineClasses.hpp
+++ b/src/hotspot/share/prims/jvmtiRedefineClasses.hpp
@@ -363,11 +363,15 @@ class VM_RedefineClasses: public VM_Operation {
   int                         _index_map_count;
   intArray *                  _index_map_p;
 
-  // _operands_index_map_count is just an optimization for knowing if
-  // _operands_index_map_p contains any entries.
-  int                         _operands_cur_length;
-  int                         _operands_index_map_count;
-  intArray *                  _operands_index_map_p;
+  // _bsm_index_map_count is just an optimization for knowing if
+  // _bsm_index_map_p contains any entries.
+  int                         _bsm_index_map_count;
+  intArray *                  _bsm_index_map_p;
+
+  // After merge_constant_pools pass 0 the BSMAttribute entries of merge_cp_p will have been expanded to fit scratch_cp.
+  // However, the newly acquired space will not have been filled in yet.
+  // To append to this new space, the iterator is used.
+  BSMAttributeEntries::InsertionIterator _bsmae_iter;
 
   // ptr to _class_count scratch_classes
   InstanceKlass**             _scratch_classes;
@@ -429,9 +433,10 @@ class VM_RedefineClasses: public VM_Operation {
   // Support for constant pool merging (these routines are in alpha order):
   void append_entry(const constantPoolHandle& scratch_cp, int scratch_i,
     constantPoolHandle *merge_cp_p, int *merge_cp_length_p);
-  void append_operand(const constantPoolHandle& scratch_cp, int scratch_bootstrap_spec_index,
+  // Returns the index of the appended BSM
+  int append_operand(const constantPoolHandle& scratch_cp, int scratch_bootstrap_spec_index,
     constantPoolHandle *merge_cp_p, int *merge_cp_length_p);
-  void finalize_operands_merge(const constantPoolHandle& merge_cp, TRAPS);
+  void finalize_bsmentries_merge(const constantPoolHandle& merge_cp, TRAPS);
   u2 find_or_append_indirect_entry(const constantPoolHandle& scratch_cp, int scratch_i,
     constantPoolHandle *merge_cp_p, int *merge_cp_length_p);
   int find_or_append_operand(const constantPoolHandle& scratch_cp, int scratch_bootstrap_spec_index,
@@ -439,7 +444,7 @@ class VM_RedefineClasses: public VM_Operation {
   u2 find_new_index(int old_index);
   int find_new_operand_index(int old_bootstrap_spec_index);
   void map_index(const constantPoolHandle& scratch_cp, int old_index, int new_index);
-  void map_operand_index(int old_bootstrap_spec_index, int new_bootstrap_spec_index);
+  void map_bsm_index(int old_bootstrap_spec_index, int new_bootstrap_spec_index);
   bool merge_constant_pools(const constantPoolHandle& old_cp,
     const constantPoolHandle& scratch_cp, constantPoolHandle& merge_cp_p,
     int& merge_cp_length_p, TRAPS);

--- a/src/hotspot/share/runtime/vmStructs.cpp
+++ b/src/hotspot/share/runtime/vmStructs.cpp
@@ -171,10 +171,12 @@
   nonstatic_field(ArrayKlass,                  _dimension,                                    int)                                   \
   volatile_nonstatic_field(ArrayKlass,         _higher_dimension,                             ObjArrayKlass*)                        \
   volatile_nonstatic_field(ArrayKlass,         _lower_dimension,                              ArrayKlass*)                           \
+  nonstatic_field(BSMAttributeEntries,         _offsets,                                      Array<u4>*)                            \
+  nonstatic_field(BSMAttributeEntries,         _bootstrap_methods,                            Array<u2>*)                            \
+  nonstatic_field(ConstantPool,                _bsmaentries,                                  BSMAttributeEntries)                   \
   nonstatic_field(ConstantPool,                _tags,                                         Array<u1>*)                            \
   nonstatic_field(ConstantPool,                _cache,                                        ConstantPoolCache*)                    \
   nonstatic_field(ConstantPool,                _pool_holder,                                  InstanceKlass*)                        \
-  nonstatic_field(ConstantPool,                _operands,                                     Array<u2>*)                            \
   nonstatic_field(ConstantPool,                _resolved_klasses,                             Array<Klass*>*)                        \
   nonstatic_field(ConstantPool,                _length,                                       int)                                   \
   nonstatic_field(ConstantPool,                _minor_version,                                u2)                                    \
@@ -732,6 +734,7 @@
   unchecked_nonstatic_field(Array<int>,                _data,                                 sizeof(int))                           \
   unchecked_nonstatic_field(Array<u1>,                 _data,                                 sizeof(u1))                            \
   unchecked_nonstatic_field(Array<u2>,                 _data,                                 sizeof(u2))                            \
+  unchecked_nonstatic_field(Array<u4>,                 _data,                                 sizeof(u4))                            \
   unchecked_nonstatic_field(Array<Method*>,            _data,                                 sizeof(Method*))                       \
   unchecked_nonstatic_field(Array<Klass*>,             _data,                                 sizeof(Klass*))                        \
   unchecked_nonstatic_field(Array<ResolvedFieldEntry>, _data,                                 sizeof(ResolvedFieldEntry))            \
@@ -962,6 +965,7 @@
   declare_toplevel_type(volatile Metadata*)                               \
                                                                           \
   declare_toplevel_type(DataLayout)                                       \
+  declare_toplevel_type(BSMAttributeEntries)                              \
                                                                           \
   /********/                                                              \
   /* Oops */                                                              \

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/ConstantPool.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/ConstantPool.java
@@ -436,11 +436,11 @@ public class ConstantPool extends Metadata implements ClassConstants {
     return res;
   }
 
-    private U4Array getOffsets() {
-        Address a =  getAddress().addOffsetTo(bsmaentries);
-        if (a == null) return null;
-        a = bsmaentries_offsets.getValue(a);
-        return VMObjectFactory.newObject(U4Array.class, a);
+  private U4Array getOffsets() {
+     Address a =  getAddress().addOffsetTo(bsmaentries);
+     if (a == null) return null;
+     a = bsmaentries_offsets.getValue(a);
+     return VMObjectFactory.newObject(U4Array.class, a);
   }
   private U2Array getBootstrapMethods() {
     Address a =  getAddress().addOffsetTo(bsmaentries);

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/ConstantPool.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/ConstantPool.java
@@ -88,8 +88,11 @@ public class ConstantPool extends Metadata implements ClassConstants {
   private static synchronized void initialize(TypeDataBase db) throws WrongTypeException {
     Type type   = db.lookupType("ConstantPool");
     tags        = type.getAddressField("_tags");
-    operands    = type.getAddressField("_operands");
     cache       = type.getAddressField("_cache");
+    bsmaentries = type.getField("_bsmaentries").getOffset();
+    Type bsmaetype = db.lookupType("BSMAttributeEntries");
+    bsmaentries_offsets = bsmaetype.getAddressField("_offsets");
+    bsmaentries_bootstrap_methods = bsmaetype.getAddressField("_bootstrap_methods");
     poolHolder  = new MetadataField(type.getAddressField("_pool_holder"), 0);
     length      = new CIntField(type.getCIntegerField("_length"), 0);
     resolved_klasses = type.getAddressField("_resolved_klasses");
@@ -112,9 +115,11 @@ public class ConstantPool extends Metadata implements ClassConstants {
   public boolean isConstantPool()      { return true; }
 
   private static AddressField tags;
-  private static AddressField operands;
   private static AddressField cache;
   private static AddressField resolved_klasses;
+  private static long bsmaentries; // Offset in the constantpool where the BSMAEntries are found
+  private static AddressField bsmaentries_offsets;
+  private static AddressField bsmaentries_bootstrap_methods;
   private static MetadataField poolHolder;
   private static CIntField length; // number of elements in oop
   private static CIntField majorVersion;
@@ -130,10 +135,6 @@ public class ConstantPool extends Metadata implements ClassConstants {
   private static int INDY_ARGV_OFFSET;
 
   public U1Array           getTags()       { return new U1Array(tags.getValue(getAddress())); }
-  public U2Array           getOperands()   {
-    Address addr = operands.getValue(getAddress());
-    return VMObjectFactory.newObject(U2Array.class, addr);
-  }
   public ConstantPoolCache getCache()      {
     Address addr = cache.getValue(getAddress());
     return VMObjectFactory.newObject(ConstantPoolCache.class, addr);
@@ -435,26 +436,23 @@ public class ConstantPool extends Metadata implements ClassConstants {
     return res;
   }
 
+    private U4Array getOffsets() {
+        Address a =  getAddress().addOffsetTo(bsmaentries);
+        if (a == null) return null;
+        a = bsmaentries_offsets.getValue(a);
+        return VMObjectFactory.newObject(U4Array.class, a);
+  }
+  private U2Array getBootstrapMethods() {
+    Address a =  getAddress().addOffsetTo(bsmaentries);
+    if (a == null) return null;
+    return VMObjectFactory.newObject(U2Array.class, bsmaentries_bootstrap_methods.getValue(a));
+  }
+
   public int getBootstrapMethodsCount() {
-    U2Array operands = getOperands();
+    U4Array offsets = getOffsets();
     int count = 0;
-    if (operands != null) {
-      // Operands array consists of two parts. First part is an array of 32-bit values which denote
-      // index of the bootstrap method data in the operands array. Note that elements of operands array are of type short.
-      // So each element of first part occupies two slots in the array.
-      // Second part is the bootstrap methods data.
-      // This layout allows us to get BSM count by getting the index of first BSM and dividing it by 2.
-      //
-      // The example below shows layout of operands array with 3 bootstrap methods.
-      // First part has 3 32-bit values indicating the index of the respective bootstrap methods in
-      // the operands array.
-      // The first BSM is at index 6. So the count in this case is 6/2=3.
-      //
-      //            <-----first part----><-------second part------->
-      // index:     0     2      4      6        i2       i3
-      // operands:  |  6  |  i2  |  i3  |  bsm1  |  bsm2  |  bsm3  |
-      //
-      count = getOperandOffsetAt(operands, 0) / 2;
+    if (offsets != null) {
+      count = offsets.length();
     }
     if (DEBUG) {
       System.err.println("ConstantPool.getBootstrapMethodsCount: count = " + count);
@@ -463,12 +461,12 @@ public class ConstantPool extends Metadata implements ClassConstants {
   }
 
   public int getBootstrapMethodArgsCount(int bsmIndex) {
-    U2Array operands = getOperands();
+    U4Array offs = getOffsets();
+    U2Array bsms = getBootstrapMethods();
     if (Assert.ASSERTS_ENABLED) {
-      Assert.that(operands != null, "Operands is not present");
+      Assert.that(offs != null && bsms != null, "BSM attribute is not present");
     }
-    int bsmOffset = getOperandOffsetAt(operands, bsmIndex);
-    int argc = operands.at(bsmOffset + INDY_ARGC_OFFSET);
+    int argc = bsms.at(offs.at(bsmIndex) + INDY_ARGC_OFFSET);
     if (DEBUG) {
       System.err.println("ConstantPool.getBootstrapMethodArgsCount: bsm index = " + bsmIndex + ", args count = " + argc);
     }
@@ -476,15 +474,16 @@ public class ConstantPool extends Metadata implements ClassConstants {
   }
 
   public short[] getBootstrapMethodAt(int bsmIndex) {
-    U2Array operands = getOperands();
-    if (operands == null)  return null;  // safety first
-    int basePos = getOperandOffsetAt(operands, bsmIndex);
+    U4Array offs = getOffsets();
+    U2Array bsms = getBootstrapMethods();
+    if (offs == null || bsms == null) return null; // safety first
+    int basePos = offs.at(bsmIndex);
     int argv = basePos + INDY_ARGV_OFFSET;
-    int argc = operands.at(basePos + INDY_ARGC_OFFSET);
+    int argc = getBootstrapMethodArgsCount(bsmIndex);
     int endPos = argv + argc;
     short[] values = new short[endPos - basePos];
     for (int j = 0; j < values.length; j++) {
-        values[j] = operands.at(basePos+j);
+      values[j] = bsms.at(basePos+j);
     }
     return values;
   }
@@ -773,8 +772,7 @@ public class ConstantPool extends Metadata implements ClassConstants {
 
   // Return the offset of the requested Bootstrap Method in the operands array
   private int getOperandOffsetAt(U2Array operands, int bsmIndex) {
-    return VM.getVM().buildIntFromShorts(operands.at(bsmIndex * 2),
-                                         operands.at(bsmIndex * 2 + 1));
+      return 0;
   }
 
 }

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/U4Array.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/U4Array.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+package sun.jvm.hotspot.utilities;
+
+import sun.jvm.hotspot.debugger.Address;
+import sun.jvm.hotspot.runtime.VM;
+import sun.jvm.hotspot.types.Type;
+import sun.jvm.hotspot.types.TypeDataBase;
+import sun.jvm.hotspot.types.WrongTypeException;
+import sun.jvm.hotspot.utilities.Observable;
+import sun.jvm.hotspot.utilities.Observer;
+
+public class U4Array extends GenericArray {
+  static {
+    VM.registerVMInitializedObserver(new Observer() {
+      public void update(Observable o, Object data) {
+        initialize(VM.getVM().getTypeDataBase());
+      }
+    });
+  }
+
+  private static synchronized void initialize(TypeDataBase db) throws WrongTypeException {
+    elemType = db.lookupType("u4");
+    Type type = db.lookupType("Array<u4>");
+    dataFieldOffset = type.getAddressField("_data").getOffset();
+  }
+
+  private static long dataFieldOffset;
+  protected static Type elemType;
+
+  public U4Array(Address addr) {
+    super(addr, dataFieldOffset);
+  }
+
+  public int at(int i) {
+    return (int)getIntegerAt(i);
+  }
+
+  public Type getElemType() {
+    return elemType;
+  }
+}


### PR DESCRIPTION
Hi,

This is a refactoring of the way that we store the Bootstrap method attribute in the ConstantPool class. We used to have a single `Array<u2>` which was divided into a section of `u4` offsets and a section which was the actual data. In this refactoring we make this split more clear, by actually allocating an `Array<u4>` to store the offsets in and an `Array<u2>` to store the data in. These arrays are then put into a `BSMAttributeEntries` class, which allows us to separate out the API from that of the rest of the `ConstantPool`.

We had multiple instances of the code knowing the layout of the operands array and using this to do 'clever' ways of copying and inserting data into it. See `ConstantPool::copy_operands` and `ConstantPool::resize_operands`. I felt like we could do things in a simpler way, so I added the `start_/end_extension` protocol and added the `InsertionIterator` for this. See `ClassFileParser::parse_classfile_bootstrap_methods_attribute` for how this works. I put several relevant definitions into the inline file in hopes of encouraging the compiler to optimize these appropriately.

For the Java SA code, I had to add a `U4Array` class. I also had to fix the vmstructs definitions, etc.

On the whole, while this code is a bit less terse, I think it's a good API improvement and the underlying implementation of splitting up the operands array is also an improvement.

Testing: Oracle Tier1-Tier5 has been run succesfully multiple times. Before integration, I will merge with master and run these tiers again.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8367656](https://bugs.openjdk.org/browse/JDK-8367656): Refactor Constantpool's operand array into two (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27198/head:pull/27198` \
`$ git checkout pull/27198`

Update a local copy of the PR: \
`$ git checkout pull/27198` \
`$ git pull https://git.openjdk.org/jdk.git pull/27198/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27198`

View PR using the GUI difftool: \
`$ git pr show -t 27198`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27198.diff">https://git.openjdk.org/jdk/pull/27198.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27198#issuecomment-3291460978)
</details>
