### PR TITLE
8365385: [asan] os::pretouch_memory() is not compatible with ASAN

### DIFF
--- a/src/hotspot/share/memory/metaspace/chunkManager.cpp
+++ b/src/hotspot/share/memory/metaspace/chunkManager.cpp
@@ -117,10 +117,6 @@ Metachunk* ChunkManager::get_chunk(chunklevel_t preferred_level, chunklevel_t ma
     c = get_chunk_locked(preferred_level, max_level, min_committed_words);
   }
 
-  if (c != nullptr) {
-    ASAN_UNPOISON_MEMORY_REGION(c->base(), c->word_size() * BytesPerWord);
-  }
-
   return c;
 }
 
@@ -243,9 +239,6 @@ Metachunk* ChunkManager::get_chunk_locked(chunklevel_t preferred_level, chunklev
 // !! Note: this may invalidate the chunk. Do not access the chunk after
 //    this function returns !!
 void ChunkManager::return_chunk(Metachunk* c) {
-  // It is valid to poison the chunk payload area at this point since its physically separated from
-  // the chunk meta info.
-  ASAN_POISON_MEMORY_REGION(c->base(), c->word_size() * BytesPerWord);
   MutexLocker fcl(Metaspace_lock, Mutex::_no_safepoint_check_flag);
   return_chunk_locked(c);
 }
@@ -303,9 +296,6 @@ bool ChunkManager::attempt_enlarge_chunk(Metachunk* c) {
     enlarged = c->vsnode()->attempt_enlarge_chunk(c, &_chunks);
   }
 
-  if (enlarged) {
-    ASAN_UNPOISON_MEMORY_REGION(c->base() + old_word_size, (c->word_size() - old_word_size) * BytesPerWord);
-  }
 
   return enlarged;
 }


### PR DESCRIPTION
When ASAN is enabled, memories allocated from ChunkManager are poisoned/unpoisoned. These un-/poisoning are done in ctor/dtor of VirtualSpaceNode and whenever chunks come/leave the ChunkManager list. Since chunks can be merged or split the poisoning should also follow the new memory segments correspondingly. To have a more precise control over where/when do the un-/poisoning, the ASAN poisoning/unpoisoning memory regions is moved after os::uncommit/commit operations.

Tested on tiers1-5

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8365385](https://bugs.openjdk.org/browse/JDK-8365385): [asan] os::pretouch_memory() is not compatible with ASAN (**Enhancement** - P4)


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@jdksjolen - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27248/head:pull/27248` \
`$ git checkout pull/27248`

Update a local copy of the PR: \
`$ git checkout pull/27248` \
`$ git pull https://git.openjdk.org/jdk.git pull/27248/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27248`

View PR using the GUI difftool: \
`$ git pr show -t 27248`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27248.diff">https://git.openjdk.org/jdk/pull/27248.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27248#issuecomment-3284207571)
</details>
