### PR TITLE
8367376: call setUpdatePending(false) in a finally block

### DIFF
--- a/src/java.desktop/share/classes/sun/swing/plaf/DesktopProperty.java
+++ b/src/java.desktop/share/classes/sun/swing/plaf/DesktopProperty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -214,8 +214,11 @@ public class DesktopProperty implements UIDefaults.ActiveValue {
             setUpdatePending(true);
             Runnable uiUpdater = new Runnable() {
                 public void run() {
-                    updateAllUIs();
-                    setUpdatePending(false);
+                    try {
+                        updateAllUIs();
+                    } finally {
+                        setUpdatePending(false);
+                    }
                 }
             };
             SwingUtilities.invokeLater(uiUpdater);

--- a/test/jdk/com/sun/java/swing/plaf/Test8367376.java
+++ b/test/jdk/com/sun/java/swing/plaf/Test8367376.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+   @bug 8367376
+   @summary DesktopProperty never reset pending status to process new updates
+   @modules java.desktop/sun.swing.plaf
+   @run main Test8367376
+*/
+
+import javax.swing.JButton;
+import javax.swing.JComponent;
+import javax.swing.JFrame;
+import javax.swing.JPanel;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+import javax.swing.plaf.basic.BasicButtonUI;
+
+import sun.swing.plaf.DesktopProperty;
+
+import java.awt.AWTEvent;
+import java.awt.EventQueue;
+import java.awt.Toolkit;
+import java.util.concurrent.CountDownLatch;
+
+public class Test8367376 extends JFrame {
+
+    static class ExpectedException extends RuntimeException {}
+
+    /**
+     * The original ticket required changing the system accessibility settings.
+     * But we can instead automate this test if we just create & update our own
+     * DesktopProperty.
+     */
+    static class TestDesktopProperty extends DesktopProperty {
+
+        public TestDesktopProperty(String key, Object fallback) {
+            super(key, fallback);
+        }
+
+        @Override
+        public void updateUI() {
+            super.updateUI();
+        }
+    }
+
+    private static void setLookAndFeel() {
+        try {
+            String lf = UIManager.getSystemLookAndFeelClassName();
+            UIManager.setLookAndFeel(lf);
+            System.out.println("Set look & feel to " + lf);
+        } catch (Throwable e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static void assertEquals(int expectedValue, int actualValue) {
+        String msg = "expected " + expectedValue +
+                " observed " + actualValue;
+        if (expectedValue != actualValue) {
+            throw new RuntimeException(msg);
+        }
+        System.out.println(msg);
+    }
+
+    public static void main(String[] args) throws Exception {
+        // we only override this to intercept ExpectedExceptions
+        EventQueue newEventQueue = new EventQueue() {
+            @Override
+            protected void dispatchEvent(AWTEvent event) {
+                try {
+                    super.dispatchEvent(event);
+                } catch (ExpectedException e) {
+                    // This is  part of the test. But if we don't catch
+                    // this here the test harness says we our test failed.
+                    observedExpectedExceptionCtr++;
+                }
+            }
+        };
+        Toolkit.getDefaultToolkit().getSystemEventQueue().push(newEventQueue);
+
+        SwingUtilities.invokeLater(Test8367376::setLookAndFeel);
+
+        SwingUtilities.invokeLater(() -> {
+            Test8367376 t = new Test8367376();
+            t.pack();
+            t.setVisible(true);
+        });
+
+        TestDesktopProperty property =
+                new TestDesktopProperty("test", new Object());
+
+        SwingUtilities.invokeLater(property::updateUI);
+        SwingUtilities.invokeAndWait(() -> {});
+
+        SwingUtilities.invokeLater(property::updateUI);
+        SwingUtilities.invokeAndWait(() -> {});
+
+        CountDownLatch keepAliveLatch = new CountDownLatch(1);
+
+        SwingUtilities.invokeLater(() -> {
+            // We expect 3 updateUI invocations: during construction, the first
+            // property.updateUI, & the second property.updateUI
+            assertEquals(3, panelUpdateUIctr);
+
+            // We expect 2 attempts on buttonUI.uninstallUI
+            assertEquals(2, observedExpectedExceptionCtr);
+
+            // The test is finished
+            keepAliveLatch.countDown();
+        });
+
+        keepAliveLatch.await();
+    }
+
+    static int panelUpdateUIctr;
+    static int observedExpectedExceptionCtr;
+
+    Test8367376() {
+        JButton button = new JButton("button");
+        button.setUI(new BasicButtonUI() {
+            @Override
+            public void uninstallUI(JComponent c) {
+                throw new ExpectedException();
+            }
+        });
+        JPanel p = new JPanel() {
+            @Override
+            public void updateUI() {
+                panelUpdateUIctr++;
+            }
+        };
+        p.add(button);
+        getContentPane().add(p);
+    }
+}


### PR DESCRIPTION
Previously:

If DesktopProperty#updateAllUIs threw an exception, we would never reset the update-pending property to false. This means any subsequent call to `updateUI()` would not attempt to call `updateAllUIs()`

With this change:
Subsequent calls to DesktopProperty#updateUI() can still trigger at least one call to updateAllUIs().