### PR TITLE
8366948: AOT cache creation crashes when iterating training data

### DIFF
--- a/src/hotspot/share/oops/trainingData.hpp
+++ b/src/hotspot/share/oops/trainingData.hpp
@@ -152,6 +152,9 @@ public:
       _lock_mode = need_data() ? +1 : -1;   // if -1, we go lock-free
 #endif
     }
+    static void assert_locked_or_snapshotted() {
+      assert(safely_locked() || _snapshot, "use under TrainingDataLocker or after snapshot");
+    }
     static void assert_locked() {
       assert(safely_locked(), "use under TrainingDataLocker");
     }
@@ -338,20 +341,24 @@ private:
     }
 
     int length() const {
+      TrainingDataLocker::assert_locked_or_snapshotted();
       return (_deps_dyn != nullptr ? _deps_dyn->length()
               : _deps   != nullptr ? _deps->length()
               : 0);
     }
     E* adr_at(int i) const {
+      TrainingDataLocker::assert_locked_or_snapshotted();
       return (_deps_dyn != nullptr ? _deps_dyn->adr_at(i)
               : _deps   != nullptr ? _deps->adr_at(i)
               : nullptr);
     }
     E at(int i) const {
+      TrainingDataLocker::assert_locked_or_snapshotted();
       assert(i >= 0 && i < length(), "oob");
       return *adr_at(i);
     }
     bool append_if_missing(E dep) {
+      TrainingDataLocker::assert_can_add();
       if (_deps_dyn == nullptr) {
         _deps_dyn = new GrowableArrayCHeap<E, mtCompiler>(10);
         _deps_dyn->append(dep);
@@ -361,23 +368,27 @@ private:
       }
     }
     bool remove_if_existing(E dep) {
+      TrainingDataLocker::assert_can_add();
       if (_deps_dyn != nullptr) {
         return _deps_dyn->remove_if_existing(dep);
       }
       return false;
     }
     void clear() {
+      TrainingDataLocker::assert_can_add();
       if (_deps_dyn != nullptr)  {
         _deps_dyn->clear();
       }
     }
     void append(E dep) {
+      TrainingDataLocker::assert_can_add();
       if (_deps_dyn == nullptr) {
         _deps_dyn = new GrowableArrayCHeap<E, mtCompiler>(10);
       }
       _deps_dyn->append(dep);
     }
     bool contains(E dep) {
+      TrainingDataLocker::assert_locked();
       for (int i = 0; i < length(); i++) {
         if (dep == at(i)) {
           return true; // found

--- a/src/hotspot/share/oops/trainingData.hpp
+++ b/src/hotspot/share/oops/trainingData.hpp
@@ -591,6 +591,7 @@ public:
       DepList<Record> _data;
     public:
       OptionalReturnType find(const Args&... args) {
+        TrainingDataLocker l;
         ArgumentsType a(args...);
         for (int i = 0; i < _data.length(); i++) {
           if (_data.at(i).arguments() == a) {
@@ -599,8 +600,11 @@ public:
         }
         return OptionalReturnType(false, ReturnType());
       }
-      bool append_if_missing(const ReturnType& result, const Args&... args) {
-        return _data.append_if_missing(Record(result, ArgumentsType(args...)));
+      void append_if_missing(const ReturnType& result, const Args&... args) {
+        TrainingDataLocker l;
+        if (l.can_add()) {
+          _data.append_if_missing(Record(result, ArgumentsType(args...)));
+        }
       }
 #if INCLUDE_CDS
       void remove_unshareable_info() { _data.remove_unshareable_info(); }


### PR DESCRIPTION
I forgot a lock around `CTD::_ci_records`. It also has to respect the snapshotting protocol. Testing is good.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8366948](https://bugs.openjdk.org/browse/JDK-8366948): AOT cache creation crashes when iterating training data (**Bug** - P2)


### Reviewers
 * [Vladimir Ivanov](https://openjdk.org/census#vlivanov) (@iwanowww - **Reviewer**)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27461/head:pull/27461` \
`$ git checkout pull/27461`

Update a local copy of the PR: \
`$ git checkout pull/27461` \
`$ git pull https://git.openjdk.org/jdk.git pull/27461/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27461`

View PR using the GUI difftool: \
`$ git pr show -t 27461`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27461.diff">https://git.openjdk.org/jdk/pull/27461.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27461#issuecomment-3326102157)
</details>
