### PR TITLE
8357691: File blocked.certs contains bad content when boot jdk 25 is used, sun/security/lib/CheckBlockedCerts.java failing

### DIFF
--- a/make/ToolsJdk.gmk
+++ b/make/ToolsJdk.gmk
@@ -63,7 +63,7 @@ TOOL_GENERATECURRENCYDATA = $(JAVA_SMALL) -cp $(BUILDTOOLS_OUTPUTDIR)/jdk_tools_
 TOOL_TZDB = $(JAVA_SMALL) -cp $(BUILDTOOLS_OUTPUTDIR)/jdk_tools_classes \
     build.tools.tzdb.TzdbZoneRulesCompiler
 
-TOOL_BLOCKED_CERTS = $(JAVA_SMALL) -cp $(BUILDTOOLS_OUTPUTDIR)/jdk_tools_classes \
+TOOL_BLOCKED_CERTS = $(JAVA_SMALL) -Xlog:disable -cp $(BUILDTOOLS_OUTPUTDIR)/jdk_tools_classes \
     --add-exports java.base/sun.security.util=ALL-UNNAMED \
     build.tools.blockedcertsconverter.BlockedCertsConverter
 


### PR DESCRIPTION
When using boot JDK 25 we end up with bad content in  lib/security/blocked.certs  because  cds related warning output shows up there.

The problem is with extra lines in the generated `blocked.certs` file, at the start of the file there is something like this

```
> [0.010s][error][cds] An error has occurred while processing the shared archive file. Run with -Xlog:aot,cds for details.
> [0.010s][error][cds] Mismatched values for property jdk.module.addexports: java.base/sun.security.util=ALL-UNNAMED specified during runtime but not during dump time
> [0.010s][error][cds] Disabling optimized module handling

```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8357691](https://bugs.openjdk.org/browse/JDK-8357691): File blocked.certs contains bad content when boot jdk 25 is used, sun/security/lib/CheckBlockedCerts.java failing (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27485/head:pull/27485` \
`$ git checkout pull/27485`

Update a local copy of the PR: \
`$ git checkout pull/27485` \
`$ git pull https://git.openjdk.org/jdk.git pull/27485/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27485`

View PR using the GUI difftool: \
`$ git pr show -t 27485`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27485.diff">https://git.openjdk.org/jdk/pull/27485.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27485#issuecomment-3333043483)
</details>
