### PR TITLE
8368152: Shenandoah: Incorrect behavior at end of degenerated cycle

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahCollectorPolicy.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahCollectorPolicy.cpp
@@ -37,6 +37,7 @@ ShenandoahCollectorPolicy::ShenandoahCollectorPolicy() :
   _abbreviated_degenerated_gcs(0),
   _success_full_gcs(0),
   _consecutive_degenerated_gcs(0),
+  _consecutive_degenerated_gcs_without_progress(0),
   _consecutive_young_gcs(0),
   _mixed_gcs(0),
   _success_old_gcs(0),
@@ -67,14 +68,14 @@ void ShenandoahCollectorPolicy::record_alloc_failure_to_degenerated(ShenandoahGC
 }
 
 void ShenandoahCollectorPolicy::record_degenerated_upgrade_to_full() {
-  _consecutive_degenerated_gcs = 0;
+  reset_consecutive_degenerated_gcs();
   _alloc_failure_degenerated_upgrade_to_full++;
 }
 
 void ShenandoahCollectorPolicy::record_success_concurrent(bool is_young, bool is_abbreviated) {
   update_young(is_young);
 
-  _consecutive_degenerated_gcs = 0;
+  reset_consecutive_degenerated_gcs();
   _success_concurrent_gcs++;
   if (is_abbreviated) {
     _abbreviated_concurrent_gcs++;
@@ -95,11 +96,18 @@ void ShenandoahCollectorPolicy::record_interrupted_old() {
   _interrupted_old_gcs++;
 }
 
-void ShenandoahCollectorPolicy::record_success_degenerated(bool is_young, bool is_abbreviated) {
+void ShenandoahCollectorPolicy::record_degenerated(bool is_young, bool is_abbreviated, bool progress) {
   update_young(is_young);
 
   _success_degenerated_gcs++;
   _consecutive_degenerated_gcs++;
+
+  if (progress) {
+    _consecutive_degenerated_gcs_without_progress = 0;
+  } else {
+    _consecutive_degenerated_gcs_without_progress++;
+  }
+
   if (is_abbreviated) {
     _abbreviated_degenerated_gcs++;
   }
@@ -114,7 +122,7 @@ void ShenandoahCollectorPolicy::update_young(bool is_young) {
 }
 
 void ShenandoahCollectorPolicy::record_success_full() {
-  _consecutive_degenerated_gcs = 0;
+  reset_consecutive_degenerated_gcs();
   _consecutive_young_gcs = 0;
   _success_full_gcs++;
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahCollectorPolicy.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahCollectorPolicy.hpp
@@ -79,6 +79,11 @@ public:
   // cycles are very efficient and are worth tracking. Note that both degenerated and
   // concurrent cycles can be abbreviated.
   void record_success_concurrent(bool is_young, bool is_abbreviated);
+
+  // Record that a degenerated cycle has been completed. Note that such a cycle may or
+  // may not make "progress". We separately track the total number of degenerated cycles,
+  // the number of consecutive degenerated cycles and the number of consecutive cycles that
+  // fail ot make good progress.
   void record_degenerated(bool is_young, bool is_abbreviated, bool progress);
   void record_success_full();
   void record_alloc_failure_to_degenerated(ShenandoahGC::ShenandoahDegenPoint point);
@@ -104,6 +109,7 @@ public:
     return _consecutive_degenerated_gcs;
   }
 
+  // Genshen will only upgrade to a full gc after the configured number of futile degenerated cycles.
   bool should_upgrade_degenerated_gc() const {
     return _consecutive_degenerated_gcs_without_progress >= CONSECUTIVE_BAD_DEGEN_PROGRESS_THRESHOLD;
   }

--- a/src/hotspot/share/gc/shenandoah/shenandoahCollectorPolicy.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahCollectorPolicy.hpp
@@ -64,7 +64,10 @@ private:
 public:
   // When this number of consecutive degenerated cycles fail to make progress
   // in generational mode, run a full GC. Non-generational modes will upgrade
-  // immediately when a degenerated cycle does not make progress.
+  // immediately when a degenerated cycle does not make progress. Many degenerated
+  // cycles are caused by floating garbage. It is more efficient to attempt
+  // a second degenerated cycle in the young generation to reclaim this memory,
+  // rather than running a lengthy full GC over the entire heap.
   static constexpr size_t CONSECUTIVE_BAD_DEGEN_PROGRESS_THRESHOLD = 2;
 
   ShenandoahCollectorPolicy();

--- a/src/hotspot/share/gc/shenandoah/shenandoahCollectorPolicy.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahCollectorPolicy.hpp
@@ -83,7 +83,7 @@ public:
   // Record that a degenerated cycle has been completed. Note that such a cycle may or
   // may not make "progress". We separately track the total number of degenerated cycles,
   // the number of consecutive degenerated cycles and the number of consecutive cycles that
-  // fail ot make good progress.
+  // fail to make good progress.
   void record_degenerated(bool is_young, bool is_abbreviated, bool progress);
   void record_success_full();
   void record_alloc_failure_to_degenerated(ShenandoahGC::ShenandoahDegenPoint point);

--- a/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.cpp
@@ -49,8 +49,7 @@ ShenandoahDegenGC::ShenandoahDegenGC(ShenandoahDegenPoint degen_point, Shenandoa
   ShenandoahGC(),
   _degen_point(degen_point),
   _generation(generation),
-  _abbreviated(false),
-  _consecutive_degen_with_bad_progress(0) {
+  _abbreviated(false) {
 }
 
 bool ShenandoahDegenGC::collect(GCCause::Cause cause) {
@@ -247,7 +246,6 @@ void ShenandoahDegenGC::op_degenerated() {
           ShenandoahHeapRegion* r;
           while ((r = heap->collection_set()->next()) != nullptr) {
             if (r->is_pinned()) {
-              heap->cancel_gc(GCCause::_shenandoah_upgrade_to_full_gc);
               op_degenerated_fail();
               return;
             }
@@ -320,22 +318,16 @@ void ShenandoahDegenGC::op_degenerated() {
   // In generational mode, we'll only upgrade to full GC if we've done two degen cycles in a row and both indicated
   // bad progress.  In non-generational mode, we'll preserve the original behavior, which is to upgrade to full
   // immediately following a degenerated cycle with bad progress.  This preserves original behavior of non-generational
-  // Shenandoah so as to avoid introducing "surprising new behavior."  It also makes less sense with non-generational
+  // Shenandoah to avoid introducing "surprising new behavior."  It also makes less sense with non-generational
   // Shenandoah to replace a full GC with a degenerated GC, because both have similar pause times in non-generational
   // mode.
-  if (!metrics.is_good_progress(_generation)) {
-    _consecutive_degen_with_bad_progress++;
-  } else {
-    _consecutive_degen_with_bad_progress = 0;
-  }
-  if (!heap->mode()->is_generational() ||
-      ((heap->shenandoah_policy()->consecutive_degenerated_gc_count() > 1) && (_consecutive_degen_with_bad_progress >= 2))) {
-    heap->cancel_gc(GCCause::_shenandoah_upgrade_to_full_gc);
-    op_degenerated_futile();
-  } else {
+  const bool progress = metrics.is_good_progress(_generation);
+  ShenandoahCollectorPolicy* policy = heap->shenandoah_policy();
+  policy->record_degenerated(_generation->is_young(), _abbreviated, progress);
+  if (progress) {
     heap->notify_gc_progress();
-    heap->shenandoah_policy()->record_success_degenerated(_generation->is_young(), _abbreviated);
-    _generation->heuristics()->record_success_degenerated();
+  } else if (!heap->mode()->is_generational() || policy->should_upgrade_degenerated_gc()) {
+    op_degenerated_futile();
   }
 }
 
@@ -483,6 +475,7 @@ const char* ShenandoahDegenGC::degen_event_message(ShenandoahDegenPoint point) c
 void ShenandoahDegenGC::upgrade_to_full() {
   log_info(gc)("Degenerated GC upgrading to Full GC");
   ShenandoahHeap* heap = ShenandoahHeap::heap();
+  heap->cancel_gc(GCCause::_shenandoah_upgrade_to_full_gc);
   heap->increment_total_collections(true);
   heap->shenandoah_policy()->record_degenerated_upgrade_to_full();
   ShenandoahFullGC full_gc;

--- a/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.hpp
@@ -36,7 +36,6 @@ private:
   const ShenandoahDegenPoint  _degen_point;
   ShenandoahGeneration* _generation;
   bool _abbreviated;
-  size_t _consecutive_degen_with_bad_progress;
 
 public:
   ShenandoahDegenGC(ShenandoahDegenPoint degen_point, ShenandoahGeneration* generation);

--- a/test/hotspot/gtest/gc/shenandoah/test_shenandoahCollectorPolicy.cpp
+++ b/test/hotspot/gtest/gc/shenandoah/test_shenandoahCollectorPolicy.cpp
@@ -1,0 +1,72 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#include "gc/shenandoah/shenandoahCollectorPolicy.hpp"
+#include "unittest.hpp"
+
+TEST(ShenandoahCollectorPolicyTest, track_degen_cycles_sanity) {
+  ShenandoahCollectorPolicy policy;
+  EXPECT_EQ(policy.consecutive_degenerated_gc_count(), 0UL);
+  EXPECT_EQ(policy.should_upgrade_degenerated_gc(), false);
+}
+
+TEST(ShenandoahCollectorPolicyTest, track_degen_cycles_no_upgrade) {
+  ShenandoahCollectorPolicy policy;
+  policy.record_degenerated(true, true, true);
+  policy.record_degenerated(true, true, true);
+  EXPECT_EQ(policy.consecutive_degenerated_gc_count(), 2UL);
+  EXPECT_EQ(policy.should_upgrade_degenerated_gc(), false);
+}
+
+TEST(ShenandoahCollectorPolicyTest, track_degen_cycles_upgrade) {
+  ShenandoahCollectorPolicy policy;
+  policy.record_degenerated(true, true, false);
+  policy.record_degenerated(true, true, false);
+  EXPECT_EQ(policy.consecutive_degenerated_gc_count(), 2UL);
+  EXPECT_EQ(policy.should_upgrade_degenerated_gc(), true);
+}
+
+TEST(ShenandoahCollectorPolicyTest, track_degen_cycles_reset_progress) {
+  ShenandoahCollectorPolicy policy;
+  policy.record_degenerated(true, true, false);
+  policy.record_degenerated(true, true, true);
+  EXPECT_EQ(policy.consecutive_degenerated_gc_count(), 2UL);
+  EXPECT_EQ(policy.should_upgrade_degenerated_gc(), false);
+}
+
+TEST(ShenandoahCollectorPolicyTest, track_degen_cycles_full_reset) {
+  ShenandoahCollectorPolicy policy;
+  policy.record_degenerated(true, true, false);
+  policy.record_success_full();
+  EXPECT_EQ(policy.consecutive_degenerated_gc_count(), 0UL);
+  EXPECT_EQ(policy.should_upgrade_degenerated_gc(), false);
+}
+
+TEST(ShenandoahCollectorPolicyTest, track_degen_cycles_reset) {
+  ShenandoahCollectorPolicy policy;
+  policy.record_degenerated(true, true, false);
+  policy.record_success_concurrent(true, true);
+  EXPECT_EQ(policy.consecutive_degenerated_gc_count(), 0UL);
+  EXPECT_EQ(policy.should_upgrade_degenerated_gc(), false);
+}

--- a/test/hotspot/gtest/gc/shenandoah/test_shenandoahCollectorPolicy.cpp
+++ b/test/hotspot/gtest/gc/shenandoah/test_shenandoahCollectorPolicy.cpp
@@ -28,7 +28,7 @@
 TEST(ShenandoahCollectorPolicyTest, track_degen_cycles_sanity) {
   ShenandoahCollectorPolicy policy;
   EXPECT_EQ(policy.consecutive_degenerated_gc_count(), 0UL);
-  EXPECT_EQ(policy.should_upgrade_degenerated_gc(), false);
+  EXPECT_EQ(policy.generational_should_upgrade_degenerated_gc(), false);
 }
 
 TEST(ShenandoahCollectorPolicyTest, track_degen_cycles_no_upgrade) {
@@ -36,7 +36,7 @@ TEST(ShenandoahCollectorPolicyTest, track_degen_cycles_no_upgrade) {
   policy.record_degenerated(true, true, true);
   policy.record_degenerated(true, true, true);
   EXPECT_EQ(policy.consecutive_degenerated_gc_count(), 2UL);
-  EXPECT_EQ(policy.should_upgrade_degenerated_gc(), false);
+  EXPECT_EQ(policy.generational_should_upgrade_degenerated_gc(), false);
 }
 
 TEST(ShenandoahCollectorPolicyTest, track_degen_cycles_upgrade) {
@@ -44,7 +44,7 @@ TEST(ShenandoahCollectorPolicyTest, track_degen_cycles_upgrade) {
   policy.record_degenerated(true, true, false);
   policy.record_degenerated(true, true, false);
   EXPECT_EQ(policy.consecutive_degenerated_gc_count(), 2UL);
-  EXPECT_EQ(policy.should_upgrade_degenerated_gc(), true);
+  EXPECT_EQ(policy.generational_should_upgrade_degenerated_gc(), true);
 }
 
 TEST(ShenandoahCollectorPolicyTest, track_degen_cycles_reset_progress) {
@@ -52,7 +52,7 @@ TEST(ShenandoahCollectorPolicyTest, track_degen_cycles_reset_progress) {
   policy.record_degenerated(true, true, false);
   policy.record_degenerated(true, true, true);
   EXPECT_EQ(policy.consecutive_degenerated_gc_count(), 2UL);
-  EXPECT_EQ(policy.should_upgrade_degenerated_gc(), false);
+  EXPECT_EQ(policy.generational_should_upgrade_degenerated_gc(), false);
 }
 
 TEST(ShenandoahCollectorPolicyTest, track_degen_cycles_full_reset) {
@@ -60,7 +60,7 @@ TEST(ShenandoahCollectorPolicyTest, track_degen_cycles_full_reset) {
   policy.record_degenerated(true, true, false);
   policy.record_success_full();
   EXPECT_EQ(policy.consecutive_degenerated_gc_count(), 0UL);
-  EXPECT_EQ(policy.should_upgrade_degenerated_gc(), false);
+  EXPECT_EQ(policy.generational_should_upgrade_degenerated_gc(), false);
 }
 
 TEST(ShenandoahCollectorPolicyTest, track_degen_cycles_reset) {
@@ -68,5 +68,5 @@ TEST(ShenandoahCollectorPolicyTest, track_degen_cycles_reset) {
   policy.record_degenerated(true, true, false);
   policy.record_success_concurrent(true, true);
   EXPECT_EQ(policy.consecutive_degenerated_gc_count(), 0UL);
-  EXPECT_EQ(policy.should_upgrade_degenerated_gc(), false);
+  EXPECT_EQ(policy.generational_should_upgrade_degenerated_gc(), false);
 }


### PR DESCRIPTION
There are several issues addressed in this PR:
* Shenandoah always ran a full GC after any degenerated cycle
* The number of consecutive degenerated GCs with bad progress was reset for every degenerated cycle
* Good progress was reported in generational mode even when no progress is made

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8368152](https://bugs.openjdk.org/browse/JDK-8368152): Shenandoah: Incorrect behavior at end of degenerated cycle (**Bug** - P4)


### Reviewers
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - Committer)
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27456/head:pull/27456` \
`$ git checkout pull/27456`

Update a local copy of the PR: \
`$ git checkout pull/27456` \
`$ git pull https://git.openjdk.org/jdk.git pull/27456/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27456`

View PR using the GUI difftool: \
`$ git pr show -t 27456`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27456.diff">https://git.openjdk.org/jdk/pull/27456.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27456#issuecomment-3325375599)
</details>
