### PR TITLE
8366582: Test jdk/jshell/ToolSimpleTest.java failed: provider not found

### DIFF
--- a/src/jdk.jshell/share/classes/jdk/jshell/SourceCodeAnalysisImpl.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/SourceCodeAnalysisImpl.java
@@ -154,7 +154,6 @@ import static jdk.jshell.TreeDissector.printType;
 import static java.util.stream.Collectors.joining;
 
 import javax.lang.model.type.IntersectionType;
-import jdk.internal.jshell.debug.InternalDebugControl;
 
 /**
  * The concrete implementation of SourceCodeAnalysis.

--- a/src/jdk.jshell/share/classes/jdk/jshell/SourceCodeAnalysisImpl.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/SourceCodeAnalysisImpl.java
@@ -154,6 +154,7 @@ import static jdk.jshell.TreeDissector.printType;
 import static java.util.stream.Collectors.joining;
 
 import javax.lang.model.type.IntersectionType;
+import jdk.internal.jshell.debug.InternalDebugControl;
 
 /**
  * The concrete implementation of SourceCodeAnalysis.
@@ -2303,7 +2304,8 @@ class SourceCodeAnalysisImpl extends SourceCodeAnalysis {
     //if an index exists for the given entry, the existing index is kept unless the timestamp is modified
     private ClassIndex indexForPath(Path path) {
         if (!Files.isDirectory(path)) {
-            if (Files.exists(path)) {
+            if (Files.exists(path) &&
+                !isJRTMarkerFile(path)) { //don't directly index lib/modules
                 return PATH_TO_INDEX.compute(path, (p, index) -> {
                     try {
                         long lastModified = Files.getLastModifiedTime(p).toMillis();
@@ -2332,6 +2334,10 @@ class SourceCodeAnalysisImpl extends SourceCodeAnalysis {
                 return index;
             });
         }
+    }
+
+    private static boolean isJRTMarkerFile(Path path) {
+        return path.equals(Paths.get(System.getProperty("java.home"), "lib", "modules"));
     }
 
     //create an index based on the content of the given dirs; the original JavaFileManager entry is originalPath.

--- a/test/langtools/ProblemList.txt
+++ b/test/langtools/ProblemList.txt
@@ -52,8 +52,6 @@ jdk/jshell/UserJdiUserRemoteTest.java                                           
 jdk/jshell/UserInputTest.java                                                   8169536    generic-all
 jdk/jshell/ToolBasicTest.java                                                   8265357    macosx-aarch64
 jdk/jshell/HighlightUITest.java                                                 8284144    generic-all
-jdk/jshell/ToolSimpleTest.java                                                  8366582    generic-all
-jdk/jshell/ToolLocalSimpleTest.java                                             8366582    generic-all
 
 ###########################################################################
 #


### PR DESCRIPTION
The `jdk/jshell/ToolSimpleTest.java` randomly fails, the reason is this: when indexing the bootclasspath/`PLATFORM_CLASS_PATH`, `$JDK_HOME/lib/modules` is typically there, but it can't be opened as a FileSystem, and the exception is sent to the debugging facility. The debugging facility typically does nothing, but in this test contains a test case that enabled debugging, and if the order of things is that the debugging is first enabled, and then the `ProviderNotFoundException` is reported, the test fails.

The proposal herein is to not to try to open `$JDK_HOME/lib/modules` as a file system. Note the standard platform classes are indexed using `SYSTEM_MODULES`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8366582](https://bugs.openjdk.org/browse/JDK-8366582): Test jdk/jshell/ToolSimpleTest.java failed: provider not found (**Bug** - P4)


### Reviewers
 * [Adam Sotona](https://openjdk.org/census#asotona) (@asotona - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27333/head:pull/27333` \
`$ git checkout pull/27333`

Update a local copy of the PR: \
`$ git checkout pull/27333` \
`$ git pull https://git.openjdk.org/jdk.git pull/27333/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27333`

View PR using the GUI difftool: \
`$ git pr show -t 27333`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27333.diff">https://git.openjdk.org/jdk/pull/27333.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27333#issuecomment-3301905159)
</details>
