### PR TITLE
JDK-8368565: Adjust comment regarding dependency of libjvm.so to librt

### DIFF
--- a/make/autoconf/libraries.m4
+++ b/make/autoconf/libraries.m4
@@ -136,12 +136,11 @@ AC_DEFUN_ONCE([LIB_SETUP_LIBRARIES],
     BASIC_JVM_LIBS="$BASIC_JVM_LIBS $LIBPTHREAD"
   fi
 
-  # librt for legacy clock_gettime
+  # librt
   if test "x$OPENJDK_TARGET_OS" = xlinux; then
-    # Hotspot needs to link librt to get the clock_* functions.
-    # But once our supported minimum build and runtime platform
-    # has glibc 2.17, this can be removed as the functions are
-    # in libc.
+    # Needed for the timer_* functions from librt used in JFR
+    # (legacy usage: Hotspot needed to link librt also to get the clock_* functions
+    # on ancient distros before glibc 2.17)
     BASIC_JVM_LIBS="$BASIC_JVM_LIBS -lrt"
   fi
 


### PR DESCRIPTION
We have a legacy dependency of libjvm to librt for the` clock_*` functions :
https://github.com/openjdk/jdk/blob/f993f90c86f89eb0c7f42ebecb45a68eae0bd9ea/make/autoconf/libraries.m4#L139

But this is for very old systems with distros like RHEL 6 or SLES11 with glibc 2.16 or older, where the clock_ functions were still in librt ; but those ancient distros play no role any more for current JDK26.
On the other hand, we now use the `timer_*` functions from librt e.g. in JFR and these are _really_  in librt so the comment should be adjusted.