### PR TITLE
JDK-8017182 : [macosx] MouseClickCount.java produces click count greater than 1 when left-button click is followed by quick right button click

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -460,7 +460,6 @@ java/awt/ScrollPane/ScrollPaneEventType.java 8296516 macosx-all
 java/awt/Robot/AcceptExtraMouseButtons/AcceptExtraMouseButtons.java 7107528 linux-all,macosx-all
 java/awt/Mouse/MouseDragEvent/MouseDraggedTest.java 8080676 linux-all
 java/awt/Mouse/MouseModifiersUnitTest/MouseModifiersInKeyEvent.java 8157147 linux-all,windows-all,macosx-all
-java/awt/Mouse/MouseClickCount.java 8017182 macosx-all
 java/awt/Toolkit/ToolkitPropertyTest/ToolkitPropertyTest_Enable.java 6847163 linux-all
 java/awt/xembed/server/RunTestXEmbed.java 7034201 linux-all
 java/awt/Modal/ModalFocusTransferTests/FocusTransferDialogsDocModalTest.java 8164473 linux-all

--- a/test/jdk/java/awt/Mouse/MouseClickCount.java
+++ b/test/jdk/java/awt/Mouse/MouseClickCount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,17 +40,23 @@ public class MouseClickCount {
         String INSTRUCTIONS = """
                 1. Clicking on Frame panel quickly will produce clickCount larger than 1
                    in the TextArea the count is printed for each mouse click
+
                 2. Verify that a left-button click followed by a right button click quickly
                    will not generate 1, 2, i.e. it's not considered a double clicking.
-                 """;
+
+                PLEASE NOTE: On macOS mouse sensitivity may play a role, if you observe click
+                counts of 1,2 on press of left-mouse button followed by right-mouse button
+                verify by increasing the double-click speed or setting to maximum in
+                Settings > Mouse Sensitivity > Double-Click Speed
+                """;
+
         PassFailJFrame.builder()
-                .title("Test Instructions")
-                .instructions(INSTRUCTIONS)
-                .rows((int) INSTRUCTIONS.lines().count() + 2)
-                .columns(35)
-                .testUI(initialize())
-                .build()
-                .awaitAndCheck();
+                      .title("Test Instructions")
+                      .instructions(INSTRUCTIONS)
+                      .columns(45)
+                      .testUI(initialize())
+                      .build()
+                      .awaitAndCheck();
     }
 
     private static Frame initialize() {


### PR DESCRIPTION
On macOS mouse sensitivity setting play a role in click count increment. By increasing the double-click speed under
(Settings > Mouse Sensitivity > Double click speed), the click count no longer shows as 1,2.
