### PR TITLE
8366978: dead code in SunCertPathBuilder

### DIFF
--- a/src/java.base/share/classes/sun/security/provider/certpath/SunCertPathBuilder.java
+++ b/src/java.base/share/classes/sun/security/provider/certpath/SunCertPathBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -636,19 +636,5 @@ public final class SunCertPathBuilder extends CertPathBuilderSpi {
         } else {
             return (nextAltNameExt == null);
         }
-    }
-
-    /**
-     * Returns true if trust anchor certificate matches specified
-     * certificate constraints.
-     */
-    private static boolean anchorIsTarget(TrustAnchor anchor,
-                                          CertSelector sel)
-    {
-        X509Certificate anchorCert = anchor.getTrustedCert();
-        if (anchorCert != null) {
-            return sel.match(anchorCert);
-        }
-        return false;
     }
 }


### PR DESCRIPTION
A DESCRIPTION OF THE PROBLEM :
[JDK-7194452](https://bugs.openjdk.org/browse/JDK-7194452) left the SunCertPathBuilder.anchorIsTarget orphaned. Remove the deadcode.