### PR TITLE
8368576: PrintJob.getGraphics() does not specify behavior after PrintJob.end()

### DIFF
--- a/src/java.desktop/share/classes/java/awt/PrintJob.java
+++ b/src/java.desktop/share/classes/java/awt/PrintJob.java
@@ -46,6 +46,8 @@ public abstract class PrintJob {
      * The page is sent to the printer when the graphics
      * object is disposed.  This graphics object will also implement
      * the PrintGraphics interface.
+     * If {@code PrintJob.end()} has been called, this method will
+     * return {@code null}.
      * @see PrintGraphics
      * @return the graphics context for printing the next page
      */


### PR DESCRIPTION
Update the spec. of java.awt.PrintJob.getGraphics() to document long standing behaviour after PrintJob.end() has been called.

A CSR has been created https://bugs.openjdk.org/browse/JDK-8368577

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8368577](https://bugs.openjdk.org/browse/JDK-8368577) to be approved

### Issues
 * [JDK-8368576](https://bugs.openjdk.org/browse/JDK-8368576): PrintJob.getGraphics() does not specify behavior after PrintJob.end() (**Bug** - P4)
 * [JDK-8368577](https://bugs.openjdk.org/browse/JDK-8368577): PrintJob.getGraphics() does not specify behavior after PrintJob.end() (**CSR**)


### Reviewers
 * [Prasanta Sadhukhan](https://openjdk.org/census#psadhukhan) (@prsadhuk - **Reviewer**)
 * [Tejesh R](https://openjdk.org/census#tr) (@TejeshR13 - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27474/head:pull/27474` \
`$ git checkout pull/27474`

Update a local copy of the PR: \
`$ git checkout pull/27474` \
`$ git pull https://git.openjdk.org/jdk.git pull/27474/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27474`

View PR using the GUI difftool: \
`$ git pr show -t 27474`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27474.diff">https://git.openjdk.org/jdk/pull/27474.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27474#issuecomment-3329842553)
</details>
