### PR TITLE
8367619: String.format in outOfRangeException uses wrong format specifier for String argument

### DIFF
--- a/src/java.base/share/classes/jdk/internal/classfile/impl/Util.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/Util.java
@@ -230,7 +230,7 @@ public final class Util {
 
     public static IllegalArgumentException outOfRangeException(int value, String fieldName, String typeName) {
         return new IllegalArgumentException(
-                String.format("%s out of range of %d: %d", fieldName, typeName, value));
+                String.format("%s out of range of %s: %d", fieldName, typeName, value));
     }
 
     /// Ensures the given mask won't be truncated when written as an access flag


### PR DESCRIPTION
trivial fix

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8367619](https://bugs.openjdk.org/browse/JDK-8367619): String.format in outOfRangeException uses wrong format specifier for String argument (**Bug** - P4)


### Reviewers
 * [Francesco Andreuzzi](https://openjdk.org/census#fandreuzzi) (@fandreuz - Author)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27280/head:pull/27280` \
`$ git checkout pull/27280`

Update a local copy of the PR: \
`$ git checkout pull/27280` \
`$ git pull https://git.openjdk.org/jdk.git pull/27280/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27280`

View PR using the GUI difftool: \
`$ git pr show -t 27280`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27280.diff">https://git.openjdk.org/jdk/pull/27280.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27280#issuecomment-3290577600)
</details>
