### PR TITLE
8367910: Reduce warnings about unsupported classes in AOT cache creation

### DIFF
--- a/src/hotspot/share/cds/dumpTimeClassInfo.inline.hpp
+++ b/src/hotspot/share/cds/dumpTimeClassInfo.inline.hpp
@@ -53,7 +53,7 @@ void DumpTimeSharedClassTable::iterate_all_live_classes(Function function) const
       assert(k->is_loader_alive(), "must not change");
     } else {
       if (!SystemDictionaryShared::is_excluded_class(k)) {
-        SystemDictionaryShared::warn_excluded(k, "Class loader not alive");
+        SystemDictionaryShared::log_exclusion(k, "Class loader not alive");
         SystemDictionaryShared::set_excluded_locked(k);
       }
     }

--- a/src/hotspot/share/classfile/systemDictionaryShared.hpp
+++ b/src/hotspot/share/classfile/systemDictionaryShared.hpp
@@ -180,6 +180,7 @@ private:
   // exclusion checks
   static void check_exclusion_for_self_and_dependencies(InstanceKlass *k);
   static bool check_self_exclusion(InstanceKlass* k);
+  static const char* check_self_exclusion_helper(InstanceKlass* k, bool& log_warning);
   static bool check_dependencies_exclusion(InstanceKlass* k, DumpTimeClassInfo* info);
   static bool check_verification_constraint_exclusion(InstanceKlass* k, Symbol* constraint_class_name);
   static bool is_dependency_excluded(InstanceKlass* k, InstanceKlass* dependency, const char* type);
@@ -277,7 +278,7 @@ public:
   static void set_excluded(InstanceKlass* k);
   static void set_excluded_locked(InstanceKlass* k);
   static void set_from_class_file_load_hook(InstanceKlass* k) NOT_CDS_RETURN;
-  static bool warn_excluded(InstanceKlass* k, const char* reason);
+  static void log_exclusion(InstanceKlass* k, const char* reason, bool is_warning = false);
   static void dumptime_classes_do(class MetaspaceClosure* it);
   static void write_to_archive(bool is_static_archive = true);
   static void serialize_dictionary_headers(class SerializeClosure* soc,

--- a/src/hotspot/share/classfile/verifier.cpp
+++ b/src/hotspot/share/classfile/verifier.cpp
@@ -237,7 +237,7 @@ bool Verifier::verify(InstanceKlass* klass, bool should_verify_class, TRAPS) {
       // Exclude any classes that are verified with the old verifier, as the old verifier
       // doesn't call SystemDictionaryShared::add_verification_constraint()
       if (CDSConfig::is_dumping_archive()) {
-        SystemDictionaryShared::warn_excluded(klass, "Verified with old verifier");
+        SystemDictionaryShared::log_exclusion(klass, "Verified with old verifier");
         SystemDictionaryShared::set_excluded(klass);
       }
 #endif

--- a/src/hotspot/share/oops/trainingData.cpp
+++ b/src/hotspot/share/oops/trainingData.cpp
@@ -618,7 +618,7 @@ void CompileTrainingData::verify(bool verify_dep_counter) {
   for (int i = 0; i < init_dep_count(); i++) {
     KlassTrainingData* ktd = init_dep(i);
     if (ktd->has_holder() && ktd->holder()->defined_by_other_loaders()) {
-      LogStreamHandle(Warning, training) log;
+      LogStreamHandle(Info, training) log;
       if (log.is_enabled()) {
         ResourceMark rm;
         log.print("CTD "); print_value_on(&log);

--- a/test/hotspot/jtreg/runtime/cds/appcds/aotCache/OldClassSupport.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotCache/OldClassSupport.java
@@ -65,6 +65,7 @@ public class OldClassSupport {
         @Override
         public String[] vmArgs(RunMode runMode) {
             return new String[] {
+                "-Xlog:aot",
                 "-Xlog:aot+class=debug",
                 "-Xlog:aot+resolve=trace",
             };

--- a/test/hotspot/jtreg/runtime/cds/appcds/aotCache/VerifierFailOver.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotCache/VerifierFailOver.java
@@ -39,7 +39,7 @@ import jdk.test.lib.process.OutputAnalyzer;
 public class VerifierFailOver {
     public static void main(String... args) throws Exception {
         SimpleCDSAppTester.of("VerifierFailOver")
-            .addVmArgs("-Xlog:aot+class=debug")
+            .addVmArgs("-Xlog:aot,aot+class=debug")
             .classpath("app.jar")
             .appCommandLine("VerifierFailOverApp")
             .setTrainingChecker((OutputAnalyzer out) -> {

--- a/test/hotspot/jtreg/runtime/cds/appcds/aotClassLinking/BulkLoaderTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotClassLinking/BulkLoaderTest.java
@@ -118,7 +118,7 @@ public class BulkLoaderTest {
         @Override
         public String[] vmArgs(RunMode runMode) {
             return new String[] {
-                "-Xlog:cds,aot+load,cds+class=debug,aot+class=debug",
+                "-Xlog:cds,aot,aot+load,cds+class=debug,aot+class=debug",
                 "-XX:+AOTClassLinking",
             };
         }


### PR DESCRIPTION
Currently AOT cache creation may print lots of warning (depending on the actions performed by the application's training run). Most of these warnings are harmless and are caused by JVM limitations; there's nothing that the user can do about them:

```
[1.096s][warning][aot] Skipping jdk/internal/event/Event: JFR event class
[1.096s][warning][aot] Skipping jdk/jfr/Event: JFR event class
[1.099s][warning][aot] Skipping jdk/proxy1/$Proxy14: Unsupported location
[1.100s][warning][aot] Skipping jdk/proxy1/$Proxy12: Unsupported location
[1.100s][warning][aot] Skipping jdk/proxy1/$Proxy11: Unsupported location
```

This PR moves most of these warnings to the "info" level. The only messages that are still logged in the "warning" levels are:

- class is in an error state
- class failed verification

These could indicate issues with the application so it's good to let the user know.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8367910](https://bugs.openjdk.org/browse/JDK-8367910): Reduce warnings about unsupported classes in AOT cache creation (**Enhancement** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27480/head:pull/27480` \
`$ git checkout pull/27480`

Update a local copy of the PR: \
`$ git checkout pull/27480` \
`$ git pull https://git.openjdk.org/jdk.git pull/27480/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27480`

View PR using the GUI difftool: \
`$ git pr show -t 27480`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27480.diff">https://git.openjdk.org/jdk/pull/27480.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27480#issuecomment-3330996988)
</details>
