### PR TITLE
8252582: HotSpot Style Guide should permit variable templates

### DIFF
--- a/doc/hotspot-style.html
+++ b/doc/hotspot-style.html
@@ -86,8 +86,9 @@ values</a></li>
 <li><a href="#thread_local" id="toc-thread_local">thread_local</a></li>
 <li><a href="#nullptr" id="toc-nullptr">nullptr</a></li>
 <li><a href="#atomic" id="toc-atomic">&lt;atomic&gt;</a></li>
-<li><a href="#inline-variables" id="toc-inline-variables">Inline
-Variables</a></li>
+<li><a href="#variable-templates-and-inline-variables"
+id="toc-variable-templates-and-inline-variables">Variable Templates and
+Inline Variables</a></li>
 <li><a href="#initializing-variables-with-static-storage-duration"
 id="toc-initializing-variables-with-static-storage-duration">Initializing
 variables with static storage duration</a></li>
@@ -937,12 +938,18 @@ differ from what the Java compilers implement.</p>
 "conservative" memory ordering, which may differ from (may be stronger
 than) sequentially consistent. There are algorithms in HotSpot that are
 believed to rely on that ordering.</p>
-<h3 id="inline-variables">Inline Variables</h3>
-<p>Variables with static storage duration may be declared
-<code>inline</code> (<a href="https://wg21.link/p0386r2">p0386r2</a>).
-This has similar effects as for declaring a function inline: it can be
-defined, identically, in multiple translation units, must be defined in
-every translation unit in which it is <a
+<h3 id="variable-templates-and-inline-variables">Variable Templates and
+Inline Variables</h3>
+<p>The use of variable templates (including static data member
+templates) (<a href="https://wg21.link/N3651">N3651</a>) is permitted.
+They provide parameterized variables and constants in a simple and
+direct form, instead of requiring the use of various workarounds.</p>
+<p>Variables with static storage duration and variable templates may be
+declared <code>inline</code> (<a
+href="https://wg21.link/p0386r2">p0386r2</a>), and this usage is
+permitted. This has similar effects as for declaring a function inline:
+it can be defined, identically, in multiple translation units, must be
+defined in every translation unit in which it is <a
 href="https://en.cppreference.com/w/cpp/language/definition"
 title="One Definition Rule">ODR used</a>, and the behavior of the
 program is as if there is exactly one variable.</p>
@@ -955,16 +962,17 @@ initializations can make initialization order problems worse. The few
 ordering constraints that exist for non-inline variables don't apply, as
 there isn't a single program-designated translation unit containing the
 definition.</p>
-<p>A <code>constexpr</code> static data member is implicitly
-<code>inline</code>. As a consequence, an <a
+<p>A <code>constexpr</code> static data member or static data member
+template is implicitly <code>inline</code>. As a consequence, an <a
 href="https://en.cppreference.com/w/cpp/language/definition"
-title="One Definition Rule">ODR use</a> of such a variable doesn't
-require a definition in some .cpp file. (This is a change from
-pre-C++17. Beginning with C++17, such a definition is considered a
-duplicate definition, and is deprecated.)</p>
-<p>Declaring a <code>thread_local</code> variable <code>inline</code> is
-forbidden for HotSpot code. <a href="#thread_local">The use of
-<code>thread_local</code></a> is already heavily restricted.</p>
+title="One Definition Rule">ODR use</a> of such a member doesn't require
+a definition in some .cpp file. (This is a change from pre-C++17.
+Beginning with C++17, such a definition is considered a duplicate
+definition, and is deprecated.)</p>
+<p>Declaring a <code>thread_local</code> variable template or
+<code>inline</code> variable is forbidden in HotSpot code. <a
+href="#thread_local">The use of <code>thread_local</code></a> is already
+heavily restricted.</p>
 <h3
 id="initializing-variables-with-static-storage-duration">Initializing
 variables with static storage duration</h3>
@@ -1853,9 +1861,6 @@ Features</h3>
 <ul>
 <li><p>Trailing return type syntax for functions (<a
 href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2008/n2541.htm">n2541</a>)</p></li>
-<li><p>Variable templates (<a
-href="https://isocpp.org/files/papers/N3651.pdf">n3651</a>, <a
-href="http://wg21.link/p0127r2">p0127r2</a>)</p></li>
 <li><p>Member initializers and aggregates (<a
 href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2013/n3653.html">n3653</a>)</p></li>
 <li><p>Rvalue references and move semantics</p></li>

--- a/doc/hotspot-style.md
+++ b/doc/hotspot-style.md
@@ -856,14 +856,19 @@ ordering, which may differ from (may be stronger than) sequentially
 consistent.  There are algorithms in HotSpot that are believed to rely
 on that ordering.
 
-### Inline Variables
+### Variable Templates and Inline Variables
 
-Variables with static storage duration may be declared `inline`
-([p0386r2](https://wg21.link/p0386r2)). This has similar effects as for
-declaring a function inline: it can be defined, identically, in multiple
-translation units, must be defined in every translation unit in which it is
-[ODR used][ODR], and the behavior of the program is as if there is exactly one
-variable.
+The use of variable templates (including static data member templates)
+([N3651](https://wg21.link/N3651)) is permitted. They provide parameterized
+variables and constants in a simple and direct form, instead of requiring the
+use of various workarounds.
+
+Variables with static storage duration and variable templates may be declared
+`inline` ([p0386r2](https://wg21.link/p0386r2)), and this usage is
+permitted. This has similar effects as for declaring a function inline: it can
+be defined, identically, in multiple translation units, must be defined in
+every translation unit in which it is [ODR used][ODR], and the behavior of the
+program is as if there is exactly one variable.
 
 Declaring a variable inline allows the complete definition to be in a header
 file, rather than having a declaration in a header and the definition in a
@@ -874,13 +879,15 @@ make initialization order problems worse. The few ordering constraints
 that exist for non-inline variables don't apply, as there isn't a single
 program-designated translation unit containing the definition.
 
-A `constexpr` static data member is implicitly `inline`. As a consequence, an
-[ODR use][ODR] of such a variable doesn't require a definition in some .cpp
+A `constexpr` static data member or static data member template
+is implicitly `inline`. As a consequence, an
+[ODR use][ODR] of such a member doesn't require a definition in some .cpp
 file. (This is a change from pre-C++17. Beginning with C++17, such a
 definition is considered a duplicate definition, and is deprecated.)
 
-Declaring a `thread_local` variable `inline` is forbidden for HotSpot code.
-[The use of `thread_local`](#thread_local) is already heavily restricted.
+Declaring a `thread_local` variable template or `inline` variable is forbidden
+in HotSpot code.  [The use of `thread_local`](#thread_local) is already
+heavily restricted.
 
 ### Initializing variables with static storage duration
 
@@ -1848,10 +1855,6 @@ See Object Lifetime: C++17 6.8/8, C++20 6.7.3/8
 
 * Trailing return type syntax for functions
 ([n2541](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2008/n2541.htm))
-
-* Variable templates
-([n3651](https://isocpp.org/files/papers/N3651.pdf),
-[p0127r2](http://wg21.link/p0127r2))
 
 * Member initializers and aggregates
 ([n3653](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2013/n3653.html))


### PR DESCRIPTION
Please review this change to the HotSpot Style Guide to permit the use of
variable templates. This is a C++14 feature that, while fairly simple, didn't
get into the initial permitted for HotSpot list because I just didn't get to
it and nobody asked for it. And it has languished on the "undecided" list for
the same reasons. But recently I've had reason to want to use this feature a
couple of times, so I'm now proposing we allow it.

I merged it into the section for Inline Variables (a C++17 feature), as the
two are closely related. Variable templates were even listed as one of the
workarounds being used to make up for the lack of inline variables.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8252582](https://bugs.openjdk.org/browse/JDK-8252582): HotSpot Style Guide should permit variable templates (**Enhancement** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27240/head:pull/27240` \
`$ git checkout pull/27240`

Update a local copy of the PR: \
`$ git checkout pull/27240` \
`$ git pull https://git.openjdk.org/jdk.git pull/27240/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27240`

View PR using the GUI difftool: \
`$ git pr show -t 27240`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27240.diff">https://git.openjdk.org/jdk/pull/27240.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27240#issuecomment-3283284017)
</details>
