### PR TITLE
8368552: H3ErrorHandlingTest.testCloseControlStream intermittent timed out

### DIFF
--- a/test/jdk/java/net/httpclient/http3/H3ErrorHandlingTest.java
+++ b/test/jdk/java/net/httpclient/http3/H3ErrorHandlingTest.java
@@ -34,6 +34,7 @@ import jdk.internal.net.quic.QuicTransportException;
 import jdk.internal.net.quic.QuicVersion;
 import jdk.test.lib.net.SimpleSSLContext;
 import jdk.test.lib.net.URIBuilder;
+import jdk.test.lib.Utils;
 import org.testng.IRetryAnalyzer;
 import org.testng.ITestResult;
 import org.testng.annotations.AfterClass;
@@ -802,7 +803,7 @@ public class H3ErrorHandlingTest implements HttpServerAdapters {
             final HttpResponse<Void> response = client.sendAsync(
                             request,
                             BodyHandlers.discarding())
-                    .get(10, TimeUnit.SECONDS);
+                    .get(Utils.adjustTimeout(10), TimeUnit.SECONDS);
             fail("Expected the request to fail, got " + response);
         } catch (Exception e) {
             final String expectedMsg = "stateless reset from peer";
@@ -943,7 +944,7 @@ public class H3ErrorHandlingTest implements HttpServerAdapters {
             final HttpResponse<Void> response = client.sendAsync(
                             request,
                             BodyHandlers.discarding())
-                    .get(10, TimeUnit.SECONDS);
+                    .get(Utils.adjustTimeout(10), TimeUnit.SECONDS);
             fail("Expected the request to fail, got " + response);
         } catch (ExecutionException e) {
             System.out.println("Client exception [expected]: " + e);
@@ -966,13 +967,13 @@ public class H3ErrorHandlingTest implements HttpServerAdapters {
             final HttpResponse<Void> response = client.sendAsync(
                     request,
                     BodyHandlers.discarding())
-                    .get(10, TimeUnit.SECONDS);
+                    .get(Utils.adjustTimeout(20), TimeUnit.SECONDS);
             fail("Expected the request to fail, got " + response);
         } catch (ExecutionException e) {
             System.out.println("Client exception [expected]: " + e);
             var cause = e.getCause();
             assertTrue(cause instanceof ProtocolException, "Expected ProtocolException");
-            TerminationCause terminationCause = errorCF.get(10, TimeUnit.SECONDS);
+            TerminationCause terminationCause = errorCF.get(Utils.adjustTimeout(10), TimeUnit.SECONDS);
             System.out.println("Server reason: \"" + terminationCause.getPeerVisibleReason()+'"');
             final long actual = terminationCause.getCloseCode();
             // expected
@@ -989,13 +990,13 @@ public class H3ErrorHandlingTest implements HttpServerAdapters {
             final HttpResponse<Void> response = client.sendAsync(
                             request,
                             BodyHandlers.discarding())
-                    .get(10, TimeUnit.SECONDS);
+                    .get(Utils.adjustTimeout(10), TimeUnit.SECONDS);
             fail("Expected the request to fail, got " + response);
         } catch (ExecutionException e) {
             System.out.println("Client exception [expected]: " + e);
             var cause = e.getCause();
             assertTrue(cause instanceof ProtocolException, "Expected ProtocolException");
-            TerminationCause terminationCause = errorCF.get(10, TimeUnit.SECONDS);
+            TerminationCause terminationCause = errorCF.get(Utils.adjustTimeout(10), TimeUnit.SECONDS);
             System.out.println("Server reason: \"" + terminationCause.getPeerVisibleReason()+'"');
             final long actual = terminationCause.getCloseCode();
             // expected
@@ -1019,13 +1020,13 @@ public class H3ErrorHandlingTest implements HttpServerAdapters {
                     BodyHandlers.discarding(),
                     (initiatingRequest, pushPromiseRequest, acceptor) ->
                             acceptor.apply(BodyHandlers.discarding())
-            ).get(10, TimeUnit.SECONDS);
+            ).get(Utils.adjustTimeout(10), TimeUnit.SECONDS);
             fail("Expected the request to fail, got " + response);
         } catch (ExecutionException e) {
             System.out.println("Client exception [expected]: " + e);
             var cause = e.getCause();
             assertTrue(cause instanceof ProtocolException, "Expected ProtocolException");
-            TerminationCause terminationCause = errorCF.get(10, TimeUnit.SECONDS);
+            TerminationCause terminationCause = errorCF.get(Utils.adjustTimeout(10), TimeUnit.SECONDS);
             System.out.println("Server reason: \"" + terminationCause.getPeerVisibleReason()+'"');
             final long actual = terminationCause.getCloseCode();
             // expected


### PR DESCRIPTION
Hi all,

H3ErrorHandlingTest.testCloseControlStream(java/net/httpclient/http3/H3ErrorHandlingTest.java) intermittent timed out with fastdebug build on linux-x64.
This PR use Utils.adjustTimeout to receive the timeout factor from jtreg, and change the default timeout value in 'triggerError' function from 10 to 20 to make test run passed steady with fastdebug build.

I run this test 120 times simultancely all passed after this PR with fastdebug build.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8368552](https://bugs.openjdk.org/browse/JDK-8368552): H3ErrorHandlingTest.testCloseControlStream intermittent timed out (**Bug** - P4)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27472/head:pull/27472` \
`$ git checkout pull/27472`

Update a local copy of the PR: \
`$ git checkout pull/27472` \
`$ git pull https://git.openjdk.org/jdk.git pull/27472/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27472`

View PR using the GUI difftool: \
`$ git pr show -t 27472`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27472.diff">https://git.openjdk.org/jdk/pull/27472.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27472#issuecomment-3328756189)
</details>
