### PR TITLE
8368621: Attached Threads names do not show up in proc fs, gdb, asan

### DIFF
--- a/src/hotspot/share/prims/jni.cpp
+++ b/src/hotspot/share/prims/jni.cpp
@@ -3847,6 +3847,14 @@ static jint attach_current_thread(JavaVM *vm, void **penv, void *_args, bool dae
     return JNI_ERR;
   }
 
+  // Make thread name visible to OS
+  if (thread_name != nullptr) {
+    thread->set_native_thread_name(thread_name);
+  } else {
+    ResourceMark rm;
+    thread->set_native_thread_name(thread->name());
+  }
+
   // Update the _monitor_owner_id with the tid value.
   thread->set_monitor_owner_id(java_lang_Thread::thread_id(thread->threadObj()));
 


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Error
&nbsp;⚠️ The pull request body must not be empty.

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8368621](https://bugs.openjdk.org/browse/JDK-8368621)

### Issue
 * [JDK-8368621](https://bugs.openjdk.org/browse/JDK-8368621): In ASAN builds, attached non-main threads should have meaningful native names (**Enhancement** - P4) ⚠️ Title mismatch between PR and JBS.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27487/head:pull/27487` \
`$ git checkout pull/27487`

Update a local copy of the PR: \
`$ git checkout pull/27487` \
`$ git pull https://git.openjdk.org/jdk.git pull/27487/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27487`

View PR using the GUI difftool: \
`$ git pr show -t 27487`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27487.diff">https://git.openjdk.org/jdk/pull/27487.diff</a>

</details>
