### PR TITLE
8367801: jtreg failure_handler - don't use the -L option for ps command

### DIFF
--- a/test/failure_handler/src/share/conf/linux.properties
+++ b/test/failure_handler/src/share/conf/linux.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -108,7 +108,7 @@ system.sysctl.args=-a
 process.top.app=top
 process.top.args=-b -n 1
 process.ps.app=ps
-process.ps.args=-Leo pid,pcpu,cputime,start,pmem,vsz,rssize,stackp,stat,sgi_p,wchan,user,args
+process.ps.args=-eo pid,pcpu,cputime,start,pmem,vsz,rssize,stackp,stat,sgi_p,wchan,user,args
 
 memory.free.app=free
 memory.free.args=-h


### PR DESCRIPTION
Can I please get a review of this trivial change to a jtreg failure handler command?

As noted in https://bugs.openjdk.org/browse/JDK-8367801, the change in this PR removes the use of "-L" option from the "ps" command to reduce the noise in the output of "ps". I have verified that the command continues to function properly when run as a failure handler action and it no longer contains the thread entries in the output.