### PR TITLE
8367953: JFR sampler threads does not appear in thread dump

### DIFF
--- a/src/hotspot/share/jfr/periodic/sampling/jfrCPUTimeThreadSampler.cpp
+++ b/src/hotspot/share/jfr/periodic/sampling/jfrCPUTimeThreadSampler.cpp
@@ -275,7 +275,7 @@ public:
   void handle_timer_signal(siginfo_t* info, void* context);
   bool init_timers();
   void stop_timer();
-  virtual void print_on(outputStream* st) const override;
+  virtual void print_on(outputStream* st) const;
 
   void trigger_async_processing_of_cpu_time_jfr_requests();
 

--- a/src/hotspot/share/jfr/periodic/sampling/jfrThreadSampler.cpp
+++ b/src/hotspot/share/jfr/periodic/sampling/jfrThreadSampler.cpp
@@ -85,7 +85,7 @@ class JfrSamplerThread : public NonJavaThread {
   bool is_JfrSampler_thread() const { return true; }
   int64_t java_period() const { return AtomicAccess::load(&_java_period_millis); };
   int64_t native_period() const { return AtomicAccess::load(&_native_period_millis); };
-  virtual void print_on(outputStream* st) const override;
+  virtual void print_on(outputStream* st) const;
 };
 
 JfrSamplerThread::JfrSamplerThread(int64_t java_period_millis, int64_t native_period_millis, u4 max_frames) :


### PR DESCRIPTION
I tried to get thread dump of the process which is enabled JFR, then I got strange thread dump like this:

```
os_prio=0 cpu=64.47ms elapsed=20.34s tid=0x00007ff7cd3ffae0 nid=59812 runnable
os_prio=0 cpu=12.76ms elapsed=20.34s tid=0x00007ff7cd3ff5a0 nid=59811 runnable
```

Thread name is lacked in the dump (and lacks of LF in addition).
I checked them with `ps -eL -o pid,tid,comm`, then I was aware they were JFR sampler threads.

```
  59789 59811 JFR CPU Sampler
  59789 59812 JFR Sampler Thr
```

So they should be shown like this:

```
"JFR Sampler Thread" os_prio=0 cpu=25.59ms elapsed=8.77s tid=0x00007f5f45626a50 nid=62979 runnable

"JFR CPU Sampler Thread" os_prio=0 cpu=4.78ms elapsed=8.78s tid=0x00007f5f45626060 nid=62978 runnable
```

They are implemented in `JfrSamplerThread` and `JfrCPUSamplerThread`, extends `NonJavaThread`. They do not have `print_on()`, so `Thread::print_on()` would be used - it would not print thread name.

Other child class of `NonJavaThread` like `WatcherThread` overrides `print_on` to show thread name. Thus both of JFR sampler threads should do so.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8367953](https://bugs.openjdk.org/browse/JDK-8367953): JFR sampler threads does not appear in thread dump (**Bug** - P4)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27357/head:pull/27357` \
`$ git checkout pull/27357`

Update a local copy of the PR: \
`$ git checkout pull/27357` \
`$ git pull https://git.openjdk.org/jdk.git pull/27357/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27357`

View PR using the GUI difftool: \
`$ git pr show -t 27357`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27357.diff">https://git.openjdk.org/jdk/pull/27357.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27357#issuecomment-3306095277)
</details>
