### PR TITLE
8367629: Parallel: Remove logging in PSAdjustWeakRootsClosure

### DIFF
--- a/src/hotspot/share/gc/parallel/psClosure.inline.hpp
+++ b/src/hotspot/share/gc/parallel/psClosure.inline.hpp
@@ -44,12 +44,6 @@ public:
       assert(!PSScavenge::is_obj_in_to_space(o), "Revisiting roots?");
       assert(o->is_forwarded(), "Objects are already forwarded before weak processing");
       oop new_obj = o->forwardee();
-      if (log_develop_is_enabled(Trace, gc, scavenge)) {
-        ResourceMark rm; // required by internal_name()
-        log_develop_trace(gc, scavenge)("{%s %s " PTR_FORMAT " -> " PTR_FORMAT " (%zu)}",
-                                        "forwarding",
-                                        new_obj->klass()->internal_name(), p2i((void *)o), p2i((void *)new_obj), new_obj->size());
-      }
       RawAccess<IS_NOT_NULL>::oop_store(p, new_obj);
     }
   }


### PR DESCRIPTION
Trivial removing a develop-log print during young-gc weak root processing.

Test: tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8367629](https://bugs.openjdk.org/browse/JDK-8367629): Parallel: Remove logging in PSAdjustWeakRootsClosure (**Enhancement** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27287/head:pull/27287` \
`$ git checkout pull/27287`

Update a local copy of the PR: \
`$ git checkout pull/27287` \
`$ git pull https://git.openjdk.org/jdk.git pull/27287/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27287`

View PR using the GUI difftool: \
`$ git pr show -t 27287`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27287.diff">https://git.openjdk.org/jdk/pull/27287.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27287#issuecomment-3291083403)
</details>
