### PR TITLE
8327236: JFileChooser/8194044/FileSystemRootTest.java fails on Windows 11: root drive reported as false

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -685,7 +685,6 @@ javax/swing/JTree/DnD/LastNodeLowerHalfDrop.java 8159131 linux-all
 javax/swing/JTree/4633594/JTreeFocusTest.java 7105441 macosx-all
 javax/swing/AbstractButton/6711682/bug6711682.java 8060765 windows-all,macosx-all
 javax/swing/JFileChooser/6396844/TwentyThousandTest.java 8198003 generic-all
-javax/swing/JFileChooser/8194044/FileSystemRootTest.java 8327236 windows-all
 javax/swing/JPopupMenu/6800513/bug6800513.java 7184956 macosx-all
 javax/swing/JTabbedPane/4624207/bug4624207.java 8064922 macosx-all
 javax/swing/SwingUtilities/TestBadBreak/TestBadBreak.java 8160720 generic-all

--- a/test/jdk/javax/swing/JFileChooser/8194044/FileSystemRootTest.java
+++ b/test/jdk/javax/swing/JFileChooser/8194044/FileSystemRootTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,6 +36,10 @@ import java.io.File;
 
 public class FileSystemRootTest {
     public static void main(String[] args) throws Exception {
+        if (System.getProperty("os.name").equalsIgnoreCase("Windows 11")) {
+            System.out.println("Test not applicable for Win 11");
+            return;
+        }
         FileSystemView fileSystemView = FileSystemView.getFileSystemView();
 
         /*


### PR DESCRIPTION
The logic no longer applies to window 11 since getParentDirectory("C:\\...\\Documents") return "C:\\..\\Desktop". This will require thorough analysis and might call for a product fix. Hence bypassing this test for Windows 11 OS.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8327236](https://bugs.openjdk.org/browse/JDK-8327236): JFileChooser/8194044/FileSystemRootTest.java fails on Windows 11: root drive reported as false (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27329/head:pull/27329` \
`$ git checkout pull/27329`

Update a local copy of the PR: \
`$ git checkout pull/27329` \
`$ git pull https://git.openjdk.org/jdk.git pull/27329/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27329`

View PR using the GUI difftool: \
`$ git pr show -t 27329`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27329.diff">https://git.openjdk.org/jdk/pull/27329.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27329#issuecomment-3301398026)
</details>
