### PR TITLE
8367740: assembler_<cpu>.inline.hpp should not include assembler.inline.hpp

### DIFF
--- a/src/hotspot/cpu/aarch64/assembler_aarch64.inline.hpp
+++ b/src/hotspot/cpu/aarch64/assembler_aarch64.inline.hpp
@@ -26,7 +26,7 @@
 #ifndef CPU_AARCH64_ASSEMBLER_AARCH64_INLINE_HPP
 #define CPU_AARCH64_ASSEMBLER_AARCH64_INLINE_HPP
 
-#include "asm/assembler.inline.hpp"
+#include "asm/assembler.hpp"
 #include "asm/codeBuffer.hpp"
 #include "code/codeCache.hpp"
 

--- a/src/hotspot/cpu/ppc/assembler_ppc.inline.hpp
+++ b/src/hotspot/cpu/ppc/assembler_ppc.inline.hpp
@@ -26,7 +26,7 @@
 #ifndef CPU_PPC_ASSEMBLER_PPC_INLINE_HPP
 #define CPU_PPC_ASSEMBLER_PPC_INLINE_HPP
 
-#include "asm/assembler.inline.hpp"
+#include "asm/assembler.hpp"
 #include "asm/codeBuffer.hpp"
 #include "code/codeCache.hpp"
 #include "runtime/vm_version.hpp"

--- a/src/hotspot/cpu/riscv/assembler_riscv.inline.hpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv.inline.hpp
@@ -27,7 +27,7 @@
 #ifndef CPU_RISCV_ASSEMBLER_RISCV_INLINE_HPP
 #define CPU_RISCV_ASSEMBLER_RISCV_INLINE_HPP
 
-#include "asm/assembler.inline.hpp"
+#include "asm/assembler.hpp"
 #include "asm/codeBuffer.hpp"
 #include "code/codeCache.hpp"
 

--- a/src/hotspot/cpu/s390/assembler_s390.inline.hpp
+++ b/src/hotspot/cpu/s390/assembler_s390.inline.hpp
@@ -26,7 +26,7 @@
 #ifndef CPU_S390_ASSEMBLER_S390_INLINE_HPP
 #define CPU_S390_ASSEMBLER_S390_INLINE_HPP
 
-#include "asm/assembler.inline.hpp"
+#include "asm/assembler.hpp"
 #include "asm/codeBuffer.hpp"
 #include "code/codeCache.hpp"
 

--- a/src/hotspot/cpu/zero/assembler_zero.inline.hpp
+++ b/src/hotspot/cpu/zero/assembler_zero.inline.hpp
@@ -26,7 +26,7 @@
 #ifndef CPU_ZERO_ASSEMBLER_ZERO_INLINE_HPP
 #define CPU_ZERO_ASSEMBLER_ZERO_INLINE_HPP
 
-#include "asm/assembler.inline.hpp"
+#include "asm/assembler.hpp"
 #include "asm/codeBuffer.hpp"
 #include "code/codeCache.hpp"
 #include "runtime/handles.inline.hpp"


### PR DESCRIPTION
This is the content of assembler.inline.hpp:
https://github.com/openjdk/jdk/blob/ca89cd06d39ed3a6bbe16f60fea4d7382849edbd/src/hotspot/share/asm/assembler.inline.hpp#L28-L30

Most of the `assembler_<cpu>.inline.hpp` include it:
https://github.com/openjdk/jdk/blob/ca89cd06d39ed3a6bbe16f60fea4d7382849edbd/src/hotspot/cpu/zero/assembler_zero.inline.hpp#L29-L32

They should probably include `assembler.hpp` instead.

Testing: tier1 in GHA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8367740](https://bugs.openjdk.org/browse/JDK-8367740): assembler_&lt;cpu&gt;.inline.hpp should not include assembler.inline.hpp (**Enhancement** - P4)


### Reviewers
 * [Damon Fenacci](https://openjdk.org/census#dfenacci) (@dafedafe - Committer)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27311/head:pull/27311` \
`$ git checkout pull/27311`

Update a local copy of the PR: \
`$ git checkout pull/27311` \
`$ git pull https://git.openjdk.org/jdk.git pull/27311/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27311`

View PR using the GUI difftool: \
`$ git pr show -t 27311`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27311.diff">https://git.openjdk.org/jdk/pull/27311.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27311#issuecomment-3297496452)
</details>
