### PR TITLE
8367724: Remove Trailing Return Types from undecided list

### DIFF
--- a/doc/hotspot-style.html
+++ b/doc/hotspot-style.html
@@ -1859,8 +1859,6 @@ difference.</p>
 <h3 id="additional-undecided-features">Additional Undecided
 Features</h3>
 <ul>
-<li><p>Trailing return type syntax for functions (<a
-href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2008/n2541.htm">n2541</a>)</p></li>
 <li><p>Member initializers and aggregates (<a
 href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2013/n3653.html">n3653</a>)</p></li>
 <li><p>Rvalue references and move semantics</p></li>

--- a/doc/hotspot-style.md
+++ b/doc/hotspot-style.md
@@ -1853,9 +1853,6 @@ See Object Lifetime: C++17 6.8/8, C++20 6.7.3/8
 
 ### Additional Undecided Features
 
-* Trailing return type syntax for functions
-([n2541](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2008/n2541.htm))
-
 * Member initializers and aggregates
 ([n3653](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2013/n3653.html))
 


### PR DESCRIPTION
Please review this trivial editorial change to the HotSpot Style Guide. This
change removes Trailing Return Types from the undecided list. This should have
been done as part of JDK-8366057, but was forgotten.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8367724](https://bugs.openjdk.org/browse/JDK-8367724): Remove Trailing Return Types from undecided list (**Enhancement** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Paul Hübner](https://openjdk.org/census#phubner) (@Arraying - Author)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27305/head:pull/27305` \
`$ git checkout pull/27305`

Update a local copy of the PR: \
`$ git checkout pull/27305` \
`$ git pull https://git.openjdk.org/jdk.git pull/27305/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27305`

View PR using the GUI difftool: \
`$ git pr show -t 27305`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27305.diff">https://git.openjdk.org/jdk/pull/27305.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27305#issuecomment-3295587838)
</details>
