### PR TITLE
8367401: Parallel: Remove unused field in PSKeepAliveClosure

### DIFF
--- a/src/hotspot/share/gc/parallel/psScavenge.cpp
+++ b/src/hotspot/share/gc/parallel/psScavenge.cpp
@@ -148,15 +148,10 @@ public:
 PSIsAliveClosure PSScavenge::_is_alive_closure;
 
 class PSKeepAliveClosure: public OopClosure {
-protected:
-  MutableSpace* _to_space;
   PSPromotionManager* _promotion_manager;
 
 public:
   PSKeepAliveClosure(PSPromotionManager* pm) : _promotion_manager(pm) {
-    ParallelScavengeHeap* heap = ParallelScavengeHeap::heap();
-    _to_space = heap->young_gen()->to_space();
-
     assert(_promotion_manager != nullptr, "Sanity");
   }
 


### PR DESCRIPTION
Trivial removing dead code.

Test: tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8367401](https://bugs.openjdk.org/browse/JDK-8367401): Parallel: Remove unused field in PSKeepAliveClosure (**Enhancement** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Francesco Andreuzzi](https://openjdk.org/census#fandreuzzi) (@fandreuz - Author)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27210/head:pull/27210` \
`$ git checkout pull/27210`

Update a local copy of the PR: \
`$ git checkout pull/27210` \
`$ git pull https://git.openjdk.org/jdk.git pull/27210/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27210`

View PR using the GUI difftool: \
`$ git pr show -t 27210`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27210.diff">https://git.openjdk.org/jdk/pull/27210.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27210#issuecomment-3279298359)
</details>
