### PR TITLE
8368080: G1: Unnecessary initialization of G1CMTask's mark stats table

### DIFF
--- a/src/hotspot/share/gc/g1/g1FullGCMarker.cpp
+++ b/src/hotspot/share/gc/g1/g1FullGCMarker.cpp
@@ -43,6 +43,7 @@ G1FullGCMarker::G1FullGCMarker(G1FullCollector* collector,
     _cld_closure(mark_closure(), ClassLoaderData::_claim_stw_fullgc_mark),
     _mark_stats_cache(mark_stats, G1RegionMarkStatsCache::RegionMarkStatsCacheSize) {
   ClassLoaderDataGraph::verify_claimed_marks_cleared(ClassLoaderData::_claim_stw_fullgc_mark);
+  _mark_stats_cache.reset();
 }
 
 G1FullGCMarker::~G1FullGCMarker() {

--- a/src/hotspot/share/gc/g1/g1RegionMarkStatsCache.cpp
+++ b/src/hotspot/share/gc/g1/g1RegionMarkStatsCache.cpp
@@ -35,7 +35,6 @@ G1RegionMarkStatsCache::G1RegionMarkStatsCache(G1RegionMarkStats* target, uint n
   guarantee(is_power_of_2(num_cache_entries),
             "Number of cache entries must be power of two, but is %u", num_cache_entries);
   _cache = NEW_C_HEAP_ARRAY(G1RegionMarkStatsCacheEntry, _num_cache_entries, mtGC);
-  reset();
 }
 
 G1RegionMarkStatsCache::~G1RegionMarkStatsCache() {

--- a/src/hotspot/share/gc/g1/g1RegionMarkStatsCache.hpp
+++ b/src/hotspot/share/gc/g1/g1RegionMarkStatsCache.hpp
@@ -103,6 +103,8 @@ public:
   // to have a very low cache miss rate.
   static const uint RegionMarkStatsCacheSize = 1024;
 
+  // Initialize cache. Does not reset the cache immediately to avoid the cost
+  // during startup.
   G1RegionMarkStatsCache(G1RegionMarkStats* target, uint num_cache_entries);
 
   ~G1RegionMarkStatsCache();


### PR DESCRIPTION
Hi all,

  please review this tiny change that leaves out resetting the mark stat caches at startup.

This has some (somewhat tiny, depending on heap size and number of threads) positive impact on startup time.

Testing: tier1-5, gha

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8368080](https://bugs.openjdk.org/browse/JDK-8368080): G1: Unnecessary initialization of G1CMTask's mark stats table (**Enhancement** - P4)


### Reviewers
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27390/head:pull/27390` \
`$ git checkout pull/27390`

Update a local copy of the PR: \
`$ git checkout pull/27390` \
`$ git pull https://git.openjdk.org/jdk.git pull/27390/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27390`

View PR using the GUI difftool: \
`$ git pr show -t 27390`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27390.diff">https://git.openjdk.org/jdk/pull/27390.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27390#issuecomment-3317045664)
</details>
