### PR TITLE
8368205: [TESTBUG] VectorMaskCompareNotTest.java crashes when MaxVectorSize=8

### DIFF
--- a/test/hotspot/jtreg/compiler/vectorapi/VectorMaskCompareNotTest.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/VectorMaskCompareNotTest.java
@@ -30,7 +30,7 @@ import jdk.test.lib.Asserts;
 
 /*
  * @test
- * @bug 8354242 8368205
+ * @bug 8354242
  * @key randomness
  * @library /test/lib /
  * @requires vm.opt.MaxVectorSize == "null" | vm.opt.MaxVectorSize >= 16


### PR DESCRIPTION
The VectorShape size of `I_SPECIES_FOR_CAST` declared in test **VectorMaskCompareNotTest.java** is half that of `L_SPECIES_FOR_CAST`. And `L_SPECIES_FOR_CAST` is created with the maximum shape. Therefore, if `MaxVectorSize` is set to 8, the shape size of `I_SPECIES_FOR_CAST` is 4, which is an illegal value because the minimum vector size requirement is 8 bytes.

This pull request addresses the issue by ensuring that this test runs only when `MaxVectorSize` is set to 16 bytes or higher.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8368205](https://bugs.openjdk.org/browse/JDK-8368205): [TESTBUG] VectorMaskCompareNotTest.java crashes when MaxVectorSize=8 (**Bug** - P4)


### Reviewers
 * [Galder Zamarreño](https://openjdk.org/census#galder) (@galderz - Author) 🔄 Re-review required (review applies to [2818a686](https://git.openjdk.org/jdk/pull/27418/files/2818a686c6013217c0eedd623bac38929ae457cb))

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27418/head:pull/27418` \
`$ git checkout pull/27418`

Update a local copy of the PR: \
`$ git checkout pull/27418` \
`$ git pull https://git.openjdk.org/jdk.git pull/27418/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27418`

View PR using the GUI difftool: \
`$ git pr show -t 27418`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27418.diff">https://git.openjdk.org/jdk/pull/27418.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27418#issuecomment-3317401499)
</details>
