### PR TITLE
8367417: Serial: Use NMethodToOopClosure during Young GC

### DIFF
--- a/src/hotspot/share/gc/serial/defNewGeneration.cpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.cpp
@@ -606,13 +606,11 @@ bool DefNewGeneration::collect(bool clear_all_soft_refs) {
                                                   &old_gen_cl);
 
   {
-    StrongRootsScope srs(0);
     RootScanClosure oop_closure{this};
     CLDScanClosure cld_closure{this};
 
-    MarkingNMethodClosure nmethod_closure(&oop_closure,
-                                          NMethodToOopClosure::FixRelocations,
-                                          false /* keepalive_nmethods */);
+    NMethodToOopClosure nmethod_closure(&oop_closure,
+                                        NMethodToOopClosure::FixRelocations);
 
     // Starting tracing from roots, there are 4 kinds of roots in young-gc.
     //


### PR DESCRIPTION
Change `MarkingNMethodClosure` to `NMethodToOopClosure` in young-gc, because no marking is done during young-gc. After that, `StrongRootsScope` becomes unnecessary as well, it's essentially calling `oops_do_marking_epilogue` to undo the effect of `MarkingNMethodClosure`.

Test: tier1-5

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8367417](https://bugs.openjdk.org/browse/JDK-8367417): Serial: Use NMethodToOopClosure during Young GC (**Enhancement** - P4)


### Reviewers
 * [Francesco Andreuzzi](https://openjdk.org/census#fandreuzzi) (@fandreuz - Author)
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27226/head:pull/27226` \
`$ git checkout pull/27226`

Update a local copy of the PR: \
`$ git checkout pull/27226` \
`$ git pull https://git.openjdk.org/jdk.git pull/27226/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27226`

View PR using the GUI difftool: \
`$ git pr show -t 27226`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27226.diff">https://git.openjdk.org/jdk/pull/27226.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27226#issuecomment-3280616548)
</details>
