### PR TITLE
8361955: [GCC static analyzer] libjdwp/threadControl.c threadControl_setPendingInterrupt error: dereference of NULL 'node'

### DIFF
--- a/src/jdk.jdwp.agent/share/native/libjdwp/threadControl.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/threadControl.c
@@ -2317,8 +2317,9 @@ threadControl_setPendingInterrupt(jthread thread)
     debugMonitorEnter(threadLock);
 
     node = findRunningThread(thread);
-    JDI_ASSERT(node != NULL);
-    node->pendingInterrupt = JNI_TRUE;
+    if (node != NULL) {
+        node->pendingInterrupt = JNI_TRUE;
+    }
 
     debugMonitorExit(threadLock);
 }


### PR DESCRIPTION
Fix gcc static analyzer warning. It was introduced by [JDK-8324868](https://bugs.openjdk.org/browse/JDK-8324868) early last year. For the most part the fix is to revert the relevant [JDK-8324868](https://bugs.openjdk.org/browse/JDK-8324868) changes, except for leaving in the replacement of calling findThread() with instead calling findRunningThread().

Ran all svc tier2 and tier5 tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8361955](https://bugs.openjdk.org/browse/JDK-8361955): [GCC static analyzer] libjdwp/threadControl.c threadControl_setPendingInterrupt error: dereference of NULL 'node' (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27378/head:pull/27378` \
`$ git checkout pull/27378`

Update a local copy of the PR: \
`$ git checkout pull/27378` \
`$ git pull https://git.openjdk.org/jdk.git pull/27378/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27378`

View PR using the GUI difftool: \
`$ git pr show -t 27378`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27378.diff">https://git.openjdk.org/jdk/pull/27378.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27378#issuecomment-3309915881)
</details>
