### PR TITLE
8368185: Test javax/swing/plaf/synth/SynthButtonUI/6276188/bug6276188.java failed: Synth ButtonUI does not handle PRESSED & MOUSE_OVER state

### DIFF
--- a/test/jdk/javax/swing/plaf/synth/SynthButtonUI/6276188/bug6276188.java
+++ b/test/jdk/javax/swing/plaf/synth/SynthButtonUI/6276188/bug6276188.java
@@ -98,7 +98,6 @@ public class bug6276188 {
             robot.mouseMove(p.x , p.y);
             robot.waitForIdle();
             robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
-            robot.waitForIdle();
             latch.await();
             robot.delay(1000);
 

--- a/test/jdk/javax/swing/plaf/synth/SynthButtonUI/6276188/bug6276188.java
+++ b/test/jdk/javax/swing/plaf/synth/SynthButtonUI/6276188/bug6276188.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,16 +26,26 @@
  * @bug 6276188
  * @library ../../../../regtesthelpers
  * @build Util
- * @author Romain Guy
  * @summary Tests PRESSED and MOUSE_OVER and FOCUSED state for buttons with Synth.
  * @run main/othervm -Dsun.java2d.uiScale=1 bug6276188
  */
-import java.awt.*;
-import java.awt.image.*;
-import java.awt.event.*;
 
-import javax.swing.*;
-import javax.swing.plaf.synth.*;
+import java.io.File;
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.Robot;
+import java.awt.Toolkit;
+import java.awt.image.BufferedImage;
+import java.awt.event.InputEvent;
+import javax.imageio.ImageIO;
+import javax.swing.JButton;
+import javax.swing.JFrame;
+import javax.swing.plaf.synth.SynthLookAndFeel;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
 
 public class bug6276188 {
 
@@ -44,12 +54,12 @@ public class bug6276188 {
     private static JFrame testFrame;
 
      // move away from cursor
-    private final static int OFFSET_X = -20;
-    private final static int OFFSET_Y = -20;
+    private final static int OFFSET_X = 20;
+    private final static int OFFSET_Y = 20;
 
     public static void main(String[] args) throws Throwable {
+        Robot robot = new Robot();
         try {
-            Robot robot = new Robot();
             robot.setAutoDelay(100);
 
             SynthLookAndFeel lookAndFeel = new SynthLookAndFeel();
@@ -79,6 +89,7 @@ public class bug6276188 {
             robot.waitForIdle();
             robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
             robot.waitForIdle();
+            robot.delay(2000);
 
             Color color = robot.getPixelColor(p.x - OFFSET_X, p.y - OFFSET_Y);
             robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
@@ -89,7 +100,7 @@ public class bug6276188 {
                 Dimension screenSize = Toolkit.getDefaultToolkit().getScreenSize();
                 Rectangle screen = new Rectangle(0, 0, (int) screenSize.getWidth(), (int) screenSize.getHeight());
                 BufferedImage img = robot.createScreenCapture(screen);
-                javax.imageio.ImageIO.write(img, "png", new java.io.File("image.png"));
+                ImageIO.write(img, "png", new File("image.png"));
                 throw new RuntimeException("Synth ButtonUI does not handle PRESSED & MOUSE_OVER state");
             }
         } finally {


### PR DESCRIPTION
Test frame is changed to Red for Mouse PRESSED and MOUSE_OVER state but it seem time is too less before it is moved to Green when mouse press is released so it retrieves Green instead of Red.
Also, the pixel color retrieval point is conflicting with mouse cursor position, which gets picked up during `robot.createSceenCapture` execution so retrieval point is moved slightly up instead of down.

100 iterations of the test passed in all platforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8368185](https://bugs.openjdk.org/browse/JDK-8368185): Test javax/swing/plaf/synth/SynthButtonUI/6276188/bug6276188.java failed: Synth ButtonUI does not handle PRESSED &amp; MOUSE_OVER state (**Bug** - P4)


### Reviewers
 * [Tejesh R](https://openjdk.org/census#tr) (@TejeshR13 - **Reviewer**)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27444/head:pull/27444` \
`$ git checkout pull/27444`

Update a local copy of the PR: \
`$ git checkout pull/27444` \
`$ git pull https://git.openjdk.org/jdk.git pull/27444/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27444`

View PR using the GUI difftool: \
`$ git pr show -t 27444`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27444.diff">https://git.openjdk.org/jdk/pull/27444.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27444#issuecomment-3322724824)
</details>
