### PR TITLE
8144124: [macosx] The tabs can't be aligned when we pressing the key of 'R','B','L','C' or 'T'.

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -785,7 +785,6 @@ java/foreign/TestBufferStackStress.java                         8350455 macosx-a
 javax/swing/JFileChooser/6698013/bug6698013.java 8024419 macosx-all
 javax/swing/JColorChooser/8065098/bug8065098.java 8065647 macosx-all
 javax/swing/JTabbedPane/bug4499556.java 8267500 macosx-all
-javax/swing/JTabbedPane/bug4666224.java 8144124  macosx-all
 javax/swing/JTabbedPane/TestJTabbedPaneOpaqueColor.java 8345090 windows-all,linux-all
 javax/swing/SwingUtilities/TestTextPosInPrint.java 8227025 windows-all
 javax/swing/JInternalFrame/bug4134077.java 8184985 windows-all


### PR DESCRIPTION
Test is passing on macos following the instructions listed in the test so deproblemlisting

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found trailing period in issue title for `8144124: [macosx] The tabs can't be aligned when we pressing the key of 'R','B','L','C' or 'T'.`

### Issue
 * [JDK-8144124](https://bugs.openjdk.org/browse/JDK-8144124): [macosx] The tabs can't be aligned when we pressing the key of 'R','B','L','C' or 'T'. (**Bug** - P5)


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27216/head:pull/27216` \
`$ git checkout pull/27216`

Update a local copy of the PR: \
`$ git checkout pull/27216` \
`$ git pull https://git.openjdk.org/jdk.git pull/27216/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27216`

View PR using the GUI difftool: \
`$ git pr show -t 27216`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27216.diff">https://git.openjdk.org/jdk/pull/27216.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27216#issuecomment-3279788420)
</details>
