### PR TITLE
8367721: Test compiler/arguments/TestCompileTaskTimeout.java crashed: SIGSEGV

### DIFF
--- a/src/hotspot/share/compiler/compileBroker.cpp
+++ b/src/hotspot/share/compiler/compileBroker.cpp
@@ -224,12 +224,15 @@ CompileTaskWrapper::CompileTaskWrapper(CompileTask* task) {
 
 CompileTaskWrapper::~CompileTaskWrapper() {
   CompilerThread* thread = CompilerThread::current();
+
+  // First, disarm the timeout. This still relies on the underlying task.
+  thread->timeout()->disarm();
+
   CompileTask* task = thread->task();
   CompileLog*  log  = thread->log();
   if (log != nullptr && !task->is_unloaded())  task->log_task_done(log);
   thread->set_task(nullptr);
   thread->set_env(nullptr);
-  thread->timeout()->disarm();
   if (task->is_blocking()) {
     bool free_task = false;
     {


### PR DESCRIPTION
The test `TestCompileTaskTimeout.java` runs `java -Xcomp -XX:CompileTaskTimeout=1 --version` to demonstrate that the timeout works. Part of the timeout working involves it printing the method of the compile task. Inspecting the core file of the execution that failed with a `SIGSEGV` in the compile task timeout signal handler, the backtrace looks as follows:
```
#n   <called signal handler>
#n+1 CompilerThreadTimeoutLinux::signal_handler()
#n+2 <called signal handler>
#n+3 timer_settime()
#n+4 CompilerThreadTimeoutLinux::disarm()
#n+5 CompileTaskWrapper::~CompileTaskWrapper()
```
So, the compile task hit the timeout during destruction of the underlying `CompileTaskWrapper`. Since the timeout was disarmed only after setting the task to null in the destructor, the signal handler segfaulted when trying to access the method of the compile task to print it out. This PR addresses this issue by moving up the disarmament of the timeout to the top of the destructor.

Because this issue can only be triggered with bad --- or good, depending on your view --- luck on timing, I could not devise a regression test. But this is not too big of an issue, since the CI already caught this issue.

Testing:
 - [ ] Github Actions
 - [ ] tier1,tier2,tier3 plus stress testing on Oracle supported platforms