### PR TITLE
8367112: HttpClient does not support Named Groups set on SSLParameters

### DIFF
--- a/src/java.net.http/share/classes/jdk/internal/net/http/common/Utils.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/common/Utils.java
@@ -610,6 +610,8 @@ public final class Utils {
         p1.setSNIMatchers(p.getSNIMatchers());
         p1.setServerNames(p.getServerNames());
         p1.setUseCipherSuitesOrder(p.getUseCipherSuitesOrder());
+        p1.setSignatureSchemes(p.getSignatureSchemes());
+        p1.setNamedGroups(p.getNamedGroups());
         return p1;
     }
 

--- a/test/jdk/java/net/httpclient/HttpClientBuilderTest.java
+++ b/test/jdk/java/net/httpclient/HttpClientBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -57,7 +57,7 @@ import static org.testng.Assert.*;
 
 /*
  * @test
- * @bug 8209137 8326233
+ * @bug 8209137 8326233 8367112
  * @summary HttpClient[.Builder] API and behaviour checks
  * @library /test/lib
  * @build jdk.test.lib.net.SimpleSSLContext
@@ -270,6 +270,20 @@ public class HttpClientBuilderTest {
         c.setProtocols(new String[] { "D" });
         try (var closer = closeable(builder)) {
             assertTrue(closer.build().sslParameters().getProtocols()[0].equals("C"));
+        }
+        SSLParameters d = new SSLParameters();
+        d.setSignatureSchemes(new String[] { "C" });
+        builder.sslParameters(d);
+        d.setSignatureSchemes(new String[] { "D" });
+        try (var closer = closeable(builder)) {
+            assertTrue(closer.build().sslParameters().getSignatureSchemes()[0].equals("C"));
+        }
+        SSLParameters e = new SSLParameters();
+        e.setNamedGroups(new String[] { "C" });
+        builder.sslParameters(e);
+        e.setNamedGroups(new String[] { "D" });
+        try (var closer = closeable(builder)) {
+            assertTrue(closer.build().sslParameters().getNamedGroups()[0].equals("C"));
         }
         // test defaults for needClientAuth and wantClientAuth
         builder.sslParameters(new SSLParameters());


### PR DESCRIPTION
HttpClient currently ignores the named groups and signature schemes configured on the SSLParameters. Given that it processes the configured protocols and cipher suites, I think it should process named groups and signature schemes as well.

Tier1-3 tests continue to pass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8367112](https://bugs.openjdk.org/browse/JDK-8367112): HttpClient does not support Named Groups set on SSLParameters (**Bug** - P4)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27292/head:pull/27292` \
`$ git checkout pull/27292`

Update a local copy of the PR: \
`$ git checkout pull/27292` \
`$ git pull https://git.openjdk.org/jdk.git pull/27292/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27292`

View PR using the GUI difftool: \
`$ git pr show -t 27292`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27292.diff">https://git.openjdk.org/jdk/pull/27292.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27292#issuecomment-3291855490)
</details>
