### PR TITLE
8367573: JNI exception pending in os_getCmdlineAndUserInfo of ProcessHandleImpl_aix.c

### DIFF
--- a/src/java.base/aix/native/libjava/ProcessHandleImpl_aix.c
+++ b/src/java.base/aix/native/libjava/ProcessHandleImpl_aix.c
@@ -224,6 +224,7 @@ void os_getCmdlineAndUserInfo(JNIEnv *env, jobject jinfo, pid_t pid) {
     }
 
     unix_getUserInfo(env, jinfo, psinfo.pr_uid);
+    JNU_CHECK_EXCEPTION(env);
 
     /*
      * Now read psinfo.pr_psargs which contains the first PRARGSZ characters of the


### PR DESCRIPTION
Similar to JDK-8367138 , we should add a JNI exception check to os_getCmdlineAndUserInfo on AIX .

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8367573](https://bugs.openjdk.org/browse/JDK-8367573): JNI exception pending in os_getCmdlineAndUserInfo of ProcessHandleImpl_aix.c (**Bug** - P3)


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27313/head:pull/27313` \
`$ git checkout pull/27313`

Update a local copy of the PR: \
`$ git checkout pull/27313` \
`$ git pull https://git.openjdk.org/jdk.git pull/27313/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27313`

View PR using the GUI difftool: \
`$ git pr show -t 27313`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27313.diff">https://git.openjdk.org/jdk/pull/27313.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27313#issuecomment-3298902803)
</details>
