### PR TITLE
8367472: Swap conditions order in PSScavengeCLDOopClosure::do_oop(oop*)

### DIFF
--- a/src/hotspot/share/gc/parallel/psClosure.inline.hpp
+++ b/src/hotspot/share/gc/parallel/psClosure.inline.hpp
@@ -98,7 +98,7 @@ public:
       oop new_obj = _pm->copy_to_survivor_space</*promote_immediately=*/false>(o);
       RawAccess<IS_NOT_NULL>::oop_store(p, new_obj);
 
-      if (PSScavenge::is_obj_in_young(new_obj) && !_has_oops_into_young_gen) {
+      if (!_has_oops_into_young_gen && PSScavenge::is_obj_in_young(new_obj)) {
         _has_oops_into_young_gen = true;
       }
     }


### PR DESCRIPTION
In this PR I propose to swap the order of conditions in `PSScavengeCLDOopClosure::do_oop`, as proposed during the review of #27199. This change will move the trivial check first in the `if` clause, which is easier for the reader and potentially for the branch predictor. This will also bring parity with `CLDOopClosure` (Serial).

Passes `tier1`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8367472](https://bugs.openjdk.org/browse/JDK-8367472): Swap conditions order in PSScavengeCLDOopClosure::do_oop(oop*) (**Enhancement** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Hamlin Li](https://openjdk.org/census#mli) (@Hamlin-Li - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27237/head:pull/27237` \
`$ git checkout pull/27237`

Update a local copy of the PR: \
`$ git checkout pull/27237` \
`$ git pull https://git.openjdk.org/jdk.git pull/27237/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27237`

View PR using the GUI difftool: \
`$ git pr show -t 27237`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27237.diff">https://git.openjdk.org/jdk/pull/27237.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27237#issuecomment-3282859219)
</details>
