### PR TITLE
8368599: ShenandoahConcurrentMark could use ThreadsClaimTokenScope

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentMark.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentMark.cpp
@@ -25,7 +25,6 @@
 
 
 #include "gc/shared/satbMarkQueue.hpp"
-#include "gc/shared/strongRootsScope.hpp"
 #include "gc/shared/taskTerminator.hpp"
 #include "gc/shenandoah/shenandoahBarrierSet.inline.hpp"
 #include "gc/shenandoah/shenandoahClosures.inline.hpp"
@@ -297,7 +296,7 @@ void ShenandoahConcurrentMark::finish_mark_work() {
   uint nworkers = heap->workers()->active_workers();
   task_queues()->reserve(nworkers);
 
-  StrongRootsScope scope(nworkers);
+  ThreadsClaimTokenScope scope;
   TaskTerminator terminator(nworkers, task_queues());
 
   switch (_generation->type()) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentMark.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentMark.cpp
@@ -93,10 +93,12 @@ private:
   ShenandoahConcurrentMark* _cm;
   TaskTerminator*           _terminator;
   bool                      _dedup_string;
+  ThreadsClaimTokenScope    _threads_claim_token_scope; // needed for Threads::possibly_parallel_threads_do
 
 public:
   ShenandoahFinalMarkingTask(ShenandoahConcurrentMark* cm, TaskTerminator* terminator, bool dedup_string) :
-    WorkerTask("Shenandoah Final Mark"), _cm(cm), _terminator(terminator), _dedup_string(dedup_string) {
+    WorkerTask("Shenandoah Final Mark"), _cm(cm), _terminator(terminator), _dedup_string(dedup_string),
+    _threads_claim_token_scope() {
   }
 
   void work(uint worker_id) {
@@ -296,7 +298,6 @@ void ShenandoahConcurrentMark::finish_mark_work() {
   uint nworkers = heap->workers()->active_workers();
   task_queues()->reserve(nworkers);
 
-  ThreadsClaimTokenScope scope;
   TaskTerminator terminator(nworkers, task_queues());
 
   switch (_generation->type()) {


### PR DESCRIPTION
Replace `StrongRootsScope` with `ThreadsClaimTokenScope` in `ShenandoahConcurrentMark::finish_mark_work` to be more precise with what is actually needed and why. Similar to #27385.

Test: tier1, and tier[1,2,3]_gc_shenandoah

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8368599](https://bugs.openjdk.org/browse/JDK-8368599): ShenandoahConcurrentMark could use ThreadsClaimTokenScope (**Enhancement** - P4)


### Reviewers
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - **Reviewer**) Review applies to [44377b16](https://git.openjdk.org/jdk/pull/27477/files/44377b169e890d9c88fd0f974b5e08f5a9ff6a23)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27477/head:pull/27477` \
`$ git checkout pull/27477`

Update a local copy of the PR: \
`$ git checkout pull/27477` \
`$ git pull https://git.openjdk.org/jdk.git pull/27477/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27477`

View PR using the GUI difftool: \
`$ git pr show -t 27477`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27477.diff">https://git.openjdk.org/jdk/pull/27477.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27477#issuecomment-3330941300)
</details>
