### PR TITLE
8366454: TLS1.3 server fails with bad_record_mac when receiving encrypted records with empty body

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/Alert.java
+++ b/src/java.base/share/classes/sun/security/ssl/Alert.java
@@ -181,6 +181,16 @@ public enum Alert {
 
         AlertMessage(TransportContext context,
                 ByteBuffer m) throws IOException {
+            // From RFC 8446 "Implementations
+            // MUST NOT send Handshake and Alert records that have a zero-length
+            // TLSInnerPlaintext.content; if such a message is received, the
+            // receiving implementation MUST terminate the connection with an
+            // "unexpected_message" alert."
+            if (m.remaining() == 0) {
+                throw context.fatal(Alert.UNEXPECTED_MESSAGE,
+                        "Invalid Alert message: no sufficient data");
+            }
+
             //  struct {
             //      AlertLevel level;
             //      AlertDescription description;

--- a/src/java.base/share/classes/sun/security/ssl/Alert.java
+++ b/src/java.base/share/classes/sun/security/ssl/Alert.java
@@ -188,7 +188,7 @@ public enum Alert {
             // "unexpected_message" alert."
             if (m.remaining() == 0) {
                 throw context.fatal(Alert.UNEXPECTED_MESSAGE,
-                        "Invalid Alert message: no sufficient data");
+                        "Alert fragments must not be zero length.");
             }
 
             //  struct {

--- a/src/java.base/share/classes/sun/security/ssl/SSLCipher.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLCipher.java
@@ -1925,7 +1925,7 @@ enum SSLCipher {
                 int i = pt.limit() - 1;
                 for (; i > 0 && pt.get(i) == 0; i--);
 
-                if (i < (pos + 1)) {
+                if (i < pos) {
                     throw new BadPaddingException(
                             "Incorrect inner plaintext: no content type");
                 }
@@ -2444,7 +2444,7 @@ enum SSLCipher {
                 for (; i > 0 && pt.get(i) == 0; i--) {
                     // blank
                 }
-                if (i < (pos + 1)) {
+                if (i < pos) {
                     throw new BadPaddingException(
                             "Incorrect inner plaintext: no content type");
                 }

--- a/test/jdk/sun/security/ssl/SSLEngineImpl/SSLEngineEmptyFragments.java
+++ b/test/jdk/sun/security/ssl/SSLEngineImpl/SSLEngineEmptyFragments.java
@@ -103,7 +103,7 @@ public class SSLEngineEmptyFragments extends SSLContextTemplate {
         try {
             unwrap(serverEngine, alert, serverIn);
             throw new RuntimeException("Expected exception was not thrown.");
-        } catch (SSLHandshakeException exc) {
+        } catch (SSLProtocolException exc) {
             log("Got the exception I wanted.");
         }
     }
@@ -133,7 +133,7 @@ public class SSLEngineEmptyFragments extends SSLContextTemplate {
             unwrap(serverEngine, alert, serverIn);
             log("Server unwrap was successful when it should have failed.");
             throw new RuntimeException("Expected exception was not thrown.");
-        } catch (SSLHandshakeException exc) {
+        } catch (SSLProtocolException exc) {
             log("Got the exception I wanted.");
         }
     }

--- a/test/jdk/sun/security/ssl/SSLSocketImpl/SSLSocketEmptyFragments.java
+++ b/test/jdk/sun/security/ssl/SSLSocketImpl/SSLSocketEmptyFragments.java
@@ -351,9 +351,9 @@ public class SSLSocketEmptyFragments extends SSLContextTemplate {
         tests.executeTest(
                 tests::testEmptyHandshakeRecord, SSLProtocolException.class);
         tests.executeTest(
-                tests::testEmptyAlertNotHandshaking, SSLHandshakeException.class);
+                tests::testEmptyAlertNotHandshaking, SSLProtocolException.class);
         tests.executeTest(
-                tests::testEmptyAlertDuringHandshake, SSLHandshakeException.class);
+                tests::testEmptyAlertDuringHandshake, SSLProtocolException.class);
         tests.executeTest(
                 tests::testEmptyChangeCipherSpecMessage, SSLProtocolException.class);
 
@@ -361,6 +361,6 @@ public class SSLSocketEmptyFragments extends SSLContextTemplate {
         tests.executeTest(
                 tests::testEmptyHandshakeRecord, SSLProtocolException.class);
         tests.executeTest(
-                tests::testEmptyAlertNotHandshaking, SSLHandshakeException.class);
+                tests::testEmptyAlertNotHandshaking, SSLProtocolException.class);
     }
 }


### PR DESCRIPTION
According to RFC 8446 section 5.4, third paragraph 
> Application Data records may contain a zero-length
>    TLSInnerPlaintext.content if the sender desires.  This permits
>    generation of plausibly sized cover traffic in contexts where the
>    presence or absence of activity may be sensitive.  Implementations
>    MUST NOT send Handshake and Alert records that have a zero-length
>    TLSInnerPlaintext.content; if such a message is received, the
>    receiving implementation MUST terminate the connection with an
>    "unexpected_message" alert.


The proposed change removes an off by 1 error in the SSLCipher implementation, as well as updating some tests which detected the BadPaddingException but now detect a SSLProtocolException, which is thrown by the new `TransportContext.fatal`