### PR TITLE
8368677: acvp test should throw SkippedException when no ACVP-Server available

### DIFF
--- a/test/jdk/sun/security/provider/acvp/Launcher.java
+++ b/test/jdk/sun/security/provider/acvp/Launcher.java
@@ -24,7 +24,9 @@
 import jdk.test.lib.artifacts.Artifact;
 import jdk.test.lib.artifacts.ArtifactResolver;
 import jdk.test.lib.json.JSONValue;
+import jtreg.SkippedException;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
 import java.security.Provider;
@@ -114,7 +116,14 @@ public class Launcher {
 
     public static void main(String[] args) throws Exception {
 
-        Path archivePath = ArtifactResolver.fetchOne(ACVP_SERVER_TESTS.class);
+        Path archivePath = null;
+        try {
+            archivePath = ArtifactResolver.fetchOne(ACVP_SERVER_TESTS.class);
+        } catch (IOException e) {
+            if (e.getMessage().contains("Cannot find the artifact ACVP-Server")) {
+                throw new SkippedException("ACVP-Server not available, skip test.");
+            }
+        }
         System.out.println("Data path: " + archivePath);
 
         if (PROVIDER != null) {


### PR DESCRIPTION
Hi all,

Currently sun/security/provider/acvp/Launcher.java report fails "java.io.IOException: Cannot find the artifact ACVP-Server". This is not jvm bug cause this failure, so I think sun/security/provider/acvp/Launcher.java test should throw SkippedException when no ACVP-Server available.
