### PR TITLE
8367848: Parallel: Use NMethodToOopClosure during Young GC

### DIFF
--- a/src/hotspot/share/gc/parallel/psScavenge.cpp
+++ b/src/hotspot/share/gc/parallel/psScavenge.cpp
@@ -234,15 +234,7 @@ public:
 };
 
 class ScavengeRootsTask : public WorkerTask {
-  struct ThreadsClaimTokenScope : StackObj {
-    ThreadsClaimTokenScope() {
-      Threads::change_thread_claim_token();
-    }
-    ~ThreadsClaimTokenScope() {
-      Threads::assert_all_threads_claimed();
-    }
-  };
-  ThreadsClaimTokenScope _threads_claim_token_scope; // needed for Threads::possibly_parallel_threads_do
+  Threads::ThreadsClaimTokenScope _threads_claim_token_scope; // needed for Threads::possibly_parallel_threads_do
   OopStorageSetStrongParState<false /* concurrent */, false /* is_const */> _oop_storage_strong_par_state;
   SequentialSubTasksDone _subtasks;
   PSOldGen* _old_gen;

--- a/src/hotspot/share/gc/parallel/psScavenge.cpp
+++ b/src/hotspot/share/gc/parallel/psScavenge.cpp
@@ -99,7 +99,7 @@ static void scavenge_roots_work(ParallelRootType::Value root_type, uint worker_i
 
     case ParallelRootType::code_cache:
       {
-        MarkingNMethodClosure code_closure(&roots_to_old_closure, NMethodToOopClosure::FixRelocations, false /* keepalive nmethods */);
+        NMethodToOopClosure code_closure(&roots_to_old_closure, NMethodToOopClosure::FixRelocations);
         ScavengableNMethods::nmethods_do(&code_closure);
       }
       break;
@@ -234,7 +234,15 @@ public:
 };
 
 class ScavengeRootsTask : public WorkerTask {
-  StrongRootsScope _strong_roots_scope; // needed for Threads::possibly_parallel_threads_do
+  struct ThreadsClaimTokenScope : StackObj {
+    ThreadsClaimTokenScope() {
+      Threads::change_thread_claim_token();
+    }
+    ~ThreadsClaimTokenScope() {
+      Threads::assert_all_threads_claimed();
+    }
+  };
+  ThreadsClaimTokenScope _threads_claim_token_scope; // needed for Threads::possibly_parallel_threads_do
   OopStorageSetStrongParState<false /* concurrent */, false /* is_const */> _oop_storage_strong_par_state;
   SequentialSubTasksDone _subtasks;
   PSOldGen* _old_gen;
@@ -247,7 +255,7 @@ public:
   ScavengeRootsTask(PSOldGen* old_gen,
                     uint active_workers) :
     WorkerTask("ScavengeRootsTask"),
-    _strong_roots_scope(active_workers),
+    _threads_claim_token_scope(),
     _subtasks(ParallelRootType::sentinel),
     _old_gen(old_gen),
     _gen_top(old_gen->object_space()->top()),

--- a/src/hotspot/share/gc/parallel/psScavenge.cpp
+++ b/src/hotspot/share/gc/parallel/psScavenge.cpp
@@ -234,7 +234,7 @@ public:
 };
 
 class ScavengeRootsTask : public WorkerTask {
-  Threads::ThreadsClaimTokenScope _threads_claim_token_scope; // needed for Threads::possibly_parallel_threads_do
+  ThreadsClaimTokenScope _threads_claim_token_scope; // needed for Threads::possibly_parallel_threads_do
   OopStorageSetStrongParState<false /* concurrent */, false /* is_const */> _oop_storage_strong_par_state;
   SequentialSubTasksDone _subtasks;
   PSOldGen* _old_gen;

--- a/src/hotspot/share/runtime/threads.hpp
+++ b/src/hotspot/share/runtime/threads.hpp
@@ -102,15 +102,6 @@ public:
   static void change_thread_claim_token();
   static void assert_all_threads_claimed() NOT_DEBUG_RETURN;
 
-  struct ThreadsClaimTokenScope : StackObj {
-    ThreadsClaimTokenScope() {
-      Threads::change_thread_claim_token();
-    }
-    ~ThreadsClaimTokenScope() {
-      Threads::assert_all_threads_claimed();
-    }
-  };
-
   // Apply "f->do_oop" to all root oops in all threads.
   // This version may only be called by sequential code.
   static void oops_do(OopClosure* f, NMethodClosure* cf);
@@ -152,6 +143,16 @@ public:
   static int number_of_non_daemon_threads()      { return _number_of_non_daemon_threads; }
 
   struct Test;                  // For private gtest access.
+};
+
+// Used by GC for calling Threads::possibly_parallel_oops_do.
+struct ThreadsClaimTokenScope : StackObj {
+  ThreadsClaimTokenScope() {
+    Threads::change_thread_claim_token();
+  }
+  ~ThreadsClaimTokenScope() {
+    Threads::assert_all_threads_claimed();
+  }
 };
 
 #endif // SHARE_RUNTIME_THREADS_HPP

--- a/src/hotspot/share/runtime/threads.hpp
+++ b/src/hotspot/share/runtime/threads.hpp
@@ -102,6 +102,15 @@ public:
   static void change_thread_claim_token();
   static void assert_all_threads_claimed() NOT_DEBUG_RETURN;
 
+  struct ThreadsClaimTokenScope : StackObj {
+    ThreadsClaimTokenScope() {
+      Threads::change_thread_claim_token();
+    }
+    ~ThreadsClaimTokenScope() {
+      Threads::assert_all_threads_claimed();
+    }
+  };
+
   // Apply "f->do_oop" to all root oops in all threads.
   // This version may only be called by sequential code.
   static void oops_do(OopClosure* f, NMethodClosure* cf);


### PR DESCRIPTION
Replace `MarkingNMethodClosure` with `NMethodToOopClosure` during young-gc. After that, a new local `ThreadsClaimTokenScope` is introduced instead of `StrongRootsScope` to make the thread-claim-token logic visible in the current context.
 
Test: tier1-3

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8367848](https://bugs.openjdk.org/browse/JDK-8367848): Parallel: Use NMethodToOopClosure during Young GC (**Enhancement** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27336/head:pull/27336` \
`$ git checkout pull/27336`

Update a local copy of the PR: \
`$ git checkout pull/27336` \
`$ git pull https://git.openjdk.org/jdk.git pull/27336/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27336`

View PR using the GUI difftool: \
`$ git pr show -t 27336`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27336.diff">https://git.openjdk.org/jdk/pull/27336.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27336#issuecomment-3302047279)
</details>
