### PR TITLE
8367005: ImageReader refactor caused performance regressions for startup and footprint

### DIFF
--- a/src/java.base/share/classes/jdk/internal/module/SystemModuleFinders.java
+++ b/src/java.base/share/classes/jdk/internal/module/SystemModuleFinders.java
@@ -414,26 +414,18 @@ public final class SystemModuleFinders {
          * Returns {@code true} if the given resource exists, {@code false}
          * if not found.
          */
-        private boolean containsResource(String resourcePath) throws IOException {
-            Objects.requireNonNull(resourcePath);
+        private boolean containsResource(String module, String name) throws IOException {
+            Objects.requireNonNull(name);
             if (closed)
                 throw new IOException("ModuleReader is closed");
             ImageReader imageReader = SystemImage.reader();
-            if (imageReader != null) {
-                ImageReader.Node node = imageReader.findNode("/modules" + resourcePath);
-                return node != null && node.isResource();
-            } else {
-                // not an images build
-                return false;
-            }
+            return imageReader != null && imageReader.containsResource(module, name);
         }
 
         @Override
         public Optional<URI> find(String name) throws IOException {
-            Objects.requireNonNull(name);
-            String resourcePath = "/" + module + "/" + name;
-            if (containsResource(resourcePath)) {
-                URI u = JNUA.create("jrt", resourcePath);
+            if (containsResource(module, name)) {
+                URI u = JNUA.create("jrt", "/" + module + "/" + name);
                 return Optional.of(u);
             } else {
                 return Optional.empty();
@@ -465,9 +457,7 @@ public final class SystemModuleFinders {
             if (closed) {
                 throw new IOException("ModuleReader is closed");
             }
-            String nodeName = "/modules/" + module + "/" + name;
-            ImageReader.Node node = reader.findNode(nodeName);
-            return (node != null && node.isResource()) ? node : null;
+            return reader.findResourceNode(module, name);
         }
 
         @Override

--- a/test/jdk/jdk/internal/jimage/ImageReaderTest.java
+++ b/test/jdk/jdk/internal/jimage/ImageReaderTest.java
@@ -43,6 +43,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -119,6 +120,44 @@ public class ImageReaderTest {
             assertEquals("Class: com.foo.Beta", loader.loadAndGetToString("modfoo", "com.foo.Beta"));
             assertEquals("Class: com.foo.bar.Gamma", loader.loadAndGetToString("modfoo", "com.foo.bar.Gamma"));
             assertEquals("Class: com.bar.One", loader.loadAndGetToString("modbar", "com.bar.One"));
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "modfoo:com/foo/Alpha.class",
+            "modbar:com/bar/One.class",
+    })
+    public void testResourceNodes_present(String modAndPath) throws IOException {
+        try (ImageReader reader = ImageReader.open(image)) {
+            String[] parts = modAndPath.split(":");
+            assertNotNull(reader.findResourceNode(parts[0], parts[1]));
+            assertTrue(reader.containsResource(parts[0], parts[1]));
+        }
+    }
+
+    // Important to ensure we cannot be fooled.
+    @ParameterizedTest
+    @ValueSource(strings = {
+            // Absolute resource names are not allowed.
+            "modfoo:/com/bar/One.class",
+            // Resource in wrong module.
+            "modfoo:com/bar/One.class",
+            "modbar:com/foo/Alpha.class",
+            // JImage entries exist for these, but they are not resources.
+            "modules:modfoo/com/foo/Alpha.class",
+            "packages:com.foo/modfoo",
+            // Don't permit module names to contain paths.
+            "modfoo/com/bar:One.class",
+            "modfoo/com:bar/One.class",
+            "modules/modfoo/com:foo/Alpha.class",
+            // Or module name to be empty.
+            ":modfoo/com/foo/Alpha.class"})
+    public void testFindResourceNode_absent(String modAndPath) throws IOException {
+        try (ImageReader reader = ImageReader.open(image)) {
+            String[] parts = modAndPath.split(":");
+            assertNull(reader.findResourceNode(parts[0], parts[1]));
+            assertFalse(reader.containsResource(parts[0], parts[1]));
         }
     }
 


### PR DESCRIPTION
Summary: Add two new methods to ImageReader to make SystemModuleReader more performant.

Analysis of benchmarks shows that when the vast majority of resources (~11,000 in the Perfstartup-SwingSet-G1 benchmark) tested for in SystemModuleReader do NOT exist, performance is degraded compared to this code prior to the refactoring in JDK-8360037.

The current refactoring of ImageReader has everything going through a single "findNode()" method for simplest possible encapsulation, but while this is functionally correct, it's not tuned for testing for the non-existence of resources.

In particular:
1. SystemModuleReader only requests resources (i.e. things in the jimage file with paths *not* starting /modules/ or /packages/). This means findNode() does two look-ups for the resource, the first of which will always fail.
2. The containsResource() logic doesn't need to create and cache nodes in ImageReader, it can just check for the presence of an ImageLocation corresponding to a resource.

Thus two new methods are added to resolve these cases:
* findResourceNode(module, path)
* containsResource(module, path)

Their API takes module and path separately so as to not be confusable with findNode(nodename).

However care must be taken to prevent these methods being fooled into returning non-resource entries (this was possible before the refactoring by using module names like "modules" or "packages") so new tests have been added.