### PR TITLE
8333526: Restructure java/nio/channels/DatagramChannel/StressNativeSignal.java to a fail fast exception handling policy

### DIFF
--- a/test/jdk/java/nio/channels/DatagramChannel/StressNativeSignal.java
+++ b/test/jdk/java/nio/channels/DatagramChannel/StressNativeSignal.java
@@ -93,7 +93,7 @@ public class StressNativeSignal {
         private final CountDownLatch threadStarted = new CountDownLatch(1);
 
         public ServerSocketThread() throws IOException {
-            socket = new ServerSocket(1122);
+            socket = new ServerSocket(0);
         }
 
         public void run() {
@@ -139,7 +139,7 @@ public class StressNativeSignal {
         public UDPThread() throws IOException {
             channel = DatagramChannel.open();
             channel.setOption(StandardSocketOptions.SO_RCVBUF, 6553600);
-            channel.bind(new InetSocketAddress(19870));
+            channel.bind(new InetSocketAddress(0));
         }
 
         @Override
@@ -176,7 +176,7 @@ public class StressNativeSignal {
                 threadStarted.await();
             } catch (InterruptedException z) {
                 z.printStackTrace(System.err);
-                // ignore;
+                // ignore
             }
         }
     }


### PR DESCRIPTION
This task addresses the restructuring of the test to handle exception, especially during test setup, in a more immediate "fail fast" manner.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333526](https://bugs.openjdk.org/browse/JDK-8333526): Restructure java/nio/channels/DatagramChannel/StressNativeSignal.java to a fail fast exception handling policy (**Enhancement** - P4)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27294/head:pull/27294` \
`$ git checkout pull/27294`

Update a local copy of the PR: \
`$ git checkout pull/27294` \
`$ git pull https://git.openjdk.org/jdk.git pull/27294/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27294`

View PR using the GUI difftool: \
`$ git pr show -t 27294`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27294.diff">https://git.openjdk.org/jdk/pull/27294.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27294#issuecomment-3291980832)
</details>
