### PR TITLE
8367610: Test tools/sincechecker/modules/java.base/JavaBaseCheckSince.java timed out on Windows

### DIFF
--- a/test/jdk/tools/sincechecker/modules/java.base/JavaBaseCheckSince.java
+++ b/test/jdk/tools/sincechecker/modules/java.base/JavaBaseCheckSince.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8331051
+ * @bug 8331051 8367610
  * @summary Test for `@since` in java.base module
  * @library /test/lib /test/jdk/tools/sincechecker
  * @run main/timeout=480 SinceChecker java.base --exclude java.lang.classfile


### PR DESCRIPTION
Timeout after "8260555: Change the default TIMEOUT_FACTOR from 4 to 1"

The test usually runs in 30 seconds but it seems to be struggling sometimes with the 120 second timeout.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8367610](https://bugs.openjdk.org/browse/JDK-8367610): Test tools/sincechecker/modules/java.base/JavaBaseCheckSince.java timed out on Windows (**Bug** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27453/head:pull/27453` \
`$ git checkout pull/27453`

Update a local copy of the PR: \
`$ git checkout pull/27453` \
`$ git pull https://git.openjdk.org/jdk.git pull/27453/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27453`

View PR using the GUI difftool: \
`$ git pr show -t 27453`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27453.diff">https://git.openjdk.org/jdk/pull/27453.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27453#issuecomment-3324226459)
</details>
