### PR TITLE
8367969: C2: compiler/vectorapi/TestVectorMathLib.java fails without UnlockDiagnosticVMOptions

### DIFF
--- a/test/hotspot/jtreg/compiler/vectorapi/TestVectorMathLib.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/TestVectorMathLib.java
@@ -34,7 +34,9 @@ import jdk.incubator.vector.VectorSpecies;
  * @modules jdk.incubator.vector
  * @library /test/lib
  *
- * @run main/othervm -Xbatch -XX:-TieredCompilation -XX:+StressIncrementalInlining -XX:CompileCommand=quiet
+ * @run main/othervm -Xbatch -XX:-TieredCompilation
+ *                   -XX:+UnlockDiagnosticVMOptions -XX:+StressIncrementalInlining
+ *                   -XX:CompileCommand=quiet
  *                   -XX:CompileCommand=compileonly,compiler.vectorapi.TestVectorMathLib::test*
  *                   compiler.vectorapi.TestVectorMathLib
  */


### PR DESCRIPTION
Adding missing `-XX:+UnlockDiagnosticVMOptions`.

Seems the test from https://github.com/openjdk/jdk/pull/27263 was not tested with the product build before integration.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8367969](https://bugs.openjdk.org/browse/JDK-8367969): C2: compiler/vectorapi/TestVectorMathLib.java fails without UnlockDiagnosticVMOptions (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Manuel Hässig](https://openjdk.org/census#mhaessig) (@mhaessig - Committer)

### Reviewers without OpenJDK IDs
 * @donphelix (no known openjdk.org user name / role)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27359/head:pull/27359` \
`$ git checkout pull/27359`

Update a local copy of the PR: \
`$ git checkout pull/27359` \
`$ git pull https://git.openjdk.org/jdk.git pull/27359/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27359`

View PR using the GUI difftool: \
`$ git pr show -t 27359`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27359.diff">https://git.openjdk.org/jdk/pull/27359.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27359#issuecomment-3306018233)
</details>
