### PR TITLE
8368206: RISC-V: compiler/vectorapi/VectorMaskCompareNotTest.java fails when running without RVV

### DIFF
--- a/test/hotspot/jtreg/compiler/vectorapi/VectorMaskCompareNotTest.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/VectorMaskCompareNotTest.java
@@ -35,6 +35,7 @@ import jdk.test.lib.Asserts;
  * @library /test/lib /
  * @summary test combining vector not operation with compare
  * @modules jdk.incubator.vector
+ * @requires (os.arch != "riscv64" | (os.arch == "riscv64" & vm.cpu.features ~= ".*rvv.*"))
  *
  * @run driver compiler.vectorapi.VectorMaskCompareNotTest
  */


### PR DESCRIPTION
Hi,
Can you help to review this patch? Thanks!

We noticed that compiler/vectorapi/VectorMaskCompareNotTest.java fails when running on sg2042.
On RISC-V without RVV, ofLargestShape(long.class) falls back to 64 bits (see getMaxVectorBitSize in VectorShape.java),
leading to VectorShape.forBitSize(32) which is unsupported and throws IllegalArgumentException.

### Test (fastdebug)
- [x] Run compiler/vectorapi/VectorMaskCompareNotTest.java on sg2042

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8368206](https://bugs.openjdk.org/browse/JDK-8368206): RISC-V: compiler/vectorapi/VectorMaskCompareNotTest.java fails when running without RVV (**Bug** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Manuel Hässig](https://openjdk.org/census#mhaessig) (@mhaessig - Committer)
 * [Hamlin Li](https://openjdk.org/census#mli) (@Hamlin-Li - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27414/head:pull/27414` \
`$ git checkout pull/27414`

Update a local copy of the PR: \
`$ git checkout pull/27414` \
`$ git pull https://git.openjdk.org/jdk.git pull/27414/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27414`

View PR using the GUI difftool: \
`$ git pr show -t 27414`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27414.diff">https://git.openjdk.org/jdk/pull/27414.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27414#issuecomment-3316630413)
</details>
