### PR TITLE
8368326: Don't export unresolved make variables from configure

### DIFF
--- a/make/autoconf/boot-jdk.m4
+++ b/make/autoconf/boot-jdk.m4
@@ -597,10 +597,9 @@ AC_DEFUN([BOOTJDK_SETUP_BUILD_JDK],
   AC_ARG_WITH(build-jdk, [AS_HELP_STRING([--with-build-jdk],
       [path to JDK of same version as is being built@<:@the newly built JDK@:>@])])
 
-  CREATE_BUILDJDK=false
-  EXTERNAL_BUILDJDK=false
-  BUILD_JDK_FOUND="no"
+  EXTERNAL_BUILDJDK_PATH=""
   if test "x$with_build_jdk" != "x"; then
+    BUILD_JDK_FOUND=no
     BOOTJDK_CHECK_BUILD_JDK([
       if test "x$with_build_jdk" != x; then
         BUILD_JDK=$with_build_jdk
@@ -608,40 +607,15 @@ AC_DEFUN([BOOTJDK_SETUP_BUILD_JDK],
         AC_MSG_NOTICE([Found potential Build JDK using configure arguments])
       fi
     ])
-    EXTERNAL_BUILDJDK=true
-  else
-    if test "x$COMPILE_TYPE" = "xcross"; then
-      BUILD_JDK="\$(BUILDJDK_OUTPUTDIR)/jdk"
-      BUILD_JDK_FOUND=yes
-      CREATE_BUILDJDK=true
+    if test "x$BUILD_JDK_FOUND" != "xyes"; then
       AC_MSG_CHECKING([for Build JDK])
-      AC_MSG_RESULT([yes, will build it for the host platform])
-    else
-      BUILD_JDK="\$(JDK_OUTPUTDIR)"
-      BUILD_JDK_FOUND=yes
-      AC_MSG_CHECKING([for Build JDK])
-      AC_MSG_RESULT([yes, will use output dir])
+      AC_MSG_RESULT([no])
+      AC_MSG_ERROR([Could not find a suitable Build JDK])
     fi
+    EXTERNAL_BUILDJDK_PATH="$BUILD_JDK"
   fi
 
-  # Since these tools do not yet exist, we cannot use UTIL_FIXUP_EXECUTABLE to
-  # detect the need of fixpath
-  JMOD="$BUILD_JDK/bin/jmod"
-  UTIL_ADD_FIXPATH(JMOD)
-  JLINK="$BUILD_JDK/bin/jlink"
-  UTIL_ADD_FIXPATH(JLINK)
-  AC_SUBST(JMOD)
-  AC_SUBST(JLINK)
-
-  if test "x$BUILD_JDK_FOUND" != "xyes"; then
-    AC_MSG_CHECKING([for Build JDK])
-    AC_MSG_RESULT([no])
-    AC_MSG_ERROR([Could not find a suitable Build JDK])
-  fi
-
-  AC_SUBST(CREATE_BUILDJDK)
-  AC_SUBST(BUILD_JDK)
-  AC_SUBST(EXTERNAL_BUILDJDK)
+  AC_SUBST(EXTERNAL_BUILDJDK_PATH)
 ])
 
 # The docs-reference JDK is used to run javadoc for the docs-reference targets.

--- a/make/autoconf/spec.gmk.template
+++ b/make/autoconf/spec.gmk.template
@@ -386,9 +386,22 @@ CAPSTONE_ARCH_AARCH64_NAME := @CAPSTONE_ARCH_AARCH64_NAME@
 # it in sync.
 BOOT_JDK := @BOOT_JDK@
 
-BUILD_JDK := @BUILD_JDK@
-CREATE_BUILDJDK := @CREATE_BUILDJDK@
-EXTERNAL_BUILDJDK := @EXTERNAL_BUILDJDK@
+EXTERNAL_BUILDJDK_PATH := @EXTERNAL_BUILDJDK_PATH@
+
+ifneq ($(EXTERNAL_BUILDJDK_PATH), )
+  EXTERNAL_BUILDJDK := true
+  CREATE_BUILDJDK := false
+  BUILD_JDK := $(EXTERNAL_BUILDJDK_PATH)
+else
+  EXTERNAL_BUILDJDK := false
+  ifeq ($(COMPILE_TYPE), cross)
+    CREATE_BUILDJDK := true
+    BUILD_JDK := $(BUILDJDK_OUTPUTDIR)/jdk
+  else
+    CREATE_BUILDJDK := false
+    BUILD_JDK := $(JDK_OUTPUTDIR)
+  endif
+endif
 
 # Whether the boot jdk jar supports --date=TIMESTAMP
 BOOT_JDK_JAR_SUPPORTS_DATE := @BOOT_JDK_JAR_SUPPORTS_DATE@
@@ -648,8 +661,8 @@ JAVA_CMD := @JAVA@
 JAVAC_CMD := @JAVAC@
 JAVADOC_CMD := @JAVADOC@
 JAR_CMD := @JAR@
-JLINK_CMD := @JLINK@
-JMOD_CMD := @JMOD@
+JLINK_CMD := @FIXPATH@ $(BUILD_JDK)/bin/jlink
+JMOD_CMD := @FIXPATH@ $(BUILD_JDK)/bin/jmod
 # These variables are meant to be used. They are defined with = instead of := to make
 # it possible to override only the *_CMD variables.
 JAVA = $(JAVA_CMD) $(JAVA_FLAGS_BIG) $(JAVA_FLAGS)


### PR DESCRIPTION
A few remaining variables in spec.gmk, like `BUILD_JDK`, is setup by configure to include makefile variables, like `$(JDK_OUTPUTDIR)`.

This makes reasoning about spec.gmk unnecessary complex. Instead, we should just expose simple, resolved text strings from configure. Any remaining logic is better expressed directly in the makefiles.

This is part of an effort to clean up spec.gmk to not contain so much weird stuff.
