### PR TITLE
8368214: ZGC: Remove double newlines

### DIFF
--- a/src/hotspot/cpu/aarch64/gc/z/zBarrierSetAssembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/gc/z/zBarrierSetAssembler_aarch64.hpp
@@ -275,7 +275,6 @@ public:
   Label* entry();
 };
 
-
 class ZStoreBarrierStubC2Aarch64 : public ZStoreBarrierStubC2 {
 private:
   bool _deferred_emit;

--- a/src/hotspot/cpu/aarch64/gc/z/z_aarch64.ad
+++ b/src/hotspot/cpu/aarch64/gc/z/z_aarch64.ad
@@ -239,7 +239,6 @@ instruct zCompareAndSwapPAcq(iRegINoSp res, indirect mem, iRegP oldval, iRegP ne
   ins_pipe(pipe_slow);
 %}
 
-
 instruct zCompareAndExchangeP(iRegPNoSp res, indirect mem, iRegP oldval, iRegP newval, iRegPNoSp oldval_tmp, iRegPNoSp newval_tmp, rFlagsReg cr) %{
   match(Set res (CompareAndExchangeP mem (Binary oldval newval)));
   predicate(UseZGC && !needs_acquiring_load_exclusive(n) && n->as_LoadStore()->barrier_data() != 0);

--- a/src/hotspot/cpu/ppc/gc/z/zBarrierSetAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/gc/z/zBarrierSetAssembler_ppc.cpp
@@ -114,7 +114,6 @@ public:
   }
 };
 
-
 void ZBarrierSetAssembler::load_at(MacroAssembler* masm, DecoratorSet decorators, BasicType type,
                                    Register base, RegisterOrConstant ind_or_offs, Register dst,
                                    Register tmp1, Register tmp2,
@@ -561,7 +560,6 @@ void ZBarrierSetAssembler::generate_conjoint_oop_copy(MacroAssembler* masm, bool
   copy_store_at_slow(masm, R4_ARG2, tmp, store_bad, store_good, dest_uninitialized);
 }
 
-
 // Verify a colored pointer.
 void ZBarrierSetAssembler::check_oop(MacroAssembler *masm, Register obj, const char* msg) {
   if (!VerifyOops) {
@@ -582,7 +580,6 @@ void ZBarrierSetAssembler::check_oop(MacroAssembler *masm, Register obj, const c
   __ verify_oop(R0, msg);
   __ bind(done);
 }
-
 
 void ZBarrierSetAssembler::try_resolve_jobject_in_native(MacroAssembler* masm, Register dst, Register jni_env,
                                                          Register obj, Register tmp, Label& slowpath) {

--- a/src/hotspot/cpu/x86/gc/z/zBarrierSetAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/gc/z/zBarrierSetAssembler_x86.cpp
@@ -1410,10 +1410,8 @@ void ZBarrierSetAssembler::patch_barriers() {
   }
 }
 
-
 #undef __
 #define __ masm->
-
 
 void ZBarrierSetAssembler::check_oop(MacroAssembler* masm, Register obj, Register tmp1, Register tmp2, Label& error) {
   // C1 calls verfy_oop in the middle of barriers, before they have been uncolored

--- a/src/hotspot/os_cpu/linux_ppc/gc/z/zSyscall_linux_ppc.hpp
+++ b/src/hotspot/os_cpu/linux_ppc/gc/z/zSyscall_linux_ppc.hpp
@@ -31,7 +31,6 @@
 // Support for building on older Linux systems
 //
 
-
 #ifndef SYS_memfd_create
 #define SYS_memfd_create     360
 #endif

--- a/src/hotspot/share/gc/z/zBarrierSet.inline.hpp
+++ b/src/hotspot/share/gc/z/zBarrierSet.inline.hpp
@@ -349,7 +349,6 @@ inline bool ZBarrierSet::AccessBarrier<decorators, BarrierSetT>::oop_copy_one_ch
   return true;
 }
 
-
 template <DecoratorSet decorators, typename BarrierSetT>
 inline bool ZBarrierSet::AccessBarrier<decorators, BarrierSetT>::oop_arraycopy_in_heap_check_cast(zpointer* dst, zpointer* src, size_t length, Klass* dst_klass) {
   // Check cast and copy each elements

--- a/src/hotspot/share/gc/z/zGeneration.cpp
+++ b/src/hotspot/share/gc/z/zGeneration.cpp
@@ -661,7 +661,6 @@ public:
   }
 };
 
-
 bool ZGenerationYoung::pause_mark_end() {
   return VM_ZMarkEndYoung().pause();
 }
@@ -1319,7 +1318,6 @@ class ZRendezvousGCThreads: public VM_Operation {
     SuspendibleThreadSet::desynchronize();
   };
 };
-
 
 void ZGenerationOld::process_non_strong_references() {
   // Process Soft/Weak/Final/PhantomReferences

--- a/src/hotspot/share/gc/z/zMark.cpp
+++ b/src/hotspot/share/gc/z/zMark.cpp
@@ -388,7 +388,6 @@ void ZMark::follow_object(oop obj, bool finalizable) {
   }
 }
 
-
 void ZMark::mark_and_follow(ZMarkContext* context, ZMarkStackEntry entry) {
   // Decode flags
   const bool finalizable = entry.finalizable();

--- a/src/hotspot/share/gc/z/zPage.inline.hpp
+++ b/src/hotspot/share/gc/z/zPage.inline.hpp
@@ -368,7 +368,6 @@ inline bool ZPage::was_remembered(volatile zpointer* p) {
   return _remembered_set.at_previous(l_offset);
 }
 
-
 inline zaddress_unsafe ZPage::find_base_unsafe(volatile zpointer* p) {
   if (is_large()) {
     return ZOffset::address_unsafe(start());

--- a/src/hotspot/share/gc/z/zPageAllocator.cpp
+++ b/src/hotspot/share/gc/z/zPageAllocator.cpp
@@ -1051,7 +1051,6 @@ void ZPartition::copy_physical_segments_from_partition(const ZVirtualMemory& at,
 
   ZPhysicalMemoryManager& manager = physical_memory_manager();
 
-
   // Copy segments
   manager.copy_physical_segments(to, at);
 }

--- a/src/hotspot/share/gc/z/zRelocate.cpp
+++ b/src/hotspot/share/gc/z/zRelocate.cpp
@@ -671,7 +671,6 @@ private:
     assert(ZHeap::heap()->is_in_page_relaxed(from_page, from_addr), "Must be");
     assert(to_page->is_in(to_addr), "Must be");
 
-
     // Read the size from the to-object, since the from-object
     // could have been overwritten during in-place relocation.
     const size_t size = ZUtils::object_size(to_addr);

--- a/src/hotspot/share/gc/z/zValue.inline.hpp
+++ b/src/hotspot/share/gc/z/zValue.inline.hpp
@@ -238,5 +238,4 @@ inline bool ZValueConstIterator<S, T>::next(const T** value) {
   return false;
 }
 
-
 #endif // SHARE_GC_Z_ZVALUE_INLINE_HPP

--- a/src/hotspot/share/gc/z/zVirtualMemoryManager.inline.hpp
+++ b/src/hotspot/share/gc/z/zVirtualMemoryManager.inline.hpp
@@ -29,7 +29,6 @@
 #include "gc/z/zRangeRegistry.inline.hpp"
 #include "utilities/globalDefinitions.hpp"
 
-
 inline bool ZVirtualMemoryManager::is_multi_partition_enabled() const {
   return _is_multi_partition_enabled;
 }

--- a/test/hotspot/jtreg/gc/z/TestZNMT.java
+++ b/test/hotspot/jtreg/gc/z/TestZNMT.java
@@ -59,7 +59,6 @@ public class TestZNMT {
         }
     }
 
-
     private static void testValue(int zForceDiscontiguousHeapReservations) throws Exception  {
         /**
          *  Xmx is picked so that it is divisible by 'ZForceDiscontiguousHeapReservations * ZGranuleSize'


### PR DESCRIPTION
We avoid having two empty newlines in a row. But we have a hand full. Trivial change to remove them.