### PR TITLE
8367365: java/math/BigInteger/BigIntegerTest.java failed in jtreg timeout

### DIFF
--- a/test/jdk/java/math/BigInteger/BigIntegerTest.java
+++ b/test/jdk/java/math/BigInteger/BigIntegerTest.java
@@ -23,14 +23,13 @@
 
 /*
  * @test
+ * @bug 4181191 4161971 4227146 4194389 4823171 4624738 4812225 4837946 4026465
+ *      8074460 8078672 8032027 8229845 8077587 8367365
+ * @summary tests methods in BigInteger (use -Dseed=X to set PRNG seed)
+ * @key randomness
  * @library /test/lib
  * @build jdk.test.lib.RandomFactory
- * @run main BigIntegerTest
- * @bug 4181191 4161971 4227146 4194389 4823171 4624738 4812225 4837946 4026465 8074460 8078672 8032027 8229845 8077587
- * @summary tests methods in BigInteger (use -Dseed=X to set PRNG seed)
- * @run main/timeout=400 BigIntegerTest
- * @author madbot
- * @key randomness
+ * @run main/timeout=480 BigIntegerTest
  */
 
 import java.io.File;
@@ -1397,8 +1396,8 @@ public class BigIntegerTest {
     public static void main(String[] args) throws Exception {
         // subset zero indicates to run all subsets
         int subset = Integer.valueOf(System.getProperty("subset",
-            String.valueOf(1 + random.nextInt(3))));
-        if (subset < 0 || subset > 3) {
+            String.valueOf(1 + random.nextInt(4))));
+        if (subset < 0 || subset > 4) {
             throw new RuntimeException("Unknown subset " + subset);
         }
         if (subset == 0)
@@ -1443,11 +1442,6 @@ public class BigIntegerTest {
             square(ORDER_KARATSUBA_SQUARE);
             square(ORDER_TOOM_COOK_SQUARE);
 
-            squareRoot();
-            squareRootAndRemainder();
-            nthRoot();
-            nthRootAndRemainder();
-
             bitCount();
             bitLength();
             bitOps(order1);
@@ -1473,6 +1467,13 @@ public class BigIntegerTest {
             multiplyLarge();
             squareLarge();
             divideLarge();
+        }
+        if (subset == 0 || subset == 4) {
+            squareRoot();
+            squareRootAndRemainder();
+
+            nthRoot();
+            nthRootAndRemainder();
         }
 
         if (failure)


### PR DESCRIPTION
This PR
* Moves sqrt() and nthRoot() tests to a new subset.
* Removes a leftover `@run` tag without a timeout.
* Increases the explicit timeout from 400 to 480.
* Sorts the jtreg tags according to standard conventions.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8367365](https://bugs.openjdk.org/browse/JDK-8367365): java/math/BigInteger/BigIntegerTest.java failed in jtreg timeout (**Bug** - P4)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27211/head:pull/27211` \
`$ git checkout pull/27211`

Update a local copy of the PR: \
`$ git checkout pull/27211` \
`$ git pull https://git.openjdk.org/jdk.git pull/27211/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27211`

View PR using the GUI difftool: \
`$ git pr show -t 27211`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27211.diff">https://git.openjdk.org/jdk/pull/27211.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27211#issuecomment-3279331573)
</details>
