### PR TITLE
8367371: Remove @requires vm.opt.UseLargePages from InternSharedString.java test

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/InternSharedString.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/InternSharedString.java
@@ -27,7 +27,6 @@
  * @summary Test shared strings together with string intern operation
  * @requires vm.cds.write.archived.java.heap
  * @requires vm.gc == null
- * @comment CDS archive heap mapping is not supported with large pages
  * @library /test/hotspot/jtreg/runtime/cds/appcds /test/lib
  * @compile InternStringTest.java
  * @build jdk.test.whitebox.WhiteBox


### PR DESCRIPTION
Hi all,

This PR removes the requirement to not use large pages for the given CDS test. CDS now supports large pages.

Tested `InternSharedString.java` on Linux x64 and Linux AArch64 with `-XX:+UseLargePages`. 5x 100 iterations.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8367371](https://bugs.openjdk.org/browse/JDK-8367371): Remove @<!---->requires vm.opt.UseLargePages from InternSharedString.java test (**Enhancement** - P4)


### Reviewers
 * [Joel Sikström](https://openjdk.org/census#jsikstro) (@jsikstro - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27218/head:pull/27218` \
`$ git checkout pull/27218`

Update a local copy of the PR: \
`$ git checkout pull/27218` \
`$ git pull https://git.openjdk.org/jdk.git pull/27218/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27218`

View PR using the GUI difftool: \
`$ git pr show -t 27218`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27218.diff">https://git.openjdk.org/jdk/pull/27218.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27218#issuecomment-3280791503)
</details>
