### PR TITLE
8365792: GenShen: assertion "Generations aren't reconciled"

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahAsserts.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahAsserts.cpp
@@ -543,7 +543,8 @@ void ShenandoahAsserts::assert_control_or_vm_thread_at_safepoint(bool at_safepoi
 }
 
 void ShenandoahAsserts::assert_generations_reconciled(const char* file, int line) {
-  if (!SafepointSynchronize::is_at_safepoint()) {
+  if (!ShenandoahSafepoint::is_at_shenandoah_safepoint()) {
+    // Only shenandoah safepoint operations participate in the active/gc generation scheme
     return;
   }
 
@@ -554,7 +555,7 @@ void ShenandoahAsserts::assert_generations_reconciled(const char* file, int line
     return;
   }
 
-  ShenandoahMessageBuffer msg("Active(%d) & GC(%d) Generations aren't reconciled", agen->type(), ggen->type());
+  ShenandoahMessageBuffer msg("Active(%s) & GC(%s) Generations aren't reconciled", agen->name(), ggen->name());
   report_vm_error(file, line, msg.buffer());
 }
 


### PR DESCRIPTION
The coalesce-and-fill phase of an old gc cycle may be resumed at any time _without_ running a Shenandoah vm operation. The assertion itself is only meant to run during an operation which changes the active/gc generation. However, the assertion is made in places that may also run concurrently. The original assertion would be enforced if _any_ vm operation were running. For example, the assertions failures in the ticket show Shenandoah concurrently making old regions parsable (this assert should not be enforced) when a heap inspection operation takes a safepoint and (erroneously) causes this assertion to be enforced.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8365792](https://bugs.openjdk.org/browse/JDK-8365792): GenShen: assertion "Generations aren't reconciled" (**Bug** - P4)


### Reviewers
 * [Xiaolong Peng](https://openjdk.org/census#xpeng) (@pengxiaolong - Committer)
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27373/head:pull/27373` \
`$ git checkout pull/27373`

Update a local copy of the PR: \
`$ git checkout pull/27373` \
`$ git pull https://git.openjdk.org/jdk.git pull/27373/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27373`

View PR using the GUI difftool: \
`$ git pr show -t 27373`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27373.diff">https://git.openjdk.org/jdk/pull/27373.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27373#issuecomment-3309450931)
</details>
