### PR TITLE
8368546: java/net/httpclient/RedirectTimeoutTest.java fails intermittently for HTTP/3 in tier7

### DIFF
--- a/test/jdk/java/net/httpclient/RedirectTimeoutTest.java
+++ b/test/jdk/java/net/httpclient/RedirectTimeoutTest.java
@@ -133,7 +133,7 @@ public class RedirectTimeoutTest implements HttpServerAdapters {
         if (version == HTTP_3) {
             reqBuilder = reqBuilder.version(HTTP_3).setOption(H3_DISCOVERY, HTTP_3_URI_ONLY);
         }
-        HttpRequest request = reqBuilder
+        HttpRequest request = reqBuilder.copy()
                 .GET()
                 .version(version)
                 .timeout(Duration.ofMillis(adjustTimeout(TIMEOUT_MILLIS)))


### PR DESCRIPTION
The java/net/httpclient/RedirectTimeoutTest.java has been observed failing (once) for HTTP/3 on Windows in tier 7 (debug builds)

The log reveals that it's the HEAD request used for warmup that is failing in timeout. This was surprising as this HEAD request was not supposed to be configured with a timeout, and a reading of the test code revealed that a non-obvious call to HttpRequest.Builder::copy was missing in the test. I added that call, which should fix the issue.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8368546](https://bugs.openjdk.org/browse/JDK-8368546): java/net/httpclient/RedirectTimeoutTest.java fails intermittently for HTTP/3 in tier7 (**Bug** - P4)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [SendaoYan](https://openjdk.org/census#syan) (@sendaoYan - Committer)
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - **Reviewer**)
 * [Volkan Yazici](https://openjdk.org/census#vyazici) (@vy - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27471/head:pull/27471` \
`$ git checkout pull/27471`

Update a local copy of the PR: \
`$ git checkout pull/27471` \
`$ git pull https://git.openjdk.org/jdk.git pull/27471/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27471`

View PR using the GUI difftool: \
`$ git pr show -t 27471`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27471.diff">https://git.openjdk.org/jdk/pull/27471.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27471#issuecomment-3328675105)
</details>
