### PR TITLE
8368250: [AIX] now ubsan vptr check is also possible (follow up of JDK-8354686)

### DIFF
--- a/make/autoconf/flags-ldflags.m4
+++ b/make/autoconf/flags-ldflags.m4
@@ -79,7 +79,7 @@ AC_DEFUN([FLAGS_SETUP_LDFLAGS_HELPER],
     fi
     if test "x$OPENJDK_TARGET_OS" = xaix; then
       BASIC_LDFLAGS="-Wl,-b64 -Wl,-brtl -Wl,-bnorwexec -Wl,-blibpath:/usr/lib:lib -Wl,-bnoexpall \
-        -Wl,-bernotok -Wl,-bdatapsize:64k -Wl,-btextpsize:64k -Wl,-bstackpsize:64k"
+        -Wl,-bernotok -Wl,-bcdtors:mbr::s -Wl,-bdatapsize:64k -Wl,-btextpsize:64k -Wl,-bstackpsize:64k"
       BASIC_LDFLAGS_JVM_ONLY="$BASIC_LDFLAGS_JVM_ONLY -Wl,-lC_r -Wl,-bbigtoc"
     fi
 

--- a/make/autoconf/jdk-options.m4
+++ b/make/autoconf/jdk-options.m4
@@ -567,12 +567,12 @@ AC_DEFUN_ONCE([JDKOPT_SETUP_UNDEFINED_BEHAVIOR_SANITIZER],
   # their relation is fixed.
   # In the ubsan case we have to link every binary with the C++-compiler as linker, because inherently
   # the C-Compiler and the C++-compiler used as linker provide a different set of ubsan exports.
-  # Linkung an executable with the C-compiler and one of its shared libraries with the C++-compiler
+  # Linking an executable with the C-compiler and one of its shared libraries with the C++-compiler
   # leeds to unresolved symbols.
   if test "x$TOOLCHAIN_TYPE" = "xclang" && test "x$OPENJDK_TARGET_OS" = "xaix"; then
-      UBSAN_CFLAGS="$UBSAN_CFLAGS -DLLVM_SYMBOLIZER=$(dirname $(dirname $CC))/tools/ibm-llvm-symbolizer"
-      UBSAN_LDFLAGS="$UBSAN_LDFLAGS -Wl,-bbigtoc"
-      LD="$LDCXX"
+    UBSAN_CFLAGS="$UBSAN_CFLAGS -DLLVM_SYMBOLIZER=$(dirname $(dirname $CC))/tools/ibm-llvm-symbolizer"
+    UBSAN_LDFLAGS="$UBSAN_LDFLAGS -Wl,-bbigtoc"
+    LD="$LDCXX"
   fi
   UTIL_ARG_ENABLE(NAME: ubsan, DEFAULT: false, RESULT: UBSAN_ENABLED,
       DESC: [enable UndefinedBehaviorSanitizer],

--- a/make/autoconf/jdk-options.m4
+++ b/make/autoconf/jdk-options.m4
@@ -565,9 +565,14 @@ AC_DEFUN_ONCE([JDKOPT_SETUP_UNDEFINED_BEHAVIOR_SANITIZER],
   # with an additional define LLVM_SYMBOLIZER, which we set here.
   # To calculate the correct llvm_symbolizer path we can use the location of the compiler, because
   # their relation is fixed.
+  # In the ubsan case we have to link every binary with the C++-compiler as linker, because inherently
+  # the C-Compiler and the C++-compiler used as linker provide a different set of ubsan exports.
+  # Linkung an executable with the C-compiler and one of its shared libraries with the C++-compiler
+  # leeds to unresolved symbols.
   if test "x$TOOLCHAIN_TYPE" = "xclang" && test "x$OPENJDK_TARGET_OS" = "xaix"; then
-      UBSAN_CFLAGS="$UBSAN_CFLAGS -fno-sanitize=function,vptr -DLLVM_SYMBOLIZER=$(dirname $(dirname $CC))/tools/ibm-llvm-symbolizer"
-      UBSAN_LDFLAGS="$UBSAN_LDFLAGS -fno-sanitize=function,vptr -Wl,-bbigtoc"
+      UBSAN_CFLAGS="$UBSAN_CFLAGS -DLLVM_SYMBOLIZER=$(dirname $(dirname $CC))/tools/ibm-llvm-symbolizer"
+      UBSAN_LDFLAGS="$UBSAN_LDFLAGS -Wl,-bbigtoc"
+      LD="$LDCXX"
   fi
   UTIL_ARG_ENABLE(NAME: ubsan, DEFAULT: false, RESULT: UBSAN_ENABLED,
       DESC: [enable UndefinedBehaviorSanitizer],

--- a/src/hotspot/share/oops/compressedKlass.cpp
+++ b/src/hotspot/share/oops/compressedKlass.cpp
@@ -110,7 +110,7 @@ void CompressedKlassPointers::sanity_check_after_initialization() {
   // Check that Klass range is fully engulfed in the encoding range
   const address encoding_start = _base;
   const address encoding_end = (address)
-      LP64_ONLY(p2u(_base) + (uintptr_t)nth_bit(narrow_klass_pointer_bits() + _shift))
+      LP64_ONLY((p2u(_base) + (uintptr_t)nth_bit(narrow_klass_pointer_bits() + _shift)))
       NOT_LP64(max_klass_range_size());
   ASSERT_HERE_2(_klass_range_start >= _base && _klass_range_end <= encoding_end,
                 "Resulting encoding range does not fully cover the class range");


### PR DESCRIPTION
After [JDK-8354686](https://bugs.openjdk.org/browse/JDK-8354686) the ubsan vptr checks still did not work. We finally found out, that they only work, if all linkage units are linked with the C++ compiler frontend as linker, especially the main executables (java, javac, ...) which are linked with the C compiler frontend.
So for a ubsan enabled build on AIX we let everything link with the C++ compiler frontend.
Background: The C++ compiler frontend inherently adds special static libraries which the C compiler does not. This results in missing symbols when trying to start a program and its shared libraries, when they were linked in mixed mode.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8368250](https://bugs.openjdk.org/browse/JDK-8368250): [AIX] now ubsan vptr check is also possible (follow up of JDK-8354686) (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27468/head:pull/27468` \
`$ git checkout pull/27468`

Update a local copy of the PR: \
`$ git checkout pull/27468` \
`$ git pull https://git.openjdk.org/jdk.git pull/27468/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27468`

View PR using the GUI difftool: \
`$ git pr show -t 27468`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27468.diff">https://git.openjdk.org/jdk/pull/27468.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27468#issuecomment-3328456640)
</details>
