### PR TITLE
8367616: RISC-V: Auto-enable Zicboz extension for debug builds

### DIFF
--- a/src/hotspot/os_cpu/linux_riscv/riscv_hwprobe.cpp
+++ b/src/hotspot/os_cpu/linux_riscv/riscv_hwprobe.cpp
@@ -191,6 +191,9 @@ void RiscvHwprobe::add_features_from_query_result() {
     VM_Version::ext_Zbs.enable_feature();
   }
 #ifndef PRODUCT
+  if (is_set(RISCV_HWPROBE_KEY_IMA_EXT_0, RISCV_HWPROBE_EXT_ZICBOZ)) {
+    VM_Version::ext_Zicboz.enable_feature();
+  }
   if (is_set(RISCV_HWPROBE_KEY_IMA_EXT_0, RISCV_HWPROBE_EXT_ZBKB)) {
     VM_Version::ext_Zbkb.enable_feature();
   }


### PR DESCRIPTION
Hi,
Can you help to review this patch? Thanks!

This is a followup change after https://bugs.openjdk.org/browse/JDK-8353829. 
We can add detection and enablement of Zicboz extension.

Testing: hs:tier1 tested with qemu-system(kernel 6.14) with Zicboz extension.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8367616](https://bugs.openjdk.org/browse/JDK-8367616): RISC-V: Auto-enable Zicboz extension for debug builds (**Enhancement** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Feilong Jiang](https://openjdk.org/census#fjiang) (@feilongjiang - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27277/head:pull/27277` \
`$ git checkout pull/27277`

Update a local copy of the PR: \
`$ git checkout pull/27277` \
`$ git pull https://git.openjdk.org/jdk.git pull/27277/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27277`

View PR using the GUI difftool: \
`$ git pr show -t 27277`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27277.diff">https://git.openjdk.org/jdk/pull/27277.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27277#issuecomment-3290363390)
</details>
