### PR TITLE
8298823: [macos] java/awt/Mouse/EnterExitEvents/DragWindowTest.java continues to fail with "No MouseReleased event on label!"

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -188,7 +188,6 @@ java/awt/Mixing/AWT_Mixing/JTextFieldOverlapping.java 8158801 windows-all
 java/awt/Mixing/AWT_Mixing/JToggleButtonInGlassPaneOverlapping.java 8158801 windows-all
 java/awt/Mixing/AWT_Mixing/JToggleButtonOverlapping.java 8158801 windows-all
 java/awt/Mixing/NonOpaqueInternalFrame.java 7124549 macosx-all
-java/awt/Mouse/EnterExitEvents/DragWindowTest.java 8298823 macosx-all
 java/awt/Focus/ActualFocusedWindowTest/ActualFocusedWindowRetaining.java 6829264 generic-all
 java/awt/datatransfer/DragImage/MultiResolutionDragImageTest.java 8080982 generic-all
 java/awt/datatransfer/SystemFlavorMap/AddFlavorTest.java 8079268 linux-all

--- a/test/jdk/java/awt/Mouse/EnterExitEvents/DragWindowTest.java
+++ b/test/jdk/java/awt/Mouse/EnterExitEvents/DragWindowTest.java
@@ -63,37 +63,36 @@ public class DragWindowTest {
             Robot robot = new Robot();
             robot.setAutoDelay(100);
 
-            SwingUtilities.invokeAndWait((Runnable) () -> createAndShowGUI());
+            SwingUtilities.invokeAndWait(DragWindowTest::createAndShowGUI);
 
             robot.delay(250);
             robot.waitForIdle();
 
-            SwingUtilities.invokeAndWait(() -> pointToClick = getCenterPoint(label));
+            SwingUtilities.invokeAndWait(() -> {
+                pointToClick = getCenterPoint(label);
+                pointToDrag = getCenterPoint(button);
+            });
 
             robot.mouseMove(pointToClick.x, pointToClick.y);
             robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
             robot.waitForIdle();
+            robot.delay(250);
 
             if (dragWindowMouseEnteredCount != 1) {
                 throw new RuntimeException("No MouseEntered event on Drag Window!");
             }
 
-            SwingUtilities.invokeAndWait(() -> {
-                button.addMouseListener(new ButtonMouseListener());
-                pointToDrag = getCenterPoint(button);
-            });
-
-            robot.delay(250);
             robot.mouseMove(pointToDrag.x, pointToDrag.y);
             robot.waitForIdle();
+            robot.delay(250);
 
             if (buttonMouseEnteredCount != 0) {
                 throw new RuntimeException("Extra MouseEntered event on button!");
             }
 
-            robot.delay(250);
             robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
             robot.waitForIdle();
+            robot.delay(250);
 
             if (labelMouseReleasedCount != 1) {
                 throw new RuntimeException("No MouseReleased event on label!");
@@ -126,6 +125,7 @@ public class DragWindowTest {
 
         button = new JButton("Button");
         Panel panel = new Panel(new BorderLayout());
+        button.addMouseListener(new ButtonMouseListener());
 
         panel.add(label, BorderLayout.NORTH);
         panel.add(button, BorderLayout.CENTER);

--- a/test/jdk/java/awt/Mouse/EnterExitEvents/DragWindowTest.java
+++ b/test/jdk/java/awt/Mouse/EnterExitEvents/DragWindowTest.java
@@ -82,6 +82,9 @@ public class DragWindowTest {
                 throw new RuntimeException("No MouseEntered event on Drag Window!");
             }
 
+            SwingUtilities.invokeAndWait(() ->
+                    button.addMouseListener(new ButtonMouseListener()));
+
             robot.mouseMove(pointToDrag.x, pointToDrag.y);
             robot.waitForIdle();
             robot.delay(250);
@@ -125,7 +128,6 @@ public class DragWindowTest {
 
         button = new JButton("Button");
         Panel panel = new Panel(new BorderLayout());
-        button.addMouseListener(new ButtonMouseListener());
 
         panel.add(label, BorderLayout.NORTH);
         panel.add(button, BorderLayout.CENTER);

--- a/test/jdk/java/awt/Mouse/EnterExitEvents/DragWindowTest.java
+++ b/test/jdk/java/awt/Mouse/EnterExitEvents/DragWindowTest.java
@@ -51,8 +51,10 @@ public class DragWindowTest {
     private static volatile int dragWindowMouseEnteredCount = 0;
     private static volatile int buttonMouseEnteredCount = 0;
     private static volatile int labelMouseReleasedCount = 0;
+
     private static volatile Point pointToClick;
     private static volatile Point pointToDrag;
+
     private static MyDragWindow dragWindow;
     private static JLabel label;
     private static JButton button;

--- a/test/jdk/java/awt/Mouse/EnterExitEvents/DragWindowTest.java
+++ b/test/jdk/java/awt/Mouse/EnterExitEvents/DragWindowTest.java
@@ -82,9 +82,8 @@ public class DragWindowTest {
                 throw new RuntimeException("No MouseEntered event on Drag Window!");
             }
 
-            SwingUtilities.invokeAndWait(() ->
-                    button.addMouseListener(new ButtonMouseListener()));
-
+            // Reset entered count to check if mouse entered starting from here
+            buttonMouseEnteredCount = 0;
             robot.mouseMove(pointToDrag.x, pointToDrag.y);
             robot.waitForIdle();
             robot.delay(250);
@@ -128,6 +127,7 @@ public class DragWindowTest {
 
         button = new JButton("Button");
         Panel panel = new Panel(new BorderLayout());
+        button.addMouseListener(new ButtonMouseListener());
 
         panel.add(label, BorderLayout.NORTH);
         panel.add(button, BorderLayout.CENTER);


### PR DESCRIPTION
Test is currently problem-listed due to the test failing on both macOS arm and x64 machines. Updated the test to use `SwingUtilities.invokeAndWait` and use the EDT to dispose of the frame. Also needed to modify the delay for stability. Initially, I removed `setAutoDelay` since this has caused issues previously, but this caused a failure in linux (when previously linux has never failed). However, keeping the auto delay and adding additional small delays seems to be stable with all of the other changes to the test. The test passes in CI with multiple runs of 100 on all OS's with the proposed changes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298823](https://bugs.openjdk.org/browse/JDK-8298823): [macos] java/awt/Mouse/EnterExitEvents/DragWindowTest.java continues to fail with "No MouseReleased event on label!" (**Bug** - P3)


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**) Review applies to [5e393187](https://git.openjdk.org/jdk/pull/27478/files/5e3931876d4c320b3a26c415a256a1d5f52037b5)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27478/head:pull/27478` \
`$ git checkout pull/27478`

Update a local copy of the PR: \
`$ git checkout pull/27478` \
`$ git pull https://git.openjdk.org/jdk.git pull/27478/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27478`

View PR using the GUI difftool: \
`$ git pr show -t 27478`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27478.diff">https://git.openjdk.org/jdk/pull/27478.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27478#issuecomment-3330956914)
</details>
