### PR TITLE
8367739: Serial: Retry allocation after lock acquire in mem_allocate_work

### DIFF
--- a/src/hotspot/share/gc/serial/serialHeap.cpp
+++ b/src/hotspot/share/gc/serial/serialHeap.cpp
@@ -292,27 +292,44 @@ HeapWord* SerialHeap::expand_heap_and_allocate(size_t size, bool is_tlab) {
   return result;
 }
 
+HeapWord* SerialHeap::mem_allocate_cas_noexpand(size_t size, bool is_tlab) {
+  HeapWord* result = _young_gen->par_allocate(size);
+  if (result != nullptr) {
+    return result;
+  }
+  // Try old-gen allocation for non-TLAB.
+  if (!is_tlab) {
+    // If it's too large for young-gen or heap is too full.
+    if (size > heap_word_size(_young_gen->capacity_before_gc()) || _is_heap_almost_full) {
+      result = _old_gen->par_allocate(size);
+      if (result != nullptr) {
+        return result;
+      }
+    }
+  }
+
+  return nullptr;
+}
+
 HeapWord* SerialHeap::mem_allocate_work(size_t size, bool is_tlab) {
   HeapWord* result = nullptr;
 
   for (uint try_count = 1; /* break */; try_count++) {
-    result = _young_gen->par_allocate(size);
+    result = mem_allocate_cas_noexpand(size, is_tlab);
     if (result != nullptr) {
       break;
-    }
-    // Try old-gen allocation for non-TLAB.
-    if (!is_tlab) {
-      // If it's too large for young-gen or heap is too full.
-      if (size > heap_word_size(_young_gen->capacity_before_gc()) || _is_heap_almost_full) {
-        result = _old_gen->par_allocate(size);
-        if (result != nullptr) {
-          break;
-        }
-      }
     }
     uint gc_count_before;  // Read inside the Heap_lock locked region.
     {
       MutexLocker ml(Heap_lock);
+
+      // Re-try after acquiring the lock, because a GC might have occurred
+      // while waiting for this lock.
+      result = mem_allocate_cas_noexpand(size, is_tlab);
+      if (result != nullptr) {
+        break;
+      }
+
       gc_count_before = total_collections();
     }
 

--- a/src/hotspot/share/gc/serial/serialHeap.hpp
+++ b/src/hotspot/share/gc/serial/serialHeap.hpp
@@ -222,6 +222,7 @@ private:
   // Try to allocate space by expanding the heap.
   HeapWord* expand_heap_and_allocate(size_t size, bool is_tlab);
 
+  HeapWord* mem_allocate_cas_noexpand(size_t size, bool is_tlab);
   HeapWord* mem_allocate_work(size_t size, bool is_tlab);
 
   MemoryPool* _eden_pool;


### PR DESCRIPTION
Restoring the allocation retrying logic inside lock-region to avoid premature GCs. This logic was mistakenly removed in [JDK-8364628](https://bugs.openjdk.org/browse/JDK-8364628).

Test: tier1-3

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8367739](https://bugs.openjdk.org/browse/JDK-8367739): Serial: Retry allocation after lock acquire in mem_allocate_work (**Enhancement** - P4)


### Reviewers
 * [Francesco Andreuzzi](https://openjdk.org/census#fandreuzzi) (@fandreuz - Author)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27340/head:pull/27340` \
`$ git checkout pull/27340`

Update a local copy of the PR: \
`$ git checkout pull/27340` \
`$ git pull https://git.openjdk.org/jdk.git pull/27340/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27340`

View PR using the GUI difftool: \
`$ git pr show -t 27340`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27340.diff">https://git.openjdk.org/jdk/pull/27340.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27340#issuecomment-3302438466)
</details>
