### PR TITLE
Draft: JMX: Add an MXBeans method to query GC CPU time

### DIFF
--- a/src/hotspot/share/include/jmm.h
+++ b/src/hotspot/share/include/jmm.h
@@ -53,7 +53,8 @@ enum {
   JMM_VERSION_2   = 0x20020000, // JDK 10
   JMM_VERSION_3   = 0x20030000, // JDK 14
   JMM_VERSION_4   = 0x20040000, // JDK 21
-  JMM_VERSION     = JMM_VERSION_4
+  JMM_VERSION_5   = 0x20050000, // JDK 26
+  JMM_VERSION     = JMM_VERSION_5
 };
 
 typedef struct {
@@ -80,7 +81,8 @@ typedef enum {
   JMM_COMPILE_TOTAL_TIME_MS          = 8,    /* Total accumulated time spent in compilation */
   JMM_GC_TIME_MS                     = 9,    /* Total accumulated time spent in collection */
   JMM_GC_COUNT                       = 10,   /* Total number of collections */
-  JMM_JVM_UPTIME_MS                  = 11,   /* The JVM uptime in milliseconds */
+  JMM_GC_CPU_TIME                    = 11,   /* Total accumulated GC CPU time */
+  JMM_JVM_UPTIME_MS                  = 12,   /* The JVM uptime in milliseconds */
 
   JMM_INTERNAL_ATTRIBUTE_INDEX       = 100,
   JMM_CLASS_LOADED_BYTES             = 101,  /* Number of bytes loaded instance classes */

--- a/src/hotspot/share/services/cpuTimeUsage.cpp
+++ b/src/hotspot/share/services/cpuTimeUsage.cpp
@@ -36,6 +36,7 @@
 volatile bool CPUTimeUsage::Error::_has_error = false;
 
 static inline jlong thread_cpu_time_or_zero(Thread* thread) {
+  assert(!Universe::is_shutting_down(), "Should not query during shutdown");
   jlong cpu_time = os::thread_cpu_time(thread);
   if (cpu_time == -1) {
     CPUTimeUsage::Error::mark_error();

--- a/src/hotspot/share/services/management.cpp
+++ b/src/hotspot/share/services/management.cpp
@@ -54,6 +54,7 @@
 #include "runtime/threadSMR.hpp"
 #include "runtime/vmOperations.hpp"
 #include "services/classLoadingService.hpp"
+#include "services/cpuTimeUsage.hpp"
 #include "services/diagnosticCommand.hpp"
 #include "services/diagnosticFramework.hpp"
 #include "services/finalizerService.hpp"
@@ -889,6 +890,21 @@ static jint get_num_flags() {
   return count;
 }
 
+static jlong getGcCpuTime() {
+  if (!os::is_thread_cpu_time_supported()) {
+    return -1;
+  }
+
+  {
+    MutexLocker hl(Heap_lock);
+    if (Universe::heap()->is_shutting_down()) {
+      return -1;
+    }
+
+    return CPUTimeUsage::GC::total();
+  }
+}
+
 static jlong get_long_attribute(jmmLongAttribute att) {
   switch (att) {
   case JMM_CLASS_LOADED_COUNT:
@@ -914,6 +930,9 @@ static jlong get_long_attribute(jmmLongAttribute att) {
 
   case JMM_JVM_UPTIME_MS:
     return Management::ticks_to_ms(os::elapsed_counter());
+
+  case JMM_GC_CPU_TIME:
+    return getGcCpuTime();
 
   case JMM_COMPILE_TOTAL_TIME_MS:
     return Management::ticks_to_ms(CompileBroker::total_compilation_ticks());

--- a/src/java.management/share/classes/java/lang/management/MemoryMXBean.java
+++ b/src/java.management/share/classes/java/lang/management/MemoryMXBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -268,6 +268,24 @@ public interface MemoryMXBean extends PlatformManagedObject {
     public MemoryUsage getNonHeapMemoryUsage();
 
     /**
+     * Returns the CPU time used by all garbage collection threads.
+     *
+     * <p> This include time since genesis, so the value can be
+     * non-zero even if no garbage collection cycles occured. In
+     * general this includes time for all driver threads,
+     * workers, VM operations on the VM thread and the string
+     * deduplication thread (if enabled). This method returns
+     * {@code -1} if the platform does not support this operation
+     * or if called during shutdown.
+     *
+     * @return the total CPU time for all garbage collection
+     * threads in nanoseconds.
+     *
+     * @since 26
+     */
+    public long getGcCpuTime();
+
+    /**
      * Tests if verbose output for the memory system is enabled.
      *
      * @return {@code true} if verbose output for the memory
@@ -302,5 +320,4 @@ public interface MemoryMXBean extends PlatformManagedObject {
      * @see     java.lang.System#gc()
      */
     public void gc();
-
 }

--- a/src/java.management/share/classes/sun/management/MemoryImpl.java
+++ b/src/java.management/share/classes/sun/management/MemoryImpl.java
@@ -67,6 +67,10 @@ class MemoryImpl extends NotificationEmitterSupport
         Runtime.getRuntime().gc();
     }
 
+    public long getGcCpuTime() {
+        return jvm.getGcCpuTime();
+    }
+
     // Need to make a VM call to get coherent value
     public MemoryUsage getHeapMemoryUsage() {
         return getMemoryUsage0(true);

--- a/src/java.management/share/classes/sun/management/VMManagement.java
+++ b/src/java.management/share/classes/sun/management/VMManagement.java
@@ -55,6 +55,7 @@ public interface VMManagement {
     public boolean getVerboseClass();
 
     // Memory Subsystem
+    public long    getGcCpuTime();
     public boolean getVerboseGC();
 
     // Runtime Subsystem

--- a/src/java.management/share/classes/sun/management/VMManagementImpl.java
+++ b/src/java.management/share/classes/sun/management/VMManagementImpl.java
@@ -33,6 +33,7 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.List;
+
 import java.util.Arrays;
 import java.util.Collections;
 
@@ -128,6 +129,7 @@ class VMManagementImpl implements VMManagement {
     public native boolean getVerboseClass();
 
     // Memory Subsystem
+    public native long getGcCpuTime();
     public native boolean getVerboseGC();
 
     // Runtime Subsystem

--- a/src/java.management/share/native/libmanagement/VMManagementImpl.c
+++ b/src/java.management/share/native/libmanagement/VMManagementImpl.c
@@ -121,6 +121,13 @@ Java_sun_management_VMManagementImpl_getUnloadedClassCount
     return count;
 }
 
+JNIEXPORT jlong JNICALL
+Java_sun_management_VMManagementImpl_getGcCpuTime
+  (JNIEnv *env, jobject dummy)
+{
+    return jmm_interface->GetLongAttribute(env, NULL, JMM_GC_CPU_TIME);
+}
+
 JNIEXPORT jboolean JNICALL
 Java_sun_management_VMManagementImpl_getVerboseGC
   (JNIEnv *env, jobject dummy)

--- a/test/hotspot/jtreg/vmTestbase/nsk/monitoring/share/server/ServerMemoryMXBean.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/monitoring/share/server/ServerMemoryMXBean.java
@@ -58,6 +58,10 @@ public class ServerMemoryMXBean extends ServerMXBean implements MemoryMXBean {
                 return getIntAttribute(OBJECT_PENDING_FINALIZATION_COUNT);
         }
 
+        public long getGcCpuTime() {
+                throw new UnsupportedOperationException("This method is not supported");
+        }
+
         public boolean isVerbose() {
                 return getBooleanAttribute(VERBOSE);
         }

--- a/test/jdk/java/lang/management/MemoryMXBean/GetGcCpuTime.java
+++ b/test/jdk/java/lang/management/MemoryMXBean/GetGcCpuTime.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug     8368527
+ * @library /test/lib
+ * @summary Basic test of MemoryMXBean.getGcCpuTime
+ *
+ * @run main/othervm -XX:+UseSerialGC GetGcCpuTime _
+ * @run main/othervm -XX:+UseParallelGC GetGcCpuTime _
+ * @run main/othervm -XX:+UseG1GC GetGcCpuTime _
+ * @run main/othervm -XX:+UseZGC GetGcCpuTime _
+ */
+
+import jdk.test.lib.process.OutputAnalyzer;
+import static jdk.test.lib.process.ProcessTools.createTestJavaProcessBuilder;
+import static jdk.test.lib.process.ProcessTools.executeProcess;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.MemoryMXBean;
+import java.lang.management.ThreadMXBean;
+
+ public class GetGcCpuTime {
+    static final ThreadMXBean mxThreadBean = ManagementFactory.getThreadMXBean();
+    static final MemoryMXBean mxMemoryBean = ManagementFactory.getMemoryMXBean();
+
+    public static void main(String[] args) throws Exception {
+        if (args.length > 0) {
+            ProcessBuilder pb = createTestJavaProcessBuilder("GetGcCpuTime");
+            OutputAnalyzer output = executeProcess(pb);
+            output.shouldNotContain("GC CPU time should");
+            output.shouldHaveExitValue(0);
+            return;
+        }
+
+        try {
+            if (!mxThreadBean.isThreadCpuTimeEnabled()) {
+                return;
+            }
+        } catch (UnsupportedOperationException e) {
+            if (mxMemoryBean.getGcCpuTime() != -1) {
+                throw new Error("GC CPU time should be -1");
+            }
+            return;
+        }
+        System.gc();
+        long gcCpuTime = mxMemoryBean.getGcCpuTime();
+        if (gcCpuTime == 0) {
+            throw new Error("GC CPU time should not be zero after System.gc()");
+        }
+
+        final int numberOfThreads = 1000;
+        for (int i = 0; i < numberOfThreads; i++) {
+            Thread t = new Thread(() -> {
+                while (true) {
+                    long gcCpuTimeFromThread = mxMemoryBean.getGcCpuTime();
+                    if (gcCpuTimeFromThread < -1) {
+                        throw new Error("GC CPU time should never be less than -1 but was " + gcCpuTimeFromThread);
+                    }
+                }
+            });
+            t.start();
+        }
+
+        System.exit(0);
+     }
+ }

--- a/test/jdk/javax/management/mxbean/MXBeanInteropTest1.java
+++ b/test/jdk/javax/management/mxbean/MXBeanInteropTest1.java
@@ -222,6 +222,8 @@ public class MXBeanInteropTest1 {
                     + memory.getNonHeapMemoryUsage());
             System.out.println("getObjectPendingFinalizationCount\t\t"
                     + memory.getObjectPendingFinalizationCount());
+            System.out.println("getGcCpuTime\t\t"
+                    + memory.getGcCpuTime());
             System.out.println("isVerbose\t\t"
                     + memory.isVerbose());
 


### PR DESCRIPTION


<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Change requires CSR request [JDK-8368529](https://bugs.openjdk.org/browse/JDK-8368529) to be approved
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8368527](https://bugs.openjdk.org/browse/JDK-8368527): JMX: Add an MXBeans method to query GC CPU time (**Enhancement** - P4)
 * [JDK-8368529](https://bugs.openjdk.org/browse/JDK-8368529): JMX: Add an MXBeans method to query GC CPU time (**CSR**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27466/head:pull/27466` \
`$ git checkout pull/27466`

Update a local copy of the PR: \
`$ git checkout pull/27466` \
`$ git pull https://git.openjdk.org/jdk.git pull/27466/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27466`

View PR using the GUI difftool: \
`$ git pr show -t 27466`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27466.diff">https://git.openjdk.org/jdk/pull/27466.diff</a>

</details>
