### PR TITLE
8368373: Test H3MalformedResponseTest.testMalformedResponse intermittent timed out

### DIFF
--- a/test/jdk/java/net/httpclient/http3/H3MalformedResponseTest.java
+++ b/test/jdk/java/net/httpclient/http3/H3MalformedResponseTest.java
@@ -29,6 +29,7 @@ import jdk.internal.net.http.quic.TerminationCause;
 import jdk.internal.net.quic.QuicVersion;
 import jdk.test.lib.net.SimpleSSLContext;
 import jdk.test.lib.net.URIBuilder;
+import jdk.test.lib.Utils;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
@@ -368,7 +369,7 @@ public class H3MalformedResponseTest implements HttpServerAdapters {
             final HttpResponse<Void> response1 = client.sendAsync(
                             request,
                             BodyHandlers.discarding())
-                    .get(30, TimeUnit.SECONDS);
+                    .get(Utils.adjustTimeout(10), TimeUnit.SECONDS);
             fail("Expected the request to fail, got " + response1);
         } catch (TimeoutException e) {
             throw e;


### PR DESCRIPTION
Hi all,

The sub-test H3MalformedResponseTest.testMalformedResponse in test/jdk/java/net/httpclient/http3/H3MalformedResponseTest.java intermittent report java.util.concurrent.TimeoutException, espicial when this test run with other jtreg tests simultancely. This PR change the timeout vaule from 10 to 30 to make test run passed steady.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8368373](https://bugs.openjdk.org/browse/JDK-8368373): Test H3MalformedResponseTest.testMalformedResponse intermittent timed out (**Bug** - P4)


### Reviewers
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - **Reviewer**) Review applies to [16d6b3e2](https://git.openjdk.org/jdk/pull/27447/files/16d6b3e2cf55059150d5e97f877166eb777a5714)
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27447/head:pull/27447` \
`$ git checkout pull/27447`

Update a local copy of the PR: \
`$ git checkout pull/27447` \
`$ git pull https://git.openjdk.org/jdk.git pull/27447/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27447`

View PR using the GUI difftool: \
`$ git pr show -t 27447`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27447.diff">https://git.openjdk.org/jdk/pull/27447.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27447#issuecomment-3322883163)
</details>
