### PR TITLE
8361530: Test javax/swing/GraphicsConfigNotifier/StalePreferredSize.java timed out

### DIFF
--- a/test/jdk/javax/swing/GraphicsConfigNotifier/StalePreferredSize.java
+++ b/test/jdk/javax/swing/GraphicsConfigNotifier/StalePreferredSize.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
This test takes an insane amount of time on some systems. I just saw it take 1,042 seconds to PASS on an x64 Mac.
It doesn't help that there are 3 @run commands.
But also it loops over L&Fs, fonts, etc, testing many component types and created 4.600 top level frames and 2,300 popups 

I don't think we need all 3 run commands and I think testing with one font is fine for this.

That would bring that successful run down to just under 3 minutes. 
And since each test is doing 1/3 of the work a slight reduction in timeout : 600 -> 420, seems appropriate.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8361530](https://bugs.openjdk.org/browse/JDK-8361530): Test javax/swing/GraphicsConfigNotifier/StalePreferredSize.java timed out (**Bug** - P4)


### Reviewers
 * [Prasanta Sadhukhan](https://openjdk.org/census#psadhukhan) (@prsadhuk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27200/head:pull/27200` \
`$ git checkout pull/27200`

Update a local copy of the PR: \
`$ git checkout pull/27200` \
`$ git pull https://git.openjdk.org/jdk.git pull/27200/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27200`

View PR using the GUI difftool: \
`$ git pr show -t 27200`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27200.diff">https://git.openjdk.org/jdk/pull/27200.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27200#issuecomment-3276070652)
</details>
