### PR TITLE
8368050: Validation missing in ClassFile signature factories

### DIFF
--- a/src/java.base/share/classes/java/lang/classfile/MethodSignature.java
+++ b/src/java.base/share/classes/java/lang/classfile/MethodSignature.java
@@ -113,13 +113,14 @@ public sealed interface MethodSignature
      *
      * @param result signature for the return type
      * @param arguments signatures for the method parameters
+     * @throws IllegalArgumentException if any of {@code arguments} is void
      */
     public static MethodSignature of(Signature result,
                                      Signature... arguments) {
         return new SignaturesImpl.MethodSignatureImpl(List.of(),
                                                       List.of(),
                                                       requireNonNull(result),
-                                                      List.of(arguments));
+                                                      SignaturesImpl.validateArgumentList(arguments));
     }
 
     /**
@@ -131,6 +132,7 @@ public sealed interface MethodSignature
      * @param exceptions signatures for the exceptions
      * @param result signature for the return type
      * @param arguments signatures for the method parameters
+     * @throws IllegalArgumentException if any of {@code arguments} is void
      */
     public static MethodSignature of(List<Signature.TypeParam> typeParameters,
                                      List<Signature.ThrowableSig> exceptions,
@@ -140,7 +142,7 @@ public sealed interface MethodSignature
                 List.copyOf(requireNonNull(typeParameters)),
                 List.copyOf(requireNonNull(exceptions)),
                 requireNonNull(result),
-                List.of(arguments));
+                SignaturesImpl.validateArgumentList(arguments));
     }
 
     /**

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/ClassRemapperImpl.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/ClassRemapperImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -309,7 +309,7 @@ public record ClassRemapperImpl(Function<ClassDesc, ClassDesc> mapFunction) impl
             case Signature.ClassTypeSig cts ->
                 Signature.ClassTypeSig.of(
                         cts.outerType().map(this::mapSignature).orElse(null),
-                        map(cts.classDesc()),
+                        Util.toInternalName(map(cts.classDesc())), // wrong, needs fix with InnerClasses
                         cts.typeArgs().stream().map(ta -> switch (ta) {
                             case Signature.TypeArg.Unbounded u -> u;
                             case Signature.TypeArg.Bounded bta -> Signature.TypeArg.bounded(

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/SignaturesImpl.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/SignaturesImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -226,19 +226,86 @@ public final class SignaturesImpl {
      */
     private int requireIdentifier() {
         int start = sigp;
-        l:
         while (sigp < sig.length()) {
-            switch (sig.charAt(sigp)) {
-                case '.', ';', '[', '/', '<', '>', ':' -> {
-                    break l;
-                }
-            }
+            if (isNonIdentifierChar(sig.charAt(sigp)))
+                break;
             sigp++;
         }
         if (start == sigp) {
             throw unexpectedError("an identifier");
         }
         return sigp;
+    }
+
+    // Non-identifier chars in ascii 0 to 63, note [ is larger
+    private static final long SMALL_NON_IDENTIFIER_CHARS_SET = (1L << '.')
+            | (1L << ';')
+            | (1L << '/')
+            | (1L << '<')
+            | (1L << '>')
+            | (1L << ':');
+
+    private static boolean isNonIdentifierChar(char c) {
+        return c < Long.SIZE ? (SMALL_NON_IDENTIFIER_CHARS_SET & (1L << c)) != 0 : c == '[';
+    }
+
+    /// {@return exclusive end of the next identifier}
+    public static int nextIdentifierEnd(String st, int start) {
+        int end = st.length();
+        for (int i = start; i < end; i++) {
+            if (isNonIdentifierChar(st.charAt(i))) {
+                return i;
+            }
+        }
+        return end;
+    }
+
+    /// Validates this string as a simple identifier.
+    public static String validateIdentifier(String st) {
+        var len = st.length(); // implicit null check
+        if (len == 0 || nextIdentifierEnd(st, 0) != len) {
+            throw new IllegalArgumentException("Not a valid identifier: " + st);
+        }
+        return st;
+    }
+
+    /// Validates this string as slash-separated one or more identifiers.
+    public static String validatePackageSpecifierPlusIdentifier(String st) {
+        int nextIdentifierStart = 0;
+        int len = st.length();
+        while (nextIdentifierStart < len) {
+            int end = nextIdentifierEnd(st, nextIdentifierStart);
+            if (end == len)
+                return st;
+            if (end == nextIdentifierStart || st.charAt(end) != '/')
+                throw new IllegalArgumentException("Not a class name: " + st);
+            nextIdentifierStart = end + 1;
+        }
+        // Couldn't get an identifier initially or after a separator.
+        throw new IllegalArgumentException("Not a class name: " + st);
+    }
+
+    /// Validates the signature to be non-void (a valid field type).
+    public static Signature validateNonVoid(Signature incoming) {
+        Objects.requireNonNull(incoming);
+        if (incoming instanceof Signature.BaseTypeSig baseType && baseType.baseType() == 'V')
+            throw new IllegalArgumentException("void");
+        return incoming;
+    }
+
+    /// Returns the validated immutable argument list or fails with IAE.
+    public static List<Signature> validateArgumentList(Signature[] signatures) {
+        return validateArgumentList(List.of(signatures));
+    }
+
+    /// Returns the validated immutable argument list or fails with IAE.
+    public static List<Signature> validateArgumentList(List<Signature> signatures) {
+        var res = List.copyOf(signatures); // deep null checks
+        for (var sig : signatures) {
+            if (sig instanceof Signature.BaseTypeSig baseType && baseType.baseType() == 'V')
+                throw new IllegalArgumentException("void");
+        }
+        return res;
     }
 
     public static record BaseTypeSigImpl(char baseType) implements Signature.BaseTypeSig {
@@ -316,13 +383,13 @@ public final class SignaturesImpl {
 
     private static StringBuilder printTypeParameters(List<TypeParam> typeParameters) {
         var sb = new StringBuilder();
-        if (typeParameters != null && !typeParameters.isEmpty()) {
+        if (!typeParameters.isEmpty()) {
             sb.append('<');
             for (var tp : typeParameters) {
                 sb.append(tp.identifier()).append(':');
                 if (tp.classBound().isPresent())
                     sb.append(tp.classBound().get().signatureString());
-                if (tp.interfaceBounds() != null) for (var is : tp.interfaceBounds())
+                for (var is : tp.interfaceBounds())
                     sb.append(':').append(is.signatureString());
             }
             sb.append('>');
@@ -337,7 +404,7 @@ public final class SignaturesImpl {
         public String signatureString() {
             var sb = printTypeParameters(typeParameters);
             sb.append(superclassSignature.signatureString());
-            if (superinterfaceSignatures != null) for (var in : superinterfaceSignatures)
+            for (var in : superinterfaceSignatures)
                 sb.append(in.signatureString());
             return sb.toString();
         }

--- a/test/jdk/jdk/classfile/SignaturesTest.java
+++ b/test/jdk/jdk/classfile/SignaturesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,6 +48,9 @@ import java.lang.classfile.Attributes;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
 import static helpers.ClassRecord.assertEqualsDeep;
 import static java.lang.constant.ConstantDescs.*;
 import java.util.function.Consumer;
@@ -63,7 +66,7 @@ class SignaturesTest {
                 ClassSignature.of(
                         ClassTypeSig.of(
                                 ClassTypeSig.of(ClassDesc.of("java.util.LinkedHashMap"), TypeArg.of(TypeVarSig.of("K")), TypeArg.of(TypeVarSig.of("V"))),
-                                ClassDesc.of("LinkedHashIterator")),
+                                "LinkedHashIterator"),
                         ClassTypeSig.of(ClassDesc.of("java.util.Iterator"),
                                 TypeArg.of(ClassTypeSig.of(ClassDesc.of("java.util.Map$Entry"), TypeArg.of(TypeVarSig.of("K")), TypeArg.of(TypeVarSig.of("V")))))),
                 ClassSignature.parseFrom("Ljava/util/LinkedHashMap<TK;TV;>.LinkedHashIterator;Ljava/util/Iterator<Ljava/util/Map$Entry<TK;TV;>;>;"));
@@ -117,6 +120,67 @@ class SignaturesTest {
         assertEqualsDeep(
                 ArrayTypeSig.of(2, TypeVarSig.of("E")),
                 Signature.parseFrom("[[TE;"));
+    }
+
+    @Test
+    void testGenericCreationChecks() {
+        var weirdNameClass = ClassDesc.of("<Unsupported>");
+        var voidSig = BaseTypeSig.of('V');
+        Assertions.assertThrows(IllegalArgumentException.class, () -> Signature.of(weirdNameClass));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> BaseTypeSig.of(CD_Object));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> BaseTypeSig.of(CD_int.arrayType()));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> ClassTypeSig.of(CD_int));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> ClassTypeSig.of(CD_Object.arrayType()));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> ClassTypeSig.of(weirdNameClass));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> ArrayTypeSig.of(voidSig));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> ArrayTypeSig.of(255, voidSig));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> MethodSignature.of(voidSig, voidSig));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> MethodSignature.of(List.of(), List.of(), voidSig, voidSig));
+    }
+
+    static Stream<String> goodIdentifiers() {
+        return Stream.of("T", "Hello", "Mock", "(Weird)", " Huh? ");
+    }
+
+    static Stream<String> badIdentifiers() {
+        return Stream.of("", ";", ".", "/", "<", ">", "[", ":",
+                "<Unsupported>", "has.chars", "/Outer", "test/", "test//Outer");
+    }
+
+    static Stream<String> slashedIdentifiers() {
+        return Stream.of("test/Outer", "java/lang/Integer");
+    }
+
+    @ParameterizedTest
+    @MethodSource({"badIdentifiers", "slashedIdentifiers"})
+    void testBadSimpleIdentifier(String st) {
+        ClassTypeSig outer = ClassTypeSig.of("test/Outer");
+        Assertions.assertThrows(IllegalArgumentException.class, () -> ClassTypeSig.of(outer, st));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> TypeVarSig.of(st));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> TypeParam.of(st, (RefTypeSig) null));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> TypeParam.of(st, Optional.empty()));
+    }
+
+    @ParameterizedTest
+    @MethodSource("goodIdentifiers")
+    void testGoodSimpleIdentifier(String st) {
+        ClassTypeSig outer = ClassTypeSig.of("test/Outer");
+        ClassTypeSig.of(outer, st);
+        TypeVarSig.of(st);
+        TypeParam.of(st, (RefTypeSig) null);
+        TypeParam.of(st, Optional.empty());
+    }
+
+    @ParameterizedTest
+    @MethodSource("badIdentifiers")
+    void testBadSlashedIdentifier(String st) {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> ClassTypeSig.of(st));
+    }
+
+    @ParameterizedTest
+    @MethodSource({"goodIdentifiers", "slashedIdentifiers"})
+    void testGoodSlashedIdentifier(String st) {
+        ClassTypeSig.of(st);
     }
 
     @Test


### PR DESCRIPTION
The Signature modeling in the ClassFile API is missing some validations required by JVMS, notably identifier character restrictions and void type restrictions. In addition, the model currently uses `ClassDesc` to indicate a simple name for an inner class signature, which is incorrect, and this patch proposes to deprecate that API for removal.