### PR TITLE
8367347: Serial: Refactor CLDScanClosure

### DIFF
--- a/src/hotspot/share/gc/serial/defNewGeneration.cpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.cpp
@@ -94,7 +94,7 @@ public:
 class CLDScanClosure: public CLDClosure {
 
   class CLDOopClosure : public OffHeapScanClosure {
-    ClassLoaderData* _scanned_cld;
+    DefNewGeneration* _g;
 
     template <typename T>
     void do_oop_work(T* p) {
@@ -102,42 +102,41 @@ class CLDScanClosure: public CLDClosure {
 
       try_scavenge(p, [&] (oop new_obj) {
         assert(_scanned_cld != nullptr, "inv");
-        if (is_in_young_gen(new_obj) && !_scanned_cld->has_modified_oops()) {
-          _scanned_cld->record_modified_oops();
+        if (is_in_young_gen(new_obj)  && !_has_oops_into_young_gen) {
+          _has_oops_into_young_gen = true;
         }
       });
     }
 
   public:
-    CLDOopClosure(DefNewGeneration* g) : OffHeapScanClosure(g),
-      _scanned_cld(nullptr) {}
+    // Records whether this CLD contains oops pointing into young-gen after scavenging.
+    bool _has_oops_into_young_gen;
 
-    void set_scanned_cld(ClassLoaderData* cld) {
-      assert(cld == nullptr || _scanned_cld == nullptr, "Must be");
-      _scanned_cld = cld;
-    }
+    CLDOopClosure(DefNewGeneration* g) : OffHeapScanClosure(g),
+      _has_oops_into_young_gen(false) {}
 
     void do_oop(oop* p)       { do_oop_work(p); }
     void do_oop(narrowOop* p) { ShouldNotReachHere(); }
   };
 
-  CLDOopClosure _oop_closure;
+  DefNewGeneration* _g;
  public:
-  CLDScanClosure(DefNewGeneration* g) : _oop_closure(g) {}
+  CLDScanClosure(DefNewGeneration* g) : _g(g) {}
 
   void do_cld(ClassLoaderData* cld) {
     // If the cld has not been dirtied we know that there's
     // no references into  the young gen and we can skip it.
-    if (cld->has_modified_oops()) {
+    if (!cld->has_modified_oops()) {
+      return;
+    }
 
-      // Tell the closure which CLD is being scanned so that it can be dirtied
-      // if oops are left pointing into the young gen.
-      _oop_closure.set_scanned_cld(cld);
+    CLDOopClosure oop_closure{_g};
 
-      // Clean the cld since we're going to scavenge all the metadata.
-      cld->oops_do(&_oop_closure, ClassLoaderData::_claim_none, /*clear_modified_oops*/true);
+    // Clean the cld since we're going to scavenge all the metadata.
+    cld->oops_do(&oop_closure, ClassLoaderData::_claim_none, /*clear_modified_oops*/true);
 
-      _oop_closure.set_scanned_cld(nullptr);
+    if (oop_closure._has_oops_into_young_gen) {
+      cld->record_modified_oops();
     }
   }
 };

--- a/src/hotspot/share/gc/serial/defNewGeneration.cpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.cpp
@@ -102,7 +102,7 @@ class CLDScanClosure: public CLDClosure {
 
       try_scavenge(p, [&] (oop new_obj) {
         assert(_scanned_cld != nullptr, "inv");
-        if (is_in_young_gen(new_obj)  && !_has_oops_into_young_gen) {
+        if (is_in_young_gen(new_obj) && !_has_oops_into_young_gen) {
           _has_oops_into_young_gen = true;
         }
       });


### PR DESCRIPTION
Refactor `CLDScanClosure` so that all CLD logic is encapsulated in the CLD closure, without polluting the oop closure.

Test: tier1-2, running tier3

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8367347](https://bugs.openjdk.org/browse/JDK-8367347): Serial: Refactor CLDScanClosure (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27199/head:pull/27199` \
`$ git checkout pull/27199`

Update a local copy of the PR: \
`$ git checkout pull/27199` \
`$ git pull https://git.openjdk.org/jdk.git pull/27199/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27199`

View PR using the GUI difftool: \
`$ git pr show -t 27199`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27199.diff">https://git.openjdk.org/jdk/pull/27199.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27199#issuecomment-3275694939)
</details>
