### PR TITLE
8071277: G1: Merge commits and uncommits of contiguous memory

### DIFF
--- a/src/hotspot/share/gc/g1/g1NUMA.cpp
+++ b/src/hotspot/share/gc/g1/g1NUMA.cpp
@@ -203,9 +203,7 @@ uint G1NUMA::index_for_region(G1HeapRegion* hr) const {
 //      * G1HeapRegion #: |-#0-||-#1-||-#2-||-#3-||-#4-||-#5-||-#6-||-#7-||-#8-||-#9-||#10-||#11-||#12-||#13-||#14-||#15-|
 //      * NUMA node #:    |----#0----||----#1----||----#2----||----#3----||----#0----||----#1----||----#2----||----#3----|
 void G1NUMA::request_memory_on_node(void* aligned_address, size_t size_in_bytes, uint region_index) {
-  if (!is_enabled()) {
-    return;
-  }
+  assert(is_enabled(), "must be, check before");
 
   if (size_in_bytes == 0) {
     return;

--- a/src/hotspot/share/gc/g1/g1RegionToSpaceMapper.cpp
+++ b/src/hotspot/share/gc/g1/g1RegionToSpaceMapper.cpp
@@ -216,18 +216,18 @@ class G1RegionsSmallerThanCommitSizeMapper : public G1RegionToSpaceMapper {
       log_debug(gc,ihop)("commit-regions start-region %u num_regions %zu start-page %zu end-page %zu", start_idx, num_regions, start_page, end_page);
 
       size_t uncommitted_l = find_first_uncommitted(start_page, end_page);
-      size_t committed_r = find_first_committed(uncommitted_l + 1, end_page);
+      size_t uncommitted_r = find_first_committed(uncommitted_l + 1, end_page);
 
       first_newly_committed = uncommitted_l;
-      num_committed_pages = committed_r - uncommitted_l;
+      num_committed_pages = uncommitted_r - uncommitted_l;
 
-      log_debug(gc,ihop)("uncommit-regions chunk page %zu to page %zu size %zu", uncommitted_l, committed_r, num_committed_pages);
+      log_debug(gc,ihop)("uncommit-regions chunk page %zu to page %zu size %zu", uncommitted_l, uncommitted_r, num_committed_pages);
       if (num_committed_pages > 0 &&
           !commit_pages(first_newly_committed, num_committed_pages)) {
         all_zero_filled = false;
       }
 
-      all_zero_filled &= (uncommitted_l == start_page) && (committed_r == end_page);
+      all_zero_filled &= (uncommitted_l == start_page) && (uncommitted_r == end_page);
 
       // Update the commit map for the given range. Not using the par_set_range
       // since updates to _region_commit_map for this mapper is protected by _lock.
@@ -264,11 +264,11 @@ class G1RegionsSmallerThanCommitSizeMapper : public G1RegionToSpaceMapper {
     // the page is still marked as committed after the clear we should
     // not uncommit it.
     size_t uncommitted_l = find_first_uncommitted(start_page, end_page);
-    size_t committed_r = find_first_committed(uncommitted_l + 1, end_page);
+    size_t uncommitted_r = find_first_committed(uncommitted_l + 1, end_page);
 
-    size_t num_uncommitted_pages_found = committed_r - uncommitted_l;
+    size_t num_uncommitted_pages_found = uncommitted_r - uncommitted_l;
 
-    log_debug(gc,ihop)("uncommit-regions chunk page %zu to page %zu size %zu", uncommitted_l, committed_r, num_uncommitted_pages_found);
+    log_debug(gc,ihop)("uncommit-regions chunk page %zu to page %zu size %zu", uncommitted_l, uncommitted_r, num_uncommitted_pages_found);
 
     if (num_uncommitted_pages_found > 0) {
       _storage.uncommit(uncommitted_l, num_uncommitted_pages_found);

--- a/src/hotspot/share/gc/g1/g1RegionToSpaceMapper.hpp
+++ b/src/hotspot/share/gc/g1/g1RegionToSpaceMapper.hpp
@@ -58,6 +58,8 @@ class G1RegionToSpaceMapper : public CHeapObj<mtGC> {
   G1RegionToSpaceMapper(ReservedSpace rs, size_t used_size, size_t page_size, size_t region_granularity, size_t commit_factor, MemTag mem_tag);
 
   void fire_on_commit(uint start_idx, size_t num_regions, bool zero_filled);
+
+  bool should_distribute_across_numa_nodes() const;
  public:
   MemRegion reserved() { return _storage.reserved(); }
 


### PR DESCRIPTION
Hi all,

  please review this change to G1 commit/uncommit to merge commit/uncommit calls to the operating system as much as possible. This significantly improves startup performanc

Performance results before/after on Zen3 processor for a "HelloWorld" application:

```
 $ hyperfine -w 10 -r 10 "baseline/bin/java -XX:+UseG1GC -Xms128m -Xmx128m Hello"
Benchmark 1: baseline/bin/java -XX:+UseG1GC -Xms128m -Xmx128m Hello
  Time (mean ± σ): 16.4 ms ± 0.4 ms [User: 11.0 ms, System: 14.4 ms]
  Range (min … max): 15.7 ms … 16.8 ms 10 runs

$ hyperfine -w 10 -r 10 "baseline/bin/java -XX:+UseG1GC -Xms2g -Xmx2g Hello"
Benchmark 1: baseline/bin/java -XX:+UseG1GC -Xms2g -Xmx2g Hello
  Time (mean ± σ): 24.7 ms ± 0.4 ms [User: 10.7 ms, System: 22.7 ms]
  Range (min … max): 24.2 ms … 25.4 ms 10 runs

My reimplementation of JDK-8071277 does show improvements here:

$ hyperfine -w 10 -r 10 "changes/bin/java -XX:+UseG1GC -Xms128m -Xmx128m Hello"
Benchmark 1: changes/bin/java -XX:+UseG1GC -Xms128m -Xmx128m Hello
  Time (mean ± σ): 15.9 ms ± 0.4 ms [User: 11.9 ms, System: 13.1 ms]
  Range (min … max): 15.4 ms … 16.7 ms 10 runs

$ hyperfine -w 10 -r 10 "changes/bin/java -XX:+UseG1GC -Xms2g -Xmx2g Hello"
Benchmark 1: changes/bin/java -XX:+UseG1GC -Xms2g -Xmx2g Hello
  Time (mean ± σ): 19.7 ms ± 0.3 ms [User: 11.3 ms, System: 17.4 ms]
  Range (min … max): 19.2 ms … 20.1 ms 10 runs
```

I.e., depending on actually committed heap size (`-Xms`), reduction of startup time by 20% or so in above cases.

Testing: tier1-5, gha

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8071277](https://bugs.openjdk.org/browse/JDK-8071277): G1: Merge commits and uncommits of contiguous memory (**Enhancement** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**) Review applies to [eadbba67](https://git.openjdk.org/jdk/pull/27381/files/eadbba676e2d900612225761df03a3c1ae789812)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27381/head:pull/27381` \
`$ git checkout pull/27381`

Update a local copy of the PR: \
`$ git checkout pull/27381` \
`$ git pull https://git.openjdk.org/jdk.git pull/27381/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27381`

View PR using the GUI difftool: \
`$ git pr show -t 27381`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27381.diff">https://git.openjdk.org/jdk/pull/27381.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27381#issuecomment-3311458220)
</details>
