### PR TITLE
8367585: Move Utf8Entry length validation earlier

### DIFF
--- a/src/java.base/share/classes/jdk/internal/classfile/impl/AbstractPoolEntry.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/AbstractPoolEntry.java
@@ -35,6 +35,7 @@ import jdk.internal.access.SharedSecrets;
 import jdk.internal.constant.ClassOrInterfaceDescImpl;
 import jdk.internal.constant.PrimitiveClassDescImpl;
 import jdk.internal.util.ArraysSupport;
+import jdk.internal.util.ModifiedUtf;
 import jdk.internal.vm.annotation.Stable;
 
 import static java.util.Objects.requireNonNull;
@@ -154,6 +155,10 @@ public abstract sealed class AbstractPoolEntry {
         }
 
         Utf8EntryImpl(ConstantPool cpm, int index, String s, int contentHash) {
+            if (!ModifiedUtf.isValidLengthInConstantPool(s)) {
+                int encodedLength = ModifiedUtf.utfLen(s, 0);
+                throw Util.outOfRangeException(encodedLength, "utf8 length", "u2");
+            }
             super(cpm, index, 0);
             this.rawBytes = null;
             this.offset = 0;

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/BufWriterImpl.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/BufWriterImpl.java
@@ -276,7 +276,7 @@ public final class BufWriterImpl implements BufWriter {
         int strlen = str.length();
         int countNonZeroAscii = JLA.countNonZeroAscii(str);
         int utflen = utfLen(str, countNonZeroAscii);
-        Util.checkU2(utflen, "utf8 length");
+        assert (char) utflen == utflen : "Bad utflen " + utflen;
         reserveSpace(utflen + 3);
 
         int offset = this.offset;

--- a/src/java.base/share/classes/jdk/internal/util/ModifiedUtf.java
+++ b/src/java.base/share/classes/jdk/internal/util/ModifiedUtf.java
@@ -27,14 +27,11 @@ package jdk.internal.util;
 
 import jdk.internal.vm.annotation.ForceInline;
 
-/**
- * Helper to JDK UTF putChar and Calculate length
- *
- * @since 24
- */
-public abstract class ModifiedUtf {
-    // Maximum number of bytes allowed for a Modified UTF-8 encoded string
-    // in a ClassFile constant pool entry (CONSTANT_Utf8_info).
+/// Utilities for string encoding and decoding with the
+/// [Modified UTF-8][java.io.DataInput##modified-utf-8] format.
+public final class ModifiedUtf {
+    /// Maximum number of bytes allowed for a Modified UTF-8 encoded string
+    /// in a [java.lang.classfile.constantpool.Utf8Entry] or a hotspot `Symbol`.
     public static final int CONSTANT_POOL_UTF8_MAX_BYTES = 65535;
 
     private ModifiedUtf() {
@@ -57,11 +54,23 @@ public abstract class ModifiedUtf {
         return offset;
     }
 
-    /**
-     * Calculate the utf length of a string
-     * @param str input string
-     * @param countNonZeroAscii the number of non-zero ascii characters in the prefix calculated by JLA.countNonZeroAscii(str)
-     */
+    /// Calculate the encoded length of an input String.
+    /// For many workloads that have fast paths for ASCII-only prefixes,
+    /// [#utfLen(String, int)] skips scanning that prefix.
+    ///
+    /// @param str input string
+    public static int utfLen(String str) {
+        return utfLen(str, 0);
+    }
+
+    /// Calculate the encoded length of trailing parts of an input String,
+    /// after [jdk.internal.access.JavaLangAccess#countNonZeroAscii(String)]
+    /// calculates the number of contiguous single-byte characters in the
+    /// beginning of the string.
+    ///
+    /// @param str input string
+    /// @param countNonZeroAscii the number of non-zero ascii characters in the
+    ///        prefix calculated by JLA.countNonZeroAscii(str)
     @ForceInline
     public static int utfLen(String str, int countNonZeroAscii) {
         int utflen = str.length();
@@ -73,11 +82,11 @@ public abstract class ModifiedUtf {
         return utflen;
     }
 
-    /**
-     * Checks whether the Modified UTF-8 encoded length of the given string
-     * fits within the ClassFile constant pool limit (u2 length = 65535 bytes).
-     * @param str the string to check
-     */
+    /// Checks whether an input String can be encoded in a
+    /// [java.lang.classfile.constantpool.Utf8Entry], or represented as a
+    /// hotspot `Symbol` (which has the same length limit).
+    ///
+    /// @param str input string
     @ForceInline
     public static boolean isValidLengthInConstantPool(String str) {
         // Quick approximation: each char can be at most 3 bytes in Modified UTF-8.
@@ -91,7 +100,7 @@ public abstract class ModifiedUtf {
         }
         // Check exact Modified UTF-8 length.
         // The check strLen > CONSTANT_POOL_UTF8_MAX_BYTES above ensures that utfLen can't overflow here.
-        int utfLen = utfLen(str, 0);
+        int utfLen = utfLen(str);
         return utfLen <= CONSTANT_POOL_UTF8_MAX_BYTES;
     }
 }


### PR DESCRIPTION
John Rose suggests in https://github.com/openjdk/jdk/pull/26802#issuecomment-3201402304 that ClassFile API should validate Utf8Entry length eagerly upon construction. Currently we validate upon writing to bytes, which avoids validation overhead. However, given that most class file utf8 data are shorter than 1/3 of the max length, which is always an encodable length, the performance impact should be low.

Preventing the creation of unrepresentable UTF8 entries can prevent passing such invalid instances around, making such problems easier to debug than a failure at building.

Tier 1-3 seems clear. The performance impact to jdk.classfile.Write or any of the regularly run transformation benchmarks seems neutral, less than 5% perturbations.

I will update docs to reflect this change, given how widespread this is across JDK - it seems the only exempt classes are Signature, ClassSignature, and MethodSignature.