### PR TITLE
8368514

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/SessionTicketExtension.java
+++ b/src/java.base/share/classes/sun/security/ssl/SessionTicketExtension.java
@@ -279,7 +279,7 @@ final class SessionTicketExtension {
                 c.updateAAD(aad);
 
                 ByteBuffer out = ByteBuffer.allocate(
-                        data.remaining() - GCM_TAG_LEN / 8);
+                        c.getOutputSize(data.remaining()));
                 c.doFinal(data, out);
                 out.flip();
 
@@ -291,7 +291,7 @@ final class SessionTicketExtension {
                 return out;
             } catch (Exception e) {
                 if (SSLLogger.isOn && SSLLogger.isOn("ssl,handshake")) {
-                    SSLLogger.fine("Decryption failed." + e.getMessage());
+                    SSLLogger.fine("Decryption failed." + e);
                 }
             }
 

--- a/test/jdk/sun/security/pkcs11/tls/tls12/FipsModeTLS12.java
+++ b/test/jdk/sun/security/pkcs11/tls/tls12/FipsModeTLS12.java
@@ -24,7 +24,7 @@
 
 /*
  * @test
- * @bug 8029661 8325164 8368073
+ * @bug 8029661 8325164 8368073 8368514
  * @summary Test TLS 1.2 and TLS 1.3
  * @modules java.base/sun.security.internal.spec
  *          java.base/sun.security.util
@@ -42,7 +42,13 @@ import java.io.FileInputStream;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 
-import java.security.*;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.KeyStore;
+import java.security.NoSuchAlgorithmException;
+import java.security.Provider;
+import java.security.SecureRandom;
+import java.security.Security;
 
 import java.util.Arrays;
 import java.util.LinkedList;
@@ -423,7 +429,7 @@ public final class FipsModeTLS12 extends SecmodTest {
         }
 
         private static SSLContext sslCtx;
-        private static void initSslContext() throws NoSuchAlgorithmException, NoSuchProviderException, KeyStoreException, UnrecoverableKeyException, KeyManagementException {
+        private static void initSslContext() throws Exception {
             KeyManagerFactory kmf = KeyManagerFactory.getInstance("PKIX", "SunJSSE");
             kmf.init(ks, passphrase);
 


### PR DESCRIPTION
Please review this trivial patch that fixes stateless session resumption with JCE providers that require extra space for AES/GCM decryption.

I modified the existing FipsModeTLS12 test to additionally verify that session resumption works. The TLS 1.3 test resumes the session using a stateless ticket; the TLS 1.2 test uses stateful sessions, because stateless ticket creation fails for other reasons.

Tier1-3 tests continue to pass.