### PR TITLE
8367378: GenShen: Missing timing stats when old mark buffers are flushed during final update refs

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
@@ -1187,6 +1187,7 @@ void ShenandoahConcurrentGC::op_final_update_refs() {
     // We are not concerned about skipping this step in abbreviated cycles because regions
     // with no live objects cannot have been written to and so cannot have entries in the SATB
     // buffers.
+    ShenandoahGCPhase phase(ShenandoahPhaseTimings::final_update_refs_transfer_satb);
     heap->old_generation()->transfer_pointers_from_satb();
 
     // Aging_cycle is only relevant during evacuation cycle for individual objects and during final mark for

--- a/src/hotspot/share/gc/shenandoah/shenandoahPhaseTimings.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahPhaseTimings.hpp
@@ -126,6 +126,7 @@ class outputStream;
   f(final_update_refs,                              "Pause Final Update Refs (N)")     \
   f(final_update_refs_verify,                       "  Verify")                        \
   f(final_update_refs_update_region_states,         "  Update Region States")          \
+  f(final_update_refs_transfer_satb,                "  Transfer Old From SATB")        \
   f(final_update_refs_trash_cset,                   "  Trash Collection Set")          \
   f(final_update_refs_rebuild_freeset,              "  Rebuild Free Set")              \
   f(final_update_refs_propagate_gc_state,           "  Propagate GC State")            \


### PR DESCRIPTION
This change adds timing to the 'flush old SATB buffers' subphase of final update refs. Ultimately, we hope to move this phase to a handshake (or not have it all). In the interim, we should at least know how long it takes. The updated phase timings message in the logs has the form:
```
[2025-09-11T18:43:11.463+0000][291.626s][3541][info ][gc,stats       ] Pause Final Update Refs (N)         377 us, workers (us): ---, ---, ---, ---, ---, ---, ---, ---, 
[2025-09-11T18:43:11.463+0000][291.626s][3541][info ][gc,stats       ]   Update Region States               98 us
[2025-09-11T18:43:11.463+0000][291.626s][3541][info ][gc,stats       ]   Transfer Old From SATB             74 us
[2025-09-11T18:43:11.463+0000][291.626s][3541][info ][gc,stats       ]   Trash Collection Set               48 us
[2025-09-11T18:43:11.463+0000][291.626s][3541][info ][gc,stats       ]   Rebuild Free Set                  132 us
[2025-09-11T18:43:11.463+0000][291.626s][3541][info ][gc,stats       ]   Propagate GC State                  6 us
```
The `Transfer Old From SATB` is new.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8367378](https://bugs.openjdk.org/browse/JDK-8367378): GenShen: Missing timing stats when old mark buffers are flushed during final update refs (**Enhancement** - P4)


### Reviewers
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - Committer)
 * [Xiaolong Peng](https://openjdk.org/census#xpeng) (@pengxiaolong - Committer)
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27234/head:pull/27234` \
`$ git checkout pull/27234`

Update a local copy of the PR: \
`$ git checkout pull/27234` \
`$ git pull https://git.openjdk.org/jdk.git pull/27234/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27234`

View PR using the GUI difftool: \
`$ git pr show -t 27234`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27234.diff">https://git.openjdk.org/jdk/pull/27234.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27234#issuecomment-3282550398)
</details>
