### PR TITLE
8368499: GenShen: Do not collect age census during evac when adaptive tenuring is disabled

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahAgeCensus.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahAgeCensus.hpp
@@ -97,8 +97,8 @@ struct ShenandoahNoiseStats {
 // once the per-worker data is consolidated into the appropriate population vector
 // per minor collection. The _local_age_table is thus C x N, for N GC workers.
 class ShenandoahAgeCensus: public CHeapObj<mtGC> {
-  AgeTable** _global_age_table;      // Global age table used for adapting tenuring threshold, one per snapshot
-  AgeTable** _local_age_table;       // Local scratch age tables to track object ages, one per worker
+  AgeTable** _global_age_tables;      // Global age tables used for adapting tenuring threshold, one per snapshot
+  AgeTable** _local_age_tables;       // Local scratch age tables to track object ages, one per worker
 
 #ifdef SHENANDOAH_CENSUS_NOISE
   ShenandoahNoiseStats* _global_noise; // Noise stats, one per snapshot
@@ -175,7 +175,7 @@ class ShenandoahAgeCensus: public CHeapObj<mtGC> {
   // Return the local age table (population vector) for worker_id.
   // Only used in the case of ShenandoahGenerationalAdaptiveTenuring
   AgeTable* get_local_age_table(uint worker_id) const {
-    return _local_age_table[worker_id];
+    return _local_age_tables[worker_id];
   }
 
   // Return the most recently computed tenuring threshold.
@@ -209,11 +209,7 @@ class ShenandoahAgeCensus: public CHeapObj<mtGC> {
   // age0_pop is the population of Cohort 0 that may have been missed in
   // the regular census during the marking cycle, corresponding to objects
   // allocated when the concurrent marking was in progress.
-  // Optional parameters, pv1 and pv2 are population vectors that together
-  // provide object census data (only) for the case when
-  // ShenandoahGenerationalCensusAtEvac. In this case, the age0_pop
-  // is 0, because the evacuated objects have all had their ages incremented.
-  void update_census(size_t age0_pop, AgeTable* pv1 = nullptr, AgeTable* pv2 = nullptr);
+  void update_census(size_t age0_pop);
 
   // Reset the epoch, clearing accumulated census history
   // Note: this isn't currently used, but reserved for planned

--- a/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
@@ -201,26 +201,8 @@ void ShenandoahControlThread::run_service() {
         heuristics->clear_metaspace_oom();
       }
 
-      // Commit worker statistics to cycle data
-      heap->phase_timings()->flush_par_workers_to_cycle();
-
-      // Print GC stats for current cycle
-      {
-        LogTarget(Info, gc, stats) lt;
-        if (lt.is_enabled()) {
-          ResourceMark rm;
-          LogStream ls(lt);
-          heap->phase_timings()->print_cycle_on(&ls);
-          if (ShenandoahEvacTracking) {
-            ShenandoahEvacuationTracker* evac_tracker = heap->evac_tracker();
-            ShenandoahCycleStats         evac_stats   = evac_tracker->flush_cycle_to_global();
-            evac_tracker->print_evacuations_on(&ls, &evac_stats.workers, &evac_stats.mutators);
-          }
-        }
-      }
-
-      // Commit statistics to globals
-      heap->phase_timings()->flush_cycle_to_global();
+      // Manage and print gc stats
+      heap->process_gc_stats();
 
       // Print Metaspace change following GC (if logging is enabled).
       MetaspaceUtils::print_metaspace_change(meta_sizes);

--- a/src/hotspot/share/gc/shenandoah/shenandoahEvacTracker.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahEvacTracker.cpp
@@ -92,28 +92,13 @@ void ShenandoahEvacuationTracker::print_global_on(outputStream* st) {
 void ShenandoahEvacuationTracker::print_evacuations_on(outputStream* st,
                                                        ShenandoahEvacuationStats* workers,
                                                        ShenandoahEvacuationStats* mutators) {
-  if (ShenandoahEvacTracking) {
-    st->print_cr("Workers: ");
-    workers->print_on(st);
-    st->cr();
-    st->print_cr("Mutators: ");
-    mutators->print_on(st);
-    st->cr();
-  }
-
-  ShenandoahHeap* heap = ShenandoahHeap::heap();
-  if (heap->mode()->is_generational()) {
-    AgeTable young_region_ages(false);
-    for (uint i = 0; i < heap->num_regions(); ++i) {
-      ShenandoahHeapRegion* r = heap->get_region(i);
-      if (r->is_young()) {
-        young_region_ages.add(r->age(), r->get_live_data_words());
-      }
-    }
-    st->print("Young regions: ");
-    young_region_ages.print_on(st);
-    st->cr();
-  }
+  assert(ShenandoahEvacTracking, "Only when evac tracking is enabled");
+  st->print_cr("Workers: ");
+  workers->print_on(st);
+  st->cr();
+  st->print_cr("Mutators: ");
+  mutators->print_on(st);
+  st->cr();
 }
 
 class ShenandoahStatAggregator : public ThreadClosure {

--- a/src/hotspot/share/gc/shenandoah/shenandoahEvacTracker.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahEvacTracker.cpp
@@ -23,7 +23,6 @@
  *
  */
 
-#include "gc/shenandoah/shenandoahAgeCensus.hpp"
 #include "gc/shenandoah/shenandoahEvacTracker.hpp"
 #include "gc/shenandoah/shenandoahHeap.inline.hpp"
 #include "gc/shenandoah/shenandoahThreadLocalData.hpp"
@@ -44,19 +43,6 @@ ShenandoahEvacuationStats::ShenandoahEvacuations* ShenandoahEvacuationStats::get
   return &_old;
 }
 
-ShenandoahEvacuationStats::ShenandoahEvacuationStats()
-  : _use_age_table(!ShenandoahGenerationalAdaptiveTenuring),
-    _age_table(nullptr) {
-  if (_use_age_table) {
-    _age_table = new AgeTable(false);
-  }
-}
-
-AgeTable* ShenandoahEvacuationStats::age_table() const {
-  assert(_use_age_table, "Don't call");
-  return _age_table;
-}
-
 void ShenandoahEvacuationStats::begin_evacuation(size_t bytes, ShenandoahAffiliation from, ShenandoahAffiliation to) {
   ShenandoahEvacuations* category = get_category(from, to);
   category->_evacuations_attempted++;
@@ -70,31 +56,16 @@ void ShenandoahEvacuationStats::end_evacuation(size_t bytes, ShenandoahAffiliati
   category->_bytes_completed += bytes;
 }
 
-void ShenandoahEvacuationStats::record_age(size_t bytes, uint age) {
-  assert(_use_age_table, "Don't call!");
-  if (age <= markWord::max_age) { // Filter age sentinel.
-    _age_table->add(age, bytes >> LogBytesPerWord);
-  }
-}
-
 void ShenandoahEvacuationStats::accumulate(const ShenandoahEvacuationStats* other) {
   _young.accumulate(other->_young);
   _old.accumulate(other->_old);
   _promotion.accumulate(other->_promotion);
-
-  if (_use_age_table) {
-    _age_table->merge(other->age_table());
-  }
 }
 
 void ShenandoahEvacuationStats::reset() {
   _young.reset();
   _old.reset();
   _promotion.reset();
-
-  if (_use_age_table) {
-    _age_table->clear();
-  }
 }
 
 void ShenandoahEvacuationStats::ShenandoahEvacuations::print_on(outputStream* st) const {
@@ -111,10 +82,6 @@ void ShenandoahEvacuationStats::print_on(outputStream* st) const {
   if (ShenandoahHeap::heap()->mode()->is_generational()) {
     st->print("Promotion: "); _promotion.print_on(st);
     st->print("Old: "); _old.print_on(st);
-  }
-
-  if (_use_age_table) {
-    _age_table->print_on(st);
   }
 }
 
@@ -173,15 +140,6 @@ ShenandoahCycleStats ShenandoahEvacuationTracker::flush_cycle_to_global() {
   _mutators_global.accumulate(&mutators);
   _workers_global.accumulate(&workers);
 
-  if (!ShenandoahGenerationalAdaptiveTenuring) {
-    // Ingest mutator & worker collected population vectors into the heap's
-    // global census data, and use it to compute an appropriate tenuring threshold
-    // for use in the next cycle.
-    // The first argument is used for any age 0 cohort population that we may otherwise have
-    // missed during the census. This is non-zero only when census happens at marking.
-    ShenandoahGenerationalHeap::heap()->age_census()->update_census(0, mutators.age_table(), workers.age_table());
-  }
-
   return {workers, mutators};
 }
 
@@ -191,8 +149,4 @@ void ShenandoahEvacuationTracker::begin_evacuation(Thread* thread, size_t bytes,
 
 void ShenandoahEvacuationTracker::end_evacuation(Thread* thread, size_t bytes, ShenandoahAffiliation from, ShenandoahAffiliation to) {
   ShenandoahThreadLocalData::end_evacuation(thread, bytes, from, to);
-}
-
-void ShenandoahEvacuationTracker::record_age(Thread* thread, size_t bytes, uint age) {
-  ShenandoahThreadLocalData::record_age(thread, bytes, age);
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahEvacTracker.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahEvacTracker.hpp
@@ -66,20 +66,12 @@ private:
   ShenandoahEvacuations _old;
   ShenandoahEvacuations _promotion;
 
-  bool      _use_age_table;
-  AgeTable* _age_table;
-
  public:
-  ShenandoahEvacuationStats();
-
-  AgeTable* age_table() const;
-
   // Record that the current thread is attempting to copy this many bytes.
   void begin_evacuation(size_t bytes, ShenandoahAffiliation from, ShenandoahAffiliation to);
 
   // Record that the current thread has completed copying this many bytes.
   void end_evacuation(size_t bytes, ShenandoahAffiliation from, ShenandoahAffiliation to);
-  void record_age(size_t bytes, uint age);
 
   void print_on(outputStream* st) const;
   void accumulate(const ShenandoahEvacuationStats* other);
@@ -106,7 +98,6 @@ public:
   // Multiple threads may attempt to evacuate the same object, but only the successful thread will end the evacuation.
   // Evacuations that were begun, but not ended are considered 'abandoned'.
   void end_evacuation(Thread* thread, size_t bytes, ShenandoahAffiliation from, ShenandoahAffiliation to);
-  void record_age(Thread* thread, size_t bytes, uint age);
 
   void print_global_on(outputStream* st);
   void print_evacuations_on(outputStream* st,

--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalControlThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalControlThread.cpp
@@ -201,6 +201,24 @@ ShenandoahGenerationalControlThread::GCMode ShenandoahGenerationalControlThread:
   return request.generation->is_old() ? servicing_old : concurrent_normal;
 }
 
+void ShenandoahGenerationalControlThread::maybe_print_young_region_ages() const {
+  LogTarget(Debug, gc, age) lt;
+  if (lt.is_enabled()) {
+    LogStream ls(lt);
+    AgeTable young_region_ages(false);
+    for (uint i = 0; i < _heap->num_regions(); ++i) {
+      const ShenandoahHeapRegion* r = _heap->get_region(i);
+      if (r->is_young()) {
+        young_region_ages.add(r->age(), r->get_live_data_words());
+      }
+    }
+
+    ls.print("Young regions: ");
+    young_region_ages.print_on(&ls);
+    ls.cr();
+  }
+}
+
 void ShenandoahGenerationalControlThread::maybe_set_aging_cycle() {
   if (_age_period-- == 0) {
     _heap->set_aging_cycle(true);
@@ -298,7 +316,11 @@ void ShenandoahGenerationalControlThread::run_gc_cycle(const ShenandoahGCRequest
     _heap->global_generation()->heuristics()->clear_metaspace_oom();
   }
 
-  process_phase_timings();
+  // Manage and print gc stats
+  _heap->process_gc_stats();
+
+  // Print table for young region ages if log is enabled
+  maybe_print_young_region_ages();
 
   // Print Metaspace change following GC (if logging is enabled).
   MetaspaceUtils::print_metaspace_change(meta_sizes);
@@ -315,29 +337,6 @@ void ShenandoahGenerationalControlThread::run_gc_cycle(const ShenandoahGCRequest
 
   log_debug(gc, thread)("Completed GC (%s): %s, %s, cancelled: %s",
     gc_mode_name(gc_mode()), GCCause::to_string(request.cause), request.generation->name(), GCCause::to_string(_heap->cancelled_cause()));
-}
-
-void ShenandoahGenerationalControlThread::process_phase_timings() const {
-  // Commit worker statistics to cycle data
-  _heap->phase_timings()->flush_par_workers_to_cycle();
-
-  ShenandoahEvacuationTracker* evac_tracker = _heap->evac_tracker();
-  ShenandoahCycleStats         evac_stats   = evac_tracker->flush_cycle_to_global();
-
-  // Print GC stats for current cycle
-  {
-    LogTarget(Info, gc, stats) lt;
-    if (lt.is_enabled()) {
-      ResourceMark rm;
-      LogStream ls(lt);
-      _heap->phase_timings()->print_cycle_on(&ls);
-      evac_tracker->print_evacuations_on(&ls, &evac_stats.workers,
-                                              &evac_stats.mutators);
-    }
-  }
-
-  // Commit statistics to globals
-  _heap->phase_timings()->flush_cycle_to_global();
 }
 
 // Young and old concurrent cycles are initiated by the regulator. Implicit
@@ -417,7 +416,7 @@ void ShenandoahGenerationalControlThread::service_concurrent_old_cycle(const She
       set_gc_mode(bootstrapping_old);
       young_generation->set_old_gen_task_queues(old_generation->task_queues());
       service_concurrent_cycle(young_generation, request.cause, true);
-      process_phase_timings();
+      _heap->process_gc_stats();
       if (_heap->cancelled_gc()) {
         // Young generation bootstrap cycle has failed. Concurrent mark for old generation
         // is going to resume after degenerated bootstrap cycle completes.

--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalControlThread.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalControlThread.hpp
@@ -129,9 +129,6 @@ private:
   // Returns true if the old generation marking was interrupted to allow a young cycle.
   bool preempt_old_marking(ShenandoahGeneration* generation);
 
-  // Flushes cycle timings to global timings and prints the phase timings for the last completed cycle.
-  void process_phase_timings() const;
-
   // Set the gc mode and post a notification if it has changed. The overloaded variant should be used
   // when the _control_lock is already held.
   void set_gc_mode(GCMode new_mode);
@@ -160,6 +157,9 @@ private:
   GCMode prepare_for_allocation_failure_gc(ShenandoahGCRequest &request);
   GCMode prepare_for_explicit_gc(ShenandoahGCRequest &request) const;
   GCMode prepare_for_concurrent_gc(const ShenandoahGCRequest &request) const;
+
+  // Print table for young region ages if log is enabled
+  void maybe_print_young_region_ages() const;
 };
 
 #endif // SHARE_GC_SHENANDOAH_SHENANDOAHGENERATIONALCONTROLTHREAD_HPP

--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.cpp
@@ -360,11 +360,6 @@ oop ShenandoahGenerationalHeap::try_evacuate_object(oop p, Thread* thread, Shena
       // When copying to the old generation above, we don't care
       // about recording object age in the census stats.
       assert(target_gen == YOUNG_GENERATION, "Error");
-      // We record this census only when simulating pre-adaptive tenuring behavior, or
-      // when we have been asked to record the census at evacuation rather than at mark
-      if (!ShenandoahGenerationalAdaptiveTenuring) {
-        evac_tracker()->record_age(thread, size * HeapWordSize, ShenandoahHeap::get_object_age(copy_val));
-      }
     }
     shenandoah_assert_correct(nullptr, copy_val);
     return copy_val;

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
@@ -206,8 +206,11 @@ public:
   void initialize_serviceability() override;
 
   void print_heap_on(outputStream* st)         const override;
-  void print_gc_on(outputStream *st)           const override;
+  void print_gc_on(outputStream* st)           const override;
   void print_heap_regions_on(outputStream* st) const;
+
+  // Flushes cycle timings to global timings and prints the phase timings for the last completed cycle.
+  void process_gc_stats() const;
 
   void prepare_for_verify() override;
   void verify(VerifyOption vo) override;

--- a/src/hotspot/share/gc/shenandoah/shenandoahThreadLocalData.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahThreadLocalData.hpp
@@ -166,10 +166,6 @@ public:
     data(thread)->_evacuation_stats->end_evacuation(bytes, from, to);
   }
 
-  static void record_age(Thread* thread, size_t bytes, uint age) {
-    data(thread)->_evacuation_stats->record_age(bytes, age);
-  }
-
   static ShenandoahEvacuationStats* evacuation_stats(Thread* thread) {
     return data(thread)->_evacuation_stats;
   }


### PR DESCRIPTION
This is a simplification to `ShenandoahEvacTracker` (which is a diagnostic feature). The ability to compute the age census during evacuation was still in the code, even though the (experimental) option to enable it was removed. Removing the rest of the code allows us to take an additional flag-check off the evacuation path and to consolidate duplicated gc stat processing code between `shControlThread` and `shGenerationalControlThread`.