### PR TITLE
8368366: RISC-V: AlignVector is mistakenly set to AvoidUnalignedAccesses

### DIFF
--- a/src/hotspot/cpu/riscv/vm_version_riscv.cpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.cpp
@@ -477,10 +477,6 @@ void VM_Version::c2_initialize() {
     warning("AES/CTR intrinsics are not available on this CPU");
     FLAG_SET_DEFAULT(UseAESCTRIntrinsics, false);
   }
-
-  if (FLAG_IS_DEFAULT(AlignVector)) {
-    FLAG_SET_DEFAULT(AlignVector, AvoidUnalignedAccesses);
-  }
 }
 
 #endif // COMPILER2


### PR DESCRIPTION
Hi, please consider this small change fixing setting of `AlignVector` flag on RISC-V.

According to the latest RISC-V linux hardware probing syscall [1], the performance of misaligned memory accesses
has been divided into two cases: `RISCV_HWPROBE_KEY_MISALIGNED_SCALAR_PERF` and `RISCV_HWPROBE_KEY_MISALIGNED_VECTOR_PERF`
for scalar and vector respectively. And `RISCV_HWPROBE_KEY_CPUPERF_0` is now deprecated and it returns similar values
to `RISCV_HWPROBE_KEY_MISALIGNED_SCALAR_PERF`.

Previously, we use `RISCV_HWPROBE_KEY_CPUPERF_0` to detect support for misaligned memory accesses and reflect the result
on these VM flags: `AvoidUnalignedAccesses`, `UseUnalignedAccesses` and `AlignVector`. But it doesn't seem correct to update
`AlignVector` according to this value. And this is causing issues on RISC-V hardwares which have fast misaligned accesses only
for the scalar case. I witnessed SIGBUG error on these hardwares when doing vector misaligned accesses.

So we should align AlignVector with `RISCV_HWPROBE_KEY_MISALIGNED_VECTOR_PERF` instead. This patch just reverts the previous
setting of AlignVector and just let it have the default value which is true. I will try to add detection in a separate PR
for `RISCV_HWPROBE_KEY_MISALIGNED_VECTOR_PERF` and update `AlignVector` accordingly.

[1] https://docs.kernel.org/arch/riscv/hwprobe.html

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8368366](https://bugs.openjdk.org/browse/JDK-8368366): RISC-V: AlignVector is mistakenly set to AvoidUnalignedAccesses (**Bug** - P4)


### Reviewers
 * [Feilong Jiang](https://openjdk.org/census#fjiang) (@feilongjiang - Committer)
 * [Robbin Ehn](https://openjdk.org/census#rehn) (@robehn - **Reviewer**)
 * [Hamlin Li](https://openjdk.org/census#mli) (@Hamlin-Li - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27445/head:pull/27445` \
`$ git checkout pull/27445`

Update a local copy of the PR: \
`$ git checkout pull/27445` \
`$ git pull https://git.openjdk.org/jdk.git pull/27445/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27445`

View PR using the GUI difftool: \
`$ git pr show -t 27445`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27445.diff">https://git.openjdk.org/jdk/pull/27445.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27445#issuecomment-3322761054)
</details>
