### PR TITLE
8367981: Update CompactHashtable for readability

### DIFF
--- a/src/hotspot/share/classfile/compactHashtable.cpp
+++ b/src/hotspot/share/classfile/compactHashtable.cpp
@@ -73,9 +73,9 @@ CompactHashtableWriter::~CompactHashtableWriter() {
 }
 
 // Add an entry to the temporary hash table
-void CompactHashtableWriter::add(unsigned int hash, u4 value) {
+void CompactHashtableWriter::add(unsigned int hash, u4 encoded_value) {
   int index = hash % _num_buckets;
-  _buckets[index]->append_if_missing(Entry(hash, value));
+  _buckets[index]->append_if_missing(Entry(hash, encoded_value));
   _num_entries_written++;
 }
 
@@ -117,18 +117,18 @@ void CompactHashtableWriter::dump_table(NumberSeq* summary) {
       _compact_buckets->at_put(index, BUCKET_INFO(offset, VALUE_ONLY_BUCKET_TYPE));
 
       Entry ent = bucket->at(0);
-      // bucket with one entry is value_only and only has the value
-      _compact_entries->at_put(offset++, ent.value());
+      // bucket with one entry is value_only and only has the encoded_value
+      _compact_entries->at_put(offset++, ent.encoded_value());
       _num_value_only_buckets++;
     } else {
       // regular bucket, it could contain zero or more than one entry,
-      // each entry is a (hash, value) pair
+      // each entry is a <hash, encoded_value> pair
       _compact_buckets->at_put(index, BUCKET_INFO(offset, REGULAR_BUCKET_TYPE));
 
       for (int i=0; i<bucket_size; i++) {
         Entry ent = bucket->at(i);
-        _compact_entries->at_put(offset++, u4(ent.hash())); // write entry hash
-        _compact_entries->at_put(offset++, ent.value());    // write entry value
+        _compact_entries->at_put(offset++, u4(ent.hash()));      // write entry hash
+        _compact_entries->at_put(offset++, ent.encoded_value()); // write entry encoded_value
       }
       if (bucket_size == 0) {
         _num_empty_buckets++;

--- a/src/hotspot/share/classfile/compactHashtable.hpp
+++ b/src/hotspot/share/classfile/compactHashtable.hpp
@@ -62,8 +62,8 @@ public:
 // The compact hash table writer. Used at dump time for writing out
 // the compact table to the shared archive.
 //
-// At dump time, the CompactHashtableWriter obtains all entries from the
-// a table (the table could be in any form of a collection of <hash, value> pair)
+// At dump time, the CompactHashtableWriter obtains all entries from
+// a table (the table could be in any form of a collection of <hash, encoded_value> pair)
 // and adds them to a new temporary hash table (_buckets). The hash
 // table size (number of buckets) is calculated using
 // '(num_entries + bucket_size - 1) / bucket_size'. The default bucket
@@ -78,8 +78,8 @@ public:
 // offsets are written to the archive as part of the compact table. The
 // bucket offset is encoded in the low 30-bit (0-29) and the bucket type
 // (regular or value_only) are encoded in bit[31, 30]. For buckets with more
-// than one entry, both hash and entry value are written to the
-// table. For buckets with only one entry, only the entry value is written
+// than one entry, both hash and encoded_value are written to the
+// table. For buckets with only one entry, only the encoded_value is written
 // to the table and the buckets are tagged as value_only in their type bits.
 // Buckets without entry are skipped from the table. Their offsets are
 // still written out for faster lookup.
@@ -92,9 +92,9 @@ public:
 
   public:
     Entry() {}
-    Entry(unsigned int hash, u4 val) : _hash(hash), _encoded_value(val) {}
+    Entry(unsigned int hash, u4 encoded_value) : _hash(hash), _encoded_value(encoded_value) {}
 
-    u4 value() {
+    u4 encoded_value() {
       return _encoded_value;
     }
     unsigned int hash() {
@@ -122,7 +122,7 @@ public:
   CompactHashtableWriter(int num_entries, CompactHashtableStats* stats);
   ~CompactHashtableWriter();
 
-  void add(unsigned int hash, u4 value);
+  void add(unsigned int hash, u4 encoded_value);
   void dump(SimpleCompactHashtable *cht, const char* table_name);
 
 private:
@@ -148,7 +148,7 @@ private:
 /////////////////////////////////////////////////////////////////////////////
 //
 // CompactHashtable is used to store the CDS archive's tables.
-// A table could be in any form of a collection of <hash, value> pair.
+// A table could be in any form of a collection of <hash, encoded_value> pair.
 //
 // Because these tables are read-only (no entries can be added/deleted) at run-time
 // and tend to have large number of entries, we try to minimize the footprint
@@ -176,7 +176,7 @@ private:
 //                     //   V entry = (V)(base_address + offset)
 //                     // see StringTable, SymbolTable and AdapterHandlerLibrary for examples
 //
-// For value_only buckets, each entry has only the 4-byte 'value' in the entries[].
+// For value_only buckets, each entry has only the 4-byte 'encoded_value' in the entries[].
 //
 // The single table_end bucket has no corresponding entry.
 //
@@ -192,9 +192,9 @@ private:
 // always encoded as regular buckets.
 //
 // In the following example:
-//   - The 0-th bucket is a REGULAR_BUCKET_TYPE with two entries
-//   - The 1-st bucket is a VALUE_ONLY_BUCKET_TYPE with one entry.
-//   - The 2-th bucket is a REGULAR_BUCKET_TYPE with zeo entries.
+//   - Bucket #0 is a REGULAR_BUCKET_TYPE with two entries
+//   - Bucket #1 is a VALUE_ONLY_BUCKET_TYPE with one entry.
+//   - Bucket #2 is a REGULAR_BUCKET_TYPE with zero entries.
 //
 // buckets[0, 4, 5(empty), 5, ...., N(table_end)]
 //         |  |  |         |        |


### PR DESCRIPTION
Hi,
Can you help to review this patch?

The comments of CompactHashtable and related classes are out of date, and some comments are unclear, wrong or misleading.
As the related classes are used in more and more scenarios, it's helpful to update the comments.

To improve readability (of both the source code and the comments), we should also rename some of the field/parameters to distinguish between the type V (the "value " stored inside the table; it could be a 64-bit pointer) vs "encoded value" (the 32-bit representation of V in the CompactHashtable storage).

Thanks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8367981](https://bugs.openjdk.org/browse/JDK-8367981): Update CompactHashtable for readability (**Enhancement** - P4)


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)
 * [Matias Saavedra Silva](https://openjdk.org/census#matsaave) (@matias9927 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27360/head:pull/27360` \
`$ git checkout pull/27360`

Update a local copy of the PR: \
`$ git checkout pull/27360` \
`$ git pull https://git.openjdk.org/jdk.git pull/27360/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27360`

View PR using the GUI difftool: \
`$ git pr show -t 27360`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27360.diff">https://git.openjdk.org/jdk/pull/27360.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27360#issuecomment-3306822488)
</details>
