### PR TITLE
7156751: [macosx] Problem with printing

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CTextPipe.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CTextPipe.m
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CTextPipe.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CTextPipe.m
@@ -457,14 +457,16 @@ static inline void doDrawGlyphsPipe_fillGlyphAndAdvanceBuffers
         }
     }
     if (positions != NULL) {
+
+        CGAffineTransform invTx = CGAffineTransformInvert(strike->fFontTx);
+
         CGPoint prev;
         prev.x = positions[0];
         prev.y = positions[1];
+        prev = CGPointApplyAffineTransform(prev, invTx);
 
         // <rdar://problem/4294061> take the first point, and move the context to that location
         CGContextTranslateCTM(qsdo->cgRef, prev.x, prev.y);
-
-        CGAffineTransform invTx = CGAffineTransformInvert(strike->fFontTx);
 
         // for each position, figure out the advance (since CG won't take positions directly)
         size_t i;
@@ -476,7 +478,7 @@ static inline void doDrawGlyphsPipe_fillGlyphAndAdvanceBuffers
             pt.y = positions[i2+1];
             pt = CGPointApplyAffineTransform(pt, invTx);
             advances[i].width = pt.x - prev.x;
-            advances[i].height = -(pt.y - prev.y); // negative to translate to device space
+            advances[i].height = pt.y - prev.y;
             prev.x = pt.x;
             prev.y = pt.y;
         }

--- a/test/jdk/java/awt/print/PrinterJob/PrintTextTest.java
+++ b/test/jdk/java/awt/print/PrinterJob/PrintTextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/awt/print/PrinterJob/PrintTextTest.java
+++ b/test/jdk/java/awt/print/PrinterJob/PrintTextTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 6425068 7157659 8029204 8132890 8148334 8344637
+ * @bug 6425068 7156751 7157659 8029204 8132890 8148334 8344637
  * @key printer
  * @summary Confirm that text prints where we expect to the length we expect.
  * @library /java/awt/regtesthelpers


### PR DESCRIPTION
This PR fixes one more issue preventing `test/jdk/java/awt/print/PrinterJob/PrintTextTest.java` from being removed from the problem list on macOS. The issue is the placement of line 8 ("GlyphVector with position adjustments") during printing. There were two issues: (a) the necessary transform was being applied to each glyph position, but not to the initial start position, and (b) the y-advances were being unnecessarily inverted. This last one is a head-scratcher, because it seems very intentional, but seems to generate incorrect results (every second character was drawing below the line instead of above it).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-7156751](https://bugs.openjdk.org/browse/JDK-7156751): [macosx] Problem with printing (**Bug** - P4)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27486/head:pull/27486` \
`$ git checkout pull/27486`

Update a local copy of the PR: \
`$ git checkout pull/27486` \
`$ git pull https://git.openjdk.org/jdk.git pull/27486/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27486`

View PR using the GUI difftool: \
`$ git pr show -t 27486`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27486.diff">https://git.openjdk.org/jdk/pull/27486.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27486#issuecomment-3333815754)
</details>
