### PR TITLE
8368212: ZGC: Fix spelling and typos in comments

### DIFF
--- a/src/hotspot/share/gc/z/zArguments.cpp
+++ b/src/hotspot/share/gc/z/zArguments.cpp
@@ -45,7 +45,7 @@ void ZArguments::initialize_heap_flags_and_sizes() {
       !FLAG_IS_CMDLINE(SoftMaxHeapSize)) {
     // We are really just guessing how much memory the program needs.
     // When that is the case, we don't want the soft and hard limits to be the same
-    // as it can cause flakyness in the number of GC threads used, in order to keep
+    // as it can cause flakiness in the number of GC threads used, in order to keep
     // to a random number we just pulled out of thin air.
     FLAG_SET_ERGO(SoftMaxHeapSize, MaxHeapSize * 90 / 100);
   }

--- a/src/hotspot/share/gc/z/zBarrierSet.cpp
+++ b/src/hotspot/share/gc/z/zBarrierSet.cpp
@@ -117,7 +117,7 @@ static void deoptimize_allocation(JavaThread* thread) {
   const nmethod* const nm = caller_frame.cb()->as_nmethod();
   if ((nm->is_compiled_by_c2() || nm->is_compiled_by_jvmci()) && !caller_frame.is_deoptimized_frame()) {
     // The JIT might have elided barriers on this object so deoptimize the frame and let the
-    // intepreter deal with it.
+    // interpreter deal with it.
     Deoptimization::deoptimize_frame(thread, caller_frame.id());
   }
 }

--- a/src/hotspot/share/gc/z/zDirector.cpp
+++ b/src/hotspot/share/gc/z/zDirector.cpp
@@ -302,7 +302,7 @@ static bool is_young_small(const ZDirectorStats& stats) {
 
   // If the freeable memory isn't even 5% of the heap, we can't expect to free up
   // all that much memory, so let's not even try - it will likely be a wasted effort
-  // that takes away CPU power to the hopefullt more profitable major colelction.
+  // that takes away CPU power to the hopefully more profitable major collection.
   return young_used_percent <= 5.0;
 }
 

--- a/src/hotspot/share/gc/z/zHeapIterator.cpp
+++ b/src/hotspot/share/gc/z/zHeapIterator.cpp
@@ -364,7 +364,7 @@ public:
   virtual void do_nmethod(nmethod* nm) {
     // If ClassUnloading is turned off, all nmethods are considered strong,
     // not only those on the call stacks. The heap iteration might happen
-    // before the concurrent processign of the code cache, make sure that
+    // before the concurrent processing of the code cache, make sure that
     // all nmethods have been processed before visiting the oops.
     _bs_nm->nmethod_entry_barrier(nm);
 

--- a/src/hotspot/share/gc/z/zJNICritical.cpp
+++ b/src/hotspot/share/gc/z/zJNICritical.cpp
@@ -160,7 +160,7 @@ void ZJNICritical::exit_inner() {
       // and we should signal that all Java threads have now exited the
       // critical region and we are now blocked.
       if (count == -2) {
-        // Nofity blocked
+        // Notify blocked
         ZLocker<ZConditionLock> locker(_lock);
         _lock->notify_all();
       }

--- a/src/hotspot/share/gc/z/zNMethod.cpp
+++ b/src/hotspot/share/gc/z/zNMethod.cpp
@@ -314,7 +314,7 @@ oop ZNMethod::oop_load_phantom(const nmethod* nm, int index) {
 
 oop ZNMethod::oop_load(const nmethod* const_nm, int index, bool keep_alive) {
   // The rest of the code is not ready to handle const nmethod, so cast it away
-  // until we are more consistent with our const corectness.
+  // until we are more consistent with our const correctness.
   nmethod* nm = const_cast<nmethod*>(const_nm);
 
   if (!is_armed(nm)) {


### PR DESCRIPTION
Trivial fix of a hand full of comments which have typos or miss-spellings. Only fix obvious miss-spellings, not American vs British vs colloquial inconsistencies, nor englishified jargon. 