### PR TITLE
8372710: Update ProcessBuilder/Basic regex

### DIFF
--- a/test/jdk/java/lang/ProcessBuilder/Basic.java
+++ b/test/jdk/java/lang/ProcessBuilder/Basic.java
@@ -85,8 +85,8 @@ public class Basic {
     static final String libpath = System.getenv("LIBPATH");
 
     /* Used for regex String matching for long error messages */
-    static final String PERMISSION_DENIED_ERROR_MSG = "(Permission denied|error=13)";
-    static final String NO_SUCH_FILE_ERROR_MSG = "(No such file|error=2)";
+    static final String PERMISSION_DENIED_ERROR_MSG = "(Permission denied|error:13)";
+    static final String NO_SUCH_FILE_ERROR_MSG = "(No such file|error:2)";
     static final String SPAWNHELPER_FAILURE_MSG = "(Possible reasons:)";
 
     /**


### PR DESCRIPTION
The exception format was changed by [JDK-8352533](https://github.com/openjdk/jdk/pull/24149). This pr implement those changes for the PERMISSION_DENIED_ERROR_MSG and NO_SUCH_FILE_ERROR_MSG.
Similar changes was also done here [ibmruntimes/openj9-openjdk-jdk25/commit/51102b1](https://github.com/ibmruntimes/openj9-openjdk-jdk25/pull/40) done by @theresa-m

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8372710](https://bugs.openjdk.org/browse/JDK-8372710): Update ProcessBuilder/Basic regex (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Amit Kumar](https://openjdk.org/census#amitkumar) (@offamitkumar - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27244/head:pull/27244` \
`$ git checkout pull/27244`

Update a local copy of the PR: \
`$ git checkout pull/27244` \
`$ git pull https://git.openjdk.org/jdk.git pull/27244/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27244`

View PR using the GUI difftool: \
`$ git pr show -t 27244`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27244.diff">https://git.openjdk.org/jdk/pull/27244.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27244#issuecomment-3588000681)
</details>
