### PR TITLE
8299304: Test "java/awt/print/PrinterJob/PageDialogTest.java" fails on macOS 13 x64 because the Page Dialog blocks the Toolkit

### DIFF
--- a/test/jdk/java/awt/print/PrinterJob/PageDialogTest.java
+++ b/test/jdk/java/awt/print/PrinterJob/PageDialogTest.java
@@ -22,11 +22,12 @@
  */
 
 /*
-   @test
-   @bug 6302514
-   @key printer
-   @run main/manual PageDialogTest
-   @summary A toolkit modal dialog should not be blocked by Page/Print dialog.
+ *  @test
+ *  @bug 6302514
+ *  @key printer
+ *  @requires (os.family != "mac")
+ *  @run main/manual PageDialogTest
+ *  @summary A toolkit modal dialog should not be blocked by Page/Print dialog.
 */
 
 import java.awt.BorderLayout;


### PR DESCRIPTION
mac printer dialog blocks underlying window even on native platform so this is not applicable to the test so restricting to run on osx

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299304](https://bugs.openjdk.org/browse/JDK-8299304): Test "java/awt/print/PrinterJob/PageDialogTest.java" fails on macOS 13 x64 because the Page Dialog blocks the Toolkit (**Bug** - P5)


### Reviewers
 * [Tejesh R](https://openjdk.org/census#tr) (@TejeshR13 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27243/head:pull/27243` \
`$ git checkout pull/27243`

Update a local copy of the PR: \
`$ git checkout pull/27243` \
`$ git pull https://git.openjdk.org/jdk.git pull/27243/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27243`

View PR using the GUI difftool: \
`$ git pr show -t 27243`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27243.diff">https://git.openjdk.org/jdk/pull/27243.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27243#issuecomment-3283807814)
</details>
