### PR TITLE
8366884: NMT fails with MallocLimit: reached category "mtCompiler" limit

### DIFF
--- a/test/hotspot/jtreg/runtime/NMT/MallocLimitTest.java
+++ b/test/hotspot/jtreg/runtime/NMT/MallocLimitTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2022 SAP SE. All rights reserved.
- * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,7 +47,7 @@
  * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
- * @run driver MallocLimitTest compiler-limit-fatal
+ * @run driver/timeout=480 MallocLimitTest compiler-limit-fatal
  */
 
 /*


### PR DESCRIPTION
The JTREG test expects that jvm exits with error on malloc-limit reached. JVM reports this and exits but test is timed out before reading the output.
The timeout value for the test is set explicitly to 480. 

Tested couple of 100 times in mach5.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8366884](https://bugs.openjdk.org/browse/JDK-8366884): NMT fails with MallocLimit: reached category "mtCompiler" limit (**Bug** - P3)


### Reviewers
 * [Paul Hübner](https://openjdk.org/census#phubner) (@Arraying - Author)
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@jdksjolen - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27246/head:pull/27246` \
`$ git checkout pull/27246`

Update a local copy of the PR: \
`$ git checkout pull/27246` \
`$ git pull https://git.openjdk.org/jdk.git pull/27246/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27246`

View PR using the GUI difftool: \
`$ git pr show -t 27246`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27246.diff">https://git.openjdk.org/jdk/pull/27246.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27246#issuecomment-3284135959)
</details>
