### PR TITLE
8367031: Revert "8334742: Change java.time month/day field types to 'byte'"

### DIFF
--- a/src/java.base/share/classes/java/time/LocalDate.java
+++ b/src/java.base/share/classes/java/time/LocalDate.java
@@ -182,11 +182,11 @@ public final class LocalDate
     /**
      * @serial The month-of-year.
      */
-    private final byte month;
+    private final short month;
     /**
      * @serial The day-of-month.
      */
-    private final byte day;
+    private final short day;
 
     //-----------------------------------------------------------------------
     /**
@@ -490,8 +490,8 @@ public final class LocalDate
      */
     private LocalDate(int year, int month, int dayOfMonth) {
         this.year = year;
-        this.month = (byte) month;
-        this.day = (byte) dayOfMonth;
+        this.month = (short) month;
+        this.day = (short) dayOfMonth;
     }
 
     //-----------------------------------------------------------------------

--- a/src/java.base/share/classes/java/time/MonthDay.java
+++ b/src/java.base/share/classes/java/time/MonthDay.java
@@ -146,11 +146,11 @@ public final class MonthDay
     /**
      * @serial The month-of-year, not null.
      */
-    private final byte month;
+    private final int month;
     /**
      * @serial The day-of-month.
      */
-    private final byte day;
+    private final int day;
 
     //-----------------------------------------------------------------------
     /**
@@ -319,8 +319,8 @@ public final class MonthDay
      * @param dayOfMonth  the day-of-month to represent, validated from 1 to 29-31
      */
     private MonthDay(int month, int dayOfMonth) {
-        this.month = (byte) month;
-        this.day = (byte) dayOfMonth;
+        this.month = month;
+        this.day = dayOfMonth;
     }
 
     //-----------------------------------------------------------------------

--- a/src/java.base/share/classes/java/time/YearMonth.java
+++ b/src/java.base/share/classes/java/time/YearMonth.java
@@ -153,7 +153,7 @@ public final class YearMonth
     /**
      * @serial The month-of-year, not null.
      */
-    private final byte month;
+    private final int month;
 
     //-----------------------------------------------------------------------
     /**
@@ -306,7 +306,7 @@ public final class YearMonth
      */
     private YearMonth(int year, int month) {
         this.year = year;
-        this.month = (byte) month;
+        this.month = month;
     }
 
     /**

--- a/src/java.base/share/classes/java/time/chrono/HijrahDate.java
+++ b/src/java.base/share/classes/java/time/chrono/HijrahDate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -137,11 +137,11 @@ public final class HijrahDate
     /**
      * The month-of-year.
      */
-    private final transient byte monthOfYear;
+    private final transient int monthOfYear;
     /**
      * The day-of-month.
      */
-    private final transient byte dayOfMonth;
+    private final transient int dayOfMonth;
 
     //-------------------------------------------------------------------------
     /**
@@ -273,8 +273,8 @@ public final class HijrahDate
 
         this.chrono = chrono;
         this.prolepticYear = prolepticYear;
-        this.monthOfYear = (byte) monthOfYear;
-        this.dayOfMonth = (byte) dayOfMonth;
+        this.monthOfYear = monthOfYear;
+        this.dayOfMonth = dayOfMonth;
     }
 
     /**
@@ -287,8 +287,8 @@ public final class HijrahDate
 
         this.chrono = chrono;
         this.prolepticYear = dateInfo[0];
-        this.monthOfYear = (byte) dateInfo[1];
-        this.dayOfMonth = (byte) dateInfo[2];
+        this.monthOfYear = dateInfo[1];
+        this.dayOfMonth = dateInfo[2];
     }
 
     //-----------------------------------------------------------------------


### PR DESCRIPTION
This reverts commit 4ced4e73fc0a517df826860839681004bb67e624.

Restore the previous field types to maintain compatibility with previous releases of the serialized form 
of classes of java.time. 
The classes reverted are LocalDate, MonthDay, YearMonth, and HijrahDate.