### PR TITLE
8367789: AArch64 missing acquire in JNI_FastGetField::generate_fast_get_int_field0

### DIFF
--- a/src/hotspot/cpu/aarch64/jniFastGetField_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/jniFastGetField_aarch64.cpp
@@ -121,7 +121,8 @@ address JNI_FastGetField::generate_fast_get_int_field0(BasicType type) {
   __ adrp(rcounter_addr,
           SafepointSynchronize::safepoint_counter_addr(), offset);
   Address safepoint_counter_addr(rcounter_addr, offset);
-  __ ldrw(rcounter, safepoint_counter_addr);
+  __ lea(rcounter, safepoint_counter_addr);
+  __ ldarw(rcounter, rcounter);
   __ tbnz(rcounter, 0, slow);
 
   // It doesn't need to issue a full barrier here even if the field
@@ -171,7 +172,8 @@ address JNI_FastGetField::generate_fast_get_int_field0(BasicType type) {
     default:        ShouldNotReachHere();
   }
 
-  __ ldrw(rscratch1, safepoint_counter_addr);
+  __ lea(rscratch1, safepoint_counter_addr);
+  __ ldarw(rscratch1, rscratch1);
   __ cmpw(rcounter, rscratch1);
   __ br (Assembler::NE, slow);
 


### PR DESCRIPTION
Use a load-acquire to match the store-release used by C++ to update `safepoint_counter` during arming.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8367789](https://bugs.openjdk.org/browse/JDK-8367789): AArch64 missing acquire in JNI_FastGetField::generate_fast_get_int_field0 (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27325/head:pull/27325` \
`$ git checkout pull/27325`

Update a local copy of the PR: \
`$ git checkout pull/27325` \
`$ git pull https://git.openjdk.org/jdk.git pull/27325/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27325`

View PR using the GUI difftool: \
`$ git pr show -t 27325`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27325.diff">https://git.openjdk.org/jdk/pull/27325.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27325#issuecomment-3300438347)
</details>
