### PR TITLE
8368674: Incremental builds keep rebuilding interim jmod

### DIFF
--- a/make/common/Execute.gmk
+++ b/make/common/Execute.gmk
@@ -149,7 +149,7 @@ define SetupExecuteBody
   endif
 
   $1_VARDEPS := $$($1_COMMAND) $$($1_PRE_COMMAND) $$($1_POST_COMMAND)
-  $1_VARDEPS_FILE := $$(call DependOnVariable, $1_VARDEPS)
+  $1_VARDEPS_FILE := $$(call DependOnVariable, $1_VARDEPS, $$($1_BASE)_exec.vardeps)
 
   ifneq ($$($1_PRE_COMMAND), )
 


### PR DESCRIPTION
After [JDK-8366899](https://bugs.openjdk.org/browse/JDK-8366899), the interim jmods will be constantly rebuilt during incremental builds, triggering a cascade that ends with the entire JDK image being rebuilt.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8368674](https://bugs.openjdk.org/browse/JDK-8368674): Incremental builds keep rebuilding interim jmod (**Bug** - P3)


### Reviewers
 * [Christian Stein](https://openjdk.org/census#cstein) (@sormuras - Committer)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27490/head:pull/27490` \
`$ git checkout pull/27490`

Update a local copy of the PR: \
`$ git checkout pull/27490` \
`$ git pull https://git.openjdk.org/jdk.git pull/27490/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27490`

View PR using the GUI difftool: \
`$ git pr show -t 27490`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27490.diff">https://git.openjdk.org/jdk/pull/27490.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27490#issuecomment-3334724703)
</details>
