### PR TITLE
8367787: Expand use of representation equivalence terminology in Float16

### DIFF
--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float16.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float16.java
@@ -890,7 +890,9 @@ public final class Float16
      * is {@code true} if and only if the argument is not
      * {@code null} and is a {@code Float16} object that
      * represents a {@code Float16} that has the same value as the
-     * {@code double} represented by this object.
+     * {@code Float16} represented by this object.
+     * {@linkplain Double##repEquivalence Representation
+     * equivalence} is used to compare the {@code Float16} values.
      *
      * @jls 15.21.1 Numerical Equality Operators == and !=
      */
@@ -987,6 +989,13 @@ public final class Float16
 
     /**
      * Compares the two specified {@code Float16} values.
+     *
+     * @apiNote
+     * One idiom to implement {@linkplain Double##repEquivalence
+     * representation equivalence} on {@code Float16} values is
+     * {@snippet lang="java" :
+     * Float16.compare(a, b) == 0
+     * }
      *
      * @param   f1        the first {@code Float16} to compare
      * @param   f2        the second {@code Float16} to compare


### PR DESCRIPTION
Analogous to recent updates made in Float and Double, along with a double -> Float16 typo fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8367787](https://bugs.openjdk.org/browse/JDK-8367787): Expand use of representation equivalence terminology in Float16 (**Enhancement** - P4)


### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27322/head:pull/27322` \
`$ git checkout pull/27322`

Update a local copy of the PR: \
`$ git checkout pull/27322` \
`$ git pull https://git.openjdk.org/jdk.git pull/27322/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27322`

View PR using the GUI difftool: \
`$ git pr show -t 27322`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27322.diff">https://git.openjdk.org/jdk/pull/27322.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27322#issuecomment-3300293443)
</details>
