### PR TITLE
Improve UseAVX setting and add cpu descriptions for zhaoxin processors.

### DIFF
--- a/src/hotspot/cpu/x86/vm_version_x86.cpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.cpp
@@ -931,9 +931,17 @@ void VM_Version::get_processor_features() {
   if (UseSSE < 1)
     _features.clear_feature(CPU_SSE);
 
-  //since AVX instructions is slower than SSE in some ZX cpus, force USEAVX=0.
-  if (is_zx() && ((cpu_family() == 6) || (cpu_family() == 7))) {
-    UseAVX = 0;
+  // ZX cpus specific settings
+  if (is_zx() && FLAG_IS_DEFAULT(UseAVX)) {
+    if (cpu_family() == 7) {
+      if (extended_cpu_model() == 0x5B || extended_cpu_model() == 0x6B) {
+        UseAVX = 1;
+      } else if (extended_cpu_model() == 0x1B || extended_cpu_model() == 0x3B) {
+        UseAVX = 0;
+      }
+    } else if (cpu_family() == 6) {
+      UseAVX = 0;
+    }
   }
 
   // UseSSE is set to the smaller of what hardware supports and what
@@ -2592,6 +2600,7 @@ void VM_Version::resolve_cpu_information_details(void) {
 
 const char* VM_Version::cpu_family_description(void) {
   int cpu_family_id = extended_cpu_family();
+  int cpu_model_id = extended_cpu_model();
   if (is_amd()) {
     if (cpu_family_id < ExtendedFamilyIdLength_AMD) {
       return _family_id_amd[cpu_family_id];
@@ -2603,6 +2612,22 @@ const char* VM_Version::cpu_family_description(void) {
     }
     if (cpu_family_id < ExtendedFamilyIdLength_INTEL) {
       return _family_id_intel[cpu_family_id];
+    }
+  }
+  if (is_zx()) {
+    if (cpu_family_id == 7) {
+      switch (cpu_model_id) {
+        case 0x1B:
+          return "wudaokou";
+        case 0x3B:
+          return "lujiazui";
+        case 0x5B:
+          return "yongfeng";
+        case 0x6B:
+          return "shijidadao";
+      }
+    } else if (cpu_family_id == 6) {
+      return "zhangjiang";
     }
   }
   if (is_hygon()) {
@@ -2624,6 +2649,9 @@ int VM_Version::cpu_type_description(char* const buf, size_t buf_len) {
   } else if (is_amd()) {
     cpu_type = "AMD";
     x64 = cpu_is_em64t() ? " AMD64" : "";
+  } else if (is_zx()) {
+    cpu_type = "Zhaoxin";
+    x64 = cpu_is_em64t() ? " x86_64" : "";
   } else if (is_hygon()) {
     cpu_type = "Hygon";
     x64 = cpu_is_em64t() ? " AMD64" : "";
@@ -3235,6 +3263,12 @@ int VM_Version::allocate_prefetch_distance(bool use_watermark_prefetch) {
       return 256; // Opteron
     } else {
       return 128; // Athlon
+    }
+  } else if (is_zx()) {
+    if (supports_sse2()) {
+      return 256;
+    } else {
+      return 128;
     }
   } else { // Intel
     if (supports_sse3() && is_intel_server_family()) {


### PR DESCRIPTION
Here is the patch that improving the UseAVX setting and add cpu descriptions for zhaoxin processors.
Can you help to review this patch?
Thank you!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27222/head:pull/27222` \
`$ git checkout pull/27222`

Update a local copy of the PR: \
`$ git checkout pull/27222` \
`$ git pull https://git.openjdk.org/jdk.git pull/27222/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27222`

View PR using the GUI difftool: \
`$ git pr show -t 27222`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27222.diff">https://git.openjdk.org/jdk/pull/27222.diff</a>

</details>
