### PR TITLE
8367475: Incorrect lock usage in LambdaFormInvokers::regenerate_holder_classes

### DIFF
--- a/src/hotspot/share/cds/cdsConfig.cpp
+++ b/src/hotspot/share/cds/cdsConfig.cpp
@@ -865,6 +865,11 @@ bool CDSConfig::current_thread_is_vm_or_dumper() {
   return t != nullptr && (t->is_VM_thread() || t == _dumper_thread);
 }
 
+bool CDSConfig::current_thread_is_dumper() {
+  Thread* t = Thread::current();
+  return t != nullptr && t == _dumper_thread;
+}
+
 const char* CDSConfig::type_of_archive_being_loaded() {
   if (is_dumping_final_static_archive()) {
     return "AOT configuration file";

--- a/src/hotspot/share/cds/cdsConfig.cpp
+++ b/src/hotspot/share/cds/cdsConfig.cpp
@@ -862,12 +862,11 @@ CDSConfig::DumperThreadMark::~DumperThreadMark() {
 
 bool CDSConfig::current_thread_is_vm_or_dumper() {
   Thread* t = Thread::current();
-  return t != nullptr && (t->is_VM_thread() || t == _dumper_thread);
+  return t->is_VM_thread() || t == _dumper_thread;
 }
 
 bool CDSConfig::current_thread_is_dumper() {
-  Thread* t = Thread::current();
-  return t != nullptr && t == _dumper_thread;
+  return Thread::current() == _dumper_thread;
 }
 
 const char* CDSConfig::type_of_archive_being_loaded() {

--- a/src/hotspot/share/cds/cdsConfig.hpp
+++ b/src/hotspot/share/cds/cdsConfig.hpp
@@ -216,6 +216,7 @@ public:
     ~DumperThreadMark();
   };
 
+  static bool current_thread_is_dumper() NOT_CDS_RETURN_(false);
   static bool current_thread_is_vm_or_dumper() NOT_CDS_RETURN_(false);
 };
 

--- a/src/hotspot/share/cds/lambdaFormInvokers.cpp
+++ b/src/hotspot/share/cds/lambdaFormInvokers.cpp
@@ -127,6 +127,7 @@ void LambdaFormInvokers::regenerate_holder_classes(TRAPS) {
   Klass*  cds_klass = SystemDictionary::resolve_or_null(cds_name, THREAD);
   guarantee(cds_klass != nullptr, "jdk/internal/misc/CDS must exist!");
 
+  assert(CDSConfig::current_thread_is_dumper(), "not supposed to be called from other threads");
   {
     // Stop other threads from recording into _lambdaform_lines.
     MutexLocker ml(Thread::current(), LambdaFormInvokers_lock);

--- a/src/hotspot/share/cds/lambdaFormInvokers.cpp
+++ b/src/hotspot/share/cds/lambdaFormInvokers.cpp
@@ -53,6 +53,7 @@
 
 GrowableArrayCHeap<char*, mtClassShared>* LambdaFormInvokers::_lambdaform_lines = nullptr;
 Array<u4>*  LambdaFormInvokers::_static_archive_invokers = nullptr;
+static bool _stop_appending = false;
 
 #define NUM_FILTER 4
 static const char* filter[NUM_FILTER] = {"java.lang.invoke.Invokers$Holder",
@@ -71,7 +72,12 @@ static bool should_be_archived(char* line) {
 #undef NUM_FILTER
 
 void LambdaFormInvokers::append(char* line) {
+  // This function can be called by concurrent Java threads, even after
+  // LambdaFormInvokers::regenerate_holder_classes() has been called.
   MutexLocker ml(Thread::current(), LambdaFormInvokers_lock);
+  if (_stop_appending) {
+    return;
+  }
   if (_lambdaform_lines == nullptr) {
     _lambdaform_lines = new GrowableArrayCHeap<char*, mtClassShared>(150);
   }
@@ -112,12 +118,6 @@ void LambdaFormInvokers::regenerate_holder_classes(TRAPS) {
     return;
   }
 
-  PrintLambdaFormMessage plm;
-  if (_lambdaform_lines == nullptr || _lambdaform_lines->length() == 0) {
-    log_info(aot)("Nothing to regenerate for holder classes");
-    return;
-  }
-
   ResourceMark rm(THREAD);
 
   // Filter out AOT tooling classes like java.lang.invoke.GenerateJLIClassesHelper, etc.
@@ -127,18 +127,26 @@ void LambdaFormInvokers::regenerate_holder_classes(TRAPS) {
   Klass*  cds_klass = SystemDictionary::resolve_or_null(cds_name, THREAD);
   guarantee(cds_klass != nullptr, "jdk/internal/misc/CDS must exist!");
 
+  {
+    // Stop other threads from recording into _lambdaform_lines.
+    MutexLocker ml(Thread::current(), LambdaFormInvokers_lock);
+    _stop_appending = true;
+  }
+
+  PrintLambdaFormMessage plm;
+  if (_lambdaform_lines == nullptr || _lambdaform_lines->length() == 0) {
+    log_info(aot)("Nothing to regenerate for lambda form holder classes");
+    return;
+  }
+
   HandleMark hm(THREAD);
   int len = _lambdaform_lines->length();
-  objArrayHandle list_lines;
-  {
-    MutexLocker ml(Thread::current(), LambdaFormInvokers_lock);
-    list_lines = oopFactory::new_objArray_handle(vmClasses::String_klass(), len, CHECK);
-    for (int i = 0; i < len; i++) {
-      Handle h_line = java_lang_String::create_from_str(_lambdaform_lines->at(i), CHECK);
-      list_lines->obj_at_put(i, h_line());
-    }
-  } // Before calling into java, release vm lock.
-  //
+  objArrayHandle list_lines = oopFactory::new_objArray_handle(vmClasses::String_klass(), len, CHECK);
+  for (int i = 0; i < len; i++) {
+    Handle h_line = java_lang_String::create_from_str(_lambdaform_lines->at(i), CHECK);
+    list_lines->obj_at_put(i, h_line());
+  }
+
   // Object[] CDS.generateLambdaFormHolderClasses(String[] lines)
   // the returned Object[] layout:
   //   name, byte[], name, byte[] ....
@@ -232,6 +240,7 @@ void LambdaFormInvokers::regenerate_class(char* class_name, ClassFileStream& st,
 }
 
 void LambdaFormInvokers::dump_static_archive_invokers() {
+  assert(SafepointSynchronize::is_at_safepoint(), "no concurrent update to _lambdaform_lines");
   if (_lambdaform_lines != nullptr && _lambdaform_lines->length() > 0) {
     int count = 0;
     int len   = _lambdaform_lines->length();


### PR DESCRIPTION
The assert happens because we attempt to allocate Java objects while holding a mutex:

```
    MutexLocker ml(Thread::current(), LambdaFormInvokers_lock);
    list_lines = oopFactory::new_objArray_handle(vmClasses::String_klass(), len, CHECK);
    for (int i = 0; i < len; i++) {
      Handle h_line = java_lang_String::create_from_str(_lambdaform_lines->at(i), CHECK);
```

It's possible for the allocations to trigger a call to Java when JVMTI is enabled.

The fix is to do the allocation outside of the mutex. However, we still use the mutex to make sure we have a consistent view of `_lambdaform_lines`, which may be modified by concurrent Java threads.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8367475](https://bugs.openjdk.org/browse/JDK-8367475): Incorrect lock usage in LambdaFormInvokers::regenerate_holder_classes (**Bug** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**) Review applies to [f018244e](https://git.openjdk.org/jdk/pull/27231/files/f018244e3e16ac14afdbdb5a24e5eea68ff2a23e)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Matias Saavedra Silva](https://openjdk.org/census#matsaave) (@matias9927 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27231/head:pull/27231` \
`$ git checkout pull/27231`

Update a local copy of the PR: \
`$ git checkout pull/27231` \
`$ git pull https://git.openjdk.org/jdk.git pull/27231/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27231`

View PR using the GUI difftool: \
`$ git pr show -t 27231`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27231.diff">https://git.openjdk.org/jdk/pull/27231.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27231#issuecomment-3282854199)
</details>
