### PR TITLE
8367983: javax/management/monitor/ThreadPoolTest.java and StartStopTest.java fail with Unexpected Maximum Pool Size Overflow!

### DIFF
--- a/test/jdk/javax/management/monitor/StartStopTest.java
+++ b/test/jdk/javax/management/monitor/StartStopTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -62,6 +62,8 @@ import jdk.test.lib.Utils;
 public class StartStopTest {
     static int maxPoolSize;
     static final AtomicInteger counter = new AtomicInteger();
+
+    public static final int TIMEOUT = 2500;
 
     // MBean class
     public class ObservedObject implements ObservedObjectMBean {
@@ -148,7 +150,7 @@ public class StartStopTest {
                 for (int i = 0; i < nTasks; i++)
                     monitor[i].start();
                 echo(">>> MONITORS started");
-                doSleep(500);
+                doSleep(TIMEOUT);
                 echo(">>> Check FLAGS true");
                 for (int i = 0; i < nTasks; i++)
                     if (!monitored[i].called) {
@@ -160,7 +162,7 @@ public class StartStopTest {
                 for (int i = 0; i < nTasks; i++)
                     monitor[i].stop();
                 echo(">>> MONITORS stopped");
-                doSleep(500);
+                doSleep(TIMEOUT);
                 echo(">>> Set FLAGS to false");
                 for (int i = 0; i < nTasks; i++)
                     monitored[i].called = false;


### PR DESCRIPTION
This test has failed due to a timing issue, but not continually or reproducibly.
Looks like an effect of the TIMEOUT_FACTOR change (8260555).

The recent failure has -J-Dtest.timeout.factor=1.0 and I see older logs passing with -Dtest.timeout.factor=4.0

We should increase the timeout.  As there have been occasional failures before, looking back a few years, so multiply the current 500ms by a little more than 4.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8367983](https://bugs.openjdk.org/browse/JDK-8367983): javax/management/monitor/ThreadPoolTest.java and StartStopTest.java fail with Unexpected Maximum Pool Size Overflow! (**Bug** - P4)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27361/head:pull/27361` \
`$ git checkout pull/27361`

Update a local copy of the PR: \
`$ git checkout pull/27361` \
`$ git pull https://git.openjdk.org/jdk.git pull/27361/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27361`

View PR using the GUI difftool: \
`$ git pr show -t 27361`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27361.diff">https://git.openjdk.org/jdk/pull/27361.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27361#issuecomment-3307143749)
</details>
