### PR TITLE
8367987

### DIFF
--- a/src/hotspot/share/nmt/memBaseline.hpp
+++ b/src/hotspot/share/nmt/memBaseline.hpp
@@ -89,6 +89,10 @@ class MemBaseline {
     _baseline_type(Not_baselined) {
   }
 
+  ~MemBaseline() {
+    delete _vma_allocations;
+  }
+
   void baseline(bool summaryOnly = true);
 
   BaselineType baseline_type() const { return _baseline_type; }


### PR DESCRIPTION
Hi,

I forgot to add a destructor which deletes the `_vma_allocations` for JDK-8367249. This PR rectifies this mistake.

Thank you.