### PR TITLE
6850365: java/awt/Focus/WindowActivationFocusTest.java fails

### DIFF
--- a/test/jdk/java/awt/Focus/WindowActivationFocusTest.java
+++ b/test/jdk/java/awt/Focus/WindowActivationFocusTest.java
@@ -26,7 +26,7 @@
  * @bug 4369903
  * @summary Focus on window activation does not work correctly
  * @key headful
- * @run main ActivateFocusTest
+ * @run main WindowActivationFocusTest
  */
 
 import java.awt.Color;
@@ -41,14 +41,14 @@ import java.awt.event.FocusListener;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 
-public class ActivateFocusTest {
+public class WindowActivationFocusTest {
 
     private static final int NUM_FRAMES = 2;
     private static ActivateFocus[] af;
 
     public static void main(final String[] args) throws Exception {
         try {
-            ActivateFocusTest app = new ActivateFocusTest();
+            WindowActivationFocusTest app = new WindowActivationFocusTest();
             EventQueue.invokeAndWait(() -> app.doTest());
 
             Thread.sleep(1000);


### PR DESCRIPTION
Test is made more robust by executing in EDT and cleanup done by frame dispose. Testing result is green.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-6850365](https://bugs.openjdk.org/browse/JDK-6850365): java/awt/Focus/WindowActivationFocusTest.java fails (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27214/head:pull/27214` \
`$ git checkout pull/27214`

Update a local copy of the PR: \
`$ git checkout pull/27214` \
`$ git pull https://git.openjdk.org/jdk.git pull/27214/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27214`

View PR using the GUI difftool: \
`$ git pr show -t 27214`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27214.diff">https://git.openjdk.org/jdk/pull/27214.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27214#issuecomment-3279714698)
</details>
