### PR TITLE
8368261

### DIFF
--- a/src/hotspot/share/code/nmethod.hpp
+++ b/src/hotspot/share/code/nmethod.hpp
@@ -1080,4 +1080,13 @@ public:
   static const Vptr _vpntr;
 };
 
+struct NMethodMarkingScope : StackObj {
+  NMethodMarkingScope() {
+    nmethod::oops_do_marking_prologue();
+  }
+  ~NMethodMarkingScope() {
+    nmethod::oops_do_marking_epilogue();
+  }
+};
+
 #endif // SHARE_CODE_NMETHOD_HPP


### PR DESCRIPTION
Small patch of extracting out the nmethod-marking-scope logic in Serial full-gc. The new `NMethodMarkingScope` is placed in `nmethod.hpp` like its counterpart `ThreadsClaimTokenScope`.

The new `struct` is almost identical to the existing `MarkScope`, so there is a planned followup PR that will address all other users of `StrongRootsScope` to use the recently introduced `ThreadsClaimTokenScope` and the new `NMethodMarkingScope` introduced in this PR, which would make it less abtract than the name `StrongRootsScope`.

Test: tier1-3