### PR TITLE
8366941: Excessive logging in serviceability tests causes timeout

### DIFF
--- a/test/hotspot/jtreg/serviceability/logging/TestBasicLogOutput.java
+++ b/test/hotspot/jtreg/serviceability/logging/TestBasicLogOutput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@ import jdk.test.lib.process.OutputAnalyzer;
 public class TestBasicLogOutput {
 
     public static void main(String[] args) throws Exception {
-        ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder("-Xlog:all=trace", "-version");
+        ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder("-Xlog:all=info", "-version");
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         output.shouldMatch("\\[logging *\\]"); // expected tag(s)
         output.shouldContain("Log configuration fully initialized."); // expected message

--- a/test/hotspot/jtreg/serviceability/logging/TestFullNames.java
+++ b/test/hotspot/jtreg/serviceability/logging/TestFullNames.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -64,7 +64,7 @@ public class TestFullNames {
             Asserts.assertFalse(file.exists());
             // Run with logging=trace on stdout so that we can verify the log configuration afterwards.
             ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder("-Xlog:logging=trace",
-                                                                                 "-Xlog:all=trace:" + logOutput,
+                                                                                 "-Xlog:all=info:" + logOutput,
                                                                                  "-version");
             OutputAnalyzer output = new OutputAnalyzer(pb.start());
             output.shouldHaveExitValue(0);

--- a/test/hotspot/jtreg/serviceability/logging/TestQuotedLogOutputs.java
+++ b/test/hotspot/jtreg/serviceability/logging/TestQuotedLogOutputs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -74,7 +74,7 @@ public class TestQuotedLogOutputs {
         for (String logOutput : validOutputs) {
             // Run with logging=trace on stdout so that we can verify the log configuration afterwards.
             ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder("-Xlog:logging=trace",
-                                                                                 "-Xlog:all=trace:" + logOutput,
+                                                                                 "-Xlog:all=info:" + logOutput,
                                                                                  "-version");
             OutputAnalyzer output = new OutputAnalyzer(pb.start());
             output.shouldHaveExitValue(0);
@@ -99,7 +99,7 @@ public class TestQuotedLogOutputs {
         };
         for (String logOutput : invalidOutputs) {
             ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder("-Xlog:logging=trace",
-                                                                                 "-Xlog:all=trace:" + logOutput,
+                                                                                 "-Xlog:all=info:" + logOutput,
                                                                                  "-version");
             OutputAnalyzer output = new OutputAnalyzer(pb.start());
             output.shouldHaveExitValue(1);


### PR DESCRIPTION
These tests use `-Xlog:all=trace` which can cause excessive output that runs very slowly, especially on Windows.
A recent change, [JDK-8362566](https://bugs.openjdk.org/browse/JDK-8362566), adds lots of output to `-Xlog:aot+map*=trace`. As a result, some of these tests are starting to timeout.

None of these tests actually require a lot of logging output. The should be fixed to use `-Xlog:all=info` instead.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8366941](https://bugs.openjdk.org/browse/JDK-8366941): Excessive logging in serviceability tests causes timeout (**Bug** - P4)


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27401/head:pull/27401` \
`$ git checkout pull/27401`

Update a local copy of the PR: \
`$ git checkout pull/27401` \
`$ git pull https://git.openjdk.org/jdk.git pull/27401/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27401`

View PR using the GUI difftool: \
`$ git pr show -t 27401`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27401.diff">https://git.openjdk.org/jdk/pull/27401.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27401#issuecomment-3314366230)
</details>
