### PR TITLE
8367728: IGV: dump node address type

### DIFF
--- a/src/hotspot/share/opto/idealGraphPrinter.cpp
+++ b/src/hotspot/share/opto/idealGraphPrinter.cpp
@@ -448,6 +448,11 @@ void IdealGraphPrinter::visit_node(Node* n, bool edges) {
         }
       }
     }
+    if (n->adr_type() != nullptr) {
+      stringStream adr_type_stream;
+      n->adr_type()->dump_on(&adr_type_stream);
+      print_prop("adr_type", adr_type_stream.freeze());
+    }
 
     if (C->cfg() != nullptr) {
       Block* block = C->cfg()->get_block_for_node(node);


### PR DESCRIPTION
This changeset dumps the address type of each node (`Node::adr_type()`), when not null, into the IGV graphs. This should improve the visibility and diagnosability of C2 type inconsistencies, see e.g. [JDK-8367667](https://bugs.openjdk.org/browse/JDK-8367667).

#### Testing
- tier1 (windows-x64, linux-x64, linux-aarch64, macosx-x64, and macosx-aarch64; release and debug mode).
- Tested IGV manually on a few selected graphs. Tested automatically that dumping thousands of graphs does not trigger any assertion failure (by running `java -Xcomp -XX:PrintIdealGraphLevel=1`).