### PR TITLE
8367737: Parallel: Retry allocation after lock acquire in mem_allocate_work

### DIFF
--- a/src/hotspot/share/gc/parallel/parallelScavengeHeap.cpp
+++ b/src/hotspot/share/gc/parallel/parallelScavengeHeap.cpp
@@ -275,38 +275,46 @@ HeapWord* ParallelScavengeHeap::mem_allocate(size_t size) {
   return mem_allocate_work(size, is_tlab);
 }
 
+HeapWord* ParallelScavengeHeap::mem_allocate_cas_noexpand(size_t size, bool is_tlab) {
+  // Try young-gen first.
+  HeapWord* result = young_gen()->allocate(size);
+  if (result != nullptr) {
+    return result;
+  }
+
+  // Try allocating from the old gen for non-TLAB in certain scenarios.
+  if (!is_tlab) {
+    if (!should_alloc_in_eden(size) || _is_heap_almost_full) {
+      result = old_gen()->cas_allocate_noexpand(size);
+      if (result != nullptr) {
+        return result;
+      }
+    }
+  }
+
+  return nullptr;
+}
+
 HeapWord* ParallelScavengeHeap::mem_allocate_work(size_t size, bool is_tlab) {
   for (uint loop_count = 0; /* empty */; ++loop_count) {
-    // Try young-gen first.
-    HeapWord* result = young_gen()->allocate(size);
+    HeapWord* result = mem_allocate_cas_noexpand(size, is_tlab);
     if (result != nullptr) {
       return result;
     }
 
-    // Try allocating from the old gen for non-TLAB in certain scenarios.
-    if (!is_tlab) {
-      if (!should_alloc_in_eden(size) || _is_heap_almost_full) {
-        result = old_gen()->cas_allocate_noexpand(size);
-        if (result != nullptr) {
-          return result;
-        }
-      }
-    }
-
-    // We don't want to have multiple collections for a single filled generation.
-    // To prevent this, each thread tracks the total_collections() value, and if
-    // the count has changed, does not do a new collection.
-    //
-    // The collection count must be read only while holding the heap lock. VM
-    // operations also hold the heap lock during collections. There is a lock
-    // contention case where thread A blocks waiting on the Heap_lock, while
-    // thread B is holding it doing a collection. When thread A gets the lock,
-    // the collection count has already changed. To prevent duplicate collections,
-    // The policy MUST attempt allocations during the same period it reads the
-    // total_collections() value!
+    // Read total_collections() under the lock so that multiple
+    // allocation-failures result in one GC.
     uint gc_count;
     {
       MutexLocker ml(Heap_lock);
+
+      // Re-try after acquiring the lock, because a GC might have occurred
+      // while waiting for this lock.
+      result = mem_allocate_cas_noexpand(size, is_tlab);
+      if (result != nullptr) {
+        return result;
+      }
+
       gc_count = total_collections();
     }
 

--- a/src/hotspot/share/gc/parallel/parallelScavengeHeap.hpp
+++ b/src/hotspot/share/gc/parallel/parallelScavengeHeap.hpp
@@ -102,6 +102,7 @@ class ParallelScavengeHeap : public CollectedHeap {
 
   inline bool should_alloc_in_eden(size_t size) const;
 
+  HeapWord* mem_allocate_cas_noexpand(size_t size, bool is_tlab);
   HeapWord* mem_allocate_work(size_t size, bool is_tlab);
 
   HeapWord* expand_heap_and_allocate(size_t size, bool is_tlab);


### PR DESCRIPTION
Restoring the allocation retrying logic inside lock-region to avoid premature GCs. This logic was mistakenly removed in [JDK-8365557](https://bugs.openjdk.org/browse/JDK-8365557).

Test: tier1-3

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8367737](https://bugs.openjdk.org/browse/JDK-8367737): Parallel: Retry allocation after lock acquire in mem_allocate_work (**Enhancement** - P4)


### Reviewers
 * [Francesco Andreuzzi](https://openjdk.org/census#fandreuzzi) (@fandreuz - Author)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27308/head:pull/27308` \
`$ git checkout pull/27308`

Update a local copy of the PR: \
`$ git checkout pull/27308` \
`$ git pull https://git.openjdk.org/jdk.git pull/27308/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27308`

View PR using the GUI difftool: \
`$ git pr show -t 27308`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27308.diff">https://git.openjdk.org/jdk/pull/27308.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27308#issuecomment-3297211569)
</details>
