### PR TITLE
8367609: serviceability/sa/ClhsdbPmap.java fails when built with Clang

### DIFF
--- a/src/jdk.hotspot.agent/linux/native/libsaproc/ps_core.c
+++ b/src/jdk.hotspot.agent/linux/native/libsaproc/ps_core.c
@@ -420,15 +420,15 @@ static bool read_lib_segments(struct ps_prochandle* ph, int lib_fd, ELF_EHDR* li
         // Coredump stores value of p_memsz elf field
         // rounded up to page boundary.
 
+        // Account for the PH being at some vaddr offset from mapping in core file.
         uint64_t lib_memsz = lib_php->p_memsz;
         if (target_vaddr > existing_map->vaddr) {
             lib_memsz += target_vaddr - existing_map->vaddr;
         }
-        lib_memsz = ROUNDUP(lib_memsz, page_size);
 
         if ((existing_map->memsz != page_size) &&
             (existing_map->fd != lib_fd) &&
-            (ROUNDUP(existing_map->memsz, page_size) != lib_memsz)) {
+            (ROUNDUP(existing_map->memsz, page_size) != ROUNDUP(lib_memsz, page_size))) {
 
           print_error("address conflict @ 0x%lx (existing map size = %ld, size = %ld, flags = %d)\n",
                         target_vaddr, existing_map->memsz, lib_php->p_memsz, lib_php->p_flags);


### PR DESCRIPTION
The problem seems to be in read_lib_segments (ps_core.c), this check is too harsh:

https://github.com/openjdk/jdk/blob/5271448b3a013b2e3edcd619a4a3b975b292dae1/src/jdk.hotspot.agent/linux/native/libsaproc/ps_core.c#L423-L425

In my run, `existing_map->memsz = 0xe24000`, while the rhs in L425 is `0xe23000`. According to the NT_FILE entry, this segment of `libjvm.so` has file offset 0x67f000. It seems that the linker aligned it down according to the page size (0x1000). The offset of the same segment according to `readelf -l libjvm.so` is 0x67fc80. This additional offset should be added to `p_memsz` to obtain the 0xe24000, which we see in the core dump.

I added some files to the ticket for context.

Passes `tier1` and `tier2`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8367609](https://bugs.openjdk.org/browse/JDK-8367609): serviceability/sa/ClhsdbPmap.java fails when built with Clang (**Bug** - P4)


### Reviewers
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - **Reviewer**)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27274/head:pull/27274` \
`$ git checkout pull/27274`

Update a local copy of the PR: \
`$ git checkout pull/27274` \
`$ git pull https://git.openjdk.org/jdk.git pull/27274/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27274`

View PR using the GUI difftool: \
`$ git pr show -t 27274`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27274.diff">https://git.openjdk.org/jdk/pull/27274.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27274#issuecomment-3290023838)
</details>
