### PR TITLE
8367292: VectorAPI: Optimize VectorMask.fromLong/toLong() for SVE

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64_vector.ad
+++ b/src/hotspot/cpu/aarch64/aarch64_vector.ad
@@ -387,6 +387,25 @@ source %{
     return false;
   }
 
+  // Return true if vector mask operation with "opcode" requires the mask to be
+  // saved in a predicate register.
+  bool Matcher::vector_mask_requires_predicate(int opcode, const TypeVect* vt) {
+    if (vt->isa_vectmask() == nullptr) {
+      return false;
+    }
+
+    switch (opcode) {
+      case Op_VectorLongToMask:
+      case Op_VectorMaskToLong:
+        // These ops do not have native predicate instructions on SVE. Instead,
+        // they are implemented with vector instructions. Using the vector layout
+        // for the input/output mask is more efficient in these cases.
+        return false;
+      default:
+        return true;
+    }
+  }
+
   // Assert that the given node is not a variable shift.
   bool assert_not_var_shift(const Node* n) {
     assert(!n->as_ShiftV()->is_var_shift(), "illegal variable shift");
@@ -6243,31 +6262,44 @@ instruct vmask_tolong_neon(iRegLNoSp dst, vReg src) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct vmask_tolong_sve(iRegLNoSp dst, pReg src, vReg tmp1, vReg tmp2) %{
-  predicate(UseSVE > 0);
+instruct vmask_tolong_sve(iRegLNoSp dst, vReg src, vReg tmp) %{
+  predicate(UseSVE > 0 && !VM_Version::supports_svebitperm());
+  match(Set dst (VectorMaskToLong src));
+  effect(TEMP tmp);
+  format %{ "vmask_tolong_sve $dst, $src\t# KILL $tmp" %}
+  ins_encode %{
+    // Input "src" is a vector of boolean represented as
+    // bytes with 0x00/0x01 as element values.
+    __ sve_vmask_tolong($dst$$Register, $src$$FloatRegister,
+                        $tmp$$FloatRegister, Matcher::vector_length(this, $src));
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+instruct vmask_tolong_sve2(iRegLNoSp dst, vReg src, vReg tmp1, vReg tmp2) %{
+  predicate(VM_Version::supports_svebitperm());
   match(Set dst (VectorMaskToLong src));
   effect(TEMP tmp1, TEMP tmp2);
-  format %{ "vmask_tolong_sve $dst, $src\t# KILL $tmp1, $tmp2" %}
+  format %{ "vmask_tolong_sve2 $dst, $src\t# KILL $tmp1, $tmp2" %}
   ins_encode %{
-    __ sve_vmask_tolong($dst$$Register, $src$$PRegister,
-                        Matcher::vector_element_basic_type(this, $src),
-                        Matcher::vector_length(this, $src),
-                        $tmp1$$FloatRegister, $tmp2$$FloatRegister);
+    // Input "src" is a vector of boolean represented as
+    // bytes with 0x00/0x01 as element values.
+    __ sve2_vmask_tolong($dst$$Register, $src$$FloatRegister,
+                         $tmp1$$FloatRegister, $tmp2$$FloatRegister,
+                         Matcher::vector_length(this, $src));
   %}
   ins_pipe(pipe_slow);
 %}
 
 // fromlong
 
-instruct vmask_fromlong(pReg dst, iRegL src, vReg tmp1, vReg tmp2) %{
+instruct vmask_fromlong(vReg dst, iRegL src, vReg tmp) %{
   match(Set dst (VectorLongToMask src));
-  effect(TEMP tmp1, TEMP tmp2);
-  format %{ "vmask_fromlong $dst, $src\t# vector (sve2). KILL $tmp1, $tmp2" %}
+  effect(TEMP_DEF dst, TEMP tmp);
+  format %{ "vmask_fromlong $dst, $src\t# vector (sve2). KILL $tmp" %}
   ins_encode %{
-    __ sve_vmask_fromlong($dst$$PRegister, $src$$Register,
-                          Matcher::vector_element_basic_type(this),
-                          Matcher::vector_length(this),
-                          $tmp1$$FloatRegister, $tmp2$$FloatRegister);
+    __ sve_vmask_fromlong($dst$$FloatRegister, $src$$Register,
+                          $tmp$$FloatRegister, Matcher::vector_length(this));
   %}
   ins_pipe(pipe_slow);
 %}

--- a/src/hotspot/cpu/aarch64/aarch64_vector_ad.m4
+++ b/src/hotspot/cpu/aarch64/aarch64_vector_ad.m4
@@ -377,6 +377,25 @@ source %{
     return false;
   }
 
+  // Return true if vector mask operation with "opcode" requires the mask to be
+  // saved in a predicate register.
+  bool Matcher::vector_mask_requires_predicate(int opcode, const TypeVect* vt) {
+    if (vt->isa_vectmask() == nullptr) {
+      return false;
+    }
+
+    switch (opcode) {
+      case Op_VectorLongToMask:
+      case Op_VectorMaskToLong:
+        // These ops do not have native predicate instructions on SVE. Instead,
+        // they are implemented with vector instructions. Using the vector layout
+        // for the input/output mask is more efficient in these cases.
+        return false;
+      default:
+        return true;
+    }
+  }
+
   // Assert that the given node is not a variable shift.
   bool assert_not_var_shift(const Node* n) {
     assert(!n->as_ShiftV()->is_var_shift(), "illegal variable shift");
@@ -4297,31 +4316,44 @@ instruct vmask_tolong_neon(iRegLNoSp dst, vReg src) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct vmask_tolong_sve(iRegLNoSp dst, pReg src, vReg tmp1, vReg tmp2) %{
-  predicate(UseSVE > 0);
+instruct vmask_tolong_sve(iRegLNoSp dst, vReg src, vReg tmp) %{
+  predicate(UseSVE > 0 && !VM_Version::supports_svebitperm());
+  match(Set dst (VectorMaskToLong src));
+  effect(TEMP tmp);
+  format %{ "vmask_tolong_sve $dst, $src\t# KILL $tmp" %}
+  ins_encode %{
+    // Input "src" is a vector of boolean represented as
+    // bytes with 0x00/0x01 as element values.
+    __ sve_vmask_tolong($dst$$Register, $src$$FloatRegister,
+                        $tmp$$FloatRegister, Matcher::vector_length(this, $src));
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+instruct vmask_tolong_sve2(iRegLNoSp dst, vReg src, vReg tmp1, vReg tmp2) %{
+  predicate(VM_Version::supports_svebitperm());
   match(Set dst (VectorMaskToLong src));
   effect(TEMP tmp1, TEMP tmp2);
-  format %{ "vmask_tolong_sve $dst, $src\t# KILL $tmp1, $tmp2" %}
+  format %{ "vmask_tolong_sve2 $dst, $src\t# KILL $tmp1, $tmp2" %}
   ins_encode %{
-    __ sve_vmask_tolong($dst$$Register, $src$$PRegister,
-                        Matcher::vector_element_basic_type(this, $src),
-                        Matcher::vector_length(this, $src),
-                        $tmp1$$FloatRegister, $tmp2$$FloatRegister);
+    // Input "src" is a vector of boolean represented as
+    // bytes with 0x00/0x01 as element values.
+    __ sve2_vmask_tolong($dst$$Register, $src$$FloatRegister,
+                         $tmp1$$FloatRegister, $tmp2$$FloatRegister,
+                         Matcher::vector_length(this, $src));
   %}
   ins_pipe(pipe_slow);
 %}
 
 // fromlong
 
-instruct vmask_fromlong(pReg dst, iRegL src, vReg tmp1, vReg tmp2) %{
+instruct vmask_fromlong(vReg dst, iRegL src, vReg tmp) %{
   match(Set dst (VectorLongToMask src));
-  effect(TEMP tmp1, TEMP tmp2);
-  format %{ "vmask_fromlong $dst, $src\t# vector (sve2). KILL $tmp1, $tmp2" %}
+  effect(TEMP_DEF dst, TEMP tmp);
+  format %{ "vmask_fromlong $dst, $src\t# vector (sve2). KILL $tmp" %}
   ins_encode %{
-    __ sve_vmask_fromlong($dst$$PRegister, $src$$Register,
-                          Matcher::vector_element_basic_type(this),
-                          Matcher::vector_length(this),
-                          $tmp1$$FloatRegister, $tmp2$$FloatRegister);
+    __ sve_vmask_fromlong($dst$$FloatRegister, $src$$Register,
+                          $tmp$$FloatRegister, Matcher::vector_length(this));
   %}
   ins_pipe(pipe_slow);
 %}

--- a/src/hotspot/cpu/aarch64/c2_MacroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c2_MacroAssembler_aarch64.cpp
@@ -1399,137 +1399,126 @@ void C2_MacroAssembler::bytemask_compress(Register dst) {
   andr(dst, dst, 0xff);                   // dst = 0x8D
 }
 
-// Pack the lowest-numbered bit of each mask element in src into a long value
-// in dst, at most the first 64 lane elements.
-// Clobbers: rscratch1, if UseSVE=1 or the hardware doesn't support FEAT_BITPERM.
-void C2_MacroAssembler::sve_vmask_tolong(Register dst, PRegister src, BasicType bt, int lane_cnt,
-                                         FloatRegister vtmp1, FloatRegister vtmp2) {
+// Pack the value of each mask element in "src" into a long value in "dst", at most
+// the first 64 lane elements. The input "src" is a vector of boolean represented as
+// bytes with 0x00/0x01 as element values. Each lane value from "src" is packed into
+// one bit in "dst".
+//
+// Example:   src = 0x0001010000010001 0100000001010001, lane_cnt = 16
+// Expected:  dst = 0x658D
+//
+// Clobbers: rscratch1
+void C2_MacroAssembler::sve_vmask_tolong(Register dst, FloatRegister src,
+                                         FloatRegister vtmp, int lane_cnt) {
   assert(lane_cnt <= 64 && is_power_of_2(lane_cnt), "Unsupported lane count");
   assert_different_registers(dst, rscratch1);
-  assert_different_registers(vtmp1, vtmp2);
+  assert_different_registers(src, vtmp);
+  assert(UseSVE > 0, "must be");
 
-  Assembler::SIMD_RegVariant size = elemType_to_regVariant(bt);
-  // Example:   src = 0b01100101 10001101, bt = T_BYTE, lane_cnt = 16
-  // Expected:  dst = 0x658D
+  // Compress the lowest 8 bytes.
+  fmovd(dst, src);
+  bytemask_compress(dst);
+  if (lane_cnt <= 8) return;
 
-  // Convert the mask into vector with sequential bytes.
-  // vtmp1 = 0x00010100 0x00010001 0x01000000 0x01010001
-  sve_cpy(vtmp1, size, src, 1, false);
-  if (bt != T_BYTE) {
-    sve_vector_narrow(vtmp1, B, vtmp1, size, vtmp2);
-  }
-
-  if (UseSVE > 1 && VM_Version::supports_svebitperm()) {
-    // Given a vector with the value 0x00 or 0x01 in each byte, the basic idea
-    // is to compress each significant bit of the byte in a cross-lane way. Due
-    // to the lack of a cross-lane bit-compress instruction, we use BEXT
-    // (bit-compress in each lane) with the biggest lane size (T = D) then
-    // concatenate the results.
-
-    // The second source input of BEXT, initialized with 0x01 in each byte.
-    // vtmp2 = 0x01010101 0x01010101 0x01010101 0x01010101
-    sve_dup(vtmp2, B, 1);
-
-    // BEXT vtmp1.D, vtmp1.D, vtmp2.D
-    // vtmp1 = 0x0001010000010001 | 0x0100000001010001
-    // vtmp2 = 0x0101010101010101 | 0x0101010101010101
-    //         ---------------------------------------
-    // vtmp1 = 0x0000000000000065 | 0x000000000000008D
-    sve_bext(vtmp1, D, vtmp1, vtmp2);
-
-    // Concatenate the lowest significant 8 bits in each 8 bytes, and extract the
-    // result to dst.
-    // vtmp1 = 0x0000000000000000 | 0x000000000000658D
-    // dst   = 0x658D
-    if (lane_cnt <= 8) {
-      // No need to concatenate.
-      umov(dst, vtmp1, B, 0);
-    } else if (lane_cnt <= 16) {
-      ins(vtmp1, B, vtmp1, 1, 8);
-      umov(dst, vtmp1, H, 0);
-    } else {
-      // As the lane count is 64 at most, the final expected value must be in
-      // the lowest 64 bits after narrowing vtmp1 from D to B.
-      sve_vector_narrow(vtmp1, B, vtmp1, D, vtmp2);
-      umov(dst, vtmp1, D, 0);
-    }
-  } else if (UseSVE > 0) {
-    // Compress the lowest 8 bytes.
-    fmovd(dst, vtmp1);
-    bytemask_compress(dst);
-    if (lane_cnt <= 8) return;
-
-    // Repeat on higher bytes and join the results.
-    // Compress 8 bytes in each iteration.
-    for (int idx = 1; idx < (lane_cnt / 8); idx++) {
-      sve_extract_integral(rscratch1, T_LONG, vtmp1, idx, vtmp2);
-      bytemask_compress(rscratch1);
-      orr(dst, dst, rscratch1, Assembler::LSL, idx << 3);
-    }
-  } else {
-    assert(false, "unsupported");
-    ShouldNotReachHere();
+  // Repeat on higher bytes and join the results.
+  // Compress 8 bytes in each iteration.
+  for (int idx = 1; idx < (lane_cnt / 8); idx++) {
+    sve_extract_integral(rscratch1, T_LONG, src, idx, vtmp);
+    bytemask_compress(rscratch1);
+    orr(dst, dst, rscratch1, Assembler::LSL, idx << 3);
   }
 }
 
-// Unpack the mask, a long value in src, into predicate register dst based on the
-// corresponding data type. Note that dst can support at most 64 lanes.
-// Below example gives the expected dst predicate register in different types, with
-// a valid src(0x658D) on a 1024-bit vector size machine.
-// BYTE:  dst = 0x00 00 00 00 00 00 00 00 00 00 00 00 00 00 65 8D
-// SHORT: dst = 0x00 00 00 00 00 00 00 00 00 00 00 00 14 11 40 51
-// INT:   dst = 0x00 00 00 00 00 00 00 00 01 10 01 01 10 00 11 01
-// LONG:  dst = 0x00 01 01 00 00 01 00 01 01 00 00 00 01 01 00 01
-//
-// The number of significant bits of src must be equal to lane_cnt. E.g., 0xFF658D which
-// has 24 significant bits would be an invalid input if dst predicate register refers to
-// a LONG type 1024-bit vector, which has at most 16 lanes.
-void C2_MacroAssembler::sve_vmask_fromlong(PRegister dst, Register src, BasicType bt, int lane_cnt,
-                                           FloatRegister vtmp1, FloatRegister vtmp2) {
-  assert(UseSVE == 2 && VM_Version::supports_svebitperm() &&
-         lane_cnt <= 64 && is_power_of_2(lane_cnt), "unsupported");
-  Assembler::SIMD_RegVariant size = elemType_to_regVariant(bt);
-  // Example:   src = 0x658D, bt = T_BYTE, size = B, lane_cnt = 16
-  // Expected:  dst = 0b01101001 10001101
+// The function is same as above "sve_vmask_tolong", but it uses SVE2's BDEP
+// instruction which requires the FEAT_BITPERM feature.
+void C2_MacroAssembler::sve2_vmask_tolong(Register dst, FloatRegister src,
+                                          FloatRegister vtmp1, FloatRegister vtmp2,
+                                          int lane_cnt) {
+  assert(lane_cnt <= 64 && is_power_of_2(lane_cnt), "Unsupported lane count");
+  assert_different_registers(src, vtmp1, vtmp2);
+  assert(UseSVE > 1 && VM_Version::supports_svebitperm(), "must be");
 
-  // Put long value from general purpose register into the first lane of vector.
-  // vtmp1 = 0x0000000000000000 | 0x000000000000658D
-  sve_dup(vtmp1, B, 0);
-  mov(vtmp1, D, 0, src);
+  // Given a vector with the value 0x00 or 0x01 in each byte, the basic idea
+  // is to compress each significant bit of the byte in a cross-lane way. Due
+  // to the lack of a cross-lane bit-compress instruction, we use BEXT
+  // (bit-compress in each lane) with the biggest lane size (T = D) then
+  // concatenate the results.
 
-  // As sve_cmp generates mask value with the minimum unit in byte, we should
-  // transform the value in the first lane which is mask in bit now to the
-  // mask in byte, which can be done by SVE2's BDEP instruction.
-
-  // The first source input of BDEP instruction. Deposite each byte in every 8 bytes.
-  // vtmp1 = 0x0000000000000065 | 0x000000000000008D
-  if (lane_cnt <= 8) {
-    // Nothing. As only one byte exsits.
-  } else if (lane_cnt <= 16) {
-    ins(vtmp1, B, vtmp1, 8, 1);
-    mov(vtmp1, B, 1, zr);
-  } else {
-    sve_vector_extend(vtmp1, D, vtmp1, B);
-  }
-
-  // The second source input of BDEP instruction, initialized with 0x01 for each byte.
+  // The second source input of BEXT, initialized with 0x01 in each byte.
   // vtmp2 = 0x01010101 0x01010101 0x01010101 0x01010101
   sve_dup(vtmp2, B, 1);
 
-  // BDEP vtmp1.D, vtmp1.D, vtmp2.D
-  // vtmp1 = 0x0000000000000065 | 0x000000000000008D
+  // BEXT vtmp1.D, src.D, vtmp2.D
+  // src   = 0x0001010000010001 | 0x0100000001010001
   // vtmp2 = 0x0101010101010101 | 0x0101010101010101
   //         ---------------------------------------
-  // vtmp1 = 0x0001010000010001 | 0x0100000001010001
-  sve_bdep(vtmp1, D, vtmp1, vtmp2);
+  // vtmp1 = 0x0000000000000065 | 0x000000000000008D
+  sve_bext(vtmp1, D, src, vtmp2);
 
-  if (bt != T_BYTE) {
-    sve_vector_extend(vtmp1, size, vtmp1, B);
+  // Concatenate the lowest significant 8 bits in each 8 bytes, and extract the
+  // result to dst.
+  // vtmp1 = 0x0000000000000000 | 0x000000000000658D
+  // dst   = 0x658D
+  if (lane_cnt <= 8) {
+    // No need to concatenate.
+    umov(dst, vtmp1, B, 0);
+  } else if (lane_cnt <= 16) {
+    ins(vtmp1, B, vtmp1, 1, 8);
+    umov(dst, vtmp1, H, 0);
+  } else {
+    // As the lane count is 64 at most, the final expected value must be in
+    // the lowest 64 bits after narrowing vtmp1 from D to B.
+    sve_vector_narrow(vtmp1, B, vtmp1, D, vtmp2);
+    umov(dst, vtmp1, D, 0);
   }
-  // Generate mask according to the given vector, in which the elements have been
-  // extended to expected type.
-  // dst = 0b01101001 10001101
-  sve_cmp(Assembler::NE, dst, size, ptrue, vtmp1, 0);
+}
+
+// Unpack the mask, a long value in "src", into a vector register of boolean
+// represented as bytes with 0x00/0x01 as element values in "dst".  Each bit in
+// "src" is unpacked into one byte lane in "dst". Note that "dst" can support at
+// most 64 lanes.
+//
+// Below example gives the expected dst vector register, with a valid src(0x658D)
+// on a 128-bit vector size machine.
+// dst = 0x00 01 01 00 00 01 00 01 01 00 00 00 01 01 00 01
+void C2_MacroAssembler::sve_vmask_fromlong(FloatRegister dst, Register src,
+                                           FloatRegister vtmp, int lane_cnt) {
+  assert_different_registers(dst, vtmp);
+  assert(UseSVE == 2 && VM_Version::supports_svebitperm() &&
+         lane_cnt <= 64 && is_power_of_2(lane_cnt), "unsupported");
+
+  // Example:   src = 0x658D, lane_cnt = 16
+  // Expected:  dst = 0x00 01 01 00 00 01 00 01 01 00 00 00 01 01 00 01
+
+  // Put long value from general purpose register into the first lane of vector.
+  // vtmp = 0x0000000000000000 | 0x000000000000658D
+  sve_dup(vtmp, B, 0);
+  mov(vtmp, D, 0, src);
+
+  // Transform the value in the first lane which is mask in bit now to the mask in
+  // byte, which can be done by SVE2's BDEP instruction.
+
+  // The first source input of BDEP instruction. Deposite each byte in every 8 bytes.
+  // vtmp = 0x0000000000000065 | 0x000000000000008D
+  if (lane_cnt <= 8) {
+    // Nothing. As only one byte exsits.
+  } else if (lane_cnt <= 16) {
+    ins(vtmp, B, vtmp, 8, 1);
+    mov(vtmp, B, 1, zr);
+  } else {
+    sve_vector_extend(vtmp, D, vtmp, B);
+  }
+
+  // The second source input of BDEP instruction, initialized with 0x01 for each byte.
+  // dst = 0x01010101 0x01010101 0x01010101 0x01010101
+  sve_dup(dst, B, 1);
+
+  // BDEP dst.D, vtmp.D, dst.D
+  // vtmp = 0x0000000000000065 | 0x000000000000008D
+  // dst  = 0x0101010101010101 | 0x0101010101010101
+  //        ---------------------------------------
+  // dst  = 0x0001010000010001 | 0x0100000001010001
+  sve_bdep(dst, D, vtmp, dst);
 }
 
 // Clobbers: rflags

--- a/src/hotspot/cpu/aarch64/c2_MacroAssembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/c2_MacroAssembler_aarch64.hpp
@@ -85,15 +85,19 @@
   // the higher garbage bits.
   void bytemask_compress(Register dst);
 
-  // Pack the lowest-numbered bit of each mask element in src into a long value
-  // in dst, at most the first 64 lane elements.
-  void sve_vmask_tolong(Register dst, PRegister src, BasicType bt, int lane_cnt,
-                        FloatRegister vtmp1, FloatRegister vtmp2);
+  // Pack the value of each mask element in "src" into a long value in "dst", at most the
+  // first 64 lane elements. The input "src" is a vector of boolean represented as bytes
+  // with 0x00/0x01 as element values. Each lane value from "src" is packed into one bit in
+  // "dst".
+  void sve_vmask_tolong(Register dst, FloatRegister src, FloatRegister vtmp, int lane_cnt);
 
-  // Unpack the mask, a long value in src, into predicate register dst based on the
-  // corresponding data type. Note that dst can support at most 64 lanes.
-  void sve_vmask_fromlong(PRegister dst, Register src, BasicType bt, int lane_cnt,
-                          FloatRegister vtmp1, FloatRegister vtmp2);
+  void sve2_vmask_tolong(Register dst, FloatRegister src, FloatRegister vtmp1,
+                         FloatRegister vtmp2, int lane_cnt);
+
+  // Unpack the mask, a long value in "src", into vector register "dst" with boolean type.
+  // Each bit in "src" is unpacked into one byte lane in "dst". Note that "dst" can support
+  // at most 64 lanes.
+  void sve_vmask_fromlong(FloatRegister dst, Register src, FloatRegister vtmp, int lane_cnt);
 
   // SIMD&FP comparison
   void neon_compare(FloatRegister dst, BasicType bt, FloatRegister src1,

--- a/src/hotspot/cpu/arm/arm.ad
+++ b/src/hotspot/cpu/arm/arm.ad
@@ -1003,6 +1003,10 @@ bool Matcher::vector_rearrange_requires_load_shuffle(BasicType elem_bt, int vlen
   return false;
 }
 
+bool Matcher::vector_mask_requires_predicate(int opcode, const TypeVect* vt) {
+  return false;
+}
+
 const RegMask* Matcher::predicate_reg_mask(void) {
   return nullptr;
 }

--- a/src/hotspot/cpu/ppc/ppc.ad
+++ b/src/hotspot/cpu/ppc/ppc.ad
@@ -2292,6 +2292,10 @@ bool Matcher::vector_rearrange_requires_load_shuffle(BasicType elem_bt, int vlen
   return false;
 }
 
+bool Matcher::vector_mask_requires_predicate(int opcode, const TypeVect* vt) {
+  return false;
+}
+
 const RegMask* Matcher::predicate_reg_mask(void) {
   return nullptr;
 }

--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -164,6 +164,12 @@ source %{
   bool Matcher::vector_rearrange_requires_load_shuffle(BasicType elem_bt, int vlen) {
     return false;
   }
+
+  // Return true if vector mask operation with "opcode" requires the mask to be
+  // saved with predicate type.
+  bool Matcher::vector_mask_requires_predicate(int opcode, const TypeVect* vt) {
+    return vt->isa_vectmask() != nullptr;
+  }
 %}
 
 // All VEC instructions

--- a/src/hotspot/cpu/s390/s390.ad
+++ b/src/hotspot/cpu/s390/s390.ad
@@ -1809,6 +1809,10 @@ bool Matcher::vector_rearrange_requires_load_shuffle(BasicType elem_bt, int vlen
   return false;
 }
 
+bool Matcher::vector_mask_requires_predicate(int opcode, const TypeVect* vt) {
+  return false;
+}
+
 const RegMask* Matcher::predicate_reg_mask(void) {
   return nullptr;
 }

--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -2103,6 +2103,12 @@ bool Matcher::vector_rearrange_requires_load_shuffle(BasicType elem_bt, int vlen
   }
 }
 
+// Return true if vector mask operation with "opcode" requires the mask to be
+// saved with predicate type.
+bool Matcher::vector_mask_requires_predicate(int opcode, const TypeVect* vt) {
+  return vt->isa_vectmask() != nullptr;
+}
+
 MachOper* Matcher::pd_specialize_generic_vector_operand(MachOper* generic_opnd, uint ideal_reg, bool is_temp) {
   assert(Matcher::is_generic_vector(generic_opnd), "not generic");
   bool legacy = (generic_opnd->opcode() == LEGVEC);

--- a/src/hotspot/share/opto/matcher.hpp
+++ b/src/hotspot/share/opto/matcher.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -337,6 +337,10 @@ public:
   static bool vector_needs_partial_operations(Node* node, const TypeVect* vt);
 
   static bool vector_rearrange_requires_load_shuffle(BasicType elem_bt, int vlen);
+
+  // Identify if a vector mask operation requires the mask to be saved with a
+  // predicate type.
+  static bool vector_mask_requires_predicate(int opcode, const TypeVect* vt);
 
   static const RegMask* predicate_reg_mask(void);
 

--- a/src/hotspot/share/opto/vectorIntrinsics.cpp
+++ b/src/hotspot/share/opto/vectorIntrinsics.cpp
@@ -622,7 +622,7 @@ bool LibraryCallKit::inline_vector_mask_operation() {
     return false;
   }
 
-  if (mask_vec->bottom_type()->isa_vectmask() == nullptr) {
+  if (!Matcher::vector_mask_requires_predicate(mopc, mask_vec->bottom_type()->is_vect())) {
     mask_vec = gvn().transform(VectorStoreMaskNode::make(gvn(), mask_vec, elem_bt, num_elem));
   }
   const Type* maskoper_ty = mopc == Op_VectorMaskToLong ? (const Type*)TypeLong::LONG : (const Type*)TypeInt::INT;
@@ -708,7 +708,7 @@ bool LibraryCallKit::inline_vector_frombits_coerced() {
 
   if (opc == Op_VectorLongToMask) {
     const TypeVect* vt = TypeVect::makemask(elem_bt, num_elem);
-    if (vt->isa_vectmask()) {
+    if (Matcher::vector_mask_requires_predicate(opc, vt)) {
       broadcast = gvn().transform(new VectorLongToMaskNode(elem, vt));
     } else {
       const TypeVect* mvt = TypeVect::make(T_BOOLEAN, num_elem);
@@ -2545,7 +2545,7 @@ bool LibraryCallKit::inline_vector_extract() {
         return false;
       }
       // VectorMaskToLongNode requires the input is either a mask or a vector with BOOLEAN type.
-      if (opd->bottom_type()->isa_vectmask() == nullptr) {
+      if (!Matcher::vector_mask_requires_predicate(Op_VectorMaskToLong, opd->bottom_type()->is_vect())) {
         opd = gvn().transform(VectorStoreMaskNode::make(gvn(), opd, elem_bt, num_elem));
       }
       // ((toLong() >>> pos) & 1L

--- a/src/hotspot/share/opto/vectornode.cpp
+++ b/src/hotspot/share/opto/vectornode.cpp
@@ -1518,7 +1518,7 @@ Node* ReductionNode::Ideal(PhaseGVN* phase, bool can_reshape) {
 }
 
 // Convert fromLong to maskAll if the input sets or unsets all lanes.
-Node* convertFromLongToMaskAll(PhaseGVN* phase, const TypeLong* bits_type, bool is_mask, const TypeVect* vt) {
+static Node* convertFromLongToMaskAll(PhaseGVN* phase, const TypeLong* bits_type, const TypeVect* vt) {
   uint vlen = vt->length();
   BasicType bt = vt->element_basic_type();
   // The "maskAll" API uses the corresponding integer types for floating-point data.
@@ -1533,7 +1533,7 @@ Node* convertFromLongToMaskAll(PhaseGVN* phase, const TypeLong* bits_type, bool 
     } else {
       con = phase->intcon(con_value);
     }
-    Node* res = VectorNode::scalar2vector(con, vlen, maskall_bt, is_mask);
+    Node* res = VectorNode::scalar2vector(con, vlen, maskall_bt, vt->isa_vectmask() != nullptr);
     // Convert back to the original floating-point data type.
     if (is_floating_point_type(bt)) {
       res = new VectorMaskCastNode(phase->transform(res), vt);
@@ -1547,7 +1547,7 @@ Node* VectorLoadMaskNode::Ideal(PhaseGVN* phase, bool can_reshape) {
   // VectorLoadMask(VectorLongToMask(-1/0)) => Replicate(-1/0)
   if (in(1)->Opcode() == Op_VectorLongToMask) {
     const TypeVect* vt = bottom_type()->is_vect();
-    Node* res = convertFromLongToMaskAll(phase, in(1)->in(1)->bottom_type()->isa_long(), false, vt);
+    Node* res = convertFromLongToMaskAll(phase, in(1)->in(1)->bottom_type()->isa_long(), vt);
     if (res != nullptr) {
       return res;
     }
@@ -1987,9 +1987,11 @@ Node* VectorMaskCastNode::Identity(PhaseGVN* phase) {
 // l is -1 or 0.
 Node* VectorMaskToLongNode::Ideal_MaskAll(PhaseGVN* phase) {
   Node* in1 = in(1);
-  // VectorMaskToLong follows a VectorStoreMask if predicate is not supported.
+  // VectorMaskToLong follows a VectorStoreMask if it doesn't require the mask
+  // saved with a predicate type.
   if (in1->Opcode() == Op_VectorStoreMask) {
-    assert(!in1->in(1)->bottom_type()->isa_vectmask(), "sanity");
+    assert(!Matcher::vector_mask_requires_predicate(Op_VectorMaskToLong,
+                         in1->in(1)->bottom_type()->is_vect()), "sanity");
     in1 = in1->in(1);
   }
   if (VectorNode::is_all_ones_vector(in1)) {
@@ -2047,7 +2049,7 @@ Node* VectorLongToMaskNode::Ideal(PhaseGVN* phase, bool can_reshape) {
   // VectorLongToMask(-1/0) => MaskAll(-1/0)
   const TypeLong* bits_type = in(1)->bottom_type()->isa_long();
   if (bits_type && is_mask) {
-    Node* res = convertFromLongToMaskAll(phase, bits_type, true, dst_type);
+    Node* res = convertFromLongToMaskAll(phase, bits_type, dst_type);
     if (res != nullptr) {
       return res;
     }

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
@@ -2030,6 +2030,16 @@ public class IRNode {
         beforeMatchingNameRegex(STORE_VECTOR_SCATTER_MASKED, "StoreVectorScatterMasked");
     }
 
+    public static final String VECTOR_LOAD_MASK = PREFIX + "VECTOR_LOAD_MASK" + POSTFIX;
+    static {
+        beforeMatchingNameRegex(VECTOR_LOAD_MASK, "VectorLoadMask");
+    }
+
+    public static final String VECTOR_STORE_MASK = PREFIX + "VECTOR_STORE_MASK" + POSTFIX;
+    static {
+        beforeMatchingNameRegex(VECTOR_STORE_MASK, "VectorStoreMask");
+    }
+
     public static final String SUB = PREFIX + "SUB" + POSTFIX;
     static {
         beforeMatchingNameRegex(SUB, "Sub(I|L|F|D|HF)");

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/test/IREncodingPrinter.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/test/IREncodingPrinter.java
@@ -112,6 +112,7 @@ public class IREncodingPrinter {
         "asimd",
         "sve",
         "sve2",
+        "svebitperm",
         "fphp",
         "asimdhp",
         // RISCV64

--- a/test/jdk/jdk/incubator/vector/Byte128VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Byte128VectorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -6925,9 +6925,12 @@ public class Byte128VectorTests extends AbstractVectorTest {
 
     @Test(dataProvider = "longMaskProvider")
     static void maskFromToLongByte128VectorTestsSmokeTest(long inputLong) {
-        var vmask = VectorMask.fromLong(SPECIES, inputLong);
-        long outputLong = vmask.toLong();
-        Assert.assertEquals(outputLong, (inputLong & (((0xFFFFFFFFFFFFFFFFL >>> (64 - SPECIES.length()))))));
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            var vmask = VectorMask.fromLong(SPECIES, inputLong);
+            // Insert "not()" to avoid the "fromLong/toLong" being optimized out by compiler.
+            long outputLong = vmask.not().toLong();
+            Assert.assertEquals(outputLong, ((inputLong ^ -1L) & (((0xFFFFFFFFFFFFFFFFL >>> (64 - SPECIES.length()))))));
+        }
     }
 
     @DataProvider

--- a/test/jdk/jdk/incubator/vector/Byte256VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Byte256VectorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -6925,9 +6925,12 @@ public class Byte256VectorTests extends AbstractVectorTest {
 
     @Test(dataProvider = "longMaskProvider")
     static void maskFromToLongByte256VectorTestsSmokeTest(long inputLong) {
-        var vmask = VectorMask.fromLong(SPECIES, inputLong);
-        long outputLong = vmask.toLong();
-        Assert.assertEquals(outputLong, (inputLong & (((0xFFFFFFFFFFFFFFFFL >>> (64 - SPECIES.length()))))));
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            var vmask = VectorMask.fromLong(SPECIES, inputLong);
+            // Insert "not()" to avoid the "fromLong/toLong" being optimized out by compiler.
+            long outputLong = vmask.not().toLong();
+            Assert.assertEquals(outputLong, ((inputLong ^ -1L) & (((0xFFFFFFFFFFFFFFFFL >>> (64 - SPECIES.length()))))));
+        }
     }
 
     @DataProvider

--- a/test/jdk/jdk/incubator/vector/Byte512VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Byte512VectorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -6925,9 +6925,12 @@ public class Byte512VectorTests extends AbstractVectorTest {
 
     @Test(dataProvider = "longMaskProvider")
     static void maskFromToLongByte512VectorTestsSmokeTest(long inputLong) {
-        var vmask = VectorMask.fromLong(SPECIES, inputLong);
-        long outputLong = vmask.toLong();
-        Assert.assertEquals(outputLong, (inputLong & (((0xFFFFFFFFFFFFFFFFL >>> (64 - SPECIES.length()))))));
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            var vmask = VectorMask.fromLong(SPECIES, inputLong);
+            // Insert "not()" to avoid the "fromLong/toLong" being optimized out by compiler.
+            long outputLong = vmask.not().toLong();
+            Assert.assertEquals(outputLong, ((inputLong ^ -1L) & (((0xFFFFFFFFFFFFFFFFL >>> (64 - SPECIES.length()))))));
+        }
     }
 
     @DataProvider

--- a/test/jdk/jdk/incubator/vector/Byte64VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Byte64VectorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -6925,9 +6925,12 @@ public class Byte64VectorTests extends AbstractVectorTest {
 
     @Test(dataProvider = "longMaskProvider")
     static void maskFromToLongByte64VectorTestsSmokeTest(long inputLong) {
-        var vmask = VectorMask.fromLong(SPECIES, inputLong);
-        long outputLong = vmask.toLong();
-        Assert.assertEquals(outputLong, (inputLong & (((0xFFFFFFFFFFFFFFFFL >>> (64 - SPECIES.length()))))));
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            var vmask = VectorMask.fromLong(SPECIES, inputLong);
+            // Insert "not()" to avoid the "fromLong/toLong" being optimized out by compiler.
+            long outputLong = vmask.not().toLong();
+            Assert.assertEquals(outputLong, ((inputLong ^ -1L) & (((0xFFFFFFFFFFFFFFFFL >>> (64 - SPECIES.length()))))));
+        }
     }
 
     @DataProvider

--- a/test/jdk/jdk/incubator/vector/ByteMaxVectorTests.java
+++ b/test/jdk/jdk/incubator/vector/ByteMaxVectorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/incubator/vector/Double128VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Double128VectorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -5320,9 +5320,12 @@ relativeError));
 
     @Test(dataProvider = "longMaskProvider")
     static void maskFromToLongDouble128VectorTestsSmokeTest(long inputLong) {
-        var vmask = VectorMask.fromLong(SPECIES, inputLong);
-        long outputLong = vmask.toLong();
-        Assert.assertEquals(outputLong, (inputLong & (((0xFFFFFFFFFFFFFFFFL >>> (64 - SPECIES.length()))))));
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            var vmask = VectorMask.fromLong(SPECIES, inputLong);
+            // Insert "not()" to avoid the "fromLong/toLong" being optimized out by compiler.
+            long outputLong = vmask.not().toLong();
+            Assert.assertEquals(outputLong, ((inputLong ^ -1L) & (((0xFFFFFFFFFFFFFFFFL >>> (64 - SPECIES.length()))))));
+        }
     }
 
     @DataProvider

--- a/test/jdk/jdk/incubator/vector/Double256VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Double256VectorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -5320,9 +5320,12 @@ relativeError));
 
     @Test(dataProvider = "longMaskProvider")
     static void maskFromToLongDouble256VectorTestsSmokeTest(long inputLong) {
-        var vmask = VectorMask.fromLong(SPECIES, inputLong);
-        long outputLong = vmask.toLong();
-        Assert.assertEquals(outputLong, (inputLong & (((0xFFFFFFFFFFFFFFFFL >>> (64 - SPECIES.length()))))));
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            var vmask = VectorMask.fromLong(SPECIES, inputLong);
+            // Insert "not()" to avoid the "fromLong/toLong" being optimized out by compiler.
+            long outputLong = vmask.not().toLong();
+            Assert.assertEquals(outputLong, ((inputLong ^ -1L) & (((0xFFFFFFFFFFFFFFFFL >>> (64 - SPECIES.length()))))));
+        }
     }
 
     @DataProvider

--- a/test/jdk/jdk/incubator/vector/Double512VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Double512VectorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -5320,9 +5320,12 @@ relativeError));
 
     @Test(dataProvider = "longMaskProvider")
     static void maskFromToLongDouble512VectorTestsSmokeTest(long inputLong) {
-        var vmask = VectorMask.fromLong(SPECIES, inputLong);
-        long outputLong = vmask.toLong();
-        Assert.assertEquals(outputLong, (inputLong & (((0xFFFFFFFFFFFFFFFFL >>> (64 - SPECIES.length()))))));
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            var vmask = VectorMask.fromLong(SPECIES, inputLong);
+            // Insert "not()" to avoid the "fromLong/toLong" being optimized out by compiler.
+            long outputLong = vmask.not().toLong();
+            Assert.assertEquals(outputLong, ((inputLong ^ -1L) & (((0xFFFFFFFFFFFFFFFFL >>> (64 - SPECIES.length()))))));
+        }
     }
 
     @DataProvider

--- a/test/jdk/jdk/incubator/vector/Double64VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Double64VectorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -5320,9 +5320,12 @@ relativeError));
 
     @Test(dataProvider = "longMaskProvider")
     static void maskFromToLongDouble64VectorTestsSmokeTest(long inputLong) {
-        var vmask = VectorMask.fromLong(SPECIES, inputLong);
-        long outputLong = vmask.toLong();
-        Assert.assertEquals(outputLong, (inputLong & (((0xFFFFFFFFFFFFFFFFL >>> (64 - SPECIES.length()))))));
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            var vmask = VectorMask.fromLong(SPECIES, inputLong);
+            // Insert "not()" to avoid the "fromLong/toLong" being optimized out by compiler.
+            long outputLong = vmask.not().toLong();
+            Assert.assertEquals(outputLong, ((inputLong ^ -1L) & (((0xFFFFFFFFFFFFFFFFL >>> (64 - SPECIES.length()))))));
+        }
     }
 
     @DataProvider

--- a/test/jdk/jdk/incubator/vector/DoubleMaxVectorTests.java
+++ b/test/jdk/jdk/incubator/vector/DoubleMaxVectorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/incubator/vector/Float128VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Float128VectorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -5299,9 +5299,12 @@ relativeError));
 
     @Test(dataProvider = "longMaskProvider")
     static void maskFromToLongFloat128VectorTestsSmokeTest(long inputLong) {
-        var vmask = VectorMask.fromLong(SPECIES, inputLong);
-        long outputLong = vmask.toLong();
-        Assert.assertEquals(outputLong, (inputLong & (((0xFFFFFFFFFFFFFFFFL >>> (64 - SPECIES.length()))))));
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            var vmask = VectorMask.fromLong(SPECIES, inputLong);
+            // Insert "not()" to avoid the "fromLong/toLong" being optimized out by compiler.
+            long outputLong = vmask.not().toLong();
+            Assert.assertEquals(outputLong, ((inputLong ^ -1L) & (((0xFFFFFFFFFFFFFFFFL >>> (64 - SPECIES.length()))))));
+        }
     }
 
     @DataProvider

--- a/test/jdk/jdk/incubator/vector/Float256VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Float256VectorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -5299,9 +5299,12 @@ relativeError));
 
     @Test(dataProvider = "longMaskProvider")
     static void maskFromToLongFloat256VectorTestsSmokeTest(long inputLong) {
-        var vmask = VectorMask.fromLong(SPECIES, inputLong);
-        long outputLong = vmask.toLong();
-        Assert.assertEquals(outputLong, (inputLong & (((0xFFFFFFFFFFFFFFFFL >>> (64 - SPECIES.length()))))));
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            var vmask = VectorMask.fromLong(SPECIES, inputLong);
+            // Insert "not()" to avoid the "fromLong/toLong" being optimized out by compiler.
+            long outputLong = vmask.not().toLong();
+            Assert.assertEquals(outputLong, ((inputLong ^ -1L) & (((0xFFFFFFFFFFFFFFFFL >>> (64 - SPECIES.length()))))));
+        }
     }
 
     @DataProvider

--- a/test/jdk/jdk/incubator/vector/Float512VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Float512VectorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -5299,9 +5299,12 @@ relativeError));
 
     @Test(dataProvider = "longMaskProvider")
     static void maskFromToLongFloat512VectorTestsSmokeTest(long inputLong) {
-        var vmask = VectorMask.fromLong(SPECIES, inputLong);
-        long outputLong = vmask.toLong();
-        Assert.assertEquals(outputLong, (inputLong & (((0xFFFFFFFFFFFFFFFFL >>> (64 - SPECIES.length()))))));
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            var vmask = VectorMask.fromLong(SPECIES, inputLong);
+            // Insert "not()" to avoid the "fromLong/toLong" being optimized out by compiler.
+            long outputLong = vmask.not().toLong();
+            Assert.assertEquals(outputLong, ((inputLong ^ -1L) & (((0xFFFFFFFFFFFFFFFFL >>> (64 - SPECIES.length()))))));
+        }
     }
 
     @DataProvider

--- a/test/jdk/jdk/incubator/vector/Float64VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Float64VectorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -5299,9 +5299,12 @@ relativeError));
 
     @Test(dataProvider = "longMaskProvider")
     static void maskFromToLongFloat64VectorTestsSmokeTest(long inputLong) {
-        var vmask = VectorMask.fromLong(SPECIES, inputLong);
-        long outputLong = vmask.toLong();
-        Assert.assertEquals(outputLong, (inputLong & (((0xFFFFFFFFFFFFFFFFL >>> (64 - SPECIES.length()))))));
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            var vmask = VectorMask.fromLong(SPECIES, inputLong);
+            // Insert "not()" to avoid the "fromLong/toLong" being optimized out by compiler.
+            long outputLong = vmask.not().toLong();
+            Assert.assertEquals(outputLong, ((inputLong ^ -1L) & (((0xFFFFFFFFFFFFFFFFL >>> (64 - SPECIES.length()))))));
+        }
     }
 
     @DataProvider

--- a/test/jdk/jdk/incubator/vector/FloatMaxVectorTests.java
+++ b/test/jdk/jdk/incubator/vector/FloatMaxVectorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/incubator/vector/Int128VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Int128VectorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -6958,9 +6958,12 @@ public class Int128VectorTests extends AbstractVectorTest {
 
     @Test(dataProvider = "longMaskProvider")
     static void maskFromToLongInt128VectorTestsSmokeTest(long inputLong) {
-        var vmask = VectorMask.fromLong(SPECIES, inputLong);
-        long outputLong = vmask.toLong();
-        Assert.assertEquals(outputLong, (inputLong & (((0xFFFFFFFFFFFFFFFFL >>> (64 - SPECIES.length()))))));
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            var vmask = VectorMask.fromLong(SPECIES, inputLong);
+            // Insert "not()" to avoid the "fromLong/toLong" being optimized out by compiler.
+            long outputLong = vmask.not().toLong();
+            Assert.assertEquals(outputLong, ((inputLong ^ -1L) & (((0xFFFFFFFFFFFFFFFFL >>> (64 - SPECIES.length()))))));
+        }
     }
 
     @DataProvider

--- a/test/jdk/jdk/incubator/vector/Int256VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Int256VectorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -6958,9 +6958,12 @@ public class Int256VectorTests extends AbstractVectorTest {
 
     @Test(dataProvider = "longMaskProvider")
     static void maskFromToLongInt256VectorTestsSmokeTest(long inputLong) {
-        var vmask = VectorMask.fromLong(SPECIES, inputLong);
-        long outputLong = vmask.toLong();
-        Assert.assertEquals(outputLong, (inputLong & (((0xFFFFFFFFFFFFFFFFL >>> (64 - SPECIES.length()))))));
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            var vmask = VectorMask.fromLong(SPECIES, inputLong);
+            // Insert "not()" to avoid the "fromLong/toLong" being optimized out by compiler.
+            long outputLong = vmask.not().toLong();
+            Assert.assertEquals(outputLong, ((inputLong ^ -1L) & (((0xFFFFFFFFFFFFFFFFL >>> (64 - SPECIES.length()))))));
+        }
     }
 
     @DataProvider

--- a/test/jdk/jdk/incubator/vector/Int512VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Int512VectorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -6958,9 +6958,12 @@ public class Int512VectorTests extends AbstractVectorTest {
 
     @Test(dataProvider = "longMaskProvider")
     static void maskFromToLongInt512VectorTestsSmokeTest(long inputLong) {
-        var vmask = VectorMask.fromLong(SPECIES, inputLong);
-        long outputLong = vmask.toLong();
-        Assert.assertEquals(outputLong, (inputLong & (((0xFFFFFFFFFFFFFFFFL >>> (64 - SPECIES.length()))))));
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            var vmask = VectorMask.fromLong(SPECIES, inputLong);
+            // Insert "not()" to avoid the "fromLong/toLong" being optimized out by compiler.
+            long outputLong = vmask.not().toLong();
+            Assert.assertEquals(outputLong, ((inputLong ^ -1L) & (((0xFFFFFFFFFFFFFFFFL >>> (64 - SPECIES.length()))))));
+        }
     }
 
     @DataProvider

--- a/test/jdk/jdk/incubator/vector/Int64VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Int64VectorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -6958,9 +6958,12 @@ public class Int64VectorTests extends AbstractVectorTest {
 
     @Test(dataProvider = "longMaskProvider")
     static void maskFromToLongInt64VectorTestsSmokeTest(long inputLong) {
-        var vmask = VectorMask.fromLong(SPECIES, inputLong);
-        long outputLong = vmask.toLong();
-        Assert.assertEquals(outputLong, (inputLong & (((0xFFFFFFFFFFFFFFFFL >>> (64 - SPECIES.length()))))));
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            var vmask = VectorMask.fromLong(SPECIES, inputLong);
+            // Insert "not()" to avoid the "fromLong/toLong" being optimized out by compiler.
+            long outputLong = vmask.not().toLong();
+            Assert.assertEquals(outputLong, ((inputLong ^ -1L) & (((0xFFFFFFFFFFFFFFFFL >>> (64 - SPECIES.length()))))));
+        }
     }
 
     @DataProvider

--- a/test/jdk/jdk/incubator/vector/IntMaxVectorTests.java
+++ b/test/jdk/jdk/incubator/vector/IntMaxVectorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/incubator/vector/Long128VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Long128VectorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -6844,9 +6844,12 @@ public class Long128VectorTests extends AbstractVectorTest {
 
     @Test(dataProvider = "longMaskProvider")
     static void maskFromToLongLong128VectorTestsSmokeTest(long inputLong) {
-        var vmask = VectorMask.fromLong(SPECIES, inputLong);
-        long outputLong = vmask.toLong();
-        Assert.assertEquals(outputLong, (inputLong & (((0xFFFFFFFFFFFFFFFFL >>> (64 - SPECIES.length()))))));
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            var vmask = VectorMask.fromLong(SPECIES, inputLong);
+            // Insert "not()" to avoid the "fromLong/toLong" being optimized out by compiler.
+            long outputLong = vmask.not().toLong();
+            Assert.assertEquals(outputLong, ((inputLong ^ -1L) & (((0xFFFFFFFFFFFFFFFFL >>> (64 - SPECIES.length()))))));
+        }
     }
 
     @DataProvider

--- a/test/jdk/jdk/incubator/vector/Long256VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Long256VectorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -6844,9 +6844,12 @@ public class Long256VectorTests extends AbstractVectorTest {
 
     @Test(dataProvider = "longMaskProvider")
     static void maskFromToLongLong256VectorTestsSmokeTest(long inputLong) {
-        var vmask = VectorMask.fromLong(SPECIES, inputLong);
-        long outputLong = vmask.toLong();
-        Assert.assertEquals(outputLong, (inputLong & (((0xFFFFFFFFFFFFFFFFL >>> (64 - SPECIES.length()))))));
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            var vmask = VectorMask.fromLong(SPECIES, inputLong);
+            // Insert "not()" to avoid the "fromLong/toLong" being optimized out by compiler.
+            long outputLong = vmask.not().toLong();
+            Assert.assertEquals(outputLong, ((inputLong ^ -1L) & (((0xFFFFFFFFFFFFFFFFL >>> (64 - SPECIES.length()))))));
+        }
     }
 
     @DataProvider

--- a/test/jdk/jdk/incubator/vector/Long512VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Long512VectorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -6844,9 +6844,12 @@ public class Long512VectorTests extends AbstractVectorTest {
 
     @Test(dataProvider = "longMaskProvider")
     static void maskFromToLongLong512VectorTestsSmokeTest(long inputLong) {
-        var vmask = VectorMask.fromLong(SPECIES, inputLong);
-        long outputLong = vmask.toLong();
-        Assert.assertEquals(outputLong, (inputLong & (((0xFFFFFFFFFFFFFFFFL >>> (64 - SPECIES.length()))))));
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            var vmask = VectorMask.fromLong(SPECIES, inputLong);
+            // Insert "not()" to avoid the "fromLong/toLong" being optimized out by compiler.
+            long outputLong = vmask.not().toLong();
+            Assert.assertEquals(outputLong, ((inputLong ^ -1L) & (((0xFFFFFFFFFFFFFFFFL >>> (64 - SPECIES.length()))))));
+        }
     }
 
     @DataProvider

--- a/test/jdk/jdk/incubator/vector/Long64VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Long64VectorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -6844,9 +6844,12 @@ public class Long64VectorTests extends AbstractVectorTest {
 
     @Test(dataProvider = "longMaskProvider")
     static void maskFromToLongLong64VectorTestsSmokeTest(long inputLong) {
-        var vmask = VectorMask.fromLong(SPECIES, inputLong);
-        long outputLong = vmask.toLong();
-        Assert.assertEquals(outputLong, (inputLong & (((0xFFFFFFFFFFFFFFFFL >>> (64 - SPECIES.length()))))));
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            var vmask = VectorMask.fromLong(SPECIES, inputLong);
+            // Insert "not()" to avoid the "fromLong/toLong" being optimized out by compiler.
+            long outputLong = vmask.not().toLong();
+            Assert.assertEquals(outputLong, ((inputLong ^ -1L) & (((0xFFFFFFFFFFFFFFFFL >>> (64 - SPECIES.length()))))));
+        }
     }
 
     @DataProvider

--- a/test/jdk/jdk/incubator/vector/LongMaxVectorTests.java
+++ b/test/jdk/jdk/incubator/vector/LongMaxVectorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/incubator/vector/Short128VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Short128VectorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -6905,9 +6905,12 @@ public class Short128VectorTests extends AbstractVectorTest {
 
     @Test(dataProvider = "longMaskProvider")
     static void maskFromToLongShort128VectorTestsSmokeTest(long inputLong) {
-        var vmask = VectorMask.fromLong(SPECIES, inputLong);
-        long outputLong = vmask.toLong();
-        Assert.assertEquals(outputLong, (inputLong & (((0xFFFFFFFFFFFFFFFFL >>> (64 - SPECIES.length()))))));
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            var vmask = VectorMask.fromLong(SPECIES, inputLong);
+            // Insert "not()" to avoid the "fromLong/toLong" being optimized out by compiler.
+            long outputLong = vmask.not().toLong();
+            Assert.assertEquals(outputLong, ((inputLong ^ -1L) & (((0xFFFFFFFFFFFFFFFFL >>> (64 - SPECIES.length()))))));
+        }
     }
 
     @DataProvider

--- a/test/jdk/jdk/incubator/vector/Short256VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Short256VectorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -6905,9 +6905,12 @@ public class Short256VectorTests extends AbstractVectorTest {
 
     @Test(dataProvider = "longMaskProvider")
     static void maskFromToLongShort256VectorTestsSmokeTest(long inputLong) {
-        var vmask = VectorMask.fromLong(SPECIES, inputLong);
-        long outputLong = vmask.toLong();
-        Assert.assertEquals(outputLong, (inputLong & (((0xFFFFFFFFFFFFFFFFL >>> (64 - SPECIES.length()))))));
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            var vmask = VectorMask.fromLong(SPECIES, inputLong);
+            // Insert "not()" to avoid the "fromLong/toLong" being optimized out by compiler.
+            long outputLong = vmask.not().toLong();
+            Assert.assertEquals(outputLong, ((inputLong ^ -1L) & (((0xFFFFFFFFFFFFFFFFL >>> (64 - SPECIES.length()))))));
+        }
     }
 
     @DataProvider

--- a/test/jdk/jdk/incubator/vector/Short512VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Short512VectorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -6905,9 +6905,12 @@ public class Short512VectorTests extends AbstractVectorTest {
 
     @Test(dataProvider = "longMaskProvider")
     static void maskFromToLongShort512VectorTestsSmokeTest(long inputLong) {
-        var vmask = VectorMask.fromLong(SPECIES, inputLong);
-        long outputLong = vmask.toLong();
-        Assert.assertEquals(outputLong, (inputLong & (((0xFFFFFFFFFFFFFFFFL >>> (64 - SPECIES.length()))))));
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            var vmask = VectorMask.fromLong(SPECIES, inputLong);
+            // Insert "not()" to avoid the "fromLong/toLong" being optimized out by compiler.
+            long outputLong = vmask.not().toLong();
+            Assert.assertEquals(outputLong, ((inputLong ^ -1L) & (((0xFFFFFFFFFFFFFFFFL >>> (64 - SPECIES.length()))))));
+        }
     }
 
     @DataProvider

--- a/test/jdk/jdk/incubator/vector/Short64VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Short64VectorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -6905,9 +6905,12 @@ public class Short64VectorTests extends AbstractVectorTest {
 
     @Test(dataProvider = "longMaskProvider")
     static void maskFromToLongShort64VectorTestsSmokeTest(long inputLong) {
-        var vmask = VectorMask.fromLong(SPECIES, inputLong);
-        long outputLong = vmask.toLong();
-        Assert.assertEquals(outputLong, (inputLong & (((0xFFFFFFFFFFFFFFFFL >>> (64 - SPECIES.length()))))));
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            var vmask = VectorMask.fromLong(SPECIES, inputLong);
+            // Insert "not()" to avoid the "fromLong/toLong" being optimized out by compiler.
+            long outputLong = vmask.not().toLong();
+            Assert.assertEquals(outputLong, ((inputLong ^ -1L) & (((0xFFFFFFFFFFFFFFFFL >>> (64 - SPECIES.length()))))));
+        }
     }
 
     @DataProvider

--- a/test/jdk/jdk/incubator/vector/ShortMaxVectorTests.java
+++ b/test/jdk/jdk/incubator/vector/ShortMaxVectorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/incubator/vector/templates/Unit-Miscellaneous.template
+++ b/test/jdk/jdk/incubator/vector/templates/Unit-Miscellaneous.template
@@ -608,9 +608,12 @@
 
     @Test(dataProvider = "longMaskProvider")
     static void maskFromToLong$vectorteststype$SmokeTest(long inputLong) {
-        var vmask = VectorMask.fromLong(SPECIES, inputLong);
-        long outputLong = vmask.toLong();
-        Assert.assertEquals(outputLong, (inputLong & (((0xFFFFFFFFFFFFFFFFL >>> (64 - SPECIES.length()))))));
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            var vmask = VectorMask.fromLong(SPECIES, inputLong);
+            // Insert "not()" to avoid the "fromLong/toLong" being optimized out by compiler.
+            long outputLong = vmask.not().toLong();
+            Assert.assertEquals(outputLong, ((inputLong ^ -1L) & (((0xFFFFFFFFFFFFFFFFL >>> (64 - SPECIES.length()))))));
+        }
     }
 #end[!MaxBit]
 

--- a/test/jdk/jdk/incubator/vector/templates/Unit-header.template
+++ b/test/jdk/jdk/incubator/vector/templates/Unit-header.template
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
The current implementations of `VectorMask.fromLong()` and `toLong()` on AArch64 SVE are inefficient. SVE does not support naive predicate instructions for these operations. Instead, they are implemented with vector instructions, but the output/input of `fromLong/toLong` are defined as masks with predicate registers on SVE architectures.

For `toLong()`, the current implementation generates a vector mask stored in a vector register with bool type first, then converts the vector to predicate layout. For `fromLong()`, the opposite conversion is needed at the start of codegen.

These conversions are expensive and are implemented in the IR backend codegen, which is inefficient. The performance impact is significant on SVE architectures.

This patch optimizes the implementation by leveraging two existing C2 IRs (`VectorLoadMask/VectorStoreMask`) that can handle the conversion efficiently. By splitting this work at the mid-end IR level, we align with the current IR pattern used on architectures without predicate features (like AArch64 Neon) and enable sharing of existing common IR optimizations.

It also modifies the Vector API jtreg tests for well testing. Here is the details:

1) Fix the smoke tests of `fromLong/toLong` to make sure these APIs are tested actually. These two APIs are not well tested before. Because in the original test, the C2 IRs for `fromLong` and `toLong` are optimized out completely by compiler due to following IR identity:
```
  VectorMaskToLong (VectorLongToMask l) => l
```
Besides, an additional warmup loop is necessary to guarantee the APIs are compiled by C2.

2) Refine existing IR tests to verify the expected IR patterns after this patch. Also changed to use the exact required cpu feature on AArch64 for these ops. `fromLong` requires "svebitperm" instead of "sve2".

Performance shows significant improvement on NVIDIA's Grace CPU.

Here is the performance data with `-XX:UseSVE=2`:
```
Benchmark                                   bits inputs Mode   Unit     Before       After    Gain
MaskQueryOperationsBenchmark.testToLongByte  128    1  thrpt  ops/ms  322151.976  1318576.736 4.09
MaskQueryOperationsBenchmark.testToLongByte  128    2  thrpt  ops/ms  322187.144  1315736.931 4.08
MaskQueryOperationsBenchmark.testToLongByte  128    3  thrpt  ops/ms  322213.330  1353272.882 4.19
MaskQueryOperationsBenchmark.testToLongInt   128    1  thrpt  ops/ms 1009426.292  1339834.833 1.32
MaskQueryOperationsBenchmark.testToLongInt   128    2  thrpt  ops/ms 1010311.371  1368379.465 1.35
MaskQueryOperationsBenchmark.testToLongInt   128    3  thrpt  ops/ms 1013333.729  1368077.534 1.35
MaskQueryOperationsBenchmark.testToLongLong  128    1  thrpt  ops/ms  892649.449  1301954.698 1.45
MaskQueryOperationsBenchmark.testToLongLong  128    2  thrpt  ops/ms  894593.615  1324922.719 1.48
MaskQueryOperationsBenchmark.testToLongLong  128    3  thrpt  ops/ms  884498.938  1289828.319 1.45
MaskQueryOperationsBenchmark.testToLongShort 128    1  thrpt  ops/ms 1093444.011  1374164.132 1.25
MaskQueryOperationsBenchmark.testToLongShort 128    2  thrpt  ops/ms 1080117.255  1369234.390 1.26
MaskQueryOperationsBenchmark.testToLongShort 128    3  thrpt  ops/ms 1076327.072  1373219.435 1.27
```

And here is the performance data with `-XX:UseSVE=1`:
```
Benchmark                                   bits inputs Mode   Unit   Before        After     Gain
MaskQueryOperationsBenchmark.testToLongByte  128    1  thrpt  ops/ms 686584.179   800329.010  1.16
MaskQueryOperationsBenchmark.testToLongByte  128    2  thrpt  ops/ms 686184.083   801754.893  1.16
MaskQueryOperationsBenchmark.testToLongByte  128    3  thrpt  ops/ms 686426.883   799058.199  1.16
MaskQueryOperationsBenchmark.testToLongInt   128    1  thrpt  ops/ms 945359.331  1179824.693  1.24
MaskQueryOperationsBenchmark.testToLongInt   128    2  thrpt  ops/ms 946546.502  1169208.723  1.23
MaskQueryOperationsBenchmark.testToLongInt   128    3  thrpt  ops/ms 943207.037  1176056.895  1.24
MaskQueryOperationsBenchmark.testToLongLong  128    1  thrpt  ops/ms 874121.577  1179473.834  1.34
MaskQueryOperationsBenchmark.testToLongLong  128    2  thrpt  ops/ms 881023.640  1180854.086  1.34
MaskQueryOperationsBenchmark.testToLongLong  128    3  thrpt  ops/ms 880149.334  1160048.226  1.31
MaskQueryOperationsBenchmark.testToLongShort 128    1  thrpt  ops/ms 938451.594  1164668.529  1.24
MaskQueryOperationsBenchmark.testToLongShort 128    2  thrpt  ops/ms 939189.649  1187096.328  1.26
MaskQueryOperationsBenchmark.testToLongShort 128    3  thrpt  ops/ms 938601.147  1181154.558  1.25
```