### PR TITLE
8368615: VSCode IDE: Oracle Java extension routinely runs out of memory

### DIFF
--- a/make/ide/vscode/hotspot/template-workspace.jsonc
+++ b/make/ide/vscode/hotspot/template-workspace.jsonc
@@ -22,6 +22,7 @@
 		// Java extension
 		"jdk.project.jdkhome": "{{OUTPUTDIR}}/jdk",
 		"jdk.java.onSave.organizeImports": false, // prevents unnecessary changes
+		"jdk.serverVmOptions": ["-Xmx2G"], // prevent out of memory
 
 		// Additional conventions
 		"files.associations": {


### PR DESCRIPTION
This PR increases the maximum heap size for language server of the Oracle Java VSCode extension from 1GB to 2GB. Without this increase, the server runs out of memory when scanning the large code base of the JDK and starts hogging the CPU.

I have been using this configuration for the past few days and it is working well.