### PR TITLE
8360401: [AIX] java/lang/ProcessBuilder/FDLeakTest/FDLeakTest.java fails since JDK-8210549

### DIFF
--- a/src/java.base/unix/native/libjava/childproc.c
+++ b/src/java.base/unix/native/libjava/childproc.c
@@ -68,7 +68,7 @@ markCloseOnExec(int fd)
 }
 
 #if !defined(_AIX)
-  /* The /proc file System in AIX does not contain open system files
+  /* The /proc file System on AIX does not contain open system files
    * like /dev/random. Therefore we use a different approach and do
    * not need isAsciiDigit() or FD_DIR */
 static int
@@ -91,10 +91,12 @@ markDescriptorsCloseOnExec(void)
     /* We rely on the current childProcess() functions semantic.
      * When the parent childProcess() function reaches the call of this function
      * only the FDs 0,1,2 and 3 are further used until the exec() or the exit(-1).
-     * So we can close all FDs beginning with 4. FD 3 is only used if the exec fails
-     * to report the reason to the JVM. It should not survive a passing exec().
-     * So we can set the close_on_exec flag for FD 3. FDs 0,1 and 2 should survive
-     * the exec(), so we do not change them. */
+     * So we can close all FDs beginning with 4 (with fcntl(x, F_CLOSEM, 0); AIX
+     * provides a special fcntl call to close all open FDs greater equal x in one call).
+     * FD 3 is only used if the exec fails to report the reason to the JVM.
+     * It should not survive a passing exec(). So we can set the close_on_exec
+     * flag for FD 3. FDs 0,1 and 2 should survive the exec(), we do not change them.
+     */
     if (fcntl(STDERR_FILENO + 2, F_CLOSEM, 0) == -1 ||
         (markCloseOnExec(STDERR_FILENO + 1) == -1 && errno != EBADF)) {
         return -1;

--- a/src/java.base/unix/native/libjava/childproc.c
+++ b/src/java.base/unix/native/libjava/childproc.c
@@ -95,8 +95,8 @@ markDescriptorsCloseOnExec(void)
      * alive until the exec call. Therefore we mark the fail pipe fd with close on exec
      * like the other OSes do, but then proceed to hard-close file descriptors beyond that.
      */
-    if (fcntl(STDERR_FILENO + 2, F_CLOSEM, 0) == -1 ||
-        (markCloseOnExec(STDERR_FILENO + 1) == -1 && errno != EBADF)) {
+    if (fcntl(FAIL_FILENO + 1, F_CLOSEM, 0) == -1 ||
+        (markCloseOnExec(FAIL_FILENO) == -1 && errno != EBADF)) {
         return -1;
     }
 #else


### PR DESCRIPTION
The new tests
java/lang/ProcessBuilder/FDLeakTest/FDLeakTest.java#fork
java/lang/ProcessBuilder/FDLeakTest/FDLeakTest.java#posix_spawn
fail on AIX.
The tests were added with [JDK-8210549](https://bugs.openjdk.org/browse/JDK-8210549) .

Error output is
java/lang/ProcessBuilder/FDLeakTest/FDLeakTest.java#fork

Opened and leaked ./testfile_FDLeaker.txt (4)
----------System.err:(13/647)----------
*** Parent leaked file descriptor 9 ***
*** Parent leaked file descriptor 10 ***
java.lang.RuntimeException: Failed
at FDLeakTest.main(FDLeakTest.java:69)
at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
at java.base/java.lang.reflect.Method.invoke(Method.java:565)
at com.sun.javatest.regtest.agent.MainWrapper$MainTask.run(MainWrapper.java:138)
at java.base/java.lang.Thread.run(Thread.java:1474)
 
 
java/lang/ProcessBuilder/FDLeakTest/FDLeakTest.java#posix_spawn


----------System.out:(1/46)----------
Opened and leaked ./testfile_FDLeaker.txt (4)
----------System.err:(13/647)----------
*** Parent leaked file descriptor 9 ***
*** Parent leaked file descriptor 10 ***
java.lang.RuntimeException: Failed
at FDLeakTest.main(FDLeakTest.java:69)
at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
at java.base/java.lang.reflect.Method.invoke(Method.java:565)
at com.sun.javatest.regtest.agent.MainWrapper$MainTask.run(MainWrapper.java:138)
at java.base/java.lang.Thread.run(Thread.java:1474)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8360401](https://bugs.openjdk.org/browse/JDK-8360401): [AIX] java/lang/ProcessBuilder/FDLeakTest/FDLeakTest.java fails since JDK-8210549 (**Bug** - P4)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27291/head:pull/27291` \
`$ git checkout pull/27291`

Update a local copy of the PR: \
`$ git checkout pull/27291` \
`$ git pull https://git.openjdk.org/jdk.git pull/27291/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27291`

View PR using the GUI difftool: \
`$ git pr show -t 27291`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27291.diff">https://git.openjdk.org/jdk/pull/27291.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27291#issuecomment-3291664151)
</details>
