### PR TITLE
8367398

### DIFF
--- a/test/hotspot/jtreg/runtime/Thread/TooSmallStackSize.java
+++ b/test/hotspot/jtreg/runtime/Thread/TooSmallStackSize.java
@@ -28,6 +28,7 @@
  * VMThreadStackSize values should result in an error message that shows
  * the minimum stack size value for each thread type.
  * @library /test/lib
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  *          java.management
  * @run driver TooSmallStackSize


### PR DESCRIPTION
Hi all,

This change forces the `TooSmallStackSize.java` test to run on flagless VMs. Previously, this could get influenced by GC choice, whose flags were never propagated to the subprocess. 