### PR TITLE
8368273: LIBPTHREAD dependency is not needed for some jdk libs

### DIFF
--- a/make/modules/jdk.sctp/Lib.gmk
+++ b/make/modules/jdk.sctp/Lib.gmk
@@ -41,7 +41,7 @@ ifeq ($(call isTargetOs, linux), true)
           java.base:libnio \
           java.base:libnio/ch, \
       JDK_LIBS := java.base:libjava java.base:libnet, \
-      LIBS_linux := $(LIBDL) $(LIBPTHREAD), \
+      LIBS_linux := $(LIBDL), \
   ))
 
   TARGETS += $(BUILD_LIBSCTP)


### PR DESCRIPTION
A couple of JDK native libs link to $(LIBPTHREAD) but the dependency is not needed.

libsctp has no `pthread*` calls so most likely we can omit $(LIBPTHREAD).
libawt_xawt only uses `pthread_self()` ; so on Linux it links without adding $(LIBPTHREAD) because it then uses `pthread_self() `from glibc;  however it might still be better to link $(LIBPTHREAD) in this special case.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8368273](https://bugs.openjdk.org/browse/JDK-8368273): LIBPTHREAD dependency is not needed for some jdk libs (**Bug** - P4)


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27426/head:pull/27426` \
`$ git checkout pull/27426`

Update a local copy of the PR: \
`$ git checkout pull/27426` \
`$ git pull https://git.openjdk.org/jdk.git pull/27426/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27426`

View PR using the GUI difftool: \
`$ git pr show -t 27426`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27426.diff">https://git.openjdk.org/jdk/pull/27426.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27426#issuecomment-3318792686)
</details>
