### PR TITLE
8367772: Refactor createUI in PassFailJFrame

### DIFF
--- a/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
+++ b/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
@@ -486,11 +486,11 @@ public final class PassFailJFrame {
                           long testTimeOut,
                           int rows, int columns)
             throws InterruptedException, InvocationTargetException {
-        invokeOnEDT(() -> createUI(builder().title(title)
-                                            .instructions(instructions)
-                                            .testTimeOut(testTimeOut)
-                                            .rows(rows)
-                                            .columns(columns)));
+        this(builder().title(title)
+                      .instructions(instructions)
+                      .testTimeOut(testTimeOut)
+                      .rows(rows)
+                      .columns(columns));
     }
 
     /**
@@ -505,6 +505,7 @@ public final class PassFailJFrame {
      */
     private PassFailJFrame(final Builder builder)
             throws InterruptedException, InvocationTargetException {
+        builder.validate();
         invokeOnEDT(() -> createUI(builder));
 
         if (!builder.splitUI && builder.panelCreator != null) {
@@ -1818,7 +1819,6 @@ public final class PassFailJFrame {
         public PassFailJFrame build() throws InterruptedException,
                 InvocationTargetException {
             try {
-                validate();
                 return new PassFailJFrame(this);
             } catch (final Throwable t) {
                 // Dispose of all the windows, including those that may not


### PR DESCRIPTION
Code review https://git.openjdk.org/jdk/pull/27197 for [JDK-8367348](https://bugs.openjdk.org/browse/JDK-8367348) made me think how to avoid adding more parameters to methods, in particular `createInstructionUIPanel`. The `Builder` object captures all the required configuration data, it is the `Builder` object that should be used to pass the configuration.

This changeset refactors UI creation in `PassFailJFrame`.

* The remaining constructor that accepts positional parameters now creates a builder to pass the configuration data.
* The `createInstructionUIPanel` method now accepts `Builder` instead of a set of parameters from it.
* The `createUI` method with positional parameters has become redundant and is removed. Code duplication between two versions of `createUI` is now eliminated.

There are no functional differences. I verified it by launching a few tests which use `PassFailJFrame` constructors and builder.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8367772](https://bugs.openjdk.org/browse/JDK-8367772): Refactor createUI in PassFailJFrame (**Bug** - P4)


### Reviewers
 * [Damon Nguyen](https://openjdk.org/census#dnguyen) (@DamonGuy - Committer)
 * [Harshitha Onkar](https://openjdk.org/census#honkar) (@honkar-jdk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27321/head:pull/27321` \
`$ git checkout pull/27321`

Update a local copy of the PR: \
`$ git checkout pull/27321` \
`$ git pull https://git.openjdk.org/jdk.git pull/27321/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27321`

View PR using the GUI difftool: \
`$ git pr show -t 27321`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27321.diff">https://git.openjdk.org/jdk/pull/27321.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27321#issuecomment-3300077668)
</details>
