### PR TITLE
8367862: debug.cpp: Do not print help message for methods ifdef'd out

### DIFF
--- a/src/hotspot/share/utilities/debug.cpp
+++ b/src/hotspot/share/utilities/debug.cpp
@@ -684,7 +684,7 @@ void help() {
 
   tty->print_cr("method metadata.");
   tty->print_cr("  blob(CodeBlob* p)      - print CodeBlob");
-  tty->print_cr("  dump_vtable(address p) - dumps vtable of the Klass");
+  tty->print_cr("  dump_vtable(address p) - dump vtable of the Klass");
   tty->print_cr("  nm(intptr_t p)         - find & print CodeBlob details");
   tty->print_cr("  disnm(intptr_t p)      - find & print disassembly of CodeBlob");
   tty->print_cr("  printnm(intptr_t p)    - print nmethod details");


### PR DESCRIPTION
The `help` command in `debug.cpp` was out of date, listing only a fraction of the available functions. This and other commands callable from gdb via `call help()`.

I added all commands to the help message, except `pns2` as it is documented as not being useful when called from gdb.

Also fixed is the message for the conditional `pns` command appearing in PRODUCT builds.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8367862](https://bugs.openjdk.org/browse/JDK-8367862): debug.cpp: Do not print help message for methods ifdef'd out (**Bug** - P4)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**) Review applies to [e1bdce21](https://git.openjdk.org/jdk/pull/27341/files/e1bdce2156a6c560679be49223218da471f8646e)
 * [Manuel Hässig](https://openjdk.org/census#mhaessig) (@mhaessig - Committer)
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27341/head:pull/27341` \
`$ git checkout pull/27341`

Update a local copy of the PR: \
`$ git checkout pull/27341` \
`$ git pull https://git.openjdk.org/jdk.git pull/27341/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27341`

View PR using the GUI difftool: \
`$ git pr show -t 27341`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27341.diff">https://git.openjdk.org/jdk/pull/27341.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27341#issuecomment-3302581913)
</details>
