### PR TITLE
8367552: JCmdTestFileSafety.java fails when run by root user

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/jcmd/JCmdTestFileSafety.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/jcmd/JCmdTestFileSafety.java
@@ -142,7 +142,7 @@ public class JCmdTestFileSafety extends JCmdTestDumpBase {
             throw new jtreg.SkippedException("Test skipped on Windows");
         }
         if (Platform.isRoot()) {
-            throw new jtreg.SkippedException("Write permissions do not apply to root user");
+            throw new jtreg.SkippedException("Test skipped when executed by root user.");
         }
         runTest(JCmdTestFileSafety::test);
     }


### PR DESCRIPTION
I noticed this while running the test in a Docker container. The test tries to call `File.setWriteable(false)` on a directory in which it later tries to override an existing CDS archive. Since the root user is not affected by the missing write permission, the test fails consistently.

I propose to skip it if we detect that 'root' is running it, should be a trivial change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8367552](https://bugs.openjdk.org/browse/JDK-8367552): JCmdTestFileSafety.java fails when run by root user (**Enhancement** - P4)


### Reviewers
 * [Paul Hübner](https://openjdk.org/census#phubner) (@Arraying - Author) Review applies to [373f0c3f](https://git.openjdk.org/jdk/pull/27261/files/373f0c3f099553ddae506d30ad8b67a9312b8ed3)
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27261/head:pull/27261` \
`$ git checkout pull/27261`

Update a local copy of the PR: \
`$ git checkout pull/27261` \
`$ git pull https://git.openjdk.org/jdk.git pull/27261/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27261`

View PR using the GUI difftool: \
`$ git pr show -t 27261`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27261.diff">https://git.openjdk.org/jdk/pull/27261.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27261#issuecomment-3285773683)
</details>
