### PR TITLE
8367702: PrintJob.getGraphics() should return null after PrintJob.end

### DIFF
--- a/src/java.desktop/share/classes/sun/print/PrintJob2D.java
+++ b/src/java.desktop/share/classes/sun/print/PrintJob2D.java
@@ -79,7 +79,12 @@ public class PrintJob2D extends PrintJob {
          * needs to implement PrintGraphics, so we wrap
          * the Graphics2D instance.
          */
-        return new ProxyPrintGraphics(printJobDelegate.getGraphics(), this);
+        Graphics g = printJobDelegate.getGraphics();
+        if (g == null) { // PrintJob.end() has been called.
+            return null;
+        } else {
+            return new ProxyPrintGraphics(g, this);
+        }
     }
 
     /**

--- a/test/jdk/java/awt/PrintJob/GetGraphicsTest.java
+++ b/test/jdk/java/awt/PrintJob/GetGraphicsTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2004, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+  @test
+  @bug 50510568367702
+  @key headful printer
+  @summary  PrintJob.getGraphics() should return null after PrintJob.end() is called.
+  @run main GetGraphicsTest
+*/
+
+import java.awt.Frame;
+import java.awt.Graphics;
+import java.awt.JobAttributes;
+import java.awt.PageAttributes;
+import java.awt.PrintJob;
+import java.awt.Toolkit;
+
+public class GetGraphicsTest {
+
+    public static void main(String[] args) {
+
+        JobAttributes ja = new JobAttributes();
+        ja.setDialog(JobAttributes.DialogType.NONE);
+        PageAttributes pa = new PageAttributes();
+        pa.setOrigin( PageAttributes.OriginType.PRINTABLE);
+
+        Toolkit tk = Toolkit.getDefaultToolkit();
+        PrintJob pjob = tk.getPrintJob(new Frame(),"Printing Test", ja,pa);
+        if (pjob != null) {
+            pjob.end();
+            Graphics pg = pjob.getGraphics();
+            if (pg == null) {
+                System.out.println("Graphics is null, TEST PASSES");
+            }
+            else {
+               throw new RuntimeException("Graphics is NOT null, TEST FAILED");
+            }
+        }
+    }
+}


### PR DESCRIPTION
A few days ago it was noticed that there was a printing test (in closed) that didn't have a test tag and on closer examination that was unfortunate because it tested that PrintJob.getGraphics() returns null after PrintJob.end() and that was broken by a recent JDK 26 change

This fixes that and creates an updated open jtreg test so this should not happen again.
The above will restore the status quo but it was also noted that the PrintJob spec. doesn't describe this.
I prefer to handle the spec update separately and will do so as soon as this is resolved.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8367702](https://bugs.openjdk.org/browse/JDK-8367702): PrintJob.getGraphics() should return null after PrintJob.end (**Bug** - P3)


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27458/head:pull/27458` \
`$ git checkout pull/27458`

Update a local copy of the PR: \
`$ git checkout pull/27458` \
`$ git pull https://git.openjdk.org/jdk.git pull/27458/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27458`

View PR using the GUI difftool: \
`$ git pr show -t 27458`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27458.diff">https://git.openjdk.org/jdk/pull/27458.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27458#issuecomment-3325555858)
</details>
