### PR TITLE
8368525: nmethod ic cleanup

### DIFF
--- a/src/hotspot/share/code/nmethod.cpp
+++ b/src/hotspot/share/code/nmethod.cpp
@@ -868,7 +868,7 @@ void nmethod::cleanup_inline_caches_impl(bool unloading_occurred, bool clean_all
       if (unloading_occurred) {
         // If class unloading occurred we first clear ICs where the cached metadata
         // is referring to an unloaded klass or method.
-        CompiledIC_at(&iter)->clean_metadata();;
+        CompiledIC_at(&iter)->clean_metadata();
       }
 
       clean_if_nmethod_is_unloaded(CompiledIC_at(&iter), clean_all);


### PR DESCRIPTION
Hi,
Can you help to review this simple patch?

There is some unused parameter and unnecessary/misleading method in nmethod.cpp, better to clean it up.
I guess it might be a leftover after some previous refactoring? But I did not check further.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8368525: nmethod ic cleanup`

### Issue
 * [JDK-8368525](https://bugs.openjdk.org/browse/JDK-8368525): nmethod ic cleanup (**Enhancement** - P4)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Manuel Hässig](https://openjdk.org/census#mhaessig) (@mhaessig - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27464/head:pull/27464` \
`$ git checkout pull/27464`

Update a local copy of the PR: \
`$ git checkout pull/27464` \
`$ git pull https://git.openjdk.org/jdk.git pull/27464/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27464`

View PR using the GUI difftool: \
`$ git pr show -t 27464`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27464.diff">https://git.openjdk.org/jdk/pull/27464.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27464#issuecomment-3327533589)
</details>
