### PR TITLE
8368699: nsk/jvmti/scenarios/events/EM04/em04t001/em04t001.cpp destroys jvmti monitor when VM is dead

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM04/em04t001/em04t001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM04/em04t001/em04t001.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -118,6 +118,13 @@ cbDynamicCodeGenerated2(jvmtiEnv *jvmti_env, const char *name,
 
 }
 
+void JNICALL
+cbVMDeath(jvmtiEnv* jvmti, JNIEnv* jni) {
+    if (!NSK_JVMTI_VERIFY(jvmti->DestroyRawMonitor(syncLock))) {
+        nsk_jvmti_setFailStatus();
+    }
+}
+
 /* ============================================================================= */
 
 static int
@@ -138,6 +145,7 @@ int setCallBacks(int stage) {
     eventCallbacks.DynamicCodeGenerated = (stage == 1) ?
                             cbDynamicCodeGenerated1 : cbDynamicCodeGenerated2;
 
+    eventCallbacks.VMDeath = &cbVMDeath;
     if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks))))
         return NSK_FALSE;
 
@@ -256,9 +264,6 @@ Agent_OnUnload(JavaVM *jvm)
         nsk_jvmti_setFailStatus();
     }
 
-    if (!NSK_JVMTI_VERIFY(jvmti->DestroyRawMonitor(syncLock))) {
-        nsk_jvmti_setFailStatus();
-    }
 }
 
 }


### PR DESCRIPTION
Test
nsk/jvmti/scenarios/events/EM04/em04t001/em04t001.cpp
destroys jvmti raw monitor in incorrect phase. 

The test is not failing because currently the failure is ignored.
However I plan to fix https://bugs.openjdk.org/browse/JDK-8352654 and the test going to fails.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8368699](https://bugs.openjdk.org/browse/JDK-8368699): nsk/jvmti/scenarios/events/EM04/em04t001/em04t001.cpp destroys jvmti monitor when VM is dead (**Bug** - P4)


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27495/head:pull/27495` \
`$ git checkout pull/27495`

Update a local copy of the PR: \
`$ git checkout pull/27495` \
`$ git pull https://git.openjdk.org/jdk.git pull/27495/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27495`

View PR using the GUI difftool: \
`$ git pr show -t 27495`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27495.diff">https://git.openjdk.org/jdk/pull/27495.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27495#issuecomment-3335130659)
</details>
