### PR TITLE
8367372: Test `test/hotspot/jtreg/gc/TestObjectAlignmentCardSize.java` fails on 32 bit systems

### DIFF
--- a/test/hotspot/jtreg/gc/TestObjectAlignmentCardSize.java
+++ b/test/hotspot/jtreg/gc/TestObjectAlignmentCardSize.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
On 32-bit systems, the `test/hotspot/jtreg/gc/TestObjectAlignmentCardSize.java` uses the `ObjectAlignmentInBytes` flag, which isn't supported on 32 bit systems. I'm adjusting this test to require `vm.bits` is 64 as per similar [tests](https://github.com/openjdk/jdk/blob/85715e1050fa774c3267dbbe2f749717aeeec8ff/test/hotspot/jtreg/runtime/CompressedOops/CompressedKlassPointerAndOops.java#L31).

Tested on:
* 64-bit: with and without change (passes both times)
* 32-bit: with and without change (fails before, skips after)
Note: seeing some GHA failures, but unrelated to the actual test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8367372](https://bugs.openjdk.org/browse/JDK-8367372): Test `test/hotspot/jtreg/gc/TestObjectAlignmentCardSize.java` fails on 32 bit systems (**Bug** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Hamlin Li](https://openjdk.org/census#mli) (@Hamlin-Li - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27230/head:pull/27230` \
`$ git checkout pull/27230`

Update a local copy of the PR: \
`$ git checkout pull/27230` \
`$ git pull https://git.openjdk.org/jdk.git pull/27230/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27230`

View PR using the GUI difftool: \
`$ git pr show -t 27230`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27230.diff">https://git.openjdk.org/jdk/pull/27230.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27230#issuecomment-3281991829)
</details>
