### PR TITLE
8364657: Crash for SecureRandom.generateSeed(0) on Windows x86-64

### DIFF
--- a/src/jdk.crypto.mscapi/windows/native/libsunmscapi/security.cpp
+++ b/src/jdk.crypto.mscapi/windows/native/libsunmscapi/security.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -366,7 +366,11 @@ JNIEXPORT jbyteArray JNICALL Java_sun_security_mscapi_PRNG_generateSeed
 
         } else {
 
-            if (length > 0) {
+            /*
+             * seed could be NULL here when SecureRandom.generateSeed() is
+             * called with a length of zero.
+             */
+            if ((length > 0) || (seed == NULL)) {
                 seed = env->NewByteArray(length);
                 if (seed == NULL) {
                     __leave;

--- a/test/jdk/java/security/SecureRandom/TestStrong.java
+++ b/test/jdk/java/security/SecureRandom/TestStrong.java
@@ -1,0 +1,21 @@
+import java.security.SecureRandom;
+import java.util.Arrays;
+
+/*
+ * @test
+ * @bug 8364657
+ * @summary verify the behaviour of SecureRandom instance returned by
+ *          SecureRandom.getInstanceStrong()
+ * @run main TestStrong
+ */
+public class TestStrong {
+
+    public static void main(String[] args) throws Exception {
+
+        final SecureRandom random = SecureRandom.getInstanceStrong();
+        System.out.println("going to generate random seed using " + random);
+        final byte[] seed = random.generateSeed(0);
+        System.out.println("random seed generated");
+        System.out.println("seed: " + Arrays.toString(seed));
+    }
+}

--- a/test/jdk/java/security/SecureRandom/TestStrong.java
+++ b/test/jdk/java/security/SecureRandom/TestStrong.java
@@ -1,10 +1,33 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
 import java.security.SecureRandom;
 import java.util.Arrays;
 
 /*
  * @test
  * @bug 8364657
- * @summary verify the behaviour of SecureRandom instance returned by
+ * @summary verify the behavior of SecureRandom instance returned by
  *          SecureRandom.getInstanceStrong()
  * @run main TestStrong
  */


### PR DESCRIPTION
The JVM will crash when given a zero byte seed length for SecureRandom.generateSeed() while using the Window's PRNG.  The solution is to first check to see if the seed is null or not and if null then generate a zero length byte array.  This may seem to be odd but this mimics the same behavior in other operating systems such as MacOS and Linux.

The new unit test case* provided with this PR replicates the issue before the fix and is confirmed not to replicate the issue after the proposed fix.

* The TestStrong.java unit test code is a contribution from @jaikiran, thank you!