### PR TITLE
8367478: Improve UseAVX setting and add cpu descriptions for zhaoxin processors

### DIFF
--- a/src/hotspot/cpu/x86/vm_version_x86.cpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
Here is the patch that improving the UseAVX setting and add cpu descriptions for zhaoxin processors.
Can you help to review this patch?
Thank you!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8367478](https://bugs.openjdk.org/browse/JDK-8367478): Improve UseAVX setting and add cpu descriptions for zhaoxin processors (**Enhancement** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) Review applies to [535af7ba](https://git.openjdk.org/jdk/pull/27241/files/535af7baa4cddf20e09e2b40c00353033ef26b2b)
 * [Jie Fu](https://openjdk.org/census#jiefu) (@DamonFool - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27241/head:pull/27241` \
`$ git checkout pull/27241`

Update a local copy of the PR: \
`$ git checkout pull/27241` \
`$ git pull https://git.openjdk.org/jdk.git pull/27241/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27241`

View PR using the GUI difftool: \
`$ git pr show -t 27241`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27241.diff">https://git.openjdk.org/jdk/pull/27241.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27241#issuecomment-3609299829)
</details>
