### PR TITLE
8367703: Unneeded cast in java.text.DigitList.append

### DIFF
--- a/src/java.base/share/classes/java/text/DecimalFormat.java
+++ b/src/java.base/share/classes/java/text/DecimalFormat.java
@@ -2593,14 +2593,14 @@ public class DecimalFormat extends NumberFormat {
                     } else {
                         ++digitCount;
                         if (!sawDecimal || !isParseIntegerOnly()) {
-                            digits.append((char)(digit + '0'));
+                            digits.append((byte) (digit + '0'));
                         }
                     }
                 } else if (digit > 0 && digit <= 9) { // [sic] digit==0 handled above
                     sawDigit = true;
                     ++digitCount;
                     if (!sawDecimal || !isParseIntegerOnly()) {
-                        digits.append((char) (digit + '0'));
+                        digits.append((byte) (digit + '0'));
                     }
 
                     // Cancel out backup setting (see grouping handler below)

--- a/src/java.base/share/classes/java/text/DigitList.java
+++ b/src/java.base/share/classes/java/text/DigitList.java
@@ -155,13 +155,13 @@ final class DigitList implements Cloneable {
     /**
      * Appends a digit to the list, extending the list when necessary.
      */
-    public void append(char digit) {
+    public void append(byte digit) {
         if (count == digits.length) {
             byte[] data = new byte[ArraysSupport.newLength(count, 1, count)];
             System.arraycopy(digits, 0, data, 0, count);
             digits = data;
         }
-        digits[count++] = (byte) digit;
+        digits[count++] = digit;
     }
 
     /**


### PR DESCRIPTION
During parse routines, DecimalFormat uses DigitList to append digits from the parsed text.

Note that `digit` is always the int value 0 through 9 (and subsequently the code point 48 through 57) when passed to `append`.

Currently, `append` accepts a char which forces an int -> char -> byte conversion to be stored in `digits`. This can be simplified to int -> byte if the parameter type for the method is updated. The two call sites can safely make this swap.

Tiers 1-3 and java.text JCK tests continue to pass with this change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8367703](https://bugs.openjdk.org/browse/JDK-8367703): Unneeded cast in java.text.DigitList.append (**Bug** - P4)


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27300/head:pull/27300` \
`$ git checkout pull/27300`

Update a local copy of the PR: \
`$ git checkout pull/27300` \
`$ git pull https://git.openjdk.org/jdk.git pull/27300/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27300`

View PR using the GUI difftool: \
`$ git pr show -t 27300`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27300.diff">https://git.openjdk.org/jdk/pull/27300.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27300#issuecomment-3294010423)
</details>
