### PR TITLE
8367271: Add parsing tests to DateFormat JMH benchmark

### DIFF
--- a/test/micro/org/openjdk/bench/java/text/DateFormatterBench.java
+++ b/test/micro/org/openjdk/bench/java/text/DateFormatterBench.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2024, Alibaba Group Holding Limited. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -38,6 +39,7 @@ import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 
 import java.text.DateFormat;
+import java.text.ParseException;
 import java.util.Date;
 import java.util.Locale;
 import java.util.concurrent.TimeUnit;
@@ -51,25 +53,49 @@ import java.util.concurrent.TimeUnit;
 public class DateFormatterBench {
 
     private Date date;
-
     private Object objDate;
+    private String dateStr;
+    private String timeStr;
+
+    private DateFormat dateFormat = DateFormat.getDateInstance(DateFormat.FULL, Locale.ENGLISH);
+    private DateFormat timeFormat = DateFormat.getTimeInstance(DateFormat.FULL, Locale.ENGLISH);
 
     @Setup
     public void setup() {
         date = new Date();
         objDate = new Date();
+        timeStr = timeFormat.format(date);
+        dateStr = dateFormat.format(date);
     }
 
-    private DateFormat dateFormat = DateFormat.getDateInstance(DateFormat.FULL, Locale.ENGLISH);
+    @Benchmark
+    public String testTimeFormat() {
+        return timeFormat.format(date);
+    }
 
     @Benchmark
-    public String testFormatDate() {
+    public String testTimeFormatObject() {
+        return timeFormat.format(objDate);
+    }
+
+    @Benchmark
+    public String testDateFormat() {
         return dateFormat.format(date);
     }
 
     @Benchmark
-    public String testFormatObject() {
+    public String testDateFormatObject() {
         return dateFormat.format(objDate);
+    }
+
+    @Benchmark
+    public Date testDateParse() throws ParseException {
+        return dateFormat.parse(dateStr);
+    }
+
+    @Benchmark
+    public Date testTimeParse() throws ParseException {
+        return timeFormat.parse(timeStr);
     }
 
     public static void main(String... args) throws Exception {

--- a/test/micro/org/openjdk/bench/java/text/DateFormatterBench.java
+++ b/test/micro/org/openjdk/bench/java/text/DateFormatterBench.java
@@ -40,8 +40,8 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 
 import java.text.DateFormat;
 import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.util.Date;
-import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 
 @BenchmarkMode(Mode.Throughput)
@@ -57,15 +57,21 @@ public class DateFormatterBench {
     private String dateStr;
     private String timeStr;
 
-    private DateFormat dateFormat = DateFormat.getDateInstance(DateFormat.FULL, Locale.ENGLISH);
-    private DateFormat timeFormat = DateFormat.getTimeInstance(DateFormat.FULL, Locale.ENGLISH);
+    private final String datePattern = "EEEE, MMMM d, y";
+    private final String timePattern = "h:mm:ss a zzzz";
+
+    // Use non-factory methods w/ pattern to ensure test data can be round
+    // tripped and guarantee no re-use of the same instance
+    private DateFormat dateFormat = new SimpleDateFormat(datePattern);
+    private DateFormat timeFormat = new SimpleDateFormat(timePattern);
 
     @Setup
     public void setup() {
         date = new Date();
         objDate = new Date();
-        timeStr = timeFormat.format(date);
-        dateStr = dateFormat.format(date);
+        // Generate the strings for parsing using dedicated separate instances
+        dateStr = new SimpleDateFormat(datePattern).format(date);
+        timeStr = new SimpleDateFormat(timePattern).format(date);
     }
 
     @Benchmark


### PR DESCRIPTION
This PR expands the DateFormat benchmark with parsing cases (in addition to the existing formatting ones) such that performance regressions are easier to identify for parsing. Also adding in a time instance and respective measurement tests.  The patterns used correspond to FULL Locale.ENGLISH patterns (w/ the NBSP replaced for time pattern for clarity sake).

Further context in comment on JBS issue.