### PR TITLE
8367366: Do not support -XX:+AOTClassLinking for dynamic CDS archive

### DIFF
--- a/src/hotspot/share/cds/aotClassLinker.cpp
+++ b/src/hotspot/share/cds/aotClassLinker.cpp
@@ -191,7 +191,7 @@ void AOTClassLinker::write_to_archive() {
   assert_at_safepoint();
 
   if (CDSConfig::is_dumping_aot_linked_classes()) {
-    AOTLinkedClassTable* table = AOTLinkedClassTable::get(CDSConfig::is_dumping_static_archive());
+    AOTLinkedClassTable* table = AOTLinkedClassTable::get();
     table->set_boot(write_classes(nullptr, true));
     table->set_boot2(write_classes(nullptr, false));
     table->set_platform(write_classes(SystemDictionary::java_platform_loader(), false));
@@ -212,16 +212,7 @@ Array<InstanceKlass*>* AOTClassLinker::write_classes(oop class_loader, bool is_j
       continue;
     }
 
-    if (ik->in_aot_cache() && CDSConfig::is_dumping_dynamic_archive()) {
-      if (CDSConfig::is_using_aot_linked_classes()) {
-        // This class was recorded as AOT-linked for the base archive,
-        // so there's no need to do so again for the dynamic archive.
-      } else {
-        list.append(ik);
-      }
-    } else {
-      list.append(ArchiveBuilder::current()->get_buffered_addr(ik));
-    }
+    list.append(ArchiveBuilder::current()->get_buffered_addr(ik));
   }
 
   if (list.length() == 0) {

--- a/src/hotspot/share/cds/aotLinkedClassBulkLoader.cpp
+++ b/src/hotspot/share/cds/aotLinkedClassBulkLoader.cpp
@@ -46,8 +46,8 @@ bool AOTLinkedClassBulkLoader::_platform_completed = false;
 bool AOTLinkedClassBulkLoader::_app_completed = false;
 bool AOTLinkedClassBulkLoader::_all_completed = false;
 
-void AOTLinkedClassBulkLoader::serialize(SerializeClosure* soc, bool is_static_archive) {
-  AOTLinkedClassTable::get(is_static_archive)->serialize(soc);
+void AOTLinkedClassBulkLoader::serialize(SerializeClosure* soc) {
+  AOTLinkedClassTable::get()->serialize(soc);
 }
 
 bool AOTLinkedClassBulkLoader::class_preloading_finished() {
@@ -117,27 +117,24 @@ void AOTLinkedClassBulkLoader::exit_on_exception(JavaThread* current) {
 
 void AOTLinkedClassBulkLoader::load_classes_in_loader_impl(AOTLinkedClassCategory class_category, oop class_loader_oop, TRAPS) {
   Handle h_loader(THREAD, class_loader_oop);
-  load_table(AOTLinkedClassTable::for_static_archive(),  class_category, h_loader, CHECK);
-  load_table(AOTLinkedClassTable::for_dynamic_archive(), class_category, h_loader, CHECK);
+  AOTLinkedClassTable* table = AOTLinkedClassTable::get();
+  load_table(table, class_category, h_loader, CHECK);
 
   // Initialize the InstanceKlasses of all archived heap objects that are reachable from the
   // archived java class mirrors.
-  //
-  // Only the classes in the static archive can have archived mirrors.
-  AOTLinkedClassTable* static_table = AOTLinkedClassTable::for_static_archive();
   switch (class_category) {
   case AOTLinkedClassCategory::BOOT1:
     // Delayed until finish_loading_javabase_classes(), as the VM is not ready to
     // execute some of the <clinit> methods.
     break;
   case AOTLinkedClassCategory::BOOT2:
-    init_required_classes_for_loader(h_loader, static_table->boot2(), CHECK);
+    init_required_classes_for_loader(h_loader, table->boot2(), CHECK);
     break;
   case AOTLinkedClassCategory::PLATFORM:
-    init_required_classes_for_loader(h_loader, static_table->platform(), CHECK);
+    init_required_classes_for_loader(h_loader, table->platform(), CHECK);
     break;
   case AOTLinkedClassCategory::APP:
-    init_required_classes_for_loader(h_loader, static_table->app(), CHECK);
+    init_required_classes_for_loader(h_loader, table->app(), CHECK);
     break;
   case AOTLinkedClassCategory::UNREGISTERED:
     ShouldNotReachHere();
@@ -333,7 +330,7 @@ void AOTLinkedClassBulkLoader::load_hidden_class(ClassLoaderData* loader_data, I
 }
 
 void AOTLinkedClassBulkLoader::finish_loading_javabase_classes(TRAPS) {
-  init_required_classes_for_loader(Handle(), AOTLinkedClassTable::for_static_archive()->boot(), CHECK);
+  init_required_classes_for_loader(Handle(), AOTLinkedClassTable::get()->boot(), CHECK);
 }
 
 // Some AOT-linked classes for <class_loader> must be initialized early. This includes
@@ -427,8 +424,7 @@ void AOTLinkedClassBulkLoader::replay_training_at_init(Array<InstanceKlass*>* cl
 
 void AOTLinkedClassBulkLoader::replay_training_at_init_for_preloaded_classes(TRAPS) {
   if (CDSConfig::is_using_aot_linked_classes() && TrainingData::have_data()) {
-    // Only static archive can have training data.
-    AOTLinkedClassTable* table = AOTLinkedClassTable::for_static_archive();
+    AOTLinkedClassTable* table = AOTLinkedClassTable::get();
     replay_training_at_init(table->boot(),     CHECK);
     replay_training_at_init(table->boot2(),    CHECK);
     replay_training_at_init(table->platform(), CHECK);

--- a/src/hotspot/share/cds/aotLinkedClassBulkLoader.hpp
+++ b/src/hotspot/share/cds/aotLinkedClassBulkLoader.hpp
@@ -57,7 +57,7 @@ class AOTLinkedClassBulkLoader :  AllStatic {
   static void init_required_classes_for_loader(Handle class_loader, Array<InstanceKlass*>* classes, TRAPS);
   static void replay_training_at_init(Array<InstanceKlass*>* classes, TRAPS) NOT_CDS_RETURN;
 public:
-  static void serialize(SerializeClosure* soc, bool is_static_archive) NOT_CDS_RETURN;
+  static void serialize(SerializeClosure* soc) NOT_CDS_RETURN;
 
   static void load_javabase_classes(JavaThread* current) NOT_CDS_RETURN;
   static void load_non_javabase_classes(JavaThread* current) NOT_CDS_RETURN;

--- a/src/hotspot/share/cds/aotLinkedClassTable.cpp
+++ b/src/hotspot/share/cds/aotLinkedClassTable.cpp
@@ -27,8 +27,7 @@
 #include "cds/serializeClosure.hpp"
 #include "oops/array.hpp"
 
-AOTLinkedClassTable AOTLinkedClassTable::_for_static_archive;
-AOTLinkedClassTable AOTLinkedClassTable::_for_dynamic_archive;
+AOTLinkedClassTable AOTLinkedClassTable::_instance;
 
 void AOTLinkedClassTable::serialize(SerializeClosure* soc) {
   soc->do_ptr((void**)&_boot);

--- a/src/hotspot/share/cds/aotLinkedClassTable.hpp
+++ b/src/hotspot/share/cds/aotLinkedClassTable.hpp
@@ -39,10 +39,7 @@ class SerializeClosure;
 // in a production run.
 //
 class AOTLinkedClassTable {
-  // The VM may load up to 2 CDS archives -- static and dynamic. Each
-  // archive can have its own AOTLinkedClassTable.
-  static AOTLinkedClassTable _for_static_archive;
-  static AOTLinkedClassTable _for_dynamic_archive;
+  static AOTLinkedClassTable _instance;
 
   Array<InstanceKlass*>* _boot;  // only java.base classes
   Array<InstanceKlass*>* _boot2; // boot classes in other modules
@@ -54,11 +51,8 @@ public:
     _boot(nullptr), _boot2(nullptr),
     _platform(nullptr), _app(nullptr) {}
 
-  static AOTLinkedClassTable* for_static_archive()  { return &_for_static_archive; }
-  static AOTLinkedClassTable* for_dynamic_archive() { return &_for_dynamic_archive; }
-
-  static AOTLinkedClassTable* get(bool is_static_archive) {
-    return is_static_archive ? for_static_archive() : for_dynamic_archive();
+  static AOTLinkedClassTable* get() {
+    return &_instance;
   }
 
   Array<InstanceKlass*>* boot()     const { return _boot;     }

--- a/src/hotspot/share/cds/aotMetaspace.cpp
+++ b/src/hotspot/share/cds/aotMetaspace.cpp
@@ -501,7 +501,7 @@ void AOTMetaspace::serialize(SerializeClosure* soc) {
   StringTable::serialize_shared_table_header(soc);
   HeapShared::serialize_tables(soc);
   SystemDictionaryShared::serialize_dictionary_headers(soc);
-  AOTLinkedClassBulkLoader::serialize(soc, true);
+  AOTLinkedClassBulkLoader::serialize(soc);
   FinalImageRecipes::serialize(soc);
   TrainingData::serialize(soc);
   InstanceMirrorKlass::serialize_offsets(soc);
@@ -2000,7 +2000,7 @@ void AOTMetaspace::initialize_shared_spaces() {
   if (dynamic_mapinfo != nullptr) {
     intptr_t* buffer = (intptr_t*)dynamic_mapinfo->serialized_data();
     ReadClosure rc(&buffer, (intptr_t)SharedBaseAddress);
-    ArchiveBuilder::serialize_dynamic_archivable_items(&rc);
+    DynamicArchive::serialize(&rc);
     DynamicArchive::setup_array_klasses();
   }
 

--- a/src/hotspot/share/cds/archiveBuilder.cpp
+++ b/src/hotspot/share/cds/archiveBuilder.cpp
@@ -24,7 +24,6 @@
 
 #include "cds/aotArtifactFinder.hpp"
 #include "cds/aotClassLinker.hpp"
-#include "cds/aotLinkedClassBulkLoader.hpp"
 #include "cds/aotLogging.hpp"
 #include "cds/aotMapLogger.hpp"
 #include "cds/aotMetaspace.hpp"
@@ -1013,13 +1012,6 @@ void ArchiveBuilder::make_training_data_shareable() {
     }
   };
   _src_obj_table.iterate_all(clean_td);
-}
-
-void ArchiveBuilder::serialize_dynamic_archivable_items(SerializeClosure* soc) {
-  SymbolTable::serialize_shared_table_header(soc, false);
-  SystemDictionaryShared::serialize_dictionary_headers(soc, false);
-  DynamicArchive::serialize_array_klasses(soc);
-  AOTLinkedClassBulkLoader::serialize(soc, false);
 }
 
 uintx ArchiveBuilder::buffer_to_offset(address p) const {

--- a/src/hotspot/share/cds/archiveBuilder.hpp
+++ b/src/hotspot/share/cds/archiveBuilder.hpp
@@ -382,7 +382,6 @@ public:
   bool gather_klass_and_symbol(MetaspaceClosure::Ref* ref, bool read_only);
   bool gather_one_source_obj(MetaspaceClosure::Ref* ref, bool read_only);
   void remember_embedded_pointer_in_enclosing_obj(MetaspaceClosure::Ref* ref);
-  static void serialize_dynamic_archivable_items(SerializeClosure* soc);
 
   DumpRegion* pz_region() { return &_pz_region; }
   DumpRegion* rw_region() { return &_rw_region; }

--- a/src/hotspot/share/cds/cdsConfig.cpp
+++ b/src/hotspot/share/cds/cdsConfig.cpp
@@ -757,6 +757,7 @@ void CDSConfig::prepare_for_dumping() {
   assert(CDSConfig::is_dumping_archive(), "sanity");
 
   if (is_dumping_dynamic_archive() && AOTClassLinking) {
+    assert(FLAG_IS_CMDLINE(AOTClassLinking), "should not be set ergonomically");
     log_warning(cds)("AOTClassLinking is not supported for dynamic CDS archive");
     FLAG_SET_ERGO(AOTClassLinking, false);
   }

--- a/src/hotspot/share/cds/cdsConfig.cpp
+++ b/src/hotspot/share/cds/cdsConfig.cpp
@@ -757,8 +757,9 @@ void CDSConfig::prepare_for_dumping() {
   assert(CDSConfig::is_dumping_archive(), "sanity");
 
   if (is_dumping_dynamic_archive() && AOTClassLinking) {
-    assert(FLAG_IS_CMDLINE(AOTClassLinking), "should not be set ergonomically");
-    log_warning(cds)("AOTClassLinking is not supported for dynamic CDS archive");
+    if (FLAG_IS_CMDLINE(AOTClassLinking)) {
+      log_warning(cds)("AOTClassLinking is not supported for dynamic CDS archive");
+    }
     FLAG_SET_ERGO(AOTClassLinking, false);
   }
 

--- a/src/hotspot/share/cds/cdsConfig.cpp
+++ b/src/hotspot/share/cds/cdsConfig.cpp
@@ -756,6 +756,11 @@ void CDSConfig::setup_compiler_args() {
 void CDSConfig::prepare_for_dumping() {
   assert(CDSConfig::is_dumping_archive(), "sanity");
 
+  if (is_dumping_dynamic_archive() && AOTClassLinking) {
+    log_warning(cds)("AOTClassLinking is not supported for dynamic CDS archive");
+    FLAG_SET_ERGO(AOTClassLinking, false);
+  }
+
   if (is_dumping_dynamic_archive() && !is_using_archive()) {
     assert(!is_dumping_static_archive(), "cannot be dumping both static and dynamic archives");
 

--- a/src/hotspot/share/cds/cdsConfig.cpp
+++ b/src/hotspot/share/cds/cdsConfig.cpp
@@ -1010,11 +1010,10 @@ void CDSConfig::stop_using_full_module_graph(const char* reason) {
 }
 
 bool CDSConfig::is_dumping_aot_linked_classes() {
-  if (is_dumping_preimage_static_archive()) {
-    return false;
-  } else if (is_dumping_dynamic_archive()) {
-    return is_using_full_module_graph() && AOTClassLinking;
-  } else if (is_dumping_static_archive()) {
+  if (is_dumping_classic_static_archive() || is_dumping_final_static_archive()) {
+    // FMG is required to guarantee that all cached boot/platform/app classes
+    // are visible in the production run, so they can be unconditionally
+    // loaded during VM bootstrap.
     return is_dumping_full_module_graph() && AOTClassLinking;
   } else {
     return false;

--- a/src/hotspot/share/cds/dynamicArchive.hpp
+++ b/src/hotspot/share/cds/dynamicArchive.hpp
@@ -71,7 +71,7 @@ public:
   static void dump_array_klasses();
   static void setup_array_klasses();
   static void append_array_klass(ObjArrayKlass* oak);
-  static void serialize_array_klasses(SerializeClosure* soc);
+  static void serialize(SerializeClosure* soc);
   static void make_array_klasses_shareable();
   static void post_dump();
   static int  num_array_klasses();

--- a/src/hotspot/share/classfile/systemDictionaryShared.cpp
+++ b/src/hotspot/share/classfile/systemDictionaryShared.cpp
@@ -867,11 +867,6 @@ bool SystemDictionaryShared::should_be_excluded(Klass* k) {
   } else {
     InstanceKlass* ik = InstanceKlass::cast(k);
 
-    if (CDSConfig::is_dumping_dynamic_archive() && ik->in_aot_cache()) {
-      // ik is already part of the static archive, so it will never be considered as excluded.
-      return false;
-    }
-
     if (!SafepointSynchronize::is_at_safepoint()) {
       if (!ik->is_linked()) {
         // should_be_excluded_impl() below doesn't link unlinked classes. We come

--- a/test/hotspot/jtreg/TEST.groups
+++ b/test/hotspot/jtreg/TEST.groups
@@ -534,17 +534,7 @@ hotspot_aot_classlinking = \
  -runtime/cds/appcds/customLoader/ParallelTestSingleFP.java \
  -runtime/cds/appcds/customLoader/SameNameInTwoLoadersTest.java \
  -runtime/cds/appcds/DumpClassListWithLF.java \
- -runtime/cds/appcds/dynamicArchive/LambdaContainsOldInf.java \
- -runtime/cds/appcds/dynamicArchive/LambdaCustomLoader.java \
- -runtime/cds/appcds/dynamicArchive/LambdaForOldInfInBaseArchive.java \
- -runtime/cds/appcds/dynamicArchive/LambdaInBaseArchive.java \
- -runtime/cds/appcds/dynamicArchive/LambdasInTwoArchives.java \
- -runtime/cds/appcds/dynamicArchive/ModulePath.java \
- -runtime/cds/appcds/dynamicArchive/NestHostOldInf.java \
- -runtime/cds/appcds/dynamicArchive/OldClassAndInf.java \
- -runtime/cds/appcds/dynamicArchive/OldClassInBaseArchive.java \
- -runtime/cds/appcds/dynamicArchive/OldClassVerifierTrouble.java \
- -runtime/cds/appcds/dynamicArchive/RedefineCallerClassTest.java \
+ -runtime/cds/appcds/dynamicArchive \
  -runtime/cds/appcds/HelloExtTest.java \
  -runtime/cds/appcds/javaldr/ExceptionDuringDumpAtObjectsInitPhase.java \
  -runtime/cds/appcds/javaldr/GCDuringDump.java \

--- a/test/hotspot/jtreg/runtime/cds/appcds/aotClassLinking/BulkLoaderTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotClassLinking/BulkLoaderTest.java
@@ -41,20 +41,6 @@
  */
 
 /*
- * @test id=dynamic
- * @requires vm.cds.supports.aot.class.linking
- * @library /test/jdk/lib/testlibrary /test/lib /test/hotspot/jtreg/runtime/cds/appcds/test-classes
- * @build InitiatingLoaderTester BadOldClassA BadOldClassB
- * @build jdk.test.whitebox.WhiteBox BulkLoaderTest SimpleCusty
- * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar BulkLoaderTestApp.jar BulkLoaderTestApp MyUtil InitiatingLoaderTester
- *                 BadOldClassA BadOldClassB
- * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar cust.jar
- *                 SimpleCusty
- * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar WhiteBox.jar jdk.test.whitebox.WhiteBox
- * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:WhiteBox.jar BulkLoaderTest DYNAMIC
- */
-
-/*
  * @test id=aot
  * @requires vm.cds.supports.aot.class.linking
  * @library /test/jdk/lib/testlibrary /test/lib /test/hotspot/jtreg/runtime/cds/appcds/test-classes
@@ -279,10 +265,6 @@ class BulkLoaderTestApp {
         }
 
         try {
-            // In dynamic dump, the VM loads BadOldClassB and then attempts to
-            // link it. This will leave BadOldClassB in a "failed verification" state.
-            // All refernces to BadOldClassB from the CP should be purged from the CDS
-            // archive.
             c = BadOldClassB.class;
             c.newInstance();
             throw new RuntimeException("Must not succeed");

--- a/test/hotspot/jtreg/runtime/cds/appcds/resolvedConstants/ResolvedConstants.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/resolvedConstants/ResolvedConstants.java
@@ -73,7 +73,9 @@ public class ResolvedConstants {
     static boolean aotClassLinking;
     public static void main(String[] args) throws Exception {
         test(args, false);
-        test(args, true);
+        if (!args[0].equals("DYNAMIC")) {
+            test(args, true);
+        }
     }
 
     static void test(String[] args, boolean testMode) throws Exception {


### PR DESCRIPTION
Support of `-XX:+AOTClassLinking` for  dynamic CDS archive is not an documented feature of [JEP 483](https://openjdk.org/jeps/483). It has very small performance benefit and complicates the development of future AOT optimizations.

After this PR, `-XX:+AOTClassLinking` will have no effect when creating a dynamic CDS archive.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8367366](https://bugs.openjdk.org/browse/JDK-8367366): Do not support -XX:+AOTClassLinking for dynamic CDS archive (**Enhancement** - P4)


### Reviewers
 * [Ashutosh Mehra](https://openjdk.org/census#asmehra) (@ashu-mehra - Committer) Review applies to [e94f0503](https://git.openjdk.org/jdk/pull/27242/files/e94f0503111dbc60e67e27e03f9c84742d919274)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27242/head:pull/27242` \
`$ git checkout pull/27242`

Update a local copy of the PR: \
`$ git checkout pull/27242` \
`$ git pull https://git.openjdk.org/jdk.git pull/27242/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27242`

View PR using the GUI difftool: \
`$ git pr show -t 27242`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27242.diff">https://git.openjdk.org/jdk/pull/27242.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27242#issuecomment-3283532058)
</details>
