### PR TITLE
8366899: SetupExecute should add the command line to vardeps

### DIFF
--- a/make/common/Execute.gmk
+++ b/make/common/Execute.gmk
@@ -150,11 +150,10 @@ define SetupExecuteBody
 
   $1_VARDEPS := $$($1_COMMAND) $$($1_PRE_COMMAND) $$($1_POST_COMMAND)
   $1_VARDEPS_FILE := $$(call DependOnVariable, $1_VARDEPS)
-  $1_DEPS += $$($1_VARDEPS_FILE)
 
   ifneq ($$($1_PRE_COMMAND), )
 
-    $$($1_PRE_MARKER): $$($1_DEPS)
+    $$($1_PRE_MARKER): $$($1_DEPS) $$($1_VARDEPS_FILE)
         ifneq ($$($1_WARN), )
 	  $$(call LogWarn, $$($1_WARN))
         endif
@@ -180,7 +179,7 @@ define SetupExecuteBody
 
     $1 := $$($1_PRE_MARKER) $$($1_EXEC_RESULT)
   else
-    $$($1_EXEC_RESULT): $$($1_DEPS)
+    $$($1_EXEC_RESULT): $$($1_DEPS) $$($1_VARDEPS_FILE)
         ifneq ($$($1_WARN), )
 	  $$(call LogWarn, $$($1_WARN))
         endif


### PR DESCRIPTION
If the command line changes, it is reason to re-run the command.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8366899](https://bugs.openjdk.org/browse/JDK-8366899): SetupExecute should add the command line to vardeps (**Bug** - P3)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27348/head:pull/27348` \
`$ git checkout pull/27348`

Update a local copy of the PR: \
`$ git checkout pull/27348` \
`$ git pull https://git.openjdk.org/jdk.git pull/27348/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27348`

View PR using the GUI difftool: \
`$ git pr show -t 27348`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27348.diff">https://git.openjdk.org/jdk/pull/27348.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27348#issuecomment-3303647585)
</details>
