### PR TITLE
8368367: Test jdk/jfr/event/gc/detailed/TestGCHeapMemoryUsageEvent.java fails  jdk.GCHeapMemoryUsage "expected 0 > 0"

### DIFF
--- a/test/jdk/jdk/jfr/event/gc/detailed/TestGCHeapMemoryUsageEvent.java
+++ b/test/jdk/jdk/jfr/event/gc/detailed/TestGCHeapMemoryUsageEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
Hi all,

  please review this change to the TestGCHeapMemoryUsageEvent test that checks whether these kind of events are posted and contain some sensibles values.

In this failure, the `used` metric for the first of two events that is checked was zero. This is because G1, the default collector, updates the `used` value only at certain synchronization points to avoid inconsistencies in other cases. One of these synchronization points is region refill. With the 30gb heap in the test environment, region size is larger than what is allocated during startup, so no region refill/synchronization point has been reached yet, and `used` turns out to be `0`.

This change fixes this by checking the last event instead of the first, it must have happened after that `system.gc()` call in the test, and `used` ought to be larger than zero because of allocations during VM startup.

An alternative could be limiting the test's heap size to something small, that would also help, but I thought this might need additional explanations.

Testing: local runs with G1 heap region size >= 16M or so do not fail any more.

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8368367](https://bugs.openjdk.org/browse/JDK-8368367): Test jdk/jfr/event/gc/detailed/TestGCHeapMemoryUsageEvent.java fails  jdk.GCHeapMemoryUsage "expected 0 &gt; 0" (**Bug** - P4)


### Reviewers
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [SendaoYan](https://openjdk.org/census#syan) (@sendaoYan - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27451/head:pull/27451` \
`$ git checkout pull/27451`

Update a local copy of the PR: \
`$ git checkout pull/27451` \
`$ git pull https://git.openjdk.org/jdk.git pull/27451/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27451`

View PR using the GUI difftool: \
`$ git pr show -t 27451`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27451.diff">https://git.openjdk.org/jdk/pull/27451.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27451#issuecomment-3323871497)
</details>
