### PR TITLE
8367782: VerifyJarEntryName.java: Fix modifyJarEntryName to operate on bytes and re-introduce verifySignatureEntryName

### DIFF
--- a/test/jdk/sun/security/tools/jarsigner/VerifyJarEntryName.java
+++ b/test/jdk/sun/security/tools/jarsigner/VerifyJarEntryName.java
@@ -38,12 +38,13 @@ import java.io.FileOutputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.jar.JarFile;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
 import jdk.test.lib.SecurityTools;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class VerifyJarEntryName {
 
@@ -85,13 +86,29 @@ public class VerifyJarEntryName {
      */
     @Test
     void verifyManifestEntryName() throws Exception {
-        modifyJarEntryName(ORIGINAL_JAR, MODIFIED_JAR, "MANIFEST.MF");
+        modifyJarEntryName(ORIGINAL_JAR, MODIFIED_JAR, "META-INF/MANIFEST.MF");
         SecurityTools.jarsigner("-verify -verbose " + MODIFIED_JAR)
                 .shouldContain("This JAR file contains internal " +
                         "inconsistencies that may result in different " +
                         "contents when reading via JarFile and JarInputStream:")
                 .shouldContain("- Manifest is missing when " +
                         "reading via JarInputStream")
+                .shouldHaveExitValue(0);
+    }
+
+    /*
+     * Modify a single byte in signature filename in LOC, and
+     * validate that jarsigner -verify emits a warning message.
+     */
+    @Test
+    void verifySignatureEntryName() throws Exception {
+        modifyJarEntryName(ORIGINAL_JAR, MODIFIED_JAR, "META-INF/MYKEY.SF");
+        SecurityTools.jarsigner("-verify -verbose " + MODIFIED_JAR)
+                .shouldContain("This JAR file contains internal " +
+                        "inconsistencies that may result in different " +
+                        "contents when reading via JarFile and JarInputStream:")
+                .shouldContain("- Entry XETA-INF/MYKEY.SF is present when reading " +
+                        "via JarInputStream but missing when reading via JarFile")
                 .shouldHaveExitValue(0);
     }
 
@@ -111,9 +128,14 @@ public class VerifyJarEntryName {
     private void modifyJarEntryName(Path origJar, Path modifiedJar,
             String entryName) throws Exception {
         byte[] jarBytes = Files.readAllBytes(origJar);
-        var jarString = new String(jarBytes, StandardCharsets.UTF_8);
-        var pos = jarString.indexOf(entryName);
-        assertTrue(pos != -1, entryName + " is not present in the JAR");
+        byte[] entryNameBytes = entryName.getBytes(StandardCharsets.UTF_8);
+        int pos = 0;
+        try {
+            while (!Arrays.equals(jarBytes, pos, pos + entryNameBytes.length,
+                    entryNameBytes, 0, entryNameBytes.length)) pos++;
+        } catch (ArrayIndexOutOfBoundsException ignore) {
+            fail(entryName + " is not present in the JAR");
+        }
         jarBytes[pos] = 'X';
         Files.write(modifiedJar, jarBytes);
     }


### PR DESCRIPTION
Hi, this is a second take of [JDK-8353299](https://bugs.openjdk.org/browse/JDK-8353299 "VerifyJarEntryName.java test fails") (#24337, acd4da49a01760599ec4c325ff6c56f53ba5cc9c), by making `modifyJarEntryName` operate on bytes and re-introduce `verifySignatureEntryName`.

Please see [this JDK-8353299 comment](https://bugs.openjdk.org/browse/JDK-8353299?focusedId=14817153&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-14817153) for further explanation.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8367782](https://bugs.openjdk.org/browse/JDK-8367782): VerifyJarEntryName.java: Fix modifyJarEntryName to operate on bytes and re-introduce verifySignatureEntryName (**Bug** - P4)


### Reviewers
 * [Hai-May Chao](https://openjdk.org/census#hchao) (@haimaychao - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27319/head:pull/27319` \
`$ git checkout pull/27319`

Update a local copy of the PR: \
`$ git checkout pull/27319` \
`$ git pull https://git.openjdk.org/jdk.git pull/27319/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27319`

View PR using the GUI difftool: \
`$ git pr show -t 27319`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27319.diff">https://git.openjdk.org/jdk/pull/27319.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27319#issuecomment-3299744121)
</details>
