### PR TITLE
8367409: G1: Remove unused G1MonotonicArena::Segment::copy_to()

### DIFF
--- a/src/hotspot/share/gc/g1/g1MonotonicArena.hpp
+++ b/src/hotspot/share/gc/g1/g1MonotonicArena.hpp
@@ -174,7 +174,7 @@ public:
   }
 
   static Segment* create_segment(uint slot_size, uint num_slots, Segment* next, MemTag mem_tag);
-  static void delete_segment(Segment *segment);
+  static void delete_segment(Segment* segment);
 
   bool is_full() const { return _next_allocate >= _num_slots; }
 };


### PR DESCRIPTION
The code compiles.

<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8367409](https://bugs.openjdk.org/browse/JDK-8367409): G1: Remove unused G1MonotonicArena::Segment::copy_to() (**Enhancement** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27221/head:pull/27221` \
`$ git checkout pull/27221`

Update a local copy of the PR: \
`$ git checkout pull/27221` \
`$ git pull https://git.openjdk.org/jdk.git pull/27221/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27221`

View PR using the GUI difftool: \
`$ git pr show -t 27221`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27221.diff">https://git.openjdk.org/jdk/pull/27221.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27221#issuecomment-3285009267)
</details>
