### PR TITLE
8368349: Add library notes discussing abs and IEEE 754 operations

### DIFF
--- a/src/java.base/share/classes/java/lang/Math.java
+++ b/src/java.base/share/classes/java/lang/Math.java
@@ -1972,6 +1972,10 @@ public final class Math {
      * argument but with a guaranteed zero sign bit indicating a
      * positive value:<br>
      * {@code Float.intBitsToFloat(0x7fffffff & Float.floatToRawIntBits(a))}
+     * <p>
+     * This method corresponds to the abs operation defined in IEEE
+     * 754, but without the requirements that the sign bit of a
+     * NaN result be set to 0.
      *
      * @param   a   the argument whose absolute value is to be determined
      * @return  the absolute value of the argument.
@@ -1998,6 +2002,10 @@ public final class Math {
      * argument but with a guaranteed zero sign bit indicating a
      * positive value:<br>
      * {@code Double.longBitsToDouble((Double.doubleToRawLongBits(a)<<1)>>>1)}
+     * <p>
+     * This method corresponds to the abs operation defined in IEEE
+     * 754, but without the requirements that the sign bit of a
+     * NaN result be set to 0.
      *
      * @param   a   the argument whose absolute value is to be determined
      * @return  the absolute value of the argument.

--- a/src/java.base/share/classes/java/lang/StrictMath.java
+++ b/src/java.base/share/classes/java/lang/StrictMath.java
@@ -1631,6 +1631,10 @@ public final class StrictMath {
      * argument but with a guaranteed zero sign bit indicating a
      * positive value: <br>
      * {@code Float.intBitsToFloat(0x7fffffff & Float.floatToRawIntBits(a))}
+     * <p>
+     * This method corresponds to the abs operation defined in IEEE
+     * 754, but without the requirements that the sign bit of a
+     * NaN result be set to 0.
      *
      * @param   a   the argument whose absolute value is to be determined
      * @return  the absolute value of the argument.
@@ -1655,6 +1659,10 @@ public final class StrictMath {
      * argument but with a guaranteed zero sign bit indicating a
      * positive value: <br>
      * {@code Double.longBitsToDouble((Double.doubleToRawLongBits(a)<<1)>>>1)}
+     * <p>
+     * This method corresponds to the abs operation defined in IEEE
+     * 754, but without the requirements that the sign bit of a
+     * NaN result be set to 0.
      *
      * @param   a   the argument whose absolute value is to be determined
      * @return  the absolute value of the argument.


### PR DESCRIPTION
Add apiNote linking {Math, StrictMath}.abs to the IEEE 754 abs operation.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8368349](https://bugs.openjdk.org/browse/JDK-8368349): Add library notes discussing abs and IEEE 754 operations (**Enhancement** - P4)


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27443/head:pull/27443` \
`$ git checkout pull/27443`

Update a local copy of the PR: \
`$ git checkout pull/27443` \
`$ git pull https://git.openjdk.org/jdk.git pull/27443/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27443`

View PR using the GUI difftool: \
`$ git pr show -t 27443`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27443.diff">https://git.openjdk.org/jdk/pull/27443.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27443#issuecomment-3322215808)
</details>
