### PR TITLE
8367325: [s390x] build failure due to JDK-8361376

### DIFF
--- a/src/hotspot/cpu/s390/gc/shared/barrierSetAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/gc/shared/barrierSetAssembler_s390.cpp
@@ -171,7 +171,7 @@ void BarrierSetAssembler::try_resolve_jobject_in_native(MacroAssembler* masm, Re
 
 void BarrierSetAssembler::nmethod_entry_barrier(MacroAssembler* masm) {
   BarrierSetNMethod* bs_nm = BarrierSet::barrier_set()->barrier_set_nmethod();
-  __ align(4, __ offset() + PATCHABLE_INSTRUCTION_OFFSET); // must align the following block which requires atomic updates
+  __ align(4, __ offset() + PATCHABLE_BARRIER_VALUE_OFFSET); // must align the following block which requires atomic updates
   __ block_comment("nmethod_entry_barrier (nmethod_entry_barrier) {");
 
     // Load jump addr:

--- a/src/hotspot/cpu/s390/gc/shared/barrierSetAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/gc/shared/barrierSetAssembler_s390.cpp
@@ -171,6 +171,7 @@ void BarrierSetAssembler::try_resolve_jobject_in_native(MacroAssembler* masm, Re
 
 void BarrierSetAssembler::nmethod_entry_barrier(MacroAssembler* masm) {
   BarrierSetNMethod* bs_nm = BarrierSet::barrier_set()->barrier_set_nmethod();
+  __ align(8); // must align the following block which requires atomic updates
   __ block_comment("nmethod_entry_barrier (nmethod_entry_barrier) {");
 
     // Load jump addr:

--- a/src/hotspot/cpu/s390/gc/shared/barrierSetAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/gc/shared/barrierSetAssembler_s390.cpp
@@ -171,7 +171,7 @@ void BarrierSetAssembler::try_resolve_jobject_in_native(MacroAssembler* masm, Re
 
 void BarrierSetAssembler::nmethod_entry_barrier(MacroAssembler* masm) {
   BarrierSetNMethod* bs_nm = BarrierSet::barrier_set()->barrier_set_nmethod();
-  __ align(4, __ offset() + BARRIER_TOTAL_LENGTH); // must align the following block which requires atomic updates
+  __ align(4, __ offset() + OFFSET_TO_PATCHABLE_DATA); // must align the following block which requires atomic updates
   __ block_comment("nmethod_entry_barrier (nmethod_entry_barrier) {");
 
     // Load jump addr:

--- a/src/hotspot/cpu/s390/gc/shared/barrierSetAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/gc/shared/barrierSetAssembler_s390.cpp
@@ -171,7 +171,7 @@ void BarrierSetAssembler::try_resolve_jobject_in_native(MacroAssembler* masm, Re
 
 void BarrierSetAssembler::nmethod_entry_barrier(MacroAssembler* masm) {
   BarrierSetNMethod* bs_nm = BarrierSet::barrier_set()->barrier_set_nmethod();
-  __ align(8); // must align the following block which requires atomic updates
+  __ align(4, __ offset() + PATCHABLE_INSTRUCTION_OFFSET); // must align the following block which requires atomic updates
   __ block_comment("nmethod_entry_barrier (nmethod_entry_barrier) {");
 
     // Load jump addr:

--- a/src/hotspot/cpu/s390/gc/shared/barrierSetAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/gc/shared/barrierSetAssembler_s390.cpp
@@ -171,7 +171,7 @@ void BarrierSetAssembler::try_resolve_jobject_in_native(MacroAssembler* masm, Re
 
 void BarrierSetAssembler::nmethod_entry_barrier(MacroAssembler* masm) {
   BarrierSetNMethod* bs_nm = BarrierSet::barrier_set()->barrier_set_nmethod();
-  __ align(4, __ offset() + PATCHABLE_BARRIER_VALUE_OFFSET); // must align the following block which requires atomic updates
+  __ align(4, __ offset() + BARRIER_TOTAL_LENGTH); // must align the following block which requires atomic updates
   __ block_comment("nmethod_entry_barrier (nmethod_entry_barrier) {");
 
     // Load jump addr:

--- a/src/hotspot/cpu/s390/gc/shared/barrierSetAssembler_s390.hpp
+++ b/src/hotspot/cpu/s390/gc/shared/barrierSetAssembler_s390.hpp
@@ -67,8 +67,8 @@ public:
                                 OptoReg::Name opto_reg) const;
 #endif // COMPILER2
 
-  static const int PATCHABLE_SEQ_START_OFFSET = 3 * 6;
-  static const int PATCHABLE_BARRIER_VALUE_OFFSET = PATCHABLE_SEQ_START_OFFSET + 2;
+  static const int OFFSET_TO_PATCHABLE_DATA_INSTRUCTION = 6 + 6 + 6; // iihf(6) + iilf(6) + lg(6)
+  static const int BARRIER_TOTAL_LENGTH = OFFSET_TO_PATCHABLE_DATA_INSTRUCTION + 6 + 6 + 2; // cfi(6) + larl(6) + bcr(2)
 };
 
 #ifdef COMPILER2

--- a/src/hotspot/cpu/s390/gc/shared/barrierSetAssembler_s390.hpp
+++ b/src/hotspot/cpu/s390/gc/shared/barrierSetAssembler_s390.hpp
@@ -69,6 +69,11 @@ public:
 
   static const int OFFSET_TO_PATCHABLE_DATA_INSTRUCTION = 6 + 6 + 6; // iihf(6) + iilf(6) + lg(6)
   static const int BARRIER_TOTAL_LENGTH = OFFSET_TO_PATCHABLE_DATA_INSTRUCTION + 6 + 6 + 2; // cfi(6) + larl(6) + bcr(2)
+
+  // first 2 bytes are for cfi instruction opcode and next 4 bytes will be the value/data to be patched,
+  // so we are skipping first 2 bytes and returning the address of value/data field
+  static const int OFFSET_TO_PATCHABLE_DATA = 6 + 6 + 6 + 2; // iihf(6) + iilf(6) + lg(6) + CFI_OPCODE(2)
+
 };
 
 #ifdef COMPILER2

--- a/src/hotspot/cpu/s390/gc/shared/barrierSetAssembler_s390.hpp
+++ b/src/hotspot/cpu/s390/gc/shared/barrierSetAssembler_s390.hpp
@@ -66,6 +66,8 @@ public:
   OptoReg::Name refine_register(const Node* node,
                                 OptoReg::Name opto_reg) const;
 #endif // COMPILER2
+
+  static const int PATCHABLE_INSTRUCTION_OFFSET = 3 * 6 + 2;
 };
 
 #ifdef COMPILER2

--- a/src/hotspot/cpu/s390/gc/shared/barrierSetAssembler_s390.hpp
+++ b/src/hotspot/cpu/s390/gc/shared/barrierSetAssembler_s390.hpp
@@ -67,7 +67,8 @@ public:
                                 OptoReg::Name opto_reg) const;
 #endif // COMPILER2
 
-  static const int PATCHABLE_INSTRUCTION_OFFSET = 3 * 6 + 2;
+  static const int PATCHABLE_SEQ_START_OFFSET = 3 * 6;
+  static const int PATCHABLE_BARRIER_VALUE_OFFSET = PATCHABLE_SEQ_START_OFFSET + 2;
 };
 
 #ifdef COMPILER2

--- a/src/hotspot/cpu/s390/gc/shared/barrierSetNMethod_s390.cpp
+++ b/src/hotspot/cpu/s390/gc/shared/barrierSetNMethod_s390.cpp
@@ -27,25 +27,25 @@
 #include "code/nativeInst.hpp"
 #include "code/nmethod.hpp"
 #include "gc/shared/barrierSetNMethod.hpp"
+#include "gc/shared/barrierSetAssembler.hpp"
 #include "utilities/debug.hpp"
 
 class NativeMethodBarrier: public NativeInstruction {
   private:
-    static const int PATCHABLE_INSTRUCTION_OFFSET = 3*6; // bytes
 
     address get_barrier_start_address() const {
       return NativeInstruction::addr_at(0);
     }
 
     address get_patchable_data_address() const {
-      address inst_addr = get_barrier_start_address() + PATCHABLE_INSTRUCTION_OFFSET;
+      address inst_addr = get_barrier_start_address() + BarrierSetAssembler::PATCHABLE_INSTRUCTION_OFFSET;
 
       DEBUG_ONLY(Assembler::is_z_cfi(*((long*)inst_addr)));
-      return inst_addr + 2;
+      return inst_addr;
     }
 
   public:
-    static const int BARRIER_TOTAL_LENGTH = PATCHABLE_INSTRUCTION_OFFSET + 2*6 + 2; // bytes
+    static const int BARRIER_TOTAL_LENGTH = BarrierSetAssembler::PATCHABLE_INSTRUCTION_OFFSET + 2*6; // bytes
 
     int get_guard_value() const {
       address data_addr = get_patchable_data_address();

--- a/src/hotspot/cpu/s390/gc/shared/barrierSetNMethod_s390.cpp
+++ b/src/hotspot/cpu/s390/gc/shared/barrierSetNMethod_s390.cpp
@@ -38,16 +38,16 @@ class NativeMethodBarrier: public NativeInstruction {
     }
 
     address get_patchable_data_address() const {
-      address inst_addr = get_barrier_start_address() + BarrierSetAssembler::OFFSET_TO_PATCHABLE_DATA_INSTRUCTION;
+      address start_address = get_barrier_start_address();
+#ifdef ASSERT
+      address inst_addr = start_address + BarrierSetAssembler::OFFSET_TO_PATCHABLE_DATA_INSTRUCTION;
 
       unsigned long instr = 0;
       Assembler::get_instruction(inst_addr, &instr);
       assert(Assembler::is_z_cfi(instr), "sanity check");
+#endif // ASSERT
 
-      // we are currently pointing to cfi instruction,
-      // first 2 bytes are for instruction opcode and next 4 bytes will be the value/data to be patched,
-      // so we can skip the first 2 bytes and just return the value/data
-      return inst_addr + 2;
+      return start_address + BarrierSetAssembler::OFFSET_TO_PATCHABLE_DATA;
     }
 
   public:
@@ -95,7 +95,7 @@ class NativeMethodBarrier: public NativeInstruction {
         assert(Assembler::is_z_lg(instr), "sanity check");
         offset += Assembler::instr_len(&start[offset]);
 
-        // it will be assignment operation, doesn't matter what's already there instr
+        // it will be assignment operation, So it doesn't matter what value is already present in instr
         // hence, no need to 0 it out.
         Assembler::get_instruction(start + offset, &instr);
         assert(Assembler::is_z_cfi(instr), "sanity check");

--- a/src/hotspot/cpu/s390/gc/shared/barrierSetNMethod_s390.cpp
+++ b/src/hotspot/cpu/s390/gc/shared/barrierSetNMethod_s390.cpp
@@ -26,8 +26,8 @@
 #include "code/codeBlob.hpp"
 #include "code/nativeInst.hpp"
 #include "code/nmethod.hpp"
-#include "gc/shared/barrierSetNMethod.hpp"
 #include "gc/shared/barrierSetAssembler.hpp"
+#include "gc/shared/barrierSetNMethod.hpp"
 #include "utilities/debug.hpp"
 
 class NativeMethodBarrier: public NativeInstruction {
@@ -38,14 +38,14 @@ class NativeMethodBarrier: public NativeInstruction {
     }
 
     address get_patchable_data_address() const {
-      address inst_addr = get_barrier_start_address() + BarrierSetAssembler::PATCHABLE_INSTRUCTION_OFFSET;
+      address inst_addr = get_barrier_start_address() + BarrierSetAssembler::PATCHABLE_SEQ_START_OFFSET;
 
       DEBUG_ONLY(Assembler::is_z_cfi(*((long*)inst_addr)));
-      return inst_addr;
+      return inst_addr + 2;
     }
 
   public:
-    static const int BARRIER_TOTAL_LENGTH = BarrierSetAssembler::PATCHABLE_INSTRUCTION_OFFSET + 2*6; // bytes
+    static const int BARRIER_TOTAL_LENGTH = BarrierSetAssembler::PATCHABLE_BARRIER_VALUE_OFFSET + 2*6; // bytes
 
     int get_guard_value() const {
       address data_addr = get_patchable_data_address();


### PR DESCRIPTION
Fixes the SIGLL caused after [JDK-8361376](https://bugs.openjdk.org/browse/JDK-8361376). 

Issue was with `cs` instruction, which requires the address to be aligned. And after this change address at which operating was not aligned.

Wisdom from Principle of Z Operations: 

Sytax: CS R<sub>1</sub>,R<sub>3</sub>,D<sub>2</sub>(B<sub>2</sub>)

Sytax: CSY R<sub>1</sub>,R<sub>3</sub>,D<sub>2</sub>(B<sub>2</sub>)

`
The second operand of COMPARE AND SWAP (CS, CSY) must be designated on a word boundary.
`


```cpp
=> 0x3fffc3149ba <_ZN17BarrierSetNMethod15set_guard_valueEP7nmethodii+266>: cs %r1,%r4,0(%r3)
(gdb) i r r3
r3             0x3ffe500017a       4397593526650
(gdb) p ($r3 % 8) 
$5 = 2
(gdb) si 

Thread 16 "C1 CompilerThre" received signal SIGILL, Illegal instruction.
NativeMethodBarrier::set_guard_value (bit_mask=2147483647, value=1, this=0x3ffe5000166)
    at /home/amit/jdk/src/hotspot/cpu/s390/gc/shared/barrierSetNMethod_s390.cpp:74
74         if (v == old_value) break;
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8367325](https://bugs.openjdk.org/browse/JDK-8367325): [s390x] build failure due to JDK-8361376 (**Bug** - P1)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27213/head:pull/27213` \
`$ git checkout pull/27213`

Update a local copy of the PR: \
`$ git checkout pull/27213` \
`$ git pull https://git.openjdk.org/jdk.git pull/27213/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27213`

View PR using the GUI difftool: \
`$ git pr show -t 27213`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27213.diff">https://git.openjdk.org/jdk/pull/27213.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27213#issuecomment-3279742565)
</details>
