### PR TITLE
8328046: Need to keep leading zeros in TlsPremasterSecret of TLS1.3 DHKeyAgreement

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/KAKeyDerivation.java
+++ b/src/java.base/share/classes/sun/security/ssl/KAKeyDerivation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
TLS 1.3 changed the way it generates the FFDHE shared secret. In TLS 1.2, the leading zeroes in the shared secret were stripped, and in TLS 1.3 the leading zeroes are preserved.

Thanks to the recent work in [JDK-8189441](https://bugs.openjdk.org/browse/JDK-8189441), we now have a new algorithm name `Generic` that can be used to generate a shared secret with the leading zeroes preserved.

This PR changes the TLS 1.3 handshake to use the new algorithm name.

I didn't add any tests to verify the correctness of the handshake. This can be verified using tlsfuzzer, see JBS for details.

Tier1-3 tests continue to pass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8328046](https://bugs.openjdk.org/browse/JDK-8328046): Need to keep leading zeros in TlsPremasterSecret of TLS1.3 DHKeyAgreement (**Bug** - P3)


### Reviewers
 * [Hai-May Chao](https://openjdk.org/census#hchao) (@haimaychao - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27343/head:pull/27343` \
`$ git checkout pull/27343`

Update a local copy of the PR: \
`$ git checkout pull/27343` \
`$ git pull https://git.openjdk.org/jdk.git pull/27343/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27343`

View PR using the GUI difftool: \
`$ git pr show -t 27343`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27343.diff">https://git.openjdk.org/jdk/pull/27343.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27343#issuecomment-3302985769)
</details>
