### PR TITLE
8366925: Improper std::nothrow new expression in NativeHeapTrimmerThread ctor

### DIFF
--- a/src/hotspot/share/runtime/trimNativeHeap.cpp
+++ b/src/hotspot/share/runtime/trimNativeHeap.cpp
@@ -168,6 +168,10 @@ public:
     _suspend_count(0),
     _num_trims_performed(0)
   {
+    if (_lock == nullptr) {
+        vm_exit_out_of_memory(0, OOM_MALLOC_ERROR,
+                              "Failed to allocate NativeHeapTrimmer_lock");
+    }
     set_name("Native Heap Trimmer");
     if (os::create_thread(this, os::vm_thread)) {
       os::start_thread(this);

--- a/src/hotspot/share/runtime/trimNativeHeap.cpp
+++ b/src/hotspot/share/runtime/trimNativeHeap.cpp
@@ -163,15 +163,11 @@ class NativeHeapTrimmerThread : public NamedThread {
 public:
 
   NativeHeapTrimmerThread() :
-    _lock(new (std::nothrow) PaddedMonitor(Mutex::nosafepoint, "NativeHeapTrimmer_lock")),
+    _lock(new PaddedMonitor(Mutex::nosafepoint, "NativeHeapTrimmer_lock")),
     _stop(false),
     _suspend_count(0),
     _num_trims_performed(0)
   {
-    if (_lock == nullptr) {
-        vm_exit_out_of_memory(0, OOM_MALLOC_ERROR,
-                              "Failed to allocate NativeHeapTrimmer_lock");
-    }
     set_name("Native Heap Trimmer");
     if (os::create_thread(this, os::vm_thread)) {
       os::start_thread(this);


### PR DESCRIPTION
Please review this Patch.

**Description:**
Add null check for _lock in NativeHeapTrimmerThread constructor. If allocation of the lock fails (_lock == nullptr), it indicates an out-of-memory condition. Since even this small allocation failed, it's unlikely that subsequent operations would succeed, so we terminate the JVM immediately.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8366925](https://bugs.openjdk.org/browse/JDK-8366925): Improper std::nothrow new expression in NativeHeapTrimmerThread ctor (**Enhancement** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27275/head:pull/27275` \
`$ git checkout pull/27275`

Update a local copy of the PR: \
`$ git checkout pull/27275` \
`$ git pull https://git.openjdk.org/jdk.git pull/27275/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27275`

View PR using the GUI difftool: \
`$ git pr show -t 27275`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27275.diff">https://git.openjdk.org/jdk/pull/27275.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27275#issuecomment-3290153174)
</details>
