### PR TITLE
8368089: G1: G1PeriodicGCTask::should_start_periodic_gc may use uninitialised value if os::loadavg is unsupported

### DIFF
--- a/src/hotspot/share/gc/g1/g1PeriodicGCTask.cpp
+++ b/src/hotspot/share/gc/g1/g1PeriodicGCTask.cpp
@@ -54,11 +54,10 @@ bool G1PeriodicGCTask::should_start_periodic_gc(G1CollectedHeap* g1h,
 
   // Check if load is lower than max.
   double recent_load;
-  if (G1PeriodicGCSystemLoadThreshold > 0.0f) {
+  if (G1PeriodicGCSystemLoadThreshold > 0.0) {
     if (os::loadavg(&recent_load, 1) == -1) {
-      G1PeriodicGCInterval = 0;
-      log_warning(gc, periodic)("System loadavg not supported. Periodic GC is disabled "
-                                "by setting G1PeriodicGCInterval to 0.");
+      G1PeriodicGCSystemLoadThreshold = 0.0;
+      log_warning(gc, periodic)("System loadavg not supported, G1PeriodicGCSystemLoadThreshold check is disabled");
       return false;
     }
     if (recent_load > G1PeriodicGCSystemLoadThreshold) {

--- a/src/hotspot/share/gc/g1/g1PeriodicGCTask.cpp
+++ b/src/hotspot/share/gc/g1/g1PeriodicGCTask.cpp
@@ -57,10 +57,10 @@ bool G1PeriodicGCTask::should_start_periodic_gc(G1CollectedHeap* g1h,
   if (G1PeriodicGCSystemLoadThreshold > 0.0) {
     if (os::loadavg(&recent_load, 1) == -1) {
       G1PeriodicGCSystemLoadThreshold = 0.0;
-      log_warning(gc, periodic)("System loadavg not supported, G1PeriodicGCSystemLoadThreshold check is disabled.");
-      return false;
-    }
-    if (recent_load > G1PeriodicGCSystemLoadThreshold) {
+      log_warning(gc, periodic)("System loadavg() call failed, "
+                                "disabling G1PeriodicGCSystemLoadThreshold check.");
+      // Fall through and start the periodic GC.
+    } else if (recent_load > G1PeriodicGCSystemLoadThreshold) {
       log_debug(gc, periodic)("Load %1.2f is higher than threshold %1.2f. Skipping.",
                               recent_load, G1PeriodicGCSystemLoadThreshold);
       return false;

--- a/src/hotspot/share/gc/g1/g1PeriodicGCTask.cpp
+++ b/src/hotspot/share/gc/g1/g1PeriodicGCTask.cpp
@@ -57,7 +57,7 @@ bool G1PeriodicGCTask::should_start_periodic_gc(G1CollectedHeap* g1h,
   if (G1PeriodicGCSystemLoadThreshold > 0.0) {
     if (os::loadavg(&recent_load, 1) == -1) {
       G1PeriodicGCSystemLoadThreshold = 0.0;
-      log_warning(gc, periodic)("System loadavg not supported, G1PeriodicGCSystemLoadThreshold check is disabled");
+      log_warning(gc, periodic)("System loadavg not supported, G1PeriodicGCSystemLoadThreshold check is disabled.");
       return false;
     }
     if (recent_load > G1PeriodicGCSystemLoadThreshold) {

--- a/src/hotspot/share/gc/g1/g1PeriodicGCTask.cpp
+++ b/src/hotspot/share/gc/g1/g1PeriodicGCTask.cpp
@@ -54,11 +54,16 @@ bool G1PeriodicGCTask::should_start_periodic_gc(G1CollectedHeap* g1h,
 
   // Check if load is lower than max.
   double recent_load;
-  if ((G1PeriodicGCSystemLoadThreshold > 0.0f) &&
-      (os::loadavg(&recent_load, 1) == -1 || recent_load > G1PeriodicGCSystemLoadThreshold)) {
-    log_debug(gc, periodic)("Load %1.2f is higher than threshold %1.2f. Skipping.",
-                            recent_load, G1PeriodicGCSystemLoadThreshold);
-    return false;
+  if (G1PeriodicGCSystemLoadThreshold > 0.0f) {
+    if (os::loadavg(&recent_load, 1) == -1) {
+      log_debug(gc, periodic)("System loadavg not supported. Skipping.");
+      return false;
+    }
+    if (recent_load > G1PeriodicGCSystemLoadThreshold) {
+      log_debug(gc, periodic)("Load %1.2f is higher than threshold %1.2f. Skipping.",
+                              recent_load, G1PeriodicGCSystemLoadThreshold);
+      return false;
+    }
   }
 
   // Record counters with GC safepoints blocked, to get a consistent snapshot.

--- a/src/hotspot/share/gc/g1/g1PeriodicGCTask.cpp
+++ b/src/hotspot/share/gc/g1/g1PeriodicGCTask.cpp
@@ -56,7 +56,9 @@ bool G1PeriodicGCTask::should_start_periodic_gc(G1CollectedHeap* g1h,
   double recent_load;
   if (G1PeriodicGCSystemLoadThreshold > 0.0f) {
     if (os::loadavg(&recent_load, 1) == -1) {
-      log_debug(gc, periodic)("System loadavg not supported. Skipping.");
+      G1PeriodicGCInterval = 0;
+      log_warning(gc, periodic)("System loadavg not supported. Periodic GC is disabled "
+                                "by setting G1PeriodicGCInterval to 0.");
       return false;
     }
     if (recent_load > G1PeriodicGCSystemLoadThreshold) {


### PR DESCRIPTION
Please review this change. Thanks!

**Description:**

Previously the check combined loadavg() failure and threshold comparison in a single condition. When os::loadavg() returned -1, `recent_load` contained an undefined value but was still logged as if it was a real load average, leading to misleading log output.

**Fix:**

This change separates the failure case from the combined check:
- If os::loadavg() returns -1, log "System loadavg not supported" and skip.
- Only compare `recent_load` to the threshold when loadavg() succeeds.

**Test:**

GHA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8368089](https://bugs.openjdk.org/browse/JDK-8368089): G1: G1PeriodicGCTask::should_start_periodic_gc may use uninitialised value if os::loadavg is unsupported (**Bug** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27413/head:pull/27413` \
`$ git checkout pull/27413`

Update a local copy of the PR: \
`$ git checkout pull/27413` \
`$ git pull https://git.openjdk.org/jdk.git pull/27413/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27413`

View PR using the GUI difftool: \
`$ git pr show -t 27413`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27413.diff">https://git.openjdk.org/jdk/pull/27413.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27413#issuecomment-3316355854)
</details>
