### PR TITLE
8367869: Test java/io/FileDescriptor/Sync.java timed out

### DIFF
--- a/test/jdk/java/io/FileDescriptor/Sync.java
+++ b/test/jdk/java/io/FileDescriptor/Sync.java
@@ -39,7 +39,7 @@ import jdk.test.lib.thread.VThreadRunner;
 public class Sync {
 
     static final String TEST_DIR = System.getProperty("test.dir", ".");
-    static final int TRIES = 10_000;
+    static final int TRIES = 1_000;
 
     public static void testWith(File file) throws Exception {
         try (FileOutputStream fos = new FileOutputStream(file)) {


### PR DESCRIPTION
Hi all,

After [JDK-8260555](https://bugs.openjdk.org/browse/JDK-8260555) changed the default TIMEOUT_FACTOR from 4 to 1, test java/io/FileDescriptor/Sync.java intermittent timed out when run with other test simultancely.

If I run this test seperately, it shows that test exhaust about 40+ seconds to finish on linux-x64 machine with release jdk build.

This PR change the test count from 10_000 to 1_000, this will make test exhaust less time to finish. I think 1_000 will be enough.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8367869](https://bugs.openjdk.org/browse/JDK-8367869): Test java/io/FileDescriptor/Sync.java timed out (**Bug** - P4)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27344/head:pull/27344` \
`$ git checkout pull/27344`

Update a local copy of the PR: \
`$ git checkout pull/27344` \
`$ git pull https://git.openjdk.org/jdk.git pull/27344/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27344`

View PR using the GUI difftool: \
`$ git pr show -t 27344`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27344.diff">https://git.openjdk.org/jdk/pull/27344.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27344#issuecomment-3302900288)
</details>
