### PR TITLE
JDK-8368178 Add specialization of SequencedCollection methods to emptyList, singletonList and nCopies

### DIFF
--- a/src/java.base/share/classes/java/util/Collections.java
+++ b/src/java.base/share/classes/java/util/Collections.java
@@ -4944,6 +4944,11 @@ public final class Collections {
         }
 
         @Override
+        public List<E> reversed() {
+          return this;
+        }
+
+        @Override
         public Spliterator<E> spliterator() { return Spliterators.emptySpliterator(); }
 
         // Preserves singleton property
@@ -5310,6 +5315,18 @@ public final class Collections {
         public void sort(Comparator<? super E> c) {
         }
         @Override
+        public List<E> reversed() {
+          return this;
+        }
+        @Override
+        public E getFirst() {
+          return element;
+        }
+        @Override
+        public E getLast() {
+          return element;
+        }
+        @Override
         public Spliterator<E> spliterator() {
             return singletonSpliterator(element);
         }
@@ -5550,6 +5567,11 @@ public final class Collections {
                     a[n] = null;
             }
             return a;
+        }
+
+        @Override
+        public List<E> reversed() {
+          return this;
         }
 
         public List<E> subList(int fromIndex, int toIndex) {

--- a/test/jdk/java/util/Collections/EmptyListTest.java
+++ b/test/jdk/java/util/Collections/EmptyListTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8368178
+ * @summary Collections.emptyList tests
+ * @run junit EmptyListTest
+ */
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public final class EmptyListTest {
+    @Test
+    public void testGetFirst() {
+        List<String> emptyList = Collections.emptyList();
+        assertThrows(NoSuchElementException.class, emptyList::getFirst);
+    }
+
+    @Test
+    public void testGetLast() {
+        List<String> emptyList = Collections.emptyList();
+        assertThrows(NoSuchElementException.class, emptyList::getLast);
+    }
+
+    @Test
+    public void testReversed() {
+        List<String> emptyList = Collections.emptyList();
+        assertEquals(emptyList, emptyList.reversed());
+    }
+}

--- a/test/jdk/java/util/Collections/NCopies.java
+++ b/test/jdk/java/util/Collections/NCopies.java
@@ -135,6 +135,13 @@ public class NCopies {
         check(Collections.nCopies(0, null).equals(Collections.nCopies(0, "non-null")));
     }
 
+    private static void checkReversed() {
+        List<String> copies = Collections.nCopies(10, "content");
+        check(copies.equals(copies.reversed()));
+        List<String> empty = Collections.nCopies(0, "content");
+        check(empty.equals(empty.reversed()));
+    }
+
     public static void main(String[] args) {
         try {
             List<String> empty = Collections.nCopies(0, "foo");
@@ -148,6 +155,8 @@ public class NCopies {
             checkHashCode();
 
             checkEquals();
+
+            checkReversed();
 
         } catch (Throwable t) { unexpected(t); }
 

--- a/test/jdk/java/util/Collections/SingletonListTest.java
+++ b/test/jdk/java/util/Collections/SingletonListTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8368178
+ * @summary Collections.singletonList tests
+ * @run junit SingletonListTest
+ */
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public final class SingletonListTest {
+    @Test
+    public void testGetFirst() {
+        List<String> singletonList = Collections.singletonList("test");
+        assertEquals("test", singletonList.getFirst());
+    }
+
+    @Test
+    public void testGetLast() {
+        List<String> singletonList = Collections.singletonList("test");
+        assertEquals("test", singletonList.getFirst());
+    }
+
+    @Test
+    public void testReversed() {
+        List<String> singletonList = Collections.singletonList("test");
+        List<String> reversed = singletonList.reversed();
+        assertEquals(singletonList, reversed);
+        assertEquals("test", reversed.getFirst());
+        assertEquals("test", reversed.getLast());
+    }
+}


### PR DESCRIPTION
Please review this small change. If you have more ideas which classes may miss specializations of SequencedCollection methods, I can add them to this PR as well.