### PR TITLE
8367133: DTLS: fragmentation of Finished message results in handshake failure

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/DTLSInputRecord.java
+++ b/src/java.base/share/classes/sun/security/ssl/DTLSInputRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -801,8 +801,11 @@ final class DTLSInputRecord extends InputRecord implements DTLSRecord {
 
             // buffer this fragment
             if (hsf.handshakeType == SSLHandshake.FINISHED.id) {
-                // Need no status update.
-                bufferedFragments.add(hsf);
+                // Make sure it's not a retransmitted message
+                if (hsf.recordEpoch > handshakeEpoch) {
+                    bufferedFragments.add(hsf);
+                    flightIsReady = holes.isEmpty();
+                }
             } else {
                 bufferFragment(hsf);
             }

--- a/test/jdk/javax/net/ssl/DTLS/DTLSOverDatagram.java
+++ b/test/jdk/javax/net/ssl/DTLS/DTLSOverDatagram.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
 
 /*
  * @test
- * @bug 8043758
+ * @bug 8043758 8367133
  * @summary Datagram Transport Layer Security (DTLS)
  * @modules java.base/sun.security.util
  * @library /test/lib
@@ -362,6 +362,14 @@ public class DTLSOverDatagram {
             SSLEngineResult.HandshakeStatus hs = r.getHandshakeStatus();
             log(side, "----produce handshake packet(" +
                     ++loops + ", " + rs + ", " + hs + ")----");
+
+            if (oNet.remaining() < 30) { // detect ChangeCipherSpec
+                // Reduce the maximumPacketSize to force fragmentation
+                // of the Finished message for JDK-8367133
+                SSLParameters params = engine.getSSLParameters();
+                params.setMaximumPacketSize(53);
+                engine.setSSLParameters(params);
+            }
 
             verifySSLEngineResultStatus(r, side);
 

--- a/test/jdk/javax/net/ssl/DTLS/DTLSOverDatagram.java
+++ b/test/jdk/javax/net/ssl/DTLS/DTLSOverDatagram.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
 
 /*
  * @test
- * @bug 8043758 8367133
+ * @bug 8043758
  * @summary Datagram Transport Layer Security (DTLS)
  * @modules java.base/sun.security.util
  * @library /test/lib
@@ -362,14 +362,6 @@ public class DTLSOverDatagram {
             SSLEngineResult.HandshakeStatus hs = r.getHandshakeStatus();
             log(side, "----produce handshake packet(" +
                     ++loops + ", " + rs + ", " + hs + ")----");
-
-            if (oNet.remaining() < 30) { // detect ChangeCipherSpec
-                // Reduce the maximumPacketSize to force fragmentation
-                // of the Finished message for JDK-8367133
-                SSLParameters params = engine.getSSLParameters();
-                params.setMaximumPacketSize(53);
-                engine.setSSLParameters(params);
-            }
 
             verifySSLEngineResultStatus(r, side);
 

--- a/test/jdk/javax/net/ssl/DTLS/FragmentedFinished.java
+++ b/test/jdk/javax/net/ssl/DTLS/FragmentedFinished.java
@@ -61,7 +61,7 @@ public class FragmentedFinished extends DTLSOverDatagram {
     DatagramPacket createHandshakePacket(byte[] ba, SocketAddress socketAddr) {
         if (ba.length < 30) { // detect ChangeCipherSpec
             // Reduce the maximumPacketSize to force fragmentation
-            // of the Finished message for JDK-8367133
+            // of the Finished message
             SSLParameters params = serverSSLEngine.getSSLParameters();
             params.setMaximumPacketSize(53);
             serverSSLEngine.setSSLParameters(params);

--- a/test/jdk/javax/net/ssl/DTLS/FragmentedFinished.java
+++ b/test/jdk/javax/net/ssl/DTLS/FragmentedFinished.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+// SunJSSE does not support dynamic system properties, no way to re-use
+// system properties in samevm/agentvm mode.
+
+/*
+ * @test
+ * @bug 8367133
+ * @summary Verify that handshake succeeds when Finished message is fragmented
+ * @modules java.base/sun.security.util
+ * @library /test/lib
+ * @build DTLSOverDatagram
+ * @run main/othervm FragmentedFinished
+ */
+
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLParameters;
+import java.net.DatagramPacket;
+import java.net.SocketAddress;
+import java.util.ArrayList;
+import java.util.List;
+
+public class FragmentedFinished extends DTLSOverDatagram {
+    private SSLEngine serverSSLEngine;
+    public static void main(String[] args) throws Exception {
+        FragmentedFinished testCase = new FragmentedFinished();
+        testCase.runTest(testCase);
+    }
+
+    @Override
+    SSLEngine createSSLEngine(boolean isClient) throws Exception {
+        SSLEngine sslEngine = super.createSSLEngine(isClient);
+        if (!isClient) {
+            serverSSLEngine = sslEngine;
+        }
+        return sslEngine;
+    }
+
+    @Override
+    DatagramPacket createHandshakePacket(byte[] ba, SocketAddress socketAddr) {
+        if (ba.length < 30) { // detect ChangeCipherSpec
+            // Reduce the maximumPacketSize to force fragmentation
+            // of the Finished message for JDK-8367133
+            SSLParameters params = serverSSLEngine.getSSLParameters();
+            params.setMaximumPacketSize(53);
+            serverSSLEngine.setSSLParameters(params);
+        }
+
+        return super.createHandshakePacket(ba, socketAddr);
+    }
+}


### PR DESCRIPTION
The DTLSReassembler may release a Finished message before assembling all necessary fragments.

The newly added test fails without the DTLSReassembler changes, passes with the changes. Other tier1-3 tests continue to pass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8367133](https://bugs.openjdk.org/browse/JDK-8367133): DTLS: fragmentation of Finished message results in handshake failure (**Bug** - P4)


### Reviewers
 * [Jamil Nimeh](https://openjdk.org/census#jnimeh) (@jnimeh - **Reviewer**)

### Reviewers without OpenJDK IDs
 * @ragkale (no known openjdk.org user name / role)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27284/head:pull/27284` \
`$ git checkout pull/27284`

Update a local copy of the PR: \
`$ git checkout pull/27284` \
`$ git pull https://git.openjdk.org/jdk.git pull/27284/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27284`

View PR using the GUI difftool: \
`$ git pr show -t 27284`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27284.diff">https://git.openjdk.org/jdk/pull/27284.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27284#issuecomment-3291596597)
</details>
