### PR TITLE
8367984: Eliminate offset_of in vmStructs

### DIFF
--- a/src/hotspot/share/runtime/vmStructs.cpp
+++ b/src/hotspot/share/runtime/vmStructs.cpp
@@ -1981,31 +1981,31 @@ extern "C" {
 #define STRIDE(array) ((char*)&array[1] - (char*)&array[0])
 
 JNIEXPORT VMStructEntry* gHotSpotVMStructs = VMStructs::localHotSpotVMStructs;
-JNIEXPORT uint64_t gHotSpotVMStructEntryTypeNameOffset = offset_of(VMStructEntry, typeName);
-JNIEXPORT uint64_t gHotSpotVMStructEntryFieldNameOffset = offset_of(VMStructEntry, fieldName);
-JNIEXPORT uint64_t gHotSpotVMStructEntryTypeStringOffset = offset_of(VMStructEntry, typeString);
-JNIEXPORT uint64_t gHotSpotVMStructEntryIsStaticOffset = offset_of(VMStructEntry, isStatic);
-JNIEXPORT uint64_t gHotSpotVMStructEntryOffsetOffset = offset_of(VMStructEntry, offset);
-JNIEXPORT uint64_t gHotSpotVMStructEntryAddressOffset = offset_of(VMStructEntry, address);
+extern JNIEXPORT constexpr uint64_t gHotSpotVMStructEntryTypeNameOffset = offsetof(VMStructEntry, typeName);
+extern JNIEXPORT constexpr uint64_t gHotSpotVMStructEntryFieldNameOffset = offsetof(VMStructEntry, fieldName);
+extern JNIEXPORT constexpr uint64_t gHotSpotVMStructEntryTypeStringOffset = offsetof(VMStructEntry, typeString);
+extern JNIEXPORT constexpr uint64_t gHotSpotVMStructEntryIsStaticOffset = offsetof(VMStructEntry, isStatic);
+extern JNIEXPORT constexpr uint64_t gHotSpotVMStructEntryOffsetOffset = offsetof(VMStructEntry, offset);
+extern JNIEXPORT constexpr uint64_t gHotSpotVMStructEntryAddressOffset = offsetof(VMStructEntry, address);
 JNIEXPORT uint64_t gHotSpotVMStructEntryArrayStride = STRIDE(gHotSpotVMStructs);
 
 JNIEXPORT VMTypeEntry* gHotSpotVMTypes = VMStructs::localHotSpotVMTypes;
-JNIEXPORT uint64_t gHotSpotVMTypeEntryTypeNameOffset = offset_of(VMTypeEntry, typeName);
-JNIEXPORT uint64_t gHotSpotVMTypeEntrySuperclassNameOffset = offset_of(VMTypeEntry, superclassName);
-JNIEXPORT uint64_t gHotSpotVMTypeEntryIsOopTypeOffset = offset_of(VMTypeEntry, isOopType);
-JNIEXPORT uint64_t gHotSpotVMTypeEntryIsIntegerTypeOffset = offset_of(VMTypeEntry, isIntegerType);
-JNIEXPORT uint64_t gHotSpotVMTypeEntryIsUnsignedOffset = offset_of(VMTypeEntry, isUnsigned);
-JNIEXPORT uint64_t gHotSpotVMTypeEntrySizeOffset = offset_of(VMTypeEntry, size);
+extern JNIEXPORT constexpr uint64_t gHotSpotVMTypeEntryTypeNameOffset = offsetof(VMTypeEntry, typeName);
+extern JNIEXPORT constexpr uint64_t gHotSpotVMTypeEntrySuperclassNameOffset = offsetof(VMTypeEntry, superclassName);
+extern JNIEXPORT constexpr uint64_t gHotSpotVMTypeEntryIsOopTypeOffset = offsetof(VMTypeEntry, isOopType);
+extern JNIEXPORT constexpr uint64_t gHotSpotVMTypeEntryIsIntegerTypeOffset = offsetof(VMTypeEntry, isIntegerType);
+extern JNIEXPORT constexpr uint64_t gHotSpotVMTypeEntryIsUnsignedOffset = offsetof(VMTypeEntry, isUnsigned);
+extern JNIEXPORT constexpr uint64_t gHotSpotVMTypeEntrySizeOffset = offsetof(VMTypeEntry, size);
 JNIEXPORT uint64_t gHotSpotVMTypeEntryArrayStride = STRIDE(gHotSpotVMTypes);
 
 JNIEXPORT VMIntConstantEntry* gHotSpotVMIntConstants = VMStructs::localHotSpotVMIntConstants;
-JNIEXPORT uint64_t gHotSpotVMIntConstantEntryNameOffset = offset_of(VMIntConstantEntry, name);
-JNIEXPORT uint64_t gHotSpotVMIntConstantEntryValueOffset = offset_of(VMIntConstantEntry, value);
+extern JNIEXPORT constexpr uint64_t gHotSpotVMIntConstantEntryNameOffset = offsetof(VMIntConstantEntry, name);
+extern JNIEXPORT constexpr uint64_t gHotSpotVMIntConstantEntryValueOffset = offsetof(VMIntConstantEntry, value);
 JNIEXPORT uint64_t gHotSpotVMIntConstantEntryArrayStride = STRIDE(gHotSpotVMIntConstants);
 
 JNIEXPORT VMLongConstantEntry* gHotSpotVMLongConstants = VMStructs::localHotSpotVMLongConstants;
-JNIEXPORT uint64_t gHotSpotVMLongConstantEntryNameOffset = offset_of(VMLongConstantEntry, name);
-JNIEXPORT uint64_t gHotSpotVMLongConstantEntryValueOffset = offset_of(VMLongConstantEntry, value);
+extern JNIEXPORT constexpr uint64_t gHotSpotVMLongConstantEntryNameOffset = offsetof(VMLongConstantEntry, name);
+extern JNIEXPORT constexpr uint64_t gHotSpotVMLongConstantEntryValueOffset = offsetof(VMLongConstantEntry, value);
 JNIEXPORT uint64_t gHotSpotVMLongConstantEntryArrayStride = STRIDE(gHotSpotVMLongConstants);
 } // "C"
 

--- a/src/hotspot/share/runtime/vmStructs.hpp
+++ b/src/hotspot/share/runtime/vmStructs.hpp
@@ -27,6 +27,8 @@
 
 #include "utilities/debug.hpp"
 #include "utilities/globalDefinitions.hpp"
+
+#include <cstddef>
 #ifdef COMPILER1
 #include "c1/c1_Runtime1.hpp"
 #endif
@@ -157,7 +159,7 @@ private:
 
 // This macro generates a VMStructEntry line for a nonstatic field
 #define GENERATE_NONSTATIC_VM_STRUCT_ENTRY(typeName, fieldName, type)              \
- { QUOTE(typeName), QUOTE(fieldName), QUOTE(type), 0, offset_of(typeName, fieldName), nullptr },
+ { QUOTE(typeName), QUOTE(fieldName), QUOTE(type), 0, offsetof(typeName, fieldName), nullptr },
 
 // This macro generates a VMStructEntry line for a static field
 #define GENERATE_STATIC_VM_STRUCT_ENTRY(typeName, fieldName, type)                 \
@@ -172,7 +174,7 @@ private:
 // nonstatic field, in which the size of the type is also specified.
 // The type string is given as null, indicating an "opaque" type.
 #define GENERATE_UNCHECKED_NONSTATIC_VM_STRUCT_ENTRY(typeName, fieldName, size)    \
-  { QUOTE(typeName), QUOTE(fieldName), nullptr, 0, offset_of(typeName, fieldName), nullptr },
+  { QUOTE(typeName), QUOTE(fieldName), nullptr, 0, offsetof(typeName, fieldName), nullptr },
 
 // This macro generates a VMStructEntry line for an unchecked
 // static field, in which the size of the type is also specified.


### PR DESCRIPTION
There are several usages of `offset_of` in `vmStructs`, they can be replaced with standard `offsetof` due to [JDK-8367016](https://bugs.openjdk.org/browse/JDK-8367016).

Passes `tier1`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8367984](https://bugs.openjdk.org/browse/JDK-8367984): Eliminate offset_of in vmStructs (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27362/head:pull/27362` \
`$ git checkout pull/27362`

Update a local copy of the PR: \
`$ git checkout pull/27362` \
`$ git pull https://git.openjdk.org/jdk.git pull/27362/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27362`

View PR using the GUI difftool: \
`$ git pr show -t 27362`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27362.diff">https://git.openjdk.org/jdk/pull/27362.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27362#issuecomment-3307293943)
</details>
