### PR TITLE
8359378: aarch64: crash when using -XX:+UseFPUForSpilling

### DIFF
--- a/src/hotspot/cpu/aarch64/gc/shared/barrierSetAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/gc/shared/barrierSetAssembler_aarch64.cpp
@@ -398,14 +398,18 @@ void BarrierSetAssembler::check_oop(MacroAssembler* masm, Register obj, Register
 OptoReg::Name BarrierSetAssembler::encode_float_vector_register_size(const Node* node, OptoReg::Name opto_reg) {
   switch (node->ideal_reg()) {
     case Op_RegF:
+    case Op_RegI: // RA may place scalar values (Op_RegI/N/L/P) in FP registers when UseFPUForSpilling is enabled
+    case Op_RegN:
       // No need to refine. The original encoding is already fine to distinguish.
-      assert(opto_reg % 4 == 0, "Float register should only occupy a single slot");
+      assert(opto_reg % 4 == 0, "32-bit register should only occupy a single slot");
       break;
     // Use different encoding values of the same fp/vector register to help distinguish different sizes.
     // Such as V16. The OptoReg::name and its corresponding slot value are
     // "V16": 64, "V16_H": 65, "V16_J": 66, "V16_K": 67.
     case Op_RegD:
     case Op_VecD:
+    case Op_RegL:
+    case Op_RegP:
       opto_reg &= ~3;
       opto_reg |= 1;
       break;


### PR DESCRIPTION
AArch64 BarrierSetAssembler path assumes only FP/vector ideal regs reach the FP spill/restore encoding. With -XX:+UseFPUForSpilling Register Allocator may allocate scalar values in FP registers. When such values (Op_RegI/Op_RegN/Op_RegL/Op_RegP) hit `BarrierSetAssembler::encode_float_vector_register_size`, we trip ShouldNotReachHere in release build and **"unexpected ideal register"** assertion in debug build.

Fix: teach the encoder to handle scalar ideal regs when they physically live in FP regs:
- treat Op_RegI / Op_RegN as 32-bit (single slot) - same class as Op_RegF
- treat Op_RegL / Op_RegP as 64-bit (two slots) - same class as Op_RegD

Related:
- reproduced since #19746
- spilling logic: 
  - #18967
  - #17977

Testing: tier1-3 with javaoptions -Xcomp -Xbatch -XX:+UseFPUForSpilling on AARCH

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8359378](https://bugs.openjdk.org/browse/JDK-8359378): aarch64: crash when using -XX:+UseFPUForSpilling (**Bug** - P3)


### Reviewers
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)
 * [Roberto Castañeda Lozano](https://openjdk.org/census#rcastanedalo) (@robcasloz - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27350/head:pull/27350` \
`$ git checkout pull/27350`

Update a local copy of the PR: \
`$ git checkout pull/27350` \
`$ git pull https://git.openjdk.org/jdk.git pull/27350/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27350`

View PR using the GUI difftool: \
`$ git pr show -t 27350`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27350.diff">https://git.openjdk.org/jdk/pull/27350.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27350#issuecomment-3303957828)
</details>
