### PR TITLE
8367597: Runtime.exit logging failed: Cannot invoke "java.lang.Module.getClassLoader()" because "m" is null

### DIFF
--- a/src/java.base/share/classes/java/lang/Shutdown.java
+++ b/src/java.base/share/classes/java/lang/Shutdown.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -174,6 +174,10 @@ class Shutdown {
      */
     private static void logRuntimeExit(int status) {
         try {
+            if (!VM.isBooted()) {
+                // skip logging when invoked too early during VM startup
+                return;
+            }
             System.Logger log = System.getLogger("java.lang.Runtime");
             if (log.isLoggable(System.Logger.Level.DEBUG)) {
                 Throwable throwable = new Throwable("Runtime.exit(" + status + ")");

--- a/src/java.base/share/classes/java/lang/Shutdown.java
+++ b/src/java.base/share/classes/java/lang/Shutdown.java
@@ -157,8 +157,10 @@ class Shutdown {
      * which should pass a nonzero status code.
      */
     static void exit(int status) {
-        logRuntimeExit(status);         // Log without holding the lock;
-
+        // log only if VM is fully initialized
+        if (VM.isBooted()) {
+            logRuntimeExit(status);         // Log without holding the lock;
+        }
         synchronized (Shutdown.class) {
             /* Synchronize on the class object, causing any other thread
              * that attempts to initiate shutdown to stall indefinitely
@@ -173,10 +175,6 @@ class Shutdown {
      * Catch and ignore any and all exceptions.
      */
     private static void logRuntimeExit(int status) {
-        if (!VM.isBooted()) {
-            // skip logging when invoked too early during VM startup
-            return;
-        }
         try {
             System.Logger log = System.getLogger("java.lang.Runtime");
             if (log.isLoggable(System.Logger.Level.DEBUG)) {

--- a/src/java.base/share/classes/java/lang/Shutdown.java
+++ b/src/java.base/share/classes/java/lang/Shutdown.java
@@ -173,11 +173,11 @@ class Shutdown {
      * Catch and ignore any and all exceptions.
      */
     private static void logRuntimeExit(int status) {
+        if (!VM.isBooted()) {
+            // skip logging when invoked too early during VM startup
+            return;
+        }
         try {
-            if (!VM.isBooted()) {
-                // skip logging when invoked too early during VM startup
-                return;
-            }
             System.Logger log = System.getLogger("java.lang.Runtime");
             if (log.isLoggable(System.Logger.Level.DEBUG)) {
                 Throwable throwable = new Throwable("Runtime.exit(" + status + ")");


### PR DESCRIPTION
Can I please get a review of this change which addresses the issue noted in https://bugs.openjdk.org/browse/JDK-8367597? 

As noted in that issue, on certain occasions, during shutdown of the JVM, the logging in `Runtime.exit()` generates a `NullPointerException`. The issue is due to the JVM not being fully initialized when (concurrently) the signal handler thread calls the `Runtime.exit()` code which then attempts to log a message.

The commit in this PR skips the logging from `Runtime.exit()` if the JVM isn't fully initialized at that point in time. I've manually verified that this change indeed addresses the issue by running the same tests on the hosts where this was previously failing. No new regressions tests have been introduced given the nature of the issue.

tier1 testing with this change completed without any related issues and additional tier testing is currently in progress.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8367597](https://bugs.openjdk.org/browse/JDK-8367597): Runtime.exit logging failed: Cannot invoke "java.lang.Module.getClassLoader()" because "m" is null (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27270/head:pull/27270` \
`$ git checkout pull/27270`

Update a local copy of the PR: \
`$ git checkout pull/27270` \
`$ git pull https://git.openjdk.org/jdk.git pull/27270/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27270`

View PR using the GUI difftool: \
`$ git pr show -t 27270`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27270.diff">https://git.openjdk.org/jdk/pull/27270.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27270#issuecomment-3287718627)
</details>
