### PR TITLE
8367501: RISC-V: build broken after JDK-8365926

### DIFF
--- a/src/hotspot/cpu/riscv/nativeInst_riscv.cpp
+++ b/src/hotspot/cpu/riscv/nativeInst_riscv.cpp
@@ -28,6 +28,7 @@
 #include "code/compiledIC.hpp"
 #include "nativeInst_riscv.hpp"
 #include "oops/oop.inline.hpp"
+#include "runtime/atomicAccess.hpp"
 #include "runtime/handles.hpp"
 #include "runtime/orderAccess.hpp"
 #include "runtime/safepoint.hpp"
@@ -99,10 +100,10 @@ void NativeCall::optimize_call(address dest, bool mt_safe) {
   if (Assembler::reachable_from_branch_at(jmp_ins_pc, dest)) {
     int64_t distance = dest - jmp_ins_pc;
     uint32_t new_jal = Assembler::encode_jal(ra, distance);
-    Atomic::store((uint32_t *)jmp_ins_pc, new_jal);
+    AtomicAccess::store((uint32_t *)jmp_ins_pc, new_jal);
   } else if (!MacroAssembler::is_jalr_at(jmp_ins_pc)) { // The jalr is always identical: jalr ra, 0(t1)
     uint32_t new_jalr = Assembler::encode_jalr(ra, t1, 0);
-    Atomic::store((uint32_t *)jmp_ins_pc, new_jalr);
+    AtomicAccess::store((uint32_t *)jmp_ins_pc, new_jalr);
   } else {
     // No change to instruction stream
     return;


### PR DESCRIPTION
Hi,
Can you help to review this patch?

check https://github.com/openjdk/jdk/pull/26944, https://github.com/openjdk/jdk/pull/27135

Thanks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8367501](https://bugs.openjdk.org/browse/JDK-8367501): RISC-V: build broken after JDK-8365926 (**Bug** - P4)


### Reviewers
 * [Robbin Ehn](https://openjdk.org/census#rehn) (@robehn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27251/head:pull/27251` \
`$ git checkout pull/27251`

Update a local copy of the PR: \
`$ git checkout pull/27251` \
`$ git pull https://git.openjdk.org/jdk.git pull/27251/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27251`

View PR using the GUI difftool: \
`$ git pr show -t 27251`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27251.diff">https://git.openjdk.org/jdk/pull/27251.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27251#issuecomment-3284458645)
</details>
