### PR TITLE
8367391: Loss of precision on implicit conversion in vectornode.cpp

### DIFF
--- a/src/hotspot/share/opto/vectornode.cpp
+++ b/src/hotspot/share/opto/vectornode.cpp
@@ -439,8 +439,8 @@ bool VectorNode::is_maskall_type(const TypeLong* type, int vlen) {
   if (!type->is_con()) {
     return false;
   }
-  long mask = (-1ULL >> (64 - vlen));
-  long bit  = type->get_con() & mask;
+  jlong mask = (-1ULL >> (64 - vlen));
+  jlong bit = type->get_con() & mask;
   return bit == 0 || bit == mask;
 }
 

--- a/test/hotspot/jtreg/compiler/vectorapi/VectorMaskFromLongTest.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/VectorMaskFromLongTest.java
@@ -23,7 +23,7 @@
 
 /*
 * @test
-* @bug 8356760
+* @bug 8356760 8367391
 * @library /test/lib /
 * @summary Optimize VectorMask.fromLong for all-true/all-false cases
 * @modules jdk.incubator.vector
@@ -173,92 +173,98 @@ public class VectorMaskFromLongTest {
 
     @Test
     @IR(counts = { IRNode.MASK_ALL, "= 0",
-                   IRNode.VECTOR_LONG_TO_MASK, "> 0" },
+                   IRNode.VECTOR_LONG_TO_MASK, "= 2" },
         applyIfCPUFeatureOr = { "sve2", "true", "avx512", "true", "rvv", "true" })
     @IR(counts = { IRNode.REPLICATE_B, "= 0",
                    IRNode.VECTOR_LONG_TO_MASK, "= 0" },
         applyIfCPUFeatureAnd = { "asimd", "true", "sve", "false" })
     @IR(counts = { IRNode.REPLICATE_B, "= 0",
-                   IRNode.VECTOR_LONG_TO_MASK, "> 0" },
+                   IRNode.VECTOR_LONG_TO_MASK, "= 2" },
         applyIfCPUFeatureAnd = { "avx2", "true", "avx512", "false" })
     public static void testMaskFromLongByte() {
-        // Test the case where some but not all bits are set.
-        testMaskFromLong(B_SPECIES, (-1L >>> (64 - B_SPECIES.length()))-1);
+        // Test cases where some but not all bits are set.
+        testMaskFromLong(B_SPECIES, (-1L >>> (64 - B_SPECIES.length())) - 1);
+        testMaskFromLong(B_SPECIES, (-1L >>> (64 - B_SPECIES.length())) >>> 1);
     }
 
     @Test
     @IR(counts = { IRNode.MASK_ALL, "= 0",
-                   IRNode.VECTOR_LONG_TO_MASK, "> 0" },
+                   IRNode.VECTOR_LONG_TO_MASK, "= 2" },
         applyIfCPUFeatureOr = { "sve2", "true", "avx512", "true", "rvv", "true" })
     @IR(counts = { IRNode.REPLICATE_S, "= 0",
                    IRNode.VECTOR_LONG_TO_MASK, "= 0" },
         applyIfCPUFeatureAnd = { "asimd", "true", "sve", "false" })
     @IR(counts = { IRNode.REPLICATE_S, "= 0",
-                   IRNode.VECTOR_LONG_TO_MASK, "> 0" },
+                   IRNode.VECTOR_LONG_TO_MASK, "= 2" },
         applyIfCPUFeatureAnd = { "avx2", "true", "avx512", "false" })
     public static void testMaskFromLongShort() {
-        // Test the case where some but not all bits are set.
-        testMaskFromLong(S_SPECIES, (-1L >>> (64 - S_SPECIES.length()))-1);
+        // Test cases where some but not all bits are set.
+        testMaskFromLong(S_SPECIES, (-1L >>> (64 - S_SPECIES.length())) - 1);
+        testMaskFromLong(S_SPECIES, (-1L >>> (64 - S_SPECIES.length())) >>> 1);
     }
 
     @Test
     @IR(counts = { IRNode.MASK_ALL, "= 0",
-                   IRNode.VECTOR_LONG_TO_MASK, "> 0" },
+                   IRNode.VECTOR_LONG_TO_MASK, "= 2" },
         applyIfCPUFeatureOr = { "sve2", "true", "avx512", "true", "rvv", "true" })
     @IR(counts = { IRNode.REPLICATE_I, "= 0",
                    IRNode.VECTOR_LONG_TO_MASK, "= 0" },
         applyIfCPUFeatureAnd = { "asimd", "true", "sve", "false" })
     @IR(counts = { IRNode.REPLICATE_I, "= 0",
-                   IRNode.VECTOR_LONG_TO_MASK, "> 0" },
+                   IRNode.VECTOR_LONG_TO_MASK, "= 2" },
         applyIfCPUFeatureAnd = { "avx2", "true", "avx512", "false" })
     public static void testMaskFromLongInt() {
-        // Test the case where some but not all bits are set.
-        testMaskFromLong(I_SPECIES, (-1L >>> (64 - I_SPECIES.length()))-1);
+        // Test cases where some but not all bits are set.
+        testMaskFromLong(I_SPECIES, (-1L >>> (64 - I_SPECIES.length())) - 1);
+        testMaskFromLong(I_SPECIES, (-1L >>> (64 - I_SPECIES.length())) >>> 1);
     }
 
     @Test
     @IR(counts = { IRNode.MASK_ALL, "= 0",
-                   IRNode.VECTOR_LONG_TO_MASK, "> 0" },
+                   IRNode.VECTOR_LONG_TO_MASK, "= 2" },
         applyIfCPUFeatureOr = { "sve2", "true", "avx512", "true", "rvv", "true" })
     @IR(counts = { IRNode.REPLICATE_L, "= 0",
                    IRNode.VECTOR_LONG_TO_MASK, "= 0" },
         applyIfCPUFeatureAnd = { "asimd", "true", "sve", "false" })
     @IR(counts = { IRNode.REPLICATE_L, "= 0",
-                   IRNode.VECTOR_LONG_TO_MASK, "> 0" },
+                   IRNode.VECTOR_LONG_TO_MASK, "= 2" },
         applyIfCPUFeatureAnd = { "avx2", "true", "avx512", "false" })
     public static void testMaskFromLongLong() {
-        // Test the case where some but not all bits are set.
-        testMaskFromLong(L_SPECIES, (-1L >>> (64 - L_SPECIES.length()))-1);
+        // Test cases where some but not all bits are set.
+        testMaskFromLong(L_SPECIES, (-1L >>> (64 - L_SPECIES.length())) - 1);
+        testMaskFromLong(L_SPECIES, (-1L >>> (64 - L_SPECIES.length())) >>> 1);
     }
 
     @Test
     @IR(counts = { IRNode.MASK_ALL, "= 0",
-                   IRNode.VECTOR_LONG_TO_MASK, "> 0" },
+                   IRNode.VECTOR_LONG_TO_MASK, "= 2" },
         applyIfCPUFeatureOr = { "sve2", "true", "avx512", "true", "rvv", "true" })
     @IR(counts = { IRNode.REPLICATE_I, "= 0",
                    IRNode.VECTOR_LONG_TO_MASK, "= 0" },
         applyIfCPUFeatureAnd = { "asimd", "true", "sve", "false" })
     @IR(counts = { IRNode.REPLICATE_I, "= 0",
-                   IRNode.VECTOR_LONG_TO_MASK, "> 0" },
+                   IRNode.VECTOR_LONG_TO_MASK, "= 2" },
         applyIfCPUFeatureAnd = { "avx2", "true", "avx512", "false" })
     public static void testMaskFromLongFloat() {
-        // Test the case where some but not all bits are set.
-        testMaskFromLong(F_SPECIES, (-1L >>> (64 - F_SPECIES.length()))-1);
+        // Test cases where some but not all bits are set.
+        testMaskFromLong(F_SPECIES, (-1L >>> (64 - F_SPECIES.length())) - 1);
+        testMaskFromLong(F_SPECIES, (-1L >>> (64 - F_SPECIES.length())) >>> 1);
     }
 
     @Test
     @IR(counts = { IRNode.MASK_ALL, "= 0",
-                   IRNode.VECTOR_LONG_TO_MASK, "> 0" },
+                   IRNode.VECTOR_LONG_TO_MASK, "= 2" },
         applyIfCPUFeatureOr = { "sve2", "true", "avx512", "true", "rvv", "true" })
     @IR(counts = { IRNode.REPLICATE_L, "= 0",
                    IRNode.VECTOR_LONG_TO_MASK, "= 0" },
         applyIfCPUFeatureAnd = { "asimd", "true", "sve", "false" })
     @IR(counts = { IRNode.REPLICATE_L, "= 0",
-                   IRNode.VECTOR_LONG_TO_MASK, "> 0" },
+                   IRNode.VECTOR_LONG_TO_MASK, "= 2" },
         applyIfCPUFeatureAnd = { "avx2", "true", "avx512", "false" })
     public static void testMaskFromLongDouble() {
-        // Test the case where some but not all bits are set.
-        testMaskFromLong(D_SPECIES, (-1L >>> (64 - D_SPECIES.length()))-1);
+        // Test cases where some but not all bits are set.
+        testMaskFromLong(D_SPECIES, (-1L >>> (64 - D_SPECIES.length())) - 1);
+        testMaskFromLong(D_SPECIES, (-1L >>> (64 - D_SPECIES.length())) >>> 1);
     }
 
     public static void main(String[] args) {


### PR DESCRIPTION
There is an issue with fix against JDK-8356760 on windows-x64 related to following lines
```
  long mask = (-1ULL >> (64 - vlen));
  long bit  = type->get_con() & mask;
```

`-1ULL` is an unsigned **64-bit** value; on Linux/macOS-x64, `long` is **64** bits, but on Windows-x64 it’s **32** bits. When assigning `-1ULL >> (64 - vlen)` to a `long` on Windows-x64, the **64-bit** result is truncated to **32** bits, causing precision loss as the upper 32 bits are discarded.

This pull request addresses the issue by replacing the `long` type with `jlong`. The fix has been verified on a Windows x64 machine with avx-512 support and resolves the reported problem.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8367391](https://bugs.openjdk.org/browse/JDK-8367391): Loss of precision on implicit conversion in vectornode.cpp (**Bug** - P4)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Roland Westrelin](https://openjdk.org/census#roland) (@rwestrel - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27449/head:pull/27449` \
`$ git checkout pull/27449`

Update a local copy of the PR: \
`$ git checkout pull/27449` \
`$ git pull https://git.openjdk.org/jdk.git pull/27449/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27449`

View PR using the GUI difftool: \
`$ git pr show -t 27449`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27449.diff">https://git.openjdk.org/jdk/pull/27449.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27449#issuecomment-3323302819)
</details>
