### PR TITLE
8368303: AlwaysAtomicAccesses is excessively strict

### DIFF
--- a/src/hotspot/share/gc/shared/c1/barrierSetC1.cpp
+++ b/src/hotspot/share/gc/shared/c1/barrierSetC1.cpp
@@ -42,7 +42,7 @@
 
 // The JMM requires atomicity for all accesses to fields of primitive
 // types other than double and long. In practice, HotSpot assumes that
-// on all all processors, accesses to memory operands of wordSize and
+// on all processors, accesses to memory operands of wordSize and
 // smaller are atomic.
 static bool access_is_atomic(BasicType bt) {
   return type2aelembytes(bt) <= wordSize;

--- a/src/hotspot/share/gc/shared/c1/barrierSetC1.cpp
+++ b/src/hotspot/share/gc/shared/c1/barrierSetC1.cpp
@@ -179,7 +179,7 @@ void BarrierSetC1::load_at_resolved(LIRAccess& access, LIR_Opr result) {
   LIRGenerator *gen = access.gen();
   DecoratorSet decorators = access.decorators();
   bool is_volatile = (decorators & MO_SEQ_CST) != 0;
-  bool needs_atomic = is_volatile || (AlwaysAtomicAccesses && !access_is_atomic(result->type()));
+  bool needs_atomic = AlwaysAtomicAccesses && !access_is_atomic(result->type());
   bool needs_patching = (decorators & C1_NEEDS_PATCHING) != 0;
   bool mask_boolean = (decorators & C1_MASK_BOOLEAN) != 0;
   bool in_native = (decorators & IN_NATIVE) != 0;


### PR DESCRIPTION
In C1, the experimental flag `AlwaysAtomicAccesses` treats accesses to all fields as if they were volatile fields. This is correct but excessive: we only need single-copy atomicity to satisfy `AlwaysAtomicAccesses`. 

We need this in order to allow progress on JDK-8365147.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8368303](https://bugs.openjdk.org/browse/JDK-8368303): AlwaysAtomicAccesses is excessively strict (**Enhancement** - P3)


### Reviewers
 * [Vladimir Ivanov](https://openjdk.org/census#vlivanov) (@iwanowww - **Reviewer**) Review applies to [f61f6fce](https://git.openjdk.org/jdk/pull/27432/files/f61f6fce38c0e2178db08118b6c8d072f724e4ff)
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**) Review applies to [f61f6fce](https://git.openjdk.org/jdk/pull/27432/files/f61f6fce38c0e2178db08118b6c8d072f724e4ff)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27432/head:pull/27432` \
`$ git checkout pull/27432`

Update a local copy of the PR: \
`$ git checkout pull/27432` \
`$ git pull https://git.openjdk.org/jdk.git pull/27432/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27432`

View PR using the GUI difftool: \
`$ git pr show -t 27432`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27432.diff">https://git.openjdk.org/jdk/pull/27432.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27432#issuecomment-3320202115)
</details>
