### PR TITLE
8347167: Reduce allocation in com.sun.net.httpserver.Headers::normalize

### DIFF
--- a/src/jdk.httpserver/share/classes/com/sun/net/httpserver/Headers.java
+++ b/src/jdk.httpserver/share/classes/com/sun/net/httpserver/Headers.java
@@ -132,7 +132,7 @@ public class Headers implements Map<String,List<String>> {
         // Find the first non-normalized `char`
         int i = 0;
         char c = key.charAt(i);
-        if (c >= 'A' && c <= 'Z') {
+        if (!(c == '\r' || c == '\n' || (c >= 'a' && c <= 'z'))) {
             i++;
             for (; i < l; i++) {
                 c = key.charAt(i);
@@ -147,18 +147,20 @@ public class Headers implements Map<String,List<String>> {
             return key;
         }
 
-        // Normalize the first `char`
+        // Upper-case the first `char`
         char[] cs = key.toCharArray();
         int o = 'a' - 'A';
         if (i == 0) {
             if (c == '\r' || c == '\n') {
                 throw new IllegalArgumentException("illegal character in key at index " + i);
             }
-            cs[0] = (char) (c - o);
+            if (c >= 'a' && c <= 'z') {
+                cs[0] = (char) (c - o);
+            }
             i++;
         }
 
-        // Normalize the secondary `char`s
+        // Lower-case the secondary `char`s
         for (; i < l; i++) {
             c = cs[i];
             if (c >= 'A' && c <= 'Z') {

--- a/test/jdk/com/sun/net/httpserver/HeadersTest.java
+++ b/test/jdk/com/sun/net/httpserver/HeadersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,6 +49,9 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
 import com.sun.net.httpserver.Headers;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
@@ -62,6 +65,8 @@ import static java.net.http.HttpClient.Builder.NO_PROXY;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertNotSame;
+import static org.testng.Assert.assertSame;
 import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
 
@@ -448,6 +453,82 @@ public class HeadersTest {
         assertEquals(h.size(), 2);
         List.of("a", "b").forEach(n -> assertTrue(h.containsKey(n)));
         List.of(List.of("1"), List.of("1", "2", "3")).forEach(v -> assertTrue(h.containsValue(v)));
+    }
+
+    @Test
+    public static void testNormalizeOnNull() {
+        assertThrows(NullPointerException.class, () -> normalize(null));
+    }
+
+    @DataProvider
+    public static Object[][] illegalKeys() {
+        var illegalChars = List.of('\r', '\n');
+        var illegalStrings = Stream
+                // Insert an illegal char at every possible position of following strings
+                .of("Ab", "ab", "_a", "2a")
+                .flatMap(s -> IntStream
+                        .range(0, s.length() + 1)
+                        .boxed()
+                        .flatMap(i -> illegalChars
+                                .stream()
+                                .map(c -> s.substring(0, i) + c + s.substring(i))));
+        return Stream
+                .concat(illegalChars.stream().map(c -> "" + c), illegalStrings)
+                .map(s -> new Object[]{s})
+                .toArray(Object[][]::new);
+    }
+
+    @Test(dataProvider = "illegalKeys")
+    public static void testNormalizeOnIllegalKeys(String illegalKey) {
+        assertThrows(IllegalArgumentException.class, () -> normalize(illegalKey));
+    }
+
+    @DataProvider
+    public static Object[][] normalizedKeys() {
+        return new Object[][]{
+                // Empty string
+                {""},
+                // Non-alpha prefix
+                {"_"},
+                {"0"},
+                {"_xy-@"},
+                {"0xy-@"},
+                // Upper-case prefix
+                {"A"},
+                {"B"},
+                {"Ayz-@"},
+                {"Byz-@"},
+        };
+    }
+
+    @Test(dataProvider = "normalizedKeys")
+    public static void testNormalizeOnNormalizedKeys(String normalizedKey) {
+        // Verify that the fast-path is taken
+        assertSame(normalize(normalizedKey), normalizedKey);
+    }
+
+    @DataProvider
+    public static Object[][] notNormalizedKeys() {
+        return new Object[][]{
+                {"a"},
+                {"b"},
+                {"axy-@"},
+                {"bxy-@"},
+        };
+    }
+
+    @Test(dataProvider = "notNormalizedKeys")
+    public static void testNormalizeOnNotNormalizedKeys(String notNormalizedKey) {
+        var normalizedKey = normalize(notNormalizedKey);
+        // Verify that the fast-path is *not* taken
+        assertNotSame(normalizedKey, notNormalizedKey);
+        // Verify the result
+        var expectedNormalizedKey = normalizedKey.substring(0, 1).toUpperCase() + normalizedKey.substring(1);
+        assertEquals(normalizedKey, expectedNormalizedKey);
+    }
+
+    private static String normalize(String key) {
+        return Headers.of(key, "foo").keySet().iterator().next();
     }
 
     // Immutability tests in UnmodifiableHeadersTest.java

--- a/test/micro/org/openjdk/bench/sun/net/httpserver/HeaderNormalization.java
+++ b/test/micro/org/openjdk/bench/sun/net/httpserver/HeaderNormalization.java
@@ -76,6 +76,7 @@ public class HeaderNormalization {
 
     @Param({
             "Accept-charset",   // Already normalized
+            "4ccept-charset",   // Already normalized with a non-alpha first letter
             "accept-charset",   // Only the first `a` must be upper-cased
             "Accept-Charset",   // Only `c` must be lower-cased
             "ACCEPT-CHARSET",   // All secondary must be lower-cased


### PR DESCRIPTION
Following the direction outlined in the net-dev discussion, I've updated the `com.sun.net.httpserver.Headers.normalize()` method to no longer allocate a superfluous char array when the header is already normalized.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347167](https://bugs.openjdk.org/browse/JDK-8347167): Reduce allocation in com.sun.net.httpserver.Headers::normalize (**Enhancement** - P4)


### Reviewers
 * [Volkan Yazici](https://openjdk.org/census#vyazici) (@vy - Committer)
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)
 * [Michael McMahon](https://openjdk.org/census#michaelm) (@Michael-Mc-Mahon - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27276/head:pull/27276` \
`$ git checkout pull/27276`

Update a local copy of the PR: \
`$ git checkout pull/27276` \
`$ git pull https://git.openjdk.org/jdk.git pull/27276/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27276`

View PR using the GUI difftool: \
`$ git pr show -t 27276`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27276.diff">https://git.openjdk.org/jdk/pull/27276.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27276#issuecomment-3320675449)
</details>
