### PR TITLE
8367451: GenShen: Remove the option to compute age census during evacuation

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahAgeCensus.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahAgeCensus.cpp
@@ -57,7 +57,7 @@ ShenandoahAgeCensus::ShenandoahAgeCensus(uint max_workers)
     // Sentinel value
     _tenuring_threshold[i] = MAX_COHORTS;
   }
-  if (ShenandoahGenerationalAdaptiveTenuring && !ShenandoahGenerationalCensusAtEvac) {
+  if (ShenandoahGenerationalAdaptiveTenuring) {
     _local_age_table = NEW_C_HEAP_ARRAY(AgeTable*, _max_workers, mtGC);
     CENSUS_NOISE(_local_noise = NEW_C_HEAP_ARRAY(ShenandoahNoiseStats, max_workers, mtGC);)
     for (uint i = 0; i < _max_workers; i++) {
@@ -152,7 +152,7 @@ void ShenandoahAgeCensus::update_census(size_t age0_pop, AgeTable* pv1, AgeTable
   prepare_for_census_update();
   assert(_global_age_table[_epoch]->is_clear(), "Dirty decks");
   CENSUS_NOISE(assert(_global_noise[_epoch].is_clear(), "Dirty decks");)
-  if (ShenandoahGenerationalAdaptiveTenuring && !ShenandoahGenerationalCensusAtEvac) {
+  if (ShenandoahGenerationalAdaptiveTenuring) {
     assert(pv1 == nullptr && pv2 == nullptr, "Error, check caller");
     // Seed cohort 0 with population that may have been missed during
     // regular census.
@@ -197,7 +197,7 @@ void ShenandoahAgeCensus::reset_global() {
 
 // Reset the local age tables, clearing any partial census.
 void ShenandoahAgeCensus::reset_local() {
-  if (!ShenandoahGenerationalAdaptiveTenuring || ShenandoahGenerationalCensusAtEvac) {
+  if (!ShenandoahGenerationalAdaptiveTenuring) {
     assert(_local_age_table == nullptr, "Error");
     return;
   }
@@ -223,7 +223,7 @@ bool ShenandoahAgeCensus::is_clear_global() {
 
 // Is local census information clear?
 bool ShenandoahAgeCensus::is_clear_local() {
-  if (!ShenandoahGenerationalAdaptiveTenuring || ShenandoahGenerationalCensusAtEvac) {
+  if (!ShenandoahGenerationalAdaptiveTenuring) {
     assert(_local_age_table == nullptr, "Error");
     return true;
   }

--- a/src/hotspot/share/gc/shenandoah/shenandoahAgeCensus.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahAgeCensus.hpp
@@ -173,7 +173,7 @@ class ShenandoahAgeCensus: public CHeapObj<mtGC> {
   ~ShenandoahAgeCensus();
 
   // Return the local age table (population vector) for worker_id.
-  // Only used in the case of (ShenandoahGenerationalAdaptiveTenuring && !ShenandoahGenerationalCensusAtEvac)
+  // Only used in the case of ShenandoahGenerationalAdaptiveTenuring
   AgeTable* get_local_age_table(uint worker_id) const {
     return _local_age_table[worker_id];
   }
@@ -204,9 +204,8 @@ class ShenandoahAgeCensus: public CHeapObj<mtGC> {
 #endif // SHENANDOAH_CENSUS_NOISE
 
   // Update the census data, and compute the new tenuring threshold.
-  // This method should be called at the end of each marking (or optionally
-  // evacuation) cycle to update the tenuring threshold to be used in
-  // the next cycle.
+  // This method should be called at the end of each marking cycle to update
+  // the tenuring threshold to be used in the next cycle.
   // age0_pop is the population of Cohort 0 that may have been missed in
   // the regular census during the marking cycle, corresponding to objects
   // allocated when the concurrent marking was in progress.
@@ -231,7 +230,7 @@ class ShenandoahAgeCensus: public CHeapObj<mtGC> {
 
   // Return the net size of objects encountered (counted or skipped) in census
   // at most recent epoch.
-  size_t get_total() { return _total; }
+  size_t get_total() const { return _total; }
 #endif // !PRODUCT
 
   // Print the age census information

--- a/src/hotspot/share/gc/shenandoah/shenandoahEvacTracker.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahEvacTracker.cpp
@@ -45,7 +45,7 @@ ShenandoahEvacuationStats::ShenandoahEvacuations* ShenandoahEvacuationStats::get
 }
 
 ShenandoahEvacuationStats::ShenandoahEvacuationStats()
-  : _use_age_table(ShenandoahGenerationalCensusAtEvac || !ShenandoahGenerationalAdaptiveTenuring),
+  : _use_age_table(!ShenandoahGenerationalAdaptiveTenuring),
     _age_table(nullptr) {
   if (_use_age_table) {
     _age_table = new AgeTable(false);
@@ -168,7 +168,7 @@ ShenandoahCycleStats ShenandoahEvacuationTracker::flush_cycle_to_global() {
   _mutators_global.accumulate(&mutators);
   _workers_global.accumulate(&workers);
 
-  if (ShenandoahGenerationalCensusAtEvac || !ShenandoahGenerationalAdaptiveTenuring) {
+  if (!ShenandoahGenerationalAdaptiveTenuring) {
     // Ingest mutator & worker collected population vectors into the heap's
     // global census data, and use it to compute an appropriate tenuring threshold
     // for use in the next cycle.

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
@@ -678,7 +678,7 @@ void ShenandoahGeneration::prepare_regions_and_collection_set(bool concurrent) {
   }
 
   // Tally the census counts and compute the adaptive tenuring threshold
-  if (is_generational && ShenandoahGenerationalAdaptiveTenuring && !ShenandoahGenerationalCensusAtEvac) {
+  if (is_generational && ShenandoahGenerationalAdaptiveTenuring) {
     // Objects above TAMS weren't included in the age census. Since they were all
     // allocated in this cycle they belong in the age 0 cohort. We walk over all
     // young regions and sum the volume of objects between TAMS and top.

--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.cpp
@@ -357,7 +357,7 @@ oop ShenandoahGenerationalHeap::try_evacuate_object(oop p, Thread* thread, Shena
       assert(target_gen == YOUNG_GENERATION, "Error");
       // We record this census only when simulating pre-adaptive tenuring behavior, or
       // when we have been asked to record the census at evacuation rather than at mark
-      if (ShenandoahGenerationalCensusAtEvac || !ShenandoahGenerationalAdaptiveTenuring) {
+      if (!ShenandoahGenerationalAdaptiveTenuring) {
         evac_tracker()->record_age(thread, size * HeapWordSize, ShenandoahHeap::get_object_age(copy_val));
       }
     }

--- a/src/hotspot/share/gc/shenandoah/shenandoahMark.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahMark.inline.hpp
@@ -118,7 +118,7 @@ inline void ShenandoahMark::count_liveness(ShenandoahLiveData* live_data, oop ob
   // Age census for objects in the young generation
   if (GENERATION == YOUNG || (GENERATION == GLOBAL && region->is_young())) {
     assert(heap->mode()->is_generational(), "Only if generational");
-    if (ShenandoahGenerationalAdaptiveTenuring && !ShenandoahGenerationalCensusAtEvac) {
+    if (ShenandoahGenerationalAdaptiveTenuring) {
       assert(region->is_young(), "Only for young objects");
       uint age = ShenandoahHeap::get_object_age(obj);
       ShenandoahAgeCensus* const census = ShenandoahGenerationalHeap::heap()->age_census();

--- a/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
@@ -70,10 +70,6 @@
           "many consecutive young-gen collections have been "               \
           "completed following the preceding old-gen collection.")          \
                                                                             \
-  product(bool, ShenandoahGenerationalCensusAtEvac, false, EXPERIMENTAL,    \
-          "(Generational mode only) Object age census at evacuation, "      \
-          "rather than during marking.")                                    \
-                                                                            \
   product(bool, ShenandoahGenerationalAdaptiveTenuring, true, EXPERIMENTAL, \
           "(Generational mode only) Dynamically adapt tenuring age.")       \
                                                                             \


### PR DESCRIPTION
This experimental option has always defaulted to false. We are working on changes that will make it impractical to maintain this option. We also do not regularly test this configuration.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8367451](https://bugs.openjdk.org/browse/JDK-8367451): GenShen: Remove the option to compute age census during evacuation (**Enhancement** - P4)


### Reviewers
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - Committer)
 * [Xiaolong Peng](https://openjdk.org/census#xpeng) (@pengxiaolong - Committer)
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27236/head:pull/27236` \
`$ git checkout pull/27236`

Update a local copy of the PR: \
`$ git checkout pull/27236` \
`$ git pull https://git.openjdk.org/jdk.git pull/27236/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27236`

View PR using the GUI difftool: \
`$ git pr show -t 27236`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27236.diff">https://git.openjdk.org/jdk/pull/27236.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27236#issuecomment-3282817945)
</details>
