### PR TITLE
JDK-8318662: Refactor some jdk/java/net/httpclient/http2 tests to JUnit

### DIFF
--- a/test/jdk/java/net/httpclient/http2/BadHeadersTest.java
+++ b/test/jdk/java/net/httpclient/http2/BadHeadersTest.java
@@ -29,7 +29,7 @@
  *          with bad header fields.
  * @library /test/lib /test/jdk/java/net/httpclient/lib
  * @build jdk.httpclient.test.lib.http2.Http2TestServer jdk.test.lib.net.SimpleSSLContext
- * @run testng/othervm -Djdk.internal.httpclient.debug=true BadHeadersTest
+ * @run junit/othervm -Djdk.internal.httpclient.debug=true BadHeadersTest
  */
 
 import jdk.internal.net.http.common.HttpHeadersBuilder;
@@ -38,10 +38,11 @@ import jdk.internal.net.http.frame.HeaderFrame;
 import jdk.internal.net.http.frame.HeadersFrame;
 import jdk.internal.net.http.frame.Http2Frame;
 import jdk.test.lib.net.SimpleSSLContext;
-import org.testng.annotations.AfterTest;
-import org.testng.annotations.BeforeTest;
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSession;
 import java.io.IOException;
@@ -61,6 +62,8 @@ import java.util.List;
 import java.util.Map.Entry;
 import java.util.concurrent.ExecutionException;
 import java.util.function.BiFunction;
+import java.util.stream.Stream;
+
 import jdk.httpclient.test.lib.http2.Http2TestServer;
 import jdk.httpclient.test.lib.http2.Http2TestExchange;
 import jdk.httpclient.test.lib.http2.Http2TestExchangeImpl;
@@ -69,8 +72,9 @@ import jdk.httpclient.test.lib.http2.BodyOutputStream;
 import jdk.httpclient.test.lib.http2.Http2TestServerConnection;
 import static java.util.List.of;
 import static java.util.Map.entry;
-import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 // Code copied from ContinuationFrameTest
 public class BadHeadersTest {
@@ -85,11 +89,11 @@ public class BadHeadersTest {
         of(entry("hello", "world!"), entry(":status", "200"))                      // Pseudo header is not the first one
     );
 
-    SSLContext sslContext;
-    Http2TestServer http2TestServer;   // HTTP/2 ( h2c )
-    Http2TestServer https2TestServer;  // HTTP/2 ( h2  )
-    String http2URI;
-    String https2URI;
+    static SSLContext sslContext;
+    static Http2TestServer http2TestServer;   // HTTP/2 ( h2c )
+    static Http2TestServer https2TestServer;  // HTTP/2 ( h2  )
+    static String http2URI;
+    static String https2URI;
 
     /**
      * A function that returns a list of 1) one HEADERS frame ( with an empty
@@ -127,23 +131,23 @@ public class BadHeadersTest {
                 return frames;
             };
 
-    @DataProvider(name = "variants")
-    public Object[][] variants() {
-        return new Object[][] {
-                { http2URI,  false, oneContinuation },
-                { https2URI, false, oneContinuation },
-                { http2URI,  true,  oneContinuation },
-                { https2URI, true,  oneContinuation },
+    static Stream<Arguments> variants() {
+        return Stream.of(
+                Arguments.of(http2URI,  false, oneContinuation),
+                Arguments.of(https2URI, false, oneContinuation),
+                Arguments.of(http2URI,  true,  oneContinuation),
+                Arguments.of(https2URI, true,  oneContinuation),
 
-                { http2URI,  false, byteAtATime },
-                { https2URI, false, byteAtATime },
-                { http2URI,  true,  byteAtATime },
-                { https2URI, true,  byteAtATime },
-        };
+                Arguments.of(http2URI,  false, byteAtATime),
+                Arguments.of(https2URI, false, byteAtATime),
+                Arguments.of(http2URI,  true,  byteAtATime),
+                Arguments.of(https2URI, true,  byteAtATime)
+        );
     }
 
 
-    @Test(dataProvider = "variants")
+    @ParameterizedTest
+    @MethodSource("variants")
     void test(String uri,
               boolean sameClient,
               BiFunction<Integer,List<ByteBuffer>,List<Http2Frame>> headerFramesSupplier)
@@ -172,7 +176,8 @@ public class BadHeadersTest {
         }
     }
 
-    @Test(dataProvider = "variants")
+    @ParameterizedTest
+    @MethodSource("variants")
     void testAsync(String uri,
                    boolean sameClient,
                    BiFunction<Integer,List<ByteBuffer>,List<Http2Frame>> headerFramesSupplier)
@@ -211,8 +216,7 @@ public class BadHeadersTest {
     // sync with implementation.
     static void assertDetailMessage(Throwable throwable, int iterationIndex) {
         try {
-            assertTrue(throwable instanceof ProtocolException,
-                    "Expected ProtocolException, got " + throwable);
+            assertInstanceOf(ProtocolException.class, throwable, "Expected ProtocolException, got " + throwable);
             assertTrue(throwable.getMessage().contains("malformed response"),
                     "Expected \"malformed response\" in: " + throwable.getMessage());
 
@@ -239,8 +243,8 @@ public class BadHeadersTest {
         }
     }
 
-    @BeforeTest
-    public void setup() throws Exception {
+    @BeforeAll
+    public static void setup() throws Exception {
         sslContext = new SimpleSSLContext().get();
         if (sslContext == null)
             throw new AssertionError("Unexpected null sslContext");
@@ -264,8 +268,8 @@ public class BadHeadersTest {
         https2TestServer.start();
     }
 
-    @AfterTest
-    public void teardown() throws Exception {
+    @AfterAll
+    public static void teardown() throws Exception {
         http2TestServer.stop();
         https2TestServer.stop();
     }

--- a/test/jdk/java/net/httpclient/http2/BadPushPromiseTest.java
+++ b/test/jdk/java/net/httpclient/http2/BadPushPromiseTest.java
@@ -26,16 +26,16 @@
  * @bug 8354276
  * @library /test/lib /test/jdk/java/net/httpclient/lib
  * @build jdk.test.lib.net.SimpleSSLContext jdk.httpclient.test.lib.http2.Http2TestServer
- * @run testng/othervm
+ * @run junit/othervm
  *      -Djdk.internal.httpclient.debug=true
  *      -Djdk.httpclient.HttpClient.log=errors,requests,responses,trace
  *      BadPushPromiseTest
  */
 
 import jdk.httpclient.test.lib.common.HttpServerAdapters;
-import org.testng.annotations.AfterTest;
-import org.testng.annotations.BeforeTest;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -59,7 +59,7 @@ import java.util.concurrent.ConcurrentMap;
 import static java.net.http.HttpClient.Version.HTTP_2;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.List.of;
-import static org.testng.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class BadPushPromiseTest {
 
@@ -73,11 +73,11 @@ public class BadPushPromiseTest {
 
     static final String MAIN_RESPONSE_BODY = "the main response body";
 
-    HttpServerAdapters.HttpTestServer server;
-    URI uri;
+    static HttpServerAdapters.HttpTestServer server;
+    static URI uri;
 
-    @BeforeTest
-    public void setup() throws Exception {
+    @BeforeAll
+    public static void setup() throws Exception {
         server = HttpServerAdapters.HttpTestServer.create(HTTP_2);
         HttpServerAdapters.HttpTestHandler handler = new ServerPushHandler(MAIN_RESPONSE_BODY);
         server.addHandler(handler, "/");
@@ -87,8 +87,8 @@ public class BadPushPromiseTest {
         uri = new URI("http://" + authority + "/foo/a/b/c");
     }
 
-    @AfterTest
-    public void teardown() {
+    @AfterAll
+    public static void teardown() {
         server.stop();
     }
 
@@ -123,8 +123,7 @@ public class BadPushPromiseTest {
     // sync with implementation.
     static void assertDetailMessage(Throwable throwable, int iterationIndex) {
         try {
-            assertTrue(throwable instanceof ProtocolException,
-                    "Expected ProtocolException, got " + throwable);
+            assertInstanceOf(ProtocolException.class, throwable, "Expected ProtocolException, got " + throwable);
 
             if (iterationIndex == 0) { // unknown
                 assertTrue(throwable.getMessage().contains("Unknown pseudo-header"),

--- a/test/jdk/java/net/httpclient/http2/BasicTest.java
+++ b/test/jdk/java/net/httpclient/http2/BasicTest.java
@@ -32,7 +32,7 @@
  *        jdk.test.lib.Asserts
  *        jdk.test.lib.Utils
  *        jdk.test.lib.net.SimpleSSLContext
- * @run testng/othervm -Djdk.httpclient.HttpClient.log=ssl,requests,responses,errors BasicTest
+ * @run junit/othervm -Djdk.httpclient.HttpClient.log=ssl,requests,responses,errors BasicTest
  */
 
 import java.io.IOException;
@@ -53,14 +53,13 @@ import jdk.httpclient.test.lib.http2.Http2TestServer;
 import jdk.httpclient.test.lib.http2.Http2TestExchange;
 import jdk.httpclient.test.lib.http2.Http2EchoHandler;
 import jdk.test.lib.net.SimpleSSLContext;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 import static java.net.http.HttpClient.Version.HTTP_2;
 import static jdk.test.lib.Asserts.assertFileContentsEqual;
 import static jdk.test.lib.Utils.createTempFile;
 import static jdk.test.lib.Utils.createTempFileOfSize;
 
-@Test
 public class BasicTest {
 
     private static final String TEMP_FILE_PREFIX =
@@ -127,7 +126,7 @@ public class BasicTest {
     }
 
     @Test
-    public static void test() throws Exception {
+    public void test() throws Exception {
         try {
             initialize();
             warmup(false);


### PR DESCRIPTION
Refactoring following httpclient/http2 testng test to JUnit :
test/jdk/java/net/httpclient/http2/BadHeadersTest.java
test/jdk/java/net/httpclient/http2/BadPushPromiseTest.java
test/jdk/java/net/httpclient/http2/BasicTest.java
test/jdk/java/net/httpclient/http2/ConnectionFlowControlTest.java
test/jdk/java/net/httpclient/http2/ContinuationFrameTest.java 