### PR TITLE
8368181: ProblemList java/awt/Dialog/ModalExcludedTest/ModalExcludedTest.java

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -270,6 +270,7 @@ java/awt/Clipboard/ClipboardSecurity.java 8054809 macosx-all
 java/awt/Clipboard/GetAltContentsTest/SystemClipboardTest.java 8234140 macosx-all
 java/awt/Clipboard/ImageTransferTest.java 8030710 generic-all
 java/awt/Clipboard/NoDataConversionFailureTest.java 8234140 macosx-all
+java/awt/Dialog/ModalExcludedTest.java 7125054 macosx-all
 java/awt/Frame/MiscUndecorated/RepaintTest.java 8266244 macosx-aarch64
 java/awt/Modal/FileDialog/FileDialogAppModal1Test.java 7186009 macosx-all
 java/awt/Modal/FileDialog/FileDialogAppModal2Test.java 7186009 macosx-all


### PR DESCRIPTION
Test was moved to open in 8340494: Open some dialog awt tests 4  but not the PL entry which needs to be added as the failure is same as https://github.com/openjdk/jdk/pull/27243

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8368181](https://bugs.openjdk.org/browse/JDK-8368181): ProblemList java/awt/Dialog/ModalExcludedTest/ModalExcludedTest.java (**Bug** - P4)


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27410/head:pull/27410` \
`$ git checkout pull/27410`

Update a local copy of the PR: \
`$ git checkout pull/27410` \
`$ git pull https://git.openjdk.org/jdk.git pull/27410/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27410`

View PR using the GUI difftool: \
`$ git pr show -t 27410`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27410.diff">https://git.openjdk.org/jdk/pull/27410.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27410#issuecomment-3315998558)
</details>
