### PR TITLE
8367614: Test vmTestbase/nsk/jdi/stress/serial/heapwalking001/TestDescription.java failed, passed and timed-out

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/referringObjects/referringObjects001/referringObjects001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/referringObjects/referringObjects001/referringObjects001.java
@@ -244,6 +244,7 @@ public class referringObjects001 extends HeapwalkingDebugger {
                 }
             }
         } catch (Throwable t) {
+            setSuccess(false);
             log.complain("Unexpected exception:");
             t.printStackTrace(log.getOutStream());
         }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/referringObjects/referringObjects003/referringObjects003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/referringObjects/referringObjects003/referringObjects003.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,12 +45,11 @@
  *         - Debugee VM
  *             - stop all threads and remove all references to threads and thread group
  *       - Debugger VM
- *         - check that thread group have only 1 referrer: parent thread group
+ *         - force GC
+ *         - check that the test thread group has been collected. The reference from the
+ *           parent thread group is weak and should not prevent the test thread group from
+ *           being collected.
  *         - check that threre are no references to test threads in target VM
- *       - Debugger VM
- *         - test ObjectReference.disableCollection, ObjectReference.enableCollection for ThreadGroupReference:
- *         can't force collection of thread group because of thread group always has 1 referrer - parent thread group, so
- *         just test disableCollection/enableCollection don't throw any unexpected exceptions
  *
  * @requires !vm.graal.enabled
  * @library /vmTestbase
@@ -107,9 +106,8 @@ public class referringObjects003 extends HeapwalkingDebugger {
 
             if (referrerCount != expectedCount) {
                 setSuccess(false);
-                log
-                        .complain("List with wrong size was returned by ObjectReference.referringObjects(ThreadGroupReference): "
-                                + referrerCount + ", expected: " + expectedCount);
+                log.complain("List with wrong size was returned by ObjectReference.referringObjects(ThreadGroupReference): "
+                             + referrerCount + ", expected: " + expectedCount);
             }
         }
     }
@@ -181,57 +179,36 @@ public class referringObjects003 extends HeapwalkingDebugger {
         if (!isDebuggeeReady())
             return;
 
-        checkDebugeeAnswer_instances("java.lang.ThreadGroup", threadGroupsToFilter.size() + 1);
+        // Force the test ThreadGroup to be collected. The only reference to it is a weak
+        // reference from the parent ThreadGroup.
+        forceGC();
+
+        checkDebugeeAnswer_instances("java.lang.ThreadGroup", threadGroupsToFilter.size());
         checkDebugeeAnswer_instances("java.lang.Thread", threadsToFilter.size());
 
         threadGroups = HeapwalkingDebugger.filterObjectReferrence(threadGroupsToFilter, HeapwalkingDebugger
                 .getObjectReferences("java.lang.ThreadGroup", vm));
 
-        // 1 referrer(parent thread group) is left
-        checkThreadGroupReferrersCount(threadGroups, 1);
+        if (threadGroups.size() != 0) {
+            setSuccess(false);
+            log.complain("All test threads groups should be removed");
+            log.complain("Unexpected threads groups:");
+            for (ObjectReference objectReference : threadGroups) {
+                log.complain(objectReference.toString());
+            }
+        }
 
         threads = HeapwalkingDebugger.filterObjectReferrence(threadsToFilter, HeapwalkingDebugger.getObjectReferences(
                 "java.lang.Thread",
                 vm));
 
         if (threads.size() != 0) {
+            setSuccess(false);
             log.complain("All test threads should be removed");
             log.complain("Unexpected threads:");
             for (ObjectReference objectReference : threads) {
                 log.complain(objectReference.toString());
             }
-        }
-
-        checkThreadGroupDisableCollection(threadGroups);
-    }
-
-    // can't force collection of thread group because of 1 reference is always
-    // left in parent tread group
-    public void checkThreadGroupDisableCollection(List<ObjectReference> objectReferences) {
-        try {
-            for (ObjectReference objectReference : objectReferences)
-                objectReference.disableCollection();
-        } catch (Throwable t) {
-            log.complain("Unexpected exception: " + t);
-            t.printStackTrace(log.getOutStream());
-        }
-
-        forceGC();
-        try {
-            for (ObjectReference objectReference : objectReferences)
-                objectReference.enableCollection();
-        } catch (Throwable t) {
-            log.complain("Unexpected exception: " + t);
-            t.printStackTrace(log.getOutStream());
-        }
-
-        forceGC();
-        try {
-            for (ObjectReference objectReference : objectReferences)
-                objectReference.referringObjects(0);
-        } catch (Throwable t) {
-            log.complain("Unexpected exception: " + t);
-            t.printStackTrace(log.getOutStream());
         }
     }
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/referringObjects/referringObjects003/referringObjects003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/referringObjects/referringObjects003/referringObjects003.java
@@ -49,7 +49,7 @@
  *         - check that the test thread group has been collected. The reference from the
  *           parent thread group is weak and should not prevent the test thread group from
  *           being collected.
- *         - check that threre are no references to test threads in target VM
+ *         - check that there are no references to test threads in target VM
  *
  * @requires !vm.graal.enabled
  * @library /vmTestbase


### PR DESCRIPTION
This test has been silently throwing ObjectCollectedException probably but still passing. I believe it has always done this. The exception went unnoticed because it is caught and then setSuccess(false) is never called. It was finally noticed when this test failed due to a timeout (which seems to be a separate issue), and the ObjectCollectedException was noted in the log.

This PR fixes the setSuccess(false) call in a few places, including in one other test that didn't seem to be otherwise be failing.

The cause of the ObjectCollectedException is a test bug. The test is testing the following:

    // can't force collection of thread group because of 1 reference is always
    // left in parent tread group

So it forces a GC and expects the ObjectReference it has for a ThreadGroup to still be alive. However, the above comment is incorrect. The ThreadGroup spec says:

"A thread group is weakly reachable from its parent group so that it is eligible for garbage collection when there are no live threads in the group and the thread group is otherwise unreachable. "

So this ThreadGroup is being collected, resulting in the ObjectCollectedException in the following code:

            for (ObjectReference objectReference : objectReferences)
                objectReference.referringObjects(0);

This part of the test is invalid and has been removed. I also slightly updated the rest of the test by forcing a gc earlier so we can verify that the ThreadGroup is collected.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8367614](https://bugs.openjdk.org/browse/JDK-8367614): Test vmTestbase/nsk/jdi/stress/serial/heapwalking001/TestDescription.java failed, passed and timed-out (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27327/head:pull/27327` \
`$ git checkout pull/27327`

Update a local copy of the PR: \
`$ git checkout pull/27327` \
`$ git pull https://git.openjdk.org/jdk.git pull/27327/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27327`

View PR using the GUI difftool: \
`$ git pr show -t 27327`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27327.diff">https://git.openjdk.org/jdk/pull/27327.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27327#issuecomment-3301091905)
</details>
