### PR TITLE
8366940: Test compiler/loopopts/superword/TestAliasingFuzzer.java timed out

### DIFF
--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestAliasingFuzzer.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestAliasingFuzzer.java
@@ -30,7 +30,7 @@
  * @compile ../../../compiler/lib/ir_framework/TestFramework.java
  * @compile ../../../compiler/lib/generators/Generators.java
  * @compile ../../../compiler/lib/verify/Verify.java
- * @run driver compiler.loopopts.superword.TestAliasingFuzzer vanilla
+ * @run driver/timeout=200 compiler.loopopts.superword.TestAliasingFuzzer vanilla
  */
 
 /*
@@ -42,7 +42,7 @@
  * @compile ../../../compiler/lib/ir_framework/TestFramework.java
  * @compile ../../../compiler/lib/generators/Generators.java
  * @compile ../../../compiler/lib/verify/Verify.java
- * @run driver compiler.loopopts.superword.TestAliasingFuzzer random-flags
+ * @run driver/timeout=200 compiler.loopopts.superword.TestAliasingFuzzer random-flags
  */
 
 package compiler.loopopts.superword;


### PR DESCRIPTION
`TestAliasingFuzzer.java` generates 30 subtests for every run. They are randomized. Some vectorize and execute faster, some fail to vectorize and execute slower.

Hence, some natural variance in the duration is expected.
On most machines, it seems the variance in "Running Tests" is about 30-50sec (total test time about 35-70sec). But on some machines (macosx-x64-debug), the execution time is a bit slower: 60-100 in "Running Tests", with some outliers at 110+sec. These occasionally trip the 120sec timeout, and when they trip it, they somehow cause the harness to take an excessive 9+min to shut everything down.

Solutions:
- Option 1: generate fewer tests in `TestAliasingFuzzer.java`. Would be sad, the test has now found 2 real bugs within 2 weeks.
- Option 2: increase test timeout. That is what I'll do. Because the "outliers" that caused the timeouts were not far from all other cases on the same platform, and so they are acceptable.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8366940](https://bugs.openjdk.org/browse/JDK-8366940): Test compiler/loopopts/superword/TestAliasingFuzzer.java timed out (**Bug** - P4)


### Reviewers
 * [SendaoYan](https://openjdk.org/census#syan) (@sendaoYan - Committer)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27257/head:pull/27257` \
`$ git checkout pull/27257`

Update a local copy of the PR: \
`$ git checkout pull/27257` \
`$ git pull https://git.openjdk.org/jdk.git pull/27257/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27257`

View PR using the GUI difftool: \
`$ git pr show -t 27257`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27257.diff">https://git.openjdk.org/jdk/pull/27257.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27257#issuecomment-3285040968)
</details>
