### PR TITLE
JDK-8367994: test/jdk/sun/security/pkcs11/Signature/ tests pass when they should skip

### DIFF
--- a/test/jdk/sun/security/pkcs11/Signature/InitAgainPSS.java
+++ b/test/jdk/sun/security/pkcs11/Signature/InitAgainPSS.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -20,8 +20,15 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-import java.security.*;
-import java.security.spec.*;
+import jtreg.SkippedException;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.security.Provider;
+import java.security.Signature;
+import java.security.spec.MGF1ParameterSpec;
+import java.security.spec.PSSParameterSpec;
 
 /**
  * @test
@@ -46,9 +53,7 @@ public class InitAgainPSS extends PKCS11Test {
         try {
             s1 = Signature.getInstance(sigAlg, p);
         } catch (NoSuchAlgorithmException e) {
-            System.out.println("Skip testing " + sigAlg +
-                " due to no support");
-            return;
+            throw new SkippedException("No support " + sigAlg);
         }
 
         byte[] msg = "hello".getBytes();

--- a/test/jdk/sun/security/pkcs11/Signature/KeyAndParamCheckForPSS.java
+++ b/test/jdk/sun/security/pkcs11/Signature/KeyAndParamCheckForPSS.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -20,9 +20,16 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-import java.security.*;
-import java.security.interfaces.*;
-import java.security.spec.*;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.InvalidKeyException;
+import java.security.KeyPair;
+import java.security.PrivateKey;
+import java.security.Provider;
+import java.security.PublicKey;
+import java.security.Signature;
+import java.security.spec.AlgorithmParameterSpec;
+import java.security.spec.MGF1ParameterSpec;
+import java.security.spec.PSSParameterSpec;
 
 import jtreg.SkippedException;
 
@@ -84,7 +91,11 @@ public class KeyAndParamCheckForPSS extends PKCS11Test {
         System.out.println("Testing " + hashAlg + " and MGF1" + mgfHashAlg);
         PSSUtil.AlgoSupport s = PSSUtil.isHashSupported(p, hashAlg, mgfHashAlg);
         if (s == PSSUtil.AlgoSupport.NO) {
-            System.out.println("=> Skip; no support");
+            System.out.printf("=> Skip; no support keysize: %d, hash alg: %s, mgf Hash Alg: %s%n",
+                    keySize,
+                    hashAlg,
+                    mgfHashAlg);
+            skipTest = true;
             return;
         }
 

--- a/test/jdk/sun/security/pkcs11/Signature/SigInteropPSS.java
+++ b/test/jdk/sun/security/pkcs11/Signature/SigInteropPSS.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,9 +21,15 @@
  * questions.
  */
 
-import java.security.*;
-import java.security.spec.*;
-import java.security.interfaces.*;
+import jtreg.SkippedException;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.security.Provider;
+import java.security.Signature;
+import java.security.spec.MGF1ParameterSpec;
+import java.security.spec.PSSParameterSpec;
 
 /*
  * @test
@@ -53,9 +59,7 @@ public class SigInteropPSS extends PKCS11Test {
         try {
             sigPkcs11 = Signature.getInstance("RSASSA-PSS", p);
         } catch (NoSuchAlgorithmException e) {
-            System.out.println("Skip testing RSASSA-PSS" +
-                " due to no support");
-            return;
+            throw new SkippedException("No support for RSASSA-PSS");
         }
 
         Signature sigSunRsaSign =

--- a/test/jdk/sun/security/pkcs11/Signature/SigInteropPSS2.java
+++ b/test/jdk/sun/security/pkcs11/Signature/SigInteropPSS2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,9 +21,16 @@
  * questions.
  */
 
-import java.security.*;
-import java.security.spec.*;
-import java.security.interfaces.*;
+import jtreg.SkippedException;
+
+import java.security.AlgorithmParameters;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.security.Provider;
+import java.security.Security;
+import java.security.Signature;
+import java.security.spec.PSSParameterSpec;
 
 /*
  * @test
@@ -67,9 +74,7 @@ public class SigInteropPSS2 extends PKCS11Test {
             try {
                 sigPkcs11 = Signature.getInstance(digest + "withRSASSA-PSS", p);
             } catch (NoSuchAlgorithmException e) {
-                System.out.println("Skip testing " + digest + "withRSASSA-PSS" +
-                    " due to no support");
-                continue;
+                throw new SkippedException("No support for " + digest + "withRSASSA-PSS");
             }
 
             runTest(sigPkcs11, sigSunRsaSign, kp);

--- a/test/jdk/sun/security/pkcs11/Signature/SignatureTestPSS2.java
+++ b/test/jdk/sun/security/pkcs11/Signature/SignatureTestPSS2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -20,13 +20,23 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-import java.security.*;
-import java.security.interfaces.*;
-import java.security.spec.*;
+import jtreg.SkippedException;
+
+import java.security.InvalidAlgorithmParameterException;
+import java.security.InvalidKeyException;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
+import java.security.PrivateKey;
+import java.security.Provider;
+import java.security.PublicKey;
+import java.security.Signature;
+import java.security.SignatureException;
 import java.util.stream.IntStream;
 
 /**
- * @test
+ * @test id=old_alg
  * @bug 8244154 8242332
  * @summary Generate a <digest>withRSASSA-PSS signature and verify it using
  *         PKCS11 provider
@@ -34,13 +44,25 @@ import java.util.stream.IntStream;
  * @modules jdk.crypto.cryptoki
  * @run main SignatureTestPSS2
  */
+
+/**
+ * @test id=new_alg
+ * @bug 8244154 8242332
+ * @summary Generate a <digest>withRSASSA-PSS signature and verify it using
+ *         PKCS11 provider
+ * @library /test/lib ..
+ * @modules jdk.crypto.cryptoki
+ * @run main SignatureTestPSS2 new-alg
+ */
 public class SignatureTestPSS2 extends PKCS11Test {
 
     // PKCS11 does not support RSASSA-PSS keys yet
     private static final String KEYALG = "RSA";
-    private static final String[] SIGALGS = {
+    private static String[] SIGALGS = {
             "SHA224withRSASSA-PSS", "SHA256withRSASSA-PSS",
-            "SHA384withRSASSA-PSS", "SHA512withRSASSA-PSS",
+            "SHA384withRSASSA-PSS", "SHA512withRSASSA-PSS"
+    };
+    private static final String[] SIGALGS_NEW = {
             "SHA3-224withRSASSA-PSS", "SHA3-256withRSASSA-PSS",
             "SHA3-384withRSASSA-PSS", "SHA3-512withRSASSA-PSS"
     };
@@ -53,6 +75,9 @@ public class SignatureTestPSS2 extends PKCS11Test {
     private static final int UPDATE_TIMES = 2;
 
     public static void main(String[] args) throws Exception {
+        if (args.length>0 && "new-alg".equals(args[0])){
+            SIGALGS = SIGALGS_NEW;
+        }
         main(new SignatureTestPSS2(), args);
     }
 
@@ -63,9 +88,7 @@ public class SignatureTestPSS2 extends PKCS11Test {
             try {
                 sig = Signature.getInstance(sa, p);
             } catch (NoSuchAlgorithmException e) {
-                System.out.println("Skip testing " + sa +
-                    " due to no support");
-                return;
+                throw new SkippedException("No support for " + sa);
             }
             for (int i : KEYSIZES) {
                 runTest(sig, i);
@@ -94,7 +117,7 @@ public class SignatureTestPSS2 extends PKCS11Test {
                  SignatureException | NoSuchProviderException ex) {
             throw new RuntimeException(ex);
         } catch (InvalidAlgorithmParameterException ex2) {
-            System.out.println("Skip test due to " + ex2);
+            throw new SkippedException(ex2.toString());
         }
     }
 

--- a/test/jdk/sun/security/pkcs11/Signature/TestDSA.java
+++ b/test/jdk/sun/security/pkcs11/Signature/TestDSA.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,8 @@
  * @modules jdk.crypto.cryptoki
  * @run main/othervm TestDSA
  */
+
+import jtreg.SkippedException;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -122,8 +124,7 @@ public class TestDSA extends PKCS11Test {
         System.out.println("Testing provider " + provider + "...");
 
         if (provider.getService("Signature", "SHA1withDSA") == null) {
-            System.out.println("DSA not supported, skipping");
-            return;
+            throw new SkippedException("DSA not supported");
         }
 
         KeyFactory kf = KeyFactory.getInstance("DSA", provider);


### PR DESCRIPTION
* test/jdk/sun/security/pkcs11/Signature/InitAgainPSS.java
* test/jdk/sun/security/pkcs11/Signature/KeyAndParamCheckForPSS.java
* test/jdk/sun/security/pkcs11/Signature/SigInteropPSS.java
* test/jdk/sun/security/pkcs11/Signature/SigInteropPSS2.java
* test/jdk/sun/security/pkcs11/Signature/SignatureTestPSS.java
* test/jdk/sun/security/pkcs11/Signature/SignatureTestPSS2.java
*test/jdk/sun/security/pkcs11/Signature/TestDSA.java