### PR TITLE
8367988: NewFileSystemTests.readOnlyZipFileFailure fails when run by root user

### DIFF
--- a/test/jdk/jdk/nio/zipfs/NewFileSystemTests.java
+++ b/test/jdk/jdk/nio/zipfs/NewFileSystemTests.java
@@ -35,6 +35,7 @@ import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.util.Iterator;
 import java.util.Map;
+import jdk.test.lib.Platform;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.testng.Assert.assertEquals;
@@ -48,6 +49,7 @@ import static org.testng.Assert.assertTrue;
  * @bug 8218875
  * @summary ZIP File System tests that leverage Files.newFileSystem
  * @modules jdk.zipfs
+ * @library /test/lib
  * @compile NewFileSystemTests.java
  * @run testng NewFileSystemTests
  */
@@ -219,6 +221,9 @@ public class NewFileSystemTests {
      */
     @Test
     public void readOnlyZipFileFailure() throws IOException {
+        if (Platform.isRoot()) {
+            throw new org.testng.SkipException("Test skipped when executed by root user.");
+        }
         // Underlying file is read-only.
         Path readOnlyZip = Utils.createJarFile("read_only.zip", Map.of("file.txt", "Hello World"));
         // In theory this can fail, and we should avoid unwanted false-negatives.

--- a/test/jdk/jdk/nio/zipfs/NewFileSystemTests.java
+++ b/test/jdk/jdk/nio/zipfs/NewFileSystemTests.java
@@ -25,6 +25,7 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+import org.testng.SkipException;
 
 import java.io.IOException;
 import java.net.URI;
@@ -222,7 +223,7 @@ public class NewFileSystemTests {
     @Test
     public void readOnlyZipFileFailure() throws IOException {
         if (Platform.isRoot()) {
-            throw new org.testng.SkipException("Test skipped when executed by root user.");
+            throw new SkipException("Test skipped when executed by root user.");
         }
         // Underlying file is read-only.
         Path readOnlyZip = Utils.createJarFile("read_only.zip", Map.of("file.txt", "Hello World"));


### PR DESCRIPTION
I propose a small patch to skip a tier2 test which fails when it runs as the root user. The test expects an exception when it tries to open a read-only file as `rw`, but this does not happen for the root user.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8367988](https://bugs.openjdk.org/browse/JDK-8367988): NewFileSystemTests.readOnlyZipFileFailure fails when run by root user (**Enhancement** - P4)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27376/head:pull/27376` \
`$ git checkout pull/27376`

Update a local copy of the PR: \
`$ git checkout pull/27376` \
`$ git pull https://git.openjdk.org/jdk.git pull/27376/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27376`

View PR using the GUI difftool: \
`$ git pr show -t 27376`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27376.diff">https://git.openjdk.org/jdk/pull/27376.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27376#issuecomment-3309870522)
</details>
