### PR TITLE
8358723: jpackage signing issues: the main launcher doesn't have entitlements

### DIFF
--- a/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/AppImageSigner.java
+++ b/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/AppImageSigner.java
@@ -237,7 +237,7 @@ final class AppImageSigner {
 
             final var codesignExecutableFile = Codesign.build(signingCfg::toCodesignArgs).quiet(true).create().asConsumer();
             final var codesignFile = Codesign.build(signingCfgWithoutEntitlements::toCodesignArgs).quiet(true).create().asConsumer();
-            final var codesignDir = Codesign.build(signingCfgWithoutEntitlements::toCodesignArgs).force(true).create().asConsumer();
+            final var codesignDir = Codesign.build(signingCfg::toCodesignArgs).force(true).create().asConsumer();
 
             return new Codesigners(codesignFile, codesignExecutableFile, codesignDir);
         }

--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/util/PListReader.java
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/util/PListReader.java
@@ -111,7 +111,7 @@ public final class PListReader {
     /**
      * Returns the contents of the the underlying "dict" element as a Map.
      * <p>
-     * The keys in the returned map are names of the keys.
+     * The keys in the returned map are names of the properties.
      * <p>
      * Values of nested "dict" properties are stored as {@code Map<String, Object>}
      * or {@code PListReader} objects depending on the value of the
@@ -150,13 +150,14 @@ public final class PListReader {
     }
 
     /**
-     * Returns the value of the given string key in the underlying "dict" element.
+     * Returns the value of the given string property in the underlying "dict"
+     * element.
      *
-     * @param keyName the name of a string key whose value to query
-     * @return the value of the string key with the specified name in the underlying
-     *         "dict" element
-     * @throws NoSuchElementException if there is no string key with the given name
-     *                                in the underlying "dict" element
+     * @param keyName the name of a string property whose value to query
+     * @return the value of the string property with the specified name in the
+     *         underlying "dict" element
+     * @throws NoSuchElementException if there is no string property with the given
+     *                                name in the underlying "dict" element
      */
     public String queryValue(String keyName) {
         final var node = getNode(keyName);
@@ -169,15 +170,38 @@ public final class PListReader {
             }
         }
     }
+    
+    /**
+     * Returns the value of the given "dict" property in the underlying "dict"
+     * element.
+     *
+     * @param keyName the name of a "dict" property whose value to query
+     * @return the value of the "dict" property with the specified name in the
+     *         underlying "dict" element
+     * @throws NoSuchElementException if there is no "dict" property with the given
+     *                                name in the underlying "dict" element
+     */
+    public PListReader queryDictValue(String keyName) {
+        final var node = getNode(keyName);
+        switch (node.getNodeName()) {
+            case "dict" -> {
+                return new PListReader(node);
+            }
+            default -> {
+                throw new NoSuchElementException();
+            }
+        }
+    }
 
     /**
-     * Returns the value of the given boolean key in the underlying "dict" element.
+     * Returns the value of the given boolean property in the underlying "dict"
+     * element.
      *
-     * @param keyName the name of a boolean key whose value to query
-     * @return the value of the boolean key with the specified name in the
+     * @param keyName the name of a boolean property whose value to query
+     * @return the value of the boolean property with the specified name in the
      *         underlying "dict" element
-     * @throws NoSuchElementException if there is no string key with the given name
-     *                                in the underlying "dict" element
+     * @throws NoSuchElementException if there is no string property with the given
+     *                                name in the underlying "dict" element
      */
     public boolean queryBoolValue(String keyName) {
         final var node = getNode(keyName);
@@ -195,18 +219,18 @@ public final class PListReader {
     }
 
     /**
-     * Returns the value of the given array key in the underlying "dict" element as
-     * a list of strings.
+     * Returns the value of the given array property in the underlying "dict"
+     * element as a list of strings.
      * <p>
      * Processes the result of calling {@link #queryArrayValue(String)} on the
-     * specified key by filtering {@link Raw} instances of type
+     * specified property name by filtering {@link Raw} instances of type
      * {@link Raw.Type#STRING}.
      *
-     * @param keyName the name of an array key whose value to query
-     * @return the value of the array key with the specified name in the underlying
-     *         "dict" element
-     * @throws NoSuchElementException if there is no array key with the given name
-     *                                in the underlying "dict" element
+     * @param keyName the name of an array property whose value to query
+     * @return the value of the array property with the specified name in the
+     *         underlying "dict" element
+     * @throws NoSuchElementException if there is no array property with the given
+     *                                name in the underlying "dict" element
      */
     public List<String> queryStringArrayValue(String keyName) {
         return queryArrayValue(keyName, false).map(v -> {
@@ -220,8 +244,8 @@ public final class PListReader {
     }
 
     /**
-     * Returns the value of the given array key in the underlying "dict" element as
-     * a stream of {@link Object}-s.
+     * Returns the value of the given array property in the underlying "dict"
+     * element as a stream of {@link Object}-s.
      * <p>
      * Values of "dict" array items are stored as {@code Map<String, Object>} or
      * {@code PListReader} objects depending on the value of the
@@ -231,13 +255,13 @@ public final class PListReader {
      * <p>
      * Values of other types are stored as {@code Raw} objects.
      *
-     * @param keyName           the name of an array key whose value to query
+     * @param keyName           the name of an array property whose value to query
      * @param fetchDictionaries controls the type of objects of "dict" elements. If
      *                          the value is {@code true},
      *                          {@code Map<String, Object>} type is used, and
      *                          {@code PListReader} type otherwise.
-     * @return the value of the array key with the specified name in the underlying
-     *         "dict" element
+     * @return the value of the array property with the specified name in the
+     *         underlying "dict" element
      * @throws NoSuchElementException if there is no array key with the given name
      *                                in the underlying "dict" element
      */
@@ -256,9 +280,9 @@ public final class PListReader {
     /**
      * Creates plist reader from the given node.
      * <p>
-     * If the name of the specified node is an element with the name "dict", the
-     * reader is bound to the given node; otherwise, it is bound to the
-     * {@code /plist/dict} element.
+     * If the specified node is an element with the name "dict", the reader is bound
+     * to the specified node; otherwise, it is bound to the {@code /plist/dict}
+     * element in the document.
      *
      * @param node the node
      * @throws NoSuchElementException if the specified node is not an element with

--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/util/PListReader.java
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/util/PListReader.java
@@ -318,8 +318,8 @@ public final class PListReader {
     }
 
 
-    private final static class XPathSingleton {
-        private final static XPath INSTANCE = XPathFactory.newInstance().newXPath();
+    private static final class XPathSingleton {
+        private static final XPath INSTANCE = XPathFactory.newInstance().newXPath();
     }
 
 

--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/util/PListReader.java
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/util/PListReader.java
@@ -170,7 +170,7 @@ public final class PListReader {
             }
         }
     }
-    
+
     /**
      * Returns the value of the given "dict" property in the underlying "dict"
      * element.

--- a/test/jdk/tools/jpackage/TEST.properties
+++ b/test/jdk/tools/jpackage/TEST.properties
@@ -22,5 +22,6 @@ modules = \
     jdk.jpackage/jdk.jpackage.internal:+open \
     jdk.jpackage/jdk.jpackage.internal.util \
     jdk.jpackage/jdk.jpackage.internal.util.function \
+    jdk.jpackage/jdk.jpackage.internal.resources \
     java.base/jdk.internal.util \
     jdk.jlink/jdk.tools.jlink.internal

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/JPackageCommand.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/JPackageCommand.java
@@ -1085,7 +1085,9 @@ public class JPackageCommand extends CommandArguments<JPackageCommand> {
         }),
         MAIN_LAUNCHER_FILES(cmd -> {
             if (!cmd.isRuntime()) {
-                new LauncherVerifier(cmd).verify(cmd, LauncherVerifier.Action.VERIFY_INSTALLED);
+                new LauncherVerifier(cmd).verify(cmd,
+                        LauncherVerifier.Action.VERIFY_INSTALLED,
+                        LauncherVerifier.Action.VERIFY_MAC_ENTITLEMENTS);
             }
         }),
         MAIN_JAR_FILE(cmd -> {

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/LauncherAsServiceVerifier.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/LauncherAsServiceVerifier.java
@@ -311,7 +311,7 @@ public final class LauncherAsServiceVerifier {
 
         var servicePlist = MacHelper.readPList(servicePlistFile);
 
-        var args = servicePlist.queryArrayValue("ProgramArguments");
+        var args = servicePlist.queryStringArrayValue("ProgramArguments");
         TKit.assertEquals(1, args.size(),
                 "Check number of array elements in 'ProgramArguments' property in the property file");
         TKit.assertEquals(installedLauncherPath.toString(), args.get(0),

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/LauncherVerifier.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/LauncherVerifier.java
@@ -399,8 +399,8 @@ public final class LauncherVerifier {
             }).get();
         }
 
-        final static Map<String, Object> STANDARD = loadFromResources("entitlements.plist");
-        final static Map<String, Object> APP_STORE = loadFromResources("sandbox.plist");
+        static final Map<String, Object> STANDARD = loadFromResources("entitlements.plist");
+        static final Map<String, Object> APP_STORE = loadFromResources("sandbox.plist");
     }
 
 

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/LauncherVerifier.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/LauncherVerifier.java
@@ -37,9 +37,14 @@ import java.util.function.BiConsumer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
+import javax.xml.parsers.ParserConfigurationException;
+import jdk.jpackage.internal.resources.ResourceLocator;
+import jdk.jpackage.internal.util.PListReader;
 import jdk.jpackage.internal.util.function.ThrowingBiConsumer;
+import jdk.jpackage.internal.util.function.ThrowingSupplier;
 import jdk.jpackage.test.AdditionalLauncher.PropertyFile;
 import jdk.jpackage.test.LauncherShortcut.StartupDirectory;
+import org.xml.sax.SAXException;
 
 public final class LauncherVerifier {
 
@@ -82,6 +87,11 @@ public final class LauncherVerifier {
                 verifier.verifyInAppImageFile(cmd);
             }
         }),
+        VERIFY_MAC_ENTITLEMENTS((verifier, cmd) -> {
+            if (TKit.isOSX() && MacHelper.appImageSigned(cmd)) {
+                verifier.verifyMacEntitlements(cmd);
+            }
+        }),
         EXECUTE_LAUNCHER(LauncherVerifier::executeLauncher),
         ;
 
@@ -96,7 +106,7 @@ public final class LauncherVerifier {
         private final BiConsumer<LauncherVerifier, JPackageCommand> action;
 
         static final List<Action> VERIFY_APP_IMAGE = List.of(
-                VERIFY_ICON, VERIFY_DESCRIPTION, VERIFY_INSTALLED, VERIFY_APP_IMAGE_FILE
+                VERIFY_ICON, VERIFY_DESCRIPTION, VERIFY_INSTALLED, VERIFY_APP_IMAGE_FILE, VERIFY_MAC_ENTITLEMENTS
         );
 
         static final List<Action> VERIFY_DEFAULTS = Stream.concat(
@@ -323,6 +333,24 @@ public final class LauncherVerifier {
         }
     }
 
+    private void verifyMacEntitlements(JPackageCommand cmd) throws ParserConfigurationException, SAXException, IOException {
+        Path launcherPath = cmd.appLauncherPath(name);
+        var entitlements = MacSignVerify.findEntitlements(launcherPath);
+
+        TKit.assertTrue(entitlements.isPresent(), String.format("Check [%s] launcher is signed with entitlements", name));
+
+        Map<String, Object> expected;
+        if (cmd.hasArgument("--mac-entitlements")) {
+            expected = new PListReader(Files.readAllBytes(Path.of(cmd.getArgumentValue("--mac-entitlements")))).toMap(true);
+        } else if (cmd.hasArgument("--mac-app-store")) {
+            expected = DefaultEntitlements.APP_STORE;
+        } else {
+            expected = DefaultEntitlements.STANDARD;
+        }
+
+        TKit.assertEquals(expected, entitlements.orElseThrow().toMap(true), String.format("Check [%s] launcher is signed with expected entitlements", name));
+    }
+
     private void executeLauncher(JPackageCommand cmd) throws IOException {
         Path launcherPath = cmd.appLauncherPath(name);
 
@@ -361,6 +389,20 @@ public final class LauncherVerifier {
             }
         });
     }
+
+
+    private static final class DefaultEntitlements {
+        private static Map<String, Object> loadFromResources(String resourceName) {
+            return ThrowingSupplier.toSupplier(() -> {
+                var bytes = ResourceLocator.class.getResourceAsStream("entitlements.plist").readAllBytes();
+                return new PListReader(bytes).toMap(true);
+            }).get();
+        }
+
+        final static Map<String, Object> STANDARD = loadFromResources("entitlements.plist");
+        final static Map<String, Object> APP_STORE = loadFromResources("sandbox.plist");
+    }
+
 
     private final String name;
     private final Optional<List<String>> javaOptions;

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/MacHelper.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/MacHelper.java
@@ -74,7 +74,8 @@ public final class MacHelper {
 
         Path mountPoint = null;
         try {
-            var plist = readPList(attachExecutor.getOutput());
+            // The first "dict" item of "system-entities" array property contains "mount-point" string property.
+            var plist = readPList(attachExecutor.getOutput()).queryArrayValue("system-entities", false).findFirst().map(PListReader.class::cast).orElseThrow();
             mountPoint = Path.of(plist.queryValue("mount-point"));
 
             // code here used to copy just <runtime name> or <app name>.app

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/MacSignVerify.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/MacSignVerify.java
@@ -56,6 +56,17 @@ public final class MacSignVerify {
                 String.format("Check [%s] signed with adhoc signature", path));
     }
 
+    public static Optional<PListReader> findEntitlements(Path path) {
+        final var exec = Executor.of("/usr/bin/codesign", "-d", "--entitlements", "-", "--xml", path.toString()).saveOutput().dumpOutput();
+        final var result = exec.execute();
+        var xml = result.stdout().getOutput();
+        if (xml.isEmpty()) {
+            return Optional.empty();
+        } else {
+            return Optional.of(MacHelper.readPList(xml));
+        }
+    }
+
     public static void assertUnsigned(Path path) {
         TKit.assertTrue(findSpctlSignOrigin(SpctlType.EXEC, path).isEmpty(),
                 String.format("Check [%s] unsigned", path));

--- a/test/jdk/tools/jpackage/junit/share/jdk.jpackage/jdk/jpackage/internal/util/PListReaderTest.java
+++ b/test/jdk/tools/jpackage/junit/share/jdk.jpackage/jdk/jpackage/internal/util/PListReaderTest.java
@@ -379,6 +379,14 @@ public class PListReaderTest {
                 testSpec(QueryType.BOOLEAN).xml("<key>foo</key><False/><key>foo</key><true/>"),
 
                 //
+                // Test that it doesn't look up keys in nested "dict" or "array" elements.
+                //
+                testSpec().xml("<key>foo</key><dict><key>foo</key><string>A</string></dict>"),
+                testSpec().expect("B").xml("<key>bar</key><dict><key>foo</key><string>A</string></dict><key>foo</key><string>B</string>"),
+                testSpec().xml("<key>foo</key><array><dict><key>foo</key><string>A</string></dict></array>"),
+                testSpec().expect("B").xml("<key>bar</key><array><dict><key>foo</key><string>A</string></dict></array><key>foo</key><string>B</string>"),
+
+                //
                 // Test empty arrays.
                 //
                 testSpec().expect(List.of()).queryType(QueryType.RAW_ARRAY_RECURSIVE).xml("<key>foo</key><array/>"),

--- a/test/jdk/tools/jpackage/junit/share/jdk.jpackage/jdk/jpackage/internal/util/PListReaderTest.java
+++ b/test/jdk/tools/jpackage/junit/share/jdk.jpackage/jdk/jpackage/internal/util/PListReaderTest.java
@@ -272,7 +272,7 @@ public class PListReaderTest {
                 "</array>"
         );
 
-        var actual = new PListReader(xml.getBytes(StandardCharsets.UTF_8)).toMap();
+        var actual = new PListReader(xml.getBytes(StandardCharsets.UTF_8)).toMap(true);
 
         var expected = Map.of(
                 "AppName", new Raw("Hello", Raw.Type.STRING),

--- a/test/jdk/tools/jpackage/macosx/MacFileAssociationsTest.java
+++ b/test/jdk/tools/jpackage/macosx/MacFileAssociationsTest.java
@@ -21,15 +21,16 @@
  * questions.
  */
 
+import static java.util.Map.entry;
+
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
-import static java.util.Map.entry;
-import jdk.jpackage.test.JPackageCommand;
-import jdk.jpackage.test.TKit;
-import jdk.jpackage.test.MacHelper;
 import jdk.jpackage.internal.util.PListReader;
 import jdk.jpackage.test.Annotations.Test;
+import jdk.jpackage.test.JPackageCommand;
+import jdk.jpackage.test.MacHelper;
+import jdk.jpackage.test.TKit;
 
 /**
  * Tests generation of app image with --file-associations and mac additional file
@@ -80,9 +81,9 @@ public class MacFileAssociationsTest {
                 "Check value of %s plist key", key));
     }
 
-    private static void checkBoolValue(PListReader plist, String key, Boolean value) {
-        Boolean result = plist.queryBoolValue(key);
-        TKit.assertEquals(value.toString(), result.toString(), String.format(
+    private static void checkBoolValue(PListReader plist, String key, boolean value) {
+        boolean result = plist.queryBoolValue(key);
+        TKit.assertEquals(value, result, String.format(
                 "Check value of %s plist key", key));
     }
 
@@ -94,7 +95,12 @@ public class MacFileAssociationsTest {
     }
 
     private static void verifyPList(Path appImage) throws Exception {
-        var plist = MacHelper.readPListFromAppImage(appImage);
+        final var rootPlist = MacHelper.readPListFromAppImage(appImage);
+
+        TKit.traceFileContents(appImage.resolve("Contents/Info.plist"), "Info.plist");
+
+        var plist = rootPlist.queryArrayValue("CFBundleDocumentTypes", false).findFirst().map(PListReader.class::cast).orElseThrow();
+
         checkStringValue(plist, "CFBundleTypeRole", "Viewer");
         checkStringValue(plist, "LSHandlerRank", "Default");
         checkStringValue(plist, "NSDocumentClass", "SomeClass");
@@ -103,10 +109,13 @@ public class MacFileAssociationsTest {
         checkBoolValue(plist, "LSSupportsOpeningDocumentsInPlace", false);
         checkBoolValue(plist, "UISupportsDocumentBrowser", false);
 
-        checkArrayValue(plist, "NSExportableTypes", List.of("public.png",
-                                                            "public.jpg"));
+        plist = rootPlist.queryArrayValue("UTExportedTypeDeclarations", false).findFirst().map(PListReader.class::cast).orElseThrow();
 
-        checkArrayValue(plist, "UTTypeConformsTo", List.of("public.image",
-                                                           "public.data"));
+        checkArrayValue(plist, "UTTypeConformsTo", List.of("public.image", "public.data"));
+
+        plist = plist.queryDictValue("UTTypeTagSpecification");
+
+        checkArrayValue(plist, "NSExportableTypes", List.of("public.png", "public.jpg"));
+
     }
 }

--- a/test/jdk/tools/jpackage/macosx/MacFileAssociationsTest.java
+++ b/test/jdk/tools/jpackage/macosx/MacFileAssociationsTest.java
@@ -88,7 +88,7 @@ public class MacFileAssociationsTest {
 
     private static void checkArrayValue(PListReader plist, String key,
             List<String> values) {
-        List<String> result = plist.queryArrayValue(key);
+        List<String> result = plist.queryStringArrayValue(key);
         TKit.assertStringListEquals(values, result, String.format(
                 "Check value of %s plist key", key));
     }


### PR DESCRIPTION
Fix the regression introduced by [JDK-8333664](https://bugs.openjdk.org/browse/JDK-8333664) that jpackage was not using entitlements when signing directories. This gave the main launcher no entitlements.

Additionally, enhance `jdk.jpackage.internal.util.PListReader` class.

Test code will verify that all launchers have the entitlements when `--mac-sign` is used or when a predefined app image is signed.

Ensured signing tests failed without the fix to `AppImageSigner.java` and that they passed with the fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8358723: jpackage signing issues: the main launcher doesn't have entitlements`

### Issue
 * [JDK-8358723](https://bugs.openjdk.org/browse/JDK-8358723): jpackage signing issues: the main launcher doesn't have entitlements (**Bug** - P3)


### Reviewers
 * [Alexander Matveev](https://openjdk.org/census#almatvee) (@sashamatveev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27493/head:pull/27493` \
`$ git checkout pull/27493`

Update a local copy of the PR: \
`$ git checkout pull/27493` \
`$ git pull https://git.openjdk.org/jdk.git pull/27493/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27493`

View PR using the GUI difftool: \
`$ git pr show -t 27493`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27493.diff">https://git.openjdk.org/jdk/pull/27493.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27493#issuecomment-3336339442)
</details>
