### PR TITLE
8368616: runtime/cds/appcds/aotCache/JavaAgent.java#dynamic fails on non CDS platforms/builds after JDK-8362561

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/aotCache/JavaAgent.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotCache/JavaAgent.java
@@ -38,6 +38,7 @@
  * @test id=dynamic
  * @bug 8362561
  * @summary -javaagent is not allowed when creating dynamic CDS archive
+ * @requires vm.cds.supports.aot.class.linking
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds/test-classes
  * @build JavaAgent JavaAgentTransformer Util
  * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar app.jar JavaAgentApp JavaAgentApp$ShouldBeTransformed


### PR DESCRIPTION
The new subtest runtime/cds/appcds/aotCache/JavaAgent.java#dynamic fails after [JDK-8362561](https://bugs.openjdk.org/browse/JDK-8362561) on platforms without CDS or in builds without CDS.
The new subtest test misses the @requires that exists in the other subtests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8368616](https://bugs.openjdk.org/browse/JDK-8368616): runtime/cds/appcds/aotCache/JavaAgent.java#dynamic fails on non CDS platforms/builds after JDK-8362561 (**Bug** - P4)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27484/head:pull/27484` \
`$ git checkout pull/27484`

Update a local copy of the PR: \
`$ git checkout pull/27484` \
`$ git pull https://git.openjdk.org/jdk.git pull/27484/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27484`

View PR using the GUI difftool: \
`$ git pr show -t 27484`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27484.diff">https://git.openjdk.org/jdk/pull/27484.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27484#issuecomment-3333225702)
</details>
