### PR TITLE
8368029: Several tests in httpserver/simpleserver should throw SkipException

### DIFF
--- a/test/jdk/com/sun/net/httpserver/simpleserver/CustomFileSystemTest.java
+++ b/test/jdk/com/sun/net/httpserver/simpleserver/CustomFileSystemTest.java
@@ -256,63 +256,65 @@ public class CustomFileSystemTest {
 
     @Test
     public void testNotReadableFileGET() throws Exception {
-        if (!Platform.isWindows()) {  // not applicable on Windows
-            var expectedBody = openHTML + """
-                <h1>File not found</h1>
-                <p>&#x2F;aFile.txt</p>
-                """ + closeHTML;
-            var expectedLength = Integer.toString(expectedBody.getBytes(UTF_8).length);
-            var root = createDirectoryInCustomFs("testNotReadableFileGET");
-            var file = Files.writeString(root.resolve("aFile.txt"), "some text", CREATE);
+        if (Platform.isWindows()) {
+            throw new SkipException("Not applicable on Windows");
+        }
+        var expectedBody = openHTML + """
+            <h1>File not found</h1>
+            <p>&#x2F;aFile.txt</p>
+            """ + closeHTML;
+        var expectedLength = Integer.toString(expectedBody.getBytes(UTF_8).length);
+        var root = createDirectoryInCustomFs("testNotReadableFileGET");
+        var file = Files.writeString(root.resolve("aFile.txt"), "some text", CREATE);
 
-            file.toFile().setReadable(false, false);
-            assert !Files.isReadable(file);
+        file.toFile().setReadable(false, false);
+        assert !Files.isReadable(file);
 
-            var server = SimpleFileServer.createFileServer(LOOPBACK_ADDR, root, OutputLevel.VERBOSE);
-            server.start();
-            try {
-                var client = HttpClient.newBuilder().proxy(NO_PROXY).build();
-                var request = HttpRequest.newBuilder(uri(server, "aFile.txt")).build();
-                var response = client.send(request, BodyHandlers.ofString());
-                assertEquals(response.statusCode(), 404);
-                assertEquals(response.headers().firstValue("content-length").get(), expectedLength);
-                assertEquals(response.body(), expectedBody);
-            } finally {
-                server.stop(0);
-                file.toFile().setReadable(true, false);
-            }
+        var server = SimpleFileServer.createFileServer(LOOPBACK_ADDR, root, OutputLevel.VERBOSE);
+        server.start();
+        try {
+            var client = HttpClient.newBuilder().proxy(NO_PROXY).build();
+            var request = HttpRequest.newBuilder(uri(server, "aFile.txt")).build();
+            var response = client.send(request, BodyHandlers.ofString());
+            assertEquals(response.statusCode(), 404);
+            assertEquals(response.headers().firstValue("content-length").get(), expectedLength);
+            assertEquals(response.body(), expectedBody);
+        } finally {
+            server.stop(0);
+            file.toFile().setReadable(true, false);
         }
     }
 
     @Test
     public void testNotReadableSegmentGET() throws Exception {
-        if (!Platform.isWindows()) {  // not applicable on Windows
-            var expectedBody = openHTML + """
-                <h1>File not found</h1>
-                <p>&#x2F;dir&#x2F;aFile.txt</p>
-                """ + closeHTML;
-            var expectedLength = Integer.toString(expectedBody.getBytes(UTF_8).length);
-            var root = createDirectoryInCustomFs("testNotReadableSegmentGET");
-            var dir = Files.createDirectory(root.resolve("dir"));
-            var file = Files.writeString(dir.resolve("aFile.txt"), "some text", CREATE);
+        if (Platform.isWindows()) {
+            throw new SkipException("Not applicable on Windows");
+        }
+        var expectedBody = openHTML + """
+            <h1>File not found</h1>
+            <p>&#x2F;dir&#x2F;aFile.txt</p>
+            """ + closeHTML;
+        var expectedLength = Integer.toString(expectedBody.getBytes(UTF_8).length);
+        var root = createDirectoryInCustomFs("testNotReadableSegmentGET");
+        var dir = Files.createDirectory(root.resolve("dir"));
+        var file = Files.writeString(dir.resolve("aFile.txt"), "some text", CREATE);
 
-            dir.toFile().setReadable(false, false);
-            assert !Files.isReadable(dir);
-            assert Files.isReadable(file);
+        dir.toFile().setReadable(false, false);
+        assert !Files.isReadable(dir);
+        assert Files.isReadable(file);
 
-            var server = SimpleFileServer.createFileServer(LOOPBACK_ADDR, root, OutputLevel.VERBOSE);
-            server.start();
-            try {
-                var client = HttpClient.newBuilder().proxy(NO_PROXY).build();
-                var request = HttpRequest.newBuilder(uri(server, "dir/aFile.txt")).build();
-                var response = client.send(request, BodyHandlers.ofString());
-                assertEquals(response.statusCode(), 404);
-                assertEquals(response.headers().firstValue("content-length").get(), expectedLength);
-                assertEquals(response.body(), expectedBody);
-            } finally {
-                server.stop(0);
-                dir.toFile().setReadable(true, false);
-            }
+        var server = SimpleFileServer.createFileServer(LOOPBACK_ADDR, root, OutputLevel.VERBOSE);
+        server.start();
+        try {
+            var client = HttpClient.newBuilder().proxy(NO_PROXY).build();
+            var request = HttpRequest.newBuilder(uri(server, "dir/aFile.txt")).build();
+            var response = client.send(request, BodyHandlers.ofString());
+            assertEquals(response.statusCode(), 404);
+            assertEquals(response.headers().firstValue("content-length").get(), expectedLength);
+            assertEquals(response.body(), expectedBody);
+        } finally {
+            server.stop(0);
+            dir.toFile().setReadable(true, false);
         }
     }
 


### PR DESCRIPTION
I propose a change to have these tests listed appropriately as "skipped" rather than "passing" on Windows. I'm also taking the opportunity to save an indentation level since we can throw a `SkipException` early in all the related methods.