### PR TITLE
8367706: Remove redundant register used by cmove in C1 LIR generation

### DIFF
--- a/src/hotspot/share/c1/c1_LIRGenerator.cpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.cpp
@@ -2242,8 +2242,8 @@ void LIRGenerator::do_TableSwitch(TableSwitch* x) {
       int count_offset = md->byte_offset_of_slot(data, MultiBranchData::case_count_offset(i));
       __ cmp(lir_cond_equal, value, i + lo_key);
       __ cmove(lir_cond_equal,
-               data_offset_reg,
                LIR_OprFact::intptrConst(count_offset),
+               data_offset_reg,
                data_offset_reg, T_INT);
     }
 
@@ -2298,8 +2298,8 @@ void LIRGenerator::do_LookupSwitch(LookupSwitch* x) {
       int count_offset = md->byte_offset_of_slot(data, MultiBranchData::case_count_offset(i));
       __ cmp(lir_cond_equal, value, x->key_at(i));
       __ cmove(lir_cond_equal,
-               data_offset_reg,
                LIR_OprFact::intptrConst(count_offset),
+               data_offset_reg,
                data_offset_reg, T_INT);
     }
 


### PR DESCRIPTION
This PR removes redundant temp register used by cmove in C1 LIRGenerator::do_LookupSwitch and LIRGenerator::do_TableSwitch. The issue [8367706](https://bugs.openjdk.org/browse/JDK-8367706) is reported by me and it's my pleasure to fix it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8367706](https://bugs.openjdk.org/browse/JDK-8367706): Remove redundant register used by cmove in C1 LIR generation (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27307/head:pull/27307` \
`$ git checkout pull/27307`

Update a local copy of the PR: \
`$ git checkout pull/27307` \
`$ git pull https://git.openjdk.org/jdk.git pull/27307/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27307`

View PR using the GUI difftool: \
`$ git pr show -t 27307`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27307.diff">https://git.openjdk.org/jdk/pull/27307.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27307#issuecomment-3297173602)
</details>
