### PR TITLE
8367613: Test compiler/runtime/TestDontCompileHugeMethods.java failed

### DIFF
--- a/test/hotspot/jtreg/compiler/runtime/TestDontCompileHugeMethods.java
+++ b/test/hotspot/jtreg/compiler/runtime/TestDontCompileHugeMethods.java
@@ -23,10 +23,9 @@
 
 /**
  * @test
- * @bug 8366118
+ * @bug 8366118 8367613
  * @summary Check that a huge method is not compiled under -XX:+DontCompileHugeMethods.
  * @library /test/lib
- * @requires (vm.compMode != "Xcomp")
  * @run main compiler.runtime.TestDontCompileHugeMethods
  */
 package compiler.runtime;
@@ -100,6 +99,10 @@ public class TestDontCompileHugeMethods {
 
     private static void runTest(Path workDir, List jvmArgs) throws Exception {
         ArrayList<String> command = new ArrayList<>();
+        // Disable inlining for shortMethod().
+        // Otherwise under "-Xcomp -XX:TieredStopAtLevel=1", shortMethod() is inlined into main(),
+        // and is not directly executed or compiled.
+        command.add("-XX:CompileCommand=dontinline,HugeSwitch::shortMethod");
         command.add("-XX:+PrintCompilation");
         command.add("-Xbatch");
         command.addAll(jvmArgs);

--- a/test/hotspot/jtreg/compiler/runtime/TestDontCompileHugeMethods.java
+++ b/test/hotspot/jtreg/compiler/runtime/TestDontCompileHugeMethods.java
@@ -26,6 +26,7 @@
  * @bug 8366118
  * @summary Check that a huge method is not compiled under -XX:+DontCompileHugeMethods.
  * @library /test/lib
+ * @requires (vm.compMode != "Xcomp")
  * @run main compiler.runtime.TestDontCompileHugeMethods
  */
 package compiler.runtime;


### PR DESCRIPTION
Hi,

Could anyone approve this change that exclude this test when running with `-Xcomp`? This avoids the test failure reported in [JDK-8367613](https://bugs.openjdk.org/browse/JDK-8367613).

For reasons I don't yet understand, the `HugeSwitch::shortMethod` method is not compiled under `-Xcomp  -XX:TieredStopAtLevel=1`. The method gets compiled with either `-Xcomp` or `-XX:TieredStopAtLevel=1`, but not both. I appreciate if anyone could provide insights on possible reasons.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8367613](https://bugs.openjdk.org/browse/JDK-8367613): Test compiler/runtime/TestDontCompileHugeMethods.java failed (**Bug** - P4)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Damon Fenacci](https://openjdk.org/census#dfenacci) (@dafedafe - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27306/head:pull/27306` \
`$ git checkout pull/27306`

Update a local copy of the PR: \
`$ git checkout pull/27306` \
`$ git pull https://git.openjdk.org/jdk.git pull/27306/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27306`

View PR using the GUI difftool: \
`$ git pr show -t 27306`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27306.diff">https://git.openjdk.org/jdk/pull/27306.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27306#issuecomment-3295996483)
</details>
