### PR TITLE
8367576: JvmtiThreadState::_debuggable is unused

### DIFF
--- a/src/hotspot/share/prims/jvmtiThreadState.cpp
+++ b/src/hotspot/share/prims/jvmtiThreadState.cpp
@@ -59,7 +59,6 @@ JvmtiThreadState::JvmtiThreadState(JavaThread* thread, oop thread_oop)
   _thread               = thread;
   _thread_saved         = nullptr;
   _exception_state      = ES_CLEARED;
-  _debuggable           = true;
   _hide_single_stepping = false;
   _pending_interp_only_mode = false;
   _hide_level           = 0;

--- a/src/hotspot/share/prims/jvmtiThreadState.hpp
+++ b/src/hotspot/share/prims/jvmtiThreadState.hpp
@@ -444,15 +444,6 @@ class JvmtiThreadState : public CHeapObj<mtInternal> {
     return klass;
   }
 
-  // Todo: get rid of this!
- private:
-  bool _debuggable;
- public:
-  // Should the thread be enumerated by jvmtiInternal::GetAllThreads?
-  bool is_debuggable()                 { return _debuggable; }
-  // If a thread cannot be suspended (has no valid last_java_frame) then it gets marked !debuggable
-  void set_debuggable(bool debuggable) { _debuggable = debuggable; }
-
  public:
 
   // Thread local event collector setter and getter methods.


### PR DESCRIPTION
The flag has been there since 8153779ad32d1e8ddd37ced826c76c7aafc61894, but seems to be unused.

Testing: `tier1`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8367576](https://bugs.openjdk.org/browse/JDK-8367576): JvmtiThreadState::_debuggable is unused (**Enhancement** - P4)


### Reviewers
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27265/head:pull/27265` \
`$ git checkout pull/27265`

Update a local copy of the PR: \
`$ git checkout pull/27265` \
`$ git pull https://git.openjdk.org/jdk.git pull/27265/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27265`

View PR using the GUI difftool: \
`$ git pr show -t 27265`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27265.diff">https://git.openjdk.org/jdk/pull/27265.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27265#issuecomment-3286921777)
</details>
