### PR TITLE
8367780: Enable UseAPX on Intel CPUs only when both APX_F and APX_NCI_NDD_NF cpuid features are present

### DIFF
--- a/src/hotspot/cpu/x86/vm_version_x86.cpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.cpp
@@ -139,7 +139,7 @@ class VM_Version_StubGenerator: public StubCodeGenerator {
     const uint32_t CPU_FAMILY_486 = (4 << CPU_FAMILY_SHIFT);
     bool use_evex = FLAG_IS_DEFAULT(UseAVX) || (UseAVX > 2);
 
-    Label detect_486, cpu486, detect_586, std_cpuid1, std_cpuid4, std_cpuid24;
+    Label detect_486, cpu486, detect_586, std_cpuid1, std_cpuid4, std_cpuid24, std_cpuid29;
     Label sef_cpuid, sefsl1_cpuid, ext_cpuid, ext_cpuid1, ext_cpuid5, ext_cpuid7;
     Label ext_cpuid8, done, wrapup, vector_save_restore, apx_save_restore_warning;
     Label legacy_setup, save_restore_except, legacy_save_restore, start_simd_check;
@@ -337,6 +337,16 @@ class VM_Version_StubGenerator: public StubCodeGenerator {
     __ lea(rsi, Address(rbp, in_bytes(VM_Version::sefsl1_cpuid7_offset())));
     __ movl(Address(rsi, 0), rax);
     __ movl(Address(rsi, 4), rdx);
+
+    //
+    // cpuid(0x29) APX NCI NDD NF (EAX = 29H, ECX = 0).
+    //
+    __ bind(std_cpuid29);
+    __ movl(rax, 0x29);
+    __ movl(rcx, 0);
+    __ cpuid();
+    __ lea(rsi, Address(rbp, in_bytes(VM_Version::std_cpuid29_offset())));
+    __ movl(Address(rsi, 0), rbx);
 
     //
     // cpuid(0x24) Converged Vector ISA Main Leaf (EAX = 24H, ECX = 0).
@@ -1011,13 +1021,21 @@ void VM_Version::get_processor_features() {
     _features.clear_feature(CPU_AVX512_BITALG);
     _features.clear_feature(CPU_AVX512_IFMA);
     _features.clear_feature(CPU_APX_F);
+    _features.clear_feature(CPU_APX_NCI_NDD_NF);
     _features.clear_feature(CPU_AVX512_FP16);
     _features.clear_feature(CPU_AVX10_1);
     _features.clear_feature(CPU_AVX10_2);
   }
 
   // Currently APX support is only enabled for targets supporting AVX512VL feature.
-  bool apx_supported = os_supports_apx_egprs() && supports_apx_f() && supports_avx512vl();
+  bool apx_supported = os_supports_apx_egprs() && supports_apx_f() && supports_apx_nci_ndd_nf() && supports_avx512vl();
+  if (supports_apx_nci_ndd_nf()) {
+    warning("APX_NCI_NDD_NF feature is detected");
+  }
+  else {
+    warning("APX_NCI_NDD_NF feature is NOT detected");
+  }
+  
   if (UseAPX && !apx_supported) {
     warning("UseAPX is not supported on this CPU, setting it to false");
     FLAG_SET_DEFAULT(UseAPX, false);
@@ -1025,6 +1043,7 @@ void VM_Version::get_processor_features() {
 
   if (!UseAPX) {
     _features.clear_feature(CPU_APX_F);
+    _features.clear_feature(CPU_APX_NCI_NDD_NF);
   }
 
   if (UseAVX < 2) {
@@ -2912,8 +2931,10 @@ VM_Version::VM_Features VM_Version::CpuidInfo::feature_flags() const {
   if (std_cpuid1_ecx.bits.popcnt != 0)
     vm_features.set_feature(CPU_POPCNT);
   if (sefsl1_cpuid7_edx.bits.apx_f != 0 &&
-      xem_xcr0_eax.bits.apx_f != 0) {
+      xem_xcr0_eax.bits.apx_f != 0 &&
+      std_cpuid29_ebx.bits.apx_nci_ndd_nf !=0) {
     vm_features.set_feature(CPU_APX_F);
+    vm_features.set_feature(CPU_APX_NCI_NDD_NF);
   }
   if (std_cpuid1_ecx.bits.avx != 0 &&
       std_cpuid1_ecx.bits.osxsave != 0 &&

--- a/src/hotspot/cpu/x86/vm_version_x86.cpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.cpp
@@ -1029,13 +1029,6 @@ void VM_Version::get_processor_features() {
 
   // Currently APX support is only enabled for targets supporting AVX512VL feature.
   bool apx_supported = os_supports_apx_egprs() && supports_apx_f() && supports_apx_nci_ndd_nf() && supports_avx512vl();
-  if (supports_apx_nci_ndd_nf()) {
-    warning("APX_NCI_NDD_NF feature is detected");
-  }
-  else {
-    warning("APX_NCI_NDD_NF feature is NOT detected");
-  }
-  
   if (UseAPX && !apx_supported) {
     warning("UseAPX is not supported on this CPU, setting it to false");
     FLAG_SET_DEFAULT(UseAPX, false);
@@ -2932,7 +2925,7 @@ VM_Version::VM_Features VM_Version::CpuidInfo::feature_flags() const {
     vm_features.set_feature(CPU_POPCNT);
   if (sefsl1_cpuid7_edx.bits.apx_f != 0 &&
       xem_xcr0_eax.bits.apx_f != 0 &&
-      std_cpuid29_ebx.bits.apx_nci_ndd_nf !=0) {
+      std_cpuid29_ebx.bits.apx_nci_ndd_nf != 0) {
     vm_features.set_feature(CPU_APX_F);
     vm_features.set_feature(CPU_APX_NCI_NDD_NF);
   }

--- a/src/hotspot/cpu/x86/vm_version_x86.hpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.hpp
@@ -600,7 +600,7 @@ protected:
     StdCpuid24MainLeafEax std_cpuid24_eax;
     StdCpuid24MainLeafEbx std_cpuid24_ebx;
 
-    // cpuid function 0x29
+    // cpuid function 0x29 APX Advanced Performance Extensions Leaf
     // eax = 0x29, ecx = 0
     StdCpuidEax29Ecx0 std_cpuid29_ebx;
 
@@ -774,9 +774,9 @@ public:
     _features.set_feature(CPU_SSE2);
     _features.set_feature(CPU_VZEROUPPER);
   }
-  static void set_apx_cpuFeatures() { 
+  static void set_apx_cpuFeatures() {
     _features.set_feature(CPU_APX_F);
-    _features.set_feature(CPU_APX_NCI_NDD_NF); 
+    _features.set_feature(CPU_APX_NCI_NDD_NF);
   }
   static void set_bmi_cpuFeatures() {
     _features.set_feature(CPU_BMI1);

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/amd64/AMD64.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/amd64/AMD64.java
@@ -326,7 +326,7 @@ public class AMD64 extends Architecture {
 
     @Override
     public List<Register> getAvailableValueRegisters() {
-        if (features.contains(CPUFeature.APX_F)) { //TODO: what change?
+        if (features.contains(CPUFeature.APX_F)) {
             if (features.contains(CPUFeature.AVX512F)) {
                 return valueRegistersAVX512AndAPX;
             } else {

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/amd64/AMD64.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/amd64/AMD64.java
@@ -284,6 +284,7 @@ public class AMD64 extends Architecture {
         AVX512_IFMA,
         AVX_IFMA,
         APX_F,
+        APX_NCI_NDD_NF,
         SHA512,
         AVX512_FP16,
         AVX10_1,
@@ -325,7 +326,7 @@ public class AMD64 extends Architecture {
 
     @Override
     public List<Register> getAvailableValueRegisters() {
-        if (features.contains(CPUFeature.APX_F)) {
+        if (features.contains(CPUFeature.APX_F)) { //TODO: what change?
             if (features.contains(CPUFeature.AVX512F)) {
                 return valueRegistersAVX512AndAPX;
             } else {

--- a/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/BmiIntrinsicBase.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/BmiIntrinsicBase.java
@@ -111,7 +111,7 @@ public class BmiIntrinsicBase extends CompilerWhiteBoxTest {
     protected void checkEmittedCode(Executable executable) {
         final byte[] nativeCode = NMethod.get(executable, false).insts;
         final byte[] matchInstrPattern = (((BmiTestCase) testCase).getTestCaseX64() && Platform.isX64()) ? ((BmiTestCase_x64) testCase).getInstrPattern_x64() : ((BmiTestCase) testCase).getInstrPattern();
-        boolean use_apx = CPUInfo.hasFeature("apx_f");
+        boolean use_apx = CPUInfo.hasFeature("apx_f"); // TODO
         if (!((BmiTestCase) testCase).verifyPositive(nativeCode, use_apx)) {
             throw new AssertionError(testCase.name() + " " + "CPU instructions expected not found in nativeCode: " + Utils.toHexString(nativeCode) + " ---- Expected instrPattern: " +
             Utils.toHexString(matchInstrPattern));

--- a/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/BmiIntrinsicBase.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/BmiIntrinsicBase.java
@@ -111,7 +111,7 @@ public class BmiIntrinsicBase extends CompilerWhiteBoxTest {
     protected void checkEmittedCode(Executable executable) {
         final byte[] nativeCode = NMethod.get(executable, false).insts;
         final byte[] matchInstrPattern = (((BmiTestCase) testCase).getTestCaseX64() && Platform.isX64()) ? ((BmiTestCase_x64) testCase).getInstrPattern_x64() : ((BmiTestCase) testCase).getInstrPattern();
-        boolean use_apx = CPUInfo.hasFeature("apx_f"); // TODO
+        boolean use_apx = CPUInfo.hasFeature("apx_f");
         if (!((BmiTestCase) testCase).verifyPositive(nativeCode, use_apx)) {
             throw new AssertionError(testCase.name() + " " + "CPU instructions expected not found in nativeCode: " + Utils.toHexString(nativeCode) + " ---- Expected instrPattern: " +
             Utils.toHexString(matchInstrPattern));

--- a/test/lib-test/jdk/test/whitebox/CPUInfoTest.java
+++ b/test/lib-test/jdk/test/whitebox/CPUInfoTest.java
@@ -66,7 +66,7 @@ public class CPUInfoTest {
                     "hv",           "fsrm",             "avx512_bitalg",     "gfni",
                     "f16c",         "pku",              "ospke",             "cet_ibt",
                     "cet_ss",       "avx512_ifma",      "serialize",         "avx_ifma",
-                    "apx_f",        "avx10_1",          "avx10_2",           "avx512_fp16",
+                    "apx_f",        "apx_nci_ndd_nf",   "avx10_1",           "avx10_2",           "avx512_fp16",
                     "sha512",       "hybrid"
                     );
             // @formatter:on


### PR DESCRIPTION
The goal of this PR is to enable APX on Intel CPUs (i.e. enable UseAPX) only when both the APX_F and APX_NCI_NDD_NF cpuid feature flags are present.

As per the latest update to the Intel APX specification (https://www.intel.com/content/www/us/en/content-details/861610/intel-advanced-performance-extensions-intel-apx-architecture-specification.html ), when APX_F is set, processors also provide CPUID leaf 0x29 (APX Advanced Performance Extensions Leaf). Any Intel processor that enumerates APX_F also enumerates APX_NCI_NDD_NF.

This PR enhances the HotSpot x86 CPU feature detection to recognize the APX_NCI_NDD_NF sub-feature of Intel APX and update the enabling logic for UseAPX VM flag.