### PR TITLE
8368311: Allow null sourceFile in LintMapper.lintAt

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/LintMapper.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/LintMapper.java
@@ -126,7 +126,7 @@ public class LintMapper {
      */
     public Optional<Lint> lintAt(JavaFileObject sourceFile, DiagnosticPosition pos) {
         initializeIfNeeded();
-        return Optional.of(sourceFile)
+        return Optional.ofNullable(sourceFile)
           .map(fileInfoMap::get)
           .flatMap(fileInfo -> fileInfo.lintAt(pos));
     }


### PR DESCRIPTION
A null sourceFile can happen with existing code; see https://github.com/eclipse-jdtls/eclipse-jdt-core-incubator/issues/1778 for example. Moreover, use of Optional seems to allow some tolerance to nullity, so also allow null as input too.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8368311](https://bugs.openjdk.org/browse/JDK-8368311)

### Issue
 * [JDK-8368311](https://bugs.openjdk.org/browse/JDK-8368311): LintMapper.lintAt should use Optional.ofNullable() (**Bug** - P4) ⚠️ Title mismatch between PR and JBS. ⚠️ Issue is not open.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27429/head:pull/27429` \
`$ git checkout pull/27429`

Update a local copy of the PR: \
`$ git checkout pull/27429` \
`$ git pull https://git.openjdk.org/jdk.git pull/27429/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27429`

View PR using the GUI difftool: \
`$ git pr show -t 27429`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27429.diff">https://git.openjdk.org/jdk/pull/27429.diff</a>

</details>
