### PR TITLE
8368668: Several vmTestbase/vm/gc/compact tests timed out

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/vm/gc/compact/Compact_InternedStrings_Strings/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/gc/compact/Compact_InternedStrings_Strings/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,6 +38,7 @@
  *          /test/lib
  * @run main/othervm
  *      -XX:-UseGCOverheadLimit
+ *      -Xmx2G
  *      vm.gc.compact.Compact
  *      -gp interned(randomString)
  *      -gp1 randomString

--- a/test/hotspot/jtreg/vmTestbase/vm/gc/compact/Compact_NonbranchyTree/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/gc/compact/Compact_NonbranchyTree/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,6 +38,7 @@
  *          /test/lib
  * @run main/othervm
  *      -XX:-UseGCOverheadLimit
+ *      -Xmx2G
  *      vm.gc.compact.Compact
  *      -gp nonbranchyTree(high)
  *      -gp1 nonbranchyTree(high)

--- a/test/hotspot/jtreg/vmTestbase/vm/gc/compact/Compact_NonbranchyTree_ArrayOf/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/gc/compact/Compact_NonbranchyTree_ArrayOf/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,6 +38,7 @@
  *          /test/lib
  * @run main/othervm
  *      -XX:-UseGCOverheadLimit
+ *      -Xmx2G
  *      vm.gc.compact.Compact
  *      -gp nonbranchyTree(high)
  *      -gp1 arrayof(nonbranchyTree(high))

--- a/test/hotspot/jtreg/vmTestbase/vm/gc/compact/Compact_NonbranchyTree_TwoFields/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/gc/compact/Compact_NonbranchyTree_TwoFields/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,6 +38,7 @@
  *          /test/lib
  * @run main/othervm
  *      -XX:-UseGCOverheadLimit
+ *      -Xmx2G
  *      vm.gc.compact.Compact
  *      -gp nonbranchyTree(high)
  *      -gp1 twofields(nonbranchyTree(high))

--- a/test/hotspot/jtreg/vmTestbase/vm/gc/compact/Compact_Strings/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/gc/compact/Compact_Strings/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,6 +38,7 @@
  *          /test/lib
  * @run main/othervm
  *      -XX:-UseGCOverheadLimit
+ *      -Xmx2G
  *      vm.gc.compact.Compact
  *      -gp randomString
  *      -gp1 randomString

--- a/test/hotspot/jtreg/vmTestbase/vm/gc/compact/Compact_Strings_InternedStrings/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/gc/compact/Compact_Strings_InternedStrings/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,6 +38,7 @@
  *          /test/lib
  * @run main/othervm
  *      -XX:-UseGCOverheadLimit
+ *      -Xmx2G
  *      vm.gc.compact.Compact
  *      -gp randomString
  *      -gp1 interned(randomString)

--- a/test/hotspot/jtreg/vmTestbase/vm/gc/compact/Compact_Strings_TwoFields/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/gc/compact/Compact_Strings_TwoFields/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,6 +38,7 @@
  *          /test/lib
  * @run main/othervm
  *      -XX:-UseGCOverheadLimit
+ *      -Xmx2G
  *      vm.gc.compact.Compact
  *      -gp randomString
  *      -gp1 twofields(randomString)

--- a/test/hotspot/jtreg/vmTestbase/vm/gc/compact/Humongous_NonbranchyTree/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/gc/compact/Humongous_NonbranchyTree/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,6 +38,7 @@
  *          /test/lib
  * @run main/othervm
  *      -XX:-UseGCOverheadLimit
+ *      -Xmx2G
  *      vm.gc.compact.Compact
  *      -gp nonbranchyTree(high)
  *      -gp1 random(arrays)

--- a/test/hotspot/jtreg/vmTestbase/vm/gc/compact/Humongous_Strings/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/gc/compact/Humongous_Strings/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,6 +38,7 @@
  *          /test/lib
  * @run main/othervm
  *      -XX:-UseGCOverheadLimit
+ *      -Xmx2G
  *      vm.gc.compact.Compact
  *      -gp randomString
  *      -gp1 random(arrays)


### PR DESCRIPTION
Hi all,

Several vmTestbase/vm/gc/compact tests was observed timed out after JDK-8260555 set the default jtreg timeout factor to 1. The test log shows that test detect 448 threads and 30GB(32178700288) memory. Seems that this stress make tests can not finish in 120s.

This PR add '-Xmx2G' to decrease the test stress and make these tests run success steady.