### PR TITLE
8367927: Remove 8043571-related tests from problemlists

### DIFF
--- a/test/hotspot/jtreg/ProblemList-Xcomp.txt
+++ b/test/hotspot/jtreg/ProblemList-Xcomp.txt
@@ -43,9 +43,6 @@ vmTestbase/vm/mlvm/indy/func/jvmti/mergeCP_indy2none_b/TestDescription.java 8308
 vmTestbase/vm/mlvm/indy/func/jvmti/mergeCP_none2indy_b/TestDescription.java 8308367 generic-all
 vmTestbase/vm/mlvm/indy/func/jvmti/redefineClassInTarget/TestDescription.java 8308367 generic-all
 
-vmTestbase/nsk/jdi/StepRequest/addClassFilter_rt/filter_rt001/TestDescription.java 8043571 generic-all
-vmTestbase/nsk/jdi/StepRequest/addClassFilter_rt/filter_rt003/TestDescription.java 8043571 generic-all
-
 vmTestbase/nsk/jvmti/scenarios/capability/CM03/cm03t001/TestDescription.java 8299493 macosx-x64,windows-x64
 
 vmTestbase/nsk/stress/thread/thread006.java 8321476 linux-all

--- a/test/jdk/ProblemList-Xcomp.txt
+++ b/test/jdk/ProblemList-Xcomp.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -29,4 +29,3 @@
 
 java/lang/invoke/MethodHandles/CatchExceptionTest.java          8146623 generic-all
 java/lang/reflect/callerCache/ReflectionCallerCacheTest.java    8332028 generic-all
-com/sun/jdi/InterruptHangTest.java                              8043571 generic-all

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -724,8 +724,6 @@ javax/swing/plaf/synth/7158712/bug7158712.java 8324782 macosx-all
 
 # jdk_jdi
 
-com/sun/jdi/RepStep.java                                        8043571 generic-all
-
 com/sun/jdi/InvokeHangTest.java                                 8218463 linux-all
 
 ############################################################################


### PR DESCRIPTION
There are were few fixes in post_method_exit recently. I tried to reproduce this issue and failed.
Let remove tests from problemlist and see if it issue is still reproduced in CI.

The bug https://bugs.openjdk.org/browse/JDK-8043571 remains open so far. It will be closed in jdk26 if not reproduced.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8367927](https://bugs.openjdk.org/browse/JDK-8367927): Remove 8043571-related tests from problemlists (**Sub-task** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27351/head:pull/27351` \
`$ git checkout pull/27351`

Update a local copy of the PR: \
`$ git checkout pull/27351` \
`$ git pull https://git.openjdk.org/jdk.git pull/27351/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27351`

View PR using the GUI difftool: \
`$ git pr show -t 27351`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27351.diff">https://git.openjdk.org/jdk/pull/27351.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27351#issuecomment-3304283502)
</details>
