### PR TITLE
8367422: Parallel: Refactor local variables names in copy_unmarked_to_survivor_space

### DIFF
--- a/src/hotspot/share/gc/parallel/psPromotionManager.inline.hpp
+++ b/src/hotspot/share/gc/parallel/psPromotionManager.inline.hpp
@@ -236,7 +236,7 @@ inline HeapWord* PSPromotionManager::allocate_in_old_gen(Klass* klass,
 template<bool promote_immediately>
 inline oop PSPromotionManager::copy_unmarked_to_survivor_space(oop o,
                                                                markWord test_mark) {
-  oop new_obj = nullptr;
+  HeapWord* new_obj_addr = nullptr;
   bool new_obj_is_tenured = false;
 
   // NOTE: With compact headers, it is not safe to load the Klass* from old, because
@@ -259,32 +259,33 @@ inline oop PSPromotionManager::copy_unmarked_to_survivor_space(oop o,
   if (!promote_immediately) {
     // Try allocating obj in to-space (unless too old)
     if (age < PSScavenge::tenuring_threshold()) {
-      new_obj = cast_to_oop(allocate_in_young_gen(klass, new_obj_size, age));
+      new_obj_addr = allocate_in_young_gen(klass, new_obj_size, age);
     }
   }
 
   // Otherwise try allocating obj tenured
-  if (new_obj == nullptr) {
-    new_obj = cast_to_oop(allocate_in_old_gen(klass, new_obj_size, age));
-    if (new_obj == nullptr) {
+  if (new_obj_addr == nullptr) {
+    new_obj_addr = allocate_in_old_gen(klass, new_obj_size, age);
+    if (new_obj_addr == nullptr) {
       return oop_promotion_failed(o, test_mark);
     }
     new_obj_is_tenured = true;
   }
 
-  assert(new_obj != nullptr, "allocation should have succeeded");
+  assert(new_obj_addr != nullptr, "allocation should have succeeded");
 
   // Copy obj
-  Copy::aligned_disjoint_words(cast_from_oop<HeapWord*>(o), cast_from_oop<HeapWord*>(new_obj), new_obj_size);
+  Copy::aligned_disjoint_words(cast_from_oop<HeapWord*>(o), new_obj_addr, new_obj_size);
 
   // Now we have to CAS in the header.
   // Because the forwarding is done with memory_order_relaxed there is no
   // ordering with the above copy.  Clients that get the forwardee must not
   // examine its contents without other synchronization, since the contents
   // may not be up to date for them.
-  oop forwardee = o->forward_to_atomic(new_obj, test_mark, memory_order_relaxed);
+  oop forwardee = o->forward_to_atomic(cast_to_oop(new_obj_addr), test_mark, memory_order_relaxed);
   if (forwardee == nullptr) {  // forwardee is null when forwarding is successful
     // We won any races, we "own" this object.
+    oop new_obj = cast_to_oop(new_obj_addr);
     assert(new_obj == o->forwardee(), "Sanity");
 
     // Increment age if obj still in new generation. Now that
@@ -321,9 +322,9 @@ inline oop PSPromotionManager::copy_unmarked_to_survivor_space(oop o,
     assert(o->forwardee() == forwardee, "invariant");
 
     if (new_obj_is_tenured) {
-      _old_lab.unallocate_object(cast_from_oop<HeapWord*>(new_obj), new_obj_size);
+      _old_lab.unallocate_object(new_obj_addr, new_obj_size);
     } else {
-      _young_lab.unallocate_object(cast_from_oop<HeapWord*>(new_obj), new_obj_size);
+      _young_lab.unallocate_object(new_obj_addr, new_obj_size);
     }
     return forwardee;
   }


### PR DESCRIPTION
Trivial "renaming" a local variable and its type to better reflect its semantic and avoid much `HeapWord*`-vs-`oop` conversion.

Test: Comparing the generated asm in release build and they are identical.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8367422](https://bugs.openjdk.org/browse/JDK-8367422): Parallel: Refactor local variables names in copy_unmarked_to_survivor_space (**Enhancement** - P4)


### Reviewers
 * [Francesco Andreuzzi](https://openjdk.org/census#fandreuzzi) (@fandreuz - Author)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27227/head:pull/27227` \
`$ git checkout pull/27227`

Update a local copy of the PR: \
`$ git checkout pull/27227` \
`$ git pull https://git.openjdk.org/jdk.git pull/27227/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27227`

View PR using the GUI difftool: \
`$ git pr show -t 27227`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27227.diff">https://git.openjdk.org/jdk/pull/27227.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27227#issuecomment-3280955217)
</details>
