### PR TITLE
8367237: Thread-Safety Usage Warning for java.text.Collator Classes

### DIFF
--- a/src/java.base/share/classes/java/text/Collator.java
+++ b/src/java.base/share/classes/java/text/Collator.java
@@ -113,10 +113,10 @@ import sun.util.locale.provider.LocaleServiceProviderPool;
  * {@code Collator}s can not be compared. See the class description
  * for {@link CollationKey} for an example using {@code CollationKey}s.
  *
- * @implNote The standard provider of the JDK reference implementation
- * returns thread safe instances of {@code Collator} from the static factory methods.
- * However, using a separate instance for each thread is the recommended approach
- * for multithreaded environments.
+ * @implNote Concurrent usage of {@code Collator} instances returned by the factory
+ * methods under the standard provider may lead to significant thread contention.
+ * As such, users should consider retrieving a separate instance for each thread
+ * when used in multithreaded environments.
  *
  * @see         RuleBasedCollator
  * @see         CollationKey

--- a/src/java.base/share/classes/java/text/Collator.java
+++ b/src/java.base/share/classes/java/text/Collator.java
@@ -114,7 +114,7 @@ import sun.util.locale.provider.LocaleServiceProviderPool;
  * for {@link CollationKey} for an example using {@code CollationKey}s.
  *
  * @implNote Significant thread contention may occur during concurrent usage
- * of the JDK reference implementation's {@link RuleBasedCollator}, which is the
+ * of the JDK Reference Implementation's {@link RuleBasedCollator}, which is the
  * subtype returned by the default provider of the {@link #getInstance()} factory
  * methods. As such, users should consider retrieving a separate instance for
  * each thread when used in multithreaded environments.

--- a/src/java.base/share/classes/java/text/Collator.java
+++ b/src/java.base/share/classes/java/text/Collator.java
@@ -111,8 +111,12 @@ import sun.util.locale.provider.LocaleServiceProviderPool;
  * <br>
  * @apiNote {@code CollationKey}s from different
  * {@code Collator}s can not be compared. See the class description
- * for {@link CollationKey}
- * for an example using {@code CollationKey}s.
+ * for {@link CollationKey} for an example using {@code CollationKey}s.
+ *
+ * @implNote While instances of {@code Collator} returned by {@link #getInstance()}
+ * and {@link #getInstance(Locale)} in the JDK reference implementation are
+ * thread safe, using a separate instance for each thread generally produces
+ * better performance.
  *
  * @see         RuleBasedCollator
  * @see         CollationKey

--- a/src/java.base/share/classes/java/text/Collator.java
+++ b/src/java.base/share/classes/java/text/Collator.java
@@ -113,10 +113,11 @@ import sun.util.locale.provider.LocaleServiceProviderPool;
  * {@code Collator}s can not be compared. See the class description
  * for {@link CollationKey} for an example using {@code CollationKey}s.
  *
- * @implNote Concurrent usage of {@code Collator} instances returned by the factory
- * methods under the standard provider may lead to significant thread contention.
- * As such, users should consider retrieving a separate instance for each thread
- * when used in multithreaded environments.
+ * @implNote Significant thread contention may occur during concurrent usage
+ * of the JDK reference implementation's {@link RuleBasedCollator}, which is the
+ * subtype returned by the default provider of the {@link #getInstance()} factory
+ * methods. As such, users should consider retrieving a separate instance for
+ * each thread when used in multithreaded environments.
  *
  * @see         RuleBasedCollator
  * @see         CollationKey

--- a/src/java.base/share/classes/java/text/Collator.java
+++ b/src/java.base/share/classes/java/text/Collator.java
@@ -113,10 +113,10 @@ import sun.util.locale.provider.LocaleServiceProviderPool;
  * {@code Collator}s can not be compared. See the class description
  * for {@link CollationKey} for an example using {@code CollationKey}s.
  *
- * @implNote While instances of {@code Collator} returned by {@link #getInstance()}
- * and {@link #getInstance(Locale)} in the JDK reference implementation are
- * thread safe, using a separate instance for each thread generally produces
- * better performance.
+ * @implNote The standard provider of the JDK reference implementation
+ * returns thread safe instances of {@code Collator} from the static factory methods.
+ * However, using a separate instance for each thread is the recommended approach
+ * for multithreaded environments.
  *
  * @see         RuleBasedCollator
  * @see         CollationKey

--- a/src/java.base/share/classes/java/text/RuleBasedCollator.java
+++ b/src/java.base/share/classes/java/text/RuleBasedCollator.java
@@ -236,7 +236,7 @@ package java.text;
  * </blockquote>
  *
  * @implNote While this class is thread safe, using a separate instance for each
- * thread generally produces better performance.
+ * thread is the recommended approach.
  *
  * @see        Collator
  * @see        CollationElementIterator

--- a/src/java.base/share/classes/java/text/RuleBasedCollator.java
+++ b/src/java.base/share/classes/java/text/RuleBasedCollator.java
@@ -236,9 +236,9 @@ package java.text;
  * </blockquote>
  *
  * @implNote For this implementation, concurrent usage of this class may
- * lead to significant thread contention. As such, users of this class should
- * consider creating a separate instance for each thread when used in
- * multithreaded environments.
+ * lead to significant thread contention since {@code synchronized} is employed
+ * to ensure thread-safety. As such, users of this class should consider creating
+ * a separate instance for each thread when used in multithreaded environments.
  *
  * @see        Collator
  * @see        CollationElementIterator

--- a/src/java.base/share/classes/java/text/RuleBasedCollator.java
+++ b/src/java.base/share/classes/java/text/RuleBasedCollator.java
@@ -235,8 +235,10 @@ package java.text;
  * </pre>
  * </blockquote>
  *
- * @implNote While this class is thread safe, using a separate instance for each
- * thread is the recommended approach.
+ * @implNote For this implementation, concurrent usage of this class may
+ * lead to significant thread contention. As such, users of this class should
+ * consider creating a separate instance for each thread when used in
+ * multithreaded environments.
  *
  * @see        Collator
  * @see        CollationElementIterator

--- a/src/java.base/share/classes/java/text/RuleBasedCollator.java
+++ b/src/java.base/share/classes/java/text/RuleBasedCollator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,10 +37,6 @@
  */
 
 package java.text;
-
-import java.text.Normalizer;
-import java.util.Vector;
-import java.util.Locale;
 
 /**
  * The {@code RuleBasedCollator} class is a concrete subclass of
@@ -238,6 +234,9 @@ import java.util.Locale;
  * RuleBasedCollator myCollator = new RuleBasedCollator(oldRules + addOn);
  * </pre>
  * </blockquote>
+ *
+ * @implNote While this class is thread safe, using a separate instance for each
+ * thread generally produces better performance.
  *
  * @see        Collator
  * @see        CollationElementIterator


### PR DESCRIPTION
Please review this PR which is a documentation change to make apparent the recommended approach for using Collator & RuleBasedCollator in a multi threaded environment via an implNote. The original issue and CSR have additional context.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8367285](https://bugs.openjdk.org/browse/JDK-8367285) to be approved

### Issues
 * [JDK-8367237](https://bugs.openjdk.org/browse/JDK-8367237): Thread-Safety Usage Warning for java.text.Collator Classes (**Bug** - P3)
 * [JDK-8367285](https://bugs.openjdk.org/browse/JDK-8367285): Thread-Safety Usage Warning for java.text.Collator Classes (**CSR**)


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27233/head:pull/27233` \
`$ git checkout pull/27233`

Update a local copy of the PR: \
`$ git checkout pull/27233` \
`$ git pull https://git.openjdk.org/jdk.git pull/27233/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27233`

View PR using the GUI difftool: \
`$ git pr show -t 27233`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27233.diff">https://git.openjdk.org/jdk/pull/27233.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27233#issuecomment-3282290552)
</details>
