### PR TITLE
8367784: java/awt/Focus/InitialFocusTest/InitialFocusTest1.java failed with Wrong focus owner

### DIFF
--- a/test/jdk/java/awt/Focus/InitialFocusTest/InitialFocusTest1.java
+++ b/test/jdk/java/awt/Focus/InitialFocusTest/InitialFocusTest1.java
@@ -22,6 +22,7 @@
  */
 
 import java.awt.Button;
+import java.awt.EventQueue;
 import java.awt.FlowLayout;
 import java.awt.Frame;
 import java.awt.event.FocusEvent;
@@ -39,27 +40,36 @@ public class InitialFocusTest1 extends Frame implements FocusListener {
     Button button1 = new Button("Button1");
     Button button2 = new Button("Button2");
     private static volatile Object focused;
+    private static InitialFocusTest1 app;
 
     public static void main(final String[] args) throws Exception {
-        InitialFocusTest1 app = new InitialFocusTest1();
         try {
-            app.setSize(200, 200);
-            app.setLocationRelativeTo(null);
-            app.setLayout(new FlowLayout());
+            EventQueue.invokeAndWait(() -> {
+                app = new InitialFocusTest1();
+                app.setLayout(new FlowLayout());
 
-            app.button1.addFocusListener(app);
-            app.button2.addFocusListener(app);
-            app.add(app.button1);
-            app.add(app.button2);
-            app.setVisible(true);
-            app.button2.requestFocus();
+                app.button1.addFocusListener(app);
+                app.button2.addFocusListener(app);
+                app.add(app.button1);
+                app.add(app.button2);
+
+                app.setSize(200, 200);
+                app.setLocationRelativeTo(null);
+                app.setVisible(true);
+            });
+            Thread.sleep(1000);
+            EventQueue.invokeAndWait(() -> {
+                app.button2.requestFocus();
+            });
             // wait for the very very last focus event
-            Thread.sleep(10000);
+            Thread.sleep(1000);
             if (app.button2 != focused) {
                 throw new RuntimeException("Wrong focus owner: " + focused);
             }
         } finally {
-            app.dispose();
+            EventQueue.invokeAndWait(() -> {
+                app.dispose();
+            });
         }
     }
 

--- a/test/jdk/java/awt/Focus/InitialFocusTest/InitialFocusTest1.java
+++ b/test/jdk/java/awt/Focus/InitialFocusTest/InitialFocusTest1.java
@@ -70,9 +70,7 @@ public class InitialFocusTest1 extends Frame implements FocusListener {
                 throw new RuntimeException("Wrong focus owner: " + focused);
             }
         } finally {
-            EventQueue.invokeAndWait(() -> {
-                app.dispose();
-            });
+            EventQueue.invokeAndWait(() -> app.dispose());
         }
     }
 

--- a/test/jdk/java/awt/Focus/InitialFocusTest/InitialFocusTest1.java
+++ b/test/jdk/java/awt/Focus/InitialFocusTest/InitialFocusTest1.java
@@ -25,6 +25,7 @@ import java.awt.Button;
 import java.awt.EventQueue;
 import java.awt.FlowLayout;
 import java.awt.Frame;
+import java.awt.Robot;
 import java.awt.event.FocusEvent;
 import java.awt.event.FocusListener;
 
@@ -44,6 +45,7 @@ public class InitialFocusTest1 extends Frame implements FocusListener {
 
     public static void main(final String[] args) throws Exception {
         try {
+            Robot robot = new Robot();
             EventQueue.invokeAndWait(() -> {
                 app = new InitialFocusTest1();
                 app.setLayout(new FlowLayout());
@@ -57,12 +59,13 @@ public class InitialFocusTest1 extends Frame implements FocusListener {
                 app.setLocationRelativeTo(null);
                 app.setVisible(true);
             });
-            Thread.sleep(1000);
+            robot.waitForIdle();
+            robot.delay(1000);
             EventQueue.invokeAndWait(() -> {
                 app.button2.requestFocus();
             });
             // wait for the very very last focus event
-            Thread.sleep(1000);
+            robot.delay(1000);
             if (app.button2 != focused) {
                 throw new RuntimeException("Wrong focus owner: " + focused);
             }


### PR DESCRIPTION
Test was deproblemlisted in https://github.com/openjdk/jdk/pull/27136 without any modifications as it was passing in testing.
Since it again failed, added the execution in EDT to be more thread-safe.

Fix is tested against several CI jobs each with several iterations link of which is in JBS

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8367784](https://bugs.openjdk.org/browse/JDK-8367784): java/awt/Focus/InitialFocusTest/InitialFocusTest1.java failed with Wrong focus owner (**Bug** - P4)


### Reviewers
 * [Damon Nguyen](https://openjdk.org/census#dnguyen) (@DamonGuy - Committer) Review applies to [3f1d13ed](https://git.openjdk.org/jdk/pull/27332/files/3f1d13edde982fd2d6d6aef94b99e40899ec7404)
 * [Harshitha Onkar](https://openjdk.org/census#honkar) (@honkar-jdk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27332/head:pull/27332` \
`$ git checkout pull/27332`

Update a local copy of the PR: \
`$ git checkout pull/27332` \
`$ git pull https://git.openjdk.org/jdk.git pull/27332/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27332`

View PR using the GUI difftool: \
`$ git pr show -t 27332`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27332.diff">https://git.openjdk.org/jdk/pull/27332.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27332#issuecomment-3301633067)
</details>
