### PR TITLE
8368606: Printer lookup returns empty on AIX platform due to uninitialized results list

### DIFF
--- a/src/java.desktop/unix/classes/sun/print/PrintServiceLookupProvider.java
+++ b/src/java.desktop/unix/classes/sun/print/PrintServiceLookupProvider.java
@@ -884,7 +884,7 @@ public final class PrintServiceLookupProvider extends PrintServiceLookup
                 }
             } catch (Exception e) {
                 // Print exception for tracking printer command errors
-                System.err.println(e);
+                IPPPrintService.debug_println("Printer command error: " + e);
            } finally {
                 f.delete();
                 // promptly close all streams.


### PR DESCRIPTION
Bug Ref: https://bugs.openjdk.org/browse/JDK-8368606

As part of [JDK-8344057](https://bugs.openjdk.org/browse/JDK-8344057) ("Remove doPrivileged calls from unix platform sources in the java.desktop module"), changes were made to execCmd() in
 `src/java.desktop/unix/classes/sun/print/PrintServiceLookupProvider.java`.
In the updated implementation, execCmd(...) code is missing to initialize the results variable. It declares it as null and then tries to results.add(line), which prevents the results list from being populated with printer names.

Initializing the results variable will resolve the issue.


Signed-off-by: Ravi.Patel8 <Ravi.Patel8@ibm.com>

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8368606](https://bugs.openjdk.org/browse/JDK-8368606): Printer lookup returns empty on AIX platform due to uninitialized results list (**Bug** - P2)


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**) Review applies to [80fcec26](https://git.openjdk.org/jdk/pull/27482/files/80fcec264c3a998f53ba7d8ec37952ea711f3f4e)
 * [Harshitha Onkar](https://openjdk.org/census#honkar) (@honkar-jdk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27482/head:pull/27482` \
`$ git checkout pull/27482`

Update a local copy of the PR: \
`$ git checkout pull/27482` \
`$ git pull https://git.openjdk.org/jdk.git pull/27482/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27482`

View PR using the GUI difftool: \
`$ git pr show -t 27482`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27482.diff">https://git.openjdk.org/jdk/pull/27482.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27482#issuecomment-3332522786)
</details>
