### PR TITLE
8367546: Clarify meaning of "corresponding header" for architecture-qualified .inline.hpp files

### DIFF
--- a/doc/hotspot-style.html
+++ b/doc/hotspot-style.html
@@ -290,9 +290,13 @@ the implementation depends on other .hpp files, put it in a .cpp or a
 .inline.hpp file.</p></li>
 <li><p>.inline.hpp files should only be included in .cpp or .inline.hpp
 files.</p></li>
-<li><p>All .inline.hpp files should include their corresponding .hpp
-file as the first include line with a blank line separating it from the
-rest of the include lines. Declarations needed by other files should be
+<li><p>All .inline.hpp files should include their corresponding .hpp file (same
+file name, without the ".inline" infix) as the first include line with a blank
+line separating it from the rest of the include lines. If such file does not
+exist, and the .inline.hpp file contains an architecture qualifier (e.g.
+`_x86.inline.hpp`), the .inline.hpp file should include the corresponding
+architecture-less .hpp file, if available.
+<li><p></p>Declarations needed by other files should be
 put in the .hpp file, and not in the .inline.hpp file. This rule exists
 to resolve problems with circular dependencies between .inline.hpp
 files.</p></li>

--- a/doc/hotspot-style.md
+++ b/doc/hotspot-style.md
@@ -170,9 +170,14 @@ a .inline.hpp file.
 * .inline.hpp files should only be included in .cpp or .inline.hpp
 files.
 
-* All .inline.hpp files should include their corresponding .hpp file as
-the first include line with a blank line separating it from the rest of the
-include lines. Declarations needed by other files should be put in the .hpp
+* All .inline.hpp files should include their corresponding .hpp file (same
+file name, without the ".inline" infix) as the first include line with a blank
+line separating it from the rest of the include lines. If such file does not
+exist, and the .inline.hpp file contains an architecture qualifier (e.g.
+`_x86.inline.hpp`), the .inline.hpp file should include the corresponding
+architecture-less .hpp file, if available.
+
+* Declarations needed by other files should be put in the .hpp
 file, and not in the .inline.hpp file. This rule exists to resolve problems
 with circular dependencies between .inline.hpp files.
 


### PR DESCRIPTION
During the review of #27189 we stumbled on the lack of a clear indication of what constitutes the `corresponding .hpp` file for a `.inline.hpp` file having an architecture qualifier.

For example, `continuationHelper_x86.inline.hpp` includes `runtime/continuationHelper.hpp`, and the include statement is on top as stated in the style guide:

```
#ifndef CPU_X86_CONTINUATIONHELPER_X86_INLINE_HPP
#define CPU_X86_CONTINUATIONHELPER_X86_INLINE_HPP

#include "runtime/continuationHelper.hpp"

#include "runtime/continuationEntry.inline.hpp"
#include "runtime/frame.inline.hpp"
#include "runtime/registerMap.hpp"
[...]
```

However, this order is not respected by `SortIncludes.java`, which does not designate `runtime/continuationHelper.hpp` as the "corresponding `.hpp` file". If this concept was clarified in the style guide, we could improve `SortIncludes` accordingly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8367546](https://bugs.openjdk.org/browse/JDK-8367546): Clarify meaning of "corresponding header" for architecture-qualified .inline.hpp files (**Enhancement** - P4)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27259/head:pull/27259` \
`$ git checkout pull/27259`

Update a local copy of the PR: \
`$ git checkout pull/27259` \
`$ git pull https://git.openjdk.org/jdk.git pull/27259/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27259`

View PR using the GUI difftool: \
`$ git pr show -t 27259`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27259.diff">https://git.openjdk.org/jdk/pull/27259.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27259#issuecomment-3285329423)
</details>
